### PR TITLE
Fix #98 Add support for more platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,12 @@
 #    Multiple authors (IBM Corp.) - initial implementation and documentation
 ###############################################################################
 
-language: c
+language: c++
 sudo: false
-os: linux
+
+os:
+  - linux
+  - osx
 
 # https://docs.travis-ci.com/user/caching/
 cache: ccache
@@ -30,16 +33,35 @@ addons:
     packages:
        - libnuma-dev
        - bison
+       - gcc-multilib
+       - g++-multilib
 
 before_script:
   - ulimit -c unlimited
-  - make -f run_configure.mk SPEC=linux_x86-64 OMRGLUE=./example/glue
   - export GTEST_FILTER=-*dump_test_create_dump_*:*NumaSetAffinity:*NumaSetAffinitySuspended
 # Disable the core dump tests as container based builds don't allow setting
 # core_pattern and don't have apport installed.  This can be removed when
 # apport is available in apt whitelist
 
-script: 
+env:
+  - SPEC=osx_x86-64
+  - SPEC=linux_x86-64
+  - SPEC=linux_x86-64_cmprssptrs
+  - SPEC=linux_x86
+
+matrix:
+  exclude:
+    - os: linux
+      env: SPEC=osx_x86-64
+    - os: osx
+      env: SPEC=linux_x86-64
+    - os: osx
+      env: SPEC=linux_x86-64_cmprssptrs
+    - os: osx
+      env: SPEC=linux_x86
+
+script:
+  - make -f run_configure.mk OMRGLUE=./example/glue
   - make 
   - make test
 

--- a/fvtest/omrtest.mk
+++ b/fvtest/omrtest.mk
@@ -70,7 +70,7 @@ omr_threadtest:
 	./omrthreadtest
 	./omrthreadtest --gtest_also_run_disabled_tests --gtest_filter=ThreadCreateTest.DISABLED_SetAttrThreadWeight
 ifneq (,$(findstring linux,$(SPEC)))
-	./omrthreadtest --gtest_filter=ThreadCreateTest.* -realtime
+	./omrthreadtest --gtest_filter=ThreadCreateTest.*:$(GTEST_FILTER) -realtime
 endif
 	@echo ALL $@ PASSED
 


### PR DESCRIPTION
Add OSX support
Add Linux x86-64 compressed references support
Add Linux x86 support
Fix FV test that already provided a filter to include the environment variable

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>