### PR TITLE
Issue #189: Detect truncated paths

### DIFF
--- a/port/win32/omrosbacktrace_impl.c
+++ b/port/win32/omrosbacktrace_impl.c
@@ -41,12 +41,13 @@ static wchar_t *
 buildPDBPath(struct OMRPortLibrary *portLibrary, HANDLE process)
 {
 	HMODULE hModules[128];
-	wchar_t modulePath[EsMaxPath];
+	wchar_t modulePath[EsMaxPath + 1] = {0};
 	uintptr_t pathLength = 0;
 	DWORD nModules;
 	DWORD cbNeeded;
 	uintptr_t i;
 	DWORD maxPathLength = sizeof(PPG_pdbData.searchPath) - 1;
+	DWORD modulePathLength = 0;
 
 	if (EnumProcessModules(process, hModules, sizeof(hModules), &cbNeeded) == TRUE) {
 		/* iterate over the modules and extract their paths. */
@@ -62,7 +63,8 @@ buildPDBPath(struct OMRPortLibrary *portLibrary, HANDLE process)
 		}
 
 		for (i = 0; i < nModules; i++) {
-			if (GetModuleFileNameW(hModules[i], modulePath, sizeof(modulePath)) != 0) {
+			modulePathLength = GetModuleFileNameW(hModules[i], modulePath, (EsMaxPath + 1));
+			if ((0 != modulePathLength) && (modulePathLength < (EsMaxPath + 1))) {
 				wchar_t *cursor;
 				uintptr_t j;
 				uintptr_t moduleNameLen;


### PR DESCRIPTION
GetModuleFileNameW retrieves the fully qualified path for the file that
contains the specified module.

DWORD WINAPI GetModuleFileName(
   \_In\_opt\_ HMODULE hModule,
   \_Out\_    LPTSTR  lpFilename,
   \_In\_     DWORD   nSize
);

If the length of the path exceeds the size that the nSize parameter
specifies, GetModuleFileNameW will succeed and the path is truncated to
nSize characters including the terminating null character. 

Code has been added to properly detect truncated paths.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>