### PR TITLE
Rename Node::recreate to recreateWithoutProperties

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -666,6 +666,12 @@ OMR::Node::createOnStack(TR::Node * originatingByteCodeNode, TR::ILOpCodes op, u
 TR::Node *
 OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::SymbolReference * symRef)
    {
+   return recreateWithoutProperties(originalNode, op, numChildren, symRef);
+   }
+
+TR::Node *
+OMR::Node::recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::SymbolReference * symRef)
+   {
    TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
    TR::Node *node = TR::Node::createInternal(0, op, numChildren, originalNode);
    if (symRef != NULL || node->hasSymbolReference() || node->hasRegLoadStoreSymbolReference())
@@ -888,58 +894,158 @@ OMR::Node::create(TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::N
    }
 
 
-
 TR::Node *
 OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first)
+   {
+   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first);
+   }
+
+TR::Node *
+OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second)
+   {
+   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, second);
+   }
+
+TR::Node *
+OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third)
+   {
+   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, second, third);
+   }
+
+TR::Node *
+OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth)
+   {
+   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, second, third, fourth);
+   }
+
+TR::Node *
+OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth)
+   {
+   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, second, third, fourth, fifth);
+   }
+
+TR::Node *
+OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth)
+   {
+   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, second, third, fourth, fifth, sixth);
+   }
+
+TR::Node *
+OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh)
+   {
+   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, second, third, fourth, fifth, sixth, seventh);
+   }
+
+TR::Node *
+OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh, TR::Node *eighth)
+   {
+   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, second, third, fourth, fifth, sixth, seventh, eighth);
+   }
+
+
+
+TR::Node *
+OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::SymbolReference * symRef)
+   {
+   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, symRef);
+   }
+
+TR::Node *
+OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::SymbolReference * symRef)
+   {
+   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, second, symRef);
+   }
+
+TR::Node *
+OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::SymbolReference * symRef)
+   {
+   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, second, third, symRef);
+   }
+
+TR::Node *
+OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::SymbolReference * symRef)
+   {
+   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, second, third, fourth, symRef);
+   }
+
+TR::Node *
+OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::SymbolReference * symRef)
+   {
+   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, second, third, fourth, fifth, symRef);
+   }
+
+TR::Node *
+OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::SymbolReference * symRef)
+   {
+   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, second, third, fourth, fifth, sixth, symRef);
+   }
+
+TR::Node *
+OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh, TR::SymbolReference * symRef)
+   {
+   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, second, third, fourth, fifth, sixth, seventh, symRef);
+   }
+
+
+TR::Node *
+OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh, TR::Node *eighth, TR::SymbolReference * symRef)
+   {
+   TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
+   return TR::Node::recreateWithSymRef(originalNode, op, numChildren, 8, first, second, third, fourth, fifth, sixth, seventh, eighth, symRef);
+   }
+
+
+TR::Node *
+OMR::Node::recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first)
    {
    TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
    return TR::Node::recreateWithoutSymRef(originalNode, op, numChildren, 1, first);
    }
 
 TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second)
+OMR::Node::recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second)
    {
    TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
    return TR::Node::recreateWithoutSymRef(originalNode, op, numChildren, 2, first, second);
    }
 
 TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third)
+OMR::Node::recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third)
    {
    TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
    return TR::Node::recreateWithoutSymRef(originalNode, op, numChildren, 3, first, second, third);
    }
 
 TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth)
+OMR::Node::recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth)
    {
    TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
    return TR::Node::recreateWithoutSymRef(originalNode, op, numChildren, 4, first, second, third, fourth);
    }
 
 TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth)
+OMR::Node::recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth)
    {
    TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
    return TR::Node::recreateWithoutSymRef(originalNode, op, numChildren, 5, first, second, third, fourth, fifth);
    }
 
 TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth)
+OMR::Node::recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth)
    {
    TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
    return TR::Node::recreateWithoutSymRef(originalNode, op, numChildren, 6, first, second, third, fourth, fifth, sixth);
    }
 
 TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh)
+OMR::Node::recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh)
    {
    TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
    return TR::Node::recreateWithoutSymRef(originalNode, op, numChildren, 7, first, second, third, fourth, fifth, sixth, seventh);
    }
 
 TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh, TR::Node *eighth)
+OMR::Node::recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh, TR::Node *eighth)
    {
    TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
    return TR::Node::recreateWithoutSymRef(originalNode, op, numChildren, 8, first, second, third, fourth, fifth, sixth, seventh, eighth);
@@ -948,56 +1054,56 @@ OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildr
 
 
 TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::SymbolReference * symRef)
+OMR::Node::recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::SymbolReference * symRef)
    {
    TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
    return TR::Node::recreateWithSymRef(originalNode, op, numChildren, 1, first, symRef);
    }
 
 TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::SymbolReference * symRef)
+OMR::Node::recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::SymbolReference * symRef)
    {
    TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
    return TR::Node::recreateWithSymRef(originalNode, op, numChildren, 2, first, second, symRef);
    }
 
 TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::SymbolReference * symRef)
+OMR::Node::recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::SymbolReference * symRef)
    {
    TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
    return TR::Node::recreateWithSymRef(originalNode, op, numChildren, 3, first, second, third, symRef);
    }
 
 TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::SymbolReference * symRef)
+OMR::Node::recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::SymbolReference * symRef)
    {
    TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
    return TR::Node::recreateWithSymRef(originalNode, op, numChildren, 4, first, second, third, fourth, symRef);
    }
 
 TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::SymbolReference * symRef)
+OMR::Node::recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::SymbolReference * symRef)
    {
    TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
    return TR::Node::recreateWithSymRef(originalNode, op, numChildren, 5, first, second, third, fourth, fifth, symRef);
    }
 
 TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::SymbolReference * symRef)
+OMR::Node::recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::SymbolReference * symRef)
    {
    TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
    return TR::Node::recreateWithSymRef(originalNode, op, numChildren, 6, first, second, third, fourth, fifth, sixth, symRef);
    }
 
 TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh, TR::SymbolReference * symRef)
+OMR::Node::recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh, TR::SymbolReference * symRef)
    {
    TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
    return TR::Node::recreateWithSymRef(originalNode, op, numChildren, 7, first, second, third, fourth, fifth, sixth, seventh, symRef);
    }
 
 TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh, TR::Node *eighth, TR::SymbolReference * symRef)
+OMR::Node::recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh, TR::Node *eighth, TR::SymbolReference * symRef)
    {
    TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
    return TR::Node::recreateWithSymRef(originalNode, op, numChildren, 8, first, second, third, fourth, fifth, sixth, seventh, eighth, symRef);

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -178,6 +178,7 @@ public:
    static TR::Node *createWithSymRef(TR::Node *originatingByteCodeNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node* first, TR::SymbolReference * symRef);
    static TR::Node *createOnStack(TR::Node *originatingByteCodeNode, TR::ILOpCodes op, uint16_t numChildren = 0);
    static TR::Node *recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren = 0, TR::SymbolReference * symRef = 0);
+   static TR::Node *recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren = 0, TR::SymbolReference * symRef = 0);
 
    static TR::Node *create(TR::ILOpCodes op, uint16_t numChildren = 0);
    static TR::Node *create(TR::ILOpCodes op, uint16_t numChildren, TR::TreeTop * dest);
@@ -250,6 +251,24 @@ public:
    static TR::Node *recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::SymbolReference * symRef);
    static TR::Node *recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh, TR::SymbolReference * symRef);
    static TR::Node *recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh, TR::Node *eighth, TR::SymbolReference * symRef);
+
+   static TR::Node *recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first);
+   static TR::Node *recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second);
+   static TR::Node *recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third);
+   static TR::Node *recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth);
+   static TR::Node *recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth);
+   static TR::Node *recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth);
+   static TR::Node *recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh);
+   static TR::Node *recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh, TR::Node *eighth);
+
+   static TR::Node *recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::SymbolReference * symRef);
+   static TR::Node *recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::SymbolReference * symRef);
+   static TR::Node *recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::SymbolReference * symRef);
+   static TR::Node *recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::SymbolReference * symRef);
+   static TR::Node *recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::SymbolReference * symRef);
+   static TR::Node *recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::SymbolReference * symRef);
+   static TR::Node *recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh, TR::SymbolReference * symRef);
+   static TR::Node *recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh, TR::Node *eighth, TR::SymbolReference * symRef);
 
    static TR::Node *createWithRoomForOneMore(TR::ILOpCodes op, uint16_t numChildren, void * symbolRefOrBranchTarget = 0, TR::Node *first = 0, TR::Node *second = 0, TR::Node *third = 0, TR::Node *fourth = 0, TR::Node *fifth = 0);
    static TR::Node *createWithRoomForThree(TR::ILOpCodes op, TR::Node *first, TR::Node *second, void * symbolRefOrBranchTarget = 0);

--- a/compiler/optimizer/InductionVariable.cpp
+++ b/compiler/optimizer/InductionVariable.cpp
@@ -7443,7 +7443,7 @@ void TR_IVTypeTransformer::replaceAloadWithBaseIndexInSubtree(TR::Node *node)
        performTransformation(comp(), "%s Replacing n%in aload with base int-index form\n",
              optDetailString(), child->getNodePoolIndex()))
       {
-      auto arrayRef = TR::Node::recreate(child, TR::Compiler->target.is64Bit() ? TR::aladd : TR::aiadd, 2,
+      auto arrayRef = TR::Node::recreateWithoutProperties(child, TR::Compiler->target.is64Bit() ? TR::aladd : TR::aiadd, 2,
             TR::Node::createLoad(_baseSymRef),
             TR::Node::createLoad(_intIdxSymRef));
       }

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -5733,7 +5733,7 @@ TR::Node *indirectLoadSimplifier(TR::Node * node, TR::Block * block, TR::Simplif
          if (loadDataType != addrDataType)
             {
             uint8_t precision = node->getType().isAddress() ? (TR::Compiler->target.is64Bit() ? 8 : 4) : 0;
-            TR::Node::recreate(node, convOpCode, 1);
+            TR::Node::recreateWithoutProperties(node, convOpCode, 1);
 
             loadNode = TR::Node::create(node, TR::BadILOp, 0);
             node->setAndIncChild(0, loadNode);
@@ -5742,7 +5742,7 @@ TR::Node *indirectLoadSimplifier(TR::Node * node, TR::Block * block, TR::Simplif
          if (!newOType && addrDataType == TR::Aggregate && node->getDataType() != TR::Aggregate)
             addrDataType = node->getDataType();
 
-         TR::Node::recreate(loadNode, s->comp()->il.opCodeForDirectLoad(addrDataType), 0, childRef);
+         TR::Node::recreateWithoutProperties(loadNode, s->comp()->il.opCodeForDirectLoad(addrDataType), 0, childRef);
 
          dumpOptDetails(s->comp(),"%s [" POINTER_PRINTF_FORMAT "] (load %s [" POINTER_PRINTF_FORMAT "])\n",
              node->getOpCode().getName(), node, loadNode->getOpCode().getName(), loadNode);
@@ -6593,7 +6593,7 @@ TR::Node *iaddSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          {
          TR::Node * newSecondChild = (secondChild->getReferenceCount() == 1) ? secondChild : TR::Node::create(secondChild, TR::iconst, 0);
          newSecondChild->setInt(-secondChild->getInt());
-         TR::Node::recreate(node, TR::isub, 2, firstChild, newSecondChild);
+         TR::Node::recreateWithoutProperties(node, TR::isub, 2, firstChild, newSecondChild);
          firstChild->recursivelyDecReferenceCount();
          secondChild->recursivelyDecReferenceCount();
          node->setVisitCount(0);

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -4025,7 +4025,7 @@ TR::Node *constrainVariableNewArray(TR_ValuePropagation *vp, TR::Node *node)
      {
      if (TR::Compiler->cls.isPrimitiveClass(vp->comp(), elementType))
         {
-        TR::Node::recreate(node, TR::newarray, node->getNumChildren(), vp->comp()->getSymRefTab()->findOrCreateNewArraySymbolRef(typeNode->getSymbolReference()->getOwningMethodSymbol(vp->comp())));
+        TR::Node::recreateWithoutProperties(node, TR::newarray, node->getNumChildren(), vp->comp()->getSymRefTab()->findOrCreateNewArraySymbolRef(typeNode->getSymbolReference()->getOwningMethodSymbol(vp->comp())));
 	TR::Node *typeConst = TR::Node::create(TR::iconst, 0, vp->comp()->fe()->getNewArrayTypeFromClass(constraint->getClass()));
 	vp->_curTree->insertBefore(OMR::TreeTop::create(vp->comp(), TR::Node::create(TR::treetop, 1, typeNode)));
 	node->setAndIncChild(1, typeConst);
@@ -4034,7 +4034,7 @@ TR::Node *constrainVariableNewArray(TR_ValuePropagation *vp, TR::Node *node)
 #ifdef J9_PROJECT_SPECIFIC
      else
 	{
-         TR::Node::recreate(node, TR::anewarray, node->getNumChildren(), vp->comp()->getSymRefTab()->findOrCreateANewArraySymbolRef(typeNode->getSymbolReference()->getOwningMethodSymbol(vp->comp())));
+         TR::Node::recreateWithoutProperties(node, TR::anewarray, node->getNumChildren(), vp->comp()->getSymRefTab()->findOrCreateANewArraySymbolRef(typeNode->getSymbolReference()->getOwningMethodSymbol(vp->comp())));
 	if (typeNode->getOpCodeValue() != TR::loadaddr)
 	   {
 	   TR::Node *loadaddr = TR::Node::createWithSymRef(TR::loadaddr, 0,

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -3505,7 +3505,7 @@ void TR_ValuePropagation::transformObjectCloneCall(TR::TreeTop *callTree, TR_Val
       }
 
    TR::Node *loadaddr = TR::Node::createWithSymRef(callNode, TR::loadaddr, 0, comp()->getSymRefTab()->findOrCreateClassSymbol(callNode->getSymbolReference()->getOwningMethodSymbol(comp()), 0, j9class));
-   TR::Node::recreate(callNode, TR::New, 1, comp()->getSymRefTab()->findOrCreateNewObjectSymbolRef(objNode->getSymbolReference()->getOwningMethodSymbol(comp())));
+   TR::Node::recreateWithoutProperties(callNode, TR::New, 1, comp()->getSymRefTab()->findOrCreateNewObjectSymbolRef(objNode->getSymbolReference()->getOwningMethodSymbol(comp())));
    callNode->setAndIncChild(0, loadaddr);
 
    TR::SymbolReference* helperAccessor =
@@ -3577,12 +3577,12 @@ void TR_ValuePropagation::transformArrayCloneCall(TR::TreeTop *callTree, TR_Opaq
       if (disableSkipZeroInitInVP)
          {
          TR::SymbolReference *symRef = comp()->getSymRefTab()->findOrCreateNewArraySymbolRef(objNode->getSymbolReference()->getOwningMethodSymbol(comp()));
-         TR::Node::recreate(callNode, TR::newarray, 2, lenNode, typeConst, symRef);
+         TR::Node::recreateWithoutProperties(callNode, TR::newarray, 2, lenNode, typeConst, symRef);
          }
       else
          {
          TR::SymbolReference *symRef = comp()->getSymRefTab()->findOrCreateNewArrayNoZeroInitSymbolRef(objNode->getSymbolReference()->getOwningMethodSymbol(comp()));
-         TR::Node::recreate(callNode, TR::newarray, 2, lenNode, typeConst, symRef);
+         TR::Node::recreateWithoutProperties(callNode, TR::newarray, 2, lenNode, typeConst, symRef);
          callNode->setCanSkipZeroInitialization(true);
          }
       }
@@ -3591,7 +3591,7 @@ void TR_ValuePropagation::transformArrayCloneCall(TR::TreeTop *callTree, TR_Opaq
       {
       TR::Node *loadaddr = TR::Node::createWithSymRef(callNode, TR::loadaddr, 0, comp()->getSymRefTab()->findOrCreateClassSymbol(callNode->getSymbolReference()->getOwningMethodSymbol(comp()), 0, j9class));
       TR::SymbolReference *symRef = comp()->getSymRefTab()->findOrCreateANewArraySymbolRef(objNode->getSymbolReference()->getOwningMethodSymbol(comp()));
-      TR::Node::recreate(callNode, TR::anewarray, 2, lenNode, loadaddr, symRef);
+      TR::Node::recreateWithoutProperties(callNode, TR::anewarray, 2, lenNode, loadaddr, symRef);
       }
 #endif
    TR::Node *newArray = callNode;


### PR DESCRIPTION
Most of the time, if a node is recreated, valid properties should be kept. Thus, the default `recreate` should copy the properties.

This renames `recreate` to `recreateWithoutProperties`, in preparation for another function (`recreateAndCopyValidProperties`) to be renamed to `recreate`.