### PR TITLE
Fix #96 update schema.xsd

### DIFF
--- a/gc/verbose/schema.xsd
+++ b/gc/verbose/schema.xsd
@@ -485,6 +485,8 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 
 	<complexType name="warning">
 		<attribute name="details" type="string" use="required" />
+		<attribute name="count" type="integer" use="optional" />
+		<attribute name="packetcount" type="integer" use="optional" />
 	</complexType>
 
 	<complexType name="compact-info">


### PR DESCRIPTION
Fix #96 
update schema.xsd add two attributes ("count", "packetcount") for warning element
Signed-off-by: Lin Hu <linhu@ca.ibm.com>