### PR TITLE
Always include "tests" target in postbuild_targets.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -158,10 +158,7 @@ test_targets := $(test_prereqs)
 test_targets += fvtest/rastest fvtest/util
 endif
 endif
-
-ifeq (yes,$(DO_TEST_TARGET))
 postbuild_targets += tests
-endif
 
 ###
 ### Rules


### PR DESCRIPTION
The OMR library build relies on the dependency ordering introduced
by the tests: rule even when no tests are being built or run.

Signed-off-by: Angela Lin <angela_lin@ca.ibm.com>