### PR TITLE
Issue #196 Lang. specific concurrent thread switch

### DIFF
--- a/gc/base/CollectorLanguageInterface.hpp
+++ b/gc/base/CollectorLanguageInterface.hpp
@@ -315,6 +315,13 @@ public:
 	 */
 	virtual void scavenger_fixupDestroyedSlot(MM_EnvironmentBase *env, MM_ForwardedHeader *forwardedObject, MM_MemorySubSpaceSemiSpace *subSpaceNew) = 0;
 #endif /* OMR_INTERP_COMPRESSED_OBJECT_HEADER */
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	/**
+	 * Enable/disable language specific thread local resource on Concurrent Scavenger cycle start/end 
+	 * @param[in] env The environment for the calling thread.
+	 */	 
+	virtual void scavenger_switchConcurrentForThread(MM_EnvironmentBase *env) = 0;
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
 #endif /* OMR_GC_MODRON_SCAVENGER */
 
 #if defined(OMR_GC_MODRON_CONCURRENT_MARK)

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -4572,11 +4572,13 @@ MM_Scavenger::switchConcurrentForThread(MM_EnvironmentBase *env)
     	if (!env->_concurrentScavengerInProgress) {
     		env->_concurrentScavengerInProgress = true;
     		Trc_MM_Scavenger_switchConcurrent(env->getLanguageVMThread(), 1);
+    		_cli->scavenger_switchConcurrentForThread(env);
     	}
     } else if (concurrent_state_idle == _concurrentState) {
     	if (env->_concurrentScavengerInProgress) {
     		env->_concurrentScavengerInProgress = false;
     		Trc_MM_Scavenger_switchConcurrent(env->getLanguageVMThread(), 0);
+    		_cli->scavenger_switchConcurrentForThread(env);
     	}
     }
 }


### PR DESCRIPTION
Allow language specific enabling/disabling thread local resources on
Concurrent Scavenge cycle start/end

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>