### PR TITLE
Build and test JITBuilder in the main makefile 

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -152,6 +152,8 @@ test_targets += fvtest/vmtest
 # OMR JIT
 ifeq (1,$(OMR_JIT))
 test_targets += fvtest/compilertest
+main_targets += jitbuilder
+test_targets += jitbuilder/release
 endif
 
 DO_TEST_TARGET := yes

--- a/fvtest/omrtest.mk
+++ b/fvtest/omrtest.mk
@@ -44,6 +44,9 @@ omr_algotest:
 omr_gctest:
 	./omrgctest -configListFile=fvtest/gctest/configuration/fvConfigListFile.txt
 
+omr_jitbuildertest:
+	make -C jitbuilder/release test
+
 omr_jittest:
 	./testjit
 	
@@ -89,7 +92,7 @@ ifeq (1,$(OMR_EXAMPLE))
 test: omr_vmtest omr_gctest omr_rastest omr_subscriberforktest
 endif
 ifeq (1,$(OMR_JIT))
-test: omr_jittest
+test: omr_jittest omr_jitbuildertest
 endif
 ifeq (1,$(OMR_PORT))
 test: omr_porttest

--- a/jitbuilder/release/Makefile
+++ b/jitbuilder/release/Makefile
@@ -24,6 +24,21 @@ CXXFLAGS=-g -std=c++0x -O2 -c -fno-rtti -fPIC -I./include/compiler -I./include
 
 goal: call dotproduct iterfib linkedlist localarray mandelbrot nestedloop pointer recfib simple switch pow2
 
+all: goal
+
+test: goal
+	./call
+	./dotproduct
+	./iterfib
+	./linkedlist
+	./localarray
+	./nestedloop
+	./pointer
+	./recfib
+	./simple
+	./switch
+	./pow2
+
 call : libjitbuilder.a Call.o
 	g++ -g -fno-rtti -o $@ Call.o -L. -ljitbuilder -ldl
 


### PR DESCRIPTION
If the OMR_JIT build option is enabled, build JITBuilder. If tests are also enabled, the tests are also built and run via `make test`.

As a consequence, Travis CI now builds and tests JITBuilder.