### PR TITLE
Move duplicate Z code to compiler/z/codegen

### DIFF
--- a/fvtest/compilertest/z/codegen/TestCodeGenerator.cpp
+++ b/fvtest/compilertest/z/codegen/TestCodeGenerator.cpp
@@ -16,6 +16,7 @@
  *    Multiple authors (IBM Corp.) - initial implementation and documentation
  *******************************************************************************/
 
+
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/TRSystemLinkage.hpp"
 #include "compile/Compilation.hpp"
@@ -29,39 +30,6 @@ namespace Z
 CodeGenerator::CodeGenerator() :
    Test::CodeGenerator()
    {
-   self()->getS390Linkage()->initS390RealRegisterLinkage();
-
-   self()->setAccessStaticsIndirectly(true);
-   }
-
-
-TR::Linkage *
-CodeGenerator::createLinkage(TR_LinkageConventions lc)
-   {
-   // *this    swipeable for debugging purposes
-   TR::Linkage * linkage;
-   TR::Compilation *comp = self()->comp();
-   switch (lc)
-      {
-      case TR_Helper:
-         linkage = new (self()->trHeapMemory()) TR_S390zLinuxSystemLinkage(self());
-         break;
-
-      case TR_Private:
-        // no private linkage, fall through to system
-
-      case TR_System:
-         if (TR::Compiler->target.isLinux())
-            linkage = new (self()->trHeapMemory()) TR_S390zLinuxSystemLinkage(self());
-         else
-            linkage = new (self()->trHeapMemory()) TR_S390zOSSystemLinkage(self());
-         break;
-
-      default :
-         TR_ASSERT(0, "\nTestarossa error: Illegal linkage convention %d\n", lc);
-      }
-   self()->setLinkage(lc, linkage);
-   return linkage;
    }
 
 } // namespace Z

--- a/fvtest/compilertest/z/codegen/TestCodeGenerator.hpp
+++ b/fvtest/compilertest/z/codegen/TestCodeGenerator.hpp
@@ -48,8 +48,6 @@ class OMR_EXTENSIBLE CodeGenerator : public Test::CodeGenerator
 
    CodeGenerator();
 
-   TR::Linkage *createLinkage(TR_LinkageConventions lc);
-
    };
 
 } // namespace Z

--- a/jitbuilder/z/codegen/JBCodeGenerator.cpp
+++ b/jitbuilder/z/codegen/JBCodeGenerator.cpp
@@ -16,6 +16,7 @@
  *    Multiple authors (IBM Corp.) - initial implementation and documentation
  *******************************************************************************/
 
+
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/TRSystemLinkage.hpp"
 #include "compile/Compilation.hpp"
@@ -29,39 +30,6 @@ namespace Z
 CodeGenerator::CodeGenerator() :
    JitBuilder::CodeGenerator()
    {
-   self()->getS390Linkage()->initS390RealRegisterLinkage();
-
-   self()->setAccessStaticsIndirectly(true);
-   }
-
-
-TR::Linkage *
-CodeGenerator::createLinkage(TR_LinkageConventions lc)
-   {
-   // *this    swipeable for debugging purposes
-   TR::Linkage * linkage;
-   TR::Compilation *comp = self()->comp();
-   switch (lc)
-      {
-      case TR_Helper:
-         linkage = new (self()->trHeapMemory()) TR_S390zLinuxSystemLinkage(self());
-         break;
-
-      case TR_Private:
-        // no private linkage, fall through to system
-
-      case TR_System:
-         if (TR::Compiler->target.isLinux())
-            linkage = new (self()->trHeapMemory()) TR_S390zLinuxSystemLinkage(self());
-         else
-            linkage = new (self()->trHeapMemory()) TR_S390zOSSystemLinkage(self());
-         break;
-
-      default :
-         TR_ASSERT(0, "\nJitBuilder error: Illegal linkage convention %d\n", lc);
-      }
-   self()->setLinkage(lc, linkage);
-   return linkage;
    }
 
 } // namespace Z

--- a/jitbuilder/z/codegen/JBCodeGenerator.hpp
+++ b/jitbuilder/z/codegen/JBCodeGenerator.hpp
@@ -48,8 +48,6 @@ class OMR_EXTENSIBLE CodeGenerator : public JitBuilder::CodeGenerator
 
    CodeGenerator();
 
-   TR::Linkage *createLinkage(TR_LinkageConventions lc);
-
    };
 
 } // namespace Z


### PR DESCRIPTION
Move copied implementations of Z-specific CodeGenerator from fvtest
and jitbuilder to compiler/z/codegen/OMRCodeGenerator.cpp.

Move duplicated body of constructor from fvtest and jitbuilder to
the OMR Z constructor in compiler/z/codegen/OMRCodeGenerator.cpp.