### PR TITLE
Add the OMR_JIT top level component flag

### DIFF
--- a/configure
+++ b/configure
@@ -719,6 +719,7 @@ OMR_EXAMPLE
 OMR_OMRSIG
 OMR_THREAD
 OMR_PORT
+OMR_JIT
 OMR_GC
 ac_ct_CXX
 CXXFLAGS
@@ -806,6 +807,7 @@ enable_fvtest_agent
 enable_tracegen
 enable_auto_build_flag
 enable_OMR_GC
+enable_OMR_JIT
 enable_OMR_PORT
 enable_OMR_THREAD
 enable_OMR_OMRSIG
@@ -1527,6 +1529,7 @@ Optional Features:
                           are not explicitly enabled or disabled. (Default:
                           yes)
   --disable-OMR_GC        Enable building the OMR GC. (Default: yes)
+  --enable-OMR_JIT        Enable building the OMR JIT. (Default: no)
   --disable-OMR_PORT      Enable building the Port library. (Default: yes)
   --disable-OMR_THREAD    Enable building the Thread library. (Default: yes)
   --disable-OMR_OMRSIG    Enable building the OMRSig library. (Default: yes)
@@ -5209,6 +5212,38 @@ else
 
 fi
 	echo "OMR_GC := 1" >> omrmakefiles/omrcfg.mk
+
+
+fi
+
+
+# Check whether --enable-OMR_JIT was given.
+if test "${enable_OMR_JIT+set}" = set; then :
+  enableval=$enable_OMR_JIT; if test "x${enableval}" = xyes; then :
+
+	if test "x" = "x"; then :
+  OMR_JIT="#define OMR_JIT"
+
+else
+  OMR_JIT="#define OMR_JIT "
+
+
+fi
+	echo "OMR_JIT := 1" >> omrmakefiles/omrcfg.mk
+
+else
+
+	OMR_JIT="#undef OMR_JIT"
+
+	echo "OMR_JIT := 0" >> omrmakefiles/omrcfg.mk
+
+
+fi
+else
+
+	OMR_JIT="#undef OMR_JIT"
+
+	echo "OMR_JIT := 0" >> omrmakefiles/omrcfg.mk
 
 
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -357,6 +357,7 @@ echo "" >> omrmakefiles/omrcfg.mk
 
 ############### Top-Level Components
 OMRCFG_DEFINE_FLAG_ON([OMR_GC], [], [Enable building the OMR GC. (Default: yes)])
+OMRCFG_DEFINE_FLAG_OFF([OMR_JIT], [], [Enable building the OMR JIT. (Default: no)])
 OMRCFG_DEFINE_FLAG_ON([OMR_PORT], [], [Enable building the Port library. (Default: yes)])
 OMRCFG_DEFINE_FLAG_ON([OMR_THREAD], [], [Enable building the Thread library. (Default: yes)])
 OMRCFG_DEFINE_FLAG_ON([OMR_OMRSIG], [], [Enable building the OMRSig library. (Default: yes)])

--- a/include_core/omrcfg.h.in
+++ b/include_core/omrcfg.h.in
@@ -33,6 +33,7 @@ extern "C" {
 #endif
 
 @OMR_GC@
+@OMR_JIT@
 @OMR_PORT@
 @OMR_THREAD@
 @OMR_OMRSIG@


### PR DESCRIPTION
Leave the OMR_JIT flag off by default.
Regenerate the configure script.

Signed-off-by: Robert Young <rwy0717@gmail.com>
/cc @youngar @charliegracie