### PR TITLE
Prefer generating XR when evaluating iconst 0

### DIFF
--- a/compiler/z/codegen/BinaryEvaluator.cpp
+++ b/compiler/z/codegen/BinaryEvaluator.cpp
@@ -810,13 +810,13 @@ lDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
       {
       if (isDivision)
          {
-         genLoadConstant(cg, node, 1, dividendPair->getLowOrder());
-         genLoadConstant(cg, node, 0, dividendPair->getHighOrder());
+         generateLoad32BitConstant(cg, node, 1, dividendPair->getLowOrder(), true);
+         generateLoad32BitConstant(cg, node, 0, dividendPair->getHighOrder(), true);
          }
       else //remainder
          {
-         genLoadConstant(cg, node, 0, dividendPair->getLowOrder());
-         genLoadConstant(cg, node, 0, dividendPair->getHighOrder());
+         generateLoad32BitConstant(cg, node, 0, dividendPair->getLowOrder(), true);
+         generateLoad32BitConstant(cg, node, 0, dividendPair->getHighOrder(), true);
          }
       node->setRegister(dividendPair);
       cg->decReferenceCount(firstChild);
@@ -848,8 +848,8 @@ lDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
          {
          if (!isDivision)  //remainder
             {
-            genLoadConstant(cg, node, 0, dividendPair->getLowOrder());
-            genLoadConstant(cg, node, 0, dividendPair->getHighOrder());
+            generateLoad32BitConstant(cg, node, 0, dividendPair->getLowOrder(), true);
+            generateLoad32BitConstant(cg, node, 0, dividendPair->getHighOrder(), true);
             }
          else
             {
@@ -885,8 +885,8 @@ lDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
          {
          if (!isDivision) //remainder
             {
-            genLoadConstant(cg, node, 0, dividendPair->getLowOrder());
-            genLoadConstant(cg, node, 0, dividendPair->getHighOrder());
+            generateLoad32BitConstant(cg, node, 0, dividendPair->getLowOrder(), true);
+            generateLoad32BitConstant(cg, node, 0, dividendPair->getHighOrder(), true);
             }
          node->setRegister(dividendPair);
          cg->decReferenceCount(firstChild);
@@ -1245,7 +1245,7 @@ lDivRemGenericEvaluator64(TR::Node * node, TR::CodeGenerator * cg, bool isDivisi
 
          if (!isDivision)  //remainder
             {
-            genLoadConstant(cg, node, 0, firstRegister);
+            generateLoad32BitConstant(cg, node, 0, firstRegister, true);
             }
          else
             {
@@ -1280,7 +1280,7 @@ lDivRemGenericEvaluator64(TR::Node * node, TR::CodeGenerator * cg, bool isDivisi
 
          if (!isDivision) //remainder
             {
-            genLoadConstant(cg, node, 0, firstRegister);
+            generateLoad32BitConstant(cg, node, 0, firstRegister, true);
             }
          node->setRegister(firstRegister);
          cg->decReferenceCount(firstChild);
@@ -1617,7 +1617,10 @@ iDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
          {
          debugObj->addInstructionComment( toS390RRInstruction(cursor),  REG_USER_DEF);
          }
-      genLoadConstant(cg, node, 0, remRegister);
+
+      // TODO: Can we allow setting the condition code here by moving the load before the compare?
+      generateLoad32BitConstant(cg, node, 0, remRegister, false);
+
       skipDiv = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
       skipDiv->setEndInternalControlFlow();
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, skipDiv);
@@ -1820,7 +1823,7 @@ genericIntShift(TR::Node * node, TR::CodeGenerator * cg, TR::InstOpCode::Mnemoni
           node->getFirstChild()->getRegister() == NULL)
          {
          srcReg = node->getFirstChild()->setRegister(cg->allocateRegister());
-         genLoadConstant(cg, node->getFirstChild(), node->getFirstChild()->getByte() & 0xFF, srcReg);
+         generateLoad32BitConstant(cg, node->getFirstChild(), node->getFirstChild()->getByte() & 0xFF, srcReg, true);
          }
       else
          {
@@ -4033,7 +4036,7 @@ OMR::Z::TreeEvaluator::idivEvaluator(TR::Node * node, TR::CodeGenerator * cg)
             {
             useTmp = true;
             tmpReg = cg->allocateRegister();
-            genLoadConstant(cg, secondChild, value, tmpReg);
+            generateLoad32BitConstant(cg, secondChild, value, tmpReg, true);
             }
          else
             {
@@ -4191,7 +4194,7 @@ OMR::Z::TreeEvaluator::iremEvaluator(TR::Node * node, TR::CodeGenerator * cg)
          bool absDividendRegIsTemp = false;
          TR::RegisterDependencyConditions *deps = NULL;
 
-         genLoadConstant(cg, secondChild, value, tmpReg);
+         generateLoad32BitConstant(cg, secondChild, value, tmpReg, true);
 
          if (node->getOpCode().isUnsigned())
             generateRSInstruction(cg, TR::InstOpCode::SRDL, node, targetRegisterPair, 32);

--- a/compiler/z/codegen/OpMemToMem.cpp
+++ b/compiler/z/codegen/OpMemToMem.cpp
@@ -26,7 +26,7 @@
 #include "codegen/RealRegister.hpp"                // for RealRegister, etc
 #include "codegen/Register.hpp"                    // for Register
 #include "codegen/RegisterDependency.hpp"
-#include "codegen/TreeEvaluator.hpp"               // for genLoadConstant, etc
+#include "codegen/TreeEvaluator.hpp"               // for generateLoad32BitConstant, etc
 #include "codegen/S390Evaluator.hpp"
 #include "compile/SymbolReferenceTable.hpp"
 #include "control/Options.hpp"
@@ -373,7 +373,7 @@ MemToMemConstLenMacroOp::generateLoop()
 
       TR::Node *targetAddress = _dstNode;
       TR::Register *targetOddRegister = _cg->allocateRegister();
-      genLoadConstant(_cg, _rootNode, len, targetOddRegister);
+      generateLoad32BitConstant(_cg, _rootNode, len, targetOddRegister, true);
 
       if (_srcReg == NULL)
          genSrcLoadAddress(0, NULL);
@@ -381,7 +381,7 @@ MemToMemConstLenMacroOp::generateLoop()
 
       TR::Node *sourceAddress = _srcNode;
       TR::Register *sourceOddRegister = _cg->allocateRegister();
-      genLoadConstant(_cg, _rootNode, len, sourceOddRegister);
+      generateLoad32BitConstant(_cg, _rootNode, len, sourceOddRegister, true);
 
       TR::RegisterPair * sourcePairRegister = _cg->allocateConsecutiveRegisterPair(sourceOddRegister,sourceEvenRegister);
       TR::RegisterPair * targetPairRegister = _cg->allocateConsecutiveRegisterPair(targetOddRegister,targetEvenRegister);
@@ -425,7 +425,7 @@ MemToMemConstLenMacroOp::generateLoop()
    if (TR::Compiler->target.is64Bit())
       cursor = genLoadLongConstant(_cg, _rootNode, largeCopies, _itersReg, cursor, NULL, NULL);
    else
-      cursor = genLoadConstant(_cg, _rootNode, largeCopies, _itersReg, cursor, NULL, NULL);
+      cursor = generateLoad32BitConstant(_cg, _rootNode, largeCopies, _itersReg, true, cursor, NULL, NULL);
 
    _startControlFlow = cursor = generateS390LabelInstruction(_cg, TR::InstOpCode::LABEL, _rootNode, topOfLoop, cursor);
 
@@ -550,7 +550,7 @@ MemInitConstLenMacroOp::generateLoop()
    if (TR::Compiler->target.is64Bit())
       cursor = genLoadLongConstant(_cg, _rootNode, largeCopies, _itersReg, cursor, NULL, NULL);
    else
-      cursor = genLoadConstant(_cg, _rootNode, largeCopies, _itersReg, cursor, NULL, NULL);
+      cursor = generateLoad32BitConstant(_cg, _rootNode, largeCopies, _itersReg, true, cursor, NULL, NULL);
 
    _startControlFlow = cursor = generateS390LabelInstruction(_cg, TR::InstOpCode::LABEL, _rootNode, topOfLoop, cursor);
 

--- a/compiler/z/codegen/S390Evaluator.hpp
+++ b/compiler/z/codegen/S390Evaluator.hpp
@@ -88,7 +88,39 @@ TR::Instruction* generateS390ImmToRegister(TR::CodeGenerator * cg,
                 intptr_t value,
                 TR::Instruction * cursor);
 
-TR::Instruction * genLoadConstant(TR::CodeGenerator *cg, TR::Node *node, int32_t value, TR::Register *targetRegister, TR::Instruction *cursor=NULL, TR::RegisterDependencyConditions *cond = 0, TR::Register *base = 0);
+/** \brief
+ *     Generates instructions to materialize (load) a 32-bit constant value into a virtual register.
+ *
+ *  \param cg
+ *     The code generator used to generate the instructions.
+ *
+ *  \param node
+ *     The node to which the generated instructions will be associated with.
+ *
+ *  \param value
+ *     The value to load into \p targetRegister.
+ *
+ *  \param targetRegister
+ *     The virtual register into which to load the \p value.
+ *
+ *  \param canSetConditionCode
+ *     Determines whether the generated instructions are allowed set any condition code.
+ *
+ *  \param cursor
+ *     The cursor instruction to append all generated instructions to.
+ *
+ *  \param dependencies
+ *     The register dependency conditions to which newly allocated registers will be added to if they are needed. All new
+ *     allocated registers will be appended as post conditions to \p cond with an AssignAny condition.
+ *
+ *  \param literalPoolRegister
+ *     The literal pool register to use if the constant \p value needs to be stored in a literal pool entry.
+ *
+ *  \return
+ *     The pointer to the last generated instruction to load the supplied \p value.
+ */
+TR::Instruction* generateLoad32BitConstant(TR::CodeGenerator* cg, TR::Node* node, int32_t value, TR::Register* targetRegister, bool canSetConditionCode, TR::Instruction* cursor = NULL, TR::RegisterDependencyConditions* dependencies = NULL, TR::Register* literalPoolRegister = NULL);
+
 TR::Instruction * genLoadLongConstant(TR::CodeGenerator *cg, TR::Node *node, int64_t value, TR::Register *targetRegister, TR::Instruction *cursor=NULL,TR::RegisterDependencyConditions *cond = 0, TR::Register *base = 0);
 TR::Instruction * genLoadAddressConstant(TR::CodeGenerator *cg, TR::Node *node, uintptrj_t value, TR::Register *targetRegister, TR::Instruction *cursor=NULL,TR::RegisterDependencyConditions *cond = 0, TR::Register *base = 0);
 TR::Instruction * genLoadAddressConstantInSnippet(TR::CodeGenerator *cg, TR::Node *node, uintptrj_t value, TR::Register *targetRegister, TR::Instruction *cursor=NULL,TR::RegisterDependencyConditions *cond = 0, TR::Register *base = 0, bool isPICCandidate=false);

--- a/compiler/z/codegen/UnaryEvaluator.cpp
+++ b/compiler/z/codegen/UnaryEvaluator.cpp
@@ -85,8 +85,8 @@ lconstHelper(TR::Node * node, TR::CodeGenerator * cg)
    int32_t highValue = node->getLongIntHigh();
    int32_t lowValue = node->getLongIntLow();
 
-   genLoadConstant(cg, node, lowValue, lowRegister);
-   genLoadConstant(cg, node, highValue, highRegister);
+   generateLoad32BitConstant(cg, node, lowValue, lowRegister, true);
+   generateLoad32BitConstant(cg, node, highValue, highRegister, true);
 
    return longRegister;
    }
@@ -116,14 +116,14 @@ lconstHelper64(TR::Node * node, TR::CodeGenerator * cg)
 
 /**
  * iconst Evaluator: load integer constant (32-bit signed 2's complement)
- * @see genLoadConstant
+ * @see generateLoad32BitConstant
  */
 TR::Register *
 OMR::Z::TreeEvaluator::iconstEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("iconst", node, cg);
    TR::Register * tempReg = node->setRegister(cg->allocateRegister());
-   genLoadConstant(cg, node, node->getInt(), tempReg);
+   generateLoad32BitConstant(cg, node, node->getInt(), tempReg, true);
    return tempReg;
    }
 
@@ -169,12 +169,12 @@ OMR::Z::TreeEvaluator::bconstEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("bconst", node, cg);
    TR::Register * tempReg = node->setRegister(cg->allocateRegister());
-   if (node->getOpCodeValue() == TR::buconst || node->isUnsignedLoad()) // PLX only supports unsigned 8 bit integer
-      genLoadConstant(cg, node, node->getByte() & 0xFF , tempReg);
+   if (node->getOpCodeValue() == TR::buconst || node->isUnsignedLoad())
+      generateLoad32BitConstant(cg, node, node->getByte() & 0xFF, tempReg, true);
    else
       {
       TR_ASSERT(1, "Should not have bconst node in the final il-tree!\n");
-      genLoadConstant(cg, node, node->getByte(), tempReg);
+      generateLoad32BitConstant(cg, node, node->getByte(), tempReg, true);
       }
    return tempReg;
    }
@@ -188,7 +188,7 @@ OMR::Z::TreeEvaluator::sconstEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    PRINT_ME("sconst", node, cg);
    TR::Register * tempReg = node->setRegister(cg->allocateRegister());
    int32_t value = (node->isUnsigned() || node->isUnsignedLoad()) ? node->getConst<uint16_t>() : node->getShortInt();
-   genLoadConstant(cg, node, value, tempReg);
+   generateLoad32BitConstant(cg, node, value, tempReg, true);
    return tempReg;
    }
 
@@ -200,7 +200,7 @@ OMR::Z::TreeEvaluator::cconstEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("cconst", node, cg);
    TR::Register * tempReg = node->setRegister(cg->allocateRegister());
-   genLoadConstant(cg, node, node->getConst<uint16_t>(), tempReg);
+   generateLoad32BitConstant(cg, node, node->getConst<uint16_t>(), tempReg, true);
    return tempReg;
    }
 


### PR DESCRIPTION
When loading the immediate value 0 into a 32-bit virtual register prefer
to generate an XR instruction rather than an LHI instruction to save 2
bytes of icache at no cost to latency.

Issue: #212
Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>