### PR TITLE
FIX #59 : Use GNU feature macros before including any system header files

### DIFF
--- a/port/linux/omrosbacktrace_impl.c
+++ b/port/linux/omrosbacktrace_impl.c
@@ -22,16 +22,16 @@
  * @brief Stack backtracing support
  */
 
+#define _GNU_SOURCE
+
 #include "omrport.h"
 #include "omrportpriv.h"
 #include "omrsignal_context.h"
 
-#include <execinfo.h>
-#include <string.h>
-#include <stdlib.h>
-
-#define __USE_GNU 1
 #include <dlfcn.h>
+#include <execinfo.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "omrintrospect.h"
 

--- a/port/linux386/omrsignal_context.c
+++ b/port/linux386/omrsignal_context.c
@@ -16,9 +16,10 @@
  *    Multiple authors (IBM Corp.) - initial API and implementation and/or initial documentation
  *******************************************************************************/
 
-#include <unistd.h>
-#define __USE_GNU 1
+#define _GNU_SOURCE
+
 #include <sys/ucontext.h>
+#include <unistd.h>
 
 #include "omrport.h"
 #include "omrsignal_context.h"

--- a/port/linuxarm/omrsignal_context.c
+++ b/port/linuxarm/omrsignal_context.c
@@ -16,9 +16,10 @@
  *    Multiple authors (IBM Corp.) - initial API and implementation and/or initial documentation
  *******************************************************************************/
 
-#include <unistd.h>
-#define __USE_GNU 1
+#define _GNU_SOURCE
+
 #include <sys/ucontext.h>
+#include <unistd.h>
 
 #include "omrport.h"
 #include "omrsignal_context.h"

--- a/port/unix/omrintrospect.c
+++ b/port/unix/omrintrospect.c
@@ -25,7 +25,6 @@
 #if defined(LINUX)
 /* _GNU_SOURCE forces GLIBC_2.0 sscanf/vsscanf/fscanf for RHEL5 compatability */
 #define _GNU_SOURCE
-#define __USE_GNU 1
 #endif /* defined(LINUX) */
 
 #include <pthread.h>

--- a/util/omrutil/unix/linux/s390/archinfo.c
+++ b/util/omrutil/unix/linux/s390/archinfo.c
@@ -19,7 +19,7 @@
 /* _GNU_SOURCE forces GLIBC_2.0 sscanf/vsscanf/fscanf for RHEL5 compatability */
 #if defined(LINUX)
 #define _GNU_SOURCE
-#endif /* defined(__GNUC__) */
+#endif /* defined(LINUX) */
 
 #include <string.h>
 #include <stdio.h>


### PR DESCRIPTION
Issue: #59 
Signed-off-by: Andrew Young <youngar17@gmail.com>