### PR TITLE
Generalize Power TOCRegister functions

### DIFF
--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -5904,35 +5904,35 @@ TR::Register *OMR::Power::TreeEvaluator::longBitCount(TR::Node *node, TR::CodeGe
 	  return inlineLongBitCount(node, cg);
 }
 
-TR::Register *OMR::Power::TreeEvaluator::retrieveTOCRegister(TR::Node *node, TR::CodeGenerator *cg, TR::RegisterDependencyConditions *dependencies)
-{
-   return cg->machine()->getPPCRealRegister(TR::RealRegister::gr2);
-}
-
-void OMR::Power::TreeEvaluator::preservePTOCRegister(TR::Node *node, TR::CodeGenerator *cg, TR::RegisterDependencyConditions *dependencies)
+void OMR::Power::TreeEvaluator::preserveTOCRegister(TR::Node *node, TR::CodeGenerator *cg, TR::RegisterDependencyConditions *dependencies)
 {
    TR::Instruction *cursor = cg->comp()->getAppendInstruction();
    TR::Compilation* comp = cg->comp();
 
-   //We need to preserve the JIT pseduo-TOC whenever we call out. We're saving this on the caller TOC slot as defined by the ABI.
-   TR::Register * grPTOCReg       = cg->machine()->getPPCRealRegister(TR::RealRegister::gr2);
+   //We need to preserve the JIT TOC whenever we call out. We're saving this on the caller TOC slot as defined by the ABI.
+   TR::Register * grTOCReg       = cg->machine()->getPPCRealRegister(TR::RealRegister::gr2);
    TR::Register * grSysStackReg   = cg->machine()->getPPCRealRegister(TR::RealRegister::gr1);
 
    int32_t callerSaveTOCOffset = (TR::Compiler->target.cpu.isBigEndian() ? 5 : 3) *  TR::Compiler->om.sizeofReferenceAddress();
 
-   cursor = generateMemSrc1Instruction(cg,TR::InstOpCode::Op_st, node, new (cg->trHeapMemory()) TR::MemoryReference(grSysStackReg, callerSaveTOCOffset, TR::Compiler->om.sizeofReferenceAddress(), cg), grPTOCReg, cursor);
+   cursor = generateMemSrc1Instruction(cg,TR::InstOpCode::Op_st, node, new (cg->trHeapMemory()) TR::MemoryReference(grSysStackReg, callerSaveTOCOffset, TR::Compiler->om.sizeofReferenceAddress(), cg), grTOCReg, cursor);
 
    comp->setAppendInstruction(cursor);
 }
 
-void OMR::Power::TreeEvaluator::restorePTOCRegister(TR::Node *node, TR::CodeGenerator *cg, TR::RegisterDependencyConditions *dependencies)
+void OMR::Power::TreeEvaluator::restoreTOCRegister(TR::Node *node, TR::CodeGenerator *cg, TR::RegisterDependencyConditions *dependencies)
 {
-   //Here we restore the JIT pseduo-TOC after returning from a call out. We're restoring from the caller TOC slot as defined by the ABI.
-   TR::Register * grPTOCReg       = cg->machine()->getPPCRealRegister(TR::RealRegister::gr2);
+   //Here we restore the JIT TOC after returning from a call out. We're restoring from the caller TOC slot as defined by the ABI.
+   TR::Register * grTOCReg       = cg->machine()->getPPCRealRegister(TR::RealRegister::gr2);
    TR::Register * grSysStackReg   = cg->machine()->getPPCRealRegister(TR::RealRegister::gr1);
    TR::Compilation* comp = cg->comp();
 
    int32_t callerSaveTOCOffset = (TR::Compiler->target.cpu.isBigEndian() ? 5 : 3) *  TR::Compiler->om.sizeofReferenceAddress();
 
-   generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, grPTOCReg, new (cg->trHeapMemory()) TR::MemoryReference(grSysStackReg, callerSaveTOCOffset, TR::Compiler->om.sizeofReferenceAddress(), cg));
+   generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, grTOCReg, new (cg->trHeapMemory()) TR::MemoryReference(grSysStackReg, callerSaveTOCOffset, TR::Compiler->om.sizeofReferenceAddress(), cg));
+}
+
+TR::Register *OMR::Power::TreeEvaluator::retrieveTOCRegister(TR::Node *node, TR::CodeGenerator *cg, TR::RegisterDependencyConditions *dependencies)
+{
+   return cg->machine()->getPPCRealRegister(TR::RealRegister::gr2);
 }

--- a/compiler/p/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.hpp
@@ -531,8 +531,8 @@ class TreeEvaluator: public OMR::TreeEvaluator
 
    // VM dependent routines
 
-   static void restorePTOCRegister(TR::Node *node, TR::CodeGenerator *cg, TR::RegisterDependencyConditions *dependencies);
-   static void preservePTOCRegister(TR::Node *node, TR::CodeGenerator *cg, TR::RegisterDependencyConditions *dependencies);
+   static void preserveTOCRegister(TR::Node *node, TR::CodeGenerator *cg, TR::RegisterDependencyConditions *dependencies);
+   static void restoreTOCRegister(TR::Node *node, TR::CodeGenerator *cg, TR::RegisterDependencyConditions *dependencies);
    static TR::Register *retrieveTOCRegister(TR::Node *node, TR::CodeGenerator *cg, TR::RegisterDependencyConditions *dependencies);
 
    static void genBranchSequence(TR::Node* node, TR::Register* src1Reg, TR::Register* src2Reg, TR::Register* trgReg,

--- a/compiler/p/codegen/PPCSystemLinkage.cpp
+++ b/compiler/p/codegen/PPCSystemLinkage.cpp
@@ -743,9 +743,7 @@ TR_PPCSystemLinkage::createPrologue(
    if(cg()->hasCall())
       {
       cg()->comp()->setAppendInstruction(cursor);
-#ifndef J9_PROJECT_SPECIFIC
-      TR::TreeEvaluator::preservePTOCRegister(firstNode, cg(), NULL);
-#endif
+      TR::TreeEvaluator::preserveTOCRegister(firstNode, cg(), NULL);
       }
 
    }
@@ -1441,11 +1439,7 @@ void TR_PPCSystemLinkage::buildDirectCall(TR::Node *callNode,
          {
          //Implies TOC needs to be restored (ie not 32bit ppc-linux-be)
          if(TR::Compiler->target.cpu.isBigEndian())
-#ifdef J9_PROJECT_SPECIFIC
             TR::TreeEvaluator::restoreTOCRegister(callNode, cg(), dependencies);
-#else
-	 ;
-#endif
          else
             {
             //For Little Endian, load target's Global Entry Point into r12, TOC will be restored at branch target.
@@ -1461,10 +1455,8 @@ void TR_PPCSystemLinkage::buildDirectCall(TR::Node *callNode,
          (uintptrj_t)callSymbol->getMethodAddress(),
          dependencies, callSymRef?callSymRef:callNode->getSymbolReference());
 
-#ifndef J9_PROJECT_SPECIFIC
-   //Restore JIT pseudo-TOC as required by FrontEnd.
-   TR::TreeEvaluator::restorePTOCRegister(callNode, cg(), dependencies);
-#endif
+   //Restore JIT TOC as required by FrontEnd.
+   TR::TreeEvaluator::restoreTOCRegister(callNode, cg(), dependencies);
    }
 
 


### PR DESCRIPTION
Fix the `restoreTOCRegister`, `preserveTOCRegister`, and
`retrieveTOCRegister` functions. Rename the OMR implementations
because the old names erroneously associated them with the
pseudo-Table-Of-Constants (PTOC), instead of the system
Table-Of-Constants (TOC). This allows the J9
implementations to override the OMR implementations, which in
turn allows `J9_PROJECT_SPECIFIC` guards to be removed.

Signed-off-by: Leonardo Banderali <leob@linux.vnet.ibm.com>