### PR TITLE
Fix optimization names and add documentation to opts

### DIFF
--- a/compiler/optimizer/OMRDeadTreesElimination.hpp
+++ b/compiler/optimizer/OMRDeadTreesElimination.hpp
@@ -57,6 +57,18 @@ class TreeInfo
 
 // Removes dead code under treetops.
 //
+/*
+ * Class DeadTreesElimination
+ * ==========================
+ *
+ * Expressions that are evaluated and not used for a few instructions can 
+ * actually be evaluated exactly where required (subject to the constraint 
+ * that their values should be the same if evaluated later). This optimization 
+ * attempts to simply delay evaluation of expressions and has the effect of 
+ * reducing register pressure by shortening live ranges. It has the effect 
+ * of removing some IL trees that are simply anchors for (already) evaluated 
+ * expressions and making the trees more compact.
+ */
 
 class DeadTreesElimination : public TR::Optimization
    {

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -907,7 +907,9 @@ static const char * optimizer_name[] =
    #define OPTIMIZATION(name) #name,
    #define OPTIMIZATION_ENUM_ONLY(entry) "****",
       #include "optimizer/Optimizations.enum"
+      OPTIMIZATION_ENUM_ONLY(numOpts)
       #include "optimizer/OptimizationGroups.enum"
+      OPTIMIZATION_ENUM_ONLY(numGroups)
    #undef OPTIMIZATION
    #undef OPTIMIZATION_ENUM_ONLY
     };

--- a/compiler/optimizer/Optimizations.hpp
+++ b/compiler/optimizer/Optimizations.hpp
@@ -26,9 +26,9 @@ namespace OMR
       #define OPTIMIZATION(name) name,
       #define OPTIMIZATION_ENUM_ONLY(entry) entry,
       #include "optimizer/Optimizations.enum"
-      numOpts,
+      OPTIMIZATION_ENUM_ONLY(numOpts)  // after all project-specific optimization enums
       #include "optimizer/OptimizationGroups.enum"
-      numGroups
+      OPTIMIZATION_ENUM_ONLY(numGroups)  // after all project-specific optimization group enums
       #undef OPTIMIZATION
       #undef OPTIMIZATION_ENUM_ONLY
       };

--- a/compiler/optimizer/ValuePropagation.hpp
+++ b/compiler/optimizer/ValuePropagation.hpp
@@ -1064,6 +1064,19 @@ class TR_GlobalValuePropagation : public TR_ValuePropagation
 
    };
 
+/*
+ * Class TR_LocalValuePropagation
+ * ==============================
+ *
+ * Constant, type and relational propagation within a block. Propagates constants 
+ * and types based on assignments and performs removal of subsumed checks and 
+ * compares. Also performs devirtualization of calls, checkcast and array store 
+ * check elimination.  Does not do value numbering, instead works on the 
+ * assumption that every expression has a unique value number (improved 
+ * effectiveness if expressions having same value are commoned by a prior 
+ * local CSE pass).  
+ */
+
 class TR_LocalValuePropagation : public TR_ValuePropagation
    {
    public:


### PR DESCRIPTION
Fix mismatch of optimization names array and optimizations enum that caused Java to crash on Z when using hot+ strategy.

Add documentation to dead tree elimination and local value propagation.