### PR TITLE
Fix #116: Preventing file path or name to be truncated in omrsl_open_shared_library

### DIFF
--- a/util/omrutil/detectVMDirectory.c
+++ b/util/omrutil/detectVMDirectory.c
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2015
+ * (c) Copyright IBM Corp. 2015, 2016
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -31,11 +31,13 @@ detectVMDirectory(wchar_t *vmDirectory, size_t vmDirectoryLength, wchar_t **vmDi
 	omr_error_t rc = OMR_ERROR_NOT_AVAILABLE;
 	LPCSTR moduleName = NULL;
 	HANDLE moduleHandle = NULL;
+	DWORD pathLength = 0;
 
 	if (OMR_ERROR_NONE == OMR_Glue_GetVMDirectoryToken((void *)&moduleName)) {
 		moduleHandle = GetModuleHandle(moduleName);
 		if (NULL != moduleHandle) {
-			if (0 != GetModuleFileNameW(moduleHandle, vmDirectory, (DWORD)vmDirectoryLength)) {
+			pathLength = GetModuleFileNameW(moduleHandle, vmDirectory, (DWORD)vmDirectoryLength);
+			if ((0 != pathLength) && (pathLength < (DWORD)vmDirectoryLength)) {
 				/* remove the module name from the path */
 				*vmDirectoryEnd = wcsrchr(vmDirectory, '\\');
 				if (NULL != *vmDirectoryEnd) {


### PR DESCRIPTION
This change prevents file paths or names to be truncated in
omrsl_open_shared_library. OMRPORT_SL_UNSUPPORTED is thrown
if a file path or name is found to be truncated. A test case
is added to check boundary conditions for file paths and
names in omrsl_open_shared_library.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>