### PR TITLE
Add the Test compiler to the main makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_script:
 # apport is available in apt whitelist
 
 env:
-  - SPEC=osx_x86-64
+  - SPEC=osx_x86-64 EXTRA_CONFIGURE_ARGS="--disable-OMR_JIT"
   - SPEC=linux_x86-64
   - SPEC=linux_x86-64_cmprssptrs
   - SPEC=linux_x86
@@ -52,7 +52,7 @@ env:
 matrix:
   exclude:
     - os: linux
-      env: SPEC=osx_x86-64
+      env: SPEC=osx_x86-64 EXTRA_CONFIGURE_ARGS="--disable-OMR_JIT"
     - os: osx
       env: SPEC=linux_x86-64
     - os: osx

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -149,6 +149,11 @@ endif
 # VM Tests
 test_targets += fvtest/vmtest
 
+# OMR JIT
+ifeq (1,$(OMR_JIT))
+test_targets += fvtest/compilertest
+endif
+
 DO_TEST_TARGET := yes
 # ENABLE_FVTEST_AGENT forces rastest to build, even if fvtests are disabled.
 ifeq (no,$(ENABLE_FVTEST))

--- a/configure
+++ b/configure
@@ -774,6 +774,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -933,6 +934,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1185,6 +1187,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1322,7 +1333,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1475,6 +1486,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -1529,7 +1541,7 @@ Optional Features:
                           are not explicitly enabled or disabled. (Default:
                           yes)
   --disable-OMR_GC        Enable building the OMR GC. (Default: yes)
-  --enable-OMR_JIT        Enable building the OMR JIT. (Default: no)
+  --disable-OMR_JIT       Enable building the OMR JIT. (Default: yes)
   --disable-OMR_PORT      Enable building the Port library. (Default: yes)
   --disable-OMR_THREAD    Enable building the Thread library. (Default: yes)
   --disable-OMR_OMRSIG    Enable building the OMRSig library. (Default: yes)
@@ -5241,9 +5253,15 @@ else
 fi
 else
 
-	OMR_JIT="#undef OMR_JIT"
+	if test "x" = "x"; then :
+  OMR_JIT="#define OMR_JIT"
 
-	echo "OMR_JIT := 0" >> omrmakefiles/omrcfg.mk
+else
+  OMR_JIT="#define OMR_JIT "
+
+
+fi
+	echo "OMR_JIT := 1" >> omrmakefiles/omrcfg.mk
 
 
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -357,7 +357,7 @@ echo "" >> omrmakefiles/omrcfg.mk
 
 ############### Top-Level Components
 OMRCFG_DEFINE_FLAG_ON([OMR_GC], [], [Enable building the OMR GC. (Default: yes)])
-OMRCFG_DEFINE_FLAG_OFF([OMR_JIT], [], [Enable building the OMR JIT. (Default: no)])
+OMRCFG_DEFINE_FLAG_ON([OMR_JIT], [], [Enable building the OMR JIT. (Default: yes)])
 OMRCFG_DEFINE_FLAG_ON([OMR_PORT], [], [Enable building the Port library. (Default: yes)])
 OMRCFG_DEFINE_FLAG_ON([OMR_THREAD], [], [Enable building the Thread library. (Default: yes)])
 OMRCFG_DEFINE_FLAG_ON([OMR_OMRSIG], [], [Enable building the OMRSig library. (Default: yes)])

--- a/example/glue/configure_includes/configure_common.mk
+++ b/example/glue/configure_includes/configure_common.mk
@@ -19,6 +19,7 @@
 CONFIGURE_ARGS += \
   --enable-OMR_EXAMPLE \
   --enable-OMR_GC \
+  --enable-OMR_JIT \
   --enable-OMR_PORT \
   --enable-OMR_THREAD \
   --enable-OMR_OMRSIG \


### PR DESCRIPTION
Enable building the JIT by default.

If you have both the JIT and tests enabled, the Test compiler will be built by running `make`. Running `make test` will run the tests for the Test compiler.

As a consequence, Travis CI now builds the Test compiler and runs the relevant tests.

The Test compiler does not currently build on OS X, so it has been disabled in Travis CI.