### PR TITLE
Rename Test namespace to TestCompiler

### DIFF
--- a/compiler/README.md
+++ b/compiler/README.md
@@ -67,7 +67,7 @@ doc/compiler | Additional documentation
 
 ## Namespaces
 
-The `OMR::`, `Test::`, and `JitBuilder::` namespaces are used to isolate compiler technology for those particular environments.  Processor architecture specialized namespaces (e.g., `X86::`, `Power::`, `Z::`, and `ARM::`) can be nested within them.  If you extend the Eclipse OMR technology you should choose a unique namespace for your project.
+The `OMR::`, `TestCompiler::`, and `JitBuilder::` namespaces are used to isolate compiler technology for those particular environments.  Processor architecture specialized namespaces (e.g., `X86::`, `Power::`, `Z::`, and `ARM::`) can be nested within them.  If you extend the Eclipse OMR technology you should choose a unique namespace for your project.
 
 In general, the `TR::` namespace (short for Testarossa) is the canonical namespace for all of the compiler technology that is visible across multiple projects.
 

--- a/fvtest/compilertest/codegen/CodeGenerator.hpp
+++ b/fvtest/compilertest/codegen/CodeGenerator.hpp
@@ -23,12 +23,12 @@
 
 namespace TR
 {
-class OMR_EXTENSIBLE CodeGenerator : public ::Test::CodeGeneratorConnector
+class OMR_EXTENSIBLE CodeGenerator : public ::TestCompiler::CodeGeneratorConnector
    {
    public:
 
    CodeGenerator() :
-      ::Test::CodeGeneratorConnector() {}
+      ::TestCompiler::CodeGeneratorConnector() {}
    };
 }
 

--- a/fvtest/compilertest/codegen/TestCodeGenerator.hpp
+++ b/fvtest/compilertest/codegen/TestCodeGenerator.hpp
@@ -24,14 +24,14 @@
  */
 #ifndef TEST_CODEGENERATORBASE_CONNECTOR
 #define TEST_CODEGENERATORBASE_CONNECTOR
-namespace Test { class CodeGenerator; }
-namespace Test { typedef CodeGenerator CodeGeneratorConnector; }
+namespace TestCompiler { class CodeGenerator; }
+namespace TestCompiler { typedef CodeGenerator CodeGeneratorConnector; }
 #endif
 
 
 #include "codegen/OMRCodeGenerator.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 
 class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGeneratorConnector

--- a/fvtest/compilertest/compile/Method.cpp
+++ b/fvtest/compilertest/compile/Method.cpp
@@ -27,7 +27,7 @@
 #include "ilgen/MethodBuilder.hpp"
 #include "ilgen/IlGeneratorMethodDetails_inlines.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 
 // needs major overhaul
@@ -189,4 +189,4 @@ ResolvedMethod::returnType()
    {
    return _returnType->getPrimitiveType();
    }
-} // namespace Test
+} // namespace TestCompiler

--- a/fvtest/compilertest/compile/Method.hpp
+++ b/fvtest/compilertest/compile/Method.hpp
@@ -40,7 +40,7 @@ namespace TR { class FrontEnd; }
 // quick and dirty implementation to get up and running
 // needs major overhaul
 
-namespace Test
+namespace TestCompiler
 {
 
 class Method : public TR_Method
@@ -181,17 +181,17 @@ class ResolvedMethod : public ResolvedMethodBase, public Method
    };
 
 
-} // namespace Test
+} // namespace TestCompiler
 
 #if defined(PUT_TEST_RESOLVEDMETHOD_INTO_TR)
 
 namespace TR
 {
-   class ResolvedMethod : public Test::ResolvedMethod
+   class ResolvedMethod : public TestCompiler::ResolvedMethod
       {
       public:
          ResolvedMethod(TR_OpaqueMethodBlock *method)
-            : Test::ResolvedMethod(method)
+            : TestCompiler::ResolvedMethod(method)
             { }
 
          ResolvedMethod(char            * fileName,
@@ -202,13 +202,13 @@ namespace TR
                         TR::IlType      * returnType,
                         void            * entryPoint,
                         TR::IlInjector  * ilInjector)
-            : Test::ResolvedMethod(fileName, lineNumber, name, numArgs,
+            : TestCompiler::ResolvedMethod(fileName, lineNumber, name, numArgs,
                                    parmTypes, returnType,
                                    entryPoint, ilInjector)
             { }
 
          ResolvedMethod(TR::MethodBuilder *methodBuilder)
-            : Test::ResolvedMethod(methodBuilder)
+            : TestCompiler::ResolvedMethod(methodBuilder)
             { }
       };
 } // namespace TR

--- a/fvtest/compilertest/control/TestJit.cpp
+++ b/fvtest/compilertest/control/TestJit.cpp
@@ -53,7 +53,7 @@ initHelper(void *helper, TR_RuntimeHelper id)
    }
 
 static void
-initializeAllHelpers(Test::JitConfig *jitConfig, TR_RuntimeHelper *helperIDs, void **helperAddresses, int32_t numHelpers)
+initializeAllHelpers(TestCompiler::JitConfig *jitConfig, TR_RuntimeHelper *helperIDs, void **helperAddresses, int32_t numHelpers)
    {
    initializeJitRuntimeHelperTable(false);
 
@@ -74,7 +74,7 @@ initializeCodeCache(TR::CodeCacheManager & codeCacheManager)
    TR::CodeCacheConfig &codeCacheConfig = codeCacheManager.codeCacheConfig();
    codeCacheConfig._codeCacheKB = 128;
 
-   // setupCodeCacheParameters must stay before Test::CodeCacheManager::initialize() because it needs trampolineCodeSize
+   // setupCodeCacheParameters must stay before TestCompiler::CodeCacheManager::initialize() because it needs trampolineCodeSize
    setupCodeCacheParameters(&codeCacheConfig._trampolineCodeSize,
                             &codeCacheConfig._mccCallbacks,
                             &codeCacheConfig._numOfRuntimeHelpers,
@@ -156,7 +156,7 @@ initializeTestJit(TR_RuntimeHelper *helperIDs, void **helperAddresses, int32_t n
    TR::Compiler->initialize();
 
    // --------------------------------------------------------------------------
-   static Test::FrontEnd fe;
+   static TestCompiler::FrontEnd fe;
    auto jitConfig = fe.jitConfig();
 
    initializeAllHelpers(jitConfig, helperIDs, helperAddresses, numHelpers);
@@ -187,7 +187,7 @@ extern "C"
 void
 shutdownJit()
    {
-   auto fe = Test::FrontEnd::instance();
+   auto fe = TestCompiler::FrontEnd::instance();
 
    TR::CodeCacheManager &codeCacheManager = fe->codeCacheManager();
    codeCacheManager.destroy();

--- a/fvtest/compilertest/env/ConcreteFE.hpp
+++ b/fvtest/compilertest/env/ConcreteFE.hpp
@@ -18,10 +18,10 @@
 
 #include "env/FrontEnd.hpp"
 
-// translate Test::FrontEnd into the OMR namespace as the frontend so that everyone
+// translate TestCompiler::FrontEnd into the OMR namespace as the frontend so that everyone
 // can use that
 namespace OMR
 {
-typedef Test::FrontEnd FrontEnd;
+typedef TestCompiler::FrontEnd FrontEnd;
 }
 

--- a/fvtest/compilertest/env/FrontEnd.cpp
+++ b/fvtest/compilertest/env/FrontEnd.cpp
@@ -39,9 +39,9 @@
 
 #define RANGE_NEEDS_FOUR_BYTE_OFFSET(r) (((r) >= (USHRT_MAX   )) ? 1 : 0)
 
-#define notImplemented(A) TR_ASSERT(0, "This function is not defined for Test::FrontEnd %s", (A) )
+#define notImplemented(A) TR_ASSERT(0, "This function is not defined for TestCompiler::FrontEnd %s", (A) )
 
-namespace Test
+namespace TestCompiler
 {
 
 FrontEnd *FrontEnd::_instance = 0;
@@ -260,4 +260,4 @@ FrontEnd::calculateSizeOfStackAtlas(
    return atlasSize;
    }
 
-} //namespace Test
+} //namespace TestCompiler

--- a/fvtest/compilertest/env/FrontEnd.hpp
+++ b/fvtest/compilertest/env/FrontEnd.hpp
@@ -33,9 +33,9 @@ class TR_ResolvedMethod;
 namespace TR
 {
 
-template <> struct FETraits<Test::FrontEnd>
+template <> struct FETraits<TestCompiler::FrontEnd>
    {
-   typedef Test::JitConfig      JitConfig;
+   typedef TestCompiler::JitConfig      JitConfig;
    typedef TR::CodeCacheManager CodeCacheManager;
    typedef TR::CodeCache        CodeCache;
    static const size_t  DEFAULT_SEG_SIZE = (128 * 1024); // 128kb
@@ -43,7 +43,7 @@ template <> struct FETraits<Test::FrontEnd>
 
 }
 
-namespace Test
+namespace TestCompiler
 {
 
 class FrontEnd : public TR::FEBase<FrontEnd>
@@ -103,11 +103,11 @@ class FrontEnd : public TR::FEBase<FrontEnd>
 
    };
 
-} // namespace Test
+} // namespace TestCompiler
 
 namespace TR
 {
-class FrontEnd : public Test::FrontEnd
+class FrontEnd : public TestCompiler::FrontEnd
    {
    public:
    FrontEnd();

--- a/fvtest/compilertest/env/ObjectModel.hpp
+++ b/fvtest/compilertest/env/ObjectModel.hpp
@@ -25,11 +25,11 @@
 namespace TR
 {
 
-class ObjectModel : public Test::ObjectModelConnector
+class ObjectModel : public TestCompiler::ObjectModelConnector
    {
    public:
 
-   ObjectModel() : Test::ObjectModelConnector() {}
+   ObjectModel() : TestCompiler::ObjectModelConnector() {}
    };
 
 }

--- a/fvtest/compilertest/env/TestObjectModel.hpp
+++ b/fvtest/compilertest/env/TestObjectModel.hpp
@@ -24,14 +24,14 @@
  */
 #ifndef TEST_OBJECTMODEL_CONNECTOR
 #define TEST_OBJECTMODEL_CONNECTOR
-namespace Test { class ObjectModel; }
-namespace Test { typedef Test::ObjectModel ObjectModelConnector; }
+namespace TestCompiler { class ObjectModel; }
+namespace TestCompiler { typedef TestCompiler::ObjectModel ObjectModelConnector; }
 #endif
 
 
 #include "env/OMRObjectModel.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 
 class ObjectModel : public OMR::ObjectModelConnector

--- a/fvtest/compilertest/ilgen/BinaryOpIlInjector.cpp
+++ b/fvtest/compilertest/ilgen/BinaryOpIlInjector.cpp
@@ -21,7 +21,7 @@
 #include "compile/Method.hpp"
 #include "ilgen/BinaryOpIlInjector.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 
 bool
@@ -38,4 +38,4 @@ BinaryOpIlInjector::injectIL()
    return true;
    }
 
-} // namespace Test
+} // namespace TestCompiler

--- a/fvtest/compilertest/ilgen/BinaryOpIlInjector.hpp
+++ b/fvtest/compilertest/ilgen/BinaryOpIlInjector.hpp
@@ -23,7 +23,7 @@
 
 namespace TR { class TypeDictionary; }
 
-namespace Test
+namespace TestCompiler
 {
 class BinaryOpIlInjector : public OpIlInjector
    {
@@ -38,6 +38,6 @@ class BinaryOpIlInjector : public OpIlInjector
    bool injectIL();
    };
 
-} // namespace Test
+} // namespace TestCompiler
 
 #endif // !defined(TEST_BINARYOPILINJECTOR_INCL)

--- a/fvtest/compilertest/ilgen/ChildlessUnaryOpIlInjector.cpp
+++ b/fvtest/compilertest/ilgen/ChildlessUnaryOpIlInjector.cpp
@@ -21,7 +21,7 @@
 #include "compile/Method.hpp"
 #include "ilgen/ChildlessUnaryOpIlInjector.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 
 bool
@@ -36,4 +36,4 @@ ChildlessUnaryOpIlInjector::injectIL()
    return true;
    }
 
-} // namespace Test
+} // namespace TestCompiler

--- a/fvtest/compilertest/ilgen/ChildlessUnaryOpIlInjector.hpp
+++ b/fvtest/compilertest/ilgen/ChildlessUnaryOpIlInjector.hpp
@@ -23,7 +23,7 @@
 
 namespace TR { class TypeDictionary; }
 
-namespace Test
+namespace TestCompiler
 {
 class ChildlessUnaryOpIlInjector : public UnaryOpIlInjector
    {
@@ -38,6 +38,6 @@ class ChildlessUnaryOpIlInjector : public UnaryOpIlInjector
    bool injectIL();
    };
 
-} // namespace Test
+} // namespace TestCompiler
 
 #endif // !defined(TEST_CHILDLESSUNARYOPILINJECTOR_INCL)

--- a/fvtest/compilertest/ilgen/CmpBranchOpIlInjector.cpp
+++ b/fvtest/compilertest/ilgen/CmpBranchOpIlInjector.cpp
@@ -21,7 +21,7 @@
 #include "compile/Method.hpp"
 #include "ilgen/CmpBranchOpIlInjector.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 bool
 CmpBranchOpIlInjector::injectIL()
@@ -49,4 +49,4 @@ CmpBranchOpIlInjector::injectIL()
    return true;
    }
 
-} // namespace Test
+} // namespace TestCompiler

--- a/fvtest/compilertest/ilgen/CmpBranchOpIlInjector.hpp
+++ b/fvtest/compilertest/ilgen/CmpBranchOpIlInjector.hpp
@@ -23,7 +23,7 @@
 
 namespace TR { class TypeDictionary; }
 
-namespace Test
+namespace TestCompiler
 {
 class CmpBranchOpIlInjector : public OpIlInjector
    {
@@ -39,6 +39,6 @@ class CmpBranchOpIlInjector : public OpIlInjector
 
    };
 
-} // namespace Test
+} // namespace TestCompiler
 
 #endif // !defined(TEST_CMPBRANCHOPILINJECTOR_INCL)

--- a/fvtest/compilertest/ilgen/IlBuilder.hpp
+++ b/fvtest/compilertest/ilgen/IlBuilder.hpp
@@ -28,7 +28,7 @@
 
 #include "compiler/ilgen/IlBuilder.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 
 class TestDriver;
@@ -49,32 +49,32 @@ public:
    IlBuilder(TestDriver *test, TR::MethodBuilder *methodBuilder, TR::TypeDictionary *types)
       : OMR::IlBuilder(methodBuilder, types)
       {
-      // need to explicitly initialize Test::IlInjector layer because
+      // need to explicitly initialize TestCompiler::IlInjector layer because
       // it's hiding behind our OMR::IlBuilder base class
       setMethodAndTest((TR::ResolvedMethod *)NULL, test);
       }
    };
 
-} // namespace Test
+} // namespace TestCompiler
 
 
 #ifdef PUT_TEST_ILBUILDER_INTO_TR
 
 namespace TR
 {
-   class IlBuilder : public Test::IlBuilder
+   class IlBuilder : public TestCompiler::IlBuilder
       {
       public:
          IlBuilder(TR::MethodBuilder *methodBuilder, TypeDictionary *types)
-            : Test::IlBuilder(methodBuilder, types)
+            : TestCompiler::IlBuilder(methodBuilder, types)
             { }
 
          IlBuilder(TR::IlBuilder *source)
-            : Test::IlBuilder(source)
+            : TestCompiler::IlBuilder(source)
             { }
 
-         IlBuilder(Test::TestDriver *test, TR::MethodBuilder *methodBuilder, TR::TypeDictionary *types)
-            : Test::IlBuilder(test, methodBuilder, types)
+         IlBuilder(TestCompiler::TestDriver *test, TR::MethodBuilder *methodBuilder, TR::TypeDictionary *types)
+            : TestCompiler::IlBuilder(test, methodBuilder, types)
             { }
       };
 

--- a/fvtest/compilertest/ilgen/IlGeneratorMethodDetails.hpp
+++ b/fvtest/compilertest/ilgen/IlGeneratorMethodDetails.hpp
@@ -28,19 +28,19 @@ namespace TR { class ResolvedMethod; }
 namespace TR
 {
 
-class OMR_EXTENSIBLE IlGeneratorMethodDetails : public Test::IlGeneratorMethodDetailsConnector
+class OMR_EXTENSIBLE IlGeneratorMethodDetails : public TestCompiler::IlGeneratorMethodDetailsConnector
    {
 
 public:
 
    IlGeneratorMethodDetails() :
-      Test::IlGeneratorMethodDetailsConnector() {}
+      TestCompiler::IlGeneratorMethodDetailsConnector() {}
 
    IlGeneratorMethodDetails(TR::ResolvedMethod *method) :
-      Test::IlGeneratorMethodDetailsConnector(method) {}
+      TestCompiler::IlGeneratorMethodDetailsConnector(method) {}
 
    IlGeneratorMethodDetails(TR_ResolvedMethod *method) :
-      Test::IlGeneratorMethodDetailsConnector(method) {}
+      TestCompiler::IlGeneratorMethodDetailsConnector(method) {}
 
    };
 }

--- a/fvtest/compilertest/ilgen/IlInjector.cpp
+++ b/fvtest/compilertest/ilgen/IlInjector.cpp
@@ -35,13 +35,13 @@
 #define OPT_DETAILS "O^O ILGEN: "
 
 void
-Test::IlInjector::setMethodAndTest(TR::IlInjector *source)
+TestCompiler::IlInjector::setMethodAndTest(TR::IlInjector *source)
    {
    setMethodAndTest(source->_method, source->_test);
    }
 
 void
-Test::IlInjector::initialize(TR::IlGeneratorMethodDetails * details,
+TestCompiler::IlInjector::initialize(TR::IlGeneratorMethodDetails * details,
                              TR::ResolvedMethodSymbol     * methodSymbol,
                              TR::FrontEnd                 * fe,
                              TR::SymbolReferenceTable     * symRefTab)
@@ -51,7 +51,7 @@ Test::IlInjector::initialize(TR::IlGeneratorMethodDetails * details,
    }
 
 TR::Node *
-Test::IlInjector::callFunction(TR::ResolvedMethod *resolvedMethod, TR::IlType *returnType, int32_t numArgs, TR::Node *firstArg)
+TestCompiler::IlInjector::callFunction(TR::ResolvedMethod *resolvedMethod, TR::IlType *returnType, int32_t numArgs, TR::Node *firstArg)
    {
    TR_ASSERT(numArgs == 1, "Hack alert: currently only supports single argument function calls!");
 

--- a/fvtest/compilertest/ilgen/IlInjector.hpp
+++ b/fvtest/compilertest/ilgen/IlInjector.hpp
@@ -35,7 +35,7 @@ namespace TR { class ResolvedMethodSymbol; }
 namespace TR { class SymbolReferenceTable; }
 namespace TR { class IlType; }
 
-namespace Test
+namespace TestCompiler
 {
 
 class TestDriver;
@@ -96,30 +96,30 @@ protected:
    TR::ResolvedMethod        * _method;
    };
 
-} // namespace Test
+} // namespace TestCompiler
 
 
 #if defined(PUT_TEST_ILINJECTOR_INTO_TR)
 
 namespace TR
 {
-   class IlInjector : public Test::IlInjector
+   class IlInjector : public TestCompiler::IlInjector
       {
       public:
          IlInjector(TR::TypeDictionary *types) 
-            : Test::IlInjector(types)
+            : TestCompiler::IlInjector(types)
             { }
 
-         IlInjector(TR::TypeDictionary *types, Test::TestDriver *test)
-            : Test::IlInjector(types, test)
+         IlInjector(TR::TypeDictionary *types, TestCompiler::TestDriver *test)
+            : TestCompiler::IlInjector(types, test)
             { }
 
-         IlInjector(TR::ResolvedMethod *method, TR::TypeDictionary *types, Test::TestDriver *test)
-            : Test::IlInjector(method, types, test)
+         IlInjector(TR::ResolvedMethod *method, TR::TypeDictionary *types, TestCompiler::TestDriver *test)
+            : TestCompiler::IlInjector(method, types, test)
             { }
 
          IlInjector(TR::IlInjector *source)
-            : Test::IlInjector(source)
+            : TestCompiler::IlInjector(source)
             { }
       };
 

--- a/fvtest/compilertest/ilgen/MethodBuilder.hpp
+++ b/fvtest/compilertest/ilgen/MethodBuilder.hpp
@@ -30,7 +30,7 @@
 
 class TR_Memory;
 
-namespace Test
+namespace TestCompiler
 {
 
 class TestDriver;
@@ -48,27 +48,27 @@ public:
    MethodBuilder(TR::TypeDictionary *types, TestDriver *test)
       : OMR::MethodBuilder(types)
       {
-      // need to explicitly initialize Test::IlInjector layer
+      // need to explicitly initialize TestCompiler::IlInjector layer
       setMethodAndTest(NULL, test);
       }
    };
 
-} // namespace Test
+} // namespace TestCompiler
 
 
 #if defined(PUT_TEST_METHODBUILDER_INTO_TR)
 
 namespace TR
 {
-   class MethodBuilder : public Test::MethodBuilder
+   class MethodBuilder : public TestCompiler::MethodBuilder
       {
       public:
          MethodBuilder(TR::TypeDictionary *types)
-            : Test::MethodBuilder(types)
+            : TestCompiler::MethodBuilder(types)
             { }
 
-         MethodBuilder(TR::TypeDictionary *types, Test::TestDriver *test)
-            : Test::MethodBuilder(types, test)
+         MethodBuilder(TR::TypeDictionary *types, TestCompiler::TestDriver *test)
+            : TestCompiler::MethodBuilder(types, test)
             { }
       };
 

--- a/fvtest/compilertest/ilgen/OpIlInjector.cpp
+++ b/fvtest/compilertest/ilgen/OpIlInjector.cpp
@@ -23,7 +23,7 @@
 #include "ilgen/TypeDictionary.hpp"
 #include "ilgen/OpIlInjector.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 void
 OpIlInjector::setDataType()
@@ -344,4 +344,4 @@ OpIlInjector::parm(uint32_t slot)
 
    return parameter(index, _types->PrimitiveType(_dataType));
    }
-} // namespace Test
+} // namespace TestCompiler

--- a/fvtest/compilertest/ilgen/OpIlInjector.hpp
+++ b/fvtest/compilertest/ilgen/OpIlInjector.hpp
@@ -27,7 +27,7 @@
 namespace TR { class Node; }
 namespace TR { class TypeDictionary; }
 
-namespace Test
+namespace TestCompiler
 {
 typedef enum ParmType { ParmInteger, ParmLong, ParmShort, ParmByte, ParmAddress, ParmDouble, ParmFloat } ParmType;
 
@@ -138,6 +138,6 @@ class OpIlInjector : public TR::IlInjector
    void setDataType();
    };
 
-} // namespace Test
+} // namespace TestCompiler
 
 #endif // !defined(TEST_OPILINJECTOR_INCL)

--- a/fvtest/compilertest/ilgen/StoreOpIlInjector.cpp
+++ b/fvtest/compilertest/ilgen/StoreOpIlInjector.cpp
@@ -22,7 +22,7 @@
 #include "ilgen/TypeDictionary.hpp"
 #include "ilgen/StoreOpIlInjector.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 
 bool
@@ -40,4 +40,4 @@ StoreOpIlInjector::injectIL()
    return true;
    }
 
-} // namespace Test
+} // namespace TestCompiler

--- a/fvtest/compilertest/ilgen/StoreOpIlInjector.hpp
+++ b/fvtest/compilertest/ilgen/StoreOpIlInjector.hpp
@@ -20,7 +20,7 @@
 
 namespace TR { class TypeDictionary; }
 
-namespace Test
+namespace TestCompiler
 {
 class StoreOpIlInjector : public OpIlInjector
    {
@@ -38,4 +38,4 @@ class StoreOpIlInjector : public OpIlInjector
 //   TR::Node *parameter1() { return parameter(0, _dataType); }
    };
 
-} // namespace Test
+} // namespace TestCompiler

--- a/fvtest/compilertest/ilgen/TernaryOpIlInjector.cpp
+++ b/fvtest/compilertest/ilgen/TernaryOpIlInjector.cpp
@@ -21,7 +21,7 @@
 #include "compile/Method.hpp"
 #include "ilgen/TernaryOpIlInjector.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 bool
 TernaryOpIlInjector::injectIL()
@@ -36,4 +36,4 @@ TernaryOpIlInjector::injectIL()
    return true;
    }
 
-} /* namespace Test */
+} /* namespace TestCompiler */

--- a/fvtest/compilertest/ilgen/TernaryOpIlInjector.hpp
+++ b/fvtest/compilertest/ilgen/TernaryOpIlInjector.hpp
@@ -23,7 +23,7 @@
 
 namespace TR { class TypeDictionary; }
 
-namespace Test
+namespace TestCompiler
 {
 class TernaryOpIlInjector : public OpIlInjector
    {
@@ -39,6 +39,6 @@ class TernaryOpIlInjector : public OpIlInjector
    bool injectIL();
    };
 
-} /* namespace Test */
+} /* namespace TestCompiler */
 
 #endif // !define (TEST_TERNARYOPILINJECTOR_INCL)

--- a/fvtest/compilertest/ilgen/TestIlGeneratorMethodDetails.cpp
+++ b/fvtest/compilertest/ilgen/TestIlGeneratorMethodDetails.cpp
@@ -26,7 +26,7 @@
 #include "compile/InlineBlock.hpp"
 #include "env/IO.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 
 IlGeneratorMethodDetails::IlGeneratorMethodDetails(TR_ResolvedMethod *method) :

--- a/fvtest/compilertest/ilgen/TestIlGeneratorMethodDetails.hpp
+++ b/fvtest/compilertest/ilgen/TestIlGeneratorMethodDetails.hpp
@@ -24,8 +24,8 @@
  */
 #ifndef TEST_ILGENERATOR_METHOD_DETAILS_CONNECTOR
 #define TEST_ILGENERATOR_METHOD_DETAILS_CONNECTOR
-namespace Test { class IlGeneratorMethodDetails; }
-namespace Test { typedef Test::IlGeneratorMethodDetails IlGeneratorMethodDetailsConnector; }
+namespace TestCompiler { class IlGeneratorMethodDetails; }
+namespace TestCompiler { typedef TestCompiler::IlGeneratorMethodDetails IlGeneratorMethodDetailsConnector; }
 #endif
 
 #include "ilgen/OMRIlGeneratorMethodDetails.hpp"
@@ -41,7 +41,7 @@ namespace TR { class ResolvedMethod; }
 namespace TR { class ResolvedMethodSymbol; }
 namespace TR { class SymbolReferenceTable; }
 
-namespace Test
+namespace TestCompiler
 {
 
 class ResolvedMethod;

--- a/fvtest/compilertest/ilgen/UnaryOpIlInjector.cpp
+++ b/fvtest/compilertest/ilgen/UnaryOpIlInjector.cpp
@@ -21,7 +21,7 @@
 #include "compile/Method.hpp"
 #include "ilgen/UnaryOpIlInjector.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 
 bool
@@ -36,4 +36,4 @@ UnaryOpIlInjector::injectIL()
    return true;
    }
 
-} // namespace Test
+} // namespace TestCompiler

--- a/fvtest/compilertest/ilgen/UnaryOpIlInjector.hpp
+++ b/fvtest/compilertest/ilgen/UnaryOpIlInjector.hpp
@@ -23,7 +23,7 @@
 
 namespace TR { class TypeDictionary; }
 
-namespace Test
+namespace TestCompiler
 {
 class UnaryOpIlInjector : public OpIlInjector
    {
@@ -38,6 +38,6 @@ class UnaryOpIlInjector : public OpIlInjector
    bool injectIL();
    };
 
-} // namespace Test
+} // namespace TestCompiler
 
 #endif // !defined(UNARYOPILINJECTOR_INCL)

--- a/fvtest/compilertest/infra/Monitor.hpp
+++ b/fvtest/compilertest/infra/Monitor.hpp
@@ -24,12 +24,12 @@
 namespace TR
 {
 
-class Monitor : public Test::MonitorConnector
+class Monitor : public TestCompiler::MonitorConnector
    {
    public:
 
    Monitor(char const *name) :
-      Test::MonitorConnector(name) {}
+      TestCompiler::MonitorConnector(name) {}
    };
 }
 

--- a/fvtest/compilertest/infra/TestMonitor.cpp
+++ b/fvtest/compilertest/infra/TestMonitor.cpp
@@ -31,45 +31,45 @@ TR::MonitorTable *OMR::MonitorTable::_instance = 0;
 TR::Monitor *memoryAllocMonitor;
 
 void *
-Test::Monitor::operator new(size_t size)
+TestCompiler::Monitor::operator new(size_t size)
    {
    return TR::globalAllocator().allocate(size);
    }
 
 void
-Test::Monitor::operator delete(void *p)
+TestCompiler::Monitor::operator delete(void *p)
    {
    TR::globalAllocator().deallocate(p, sizeof(TR::Monitor));
    }
 
 TR::Monitor *
-Test::Monitor::create(char *name)
+TestCompiler::Monitor::create(char *name)
    {
    return new TR::Monitor(name);
    }
 
-Test::Monitor::Monitor(char const *name) :
+TestCompiler::Monitor::Monitor(char const *name) :
       _name(name)
    {
    int32_t rc = pthread_mutex_init(&_monitor, 0);
    TR_ASSERT(rc == 0, "error initializing monitor\n");
    }
 
-Test::Monitor::~Monitor()
+TestCompiler::Monitor::~Monitor()
    {
    int32_t rc = pthread_mutex_destroy(&_monitor);
    TR_ASSERT(rc == 0, "error destroying monitor\n");
    }
 
 void
-Test::Monitor::enter()
+TestCompiler::Monitor::enter()
    {
    int32_t rc = pthread_mutex_lock(&_monitor);
    TR_ASSERT(rc == 0, "error locking monitor\n");
    }
 
 int32_t
-Test::Monitor::exit()
+TestCompiler::Monitor::exit()
    {
    int32_t rc = pthread_mutex_unlock(&_monitor);
    TR_ASSERT(rc == 0, "error unlocking monitor\n");

--- a/fvtest/compilertest/infra/TestMonitor.hpp
+++ b/fvtest/compilertest/infra/TestMonitor.hpp
@@ -21,15 +21,15 @@
 
 #ifndef TEST_MONITOR_CONNECTOR
 #define TEST_MONITOR_CONNECTOR
-namespace Test { class Monitor; }
-namespace Test { typedef Test::Monitor MonitorConnector; }
+namespace TestCompiler { class Monitor; }
+namespace TestCompiler { typedef TestCompiler::Monitor MonitorConnector; }
 #endif
 
 #include "infra/OMRMonitor.hpp"
 
 #include <pthread.h>
 
-namespace Test
+namespace TestCompiler
 {
 
 class Monitor : public OMR::MonitorConnector

--- a/fvtest/compilertest/runtime/CodeCacheManager.hpp
+++ b/fvtest/compilertest/runtime/CodeCacheManager.hpp
@@ -24,10 +24,10 @@
 namespace TR
 {
 
-class OMR_EXTENSIBLE CodeCacheManager : public Test::CodeCacheManagerConnector
+class OMR_EXTENSIBLE CodeCacheManager : public TestCompiler::CodeCacheManagerConnector
    {
    public:
-   CodeCacheManager(TR_FrontEnd *fe) : Test::CodeCacheManagerConnector(fe) { }
+   CodeCacheManager(TR_FrontEnd *fe) : TestCompiler::CodeCacheManagerConnector(fe) { }
    };
 
 } // namespace TR

--- a/fvtest/compilertest/runtime/TestCodeCacheManager.cpp
+++ b/fvtest/compilertest/runtime/TestCodeCacheManager.cpp
@@ -30,24 +30,24 @@
 // A value of -2 (or less) means that no reservation is requested
 
 
-TR::CodeCacheManager *Test::CodeCacheManager::_codeCacheManager = NULL;
-Test::JitConfig *Test::CodeCacheManager::_jitConfig = NULL;
+TR::CodeCacheManager *TestCompiler::CodeCacheManager::_codeCacheManager = NULL;
+TestCompiler::JitConfig *TestCompiler::CodeCacheManager::_jitConfig = NULL;
 
 
 TR::CodeCacheManager *
-Test::CodeCacheManager::self()
+TestCompiler::CodeCacheManager::self()
    {
    return static_cast<TR::CodeCacheManager *>(this);
    }
 
-Test::FrontEnd *
-Test::CodeCacheManager::pyfe()
+TestCompiler::FrontEnd *
+TestCompiler::CodeCacheManager::pyfe()
    {
    return reinterpret_cast<FrontEnd *>(self()->fe());
    }
 
 TR::CodeCache *
-Test::CodeCacheManager::initialize(bool useConsolidatedCache, uint32_t numberOfCodeCachesToCreateAtStartup)
+TestCompiler::CodeCacheManager::initialize(bool useConsolidatedCache, uint32_t numberOfCodeCachesToCreateAtStartup)
    {
    _jitConfig = self()->pyfe()->jitConfig();
    //_allocator = TR::globalAllocator("CodeCache");
@@ -55,25 +55,25 @@ Test::CodeCacheManager::initialize(bool useConsolidatedCache, uint32_t numberOfC
    }
 
 void *
-Test::CodeCacheManager::getMemory(size_t sizeInBytes)
+TestCompiler::CodeCacheManager::getMemory(size_t sizeInBytes)
    {
    void * ptr = malloc(sizeInBytes);
-   //fprintf(stderr,"Test::CodeCacheManager::getMemory(%d) allocated %p\n", sizeInBytes, ptr);
+   //fprintf(stderr,"TestCompiler::CodeCacheManager::getMemory(%d) allocated %p\n", sizeInBytes, ptr);
 
    return ptr;
    //return _allocator.allocate(sizeInBytes);
    }
 
 void
-Test::CodeCacheManager::freeMemory(void *memoryToFree)
+TestCompiler::CodeCacheManager::freeMemory(void *memoryToFree)
    {
-   //fprintf(stderr,"Test::CodeCacheManager::free(%p)\n", memoryToFree);
+   //fprintf(stderr,"TestCompiler::CodeCacheManager::free(%p)\n", memoryToFree);
    free(memoryToFree);
    //return _allocator.deallocate(memoryToFree, 0);
    }
 
 TR::CodeCacheMemorySegment *
-Test::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
+TestCompiler::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
                                               size_t &codeCacheSizeToAllocate,
                                               void *preferredStartAddress)
    {

--- a/fvtest/compilertest/runtime/TestCodeCacheManager.hpp
+++ b/fvtest/compilertest/runtime/TestCodeCacheManager.hpp
@@ -21,8 +21,8 @@
 
 #ifndef TEST_CODECACHEMANAGER_COMPOSED
 #define TEST_CODECACHEMANAGER_COMPOSED
-namespace Test { class CodeCacheManager; }
-namespace Test { typedef CodeCacheManager CodeCacheManagerConnector; }
+namespace TestCompiler { class CodeCacheManager; }
+namespace TestCompiler { typedef CodeCacheManager CodeCacheManagerConnector; }
 #endif
 
 #include <stddef.h>
@@ -33,7 +33,7 @@ namespace TR { class CodeCacheMemorySegment; }
 namespace TR { class CodeCache; }
 namespace TR { class CodeCacheManager; }
 
-namespace Test
+namespace TestCompiler
 {
 
 class JitConfig;
@@ -70,6 +70,6 @@ private :
    //static TR::GlobalAllocator & _allocator;
    };
 
-} // namespace Test
+} // namespace TestCompiler
 
 #endif // TEST_CODECACHEMANAGER_INCL

--- a/fvtest/compilertest/runtime/TestJitConfig.hpp
+++ b/fvtest/compilertest/runtime/TestJitConfig.hpp
@@ -23,10 +23,10 @@
 #include "env/FEBase.hpp"
 #include "env/JitConfig.hpp"
 
-namespace Test { class FrontEnd; }
+namespace TestCompiler { class FrontEnd; }
 
-// Singleton JitConfig. The only instance of this is Test::FrontEnd::_jitConfig
-namespace Test
+// Singleton JitConfig. The only instance of this is TestCompiler::FrontEnd::_jitConfig
+namespace TestCompiler
 {
 struct JitConfig : public TR::JitConfig
    {
@@ -34,6 +34,6 @@ struct JitConfig : public TR::JitConfig
    friend class TR::FEBase<FrontEnd>;
    JitConfig() : TR::JitConfig() {}
    };
-} // namespace Test
+} // namespace TestCompiler
 
 #endif

--- a/fvtest/compilertest/tests/BarIlInjector.cpp
+++ b/fvtest/compilertest/tests/BarIlInjector.cpp
@@ -22,7 +22,7 @@
 #include "tests/BarIlInjector.hpp"
 #include "tests/FooBarTest.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 
 bool
@@ -55,4 +55,4 @@ BarIlInjector::injectIL()
    return true;
    }
 
-} // namespace Test
+} // namespace TestCompiler

--- a/fvtest/compilertest/tests/BarIlInjector.hpp
+++ b/fvtest/compilertest/tests/BarIlInjector.hpp
@@ -20,7 +20,7 @@
 
 namespace TR { class TypeDictionary; }
 
-namespace Test
+namespace TestCompiler
 {
 class BarIlInjector : public TR::IlInjector
    {
@@ -37,4 +37,4 @@ class BarIlInjector : public TR::IlInjector
 
    };
 
-} // namespace Test
+} // namespace TestCompiler

--- a/fvtest/compilertest/tests/BuilderTest.cpp
+++ b/fvtest/compilertest/tests/BuilderTest.cpp
@@ -25,7 +25,7 @@
 #include "ilgen/TypeDictionary.hpp"
 #include "tests/BuilderTest.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 
 RecursiveFibFunctionType *BuilderTest::_recursiveFibMethod = 0;
@@ -2085,24 +2085,24 @@ ForLoopBreakAndContinueMethod::buildIL()
 
    return true;
    }
-} // namespace Test
+} // namespace TestCompiler
 
 TEST(JITTest, BuilderTest)
    {
-   ::Test::BuilderTest _builderTest;
+   ::TestCompiler::BuilderTest _builderTest;
    _builderTest.RunTest();
    }
 
 TEST(JITILBuilderTest, ControlFlowTest)
    {
-   ::Test::BuilderTest _controlFlowTest;
+   ::TestCompiler::BuilderTest _controlFlowTest;
    _controlFlowTest.compileControlFlowTestMethods();
    _controlFlowTest.invokeControlFlowTests();
    }
 
 TEST(JITILBuilderTest, NestedControlFlowLoopTest)
    {
-   ::Test::BuilderTest _nestedControlFlowLoopTest;
+   ::TestCompiler::BuilderTest _nestedControlFlowLoopTest;
    _nestedControlFlowLoopTest.compileNestedControlFlowLoopTestMethods();
    _nestedControlFlowLoopTest.invokeNestedControlFlowLoopTests();
    }

--- a/fvtest/compilertest/tests/BuilderTest.hpp
+++ b/fvtest/compilertest/tests/BuilderTest.hpp
@@ -23,7 +23,7 @@
 #include "ilgen/IlBuilder.hpp"
 #include "ilgen/MethodBuilder.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 
 class BuilderTest;
@@ -292,6 +292,6 @@ class ForLoopBreakAndContinueMethod : public TR::MethodBuilder
    BuilderTest *bldTest() { return static_cast<BuilderTest *>(test()); }
    };
 
-} // namespace Test
+} // namespace TestCompiler
 
 #endif // !defined(BUILDERTEST_INCL)

--- a/fvtest/compilertest/tests/CallIlInjector.cpp
+++ b/fvtest/compilertest/tests/CallIlInjector.cpp
@@ -23,7 +23,7 @@
 #include "tests/CallIlInjector.hpp"
 #include "tests/OpCodesTest.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 
 bool
@@ -41,4 +41,4 @@ CallIlInjector::injectIL()
    return true;
    }
 
-} // namespace Test
+} // namespace TestCompiler

--- a/fvtest/compilertest/tests/CallIlInjector.hpp
+++ b/fvtest/compilertest/tests/CallIlInjector.hpp
@@ -23,7 +23,7 @@
 
 namespace TR { class TypeDictionary; }
 
-namespace Test
+namespace TestCompiler
 {
 class CallIlInjector : public UnaryOpIlInjector
    {
@@ -38,6 +38,6 @@ class CallIlInjector : public UnaryOpIlInjector
    bool injectIL();
    };
 
-} // namespace Test
+} // namespace TestCompiler
 
 #endif // !defined(TEST_CALLILINJECTOR_INCL)

--- a/fvtest/compilertest/tests/FooBarTest.cpp
+++ b/fvtest/compilertest/tests/FooBarTest.cpp
@@ -26,7 +26,7 @@
 #include "gtest/gtest.h"
 #include "ilgen/IlGeneratorMethodDetails_inlines.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 
 
@@ -130,17 +130,17 @@ FooBarTest::invokeTests()
    ASSERT_EQ(-1, _foo(INT_MAX));
    }
 
-} // namespace Test
+} // namespace TestCompiler
 
 // This test will get assertion on S390-64, because of
 // "compiler/codegen/FrontEnd.cpp" TR_FrontEnd::methodTrampolineLookup is "notImplemented("methodTrampolineLookup");" and
-// "test/env/FrontEnd.cpp"  Test::FrontEnd::methodTrampolineLookup is "methodTrampolineLookup not implemented yet".
+// "test/env/FrontEnd.cpp"  TestCompiler::FrontEnd::methodTrampolineLookup is "methodTrampolineLookup not implemented yet".
 // This test also failed intermittent (segfault) on PPCLE, temporarily disabled this test on PPCLE, under track of Work Item
 // Please remove this #ifdef after those functions are implemented.
 #if defined(TR_TARGET_X86) || defined(TR_TARGET_S390) && !defined(TR_TARGET_64BIT) && !defined(J9ZOS390)
 TEST(JITTest, FooBarTest)
    {
-   ::Test::FooBarTest _fooBarTest;
+   ::TestCompiler::FooBarTest _fooBarTest;
    _fooBarTest.RunTest();
    }
 #endif

--- a/fvtest/compilertest/tests/FooBarTest.hpp
+++ b/fvtest/compilertest/tests/FooBarTest.hpp
@@ -18,7 +18,7 @@
 
 #include "TestDriver.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 
 typedef int32_t (FooMethodType)(int32_t);
@@ -51,4 +51,4 @@ class FooBarTest : public TestDriver
    static int32_t bar(int32_t);
    };
 
-} // namespace Test
+} // namespace TestCompiler

--- a/fvtest/compilertest/tests/FooIlInjector.cpp
+++ b/fvtest/compilertest/tests/FooIlInjector.cpp
@@ -23,7 +23,7 @@
 #include "tests/FooIlInjector.hpp"
 #include "tests/FooBarTest.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 
 bool
@@ -59,4 +59,4 @@ FooIlInjector::injectIL()
    return true;
    }
 
-} // namespace Test
+} // namespace TestCompiler

--- a/fvtest/compilertest/tests/FooIlInjector.hpp
+++ b/fvtest/compilertest/tests/FooIlInjector.hpp
@@ -20,7 +20,7 @@
 
 namespace TR { class TypeDictionary; }
 
-namespace Test
+namespace TestCompiler
 {
 class FooIlInjector : public TR::IlInjector
    {
@@ -37,4 +37,4 @@ class FooIlInjector : public TR::IlInjector
 
    };
 
-} // namespace Test
+} // namespace TestCompiler

--- a/fvtest/compilertest/tests/IndirectLoadIlInjector.cpp
+++ b/fvtest/compilertest/tests/IndirectLoadIlInjector.cpp
@@ -26,7 +26,7 @@
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 
 bool
@@ -43,4 +43,4 @@ IndirectLoadIlInjector::injectIL()
    return true;
    }
 
-} // namespace Test
+} // namespace TestCompiler

--- a/fvtest/compilertest/tests/IndirectLoadIlInjector.hpp
+++ b/fvtest/compilertest/tests/IndirectLoadIlInjector.hpp
@@ -23,7 +23,7 @@
 
 namespace TR { class TypeDictionary; }
 
-namespace Test
+namespace TestCompiler
 {
 class IndirectLoadIlInjector : public UnaryOpIlInjector
    {
@@ -38,6 +38,6 @@ class IndirectLoadIlInjector : public UnaryOpIlInjector
 
    };
 
-} // namespace Test
+} // namespace TestCompiler
 
 #endif // !defined(TEST_INDIRECTLOADIILINJECTOR_INCL)

--- a/fvtest/compilertest/tests/IndirectStoreIlInjector.cpp
+++ b/fvtest/compilertest/tests/IndirectStoreIlInjector.cpp
@@ -23,7 +23,7 @@
 #include "tests/IndirectStoreIlInjector.hpp"
 #include "tests/OpCodesTest.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 
 bool
@@ -39,4 +39,4 @@ IndirectStoreIlInjector::injectIL()
    return true;
    }
 
-} // namespace Test
+} // namespace TestCompiler

--- a/fvtest/compilertest/tests/IndirectStoreIlInjector.hpp
+++ b/fvtest/compilertest/tests/IndirectStoreIlInjector.hpp
@@ -22,7 +22,7 @@
 #include "ilgen/BinaryOpIlInjector.hpp"
 namespace TR { class TypeDictionary; }
 
-namespace Test
+namespace TestCompiler
 {
 class IndirectStoreIlInjector : public BinaryOpIlInjector
    {
@@ -37,6 +37,6 @@ class IndirectStoreIlInjector : public BinaryOpIlInjector
 
    };
 
-} // namespace Test
+} // namespace TestCompiler
 
 #endif // !defined(TEST_INDIRECTSTOREIILINJECTOR_INCL)

--- a/fvtest/compilertest/tests/OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/OpCodesTest.cpp
@@ -43,7 +43,7 @@
 
 extern "C" uint8_t *compileMethod(TR::IlGeneratorMethodDetails &, TR_Hotness, int32_t &);
 
-namespace Test
+namespace TestCompiler
 {
 //common variables definitions
 const int64_t OpCodesTest::LONG_NEG = -9;
@@ -2879,68 +2879,68 @@ OpCodesTest::invokeAddressTests()
       }
    }
 
-} // namespace Test
+} // namespace TestCompiler
 
 //groups by testname
 TEST(JITCrossPlatformsOpCodesTest, UnaryTest)
    {
-   ::Test::OpCodesTest unaryTest;
+   ::TestCompiler::OpCodesTest unaryTest;
    unaryTest.compileUnaryTestMethods();
    unaryTest.invokeUnaryTests();
    }
 
 TEST(JITCrossPlatformsOpCodesTest, IntegerArithmeticTest)
    {
-   ::Test::OpCodesTest integerArithmeticTest;
+   ::TestCompiler::OpCodesTest integerArithmeticTest;
    integerArithmeticTest.compileIntegerArithmeticTestMethods();
    integerArithmeticTest.invokeIntegerArithmeticTests();
    }
 
 TEST(JITCrossPlatformsOpCodesTest, MemoryOperationTest)
    {
-   ::Test::OpCodesTest memoryOperationTest;
+   ::TestCompiler::OpCodesTest memoryOperationTest;
    memoryOperationTest.compileMemoryOperationTestMethods();
    memoryOperationTest.invokeMemoryOperationTests();
    }
 
 TEST(JITCrossPlatformsOpCodesTest, ShiftOrRolTest)
    {
-   ::Test::OpCodesTest shiftOrRolTest;
+   ::TestCompiler::OpCodesTest shiftOrRolTest;
    shiftOrRolTest.compileShiftOrRolTestMethods();
    shiftOrRolTest.invokeShiftOrRolTests();
    }
 
 TEST(JITCrossPlatformsOpCodesTest, BitwiseTest)
    {
-   ::Test::OpCodesTest bitwiseTest;
+   ::TestCompiler::OpCodesTest bitwiseTest;
    bitwiseTest.compileBitwiseMethods();
    bitwiseTest.invokeBitwiseTests();
    }
 
 TEST(JITCrossPlatformsOpCodesTest, CompareTest)
    {
-   ::Test::OpCodesTest compareTest;
+   ::TestCompiler::OpCodesTest compareTest;
    compareTest.compileCompareTestMethods();
    compareTest.invokeCompareTests();
    }
 
 TEST(JITCrossPlatformsOpCodesTest, TernaryTest)
    {
-   ::Test::OpCodesTest ternaryTest;
+   ::TestCompiler::OpCodesTest ternaryTest;
    ternaryTest.compileTernaryTestMethods();
    ternaryTest.invokeTernaryTests();
    }
 
 TEST(JITCrossPlatformsOpCodesTest, AddressTest)
    {
-   ::Test::OpCodesTest addressTest;
+   ::TestCompiler::OpCodesTest addressTest;
    addressTest.compileAddressTestMethods();
    addressTest.invokeAddressTests();
    }
 
 TEST(JITCrossPlatformsOpCodesTest, UnsupportedOpCodesTest)
    {
-   ::Test::OpCodesTest unsupportedOpcodesTest;
+   ::TestCompiler::OpCodesTest unsupportedOpcodesTest;
    unsupportedOpcodesTest.UnsupportedOpCodesTests();
    }
 
@@ -2948,7 +2948,7 @@ TEST(JITCrossPlatformsOpCodesTest, DISABLED_OpCodesTests)
    {
    //Jazz103 Work item 110364
    //To temporarily enable "DISABLED" test, append " --gtest_also_run_disabled_tests" in the command line.
-   ::Test::OpCodesTest disabledOpCodesTest;
+   ::TestCompiler::OpCodesTest disabledOpCodesTest;
    disabledOpCodesTest.compileDisabledOpCodesTests();
    disabledOpCodesTest.invokeDisabledOpCodesTests();
    }
@@ -2959,7 +2959,7 @@ TEST(JITCrossPlatformsOpCodesTest, DISABLED_UnaryTest)
    //Jazz103 Work Item 110363
    //This defect is related to 97974: Separate group to temporarily disable crashed (will work on) testcases
    //Please move this test and recover f2i testcase number from 3 to 5.
-   ::Test::OpCodesTest disabledUnaryTest;
+   ::TestCompiler::OpCodesTest disabledUnaryTest;
    disabledUnaryTest.invokeNoHelperUnaryTests();
    }
 

--- a/fvtest/compilertest/tests/OpCodesTest.hpp
+++ b/fvtest/compilertest/tests/OpCodesTest.hpp
@@ -27,7 +27,7 @@
 
 namespace TR { class ResolvedMethod; }
 
-namespace Test
+namespace TestCompiler
 {
 //unsigned signatureChars
 typedef int32_t (unsignedSignatureCharS_I_testMethodType)(uint16_t);
@@ -742,4 +742,4 @@ class OpCodesTest : public TestDriver
    template <typename C, typename T> static T ternary(C a, T b, T c) {return a ? b : c;}
    };
 
-} // namespace Test
+} // namespace TestCompiler

--- a/fvtest/compilertest/tests/PPCOpCodesTest.cpp
+++ b/fvtest/compilertest/tests/PPCOpCodesTest.cpp
@@ -25,7 +25,7 @@
 
 #include "tests/PPCOpCodesTest.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 
 void
@@ -5190,62 +5190,62 @@ PPCOpCodesTest::invokeDisabledDirectCallTest()
       EXPECT_EQ(aUnaryDataArr[i], _acall(aUnaryDataArr[i]));
       }
    }
-} // namespace Test
+} // namespace TestCompiler
 
 #if defined(TR_TARGET_POWER)
 //groups by testname
 TEST(JITPPCOpCodesTest, UnaryTest)
    {
-   ::Test::PPCOpCodesTest PPCUnaryTest;
+   ::TestCompiler::PPCOpCodesTest PPCUnaryTest;
    PPCUnaryTest.compileUnaryTestMethods();
    PPCUnaryTest.invokeUnaryTests();
    }
 
 TEST(JITPPCOpCodesTest, MemoryOperationTest)
    {
-   ::Test::PPCOpCodesTest PPCMemoryOperationTest;
+   ::TestCompiler::PPCOpCodesTest PPCMemoryOperationTest;
    PPCMemoryOperationTest.compileMemoryOperationTestMethods();
    PPCMemoryOperationTest.invokeMemoryOperationTests();
    }
 
 TEST(JITPPCOpCodesTest, TernaryTest)
    {
-   ::Test::PPCOpCodesTest PPCTernaryTest;
+   ::TestCompiler::PPCOpCodesTest PPCTernaryTest;
    PPCTernaryTest.compileTernaryTestMethods();
    PPCTernaryTest.invokeTernaryTests();
    }
 
 TEST(JITPPCOpCodesTest, CompareTest)
    {
-   ::Test::PPCOpCodesTest PPCCompareTest;
+   ::TestCompiler::PPCOpCodesTest PPCCompareTest;
    PPCCompareTest.compileCompareTestMethods();
    PPCCompareTest.invokeCompareTests();
    }
 
 TEST(JITPPCOpCodesTest, ShiftOrRolTest)
    {
-   ::Test::PPCOpCodesTest PPCShiftOrRolTest;
+   ::TestCompiler::PPCOpCodesTest PPCShiftOrRolTest;
    PPCShiftOrRolTest.compileShiftOrRolTestMethods();
    PPCShiftOrRolTest.invokeShiftOrRolTests();
    }
 
 TEST(JITPPCOpCodesTest, BitwiseTest)
    {
-   ::Test::PPCOpCodesTest PPCBitwiseTest;
+   ::TestCompiler::PPCOpCodesTest PPCBitwiseTest;
    PPCBitwiseTest.compileBitwiseTestMethods();
    PPCBitwiseTest.invokeBitwiseTests();
    }
 
 TEST(JITPPCOpCodesTest, PPCAddressTest)
    {
-   ::Test::PPCOpCodesTest PPCAddressTest;
+   ::TestCompiler::PPCOpCodesTest PPCAddressTest;
    PPCAddressTest.compileAddressTestMethods();
    PPCAddressTest.invokeAddressTests();
    }
 
 TEST(JITPPCOpCodesTest, UnsupportedOpCodesTest)
    {
-   ::Test::PPCOpCodesTest PPCUnsupportedOpcodesTest;
+   ::TestCompiler::PPCOpCodesTest PPCUnsupportedOpcodesTest;
    PPCUnsupportedOpcodesTest.UnsupportedOpCodesTests();
    }
 
@@ -5253,7 +5253,7 @@ TEST(JITPPCOpCodesTest, DISABLED_PPCLEConvertTests)
    {
    //Jazz103 Work Item 109976
    //To temporarily enable "DISABLED" test, append " --gtest_also_run_disabled_tests" in the command line.
-   ::Test::PPCOpCodesTest disabledPPCLEConvertTest;
+   ::TestCompiler::PPCOpCodesTest disabledPPCLEConvertTest;
    disabledPPCLEConvertTest.compileDisabledConvertTestMethods();
    disabledPPCLEConvertTest.invokeDisabledConvertTests();
    }
@@ -5262,7 +5262,7 @@ TEST(JITPPCOpCodesTest, DISABLED_PPCLECompareTests)
    {
    //Jazz103 Work Item 106531
    //To temporarily enable "DISABLED" test, append " --gtest_also_run_disabled_tests" in the command line.
-   ::Test::PPCOpCodesTest disabledPPCLECompareTest;
+   ::TestCompiler::PPCOpCodesTest disabledPPCLECompareTest;
    disabledPPCLECompareTest.compileDisabledCompareTestMethods();
    disabledPPCLECompareTest.invokeDisabledCompareTests();
    }
@@ -5272,7 +5272,7 @@ TEST(JITPPCOpCodesTest, DISABLED_PPCLEIntegerArithmeticTest)
    //Jazz103 Work Item 101901
    //Jazz103 Work Item 103809
    //Testrossa Work Item 121966
-   ::Test::PPCOpCodesTest disabledPPCLEIntegerArithmeticTest;
+   ::TestCompiler::PPCOpCodesTest disabledPPCLEIntegerArithmeticTest;
    disabledPPCLEIntegerArithmeticTest.compileDisabledIntegerArithmeticTestMethods();
    disabledPPCLEIntegerArithmeticTest.invokeDisabledIntegerArithmeticTests();
    }
@@ -5280,7 +5280,7 @@ TEST(JITPPCOpCodesTest, DISABLED_PPCLEIntegerArithmeticTest)
 TEST(JITPPCOpCodesTest, DISABLED_PPCLEFloatArithmeticTest)
    {
    //Jazz103 Work Item 110358
-   ::Test::PPCOpCodesTest disabledPPCLEFloatArithmeticTest;
+   ::TestCompiler::PPCOpCodesTest disabledPPCLEFloatArithmeticTest;
    disabledPPCLEFloatArithmeticTest.compileDisabledFloatArithmeticTestMethods();
    disabledPPCLEFloatArithmeticTest.invokeDisabledFloatArithmeticTests();
    }
@@ -5288,7 +5288,7 @@ TEST(JITPPCOpCodesTest, DISABLED_PPCLEFloatArithmeticTest)
 TEST(JITPPCOpCodesTest, DISABLED_PPCLEMemoryOperationTest)
    {
    //Jazz103 Work Item 110360, 111411
-   ::Test::PPCOpCodesTest disabledPPCLEMemoryOperationTest;
+   ::TestCompiler::PPCOpCodesTest disabledPPCLEMemoryOperationTest;
    disabledPPCLEMemoryOperationTest.compileDisabledMemoryOperationTestMethods();
    disabledPPCLEMemoryOperationTest.invokeDisabledMemoryOperationTests();
    //
@@ -5297,7 +5297,7 @@ TEST(JITPPCOpCodesTest, DISABLED_PPCLEMemoryOperationTest)
 TEST(JITPPCOpCodesTest, DISABLED_PPCLEUnaryTest)
    {
    //Jazz103 Work Item 109977
-   ::Test::PPCOpCodesTest disabledPPCLEUnaryTest;
+   ::TestCompiler::PPCOpCodesTest disabledPPCLEUnaryTest;
    disabledPPCLEUnaryTest.compileDisabledUnaryTestMethods();
    disabledPPCLEUnaryTest.invokeDisabledUnaryTests();
    }
@@ -5305,7 +5305,7 @@ TEST(JITPPCOpCodesTest, DISABLED_PPCLEUnaryTest)
 TEST(JITPPCOpCodesTest, DISABLED_PPCLEShiftOrRolTest)
    {
    //Jazz103 Work Item 110361
-   ::Test::PPCOpCodesTest disabledPPCLEShiftOrRolTest;
+   ::TestCompiler::PPCOpCodesTest disabledPPCLEShiftOrRolTest;
    disabledPPCLEShiftOrRolTest.compileDisabledShiftOrRolTestMethods();
    disabledPPCLEShiftOrRolTest.invokeDisabledShiftOrRolTests();
    }
@@ -5313,7 +5313,7 @@ TEST(JITPPCOpCodesTest, DISABLED_PPCLEShiftOrRolTest)
 TEST(JITPPCOpCodesTest, DISABLED_PPCLEBitwiseTest)
    {
    //Jazz103 Work Item 110362
-   ::Test::PPCOpCodesTest disabledPPCLEBitwiseTest;
+   ::TestCompiler::PPCOpCodesTest disabledPPCLEBitwiseTest;
    disabledPPCLEBitwiseTest.compileDisabledBitwiseTestMethods();
    disabledPPCLEBitwiseTest.invokeDisabledBitwiseTests();
    }
@@ -5321,7 +5321,7 @@ TEST(JITPPCOpCodesTest, DISABLED_PPCLEBitwiseTest)
 TEST(JITPPCOpCodesTest, DISABLED_PPCLETernaryTest)
    {
    //Jazz103 Work Item 109979
-   ::Test::PPCOpCodesTest disabledPPCLETernaryTest;
+   ::TestCompiler::PPCOpCodesTest disabledPPCLETernaryTest;
    disabledPPCLETernaryTest.compileDisabledTernaryTestMethods();
    disabledPPCLETernaryTest.invokeDisabledTernaryTest();
    }
@@ -5329,7 +5329,7 @@ TEST(JITPPCOpCodesTest, DISABLED_PPCLETernaryTest)
 TEST(JITPPCOpCodesTest, DISABLED_PPCLEDirectCallTest)
    {
    //Jazz103 Work item 115240
-   ::Test::PPCOpCodesTest disabledPPCDirectCallTest;
+   ::TestCompiler::PPCOpCodesTest disabledPPCDirectCallTest;
    disabledPPCDirectCallTest.compileDisabledDirectCallTestMethods();
    disabledPPCDirectCallTest.invokeDisabledDirectCallTest();
    }

--- a/fvtest/compilertest/tests/PPCOpCodesTest.hpp
+++ b/fvtest/compilertest/tests/PPCOpCodesTest.hpp
@@ -18,7 +18,7 @@
 
 #include "OpCodesTest.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 class PPCOpCodesTest : public OpCodesTest
    {
@@ -63,4 +63,4 @@ class PPCOpCodesTest : public OpCodesTest
    virtual void invokeDisabledDirectCallTest();
    };
 
-} // namespace Test
+} // namespace TestCompiler

--- a/fvtest/compilertest/tests/Qux2IlInjector.cpp
+++ b/fvtest/compilertest/tests/Qux2IlInjector.cpp
@@ -21,7 +21,7 @@
 #include "compile/Method.hpp"
 #include "tests/Qux2IlInjector.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 
 bool
@@ -40,4 +40,4 @@ Qux2IlInjector::injectIL()
    return true;
    }
 
-} // namespace Test
+} // namespace TestCompiler

--- a/fvtest/compilertest/tests/Qux2IlInjector.hpp
+++ b/fvtest/compilertest/tests/Qux2IlInjector.hpp
@@ -20,7 +20,7 @@
 
 namespace TR { class TypeDictionary; }
 
-namespace Test
+namespace TestCompiler
 {
 class Qux2IlInjector : public TR::IlInjector
    {
@@ -37,4 +37,4 @@ class Qux2IlInjector : public TR::IlInjector
 
    };
 
-} // namespace Test
+} // namespace TestCompiler

--- a/fvtest/compilertest/tests/Qux2Test.cpp
+++ b/fvtest/compilertest/tests/Qux2Test.cpp
@@ -25,7 +25,7 @@
 #include "ilgen/TypeDictionary.hpp"
 #include "ilgen/IlGeneratorMethodDetails_inlines.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 class Qux2IlInjector;
 testMethodType  * Qux2Test::_qux2 = 0;
@@ -73,10 +73,10 @@ Qux2Test::invokeTests()
 //   EXPECT_EQ(qux2(INT_MIN), _qux2(INT_MIN));
    }
 
-} // namespace Test
+} // namespace TestCompiler
 
 TEST(JITQuxTest, QuxTest2)
    {
-   ::Test::Qux2Test qux2Test;
+   ::TestCompiler::Qux2Test qux2Test;
    qux2Test.RunTest();
    }

--- a/fvtest/compilertest/tests/Qux2Test.hpp
+++ b/fvtest/compilertest/tests/Qux2Test.hpp
@@ -18,7 +18,7 @@
 
 #include "TestDriver.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 class Qux2IlInjector;
 typedef int32_t (testMethodType)(int32_t);
@@ -40,4 +40,4 @@ class Qux2Test : public TestDriver
    static int32_t qux2(int32_t);
    };
 
-} // namespace Test
+} // namespace TestCompiler

--- a/fvtest/compilertest/tests/S390OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/S390OpCodesTest.cpp
@@ -25,7 +25,7 @@
 
 #include "tests/S390OpCodesTest.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 void
 S390OpCodesTest::compileIntegerArithmeticTestMethods()
@@ -5901,76 +5901,76 @@ S390OpCodesTest::invokeDisabledS390ConvertToAddressOpCodesTests()
       }
 #endif
    }
-} // namespace Test
+} // namespace TestCompiler
 
 #if defined(TR_TARGET_S390)
 //groups by testname
 TEST(JITS390OpCodesTest, UnaryTest)
    {
-   ::Test::S390OpCodesTest S390UnaryTest;
+   ::TestCompiler::S390OpCodesTest S390UnaryTest;
    S390UnaryTest.compileUnaryTestMethods();
    S390UnaryTest.invokeUnaryTests();
    }
 
 TEST(JITS390OpCodesTest, IntegerArithmeticTest)
    {
-   ::Test::S390OpCodesTest S390IntegerArithmeticTest;
+   ::TestCompiler::S390OpCodesTest S390IntegerArithmeticTest;
    S390IntegerArithmeticTest.compileIntegerArithmeticTestMethods();
    S390IntegerArithmeticTest.invokeIntegerArithmeticTests();
    }
 
 TEST(JITS390OpCodesTest, FloatArithmeticTest)
    {
-   ::Test::S390OpCodesTest S390FloatArithmeticTest;
+   ::TestCompiler::S390OpCodesTest S390FloatArithmeticTest;
    S390FloatArithmeticTest.compileFloatArithmeticTestMethods();
    S390FloatArithmeticTest.invokeFloatArithmeticTests();
    }
 
 TEST(JITS390OpCodesTest, MemoryOperationTest)
    {
-   ::Test::S390OpCodesTest S390MemoryOperationTest;
+   ::TestCompiler::S390OpCodesTest S390MemoryOperationTest;
    S390MemoryOperationTest.compileMemoryOperationTestMethods();
    S390MemoryOperationTest.invokeMemoryOperationTests();
    }
 
 TEST(JITS390OpCodesTest, ShiftOrRolTest)
    {
-   ::Test::S390OpCodesTest shiftOrRolTest;
+   ::TestCompiler::S390OpCodesTest shiftOrRolTest;
    shiftOrRolTest.compileShiftOrRolTestMethods();
    shiftOrRolTest.invokeShiftOrRolTests();
    }
 
 TEST(JITS390OpCodesTest, BitwiseTest)
    {
-   ::Test::S390OpCodesTest BitwiseTest;
+   ::TestCompiler::S390OpCodesTest BitwiseTest;
    BitwiseTest.compileBitwiseTestMethods();
    BitwiseTest.invokeBitwiseTests();
    }
 
 TEST(JITS390OpCodesTest, TernaryTest)
    {
-   ::Test::S390OpCodesTest S390TernaryTest;
+   ::TestCompiler::S390OpCodesTest S390TernaryTest;
    S390TernaryTest.compileTernaryTestMethods();
    S390TernaryTest.invokeTernaryTests();
    }
 
 TEST(JITS390OpCodesTest, CompareTest)
    {
-   ::Test::S390OpCodesTest S390CompareTest;
+   ::TestCompiler::S390OpCodesTest S390CompareTest;
    S390CompareTest.compileCompareTestMethods();
    S390CompareTest.invokeCompareTests();
    }
 
 TEST(JITS390OpCodesTest, DirectCallTest)
    {
-   ::Test::S390OpCodesTest S390DirectCallTest;
+   ::TestCompiler::S390OpCodesTest S390DirectCallTest;
    S390DirectCallTest.compileDirectCallTestMethods();
    S390DirectCallTest.invokeDirectCallTests();
    }
 
 TEST(JITS390OpCodesTest, S390AddressTest)
    {
-   ::Test::S390OpCodesTest S390AddressTest;
+   ::TestCompiler::S390OpCodesTest S390AddressTest;
    S390AddressTest.compileAddressTestMethods();
    S390AddressTest.invokeAddressTests();
    }
@@ -5982,7 +5982,7 @@ TEST(JITS390OpCodesTest, DISABLED_S390CompareTests)
    {
    //Jazz103 Work Item 106447
    //To temporarily enable "DISABLED" test, append " --gtest_also_run_disabled_tests" in the command line.
-   ::Test::S390OpCodesTest disabledS390CompareTest;
+   ::TestCompiler::S390OpCodesTest disabledS390CompareTest;
    disabledS390CompareTest.compileDisabledCompareOpCodesTestMethods();
    disabledS390CompareTest.invokeDisabledCompareOpCodesTests();
    }
@@ -5993,7 +5993,7 @@ TEST(JITS390OpCodesTest, DISABLED_S390IntegerArithmeticTests)
    //Jazz103 Work Item 103809
    //Testrossa Work Item 121966
    //To temporarily enable "DISABLED" test, append " --gtest_also_run_disabled_tests" in the command line.
-   ::Test::S390OpCodesTest disabledS390CompareTest;
+   ::TestCompiler::S390OpCodesTest disabledS390CompareTest;
    disabledS390CompareTest.compileDisabledIntegerArithmeticTestMethods();
    disabledS390CompareTest.invokeDisabledIntegerArithmeticTests();
    }
@@ -6001,7 +6001,7 @@ TEST(JITS390OpCodesTest, DISABLED_S390UnaryTests)
    {
    //Jazz103 Work Item 108753
    //To temporarily enable "DISABLED" test, append " --gtest_also_run_disabled_tests" in the command line.
-   ::Test::S390OpCodesTest disabledS390CompareTest;
+   ::TestCompiler::S390OpCodesTest disabledS390CompareTest;
    disabledS390CompareTest.compileDisabledUnaryTestMethods();
    disabledS390CompareTest.invokeDisabledUnaryTests();
    }
@@ -6010,7 +6010,7 @@ TEST(JITS390OpCodesTest, DISABLED_S390ShiftOrRolTests)
    {
    //Jazz103 Work Item 109995
    //To temporarily enable "DISABLED" test, append " --gtest_also_run_disabled_tests" in the command line.
-   ::Test::S390OpCodesTest disabledS390CompareTest;
+   ::TestCompiler::S390OpCodesTest disabledS390CompareTest;
    disabledS390CompareTest.compileDisabledShiftOrRolTestMethods();
    disabledS390CompareTest.invokeDisabledShiftOrRolTests();
    }
@@ -6020,7 +6020,7 @@ TEST(JITS390OpCodesTest, DISABLED_S390TernaryTests)
    //Jazz103 WI 104092
    //Jazz103 WI 109994
    //To temporarily enable "DISABLED" test, append " --gtest_also_run_disabled_tests" in the command line.
-   ::Test::S390OpCodesTest disabledS390CompareTest;
+   ::TestCompiler::S390OpCodesTest disabledS390CompareTest;
    disabledS390CompareTest.compileDisabledTernaryTestMethods();
    disabledS390CompareTest.invokeDisabledTernaryTests();
    }
@@ -6028,7 +6028,7 @@ TEST(JITS390OpCodesTest, DISABLED_S390TernaryTests)
 TEST(JITS390OpCodesTest, DISABLED_S390MemoryOperationTest)
    {
    //Jazz103 Work Item 111018, 111410
-   ::Test::S390OpCodesTest S390MemoryOperationTest;
+   ::TestCompiler::S390OpCodesTest S390MemoryOperationTest;
    S390MemoryOperationTest.compileDisabledMemoryOperationTestMethods();
    S390MemoryOperationTest.invokeDisabledMemoryOperationTests();
    }
@@ -6036,7 +6036,7 @@ TEST(JITS390OpCodesTest, DISABLED_S390MemoryOperationTest)
 TEST(JITS390OpCodesTest, DISABLED_S390BitwiseTest)
    {
    //Jazz103 Work Item 111019
-   ::Test::S390OpCodesTest S390BitwiseTest;
+   ::TestCompiler::S390OpCodesTest S390BitwiseTest;
    S390BitwiseTest.compileDisabledBitwiseTestMethods();
    S390BitwiseTest.invokeDisabledBitwiseTests();
    }
@@ -6044,7 +6044,7 @@ TEST(JITS390OpCodesTest, DISABLED_S390BitwiseTest)
 TEST(JITS390OpCodesTest, DISABLED_S390DirectCallTest)
    {
    //Jazz103 Work Item 103419
-   ::Test::S390OpCodesTest S390DirectCallTest;
+   ::TestCompiler::S390OpCodesTest S390DirectCallTest;
    S390DirectCallTest.compileDisabledDirectCallTestMethods();
    S390DirectCallTest.invokeDisabledDirectCallTests();
    }
@@ -6052,7 +6052,7 @@ TEST(JITS390OpCodesTest, DISABLED_S390DirectCallTest)
 TEST(JITS390OpCodesTest, DISABLED_S390ConvertToAddressTest)
    {
    //Jazz103 Work Item 107711
-   ::Test::S390OpCodesTest S390ConvertToAddressTest;
+   ::TestCompiler::S390OpCodesTest S390ConvertToAddressTest;
    S390ConvertToAddressTest.compileDisabledS390ConvertToAddressOpCodesTests();
    S390ConvertToAddressTest.invokeDisabledS390ConvertToAddressOpCodesTests();
    }

--- a/fvtest/compilertest/tests/S390OpCodesTest.hpp
+++ b/fvtest/compilertest/tests/S390OpCodesTest.hpp
@@ -18,7 +18,7 @@
 
 #include "OpCodesTest.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 class S390OpCodesTest : public OpCodesTest
    {
@@ -66,4 +66,4 @@ class S390OpCodesTest : public OpCodesTest
    virtual void invokeDisabledS390ConvertToAddressOpCodesTests();
    };
 
-} // namespace Test
+} // namespace TestCompiler

--- a/fvtest/compilertest/tests/TestDriver.cpp
+++ b/fvtest/compilertest/tests/TestDriver.cpp
@@ -38,7 +38,7 @@
 #include "ilgen/MethodBuilder.hpp"
 #include "gtest/gtest.h"
 
-namespace Test
+namespace TestCompiler
 {
 void
 TestDriver::RunTest()
@@ -60,4 +60,4 @@ TestDriver::compileMethodBuilder(TR::MethodBuilder *m, uint8_t ** entry)
    return rc;
    }
 
-} //namespace Test
+} //namespace TestCompiler

--- a/fvtest/compilertest/tests/TestDriver.hpp
+++ b/fvtest/compilertest/tests/TestDriver.hpp
@@ -28,7 +28,7 @@ namespace TR { class MethodBuilder; }
 typedef uint8_t * (*CompileFunctionType)(TR::IlGeneratorMethodDetails &, TR_Hotness);
 extern "C" uint8_t *compileMethod(TR::IlGeneratorMethodDetails &, TR_Hotness, int32_t &);
 
-namespace Test
+namespace TestCompiler
 {
 #define TOSTR(x)     #x
 #define LINETOSTR(x) TOSTR(x)
@@ -56,6 +56,6 @@ class TestDriver
 
    };
 
-}// namespace Test
+}// namespace TestCompiler
 
 #endif

--- a/fvtest/compilertest/tests/X86OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/X86OpCodesTest.cpp
@@ -25,7 +25,7 @@
 
 #include "tests/X86OpCodesTest.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 void
 X86OpCodesTest::compileIntegerArithmeticTestMethods()
@@ -5365,76 +5365,76 @@ X86OpCodesTest::invokeDisabledMemoryOpCodesTest()
       }
 
    }
-} // namespace Test
+} // namespace TestCompiler
 
 #if defined(TR_TARGET_X86)
 //groups by testname
 TEST(JITX86OpCodesTest, UnaryTest)
    {
-   ::Test::X86OpCodesTest X86UnaryTest;
+   ::TestCompiler::X86OpCodesTest X86UnaryTest;
    X86UnaryTest.compileUnaryTestMethods();
    X86UnaryTest.invokeUnaryTests();
    }
 
 TEST(JITX86OpCodesTest, IntegerArithmeticTest)
    {
-   ::Test::X86OpCodesTest X86IntegerArithmeticTest;
+   ::TestCompiler::X86OpCodesTest X86IntegerArithmeticTest;
    X86IntegerArithmeticTest.compileIntegerArithmeticTestMethods();
    X86IntegerArithmeticTest.invokeIntegerArithmeticTests();
    }
 
 TEST(JITX86OpCodesTest, FloatArithmeticTest)
    {
-   ::Test::X86OpCodesTest X86FloatArithmeticTest;
+   ::TestCompiler::X86OpCodesTest X86FloatArithmeticTest;
    X86FloatArithmeticTest.compileFloatArithmeticTestMethods();
    X86FloatArithmeticTest.invokeFloatArithmeticTests();
    }
 
 TEST(JITX86OpCodesTest, MemoryOperationTest)
    {
-   ::Test::X86OpCodesTest X86MemoryOperationTest;
+   ::TestCompiler::X86OpCodesTest X86MemoryOperationTest;
    X86MemoryOperationTest.compileMemoryOperationTestMethods();
    X86MemoryOperationTest.invokeMemoryOperationTests();
    }
 
 TEST(JITX86OpCodesTest, ShiftOrRolTest)
    {
-   ::Test::X86OpCodesTest shiftOrRolTest;
+   ::TestCompiler::X86OpCodesTest shiftOrRolTest;
    shiftOrRolTest.compileShiftOrRolTestMethods();
    shiftOrRolTest.invokeShiftOrRolTests();
    }
 
 TEST(JITX86OpCodesTest, BitwiseTest)
    {
-   ::Test::X86OpCodesTest BitwiseTest;
+   ::TestCompiler::X86OpCodesTest BitwiseTest;
    BitwiseTest.compileBitwiseTestMethods();
    BitwiseTest.invokeBitwiseTests();
    }
 
 TEST(JITX86OpCodesTest, DirectCallTest)
    {
-   ::Test::X86OpCodesTest X86DirectCallTest;
+   ::TestCompiler::X86OpCodesTest X86DirectCallTest;
    X86DirectCallTest.compileDirectCallTestMethods();
    X86DirectCallTest.invokeDirectCallTests();
    }
 
 TEST(JITX86OpCodesTest, CompareTest)
    {
-   ::Test::X86OpCodesTest X86CompareTest;
+   ::TestCompiler::X86OpCodesTest X86CompareTest;
    X86CompareTest.compileCompareTestMethods();
    X86CompareTest.invokeCompareTests();
    }
 
 TEST(JITX86OpCodesTest, TernaryTest)
    {
-   ::Test::X86OpCodesTest X86TernaryTest;
+   ::TestCompiler::X86OpCodesTest X86TernaryTest;
    X86TernaryTest.compileTernaryTestMethods();
    X86TernaryTest.invokeTernaryTests();
    }
 
 TEST(JITX86OpCodesTest, X86AddressTest)
    {
-   ::Test::X86OpCodesTest X86AddressTest;
+   ::TestCompiler::X86OpCodesTest X86AddressTest;
    X86AddressTest.compileAddressTestMethods();
    X86AddressTest.invokeAddressTests();
    }
@@ -5443,14 +5443,14 @@ TEST(JITX86OpCodesTest, DISABLED_X86IntegerArithmeticTest)
    {
    //Jazz103 Work Item 103809
    //Testrossa Work Item 121966
-   ::Test::X86OpCodesTest X86IntegerArithmeticTest;
+   ::TestCompiler::X86OpCodesTest X86IntegerArithmeticTest;
    X86IntegerArithmeticTest.compileDisabledIntegerArithmeticTestMethods();
    X86IntegerArithmeticTest.invokeDisabledIntegerArithmeticTests();
    }
 
 TEST(JITX86OpCodesTest, UnsupportedOpCodesTest)
    {
-   ::Test::X86OpCodesTest X86UnsupportedOpcodesTest;
+   ::TestCompiler::X86OpCodesTest X86UnsupportedOpcodesTest;
    X86UnsupportedOpcodesTest.UnsupportedOpCodesTests();
    }
 
@@ -5459,7 +5459,7 @@ TEST(JITX86OpCodesTest, DISABLED_X86UnaryTest)
    //Jazz103 Work Item 110363
    //This defect is related to 97974: Separate group to temporarily disable crashed (will work on) testcases
    //Please move this test and recover f2i testcase number from 3 to 5.
-   ::Test::X86OpCodesTest disabledUnaryTest;
+   ::TestCompiler::X86OpCodesTest disabledUnaryTest;
    disabledUnaryTest.invokeNoHelperUnaryTests();
    }
 
@@ -5469,7 +5469,7 @@ TEST(JITX86OpCodesTest, DISABLED_X86UnaryTest)
 TEST(JITX86OpCodesTest, DISABLED_X86CompareOpCodesTests)
    {
    //Jazz103 Work Item 109672
-   ::Test::X86OpCodesTest disabledX86OpcodesTest;
+   ::TestCompiler::X86OpCodesTest disabledX86OpcodesTest;
    disabledX86OpcodesTest.compileDisabledCompareOpCodesTest();
    disabledX86OpcodesTest.invokeDisabledCompareOpCodesTest();
    }
@@ -5477,7 +5477,7 @@ TEST(JITX86OpCodesTest, DISABLED_X86CompareOpCodesTests)
 TEST(JITX86OpCodesTest, DISABLED_X86ConvertOpCodesTests)
    {
    //Jazz103 Work Item 109672
-   ::Test::X86OpCodesTest disabledX86OpcodesTest;
+   ::TestCompiler::X86OpCodesTest disabledX86OpcodesTest;
    disabledX86OpcodesTest.compileDisabledConvertOpCodesTest();
    disabledX86OpcodesTest.invokeDisabledConvertOpCodesTest();
    }
@@ -5485,7 +5485,7 @@ TEST(JITX86OpCodesTest, DISABLED_X86ConvertOpCodesTests)
 TEST(JITX86OpCodesTest, DISABLED_X86MemoryOpCodesTests)
    {
    //Jazz103 111413
-   ::Test::X86OpCodesTest disabledX86MemoryOpcodesTest;
+   ::TestCompiler::X86OpCodesTest disabledX86MemoryOpcodesTest;
    disabledX86MemoryOpcodesTest.compileDisabledMemoryOpCodesTest();
    disabledX86MemoryOpcodesTest.invokeDisabledMemoryOpCodesTest();
    }

--- a/fvtest/compilertest/tests/X86OpCodesTest.hpp
+++ b/fvtest/compilertest/tests/X86OpCodesTest.hpp
@@ -18,7 +18,7 @@
 
 #include "OpCodesTest.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 class X86OpCodesTest : public OpCodesTest
    {
@@ -58,4 +58,4 @@ class X86OpCodesTest : public OpCodesTest
    virtual void invokeNoHelperUnaryTests();
    };
 
-} // namespace Test
+} // namespace TestCompiler

--- a/fvtest/compilertest/z/codegen/Evaluator.cpp
+++ b/fvtest/compilertest/z/codegen/Evaluator.cpp
@@ -26,7 +26,7 @@
 #include "env/IO.hpp"
 
 
-#define NOT_IMPLEMENTED { TR_ASSERT_FATAL(0, "This function is not implemented in Test JIT"); }
+#define NOT_IMPLEMENTED { TR_ASSERT_FATAL(0, "This function is not implemented in TestCompiler JIT"); }
 
 
 uint32_t
@@ -50,7 +50,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390RestoreGPR7Snippet *snippet)
    }
 
 void
-Test::FrontEnd::generateBinaryEncodingPrologue(
+TestCompiler::FrontEnd::generateBinaryEncodingPrologue(
       TR_BinaryEncodingData *beData,
       TR::CodeGenerator *cg)
    {

--- a/fvtest/compilertest/z/codegen/TestCodeGenerator.cpp
+++ b/fvtest/compilertest/z/codegen/TestCodeGenerator.cpp
@@ -21,13 +21,13 @@
 #include "compile/Compilation.hpp"
 #include "env/CompilerEnv.hpp"
 
-namespace Test
+namespace TestCompiler
 {
 namespace Z
 {
 
 CodeGenerator::CodeGenerator() :
-   Test::CodeGenerator()
+   TestCompiler::CodeGenerator()
    {
    self()->getS390Linkage()->initS390RealRegisterLinkage();
 
@@ -65,4 +65,4 @@ CodeGenerator::createLinkage(TR_LinkageConventions lc)
    }
 
 } // namespace Z
-} // namespace Test
+} // namespace TestCompiler

--- a/fvtest/compilertest/z/codegen/TestCodeGenerator.hpp
+++ b/fvtest/compilertest/z/codegen/TestCodeGenerator.hpp
@@ -25,11 +25,11 @@
 #ifndef TEST_CODEGENERATORBASE_CONNECTOR
 #define TEST_CODEGENERATORBASE_CONNECTOR
 
-namespace Test { namespace Z { class CodeGenerator; } }
-namespace Test { typedef Z::CodeGenerator CodeGeneratorConnector; }
+namespace TestCompiler { namespace Z { class CodeGenerator; } }
+namespace TestCompiler { typedef Z::CodeGenerator CodeGeneratorConnector; }
 
 #else
-#error Test::Z::CodeGenerator expected to be a primary connector, but a Test connector is already defined
+#error TestCompiler::Z::CodeGenerator expected to be a primary connector, but a TestCompiler connector is already defined
 #endif
 
 
@@ -37,12 +37,12 @@ namespace Test { typedef Z::CodeGenerator CodeGeneratorConnector; }
 #include "codegen/LinkageConventionsEnum.hpp"
 
 
-namespace Test
+namespace TestCompiler
 {
 namespace Z
 {
 
-class OMR_EXTENSIBLE CodeGenerator : public Test::CodeGenerator
+class OMR_EXTENSIBLE CodeGenerator : public TestCompiler::CodeGenerator
    {
    public:
 
@@ -53,7 +53,7 @@ class OMR_EXTENSIBLE CodeGenerator : public Test::CodeGenerator
    };
 
 } // namespace Z
-} // namespace Test
+} // namespace TestCompiler
 
 #endif // !defined(TEST_Z_CODEGENERATORBASE_INCL)
 


### PR DESCRIPTION
The name "CompilerTest" is more suited to the contents of the previous "Test" namespace - the Test compiler.

While this is a large commit, the changes in each file are trivial.