### PR TITLE
Issue #135 Add function to enable/disable NUMA support

### DIFF
--- a/fvtest/threadtest/createTest.cpp
+++ b/fvtest/threadtest/createTest.cpp
@@ -976,6 +976,19 @@ endthread:
 	return 0;
 }
 
+TEST_F(ThreadCreateTest, NumaEnableDisable)
+{
+#define NODE_LIST_SIZE 4
+	uintptr_t originalMaxNode = omrthread_numa_get_max_node();
+	uintptr_t numaMaxNode = 0;
+	omrthread_numa_set_enabled(false);
+	numaMaxNode = omrthread_numa_get_max_node();
+	ASSERT_EQ((uintptr_t)0, numaMaxNode) << "nmaMaxNode not zero with numa disabled";
+	omrthread_numa_set_enabled(true);
+	numaMaxNode = omrthread_numa_get_max_node();
+	ASSERT_EQ(originalMaxNode, numaMaxNode) << "Re-enabling max_node doesn't restore original value";
+}
+
 /* Since we can't read affinity on Win32, at least make sure that we can call the setAffinity API without crashing.
  * Note that this should be safe on all platforms (either succeeds or fails but we ignore the return code since
  * any answer is correct, so long as we don't crash - without reading the affinity, we don't know of any more

--- a/include_core/thread_api.h
+++ b/include_core/thread_api.h
@@ -1385,6 +1385,7 @@ omrthread_numa_get_max_node(void);
 intptr_t
 omrthread_numa_set_node_affinity(omrthread_t thread, const uintptr_t *numaNodes, uintptr_t nodeCount, uint32_t flags);
 
+
 /**
  * @brief
  * @param thread
@@ -1394,6 +1395,13 @@ omrthread_numa_set_node_affinity(omrthread_t thread, const uintptr_t *numaNodes,
  */
 intptr_t
 omrthread_numa_get_node_affinity(omrthread_t thread, uintptr_t *numaNodes, uintptr_t *nodeCount);
+
+/**
+ * Sets the NUMA enabled status.
+ * This applies to the entire process.
+ */
+void
+omrthread_numa_set_enabled(BOOLEAN enabled);
 
 /* -------------- rasthrsup.c ------------------- */
 /**

--- a/thread/common/omrthreadnuma.c
+++ b/thread/common/omrthreadnuma.c
@@ -45,6 +45,15 @@ omrthread_numa_shutdown(omrthread_library_t lib)
 }
 
 /**
+ * Sets the NUMA enabled status.
+ * This applies to the entire process.
+ */
+void
+omrthread_numa_set_enabled(BOOLEAN enabled)
+{
+}
+
+/**
  * Return the highest NUMA node ID available to the process.
  * The first node is always identified as 1, as 0 is used to indicate no affinity.
  *

--- a/thread/linux/omrthreadnuma.c
+++ b/thread/linux/omrthreadnuma.c
@@ -233,6 +233,12 @@ omrthread_numa_shutdown(omrthread_library_t lib)
 #endif /* OMR_PORT_NUMA_SUPPORT */
 }
 
+void
+omrthread_numa_set_enabled(BOOLEAN enabled)
+{
+	isNumaAvailable = enabled;
+}
+
 /**
  * Return the highest NUMA node ID available to the process.
  * The first node is always identified as 1, as 0 is used to indicate no affinity.
@@ -248,7 +254,7 @@ uintptr_t
 omrthread_numa_get_max_node(void)
 {
 	uintptr_t result = numNodes;
-	return result;
+	return isNumaAvailable ? result : 0;
 }
 
 intptr_t

--- a/thread/thread_include.mk
+++ b/thread/thread_include.mk
@@ -204,6 +204,7 @@ define WRITE_COMMON_THREAD_EXPORTS
 @echo omrthread_park >>$@
 @echo omrthread_unpark >>$@
 @echo omrthread_numa_get_max_node >>$@
+@echo omrthread_numa_set_enabled >>$@
 @echo omrthread_numa_set_node_affinity >>$@
 @echo omrthread_numa_get_node_affinity >>$@
 @echo omrthread_map_native_priority >>$@


### PR DESCRIPTION
This addes a function to enable/disable support for NUMA to match a similar
capability in the port library.  This does not affect the operating system
or hardware: it simply enables or disables the other thread library NUMA functions.
This affects the entire process.

Signed-off-by: Peter Bain <pdbain@ca.ibm.com>