### PR TITLE
Prep work prior to removing FrontEnd functions

### DIFF
--- a/compiler/codegen/FrontEnd.hpp
+++ b/compiler/codegen/FrontEnd.hpp
@@ -183,10 +183,10 @@ public:
    virtual int32_t getArrayletMask(int32_t);
    virtual int32_t getArrayletLeafIndex(int32_t, int32_t);
    virtual int32_t getObjectAlignmentInBytes();
-   virtual uintptrj_t getOffsetOfContiguousArraySizeField(); // DM: move w/ ifdef
-   virtual uintptrj_t getOffsetOfDiscontiguousArraySizeField(); // DM: move w/ ifdef
+   virtual uintptrj_t getOffsetOfContiguousArraySizeField();
+   virtual uintptrj_t getOffsetOfDiscontiguousArraySizeField();
    virtual uintptrj_t getObjectHeaderSizeInBytes();
-   virtual uintptrj_t getOffsetOfIndexableSizeField(); // DM: move w/ ifdef
+   virtual uintptrj_t getOffsetOfIndexableSizeField();
 
    // --------------------------------------------------------------------------
    // J9 Classes / VM?
@@ -197,22 +197,24 @@ public:
    virtual TR_OpaqueClassBlock * getClassClassPointer(TR_OpaqueClassBlock *objectClassPointer);
    virtual TR_OpaqueClassBlock * getClassFromMethodBlock(TR_OpaqueMethodBlock *mb);
    virtual int32_t getNewArrayTypeFromClass(TR_OpaqueClassBlock *clazz);
-   virtual TR_OpaqueClassBlock * getClassFromStatic(void *p);
 
    // VM+Shared
    virtual TR_OpaqueClassBlock * getArrayClassFromComponentClass(TR_OpaqueClassBlock * componentClass);
-   virtual uintptrj_t getClassDepthAndFlagsValue(TR_OpaqueClassBlock * classPointer);
    virtual TR_OpaqueClassBlock * getClassFromNewArrayType(int32_t arrayType);
    virtual TR_OpaqueClassBlock * getClassFromSignature(const char * sig, int32_t length, TR_ResolvedMethod *method, bool callSiteVettedForAOT=false);
    virtual TR_OpaqueClassBlock * getClassFromSignature(const char * sig, int32_t length, TR_OpaqueMethodBlock *method, bool callSiteVettedForAOT=false);
    virtual TR_OpaqueClassBlock * getClassOfMethod(TR_OpaqueMethodBlock *method);
    virtual TR_OpaqueClassBlock * getComponentClassFromArrayClass(TR_OpaqueClassBlock *arrayClass);
-   virtual TR_OpaqueClassBlock * getLeafComponentClassFromArrayClass(TR_OpaqueClassBlock *arrayClass); // DM: move w/ minor
+   virtual TR_OpaqueClassBlock * getLeafComponentClassFromArrayClass(TR_OpaqueClassBlock *arrayClass);
 
-
+   // to J9
+   virtual uintptrj_t getClassDepthAndFlagsValue(TR_OpaqueClassBlock * classPointer);
+   virtual TR_OpaqueClassBlock * getClassFromStatic(void *p);
    virtual int32_t getStringLength(uintptrj_t objectPointer);
-   virtual char *getStringUTF8(uintptrj_t objectPointer, char *buffer, intptrj_t bufferSize); // DM: move w/ ifdef    Null-terminated.  bufferSize >= 1+getStringUTF8Length(objectPointer).  Returns buffer just for convenience.
-   virtual intptrj_t getStringUTF8Length(uintptrj_t objectPointer); // DM: move w/ ifdef
+
+   // Null-terminated.  bufferSize >= 1+getStringUTF8Length(objectPointer).  Returns buffer just for convenience.
+   virtual char *getStringUTF8(uintptrj_t objectPointer, char *buffer, intptrj_t bufferSize);
+   virtual intptrj_t getStringUTF8Length(uintptrj_t objectPointer);
 
    // --------------------------------------------------------------------------
    // Code cache

--- a/compiler/env/OMRObjectModel.hpp
+++ b/compiler/env/OMRObjectModel.hpp
@@ -87,6 +87,16 @@ class ObjectModel
    int64_t maxArraySizeInElementsForAllocation(TR::Node *newArray, TR::Compilation *comp);
    int64_t maxArraySizeInElements(int32_t knownMinElementSize, TR::Compilation *comp);
    bool nativeAddressesCanChangeSize() { return false; }
+
+   int32_t arraySpineShift(int32_t width) { return 0; }
+   int32_t arrayletMask(int32_t width) { return 0; }
+   int32_t arrayletLeafIndex(int32_t index, int32_t elementSize) { return 0; }
+   int32_t objectAlignmentInBytes() { return 0; }
+   uintptrj_t offsetOfContiguousArraySizeField() { return 0; }
+   uintptrj_t offsetOfDiscontiguousArraySizeField() { return 0; }
+   uintptrj_t objectHeaderSizeInBytes() { return 0; }
+   uintptrj_t offsetOfIndexableSizeField() { return 0; }
+
    };
 }
 

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -54,6 +54,10 @@
 #include "optimizer/ValueNumberInfo.hpp"
 #include "optimizer/TransformUtil.hpp"
 
+#ifdef J9_PROJECT_SPECIFIC
+#include "env/VMJ9.h"
+#endif
+
 #define OP_PLUS  0
 #define OP_MINUS 1
 #define CLEARBIT32 0x7FFFFFFF
@@ -5677,17 +5681,20 @@ TR::Node *indirectLoadSimplifier(TR::Node * node, TR::Block * block, TR::Simplif
          somePackedOp = somePackedAddress->getOpCodeValue();
          }
 
+#ifdef J9_PROJECT_SPECIFIC
       if (nodeSymref == s->getSymRefTab()->findClassAndDepthFlagsSymbolRef()
             && somePackedOp == TR::loadaddr && !somePackedAddress->getSymbolReference()->isUnresolved())
          {
          TR::SymbolReference *childSymref = somePackedAddress->getSymbolReference();
          TR_OpaqueClassBlock* clazz = (TR_OpaqueClassBlock *)childSymref->getSymbol()->getStaticSymbol()->getStaticAddress();
-         uintptrj_t konst = s->fe()->getClassDepthAndFlagsValue(clazz);
+         uintptrj_t konst = s->comp()->fej9()->getClassDepthAndFlagsValue(clazz);
          TR::Node *konstNode = nodeOp == TR::iloadi ? TR::Node::iconst(node, konst) :
                               nodeOp == TR::lloadi ? TR::Node::lconst( node, konst) :
                                                     NULL;
          return s->replaceNode(node, konstNode, s->_curTree);
          }
+#endif
+
       }
 
    if (

--- a/compiler/optimizer/VPConstraint.cpp
+++ b/compiler/optimizer/VPConstraint.cpp
@@ -1340,7 +1340,7 @@ TR_VPConstString *TR_VPConstString::create(TR_ValuePropagation *vp, TR::SymbolRe
 
       // since vmaccess has been acquired already, chars cannot be null
       //
-      int32_t len = vp->comp()->fe()->getStringLength((uintptrj_t)string);
+      int32_t len = vp->comp()->fej9()->getStringLength((uintptrj_t)string);
       int32_t i = 0;
       uint32_t hashValue = 0;
       for (int32_t i = 0; i < len && i < TR_MAX_CHARS_FOR_HASH; i++)
@@ -1377,7 +1377,7 @@ uint16_t TR_VPConstString::charAt(int32_t i, TR::Compilation * comp)
    if (charAtCriticalSection.hasVMAccess())
       {
       uintptrj_t string = *(uintptrj_t*)_symRef->getSymbol()->castToStaticSymbol()->getStaticAddress();
-      int32_t len = comp->fe()->getStringLength(string);
+      int32_t len = comp->fej9()->getStringLength(string);
       bool canRead = true;
       if (i < 0 || i >= len)
          canRead = false;
@@ -5806,7 +5806,7 @@ void TR_VPConstString::print(TR::Compilation * comp, TR::FILE *outFile)
       if (vpConstStringPrintCriticalSection.hasVMAccess())
          {
          uintptrj_t string = *(uintptrj_t*) _symRef->getSymbol()->castToStaticSymbol()->getStaticAddress();
-         int32_t len = comp->fe()->getStringLength(string);
+         int32_t len = comp->fej9()->getStringLength(string);
          for (int32_t i = 0; i < len; ++i)
             trfprintf(outFile, "%c", TR::Compiler->cls.getStringCharacter(comp, string, i));
          trfprintf(outFile, "\" ");

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -1186,7 +1186,7 @@ bool simplifyJ9ClassFlags(TR_ValuePropagation *vp, TR::Node *node, bool isLong)
          if (baseObject && baseObject->getClassType() &&
                baseObject->getClassType()->asFixedClass())
             {
-            cdfValue = vp->fe()->getClassDepthAndFlagsValue(baseObject->getClassType()->getClass());
+            cdfValue = vp->comp()->fej9()->getClassDepthAndFlagsValue(baseObject->getClassType()->getClass());
             // if the type is a java.lang.Object, make the control branch to the call
             //
             if (baseObject->getClassType()->asFixedClass()->isJavaLangObject(vp))

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -96,6 +96,7 @@
 #ifdef J9_PROJECT_SPECIFIC
 #include "env/CHTable.hpp"                            // for TR_CHTable, etc
 #include "env/VMAccessCriticalSection.hpp"            // for VMAccessCriticalSection
+#include "env/VMJ9.h"
 #endif
 
 #ifdef AIXPPC
@@ -1938,9 +1939,9 @@ TR_Debug::getStaticName(TR::SymbolReference * symRef)
             if (stringLocation)
                {
                uintptrj_t string = *stringLocation;
-               length = comp()->fe()->getStringUTF8Length(string);
+               length = comp()->fej9()->getStringUTF8Length(string);
                contents = (char*)comp()->trMemory()->allocateMemory(length+1, stackAlloc, TR_MemoryBase::UnknownType);
-               comp()->fe()->getStringUTF8(string, contents, length+1);
+               comp()->fej9()->getStringUTF8(string, contents, length+1);
 
                //
                // We don't want to mess up the logs too much.  Make sure the


### PR DESCRIPTION
* Prepare to remove unused or J9 project-specific functions from the
TR_FrontEnd class
* Prepare to move object model query function into ObjectModel 
environment class
