### PR TITLE
Fix issue #37

### DIFF
--- a/fvtest/omrtest.mk
+++ b/fvtest/omrtest.mk
@@ -46,6 +46,10 @@ omr_gctest:
 	
 omr_porttest:
 	./omrporttest
+ifneq (,$(findstring cuda,$(SPEC)))
+	./omrporttest --gtest_filter="Cuda*" -earlyExit
+endif
+	@echo ALL $@ PASSED
 
 omr_rastest:
 	./omrrastest

--- a/port/common/omrexit.c
+++ b/port/common/omrexit.c
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2015
+ * (c) Copyright IBM Corp. 1991, 2016
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -58,6 +58,15 @@ omrexit_get_exit_code(struct OMRPortLibrary *portLibrary)
 void OMRNORETURN
 omrexit_shutdown_and_exit(struct OMRPortLibrary *portLibrary, int32_t exitCode)
 {
+#if defined(J9VM_OPT_CUDA)
+	/* Because we're exiting we don't expect the port library to be shutdown normally,
+	 * but we don't want to omit the cuda shutdown step because it resets the devices
+	 * (if any were discovered) avoiding resource leaks that may lead to trouble for
+	 * future processes. If CUDA support was never requested, this is effectively a nop.
+	 * The function is also idempotent so a subsequent call would do no harm.
+	 */
+	portLibrary->cuda_shutdown(portLibrary);
+#endif /* J9VM_OPT_CUDA */
 
 #if !defined(WIN32)
 #if defined(OMRPORT_OMRSIG_SUPPORT)


### PR DESCRIPTION
* Removed an unnecessary call to cudaMemGetInfo() during initialization.
* Opening and initializing the CUDA runtime library before opening and
initializing the CUDA driver library seems to avoid the hang on exit.
* Call omrcuda_shutdown() from omrexit_shutdown_and_exit() to ensure
resources are released and profiling data is available.
* Extend the port library test to validate that exiting early via
omrexit_shutdown_and_exit() doesn't cause the process to hang.
* Fixed places where the device was inappropriately marked as
initialized.

Signed-off-by: Keith W. Campbell <keithc@ca.ibm.com>