### PR TITLE
Issue #196 Switch thread locals on Conc. Scavenge start/end

### DIFF
--- a/gc/base/EnvironmentBase.hpp
+++ b/gc/base/EnvironmentBase.hpp
@@ -162,6 +162,9 @@ public:
 	MM_ScavengerStats _scavengerStats;
 	MM_ScavengerHotFieldStats _hotFieldStats; /**< hot field statistics for this GC thread */
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC) */
+#if defined(OMR_GC_MODRON_SCAVENGER)
+	bool _concurrentScavengerInProgress; /**< thread local flag/state, if concurrent scavenger is in progress */
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 
 private:
 
@@ -587,6 +590,10 @@ public:
 #if defined(OMR_GC_SEGREGATED_HEAP)
 		,_allocationTracker(NULL)
 #endif /* OMR_GC_SEGREGATED_HEAP */
+#if defined(OMR_GC_MODRON_SCAVENGER)
+		,_concurrentScavengerInProgress(false)
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
+
 	{
 		_typeId = __FUNCTION__;
 	}
@@ -625,6 +632,9 @@ public:
 #if defined(OMR_GC_SEGREGATED_HEAP)
 		,_allocationTracker(NULL)
 #endif /* OMR_GC_SEGREGATED_HEAP */
+#if defined(OMR_GC_MODRON_SCAVENGER)
+		,_concurrentScavengerInProgress(false)
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 	{
 		_typeId = __FUNCTION__;
 	}

--- a/gc/base/EnvironmentLanguageInterface.hpp
+++ b/gc/base/EnvironmentLanguageInterface.hpp
@@ -118,6 +118,10 @@ public:
 	virtual void exclusiveAccessForGCObtainedAfterBeatenByOtherThread() {}
 	virtual void releaseCriticalHeapAccess(uintptr_t *data) {}
 	virtual void reacquireCriticalHeapAccess(uintptr_t data) {}
+	
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	virtual void forceOutOfLineVMAccess() {}
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
 	/**
 	 * Give up exclusive access in preparation for transferring it to a collaborating thread (i.e. main-to-master or master-to-main)

--- a/gc/base/j9mm.tdf
+++ b/gc/base/j9mm.tdf
@@ -852,3 +852,5 @@ TraceAssert=Assert_MM_mustHaveJNICriticalRegion noEnv overhead=1 Level=1 Assert=
 TraceAssert=Assert_MM_inflateInvalidRange noEnv Overhead=1 Level=1 Assert="(0 /* MM_PhysicalSubArenaVirtualMemorySemiSpace::inflate - bad address range */)"
 
 TraceEvent=Trc_MM_ParallelDispatcher_adjustThreadCount_ReducedCPU noEnv Overhead=1 Level=2 Template="MM_ParallelDispatcher::adjustThreadCount limiting threads to %zu due to reduced CPU availability"
+
+TraceEvent=Trc_MM_Scavenger_switchConcurrent Overhead=1 Level=1 Group=scavenger Template="Concurrent switch %zu"

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -513,7 +513,11 @@ public:
 		return concurrent_state_idle != _concurrentState;
 	}
 
-#endif	
+	/**
+	 * Enabled/disable approriate thread local resources when starting or finishing Concurrent Scavenger Cycle
+	 */ 
+	void switchConcurrentForThread(MM_EnvironmentBase *env);	
+#endif
 
 	/**
 	 * Determine whether the object pointer is found within the heap proper.


### PR DESCRIPTION
There will be a hook in VM access acquire code that Scavenger will
register to (Language specific part). The hook will actually
enable/disable necessary resources.

When STW phase is finished, on both start and end of a cycle, GC will
request that each mutator thread takes slow path to acquire VM access,
to ensure all threads invoke the hook.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>