### PR TITLE
Remove MM_ScanClassesMode and dependencies from OMR (#127)

### DIFF
--- a/example/glue/EnvironmentLanguageInterfaceImpl.cpp
+++ b/example/glue/EnvironmentLanguageInterfaceImpl.cpp
@@ -74,12 +74,17 @@ MM_EnvironmentLanguageInterfaceImpl::tearDown(MM_EnvironmentBase *env)
 bool
 MM_EnvironmentLanguageInterfaceImpl::saveObjects(omrobjectptr_t objectPtr)
 {
+	Assert_MM_true(NULL == _omrThread->_savedObject);
+	_omrThread->_savedObject = (void *)objectPtr;
 	return true;
 }
 
 void
 MM_EnvironmentLanguageInterfaceImpl::restoreObjects(omrobjectptr_t *objectPtrIndirect)
 {
+	Assert_MM_true(NULL != _omrThread->_savedObject);
+	*objectPtrIndirect = (omrobjectptr_t)_omrThread->_savedObject;
+	_omrThread->_savedObject = NULL;
 }
 
 #if defined (OMR_GC_THREAD_LOCAL_HEAP)

--- a/example/glue/EnvironmentLanguageInterfaceImpl.hpp
+++ b/example/glue/EnvironmentLanguageInterfaceImpl.hpp
@@ -19,11 +19,13 @@
 #ifndef ENVIRONMENTLANGUAGEINTERFACEIMPL_HPP_
 #define ENVIRONMENTLANGUAGEINTERFACEIMPL_HPP_
 
+#include "ModronAssertions.h"
 #include "omr.h"
 
 #include "EnvironmentLanguageInterface.hpp"
 
 #include "EnvironmentBase.hpp"
+#include "omrExampleVM.hpp"
 
 class MM_EnvironmentLanguageInterfaceImpl : public MM_EnvironmentLanguageInterface
 {
@@ -46,6 +48,140 @@ public:
 
 	virtual bool saveObjects(omrobjectptr_t objectPtr);
 	virtual void restoreObjects(omrobjectptr_t *objectPtrIndirect);
+
+	/**
+	 * Acquire shared VM access.
+	 */
+	virtual void
+	acquireVMAccess()
+	{
+		OMR_VM_Example *exampleVM = (OMR_VM_Example *)_env->getOmrVM()->_language_vm;
+		omrthread_rwmutex_enter_read(exampleVM->_vmAccessMutex);
+	}
+
+	/**
+	 * Releases shared VM access.
+	 */
+	virtual void
+	releaseVMAccess()
+	{
+		OMR_VM_Example *exampleVM = (OMR_VM_Example *)_env->getOmrVM()->_language_vm;
+		omrthread_rwmutex_exit_read(exampleVM->_vmAccessMutex);
+	}
+
+	/**
+	 * Acquire exclusive VM access.
+	 */
+	virtual void
+	acquireExclusiveVMAccess()
+	{
+		if (0 == _omrThread->exclusiveCount) {
+			OMR_VM *omrVM = _env->getOmrVM();
+			OMR_VM_Example *exampleVM = (OMR_VM_Example *)omrVM->_language_vm;
+
+			/* tell the rest of the world that a thread is going for exclusive VM< access */
+			MM_AtomicOperations::add(&exampleVM->_vmExclusiveAccessCount, 1);
+			
+			/* unconditionally acquire exclusive VM access by locking the VM thread list mutex */
+			omrthread_rwmutex_enter_write(exampleVM->_vmAccessMutex);
+			omrthread_monitor_enter(omrVM->_vmThreadListMutex);
+		}
+		_omrThread->exclusiveCount += 1;
+	}
+
+	/**
+	 * Try and acquire exclusive access if no other thread is already requesting it.
+	 * Make an attempt at acquiring exclusive access if the current thread does not already have it.  The
+	 * attempt will abort if another thread is already going for exclusive, which means this
+	 * call can return without exclusive access being held.  As well, this call will block for any other
+	 * requesting thread, and so should be treated as a safe point.
+	 * @note call can release VM access.
+	 * @return true if exclusive access was acquired, false otherwise.
+	 */
+	virtual bool
+	tryAcquireExclusiveVMAccess()
+	{
+		if (0 == _omrThread->exclusiveCount) {
+			OMR_VM *omrVM = _env->getOmrVM();
+			OMR_VM_Example *exampleVM = (OMR_VM_Example *)omrVM->_language_vm;
+
+			/* tell the rest of the world that a thread is going for exclusive VM< access */
+			uintptr_t vmExclusiveAccessCount = MM_AtomicOperations::add(&exampleVM->_vmExclusiveAccessCount, 1);
+			
+			/* try to acquire exclusive VM access by locking the VM thread list mutex */
+			if ((1 != vmExclusiveAccessCount) || (0 != omrthread_rwmutex_try_enter_write(exampleVM->_vmAccessMutex))) {
+				/* failed to acquire exclusive VM access */
+				Assert_MM_true(0 < exampleVM->_vmExclusiveAccessCount);
+				MM_AtomicOperations::subtract(&exampleVM->_vmExclusiveAccessCount, 1);
+				return false;
+			}
+			omrthread_monitor_enter(omrVM->_vmThreadListMutex);
+		}
+		_omrThread->exclusiveCount += 1;
+		return true;
+	}
+
+	/**
+	 * Releases exclusive VM access.
+	 */
+	virtual void
+	releaseExclusiveVMAccess()
+	{
+		if (1 == _omrThread->exclusiveCount) {
+			OMR_VM_Example *exampleVM = (OMR_VM_Example *)_env->getOmrVM()->_language_vm;
+			omrthread_monitor_exit(_env->getOmrVM()->_vmThreadListMutex);
+			omrthread_rwmutex_exit_write(exampleVM->_vmAccessMutex);
+			Assert_MM_true(0 < exampleVM->_vmExclusiveAccessCount);
+			MM_AtomicOperations::subtract(&exampleVM->_vmExclusiveAccessCount, 1);
+			_omrThread->exclusiveCount -= 1;
+		} else if (1 < _omrThread->exclusiveCount) {
+			_omrThread->exclusiveCount -= 1;
+		}
+	}
+
+	virtual bool
+	isExclusiveAccessRequestWaiting()
+	{
+		OMR_VM_Example *exampleVM = (OMR_VM_Example *)_env->getOmrVM()->_language_vm;
+		if ((0 < exampleVM->_vmExclusiveAccessCount) || omrthread_rwmutex_is_writelocked(exampleVM->_vmAccessMutex)) {
+			return true;
+		}
+		if (NULL != _env->getExtensions()->gcExclusiveAccessThreadId) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Give up exclusive access in preparation for transferring it to a collaborating thread
+	 * (i.e. main-to-master or master-to-main). This may involve nothing more than
+	 * transferring OMR_VMThread::exclusiveCount from the owning thread to the another
+	 * thread that thereby assumes exclusive access. Implement if this kind of collaboration
+	 * is required.
+	 *
+	 * @return the exclusive count of the current thread before relinquishing
+	 * @see assumeExclusiveVMAccess(uintptr_t)
+	 */
+	virtual uintptr_t
+	relinquishExclusiveVMAccess()
+	{
+		uintptr_t relinquishedExclusiveCount = _omrThread->exclusiveCount;
+		_omrThread->exclusiveCount = 0;
+		return relinquishedExclusiveCount;
+	}
+
+	/**
+	 * Assume exclusive access from a collaborating thread (i.e. main-to-master or master-to-main).
+	 * Implement if this kind of collaboration is required.
+	 *
+	 * @param exclusiveCount the exclusive count to be restored
+	 * @see relinquishExclusiveVMAccess(uintptr_t)
+	 */
+	virtual void
+	assumeExclusiveVMAccess(uintptr_t exclusiveCount)
+	{
+		_omrThread->exclusiveCount = exclusiveCount;
+	}
 
 #if defined (OMR_GC_THREAD_LOCAL_HEAP)
 	virtual void disableInlineTLHAllocate();

--- a/example/glue/ScavengerBackOutScanner.hpp
+++ b/example/glue/ScavengerBackOutScanner.hpp
@@ -70,6 +70,13 @@ public:
 			}
 			objectEntry = (ObjectEntry *)hashTableNextDo(&state);
 		}
+		OMR_VMThread *walkThread;
+		GC_OMRVMThreadListIterator threadListIterator(env->getOmrVM());
+		while((walkThread = threadListIterator.nextOMRVMThread()) != NULL) {
+			if (NULL != walkThread->_savedObject) {
+				_scavenger->backOutFixSlotWithoutCompression((volatile omrobjectptr_t *) &walkThread->_savedObject);
+			}
+		}
 	}
 };
 

--- a/example/glue/configure_includes/configure_common.mk
+++ b/example/glue/configure_includes/configure_common.mk
@@ -25,5 +25,6 @@ CONFIGURE_ARGS += \
   --enable-fvtest \
   --enable-OMR_GC_SEGREGATED_HEAP \
   --enable-OMR_GC_MODRON_SCAVENGER \
+  --enable-OMR_GC_MODRON_CONCURRENT_MARK \
   --enable-OMR_THR_CUSTOM_SPIN_OPTIONS \
   --enable-OMR_NOTIFY_POLICY_CONTROL

--- a/example/glue/omrExampleVM.hpp
+++ b/example/glue/omrExampleVM.hpp
@@ -30,6 +30,8 @@ typedef struct OMR_VM_Example {
 	J9HashTable *rootTable;
 	J9HashTable *objectTable;
 	omrthread_t self;
+	omrthread_rwmutex_t _vmAccessMutex;
+	volatile uintptr_t _vmExclusiveAccessCount;
 } OMR_VM_Example;
 
 typedef struct RootEntry {

--- a/fvtest/gctest/configuration/fvConfigListFile.txt
+++ b/fvtest/gctest/configuration/fvConfigListFile.txt
@@ -19,4 +19,7 @@ fvtest/gctest/configuration/sample_GC_config.xml
 fvtest/gctest/configuration/test_system_gc.xml
 fvtest/gctest/configuration/gencon_GC_config.xml
 fvtest/gctest/configuration/gencon_GC_backout_config.xml
+fvtest/gctest/configuration/scavenger_GC_config.xml
+fvtest/gctest/configuration/scavenger_GC_backout_config.xml
+fvtest/gctest/configuration/global_GC_config.xml
 fvtest/gctest/configuration/optavgpause_GC_config.xml

--- a/fvtest/gctest/configuration/gencon_GC_backout_config.xml
+++ b/fvtest/gctest/configuration/gencon_GC_backout_config.xml
@@ -15,7 +15,7 @@
 	   Multiple authors (IBM Corp.) - initial implementation and documentation
 -->
 <gc-config>
-	<option GCPolicy="gencon" forceBackOut="true" verboseLog="VerboseGC-gencon_GC_backout" sizeUnit="MB" 
+	<option GCPolicy="gencon" concurrentMark="true" forceBackOut="true" forcePoisonEvacuate="true" verboseLog="VerboseGC-gencon_GC_backout" sizeUnit="MB" 
 			initialMemorySize="11" memoryMax="11" maxSizeDefaultMemorySpace="11" 
 			minNewSpaceSize="3" newSpaceSize="3" maxNewSpaceSize="3"
 			minOldSpaceSize="8" oldSpaceSize="8" maxOldSpaceSize="8" />

--- a/fvtest/gctest/configuration/global_GC_config.xml
+++ b/fvtest/gctest/configuration/global_GC_config.xml
@@ -15,10 +15,8 @@
 	   Multiple authors (IBM Corp.) - initial implementation and documentation
 -->
 <gc-config>
-	<option GCPolicy="gencon" concurrentMark="true" verboseLog="VerboseGC-gencon_GC" sizeUnit="MB" 
-			initialMemorySize="11" memoryMax="11" maxSizeDefaultMemorySpace="11" 
-			minNewSpaceSize="3" newSpaceSize="3" maxNewSpaceSize="3"
-			minOldSpaceSize="8" oldSpaceSize="8" maxOldSpaceSize="8" />
+	<option GCPolicy="optavgpause" concurrentMark="false" verboseLog="VerboseGC-global_GC" sizeUnit="MB" 
+			initialMemorySize="2" memoryMax="11" maxSizeDefaultMemorySpace="11" />
 	<allocation>
 		<garbagePolicy namePrefix="GAR" percentage="30" frequency="perRootStruct" structure="tree" />
 

--- a/fvtest/gctest/configuration/optavgpause_GC_config.xml
+++ b/fvtest/gctest/configuration/optavgpause_GC_config.xml
@@ -15,7 +15,7 @@
 	   Multiple authors (IBM Corp.) - initial implementation and documentation
 -->
 <gc-config>
-	<option GCPolicy="optavgpause" verboseLog="VerboseGC-optavgpause_GC" sizeUnit="MB" 
+	<option GCPolicy="optavgpause" concurrentMark="true" verboseLog="VerboseGC-optavgpause_GC" sizeUnit="MB" 
 			initialMemorySize="2" memoryMax="11" maxSizeDefaultMemorySpace="11" />
 	<allocation>
 		<garbagePolicy namePrefix="GAR" percentage="30" frequency="perRootStruct" structure="tree" />

--- a/fvtest/gctest/configuration/scavenger_GC_backout_config.xml
+++ b/fvtest/gctest/configuration/scavenger_GC_backout_config.xml
@@ -15,10 +15,11 @@
 	   Multiple authors (IBM Corp.) - initial implementation and documentation
 -->
 <gc-config>
-	<option GCPolicy="gencon" concurrentMark="true" verboseLog="VerboseGC-gencon_GC" sizeUnit="MB" 
-			initialMemorySize="11" memoryMax="11" maxSizeDefaultMemorySpace="11" 
-			minNewSpaceSize="3" newSpaceSize="3" maxNewSpaceSize="3"
-			minOldSpaceSize="8" oldSpaceSize="8" maxOldSpaceSize="8" />
+	<option GCPolicy="gencon" concurrentMark="false" forceBackOut="true" forcePoisonEvacuate="true" 
+		verboseLog="VerboseGC-gencon_GC_backout" sizeUnit="MB" 
+		initialMemorySize="11" memoryMax="11" maxSizeDefaultMemorySpace="11" 
+		minNewSpaceSize="3" newSpaceSize="3" maxNewSpaceSize="3"
+		minOldSpaceSize="8" oldSpaceSize="8" maxOldSpaceSize="8" />
 	<allocation>
 		<garbagePolicy namePrefix="GAR" percentage="30" frequency="perRootStruct" structure="tree" />
 

--- a/fvtest/gctest/configuration/scavenger_GC_config.xml
+++ b/fvtest/gctest/configuration/scavenger_GC_config.xml
@@ -15,10 +15,10 @@
 	   Multiple authors (IBM Corp.) - initial implementation and documentation
 -->
 <gc-config>
-	<option GCPolicy="gencon" concurrentMark="true" verboseLog="VerboseGC-gencon_GC" sizeUnit="MB" 
-			initialMemorySize="11" memoryMax="11" maxSizeDefaultMemorySpace="11" 
-			minNewSpaceSize="3" newSpaceSize="3" maxNewSpaceSize="3"
-			minOldSpaceSize="8" oldSpaceSize="8" maxOldSpaceSize="8" />
+	<option GCPolicy="gencon" concurrentMark="false" verboseLog="VerboseGC-gencon_GC" sizeUnit="MB" 
+		initialMemorySize="11" memoryMax="11" maxSizeDefaultMemorySpace="11" 
+		minNewSpaceSize="3" newSpaceSize="3" maxNewSpaceSize="3"
+		minOldSpaceSize="8" oldSpaceSize="8" maxOldSpaceSize="8" />
 	<allocation>
 		<garbagePolicy namePrefix="GAR" percentage="30" frequency="perRootStruct" structure="tree" />
 

--- a/gc/base/CollectorLanguageInterface.hpp
+++ b/gc/base/CollectorLanguageInterface.hpp
@@ -59,6 +59,8 @@ protected:
 public:
 
 private:
+	MMINLINE void generationalWriteBarrierStore(MM_EnvironmentStandard* env, omrobjectptr_t parentObject, omrobjectptr_t childObject);
+	MMINLINE void concurrentWriteBarrierStore(MM_EnvironmentBase* env, omrobjectptr_t parentObject);
 protected:
 public:
 
@@ -544,9 +546,19 @@ public:
 	 * to effect the assignment of a child reference to a parent slot.
 	 *
 	 * To support OMR concurrent marking and/or generational collectors, this method also
-	 * implements the necessary concurrent and generational write barriers.
+	 * calls the necessary concurrent and generational write barriers.
 	 */
 	void writeBarrierStore(OMR_VMThread *omrThread, omrobjectptr_t parentObject, fomrobject_t *parentSlot, omrobjectptr_t childObject);
+
+	/**
+	 * This method calls the concurrent and generational write barriers without effecting the assignment
+	 * of child to parent slot. Use this method in cases where the assignment has been effected by another
+	 * agent.
+	 *
+	 * To support OMR concurrent marking and/or generational collectors, this method calls the necessary
+	 * concurrent and generational write barriers.
+	 */
+	void writeBarrierUpdate(OMR_VMThread *omrThread, omrobjectptr_t parentObject, omrobjectptr_t childObject);
 
 	MM_CollectorLanguageInterface()
 		: MM_BaseVirtual()

--- a/gc/base/EnvironmentBase.hpp
+++ b/gc/base/EnvironmentBase.hpp
@@ -28,9 +28,6 @@
 #include "CardCleaningStats.hpp"
 #include "CycleState.hpp"
 #include "CompactStats.hpp"
-#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
-#include "ConcurrentGCStats.hpp"
-#endif /* defined(OMR_GC_MODRON_CONCURRENT_MARK) */
 #include "GCCode.hpp"
 #include "GCExtensionsBase.hpp"
 #include "LargeObjectAllocateStats.hpp"
@@ -47,6 +44,9 @@
 class MM_AllocationContext;
 class MM_AllocateDescription;
 class MM_Collector;
+#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
+class MM_ConcurrentGCStats;
+#endif /* defined(OMR_GC_MODRON_CONCURRENT_MARK) */
 class MM_EnvironmentLanguageInterface;
 class MM_HeapRegionQueue;
 class MM_MemorySpace;
@@ -96,7 +96,6 @@ private:
 	MM_AllocationContext *_commonAllocationContext;	/**< Common Allocation Context shared by all threads */
 
 
-	uintptr_t _exclusiveCount; /**< count of recursive exclusive VM access requests */
 	uint64_t _exclusiveAccessTime; /**< time (in ticks) of the last exclusive access request */
 	uint64_t _meanExclusiveAccessIdleTime; /**< mean idle time (in ticks) of the last exclusive access request */
 	OMR_VMThread* _lastExclusiveAccessResponder; /**< last thread to respond to last exclusive access request */
@@ -370,7 +369,7 @@ public:
 	bool
 	inquireExclusiveVMAccessForGC()
 	{
-		return (_exclusiveCount > 0);
+		return (_omrVMThread->exclusiveCount > 0);
 	}
 
 #if defined(OMR_GC_MODRON_CONCURRENT_MARK)
@@ -559,7 +558,6 @@ public:
 		,_threadScanned(false)
 		,_allocationContext(NULL)
 		,_commonAllocationContext(NULL)
-		,_exclusiveCount(0)
 		,_exclusiveAccessTime(0)
 		,_meanExclusiveAccessIdleTime(0)
 		,_lastExclusiveAccessResponder(NULL)

--- a/gc/base/EnvironmentLanguageInterface.hpp
+++ b/gc/base/EnvironmentLanguageInterface.hpp
@@ -24,6 +24,7 @@
 #include "BaseVirtual.hpp"
 #include "EnvironmentBase.hpp"
 
+#include "ModronAssertions.h"
 #include "objectdescription.h"
 #include "omr.h"
 #include "omrvm.h"
@@ -59,30 +60,54 @@ protected:
 public:
 	virtual void kill(MM_EnvironmentBase *env) = 0;
 
-	/**
-	 * Acquire shared VM access.
+	/***
+	 * NOTE: The OMR VM access model grants exclusive VM access to one thread
+	 * only if no other thread has VM access. Conversely one of more threads may
+	 * be granted shared VM access only if no other thread holds exclusive
+	 * VM access. This can be modeled as a write-bias reader/writer lock where
+	 * threads holding shared VM access periodically check for pending
+	 * requests for exclusive VM access and relinquish VM access in that event.
+	 *
+	 * It is assumed that a thread owning the exclusive lock may attempt to
+	 * reacquire exclusive access when it already has exclusive access. Each
+	 * OMR thread maintains a counter to track the number of times it has acquired
+	 * the lock and not released it. This counter (OMR_VMThread::exclusiveCount)
+	 * must be maintained in the language-specific environment language interface
+	 * (this file).
+	 *
+	 * OMR threads must acquire shared VM access and hold it as long as they are
+	 * accessing VM internal structures. In the event that another thread requests
+	 * exclusive VM access, threads holding shared VM access must release shared
+	 * VM access and suspend activities involving direct access to VM structures.
 	 */
-	virtual void
-	acquireVMAccess()
-	{
-	}
 
 	/**
-	 * Releases shared VM access.
+	 * Acquire shared VM access. Implementation must block calling thread as long
+	 * as any other thread has exclusive VM access.
 	 */
-	virtual void
-	releaseVMAccess()
-	{
-	}
+	virtual void acquireVMAccess() = 0;
 
 	/**
-	 * Acquire exclusive VM access.
+	 * Release shared VM access.
+	 */
+	virtual void releaseVMAccess() = 0;
+
+	/**
+	 * Acquire exclusive VM access. This must lock the VM thread list mutex (OMR_VM::_vmThreadListMutex).
+	 *
+	 * This method may be called by a thread that already holds exclusive VM access. In that case, the
+	 * OMR_VMThread::exclusiveCount counter is incremented (without reacquiring lock on VM thread list
+	 * mutex).
 	 */
 	virtual void
 	acquireExclusiveVMAccess()
 	{
-		_omrThread->exclusiveCount = 1;
-		omrthread_monitor_enter(_env->getOmrVM()->_vmThreadListMutex);
+		/* NOTE: This implementation is for example only. */
+		Assert_MM_unreachable();
+		if (0 == _omrThread->exclusiveCount) {
+			omrthread_monitor_enter(_env->getOmrVM()->_vmThreadListMutex);
+		}
+		_omrThread->exclusiveCount += 1;
 	}
 
 	/**
@@ -97,6 +122,8 @@ public:
 	virtual bool
 	tryAcquireExclusiveVMAccess()
 	{
+		/* NOTE: This implementation is for example only. */
+		Assert_MM_unreachable();
 		this->acquireExclusiveVMAccess();
 		return true;
 	}
@@ -107,35 +134,65 @@ public:
 	virtual void
 	releaseExclusiveVMAccess()
 	{
-		_omrThread->exclusiveCount = 0;
-		omrthread_monitor_exit(_env->getOmrVM()->_vmThreadListMutex);
+		/* NOTE: This implementation is for example only. */
+		Assert_MM_unreachable();
+		Assert_MM_true(0 < _omrThread->exclusiveCount);
+		_omrThread->exclusiveCount -= 1;
+		if (0 == _omrThread->exclusiveCount) {
+			omrthread_monitor_exit(_env->getOmrVM()->_vmThreadListMutex);
+		}
 	}
 
 	/**
-	 * TODO fill in description
+	 * This method may be required if a concurrent GC strategy is employed. It will
+	 * be called by the concurrent GC if it is unable to immediately obtain exclusive
+	 * VM access (because a stop-the-world GC is in progress). If the concurrent GC
+	 * holds resources that must be temporarily relinquished while waiting for
+	 * exclusive VM access, this is the place to release them. They can be recovered
+	 * in exclusiveAccessForGCObtainedAfterBeatenByOtherThread(), which will be called
+	 * when the stop-the-world GC completes and releases exclusive VM access.
 	 */
 	virtual void exclusiveAccessForGCBeatenByOtherThread() {}
+
+	/**
+	 * This method may be required if a concurrent GC strategy is employed. It will be
+	 * called when the stop-the-world GC completes and releases exclusive VM access if
+	 * the thread previously ran exclusiveAccessForGCObtainedAfterBeatenByOtherThread().
+	 * Any resources temporarily released in that method can be recovered here before
+	 * proceeding with exclusive VM access.
+	 */
 	virtual void exclusiveAccessForGCObtainedAfterBeatenByOtherThread() {}
+
 	virtual void releaseCriticalHeapAccess(uintptr_t *data) {}
+
 	virtual void reacquireCriticalHeapAccess(uintptr_t data) {}
 
 	/**
-	 * Give up exclusive access in preparation for transferring it to a collaborating thread (i.e. main-to-master or master-to-main)
+	 * Give up exclusive access in preparation for transferring it to a collaborating thread
+	 * (i.e. main-to-master or master-to-main). This may involve nothing more than
+	 * transferring OMR_VMThread::exclusiveCount from the owning thread to the another
+	 * thread that thereby assumes exclusive access. Implement if this kind of collaboration
+	 * is required.
+	 *
 	 * @return the exclusive count of the current thread before relinquishing 
+	 * @see assumeExclusiveVMAccess(uintptr_t)
 	 */
-	virtual uintptr_t relinquishExclusiveVMAccess() { return 0; }
+	virtual uintptr_t relinquishExclusiveVMAccess() = 0;
 	
 	/**
-	 * Assume exclusive access from a collaborating thread i.e. main-to-master or master-to-main)
+	 * Assume exclusive access from a collaborating thread (i.e. main-to-master or master-to-main).
+	 * Implement if this kind of collaboration is required.
+	 *
 	 * @param exclusiveCount the exclusive count to be restored 
+	 * @see relinquishExclusiveVMAccess(uintptr_t)
 	 */
-	virtual void assumeExclusiveVMAccess(uintptr_t exclusiveCount) {}
+	virtual void assumeExclusiveVMAccess(uintptr_t exclusiveCount) = 0;
 
 	/**
 	 * Checks to see if any thread has requested exclusive access
 	 * @return true if a thread is waiting on exclusive access, false if not.
 	 */
-	virtual bool isExclusiveAccessRequestWaiting() { return false; }
+	virtual bool isExclusiveAccessRequestWaiting() = 0;
 
 
 	/**

--- a/gc/base/standard/ConcurrentGC.cpp
+++ b/gc/base/standard/ConcurrentGC.cpp
@@ -1068,11 +1068,16 @@ MM_ConcurrentGC::switchConHelperRequest(ConHelperRequest from, ConHelperRequest 
 }
 
 MMINLINE MM_ConcurrentGC::ConHelperRequest
-MM_ConcurrentGC::getConHelperRequest()
+MM_ConcurrentGC::getConHelperRequest(MM_EnvironmentBase *env)
 {
 	ConHelperRequest result;
 
 	omrthread_monitor_enter(_conHelpersActivationMonitor);
+	if (env->isExclusiveAccessRequestWaiting()) {
+		if (CONCURRENT_HELPER_MARK == _conHelpersRequest) {
+			_conHelpersRequest = CONCURRENT_HELPER_WAIT;
+		}
+	}
 	result = _conHelpersRequest;
 	omrthread_monitor_exit(_conHelpersActivationMonitor);
 
@@ -1103,17 +1108,13 @@ MM_ConcurrentGC::conHelperEntryPoint(OMR_VMThread *omrThread, uintptr_t slaveID)
 		if (CONCURRENT_HELPER_SHUTDOWN == request) {
 			continue;
 		}
-		env->acquireVMAccess();
 
-		request = getConHelperRequest();
+		env->acquireVMAccess();
+		request = getConHelperRequest(env);
 		if (CONCURRENT_HELPER_MARK != request) {
 			env->releaseVMAccess();
 			continue;
 		}
-
-		/* TODO 90354: Find a way to reestablish this assertion
-		Assert_MM_true(0 != (vmThread->privateFlags & J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE));
-		*/
 		Assert_GC_true_with_message(env, CONCURRENT_OFF != _stats->getExecutionMode(), "MM_ConcurrentStats::_executionMode = %zu\n", _stats->getExecutionMode());
 
 		sizeTraced = 0;
@@ -1134,12 +1135,7 @@ MM_ConcurrentGC::conHelperEntryPoint(OMR_VMThread *omrThread, uintptr_t slaveID)
 				totalScanned += sizeTraced;
 				spinLimiter.reset();
 			}
-			if (env->isExclusiveAccessRequestWaiting()) {
-				request = switchConHelperRequest(CONCURRENT_HELPER_MARK, CONCURRENT_HELPER_WAIT);
-				Assert_MM_true(CONCURRENT_HELPER_MARK != request);
-			} else {
-				request = getConHelperRequest();
-			}
+			request = getConHelperRequest(env);
 		}
 
 		spinLimiter.reset();
@@ -1157,12 +1153,7 @@ MM_ConcurrentGC::conHelperEntryPoint(OMR_VMThread *omrThread, uintptr_t slaveID)
 					spinLimiter.reset();
 				}
 			}
-			if (env->isExclusiveAccessRequestWaiting()) {
-				request = switchConHelperRequest(CONCURRENT_HELPER_MARK, CONCURRENT_HELPER_WAIT);
-				Assert_MM_true(CONCURRENT_HELPER_MARK != request);
-			} else {
-				request = getConHelperRequest();
-			}
+			request = getConHelperRequest(env);
 		}
 
 		if (CONCURRENT_HELPER_MARK == request) {
@@ -2763,18 +2754,15 @@ uintptr_t
 MM_ConcurrentGC::localMark(MM_EnvironmentStandard *env, uintptr_t sizeToTrace)
 {
 	omrobjectptr_t objectPtr;
-	uintptr_t sizeTraced = 0;
 	uintptr_t gcCount = _extensions->globalGCStats.gcCount;
 
 	env->_workStack.reset(env, _markingScheme->getWorkPackets());
 	Assert_MM_true(env->_cycleState == NULL);
 	Assert_MM_true(CONCURRENT_OFF < _stats->getExecutionMode());
-#if 0	/* TODO 90354: Find a way to reestablish this assertion */
-	Assert_MM_true(((J9VMThread *)env->getLanguageVMThread())->privateFlags & J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE);
-#endif
 	Assert_MM_true(_concurrentCycleState._referenceObjectOptions == MM_CycleState::references_default);
 	env->_cycleState = &_concurrentCycleState;
 
+	uintptr_t sizeTraced = 0;
 	while(NULL != (objectPtr = (omrobjectptr_t)env->_workStack.popNoWait(env))) {
 		/* Check for array scanPtr..if we find one ignore it*/
 		if ((uintptr_t)objectPtr & PACKET_ARRAY_SPLIT_TAG){
@@ -2809,6 +2797,9 @@ MM_ConcurrentGC::localMark(MM_EnvironmentStandard *env, uintptr_t sizeToTrace)
 
 		/* Before we do any more tracing check to see if GC is waiting */
 		if (env->isExclusiveAccessRequestWaiting()) {
+			/* suspend con helper thread for pending GC */
+			uintptr_t conHelperRequest = switchConHelperRequest(CONCURRENT_HELPER_MARK, CONCURRENT_HELPER_WAIT);
+			Assert_MM_true(CONCURRENT_HELPER_MARK != conHelperRequest);
 			break;
 		}
 	}
@@ -2853,6 +2844,11 @@ MM_ConcurrentGC::cleanCards(MM_EnvironmentStandard *env, bool isMutator, uintptr
 	flushLocalBuffers(env);
 	env->_cycleState = NULL;
 
+	if (gcOccurred) {
+		/* suspend con helper thread for pending GC */
+		uintptr_t conHelperRequest = switchConHelperRequest(CONCURRENT_HELPER_MARK, CONCURRENT_HELPER_WAIT);
+		Assert_MM_true(CONCURRENT_HELPER_MARK != conHelperRequest);
+	}
 	return gcOccurred;
 }
 

--- a/gc/base/standard/ConcurrentGC.hpp
+++ b/gc/base/standard/ConcurrentGC.hpp
@@ -370,7 +370,7 @@ private:
 	 *
 	 * @return the value of _conHelperRequest.
 	 */
-	ConHelperRequest getConHelperRequest();
+	ConHelperRequest getConHelperRequest(MM_EnvironmentBase *env);
 
 protected:
 	bool initialize(MM_EnvironmentBase *env);

--- a/gc/include/omrgc.h
+++ b/gc/include/omrgc.h
@@ -38,9 +38,9 @@ extern "C" {
 
 /* Runtime API */
 
-omrobjectptr_t OMR_GC_Allocate(OMR_VMThread * omrVMThread, size_t sizeInBytes, uintptr_t flags);
+omrobjectptr_t OMR_GC_Allocate(OMR_VMThread * omrVMThread, uintptr_t sizeInBytes, uintptr_t flags);
 
-omrobjectptr_t OMR_GC_AllocateNoGC(OMR_VMThread * omrVMThread, size_t sizeInBytes, uintptr_t flags);
+omrobjectptr_t OMR_GC_AllocateNoGC(OMR_VMThread * omrVMThread, uintptr_t sizeInBytes, uintptr_t flags);
 
 omr_error_t OMR_GC_SystemCollect(OMR_VMThread* omrVMThread, uint32_t gcCode);
 

--- a/gc/stats/ConcurrentGCStats.hpp
+++ b/gc/stats/ConcurrentGCStats.hpp
@@ -19,13 +19,6 @@
 #if !defined(CONCURRENTGCSTATS_HPP_)
 #define CONCURRENTGCSTATS_HPP_
 
-#undef CONCURRENT_EXECUTION_MODE_DEBUG
-	
-#if defined(CONCURRENT_EXECUTION_MODE_DEBUG)
-#include <stdio.h>
-#include <stdlib.h>
-#endif /* CONCURRENT_EXECUTION_MODE_DEBUG */
-
 #include "omrcomp.h"
 #include "omrport.h"
 #include "modronbase.h"
@@ -88,17 +81,7 @@ public:
 	
 	MMINLINE bool switchExecutionMode(uintptr_t oldMode, uintptr_t newMode)
 	{
-		if (oldMode == MM_AtomicOperations::lockCompareExchange(&_executionMode, oldMode, newMode)) {
-#if defined(CONCURRENT_EXECUTION_MODE_DEBUG)
-			fprintf(stderr, "+++ MM_ConcurrentGCStats::switchExecutionMode: %d -> %d\n", (int) oldMode, (int) newMode);
-#endif /* CONCURRENT_EXECUTION_MODE_DEBUG */
-			return true;
-		} else {
-#if defined(CONCURRENT_EXECUTION_MODE_DEBUG)
-			fprintf(stderr, "--- MM_ConcurrentGCStats::switchExecutionMode: %d -> %d [%d]\n", (int) oldMode, (int) newMode, (int) _executionMode);
-#endif /* CONCURRENT_EXECUTION_MODE_DEBUG */
-			return false;
-		}
+		return oldMode == MM_AtomicOperations::lockCompareExchange(&_executionMode, oldMode, newMode);
 	}
 	
 	MMINLINE uintptr_t  getExecutionModeAtGC() { return _executionModeAtGC; };

--- a/include_core/omr.h
+++ b/include_core/omr.h
@@ -177,6 +177,8 @@ typedef struct OMR_VMThread {
 	struct movedObjectHashCode movedObjectHashCodeCache;
 
 	int32_t _attachCount;
+
+	void *_savedObject; /**< holds new object allocation until object can be attached to reference graph (see MM_AllocationDescription::save/restoreObjects()) */
 } OMR_VMThread;
 
 /**


### PR DESCRIPTION
This commit merges 5 commits from previous pull request !188, which 
GitHub closed (deleting contained 5 commits along with commit comments
and review comments) when I cleaned up this branch (omr-issue-127) in
my remote fork to prepare it for this merged commit. 

Summary of changes:

1- Implement VM shared/exclusive access locking for example/glue. This
was necessary to allow concurrentMark (helper thread) to run in
fvtest/gctest.

2- Extend write barrier API in CollectorLanguageInterface to allow
generational and concurrent write barriers to be called after assignment
of child to parent slot has benn effected by another agent.

3- Implement GC_ObjectModel::initializeObject() for example glue only,
to allow object header to be completed before calling
payAllocationTax(). The only call to this method is compiled only if
the OMR_EXAMPLE build flag is set -- this will be replaced with a more
generic object initialization framework shortly.

4- Fix bug in example/glue object model relating to detection of
single-slot dead objects.

5- Add new test configurations for fvtest/gctest. Now tests gencon and 
optavgpause GC policies with and without concurrentMark.

All comments raised from review on previous pull request have been
addressed.

Signed-off-by: Kim Briggs <briggs@ca.ibm.com>