### PR TITLE
Fix #122: Fix spacing around linkage specifier

### DIFF
--- a/fvtest/threadtest/main.cpp
+++ b/fvtest/threadtest/main.cpp
@@ -22,7 +22,7 @@
 
 ThreadTestEnvironment *omrTestEnv;
 
-extern "C"int
+extern "C" int
 testMain(int argc, char **argv, char **envp)
 {
 	::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Signed-off-by: Andrew Young <youngar17@gmail.com>