### PR TITLE
Fix #78: Use OMR version of J9VM macros

### DIFF
--- a/gc/base/Configuration.cpp
+++ b/gc/base/Configuration.cpp
@@ -254,7 +254,7 @@ MM_Configuration::initializeRunTimeObjectAlignmentAndCRShift(MM_EnvironmentBase*
 	MM_GCExtensionsBase* extensions = env->getExtensions();
 	OMR_VM *omrVM = env->getOmrVM();
 
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 	UDATA heapTop = (uintptr_t)heap->getHeapTop();
 	UDATA maxAddressValue = (uintptr_t)1 << 32;
 	UDATA shift = (extensions->shouldAllowShiftingCompression) ? LOW_MEMORY_HEAP_CEILING_SHIFT : 0;
@@ -290,7 +290,7 @@ MM_Configuration::initializeRunTimeObjectAlignmentAndCRShift(MM_EnvironmentBase*
 
 	omrVM->_compressedPointersShift = shift;
 
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
 
 #define MINIMUM_OBJECT_ALIGNMENT 0x8
 #define MINIMUM_OBJECT_ALIGNMENT_SHIFT 0x3

--- a/gc/base/MarkingScheme.cpp
+++ b/gc/base/MarkingScheme.cpp
@@ -30,9 +30,9 @@
 #include "MarkingScheme.hpp"
 #include "Task.hpp"
 #include "WorkPackets.hpp"
-#if defined(J9VM_GC_MODRON_CONCURRENT_MARK)
+#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
 #include "WorkPacketsConcurrent.hpp"
-#endif /* J9VM_GC_MODRON_CONCURRENT_MARK */
+#endif /* defined(OMR_GC_MODRON_CONCURRENT_MARK) */
 #include "WorkPacketsStandard.hpp"
 
 /**
@@ -343,11 +343,11 @@ MM_WorkPackets *
 MM_MarkingScheme::createWorkPackets(MM_EnvironmentBase *env) {
 	MM_WorkPackets *workPackets = NULL;
 
-#if defined(J9VM_GC_MODRON_CONCURRENT_MARK)
+#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
 	if(_extensions->concurrentMark) {
 		workPackets = MM_WorkPacketsConcurrent::newInstance(env);
 	} else
-#endif /* J9VM_GC_MODRON_CONCURRENT_MARK */
+#endif /* defined(OMR_GC_MODRON_CONCURRENT_MARK) */
 	{
 		workPackets = MM_WorkPacketsStandard::newInstance(env);
 	}

--- a/gc/base/TLHAllocationSupport.cpp
+++ b/gc/base/TLHAllocationSupport.cpp
@@ -399,4 +399,4 @@ MM_TLHAllocationSupport::objectAllocationNotify(MM_EnvironmentBase *env, void *h
 }
 #endif /* OMR_GC_OBJECT_ALLOCATION_NOTIFY */
 
-#endif /* J9VM_GC_THREAD_LOCAL_HEAP */
+#endif /* defined(OMR_GC_THREAD_LOCAL_HEAP) */

--- a/gc/base/standard/ParallelGlobalGC.hpp
+++ b/gc/base/standard/ParallelGlobalGC.hpp
@@ -23,9 +23,9 @@
 #include "modronopt.h"
 
 #include "CollectionStatisticsStandard.hpp"
-#if defined(J9VM_GC_CONCURRENT_SWEEP)
+#if defined(OMR_GC_CONCURRENT_SWEEP)
 #include "ConcurrentSweepScheme.hpp"
-#endif /* J9VM_GC_CONCURRENT_SWEEP */
+#endif /* defined(OMR_GC_CONCURRENT_SWEEP) */
 #include "CycleState.hpp"
 #include "EnvironmentBase.hpp"
 #include "GCExtensionsBase.hpp"
@@ -238,11 +238,11 @@ protected:
 	{
 		MM_ParallelSweepScheme *sweepScheme = NULL;
 
-#if defined(J9VM_GC_CONCURRENT_SWEEP)
+#if defined(OMR_GC_CONCURRENT_SWEEP)
 		if(_extensions->concurrentSweep) {
 			sweepScheme = MM_ConcurrentSweepScheme::newInstance(env, globalCollector);
 		} else
-#endif /* J9VM_GC_CONCURRENT_SWEEP */
+#endif /* defined(OMR_GC_CONCURRENT_SWEEP) */
 		{
 			sweepScheme = MM_ParallelSweepScheme::newInstance(env);
 		}

--- a/port/common/omrexit.c
+++ b/port/common/omrexit.c
@@ -58,7 +58,7 @@ omrexit_get_exit_code(struct OMRPortLibrary *portLibrary)
 void OMRNORETURN
 omrexit_shutdown_and_exit(struct OMRPortLibrary *portLibrary, int32_t exitCode)
 {
-#if defined(J9VM_OPT_CUDA)
+#if defined(OMR_OPT_CUDA)
 	/* Because we're exiting we don't expect the port library to be shutdown normally,
 	 * but we don't want to omit the cuda shutdown step because it resets the devices
 	 * (if any were discovered) avoiding resource leaks that may lead to trouble for
@@ -66,7 +66,7 @@ omrexit_shutdown_and_exit(struct OMRPortLibrary *portLibrary, int32_t exitCode)
 	 * The function is also idempotent so a subsequent call would do no harm.
 	 */
 	portLibrary->cuda_shutdown(portLibrary);
-#endif /* J9VM_OPT_CUDA */
+#endif /* defined(OMR_OPT_CUDA) */
 
 #if !defined(WIN32)
 #if defined(OMRPORT_OMRSIG_SUPPORT)


### PR DESCRIPTION
Signed-off-by: Andrew Young <youngar17@gmail.com>