### PR TITLE
Use phony targets when autogenerating C deps

### DIFF
--- a/omrmakefiles/rules.linux.mk
+++ b/omrmakefiles/rules.linux.mk
@@ -30,8 +30,8 @@ endif
 ifeq (gcc,$(OMR_TOOLCHAIN))
   ifeq (x86,$(OMR_HOST_ARCH))
     #-- GCC compilers support dependency generation --
-    GLOBAL_CFLAGS+=-MMD
-    GLOBAL_CXXFLAGS+=-MMD
+    GLOBAL_CFLAGS+=-MMD -MP
+    GLOBAL_CXXFLAGS+=-MMD -MP
   endif
 endif
 


### PR DESCRIPTION
Have GCC/Clang use the -MP flag. This causes the compilers to emit phony
targets for dependencies. This will make the build system more resilient
to missing/moved dependencies.

This enhancement was suggested in issue #55.

Signed-off-by: Robert Young <rwy0717@gmail.com>
Issue: #55