### PR TITLE
Whitelist building the JIT

### DIFF
--- a/example/glue/configure_includes/configure_common.mk
+++ b/example/glue/configure_includes/configure_common.mk
@@ -19,7 +19,7 @@
 CONFIGURE_ARGS += \
   --enable-OMR_EXAMPLE \
   --enable-OMR_GC \
-  --enable-OMR_JIT \
+  --disable-OMR_JIT \
   --enable-OMR_PORT \
   --enable-OMR_THREAD \
   --enable-OMR_OMRSIG \

--- a/example/glue/configure_includes/configure_linux_ppc.mk
+++ b/example/glue/configure_includes/configure_linux_ppc.mk
@@ -80,6 +80,7 @@ ifeq (linux_ppc-64_cmprssptrs_le_gcc_cuda, $(SPEC))
     --enable-OMR_ENV_GCC \
     --enable-OMR_ENV_LITTLE_ENDIAN \
     --enable-OMR_GC_COMPRESSED_POINTERS \
+    --enable-OMR_JIT \
     --enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER \
     --enable-OMR_INTERP_SMALL_MONITOR_SLOT \
     --enable-OMR_OPT_CUDA \
@@ -97,6 +98,7 @@ ifeq (linux_ppc-64_cmprssptrs_le_gcc, $(SPEC))
     --enable-OMR_ENV_GCC \
     --enable-OMR_ENV_LITTLE_ENDIAN \
     --enable-OMR_GC_COMPRESSED_POINTERS \
+    --enable-OMR_JIT \
     --enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER \
     --enable-OMR_INTERP_SMALL_MONITOR_SLOT \
     --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
@@ -145,6 +147,7 @@ ifeq (linux_ppc-64_le_gcc_cuda, $(SPEC))
     --enable-OMR_ENV_DATA64 \
     --enable-OMR_ENV_GCC \
     --enable-OMR_ENV_LITTLE_ENDIAN \
+    --enable-OMR_JIT \
     --enable-OMR_OPT_CUDA \
     --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
     --enable-OMR_PORT_NUMA_SUPPORT \
@@ -159,6 +162,7 @@ ifeq (linux_ppc-64_le_gcc, $(SPEC))
     --enable-OMR_ENV_DATA64 \
     --enable-OMR_ENV_GCC \
     --enable-OMR_ENV_LITTLE_ENDIAN \
+    --enable-OMR_JIT \
     --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
     --enable-OMR_PORT_NUMA_SUPPORT \
     --enable-OMR_THR_FORK_SUPPORT \

--- a/example/glue/configure_includes/configure_linux_x86.mk
+++ b/example/glue/configure_includes/configure_linux_x86.mk
@@ -28,6 +28,7 @@ include $(CONFIG_INCL_DIR)/configure_common.mk
 CONFIGURE_ARGS += \
   --enable-OMR_EXAMPLE \
   --enable-OMR_GC \
+  --enable-OMR_JIT \
   --enable-OMR_PORT \
   --enable-OMR_THREAD \
   --enable-OMR_OMRSIG \

--- a/example/glue/configure_includes/configure_osx.mk
+++ b/example/glue/configure_includes/configure_osx.mk
@@ -23,7 +23,6 @@ include $(CONFIG_INCL_DIR)/configure_common.mk
 CONFIGURE_ARGS += \
   --enable-OMR_EXAMPLE \
   --enable-OMR_GC \
-  --disable-OMR_JIT \
   --enable-OMR_PORT \
   --enable-OMR_THREAD \
   --enable-OMR_OMRSIG \


### PR DESCRIPTION
Many platforms do not support building the JIT, so it is easier to whitelist the platforms that do.