### PR TITLE
Enable basic Travis.ci build for linux_x86-64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: c
+sudo: false
+
+addons:
+  apt:
+    sources:
+       - ubuntu-toolchain-r-test
+    packages:
+       - libnuma-dev
+
+script: make -f run_configure.mk SPEC=linux_x86-64 OMRGLUE=./example/glue && make && make test
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,26 @@
+###############################################################################
+#
+# (c) Copyright IBM Corp. 2016
+#
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License v1.0 and
+#  Apache License v2.0 which accompanies this distribution.
+#
+#      The Eclipse Public License is available at
+#      http://www.eclipse.org/legal/epl-v10.html
+#
+#      The Apache License v2.0 is available at
+#      http://www.opensource.org/licenses/apache2.0.php
+#
+# Contributors:
+#    Multiple authors (IBM Corp.) - initial implementation and documentation
+###############################################################################
+
 language: c
 sudo: false
 os: linux
+
+# https://docs.travis-ci.com/user/caching/
 cache: ccache
 
 addons:
@@ -15,6 +35,11 @@ before_script:
   - ulimit -c unlimited
   - make -f run_configure.mk SPEC=linux_x86-64 OMRGLUE=./example/glue
   - export GTEST_FILTER=-*dump_test_create_dump_*
+# Disable the core dump tests as container based builds don't allow setting
+# core_pattern and don't have apport installed.  This can be removed when
+# apport is available in apt whitelist
 
-script: make && make test
+script: 
+  - make 
+  - make test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: c
 sudo: false
+os: linux
+cache: ccache
 
 addons:
   apt:
@@ -7,7 +9,12 @@ addons:
        - ubuntu-toolchain-r-test
     packages:
        - libnuma-dev
+       - bison
 
-script: make -f run_configure.mk SPEC=linux_x86-64 OMRGLUE=./example/glue && make && make test
+before_script:
+  - ulimit -c unlimited
+  - make -f run_configure.mk SPEC=linux_x86-64 OMRGLUE=./example/glue
+  - export GTEST_FILTER=-*dump_test_create_dump_*
 
+script: make && make test
 


### PR DESCRIPTION
Very basic Travis.ci build that compiles and runs make test for the linux_x86-64 spec.

Note, the .travis.yml file must have consistent delimiters - mixing spaces / tabs will cause the build to fail. https://lint.travis-ci.org/ can be used to validate the yml file without needing to commit the file and see the build fail.

The build still has three errors:
?[0;31m[ FAILED ] ?[mPortDumpTest.dump_test_create_dump_with_NO_name
?[0;31m[ FAILED ] ?[mPortDumpTest.dump_test_create_dump_with_name
?[0;31m[ FAILED ] ?[mPortDumpTest.dump_test_create_dump_from_signal_handler
which will need to be resolved under separate issue

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>