### PR TITLE
Remove convertWidthToShift from OMR::Compilation

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -1977,9 +1977,6 @@ void OMR::Compilation::registerResolvedMethodSymbolReference(TR::SymbolReference
    }
 
 
-
-uint32_t OMR::Compilation::_widthToShift[] = { 0, 0, 1, 0, 2, 0, 0, 0, 3};
-
 bool OMR::Compilation::notYetRunMeansCold()
    {
    if (_optimizer && !((TR::Optimizer*)_optimizer)->isIlGenOpt())

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -965,8 +965,6 @@ public:
 #endif
 
    // To TransformUtil
-   // @deprecated Use TransformUtil::convertWidthToShift
-   static uint32_t convertWidthToShift(int32_t i) { return _widthToShift[i]; }
    void removeTree(TR::TreeTop * tt);
    void setStartTree(TR::TreeTop * tt);
 
@@ -976,9 +974,6 @@ public:
 private:
    void resetVisitCounts(vcount_t, TR::ResolvedMethodSymbol *);
    int16_t restoreInlineDepthUntil(int32_t stopIndex, TR_ByteCodeInfo &currentInfo);
-
-   static uint32_t _widthToShift[];
-
 
 protected:
    TR::Options *_options;


### PR DESCRIPTION
Remove deprecated function OMR::Compilation::convertWidthToShift

Signed-off-by: Aman Kumar <amank@ca.ibm.com>