### PR TITLE
Change J9ZERZ10() to handle more than 2 GB fixes #275

### DIFF
--- a/util/omrutil/unix/linux/s390/64/j9memclrz10_64.s
+++ b/util/omrutil/unix/linux/s390/64/j9memclrz10_64.s
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# (c) Copyright IBM Corp. 1991, 2014
+# (c) Copyright IBM Corp. 1991, 2016
 #
 #  This program and the accompanying materials are made available
 #  under the terms of the Eclipse Public License v1.0 and
@@ -83,11 +83,12 @@
 .align 8
        START _j9Z10Zero
 
-         ltr      CARG2,CARG2
+         ltgr     CARG2,CARG2
          je       L2L3
-         ahi      CARG2,-1
-         lr       r0,CARG2
-         sra      r0,8
+         aghi     CARG2,-1
+         lgr      r0,CARG2
+         srlg     r0,r0,8
+         ltr      r0,r0
          lgr      r4,CARG1
          je       L2L20
 ## must be greater than 256 bytes

--- a/util/omrutil/unix/zos/64/j9memclrz10_64.s
+++ b/util/omrutil/unix/zos/64/j9memclrz10_64.s
@@ -1,6 +1,6 @@
 ***********************************************************************
 *
-* (c) Copyright IBM Corp. 1991, 2010
+* (c) Copyright IBM Corp. 1991, 2016
 *
 *  This program and the accompanying materials are made available
 *  under the terms of the Eclipse Public License v1.0 and
@@ -36,13 +36,14 @@ r12      EQU      12
 r13      EQU      13
 r14      EQU      14
 r15      EQU      15
-         LTR      r2,r2                               
-         JE       @2L3                                
-         AHI      r2,-1
-         LR       r0,r2                               
-         SRA      r0,8                                
-         LGR      r3,r1                               
-         JE       @2L20                               
+         LTGR     r2,r2
+         JE       @2L3
+         AGHI     r2,-1
+         LGR      r0,r2
+         SRLG     r0,r0,8
+         LTR      r0,r0
+         LGR      r3,r1
+         JE       @2L20
 * must be greater than 256 bytes
 * Check if Greater than 1024 bytes to clear
          CHI      r0,3


### PR DESCRIPTION
Change 64-bit z/OS/zLinux memory clear function J9ZERZ10() to 64-bit
unsigned arithmetic.

Signed-off-by: Peter Bain <pdbain@ca.ibm.com>