### PR TITLE
Performance works for Unsafe/Thread, Math, and GRA

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -1448,8 +1448,8 @@ OMR::SymbolReferenceTable::findOrCreateMethodSymbol(
       TR::ResolvedMethodSymbol *resSym = TR::ResolvedMethodSymbol::create(trHeapMemory(),resolvedMethod,comp());
       sym = resSym;
 #ifdef J9_PROJECT_SPECIFIC
-      if (resSym->getRecognizedMethod() == TR::java_lang_System_arraycopy)
-         canGCandReturn = false;
+      canGCandReturn = !(resSym->canDirectNativeCall() || resSym->getRecognizedMethod()==TR::java_lang_System_arraycopy);
+      canGCandExcept = !resSym->canDirectNativeCall();
 #endif
       }
    else

--- a/compiler/il/Aliases.cpp
+++ b/compiler/il/Aliases.cpp
@@ -178,7 +178,11 @@ OMR::SymbolReference::getUseonlyAliasesBV(TR::SymbolReferenceTable * symRefTab)
                case TR::java_lang_Math_abs_F:
                case TR::java_lang_Math_abs_D:
                case TR::java_lang_Math_pow:
+               case TR::java_lang_StrictMath_pow:
                case TR::java_lang_Math_exp:
+               case TR::java_lang_StrictMath_exp:
+               case TR::java_lang_Math_log:
+               case TR::java_lang_StrictMath_log:
                case TR::java_lang_Math_floor:
                case TR::java_lang_Math_ceil:
                case TR::java_lang_Math_copySign_F:
@@ -380,8 +384,11 @@ OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool includeGCSafePo
                case TR::java_lang_Math_abs_F:
                case TR::java_lang_Math_abs_D:
                case TR::java_lang_Math_pow:
+               case TR::java_lang_StrictMath_pow:
                case TR::java_lang_Math_exp:
+               case TR::java_lang_StrictMath_exp:
                case TR::java_lang_Math_log:
+               case TR::java_lang_StrictMath_log:
                case TR::java_lang_Math_floor:
                case TR::java_lang_Math_ceil:
                case TR::java_lang_Math_copySign_F:

--- a/compiler/il/symbol/OMRSymbol.hpp
+++ b/compiler/il/symbol/OMRSymbol.hpp
@@ -432,6 +432,9 @@ public:
    void setNamedShadowSymbol();
    bool isNamedShadowSymbol();
 
+   void setImmutableField() { _flags2.set(ImmutableField); }
+   bool isImmutableField()  { return _flags2.testAny(ImmutableField); }
+
    /**
     * Enum values for _flags field.
     */
@@ -556,6 +559,7 @@ public:
       RealRegister              = 0x00000080, // RegisterSymbol is machine real register
       UnsafeShadow              = 0x00000100,
       NamedShadow               = 0x00000200,
+      ImmutableField            = 0x00000400,
       };
 
 protected:

--- a/compiler/optimizer/LocalAnalysis.cpp
+++ b/compiler/optimizer/LocalAnalysis.cpp
@@ -714,7 +714,9 @@ bool TR_LocalAnalysisInfo::isCallLike(TR::Node *node) {
 
    if (node->getOpCode().hasSymbolReference())
       {
-      if (node->getSymbolReference()->getSymbol()->isVolatile() || node->getSymbolReference()->getSymbol()->isMethodMetaData())
+      if (node->getSymbolReference()->getSymbol()->isVolatile() || 
+          (node->getSymbolReference()->getSymbol()->isMethodMetaData() &&
+           !node->getSymbolReference()->getSymbol()->isImmutableField()))
          return true;
 
       if (node->getSymbolReference()->isSideEffectInfo() ||

--- a/compiler/optimizer/PartialRedundancy.cpp
+++ b/compiler/optimizer/PartialRedundancy.cpp
@@ -522,7 +522,8 @@ int32_t TR_PartialRedundancy::perform()
               !(nextOptimalNode->getOpCodeValue() == TR::treetop))
             {
             if (nextOptimalNode->getOpCode().isLoadVarDirect() &&
-                !nextOptimalNode->getSymbol()->isStatic())
+                !nextOptimalNode->getSymbol()->isStatic() &&
+                !nextOptimalNode->getSymbol()->isMethodMetaData())
                {
                TR::SymbolReference *optimalSymRef = nextOptimalNode->getSymbolReference();
                _newSymbols[nextOptimalComputation] = optimalSymRef->getSymbol();
@@ -530,7 +531,7 @@ int32_t TR_PartialRedundancy::perform()
                _newSymbolReferences[nextOptimalComputation] = optimalSymRef;
                }
             else if ((nextOptimalNode->getOpCode().isLoadVarDirect() &&
-                      nextOptimalNode->getSymbol()->isStatic()) ||
+                      (nextOptimalNode->getSymbol()->isStatic() || nextOptimalNode->getSymbol()->isMethodMetaData())) ||
                      !isNodeAnImplicitNoOp(nextOptimalNode))
                {
                if (trace())
@@ -935,7 +936,8 @@ TR::TreeTop *TR_PartialRedundancy::placeComputationsOptimally(TR::Block *block, 
       TR::Node *nextOptimalNode = (*supportedNodesAsArray)[nextOptimalComputation];
       if (
           (nextOptimalNode->getOpCode().isLoadVarDirect() &&
-           !nextOptimalNode->getSymbol()->isStatic())
+           !nextOptimalNode->getSymbol()->isStatic() &&
+           !nextOptimalNode->getSymbol()->isMethodMetaData())
             ||
           (ignoreNode(nextOptimalNode))
           )
@@ -2014,7 +2016,8 @@ bool TR_PartialRedundancy::eliminateRedundantSupportedNodes(TR::Node *parent, TR
       // then there is nothing to do
       //
       if ((node->getOpCode().isLoadVarDirect() &&
-          !node->getSymbol()->isStatic())
+          !node->getSymbol()->isStatic() &&
+          !node->getSymbol()->isMethodMetaData())
             ||
           (ignoreNode(node))
           )
@@ -2162,7 +2165,7 @@ TR::TreeTop *TR_PartialRedundancy::replaceOptimalSubNodes(TR::TreeTop *curTree, 
 
    if (isSupportedOpCode(node, parent) &&
        (!(opCode.isLoadVarDirect() &&
-          !node->getSymbol()->isStatic())) &&
+          !node->getSymbol()->isStatic() && !node->getSymbol()->isMethodMetaData())) &&
        (!isNodeAnImplicitNoOp(node)))
       {
       if (trace())

--- a/compiler/optimizer/RegisterCandidate.cpp
+++ b/compiler/optimizer/RegisterCandidate.cpp
@@ -3944,9 +3944,6 @@ TR_RegisterCandidates::computeAvailableRegisters(TR_RegisterCandidate *rc, int32
           ((i != comp()->cg()->getVMThreadGlobalRegisterNumber()) || !rc->dontAssignVMThreadRegister()))
          {
          availableRegisters->set(i);
-         // for zPDT since we are not doing register pressure simulation we can break out as soon as we have found a candidate
-         if (comp()->getOption(TR_DisableRegisterPressureSimulation))
-            break;
          }
       }
    }


### PR DESCRIPTION
Two-line changes in OMRSymbolReferenceTable.cpp conveyed the fact that direct-callable natives cannot GC and throw exception, thus allowing optimizer to do a better job.
Providing better aliasing info for Math/StrictMath methods (log/pow/exp) in Aliases.cpp.
Allowing currentThread (j/l/Thread object) to be commoned and moved outside of loop (LocalAnalysis.cpp and PartialRedundancy.cpp)
Fix the GRA performance bug in RegisterCandidate.cpp

Task: 135703
Signed-off-by: Julian Wang <zlwang@ca.ibm.com>