### PR TITLE
Remove obsolete preprocessor definitions

### DIFF
--- a/compiler/z/codegen/BinaryEvaluator.cpp
+++ b/compiler/z/codegen/BinaryEvaluator.cpp
@@ -77,10 +77,6 @@ extern void PRINT_ME(char * string, TR::Node * node, TR::CodeGenerator * cg);
 #define PRINT_ME(string,node,cg)
 #endif
 
-#if 1
-#define SPECIALDIVCASES
-#endif
-
 #define ENABLE_ZARCH_FOR_32    1
 
 /**
@@ -803,7 +799,6 @@ lDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
 
    TR::RegisterPair * dividendPair = (TR::RegisterPair *) cg->gprClobberEvaluate(firstChild);
 
-#ifdef SPECIALDIVCASES
    int32_t shiftAmnt;
    //case: A/A Q=1, R=0
    if (secondChild == firstChild)
@@ -977,7 +972,6 @@ lDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
          return dividendPair;
          }
       }
-#endif
 
    if (performTransformation(comp, "O^O Using 64bit ldiv on 32bit driver.\n"))
       {

--- a/compiler/z/codegen/OpMemToMem.cpp
+++ b/compiler/z/codegen/OpMemToMem.cpp
@@ -1521,15 +1521,6 @@ generateCmpResult(TR::CodeGenerator * cg, TR::Node * rootNode, TR::Register * ds
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, rootNode, trueLabel);
    getConditionCode(rootNode, cg, resultReg);
 
-#ifdef false
-   generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNERC, rootNode, falseLabel);
-   generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, rootNode, trueLabel);
-   generateRIInstruction(cg, TR::InstOpCode::getLoadHalfWordImmOpCode(), rootNode, resultReg, 1);
-   generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, rootNode, doneLabel);
-   generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, rootNode, falseLabel);
-   generateRRInstruction(cg, TR::InstOpCode::getXORRegOpCode(), rootNode, resultReg, resultReg);
-#endif
-
    TR::Instruction * cursor;
    cursor = generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, rootNode, doneLabel);
 

--- a/compiler/z/codegen/S390Debug.cpp
+++ b/compiler/z/codegen/S390Debug.cpp
@@ -182,11 +182,10 @@ TR_Debug::printz(TR::FILE *pOutFile, TR::Instruction * instr)
       return;
       }
 
-#ifndef DESIGN_RATRACE
    //  dump the inst's pre deps
    if (instr->getOpCodeValue() != TR::InstOpCode::ASSOCREGS && _comp->cg()->getCodeGeneratorPhase() <= TR::CodeGenPhase::BinaryEncodingPhase)
       dumpDependencies(pOutFile, instr, true, false);
-#endif
+
    switch (instr->getKind())
       {
       case TR::Instruction::IsLabel:
@@ -383,15 +382,11 @@ TR_Debug::printz(TR::FILE *pOutFile, TR::Instruction * instr)
             }
          }
       }
-#ifdef DESIGN_RATRACE
-   //  dump pre and post register dependencies after the instruction itself
-   if (instr->getOpCodeValue() != TR::InstOpCode::ASSOCREGS && _comp->cg()->getCodeGeneratorPhase() <= TR::CodeGenPhase::BinaryEncodingPhase)
-      dumpDependencies(pOutFile, instr, true, true);
-#else
+
    //  dump the inst's post deps
    if (instr->getOpCodeValue() != TR::InstOpCode::ASSOCREGS && _comp->cg()->getCodeGeneratorPhase() <= TR::CodeGenPhase::BinaryEncodingPhase)
       dumpDependencies(pOutFile, instr, false, true);
-#endif
+
    if(instr->isStartInternalControlFlow())
       {
       trfprintf(pOutFile, "\t# (Start of internal control flow)");
@@ -464,11 +459,7 @@ TR_Debug::dumpDependencies(TR::FILE *pOutFile, TR::Instruction * instr, bool pre
 
    if (pOutFile == NULL || !deps || _comp->getOption(TR_DisableTraceRegDeps))
       return;
-#ifdef DESIGN_RATRACE
-   if (_registerAssignmentTraceFlags & TRACERA_IN_PROGRESS  &&
-       !_comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRADependencies))
-      return;
-#endif
+
    if (pre)
       {
       if (deps->getNumPreConditions() > 0)


### PR DESCRIPTION
Clean up unused or obsolete preprocessor definitions for improved code
clarity.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>