### PR TITLE
Remove unused TR_FrontEnd functions

### DIFF
--- a/compiler/codegen/FrontEnd.cpp
+++ b/compiler/codegen/FrontEnd.cpp
@@ -169,17 +169,8 @@ uintptrj_t TR_FrontEnd::getObjectHeaderSizeInBytes()              { notImplement
 uintptrj_t TR_FrontEnd::getOffsetOfContiguousArraySizeField()     { notImplemented("getOffsetOfContiguousArraySizeField"); return 0; }
 uintptrj_t TR_FrontEnd::getOffsetOfDiscontiguousArraySizeField()  { notImplemented("getOffsetOfDiscontiguousArraySizeField"); return 0; }
 
-uintptrj_t TR_FrontEnd::getOffsetOfIsArrayFieldFromRomClass()     { notImplemented("getOffsetOfIsArrayFieldFromRomClass"); return 0; }
-uintptrj_t TR_FrontEnd::getOffsetOfArrayComponentTypeField()      { notImplemented("getOffsetOfArrayComponentTypeField"); return 0; }
 uintptrj_t TR_FrontEnd::getOffsetOfIndexableSizeField()           { notImplemented("getOffsetOfIndexableSizeField"); return 0; }
 
-
-int32_t
-TR_FrontEnd::getLocalObjectAlignmentInBytes()
-   {
-   notImplemented("getLocalObjectAlignmentInBytes");
-   return 0;
-   }
 
 int32_t
 TR_FrontEnd::getObjectAlignmentInBytes()
@@ -387,18 +378,6 @@ TR_FrontEnd::getClassClassPointer(TR_OpaqueClassBlock *objectClassPointer)
    return 0;
    }
 
-
-void
-TR_FrontEnd::initializeLocalObjectHeader(TR::Compilation *, TR::Node *allocationNode, TR::TreeTop *allocationTreeTop)
-   {
-   notImplemented("initializeLocalObjectHeader");
-   }
-
-void
-TR_FrontEnd::initializeLocalArrayHeader(TR::Compilation *, TR::Node *allocationNode, TR::TreeTop *allocaitonTreeTop)
-   {
-   notImplemented("initializeLocalArrayHeader");
-   }
 
 TR::CodeCache *
 TR_FrontEnd::getDesignatedCodeCache(TR::Compilation *comp)

--- a/compiler/codegen/FrontEnd.hpp
+++ b/compiler/codegen/FrontEnd.hpp
@@ -186,12 +186,7 @@ public:
    virtual uintptrj_t getOffsetOfContiguousArraySizeField(); // DM: move w/ ifdef
    virtual uintptrj_t getOffsetOfDiscontiguousArraySizeField(); // DM: move w/ ifdef
    virtual uintptrj_t getObjectHeaderSizeInBytes();
-   virtual uintptrj_t getOffsetOfArrayComponentTypeField(); // DM: move w/ ifdef
    virtual uintptrj_t getOffsetOfIndexableSizeField(); // DM: move w/ ifdef
-   virtual uintptrj_t getOffsetOfIsArrayFieldFromRomClass();
-   virtual void initializeLocalObjectHeader(TR::Compilation *, TR::Node *allocationNode, TR::TreeTop *allocationTreeTop);
-   virtual void initializeLocalArrayHeader (TR::Compilation *, TR::Node *allocationNode, TR::TreeTop *allocaitonTreeTop);
-   virtual int32_t getLocalObjectAlignmentInBytes();
 
    // --------------------------------------------------------------------------
    // J9 Classes / VM?

--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -297,20 +297,6 @@ OMR::SymbolReferenceTable::findAddressOfClassOfMethodSymbolRef()
    return element(addressOfClassOfMethodSymbol);
    }
 
-
-TR::SymbolReference *
-OMR::SymbolReferenceTable::findOrCreateClassIsArraySymbolRef()
-   {
-   if (!element(isArraySymbol))
-      {
-      TR::Symbol * sym = TR::Symbol::createShadow(trHeapMemory(), TR::Int32);
-      element(isArraySymbol) = new (trHeapMemory()) TR::SymbolReference(self(), isArraySymbol, sym);
-      element(isArraySymbol)->setOffset(fe()->getOffsetOfIsArrayFieldFromRomClass());
-      }
-   return element(isArraySymbol);
-   }
-
-
 TR::SymbolReference *
 OMR::SymbolReferenceTable::findClassIsArraySymbolRef()
    {
@@ -331,26 +317,12 @@ OMR::SymbolReferenceTable::findClassFlagsSymbolRef()
    return element(isClassFlagsSymbol);
    }
 
-TR::SymbolReference *
-OMR::SymbolReferenceTable::findOrCreateArrayComponentTypeSymbolRef()
-   {
-   if (!element(componentClassSymbol))
-      {
-      TR::Symbol * sym = TR::Symbol::createShadow(trHeapMemory(), TR::Address);
-      element(componentClassSymbol) = new (trHeapMemory()) TR::SymbolReference(self(), componentClassSymbol, sym);
-      element(componentClassSymbol)->setOffset(fe()->getOffsetOfArrayComponentTypeField());
-      if (!TR::Compiler->cls.classObjectsMayBeCollected())
-         sym->setNotCollected();
-      }
-   return element(componentClassSymbol);
-   }
 
 TR::SymbolReference *
 OMR::SymbolReferenceTable::findArrayComponentTypeSymbolRef()
    {
    return element(componentClassSymbol);
    }
-
 
 
 TR::SymbolReference *

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -285,7 +285,6 @@ class SymbolReferenceTable
 
    TR::SymbolReference * findOrCreateMethodSymbol(mcount_t owningMethodIndex, int32_t cpIndex, TR_ResolvedMethod *, TR::MethodSymbol::Kinds, bool = false);
    TR::SymbolReference * findJavaLangClassFromClassSymbolRef();
-   TR::SymbolReference * findOrCreateClassIsArraySymbolRef();
 
    // FE, CG, optimizer
    TR::SymbolReference * findOrCreateNullCheckSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);
@@ -327,7 +326,6 @@ class SymbolReferenceTable
    TR::SymbolReference * findOrCreateSymRefWithKnownObject(TR::SymbolReference *original, TR::KnownObjectTable::Index objectIndex);
    TR::SymbolReference * findOrCreateThisRangeExtensionSymRef(TR::ResolvedMethodSymbol *owningMethodSymbol = 0);
    TR::SymbolReference * findOrCreateContiguousArraySizeSymbolRef();
-   TR::SymbolReference * findOrCreateArrayComponentTypeSymbolRef();
    TR::SymbolReference * findOrCreateNewArrayNoZeroInitSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);
    TR::SymbolReference * findOrCreateNewObjectSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);
    TR::SymbolReference * findOrCreateNewObjectNoZeroInitSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);

--- a/compiler/optimizer/ValuePropagation.cpp
+++ b/compiler/optimizer/ValuePropagation.cpp
@@ -7680,8 +7680,7 @@ void TR_ValuePropagation::doDelayedTransformations()
       }
    _convertedGuards.setFirst(0);
 
-
-
+#ifdef J9_PROJECT_SPECIFIC
    ListIterator<TR::Node> nodesIt(&_javaLangClassGetComponentTypeCalls);
    TR::Node *getComponentCallNode;
    for (getComponentCallNode = nodesIt.getFirst();
@@ -7699,6 +7698,7 @@ void TR_ValuePropagation::doDelayedTransformations()
          }
       }
    _javaLangClassGetComponentTypeCalls.deleteAll();
+#endif
 
    // Process throws that can be turned into gotos
    //


### PR DESCRIPTION
* getLocalObjectAlignmentInBytes()
* initializeLocalArrayHeader()
* initializeLocalObjectHeader()
* getOffsetOfIsArrayFieldFromRomClass()
* getOffsetOfArrayComponentTypeField()

In support of that removal:

* Remove unneeded findOrCreateClassIsArraySymbolRef() from
OMR::SymbolReferenceTable
* isolate J9-specific code in ValuePropagation.cpp in preparation for
refactoring

Signed-off-by: Daryl Maier <maier@ca.ibm.com>