### PR TITLE
Fix #107: Enable up to 64 GB heaps for Compressed References platforms

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -571,6 +571,7 @@ public:
 		HEAP_INITIALIZATION_FAILURE_REASON_CAN_NOT_INSTANTIATE_SPLIT_HEAP_GEOMETRY,
 		HEAP_INITIALIZATION_FAILURE_REASON_CAN_NOT_ALLOCATE_LOW_MEMORY_RESERVE,
 		HEAP_INITIALIZATION_FAILURE_REASON_CAN_NOT_SATISFY_REQUESTED_PAGE_SIZE,
+		HEAP_INITIALIZATION_FAILURE_REASON_METRONOME_DOES_NOT_SUPPORT_4BIT_SHIFT,
 	};
 	HeapInitializationFailureReason heapInitializationFailureReason; /**< Error code provided additional information about heap initialization failure */
 	bool scavengerAlignHotFields; /**< True if the scavenger is to check the hot field description for an object in order to better cache align it when tenuring (enabled with the -Xgc:hotAlignment option) */

--- a/include_core/omrgcconsts.h
+++ b/include_core/omrgcconsts.h
@@ -394,7 +394,7 @@ typedef enum {
 /* Define the low memory heap ceiling (max heap address when -Xgc:forceLowMemHeap is specified) */
 #if defined(OMR_ENV_DATA64)
 /* highest supported shift for the low memory setting */
-#define LOW_MEMORY_HEAP_CEILING_SHIFT 3
+#define LOW_MEMORY_HEAP_CEILING_SHIFT 4
 /* shift required for the "default" low memory setting */
 #define DEFAULT_LOW_MEMORY_HEAP_CEILING_SHIFT 3
 /* 4 GiB when running scaling heap-base 0 VMs */


### PR DESCRIPTION
Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>