### PR TITLE
Convert left shifts of negative constants to multiplications

### DIFF
--- a/include_core/omrporterror.h
+++ b/include_core/omrporterror.h
@@ -111,9 +111,9 @@
  * The least significant 16 bits will identify the errno that occured while calling the function
  *
  */
-#define OMRPORT_ERROR_FILE_FSTAT_ERROR (-2<<16)
-#define OMRPORT_ERROR_FILE_FSTATFS_ERROR (-3<<16)
-#define OMRPORT_ERROR_FILE_FSTATVFS_ERROR (-3<<16)
+#define OMRPORT_ERROR_FILE_FSTAT_ERROR (-(2<<16))
+#define OMRPORT_ERROR_FILE_FSTATFS_ERROR (-(3<<16))
+#define OMRPORT_ERROR_FILE_FSTATVFS_ERROR (-(3<<16))
 
 /**
  * @name File Errors
@@ -239,8 +239,8 @@
  * The least significant 16 bits will identify the errno that occured while calling the function
  *
  */
-#define OMRPORT_ERROR_SYSINFO_GETGROUPSSIZE_ERROR (-2<<16)
-#define OMRPORT_ERROR_SYSINFO_GETGROUPS_ERROR (-3<<16)
+#define OMRPORT_ERROR_SYSINFO_GETGROUPSSIZE_ERROR (-(2<<16))
+#define OMRPORT_ERROR_SYSINFO_GETGROUPS_ERROR (-(3<<16))
 
 /**
  * @name sysinfo Errors


### PR DESCRIPTION
include_core/omrporterror.h has 5 instances of (-C<<16) that issue warnings on
recent versions of clang, which our compile flags promote into errors. Fix by
changing each instance to (-C*65536).

See Issue #171 .

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>