### PR TITLE
Disable OMR_JIT by default

### DIFF
--- a/configure
+++ b/configure
@@ -1529,7 +1529,7 @@ Optional Features:
                           are not explicitly enabled or disabled. (Default:
                           yes)
   --disable-OMR_GC        Enable building the OMR GC. (Default: yes)
-  --disable-OMR_JIT       Enable building the OMR JIT. (Default: yes)
+  --enable-OMR_JIT        Enable building the OMR JIT. (Default: no)
   --disable-OMR_PORT      Enable building the Port library. (Default: yes)
   --disable-OMR_THREAD    Enable building the Thread library. (Default: yes)
   --disable-OMR_OMRSIG    Enable building the OMRSig library. (Default: yes)
@@ -5245,15 +5245,9 @@ else
 fi
 else
 
-	if test "x" = "x"; then :
-  OMR_JIT="#define OMR_JIT"
+	OMR_JIT="#undef OMR_JIT"
 
-else
-  OMR_JIT="#define OMR_JIT "
-
-
-fi
-	echo "OMR_JIT := 1" >> omrmakefiles/omrcfg.mk
+	echo "OMR_JIT := 0" >> omrmakefiles/omrcfg.mk
 
 
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -361,7 +361,7 @@ echo "" >> omrmakefiles/omrcfg.mk
 
 ############### Top-Level Components
 OMRCFG_DEFINE_FLAG_ON([OMR_GC], [], [Enable building the OMR GC. (Default: yes)])
-OMRCFG_DEFINE_FLAG_ON([OMR_JIT], [], [Enable building the OMR JIT. (Default: yes)])
+OMRCFG_DEFINE_FLAG_OFF([OMR_JIT], [], [Enable building the OMR JIT. (Default: no)])
 OMRCFG_DEFINE_FLAG_ON([OMR_PORT], [], [Enable building the Port library. (Default: yes)])
 OMRCFG_DEFINE_FLAG_ON([OMR_THREAD], [], [Enable building the Thread library. (Default: yes)])
 OMRCFG_DEFINE_FLAG_ON([OMR_OMRSIG], [], [Enable building the OMRSig library. (Default: yes)])

--- a/example/glue/configure_includes/configure_common.mk
+++ b/example/glue/configure_includes/configure_common.mk
@@ -19,7 +19,6 @@
 CONFIGURE_ARGS += \
   --enable-OMR_EXAMPLE \
   --enable-OMR_GC \
-  --disable-OMR_JIT \
   --enable-OMR_PORT \
   --enable-OMR_THREAD \
   --enable-OMR_OMRSIG \


### PR DESCRIPTION
For non-example glues, JITBuilder and the Test compiler should not be built by default.