### PR TITLE
Include a dummy install-sh to satisfy configure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ autom4te.cache
 config.cache
 config.log
 config.status
-install-sh
 SPEC
 
 OMR_VERSION_STRING

--- a/install-sh
+++ b/install-sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+echo "This is a placeholder install script intended to satisfy the OMR configure"
+echo "script. use a system-provided install script instead."
+
+exit 1

--- a/run_configure.mk
+++ b/run_configure.mk
@@ -123,7 +123,7 @@ sh configure --disable-auto-build-flag 'OMRGLUE=$(OMRGLUE)' 'SPEC=$(SPEC)' $(CON
 touch $(CONFIGURE_OUTPUT_FILES)
 endef
 
-CONFIGURE_DEPENDENCIES := SPEC config.guess config.sub install-sh configure toolconfig/configure
+CONFIGURE_DEPENDENCIES := SPEC config.guess config.sub configure toolconfig/configure
 CONFIGURE_OUTPUT_FILES := include_core/omrcfg.h include_core/omrversionstrings.h omrmakefiles/omrcfg.mk omrmakefiles/configure.mk omrmakefiles/toolconfigure.mk CONFIGURE_SENTINEL_FILE
 CONFIGURE_INPUT_FILES := include_core/omrcfg.h.in include_core/omrversionstrings.h.in omrmakefiles/configure.mk.in omrmakefiles/toolconfigure.mk.in
 CONFIGURE_BYPRODUCTS := config.cache config.status config.log autom4te.cache toolconfig/config.cache toolconfig/config.status toolconfig/config.log toolconfig/autom4te.cache
@@ -143,9 +143,6 @@ ifeq ($(HAS_AUTOCONF),1)
 else
 	@echo "WARNING: autoconf needs to be re-run in $$PWD/toolconfig.  You should do this by hand, or set HAS_AUTOCONF=1 to have this makefile do it for you."
 endif
-
-install-sh:
-	touch install-sh
 
 config.guess:
 	curl -o config.guess "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD"


### PR DESCRIPTION
configure requires a copy of install-sh. This patch provides a dummy
version to satisfy this requirement. OMR is not installable, so
install-sh is actually unused.

Automake provides an implementation of install-sh, which we cannot check
into the project due to copyright/licensing concerns.

run_configure.mk was originally responsible for creating a dummy
install-sh. We want configure to be runnable on it's own, without the
run_configure.mk wrapper.