### PR TITLE
Resolve compile failure due to missing memset definition

### DIFF
--- a/omr/startup/omrvmstartup.cpp
+++ b/omr/startup/omrvmstartup.cpp
@@ -17,6 +17,7 @@
  *******************************************************************************/
 
 #include <stdlib.h>
+#include <string.h>
 
 #include "omrport.h"
 #if defined(OMR_GC)


### PR DESCRIPTION
Add an include of string.h when compiling OMR without the GC.  ie:  configured with '--disable-OMR_GC'

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>