### PR TITLE
Issue #191: memset footerTag padding

### DIFF
--- a/port/common/omrmemtag.c
+++ b/port/common/omrmemtag.c
@@ -106,7 +106,7 @@ wrapBlockAndSetTags(struct OMRPortLibrary *portLibrary, void *memoryPointer, uin
 	footerTag->callSite = callSite;
 	footerTag->category = category;
 #if !defined(OMR_ENV_DATA64)
-	memset(headerTag->padding, J9MEMTAG_PADDING_BYTE, sizeof(headerTag->padding));
+	memset(footerTag->padding, J9MEMTAG_PADDING_BYTE, sizeof(footerTag->padding));
 #endif
 	setTagSumCheck(footerTag, J9MEMTAG_EYECATCHER_ALLOC_FOOTER);
 


### PR DESCRIPTION
The `uint8_t[]` padding in `J9MemTag footerTag` was not memset to `J9MEMTAG_PADDING_BYTE`. Instead, the padding in `J9MemTag headerTag` was memset twice. Changed the second memset to write to the footerTag.

Signed-off-by: Bjørn Vårdal <bjornvar@ca.ibm.com>