### PR TITLE
Disable the numa tests as they fail on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ addons:
 before_script:
   - ulimit -c unlimited
   - make -f run_configure.mk SPEC=linux_x86-64 OMRGLUE=./example/glue
-  - export GTEST_FILTER=-*dump_test_create_dump_*
+  - export GTEST_FILTER=-*dump_test_create_dump_*:*NumaSetAffinity:*NumaSetAffinitySuspended
 # Disable the core dump tests as container based builds don't allow setting
 # core_pattern and don't have apport installed.  This can be removed when
 # apport is available in apt whitelist


### PR DESCRIPTION
I've added the NUMA tests to the google test ignore filter in the .travis.yml file.  They fail intermittently on travis,ci even when there are no code changes between passing and failing builds.