### PR TITLE
Fix scratch register manager for Z platform

### DIFF
--- a/compiler/z/codegen/OMRRegisterDependency.hpp
+++ b/compiler/z/codegen/OMRRegisterDependency.hpp
@@ -320,7 +320,7 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
 
    void unionNoRegPostCondition(TR::Register *reg, TR::CodeGenerator *cg)
       {
-      TR_ASSERT(0, "unionNoRegPostCondition not implemented");
+      addPostCondition(reg, TR::RealRegister::AssignAny);
       }
 
    uint32_t getNumPreConditions() {return _numPreConditions;}


### PR DESCRIPTION
We use scratch register manager in our internal control flow which
handles allocating temporary virtual registers and adding them to dependency list.

This helper was broken due to unimplemented function unionNoRegPostConditions
which should add registers allocated through scratch register manager by adding
each to post dependency list.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>