### PR TITLE
Move removeTree to TransformUtil

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -2270,6 +2270,9 @@ OMR::Compilation::getSymRefCount()
    return self()->getSymRefTab()->getNumSymRefs();
    }
 
+/**
+  * @deprecated Use TransformUtil::removeTree
+  */
 void
 OMR::Compilation::removeTree(TR::TreeTop * tt)
    {

--- a/compiler/il/OMRBlock.cpp
+++ b/compiler/il/OMRBlock.cpp
@@ -63,6 +63,7 @@
 #include "optimizer/Optimizer.hpp"             // for Optimizer
 #include "optimizer/RegisterCandidate.hpp"     // for TR_GlobalRegister
 #include "optimizer/Structure.hpp"             // for TR_BlockStructure, etc
+#include "optimizer/TransformUtil.hpp"         // for TransformUtil
 #include "ras/Debug.hpp"                       // for TR_DebugBase
 
 class TR_Memory;
@@ -612,7 +613,7 @@ OMR::Block::removeFromCFG(TR::Compilation *c)
       for (TR::TreeTop *treeTop = _pEntry, *next; ; treeTop = next)
          {
          next = treeTop->getNextTreeTop();
-         c->removeTree(treeTop);
+         TR::TransformUtil::removeTree(c, treeTop);
          if (treeTop == _pExit)
             break;
          }
@@ -651,7 +652,7 @@ OMR::Block::removeBranch(TR::Compilation *c)
    TR::TreeTop * tt = self()->getLastRealTreeTop();
    TR_ASSERT(tt->getNode()->getOpCode().isBranch(), "OMR::Block::removeBranch, block doesn't have a branch");
    c->getFlowGraph()->removeEdge(self(), tt->getNode()->getBranchDestination()->getNode()->getBlock());
-   c->removeTree(tt);
+   TR::TransformUtil::removeTree(c, tt);
    }
 
 TR::Block *

--- a/compiler/optimizer/ExpressionsSimplification.cpp
+++ b/compiler/optimizer/ExpressionsSimplification.cpp
@@ -45,6 +45,7 @@
 #include "optimizer/Optimization.hpp"            // for Optimization
 #include "optimizer/Optimization_inlines.hpp"
 #include "optimizer/Structure.hpp"               // for TR_RegionStructure, etc
+#include "optimizer/TransformUtil.hpp"           // for TransformUtil
 #include "optimizer/VPConstraint.hpp"            // for TR_VPConstraint
 #include "ras/Debug.hpp"                         // for TR_DebugBase
 
@@ -430,7 +431,7 @@ bool TR_ExpressionsSimplification::tranformSummationReductionCandidate(TR::TreeT
                   newNode->getFirstChild()->setAndIncChild(expChildNumber, expNode);
                transformNode(newNode, preheaderBlock);
                }
-            comp()->removeTree(treeTop);
+            TR::TransformUtil::removeTree(comp(), treeTop);
             }
          }
       }
@@ -468,7 +469,7 @@ void TR_ExpressionsSimplification::tranformStoreMotionCandidate(TR::TreeTop *tre
          {
          TR::Node *newNode = node->duplicateTree();
          transformNode(newNode, preheaderBlock);
-         comp()->removeTree(treeTop);
+         TR::TransformUtil::removeTree(comp(), treeTop);
          }
       }
    else

--- a/compiler/optimizer/GeneralLoopUnroller.cpp
+++ b/compiler/optimizer/GeneralLoopUnroller.cpp
@@ -46,6 +46,7 @@
 #include "optimizer/Optimization_inlines.hpp"
 #include "optimizer/Optimizer.hpp"             // for Optimizer
 #include "optimizer/Structure.hpp"             // for TR_RegionStructure, etc
+#include "optimizer/TransformUtil.hpp"         // for TransformUtil
 #include "ras/Debug.hpp"                       // for TR_DebugBase
 
 #define OPT_DETAILS "O^O GENERAL LOOP UNROLLER: "
@@ -979,7 +980,7 @@ void TR_LoopUnroller::modifyOriginalLoop(TR_RegionStructure *loop, TR_StructureS
          gotoNode->setBranchDestination(destBlock->getEntry());
          gotoNode->setSideTableIndex(CREATED_BY_GLU);
 
-         comp()->removeTree(branchBlock->getLastRealTreeTop());
+         TR::TransformUtil::removeTree(comp(), branchBlock->getLastRealTreeTop());
          branchBlock->append(gotoTree);
          oldLoopEntryTree = branchBlock->getExit()->getNextTreeTop();
 

--- a/compiler/optimizer/GlobalRegisterAllocator.cpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.cpp
@@ -67,6 +67,7 @@
 #include "optimizer/Optimizer.hpp"                  // for Optimizer
 #include "optimizer/RegisterCandidate.hpp"
 #include "optimizer/Structure.hpp"
+#include "optimizer/TransformUtil.hpp"              // for TransformUtil
 #include "optimizer/DataFlowAnalysis.hpp"           // for TR_Liveness
 #include "optimizer/UseDefInfo.hpp"                 // for TR_UseDefInfo, etc
 #include "ras/Debug.hpp"                            // for TR_DebugBase
@@ -612,7 +613,7 @@ TR_GlobalRegisterAllocator::perform()
             if (!rc->getValueModified())
                for (; store; store = stores.getNext())
                   {
-                  comp()->removeTree(store);
+                  TR::TransformUtil::removeTree(comp(), store);
                   }
            else
               {
@@ -709,7 +710,7 @@ TR_GlobalRegisterAllocator::perform()
                      !nonSplittingCopyStored.isSet(tt->getNode()->getFirstChild()->getRegLoadStoreSymbolReference()->getReferenceNumber()))
                      {
                      if (trace) traceMsg(comp(), "Remove a redundant store %p\n", tt->getNode());
-                        comp()->removeTree(tt);
+                     TR::TransformUtil::removeTree(comp(), tt);
                      }
                   }
 

--- a/compiler/optimizer/IsolatedStoreElimination.cpp
+++ b/compiler/optimizer/IsolatedStoreElimination.cpp
@@ -54,6 +54,7 @@
 #include "optimizer/Optimizations.hpp"
 #include "optimizer/Optimizer.hpp"             // for Optimizer
 #include "optimizer/Structure.hpp"             // for TR_RegionStructure, etc
+#include "optimizer/TransformUtil.hpp"         // for TransformUtil
 #include "optimizer/UseDefInfo.hpp"            // for TR_UseDefInfo, etc
 #include "optimizer/VPConstraint.hpp"          // for TR_VPConstraint
 #include "ras/Debug.hpp"                       // for TR_DebugBase
@@ -1369,7 +1370,7 @@ TR_IsolatedStoreElimination::findStructuresAndNodesUsedIn(TR_UseDefInfo *info, T
          for (TR::TreeTop *treeTop = entryBlock->getEntry()->getNextTreeTop(), *next; (treeTop != entryBlock->getExit()); treeTop = next)
             {
             next = treeTop->getNextTreeTop();
-            comp()->removeTree(treeTop);
+            TR::TransformUtil::removeTree(comp(), treeTop);
             if (next == entryBlock->getExit())
                break;
             }

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -359,7 +359,7 @@ int32_t TR_ExtendBasicBlocks::orderBlocksWithoutFrequencyInfo()
          if (!performTransformation(comp(), "%sMerge blocks %d and %d\n", optDetailString(), prevBlock->getNumber(), block->getNumber()))
             continue;
          optimizer()->prepareForTreeRemoval(tt);
-         comp()->removeTree(tt);
+         TR::TransformUtil::removeTree(comp(), tt);
          }
       else if ((firstNonFenceTree == lastNonFenceTree) &&
                (lastNonFenceTree->getNode()->getOpCodeValue() == TR::Goto)
@@ -731,7 +731,7 @@ int32_t TR_ExtendBasicBlocks::orderBlocksWithFrequencyInfo()
                if (node->getOpCodeValue() == TR::Goto)
                   {
                   optimizer()->prepareForTreeRemoval(treeTop);
-                  comp()->removeTree(treeTop);
+                  TR::TransformUtil::removeTree(comp(), treeTop);
                   }
                }
             }
@@ -1211,7 +1211,7 @@ int32_t TR_BlockManipulator::performChecksAndTreesMovement(TR::Block *newBlock, 
       else if (prevNode->getOpCodeValue() == TR::Goto)
          {
          optimizer->prepareForTreeRemoval(tt);
-         comp()->removeTree(tt);
+         TR::TransformUtil::removeTree(comp(), tt);
          }
 
       return cursorNext ? 2 : 1;
@@ -1253,7 +1253,7 @@ int32_t TR_BlockManipulator::performChecksAndTreesMovement(TR::Block *newBlock, 
       else
          {
          optimizer->prepareForTreeRemoval(tt);
-         comp()->removeTree(tt);
+         TR::TransformUtil::removeTree(comp(), tt);
          }
       return followingTree ? 2 : 1;
       */
@@ -1296,7 +1296,7 @@ int32_t TR_BlockManipulator::performChecksAndTreesMovement(TR::Block *newBlock, 
          else
             {
             optimizer->prepareForTreeRemoval(tt);
-            comp()->removeTree(tt);
+            TR::TransformUtil::removeTree(comp(), tt);
             }
 
          if (!nextTree)
@@ -1829,7 +1829,7 @@ int32_t TR_HoistBlocks::process(TR::TreeTop *startTree, TR::TreeTop *endTree)
 
                   if (tt->getNode()->getOpCode().isBranch())
                      {
-                     comp()->removeTree(tt);
+                     TR::TransformUtil::removeTree(comp(), tt);
                      }
 
                   bool needToRemoveEdge = true;
@@ -3049,7 +3049,7 @@ int32_t TR_SimplifyAnds::process(TR::TreeTop *startTree, TR::TreeTop *endTree)
                             nextBlock->getEntry()->join(nextBlock->getExit());
 
                             optimizer()->prepareForTreeRemoval(lastRealTree);
-                            comp()->removeTree(lastRealTree);
+                            TR::TransformUtil::removeTree(comp(), lastRealTree);
 
                             TR::CFGEdge* currentSucc = block->getSuccessors().front();
                             TR::CFGNode *succBlock = currentSucc->getTo();
@@ -3807,7 +3807,7 @@ int32_t TR_CleanseTrees::process(TR::TreeTop *startTree, TR::TreeTop *endTreeTop
             else
                {
                optimizer()->prepareForTreeRemoval(lastNonFenceTree);
-               comp()->removeTree(lastNonFenceTree);
+               TR::TransformUtil::removeTree(comp(), lastNonFenceTree);
                }
             }
          }
@@ -6920,7 +6920,7 @@ TR::Block *TR_BlockSplitter::splitBlock(TR::Block *pred, TR_LinkHeadAndTail<Bloc
             }
          else if (lastRealNode->getOpCode().isGoto())
             {
-            comp()->removeTree(pred->getExit()->getPrevRealTreeTop());
+            TR::TransformUtil::removeTree(comp(), pred->getExit()->getPrevRealTreeTop());
             }
          }
       }

--- a/compiler/optimizer/OMRDeadTreesElimination.cpp
+++ b/compiler/optimizer/OMRDeadTreesElimination.cpp
@@ -513,7 +513,7 @@ void OMR::DeadTreesElimination::prePerformOnBlocks()
       if (node->getOpCodeValue() == TR::treetop &&
           node->getFirstChild()->getVisitCount() == visitCount &&
           performTransformation(comp(), "%sRemove trivial dead tree: %p\n", optDetailString(), node))
-         comp()->removeTree(tt);
+         TR::TransformUtil::removeTree(comp(), tt);
       else
          {
          if (node->getOpCode().isCheck() &&
@@ -522,7 +522,7 @@ void OMR::DeadTreesElimination::prePerformOnBlocks()
              node->getFirstChild()->getSymbolReference()->getSymbol()->isResolvedMethod() &&
              node->getFirstChild()->getSymbolReference()->getSymbol()->castToResolvedMethodSymbol()->isSideEffectFree() &&
              performTransformation(comp(), "%sRemove dead check of side-effect free call: %p\n", optDetailString(), node))
-            comp()->removeTree(tt);
+            TR::TransformUtil::removeTree(comp(), tt);
          }
 
       if (node->getVisitCount() >= visitCount)

--- a/compiler/optimizer/OMROptimization.cpp
+++ b/compiler/optimizer/OMROptimization.cpp
@@ -43,6 +43,7 @@
 #include "optimizer/Optimization_inlines.hpp"  // for Optimization::self
 #include "optimizer/Optimizer.hpp"             // for Optimizer
 #include "optimizer/Simplifier.hpp"            // for TR::Simplifier
+#include "optimizer/TransformUtil.hpp"         // for TransformUtil
 
 #define MAX_DEPTH_FOR_SMART_ANCHORING 3
 
@@ -372,7 +373,7 @@ OMR::Optimization::changeConditionalToUnconditional(TR::Node*& node, TR::Block* 
            treeTop = prevTreeTop)
          {
          prevTreeTop = treeTop->getPrevRealTreeTop();
-         self()->comp()->removeTree(treeTop);
+         TR::TransformUtil::removeTree(self()->comp(), treeTop);
          blocksWereRemoved = true;
          }
       }

--- a/compiler/optimizer/OMRSimplifier.cpp
+++ b/compiler/optimizer/OMRSimplifier.cpp
@@ -74,6 +74,7 @@
 #include "optimizer/Optimizations.hpp"
 #include "optimizer/Optimizer.hpp"             // for Optimizer
 #include "optimizer/Structure.hpp"             // for TR_BlockStructure, etc
+#include "optimizer/TransformUtil.hpp"         // for TransformUtil
 #include "ras/Debug.hpp"                       // for TR_DebugBase, etc
 
 extern const SimplifierPtr simplifierOpts[];
@@ -470,7 +471,7 @@ OMR::Simplifier::simplify(TR::TreeTop * treeTop, TR::Block * block)
    if (node == NULL &&
        (!block->getPredecessors().empty() ||
         !block->getExceptionPredecessors().empty()))
-      comp()->removeTree(treeTop);
+      TR::TransformUtil::removeTree(comp(), treeTop);
 
    return next;
    }

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -15678,7 +15678,7 @@ TR::Node *endBlockSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
           (lastTree->getNode()->getOpCode().isJumpWithMultipleTargets() && lastTree->getNode()->getOpCode().hasBranchChildren()))
          {
          s->prepareToStopUsingNode(lastTree->getNode(), s->_curTree);
-         s->comp()->removeTree(lastTree);
+         TR::TransformUtil::removeTree(s->comp(), lastTree);
          }
 
       TR::CFGEdge *e = (*inEdgeIter);
@@ -15753,7 +15753,7 @@ TR::Node *endBlockSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
    nextBlock->getExit()->getNode()->setBlock(block);
    block->setExit(nextBlock->getExit());
    s->prepareToStopUsingNode(bbStartTree->getNode(), s->_curTree);
-   s->comp()->removeTree(bbStartTree);
+   TR::TransformUtil::removeTree(s->comp(), bbStartTree);
    s->prepareToStopUsingNode(node, s->_curTree);
    s->requestOpt(OMR::basicBlockPeepHole);
    return NULL;
@@ -16194,7 +16194,7 @@ static void removeRestOfBlock(TR::TreeTop *curTree, TR::Compilation *compilation
       {
       //s->removeNode(treeTop->getNode(), s->_curTree, false);
       next = treeTop->getNextTreeTop();
-      compilation->removeTree(treeTop);
+      TR::TransformUtil::removeTree(compilation, treeTop);
       }
    }
 

--- a/compiler/optimizer/OMRTransformUtil.cpp
+++ b/compiler/optimizer/OMRTransformUtil.cpp
@@ -379,7 +379,7 @@ OMR::TransformUtil::fieldShouldBeCompressed(TR::Node *node, TR::Compilation *com
    }
 
 void
-OMR::removeTree(TR::Compilation *comp, TR::TreeTop * tt)
+OMR::TransformUtil::removeTree(TR::Compilation *comp, TR::TreeTop * tt)
    {
    comp->getJittedMethodSymbol()->removeTree(tt);
    }

--- a/compiler/optimizer/OMRTransformUtil.cpp
+++ b/compiler/optimizer/OMRTransformUtil.cpp
@@ -377,3 +377,9 @@ OMR::TransformUtil::fieldShouldBeCompressed(TR::Node *node, TR::Compilation *com
    {
    return false;
    }
+
+void
+OMR::removeTree(TR::Compilation *comp, TR::TreeTop * tt)
+   {
+   comp->getJittedMethodSymbol()->removeTree(tt);
+   }

--- a/compiler/optimizer/OMRTransformUtil.hpp
+++ b/compiler/optimizer/OMRTransformUtil.hpp
@@ -91,6 +91,8 @@ class OMR_EXTENSIBLE TransformUtil
    static bool transformIndirectLoadChainAt(TR::Compilation *, TR::Node *node, TR::Node *baseExpression, uintptrj_t *baseReferenceLocation, TR::Node **removedNode);
 
    static bool fieldShouldBeCompressed(TR::Node *node, TR::Compilation *comp);
+
+   static void removeTree(TR::Compilation *, TR::TreeTop * tt);
    
    private:
 

--- a/compiler/optimizer/RedundantAsyncCheckRemoval.cpp
+++ b/compiler/optimizer/RedundantAsyncCheckRemoval.cpp
@@ -50,6 +50,7 @@
 #include "optimizer/Optimization_inlines.hpp"
 #include "optimizer/Optimizer.hpp"             // for Optimizer
 #include "optimizer/Structure.hpp"             // for TR_StructureSubGraphNode, etc
+#include "optimizer/TransformUtil.hpp"         // for TransformUtil
 #include "optimizer/VPConstraint.hpp"          // for TR_VPConstraint
 #include "optimizer/AsyncCheckInsertion.hpp"
 
@@ -324,7 +325,7 @@ int32_t TR_RedundantAsyncCheckRemoval::processBlockStructure(TR_BlockStructure *
                   {
                   prev = treeTop->getPrevTreeTop();
                   optimizer()->prepareForTreeRemoval(treeTop);
-                  comp()->removeTree(treeTop);
+                  TR::TransformUtil::removeTree(comp(), treeTop);
                   treeTop = prev;
                   }
                hadAYieldPoint = true;

--- a/compiler/optimizer/TrivialDeadBlockRemover.cpp
+++ b/compiler/optimizer/TrivialDeadBlockRemover.cpp
@@ -30,6 +30,7 @@
 #include "optimizer/Optimization_inlines.hpp"
 #include "optimizer/Optimizer.hpp"
 #include "optimizer/OMRSimplifierHelpers.hpp"
+#include "optimizer/TransformUtil.hpp"
 
 TR_YesNoMaybe TR_TrivialDeadBlockRemover::evaluateTakeBranch (TR::Node* ifNode)
    {
@@ -111,7 +112,7 @@ bool TR_TrivialDeadBlockRemover::foldIf (TR::Block* b)
       }
 
    if (!ifNode)
-      comp()->removeTree(ifTree);
+      TR::TransformUtil::removeTree(comp(), ifTree);
 
    return blocksWereRemoved;
    }

--- a/compiler/optimizer/ValuePropagation.cpp
+++ b/compiler/optimizer/ValuePropagation.cpp
@@ -2786,7 +2786,7 @@ void TR_ValuePropagation::removeRestOfBlock()
       {
       removeNode(treeTop->getNode(), false);
       next = treeTop->getNextTreeTop();
-      comp()->removeTree(treeTop);
+      TR::TransformUtil::removeTree(comp(), treeTop);
       }
    }
 
@@ -7031,7 +7031,7 @@ void TR_ValuePropagation::transformStringConcats(TR_VPStringCached *stringCached
   stringNode->setAndIncChild(0, appendedString[0]);
   stringNode->setAndIncChild(1, appendedString[1]);
   stringNode->setAndIncChild(2, indexNode);
-  comp()->removeTree(newTree);
+  TR::TransformUtil::removeTree(comp(), newTree);
   }
 
 TR::SymbolReference * TR_ValuePropagation::getStringCacheRef()

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -658,7 +658,7 @@ void TR_ValuePropagation::processTrees(TR::TreeTop *startTree, TR::TreeTop *endT
          {
          if (_curTree == treeTop)
             _curTree = treeTop->getPrevTreeTop();
-         comp()->removeTree(treeTop);
+         TR::TransformUtil::removeTree(comp(), treeTop);
          }
 
       if (_reachedMaxRelationDepth)
@@ -3414,7 +3414,7 @@ void TR_ValuePropagation::transformRTMultiLeafArrayCopy(TR_RealTimeArrayCopy *rt
                                           extraChild1,
                                           extraChild2,
                                           helperSymRef);
-   comp()->removeTree(vcallTree);
+   TR::TransformUtil::removeTree(comp(), vcallTree);
    TR::TreeTop *newCallTree = TR::TreeTop::create(comp(), prevTree,
          TR::Node::create(TR::treetop, 1, newCallNode));
 

--- a/compiler/optimizer/VirtualGuardCoalescer.cpp
+++ b/compiler/optimizer/VirtualGuardCoalescer.cpp
@@ -46,6 +46,7 @@
 #include "optimizer/Optimizations.hpp"
 #include "optimizer/Optimizer.hpp"                 // for Optimizer
 #include "optimizer/Structure.hpp"                 // for TR_BlockStructure, etc
+#include "optimizer/TransformUtil.hpp"             // for TransformUtil
 #include "optimizer/ValueNumberInfo.hpp"
 #include "optimizer/LocalOpts.hpp"
 #ifdef J9_PROJECT_SPECIFIC
@@ -199,7 +200,7 @@ void TR_VirtualGuardTailSplitter::eliminateColdVirtualGuards(TR::TreeTop *treeto
 
          //dumpOptDetails(comp(), "%s remove guard from cold block_%d\n", OPT_DETAILS, block->getNumber());
 
-         comp()->removeTree(block->getLastRealTreeTop());
+         TR::TransformUtil::removeTree(comp(), block->getLastRealTreeTop());
 
          TR::Node *gotoNode = TR::Node::create(block->getLastRealTreeTop()->getNode(), TR::Goto);
          TR::TreeTop *gotoTree = TR::TreeTop::create(comp(), gotoNode);
@@ -546,7 +547,7 @@ void TR_VirtualGuardTailSplitter::transformLinear(TR::Block *first, TR::Block *l
 
       //if (call->getLastRealTreeTop()->getNode()->getOpCode().isBranch())
       if (call->getLastRealTreeTop()->getNode()->getOpCodeValue() == TR::Goto)
-         comp()->removeTree(call->getLastRealTreeTop());
+         TR::TransformUtil::removeTree(comp(), call->getLastRealTreeTop());
 
       VGInfo *info = getVirtualGuardInfo(next);
       if (info)
@@ -555,7 +556,7 @@ void TR_VirtualGuardTailSplitter::transformLinear(TR::Block *first, TR::Block *l
          _cfg->addEdge(clone, dest);
          _cfg->removeEdge(call, next);
 
-         comp()->removeTree(clone->getLastRealTreeTop());
+         TR::TransformUtil::removeTree(comp(), clone->getLastRealTreeTop());
 
          TR::Node *gotoNode = TR::Node::create(next->getLastRealTreeTop()->getNode(), TR::Goto);
          TR::TreeTop *gotoTree = TR::TreeTop::create(comp(), gotoNode);
@@ -629,7 +630,7 @@ void TR_VirtualGuardTailSplitter::transformLinear(TR::Block *first, TR::Block *l
                   // A special case: "if (blah) goto 3; else goto 3;"
                   // replace the if by a goto
                   //
-                  comp()->removeTree(lastTree);
+                  TR::TransformUtil::removeTree(comp(), lastTree);
                   TR::Node *gotoNode = TR::Node::create(lastTree->getNode(), TR::Goto);
                   gotoNode->setBranchDestination(dest->getEntry());
                   clone->append(TR::TreeTop::create(comp(), gotoNode));
@@ -641,7 +642,7 @@ void TR_VirtualGuardTailSplitter::transformLinear(TR::Block *first, TR::Block *l
             // A special case, all cases go the same place
             // replace the switch by a goto
             //
-            comp()->removeTree(lastTree);
+            TR::TransformUtil::removeTree(comp(), lastTree);
             TR::Node *gotoNode = TR::Node::create( lastTree->getNode(), TR::Goto);
             gotoNode->setBranchDestination(dest->getEntry());
             clone->append(TR::TreeTop::create(comp(), gotoNode));

--- a/compiler/optimizer/VirtualGuardHeadMerger.cpp
+++ b/compiler/optimizer/VirtualGuardHeadMerger.cpp
@@ -35,6 +35,7 @@
 #include "infra/TRCfgEdge.hpp"                 // for CFGEdge
 #include "optimizer/Optimization_inlines.hpp"
 #include "optimizer/Optimizer.hpp"             // for Optimizer
+#include "optimizer/TransformUtil.hpp"         // for TransformUtil
 #include "ras/DebugCounter.hpp"
 
 #define OPT_DETAILS "O^O VG HEAD MERGE: "
@@ -332,7 +333,7 @@ void TR_VirtualGuardHeadMerger::tailSplitBlock(TR::Block * block, TR::Block * co
    cold1->getExit()->join(tailSplitBlock->getEntry());
 
    // remove cold1's goto
-   comp()->removeTree(cold1->getExit()->getPrevRealTreeTop());
+   TR::TransformUtil::removeTree(comp(), cold1->getExit()->getPrevRealTreeTop());
 
    // copy the exception edges
    for (auto e = block->getNextBlock()->getExceptionSuccessors().begin(); e != block->getNextBlock()->getExceptionSuccessors().end(); ++e)


### PR DESCRIPTION
Add `removeTree` to `TransformUtil`. Since `removeTree` transforms the IL tree, it makes sense for it to be within TransformUtil.

Deprecate the old implementation of `removeTree` within `OMR::Compilation`, which will be removed in a later pull request.