### PR TITLE
Add convertWidthToShift to TransformUtil

### DIFF
--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -965,6 +965,7 @@ public:
 #endif
 
    // To TransformUtil
+   // @deprecated Use TransformUtil::convertWidthToShift
    static uint32_t convertWidthToShift(int32_t i) { return _widthToShift[i]; }
    void removeTree(TR::TreeTop * tt);
    void setStartTree(TR::TreeTop * tt);

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -6043,11 +6043,11 @@ void TR_LoopVersioner::buildSpineCheckComparisonsTree(List<TR::TreeTop> *nullChe
             hdrSize = TR::Node::create(spineCheckNode, TR::iconst, 0, (int32_t)TR::Compiler->om.discontiguousArrayHeaderSizeInBytes());
 
 
-         int32_t shift = TR::Compilation::convertWidthToShift(TR::Compiler->om.sizeofReferenceField());
+         int32_t shift = TR::TransformUtil::convertWidthToShift(TR::Compiler->om.sizeofReferenceField());
          TR::Node *shiftNode = is64BitTarget ? TR::Node::lconst(spineCheckNode, (int64_t)shift) :
                                               TR::Node::iconst(spineCheckNode, shift);
 
-         int32_t strideShift = TR::Compilation::convertWidthToShift(elementSize);
+         int32_t strideShift = TR::TransformUtil::convertWidthToShift(elementSize);
          TR::Node *strideShiftNode = NULL;
          if (strideShift)
             strideShiftNode = is64BitTarget ? TR::Node::lconst(spineCheckNode, (int64_t)strideShift) :
@@ -7469,7 +7469,7 @@ void TR_LoopVersioner::collectAllExpressionsToBeChecked(List<TR::TreeTop> *nullC
       if (comp()->useCompressedPointers() &&
             node->getDataType() == TR::Address)
          dataWidth = TR::Compiler->om.sizeofReferenceField();
-      int32_t shiftWidth = TR::Compilation::convertWidthToShift(dataWidth);
+      int32_t shiftWidth = TR::TransformUtil::convertWidthToShift(dataWidth);
 
       if (childInRequiredForm)
          {

--- a/compiler/optimizer/OMRTransformUtil.cpp
+++ b/compiler/optimizer/OMRTransformUtil.cpp
@@ -284,6 +284,8 @@ OMR::TransformUtil::scalarizeAddressParameter(
    }
 
 
+uint32_t OMR::TransformUtil::_widthToShift[] = { 0, 0, 1, 0, 2, 0, 0, 0, 3};
+
 TR::Node *
 OMR::TransformUtil::transformIndirectLoad(TR::Compilation *, TR::Node *node)
    {

--- a/compiler/optimizer/OMRTransformUtil.hpp
+++ b/compiler/optimizer/OMRTransformUtil.hpp
@@ -71,6 +71,8 @@ class OMR_EXTENSIBLE TransformUtil
          TR::SymbolReference *ref,
          bool store);
 
+   static uint32_t convertWidthToShift(int32_t i) { return _widthToShift[i]; }
+   
    static bool isNoopConversion(TR::Compilation *, TR::Node *node);
    
    static void recursivelySetNodeVisitCount(TR::Node *node, vcount_t);
@@ -89,6 +91,11 @@ class OMR_EXTENSIBLE TransformUtil
    static bool transformIndirectLoadChainAt(TR::Compilation *, TR::Node *node, TR::Node *baseExpression, uintptrj_t *baseReferenceLocation, TR::Node **removedNode);
 
    static bool fieldShouldBeCompressed(TR::Node *node, TR::Compilation *comp);
+   
+   private:
+
+   static uint32_t _widthToShift[];
+
    };
 
 }

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -1747,10 +1747,10 @@ void TR_ValuePropagation::transformArrayCopyCall(TR::Node *node)
          //       iconst strideShift
          //
 
-         int32_t shift = TR::Compilation::convertWidthToShift(TR::Compiler->om.sizeofReferenceField());
+         int32_t shift = TR::TransformUtil::convertWidthToShift(TR::Compiler->om.sizeofReferenceField());
          TR::Node *shiftNode = TR::Node::create(node, TR::iconst, 0, (int32_t)shift);
 
-         int32_t strideShift = TR::Compilation::convertWidthToShift(elementSize);
+         int32_t strideShift = TR::TransformUtil::convertWidthToShift(elementSize);
          TR::Node *strideShiftNode = strideShift ? TR::Node::create(node, TR::iconst, 0, (int32_t)strideShift) : NULL;
 
          TR::Node *srcOff = srcOffNode->createLongIfNeeded();
@@ -2656,8 +2656,8 @@ void TR_ValuePropagation::generateRTArrayNodeWithoutFlags(TR_RealTimeArrayCopy *
    TR::Node *spineShiftNode = TR::Node::create(node, TR::iconst, 0, (int32_t)fe()->getArraySpineShift(elementSize));
    TR::Node *strideShiftNode = NULL;
    TR::Node *shiftNode = NULL;
-   int32_t shift = TR::Compilation::convertWidthToShift(TR::Compiler->om.sizeofReferenceField());
-   int32_t strideShift = TR::Compilation::convertWidthToShift(elementSize);
+   int32_t shift = TR::TransformUtil::convertWidthToShift(TR::Compiler->om.sizeofReferenceField());
+   int32_t strideShift = TR::TransformUtil::convertWidthToShift(elementSize);
 
    shiftNode = TR::Node::create(node, TR::iconst, 0, (int32_t)shift);
    if (strideShift)


### PR DESCRIPTION
Copy convertWidthToShift from OMR::Compilation
to OMR::TransformUtil.

Deprecate OMR::Compilation::ConvertWidthToShift

Signed-off-by: Aman Kumar <amank@ca.ibm.com>