### PR TITLE
Trace when an opt pass stops due to getNodeCount()

### DIFF
--- a/compiler/optimizer/OMRDeadTreesElimination.cpp
+++ b/compiler/optimizer/OMRDeadTreesElimination.cpp
@@ -49,6 +49,7 @@
 #include "infra/ILWalk.hpp"
 #include "infra/List.hpp"                       // for TR_ScratchList, etc
 #include "optimizer/Optimization.hpp"           // for Optimization
+#include "optimizer/Optimization_inlines.hpp"
 #include "optimizer/OptimizationManager.hpp"
 #include "optimizer/Optimizations.hpp"
 #include "optimizer/Optimizer.hpp"              // for Optimizer
@@ -75,7 +76,7 @@ static OMR::TreeInfo *findOrCreateTreeInfo(TR::TreeTop *treeTop, List<OMR::TreeI
 
 // temporarily revert this fix
 //static bool fixUpTree(TR::Node *node, TR::TreeTop *treeTop, TR::SparseBitVector &seenNodes, bool &highGlobalIndex, TR::Compilation *comp, vcount_t oldCompVisitCount)
-static bool fixUpTree(TR::Node *node, TR::TreeTop *treeTop, TR::SparseBitVector &seenNodes, bool &highGlobalIndex, TR::Compilation *comp)
+static bool fixUpTree(TR::Node *node, TR::TreeTop *treeTop, TR::SparseBitVector &seenNodes, bool &highGlobalIndex, TR::Optimization *opt)
    {
    bool containsFloatingPoint = false;
    bool anchorLoadaddr = true;
@@ -106,10 +107,18 @@ static bool fixUpTree(TR::Node *node, TR::TreeTop *treeTop, TR::SparseBitVector 
        anchorLoadaddr &&
        anchorArrayCmp)
       {
-      if (!comp->getOption(TR_ProcessHugeMethods)&& (comp->getNodeCount() > (3*USHRT_MAX/4)))
+      if (!opt->comp()->getOption(TR_ProcessHugeMethods))
          {
-         highGlobalIndex = true;
-         return containsFloatingPoint;
+         int32_t nodeCount = opt->comp()->getNodeCount();
+         int32_t nodeCountLimit = 3 * USHRT_MAX / 4;
+         if (nodeCount > nodeCountLimit)
+            {
+            dumpOptDetails(opt->comp(),
+               "%snode count %d exceeds limit %d\n",
+               opt->optDetailString(), nodeCount, nodeCountLimit);
+            highGlobalIndex = true;
+            return containsFloatingPoint;
+            }
          }
 
       seenNodes[node->getGlobalIndex()] = 1;
@@ -117,7 +126,7 @@ static bool fixUpTree(TR::Node *node, TR::TreeTop *treeTop, TR::SparseBitVector 
         containsFloatingPoint = true;
       TR::TreeTop *nextTree = treeTop->getNextTreeTop();
       node->incFutureUseCount();
-      TR::TreeTop *anchorTreeTop = TR::TreeTop::create(comp, TR::Node::create(TR::treetop, 1, node));
+      TR::TreeTop *anchorTreeTop = TR::TreeTop::create(opt->comp(), TR::Node::create(TR::treetop, 1, node));
       anchorTreeTop->getNode()->setFutureUseCount(0);
       treeTop->join(anchorTreeTop);
       anchorTreeTop->join(nextTree);
@@ -129,7 +138,7 @@ static bool fixUpTree(TR::Node *node, TR::TreeTop *treeTop, TR::SparseBitVector 
          TR::Node *child = node->getChild(i);
          // temporarily rever this fix
          //if (fixUpTree(child, treeTop, seenNodes, highGlobalIndex, comp, oldCompVisitCount))
-         if (fixUpTree(child, treeTop, seenNodes, highGlobalIndex, comp))
+         if (fixUpTree(child, treeTop, seenNodes, highGlobalIndex, opt))
             containsFloatingPoint = true;
          }
       }
@@ -626,8 +635,14 @@ int32_t OMR::DeadTreesElimination::process(TR::TreeTop *startTree, TR::TreeTop *
       if (node->getOpCodeValue() == TR::BBStart)
          block = node->getBlock();
 
-      if (comp()->getVisitCount() > (MAX_VCOUNT - 3))
+      int vcountLimit = MAX_VCOUNT - 3;
+      if (comp()->getVisitCount() > vcountLimit)
+         {
+         dumpOptDetails(comp(),
+            "%sVisit count %d exceeds limit %d; stopping\n",
+            optDetailString(), comp()->getVisitCount(), vcountLimit);
          return 0;
+         }
 
       // correct at all intermediate stages
       //
@@ -779,10 +794,15 @@ int32_t OMR::DeadTreesElimination::process(TR::TreeTop *startTree, TR::TreeTop *
                bool highGlobalIndex = false;
                // temporarily revert this fix
                //if (fixUpTree(child->getChild(i), iter.currentTree(), seenNodes, highGlobalIndex, comp(), compVisitCount))
-               if (fixUpTree(child->getChild(i), iter.currentTree(), seenNodes, highGlobalIndex, comp()))
+               if (fixUpTree(child->getChild(i), iter.currentTree(), seenNodes, highGlobalIndex, self()))
                   containsFloatingPoint = true;
                if (highGlobalIndex)
+                  {
+                  dumpOptDetails(comp(),
+                     "%sGlobal index limit exceeded; stopping\n",
+                     optDetailString());
                   return 0;
+                  }
                }
 
             if (seenConditionalBranch &&

--- a/compiler/optimizer/ValuePropagation.cpp
+++ b/compiler/optimizer/ValuePropagation.cpp
@@ -3716,6 +3716,7 @@ int32_t TR_GlobalValuePropagation::perform()
 
    if ((_firstUnresolvedSymbolValueNumber - 1) <= comp()->getNodeCount())
       {
+      dumpOptDetails(comp(), "Can't do Global Value Propagation - too many nodes\n");
       return 0;
       }
 

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -3892,7 +3892,12 @@ TR_LocalValuePropagation::TR_LocalValuePropagation(TR::OptimizationManager *mana
 
 int32_t TR_LocalValuePropagation::perform()
    {
-   if ((_firstUnresolvedSymbolValueNumber - 1) > comp()->getNodeCount())
+   if ((_firstUnresolvedSymbolValueNumber - 1) <= comp()->getNodeCount())
+      {
+      dumpOptDetails(comp(),
+         "Can't do Local Value Propagation - too many nodes\n");
+      }
+   else
       {
       // Walk the trees and process each block
       //
@@ -3916,7 +3921,13 @@ int32_t TR_LocalValuePropagation::performOnBlock(TR::Block *block)
    {
    // Walk the trees and process
    //
-   if ((_firstUnresolvedSymbolValueNumber - 1) > comp()->getNodeCount())
+   if ((_firstUnresolvedSymbolValueNumber - 1) <= comp()->getNodeCount())
+      {
+      dumpOptDetails(comp(),
+         "Can't do Local Value Propagation on block %d - too many nodes\n",
+         block->getNumber());
+      }
+   else
       {
       TR::TreeTop *treeTop = block->getEntry();
       while (treeTop)


### PR DESCRIPTION
A few optimization passes stop in their tracks, or avoid starting in the
first place, when `getNodeCount()` (which is really the next available
global index) is above some threshold. Until now dead trees elimination
and value propagation could do this silently, which would look alarming
in a trace log.

These optimizations now log a message when abandoning the pass in this
way, and dead trees elimination also prints a similar message if it
gives up due its visit count limit.

Signed-off-by: Devin Papineau <devinmp@ca.ibm.com>