### PR TITLE
FIX #127: Remove MM_ScanClassesMode and dependencies from OMR

### DIFF
--- a/example/glue/EnvironmentLanguageInterfaceImpl.hpp
+++ b/example/glue/EnvironmentLanguageInterfaceImpl.hpp
@@ -19,11 +19,13 @@
 #ifndef ENVIRONMENTLANGUAGEINTERFACEIMPL_HPP_
 #define ENVIRONMENTLANGUAGEINTERFACEIMPL_HPP_
 
+#include "ModronAssertions.h"
 #include "omr.h"
 
 #include "EnvironmentLanguageInterface.hpp"
 
 #include "EnvironmentBase.hpp"
+#include "omrExampleVM.hpp"
 
 class MM_EnvironmentLanguageInterfaceImpl : public MM_EnvironmentLanguageInterface
 {
@@ -46,6 +48,80 @@ public:
 
 	virtual bool saveObjects(omrobjectptr_t objectPtr);
 	virtual void restoreObjects(omrobjectptr_t *objectPtrIndirect);
+
+	/**
+	 * Acquire shared VM access.
+	 */
+	virtual void
+	acquireVMAccess()
+	{
+		OMR_VM_Example *exampleVM = (OMR_VM_Example *)_env->getOmrVM()->_language_vm;
+		omrthread_rwmutex_enter_read(exampleVM->_vmAccessMutex);
+	}
+
+	/**
+	 * Releases shared VM access.
+	 */
+	virtual void
+	releaseVMAccess()
+	{
+		OMR_VM_Example *exampleVM = (OMR_VM_Example *)_env->getOmrVM()->_language_vm;
+		omrthread_rwmutex_exit_read(exampleVM->_vmAccessMutex);
+	}
+
+	/**
+	 * Acquire exclusive VM access.
+	 */
+	virtual void
+	acquireExclusiveVMAccess()
+	{
+		OMR_VM_Example *exampleVM = (OMR_VM_Example *)_env->getOmrVM()->_language_vm;
+		omrthread_rwmutex_enter_write(exampleVM->_vmAccessMutex);
+		omrthread_monitor_enter(_env->getOmrVM()->_vmThreadListMutex);
+		Assert_MM_true(0 == _omrThread->exclusiveCount);
+		_omrThread->exclusiveCount = 1;
+	}
+
+	/**
+	 * Try and acquire exclusive access if no other thread is already requesting it.
+	 * Make an attempt at acquiring exclusive access if the current thread does not already have it.  The
+	 * attempt will abort if another thread is already going for exclusive, which means this
+	 * call can return without exclusive access being held.  As well, this call will block for any other
+	 * requesting thread, and so should be treated as a safe point.
+	 * @note call can release VM access.
+	 * @return true if exclusive access was acquired, false otherwise.
+	 */
+	virtual bool
+	tryAcquireExclusiveVMAccess()
+	{
+		OMR_VM_Example *exampleVM = (OMR_VM_Example *)_env->getOmrVM()->_language_vm;
+		if (0 == omrthread_rwmutex_try_enter_write(exampleVM->_vmAccessMutex)) {
+			omrthread_monitor_enter(_env->getOmrVM()->_vmThreadListMutex);
+			Assert_MM_true(0 == _omrThread->exclusiveCount);
+			_omrThread->exclusiveCount = 1;
+		}
+		return 0 != _omrThread->exclusiveCount;
+	}
+
+	/**
+	 * Releases exclusive VM access.
+	 */
+	virtual void
+	releaseExclusiveVMAccess()
+	{
+		omrthread_monitor_exit(_env->getOmrVM()->_vmThreadListMutex);
+		OMR_VM_Example *exampleVM = (OMR_VM_Example *)_env->getOmrVM()->_language_vm;
+		omrthread_rwmutex_exit_write(exampleVM->_vmAccessMutex);
+		Assert_MM_true(1 == _omrThread->exclusiveCount);
+		_omrThread->exclusiveCount = 0;
+	}
+
+	virtual bool
+	isExclusiveAccessRequestWaiting()
+	{
+		OMR_VM_Example *exampleVM = (OMR_VM_Example *)_env->getOmrVM()->_language_vm;
+		return omrthread_rwmutex_is_writelocked(exampleVM->_vmAccessMutex);
+	}
 
 #if defined (OMR_GC_THREAD_LOCAL_HEAP)
 	virtual void disableInlineTLHAllocate();

--- a/example/glue/ObjectModel.hpp
+++ b/example/glue/ObjectModel.hpp
@@ -202,8 +202,7 @@ public:
 	MMINLINE uintptr_t
 	getConsumedSizeInSlotsWithHeader(omrobjectptr_t objectPtr)
 	{
-		Assert_MM_unimplemented();
-		return 0;
+		return getConsumedSizeInBytesWithHeader(objectPtr) / sizeof(fomrobject_t);
 	}
 
 	MMINLINE uintptr_t

--- a/example/glue/omrExampleVM.hpp
+++ b/example/glue/omrExampleVM.hpp
@@ -30,6 +30,7 @@ typedef struct OMR_VM_Example {
 	J9HashTable *rootTable;
 	J9HashTable *objectTable;
 	omrthread_t self;
+	omrthread_rwmutex_t _vmAccessMutex;
 } OMR_VM_Example;
 
 typedef struct RootEntry {

--- a/fvtest/gctest/gcTestHelpers.cpp
+++ b/fvtest/gctest/gcTestHelpers.cpp
@@ -85,6 +85,7 @@ GCTestEnvironment::GCTestSetUp()
 {
 	exampleVM._omrVM = NULL;
 	exampleVM.self = NULL;
+	exampleVM._vmAccessMutex = NULL;
 
 	/* Attach main test thread */
 	intptr_t irc = omrthread_attach_ex(&exampleVM.self, J9THREAD_ATTR_DEFAULT);
@@ -93,6 +94,9 @@ GCTestEnvironment::GCTestSetUp()
 	/* Initialize the VM */
 	omr_error_t rc = OMR_Initialize(&exampleVM, &exampleVM._omrVM);
 	ASSERT_EQ(OMR_ERROR_NONE, rc) << "Setup(): OMR_Initialize failed, rc=" << rc;
+
+	/* Set up the vm access mutex */
+	omrthread_rwmutex_init(&exampleVM._vmAccessMutex, 0, "VM exclusive access");
 
 	portLib = ((exampleVM._omrVM)->_runtime)->_portLibrary;
 
@@ -103,6 +107,11 @@ void
 GCTestEnvironment::GCTestTearDown()
 {
 	ASSERT_NO_FATAL_FAILURE(clearParams());
+
+	if (NULL != exampleVM._vmAccessMutex) {
+		omrthread_rwmutex_destroy(exampleVM._vmAccessMutex);
+		exampleVM._vmAccessMutex = NULL;
+	}
 
 	/* Shut down VM */
 	omr_error_t rc = OMR_Shutdown(exampleVM._omrVM);

--- a/gc/base/EnvironmentBase.cpp
+++ b/gc/base/EnvironmentBase.cpp
@@ -28,6 +28,7 @@
 
 #include "AllocateDescription.hpp"
 #include "Collector.hpp"
+#include "ConcurrentGCStats.hpp"
 #include "EnvironmentLanguageInterface.hpp"
 #include "GCExtensionsBase.hpp"
 #include "GlobalAllocationManager.hpp"
@@ -342,20 +343,13 @@ MM_EnvironmentBase::releaseVMAccess()
 bool
 MM_EnvironmentBase::tryAcquireExclusiveVMAccess()
 {
-	if(0 == _exclusiveCount) {
-		bool result = _envLanguageInterface->tryAcquireExclusiveVMAccess();
-
-		/* Check if we won the exclusive access race..return if we lost */
-		if(!result) {
-			return false;
-		}
-
+	bool result = (0 == _exclusiveCount) && _envLanguageInterface->tryAcquireExclusiveVMAccess();
+	if (result) {
 		/* Report exclusive access time if we won race */
 		reportExclusiveAccessAcquire();
+		_exclusiveCount += 1;
 	}
-
-	_exclusiveCount += 1;
-	return true;
+	return result;
 }
 
 void

--- a/gc/base/EnvironmentBase.hpp
+++ b/gc/base/EnvironmentBase.hpp
@@ -28,9 +28,6 @@
 #include "CardCleaningStats.hpp"
 #include "CycleState.hpp"
 #include "CompactStats.hpp"
-#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
-#include "ConcurrentGCStats.hpp"
-#endif /* defined(OMR_GC_MODRON_CONCURRENT_MARK) */
 #include "GCCode.hpp"
 #include "GCExtensionsBase.hpp"
 #include "LargeObjectAllocateStats.hpp"
@@ -47,6 +44,9 @@
 class MM_AllocationContext;
 class MM_AllocateDescription;
 class MM_Collector;
+#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
+class MM_ConcurrentGCStats;
+#endif /* defined(OMR_GC_MODRON_CONCURRENT_MARK) */
 class MM_EnvironmentLanguageInterface;
 class MM_HeapRegionQueue;
 class MM_MemorySpace;

--- a/gc/base/standard/ConcurrentCardTable.cpp
+++ b/gc/base/standard/ConcurrentCardTable.cpp
@@ -849,6 +849,7 @@ MM_ConcurrentCardTable::cleanCards(MM_EnvironmentStandard *env, bool isMutator, 
 	nextDirtyCard = NULL;
 
 	/* Clean cards until we have done enough or card clean phase changes */
+	MM_ConcurrentGCStats *stats = _extensions->collectorLanguageInterface->concurrentGC_getConcurrentStats();
 	while ( cleanedSoFar < sizeToDo && currentCleaningPhase == _cardCleanPhase ) {
 
 		/* Get next dirty card; if any */
@@ -876,7 +877,7 @@ MM_ConcurrentCardTable::cleanCards(MM_EnvironmentStandard *env, bool isMutator, 
 		 * relieve work stack overflow we empty packets by dirtying cards for their referenced
 		 * objects. Therefore we cannot be sure tracing into all active TLH's will be deferred.
 		 */
-		if (isCardInActiveTLH(env,nextDirtyCard) && !(_extensions->collectorLanguageInterface->concurrentGC_getConcurrentStats()->getConcurrentWorkStackOverflowOcurred())) {
+		if (isCardInActiveTLH(env,nextDirtyCard) && !stats->getConcurrentWorkStackOverflowOcurred()) {
 			continue;
 		}
 
@@ -955,6 +956,7 @@ MM_ConcurrentCardTable::cleanSingleCard(MM_EnvironmentStandard *env, Card *card,
 	env->_threadCleaningCards = true;
 
 	/* Re-trace all objects which START in this card */
+	MM_ConcurrentGCStats *stats = _extensions->collectorLanguageInterface->concurrentGC_getConcurrentStats();
 	while (NULL != (objectPtr = markedObjectIterator.nextObject())) {
 		/* Check to see if another thread  is waiting for exclusive VM access. If so get out quick.
 	 	 */
@@ -982,7 +984,7 @@ MM_ConcurrentCardTable::cleanSingleCard(MM_EnvironmentStandard *env, Card *card,
 		 * objects. Therefore we cannot be sure all tracing into this particular TLH will be
 		 * deferred.
 		*/
-		if (isObjectInActiveTLH(env,objectPtr) && !(_extensions->collectorLanguageInterface->concurrentGC_getConcurrentStats()->getConcurrentWorkStackOverflowOcurred())) {
+		if (isObjectInActiveTLH(env,objectPtr) && !(stats->getConcurrentWorkStackOverflowOcurred())) {
 			return true;
 		}
 
@@ -1610,11 +1612,10 @@ MM_ConcurrentCardTable::resetCleaningRanges(MM_EnvironmentStandard *env)
 Card*
 MM_ConcurrentCardTable::getNextDirtyCard(MM_EnvironmentStandard *env, Card cardMask, bool concurrentCardClean)
 {
-	CleaningRange *currentRange;
-	Card *firstCard;
+	MM_ConcurrentGCStats *stats = _extensions->collectorLanguageInterface->concurrentGC_getConcurrentStats();
 
 	/* Get a local copy of next current range being cleaned */
-	currentRange = (CleaningRange *)_currentCleaningRange;
+	CleaningRange *currentRange = (CleaningRange *)_currentCleaningRange;
 
 	/* Have we finished already ? */
 	if (currentRange >= _lastCleaningRange ) {
@@ -1623,7 +1624,7 @@ MM_ConcurrentCardTable::getNextDirtyCard(MM_EnvironmentStandard *env, Card cardM
 	}
 
 	/* Get a local copy of next card to check */
-	firstCard = (Card *)currentRange->nextCard;
+	Card *firstCard = (Card *)currentRange->nextCard;
 
 	while (NULL != firstCard) {
 
@@ -1676,7 +1677,7 @@ MM_ConcurrentCardTable::getNextDirtyCard(MM_EnvironmentStandard *env, Card cardM
 				/* No .. so attempt to grab this card*/
 				nextDirtyCard = currentCard;
 				currentCard += 1;
-				if (concurrentCardClean && env->isExclusiveAccessRequestWaiting()) {
+				if (concurrentCardClean && stats) {
 					return (Card *)EXCLUSIVE_VMACCESS_REQUESTED;
 				}
 
@@ -1702,7 +1703,7 @@ MM_ConcurrentCardTable::getNextDirtyCard(MM_EnvironmentStandard *env, Card cardM
 			/* No..so someone must have beat us to next dirty card. In which case we need
 			 * to restart scan. First though make sure no thread is waiting for exclusive access.
 			 */
-			if (concurrentCardClean && env->isExclusiveAccessRequestWaiting()) {
+			if (concurrentCardClean && stats) {
 				return (Card *)EXCLUSIVE_VMACCESS_REQUESTED;
 			}
 

--- a/gc/startup/omrgcalloc.cpp
+++ b/gc/startup/omrgcalloc.cpp
@@ -60,8 +60,13 @@ allocHelper(OMR_VMThread * omrVMThread, size_t sizeInBytes, uintptr_t flags, boo
 
 	omrobjectptr_t heapBytes = (omrobjectptr_t)env->_objectAllocationInterface->allocateObject(env, &allocdescription, env->getMemorySpace(), collectOnFailure);
 
-	/* OMRTODO: Should we use zero TLH instead of memset? */
 	if (NULL != heapBytes) {
+#if defined(OMR_GC_ALLOCATION_TAX)
+		/* pay allocation tax */
+		if (extensions->payAllocationTax && (0 != allocdescription.getAllocationTaxSize())) {
+			allocdescription.payAllocationTax(env);
+		}
+#endif /* OMR_GC_ALLOCATION_TAX */
 		if (J9_ARE_ALL_BITS_SET(flags, OMR_GC_ALLOCATE_ZERO_MEMORY)) {
 			uintptr_t size = allocdescription.getBytesRequested();
 			memset(heapBytes, 0, size);


### PR DESCRIPTION
Implement VM access functions for example/glue. Complete ConcurrentGC
integration with example glue and GCTest.

Signed-off-by: Kim Briggs <briggs@ca.ibm.com>