### PR TITLE
Fix #132 by cleaning up initial glue for new languages

### DIFF
--- a/example/glue/CollectorLanguageInterfaceImpl.cpp
+++ b/example/glue/CollectorLanguageInterfaceImpl.cpp
@@ -193,6 +193,7 @@ MM_CollectorLanguageInterfaceImpl::parallelDispatcher_handleMasterThread(OMR_VMT
 	/* Do nothing for now.  only required for SRT */
 }
 
+#if defined(OMR_GC_MODRON_SCAVENGER)
 void
 MM_CollectorLanguageInterfaceImpl::generationalWriteBarrierStore(OMR_VMThread *omrThread, omrobjectptr_t parentObject, fomrobject_t *parentSlot, omrobjectptr_t childObject)
 {
@@ -210,7 +211,6 @@ MM_CollectorLanguageInterfaceImpl::generationalWriteBarrierStore(OMR_VMThread *o
 	}
 }
 
-#if defined(OMR_GC_MODRON_SCAVENGER)
 void
 MM_CollectorLanguageInterfaceImpl::scavenger_reportObjectEvents(MM_EnvironmentBase *env)
 {

--- a/example/glue/CollectorLanguageInterfaceImpl.hpp
+++ b/example/glue/CollectorLanguageInterfaceImpl.hpp
@@ -131,8 +131,8 @@ public:
 
 	virtual void workPacketOverflow_overflowItem(MM_EnvironmentBase *env, omrobjectptr_t objectPtr) {}
 
-	virtual void generationalWriteBarrierStore(OMR_VMThread *omrThread, omrobjectptr_t parentObject, fomrobject_t *parentSlot, omrobjectptr_t childObject);
 #if defined(OMR_GC_MODRON_SCAVENGER)
+	virtual void generationalWriteBarrierStore(OMR_VMThread *omrThread, omrobjectptr_t parentObject, fomrobject_t *parentSlot, omrobjectptr_t childObject);
 	virtual void scavenger_reportObjectEvents(MM_EnvironmentBase *env);
 	virtual void scavenger_masterSetupForGC(MM_EnvironmentBase *env);
 	virtual void scavenger_workerSetupForGC_clearEnvironmentLangStats(MM_EnvironmentBase *env);

--- a/fvtest/gctest/GCConfigTest.cpp
+++ b/fvtest/gctest/GCConfigTest.cpp
@@ -591,7 +591,9 @@ GCConfigTest::attachChildEntry(ObjectEntry *parentEntry, ObjectEntry *childEntry
 	OMRPORT_ACCESS_FROM_OMRVM(exampleVM->_omrVM);
 	if ((uint32_t)parentEntry->numOfRef < slotCount) {
 		fomrobject_t *childSlot = firstSlot + parentEntry->numOfRef;
+#if defined(OMR_GC_MODRON_SCAVENGER)
 		cli->generationalWriteBarrierStore(exampleVM->_omrVMThread, parentEntry->objPtr, childSlot, childEntry->objPtr);
+#endif /* OMR_GC_MODRON_SCAVENGER */
 #if defined(OMRGCTEST_DEBUG)
 		omrtty_printf("\tadd child %s(%p[0x%llx]) to parent %s(%p[0x%llx]) slot %p[%llx].\n",
 				childEntry->name, childEntry->objPtr, *(childEntry->objPtr), parentEntry->name, parentEntry->objPtr, *(parentEntry->objPtr), childSlot, (uintptr_t)*childSlot);

--- a/gc/base/CollectorLanguageInterface.hpp
+++ b/gc/base/CollectorLanguageInterface.hpp
@@ -135,6 +135,7 @@ public:
 	virtual void compactScheme_verifyHeap(MM_EnvironmentBase *env, MM_MarkMap *markMap) = 0;
 #endif /* OMR_GC_MODRON_COMPACTION */
 
+#if defined(OMR_GC_MODRON_SCAVENGER)
 	/**
 	 * In the absence of other (equivalent) write barrier, this method must be implemented and called
 	 * to store object references to other objects. For collectors that move objects, if the parent object
@@ -143,7 +144,6 @@ public:
 	 * implement the assignment of the child reference to the parent slot.
 	 */
 	virtual void generationalWriteBarrierStore(OMR_VMThread *omrThread, omrobjectptr_t parentObject, fomrobject_t *parentSlot, omrobjectptr_t childObject) = 0;
-#if defined(OMR_GC_MODRON_SCAVENGER)
 	virtual void scavenger_reportObjectEvents(MM_EnvironmentBase *env) = 0;
 	virtual void scavenger_masterSetupForGC(MM_EnvironmentBase * env) = 0;
 	virtual void scavenger_workerSetupForGC_clearEnvironmentLangStats(MM_EnvironmentBase * envBase) = 0;

--- a/glue/CollectorLanguageInterfaceImpl.cpp
+++ b/glue/CollectorLanguageInterfaceImpl.cpp
@@ -159,6 +159,7 @@ MM_CollectorLanguageInterfaceImpl::parallelDispatcher_handleMasterThread(OMR_VMT
 	/* Do nothing for now.  only required for SRT */
 }
 
+#if defined(OMR_GC_MODRON_SCAVENGER)
 void
 MM_CollectorLanguageInterfaceImpl::generationalWriteBarrierStore(OMR_VMThread *omrThread, omrobjectptr_t parentObject, fomrobject_t *parentSlot, omrobjectptr_t childObject)
 {
@@ -176,7 +177,6 @@ MM_CollectorLanguageInterfaceImpl::generationalWriteBarrierStore(OMR_VMThread *o
 	}
 }
 
-#if defined(OMR_GC_MODRON_SCAVENGER)
 void
 MM_CollectorLanguageInterfaceImpl::scavenger_reportObjectEvents(MM_EnvironmentBase *env)
 {

--- a/glue/CollectorLanguageInterfaceImpl.hpp
+++ b/glue/CollectorLanguageInterfaceImpl.hpp
@@ -124,8 +124,8 @@ public:
 	virtual void compactScheme_verifyHeap(MM_EnvironmentBase *env, MM_MarkMap *markMap);
 #endif /* OMR_GC_MODRON_COMPACTION */
 
-	virtual void generationalWriteBarrierStore(OMR_VMThread *omrThread, omrobjectptr_t parentObject, fomrobject_t *parentSlot, omrobjectptr_t childObject);
 #if defined(OMR_GC_MODRON_SCAVENGER)
+	virtual void generationalWriteBarrierStore(OMR_VMThread *omrThread, omrobjectptr_t parentObject, fomrobject_t *parentSlot, omrobjectptr_t childObject);
 	virtual void scavenger_reportObjectEvents(MM_EnvironmentBase *env);
 	virtual void scavenger_masterSetupForGC(MM_EnvironmentBase *env);
 	virtual void scavenger_workerSetupForGC_clearEnvironmentLangStats(MM_EnvironmentBase *env);

--- a/glue/EnvironmentLanguageInterfaceImpl.cpp
+++ b/glue/EnvironmentLanguageInterfaceImpl.cpp
@@ -16,8 +16,6 @@
  *    Multiple authors (IBM Corp.) - initial implementation and documentation
  *******************************************************************************/
 
-#include "omrcfg.h"
-
 #include "Collector.hpp"
 #include "EnvironmentLanguageInterfaceImpl.hpp"
 #include "EnvironmentStandard.hpp"
@@ -27,8 +25,6 @@
 
 MM_EnvironmentLanguageInterfaceImpl::MM_EnvironmentLanguageInterfaceImpl(MM_EnvironmentBase *env)
 	: MM_EnvironmentLanguageInterface(env)
-	,_portLibrary(env->getPortLibrary())
-	,_env(env)
 {
 	_typeId = __FUNCTION__;
 };
@@ -42,8 +38,8 @@ MM_EnvironmentLanguageInterfaceImpl::newInstance(MM_EnvironmentBase *env)
 	if (NULL != eli) {
 		new(eli) MM_EnvironmentLanguageInterfaceImpl(env);
 		if (!eli->initialize(env)) {
-        	eli->kill(env);
-        	eli = NULL;
+			eli->kill(env);
+			eli = NULL;
 		}
 	}
 

--- a/glue/EnvironmentLanguageInterfaceImpl.hpp
+++ b/glue/EnvironmentLanguageInterfaceImpl.hpp
@@ -28,8 +28,6 @@
 class MM_EnvironmentLanguageInterfaceImpl : public MM_EnvironmentLanguageInterface
 {
 private:
-	OMRPortLibrary *_portLibrary;
-	MM_EnvironmentBase *_env;  /**< Associated Environment */
 protected:
 public:
 
@@ -45,21 +43,6 @@ public:
 	virtual void kill(MM_EnvironmentBase *env);
 
 	static MM_EnvironmentLanguageInterfaceImpl *getInterface(MM_EnvironmentLanguageInterface *linterface) { return (MM_EnvironmentLanguageInterfaceImpl *)linterface; }
-
-	virtual void acquireVMAccess(MM_EnvironmentBase *env);
-	virtual void releaseVMAccess(MM_EnvironmentBase *env);
-
-	virtual bool tryAcquireExclusiveVMAccess();
-	virtual void acquireExclusiveVMAccess();
-	virtual void releaseExclusiveVMAccess();
-
-	virtual uint64_t getExclusiveAccessTime() { return _exclusiveAccessTime; }
-	virtual uint64_t getMeanExclusiveAccessIdleTime() { return _meanExclusiveAccessIdleTime; }
-	virtual OMR_VMThread* getLastExclusiveAccessResponder() { return _lastExclusiveAccessResponder; }
-	virtual uintptr_t getExclusiveAccessHaltedThreads() { return _exclusiveAccessHaltedThreads; }
-	virtual bool exclusiveAccessBeatenByOtherThread() { return _exclusiveAccessBeatenByOtherThread; }
-
-	virtual bool isExclusiveAccessRequestWaiting() { return false; }
 
 	virtual bool saveObjects(omrobjectptr_t objectPtr);
 	virtual void restoreObjects(omrobjectptr_t *objectPtrIndirect);


### PR DESCRIPTION
- Move the generational barrier code under OMR_GC_MODRON_SCAVENGER
- Cleanup missed code removal in EnvironmentLanguageInterfaceImpl

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>