### PR TITLE
Fix optimization names to match optimization enum

### DIFF
--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -902,12 +902,16 @@ OMR::Optimizer::Optimizer(TR::Compilation *comp, TR::ResolvedMethodSymbol *metho
 
 }
 
+// Note: optimizer_name array needs to match Optimizations enum defined
+// in compiler/optimizer/Optimizations.hpp
 static const char * optimizer_name[] =
    {
    #define OPTIMIZATION(name) #name,
    #define OPTIMIZATION_ENUM_ONLY(entry) "****",
       #include "optimizer/Optimizations.enum"
+      OPTIMIZATION_ENUM_ONLY(numOpts)
       #include "optimizer/OptimizationGroups.enum"
+      OPTIMIZATION_ENUM_ONLY(numGroups)
    #undef OPTIMIZATION
    #undef OPTIMIZATION_ENUM_ONLY
     };

--- a/compiler/optimizer/Optimizations.hpp
+++ b/compiler/optimizer/Optimizations.hpp
@@ -21,14 +21,16 @@
 
 namespace OMR
    {
+      // Note: Optimizations enum needs to match optimizer_name array
+      // defined in compiler/optimizer/OMROptimizer.cpp
       enum Optimizations
       {
       #define OPTIMIZATION(name) name,
       #define OPTIMIZATION_ENUM_ONLY(entry) entry,
       #include "optimizer/Optimizations.enum"
-      numOpts,
+      OPTIMIZATION_ENUM_ONLY(numOpts)  // after all project-specific optimization enums
       #include "optimizer/OptimizationGroups.enum"
-      numGroups
+      OPTIMIZATION_ENUM_ONLY(numGroups)  // after all project-specific optimization group enums
       #undef OPTIMIZATION
       #undef OPTIMIZATION_ENUM_ONLY
       };


### PR DESCRIPTION
Fix crash on Z when running with hot+ strategy and logging is 
turned on due to mismatch between optimization names array 
and optimization enum.

Signed-off-by: Xiaoli Liang <xsliang@ca.ibm.com>