### PR TITLE
Cleanup Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,5 @@ matrix:
 
 script:
   - make -f run_configure.mk OMRGLUE=./example/glue
-  - make 
-  - make test
+  - make && make test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_script:
 # apport is available in apt whitelist
 
 env:
-  - SPEC=osx_x86-64 EXTRA_CONFIGURE_ARGS="--disable-OMR_JIT"
+  - SPEC=osx_x86-64
   - SPEC=linux_x86-64
   - SPEC=linux_x86-64_cmprssptrs
   - SPEC=linux_x86
@@ -52,7 +52,7 @@ env:
 matrix:
   exclude:
     - os: linux
-      env: SPEC=osx_x86-64 EXTRA_CONFIGURE_ARGS="--disable-OMR_JIT"
+      env: SPEC=osx_x86-64
     - os: osx
       env: SPEC=linux_x86-64
     - os: osx

--- a/example/glue/configure_includes/configure_osx.mk
+++ b/example/glue/configure_includes/configure_osx.mk
@@ -23,6 +23,7 @@ include $(CONFIG_INCL_DIR)/configure_common.mk
 CONFIGURE_ARGS += \
   --enable-OMR_EXAMPLE \
   --enable-OMR_GC \
+  --disable-OMR_JIT \
   --enable-OMR_PORT \
   --enable-OMR_THREAD \
   --enable-OMR_OMRSIG \


### PR DESCRIPTION
Currently, Travis CI runs tests whether or not the build succeeds. This can cause confusion, since the last error in the build log can be of a test binary missing, while the true error is far above.

Additionally, move the `--disable-OMR_JIT` option into the OS X configuration file. This cleans up the `.travis.yml` file, and allows developers on OS X to build the other parts of OMR without specifying the flag.