### PR TITLE
Remove invalid TR_ASSERT from BCDCHK node instr generation

### DIFF
--- a/compiler/z/codegen/S390GenerateInstructions.cpp
+++ b/compiler/z/codegen/S390GenerateInstructions.cpp
@@ -829,7 +829,6 @@ generateRXInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
 
          //there might be cases that two or more insts generated will throw exception, and we only need one of the label.
          //so we will assume that at this moment the second child of BCDCHKNode is the label.
-         TR_ASSERT(BCDCHKNode->getNumChildren() <= 3, "Generating DAA label error: BCDCHKNode has %d children.\n", BCDCHKNode->getNumChildren());
          TR::LabelSymbol * label = (TR::LabelSymbol *)BCDCHKNode->getChild(1);
 
          TR_S390RestoreGPR7Snippet * restoreSnippet =
@@ -882,7 +881,6 @@ generateRXYInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
 
          //there might be cases that two or more insts generated will throw exception, and we only need one of the label.
          //so we will assume that at this moment the second child of BCDCHKNode is the label.
-         TR_ASSERT(BCDCHKNode->getNumChildren() <= 3, "Generating DAA label error: BCDCHKNode has %d children.\n", BCDCHKNode->getNumChildren());
          TR::LabelSymbol * label = (TR::LabelSymbol *)BCDCHKNode->getChild(1);
 
          TR_S390RestoreGPR7Snippet * restoreSnippet =
@@ -1005,7 +1003,6 @@ generateRXYInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
 
          //there might be cases that two or more insts generated will throw exception, and we only need one of the label.
          //so we will assume that at this moment the second child of BCDCHKNode is the label.
-         TR_ASSERT(BCDCHKNode->getNumChildren() <= 3, "Generating DAA label error: BCDCHKNode has %d children.\n", BCDCHKNode->getNumChildren());
          TR::LabelSymbol * label = (TR::LabelSymbol *)BCDCHKNode->getChild(1);
 
          TR_S390RestoreGPR7Snippet * restoreSnippet =
@@ -1574,7 +1571,6 @@ generateSS2Instruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
 
          //there might be cases that two or more insts generated will throw exception, and we only need one of the label.
          //so we will assume that at this moment the second child of BCDCHKNode is the label.
-         TR_ASSERT(BCDCHKNode->getNumChildren() <= 3, "Generating DAA label error: BCDCHKNode has %d children.\n", BCDCHKNode->getNumChildren());
          TR::LabelSymbol * label = (TR::LabelSymbol *)BCDCHKNode->getChild(1);
 
          TR_S390RestoreGPR7Snippet * restoreSnippet =
@@ -1620,7 +1616,6 @@ generateSS3Instruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
 
          //there might be cases that two or more insts generated will throw exception, and we only need one of the label.
          //so we will assume that at this moment the second child of BCDCHKNode is the label.
-         TR_ASSERT(BCDCHKNode->getNumChildren() <= 3, "Generating DAA label error: BCDCHKNode has %d children.\n", BCDCHKNode->getNumChildren());
          TR::LabelSymbol * label = (TR::LabelSymbol *)BCDCHKNode->getChild(1);
 
          TR_S390RestoreGPR7Snippet * restoreSnippet =
@@ -1659,7 +1654,6 @@ generateSS3Instruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
 
          //there might be cases that two or more insts generated will throw exception, and we only need one of the label.
          //so we will assume that at this moment the second child of BCDCHKNode is the label.
-         TR_ASSERT(BCDCHKNode->getNumChildren() <= 3, "Generating DAA label error: BCDCHKNode has %d children.\n", BCDCHKNode->getNumChildren());
          TR::LabelSymbol * label = (TR::LabelSymbol *)BCDCHKNode->getChild(1);
 
          TR_S390RestoreGPR7Snippet * restoreSnippet =


### PR DESCRIPTION
Remove invalid TR_ASSERT's form GenerateS390Instruction.cpp as part of the
tree refactoring work related to Byte Array APIs for conversions between primitive (integer and long) to packed decimals. BCDCHK node used to have less than or equal to 3 children. But it's no longer the case after DAA (DataAccessAccelerator) tree refactoring. It will have a variable number of children ranging
from 5 to 12, depending on what the recognized DAA method is.

Work Item 116224

Signed-off-by: Nigel Yu <yunigel@ca.ibm.com>