### PR TITLE
Fix bci in loop strider IV widening and re-enable

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -1211,7 +1211,13 @@ OMR::Node::createStore(TR::SymbolReference * symRef, TR::Node * value, TR::ILOpC
    return store;
    }
 
-
+TR::Node *
+OMR::Node::createStore(TR::Node *originatingByteCodeNode, TR::SymbolReference * symRef, TR::Node * value)
+   {
+   TR::DataType type = symRef->getSymbol()->getDataType();
+   TR::ILOpCodes op = TR::comp()->il.opCodeForDirectStore(type);
+   return TR::Node::createWithSymRef(originatingByteCodeNode, op, 1, value, symRef);
+   }
 
 TR::Node *
 OMR::Node::createRelative32BitFenceNode(void * relocationAddress)

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -270,6 +270,7 @@ public:
    static TR::Node *createStore(TR::SymbolReference * symRef, TR::Node * value);
    static TR::Node *createStore(TR::SymbolReference * symRef, TR::Node * value, TR::ILOpCodes op);
    static TR::Node *createStore(TR::SymbolReference * symRef, TR::Node * value, TR::ILOpCodes op, size_t size);
+   static TR::Node *createStore(TR::Node *originatingByteCodeNode, TR::SymbolReference * symRef, TR::Node * value);
 
    static TR::Node *createRelative32BitFenceNode(void * relocationAddress);
    static TR::Node *createRelative32BitFenceNode(TR::Node *originatingByteCodeNode, void *);

--- a/compiler/optimizer/InductionVariable.hpp
+++ b/compiler/optimizer/InductionVariable.hpp
@@ -193,7 +193,7 @@ class TR_LoopStrider : public TR_LoopTransformer
    void detectLoopsForIndVarConversion(TR_Structure *, TR::NodeChecklist &);
    void extendIVsOnLoopEntry(const TR::list<std::pair<int32_t, int32_t> > &, TR::Block *);
    void truncateIVsOnLoopExit(const TR::list<std::pair<int32_t, int32_t> > &, TR_RegionStructure *);
-   void convertIV(TR::TreeTop *, int32_t, int32_t, TR::ILOpCodes);
+   void convertIV(TR::Node *, TR::TreeTop *, int32_t, int32_t, TR::ILOpCodes);
    void createConstraintsForNewInductionVariable(TR_Structure *, TR::SymbolReference *, TR::SymbolReference *);
    bool checkExpressionForInductionVariable(TR::Node *);
    bool checkStoreOfIndVar(TR::Node *);


### PR DESCRIPTION
Outside of ilgen (intermediate language generation), new nodes need to
be created using the `TR::Node` factory methods that accept an initial
`TR::Node *originatingByteCodeNode`, to ensure that they have valid bci
(bytecode info). Loop strider's IV (induction variable) widening pass
failed to specify the bci of the nodes it created, producing garbage
offsets that interfered with later processing of those nodes.

This widening pass is re-enabled now that it provides bci for all new
nodes that it creates.

Signed-off-by: Devin Papineau <devinmp@ca.ibm.com>