### PR TITLE
Improve constraint propagation for constants in VP

### DIFF
--- a/compiler/optimizer/ValuePropagation.cpp
+++ b/compiler/optimizer/ValuePropagation.cpp
@@ -2772,6 +2772,9 @@ void TR::ValuePropagation::replaceByConstant(TR::Node *node, TR::VPConstraint *c
          break;
       }
 
+   // Make an effort to set flags as appropriate for the constant
+   constrainNewlyFoldedConst(this, node, isGlobal);
+
    setEnableSimplifier();
    }
 

--- a/compiler/optimizer/ValuePropagation.hpp
+++ b/compiler/optimizer/ValuePropagation.hpp
@@ -1105,6 +1105,7 @@ class LocalValuePropagation : public TR::ValuePropagation
 TR::Node *generateArrayletAddressTree(TR::Compilation* comp, TR::Node *vcallNode, TR::DataType type, TR::Node *off,TR::Node *obj, TR::Node *spineShiftNode,TR::Node *shiftNode,TR::Node *strideShiftNode, TR::Node *hdrSize);
 TR::Node *generateArrayAddressTree(TR::Compilation* comp, TR::Node *node, int32_t offHigh, TR::Node *offNode, TR::Node *objNode, int32_t elementSize, TR::Node * &stride, TR::Node *hdrSize);
 TR::Node * createHdrSizeNode(TR::Compilation *comp, TR::Node *n);
+void constrainNewlyFoldedConst(TR::ValuePropagation *vp, TR::Node *node, bool isGlobal);
 
 void constrainRangeByPrecision(const int64_t low, const int64_t high, const int32_t precision, int64_t &lowResult, int64_t &highResult, bool isNonNegative = false);
 


### PR DESCRIPTION
Contrary to its name, `constrainCompileTimeLoad()` would previously fold
a load into a constant *without* creating a constraint for it, defeating
further analysis of operations consuming the now-constant value. This
function now creates the appropriate constraint whenever it successfully
converts a load into an `iconst`. Other types of constant could be (but
aren't yet) treated similarly.

Signed-off-by: Devin Papineau <devinmp@ca.ibm.com>