### PR TITLE
Change -fpeel-loops to -funroll-loops

### DIFF
--- a/gc/base/makefile
+++ b/gc/base/makefile
@@ -35,8 +35,8 @@ endif
 
 ifeq (linux,$(OMR_HOST_OS))
   ifeq (x86,$(OMR_HOST_ARCH))
-    MODULE_CFLAGS += -fpeel-loops
-    MODULE_CXXFLAGS += -fpeel-loops
+    MODULE_CFLAGS += -funroll-loops
+    MODULE_CXXFLAGS += -funroll-loops
   endif
 endif
 

--- a/gc/base/standard/makefile
+++ b/gc/base/standard/makefile
@@ -29,8 +29,8 @@ MODULE_INCLUDES += ../../include ../../stats ../../structs ../../base $(OMRGLUE_
 
 ifeq (linux,$(OMR_HOST_OS))
   ifeq (x86,$(OMR_HOST_ARCH))
-    MODULE_CFLAGS += -fpeel-loops
-    MODULE_CXXFLAGS += -fpeel-loops
+    MODULE_CFLAGS += -funroll-loops
+    MODULE_CXXFLAGS += -funroll-loops
   endif
 endif
 

--- a/gc/startup/makefile
+++ b/gc/startup/makefile
@@ -29,8 +29,8 @@ MODULE_INCLUDES += ../base ../base/standard ../include ../stats ../structs ../ve
 
 ifeq (linux,$(OMR_HOST_OS))
   ifeq (x86,$(OMR_HOST_ARCH))
-    MODULE_CFLAGS += -fpeel-loops
-    MODULE_CXXFLAGS += -fpeel-loops
+    MODULE_CFLAGS += -funroll-loops
+    MODULE_CXXFLAGS += -funroll-loops
   endif
 endif
 

--- a/gc/stats/makefile
+++ b/gc/stats/makefile
@@ -29,8 +29,8 @@ MODULE_INCLUDES += ../include ../base ../structs $(OMRGLUE_INCLUDES)
 
 ifeq (linux,$(OMR_HOST_OS))
   ifeq (x86,$(OMR_HOST_ARCH))
-    MODULE_CFLAGS += -fpeel-loops
-    MODULE_CXXFLAGS += -fpeel-loops
+    MODULE_CFLAGS += -funroll-loops
+    MODULE_CXXFLAGS += -funroll-loops
   endif
 endif
 

--- a/gc/structs/makefile
+++ b/gc/structs/makefile
@@ -29,8 +29,8 @@ MODULE_INCLUDES += ../base ../stats ../include $(OMRGLUE_INCLUDES)
 
 ifeq (linux,$(OMR_HOST_OS))
   ifeq (x86,$(OMR_HOST_ARCH))
-    MODULE_CFLAGS += -fpeel-loops
-    MODULE_CXXFLAGS += -fpeel-loops
+    MODULE_CFLAGS += -funroll-loops
+    MODULE_CXXFLAGS += -funroll-loops
   endif
 endif
 

--- a/gc/verbose/handler_standard/makefile
+++ b/gc/verbose/handler_standard/makefile
@@ -29,8 +29,8 @@ MODULE_INCLUDES += ../../base ../../structs ../../stats ../../include ../../verb
 
 ifeq (linux,$(OMR_HOST_OS))
   ifeq (x86,$(OMR_HOST_ARCH))
-    MODULE_CFLAGS += -fpeel-loops
-    MODULE_CXXFLAGS += -fpeel-loops
+    MODULE_CFLAGS += -funroll-loops
+    MODULE_CXXFLAGS += -funroll-loops
   endif
 endif
 

--- a/gc/verbose/makefile
+++ b/gc/verbose/makefile
@@ -29,8 +29,8 @@ MODULE_INCLUDES += ../base ../structs ../stats ../include ../verbose/handler_sta
 
 ifeq (linux,$(OMR_HOST_OS))
   ifeq (x86,$(OMR_HOST_ARCH))
-    MODULE_CFLAGS += -fpeel-loops
-    MODULE_CXXFLAGS += -fpeel-loops
+    MODULE_CFLAGS += -funroll-loops
+    MODULE_CXXFLAGS += -funroll-loops
   endif
 endif
 

--- a/omr/startup/makefile
+++ b/omr/startup/makefile
@@ -40,8 +40,8 @@ endif
 
 ifeq (linux,$(OMR_HOST_OS))
   ifeq (x86,$(OMR_HOST_ARCH))
-    MODULE_CFLAGS += -fpeel-loops
-    MODULE_CXXFLAGS += -fpeel-loops
+    MODULE_CFLAGS += -funroll-loops
+    MODULE_CXXFLAGS += -funroll-loops
   endif
 endif
 


### PR DESCRIPTION
The GCC compiler option -fpeel-loops is not supported by Clang, which
prevents us from using Clang as a drop in compiler.  Clang does,
however, support the similiar option -funroll-loops.

-fpeel-loops is a GCC option which implies -frename-registers, uses
profile feedback to peel loops, and turns on complete loop peeling.

-funroll-loops is a GCC option which implies -frerun-cse-after-loop,
-fweb, -frename-registers, and turns on complete loop peeling.

I think -funroll-loops is the more aggressive optimization.  Since we do
not use profiles to direct optimization, I do not think it will make
much of a difference which option we use. On my machine, switching the
option did not result in identical output files.

Signed-off-by: Andrew Young <youngar17@gmail.com>