### PR TITLE
Change lower case to sentence case in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ will help us to merge your pull requests smoothly:
 
 The first line describes the change made. It is written in the imperative mood,
 say what happens when the patch is applied. Keep it short and simple. The first
-line should be less than 50 characters, lower case, and does not end in a
+line should be less than 50 characters, sentence case, and does not end in a
 period. Leave a blank line between the first line and the message body.
 
 The body should be wrapped at 72 characters, where reasonable. Write your commit in


### PR DESCRIPTION
This matches the example good commit, and also the suggested advice from
Chris Beams.

[ci-skip] Documentation change.