### PR TITLE
FIX #127: Remove MM_ScanClassesMode and dependencies from OMR

### DIFF
--- a/example/glue/CollectorLanguageInterfaceImpl.cpp
+++ b/example/glue/CollectorLanguageInterfaceImpl.cpp
@@ -149,6 +149,13 @@ MM_CollectorLanguageInterfaceImpl::markingScheme_scanRoots(MM_EnvironmentBase *e
 		_markingScheme->markObject(env, rEntry->rootPtr);
 		rEntry = (RootEntry *)hashTableNextDo(&state);
 	}
+	OMR_VMThread *walkThread;
+	GC_OMRVMThreadListIterator threadListIterator(env->getOmrVM());
+	while((walkThread = threadListIterator.nextOMRVMThread()) != NULL) {
+		if (NULL != walkThread->savedObject) {
+			_markingScheme->markObject(env, (omrobjectptr_t)walkThread->savedObject);
+		}
+	}
 }
 
 void

--- a/example/glue/CollectorLanguageInterfaceImpl.cpp
+++ b/example/glue/CollectorLanguageInterfaceImpl.cpp
@@ -324,17 +324,20 @@ MM_CollectorLanguageInterfaceImpl::scavenger_backOutIndirectObjects(MM_Environme
 void
 MM_CollectorLanguageInterfaceImpl::scavenger_reverseForwardedObject(MM_EnvironmentBase *env, MM_ForwardedHeader *forwardedHeader)
 {
-	omrobjectptr_t objectPtr = forwardedHeader->getObject();
-	omrobjectptr_t fwdObjectPtr = forwardedHeader->getForwardedObject();
-	MM_GCExtensionsBase *extensions = MM_GCExtensionsBase::getExtensions(_omrVM);
-	if (extensions->objectModel.restoreForwardedObject(forwardedHeader)) {
-		/* A reverse forwarded object is a hole whose 'next' pointer actually points at the original object.
-		 * This keeps tenure space walkable once the reverse forwarded objects are abandoned.
+	if (forwardedHeader->isForwardedPointer()) {
+		omrobjectptr_t originalObject = forwardedHeader->getObject();
+		omrobjectptr_t forwardedObject = forwardedHeader->getForwardedObject();
+
+		/* Restore the original object header from the forwarded object */
+		_extensions->objectModel.setObjectSize(originalObject, _extensions->objectModel.getSizeInBytesWithHeader(forwardedObject));
+		_extensions->objectModel.setFlags(originalObject, OMR_OBJECT_METADATA_FLAGS_MASK, OMR_OBJECT_FLAGS(forwardedObject));
+
+#if defined (OMR_INTERP_COMPRESSED_OBJECT_HEADER)
+		/* Restore destroyed overlapped slot in the original object. This slot might need to be reversed
+		 * as well or it may be already reversed - such fixup will be completed at in a later pass.
 		 */
-		UDATA evacuateObjectSizeInBytes = extensions->objectModel.getConsumedSizeInBytesWithHeader(fwdObjectPtr);
-		MM_HeapLinkedFreeHeader* freeHeader = MM_HeapLinkedFreeHeader::getHeapLinkedFreeHeader(fwdObjectPtr);
-		freeHeader->setNext((MM_HeapLinkedFreeHeader*)objectPtr);
-		freeHeader->setSize(evacuateObjectSizeInBytes);
+		forwardedHeader->restoreDestroyedOverlap();
+#endif /* defined (OMR_INTERP_COMPRESSED_OBJECT_HEADER) */
 	}
 }
 

--- a/example/glue/EnvironmentLanguageInterfaceImpl.cpp
+++ b/example/glue/EnvironmentLanguageInterfaceImpl.cpp
@@ -74,12 +74,17 @@ MM_EnvironmentLanguageInterfaceImpl::tearDown(MM_EnvironmentBase *env)
 bool
 MM_EnvironmentLanguageInterfaceImpl::saveObjects(omrobjectptr_t objectPtr)
 {
+	Assert_MM_true(NULL == _omrThread->savedObject);
+	_omrThread->savedObject = (void *)objectPtr;
 	return true;
 }
 
 void
 MM_EnvironmentLanguageInterfaceImpl::restoreObjects(omrobjectptr_t *objectPtrIndirect)
 {
+	Assert_MM_true(NULL != _omrThread->savedObject);
+	*objectPtrIndirect = (omrobjectptr_t)_omrThread->savedObject;
+	_omrThread->savedObject = NULL;
 }
 
 #if defined (OMR_GC_THREAD_LOCAL_HEAP)

--- a/example/glue/EnvironmentLanguageInterfaceImpl.hpp
+++ b/example/glue/EnvironmentLanguageInterfaceImpl.hpp
@@ -19,11 +19,13 @@
 #ifndef ENVIRONMENTLANGUAGEINTERFACEIMPL_HPP_
 #define ENVIRONMENTLANGUAGEINTERFACEIMPL_HPP_
 
+#include "ModronAssertions.h"
 #include "omr.h"
 
 #include "EnvironmentLanguageInterface.hpp"
 
 #include "EnvironmentBase.hpp"
+#include "omrExampleVM.hpp"
 
 class MM_EnvironmentLanguageInterfaceImpl : public MM_EnvironmentLanguageInterface
 {
@@ -46,6 +48,91 @@ public:
 
 	virtual bool saveObjects(omrobjectptr_t objectPtr);
 	virtual void restoreObjects(omrobjectptr_t *objectPtrIndirect);
+
+	/**
+	 * Acquire shared VM access.
+	 */
+	virtual void
+	acquireVMAccess()
+	{
+		OMR_VM_Example *exampleVM = (OMR_VM_Example *)_env->getOmrVM()->_language_vm;
+		omrthread_rwmutex_enter_read(exampleVM->_vmAccessMutex);
+	}
+
+	/**
+	 * Releases shared VM access.
+	 */
+	virtual void
+	releaseVMAccess()
+	{
+		OMR_VM_Example *exampleVM = (OMR_VM_Example *)_env->getOmrVM()->_language_vm;
+		omrthread_rwmutex_exit_read(exampleVM->_vmAccessMutex);
+	}
+
+	/**
+	 * Acquire exclusive VM access.
+	 */
+	virtual void
+	acquireExclusiveVMAccess()
+	{
+		OMR_VM *omrVM = _env->getOmrVM();
+		OMR_VM_Example *exampleVM = (OMR_VM_Example *)omrVM->_language_vm;
+		MM_AtomicOperations::add(&exampleVM->_vmExclusiveAccessCount, 1);
+		MM_AtomicOperations::readBarrier();
+		omrthread_rwmutex_enter_write(exampleVM->_vmAccessMutex);
+		omrthread_monitor_enter(omrVM->_vmThreadListMutex);
+		Assert_MM_true(0 == _omrThread->exclusiveCount);
+		_omrThread->exclusiveCount = 1;
+	}
+
+	/**
+	 * Try and acquire exclusive access if no other thread is already requesting it.
+	 * Make an attempt at acquiring exclusive access if the current thread does not already have it.  The
+	 * attempt will abort if another thread is already going for exclusive, which means this
+	 * call can return without exclusive access being held.  As well, this call will block for any other
+	 * requesting thread, and so should be treated as a safe point.
+	 * @note call can release VM access.
+	 * @return true if exclusive access was acquired, false otherwise.
+	 */
+	virtual bool
+	tryAcquireExclusiveVMAccess()
+	{
+		OMR_VM *omrVM = _env->getOmrVM();
+		OMR_VM_Example *exampleVM = (OMR_VM_Example *)omrVM->_language_vm;
+		MM_AtomicOperations::add(&exampleVM->_vmExclusiveAccessCount, 1);
+		MM_AtomicOperations::readBarrier();
+		if ((1 == exampleVM->_vmExclusiveAccessCount) && (0 == omrthread_rwmutex_try_enter_write(exampleVM->_vmAccessMutex))) {
+			omrthread_monitor_enter(omrVM->_vmThreadListMutex);
+			Assert_MM_true(0 == _omrThread->exclusiveCount);
+			_omrThread->exclusiveCount = 1;
+		} else {
+			MM_AtomicOperations::subtract(&exampleVM->_vmExclusiveAccessCount, 1);
+			MM_AtomicOperations::readBarrier();
+		}
+		return 0 != _omrThread->exclusiveCount;
+	}
+
+	/**
+	 * Releases exclusive VM access.
+	 */
+	virtual void
+	releaseExclusiveVMAccess()
+	{
+		OMR_VM_Example *exampleVM = (OMR_VM_Example *)_env->getOmrVM()->_language_vm;
+		omrthread_monitor_exit(_env->getOmrVM()->_vmThreadListMutex);
+		omrthread_rwmutex_exit_write(exampleVM->_vmAccessMutex);
+		MM_AtomicOperations::subtract(&exampleVM->_vmExclusiveAccessCount, 1);
+		MM_AtomicOperations::readBarrier();
+		Assert_MM_true(1 == _omrThread->exclusiveCount);
+		_omrThread->exclusiveCount = 0;
+	}
+
+	virtual bool
+	isExclusiveAccessRequestWaiting()
+	{
+		OMR_VM_Example *exampleVM = (OMR_VM_Example *)_env->getOmrVM()->_language_vm;
+		return (0 < exampleVM->_vmExclusiveAccessCount) || omrthread_rwmutex_is_writelocked(exampleVM->_vmAccessMutex);
+	}
 
 #if defined (OMR_GC_THREAD_LOCAL_HEAP)
 	virtual void disableInlineTLHAllocate();

--- a/example/glue/ObjectModel.hpp
+++ b/example/glue/ObjectModel.hpp
@@ -28,6 +28,7 @@
 #include "objectdescription.h"
 #include "omrgcconsts.h"
 
+#include "Bits.hpp"
 #include "ForwardedHeader.hpp"
 #include "HeapLinkedFreeHeader.hpp"
 
@@ -202,8 +203,7 @@ public:
 	MMINLINE uintptr_t
 	getConsumedSizeInSlotsWithHeader(omrobjectptr_t objectPtr)
 	{
-		Assert_MM_unimplemented();
-		return 0;
+		return MM_Bits::convertBytesToSlots(getConsumedSizeInBytesWithHeader(objectPtr));
 	}
 
 	MMINLINE uintptr_t
@@ -559,30 +559,6 @@ public:
 		uintptr_t age = objectAge << OMR_OBJECT_METADATA_AGE_SHIFT;
 		setFlags(destinationObjectPtr, OMR_OBJECT_METADATA_AGE_MASK, age);
 	}
-
-	MMINLINE bool
-	restoreForwardedObject(MM_ForwardedHeader *forwardedHeader)
-	{
-		if (forwardedHeader->isForwardedPointer()) {
-			omrobjectptr_t originalObject = forwardedHeader->getObject();
-			omrobjectptr_t forwardedObject = forwardedHeader->getForwardedObject();
-
-			/* Restore the original object header from the forwarded object */
-			setObjectSize(originalObject, getSizeInBytesWithHeader(forwardedObject));
-			setFlags(originalObject, OMR_OBJECT_METADATA_FLAGS_MASK, OMR_OBJECT_FLAGS(forwardedObject));
-
-#if defined (OMR_INTERP_COMPRESSED_OBJECT_HEADER)
-			/* Restore destroyed overlapped slot in the original object. This slot might need to be reversed
-			 * as well or it may be already reversed - such fixup will be completed at in a later pass.
-			 */
-			forwardedHeader->restoreDestroyedOverlap();
-#endif /* defined (OMR_INTERP_COMPRESSED_OBJECT_HEADER) */
-
-			return true;
-		}
-		return false;
-	}
-
 
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 

--- a/example/glue/ScavengerBackOutScanner.hpp
+++ b/example/glue/ScavengerBackOutScanner.hpp
@@ -70,6 +70,13 @@ public:
 			}
 			objectEntry = (ObjectEntry *)hashTableNextDo(&state);
 		}
+		OMR_VMThread *walkThread;
+		GC_OMRVMThreadListIterator threadListIterator(env->getOmrVM());
+		while((walkThread = threadListIterator.nextOMRVMThread()) != NULL) {
+			if (NULL != walkThread->savedObject) {
+				_scavenger->backOutFixSlotWithoutCompression((volatile omrobjectptr_t *) &walkThread->savedObject);
+			}
+		}
 	}
 };
 

--- a/example/glue/ScavengerRootScanner.hpp
+++ b/example/glue/ScavengerRootScanner.hpp
@@ -71,7 +71,6 @@ public:
 	void
 	scanRoots(MM_EnvironmentBase *env)
 	{
-		/* TODO: Consider serializing thread access so that each gc thread gets a portion of the roots. */
 		OMR_VM_Example *omrVM = (OMR_VM_Example *)env->getOmrVM()->_language_vm;
 		if (env->_currentTask->synchronizeGCThreadsAndReleaseSingleThread(env, UNIQUE_ID)) {
 			J9HashTableState state;
@@ -83,6 +82,13 @@ public:
 						_scavenger->copyObjectSlot(envStd, (volatile omrobjectptr_t *) &rootEntry->rootPtr);
 					}
 					rootEntry = (RootEntry *)hashTableNextDo(&state);
+				}
+			}
+			OMR_VMThread *walkThread;
+			GC_OMRVMThreadListIterator threadListIterator(env->getOmrVM());
+			while((walkThread = threadListIterator.nextOMRVMThread()) != NULL) {
+				if (NULL != walkThread->savedObject) {
+					_scavenger->copyObjectSlot(envStd, (volatile omrobjectptr_t *) &walkThread->savedObject);
 				}
 			}
 			env->_currentTask->releaseSynchronizedGCThreads(env);
@@ -104,8 +110,7 @@ public:
 					if (_scavenger->isObjectInEvacuateMemory(objectEntry->objPtr)) {
 						MM_ForwardedHeader fwdHeader(objectEntry->objPtr, OMR_OBJECT_METADATA_SLOT_OFFSET);
 						if (fwdHeader.isForwardedPointer()) {
-							omrobjectptr_t fwdPtr = fwdHeader.getForwardedObject();
-							objectEntry->objPtr = fwdPtr;
+							objectEntry->objPtr = fwdHeader.getForwardedObject();
 						} else {
 							hashTableDoRemove(&state);
 						}

--- a/example/glue/omrExampleVM.hpp
+++ b/example/glue/omrExampleVM.hpp
@@ -30,6 +30,8 @@ typedef struct OMR_VM_Example {
 	J9HashTable *rootTable;
 	J9HashTable *objectTable;
 	omrthread_t self;
+	omrthread_rwmutex_t _vmAccessMutex;
+	volatile uintptr_t _vmExclusiveAccessCount;
 } OMR_VM_Example;
 
 typedef struct RootEntry {

--- a/fvtest/gctest/gcTestHelpers.cpp
+++ b/fvtest/gctest/gcTestHelpers.cpp
@@ -83,6 +83,8 @@ GCTestEnvironment::GCTestSetUp()
 {
 	exampleVM._omrVM = NULL;
 	exampleVM.self = NULL;
+	exampleVM._vmAccessMutex = NULL;
+	exampleVM._vmExclusiveAccessCount = 0;
 
 	/* Attach main test thread */
 	intptr_t irc = omrthread_attach_ex(&exampleVM.self, J9THREAD_ATTR_DEFAULT);
@@ -90,7 +92,10 @@ GCTestEnvironment::GCTestSetUp()
 
 	/* Initialize the VM */
 	omr_error_t rc = OMR_Initialize(&exampleVM, &exampleVM._omrVM);
-	ASSERT_EQ(OMR_ERROR_NONE, rc) << "Setup(): OMR_Initialize failed, rc=" << rc;
+	ASSERT_EQ(OMR_ERROR_NONE, rc) << "GCTestSetUp(): OMR_Initialize failed, rc=" << rc;
+
+	/* Set up the vm access mutex */
+	omrthread_rwmutex_init(&exampleVM._vmAccessMutex, 0, "VM exclusive access");
 
 	portLib = ((exampleVM._omrVM)->_runtime)->_portLibrary;
 
@@ -101,6 +106,12 @@ void
 GCTestEnvironment::GCTestTearDown()
 {
 	ASSERT_NO_FATAL_FAILURE(clearParams());
+
+	ASSERT_EQ((uintptr_t)0, exampleVM._vmExclusiveAccessCount) << "GCTestTearDown(): _vmExclusiveAccessCount not 0, _vmExclusiveAccessCount=" << exampleVM._vmExclusiveAccessCount;
+	if (NULL != exampleVM._vmAccessMutex) {
+		omrthread_rwmutex_destroy(exampleVM._vmAccessMutex);
+		exampleVM._vmAccessMutex = NULL;
+	}
 
 	/* Shut down VM */
 	omr_error_t rc = OMR_Shutdown(exampleVM._omrVM);

--- a/gc/base/CollectorLanguageInterface.hpp
+++ b/gc/base/CollectorLanguageInterface.hpp
@@ -59,6 +59,8 @@ protected:
 public:
 
 private:
+	MMINLINE void generationalWriteBarrierStore(MM_EnvironmentStandard* env, omrobjectptr_t parentObject, omrobjectptr_t childObject);
+	MMINLINE void concurrentWriteBarrierStore(MM_EnvironmentBase* env, omrobjectptr_t parentObject);
 protected:
 public:
 
@@ -544,9 +546,19 @@ public:
 	 * to effect the assignment of a child reference to a parent slot.
 	 *
 	 * To support OMR concurrent marking and/or generational collectors, this method also
-	 * implements the necessary concurrent and generational write barriers.
+	 * calls the necessary concurrent and generational write barriers.
 	 */
 	void writeBarrierStore(OMR_VMThread *omrThread, omrobjectptr_t parentObject, fomrobject_t *parentSlot, omrobjectptr_t childObject);
+
+	/**
+	 * This method calls the concurrent and generational write barriers without effecting the assignment
+	 * of child to parent slot. Use this method in cases where the assignment has been effected by another
+	 * agent.
+	 *
+	 * To support OMR concurrent marking and/or generational collectors, this method calls the necessary
+	 * concurrent and generational write barriers.
+	 */
+	void writeBarrierUpdate(OMR_VMThread *omrThread, omrobjectptr_t parentObject, omrobjectptr_t childObject);
 
 	MM_CollectorLanguageInterface()
 		: MM_BaseVirtual()

--- a/gc/base/EnvironmentBase.hpp
+++ b/gc/base/EnvironmentBase.hpp
@@ -96,7 +96,6 @@ private:
 	MM_AllocationContext *_commonAllocationContext;	/**< Common Allocation Context shared by all threads */
 
 
-	uintptr_t _exclusiveCount; /**< count of recursive exclusive VM access requests */
 	uint64_t _exclusiveAccessTime; /**< time (in ticks) of the last exclusive access request */
 	uint64_t _meanExclusiveAccessIdleTime; /**< mean idle time (in ticks) of the last exclusive access request */
 	OMR_VMThread* _lastExclusiveAccessResponder; /**< last thread to respond to last exclusive access request */
@@ -370,7 +369,7 @@ public:
 	bool
 	inquireExclusiveVMAccessForGC()
 	{
-		return (_exclusiveCount > 0);
+		return (_omrVMThread->exclusiveCount > 0);
 	}
 
 #if defined(OMR_GC_MODRON_CONCURRENT_MARK)
@@ -559,7 +558,6 @@ public:
 		,_threadScanned(false)
 		,_allocationContext(NULL)
 		,_commonAllocationContext(NULL)
-		,_exclusiveCount(0)
 		,_exclusiveAccessTime(0)
 		,_meanExclusiveAccessIdleTime(0)
 		,_lastExclusiveAccessResponder(NULL)

--- a/gc/base/EnvironmentBase.hpp
+++ b/gc/base/EnvironmentBase.hpp
@@ -28,9 +28,6 @@
 #include "CardCleaningStats.hpp"
 #include "CycleState.hpp"
 #include "CompactStats.hpp"
-#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
-#include "ConcurrentGCStats.hpp"
-#endif /* defined(OMR_GC_MODRON_CONCURRENT_MARK) */
 #include "GCCode.hpp"
 #include "GCExtensionsBase.hpp"
 #include "LargeObjectAllocateStats.hpp"
@@ -47,6 +44,9 @@
 class MM_AllocationContext;
 class MM_AllocateDescription;
 class MM_Collector;
+#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
+class MM_ConcurrentGCStats;
+#endif /* defined(OMR_GC_MODRON_CONCURRENT_MARK) */
 class MM_EnvironmentLanguageInterface;
 class MM_HeapRegionQueue;
 class MM_MemorySpace;

--- a/gc/base/EnvironmentLanguageInterface.hpp
+++ b/gc/base/EnvironmentLanguageInterface.hpp
@@ -24,6 +24,7 @@
 #include "BaseVirtual.hpp"
 #include "EnvironmentBase.hpp"
 
+#include "ModronAssertions.h"
 #include "objectdescription.h"
 #include "omr.h"
 #include "omrvm.h"
@@ -59,30 +60,44 @@ protected:
 public:
 	virtual void kill(MM_EnvironmentBase *env) = 0;
 
-	/**
-	 * Acquire shared VM access.
+	/***
+	 * NOTE: The OMR VM access model grants exclusive VM access to one thread
+	 * only if no other thread has VM access. Conversely one of more threads may
+	 * be granted shared VM access only if no other thread holds exclusive
+	 * VM access. This can be modeled as a write-bias reader/writer lock where
+	 * threads holding shared VM access periodically check for pending
+	 * requests for exclusive VM access and relinquish VM access in that event.
+	 *
+	 * OMR threads must acquire shared VM access and hold it as long as they are
+	 * accessing VM internal structures. In the event that another thread requests
+	 * exclusive VM access, threads holding shared VM access must release shared
+	 * VM access and suspend activities involving direct access to VM structures.
 	 */
-	virtual void
-	acquireVMAccess()
-	{
-	}
 
 	/**
-	 * Releases shared VM access.
+	 * Acquire shared VM access. Implementation must block calling thread as long
+	 * as any other thread has exclusive VM access.
 	 */
-	virtual void
-	releaseVMAccess()
-	{
-	}
+	virtual void acquireVMAccess() = 0;
 
 	/**
-	 * Acquire exclusive VM access.
+	 * Release shared VM access. This method should be called
+	 */
+	virtual void releaseVMAccess() = 0;
+
+	/**
+	 * Acquire exclusive VM access. This must lock the VM thread list mutex (OMR_VM::_vmThreadListMutex).
+	 *
+	 * This method may be called by a thread that already holds exclusive VM access. In that case, the
+	 * OMR_VMThread::exclusiveCount counter is incremented.
 	 */
 	virtual void
 	acquireExclusiveVMAccess()
 	{
-		_omrThread->exclusiveCount = 1;
-		omrthread_monitor_enter(_env->getOmrVM()->_vmThreadListMutex);
+		if (0 == _omrThread->exclusiveCount) {
+			omrthread_monitor_enter(_env->getOmrVM()->_vmThreadListMutex);
+		}
+		_omrThread->exclusiveCount += 1;
 	}
 
 	/**
@@ -107,35 +122,65 @@ public:
 	virtual void
 	releaseExclusiveVMAccess()
 	{
-		_omrThread->exclusiveCount = 0;
-		omrthread_monitor_exit(_env->getOmrVM()->_vmThreadListMutex);
+		Assert_MM_true(0 < _omrThread->exclusiveCount);
+		_omrThread->exclusiveCount -= 1;
+		if (0 == _omrThread->exclusiveCount) {
+			omrthread_monitor_exit(_env->getOmrVM()->_vmThreadListMutex);
+		}
 	}
 
 	/**
-	 * TODO fill in description
+	 * This method may be required if a concurrent GC strategy is employed. It will
+	 * be called by the concurrent GC if it is unable to immediately obtain exclusive
+	 * VM access (because a stop-the-world GC is in progress). If the concurrent GC
+	 * holds resources that must be temporarily relinquished while waiting for
+	 * exclusive VM access, this is the place to release them. They can be recovered
+	 * in exclusiveAccessForGCObtainedAfterBeatenByOtherThread(), which will be called
+	 * when the stop-the-world GC completes and releases exclusive VM access.
 	 */
 	virtual void exclusiveAccessForGCBeatenByOtherThread() {}
+
+	/**
+	 * This method may be required if a concurrent GC strategy is employed. It will be
+	 * called when the stop-the-world GC completes and releases exclusive VM access if
+	 * the thread previously ran exclusiveAccessForGCObtainedAfterBeatenByOtherThread().
+	 * Any resources temporarily released in that method can be recovered here before
+	 * proceeding with exclusive VM access.
+	 */
 	virtual void exclusiveAccessForGCObtainedAfterBeatenByOtherThread() {}
+
 	virtual void releaseCriticalHeapAccess(uintptr_t *data) {}
 	virtual void reacquireCriticalHeapAccess(uintptr_t data) {}
 
 	/**
-	 * Give up exclusive access in preparation for transferring it to a collaborating thread (i.e. main-to-master or master-to-main)
+	 * Give up exclusive access in preparation for transferring it to a collaborating thread
+	 * (i.e. main-to-master or master-to-main). Implement if this kind of collaboration is
+	 * required.
+	 *
 	 * @return the exclusive count of the current thread before relinquishing 
 	 */
-	virtual uintptr_t relinquishExclusiveVMAccess() { return 0; }
+	virtual uintptr_t relinquishExclusiveVMAccess()
+	{
+		Assert_MM_unreachable();
+		return 0;
+	}
 	
 	/**
-	 * Assume exclusive access from a collaborating thread i.e. main-to-master or master-to-main)
+	 * Assume exclusive access from a collaborating thread (i.e. main-to-master or master-to-main).
+	 * Implement if this kind of collaboration is required.
+	 *
 	 * @param exclusiveCount the exclusive count to be restored 
 	 */
-	virtual void assumeExclusiveVMAccess(uintptr_t exclusiveCount) {}
+	virtual void assumeExclusiveVMAccess(uintptr_t exclusiveCount)
+	{
+		Assert_MM_unreachable();
+	}
 
 	/**
 	 * Checks to see if any thread has requested exclusive access
 	 * @return true if a thread is waiting on exclusive access, false if not.
 	 */
-	virtual bool isExclusiveAccessRequestWaiting() { return false; }
+	virtual bool isExclusiveAccessRequestWaiting() = 0;
 
 
 	/**

--- a/gc/base/standard/ConcurrentGC.cpp
+++ b/gc/base/standard/ConcurrentGC.cpp
@@ -1103,17 +1103,13 @@ MM_ConcurrentGC::conHelperEntryPoint(OMR_VMThread *omrThread, uintptr_t slaveID)
 		if (CONCURRENT_HELPER_SHUTDOWN == request) {
 			continue;
 		}
+		
 		env->acquireVMAccess();
-
 		request = getConHelperRequest();
 		if (CONCURRENT_HELPER_MARK != request) {
 			env->releaseVMAccess();
 			continue;
 		}
-
-		/* TODO 90354: Find a way to reestablish this assertion
-		Assert_MM_true(0 != (vmThread->privateFlags & J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE));
-		*/
 		Assert_GC_true_with_message(env, CONCURRENT_OFF != _stats->getExecutionMode(), "MM_ConcurrentStats::_executionMode = %zu\n", _stats->getExecutionMode());
 
 		sizeTraced = 0;
@@ -1134,12 +1130,7 @@ MM_ConcurrentGC::conHelperEntryPoint(OMR_VMThread *omrThread, uintptr_t slaveID)
 				totalScanned += sizeTraced;
 				spinLimiter.reset();
 			}
-			if (env->isExclusiveAccessRequestWaiting()) {
-				request = switchConHelperRequest(CONCURRENT_HELPER_MARK, CONCURRENT_HELPER_WAIT);
-				Assert_MM_true(CONCURRENT_HELPER_MARK != request);
-			} else {
-				request = getConHelperRequest();
-			}
+			request = getConHelperRequest();
 		}
 
 		spinLimiter.reset();
@@ -1157,12 +1148,7 @@ MM_ConcurrentGC::conHelperEntryPoint(OMR_VMThread *omrThread, uintptr_t slaveID)
 					spinLimiter.reset();
 				}
 			}
-			if (env->isExclusiveAccessRequestWaiting()) {
-				request = switchConHelperRequest(CONCURRENT_HELPER_MARK, CONCURRENT_HELPER_WAIT);
-				Assert_MM_true(CONCURRENT_HELPER_MARK != request);
-			} else {
-				request = getConHelperRequest();
-			}
+			request = getConHelperRequest();
 		}
 
 		if (CONCURRENT_HELPER_MARK == request) {
@@ -2763,18 +2749,15 @@ uintptr_t
 MM_ConcurrentGC::localMark(MM_EnvironmentStandard *env, uintptr_t sizeToTrace)
 {
 	omrobjectptr_t objectPtr;
-	uintptr_t sizeTraced = 0;
 	uintptr_t gcCount = _extensions->globalGCStats.gcCount;
 
 	env->_workStack.reset(env, _markingScheme->getWorkPackets());
 	Assert_MM_true(env->_cycleState == NULL);
 	Assert_MM_true(CONCURRENT_OFF < _stats->getExecutionMode());
-#if 0	/* TODO 90354: Find a way to reestablish this assertion */
-	Assert_MM_true(((J9VMThread *)env->getLanguageVMThread())->privateFlags & J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE);
-#endif
 	Assert_MM_true(_concurrentCycleState._referenceObjectOptions == MM_CycleState::references_default);
 	env->_cycleState = &_concurrentCycleState;
 
+	uintptr_t sizeTraced = 0;
 	while(NULL != (objectPtr = (omrobjectptr_t)env->_workStack.popNoWait(env))) {
 		/* Check for array scanPtr..if we find one ignore it*/
 		if ((uintptr_t)objectPtr & PACKET_ARRAY_SPLIT_TAG){
@@ -2809,6 +2792,9 @@ MM_ConcurrentGC::localMark(MM_EnvironmentStandard *env, uintptr_t sizeToTrace)
 
 		/* Before we do any more tracing check to see if GC is waiting */
 		if (env->isExclusiveAccessRequestWaiting()) {
+			/* suspend con helper thread for pending GC */
+			uintptr_t conHelperRequest = switchConHelperRequest(CONCURRENT_HELPER_MARK, CONCURRENT_HELPER_WAIT);
+			Assert_MM_true(CONCURRENT_HELPER_MARK != conHelperRequest);
 			break;
 		}
 	}
@@ -2853,6 +2839,11 @@ MM_ConcurrentGC::cleanCards(MM_EnvironmentStandard *env, bool isMutator, uintptr
 	flushLocalBuffers(env);
 	env->_cycleState = NULL;
 
+	if (gcOccurred) {
+		/* suspend con helper thread for pending GC */
+		uintptr_t conHelperRequest = switchConHelperRequest(CONCURRENT_HELPER_MARK, CONCURRENT_HELPER_WAIT);
+		Assert_MM_true(CONCURRENT_HELPER_MARK != conHelperRequest);
+	}
 	return gcOccurred;
 }
 

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -3080,8 +3080,7 @@ MM_Scavenger::backoutFixupAndReverseForwardPointersInSurvivor(MM_EnvironmentStan
 					freeHeader->setNext((MM_HeapLinkedFreeHeader*)objectPtr);
 					freeHeader->setSize(evacuateObjectSizeInBytes);
 #if defined(OMR_SCAVENGER_TRACE_BACKOUT)
-					MM_HeapLinkedFreeHeader* freeHeader = MM_HeapLinkedFreeHeader::getHeapLinkedFreeHeader(fwdObjectPtr);
-					omrtty_printf("{SCAV: Back out forward pointer %p@%p -> %p[%p]}\n", objectPtr, fwdObjectPtr, freeHeader->getNext(), freeHeader->getSize());
+					omrtty_printf("{SCAV: Back out forward pointer %p[%p]@%p -> %p[%p]}\n", objectPtr, *objectPtr, fwdObjectPtr, freeHeader->getNext(), freeHeader->getSize());
 #endif /* OMR_SCAVENGER_TRACE_BACKOUT */
 				}
 			}
@@ -3113,7 +3112,6 @@ MM_Scavenger::backoutFixupAndReverseForwardPointersInSurvivor(MM_EnvironmentStan
 				_cli->scavenger_fixupDestroyedSlot(env, &header, _activeSubSpace);
 #if defined(OMR_SCAVENGER_TRACE_BACKOUT)
 				omrobjectptr_t fwdObjectPtr = header.getForwardedObject();
-				MM_HeapLinkedFreeHeader* freeHeader = MM_HeapLinkedFreeHeader::getHeapLinkedFreeHeader(fwdObjectPtr);
 				omrtty_printf("{SCAV: Fixup destroyed slot %p@%p -> %u->%u}\n", objectPtr, fwdObjectPtr, originalOverlap, header.getPreservedOverlap());
 #endif /* OMR_SCAVENGER_TRACE_BACKOUT */
 			}

--- a/gc/startup/omrgcalloc.cpp
+++ b/gc/startup/omrgcalloc.cpp
@@ -61,12 +61,6 @@ allocHelper(OMR_VMThread * omrVMThread, size_t sizeInBytes, uintptr_t flags, boo
 	omrobjectptr_t heapBytes = (omrobjectptr_t)env->_objectAllocationInterface->allocateObject(env, &allocdescription, env->getMemorySpace(), collectOnFailure);
 
 	if (NULL != heapBytes) {
-#if defined(OMR_GC_ALLOCATION_TAX)
-		/* pay allocation tax */
-		if (extensions->payAllocationTax && (0 != allocdescription.getAllocationTaxSize())) {
-			allocdescription.payAllocationTax(env);
-		}
-#endif /* OMR_GC_ALLOCATION_TAX */
 		if (J9_ARE_ALL_BITS_SET(flags, OMR_GC_ALLOCATE_ZERO_MEMORY)) {
 			uintptr_t size = allocdescription.getBytesRequested();
 			memset(heapBytes, 0, size);
@@ -76,6 +70,8 @@ allocHelper(OMR_VMThread * omrVMThread, size_t sizeInBytes, uintptr_t flags, boo
 	allocdescription.setAllocationSucceeded(NULL != heapBytes);
 	/* Issue Allocation Failure Report if required */
 	env->allocationFailureEndReportIfRequired(&allocdescription);
+
+	/* TODO Initialize object header */
 
 	if (collectOnFailure) {
 		/* Done allocation - successful or not */

--- a/gc/startup/omrgcalloc.cpp
+++ b/gc/startup/omrgcalloc.cpp
@@ -60,8 +60,13 @@ allocHelper(OMR_VMThread * omrVMThread, size_t sizeInBytes, uintptr_t flags, boo
 
 	omrobjectptr_t heapBytes = (omrobjectptr_t)env->_objectAllocationInterface->allocateObject(env, &allocdescription, env->getMemorySpace(), collectOnFailure);
 
-	/* OMRTODO: Should we use zero TLH instead of memset? */
 	if (NULL != heapBytes) {
+#if defined(OMR_GC_ALLOCATION_TAX)
+		/* pay allocation tax */
+		if (extensions->payAllocationTax && (0 != allocdescription.getAllocationTaxSize())) {
+			allocdescription.payAllocationTax(env);
+		}
+#endif /* OMR_GC_ALLOCATION_TAX */
 		if (J9_ARE_ALL_BITS_SET(flags, OMR_GC_ALLOCATE_ZERO_MEMORY)) {
 			uintptr_t size = allocdescription.getBytesRequested();
 			memset(heapBytes, 0, size);

--- a/gc/stats/ConcurrentGCStats.hpp
+++ b/gc/stats/ConcurrentGCStats.hpp
@@ -19,13 +19,6 @@
 #if !defined(CONCURRENTGCSTATS_HPP_)
 #define CONCURRENTGCSTATS_HPP_
 
-#undef CONCURRENT_EXECUTION_MODE_DEBUG
-	
-#if defined(CONCURRENT_EXECUTION_MODE_DEBUG)
-#include <stdio.h>
-#include <stdlib.h>
-#endif /* CONCURRENT_EXECUTION_MODE_DEBUG */
-
 #include "omrcomp.h"
 #include "omrport.h"
 #include "modronbase.h"
@@ -36,7 +29,7 @@
 
 class MM_EnvironmentBase;
 
-/**
+/*
  * @todo Provide class documentation
  * @ingroup GC_Stats
  */
@@ -88,17 +81,7 @@ public:
 	
 	MMINLINE bool switchExecutionMode(uintptr_t oldMode, uintptr_t newMode)
 	{
-		if (oldMode == MM_AtomicOperations::lockCompareExchange(&_executionMode, oldMode, newMode)) {
-#if defined(CONCURRENT_EXECUTION_MODE_DEBUG)
-			fprintf(stderr, "+++ MM_ConcurrentGCStats::switchExecutionMode: %d -> %d\n", (int) oldMode, (int) newMode);
-#endif /* CONCURRENT_EXECUTION_MODE_DEBUG */
-			return true;
-		} else {
-#if defined(CONCURRENT_EXECUTION_MODE_DEBUG)
-			fprintf(stderr, "--- MM_ConcurrentGCStats::switchExecutionMode: %d -> %d [%d]\n", (int) oldMode, (int) newMode, (int) _executionMode);
-#endif /* CONCURRENT_EXECUTION_MODE_DEBUG */
-			return false;
-		}
+		return oldMode == MM_AtomicOperations::lockCompareExchange(&_executionMode, oldMode, newMode);
 	}
 	
 	MMINLINE uintptr_t  getExecutionModeAtGC() { return _executionModeAtGC; };

--- a/include_core/omr.h
+++ b/include_core/omr.h
@@ -177,6 +177,8 @@ typedef struct OMR_VMThread {
 	struct movedObjectHashCode movedObjectHashCodeCache;
 
 	int32_t _attachCount;
+
+	void *savedObject; /**< holds new object allocation until object can be attached to reference graph (see MM_AllocationDescription::save/restoreObjects()) */
 } OMR_VMThread;
 
 /**


### PR DESCRIPTION
Implement VM access functions for example/glue. Complete ConcurrentGC
integration with example glue and GCTest.

Signed-off-by: Kim Briggs <briggs@ca.ibm.com>

Travis build (3e5edb4): https://travis-ci.org/ktbriggs/omr/jobs/152670523