### PR TITLE
Enable basic Travis.ci build for linux_x86-64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: c
+sudo: false
+
+addons:
+  apt:
+    sources:
+       - ubuntu-toolchain-r-test
+    packages:
+       - libnuma-dev
+
+script: make -f run_configure.mk SPEC=linux_x86-64 OMRGLUE=./example/glue && make && make test
+
+


### PR DESCRIPTION
Very basic Travis.ci build that compiles and runs make test for the linux_x86-64 spec.

Note, the .travis.yml file must have consistent delimiters - mixing spaces / tabs will cause the build to fail.  https://lint.travis-ci.org/ can be used to validate the yml file without needing to commit the file and see the build fail.

The build still has three errors:
[0;31m[  FAILED  ] [mPortDumpTest.dump_test_create_dump_with_NO_name
[0;31m[  FAILED  ] [mPortDumpTest.dump_test_create_dump_with_name
[0;31m[  FAILED  ] [mPortDumpTest.dump_test_create_dump_from_signal_handler
which will need to be resolved under separate issues.