### PR TITLE
Remove duplicate exception definition

### DIFF
--- a/compiler/compile/CompilationException.hpp
+++ b/compiler/compile/CompilationException.hpp
@@ -71,22 +71,6 @@ struct InsufficientlyAggressiveCompilation : public virtual CompilationException
    virtual const char* what() const throw() { return "Insufficiently Aggressive Compilation"; }
    };
 
-// For:
-//    COMPILATION_NULL_SUBSTITUTE_CODE_CACHE
-//    COMPILATION_CODE_MEMORY_EXHAUSTED
-struct CodeCacheError : public virtual CompilationException
-   {
-   virtual const char* what() const throw() { return "Code Cache Error"; }
-   };
-
-// For:
-//    COMPILATION_ALL_CODE_CACHES_RESERVED
-//    COMPILATION_ILLEGAL_CODE_CACHE_SWITCH
-struct RecoverableCodeCacheError : public virtual CodeCacheError
-   {
-   virtual const char* what() const throw() { return "Recoverable Code Cache Error"; }
-   };
-
 // For COMPILATION_GCRPATCH_FAILURE
 struct GCRPatchFailure : public virtual CompilationException
    {

--- a/compiler/runtime/CodeCacheExceptions.hpp
+++ b/compiler/runtime/CodeCacheExceptions.hpp
@@ -24,6 +24,8 @@
 #include <exception>
 #include <new>
 
+namespace TR {
+
 // For:
 //    COMPILATION_NULL_SUBSTITUTE_CODE_CACHE
 //    COMPILATION_CODE_MEMORY_EXHAUSTED
@@ -39,5 +41,7 @@ struct RecoverableCodeCacheError : public virtual std::bad_alloc
    {
    virtual const char* what() const throw() { return "Recoverable Code Cache Error"; }
    };
+
+}
 
 #endif // CODECACHEEXCEPTIONS_HPP


### PR DESCRIPTION
TR::CodeCacheError and TR::RecoverableCodeCacheError exist in their
own file (CodeCacheExceptions.hpp) and inherit from std::bad_alloc. As
such, the old definition, namely inheriting from TR::CompilationException,
should be removed.

Signed-off-by: Irwin D'Souza <dsouzai@ca.ibm.com>