### PR TITLE
Fix JitBuilder compile errors on s390x

### DIFF
--- a/jitbuilder/optimizer/JBOptimizer.cpp
+++ b/jitbuilder/optimizer/JBOptimizer.cpp
@@ -111,7 +111,7 @@ static const OptimizationStrategy JBwarmStrategyOpts[] =
    { OMR::localCSE                                                                 },
    { OMR::treeSimplification,                        OMR::MarkLastRun              },
 #ifdef TR_HOST_S390
-   { OMR::longRegA llocation                                                       },
+   { OMR::longRegAllocation                                                        },
 #endif
    { OMR::andSimplification,                         OMR::IfEnabled                },  //clean up after versioner
    { OMR::deadTreesElimination,                      OMR::IfEnabled                }, // cleanup at the end

--- a/jitbuilder/z/codegen/JBCodeGenerator.hpp
+++ b/jitbuilder/z/codegen/JBCodeGenerator.hpp
@@ -33,7 +33,7 @@ namespace JitBuilder { typedef Z::CodeGenerator CodeGeneratorConnector; }
 #endif
 
 
-#include "codegen/JBCodeGenerator.hpp"
+#include "jitbuilder/codegen/JBCodeGenerator.hpp"
 #include "codegen/LinkageConventionsEnum.hpp"
 
 


### PR DESCRIPTION
JitBuilder can now be compiled on s390x, but is untested.

Issue: #283 
Signed-off-by: Aman Kumar <amank@ca.ibm.com>