### PR TITLE
Prevent invalid memory copy in directStoreHelper

### DIFF
--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -6345,8 +6345,8 @@ bool directMemoryStoreHelper(TR::CodeGenerator* cg, TR::Node* storeNode)
 
             TR::Node* valueNode = conversionNode->getChild(0);
 
-            // Make sure this is a truncation conversion
-            if (valueNode->getOpCode().isLoadVar() && !valueNode->getOpCode().isReverseLoadOrStore () && valueNode->isSingleRefUnevaluated())
+            // Make sure this is an integral truncation conversion
+            if (valueNode->getOpCode().isIntegralLoadVar() && !valueNode->getOpCode().isReverseLoadOrStore () && valueNode->isSingleRefUnevaluated())
                {
                if (valueNode->getSize() > storeNode->getSize())
                   {


### PR DESCRIPTION
It is invalid to perform a memory copy transformation if there is a
non-integral truncation conversion in between the load and the store
nodes. The reason being that the types could be wildly different and
that the conversion is non-trivial. Such an example occurs the the
following tree:

istore
  d2i
    dload
    
For which the d2i conversion is non-trivial albeit technically a
truncation. We must prohibit this memory copy optimization for non
integral conversions.

Task 118388

Issue: #205
Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>