### PR TITLE
Issue #152: Recalculate LOA size, only if LOA ratio really changed.

### DIFF
--- a/gc/base/MemoryPoolLargeObjects.cpp
+++ b/gc/base/MemoryPoolLargeObjects.cpp
@@ -466,16 +466,17 @@ MM_MemoryPoolLargeObjects::resetLOASize(MM_EnvironmentBase* env, double newLOARa
 	uintptr_t newLOASize, oldAreaSize;
 	bool debug = _extensions->debugLOAResize;
 
-	_currentLOARatio = newLOARatio;
-
-	/* Get total size of owning subspace */
-	oldAreaSize = _memorySubSpace->getActiveMemorySize();
-
-	/* Calculate LOA size based on new loa ratio */
-	newLOASize = MM_Math::roundToFloor(_extensions->heapAlignment, (uintptr_t)(oldAreaSize * _currentLOARatio));
-
 	/* Has LOA changed in size ? */
-	if (oldLOASize != newLOASize) {
+	if (_currentLOARatio != newLOARatio) {
+
+		_currentLOARatio = newLOARatio;
+
+		/* Get total size of owning subspace */
+		oldAreaSize = _memorySubSpace->getActiveMemorySize();
+
+		/* Calculate LOA size based on new loa ratio */
+		newLOASize = MM_Math::roundToFloor(_extensions->heapAlignment, (uintptr_t)(oldAreaSize * _currentLOARatio));
+
 		HeapResizeType resizeType = HEAP_NO_RESIZE;
 		uintptr_t resizeSize = 0;
 		/* Does this leave a reasonable sized LOA ? */


### PR DESCRIPTION
Do not try to resize LOA if ratio did not change. Check if need to resize based on ratio variable, even before calculating the size of LOA in bytes (which due to rounding and/or alignment may differ from old size, even if the ratio is same).

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>