### PR TITLE
Remove luRem Op code

### DIFF
--- a/compiler/arm/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/arm/codegen/TreeEvaluatorTable.hpp
@@ -108,7 +108,6 @@
    TR::TreeEvaluator::unImpOpEvaluator,     // TR::brem
    TR::TreeEvaluator::unImpOpEvaluator,     // TR::srem
    TR::TreeEvaluator::iremEvaluator,        // TR::iurem
-   TR::TreeEvaluator::lremEvaluator,        // TR::lurem
    TR::TreeEvaluator::inegEvaluator,        // TR::ineg
    TR::TreeEvaluator::lnegEvaluator,        // TR::lneg
 #if (defined(__VFP_FP__) && !defined(__SOFTFP__))

--- a/compiler/il/ILOpCodeProperties.hpp
+++ b/compiler/il/ILOpCodeProperties.hpp
@@ -1370,26 +1370,6 @@
    /* .ifCompareOpCode      = */ TR::BadILOp,
    },
 
-   /*!
-    * \brief unsigned remainder (long)
-    *
-    * See iurem
-    */
-   {
-   /* .opcode               = */ TR::lurem,
-   /* .name                 = */ "lurem",
-   /* .properties1          = */ ILProp1::Rem,
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE,
-   /* .properties3          = */ ILProp3::LikeUse,
-   /* .properties4          = */ 0,
-   /* .dataType             = */ TR::Int64,
-   /* .typeProperties       = */ ILTypeProp::Size_8 | ILTypeProp::Unsigned,
-   /* .swapChildrenOpCode   = */ TR::BadILOp,
-   /* .reverseBranchOpCode  = */ TR::BadILOp,
-   /* .booleanCompareOpCode = */ TR::BadILOp,
-   /* .ifCompareOpCode      = */ TR::BadILOp,
-   },
-
    {
    /* .opcode               = */ TR::ineg,
    /* .name                 = */ "ineg",

--- a/compiler/il/OMRILOpCodesEnum.hpp
+++ b/compiler/il/OMRILOpCodesEnum.hpp
@@ -133,7 +133,6 @@
    brem,     // remainder of 2 bytes                   (child1 % child2)
    srem,     // remainder of 2 short integers          (child1 % child2)
    iurem,    // remainder of 2 unsigned integers       (child1 % child2)
-   lurem,    // remainder of 2 unsigned long integers  (child1 % child2)
    ineg,     // negate an integer
    lneg,     // negate a long integer
    fneg,     // negate a float

--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -881,7 +881,6 @@ public:
          case TR::lmul:   return TR::imul;
          case TR::ldiv:   return TR::idiv;
          case TR::lrem:   return TR::irem;
-         case TR::lurem:  return TR::iurem;
          case TR::labs:   return TR::iabs;
          case TR::lneg:   return TR::ineg;
          case TR::luneg:  return TR::iuneg;

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -9891,7 +9891,6 @@ TR::Node *lremSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    // Only try to fold if the divisor is non-zero.
    // Handle the special case of dividing the maximum negative value by -1
    //
-   bool isUnsigned = node->getOpCodeValue() == TR::lurem;
    if (secondChild->getOpCode().isLoadConst())
       {
       int64_t divisor = secondChild->getLongInt();
@@ -9900,7 +9899,7 @@ TR::Node *lremSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       bool upwr2 = (udivisor & (udivisor - 1)) == 0;
       if (divisor != 0)
          {
-         if (divisor == 1 || (!isUnsigned && (divisor == -1)))
+         if (divisor == 1 || (divisor == -1))
             {
             foldLongIntConstant(node, 0, s, true /* anchorChildren */);
             return node;
@@ -9908,16 +9907,14 @@ TR::Node *lremSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          else if (firstChild->getOpCode().isLoadConst())
             {
             int64_t dividend = firstChild->getLongInt();
-            if (isUnsigned)
-               foldLongIntConstant(node, (uint64_t) dividend % (uint64_t)divisor, s, false /* !anchorChildren */);
-            else if (divisor == -1 && dividend == TR::getMinSigned<TR::Int64>())
+            if (divisor == -1 && dividend == TR::getMinSigned<TR::Int64>())
                foldLongIntConstant(node, 0, s, false /* !anchorChildren */);
             else
                foldLongIntConstant(node, dividend % divisor, s, false /* !anchorChildren */);
             return node;
             }
          // Design 1792
-         else if ( (!isUnsigned) && (!disableILRemPwr2Opt) && ((shftAmnt = TR::TreeEvaluator::checkPositiveOrNegativePowerOfTwo(divisor)) > 0) &&
+         else if ((!disableILRemPwr2Opt) && ((shftAmnt = TR::TreeEvaluator::checkPositiveOrNegativePowerOfTwo(divisor)) > 0) &&
             (secondChild->getReferenceCount()==1) && performTransformation(s->comp(), "%sPwr of 2 lrem opt node %p\n", s->optDetailString(), node) )
             {
             secondChild->decReferenceCount();
@@ -9957,16 +9954,7 @@ TR::Node *lremSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             node->getSecondChild()->incReferenceCount();
             return node;
             }
-         else if (isUnsigned && (!disableILRemPwr2Opt) && upwr2 &&
-                  performTransformation(s->comp(), "%sPwr of 2 lurem opt node %p\n", s->optDetailString(), node))
-            {
-            TR::Node::recreateAndCopyValidProperties(node, TR::land);
-            TR::Node* lconstNode = TR::Node::create(node, TR::lconst, 0, 0);
-            lconstNode->setLongInt(udivisor - 1);
-            node->getSecondChild()->decReferenceCount();
-            node->setAndIncChild(1, lconstNode);
-            }
-// Disabled pending approval of design 1055.
+         // Disabled pending approval of design 1055.
 #ifdef TR_DESIGN_1055
          else if (s->cg()->getSupportsLoweringConstLDiv() && !isPowerOf2(divisor) && !skipRemLowering(divisor, s))
             {

--- a/compiler/optimizer/OMRSimplifierTableEnum.hpp
+++ b/compiler/optimizer/OMRSimplifierTableEnum.hpp
@@ -107,7 +107,6 @@
    bremSimplifier,          // TR::brem
    sremSimplifier,          // TR::srem
    iremSimplifier,          // TR::iurem
-   lremSimplifier,          // TR::lurem
    inegSimplifier,          // TR::ineg
    lnegSimplifier,          // TR::lneg
    fnegSimplifier,          // TR::fneg

--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -100,7 +100,6 @@ TR::Node *constrainLongConst(TR_ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainLongStore(TR_ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainLor(TR_ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainLrem(TR_ValuePropagation *vp, TR::Node *node);
-TR::Node *constrainLurem(TR_ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainLshl(TR_ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainLshr(TR_ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainLushr(TR_ValuePropagation *vp, TR::Node *node);
@@ -246,7 +245,6 @@ const ValuePropagationPtr constraintHandlers[] =
    constrainChildren,        // TR::brem
    constrainChildren,        // TR::srem
    constrainIrem,            // TR::iurem
-   constrainLurem,            // TR::lurem
    constrainIneg,            // TR::ineg
    constrainLneg,            // TR::lneg
    constrainChildren,        // TR::fneg

--- a/compiler/p/codegen/BinaryEvaluator.cpp
+++ b/compiler/p/codegen/BinaryEvaluator.cpp
@@ -2376,8 +2376,6 @@ TR::Register *lrem64Evaluator(TR::Node *node, TR::CodeGenerator *cg)
    int64_t divisor = 0;
    TR::Compilation * comp = cg->comp();
 
-   TR_ASSERT(node->getOpCodeValue() != TR::lurem, "TR::ludiv is not impelemented yet for 64-bit target\n");
-
    if (secondChild->getOpCode().isLoadConst())
       divisor =  secondChild->getLongInt();
    else if ( firstChild->getOpCode().isLoadConst())
@@ -2463,7 +2461,6 @@ TR::Register *lrem64Evaluator(TR::Node *node, TR::CodeGenerator *cg)
    return trgReg;
    }
 
-// also handles lurem
 TR::Register *OMR::Power::TreeEvaluator::lremEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (TR::Compiler->target.is64Bit())

--- a/compiler/p/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/TreeEvaluatorTable.hpp
@@ -108,7 +108,6 @@
    TR::TreeEvaluator::unImpOpEvaluator,                 // TR::brem
    TR::TreeEvaluator::unImpOpEvaluator,                 // TR::srem
    TR::TreeEvaluator::iremEvaluator,                    // TR::iurem
-   TR::TreeEvaluator::lremEvaluator,                    // TR::lurem
    TR::TreeEvaluator::inegEvaluator,                    // TR::ineg
    TR::TreeEvaluator::lnegEvaluator,                    // TR::lneg
    TR::TreeEvaluator::fnegEvaluator,                    // TR::fneg

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -2411,7 +2411,6 @@ int32_t childTypes[] =
    TR::Int8,                      // TR::brem
    TR::Int16,                     // TR::srem
    TR::Int32,                     // TR::iurem
-   TR::Int64,                     // TR::lurem
    TR::Int32,                     // TR::ineg
    TR::Int64,                     // TR::lneg
    TR::Float,                      // TR::fneg

--- a/compiler/x/amd64/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/x/amd64/codegen/TreeEvaluatorTable.hpp
@@ -109,7 +109,6 @@
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::brem
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::srem
    TR::TreeEvaluator::integerDivOrRemEvaluator,         // TR::iurem
-   TR::TreeEvaluator::integerDivOrRemEvaluator,         // TR::lurem
    TR::TreeEvaluator::integerNegEvaluator,              // TR::ineg
    TR::TreeEvaluator::integerNegEvaluator,              // TR::lneg
    TR::TreeEvaluator::fnegEvaluator,                    // TR::fneg

--- a/compiler/x/i386/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/x/i386/codegen/TreeEvaluatorTable.hpp
@@ -109,7 +109,6 @@
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::brem
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::srem
    TR::TreeEvaluator::integerDivOrRemEvaluator,         // TR::iurem
-   TR::TreeEvaluator::unImpOpEvaluator,                    // TR::lurem
    TR::TreeEvaluator::integerNegEvaluator,              // TR::ineg
    TR::TreeEvaluator::integerPairNegEvaluator,         // TR::lneg
    TR::TreeEvaluator::fnegEvaluator,                    // TR::fneg

--- a/compiler/z/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/z/codegen/TreeEvaluatorTable.hpp
@@ -109,7 +109,6 @@
    TR::TreeEvaluator::unImpOpEvaluator,        // TR::brem
    TR::TreeEvaluator::unImpOpEvaluator,        // TR::srem
    TR::TreeEvaluator::iremEvaluator,        // TR::iurem
-   TR::TreeEvaluator::lremEvaluator,        // TR::lurem
    TR::TreeEvaluator::inegEvaluator,        // TR::ineg
    TR::TreeEvaluator::lnegEvaluator,        // TR::lneg
    TR::TreeEvaluator::fnegEvaluator,        // TR::fneg

--- a/fvtest/compilertest/tests/OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/OpCodesTest.cpp
@@ -305,7 +305,6 @@ signatureCharJJ_J_testMethodType  * OpCodesTest::_lMul = 0;
 signatureCharJJ_J_testMethodType  * OpCodesTest::_lDiv = 0;
 signatureCharJJ_J_testMethodType  * OpCodesTest::_lRem = 0;
 unsignedSignatureCharJJ_J_testMethodType  * OpCodesTest::_luDiv = 0;
-unsignedSignatureCharJJ_J_testMethodType  * OpCodesTest::_luRem = 0;
 
 //Float Arithmetic
 signatureCharFF_F_testMethodType  * OpCodesTest::_fAdd = 0;

--- a/fvtest/compilertest/tests/OpCodesTest.hpp
+++ b/fvtest/compilertest/tests/OpCodesTest.hpp
@@ -403,7 +403,6 @@ class OpCodesTest : public TestDriver
    static signatureCharJJ_J_testMethodType *_lDiv;
    static signatureCharJJ_J_testMethodType *_lRem;
    static unsignedSignatureCharJJ_J_testMethodType *_luDiv;
-   static unsignedSignatureCharJJ_J_testMethodType *_luRem;
 
    //Float Arithmetic
    static signatureCharFF_F_testMethodType *_fAdd;

--- a/fvtest/compilertest/tests/S390OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/S390OpCodesTest.cpp
@@ -38,7 +38,6 @@ S390OpCodesTest::compileIntegerArithmeticTestMethods()
    _lDiv = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ldiv, "lDiv", _argTypesBinaryLong, TR::Int64, rc));
    _lRem = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lrem, "lRem", _argTypesBinaryLong, TR::Int64, rc));
    _luDiv = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ludiv, "luDiv", _argTypesBinaryLong, TR::Int64, rc));
-   _luRem = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lurem, "luRem", _argTypesBinaryLong, TR::Int64, rc));
    }
 
 void
@@ -428,28 +427,6 @@ S390OpCodesTest::invokeIntegerArithmeticTests()
       EXPECT_EQ(div(ulongDivArr[i][0], ulongDivArr[i][1]), luBinaryCons(ulongDivArr[i][0], LONG_PLACEHOLDER_2));
       }
 
-   //lurem
-   //TODO: _lurem(ULONG_INT, 0)
-   testCaseArrLength = sizeof(ulongRemArr) / sizeof(ulongRemArr[0]);
-   for(uint32_t i = 0; i < testCaseArrLength; ++i)
-      {
-      EXPECT_EQ(rem(ulongRemArr[i][0], ulongRemArr[i][1]), _luRem(ulongRemArr[i][0], ulongRemArr[i][1]));
-
-      sprintf(resolvedMethodName, "luRemConst1_Testcase%d", i);
-      luBinaryCons = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lurem, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &ulongRemArr[i][0], 2, &ulongRemArr[i][1]));
-      EXPECT_EQ(rem(ulongRemArr[i][0], ulongRemArr[i][1]), luBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
-
-      sprintf(resolvedMethodName, "luRemConst2_Testcase%d", i);
-      luBinaryCons = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lurem, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &ulongRemArr[i][0]));
-      EXPECT_EQ(rem(ulongRemArr[i][0], ulongRemArr[i][1]), luBinaryCons(LONG_PLACEHOLDER_1, ulongRemArr[i][1]));
-
-      sprintf(resolvedMethodName, "luRemConst3_Testcase%d", i);
-      luBinaryCons = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lurem, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &ulongRemArr[i][1]));
-      EXPECT_EQ(rem(ulongRemArr[i][0], ulongRemArr[i][1]), luBinaryCons(ulongRemArr[i][0], LONG_PLACEHOLDER_2));
-      }
    }
 
 void

--- a/fvtest/compilertest/tests/X86OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/X86OpCodesTest.cpp
@@ -4780,11 +4780,10 @@ X86OpCodesTest::UnsupportedOpCodesTests()
 
 
 #if defined(TR_TARGET_32BIT)
-   //ldiv, lrem, ludiv, lurem
+   //ldiv, lrem, ludiv
    addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::ldiv, "lDiv", _argTypesBinaryLong, TR::Int64);
    addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::lrem, "lRem", _argTypesBinaryLong, TR::Int64);
    addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::ludiv, "luDiv", _argTypesBinaryLong, TR::Int64);
-   addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::lurem, "luRem", _argTypesBinaryLong, TR::Int64);
    addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::l2a, "l2a", _argTypesUnaryLong, TR::Address);
    addUnsupportedOpCodeTest(_numberOfTernaryArgs, TR::aternary, "aternary", _argTypesTernaryAddress, TR::Address);
 
@@ -4839,7 +4838,6 @@ X86OpCodesTest::compileDisabledIntegerArithmeticTestMethods()
    _iuRem = (unsignedSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iurem, "iuRem", _argTypesBinaryInt, TR::Int32, rc));
 
    _luDiv = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ludiv, "luDiv", _argTypesBinaryLong, TR::Int64, rc));
-   _luRem = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lurem, "luRem", _argTypesBinaryLong, TR::Int64, rc));
    }
 
 void
@@ -4908,28 +4906,6 @@ X86OpCodesTest::invokeDisabledIntegerArithmeticTests()
       EXPECT_EQ(div(ulongDivArr[i][0], ulongDivArr[i][1]), luBinaryCons(ulongDivArr[i][0], LONG_PLACEHOLDER_2));
       }
 
-   //lurem
-   //TODO: _lrem(LONG_INT, 0), _lrem(LONG_NEG, 0),
-   testCaseArrLength = sizeof(ulongRemArr) / sizeof(ulongRemArr[0]);
-   for(uint32_t i = 0; i < testCaseArrLength; ++i)
-      {
-      EXPECT_EQ(rem(ulongRemArr[i][0], ulongRemArr[i][1]), _luRem(ulongRemArr[i][0], ulongRemArr[i][1]));
-
-      sprintf(resolvedMethodName, "luRemConst1_Testcase%d", i);
-      luBinaryCons = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lurem, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &ulongRemArr[i][0], 2, &ulongRemArr[i][1]));
-      EXPECT_EQ(rem(ulongRemArr[i][0], ulongRemArr[i][1]), luBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
-
-      sprintf(resolvedMethodName, "luRemConst2_Testcase%d", i);
-      luBinaryCons = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lurem, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &ulongRemArr[i][0]));
-      EXPECT_EQ(rem(ulongRemArr[i][0], ulongRemArr[i][1]), luBinaryCons(LONG_PLACEHOLDER_1, ulongRemArr[i][1]));
-
-      sprintf(resolvedMethodName, "luRemConst3_Testcase%d", i);
-      luBinaryCons = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lurem, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &ulongRemArr[i][1]));
-      EXPECT_EQ(rem(ulongRemArr[i][0], ulongRemArr[i][1]), luBinaryCons(ulongRemArr[i][0], LONG_PLACEHOLDER_2));
-      }
 #endif
    }
 


### PR DESCRIPTION
Remove luRem (returns remainder of unsigned division)
Op code.

Fold away its usage and remove from all tables.

Signed-off-by: Aman Kumar <amank@ca.ibm.com>