### PR TITLE
Issue #218 Flush buffers in Concurrent tracing.

### DIFF
--- a/gc/base/standard/ConcurrentGC.cpp
+++ b/gc/base/standard/ConcurrentGC.cpp
@@ -3422,6 +3422,7 @@ MM_ConcurrentGC::completeTracing(MM_EnvironmentStandard *env)
 	/* ..and amount traced */
 	_stats->incCompleteTracingCount(bytesTraced);
 
+	flushLocalBuffers(env);
 }
 
 


### PR DESCRIPTION
Flush thread local buffers at the end of Concurrent tracing task.
Each task should  do it, since we can dynamically change (reduce) number
of active threads, and cannot rely that some other task (within same
cycle) will do it. Other tasks within concurrent marking do it already.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>