### PR TITLE
Redefine Node recreate functions

### DIFF
--- a/compiler/arm/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/arm/codegen/ControlFlowEvaluator.cpp
@@ -136,14 +136,14 @@ static TR::Instruction *compareIntsForOrder(TR_ARMConditionCode  branchType,
          return NULL;
 
       cannotInline = true;
-      TR::Node::recreateAndCopyValidProperties(firstChild, TR::icall);
+      TR::Node::recreate(firstChild, TR::icall);
       }
 
    src1Reg = cg->evaluate(firstChild);
 
    if (cannotInline)
       {
-      TR::Node::recreateAndCopyValidProperties(firstChild, TR::instanceof);
+      TR::Node::recreate(firstChild, TR::instanceof);
       }
 
    bool foundConst = false;
@@ -242,14 +242,14 @@ TR::Instruction *OMR::ARM::TreeEvaluator::compareIntsForEquality(TR_ARMCondition
          return NULL;
 
       cannotInline = true;
-      TR::Node::recreateAndCopyValidProperties(firstChild, TR::icall);
+      TR::Node::recreate(firstChild, TR::icall);
       }
 
    src1Reg = cg->evaluate(firstChild);
 
    if (cannotInline)
       {
-      TR::Node::recreateAndCopyValidProperties(firstChild, TR::instanceof);
+      TR::Node::recreate(firstChild, TR::instanceof);
       }
 
    bool foundConst = false;
@@ -763,9 +763,9 @@ TR::Register *OMR::ARM::TreeEvaluator::iflucmpleEvaluator(TR::Node *node, TR::Co
 
 TR::Register *OMR::ARM::TreeEvaluator::ifacmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::Node::recreateAndCopyValidProperties(node, TR::ificmpeq);
+   TR::Node::recreate(node, TR::ificmpeq);
    ificmpeqEvaluator(node, cg);
-   TR::Node::recreateAndCopyValidProperties(node, TR::ifacmpeq);
+   TR::Node::recreate(node, TR::ifacmpeq);
    return NULL;
    }
 
@@ -943,9 +943,9 @@ TR::Register *OMR::ARM::TreeEvaluator::lcmpEvaluator(TR::Node *node, TR::CodeGen
 
 TR::Register *OMR::ARM::TreeEvaluator::acmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::Node::recreateAndCopyValidProperties(node, TR::icmpeq);
+   TR::Node::recreate(node, TR::icmpeq);
    TR::Register *trgReg = icmpeqEvaluator(node, cg);
-   TR::Node::recreateAndCopyValidProperties(node, TR::acmpeq);
+   TR::Node::recreate(node, TR::acmpeq);
    return trgReg;
    }
 

--- a/compiler/arm/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.cpp
@@ -1058,9 +1058,9 @@ TR::Register *OMR::ARM::TreeEvaluator::newArrayEvaluator(TR::Node *node, TR::Cod
    if (TR::comp()->suppressAllocationInlining())
       {
       TR::ILOpCodes opCode = node->getOpCodeValue();
-      TR::Node::recreateAndCopyValidProperties(node, TR::acall);
+      TR::Node::recreate(node, TR::acall);
       TR::Register *targetRegister = directCallEvaluator(node, cg);
-      TR::Node::recreateAndCopyValidProperties(node, opCode);
+      TR::Node::recreate(node, opCode);
       return targetRegister;
       }
    else
@@ -1074,9 +1074,9 @@ TR::Register *OMR::ARM::TreeEvaluator::anewArrayEvaluator(TR::Node *node, TR::Co
    if (TR::comp()->suppressAllocationInlining())
       {
       TR::ILOpCodes opCode = node->getOpCodeValue();
-      TR::Node::recreateAndCopyValidProperties(node, TR::acall);
+      TR::Node::recreate(node, TR::acall);
       TR::Register *targetRegister = directCallEvaluator(node, cg);
-      TR::Node::recreateAndCopyValidProperties(node, opCode);
+      TR::Node::recreate(node, opCode);
       return targetRegister;
       }
    else
@@ -1089,9 +1089,9 @@ TR::Register *OMR::ARM::TreeEvaluator::anewArrayEvaluator(TR::Node *node, TR::Co
 TR::Register *OMR::ARM::TreeEvaluator::multianewArrayEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::ILOpCodes opCode = node->getOpCodeValue();
-   TR::Node::recreateAndCopyValidProperties(node, TR::acall);
+   TR::Node::recreate(node, TR::acall);
    TR::Register *targetRegister = directCallEvaluator(node, cg);
-   TR::Node::recreateAndCopyValidProperties(node, opCode);
+   TR::Node::recreate(node, opCode);
    return targetRegister;
    }
 

--- a/compiler/codegen/CodeGenPrep.cpp
+++ b/compiler/codegen/CodeGenPrep.cpp
@@ -122,12 +122,12 @@ OMR::CodeGenerator::lowerTreesPreChildrenVisit(TR::Node * parent, TR::TreeTop * 
                   {
                   if (isInteger)
                      {
-                     TR::Node::recreateAndCopyValidProperties(parent, TR::ishl);
+                     TR::Node::recreate(parent, TR::ishl);
                      }
                   else
                      {
-                     TR::Node::recreateAndCopyValidProperties(secondChild, TR::iconst);
-                     TR::Node::recreateAndCopyValidProperties(parent, TR::lshl);
+                     TR::Node::recreate(secondChild, TR::iconst);
+                     TR::Node::recreate(parent, TR::lshl);
                      }
                   secondChild->setInt(shftAmnt);
                   }
@@ -137,7 +137,7 @@ OMR::CodeGenerator::lowerTreesPreChildrenVisit(TR::Node * parent, TR::TreeTop * 
                   parent->getSecondChild()->decReferenceCount();
                   parent->setSecond(newChild);
                   parent->getSecondChild()->incReferenceCount();
-                  isInteger ? TR::Node::recreateAndCopyValidProperties(parent, TR::ishl) : TR::Node::recreateAndCopyValidProperties(parent, TR::lshl);
+                  isInteger ? TR::Node::recreate(parent, TR::ishl) : TR::Node::recreate(parent, TR::lshl);
                   }
                }
             else //negative value of the multiply constant
@@ -156,12 +156,12 @@ OMR::CodeGenerator::lowerTreesPreChildrenVisit(TR::Node * parent, TR::TreeTop * 
                   newChild->setSecond(secondChild);
                   if (isInteger)
                      {
-                     TR::Node::recreateAndCopyValidProperties(parent, TR::ineg);
+                     TR::Node::recreate(parent, TR::ineg);
                      }
                   else
                      {
-                     TR::Node::recreateAndCopyValidProperties(secondChild, TR::iconst);
-                     TR::Node::recreateAndCopyValidProperties(parent, TR::lneg);
+                     TR::Node::recreate(secondChild, TR::iconst);
+                     TR::Node::recreate(parent, TR::lneg);
                      }
                   secondChild->setInt(shftAmnt);
                   parent->setNumChildren(1);
@@ -179,7 +179,7 @@ OMR::CodeGenerator::lowerTreesPreChildrenVisit(TR::Node * parent, TR::TreeTop * 
                   parent->getFirstChild()->decReferenceCount();
                   parent->getSecondChild()->decReferenceCount();
                   parent->setNumChildren(1);
-                  isInteger ? TR::Node::recreateAndCopyValidProperties(parent, TR::ineg) : TR::Node::recreateAndCopyValidProperties(parent, TR::lneg);
+                  isInteger ? TR::Node::recreate(parent, TR::ineg) : TR::Node::recreate(parent, TR::lneg);
                   parent->setFirst(newChild2);
                   parent->getFirstChild()->incReferenceCount();
                   }
@@ -213,7 +213,7 @@ OMR::CodeGenerator::lowerTreeIfNeeded(
          {
          TR::Node *idivChild = TR::Node::create(TR::idiv, 2, firstChild->getFirstChild(), secondChild->getFirstChild());
 
-         TR::Node::recreateAndCopyValidProperties(node, TR::iu2l);
+         TR::Node::recreate(node, TR::iu2l);
          node->setNumChildren(1);
          node->setChild(0, idivChild);
          idivChild->incReferenceCount();
@@ -436,7 +436,7 @@ void OMR::CodeGenerator::identifyUnneededByteConvNodes(TR::Node * parent, TR::Tr
                     child->getFirstChild()->getOpCodeValue() == TR::iuRegLoad ) &&
                    performTransformation(self()->comp(), "%sChanging b2i node %p to unsigned conversion\n", OPT_DETAILS, child))
                   {
-                  TR::Node::recreateAndCopyValidProperties(child, (storeType == TR::Int8 ? TR::bu2i : TR::su2i));
+                  TR::Node::recreate(child, (storeType == TR::Int8 ? TR::bu2i : TR::su2i));
                   }
                else if (performTransformation(self()->comp(), "%sMarking i2b/b2i node %p as unneeded\n", OPT_DETAILS, child))
                   child->setUnneededConversion(true);

--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -1034,7 +1034,7 @@ OMR::CodeGenerator::spillLiveReferencesToTemps(TR::TreeTop *insertionTree, std::
             }
 
          // Rewrite the original reference as an aload of the temp.
-         TR::Node::recreateAndCopyValidProperties(originalReference, TR::aload);
+         TR::Node::recreate(originalReference, TR::aload);
          originalReference->setNumChildren(0);
          originalReference->setSymbolReference(tempSymRef);
          }

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -2508,11 +2508,11 @@ OMR::CodeGenerator::convertMultiplyToShift(TR::Node * node)
    node->setAndIncChild(1, secondChild);
 
    if (node->getOpCodeValue() == TR::imul || node->getOpCodeValue() == TR::iumul)
-      TR::Node::recreateAndCopyValidProperties(node, TR::ishl);
+      TR::Node::recreate(node, TR::ishl);
    else
       {
-      TR::Node::recreateAndCopyValidProperties(node, TR::lshl);
-      TR::Node::recreateAndCopyValidProperties(secondChild, TR::iconst);
+      TR::Node::recreate(node, TR::lshl);
+      TR::Node::recreate(secondChild, TR::iconst);
       }
    secondChild->setInt(shiftAmount);
    return true;

--- a/compiler/codegen/PreInstructionSelection.cpp
+++ b/compiler/codegen/PreInstructionSelection.cpp
@@ -102,7 +102,7 @@ OMR::CodeGenerator::eliminateLoadsOfLocalsThatAreNotStored(
        performTransformation(self()->comp(), "%sRemoving dead load of sym ref %d at %p\n", OPT_DETAILS, node->getSymbolReference()->getReferenceNumber(), node))
 
       {
-      TR::Node::recreateAndCopyValidProperties(node, self()->comp()->il.opCodeForConst(node->getSymbolReference()->getSymbol()->getDataType()));
+      TR::Node::recreate(node, self()->comp()->il.opCodeForConst(node->getSymbolReference()->getSymbol()->getDataType()));
       node->setLongInt(0);
       return;
       }

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -664,12 +664,6 @@ OMR::Node::createOnStack(TR::Node * originatingByteCodeNode, TR::ILOpCodes op, u
    }
 
 TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::SymbolReference * symRef)
-   {
-   return recreateWithoutProperties(originalNode, op, numChildren, symRef);
-   }
-
-TR::Node *
 OMR::Node::recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::SymbolReference * symRef)
    {
    TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
@@ -891,107 +885,6 @@ OMR::Node::create(TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::N
    {
    TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
    return TR::Node::createWithoutSymRef(op, numChildren, 8, first, second, third, fourth, fifth, sixth, seventh, eighth);
-   }
-
-
-TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first)
-   {
-   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first);
-   }
-
-TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second)
-   {
-   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, second);
-   }
-
-TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third)
-   {
-   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, second, third);
-   }
-
-TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth)
-   {
-   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, second, third, fourth);
-   }
-
-TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth)
-   {
-   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, second, third, fourth, fifth);
-   }
-
-TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth)
-   {
-   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, second, third, fourth, fifth, sixth);
-   }
-
-TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh)
-   {
-   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, second, third, fourth, fifth, sixth, seventh);
-   }
-
-TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh, TR::Node *eighth)
-   {
-   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, second, third, fourth, fifth, sixth, seventh, eighth);
-   }
-
-
-
-TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::SymbolReference * symRef)
-   {
-   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, symRef);
-   }
-
-TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::SymbolReference * symRef)
-   {
-   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, second, symRef);
-   }
-
-TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::SymbolReference * symRef)
-   {
-   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, second, third, symRef);
-   }
-
-TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::SymbolReference * symRef)
-   {
-   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, second, third, fourth, symRef);
-   }
-
-TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::SymbolReference * symRef)
-   {
-   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, second, third, fourth, fifth, symRef);
-   }
-
-TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::SymbolReference * symRef)
-   {
-   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, second, third, fourth, fifth, sixth, symRef);
-   }
-
-TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh, TR::SymbolReference * symRef)
-   {
-   return TR::Node::recreateWithoutProperties(originalNode, op, numChildren, first, second, third, fourth, fifth, sixth, seventh, symRef);
-   }
-
-
-TR::Node *
-OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh, TR::Node *eighth, TR::SymbolReference * symRef)
-   {
-   TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
-   return TR::Node::recreateWithSymRef(originalNode, op, numChildren, 8, first, second, third, fourth, fifth, sixth, seventh, eighth, symRef);
    }
 
 

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -490,9 +490,18 @@ OMR::Node::copyValidProperties(TR::Node *fromNode, TR::Node *toNode)
    }
 
 TR::Node *
-OMR::Node::recreateAndCopyValidProperties(TR::Node *originalNode, TR::ILOpCodes op)
+OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op)
    {
    return TR::Node::recreateAndCopyValidPropertiesImpl(originalNode, op, NULL);
+   }
+
+/**
+  * @deprecated Use TR::Node::recreate instead
+  */
+TR::Node *
+OMR::Node::recreateAndCopyValidProperties(TR::Node *originalNode, TR::ILOpCodes op)
+   {
+   return TR::Node::recreate(originalNode, op);
    }
 
 TR::Node *
@@ -502,7 +511,7 @@ OMR::Node::recreateWithSymRefAndCopyValidProperties(TR::Node *originalNode, TR::
    }
 
 /**
- * OMR::Node::recreateAndCopyValidProperties
+ * OMR::Node::recreate
  *
  * creates a new node with a new op, based on the originalNode, reusing the memory occupied by originalNode and returning the
  * same address as it.
@@ -3832,7 +3841,7 @@ OMR::Node::printIsReferenceArrayCopy()
 
 
 
-// OMR::Node::setOpCodeValue is now private, and deprecated. Use OMR::Node::recreateAndCopyValidProperties instead.
+// OMR::Node::setOpCodeValue is now private, and deprecated. Use OMR::Node::recreate instead.
 TR::ILOpCodes
 OMR::Node::setOpCodeValue(TR::ILOpCodes op)
    {

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -177,7 +177,6 @@ public:
    static TR::Node *createWithSymRef(TR::Node *originatingByteCodeNode, TR::ILOpCodes op, uint16_t numChildren, TR::SymbolReference * symRef);
    static TR::Node *createWithSymRef(TR::Node *originatingByteCodeNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node* first, TR::SymbolReference * symRef);
    static TR::Node *createOnStack(TR::Node *originatingByteCodeNode, TR::ILOpCodes op, uint16_t numChildren = 0);
-   static TR::Node *recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren = 0, TR::SymbolReference * symRef = 0);
    static TR::Node *recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren = 0, TR::SymbolReference * symRef = 0);
 
    static TR::Node *create(TR::ILOpCodes op, uint16_t numChildren = 0);
@@ -233,24 +232,6 @@ public:
    static TR::Node *create(TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth);
    static TR::Node *create(TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh);
    static TR::Node *create(TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh, TR::Node *eighth);
-
-   static TR::Node *recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first);
-   static TR::Node *recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second);
-   static TR::Node *recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third);
-   static TR::Node *recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth);
-   static TR::Node *recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth);
-   static TR::Node *recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth);
-   static TR::Node *recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh);
-   static TR::Node *recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh, TR::Node *eighth);
-
-   static TR::Node *recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::SymbolReference * symRef);
-   static TR::Node *recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::SymbolReference * symRef);
-   static TR::Node *recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::SymbolReference * symRef);
-   static TR::Node *recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::SymbolReference * symRef);
-   static TR::Node *recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::SymbolReference * symRef);
-   static TR::Node *recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::SymbolReference * symRef);
-   static TR::Node *recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh, TR::SymbolReference * symRef);
-   static TR::Node *recreate(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh, TR::Node *eighth, TR::SymbolReference * symRef);
 
    static TR::Node *recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first);
    static TR::Node *recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second);

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -163,6 +163,7 @@ public:
    static TR::Node *copy(TR::Node *);
    static TR::Node *copy(TR::Node *, int32_t numChildren);
 
+   static TR::Node *recreate(TR::Node *originalNode, TR::ILOpCodes op);
    static TR::Node *recreateAndCopyValidProperties(TR::Node *originalNode, TR::ILOpCodes op);
    static TR::Node *recreateWithSymRefAndCopyValidProperties(TR::Node *originalNode, TR::ILOpCodes op, TR::SymbolReference *newSymRef);
 
@@ -1537,7 +1538,7 @@ public:
 // Protected functions
 protected:
 
-   /** setOpCodeValue is now private, and deprecated. Use recreateAndCopyValidProperties instead. */
+   /** setOpCodeValue is now private, and deprecated. Use recreate instead. */
    TR::ILOpCodes setOpCodeValue(TR::ILOpCodes op);
 
    // Misc helpers

--- a/compiler/optimizer/CFGSimplifier.cpp
+++ b/compiler/optimizer/CFGSimplifier.cpp
@@ -351,7 +351,7 @@ bool TR_CFGSimplifier::simplifyBooleanStore()
          }
       // Set up the new opcode for the compare node
       //
-      TR::Node::recreateAndCopyValidProperties(compareNode, compareNode->getOpCode().getOpCodeForReverseBranch());
+      TR::Node::recreate(compareNode, compareNode->getOpCode().getOpCodeForReverseBranch());
       }
    else
       {
@@ -368,7 +368,7 @@ bool TR_CFGSimplifier::simplifyBooleanStore()
       }
    TR::Node *value = storeNode->getChild(valueIndex);
 
-   TR::Node::recreateAndCopyValidProperties(compareNode, compareNode->getOpCode().convertIfCmpToCmp());
+   TR::Node::recreate(compareNode, compareNode->getOpCode().convertIfCmpToCmp());
 
    TR::Node *node1;
    TR::ILOpCodes convertOpCode = TR::BadILOp;

--- a/compiler/optimizer/CopyPropagation.cpp
+++ b/compiler/optimizer/CopyPropagation.cpp
@@ -1164,7 +1164,7 @@ void TR_CopyPropagation::replaceCopySymbolReferenceByOriginalIn(TR::SymbolRefere
                   }
 
                // Recreate after all children and symRefs have been set
-               TR::Node::recreateAndCopyValidProperties(node, origNode->getOpCodeValue());
+               TR::Node::recreate(node, origNode->getOpCodeValue());
                }
             else if (origNode->getOpCode().isConversion() &&
                      origNode->getNumChildren() == 1)
@@ -1176,7 +1176,7 @@ void TR_CopyPropagation::replaceCopySymbolReferenceByOriginalIn(TR::SymbolRefere
                node->setFlags(origNode->getFlags());
 
                // Recreate after all children and symRefs have been set
-               TR::Node::recreateAndCopyValidProperties(node, origNode->getOpCodeValue());
+               TR::Node::recreate(node, origNode->getOpCodeValue());
 
                firstChild->setVisitCount(curVisit);
                }
@@ -1194,7 +1194,7 @@ void TR_CopyPropagation::replaceCopySymbolReferenceByOriginalIn(TR::SymbolRefere
 
                // BCD tracing might be misleading after this
                if (!origNode->getOpCode().isStore())
-                  TR::Node::recreateAndCopyValidProperties(node, origNode->getOpCodeValue());
+                  TR::Node::recreate(node, origNode->getOpCodeValue());
 
                int32_t newPrecision = 0;
                int32_t currentPrecision = 0;
@@ -1300,7 +1300,7 @@ void TR_CopyPropagation::replaceCopySymbolReferenceByOriginalIn(TR::SymbolRefere
                         }
                      else
                         {
-                        TR::Node::recreateAndCopyValidProperties(node, modPrecOp);
+                        TR::Node::recreate(node, modPrecOp);
 
                         node->setAndIncChild(0, nodeCopy);
                         node->setNumChildren(1);
@@ -1318,7 +1318,7 @@ void TR_CopyPropagation::replaceCopySymbolReferenceByOriginalIn(TR::SymbolRefere
                      // can only clean up to maxPackedPrec -- case allow should have been guaranteed by isCorrectToPropagate
                      TR_ASSERT(node->getDecimalPrecision() <= TR::DataType::getMaxPackedDecimalPrecision(),
                              "node %p prec %d must be <= max %d\n", node, node->getDecimalPrecision(), TR::DataType::getMaxPackedDecimalPrecision());
-                     TR::Node::recreateAndCopyValidProperties(node, cleanOp);
+                     TR::Node::recreate(node, cleanOp);
 
                      node->setAndIncChild(0, nodeCopy);
                      node->setNumChildren(1);
@@ -1351,7 +1351,7 @@ void TR_CopyPropagation::replaceCopySymbolReferenceByOriginalIn(TR::SymbolRefere
             else
                {
                if (!origNode->getOpCode().isStore())
-                  TR::Node::recreateAndCopyValidProperties(node, origNode->getOpCodeValue());
+                  TR::Node::recreate(node, origNode->getOpCodeValue());
 
                if (origNode->getOpCode().hasSymbolReference() && node->getOpCode().hasSymbolReference())
                   node->setSymbolReference(origNode->getSymbolReference());

--- a/compiler/optimizer/FieldPrivatizer.cpp
+++ b/compiler/optimizer/FieldPrivatizer.cpp
@@ -766,12 +766,12 @@ void TR_FieldPrivatizer::privatizeFields(TR::Node *node, bool postDominatesEntry
                if (opCode.isStore())
                   {
                   _needToStoreBack->set(autoForField->getReferenceNumber());
-                  TR::Node::recreateAndCopyValidProperties(node, comp()->il.opCodeForDirectStore(nodeDataType));
+                  TR::Node::recreate(node, comp()->il.opCodeForDirectStore(nodeDataType));
                   newFirstChild = node->getSecondChild();
                   newFirstChildNum = 1;
                   }
                else
-                  TR::Node::recreateAndCopyValidProperties(node, comp()->il.opCodeForDirectLoad(nodeDataType));
+                  TR::Node::recreate(node, comp()->il.opCodeForDirectLoad(nodeDataType));
 
                int32_t j;
                for (j=0;j<node->getNumChildren();j++)
@@ -933,12 +933,12 @@ void TR_FieldPrivatizer::placeInitializersInLoopInvariantBlock(TR::Block *block)
 	 {
            if (duplicateNode->getOpCode().isIndirect())
               {
-              TR::Node::recreateAndCopyValidProperties(duplicateNode, comp()->il.opCodeForCorrespondingIndirectStore(duplicateNode->getOpCodeValue()));
+              TR::Node::recreate(duplicateNode, comp()->il.opCodeForCorrespondingIndirectStore(duplicateNode->getOpCodeValue()));
               duplicateNode->setNumChildren(1);
               }
            else
               {
-              TR::Node::recreateAndCopyValidProperties(duplicateNode, comp()->il.opCodeForDirectLoad(duplicateNode->getDataType()));
+              TR::Node::recreate(duplicateNode, comp()->il.opCodeForDirectLoad(duplicateNode->getDataType()));
               duplicateNode->setNumChildren(0);
               }
 	 }
@@ -1152,7 +1152,7 @@ void TR_FieldPrivatizer::placeStoresBackInExit(TR::Block *block, bool placeAtEnd
             {
             if (!duplicateNode->getOpCode().isStore())
                {
-               TR::Node::recreateAndCopyValidProperties(duplicateNode, comp()->il.opCodeForCorrespondingIndirectLoad(duplicateNode->getOpCodeValue()));
+               TR::Node::recreate(duplicateNode, comp()->il.opCodeForCorrespondingIndirectLoad(duplicateNode->getOpCodeValue()));
                }
 
             if (duplicateNode->getOpCode().isWrtBar())
@@ -1166,7 +1166,7 @@ void TR_FieldPrivatizer::placeStoresBackInExit(TR::Block *block, bool placeAtEnd
          else
             {
             if (!duplicateNode->getOpCode().isStore())
-               TR::Node::recreateAndCopyValidProperties(duplicateNode, comp()->il.opCodeForDirectStore(duplicateNode->getDataType()));
+               TR::Node::recreate(duplicateNode, comp()->il.opCodeForDirectStore(duplicateNode->getDataType()));
             if (duplicateNode->getOpCode().isWrtBar())
                duplicateNode->setNumChildren(2);
             else
@@ -1455,7 +1455,7 @@ void TR_FieldPrivatizer::cleanupStringPeephole()
 
    if (prevNode->getOpCode().isStore())
       {
-      TR::Node::recreateAndCopyValidProperties(prevNode, TR::treetop);
+      TR::Node::recreate(prevNode, TR::treetop);
       TR::Node *firstChild = prevNode->getFirstChild();
       TR::TreeTop *cursorTree = prevTree->getPrevTreeTop();
       while(cursorTree)
@@ -1474,7 +1474,7 @@ void TR_FieldPrivatizer::cleanupStringPeephole()
 
        if (firstChild->getOpCodeValue() == TR::New)
           {
-          TR::Node::recreateAndCopyValidProperties(firstChild, TR::acall);
+          TR::Node::recreate(firstChild, TR::acall);
 
           TR::SymbolReference *appendSymRef = _appendSymRef ? comp()->getSymRefTab()->findOrCreateMethodSymbol(firstChild->getSymbolReference()->getOwningMethodIndex(), -1, _appendSymRef->getSymbol()->getResolvedMethodSymbol()->getResolvedMethod(), TR::MethodSymbol::Special) : 0;
 
@@ -1580,7 +1580,7 @@ void TR_FieldPrivatizer::privatizeElementCandidates()
 
       TR_ASSERT(candidate.node->getReferenceCount() == 1, "Candidate store node %p has refcount > 1... How is this possible?\n",candidate.node);
 
-      TR::Node::recreateAndCopyValidProperties(candidate.node, comp()->il.opCodeForDirectStore(storedt));
+      TR::Node::recreate(candidate.node, comp()->il.opCodeForDirectStore(storedt));
       candidate.node->setSymbolReference(tempSymRef);
       candidate.node->setFirst(candidate.node->getSecondChild());
       candidate.node->setNumChildren(1);

--- a/compiler/optimizer/GeneralLoopUnroller.cpp
+++ b/compiler/optimizer/GeneralLoopUnroller.cpp
@@ -941,30 +941,30 @@ void TR_LoopUnroller::modifyOriginalLoop(TR_RegionStructure *loop, TR_StructureS
       if (branch->getOpCodeValue() == TR::ificmpne)
          {
          if (isIncreasingLoop())
-            TR::Node::recreateAndCopyValidProperties(branch, TR::ificmplt);
+            TR::Node::recreate(branch, TR::ificmplt);
          else
-            TR::Node::recreateAndCopyValidProperties(branch, TR::ificmpgt);
+            TR::Node::recreate(branch, TR::ificmpgt);
          }
       else  if (branch->getOpCodeValue() == TR::ifiucmpne)
          {
          if (isIncreasingLoop())
-            TR::Node::recreateAndCopyValidProperties(branch, TR::ifiucmplt);
+            TR::Node::recreate(branch, TR::ifiucmplt);
          else
-            TR::Node::recreateAndCopyValidProperties(branch, TR::ifiucmpgt);
+            TR::Node::recreate(branch, TR::ifiucmpgt);
          }
       else if (branch->getOpCodeValue() == TR::iflcmpne)
          {
          if (isIncreasingLoop())
-            TR::Node::recreateAndCopyValidProperties(branch, TR::iflcmplt);
+            TR::Node::recreate(branch, TR::iflcmplt);
          else
-            TR::Node::recreateAndCopyValidProperties(branch, TR::iflcmpgt);
+            TR::Node::recreate(branch, TR::iflcmpgt);
          }
       else if (branch->getOpCodeValue() == TR::iflucmpne)
          {
          if (isIncreasingLoop())
-            TR::Node::recreateAndCopyValidProperties(branch, TR::iflucmplt);
+            TR::Node::recreate(branch, TR::iflucmplt);
          else
-            TR::Node::recreateAndCopyValidProperties(branch, TR::iflucmpgt);
+            TR::Node::recreate(branch, TR::iflucmpgt);
          }
       }
    else if (_unrollKind == CompleteUnroll) /*GGLU*/
@@ -1204,7 +1204,7 @@ void TR_LoopUnroller::modifyOriginalLoop(TR_RegionStructure *loop, TR_StructureS
 
             if (spillLoop->contains(branchDestination->getStructureOf(), parent))
                {
-               TR::Node::recreateAndCopyValidProperties(newIfTree->getNode(),
+               TR::Node::recreate(newIfTree->getNode(),
                   newIfTree->getNode()->getOpCode().getOpCodeForReverseBranch());
                newIfTree->getNode()->setBranchDestination(origExitBlock->getEntry());
                }
@@ -1426,7 +1426,7 @@ void TR_LoopUnroller::modifyOriginalLoop(TR_RegionStructure *loop, TR_StructureS
 
             if (spillLoop->contains(branchDestination->getStructureOf(), parent))
                {
-                TR::Node::recreateAndCopyValidProperties(newIfTree->getNode(),
+                TR::Node::recreate(newIfTree->getNode(),
                    newIfTree->getNode()->getOpCode().getOpCodeForReverseBranch());
                 newIfTree->getNode()->setBranchDestination(origExitBlock->getEntry());
                }
@@ -2192,7 +2192,7 @@ void TR_LoopUnroller::generateSpillLoop(TR_RegionStructure *loop,
       {
       TR_ASSERT(_spillBranchBlock->getLastRealTreeTop()->getNode()->getOpCode().isBranch(),
              "expecting a branch in the spill loop branch block");
-      TR::Node::recreateAndCopyValidProperties(_spillBranchBlock->getLastRealTreeTop()->getNode(), _origLoopCondition);
+      TR::Node::recreate(_spillBranchBlock->getLastRealTreeTop()->getNode(), _origLoopCondition);
       }
    }
 
@@ -3511,7 +3511,7 @@ TR_LoopUnroller::unroll(TR::Compilation *comp, TR_RegionStructure *loop,
             {
             unroller._wasEQorNELoop = true;
             unroller._origLoopCondition = branch->getOpCodeValue();
-            TR::Node::recreateAndCopyValidProperties(branch, opCode);
+            TR::Node::recreate(branch, opCode);
             }
          }
 

--- a/compiler/optimizer/GlobalRegisterAllocator.cpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.cpp
@@ -284,7 +284,7 @@ static void changeHeapBaseConstToLoad(TR::Compilation *comp, TR::SymbolReference
          tt->join(nextTree);
          }
 
-      TR::Node::recreateAndCopyValidProperties(node, TR::lload);
+      TR::Node::recreate(node, TR::lload);
       node->setSymbolReference(autoSymRef);
       }
 
@@ -1323,7 +1323,7 @@ TR_GlobalRegisterAllocator::transformNode(
              (oldValue->getOpCodeValue() == TR::iload) &&
              (value->getOpCodeValue() == TR::iRegLoad))
             {
-            TR::Node::recreateAndCopyValidProperties(oldValue, TR::iRegLoad);
+            TR::Node::recreate(oldValue, TR::iRegLoad);
             oldValue->setGlobalRegisterNumber(value->getGlobalRegisterNumber());
             }
 
@@ -1547,7 +1547,7 @@ TR_GlobalRegisterAllocator::transformNode(
                origStoreToMetaData = NULL;
                   {
                   TR::DataTypes regStoreType = node->getDataType();
-                  TR::Node::recreateAndCopyValidProperties(node, comp()->il.opCodeForRegisterStore(regStoreType));
+                  TR::Node::recreate(node, comp()->il.opCodeForRegisterStore(regStoreType));
                   }
 
                if (node->needsSignExtension())

--- a/compiler/optimizer/InductionVariable.cpp
+++ b/compiler/optimizer/InductionVariable.cpp
@@ -1170,17 +1170,17 @@ TR::Node *TR_LoopStrider::getNewLoopIncrement(TR_StoreTreeInfo *info, int32_t k)
 void TR_LoopStrider::changeBranchFromIntToLong(TR::Node* branch)
    {
    if (branch->getOpCodeValue() == TR::ificmplt)
-      TR::Node::recreateAndCopyValidProperties(branch, TR::iflcmplt);
+      TR::Node::recreate(branch, TR::iflcmplt);
    else if (branch->getOpCodeValue() == TR::ificmpgt)
-      TR::Node::recreateAndCopyValidProperties(branch, TR::iflcmpgt);
+      TR::Node::recreate(branch, TR::iflcmpgt);
    else if (branch->getOpCodeValue() == TR::ificmpge)
-      TR::Node::recreateAndCopyValidProperties(branch, TR::iflcmpge);
+      TR::Node::recreate(branch, TR::iflcmpge);
    else if (branch->getOpCodeValue() == TR::ificmple)
-      TR::Node::recreateAndCopyValidProperties(branch, TR::iflcmple);
+      TR::Node::recreate(branch, TR::iflcmple);
    else if (branch->getOpCodeValue() == TR::ificmpeq)
-      TR::Node::recreateAndCopyValidProperties(branch, TR::iflcmpeq);
+      TR::Node::recreate(branch, TR::iflcmpeq);
    else if (branch->getOpCodeValue() == TR::ificmpne)
-      TR::Node::recreateAndCopyValidProperties(branch, TR::iflcmpne);
+      TR::Node::recreate(branch, TR::iflcmpne);
    }
 
 
@@ -1406,7 +1406,7 @@ void TR_LoopStrider::changeLoopCondition(TR_BlockStructure *loopInvariantBlock, 
             changeBranchFromIntToLong(loopTestNode);
             }
 
-         TR::Node::recreateAndCopyValidProperties(loopTestNode, TR::ILOpCode::convertSignedCmpToUnsignedCmp(loopTestNode->getOpCodeValue()));
+         TR::Node::recreate(loopTestNode, TR::ILOpCode::convertSignedCmpToUnsignedCmp(loopTestNode->getOpCodeValue()));
          }
 
      // on 64-bit, change the loop test condition to equivalent longs
@@ -1461,12 +1461,12 @@ void TR_LoopStrider::changeLoopCondition(TR_BlockStructure *loopInvariantBlock, 
       prevFirst->recursivelyDecReferenceCount();
    if (prevSecond)
       prevSecond->recursivelyDecReferenceCount();
-   //TR::Node::recreateAndCopyValidProperties(_storeTrees[_loopDrivingInductionVar]->getNode(), TR::treetop);
+   //TR::Node::recreate(_storeTrees[_loopDrivingInductionVar]->getNode(), TR::treetop);
 
    // In a case of negative stride, exit branch needs to be reversed
    if (getMulTermConst(bestCandidate) < 0)
       {
-      TR::Node::recreateAndCopyValidProperties(loopTestNode, loopTestNode->getOpCode().getOpCodeForSwapChildren());
+      TR::Node::recreate(loopTestNode, loopTestNode->getOpCode().getOpCodeForSwapChildren());
       }
    }
 
@@ -1547,7 +1547,7 @@ void TR_LoopStrider::examineOpCodesForInductionVariableUse(TR::Node* node, TR::N
       if (isInternalPointer)
          {
          node = originalNode;
-         TR::Node::recreateAndCopyValidProperties(replacingNode, TR::aload);
+         TR::Node::recreate(replacingNode, TR::aload);
          }
 
       if (_usesLoadUsedInLoopIncrement)
@@ -1567,7 +1567,7 @@ void TR_LoopStrider::examineOpCodesForInductionVariableUse(TR::Node* node, TR::N
                   oldNode->getChild(i)->recursivelyDecReferenceCount();
                   }
                node->setAndIncChild(0, newLoad);
-               TR::Node::recreateAndCopyValidProperties(node, TR::l2i);
+               TR::Node::recreate(node, TR::l2i);
                node->setNumChildren(1);
                node->setReferenceCount(oldNode->getReferenceCount());
                downcastNode = false;
@@ -1588,7 +1588,7 @@ void TR_LoopStrider::examineOpCodesForInductionVariableUse(TR::Node* node, TR::N
             if (_storeTreeInfoForLoopIncrement)
                addLoad(_storeTreeInfoForLoopIncrement, node, index);
             nodeRememberedInLoadUsed = true;
-            TR::Node::recreateAndCopyValidProperties(node, replacingNode->getOpCodeValue());
+            TR::Node::recreate(node, replacingNode->getOpCodeValue());
             node->setSymbolReference(*newSymbolReference);
             node->setNumChildren(0);
             }
@@ -1598,7 +1598,7 @@ void TR_LoopStrider::examineOpCodesForInductionVariableUse(TR::Node* node, TR::N
          int32_t i=0;
          for (;i<node->getNumChildren();i++)
             node->getChild(i)->recursivelyDecReferenceCount();
-         TR::Node::recreateAndCopyValidProperties(node, replacingNode->getOpCodeValue());
+         TR::Node::recreate(node, replacingNode->getOpCodeValue());
          node->setSymbolReference(*newSymbolReference);
          node->setNumChildren(0);
          }
@@ -1608,10 +1608,10 @@ void TR_LoopStrider::examineOpCodesForInductionVariableUse(TR::Node* node, TR::N
          TR::Node *l2iNode = node->duplicateTree();
          node->setNumChildren(1);
          l2iNode->setNumChildren(0);
-         TR::Node::recreateAndCopyValidProperties(l2iNode, node->getOpCodeValue());
+         TR::Node::recreate(l2iNode, node->getOpCodeValue());
          l2iNode->setReferenceCount(1);
          node->setChild(0, l2iNode);
-         TR::Node::recreateAndCopyValidProperties(node, TR::l2i);
+         TR::Node::recreate(node, TR::l2i);
          // check if the parent is a long before adding an l2i
          //
          if (parent &&
@@ -1737,7 +1737,7 @@ void TR_LoopStrider::examineOpCodesForInductionVariableUse(TR::Node* node, TR::N
                adjustmentNode->setSideTableIndex(~0);
                adjustmentNode->getSecondChild()->setSideTableIndex(~0);
                }
-            TR::Node::recreateAndCopyValidProperties(replacingNode, TR::aladd);
+            TR::Node::recreate(replacingNode, TR::aladd);
             replacingNode->setIsInternalPointer(true);
             }
          else
@@ -1749,7 +1749,7 @@ void TR_LoopStrider::examineOpCodesForInductionVariableUse(TR::Node* node, TR::N
                adjustmentNode->setSideTableIndex(~0);
                adjustmentNode->getSecondChild()->setSideTableIndex(~0);
                }
-            TR::Node::recreateAndCopyValidProperties(replacingNode, TR::aiadd);
+            TR::Node::recreate(replacingNode, TR::aiadd);
             replacingNode->setIsInternalPointer(true);
             }
          }
@@ -1757,9 +1757,9 @@ void TR_LoopStrider::examineOpCodesForInductionVariableUse(TR::Node* node, TR::N
          replacingNode->getOpCodeValue() == TR::lload)
          {
          if (usingAladd || (replacingNode->getOpCodeValue() == TR::lload))
-            TR::Node::recreateAndCopyValidProperties(replacingNode, TR::ladd);
+            TR::Node::recreate(replacingNode, TR::ladd);
          else
-            TR::Node::recreateAndCopyValidProperties(replacingNode, TR::iadd);
+            TR::Node::recreate(replacingNode, TR::iadd);
          }
 
       if (differenceInAdditiveConstants != 0)
@@ -1798,7 +1798,7 @@ void TR_LoopStrider::examineOpCodesForInductionVariableUse(TR::Node* node, TR::N
       for (;i<node->getNumChildren();i++)
          node->getChild(i)->recursivelyDecReferenceCount();
 
-      TR::Node::recreateAndCopyValidProperties(node, replacingNode->getOpCodeValue());
+      TR::Node::recreate(node, replacingNode->getOpCodeValue());
       if (node->getOpCodeValue() == TR::aiadd || node->getOpCodeValue() == TR::aladd)
          {
          node->setIsInternalPointer(true);
@@ -1856,7 +1856,7 @@ void TR_LoopStrider::examineOpCodesForInductionVariableUse(TR::Node* node, TR::N
          node->getSecondChild()->recursivelyDecReferenceCount();
          node->setNumChildren(1);
          node->setChild(0, l2iNode);
-         TR::Node::recreateAndCopyValidProperties(node, TR::l2i);
+         TR::Node::recreate(node, TR::l2i);
          if (nodeRememberedInLoadUsed)
             {
             nodeRememberedInLoadUsed = false;
@@ -2639,7 +2639,7 @@ TR::Node *TR_LoopStrider::placeNewInductionVariableIncrementTree(TR_BlockStructu
       TR::Node *newConstNode = constNode->duplicateTree();
       if (constNode->getOpCode().isLoadConst())
          {
-         TR::Node::recreateAndCopyValidProperties(newConstNode, TR::lconst);
+         TR::Node::recreate(newConstNode, TR::lconst);
          newConstNode->setLongInt(GET64BITINT(constNode));
          if (constNode->getType().isInt32())
             {
@@ -2658,7 +2658,7 @@ TR::Node *TR_LoopStrider::placeNewInductionVariableIncrementTree(TR_BlockStructu
          i2lNode->setReferenceCount(1);
          newConstNode->setNumChildren(1);
          newConstNode->setChild(0, i2lNode);
-         TR::Node::recreateAndCopyValidProperties(newConstNode, TR::i2l);
+         TR::Node::recreate(newConstNode, TR::i2l);
          }
       newMulNode = TR::Node::create(TR::lmul, 2, newConstNode, multiplicativeConstant);
       newConstNode->setSideTableIndex(~0);
@@ -2737,7 +2737,7 @@ TR::Node *TR_LoopStrider::placeNewInductionVariableIncrementTree(TR_BlockStructu
             TR::Node *changedConstNode = constNode->duplicateTree();
             if (usingAladd)
                {
-               TR::Node::recreateAndCopyValidProperties(changedConstNode, TR::lconst);
+               TR::Node::recreate(changedConstNode, TR::lconst);
                changedConstNode->setLongInt(-1*GET64BITINT(constNode));
                }
             else
@@ -3532,7 +3532,7 @@ bool TR_LoopStrider::reassociateAndHoistComputations(TR::Block *loopInvariantBlo
 
          originalNode->getFirstChild()->recursivelyDecReferenceCount();
          originalNode->getSecondChild()->recursivelyDecReferenceCount();
-         TR::Node::recreateAndCopyValidProperties(originalNode, TR::aload);
+         TR::Node::recreate(originalNode, TR::aload);
          originalNode->setSymbolReference(internalPointerSymRef);
          originalNode->setNumChildren(0);
          originalNode->setSideTableIndex(~0);
@@ -4648,7 +4648,7 @@ void TR_LoopStrider::walkTreesAndFixUseDefs(
    storeNode->setAndIncChild(0, TR::Node::create(TR::i2l, 1, newIntValue));
    newIntValue->decReferenceCount();
    storeNode->setSymbolReference(newSymbolReference);
-   TR::Node::recreateAndCopyValidProperties(storeNode, TR::lstore);
+   TR::Node::recreate(storeNode, TR::lstore);
 
    TR::NodeChecklist visited(comp());
    replaceLoadsInStructure(
@@ -4715,7 +4715,7 @@ void TR_LoopStrider::replaceLoadsInSubtree(
        && node->getSymbolReference()->getReferenceNumber() == iv)
       {
       TR::Node *lload = TR::Node::createLoad(newSR);
-      TR::Node::recreateAndCopyValidProperties(node, TR::l2i);
+      TR::Node::recreate(node, TR::l2i);
       node->setNumChildren(1);
       node->setAndIncChild(0, lload);
       exLoads.add(node);
@@ -5065,7 +5065,7 @@ void TR_LoopStrider::transmuteDescendantsIntoTruncations(
       intNode->setChild(i, NULL);
       }
 
-   TR::Node::recreateAndCopyValidProperties(intNode, TR::l2i);
+   TR::Node::recreate(intNode, TR::l2i);
    intNode->setNumChildren(1);
    intNode->setAndIncChild(0, longNode);
    }

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -5215,7 +5215,7 @@ bool TR_InlinerBase::inlineCallTarget2(TR_CallStack * callStack, TR_CallTarget *
       {
       if (parent->getOpCode().isResolveCheck())
          {
-         TR::Node::recreateAndCopyValidProperties(parent, TR::NULLCHK);
+         TR::Node::recreate(parent, TR::NULLCHK);
          }
       nullCheckTreeTop = parent->extractTheNullCheck(prevTreeTop);
       }

--- a/compiler/optimizer/IsolatedStoreElimination.cpp
+++ b/compiler/optimizer/IsolatedStoreElimination.cpp
@@ -359,7 +359,7 @@ int32_t TR_IsolatedStoreElimination::perform()
                   TR::Node *child = node->getChild(0);
                   usr.anchorIfSafe(child, treeTop);
                   child->recursivelyDecReferenceCount();
-                  TR::Node::recreateAndCopyValidProperties(node, comp()->il.opCodeForConst(node->getSymbolReference()->getSymbol()->getDataType()));
+                  TR::Node::recreate(node, comp()->il.opCodeForConst(node->getSymbolReference()->getSymbol()->getDataType()));
                   node->setFlags(0);
                   node->setNumChildren(0);
                   }
@@ -385,9 +385,9 @@ int32_t TR_IsolatedStoreElimination::perform()
                   // Set opcode to nop
                   //
                   if (node->getReferenceCount() >= 1)
-                     TR::Node::recreateAndCopyValidProperties(node, TR::PassThrough);
+                     TR::Node::recreate(node, TR::PassThrough);
                   else
-                     TR::Node::recreateAndCopyValidProperties(node, TR::treetop);
+                     TR::Node::recreate(node, TR::treetop);
                   }
 
                node->setFlags(0);
@@ -436,10 +436,10 @@ int32_t TR_IsolatedStoreElimination::perform()
              if (node->getReferenceCount() < 1)
                 {
                 node->setFlags(0);
-                TR::Node::recreateAndCopyValidProperties(node, TR::treetop);
+                TR::Node::recreate(node, TR::treetop);
                 }
              else
-                TR::Node::recreateAndCopyValidProperties(node, TR::PassThrough);
+                TR::Node::recreate(node, TR::PassThrough);
              node->setFlags(0);
              eliminatedStore = true;
              dumpOptDetails(comp(), "%p \n",node);
@@ -481,10 +481,10 @@ int32_t TR_IsolatedStoreElimination::perform()
             if (node->getReferenceCount() < 1)
                {
                node->setFlags(0);
-               TR::Node::recreateAndCopyValidProperties(node, TR::treetop);
+               TR::Node::recreate(node, TR::treetop);
                }
             else
-               TR::Node::recreateAndCopyValidProperties(node, TR::PassThrough);
+               TR::Node::recreate(node, TR::PassThrough);
             node->setFlags(0);
             eliminatedStore = true;
             }
@@ -586,7 +586,7 @@ void TR_IsolatedStoreElimination::removeRedundantSpills()
                if (redundantStore &&
                    performTransformation(comp(), "%s Removing redundant spill:  (%p)\n", optDetailString(), node))
                   {
-                  TR::Node::recreateAndCopyValidProperties(node, TR::treetop);
+                  TR::Node::recreate(node, TR::treetop);
                   node->setFlags(0);
                   }
             }

--- a/compiler/optimizer/LocalAnalysis.cpp
+++ b/compiler/optimizer/LocalAnalysis.cpp
@@ -528,17 +528,17 @@ int TR_LocalAnalysisInfo::hasOldExpressionOnRhs(TR::Node *node, bool recalcConta
             {
             if (seenWriteBarrier)
                {
-               TR::Node::recreateAndCopyValidProperties(node, _compilation->il.opCodeForIndirectArrayLoad(node->getDataType()));
+               TR::Node::recreate(node, _compilation->il.opCodeForIndirectArrayLoad(node->getDataType()));
                }
             else
                {
-               TR::Node::recreateAndCopyValidProperties(node, _compilation->il.opCodeForCorrespondingIndirectStore(node->getOpCodeValue()));
+               TR::Node::recreate(node, _compilation->il.opCodeForCorrespondingIndirectStore(node->getOpCodeValue()));
                }
             node->setNumChildren(1);
             }
          else
             {
-            TR::Node::recreateAndCopyValidProperties(node, _compilation->il.opCodeForDirectLoad(node->getDataType()));
+            TR::Node::recreate(node, _compilation->il.opCodeForDirectLoad(node->getDataType()));
             node->setNumChildren(0);
             }
 
@@ -578,17 +578,17 @@ int TR_LocalAnalysisInfo::hasOldExpressionOnRhs(TR::Node *node, bool recalcConta
                {
                if (seenOtherWriteBarrier)
                   {
-                  TR::Node::recreateAndCopyValidProperties(other, _compilation->il.opCodeForIndirectArrayLoad(other->getDataType()));
+                  TR::Node::recreate(other, _compilation->il.opCodeForIndirectArrayLoad(other->getDataType()));
                   }
                else
                   {
-                  TR::Node::recreateAndCopyValidProperties(other, _compilation->il.opCodeForCorrespondingIndirectStore(other->getOpCodeValue()));
+                  TR::Node::recreate(other, _compilation->il.opCodeForCorrespondingIndirectStore(other->getOpCodeValue()));
                   }
                other->setNumChildren(1);
                }
             else
                {
-               TR::Node::recreateAndCopyValidProperties(other, _compilation->il.opCodeForDirectLoad(other->getDataType()));
+               TR::Node::recreate(other, _compilation->il.opCodeForDirectLoad(other->getDataType()));
                other->setNumChildren(0);
                }
 
@@ -610,9 +610,9 @@ int TR_LocalAnalysisInfo::hasOldExpressionOnRhs(TR::Node *node, bool recalcConta
             other->setNumChildren(otherStoreNumChildren);
 
             if (otherStoreNumChildren == 3)
-               TR::Node::recreateAndCopyValidProperties(other, TR::wrtbari);
+               TR::Node::recreate(other, TR::wrtbari);
             else
-               TR::Node::recreateAndCopyValidProperties(other, TR::wrtbar);
+               TR::Node::recreate(other, TR::wrtbar);
             }
          else if (seenOtherIndirectStore)
             {
@@ -624,9 +624,9 @@ int TR_LocalAnalysisInfo::hasOldExpressionOnRhs(TR::Node *node, bool recalcConta
 #endif
 
             if (other->getOpCode().isIndirect())
-               TR::Node::recreateAndCopyValidProperties(other, _compilation->il.opCodeForCorrespondingIndirectLoad(other->getOpCodeValue()));
+               TR::Node::recreate(other, _compilation->il.opCodeForCorrespondingIndirectLoad(other->getOpCodeValue()));
             else
-               TR::Node::recreateAndCopyValidProperties(other, _compilation->il.opCodeForDirectStore(other->getDataType()));
+               TR::Node::recreate(other, _compilation->il.opCodeForDirectStore(other->getDataType()));
             }
 
          if (areSame)
@@ -636,9 +636,9 @@ int TR_LocalAnalysisInfo::hasOldExpressionOnRhs(TR::Node *node, bool recalcConta
                node->setNumChildren(storeNumChildren);
 
                if (storeNumChildren == 3)
-                  TR::Node::recreateAndCopyValidProperties(node, TR::wrtbari);
+                  TR::Node::recreate(node, TR::wrtbari);
                else
-                  TR::Node::recreateAndCopyValidProperties(node, TR::wrtbar);
+                  TR::Node::recreate(node, TR::wrtbar);
                }
             else if (seenIndirectStore)
                {
@@ -650,9 +650,9 @@ int TR_LocalAnalysisInfo::hasOldExpressionOnRhs(TR::Node *node, bool recalcConta
 #endif
 
                if (node->getOpCode().isIndirect())
-                  TR::Node::recreateAndCopyValidProperties(node, _compilation->il.opCodeForCorrespondingIndirectLoad(node->getOpCodeValue()));
+                  TR::Node::recreate(node, _compilation->il.opCodeForCorrespondingIndirectLoad(node->getOpCodeValue()));
                else
-                  TR::Node::recreateAndCopyValidProperties(node, _compilation->il.opCodeForDirectStore(node->getDataType()));
+                  TR::Node::recreate(node, _compilation->il.opCodeForDirectStore(node->getDataType()));
                }
 
             return other->getSideTableIndex();
@@ -673,9 +673,9 @@ int TR_LocalAnalysisInfo::hasOldExpressionOnRhs(TR::Node *node, bool recalcConta
       node->setNumChildren(storeNumChildren);
 
       if (storeNumChildren == 3)
-         TR::Node::recreateAndCopyValidProperties(node, TR::wrtbari);
+         TR::Node::recreate(node, TR::wrtbari);
       else
-         TR::Node::recreateAndCopyValidProperties(node, TR::wrtbar);
+         TR::Node::recreate(node, TR::wrtbar);
       }
    else if (seenIndirectStore)
       {
@@ -687,9 +687,9 @@ int TR_LocalAnalysisInfo::hasOldExpressionOnRhs(TR::Node *node, bool recalcConta
 #endif
 
       if (node->getOpCode().isIndirect())
-         TR::Node::recreateAndCopyValidProperties(node, _compilation->il.opCodeForCorrespondingIndirectLoad(node->getOpCodeValue()));
+         TR::Node::recreate(node, _compilation->il.opCodeForCorrespondingIndirectLoad(node->getOpCodeValue()));
       else
-         TR::Node::recreateAndCopyValidProperties(node, _compilation->il.opCodeForDirectStore(node->getDataType()));
+         TR::Node::recreate(node, _compilation->il.opCodeForDirectStore(node->getDataType()));
       }
 
    return -1;

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -2059,7 +2059,7 @@ void TR_CompactNullChecks::compactNullChecks(TR::Block *block, TR_BitVector *wri
                 if (replacedPassThroughNode &&
                     (cursorNode->getOpCodeValue() == TR::NULLCHK) &&
                     (cursorNode->getNullCheckReference() == prevNode->getNullCheckReference()))
-                   TR::Node::recreateAndCopyValidProperties(cursorNode, TR::treetop);
+                   TR::Node::recreate(cursorNode, TR::treetop);
 
                 // set flag to remove tree if treetop contains vcall and ivcall
                 if (replacedPassThroughNode &&
@@ -2288,7 +2288,7 @@ bool TR_CompactNullChecks::replaceNullCheckIfPossible(TR::Node *cursorNode, TR::
             {
             ///printf("\n---found opportunity for checkcastAndNULLCHK in %s---\n", comp()->signature());
             ///fflush(stdout);
-            TR::Node::recreateAndCopyValidProperties(cursorNode, TR::treetop);
+            TR::Node::recreate(cursorNode, TR::treetop);
             if (cursorNode->getFirstChild()->getOpCodeValue() == TR::PassThrough)
                {
                TR::Node *nullChkRef = cursorNode->getFirstChild()->getFirstChild();
@@ -2319,7 +2319,7 @@ bool TR_CompactNullChecks::replaceNullCheckIfPossible(TR::Node *cursorNode, TR::
             //      aload #1
             if (!compactionDone)
                {
-               TR::Node::recreateAndCopyValidProperties(prevNode, TR::checkcastAndNULLCHK);
+               TR::Node::recreate(prevNode, TR::checkcastAndNULLCHK);
                compactionDone = true;
                TR_Pair<TR_ByteCodeInfo, TR::Node> *bcInfo = new (trHeapMemory()) TR_Pair<TR_ByteCodeInfo, TR::Node> (&prevNode->getByteCodeInfo(), cursorNode);
                comp()->getCheckcastNullChkInfo().push_front(bcInfo);
@@ -3086,7 +3086,7 @@ int32_t TR_SimplifyAnds::process(TR::TreeTop *startTree, TR::TreeTop *endTree)
             if (newOrOpcode != TR::BadILOp)
                {
                // Modify first ificmpeq
-               TR::Node::recreateAndCopyValidProperties(andNode, andNode->getOpCode().getOpCodeForReverseBranch());
+               TR::Node::recreate(andNode, andNode->getOpCode().getOpCodeForReverseBranch());
                TR::Node *orNode = TR::Node::create(newOrOpcode, 2,
                                                     lastRealNode->getFirstChild()->getSecondChild(),
                                                     andNode->getFirstChild()->getSecondChild());
@@ -3160,7 +3160,7 @@ int32_t TR_SimplifyAnds::process(TR::TreeTop *startTree, TR::TreeTop *endTree)
 
                   // The current BNDCHKwithSpineCHK node now becomes a spine check.
                   //
-                  TR::Node::recreateAndCopyValidProperties(lastRealNode, TR::SpineCHK);
+                  TR::Node::recreate(lastRealNode, TR::SpineCHK);
 
                   // The index is the third child of a spine check.
                   //
@@ -3182,7 +3182,7 @@ int32_t TR_SimplifyAnds::process(TR::TreeTop *startTree, TR::TreeTop *endTree)
                   optimizer()->prepareForNodeRemoval(prevNode->getSecondChild());
                   prevNode->getSecondChild()->recursivelyDecReferenceCount();
                   prevNode->setChild(1, lastRealNode->getSecondChild());
-                  TR::Node::recreateAndCopyValidProperties(lastRealNode, TR::treetop);
+                  TR::Node::recreate(lastRealNode, TR::treetop);
                   lastRealNode->setNumChildren(1);
                   }
                else
@@ -4031,7 +4031,7 @@ int32_t TR_ProfiledNodeVersioning::perform()
                      TR::TreeTop::create(comp(), slowTree, TR::Node::createStore(newObjectPointer, variableSizeNew));
                      TR::TreeTop::create(comp(), fastTree, TR::Node::createStore(newObjectPointer, fixedSizeNew));
                      node->removeAllChildren();
-                     TR::Node::recreateAndCopyValidProperties(node, comp()->il.opCodeForDirectLoad(newObjectPointer->getSymbol()->getDataType()));
+                     TR::Node::recreate(node, comp()->il.opCodeForDirectLoad(newObjectPointer->getSymbol()->getDataType()));
                      node->setSymbolReference(newObjectPointer);
 
                      // Set block frequencies
@@ -7780,9 +7780,9 @@ void TR_InvariantArgumentPreexistence::processIndirectCall(TR::Node *node, TR::T
 
                   node->devirtualizeCall(treeTop);
                   if (treeTop->getNode()->getOpCodeValue() == TR::ResolveCHK)
-                     TR::Node::recreateAndCopyValidProperties(treeTop->getNode(), TR::treetop);
+                     TR::Node::recreate(treeTop->getNode(), TR::treetop);
                   else if (treeTop->getNode()->getOpCodeValue() == TR::ResolveAndNULLCHK)
-                     TR::Node::recreateAndCopyValidProperties(treeTop->getNode(), TR::NULLCHK);
+                     TR::Node::recreate(treeTop->getNode(), TR::NULLCHK);
 
                   bool doInc = comp()->getCHTable()->recompileOnNewClassExtend(comp(), receiverInfo.getClass());
 

--- a/compiler/optimizer/LoopCanonicalizer.cpp
+++ b/compiler/optimizer/LoopCanonicalizer.cpp
@@ -2598,7 +2598,7 @@ bool TR_LoopCanonicalizer::examineTreeForInductionVariableUse(TR::Block *loopInv
                      adjustmentConstChild->setLongInt(additiveConstant);
 
                   nodeSetUp = true;
-                  TR::Node::recreateAndCopyValidProperties(node, _derivedInductionVarStoreInBlock->getFirstChild()->getOpCodeValue());
+                  TR::Node::recreate(node, _derivedInductionVarStoreInBlock->getFirstChild()->getOpCodeValue());
                   node->setNumChildren(2);
                   node->setAndIncChild(0, loadOfPrimaryInductionVar);
                   node->setAndIncChild(1, adjustmentConstChild);
@@ -2622,7 +2622,7 @@ bool TR_LoopCanonicalizer::examineTreeForInductionVariableUse(TR::Block *loopInv
                      adjustmentConstChild->setLongInt(-1*additiveConstant);
 
                   nodeSetUp = true;
-                  TR::Node::recreateAndCopyValidProperties(node, _primaryInductionVarStoreInBlock->getFirstChild()->getOpCodeValue());
+                  TR::Node::recreate(node, _primaryInductionVarStoreInBlock->getFirstChild()->getOpCodeValue());
                   node->setNumChildren(2);
                   node->setAndIncChild(0, loadOfPrimaryInductionVar);
                   node->setAndIncChild(1, adjustmentConstChild);
@@ -2652,7 +2652,7 @@ bool TR_LoopCanonicalizer::examineTreeForInductionVariableUse(TR::Block *loopInv
 
 
                   nodeSetUp = true;
-                  TR::Node::recreateAndCopyValidProperties(node, ((dataType == TR::Int32) ? TR::iadd : TR::ladd));
+                  TR::Node::recreate(node, ((dataType == TR::Int32) ? TR::iadd : TR::ladd));
                   node->setNumChildren(2);
                   node->setAndIncChild(0, loadOfPrimaryInductionVar);
                   node->setAndIncChild(1, adjustmentConstChild);
@@ -2679,7 +2679,7 @@ bool TR_LoopCanonicalizer::examineTreeForInductionVariableUse(TR::Block *loopInv
 
 
                   nodeSetUp = true;
-                  TR::Node::recreateAndCopyValidProperties(node, ((dataType == TR::Int32) ? TR::iadd : TR::ladd));
+                  TR::Node::recreate(node, ((dataType == TR::Int32) ? TR::iadd : TR::ladd));
                   node->setNumChildren(2);
                   node->setAndIncChild(0, loadOfPrimaryInductionVar);
                   node->setAndIncChild(1, adjustmentConstChild);
@@ -2689,7 +2689,7 @@ bool TR_LoopCanonicalizer::examineTreeForInductionVariableUse(TR::Block *loopInv
 
          if (!nodeSetUp)
             {
-            TR::Node::recreateAndCopyValidProperties(node, loadOfPrimaryInductionVar->getOpCodeValue());
+            TR::Node::recreate(node, loadOfPrimaryInductionVar->getOpCodeValue());
             node->setNumChildren(2);
             node->setChild(0, loadOfPrimaryInductionVar->getFirstChild());
             node->setChild(1, loadOfPrimaryInductionVar->getSecondChild());
@@ -4130,7 +4130,7 @@ int32_t TR_LoopInverter::detectCanonicalizedPredictableLoops(TR_Structure *loopS
                 loopTestNode->getOpCodeValue() == TR::ificmple)
                {
                testValue += 1;
-               TR::Node::recreateAndCopyValidProperties(loopTestNode, TR::ificmplt);
+               TR::Node::recreate(loopTestNode, TR::ificmplt);
                }
 
             int initValue = testValue - entryValue;
@@ -4159,21 +4159,21 @@ int32_t TR_LoopInverter::detectCanonicalizedPredictableLoops(TR_Structure *loopS
          if (storeNode->getFirstChild()->getOpCode().isAdd())
             {
             origOpCodeWasAdd = true;
-            TR::Node::recreateAndCopyValidProperties(storeNode->getFirstChild(), TR::isub);
+            TR::Node::recreate(storeNode->getFirstChild(), TR::isub);
             }
          else
-            TR::Node::recreateAndCopyValidProperties(storeNode->getFirstChild(), TR::iadd);
+            TR::Node::recreate(storeNode->getFirstChild(), TR::iadd);
 
          loopTestNode = _loopTestTree->getNode();
          if (loopTestNode->getOpCodeValue() == TR::ificmplt)
-            TR::Node::recreateAndCopyValidProperties(loopTestNode, TR::ificmpgt);
+            TR::Node::recreate(loopTestNode, TR::ificmpgt);
          else if (loopTestNode->getOpCodeValue() == TR::ificmple)
-            TR::Node::recreateAndCopyValidProperties(loopTestNode, TR::ificmpge);
+            TR::Node::recreate(loopTestNode, TR::ificmpge);
          /*
            else if (loopTestNode->getOpCodeValue() == TR::ificmpgt)
-           TR::Node::recreateAndCopyValidProperties(loopTestNode, TR::ificmplt);
+           TR::Node::recreate(loopTestNode, TR::ificmplt);
            else if (loopTestNode->getOpCodeValue() == TR::ificmpge)
-           TR::Node::recreateAndCopyValidProperties(loopTestNode, TR::ificmple);
+           TR::Node::recreate(loopTestNode, TR::ificmple);
          */
 
          loopTestNode->getSecondChild()->recursivelyDecReferenceCount();

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -4264,7 +4264,7 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
          if (child->getOpCodeValue() == TR::wrtbari && comp()->getOptions()->getGcMode() == TR_WrtbarNone &&
             performTransformation(comp(), "%sChanging iwrtbar node [%p] to an iastore\n", OPT_DETAILS_LOOP_VERSIONER, child))
             {
-            TR::Node::recreateAndCopyValidProperties(child, TR::astorei);
+            TR::Node::recreate(child, TR::astorei);
             child->getChild(2)->recursivelyDecReferenceCount();
             child->setNumChildren(2);
             }
@@ -4278,7 +4278,7 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
          if (child->getOpCodeValue() == TR::wrtbari && comp()->getOptions()->getGcMode() == TR_WrtbarNone &&
              performTransformation(comp(), "%sChanging iwrtbar node [%p] to an iastore\n", OPT_DETAILS_LOOP_VERSIONER, child))
             {
-            TR::Node::recreateAndCopyValidProperties(child, TR::astorei);
+            TR::Node::recreate(child, TR::astorei);
             child->getChild(2)->recursivelyDecReferenceCount();
             child->setNumChildren(2);
             }
@@ -4356,7 +4356,7 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
       if (firstComparisonNode)
          {
          firstComparisonNode = false;
-         //////TR::Node::recreateAndCopyValidProperties(actualComparisonNode, actualComparisonNode->getOpCode().getOpCodeForReverseBranch());
+         //////TR::Node::recreate(actualComparisonNode, actualComparisonNode->getOpCode().getOpCodeForReverseBranch());
          //////actualComparisonNode->setBranchDestination(invariantBlock->getEntry());
          //////lastComparisonBlock = comparisonBlock;
          }
@@ -4874,9 +4874,9 @@ void TR_LoopVersioner::buildNullCheckComparisonsTree(List<TR::Node> *nullChecked
          dumpOptDetails(comp(), "The node %p has been created for testing if null check is required\n", nextComparisonNode);
 
          if (nextTree->getData()->getNode()->getOpCodeValue() == TR::NULLCHK)
-            TR::Node::recreateAndCopyValidProperties(nextTree->getData()->getNode(), TR::treetop);
+            TR::Node::recreate(nextTree->getData()->getNode(), TR::treetop);
          else if (nextTree->getData()->getNode()->getOpCodeValue() == TR::ResolveAndNULLCHK)
-            TR::Node::recreateAndCopyValidProperties(nextTree->getData()->getNode(), TR::ResolveCHK);
+            TR::Node::recreate(nextTree->getData()->getNode(), TR::ResolveCHK);
 
          if (trace())
             {
@@ -5010,7 +5010,7 @@ void TR_LoopVersioner::buildDivCheckComparisonsTree(List<TR::TreeTop> *nullCheck
          comparisonTrees->add(ifNode);
          dumpOptDetails(comp(), "The node %p has been created for testing if div check is required\n", ifNode);
          }
-      TR::Node::recreateAndCopyValidProperties(divCheckNode, TR::treetop);
+      TR::Node::recreate(divCheckNode, TR::treetop);
       nextTree = nextTree->getNextElement();
       }
    }
@@ -5114,7 +5114,7 @@ void TR_LoopVersioner::convertSpecializedLongsToInts(TR::Node *node, vcount_t vi
       TR::SymbolReference *tempSymRef = symRefs[node->getSymbolReference()->getReferenceNumber()];
       if (tempSymRef)
          {
-         TR::Node::recreateAndCopyValidProperties(node, TR::iu2l);
+         TR::Node::recreate(node, TR::iu2l);
          TR::Node *newLoad = TR::Node::createWithSymRef(node, TR::iload, 0, tempSymRef);
          node->setNumChildren(1);
          node->setAndIncChild(0, newLoad);
@@ -5277,11 +5277,11 @@ bool TR_LoopVersioner::buildLoopInvariantTree(List<TR::TreeTop> *nullCheckTrees,
                   for (childNum=0;childNum<otherInvariantNode->getNumChildren(); childNum++)
                      otherInvariantNode->getChild(childNum)->recursivelyDecReferenceCount();
                   otherInvariantNode->setNumChildren(0);
-                  TR::Node::recreateAndCopyValidProperties(otherInvariantNode, comp()->il.opCodeForDirectLoad(invariantNode->getDataType()));
+                  TR::Node::recreate(otherInvariantNode, comp()->il.opCodeForDirectLoad(invariantNode->getDataType()));
                   otherInvariantNode->setSymbolReference(newSymbolReference);
                   if (otherInvariantNodeElem->getData()->_parent &&
                       otherInvariantNodeElem->getData()->_parent->getOpCode().isNullCheck())
-                     TR::Node::recreateAndCopyValidProperties(otherInvariantNodeElem->getData()->_parent, TR::treetop);
+                     TR::Node::recreate(otherInvariantNodeElem->getData()->_parent, TR::treetop);
 
                   if (prevOtherInvariantNodeElem)
                      prevOtherInvariantNodeElem->setNextElement(otherInvariantNodeElem->getNextElement());
@@ -5300,12 +5300,12 @@ bool TR_LoopVersioner::buildLoopInvariantTree(List<TR::TreeTop> *nullCheckTrees,
          for (childNum=0;childNum<invariantNode->getNumChildren(); childNum++)
             invariantNode->getChild(childNum)->recursivelyDecReferenceCount();
          invariantNode->setNumChildren(0);
-         TR::Node::recreateAndCopyValidProperties(invariantNode, comp()->il.opCodeForDirectLoad(invariantNode->getDataType()));
+         TR::Node::recreate(invariantNode, comp()->il.opCodeForDirectLoad(invariantNode->getDataType()));
          invariantNode->setSymbolReference(newSymbolReference);
 
          if (nextInvariantNode->getData()->_parent &&
              nextInvariantNode->getData()->_parent->getOpCode().isNullCheck())
-             TR::Node::recreateAndCopyValidProperties(nextInvariantNode->getData()->_parent, TR::treetop);
+             TR::Node::recreate(nextInvariantNode->getData()->_parent, TR::treetop);
          */
 
          optimizer()->setRequestOptimization(OMR::globalValuePropagation, true);
@@ -5324,7 +5324,7 @@ bool TR_LoopVersioner::buildLoopInvariantTree(List<TR::TreeTop> *nullCheckTrees,
          {
          if (nextInvariantNode->getData()->_parent &&
             nextInvariantNode->getData()->_parent->getOpCode().isNullCheck())
-            TR::Node::recreateAndCopyValidProperties(nextInvariantNode->getData()->_parent, TR::treetop);
+            TR::Node::recreate(nextInvariantNode->getData()->_parent, TR::treetop);
 
          //invariant expressions might be the part of checks we already versioned.
          //if buildXXX already removed the nodes representing the expressions
@@ -5339,7 +5339,7 @@ bool TR_LoopVersioner::buildLoopInvariantTree(List<TR::TreeTop> *nullCheckTrees,
             for (childNum=0;childNum<invariantNode->getNumChildren(); childNum++)
                invariantNode->getChild(childNum)->recursivelyDecReferenceCount();
             invariantNode->setNumChildren(0);
-            TR::Node::recreateAndCopyValidProperties(invariantNode, comp()->il.opCodeForDirectLoad(invariantNode->getDataType()));
+            TR::Node::recreate(invariantNode, comp()->il.opCodeForDirectLoad(invariantNode->getDataType()));
             invariantNode->setSymbolReference(nextInvariantNode->getData()->_symRef);
             }
          else
@@ -5450,7 +5450,7 @@ bool TR_LoopVersioner::buildSpecializationTree(List<TR::TreeTop> *nullCheckTrees
                   loopInvariantBlock->prepend(TR::TreeTop::create(comp(), newStore));
                   }
 
-               TR::Node::recreateAndCopyValidProperties(specializedNode, TR::iu2l);
+               TR::Node::recreate(specializedNode, TR::iu2l);
                TR::Node *newLoad = TR::Node::createWithSymRef(specializedNode, TR::iload, 0, tempSymRef);
                specializedNode->setNumChildren(1);
                specializedNode->setAndIncChild(0, newLoad);
@@ -5462,7 +5462,7 @@ bool TR_LoopVersioner::buildSpecializationTree(List<TR::TreeTop> *nullCheckTrees
             }
          else
             {
-            TR::Node::recreateAndCopyValidProperties(specializedNode, TR::iconst);
+            TR::Node::recreate(specializedNode, TR::iconst);
             specializedNode->setNumChildren(0);
             specializedNode->setInt(value);
             }
@@ -5921,7 +5921,7 @@ void TR_LoopVersioner::buildConditionalTree(List<TR::TreeTop> *nullCheckTrees, L
             conditionalNode->setChild(1, constNode);
             constNode->incReferenceCount();
 
-            TR::Node::recreateAndCopyValidProperties(conditionalNode, TR::ificmpeq);
+            TR::Node::recreate(conditionalNode, TR::ificmpeq);
             conditionalNode->resetIsTheVirtualGuardForAGuardedInlinedCall();
 
             if (changeConditionalToUnconditionalInBothVersions)
@@ -5947,7 +5947,7 @@ void TR_LoopVersioner::buildConditionalTree(List<TR::TreeTop> *nullCheckTrees, L
                _duplicateConditionalTree->setChild(1, constNode);
                constNode->incReferenceCount();
 
-               TR::Node::recreateAndCopyValidProperties(_duplicateConditionalTree, TR::ificmpne);
+               TR::Node::recreate(_duplicateConditionalTree, TR::ificmpne);
                _duplicateConditionalTree->resetIsTheVirtualGuardForAGuardedInlinedCall();
                }
             }
@@ -6287,7 +6287,7 @@ void TR_LoopVersioner::buildBoundCheckComparisonsTree(List<TR::TreeTop> *nullChe
             if (boundCheckNode->getOpCodeValue() == TR::BNDCHKwithSpineCHK)
                {
 
-		       TR::Node::recreateAndCopyValidProperties(boundCheckNode, TR::SpineCHK);
+		       TR::Node::recreate(boundCheckNode, TR::SpineCHK);
 		       boundCheckNode->getChild(2)->recursivelyDecReferenceCount();
 	           boundCheckNode->setAndIncChild(2, boundCheckNode->getChild(3));
 		       boundCheckNode->getChild(3)->recursivelyDecReferenceCount();
@@ -7185,7 +7185,7 @@ void TR_LoopVersioner::buildBoundCheckComparisonsTree(List<TR::TreeTop> *nullChe
                   if (trace())
                      traceMsg(comp(), "Induction variable added in each iter -> Creating %p (%s)\n", nextComparisonNode, nextComparisonNode->getOpCode().getName());
 
-                  TR::Node::recreateAndCopyValidProperties(duplicateMulHNode,TR::imulh);
+                  TR::Node::recreate(duplicateMulHNode,TR::imulh);
                   nextComparisonNode = TR::Node::createif(TR::ifiucmpgt, duplicateMulHNode, TR::Node::create(boundCheckNode, TR::iconst, 0, 0), exitGotoBlock->getEntry());
                   nextComparisonNode->setIsVersionableIfWithMaxExpr(comp());
                   if (comp()->requiresSpineChecks())
@@ -7210,7 +7210,7 @@ void TR_LoopVersioner::buildBoundCheckComparisonsTree(List<TR::TreeTop> *nullChe
 
             if (boundCheckNode->getOpCodeValue() == TR::BNDCHKwithSpineCHK)
                {
-			TR::Node::recreateAndCopyValidProperties(boundCheckNode, TR::SpineCHK);
+			TR::Node::recreate(boundCheckNode, TR::SpineCHK);
 			boundCheckNode->getChild(2)->recursivelyDecReferenceCount();
 	        boundCheckNode->setAndIncChild(2, boundCheckNode->getChild(3));
 			boundCheckNode->getChild(3)->recursivelyDecReferenceCount();
@@ -7281,9 +7281,9 @@ void TR_LoopVersioner::collectAllExpressionsToBeChecked(List<TR::TreeTop> *nullC
                if (nullCheckNode->getNullCheckReference() == node->getFirstChild())
                   {
                   if (nullCheckTree->getData()->getNode()->getOpCodeValue() == TR::NULLCHK)
-                     TR::Node::recreateAndCopyValidProperties(nullCheckTree->getData()->getNode(), TR::treetop);
+                     TR::Node::recreate(nullCheckTree->getData()->getNode(), TR::treetop);
                   else if (nullCheckTree->getData()->getNode()->getOpCodeValue() == TR::ResolveAndNULLCHK)
-                     TR::Node::recreateAndCopyValidProperties(nullCheckTree->getData()->getNode(), TR::ResolveCHK);
+                     TR::Node::recreate(nullCheckTree->getData()->getNode(), TR::ResolveCHK);
                   eliminatedNullCheck = true;
                   break;
                   }
@@ -7303,9 +7303,9 @@ void TR_LoopVersioner::collectAllExpressionsToBeChecked(List<TR::TreeTop> *nullC
                   if (nullCheckNode->getNullCheckReference() == node->getFirstChild())
                      {
                      if (nullCheckTree->getData()->getNode()->getOpCodeValue() == TR::NULLCHK)
-                        TR::Node::recreateAndCopyValidProperties(nullCheckTree->getData()->getNode(), TR::treetop);
+                        TR::Node::recreate(nullCheckTree->getData()->getNode(), TR::treetop);
                      else if (nullCheckTree->getData()->getNode()->getOpCodeValue() == TR::ResolveAndNULLCHK)
-                        TR::Node::recreateAndCopyValidProperties(nullCheckTree->getData()->getNode(), TR::ResolveCHK);
+                        TR::Node::recreate(nullCheckTree->getData()->getNode(), TR::ResolveCHK);
                      eliminatedNullCheck = true;
                      break;
                      }
@@ -7545,7 +7545,7 @@ void TR_LoopVersioner::collectAllExpressionsToBeChecked(List<TR::TreeTop> *nullC
             {
             if (divCheckNode->getFirstChild() == node)
                {
-               TR::Node::recreateAndCopyValidProperties(divCheckTree->getData()->getNode(), TR::treetop);
+               TR::Node::recreate(divCheckTree->getData()->getNode(), TR::treetop);
                eliminatedDivCheck = true;
                break;
                }
@@ -7564,7 +7564,7 @@ void TR_LoopVersioner::collectAllExpressionsToBeChecked(List<TR::TreeTop> *nullC
               {
               if (divCheckNode->getFirstChild() == node)
                  {
-                 TR::Node::recreateAndCopyValidProperties(divCheckTree->getData()->getNode(), TR::treetop);
+                 TR::Node::recreate(divCheckTree->getData()->getNode(), TR::treetop);
                  break;
                  }
               }
@@ -8331,7 +8331,7 @@ void TR_LoopVersioner::findAndReplaceContigArrayLen(TR::Node *parent, TR::Node *
       return;
 
    if ((node->getOpCodeValue() == TR::contigarraylength))  //future: || (node->getOpCodeValue() == TR::discontigarraylength))
-	  TR::Node::recreateAndCopyValidProperties(node, TR::arraylength);
+	  TR::Node::recreate(node, TR::arraylength);
 
 
    int32_t i;

--- a/compiler/optimizer/OMRLocalCSE.cpp
+++ b/compiler/optimizer/OMRLocalCSE.cpp
@@ -803,7 +803,7 @@ void OMR::LocalCSE::doCommoningAgainIfPreviouslyCommoned(TR::Node *node, TR::Nod
 
          if (parent->getOpCode().isResolveOrNullCheck() || ((parent->getOpCodeValue() == TR::compressedRefs) && (childNum == 0)))
             {
-            TR::Node::recreateAndCopyValidProperties(parent, TR::treetop);
+            TR::Node::recreate(parent, TR::treetop);
             for (int32_t index =1;index < parent->getNumChildren(); index++)
                parent->getChild(index)->recursivelyDecReferenceCount() ;
             parent->setNumChildren(1);
@@ -860,7 +860,7 @@ void OMR::LocalCSE::doCommoningIfAvailable(TR::Node *node, TR::Node *parent, int
                int32_t endIndex = _treeBeingExamined->getNode()->getNumChildren();
                if (parent->getOpCodeValue() == TR::compressedRefs)
                   {
-                  TR::Node::recreateAndCopyValidProperties(parent, TR::treetop);
+                  TR::Node::recreate(parent, TR::treetop);
                   for (int32_t index =1;index < parent->getNumChildren(); index++)
                      parent->getChild(index)->recursivelyDecReferenceCount() ;
                   parent->setNumChildren(1);
@@ -893,7 +893,7 @@ void OMR::LocalCSE::doCommoningIfAvailable(TR::Node *node, TR::Node *parent, int
                   {
                   if ((comp()->useAnchors() && node->getFirstChild()->getOpCode().isStoreIndirect()))
                      {
-                     TR::Node::recreateAndCopyValidProperties(node, TR::treetop);
+                     TR::Node::recreate(node, TR::treetop);
                      }
                   else
                      {
@@ -908,7 +908,7 @@ void OMR::LocalCSE::doCommoningIfAvailable(TR::Node *node, TR::Node *parent, int
                   }
                else
                   {
-                  TR::Node::recreateAndCopyValidProperties(node, TR::treetop);
+                  TR::Node::recreate(node, TR::treetop);
                   }
                }
             else
@@ -1004,7 +1004,7 @@ bool OMR::LocalCSE::doCopyPropagationIfPossible(TR::Node *node, TR::Node *parent
 
       if (parent->getOpCode().isResolveOrNullCheck() || ((parent->getOpCodeValue() == TR::compressedRefs) && (childNum == 0)))
          {
-         TR::Node::recreateAndCopyValidProperties(parent, TR::treetop);
+         TR::Node::recreate(parent, TR::treetop);
          for (int32_t index =1;index < parent->getNumChildren(); index++)
             parent->getChild(index)->recursivelyDecReferenceCount() ;
          parent->setNumChildren(1);

--- a/compiler/optimizer/OMROptimization.cpp
+++ b/compiler/optimizer/OMROptimization.cpp
@@ -179,7 +179,7 @@ OMR::Optimization::prepareToReplaceNode(TR::Node * node)
 void
 OMR::Optimization::prepareToReplaceNode(TR::Node * node, TR::ILOpCodes opcode)
    {
-   TR::Node::recreateAndCopyValidProperties(node, opcode);
+   TR::Node::recreate(node, opcode);
    self()->prepareToReplaceNode(node);
    }
 
@@ -299,7 +299,7 @@ OMR::Optimization::removeOrconvertIfToGoto(TR::Node* &node, TR::Block* block, in
          return false;
       self()->anchorChildren(node, curTree);
       self()->prepareToReplaceNode(node);
-      TR::Node::recreateAndCopyValidProperties(node, TR::Goto);
+      TR::Node::recreate(node, TR::Goto);
       reachableTarget = node->getBranchDestination();
       unreachableTarget = block->getExit()->getNextTreeTop();
       }

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -690,7 +690,7 @@ static TR::Node *addSimplifierCommon(TR::Node* node, TR::Block * block, TR::Simp
 
             node->setAndIncChild(0, newFirstChild);
             node->setAndIncChild(1, firstChild->getSecondChild());
-            TR::Node::recreateAndCopyValidProperties(node, subOps[node->getDataType()]);
+            TR::Node::recreate(node, subOps[node->getDataType()]);
 
             firstChild->recursivelyDecReferenceCount();
             secondChild->recursivelyDecReferenceCount();
@@ -723,7 +723,7 @@ static TR::Node *addSimplifierCommon(TR::Node* node, TR::Block * block, TR::Simp
             newSecondChild->setAndIncChild(0, firstChild->getSecondChild());
             newSecondChild->setAndIncChild(1, secondChild->getSecondChild());
 
-            TR::Node::recreateAndCopyValidProperties(node, firstChild->getOpCodeValue());
+            TR::Node::recreate(node, firstChild->getOpCodeValue());
             node->setAndIncChild(0, newFirstChild);
             node->setAndIncChild(1, newSecondChild);
             firstChild->recursivelyDecReferenceCount();
@@ -870,7 +870,7 @@ static TR::Node *addSimplifier(TR::Node * node, TR::Block * block, TR::Simplifie
       {
       if (performTransformation(s->comp(), "%sNormalized xadd of xconst > 0 in node [%s] to xsub of -xconst\n", s->optDetailString(), node->getName(s->getDebug())))
          {
-      TR::Node::recreateAndCopyValidProperties(node, TR::ILOpCode::getSubOpCode<T>());
+      TR::Node::recreate(node, TR::ILOpCode::getSubOpCode<T>());
          if (secondChild->getReferenceCount() == 1)
             {
             secondChild->setConst<T>(-secondChild->getConst<T>());
@@ -898,7 +898,7 @@ static TR::Node *addSimplifier(TR::Node * node, TR::Block * block, TR::Simplifie
          if (performTransformation(s->comp(), "%sReduced xadd of -1 and an xneg in node [%s] to bitwise complement\n", s->optDetailString(), node->getName(s->getDebug())))
             {
             s->anchorChildren(node, s->_curTree);
-            TR::Node::recreateAndCopyValidProperties(node, TR::ixor);
+            TR::Node::recreate(node, TR::ixor);
             node->setAndIncChild(0, newFirstChild);
             firstChild->recursivelyDecReferenceCount();
             node->setVisitCount(0);
@@ -910,7 +910,7 @@ static TR::Node *addSimplifier(TR::Node * node, TR::Block * block, TR::Simplifie
       else if (performTransformation(s->comp(), "%sReduced iadd with negated first child in node [%s] to isub\n", s->optDetailString(), node->getName(s->getDebug())))
          {
          s->anchorChildren(node, s->_curTree);
-         TR::Node::recreateAndCopyValidProperties(node, TR::ILOpCode::getSubOpCode<T>());
+         TR::Node::recreate(node, TR::ILOpCode::getSubOpCode<T>());
          node->setAndIncChild(1, newFirstChild);
          node->setChild(0, secondChild);
          firstChild->recursivelyDecReferenceCount();
@@ -926,7 +926,7 @@ static TR::Node *addSimplifier(TR::Node * node, TR::Block * block, TR::Simplifie
          {
          s->anchorChildren(node, s->_curTree);
          TR::Node * newSecondChild = secondChild->getFirstChild();
-         TR::Node::recreateAndCopyValidProperties(node, TR::ILOpCode::getSubOpCode<T>());
+         TR::Node::recreate(node, TR::ILOpCode::getSubOpCode<T>());
          node->setAndIncChild(1, newSecondChild);
          secondChild->recursivelyDecReferenceCount();
          s->_alteredBlock = true;
@@ -950,7 +950,7 @@ static TR::Node *addSimplifier(TR::Node * node, TR::Block * block, TR::Simplifie
 
          if (iMulDecomposeReport)
             dumpOptDetails(s->comp(), "Putting the node back to imul with %d, for node [%s]. \n", iMulComposerValue, iMulComposerChild->getName(s->getDebug()));
-         TR::Node::recreateAndCopyValidProperties(node, TR::ILOpCode::getMulOpCode<T>());
+         TR::Node::recreate(node, TR::ILOpCode::getMulOpCode<T>());
 
          node->setAndIncChild(0, iMulComposerChild);
          constNode = TR::Node::create(node, TR::ILOpCode::getConstOpCode<T>(), 0, iMulComposerValue);
@@ -1017,9 +1017,9 @@ static TR::Node *addSimplifier(TR::Node * node, TR::Block * block, TR::Simplifie
             }
          else
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::ILOpCode::getMulOpCode<T>());
+            TR::Node::recreate(node, TR::ILOpCode::getMulOpCode<T>());
             node->setChild(0, factorChild)->decReferenceCount();
-            TR::Node::recreateAndCopyValidProperties(secondChild, TR::ILOpCode::getAddOpCode<T>());
+            TR::Node::recreate(secondChild, TR::ILOpCode::getAddOpCode<T>());
             firstChild->decReferenceCount();
             secondChild->setVisitCount(0);
             node->setVisitCount(0);
@@ -1067,7 +1067,7 @@ static TR::Node *addSimplifier(TR::Node * node, TR::Block * block, TR::Simplifie
                if (value > 0)
                   {
                   value = -value;
-                  TR::Node::recreateAndCopyValidProperties(node, TR::ILOpCode::getSubOpCode<T>());
+                  TR::Node::recreate(node, TR::ILOpCode::getSubOpCode<T>());
                   }
                if (secondChild->getReferenceCount() == 1)
                   {
@@ -1094,8 +1094,8 @@ static TR::Node *addSimplifier(TR::Node * node, TR::Block * block, TR::Simplifie
             // move constants up the tree so they will tend to get merged together
             node->setChild(1, lrChild);
             firstChild->setChild(1, secondChild);
-            TR::Node::recreateAndCopyValidProperties(node, firstChildOp.getOpCodeValue());
-            TR::Node::recreateAndCopyValidProperties(firstChild, TR::ILOpCode::getAddOpCode<T>());
+            TR::Node::recreate(node, firstChildOp.getOpCodeValue());
+            TR::Node::recreate(firstChild, TR::ILOpCode::getAddOpCode<T>());
             node->setVisitCount(0);
             s->_alteredBlock = true;
             }
@@ -1216,7 +1216,7 @@ TR::Node *subSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             node->setChild(0, 0);
             node->setChild(1, 0);
 
-            TR::Node::recreateAndCopyValidProperties(node, TR::ILOpCode::getConstOpCode<T>());
+            TR::Node::recreate(node, TR::ILOpCode::getConstOpCode<T>());
             if (secondChildOp.isAdd())
                node->setConst<T>(-1*rrChild->getConst<T>());
             else
@@ -1236,7 +1236,7 @@ TR::Node *subSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       {
       if (performTransformation(s->comp(), "%sNormalized isub of iconst > 0 in node [%s] to iadd of -iconst \n", s->optDetailString(), node->getName(s->getDebug())))
          {
-         TR::Node::recreateAndCopyValidProperties(node, TR::ILOpCode::getAddOpCode<T>());
+         TR::Node::recreate(node, TR::ILOpCode::getAddOpCode<T>());
          if (secondChild->getReferenceCount() == 1)
             {
             secondChild->setConst<T>(-secondChild->getConst<T>());
@@ -1259,7 +1259,7 @@ TR::Node *subSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       if (performTransformation(s->comp(), "%sReduced xsub with negated second child in node [%s] to xadd\n", s->optDetailString(), node->getName(s->getDebug())))
          {
          TR::Node * newSecondChild = secondChild->getFirstChild();
-         TR::Node::recreateAndCopyValidProperties(node, TR::ILOpCode::getAddOpCode<T>());
+         TR::Node::recreate(node, TR::ILOpCode::getAddOpCode<T>());
          node->setAndIncChild(1, newSecondChild);
          secondChild->recursivelyDecReferenceCount();
          node->setVisitCount(0);
@@ -1273,7 +1273,7 @@ TR::Node *subSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       if (performTransformation(s->comp(), "%sReduced xsub with negated first child in node [%s] to ineg of xadd\n", s->optDetailString(), node->getName(s->getDebug())))
          {
          TR::Node * newFirstChild = firstChild->getFirstChild();
-         TR::Node::recreateAndCopyValidProperties(node, TR::ILOpCode::getNegOpCode<T>());
+         TR::Node::recreate(node, TR::ILOpCode::getNegOpCode<T>());
          TR::Node * newNode = TR::Node::create(node, TR::ILOpCode::getAddOpCode<T>(), 2);
          newNode->setAndIncChild(0, newFirstChild);
          newNode->setChild(1, secondChild);
@@ -1294,7 +1294,7 @@ TR::Node *subSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       if (performTransformation(s->comp(), "%sReduced isub of bitwise complement and iconst -1 in node [%s] to 2s complement negation\n", s->optDetailString(), node->getName(s->getDebug())))
          {
          TR::Node * firstGrandChild = firstChild->getFirstChild();
-         TR::Node::recreateAndCopyValidProperties(node, TR::ILOpCode::getNegOpCode<T>());
+         TR::Node::recreate(node, TR::ILOpCode::getNegOpCode<T>());
          node->setAndIncChild(0, firstGrandChild);
          node->setNumChildren(1);
          secondChild->recursivelyDecReferenceCount();
@@ -1319,7 +1319,7 @@ TR::Node *subSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
 
          if (iMulDecomposeReport)
             dumpOptDetails(s->comp(), "Putting the node back to imul with %d, for node [%s]. \n", MulComposerValue, MulComposerChild->getName(s->getDebug()));
-         TR::Node::recreateAndCopyValidProperties(node, TR::ILOpCode::getMulOpCode<T>());
+         TR::Node::recreate(node, TR::ILOpCode::getMulOpCode<T>());
 
          node->setAndIncChild(0, MulComposerChild);
          constNode = TR::Node::create(node, TR::ILOpCode::getConstOpCode<T>(), 0, MulComposerValue);
@@ -1387,9 +1387,9 @@ TR::Node *subSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             }
          else
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::ILOpCode::getMulOpCode<T>());
+            TR::Node::recreate(node, TR::ILOpCode::getMulOpCode<T>());
             node->setChild(factorChild->getOpCode().isLoadConst() ? 1:0, factorChild)->decReferenceCount();
-            TR::Node::recreateAndCopyValidProperties(secondChild, TR::ILOpCode::getSubOpCode<T>());
+            TR::Node::recreate(secondChild, TR::ILOpCode::getSubOpCode<T>());
             firstChild->decReferenceCount();
             secondChild->setVisitCount(0);
             node->setVisitCount(0);
@@ -1446,7 +1446,7 @@ TR::Node *subSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                   }
                else
                   {
-                  TR::Node::recreateAndCopyValidProperties(node, TR::ILOpCode::getAddOpCode<T>());
+                  TR::Node::recreate(node, TR::ILOpCode::getAddOpCode<T>());
                   }
                if (secondChild->getReferenceCount() == 1)
                   {
@@ -1475,8 +1475,8 @@ TR::Node *subSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             // move constants up the tree so they will tend to get merged together
             node->setChild(1, lrChild);
             firstChild->setChild(1, secondChild);
-            TR::Node::recreateAndCopyValidProperties(node, firstChildOp.getOpCodeValue());
-            TR::Node::recreateAndCopyValidProperties(firstChild, TR::ILOpCode::getSubOpCode<T>());
+            TR::Node::recreate(node, firstChildOp.getOpCodeValue());
+            TR::Node::recreate(firstChild, TR::ILOpCode::getSubOpCode<T>());
             node->setVisitCount(0);
             s->_alteredBlock = true;
             }
@@ -1486,7 +1486,7 @@ TR::Node *subSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             firstChild->getConst<T>() == 0 &&
             performTransformation(s->comp(), "%sReduce xsub from 0 [%s] to xneg \n",s->optDetailString(),node->getName(s->getDebug())))
       {
-      TR::Node::recreateAndCopyValidProperties(node, TR::ILOpCode::negateOpCode(node->getDataType()));
+      TR::Node::recreate(node, TR::ILOpCode::negateOpCode(node->getDataType()));
       node->setVisitCount(0);
       node->getFirstChild()->recursivelyDecReferenceCount();
       node->setChild(0, node->getSecondChild());
@@ -1609,7 +1609,7 @@ static TR::Node *foldDemotionConversion(TR::Node * node, TR::ILOpCodes opcode, T
                               s->optDetailString(), node->getName(s->getDebug()), node->getOpCode().getName(),
                               firstChild->getName(s->getDebug()), firstChild->getOpCode().getName()))
       {
-      TR::Node::recreateAndCopyValidProperties(node, foldedOpCode);
+      TR::Node::recreate(node, foldedOpCode);
       node->setAndIncChild(0, firstChild->getFirstChild());
       s->prepareToStopUsingNode(firstChild, s->_curTree);
       firstChild->recursivelyDecReferenceCount();
@@ -1675,7 +1675,7 @@ static bool reduceLongOp(TR::Node * node, TR::Block * block, TR::Simplifier * s,
                // shift by > 31 bits gets constant 0
                if (newConversionOp == TR::BadILOp)
                   {
-                  TR::Node::recreateAndCopyValidProperties(node, isUnsigned ? TR::iuconst : TR::iconst);
+                  TR::Node::recreate(node, isUnsigned ? TR::iuconst : TR::iconst);
                   firstChild->recursivelyDecReferenceCount();
                   node->setNumChildren(0);
                   node->setChild(0, 0);
@@ -1683,14 +1683,14 @@ static bool reduceLongOp(TR::Node * node, TR::Block * block, TR::Simplifier * s,
                   }
                else
                   {
-                  TR::Node::recreateAndCopyValidProperties(firstChild, isUnsigned ? TR::iuconst : TR::iconst);
+                  TR::Node::recreate(firstChild, isUnsigned ? TR::iuconst : TR::iconst);
                   firstChild->getFirstChild()->recursivelyDecReferenceCount();
                   firstChild->getSecondChild()->recursivelyDecReferenceCount();
                   firstChild->setInt(0);
                   firstChild->setNumChildren(0);
                   firstChild->setChild(0, 0);
                   firstChild->setChild(1, 0);
-                  TR::Node::recreateAndCopyValidProperties(node, newConversionOp);
+                  TR::Node::recreate(node, newConversionOp);
                   }
                s->_alteredBlock = true;
                simplifyChildren(node, block, s);
@@ -1705,16 +1705,16 @@ static bool reduceLongOp(TR::Node * node, TR::Block * block, TR::Simplifier * s,
             return false;
          if (newConversionOp == TR::BadILOp)
             {
-            TR::Node::recreateAndCopyValidProperties(node, isUnsigned ? TR::iuneg : TR::ineg);
-            TR::Node::recreateAndCopyValidProperties(firstChild, TR::l2i);
+            TR::Node::recreate(node, isUnsigned ? TR::iuneg : TR::ineg);
+            TR::Node::recreate(firstChild, TR::l2i);
             }
          else
             {
             TR::Node * temp = TR::Node::create(TR::l2i, 1, firstChild->getFirstChild());
             firstChild->getFirstChild()->decReferenceCount();
-            TR::Node::recreateAndCopyValidProperties(firstChild, isUnsigned ? TR::iuneg : TR::ineg);
+            TR::Node::recreate(firstChild, isUnsigned ? TR::iuneg : TR::ineg);
             firstChild->setAndIncChild(0, temp);
-            TR::Node::recreateAndCopyValidProperties(node, newConversionOp);
+            TR::Node::recreate(node, newConversionOp);
             }
          s->_alteredBlock = true;
          simplifyChildren(node, block, s);
@@ -1736,21 +1736,21 @@ static bool reduceLongOp(TR::Node * node, TR::Block * block, TR::Simplifier * s,
    //
    if (newConversionOp == TR::BadILOp)
       {
-      TR::Node::recreateAndCopyValidProperties(node, newOp);
+      TR::Node::recreate(node, newOp);
       node->setNumChildren(2);
       node->setAndIncChild(1, convertSecondChild ?
             TR::Node::create(TR::l2i, 1, firstChild->getSecondChild()) :
             firstChild->getSecondChild());
       firstChild->getSecondChild()->decReferenceCount();
-      TR::Node::recreateAndCopyValidProperties(firstChild, TR::l2i);
+      TR::Node::recreate(firstChild, TR::l2i);
       firstChild->setNumChildren(1);
       firstChild->setChild(1, 0);
       firstChild->setIsNonNegative(false);
       }
    else
       {
-      TR::Node::recreateAndCopyValidProperties(node, newConversionOp);
-      TR::Node::recreateAndCopyValidProperties(firstChild, newOp);
+      TR::Node::recreate(node, newConversionOp);
+      TR::Node::recreate(firstChild, newOp);
       TR::Node * firstFirst  = firstChild->getFirstChild();
       TR::Node * firstSecond = firstChild->getSecondChild();
       TR::Node * temp0 = TR::Node::create(TR::l2i, 1, firstFirst);
@@ -2237,7 +2237,7 @@ static void addressCompareConversion(TR::Node * node, TR::Simplifier * s)
             (secondOp == TR::a2i))
             {
             node->setAndIncChild(0, firstChild->getFirstChild());
-            TR::Node::recreateAndCopyValidProperties(node, addresOp);
+            TR::Node::recreate(node, addresOp);
             firstChild->recursivelyDecReferenceCount();
             if (secondOp == TR::a2i)
                {
@@ -2256,7 +2256,7 @@ static void addressCompareConversion(TR::Node * node, TR::Simplifier * s)
                   }
                else
                   {
-                  TR::Node::recreateAndCopyValidProperties(secondChild, TR::aconst);
+                  TR::Node::recreate(secondChild, TR::aconst);
                   secondChild->setIsClassPointerConstant(false);
                   }
                   dumpOptDetails(s->comp(), "Address Compare Conversion: found child 1 a2i and child 2 iconst in node %p\n", node);
@@ -2272,7 +2272,7 @@ static void addressCompareConversion(TR::Node * node, TR::Simplifier * s)
             (secondOp == TR::a2l))
             {
             node->setAndIncChild(0, firstChild->getFirstChild());
-            TR::Node::recreateAndCopyValidProperties(node, addresOp);
+            TR::Node::recreate(node, addresOp);
             firstChild->recursivelyDecReferenceCount();
             if (secondOp == TR::a2l)
                {
@@ -2291,7 +2291,7 @@ static void addressCompareConversion(TR::Node * node, TR::Simplifier * s)
                   }
                else
                   {
-                  TR::Node::recreateAndCopyValidProperties(secondChild, TR::aconst);
+                  TR::Node::recreate(secondChild, TR::aconst);
                   secondChild->setIsClassPointerConstant(false);
                   }
                dumpOptDetails(s->comp(), "Address Compare Conversion: found child 1 a2l and child 2 lconst in node %p\n", node);
@@ -2319,7 +2319,7 @@ static void longCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::ILOpCod
               secondChild->getLongInt() <= INT_MAX))
             {
             node->setAndIncChild(0, firstChild->getFirstChild());
-            TR::Node::recreateAndCopyValidProperties(node, intOp);
+            TR::Node::recreate(node, intOp);
             node->notifyChangeToValueOfNode();
             firstChild->recursivelyDecReferenceCount();
             if (secondOp == TR::i2l)
@@ -2335,7 +2335,7 @@ static void longCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::ILOpCod
                {
                if (secondChild->getReferenceCount()==1)
                   {
-                  TR::Node::recreateAndCopyValidProperties(secondChild, TR::iconst);
+                  TR::Node::recreate(secondChild, TR::iconst);
                   secondChild->setInt((int32_t)secondChild->getLongInt());
                   secondChild->notifyChangeToValueOfNode();
                   }
@@ -2367,7 +2367,7 @@ static void longCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::ILOpCod
              (val2 & 0xffffffff00000000ull) == 0 &&
              performTransformation(s->comp(), "%sLong compare narrower: equality with no upper bits [%p]\n", s->optDetailString(), node))
             {
-            TR::Node::recreateAndCopyValidProperties(node, intOp);
+            TR::Node::recreate(node, intOp);
             node->notifyChangeToValueOfNode();
             TR::Node* ival1 = TR::Node::create(node, TR::iconst, 0);
             ival1->setInt((int)val1);
@@ -2395,7 +2395,7 @@ static void longCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::ILOpCod
                  secondChild->getLongInt() <= USHRT_MAX))
                {
                node->setAndIncChild(0, firstChild->getFirstChild());
-               TR::Node::recreateAndCopyValidProperties(node, charOp);
+               TR::Node::recreate(node, charOp);
                node->notifyChangeToValueOfNode();
                firstChild->recursivelyDecReferenceCount();
                if (secondOp == TR::su2l)
@@ -2411,7 +2411,7 @@ static void longCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::ILOpCod
                   {
                   if (secondChild->getReferenceCount()==1)
                      {
-                     TR::Node::recreateAndCopyValidProperties(secondChild, TR::cconst);
+                     TR::Node::recreate(secondChild, TR::cconst);
                      secondChild->setConst<uint16_t>((uint16_t)secondChild->getLongInt());
                      secondChild->notifyChangeToValueOfNode();
                      }
@@ -2440,7 +2440,7 @@ static void longCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::ILOpCod
                  secondChild->getLongInt() <= SHRT_MAX))
                {
                node->setAndIncChild(0, firstChild->getFirstChild());
-               TR::Node::recreateAndCopyValidProperties(node, shortOp);
+               TR::Node::recreate(node, shortOp);
                node->notifyChangeToValueOfNode();
                firstChild->recursivelyDecReferenceCount();
                if (secondOp == TR::s2l)
@@ -2456,7 +2456,7 @@ static void longCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::ILOpCod
                   {
                   if (secondChild->getReferenceCount()==1)
                      {
-                     TR::Node::recreateAndCopyValidProperties(secondChild, TR::sconst);
+                     TR::Node::recreate(secondChild, TR::sconst);
                      secondChild->setShortInt((int16_t)secondChild->getLongInt());
                      secondChild->notifyChangeToValueOfNode();
                      }
@@ -2486,7 +2486,7 @@ static void longCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::ILOpCod
                  secondChild->getLongInt() <= SCHAR_MAX))
                {
                node->setAndIncChild(0, firstChild->getFirstChild());
-               TR::Node::recreateAndCopyValidProperties(node, byteOp);
+               TR::Node::recreate(node, byteOp);
                node->notifyChangeToValueOfNode();
                firstChild->recursivelyDecReferenceCount();
                if (secondOp == TR::b2l)
@@ -2502,7 +2502,7 @@ static void longCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::ILOpCod
                   {
                   if (secondChild->getReferenceCount()==1)
                      {
-                     TR::Node::recreateAndCopyValidProperties(secondChild, TR::bconst);
+                     TR::Node::recreate(secondChild, TR::bconst);
                      secondChild->setByte((int8_t)secondChild->getLongInt());
                      secondChild->notifyChangeToValueOfNode();
                      }
@@ -3186,7 +3186,7 @@ static void decomposeMultiply(TR::Node *node, TR::Simplifier *s, bool isLong)
 
       TR::Node * decomposedMulNode = generateDecomposedTree(node, firstChild, s, bitPosition, operationType, 0, count, 0, isLong);
 
-      TR::Node::recreateAndCopyValidProperties(node, decomposedMulNode->getOpCodeValue());
+      TR::Node::recreate(node, decomposedMulNode->getOpCodeValue());
       node->setChild(0, decomposedMulNode->getFirstChild());
       if (decomposedMulNode->getNumChildren() == 2)
          {
@@ -3410,7 +3410,7 @@ static void changeConverts2Unsigned(TR::Node *node, TR::ILOpCodes searchOp,TR::S
 
       if (performTransformation(s->comp(), "%sConverted x2i [%s] to unsigned xu2i\n", s->optDetailString(), node->getName(s->getDebug())))
          {
-         TR::Node::recreateAndCopyValidProperties(node, newOp);
+         TR::Node::recreate(node, newOp);
          return;
          }
       }
@@ -4403,7 +4403,7 @@ static void intCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::ILOpCode
               secondChild->getInt() <= USHRT_MAX))
             {
             node->setAndIncChild(0, firstChild->getFirstChild());
-            TR::Node::recreateAndCopyValidProperties(node, ushortOp);
+            TR::Node::recreate(node, ushortOp);
             firstChild->recursivelyDecReferenceCount();
             if (secondOp == TR::su2i)
                {
@@ -4424,7 +4424,7 @@ static void intCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::ILOpCode
                   }
                else
                   {
-                  TR::Node::recreateAndCopyValidProperties(secondChild, TR::cconst);
+                  TR::Node::recreate(secondChild, TR::cconst);
                   secondChild->setConst<uint16_t>((uint16_t)secondChild->getInt());
                   }
                if (reportCompareDemotions)
@@ -4446,7 +4446,7 @@ static void intCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::ILOpCode
               secondChild->getInt() <= SHRT_MAX))
             {
             node->setAndIncChild(0, firstChild->getFirstChild());
-            TR::Node::recreateAndCopyValidProperties(node, shortOp);
+            TR::Node::recreate(node, shortOp);
             firstChild->recursivelyDecReferenceCount();
             if (secondOp == TR::s2i)
                {
@@ -4468,7 +4468,7 @@ static void intCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::ILOpCode
                   }
                else
                   {
-                  TR::Node::recreateAndCopyValidProperties(secondChild, TR::sconst);
+                  TR::Node::recreate(secondChild, TR::sconst);
                   secondChild->setShortInt((int16_t)secondChild->getInt());
                   }
                if (reportCompareDemotions)
@@ -4490,7 +4490,7 @@ static void intCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::ILOpCode
               secondChild->getInt() <= SCHAR_MAX))
             {
             node->setAndIncChild(0, firstChild->getFirstChild());
-            TR::Node::recreateAndCopyValidProperties(node, byteOp);
+            TR::Node::recreate(node, byteOp);
             firstChild->recursivelyDecReferenceCount();
             if (secondOp == TR::b2i)
                {
@@ -4511,7 +4511,7 @@ static void intCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::ILOpCode
                   }
                else
                   {
-                  TR::Node::recreateAndCopyValidProperties(secondChild, TR::bconst);
+                  TR::Node::recreate(secondChild, TR::bconst);
                   secondChild->setByte((int8_t)secondChild->getInt());
                   }
 
@@ -4545,7 +4545,7 @@ static void unsignedIntCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::
               secondChild->getUnsignedInt() <= USHRT_MAX))
             {
             node->setAndIncChild(0, firstChild->getFirstChild());
-            TR::Node::recreateAndCopyValidProperties(node, ushortOp);
+            TR::Node::recreate(node, ushortOp);
             firstChild->recursivelyDecReferenceCount();
             if (secondOp == TR::su2i)
                {
@@ -4566,7 +4566,7 @@ static void unsignedIntCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::
                   }
                else
                   {
-                  TR::Node::recreateAndCopyValidProperties(secondChild, TR::cconst);
+                  TR::Node::recreate(secondChild, TR::cconst);
                   secondChild->setConst<uint16_t>((uint16_t)secondChild->getUnsignedInt());
                   }
                if (reportCompareDemotions)
@@ -4587,7 +4587,7 @@ static void unsignedIntCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::
               secondChild->getUnsignedInt() <= SHRT_MAX))
             {
             node->setAndIncChild(0, firstChild->getFirstChild());
-            TR::Node::recreateAndCopyValidProperties(node, ushortOp);
+            TR::Node::recreate(node, ushortOp);
             firstChild->recursivelyDecReferenceCount();
             if (secondOp == TR::s2i)
                {
@@ -4608,7 +4608,7 @@ static void unsignedIntCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::
                   }
                else
                   {
-                  TR::Node::recreateAndCopyValidProperties(secondChild, TR::sconst);
+                  TR::Node::recreate(secondChild, TR::sconst);
                   secondChild->setShortInt((int16_t)secondChild->getInt());
                   }
                if (reportCompareDemotions)
@@ -4629,7 +4629,7 @@ static void unsignedIntCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::
               secondChild->getUnsignedInt() <= SCHAR_MAX))
             {
             node->setAndIncChild(0, firstChild->getFirstChild());
-            TR::Node::recreateAndCopyValidProperties(node, ubyteOp);
+            TR::Node::recreate(node, ubyteOp);
             firstChild->recursivelyDecReferenceCount();
             if (secondOp == TR::b2i)
                {
@@ -4650,7 +4650,7 @@ static void unsignedIntCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::
                   }
                else
                   {
-                  TR::Node::recreateAndCopyValidProperties(secondChild, TR::bconst);
+                  TR::Node::recreate(secondChild, TR::bconst);
                   secondChild->setByte((int8_t)secondChild->getInt());
                   }
 
@@ -4890,7 +4890,7 @@ static bool checkAndReplaceRotation(TR::Node *node,TR::Block *block, TR::Simplif
          TR_ASSERT(0, "Data Type of node %p not supported in checkAndReplaceRotation!\n",mulConstNode);
       }
 
-   TR::Node::recreateAndCopyValidProperties(node, TR::ILOpCode::getRotateOpCodeFromDt(mulConstNode->getDataType())); // this line will have to change based on T
+   TR::Node::recreate(node, TR::ILOpCode::getRotateOpCodeFromDt(mulConstNode->getDataType())); // this line will have to change based on T
 
    // Set the common nonconst node (child of mul and shift) as the child of rol node,
    // and then recursively decrement both mul and shift node.
@@ -5069,7 +5069,7 @@ static bool convertToSinglePrecisionSQRT(TR::Simplifier *s,TR::Node *sqrtCall)
    TR_ASSERT(callTreeTop != NULL, "should have been able to find this tree top (call %p) in block %d",
            sqrtCall, s->_curTree->getEnclosingBlock()->getNumber());
 
-   TR::Node::recreateAndCopyValidProperties(sqrtCall, TR::fcall);
+   TR::Node::recreate(sqrtCall, TR::fcall);
    sqrtCall->setSymbolReference(fsqrtSymRef);
 
    // replace child
@@ -5080,7 +5080,7 @@ static bool convertToSinglePrecisionSQRT(TR::Simplifier *s,TR::Node *sqrtCall)
    if (callTreeNode->getOpCode().isResolveCheck())
       {
       if (callTreeNode->getOpCodeValue() == TR::ResolveCHK)
-         TR::Node::recreateAndCopyValidProperties(callTreeNode, TR::treetop);
+         TR::Node::recreate(callTreeNode, TR::treetop);
       else
          TR_ASSERT(0, "Null check not expected in call to static method sqrt\n");
       }
@@ -5513,7 +5513,7 @@ static void bitwiseToLogical(TR::Node * node, TR::Block * block, TR::Simplifier 
       isZero = !isZero;
 
    // fixup current tree to do the first compare
-   TR::Node::recreateAndCopyValidProperties(node, (disjunctive) ?
+   TR::Node::recreate(node, (disjunctive) ?
                         cmp1->getOpCode().convertCmpToIfCmp() :
                         TR::ILOpCode(cmp1->getOpCode().getOpCodeForReverseBranch()).convertCmpToIfCmp());
    node->setAndIncChild(0, cmp1->getFirstChild ());
@@ -5876,7 +5876,7 @@ TR::Node *indirectStoreSimplifier(TR::Node * node, TR::Block * block, TR::Simpli
             node->setChild(0, secondChild);
             }
 
-         TR::Node::recreateAndCopyValidProperties(node, s->comp()->il.opCodeForDirectStore(addrDataType));
+         TR::Node::recreate(node, s->comp()->il.opCodeForDirectStore(addrDataType));
          node->setSymbolReference(firstChild->getSymbolReference());
          firstChild->recursivelyDecReferenceCount();
          node->setNumChildren(1);
@@ -5934,7 +5934,7 @@ TR::Node *indirectStoreSimplifier(TR::Node * node, TR::Block * block, TR::Simpli
          if (removeWrtBar && !s->comp()->getOptions()->realTimeGC() &&
              performTransformation(s->comp(), "%sFolded indirect write barrier to iastore because GC could not have occurred enough times to require iwrtbar [" POINTER_PRINTF_FORMAT "]\n", s->optDetailString(), node))
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::astorei);
+            TR::Node::recreate(node, TR::astorei);
             node->getChild(2)->recursivelyDecReferenceCount();
             node->setNumChildren(2);
             }
@@ -6269,7 +6269,7 @@ TR::Node *lcallSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
             TR::Node* divConstNode = TR::Node::create(node, TR::lconst);
             divConstNode->setLongInt(divisor);
 
-            TR::Node::recreateAndCopyValidProperties(node, TR::ldiv);
+            TR::Node::recreate(node, TR::ldiv);
             node->setNumChildren(2);
             node->setAndIncChild(0, lcallNode);
 
@@ -6279,7 +6279,7 @@ TR::Node *lcallSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
             if (callTreeNode->getOpCode().isResolveCheck())
                {
                if (callTreeNode->getOpCodeValue() == TR::ResolveCHK)
-                  TR::Node::recreateAndCopyValidProperties(callTreeNode, TR::treetop);
+                  TR::Node::recreate(callTreeNode, TR::treetop);
                else
                   TR_ASSERT(0, "Null check not expected in call to static method in class System\n");
                }
@@ -6306,7 +6306,7 @@ TR::Node *lcallSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
             TR::Node* mulConstNode = TR::Node::create(node, TR::lconst);
             mulConstNode->setLongInt(multiplier);
 
-            TR::Node::recreateAndCopyValidProperties(node, TR::lmul);
+            TR::Node::recreate(node, TR::lmul);
             node->setNumChildren(2);
             node->setAndIncChild(0, lcallNode);
 
@@ -6316,7 +6316,7 @@ TR::Node *lcallSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
             if (callTreeNode->getOpCode().isResolveCheck())
                {
                if (callTreeNode->getOpCodeValue() == TR::ResolveCHK)
-                  TR::Node::recreateAndCopyValidProperties(callTreeNode, TR::treetop);
+                  TR::Node::recreate(callTreeNode, TR::treetop);
                else
                   TR_ASSERT(0, "Null check not expected in call to static method in class System\n");
                }
@@ -6440,7 +6440,7 @@ TR::Node *acallSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
       for (i = 0; i < node->getNumChildren(); i++)
          node->getChild(i)->recursivelyDecReferenceCount();
 
-      TR::Node::recreateAndCopyValidProperties(node, TR::PassThrough);
+      TR::Node::recreate(node, TR::PassThrough);
       node->setNumChildren(1);
       }
 #endif
@@ -6525,7 +6525,7 @@ TR::Node *anchorSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * 
             }
          else
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::treetop);
+            TR::Node::recreate(node, TR::treetop);
             ////firstChild->decReferenceCount();
             secondChild->decReferenceCount();
             node->setNumChildren(1);
@@ -6618,7 +6618,7 @@ TR::Node *iaddSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          if (performTransformation(s->comp(), "%sReduced iadd of -1 and an ineg in node [%s] to bitwise complement\n", s->optDetailString(), node->getName(s->getDebug())))
             {
             s->anchorChildren(node, s->_curTree);
-            TR::Node::recreateAndCopyValidProperties(node, TR::ixor);
+            TR::Node::recreate(node, TR::ixor);
             node->setAndIncChild(0, newFirstChild);
             firstChild->recursivelyDecReferenceCount();
             node->setVisitCount(0);
@@ -6630,7 +6630,7 @@ TR::Node *iaddSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       else if (performTransformation(s->comp(), "%sReduced iadd with negated first child in node [%s] to isub\n", s->optDetailString(), node->getName(s->getDebug())))
          {
          s->anchorChildren(node, s->_curTree);
-         TR::Node::recreateAndCopyValidProperties(node, TR::isub);
+         TR::Node::recreate(node, TR::isub);
          node->setAndIncChild(1, newFirstChild);
          node->setChild(0, secondChild);
          firstChild->recursivelyDecReferenceCount();
@@ -6646,7 +6646,7 @@ TR::Node *iaddSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          {
          s->anchorChildren(node, s->_curTree);
          TR::Node * newSecondChild = secondChild->getFirstChild();
-         TR::Node::recreateAndCopyValidProperties(node, TR::isub);
+         TR::Node::recreate(node, TR::isub);
          node->setAndIncChild(1, newSecondChild);
          secondChild->recursivelyDecReferenceCount();
          s->_alteredBlock = true;
@@ -6669,7 +6669,7 @@ TR::Node *iaddSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
 
          if (iMulDecomposeReport)
             dumpOptDetails(s->comp(), "Putting the node back to imul with %d, for node [%s]. \n", iMulComposerValue, iMulComposerChild->getName(s->getDebug()));
-         TR::Node::recreateAndCopyValidProperties(node, TR::imul);
+         TR::Node::recreate(node, TR::imul);
 
          node->setAndIncChild(0, iMulComposerChild);
          constNode = TR::Node::create(node, TR::iconst, 0, iMulComposerValue);
@@ -6737,9 +6737,9 @@ TR::Node *iaddSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             }
          else
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::imul);
+            TR::Node::recreate(node, TR::imul);
             node->setChild(0, factorChild)->decReferenceCount();
-            TR::Node::recreateAndCopyValidProperties(secondChild, TR::iadd);
+            TR::Node::recreate(secondChild, TR::iadd);
             firstChild->decReferenceCount();
             secondChild->setVisitCount(0);
             node->setVisitCount(0);
@@ -6787,7 +6787,7 @@ TR::Node *iaddSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                if (value > 0)
                   {
                   value = -value;
-                  TR::Node::recreateAndCopyValidProperties(node, TR::isub);
+                  TR::Node::recreate(node, TR::isub);
                   }
                if (secondChild->getReferenceCount() == 1)
                   {
@@ -6814,8 +6814,8 @@ TR::Node *iaddSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             // move constants up the tree so they will tend to get merged together
             node->setChild(1, lrChild);
             firstChild->setChild(1, secondChild);
-            TR::Node::recreateAndCopyValidProperties(node, firstChildOp);
-            TR::Node::recreateAndCopyValidProperties(firstChild, TR::iadd);
+            TR::Node::recreate(node, firstChildOp);
+            TR::Node::recreate(firstChild, TR::iadd);
             firstChild->setIsNonZero(false);
             firstChild->setIsZero(false);
             firstChild->setIsNonNegative(false);
@@ -6972,7 +6972,7 @@ TR::Node *laddSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       int64_t val2 = (secondChild->getDataType() == TR::Address) ? secondChild->getAddress() : secondChild->getLongInt();
       foldLongIntConstant(node, val1 + val2, s, false /* !anchorChildren */);
       if (node->getOpCodeValue() == TR::aladd)
-         TR::Node::recreateAndCopyValidProperties(node, TR::aconst);
+         TR::Node::recreate(node, TR::aconst);
 
       return node;
       }
@@ -6999,7 +6999,7 @@ TR::Node *laddSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       {
       if (performTransformation(s->comp(), "%sNormalized ladd of lconst > 0 in node [" POINTER_PRINTF_FORMAT "] to lsub of -lconst\n", s->optDetailString(), node))
          {
-         TR::Node::recreateAndCopyValidProperties(node, TR::lsub);
+         TR::Node::recreate(node, TR::lsub);
          if (secondChild->getReferenceCount() == 1)
             {
             secondChild->setLongInt(-secondChild->getLongInt());
@@ -7027,7 +7027,7 @@ TR::Node *laddSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          if (performTransformation(s->comp(), "%sReduced ladd of -1 and an lneg in node [" POINTER_PRINTF_FORMAT "] to bitwise complement\n", s->optDetailString(), node))
             {
             s->anchorChildren(node, s->_curTree);
-            TR::Node::recreateAndCopyValidProperties(node, TR::lxor);
+            TR::Node::recreate(node, TR::lxor);
             node->setAndIncChild(0, newFirstChild);
             firstChild->recursivelyDecReferenceCount();
             node->setVisitCount(0);
@@ -7040,7 +7040,7 @@ TR::Node *laddSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          if (performTransformation(s->comp(), "%sReduced ladd with negated first child in node [" POINTER_PRINTF_FORMAT "] to lsub\n", s->optDetailString(), node))
             {
             s->anchorChildren(node, s->_curTree);
-            TR::Node::recreateAndCopyValidProperties(node, TR::lsub);
+            TR::Node::recreate(node, TR::lsub);
             node->setAndIncChild(1, newFirstChild);
             node->setChild(0, secondChild);
             firstChild->recursivelyDecReferenceCount();
@@ -7057,7 +7057,7 @@ TR::Node *laddSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          {
          s->anchorChildren(node, s->_curTree);
          TR::Node * newSecondChild = secondChild->getFirstChild();
-         TR::Node::recreateAndCopyValidProperties(node, TR::lsub);
+         TR::Node::recreate(node, TR::lsub);
          node->setAndIncChild(1, newSecondChild);
          secondChild->recursivelyDecReferenceCount();
          node->setVisitCount(0);
@@ -7100,9 +7100,9 @@ TR::Node *laddSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             }
          if (factorChild)
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::lmul);
+            TR::Node::recreate(node, TR::lmul);
             node->setChild(0, factorChild)->decReferenceCount();
-            TR::Node::recreateAndCopyValidProperties(secondChild, TR::ladd);
+            TR::Node::recreate(secondChild, TR::ladd);
             firstChild->decReferenceCount();
             secondChild->setVisitCount(0);
             node->setVisitCount(0);
@@ -7146,7 +7146,7 @@ TR::Node *laddSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                if (value > 0)
                   {
                   value = -value;
-                  TR::Node::recreateAndCopyValidProperties(node, TR::lsub);
+                  TR::Node::recreate(node, TR::lsub);
                   }
                if (secondChild->getReferenceCount() == 1)
                   {
@@ -7172,8 +7172,8 @@ TR::Node *laddSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                {
                node->setChild(1, lrChild);
                firstChild->setChild(1, secondChild);
-               TR::Node::recreateAndCopyValidProperties(node, firstChildOp);
-               TR::Node::recreateAndCopyValidProperties(firstChild, TR::ladd);
+               TR::Node::recreate(node, firstChildOp);
+               TR::Node::recreate(firstChild, TR::ladd);
                node->setVisitCount(0);
                s->_alteredBlock = true;
                }
@@ -7398,7 +7398,7 @@ TR::Node *isubSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             node->setChild(0, 0);
             node->setChild(1, 0);
 
-            TR::Node::recreateAndCopyValidProperties(node, TR::iconst);
+            TR::Node::recreate(node, TR::iconst);
             if (secondChildOp == TR::iadd)
                node->setInt(-1*rrChild->getInt());
             else
@@ -7418,7 +7418,7 @@ TR::Node *isubSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       {
       if (performTransformation(s->comp(), "%sNormalized isub of iconst > 0 in node [%s] to iadd of -iconst \n", s->optDetailString(), node->getName(s->getDebug())))
          {
-         TR::Node::recreateAndCopyValidProperties(node, TR::iadd);
+         TR::Node::recreate(node, TR::iadd);
          if (secondChild->getReferenceCount() == 1)
             {
             secondChild->setInt(-secondChild->getInt());
@@ -7441,7 +7441,7 @@ TR::Node *isubSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       if (performTransformation(s->comp(), "%sReduced isub with negated second child in node [%s] to iadd\n", s->optDetailString(), node->getName(s->getDebug())))
          {
          TR::Node * newSecondChild = secondChild->getFirstChild();
-         TR::Node::recreateAndCopyValidProperties(node, TR::iadd);
+         TR::Node::recreate(node, TR::iadd);
          node->setAndIncChild(1, newSecondChild);
          secondChild->recursivelyDecReferenceCount();
          node->setVisitCount(0);
@@ -7455,7 +7455,7 @@ TR::Node *isubSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       if (performTransformation(s->comp(), "%sReduced isub with negated first child in node [%s] to ineg of iadd\n", s->optDetailString(), node->getName(s->getDebug())))
          {
          TR::Node * newFirstChild = firstChild->getFirstChild();
-         TR::Node::recreateAndCopyValidProperties(node, TR::ineg);
+         TR::Node::recreate(node, TR::ineg);
          TR::Node * newNode = TR::Node::create(node, TR::iadd, 2);
          newNode->setAndIncChild(0, newFirstChild);
          newNode->setChild(1, secondChild);
@@ -7476,7 +7476,7 @@ TR::Node *isubSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       if (performTransformation(s->comp(), "%sReduced isub of bitwise complement and iconst -1 in node [%s] to 2s complement negation\n", s->optDetailString(), node->getName(s->getDebug())))
          {
          TR::Node * firstGrandChild = firstChild->getFirstChild();
-         TR::Node::recreateAndCopyValidProperties(node, TR::ineg);
+         TR::Node::recreate(node, TR::ineg);
          node->setAndIncChild(0, firstGrandChild);
          node->setNumChildren(1);
          secondChild->recursivelyDecReferenceCount();
@@ -7500,7 +7500,7 @@ TR::Node *isubSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
 
          if (iMulDecomposeReport)
             dumpOptDetails(s->comp(), "Putting the node back to imul with %d, for node [%s]. \n", iMulComposerValue, iMulComposerChild->getName(s->getDebug()));
-         TR::Node::recreateAndCopyValidProperties(node, TR::imul);
+         TR::Node::recreate(node, TR::imul);
 
          node->setAndIncChild(0, iMulComposerChild);
          constNode = TR::Node::create(node, TR::iconst, 0, iMulComposerValue);
@@ -7568,9 +7568,9 @@ TR::Node *isubSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             }
          else
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::imul);
+            TR::Node::recreate(node, TR::imul);
             node->setChild(factorChild->getOpCode().isLoadConst() ? 1:0, factorChild)->decReferenceCount();
-            TR::Node::recreateAndCopyValidProperties(secondChild, TR::isub);
+            TR::Node::recreate(secondChild, TR::isub);
             firstChild->decReferenceCount();
             secondChild->setVisitCount(0);
             node->setVisitCount(0);
@@ -7627,7 +7627,7 @@ TR::Node *isubSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                   }
                else
                   {
-                  TR::Node::recreateAndCopyValidProperties(node, TR::iadd);
+                  TR::Node::recreate(node, TR::iadd);
                   }
                if (secondChild->getReferenceCount() == 1)
                   {
@@ -7656,8 +7656,8 @@ TR::Node *isubSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             // move constants up the tree so they will tend to get merged together
             node->setChild(1, lrChild);
             firstChild->setChild(1, secondChild);
-            TR::Node::recreateAndCopyValidProperties(node, firstChildOp);
-            TR::Node::recreateAndCopyValidProperties(firstChild, TR::isub);
+            TR::Node::recreate(node, firstChildOp);
+            TR::Node::recreate(firstChild, TR::isub);
 
             // conservatively reset flags -- a future pass of VP will set them up
             // again if needed
@@ -7677,7 +7677,7 @@ TR::Node *isubSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             node->getFirstChild()->get64bitIntegralValue() == 0 &&
             performTransformation(s->comp(), "%sReduce isub from 0 [%s] to ineg \n",s->optDetailString(),node->getName(s->getDebug())))
       {
-      TR::Node::recreateAndCopyValidProperties(node, TR::ILOpCode::negateOpCode(node->getDataType()));
+      TR::Node::recreate(node, TR::ILOpCode::negateOpCode(node->getDataType()));
       node->setVisitCount(0);
       node->getFirstChild()->recursivelyDecReferenceCount();
       node->setChild(0, node->getSecondChild());
@@ -7812,7 +7812,7 @@ TR::Node *lsubSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             node->setChild(0, 0);
             node->setChild(1, 0);
 
-            TR::Node::recreateAndCopyValidProperties(node, TR::lconst);
+            TR::Node::recreate(node, TR::lconst);
             if (secondChildOp == TR::ladd)
                node->setLongInt(-1*rrChild->getLongInt());
             else
@@ -7832,7 +7832,7 @@ TR::Node *lsubSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       {
       if (performTransformation(s->comp(), "%sNormalized lsub of lconst > 0 in node [" POINTER_PRINTF_FORMAT "] to ladd of -lconst \n", s->optDetailString(), node))
          {
-         TR::Node::recreateAndCopyValidProperties(node, TR::ladd);
+         TR::Node::recreate(node, TR::ladd);
          if (secondChild->getReferenceCount() == 1)
             {
             secondChild->setLongInt(-secondChild->getLongInt());
@@ -7856,7 +7856,7 @@ TR::Node *lsubSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       if (performTransformation(s->comp(), "%sReduced lsub with negated second child in node [" POINTER_PRINTF_FORMAT "] to ladd\n", s->optDetailString(), node))
          {
          TR::Node * newSecondChild = secondChild->getFirstChild();
-         TR::Node::recreateAndCopyValidProperties(node, TR::ladd);
+         TR::Node::recreate(node, TR::ladd);
          node->setChild(1, newSecondChild);
          if (secondChild->decReferenceCount() != 0)
             {
@@ -7873,7 +7873,7 @@ TR::Node *lsubSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       if (performTransformation(s->comp(), "%sReduced lsub with negated first child in node [" POINTER_PRINTF_FORMAT "] to lneg of ladd\n", s->optDetailString(), node))
          {
          TR::Node * newFirstChild = firstChild->getFirstChild();
-         TR::Node::recreateAndCopyValidProperties(node, TR::lneg);
+         TR::Node::recreate(node, TR::lneg);
          TR::Node * newNode = TR::Node::create(node, TR::ladd, 2);
          newNode->setChild(0, newFirstChild);
          newNode->setChild(1, secondChild);
@@ -7897,7 +7897,7 @@ TR::Node *lsubSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       if (performTransformation(s->comp(), "%sReduced lsub of bitwise complement and lconst -1 in node [" POINTER_PRINTF_FORMAT "] to 2s complement negation\n", s->optDetailString(), node))
          {
          TR::Node * firstGrandChild = firstChild->getFirstChild();
-         TR::Node::recreateAndCopyValidProperties(node, TR::lneg);
+         TR::Node::recreate(node, TR::lneg);
          node->setAndIncChild(0, firstGrandChild);
          node->setNumChildren(1);
          secondChild->recursivelyDecReferenceCount();
@@ -7943,9 +7943,9 @@ TR::Node *lsubSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             }
          if (factorChild)
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::lmul);
+            TR::Node::recreate(node, TR::lmul);
             node->setChild(0, factorChild)->decReferenceCount();
-            TR::Node::recreateAndCopyValidProperties(secondChild, TR::lsub);
+            TR::Node::recreate(secondChild, TR::lsub);
             firstChild->decReferenceCount();
             secondChild->setVisitCount(0);
             node->setVisitCount(0);
@@ -7991,7 +7991,7 @@ TR::Node *lsubSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                   }
                else
                   {
-                  TR::Node::recreateAndCopyValidProperties(node, TR::ladd);
+                  TR::Node::recreate(node, TR::ladd);
                   }
                if (secondChild->getReferenceCount() == 1)
                   {
@@ -8017,8 +8017,8 @@ TR::Node *lsubSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                {
                node->setChild(1, lrChild);
                firstChild->setChild(1, secondChild);
-               TR::Node::recreateAndCopyValidProperties(node, firstChildOp);
-               TR::Node::recreateAndCopyValidProperties(firstChild, TR::lsub);
+               TR::Node::recreate(node, firstChildOp);
+               TR::Node::recreate(firstChild, TR::lsub);
                node->setVisitCount(0);
                s->_alteredBlock = true;
                }
@@ -8039,7 +8039,7 @@ TR::Node *lsubSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
           (lSubValue & (lSubValue + 1)) == 0 &&
           lAndValue <= lSubValue)
          {
-         TR::Node::recreateAndCopyValidProperties(node, TR::lxor);
+         TR::Node::recreate(node, TR::lxor);
          node->setVisitCount(0);
          s->_alteredBlock = true;
          node = s->simplify(node, block);
@@ -8214,7 +8214,7 @@ TR::Node *lsubSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                         }
                      else
                         {
-                        TR::Node::recreateAndCopyValidProperties(node, TR::ladd);
+                        TR::Node::recreate(node, TR::ladd);
                         }
 
                      if (secondChild->getReferenceCount() == 1)
@@ -8304,7 +8304,7 @@ TR::Node *lsubSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       if (((mask + 1) & mask) == 0 && // mask + 1 power of two?
           performTransformation(s->comp(), "%sNext lower pwr of 2 using land [" POINTER_PRINTF_FORMAT "]\n", s->optDetailString(), node))
          {
-         node->recreateAndCopyValidProperties(node, TR::land);
+         node->recreate(node, TR::land);
          TR::Node* maskNode = TR::Node::create(node, TR::lconst, 0);
          mask = ~mask;
          maskNode->setLongInt(mask);
@@ -8441,7 +8441,7 @@ TR::Node *imulSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
        secondChild->getInt() != TR::getMinSigned<TR::Int32>() &&
        performTransformation(s->comp(), "%sFound a*(-c) = -(a*c) in imul [%s]\n", s->optDetailString(), node->getName(s->getDebug())))
       {
-      TR::Node::recreateAndCopyValidProperties(node, TR::ineg);
+      TR::Node::recreate(node, TR::ineg);
       node->setNumChildren(1);
       if (secondChild->getReferenceCount() == 1)
          {
@@ -8529,12 +8529,12 @@ TR::Node *imulSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          if (product > 0)
             {
             productNode->setInt((int32_t)-product);
-            TR::Node::recreateAndCopyValidProperties(node, TR::isub);
+            TR::Node::recreate(node, TR::isub);
             }
          else
             {
             productNode->setInt((int32_t)product);
-            TR::Node::recreateAndCopyValidProperties(node, TR::iadd);
+            TR::Node::recreate(node, TR::iadd);
             }
          if (firstChild->getReferenceCount() != 1)
             {
@@ -8548,7 +8548,7 @@ TR::Node *imulSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             }
          else
             {
-            TR::Node::recreateAndCopyValidProperties(firstChild, TR::imul);
+            TR::Node::recreate(firstChild, TR::imul);
             }
          if (lrChild->getReferenceCount() != 1)
             {
@@ -8593,7 +8593,7 @@ TR::Node *imulSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          TR::Node *firstChild = node->getFirstChild();
          TR::Node *secondChild = node->getSecondChild();
 
-         TR::Node::recreateAndCopyValidProperties(node, TR::iand);
+         TR::Node::recreate(node, TR::iand);
 
          TR::Node * newConst = TR::Node::create(node, TR::iconst, 0);
          newConst->setInt(~(size-1));
@@ -8647,11 +8647,11 @@ TR::Node *imulSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       {
       if (performTransformation(s->comp(), "%sApplied reassociation rule 11 to node 0x%p\n", s->optDetailString(), node))
          {
-         TR::Node::recreateAndCopyValidProperties(node, TR::iadd);
+         TR::Node::recreate(node, TR::iadd);
          TR::Node *newSecondChild = TR::Node::create(node, TR::imul, 2);
          newSecondChild->setChild(0, node->getFirstChild()->getSecondChild());
          newSecondChild->setAndIncChild(1, node->getSecondChild());
-         TR::Node::recreateAndCopyValidProperties(node->getFirstChild(), TR::imul);
+         TR::Node::recreate(node->getFirstChild(), TR::imul);
          node->getFirstChild()->setChild(1, node->getSecondChild());
          node->setAndIncChild(1, newSecondChild);
 
@@ -8671,7 +8671,7 @@ TR::Node *imulSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       {
       if (performTransformation(s->comp(), "%sApplied reassociation rule 13 to node 0x%p\n", s->optDetailString(), node))
          {
-         TR::Node::recreateAndCopyValidProperties(node, TR::iadd);
+         TR::Node::recreate(node, TR::iadd);
          TR::Node *firstChild = node->getFirstChild();
          TR::Node *secondChild = node->getSecondChild();
 
@@ -8705,7 +8705,7 @@ TR::Node *imulSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       {
       if (performTransformation(s->comp(), "%sApplied reassociation rule 15 to node 0x%p\n", s->optDetailString(), node))
          {
-         TR::Node::recreateAndCopyValidProperties(node, TR::isub);
+         TR::Node::recreate(node, TR::isub);
          TR::Node *firstChild = node->getFirstChild();
          TR::Node *secondChild = node->getSecondChild();
 
@@ -8720,7 +8720,7 @@ TR::Node *imulSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          // if e2 is const, convert node to TR::iadd
          if (mul2->getFirstChild()->getOpCodeValue() == TR::iconst)
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::iadd);
+            TR::Node::recreate(node, TR::iadd);
             TR::Node * newConst = TR::Node::create(node, TR::iconst, 0);
             newConst->setInt(-mul2->getFirstChild()->getInt());
             mul2->getFirstChild()->recursivelyDecReferenceCount();
@@ -8729,7 +8729,7 @@ TR::Node *imulSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          // if c is const, convert node to TR::iadd
          else if (mul2->getSecondChild()->getOpCodeValue() == TR::iconst)
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::iadd);
+            TR::Node::recreate(node, TR::iadd);
             TR::Node * newConst = TR::Node::create(node, TR::iconst, 0);
             newConst->setInt(-mul2->getSecondChild()->getInt());
             mul2->getSecondChild()->recursivelyDecReferenceCount();
@@ -8835,12 +8835,12 @@ TR::Node *lmulSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          if (product > 0)
             {
             productNode->setLongInt((int64_t)-product);
-            TR::Node::recreateAndCopyValidProperties(node, TR::lsub);
+            TR::Node::recreate(node, TR::lsub);
             }
          else
             {
             productNode->setLongInt((int64_t)product);
-            TR::Node::recreateAndCopyValidProperties(node, TR::ladd);
+            TR::Node::recreate(node, TR::ladd);
             }
 
          TR::Node *newFirst = TR::Node::create(firstChild, TR::lmul, 2);
@@ -8895,12 +8895,12 @@ TR::Node *lmulSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             if (product > 0)
                {
                productNode->setLongInt((int64_t)-product);
-               TR::Node::recreateAndCopyValidProperties(node, TR::lsub);
+               TR::Node::recreate(node, TR::lsub);
                }
             else
                {
                productNode->setLongInt((int64_t)product);
-               TR::Node::recreateAndCopyValidProperties(node, TR::ladd);
+               TR::Node::recreate(node, TR::ladd);
                }
 
 
@@ -9156,7 +9156,7 @@ TR::Node *idivSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                firstChild->incReferenceCount();
 
                s->prepareToReplaceNode(node);
-               TR::Node::recreateAndCopyValidProperties(node, TR::ineg);
+               TR::Node::recreate(node, TR::ineg);
                node->setChild(0, firstChild);
                node->setNumChildren(1);
                }
@@ -9190,7 +9190,7 @@ TR::Node *idivSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             newNode3->getSecondChild()->incReferenceCount();
             if (divisor>0)
                {
-               TR::Node::recreateAndCopyValidProperties(node, TR::ishr);
+               TR::Node::recreate(node, TR::ishr);
                node->setFirst(newNode3);
                node->setSecond(TR::Node::create(node, TR::iconst, 0, shftAmnt));
                node->getSecondChild()->incReferenceCount();
@@ -9202,7 +9202,7 @@ TR::Node *idivSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                newNode4->setSecond(TR::Node::create(node, TR::iconst, 0, shftAmnt));
                newNode4->getFirstChild()->incReferenceCount();
                newNode4->getSecondChild()->incReferenceCount();
-               TR::Node::recreateAndCopyValidProperties(node, TR::ineg);
+               TR::Node::recreate(node, TR::ineg);
                node->setNumChildren(1);
                node->setFirst(newNode4);
                }
@@ -9256,7 +9256,7 @@ TR::Node *idivSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                           TR::Node::create(node3, TR::iconst, 0, 31));
 
              s->prepareToReplaceNode(node);
-             TR::Node::recreateAndCopyValidProperties(node, TR::iadd);
+             TR::Node::recreate(node, TR::iadd);
              node->setAndIncChild(0, node3);
              node->setAndIncChild(1, node4);
              node->setNumChildren(2);
@@ -9283,7 +9283,7 @@ TR::Node *idivSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
 
             // Replace 'node' with our calculation.
             s->prepareToReplaceNode(node);
-            TR::Node::recreateAndCopyValidProperties(node, quotient->getOpCodeValue());
+            TR::Node::recreate(node, quotient->getOpCodeValue());
             // Note that we don't have to incRef since the function call
             // already took care of this for us.
             node->setFirst(quotient->getFirstChild());
@@ -9337,7 +9337,7 @@ TR::Node *ldivSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                firstChild->incReferenceCount();
 
                s->prepareToReplaceNode(node);
-               TR::Node::recreateAndCopyValidProperties(node, TR::lneg);
+               TR::Node::recreate(node, TR::lneg);
                node->setChild(0, firstChild);
                node->setNumChildren(1);
                }
@@ -9365,7 +9365,7 @@ TR::Node *ldivSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
 
                      TR::Node * node1 = TR::Node::create(TR::lshr, 2, firstChild, newChild);
                      s->prepareToReplaceNode(node);
-                     TR::Node::recreateAndCopyValidProperties(node, TR::lneg);
+                     TR::Node::recreate(node, TR::lneg);
                      node->setAndIncChild(0, node1);
                      node->setNumChildren(1);
                      }
@@ -9374,7 +9374,7 @@ TR::Node *ldivSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                   {
                   if (performTransformation(s->comp(), "%sReduced ldiv power of 2 with lshr in node [%p]\n", s->optDetailString(), node))
                      {
-                     TR::Node::recreateAndCopyValidProperties(node, TR::lshr);
+                     TR::Node::recreate(node, TR::lshr);
                      if (secondChild->getReferenceCount() > 1)
                         {
                         secondChild->decReferenceCount();
@@ -9384,7 +9384,7 @@ TR::Node *ldivSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                         }
                      else
                         {
-                        TR::Node::recreateAndCopyValidProperties(secondChild, TR::iconst);
+                        TR::Node::recreate(secondChild, TR::iconst);
                         }
                      secondChild->setInt(shiftAmount);
                      s->_alteredBlock = true;
@@ -9403,7 +9403,7 @@ TR::Node *ldivSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                      node1 = TR::Node::create(TR::lneg, 1, firstChild );
 
                      s->prepareToReplaceNode(node);
-                     TR::Node::recreateAndCopyValidProperties(node, TR::lshr);
+                     TR::Node::recreate(node, TR::lshr);
                      node->setAndIncChild(0, node1);
                      node->setAndIncChild(1, shiftNode);
                      node->setNumChildren(2);
@@ -9420,7 +9420,7 @@ TR::Node *ldivSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
 
                         node1 = TR::Node::create(TR::ladd, 2, firstChild, newChild);
                         s->prepareToReplaceNode(node);
-                        TR::Node::recreateAndCopyValidProperties(node, TR::lshr);
+                        TR::Node::recreate(node, TR::lshr);
                         node->setAndIncChild(0, node1);
                         node->setAndIncChild(1, shiftNode);
                         node->setNumChildren(2);
@@ -9428,7 +9428,7 @@ TR::Node *ldivSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                      else
                         {
                         s->prepareToReplaceNode(node);
-                        TR::Node::recreateAndCopyValidProperties(node, TR::ladd);
+                        TR::Node::recreate(node, TR::ladd);
                         node->setAndIncChild(0, TR::Node::create(TR::lshr, 2, firstChild, shiftNode));
 
                         // This is a convulted way of expressing:
@@ -9480,7 +9480,7 @@ TR::Node *ldivSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                newNode3->getSecondChild()->incReferenceCount();
                if (divisor>0)
                   {
-                  TR::Node::recreateAndCopyValidProperties(node, TR::lshr);
+                  TR::Node::recreate(node, TR::lshr);
                   node->setFirst(newNode3);
                   node->setSecond(TR::Node::create(node, TR::iconst, 0, shftAmnt));
                   node->getSecondChild()->incReferenceCount();
@@ -9492,7 +9492,7 @@ TR::Node *ldivSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                   newNode4->setSecond(TR::Node::create(node, TR::iconst, 0, shftAmnt));
                   newNode4->getFirstChild()->incReferenceCount();
                   newNode4->getSecondChild()->incReferenceCount();
-                  TR::Node::recreateAndCopyValidProperties(node, TR::lneg);
+                  TR::Node::recreate(node, TR::lneg);
                   node->setNumChildren(1);
                   node->setFirst(newNode4);
                   }
@@ -9551,7 +9551,7 @@ TR::Node *ldivSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                                         TR::Node::create(node3, TR::iconst, 0, 63));
                 }
              s->prepareToReplaceNode(node);
-             TR::Node::recreateAndCopyValidProperties(node, TR::ladd);
+             TR::Node::recreate(node, TR::ladd);
              node->setAndIncChild(0, node3);
              node->setAndIncChild(1, node4);
              node->setNumChildren(2);
@@ -9578,7 +9578,7 @@ TR::Node *ldivSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          secondChild->recursivelyDecReferenceCount();
 
          //s->prepareToReplaceNode(node);
-         TR::Node::recreateAndCopyValidProperties(node, TR::i2l);
+         TR::Node::recreate(node, TR::i2l);
          node->setAndIncChild(0, divNode);
          node->setNumChildren(1);
 
@@ -9602,7 +9602,7 @@ TR::Node *ldivSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             divCheckParent = curTree->getNode();
 
          transformToLongDivBy10Bitwise(node, node, s);
-         TR::Node::recreateAndCopyValidProperties(node, TR::ladd);
+         TR::Node::recreate(node, TR::ladd);
          firstChild->recursivelyDecReferenceCount();
          secondChild->recursivelyDecReferenceCount();
 
@@ -9639,7 +9639,7 @@ TR::Node *fdivSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          }
       if (isNZFloatPowerOfTwo(secondChild->getFloat()))
          {
-         TR::Node::recreateAndCopyValidProperties(node, TR::fmul);
+         TR::Node::recreate(node, TR::fmul);
          float multiplier = floatRecip(secondChild->getFloat());
          if (secondChild->getReferenceCount() > 1)
             {
@@ -9697,7 +9697,7 @@ TR::Node *ddivSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          }
       if (isNZDoublePowerOfTwo(secondChild->getDouble()))
          {
-         TR::Node::recreateAndCopyValidProperties(node, TR::dmul);
+         TR::Node::recreate(node, TR::dmul);
          double multiplier = doubleRecip(secondChild->getDouble());
          if (secondChild->getReferenceCount() > 1)
             {
@@ -9796,7 +9796,7 @@ TR::Node *iremSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                {
                secondChild->decReferenceCount();
                TR::Node *newNode = TR::Node::create(node, TR::iconst, 0, ((uint32_t)divisor) - 1);
-               TR::Node::recreateAndCopyValidProperties(node, TR::iand);
+               TR::Node::recreate(node, TR::iand);
                node->setSecond(newNode);
                node->getSecondChild()->incReferenceCount();
                return node;
@@ -9829,7 +9829,7 @@ TR::Node *iremSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                newNode4->setSecond(TR::Node::create(node, TR::iconst, 0, divisor>0 ? -divisor : divisor));
                newNode4->getFirstChild()->incReferenceCount();
                newNode4->getSecondChild()->incReferenceCount();
-               TR::Node::recreateAndCopyValidProperties(node, TR::isub);
+               TR::Node::recreate(node, TR::isub);
                node->setFirst(firstChild);
                node->setSecond(newNode4);
                node->getFirstChild()->incReferenceCount();
@@ -9871,7 +9871,7 @@ TR::Node *iremSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
 
             // Replace 'node' with our calculation.
             s->prepareToReplaceNode(node);
-            TR::Node::recreateAndCopyValidProperties(node, TR::isub);
+            TR::Node::recreate(node, TR::isub);
             // Note that we have to incRef here since we haven't already
             // accounted for these references.
             node->setAndIncChild(0,firstChild);
@@ -9954,7 +9954,7 @@ TR::Node *lremSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             newNode4->getSecondChild()->setLongInt(negDivisor);
             newNode4->getFirstChild()->incReferenceCount();
             newNode4->getSecondChild()->incReferenceCount();
-            TR::Node::recreateAndCopyValidProperties(node, TR::lsub);
+            TR::Node::recreate(node, TR::lsub);
             node->setFirst(firstChild);
             node->setSecond(newNode4);
             node->getFirstChild()->incReferenceCount();
@@ -9988,7 +9988,7 @@ TR::Node *lremSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
 
             // Replace 'node' with our calculation.
             s->prepareToReplaceNode(node);
-            TR::Node::recreateAndCopyValidProperties(node, TR::lsub);
+            TR::Node::recreate(node, TR::lsub);
             // We need to incRef here because we've not accounted for these 2
             // references yet.
             node->setAndIncChild(0,firstChild);
@@ -10019,7 +10019,7 @@ TR::Node *lremSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          firstChild->recursivelyDecReferenceCount();
          secondChild->recursivelyDecReferenceCount();
 
-         TR::Node::recreateAndCopyValidProperties(node, TR::i2l);
+         TR::Node::recreate(node, TR::i2l);
          node->setAndIncChild(0, remNode);
          node->setNumChildren(1);
 
@@ -10048,7 +10048,7 @@ TR::Node *lremSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          transformToLongDivBy10Bitwise(node, ldivNode, s);
 
          // Modify the lrem node
-         TR::Node::recreateAndCopyValidProperties(node, TR::lsub);
+         TR::Node::recreate(node, TR::lsub);
          node->setNumChildren(2);
          node->setAndIncChild(0, firstChild);
          node->setAndIncChild(1, TR::Node::create(TR::lmul, 2, ldivNode, secondChild));
@@ -10185,7 +10185,7 @@ TR::Node *inegSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       {
       if (performTransformation(s->comp(), "%sReduced ineg with isub child in node [" POINTER_PRINTF_FORMAT "] to isub\n", s->optDetailString(), node))
          {
-         TR::Node::recreateAndCopyValidProperties(node, TR::isub);
+         TR::Node::recreate(node, TR::isub);
          node->setNumChildren(2);
          node->setAndIncChild(0, firstChild->getSecondChild());
          node->setAndIncChild(1, firstChild->getFirstChild());
@@ -10205,7 +10205,7 @@ TR::Node *inegSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          TR::Node* shift = TR::Node::create(node, TR::lshr, 2);
          shift->setAndIncChild(0, firstFirst->getFirstChild());
          shift->setAndIncChild(1, firstFirst->getSecondChild());
-         TR::Node::recreateAndCopyValidProperties(node, TR::l2i);
+         TR::Node::recreate(node, TR::l2i);
          node->setAndIncChild(0, shift);
          firstChild->recursivelyDecReferenceCount();
          }
@@ -10240,7 +10240,7 @@ TR::Node *lnegSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       {
       if (performTransformation(s->comp(), "%sReduced lneg with lsub child in node [" POINTER_PRINTF_FORMAT "]\n to lsub", s->optDetailString(), node))
          {
-         TR::Node::recreateAndCopyValidProperties(node, TR::lsub);
+         TR::Node::recreate(node, TR::lsub);
          node->setNumChildren(2);
          node->setAndIncChild(0, firstChild->getSecondChild());
          node->setAndIncChild(1, firstChild->getFirstChild());
@@ -10474,7 +10474,7 @@ TR::Node *ishlSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       {
       // Normalize shift by a constant into multiply by a constant
       //
-      TR::Node::recreateAndCopyValidProperties(node, node->getOpCodeValue() == TR::iushl ? TR::iumul : TR::imul);
+      TR::Node::recreate(node, node->getOpCodeValue() == TR::iushl ? TR::iumul : TR::imul);
       int32_t multiplier = 1 << (secondChild->getInt() & INT_SHIFT_MASK);
       if (secondChild->getReferenceCount() > 1)
          {
@@ -10512,7 +10512,7 @@ TR::Node *lshlSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       // Canonicalize shift by a constant into multiply by a constant
       //
       performTransformation(s->comp(), "%sCanonicalize long left shift by constant in node [" POINTER_PRINTF_FORMAT "] to long multiply by power of 2\n", s->optDetailString(), node);
-      TR::Node::recreateAndCopyValidProperties(node, TR::lmul);
+      TR::Node::recreate(node, TR::lmul);
       int64_t multiplier = (int64_t)CONSTANT64(1) << (secondChild->getInt() & LONG_SHIFT_MASK);
       if (secondChild->getReferenceCount() > 1)
          {
@@ -10523,7 +10523,7 @@ TR::Node *lshlSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          }
       else
          {
-         TR::Node::recreateAndCopyValidProperties(secondChild, TR::lconst);
+         TR::Node::recreate(secondChild, TR::lconst);
          }
       secondChild->setLongInt(multiplier);
       s->_alteredBlock = true;
@@ -10679,7 +10679,7 @@ TR::Node *iushrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
                {
                if (performTransformation(s->comp(), "%sReduced left shift followed by iushr equivalent to zero extend short in node [" POINTER_PRINTF_FORMAT "] to su2i\n", s->optDetailString(), node))
                   {
-                  TR::Node::recreateAndCopyValidProperties(node, TR::su2i);
+                  TR::Node::recreate(node, TR::su2i);
                   foundZeroExtension = true;
                   }
                }
@@ -10687,7 +10687,7 @@ TR::Node *iushrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
                {
                if (performTransformation(s->comp(), "%sReduced left shift followed by iushr equivalent to zero extend byte in node [" POINTER_PRINTF_FORMAT "] to bu2i\n", s->optDetailString(), node))
                   {
-                  TR::Node::recreateAndCopyValidProperties(node, TR::bu2i);
+                  TR::Node::recreate(node, TR::bu2i);
                   foundZeroExtension = true;
                   }
                }
@@ -10707,7 +10707,7 @@ TR::Node *iushrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
          //
          if (performTransformation(s->comp(), "%sReduced left shift followed by iushr in node [" POINTER_PRINTF_FORMAT "] to iand with mask\n", s->optDetailString(), node))
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::iand);
+            TR::Node::recreate(node, TR::iand);
             uint32_t mask = (UINT_MAX >> rightShiftValue);
             if (secondChild->getReferenceCount() == 1)
                secondChild->setInt(mask);
@@ -10807,7 +10807,7 @@ TR::Node *lushrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
                if (performTransformation(s->comp(), "%sReduced left shift followed by lushr equivalent to zero extend int in node [" POINTER_PRINTF_FORMAT "] to iu2l\n", s->optDetailString(), node))
                   {
                   foundZeroExtension = true;
-                  TR::Node::recreateAndCopyValidProperties(node, TR::iu2l);
+                  TR::Node::recreate(node, TR::iu2l);
                   }
                }
             else if (opCode == TR::s2l && rightShiftValue == 48)
@@ -10815,7 +10815,7 @@ TR::Node *lushrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
                if (performTransformation(s->comp(), "%sReduced left shift followed by lushr equivalent to zero extend byte in node [" POINTER_PRINTF_FORMAT "] to bu2l\n", s->optDetailString(), node))
                   {
                   foundZeroExtension = true;
-                  TR::Node::recreateAndCopyValidProperties(node, TR::su2l);
+                  TR::Node::recreate(node, TR::su2l);
                   }
                }
             else if (opCode == TR::b2l && rightShiftValue == 56)
@@ -10823,7 +10823,7 @@ TR::Node *lushrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
                if (performTransformation(s->comp(), "%sReduced left shift followed by lushr equivalent to zero extend byte in node [" POINTER_PRINTF_FORMAT "] to bu2l\n", s->optDetailString(), node))
                   {
                   foundZeroExtension = true;
-                  TR::Node::recreateAndCopyValidProperties(node, TR::bu2l);
+                  TR::Node::recreate(node, TR::bu2l);
                   }
                }
             if (foundZeroExtension)
@@ -10842,11 +10842,11 @@ TR::Node *lushrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
          //
          if (performTransformation(s->comp(), "%sReduced left shift followed by lushr in node [" POINTER_PRINTF_FORMAT "] to land with mask\n", s->optDetailString(), node))
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::land);
+            TR::Node::recreate(node, TR::land);
             uint64_t mask = (uint64_t) ((uint64_t) -1) >> rightShiftValue;
             if (secondChild->getReferenceCount() == 1)
                {
-               TR::Node::recreateAndCopyValidProperties(secondChild, TR::lconst);
+               TR::Node::recreate(secondChild, TR::lconst);
                secondChild->setLongInt(mask);
                }
             else
@@ -10984,7 +10984,7 @@ TR::Node *iandSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             {
             TR::Node *orNode    = TR::Node::create(TR::ior, 2, firstChild->getFirstChild(), secondChild->getFirstChild());
             TR::Node * constNode = firstChild->getSecondChild();
-            TR::Node::recreateAndCopyValidProperties(node, TR::ixor);
+            TR::Node::recreate(node, TR::ixor);
             node->setAndIncChild(0, orNode);
             node->setAndIncChild(1, constNode);
             firstChild->recursivelyDecReferenceCount();
@@ -11041,7 +11041,7 @@ TR::Node *iandSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          {
          if (performTransformation(s->comp(), "%sReduced iand with iconst 255 in node [%s] to bu2i\n", s->optDetailString(), node->getName(s->getDebug())))
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::bu2i);
+            TR::Node::recreate(node, TR::bu2i);
             foundZeroExtension = true;
             }
          }
@@ -11049,7 +11049,7 @@ TR::Node *iandSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          {
          if (performTransformation(s->comp(), "%sReduced iand with iconst 65536 in node [%s] to %s\n", s->optDetailString(), node->getName(s->getDebug()), "su2i"))
             {
-            TR::Node::recreateAndCopyValidProperties(node, firstChildOp == TR::s2i ? TR::su2i : TR::su2i);
+            TR::Node::recreate(node, firstChildOp == TR::s2i ? TR::su2i : TR::su2i);
             foundZeroExtension = true;
             }
          }
@@ -11082,7 +11082,7 @@ TR::Node *iandSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          if ((secondChild->getInt() & 0x1) == 0x1)
             {
             // (A cmp B) & 0x1 ==> A cmp B
-            TR::Node::recreateAndCopyValidProperties(node, firstChild->getOpCodeValue());
+            TR::Node::recreate(node, firstChild->getOpCodeValue());
             node->setNumChildren(2);
             node->setAndIncChild(0, firstChild->getFirstChild());
             node->setAndIncChild(1, firstChild->getSecondChild());
@@ -11127,7 +11127,7 @@ TR::Node *landSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             {
             TR::Node *orNode    = TR::Node::create(TR::lor, 2, firstChild->getFirstChild(), secondChild->getFirstChild());
             TR::Node * constNode = firstChild->getSecondChild();
-            TR::Node::recreateAndCopyValidProperties(node, TR::lxor);
+            TR::Node::recreate(node, TR::lxor);
             node->setAndIncChild(0, orNode);
             node->setAndIncChild(1, constNode);
             firstChild->recursivelyDecReferenceCount();
@@ -11186,7 +11186,7 @@ TR::Node *landSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             {
             if (performTransformation(s->comp(), "%sReduced land with lconst 255 in node [" POINTER_PRINTF_FORMAT "] to bu2l\n", s->optDetailString(), node))
                {
-               TR::Node::recreateAndCopyValidProperties(node, TR::bu2l);
+               TR::Node::recreate(node, TR::bu2l);
                foundZeroExtension = true;
                }
             }
@@ -11194,7 +11194,7 @@ TR::Node *landSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             {
             if (performTransformation(s->comp(), "%sReduced land with lconst 65536 in node [" POINTER_PRINTF_FORMAT "] to su2l\n", s->optDetailString(), node))
                {
-               TR::Node::recreateAndCopyValidProperties(node, TR::su2l);
+               TR::Node::recreate(node, TR::su2l);
                foundZeroExtension = true;
                }
             }
@@ -11202,7 +11202,7 @@ TR::Node *landSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             {
             if (performTransformation(s->comp(), "%sReduced land with lconst 0xffffffff in node [" POINTER_PRINTF_FORMAT "] to iu2l\n", s->optDetailString(), node))
                {
-               TR::Node::recreateAndCopyValidProperties(node, TR::iu2l);
+               TR::Node::recreate(node, TR::iu2l);
                foundZeroExtension = true;
                }
             }
@@ -11233,7 +11233,7 @@ TR::Node *landSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
 
             if (secondChild->getReferenceCount()==1)
                {
-               TR::Node::recreateAndCopyValidProperties(secondChild, TR::iconst);
+               TR::Node::recreate(secondChild, TR::iconst);
                secondChild->setInt(secondChild->getLongIntLow());
                constChild = secondChild;
                }
@@ -11243,7 +11243,7 @@ TR::Node *landSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                constChild->setInt(secondChild->getLongIntLow());
                }
             TR::Node * iandChild = TR::Node::create(TR::iand, 2, firstChild->getFirstChild(), constChild);
-            TR::Node::recreateAndCopyValidProperties(node, firstChildOp);
+            TR::Node::recreate(node, firstChildOp);
             node->setNumChildren(1);
             node->setAndIncChild(0, iandChild);
 
@@ -11276,7 +11276,7 @@ TR::Node *landSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          if ((secondChild->getLongInt() & 0x1) == 1)
             {
             // i2ul(A cmp B) & 0x1 ==> i2ul(A cmp B)
-            TR::Node::recreateAndCopyValidProperties(node, firstChild->getOpCodeValue());
+            TR::Node::recreate(node, firstChild->getOpCodeValue());
             node->setNumChildren(1);
             node->setAndIncChild(0, firstChild->getFirstChild());
 
@@ -11493,7 +11493,7 @@ TR::Node *iorSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             {
             TR::Node * andNode   = TR::Node::create(TR::iand, 2, firstChild->getFirstChild(), secondChild->getFirstChild());
             TR::Node * constNode = firstChild->getSecondChild();
-            TR::Node::recreateAndCopyValidProperties(node, TR::ixor);
+            TR::Node::recreate(node, TR::ixor);
             node->setAndIncChild(0, andNode);
             node->setAndIncChild(1, constNode);
             firstChild->recursivelyDecReferenceCount();
@@ -11625,7 +11625,7 @@ TR::Node *iorSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                    (addr = getUnsafeBaseAddr(byte4, -3)) && addr == byte1 &&
                    performTransformation(s->comp(), "%sconvert ior to iiload node [" POINTER_PRINTF_FORMAT "]\n", s->optDetailString(), node))
                   {
-                  TR::Node::recreateAndCopyValidProperties(node, TR::iloadi);
+                  TR::Node::recreate(node, TR::iloadi);
                   node->setNumChildren(1);
                   node->setSymbolReference(s->getSymRefTab()->findOrCreateUnsafeSymbolRef(TR::Int32));
                   node->setAndIncChild(0, byte1);
@@ -11677,7 +11677,7 @@ TR::Node *iorSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             (loadVal->getOpCode().isLoadVar() || loadVal->getOpCode().isLoadReg()) &&
             performTransformation(s->comp(), "%sTransform ior to lcmp [" POINTER_PRINTF_FORMAT "]\n", s->optDetailString(), node))
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::lcmp);
+            TR::Node::recreate(node, TR::lcmp);
             TR::Node * constZero = TR::Node::create(secondChild, TR::lconst, 0);
             constZero->setLongInt(0);
             node->setFirst(s->replaceNode(firstChild,loadVal, s->_curTree));
@@ -11741,7 +11741,7 @@ TR::Node *lorSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             {
             TR::Node * andNode   = TR::Node::create(TR::land, 2, firstChild->getFirstChild(), secondChild->getFirstChild());
             TR::Node * constNode = firstChild->getSecondChild();
-            TR::Node::recreateAndCopyValidProperties(node, TR::lxor);
+            TR::Node::recreate(node, TR::lxor);
             node->setAndIncChild(0, andNode);
             node->setAndIncChild(1, constNode);
             firstChild->recursivelyDecReferenceCount();
@@ -11813,7 +11813,7 @@ TR::Node *lorSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
 
             if (secondChild->getReferenceCount()==1)
                {
-               TR::Node::recreateAndCopyValidProperties(secondChild, TR::iconst);
+               TR::Node::recreate(secondChild, TR::iconst);
                secondChild->setInt(secondChild->getLongIntLow());
                constChild = secondChild;
                }
@@ -11823,7 +11823,7 @@ TR::Node *lorSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                constChild->setInt(secondChild->getLongIntLow());
                }
             TR::Node * iorChild = TR::Node::create(TR::ior, 2, firstChild->getFirstChild(), constChild);
-            TR::Node::recreateAndCopyValidProperties(node, firstChildOp);
+            TR::Node::recreate(node, firstChildOp);
             node->setNumChildren(1);
             node->setAndIncChild(0, iorChild);
 
@@ -12134,7 +12134,7 @@ TR::Node *lxorSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
 
             if (secondChild->getReferenceCount()==1)
                {
-               TR::Node::recreateAndCopyValidProperties(secondChild, TR::iconst);
+               TR::Node::recreate(secondChild, TR::iconst);
                secondChild->setInt(secondChild->getLongIntLow());
                constChild = secondChild;
                }
@@ -12144,7 +12144,7 @@ TR::Node *lxorSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                constChild->setInt(secondChild->getLongIntLow());
                }
             TR::Node * ixorChild = TR::Node::create(TR::ixor, 2, firstChild->getFirstChild(), constChild);
-            TR::Node::recreateAndCopyValidProperties(node, firstChildOp);
+            TR::Node::recreate(node, firstChildOp);
             node->setNumChildren(1);
             node->setAndIncChild(0, ixorChild);
 
@@ -12230,7 +12230,7 @@ TR::Node *i2lSimplifier(TR::Node * node, TR::Block *  block, TR::Simplifier * s)
          {
          if (performTransformation(s->comp(), "%sReduced i2l with su2i child in node [" POINTER_PRINTF_FORMAT "] to su2l\n", s->optDetailString(), node))
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::su2l);
+            TR::Node::recreate(node, TR::su2l);
             foundFoldableConversion = true;
             }
          }
@@ -12238,7 +12238,7 @@ TR::Node *i2lSimplifier(TR::Node * node, TR::Block *  block, TR::Simplifier * s)
          {
          if (performTransformation(s->comp(), "%sReduced i2l with su2i child in node [" POINTER_PRINTF_FORMAT "] to su2l\n", s->optDetailString(), node))
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::bu2l);
+            TR::Node::recreate(node, TR::bu2l);
             foundFoldableConversion = true;
             }
          }
@@ -12246,7 +12246,7 @@ TR::Node *i2lSimplifier(TR::Node * node, TR::Block *  block, TR::Simplifier * s)
          {
          if (performTransformation(s->comp(), "%sReduced i2l with s2i child in node [" POINTER_PRINTF_FORMAT "] to s2l\n", s->optDetailString(), node))
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::s2l);
+            TR::Node::recreate(node, TR::s2l);
             foundFoldableConversion = true;
             }
          }
@@ -12254,7 +12254,7 @@ TR::Node *i2lSimplifier(TR::Node * node, TR::Block *  block, TR::Simplifier * s)
          {
          if (performTransformation(s->comp(), "%sReduced i2l with b2i child in node [" POINTER_PRINTF_FORMAT "] to b2l\n", s->optDetailString(), node))
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::b2l);
+            TR::Node::recreate(node, TR::b2l);
             foundFoldableConversion = true;
             }
          }
@@ -12277,7 +12277,7 @@ TR::Node *i2lSimplifier(TR::Node * node, TR::Block *  block, TR::Simplifier * s)
       if (shiftBy >= 57 &&
           performTransformation(s->comp(), "%sRemove i2l/l2i from lshr node [" POINTER_PRINTF_FORMAT "]\n", s->optDetailString(), node))
          {
-         TR::Node::recreateAndCopyValidProperties(node, TR::lshr);
+         TR::Node::recreate(node, TR::lshr);
          node->setNumChildren(2);
          node->setAndIncChild(0, firstFirst->getFirstChild());
          node->setAndIncChild(1, firstFirst->getSecondChild());
@@ -12375,7 +12375,7 @@ TR::Node *i2sSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
        (address = isOrOfTwoConsecutiveBytes(firstChild, s)) &&
        performTransformation(s->comp(), "%sconvert ior to isload node [" POINTER_PRINTF_FORMAT "]\n", s->optDetailString(), node))
       {
-      TR::Node::recreateAndCopyValidProperties(node, TR::sloadi);
+      TR::Node::recreate(node, TR::sloadi);
       node->setSymbolReference(s->getSymRefTab()->findOrCreateUnsafeSymbolRef(TR::Int16));
       node->setChild(0, address);
       }
@@ -12430,7 +12430,7 @@ TR::Node *i2aSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
        performTransformation(s->comp(), "%sTransforming iu2a  [%s] to aiadd\n", s->optDetailString(), node->getName(s->getDebug()))
       )
       {
-      TR::Node::recreateAndCopyValidProperties(node, TR::aiadd);
+      TR::Node::recreate(node, TR::aiadd);
       node->setAndIncChild(0, firstChild->getFirstChild()->getFirstChild());
       node->setNumChildren(2);
       int32_t newVal = (firstChild->getOpCodeValue() == TR::isub) ? -firstChild->getSecondChild()->getInt() : firstChild->getSecondChild()->getInt();
@@ -12477,7 +12477,7 @@ TR::Node *iu2lSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          {
          if (performTransformation(s->comp(), "%sReduced iu2l with su2i child in node [" POINTER_PRINTF_FORMAT "] to su2l\n", s->optDetailString(), node))
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::su2l);
+            TR::Node::recreate(node, TR::su2l);
             foundFoldableConversion = true;
             }
          }
@@ -12485,7 +12485,7 @@ TR::Node *iu2lSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          {
          if (performTransformation(s->comp(), "%sReduced iu2l with bu2i child in node [" POINTER_PRINTF_FORMAT "] to bu2l\n", s->optDetailString(), node))
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::bu2l);
+            TR::Node::recreate(node, TR::bu2l);
             foundFoldableConversion = true;
             }
          }
@@ -12638,7 +12638,7 @@ TR::Node *l2aSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
           performTransformation(s->comp(), "%sTransforming %s [%s] to address add\n", s->optDetailString(), node->getOpCode().getName(), node->getName(s->getDebug()))
          )
          {
-         TR::Node::recreateAndCopyValidProperties(node, addressAddOp);
+         TR::Node::recreate(node, addressAddOp);
 
          node->setNumChildren(2);  // upto 2 children do not require node extension. this should suffice. Any more requires Node::addChildren
          node->setAndIncChild(0, firstChild->getFirstChild()->getFirstChild());    // aload
@@ -13026,7 +13026,7 @@ TR::Node *bu2iSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       if (shiftBy >= 56 &&
           performTransformation(s->comp(), "%sReplace bu2i/l2b of lushr with l2i node [" POINTER_PRINTF_FORMAT "]\n", s->optDetailString(), node))
          {
-         node->recreateAndCopyValidProperties(node, TR::l2i);
+         node->recreate(node, TR::l2i);
          node->setAndIncChild(0, firstChild->getFirstChild());
          firstChild->recursivelyDecReferenceCount();
          return node;
@@ -13079,7 +13079,7 @@ TR::Node *bu2lSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          //       x
          //       iconst 0-255
          TR::Node * grandChild = firstChild->getFirstChild();
-         node->recreateAndCopyValidProperties(node, TR::i2l);
+         node->recreate(node, TR::i2l);
          grandChild->incReferenceCount();
          firstChild->recursivelyDecReferenceCount();
          node->setChild(0, grandChild);
@@ -13093,7 +13093,7 @@ TR::Node *bu2lSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             performTransformation(s->comp(), "%sRemove bu2l [" POINTER_PRINTF_FORMAT "] with i2b child [" POINTER_PRINTF_FORMAT "] of compare [" POINTER_PRINTF_FORMAT "]\n", s->optDetailString(), node, firstChild, firstChild->getFirstChild()))
       {
       TR::Node * grandChild = firstChild->getFirstChild();
-      node->recreateAndCopyValidProperties(node, TR::i2l);
+      node->recreate(node, TR::i2l);
       grandChild->incReferenceCount();
       firstChild->recursivelyDecReferenceCount();
       node->setChild(0, grandChild);
@@ -13106,7 +13106,7 @@ TR::Node *bu2lSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       if (shiftBy >= 56 &&
           performTransformation(s->comp(), "%sReplace bu2l/l2b of lushr with lushr node [" POINTER_PRINTF_FORMAT "]\n", s->optDetailString(), node))
          {
-         node->recreateAndCopyValidProperties(node, TR::lushr);
+         node->recreate(node, TR::lushr);
          node->setNumChildren(2);
          node->setAndIncChild(0, firstChild->getFirstChild()->getFirstChild());
          node->setAndIncChild(1, firstChild->getFirstChild()->getSecondChild());
@@ -13179,7 +13179,7 @@ TR::Node *s2iSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          {
          if (performTransformation(s->comp(), "%sReduced s2i with bu2s child in node [" POINTER_PRINTF_FORMAT "] to bu2i\n", s->optDetailString(), node))
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::bu2i);
+            TR::Node::recreate(node, TR::bu2i);
             foundFoldableConversion = true;
             }
          }
@@ -13187,7 +13187,7 @@ TR::Node *s2iSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          {
          if (performTransformation(s->comp(), "%sReduced s2i with b2s child in node [" POINTER_PRINTF_FORMAT "] to b2i\n", s->optDetailString(), node))
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::b2i);
+            TR::Node::recreate(node, TR::b2i);
             foundFoldableConversion = true;
             }
          }
@@ -13221,7 +13221,7 @@ TR::Node *s2lSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          {
          if (performTransformation(s->comp(), "%sReduced s2l with bu2s child in node [" POINTER_PRINTF_FORMAT "] to bu2l\n", s->optDetailString(), node))
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::bu2l);
+            TR::Node::recreate(node, TR::bu2l);
             foundFoldableConversion = true;
             }
          }
@@ -13229,7 +13229,7 @@ TR::Node *s2lSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          {
          if (performTransformation(s->comp(), "%sReduced s2l with b2s child in node [" POINTER_PRINTF_FORMAT "] to b2l\n", s->optDetailString(), node))
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::b2l);
+            TR::Node::recreate(node, TR::b2l);
             foundFoldableConversion = true;
             }
          }
@@ -13426,7 +13426,7 @@ TR::Node *ificmpeqSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
       )
       {
       //Change if type
-      TR::Node::recreateAndCopyValidProperties(node, TR::ifiucmplt);
+      TR::Node::recreate(node, TR::ifiucmplt);
 
       TR::Node *newSecondChild = TR::Node::create(node, TR::iconst, 0, 1 << firstChild->getSecondChild()->getInt());
       node->setAndIncChild(1, newSecondChild);
@@ -13448,11 +13448,11 @@ TR::Node *ificmpeqSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
        (s->comp()->cg()->getSupportsJavaFloatSemantics() || !(firstChild->getNumChildren()>1 && firstChild->getFirstChild()->getOpCode().isFloatingPoint())) &&
        performTransformation(s->comp(), "%sChanging if opcode %p because first child %p is a comparison opcode\n", s->optDetailString(), node, firstChild))
       {
-      TR::Node::recreateAndCopyValidProperties(node, firstChild->getOpCode().convertCmpToIfCmp());
+      TR::Node::recreate(node, firstChild->getOpCode().convertCmpToIfCmp());
       node->setAndIncChild(0, firstChild->getFirstChild());
       node->setAndIncChild(1, firstChild->getSecondChild());
       if (secondChild->getInt() == 0)
-         TR::Node::recreateAndCopyValidProperties(node, node->getOpCode().getOpCodeForReverseBranch());
+         TR::Node::recreate(node, node->getOpCode().getOpCodeForReverseBranch());
       firstChild->recursivelyDecReferenceCount();
       secondChild->recursivelyDecReferenceCount();
       return node;
@@ -13464,7 +13464,7 @@ TR::Node *ificmpeqSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
             secondChild->getInt() == 0) &&
          performTransformation(s->comp(), "%sChanging if opcode %p because first child %p is an lcmp\n", s->optDetailString(), node, firstChild))
       {
-      TR::Node::recreateAndCopyValidProperties(node, TR::iflcmpeq); //change to iflcmp since operands are longs
+      TR::Node::recreate(node, TR::iflcmpeq); //change to iflcmp since operands are longs
       node->setAndIncChild(0, firstChild->getFirstChild());
       node->setAndIncChild(1, firstChild->getSecondChild());
       firstChild->recursivelyDecReferenceCount();
@@ -13478,7 +13478,7 @@ TR::Node *ificmpeqSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
             secondChild->getInt() == 0) &&
          performTransformation(s->comp(), "%sChanging if opcode %p because first child %p is an lcmpeq\n", s->optDetailString(), node, firstChild))
       {
-      TR::Node::recreateAndCopyValidProperties(node, TR::iflcmpne); //change to iflcmpne since operands are longs
+      TR::Node::recreate(node, TR::iflcmpne); //change to iflcmpne since operands are longs
       node->setAndIncChild(0, firstChild->getFirstChild());
       node->setAndIncChild(1, firstChild->getSecondChild());
       firstChild->recursivelyDecReferenceCount();
@@ -13545,7 +13545,7 @@ TR::Node *ificmpneSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
       )
       {
       //Change if type
-      TR::Node::recreateAndCopyValidProperties(node, TR::ifiucmpge);
+      TR::Node::recreate(node, TR::ifiucmpge);
 
       TR::Node *newSecondChild = TR::Node::create(node, TR::iconst, 0, 1 << firstChild->getSecondChild()->getInt());
       node->setAndIncChild(1, newSecondChild);
@@ -13567,11 +13567,11 @@ TR::Node *ificmpneSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
        (s->comp()->cg()->getSupportsJavaFloatSemantics() || !(firstChild->getNumChildren()>1 && firstChild->getFirstChild()->getOpCode().isFloatingPoint())) &&
        performTransformation(s->comp(), "%sChanging if opcode %p because first child %p is a comparison opcode\n", s->optDetailString(), node, firstChild))
       {
-      TR::Node::recreateAndCopyValidProperties(node, firstChild->getOpCode().convertCmpToIfCmp());
+      TR::Node::recreate(node, firstChild->getOpCode().convertCmpToIfCmp());
       node->setAndIncChild(0, firstChild->getFirstChild());
       node->setAndIncChild(1, firstChild->getSecondChild());
       if (secondChild->getInt() == 1)
-         TR::Node::recreateAndCopyValidProperties(node, node->getOpCode().getOpCodeForReverseBranch());
+         TR::Node::recreate(node, node->getOpCode().getOpCodeForReverseBranch());
       firstChild->recursivelyDecReferenceCount();
       secondChild->recursivelyDecReferenceCount();
       return node;
@@ -13582,7 +13582,7 @@ TR::Node *ificmpneSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
             secondChild->getInt() == 0) &&
          performTransformation(s->comp(), "%sChanging if opcode %p because first child %p is an lcmp\n", s->optDetailString(), node, firstChild))
       {
-      TR::Node::recreateAndCopyValidProperties(node, TR::iflcmpne); //change to iflcmp since operands are longs
+      TR::Node::recreate(node, TR::iflcmpne); //change to iflcmp since operands are longs
       node->setAndIncChild(0, firstChild->getFirstChild());
       node->setAndIncChild(1, firstChild->getSecondChild());
       firstChild->recursivelyDecReferenceCount();
@@ -14031,7 +14031,7 @@ TR::Node *normalizeCmpSimplifier(TR::Node * node, TR::Block * block, TR::Simplif
             op = doubleToFloatOp(node->getOpCodeValue());
             if (op != TR::BadILOp)
                {
-               TR::Node::recreateAndCopyValidProperties(node, op);
+               TR::Node::recreate(node, op);
                TR::Node * newSecondChild = TR::Node::create(node, TR::fconst, 0);
                newSecondChild->setFloat(fValue);
                node->setAndIncChild(0, firstChild->getFirstChild());
@@ -14047,7 +14047,7 @@ TR::Node *normalizeCmpSimplifier(TR::Node * node, TR::Block * block, TR::Simplif
             op = doubleToIntegerOp(node->getOpCodeValue());
             if (op != TR::BadILOp)
                {
-               TR::Node::recreateAndCopyValidProperties(node, op);
+               TR::Node::recreate(node, op);
                TR::Node * newSecondChild = TR::Node::create(node, TR::iconst, 0);
                newSecondChild->setInt(iValue);
                node->setAndIncChild(0, firstChild->getFirstChild());
@@ -14063,7 +14063,7 @@ TR::Node *normalizeCmpSimplifier(TR::Node * node, TR::Block * block, TR::Simplif
             op = doubleToLongOp(node->getOpCodeValue());
             if (op != TR::BadILOp)
                {
-               TR::Node::recreateAndCopyValidProperties(node, op);
+               TR::Node::recreate(node, op);
                TR::Node * newSecondChild = TR::Node::create(node, TR::lconst, 0);
                newSecondChild->setLongInt(lValue);
                node->setAndIncChild(0, firstChild->getFirstChild());
@@ -14079,7 +14079,7 @@ TR::Node *normalizeCmpSimplifier(TR::Node * node, TR::Block * block, TR::Simplif
             op = doubleToShortOp(node->getOpCodeValue());
             if (op != TR::BadILOp)
                {
-               TR::Node::recreateAndCopyValidProperties(node, op);
+               TR::Node::recreate(node, op);
                TR::Node * newSecondChild = TR::Node::sconst(node, sValue);
                node->setAndIncChild(0, firstChild->getFirstChild());
                node->setAndIncChild(1, newSecondChild);
@@ -14094,7 +14094,7 @@ TR::Node *normalizeCmpSimplifier(TR::Node * node, TR::Block * block, TR::Simplif
             op = doubleToCharOp(node->getOpCodeValue());
             if (op != TR::BadILOp)
                {
-               TR::Node::recreateAndCopyValidProperties(node, op);
+               TR::Node::recreate(node, op);
                TR::Node * newSecondChild = TR::Node::cconst(node, cValue);
                node->setAndIncChild(0, firstChild->getFirstChild());
                node->setAndIncChild(1, newSecondChild);
@@ -14109,7 +14109,7 @@ TR::Node *normalizeCmpSimplifier(TR::Node * node, TR::Block * block, TR::Simplif
             op = doubleToByteOp(node->getOpCodeValue());
             if (op != TR::BadILOp)
                {
-               TR::Node::recreateAndCopyValidProperties(node, op);
+               TR::Node::recreate(node, op);
                TR::Node * newSecondChild = TR::Node::bconst(node, bValue);
                node->setAndIncChild(0, firstChild->getFirstChild());
                node->setAndIncChild(1, newSecondChild);
@@ -14136,7 +14136,7 @@ TR::Node *normalizeCmpSimplifier(TR::Node * node, TR::Block * block, TR::Simplif
             op = floatToIntegerOp(node->getOpCodeValue());
             if (op != TR::BadILOp)
                {
-               TR::Node::recreateAndCopyValidProperties(node, op);
+               TR::Node::recreate(node, op);
                TR::Node * newSecondChild = TR::Node::create(node, TR::iconst, 0);
                newSecondChild->setInt(iValue);
                node->setAndIncChild(0, firstChild->getFirstChild());
@@ -14152,7 +14152,7 @@ TR::Node *normalizeCmpSimplifier(TR::Node * node, TR::Block * block, TR::Simplif
             op = floatToLongOp(node->getOpCodeValue());
             if (op != TR::BadILOp)
                {
-               TR::Node::recreateAndCopyValidProperties(node, op);
+               TR::Node::recreate(node, op);
                TR::Node * newSecondChild = TR::Node::create(node, TR::lconst, 0);
                newSecondChild->setLongInt(lValue);
                node->setAndIncChild(0, firstChild->getFirstChild());
@@ -14168,7 +14168,7 @@ TR::Node *normalizeCmpSimplifier(TR::Node * node, TR::Block * block, TR::Simplif
             op = floatToShortOp(node->getOpCodeValue());
             if (op != TR::BadILOp)
                {
-               TR::Node::recreateAndCopyValidProperties(node, op);
+               TR::Node::recreate(node, op);
                TR::Node * newSecondChild = TR::Node::sconst(node, sValue);
                node->setAndIncChild(0, firstChild->getFirstChild());
                node->setAndIncChild(1, newSecondChild);
@@ -14183,7 +14183,7 @@ TR::Node *normalizeCmpSimplifier(TR::Node * node, TR::Block * block, TR::Simplif
             op = floatToCharOp(node->getOpCodeValue());
             if (op != TR::BadILOp)
                {
-               TR::Node::recreateAndCopyValidProperties(node, op);
+               TR::Node::recreate(node, op);
                TR::Node * newSecondChild = TR::Node::cconst(node, cValue);
                node->setAndIncChild(0, firstChild->getFirstChild());
                node->setAndIncChild(1, newSecondChild);
@@ -14198,7 +14198,7 @@ TR::Node *normalizeCmpSimplifier(TR::Node * node, TR::Block * block, TR::Simplif
             op = floatToByteOp(node->getOpCodeValue());
             if (op != TR::BadILOp)
                {
-               TR::Node::recreateAndCopyValidProperties(node, op);
+               TR::Node::recreate(node, op);
                TR::Node * newSecondChild = TR::Node::bconst(node, bValue);
                node->setAndIncChild(0, firstChild->getFirstChild());
                node->setAndIncChild(1, newSecondChild);
@@ -14361,8 +14361,8 @@ TR::Node *ifCmpWithEqualitySimplifier(TR::Node * node, TR::Block * block, TR::Si
          if (op != TR::BadILOp &&
              performTransformation(s->comp(), "%sFolding ifbcmpeq of bconst 0 to boolean compare at node [" POINTER_PRINTF_FORMAT "] to equivalent if?cmp??\n", s->optDetailString(), node))
             {
-            TR::Node::recreateAndCopyValidProperties(node, op);
-            TR::Node::recreateAndCopyValidProperties(node, node->getOpCode().getOpCodeForReverseBranch());
+            TR::Node::recreate(node, op);
+            TR::Node::recreate(node, node->getOpCode().getOpCodeForReverseBranch());
             secondChild->recursivelyDecReferenceCount();
             node->setAndIncChild(0, firstChild->getFirstChild());
             node->setAndIncChild(1, firstChild->getSecondChild());
@@ -14460,7 +14460,7 @@ TR::Node *ifCmpWithoutEqualitySimplifier(TR::Node * node, TR::Block * block, TR:
          if (op != TR::BadILOp &&
              performTransformation(s->comp(), "%sFolding ifbcmpeq of bconst 0 to boolean compare at node [" POINTER_PRINTF_FORMAT "] to equivalent if?cmp??\n", s->optDetailString(), node))
             {
-            TR::Node::recreateAndCopyValidProperties(node, op);
+            TR::Node::recreate(node, op);
             secondChild->recursivelyDecReferenceCount();
             node->setAndIncChild(0, firstChild->getFirstChild());
             node->setAndIncChild(1, firstChild->getSecondChild());
@@ -14503,7 +14503,7 @@ TR::Node *icmpeqSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * 
         secondChild->getInt() == 0) &&
        performTransformation(s->comp(), "%sChanging icmpeq opcode %p because first child %p is an int compare\n", s->optDetailString(), node, firstChild))
       {
-      TR::Node::recreateAndCopyValidProperties(node, firstChild->getOpCode().getOpCodeForReverseBranch());
+      TR::Node::recreate(node, firstChild->getOpCode().getOpCodeForReverseBranch());
       node->setAndIncChild(0, firstChild->getFirstChild());
       node->setAndIncChild(1, firstChild->getSecondChild());
       firstChild->recursivelyDecReferenceCount();
@@ -14591,7 +14591,7 @@ TR::Node *icmpeqSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * 
            performTransformation(s->comp(), "%sChanging icmpeq opcode %p because first child %p is an %s opcode\n", s->optDetailString(), node, firstChild, firstChild->getOpCode().getName())
          )
          {
-         TR::Node::recreateAndCopyValidProperties(node, newOpCode);
+         TR::Node::recreate(node, newOpCode);
          node->setAndIncChild(0, firstChild->getFirstChild());
          node->setAndIncChild(1, firstChild->getSecondChild());
          firstChild->recursivelyDecReferenceCount();
@@ -14614,7 +14614,7 @@ TR::Node *icmpeqSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * 
          TR::Node* shiftNode = TR::Node::create(TR::iushr, 2);
          shiftNode->setAndIncChild(0, firstChild->getFirstChild());
          shiftNode->setAndIncChild(1, byNode);
-         TR::Node::recreateAndCopyValidProperties(node, TR::iand);
+         TR::Node::recreate(node, TR::iand);
          TR::Node* one = TR::Node::create(node, TR::iconst, 0);
          one->setInt(1);
          node->setAndIncChild(0, shiftNode);
@@ -14771,7 +14771,7 @@ TR::Node *lcmpeqSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * 
       int64_t val2 = secondChild->getLongInt() & 0xffffffff80000000ull;
       if (val1 == 0 && val2 == 0 && performTransformation(s->comp(), "%sChanging lcmpeq %p to icmpeq because there are no upper bits\n", s->optDetailString(), node))
          {
-         node->recreateAndCopyValidProperties(node, TR::icmpeq);
+         node->recreate(node, TR::icmpeq);
          TR::Node * newSecondChild = TR::Node::create(node, TR::iconst, 0);
          newSecondChild->setInt(secondChild->getLongInt());
          TR::Node * newFirstChild = TR::Node::create(node, TR::l2i, 1);
@@ -14803,7 +14803,7 @@ TR::Node *lcmpeqSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * 
          one->setLongInt(1);
          landNode->setAndIncChild(0, shiftNode);
          landNode->setAndIncChild(1, one);
-         TR::Node::recreateAndCopyValidProperties(node, TR::l2i);
+         TR::Node::recreate(node, TR::l2i);
          node->setAndIncChild(0, landNode);
          node->setNumChildren(1);
          firstChild->recursivelyDecReferenceCount();
@@ -14841,7 +14841,7 @@ TR::Node *lcmpneSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * 
       if (secondChild->getOpCode().isLoadConst() && (secondChild->getLongInt() == 0))
          {
          // i2l(A cmp B) != 0 ==> A cmp B
-         TR::Node::recreateAndCopyValidProperties(node, firstChild->getFirstChild()->getOpCodeValue());
+         TR::Node::recreate(node, firstChild->getFirstChild()->getOpCodeValue());
          node->setNumChildren(2);
          node->setAndIncChild(0, firstChild->getFirstChild()->getFirstChild());
          node->setAndIncChild(1, firstChild->getFirstChild()->getSecondChild());
@@ -14863,7 +14863,7 @@ TR::Node *lcmpneSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * 
           firstSecond->getFirstChild()->getLongInt() == 1 &&
           performTransformation(s->comp(), "%slcmpne of x & (1 << y) to 0 opt node [" POINTER_PRINTF_FORMAT "]\n", s->optDetailString(), node))
          {
-         TR::Node::recreateAndCopyValidProperties(node, TR::iand);
+         TR::Node::recreate(node, TR::iand);
          TR::Node* one = TR::Node::create(node, TR::iconst, 0);
          one->setInt(1);
 
@@ -14897,7 +14897,7 @@ TR::Node *lcmpneSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * 
             TR::Node* one = TR::Node::create(node, TR::iconst, 0);
             one->setInt(1);
 
-            TR::Node::recreateAndCopyValidProperties(node, TR::iand);
+            TR::Node::recreate(node, TR::iand);
             node->setAndIncChild(0, conv);
             node->setAndIncChild(1, one);
             firstChild->recursivelyDecReferenceCount();
@@ -14932,9 +14932,9 @@ TR::Node *lcmpltSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * 
       {
       TR::Node* shiftBy = TR::Node::create(node, TR::iconst, 0);
       shiftBy->setInt(63);
-      // TR::Node::recreateAndCopyValidProperties(node, TR::lushr);
+      // TR::Node::recreate(node, TR::lushr);
       TR::Node* shift = TR::Node::create(TR::lushr, 2, firstChild, shiftBy);
-      TR::Node::recreateAndCopyValidProperties(node, TR::l2i);
+      TR::Node::recreate(node, TR::l2i);
       node->setAndIncChild(0, shift);
       node->setNumChildren(1);
       firstChild->recursivelyDecReferenceCount();
@@ -16004,7 +16004,7 @@ TR::Node *switchSimplifier(TR::Node * node, TR::Block * block, bool isTableSwitc
 
       s->anchorChildren(node, s->_curTree);
       s->prepareToReplaceNode(node);
-      TR::Node::recreateAndCopyValidProperties(node, TR::Goto);
+      TR::Node::recreate(node, TR::Goto);
       node->setBranchDestination(target);
       return s->simplify(node, block);
       }
@@ -16365,7 +16365,7 @@ TR::Node *variableNewSimplifier(TR::Node * node, TR::Block * block, TR::Simplifi
       && node->getFirstChild()->getOpCodeValue() == TR::loadaddr
       && performTransformation(s->comp(), "%sReplacing TR::variableNew %p with TR::New\n", s->optDetailString(), node))
       {
-      TR::Node::recreateAndCopyValidProperties(node, TR::New);
+      TR::Node::recreate(node, TR::New);
       }
 
    return node;
@@ -16436,7 +16436,7 @@ TR::Node * imulhSimplifier(TR::Node * node, TR::Block *block, TR::Simplifier * s
             uint64_t product = src1 * src2;
             uint64_t high = product >> 32;
             uint32_t result = high;
-            TR::Node::recreateAndCopyValidProperties(node, TR::iuconst);
+            TR::Node::recreate(node, TR::iuconst);
             node->setUnsignedInt(result);
             }
          else
@@ -16446,7 +16446,7 @@ TR::Node * imulhSimplifier(TR::Node * node, TR::Block *block, TR::Simplifier * s
             int64_t product = src1 * src2;
             int64_t high = product >> 32;
             int32_t result = high;
-            TR::Node::recreateAndCopyValidProperties(node, TR::iconst);
+            TR::Node::recreate(node, TR::iconst);
             node->setInt(result);
             }
          }
@@ -16458,7 +16458,7 @@ TR::Node * imulhSimplifier(TR::Node * node, TR::Block *block, TR::Simplifier * s
          && performTransformation(s->comp(), "%ssecond child [%p] of node [%p] is 0, setting the result of imulh to 0\n",s->optDetailString(), secondChild, node))
          {
          s->prepareToReplaceNode(node);
-         TR::Node::recreateAndCopyValidProperties(node, TR::iconst);
+         TR::Node::recreate(node, TR::iconst);
          node->setInt(0);
          }
       else if (src2 == 1 || src2 == 2)
@@ -16467,14 +16467,14 @@ TR::Node * imulhSimplifier(TR::Node * node, TR::Block *block, TR::Simplifier * s
             && performTransformation(s->comp(), "%sfirst child [%p] of node [%p] is negative, setting the result of imulh to -1\n",s->optDetailString(), firstChild, node))
             {
             s->prepareToReplaceNode(node);
-            TR::Node::recreateAndCopyValidProperties(node, TR::iconst);
+            TR::Node::recreate(node, TR::iconst);
             node->setInt(-1);
             }
          else if (firstChild->isNonNegative()
                   && performTransformation(s->comp(), "%sfirst child [%p] of node [%p] is non-negative, setting the result of imulh to 0\n",s->optDetailString(), firstChild, node))
             {
                s->prepareToReplaceNode(node);
-               TR::Node::recreateAndCopyValidProperties(node, TR::iconst);
+               TR::Node::recreate(node, TR::iconst);
                node->setInt(0);
             }
          }
@@ -16488,7 +16488,7 @@ TR::Node * imulhSimplifier(TR::Node * node, TR::Block *block, TR::Simplifier * s
          // Calculate log2(src2), which is 32-msb
          int32_t msb = 0;
          while (src2 >>= 1) msb++;
-         TR::Node::recreateAndCopyValidProperties(node, TR::ishr);
+         TR::Node::recreate(node, TR::ishr);
          TR::Node * newSecondChild = TR::Node::create(TR::iconst, 0); // Create a new node because changing the value of the node might affect trees referencing this node
          newSecondChild->setInt(32-msb);
          secondChild->recursivelyDecReferenceCount();
@@ -16523,12 +16523,12 @@ TR::Node *lmulhSimplifier(TR::Node * node, TR::Block *block, TR::Simplifier * s)
 
          if (node->getOpCode().isUnsigned())
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::lconst);
+            TR::Node::recreate(node, TR::lconst);
             node->setUnsignedLongInt(lmulhu(firstChild->getUnsignedLongInt(), secondChild->getUnsignedLongInt()));
             }
          else
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::lconst);
+            TR::Node::recreate(node, TR::lconst);
             node->setLongInt(lmulh(firstChild->getLongInt(), secondChild->getLongInt()));
             }
          }
@@ -16592,7 +16592,7 @@ TR::Node *ibits2fSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier *
 
    if (firstChild->getOpCodeValue() == TR::iconst)
       {
-      TR::Node::recreateAndCopyValidProperties(node, TR::fconst);
+      TR::Node::recreate(node, TR::fconst);
       node->setNumChildren(0);
       node->setFloatBits(firstChild->getInt());
       firstChild->recursivelyDecReferenceCount();
@@ -16608,7 +16608,7 @@ TR::Node *lbits2dSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier *
 
    if (firstChild->getOpCodeValue() == TR::lconst)
       {
-      TR::Node::recreateAndCopyValidProperties(node, TR::dconst);
+      TR::Node::recreate(node, TR::dconst);
       node->setNumChildren(0);
       node->setDouble(firstChild->getDouble());
       firstChild->recursivelyDecReferenceCount();
@@ -16631,7 +16631,7 @@ TR::Node *fbits2iSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier *
          intValue = FLOAT_NAN;
       else
          intValue = firstChild->getFloatBits();
-      TR::Node::recreateAndCopyValidProperties(node, TR::iconst);
+      TR::Node::recreate(node, TR::iconst);
       node->setInt(intValue);
       node->setNumChildren(0);
       firstChild->recursivelyDecReferenceCount();
@@ -16654,7 +16654,7 @@ TR::Node *dbits2lSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier *
          longValue = DOUBLE_NAN;
       else
          longValue = firstChild->getLongInt();
-      TR::Node::recreateAndCopyValidProperties(node, TR::lconst);
+      TR::Node::recreate(node, TR::lconst);
       node->setLongInt(longValue);
       node->setNumChildren(0);
       firstChild->recursivelyDecReferenceCount();
@@ -16735,7 +16735,7 @@ TR::Node *nullchkSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier *
        nullCheckRefOp == TR::anewarray ||
        nullCheckRefOp == TR::multianewarray)
       {
-      TR::Node::recreateAndCopyValidProperties(node, TR::treetop);
+      TR::Node::recreate(node, TR::treetop);
       simplifyChildren(node, block, s);
       return node;
       }
@@ -16745,7 +16745,7 @@ TR::Node *nullchkSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier *
    if (node->getFirstChild()->getNumChildren() == 0)
       {
       dumpOptDetails(s->comp(), "%sRemoving nullchk with no grandchildren in node [%s]\n", s->optDetailString(), node->getName(s->getDebug()));
-      TR::Node::recreateAndCopyValidProperties(node, TR::treetop);
+      TR::Node::recreate(node, TR::treetop);
       s->_alteredBlock = true;
       }
    else
@@ -16753,7 +16753,7 @@ TR::Node *nullchkSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier *
       TR::Node * refNode = node->getNullCheckReference();
 
       if (refNode->isNonNull() && performTransformation(s->comp(), "%sRemoving redundant NULLCHK in node [%s]\n", s->optDetailString(), node->getName(s->getDebug())))
-         TR::Node::recreateAndCopyValidProperties(node, TR::treetop);
+         TR::Node::recreate(node, TR::treetop);
 
       if ((refNode->isNull() ||
           ((refNode->getOpCodeValue() == TR::aconst) &&
@@ -16822,7 +16822,7 @@ TR::Node *divchkSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * 
    if (child != originalChild ||
        !(child->getOpCode().isDiv() || child->getOpCode().isRem()))
       {
-      TR::Node::recreateAndCopyValidProperties(node, TR::treetop);
+      TR::Node::recreate(node, TR::treetop);
       node->setFirst(child);
       return node;
       }
@@ -16839,7 +16839,7 @@ TR::Node *divchkSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * 
          {
          //s->removeNode(node, s->_curTree);
          //return NULL;
-         TR::Node::recreateAndCopyValidProperties(node, TR::treetop);
+         TR::Node::recreate(node, TR::treetop);
          return node;
          }
       }
@@ -17227,7 +17227,7 @@ TR::Node *bndchkwithspinechkSimplifier(TR::Node * node, TR::Block * block, TR::S
       baseChild->incReferenceCount();
 
       s->prepareToReplaceNode(node);
-      TR::Node::recreateAndCopyValidProperties(node, TR::SpineCHK);
+      TR::Node::recreate(node, TR::SpineCHK);
       node->setChild(0, elementChild);
       node->setChild(1, baseChild);
       node->setChild(2, indexChild);
@@ -17242,7 +17242,7 @@ TR::Node *bndchkwithspinechkSimplifier(TR::Node * node, TR::Block * block, TR::S
       boundChild->incReferenceCount();
 
       s->prepareToReplaceNode(node);
-      TR::Node::recreateAndCopyValidProperties(node, TR::BNDCHK);
+      TR::Node::recreate(node, TR::BNDCHK);
       node->setChild(0, boundChild);
       node->setChild(1, indexChild);
       node->setNumChildren(2);

--- a/compiler/optimizer/OMRSimplifierHelpers.cpp
+++ b/compiler/optimizer/OMRSimplifierHelpers.cpp
@@ -369,7 +369,7 @@ TR::Node *foldRedundantAND(TR::Node * node, TR::ILOpCodes andOpCode, TR::ILOpCod
     performTransformation(s->comp(), "%sFolding redundant AND node [%s] and its children [%s, %s]\n",
                            s->optDetailString(), node->getName(s->getDebug()), lhsChild->getName(s->getDebug()), constChild->getName(s->getDebug())))
       {
-      TR::Node::recreateAndCopyValidProperties(andChild, andChild->getFirstChild()->getOpCodeValue());
+      TR::Node::recreate(andChild, andChild->getFirstChild()->getOpCodeValue());
       node->setAndIncChild(0, andChild->getFirstChild());
       s->prepareToStopUsingNode(andChild, s->_curTree);
       andChild->recursivelyDecReferenceCount();
@@ -415,7 +415,7 @@ void makeConstantTheRightChildAndSetOpcode(TR::Node * node, TR::Node * & firstCh
       TR_ASSERT(node->getOpCode().getOpCodeForSwapChildren() != TR::BadILOp,
              "cannot swap children of irreversible op");
       if (swapChildren(node, firstChild, secondChild, s))
-         TR::Node::recreateAndCopyValidProperties(node, node->getOpCode().getOpCodeForSwapChildren());
+         TR::Node::recreate(node, node->getOpCode().getOpCodeForSwapChildren());
       }
    }
 

--- a/compiler/optimizer/OMRTransformUtil.cpp
+++ b/compiler/optimizer/OMRTransformUtil.cpp
@@ -188,7 +188,7 @@ OMR::TransformUtil::scalarizeArrayCopy(
             cg->recursivelyDecReferenceCount(node->getChild(c));
          }
 
-      TR::Node::recreateAndCopyValidProperties(node, store->getOpCodeValue());
+      TR::Node::recreate(node, store->getOpCodeValue());
       node->setSymbolReference(store->getSymbolReference());
 
       if (store->getOpCode().isStoreIndirect())

--- a/compiler/optimizer/PartialRedundancy.cpp
+++ b/compiler/optimizer/PartialRedundancy.cpp
@@ -872,7 +872,7 @@ void TR_PartialRedundancy::processReusedNode(TR::Node *node, TR::ILOpCodes newOp
    if (newSymRef)
       node = TR::Node::recreateWithSymRefAndCopyValidProperties(node, newOpCode, newSymRef);
    else
-      node = TR::Node::recreateAndCopyValidProperties(node, newOpCode);
+      node = TR::Node::recreate(node, newOpCode);
 
    if(node->getOpCode().isLoadVarDirect()) node->setIsNodeCreatedByPRE();
 
@@ -1131,7 +1131,7 @@ TR::TreeTop *TR_PartialRedundancy::placeComputationsOptimally(TR::Block *block, 
                          }
 
                       if (notLastInsertionInBlock)
-                         TR::Node::recreateAndCopyValidProperties(notLastInsertionInBlock->getNode(), TR::treetop);
+                         TR::Node::recreate(notLastInsertionInBlock->getNode(), TR::treetop);
                       lastInsertionMade = placeToInsertOptimalComputations;
                       if (optimalNode->getSideTableIndex() != nextOptimalComputation)
                          lastInsertionCanBeRemoved = false;
@@ -1232,7 +1232,7 @@ TR::TreeTop *TR_PartialRedundancy::placeComputationsOptimally(TR::Block *block, 
                isOriginallyTreeTop = true;
 
             if (isOriginallyTreeTop)
-               TR::Node::recreateAndCopyValidProperties(nextOptimalNode, TR::NULLCHK);
+               TR::Node::recreate(nextOptimalNode, TR::NULLCHK);
 
             vcount_t visitCount1 = comp()->incOrResetVisitCount();
             TR_ScratchList<TR::Node> seenNodes(trMemory()), duplicateNodes(trMemory());
@@ -1284,7 +1284,7 @@ TR::TreeTop *TR_PartialRedundancy::placeComputationsOptimally(TR::Block *block, 
 
             duplicateOptimalNode->setReferenceCount(0);
             if (isOriginallyTreeTop)
-               TR::Node::recreateAndCopyValidProperties(nextOptimalNode, TR::treetop);
+               TR::Node::recreate(nextOptimalNode, TR::treetop);
 
             TR::SymbolReference *newSymRef = nextOptimalNode->getSymbolReference();
             TR::Node *passThroughNode = TR::Node::create(TR::PassThrough, 1, duplicateOptimalNode);
@@ -1666,12 +1666,12 @@ void TR_PartialRedundancy::eliminateRedundantComputations(TR::Block *block, TR::
                   if (0 && performTransformation(comp(), "%sEliminating redundant check computation (resolve or null check) : %p\n", OPT_DETAILS, currentTree->getNode())) // Look at check-in comment for version 1.296
                      {
                      if (firstOpCodeInTree.getOpCodeValue() == TR::NULLCHK)
-                        TR::Node::recreateAndCopyValidProperties(currentTree->getNode(), TR::treetop);
+                        TR::Node::recreate(currentTree->getNode(), TR::treetop);
                      else if (firstOpCodeInTree.getOpCodeValue() == TR::ResolveAndNULLCHK)
-                        TR::Node::recreateAndCopyValidProperties(currentTree->getNode(), TR::ResolveCHK);
+                        TR::Node::recreate(currentTree->getNode(), TR::ResolveCHK);
 
                      if (firstOpCodeInTree.getOpCodeValue() == TR::ResolveCHK)
-                        TR::Node::recreateAndCopyValidProperties(currentTree->getNode(), TR::treetop);
+                        TR::Node::recreate(currentTree->getNode(), TR::treetop);
 
                      currentTree->getNode()->setSideTableIndex(-1);
                      currentTree->getNode()->setNumChildren(1);
@@ -1786,12 +1786,12 @@ void TR_PartialRedundancy::eliminateRedundantComputations(TR::Block *block, TR::
                   if (performTransformation(comp(), "%sEliminating redundant check computation (resolve or null check) : %p\n", OPT_DETAILS, currentTree->getNode()))
                      {
                      if (firstOpCodeInTree.getOpCodeValue() == TR::NULLCHK)
-                        TR::Node::recreateAndCopyValidProperties(currentTree->getNode(), TR::treetop);
+                        TR::Node::recreate(currentTree->getNode(), TR::treetop);
                      else if (firstOpCodeInTree.getOpCodeValue() == TR::ResolveAndNULLCHK)
-                        TR::Node::recreateAndCopyValidProperties(currentTree->getNode(), TR::ResolveCHK);
+                        TR::Node::recreate(currentTree->getNode(), TR::ResolveCHK);
 
                     if (firstOpCodeInTree.getOpCodeValue() == TR::ResolveCHK)
-                       TR::Node::recreateAndCopyValidProperties(currentTree->getNode(), TR::treetop);
+                       TR::Node::recreate(currentTree->getNode(), TR::treetop);
 
                      currentTree->getNode()->setNumChildren(1);
 
@@ -1924,7 +1924,7 @@ bool TR_PartialRedundancy::eliminateRedundantSupportedNodes(TR::Node *parent, TR
          // check to a treetop
          //
          if (parent->getOpCode().isNullCheck())
-            TR::Node::recreateAndCopyValidProperties(parent, TR::treetop);
+            TR::Node::recreate(parent, TR::treetop);
          }
       return true;
       }
@@ -2125,7 +2125,7 @@ bool TR_PartialRedundancy::eliminateRedundantSupportedNodes(TR::Node *parent, TR
                manager()->setAlteredCode(true);
 
                if (parent->getOpCode().isNullCheck())
-                  TR::Node::recreateAndCopyValidProperties(parent, TR::treetop);
+                  TR::Node::recreate(parent, TR::treetop);
                }
             }
          }
@@ -2193,7 +2193,7 @@ TR::TreeTop *TR_PartialRedundancy::replaceOptimalSubNodes(TR::TreeTop *curTree, 
             if (trace())
                traceMsg(comp(), "Duplicate parent %p had its old child %p replaced by %p with symRef #%d\n", duplicateParent, duplicateOptimalNode, newLoad, newLoad->getSymbolReference()->getReferenceNumber());
             if (duplicateParent->getOpCode().isNullCheck())
-               TR::Node::recreateAndCopyValidProperties(duplicateParent, TR::treetop);
+               TR::Node::recreate(duplicateParent, TR::treetop);
             }
          else
             {

--- a/compiler/optimizer/SinkStores.cpp
+++ b/compiler/optimizer/SinkStores.cpp
@@ -2323,7 +2323,7 @@ void TR_SinkStores::doSinking()
          //originalStore->getPrevTreeTop()->setNextTreeTop(originalNext);
          //originalStore->getNextTreeTop()->setPrevTreeTop(originalPrev);
          //originalStore->getNode()->recursivelyDecReferenceCount();
-         TR::Node::recreateAndCopyValidProperties(originalStore->getNode(), TR::treetop);
+         TR::Node::recreate(originalStore->getNode(), TR::treetop);
          //requestOpt(deadTreesElimination, true, originalStore->getEnclosingBlock()->startOfExtendedBlock());
          }
       }

--- a/compiler/optimizer/StripMiner.cpp
+++ b/compiler/optimizer/StripMiner.cpp
@@ -984,7 +984,7 @@ TR::Block *TR_StripMiner::createStartOffsetLoop(LoopInfo *li, TR::Block *outerHe
 
    newLtNode->setAndIncChild(0, iAndNode);
    newLtNode->setAndIncChild(1, zeroNode);
-   TR::Node::recreateAndCopyValidProperties(newLtNode, isInt32 ? TR::ificmple : TR::iflcmple);
+   TR::Node::recreate(newLtNode, isInt32 ? TR::ificmple : TR::iflcmple);
 
    // now fixup the edges
    //
@@ -1247,7 +1247,7 @@ TR::Block *TR_StripMiner::stripMineLoop(LoopInfo *li, TR::Block *outerHeader)
    //constNode is L-1-pre-post
    jNode = jNode->duplicateTree();
    constNode = constNode->duplicateTree();
-   TR::Node::recreateAndCopyValidProperties(mainLtTree->getNode(), cmpOpCode);
+   TR::Node::recreate(mainLtTree->getNode(), cmpOpCode);
    mainLtTree->getNode()->getChild(0)->recursivelyDecReferenceCount();
    mainLtTree->getNode()->setAndIncChild(0, jNode);
    mainLtTree->getNode()->getChild(1)->recursivelyDecReferenceCount();

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -2224,7 +2224,7 @@ TR::Node *constrainIaload(TR_ValuePropagation *vp, TR::Node *node)
                         if (targetConstraint && targetConstraint->getKnownObject())
                            targetKOI = targetConstraint->getKnownObject()->getIndex();
                         vp->removeChildren(node);
-                        TR::Node::recreateAndCopyValidProperties(node, TR::aload);
+                        TR::Node::recreate(node, TR::aload);
                         node->setNumChildren(0);
                         node->setSymbolReference(vp->comp()->getSymRefTab()->createKnownStaticRefereneceSymbolRef(bypassLocation, targetKOI));
                         return node;
@@ -2742,7 +2742,7 @@ void canRemoveWrtBar(TR_ValuePropagation *vp, TR::Node *node)
                if (node->getChild(2) != node->getFirstChild())
                   invalidateInfo = true;
 
-               TR::Node::recreateAndCopyValidProperties(node, TR::astorei);
+               TR::Node::recreate(node, TR::astorei);
                node->getChild(2)->recursivelyDecReferenceCount();
                node->setNumChildren(2);
                node->setIsNull(true);
@@ -2757,7 +2757,7 @@ void canRemoveWrtBar(TR_ValuePropagation *vp, TR::Node *node)
             {
             if (performTransformation(vp->comp(), "%sChanging write barrier store into astore [%p]\n", OPT_DETAILS, node))
                {
-               TR::Node::recreateAndCopyValidProperties(node, TR::astore);
+               TR::Node::recreate(node, TR::astore);
                node->getChild(1)->recursivelyDecReferenceCount();
                node->setNumChildren(1);
                node->setIsNull(true);
@@ -3409,7 +3409,7 @@ TR::Node *constrainInstanceOf(TR_ValuePropagation *vp, TR::Node *node)
                }
             else
                {
-               TR::Node::recreateAndCopyValidProperties(node, TR::acmpne);
+               TR::Node::recreate(node, TR::acmpne);
                vp->removeNode(node->getChild(1), true);
                node->setAndIncChild(1, TR::Node::create(node, TR::aconst, 0, 0));
                }
@@ -3504,7 +3504,7 @@ TR::Node *constrainInstanceOf(TR_ValuePropagation *vp, TR::Node *node)
                      }
                   else
                      {
-                  TR::Node::recreateAndCopyValidProperties(node, TR::acmpne);
+                  TR::Node::recreate(node, TR::acmpne);
                   vp->removeNode(node->getChild(1), true);
                   node->setAndIncChild(1, TR::Node::create(node, TR::aconst, 0, 0));
                      }
@@ -3713,7 +3713,7 @@ TR::Node *constrainCheckcast(TR_ValuePropagation *vp, TR::Node *node)
       TR::Node *classNode = node->getSecondChild();
       vp->optimizer()->getEliminatedCheckcastNodes().add(node);
       vp->optimizer()->getClassPointerNodes().add(classNode);
-      TR::Node::recreateAndCopyValidProperties(node, TR::treetop);
+      TR::Node::recreate(node, TR::treetop);
       node->setNumChildren(1);
       vp->removeNode(classNode);
       vp->setChecksRemoved();
@@ -4992,7 +4992,7 @@ static void devirtualizeCall(TR_ValuePropagation *vp, TR::Node *node)
          // getResolvedInterfaceMethod.
          if (methodSymbol->isInterface())
             methodSymbol = refineMethodSymbolInCall(vp, node, symRef, resolvedMethod, offset);
-         TR::Node::recreateAndCopyValidProperties(node, methodSymbol->getMethod()->directCallOpCode());
+         TR::Node::recreate(node, methodSymbol->getMethod()->directCallOpCode());
 
          // remove the generated first argument
          //
@@ -5368,7 +5368,7 @@ TR::Node *constrainCall(TR_ValuePropagation *vp, TR::Node *node)
                vp->_curTree->insertBefore(helpersCallTT);
 
                method = hashCodeMethodSymRef->getSymbol()->castToMethodSymbol()->getMethod();
-               TR::Node::recreateAndCopyValidProperties(node, method->directCallOpCode());
+               TR::Node::recreate(node, method->directCallOpCode());
                TR::Node *removedChild = node->getFirstChild();
                //vp->removeNode(removedChild);
                removedChild->recursivelyDecReferenceCount();
@@ -5519,7 +5519,7 @@ void transformToOptimizedCloneCall(TR_ValuePropagation *vp, TR::Node *node, bool
         vp->_curTree->insertBefore(helpersCallTT);
 
         method = optimizedCloneSymRef->getSymbol()->castToMethodSymbol()->getMethod();
-        TR::Node::recreateAndCopyValidProperties(node, method->directCallOpCode());
+        TR::Node::recreate(node, method->directCallOpCode());
         TR::Node *firstChild = node->getFirstChild();
         firstChild->decReferenceCount();
         node->setNumChildren(2);
@@ -6555,7 +6555,7 @@ TR::Node *constrainLdiv(TR_ValuePropagation *vp, TR::Node *node)
           performTransformation(vp->comp(), "%sChange node [" POINTER_PRINTF_FORMAT "] ldiv->i2l of idiv\n",OPT_DETAILS, node))
          {
          // Change node into i2l to be used by any commoned references
-         TR::Node::recreateAndCopyValidProperties(node, TR::i2l);
+         TR::Node::recreate(node, TR::i2l);
          node->setNumChildren(1);
 
          TR::Node *lhsNode = TR::Node::create(TR::l2i, 1, firstChild);
@@ -7351,10 +7351,10 @@ TR::Node *constrainIshr(TR_ValuePropagation *vp, TR::Node *node)
    if(firstChild->isNonNegative() /*&& firstChild->getType().isSignedInt()*/ && vp->lastTimeThrough() &&
       performTransformation(vp->comp(), "%sChange node [" POINTER_PRINTF_FORMAT "] ishr->iushr\n",OPT_DETAILS, node))
       {
-      TR::Node::recreateAndCopyValidProperties(node, TR::iushr);
+      TR::Node::recreate(node, TR::iushr);
       //TR::Node *lhs = node->getFirstChild();
       //TR::Node *rhs = node->getSecondChild();
-      //TR::Node::recreateAndCopyValidProperties(node, TR::iu2i);
+      //TR::Node::recreate(node, TR::iu2i);
       //node->setNumChildren(1);
       //TR::Node *newIushrNode = TR::Node::create(vp->comp(), TR::iushr, 2, lhs, rhs);
       //node->setAndIncChild(0, newIushrNode);
@@ -7928,10 +7928,10 @@ TR::Node *constrainIand(TR_ValuePropagation *vp, TR::Node *node)
          performTransformation(vp->comp(), "%s Node [" POINTER_PRINTF_FORMAT "]: ishr -> iushr (parent ignores sign bits)\n",
                                 OPT_DETAILS, firstChild))
          {
-         TR::Node::recreateAndCopyValidProperties(firstChild, TR::iushr);
+         TR::Node::recreate(firstChild, TR::iushr);
          //TR::Node *lhs = firstChild->getFirstChild();
          //TR::Node *rhs = firstChild->getSecondChild();
-         //TR::Node::recreateAndCopyValidProperties(firstChild, TR::iu2i);
+         //TR::Node::recreate(firstChild, TR::iu2i);
          //firstChild->setNumChildren(1);
          //TR::Node *newIushrNode = TR::Node::create(vp->comp(), TR::iushr, 2, lhs, rhs);
          //firstChild->setAndIncChild(0, newIushrNode);
@@ -8294,8 +8294,8 @@ void replaceWithSmallerType(TR_ValuePropagation *vp, TR::Node *node)
       value->recursivelyDecReferenceCount();
 
       // change opcode of the def and use nodes to store and load smaller type
-      TR::Node::recreateAndCopyValidProperties(defNode, comp->il.opCodeForDirectStore(newType));
-      TR::Node::recreateAndCopyValidProperties(node, comp->il.opCodeForDirectLoad(newType));
+      TR::Node::recreate(defNode, comp->il.opCodeForDirectStore(newType));
+      TR::Node::recreate(node, comp->il.opCodeForDirectLoad(newType));
       node->getFirstChild()->recursivelyDecReferenceCount();
       node->setNumChildren(0);
 
@@ -8778,7 +8778,7 @@ static void changeConditionalToGoto(TR_ValuePropagation *vp, TR::Node *node, TR:
    // Remove the children and change the node to a goto,
    //
    vp->removeChildren(node, false);
-   TR::Node::recreateAndCopyValidProperties(node, TR::Goto);
+   TR::Node::recreate(node, TR::Goto);
    vp->setEnableSimplifier();
 
    // Remember that the fall-through edge is to be removed
@@ -10825,7 +10825,7 @@ static TR::Node *constrainCmpeqne(TR_ValuePropagation *vp, TR::Node *node, bool 
          {
          vp->removeChildren(node);
          TR::ILOpCodes op = /*isUnsigned ? TR::iuconst : */TR::iconst;
-         TR::Node::recreateAndCopyValidProperties(node, op);
+         TR::Node::recreate(node, op);
          node->setInt(result);
          vp->invalidateValueNumberInfo();
          return node;
@@ -11007,7 +11007,7 @@ static TR::Node *constrainCmplessthan(TR_ValuePropagation *vp, TR::Node *node, T
          {
          vp->removeChildren(node);
          TR::ILOpCodes op = /*isUnsigned ? TR::iuconst : */TR::iconst;
-         TR::Node::recreateAndCopyValidProperties(node, op);
+         TR::Node::recreate(node, op);
          node->setInt(result);
          vp->invalidateValueNumberInfo();
          return node;
@@ -11464,7 +11464,7 @@ TR::Node *constrainNullChk(TR_ValuePropagation *vp, TR::Node *node)
          if (vp->comp()->useCompressedPointers() &&
                child->getOpCode().isStoreIndirect())
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::treetop);
+            TR::Node::recreate(node, TR::treetop);
             }
          else
             {
@@ -11479,7 +11479,7 @@ TR::Node *constrainNullChk(TR_ValuePropagation *vp, TR::Node *node)
          }
       else
          {
-         TR::Node::recreateAndCopyValidProperties(node, TR::treetop);
+         TR::Node::recreate(node, TR::treetop);
          }
       vp->setChecksRemoved();
       }
@@ -11504,7 +11504,7 @@ TR::Node *constrainZeroChk(TR_ValuePropagation *vp, TR::Node *node)
             {
             for (int32_t i = 1; i < node->getNumChildren(); i++)
                node->getChild(i)->recursivelyDecReferenceCount();
-            TR::Node::recreateAndCopyValidProperties(node, TR::treetop);
+            TR::Node::recreate(node, TR::treetop);
             node->setNumChildren(1);
             vp->setChecksRemoved();
             }
@@ -11538,7 +11538,7 @@ TR::Node *constrainResolveChk(TR_ValuePropagation *vp, TR::Node *node)
    // Processing the child could have caused it to be removed
    if (node->getNumChildren()==0)
       {
-      TR::Node::recreateAndCopyValidProperties(node, TR::treetop);
+      TR::Node::recreate(node, TR::treetop);
       return node;
       }
 
@@ -11566,7 +11566,7 @@ TR::Node *constrainResolveChk(TR_ValuePropagation *vp, TR::Node *node)
          if (vp->comp()->useCompressedPointers() &&
                child->getOpCode().isStoreIndirect())
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::treetop);
+            TR::Node::recreate(node, TR::treetop);
             }
          else
             {
@@ -11582,7 +11582,7 @@ TR::Node *constrainResolveChk(TR_ValuePropagation *vp, TR::Node *node)
          }
       else
          {
-         TR::Node::recreateAndCopyValidProperties(node, TR::treetop);
+         TR::Node::recreate(node, TR::treetop);
          }
       vp->setChecksRemoved();
       }
@@ -11643,7 +11643,7 @@ TR::Node *constrainResolveNullChk(TR_ValuePropagation *vp, TR::Node *node)
          {
          if (performTransformation(vp->comp(), "%sChanging ResolveAndNULLCHK node into a treetop node [%p]\n", OPT_DETAILS, node))
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::treetop);
+            TR::Node::recreate(node, TR::treetop);
             vp->setChecksRemoved();
             }
          }
@@ -11651,7 +11651,7 @@ TR::Node *constrainResolveNullChk(TR_ValuePropagation *vp, TR::Node *node)
          {
          if (performTransformation(vp->comp(), "%sChanging ResolveAndNULLCHK node into a ResolveCHK node [%p]\n", OPT_DETAILS, node))
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::ResolveCHK);
+            TR::Node::recreate(node, TR::ResolveCHK);
             vp->setChecksRemoved();
             }
          }
@@ -11660,7 +11660,7 @@ TR::Node *constrainResolveNullChk(TR_ValuePropagation *vp, TR::Node *node)
       {
       if (performTransformation(vp->comp(), "%sChanging ResolveAndNULLCHK node into a NULLCHK node [%p]\n", OPT_DETAILS, node))
          {
-         TR::Node::recreateAndCopyValidProperties(node, TR::NULLCHK);
+         TR::Node::recreate(node, TR::NULLCHK);
          node->setSymbolReference(vp->comp()->getSymRefTab()->findOrCreateNullCheckSymbolRef(vp->comp()->getMethodSymbol()));
          vp->setChecksRemoved();
          }
@@ -11765,7 +11765,7 @@ TR::Node *constrainDivChk(TR_ValuePropagation *vp, TR::Node *node)
 
    if (removeDivCheck &&
        performTransformation(vp->comp(), "%sRemoving redundant div check node [%p]\n", OPT_DETAILS, node))
-      TR::Node::recreateAndCopyValidProperties(node, TR::treetop);
+      TR::Node::recreate(node, TR::treetop);
    else
       {
       if (!complexDivCheck)
@@ -11813,7 +11813,7 @@ TR::Node *constrainBndChk(TR_ValuePropagation *vp, TR::Node *node)
          // Change this node to a treetop containing the index (which is
          // currently the second child of the bounds check).
          //
-         TR::Node::recreateAndCopyValidProperties(node, TR::treetop);
+         TR::Node::recreate(node, TR::treetop);
          vp->removeNode(sizeNode);
          node->setChild(0, indexNode);
          node->setChild(1, NULL);
@@ -11832,7 +11832,7 @@ TR::Node *constrainBndChk(TR_ValuePropagation *vp, TR::Node *node)
       // Change this node to a treetop containing the index (which is
       // currently the second child of the bounds check).
       //
-      TR::Node::recreateAndCopyValidProperties(node, TR::treetop);
+      TR::Node::recreate(node, TR::treetop);
       vp->removeNode(sizeNode);
       node->setChild(0, indexNode);
       node->setChild(1, NULL);
@@ -12044,7 +12044,7 @@ TR::Node *constrainBndChkWithSpineChk(TR_ValuePropagation *vp, TR::Node *node)
       {
       // Change this node to a treetop containing the index.
       //
-      TR::Node::recreateAndCopyValidProperties(node, TR::treetop);
+      TR::Node::recreate(node, TR::treetop);
 
       TR::Node *arrayElement = node->getChild(0);
       TR::Node *baseArray = node->getChild(1);
@@ -12080,7 +12080,7 @@ TR::Node *constrainBndChkWithSpineChk(TR_ValuePropagation *vp, TR::Node *node)
       {
       // Convert the node to a spine check.
       //
-      TR::Node::recreateAndCopyValidProperties(node, TR::SpineCHK);
+      TR::Node::recreate(node, TR::SpineCHK);
 
       vp->removeNode(sizeNode);
       node->setChild(2, indexNode);
@@ -12093,7 +12093,7 @@ TR::Node *constrainBndChkWithSpineChk(TR_ValuePropagation *vp, TR::Node *node)
       {
       // Convert the node to a bound check.
       //
-      TR::Node::recreateAndCopyValidProperties(node, TR::BNDCHK);
+      TR::Node::recreate(node, TR::BNDCHK);
       TR::Node *arrayElement = node->getChild(0);
       TR::Node *baseArray = node->getChild(1);
       vp->removeNode(baseArray);
@@ -12505,7 +12505,7 @@ TR::Node *constrainArrayStoreChk(TR_ValuePropagation *vp, TR::Node *node)
          {
          // Child is the iastore. Just change this node to a treetop
          //
-         TR::Node::recreateAndCopyValidProperties(node, TR::treetop);
+         TR::Node::recreate(node, TR::treetop);
          //DemandLiteralPool can add extra aload to arraystore check node, but treetop can only have one child
          if (vp->comp()->cg()->supportsOnDemandLiteralPool() && node->getNumChildren() > 1)
             {

--- a/compiler/optimizer/ValuePropagation.cpp
+++ b/compiler/optimizer/ValuePropagation.cpp
@@ -2727,33 +2727,33 @@ void TR_ValuePropagation::replaceByConstant(TR::Node *node, TR_VPConstraint *con
    switch (type)
       {
       case TR::Int32:
-         TR::Node::recreateAndCopyValidProperties(node, TR::iconst);
+         TR::Node::recreate(node, TR::iconst);
          node->setInt(constraint->asIntConst()->getInt());
          dumpOptDetails(comp(), " to iconst %d\n", node->getInt());
          break;
       case TR::Int8:
-         TR::Node::recreateAndCopyValidProperties(node, TR::bconst);
+         TR::Node::recreate(node, TR::bconst);
          node->setByte(constraint->asIntConst()->getInt());
          dumpOptDetails(comp(), " to bconst %d\n", node->getByte());
          break;
       case TR::Int16:
-         TR::Node::recreateAndCopyValidProperties(node, TR::sconst);
+         TR::Node::recreate(node, TR::sconst);
          (shortConstraint == NULL) ? node->setShortInt(constraint->asIntConst()->getInt()) :
              node->setShortInt(constraint->asShortConst()->getShort());
          dumpOptDetails(comp(), " to sconst %d\n", node->getShortInt());
          break;
       case TR::Int64:
-         TR::Node::recreateAndCopyValidProperties(node, TR::lconst);
+         TR::Node::recreate(node, TR::lconst);
          node->setLongInt(constraint->asLongConst()->getLong());
          dumpOptDetails(comp(), " to lconst " INT64_PRINTF_FORMAT "\n", node->getLongInt());
          break;
       case TR::Float:
-         TR::Node::recreateAndCopyValidProperties(node, TR::fconst);
+         TR::Node::recreate(node, TR::fconst);
          node->setFloatBits(constraint->asIntConst()->getInt());
          dumpOptDetails(comp(), " to fconst [float const]\n");
          break;
       case TR::Double:
-         TR::Node::recreateAndCopyValidProperties(node, TR::dconst);
+         TR::Node::recreate(node, TR::dconst);
          node->setLongInt(constraint->asLongConst()->getLong());
          dumpOptDetails(comp(), " to dconst [double const]\n");
          break;
@@ -2762,7 +2762,7 @@ void TR_ValuePropagation::replaceByConstant(TR::Node *node, TR_VPConstraint *con
             {
             node->setIsDontMoveUnderBranch(false);
             }
-         TR::Node::recreateAndCopyValidProperties(node, TR::aconst);
+         TR::Node::recreate(node, TR::aconst);
          node->setAddress(0);
          TR_ASSERT(constraint->isNullObject(), "Only null address constant supported");
          dumpOptDetails(comp(), " to aconst " UINT64_PRINTF_FORMAT_HEX "\n", (uint64_t)node->getAddress());
@@ -6497,7 +6497,7 @@ void TR_ValuePropagation::removeBndChecksFromFastVersion(BlockVersionInfo *block
             for (TR::Node *bndchk = iter.getFirst(); bndchk; bndchk = iter.getNext())
                {
                dumpOptDetails(comp(), "blockVersioner: removing bndchk %p\n", bndchk);
-               TR::Node::recreateAndCopyValidProperties(bndchk, TR::treetop);
+               TR::Node::recreate(bndchk, TR::treetop);
                removeNode(bndchk->getFirstChild(),false);
                bndchk->setChild(0, bndchk->getSecondChild());
                bndchk->setChild(1, NULL);
@@ -6968,7 +6968,7 @@ void TR_ValuePropagation::transformUnknownTypeArrayCopy(TR_TreeTopWrtBarFlag *ar
 static void changeBranchToGoto(TR_ValuePropagation *vp, TR::Node *guardNode, TR::Block *guard)
    {
    // change the if to goto
-   TR::Node::recreateAndCopyValidProperties(guardNode, TR::Goto);
+   TR::Node::recreate(guardNode, TR::Goto);
    guardNode->getFirstChild()->recursivelyDecReferenceCount();
    guardNode->getSecondChild()->recursivelyDecReferenceCount();
    guardNode->setNumChildren(0);
@@ -7010,7 +7010,7 @@ void TR_ValuePropagation::transformStringConcats(TR_VPStringCached *stringCached
      if (appendTree[i])
         {
         appendTree[i]->getNode()->recursivelyDecReferenceCount();
-        TR::Node::recreateAndCopyValidProperties(appendTree[i]->getNode(), TR::treetop);
+        TR::Node::recreate(appendTree[i]->getNode(), TR::treetop);
         appendTree[i]->getNode()->setNumChildren(1);
         appendTree[i]->getNode()->setAndIncChild(0, appendedString[i]);
         }
@@ -7021,10 +7021,10 @@ void TR_ValuePropagation::transformStringConcats(TR_VPStringCached *stringCached
 
 
   // vCall to cachedConstantStringArray
-  TR::Node::recreateAndCopyValidProperties(toStringTree->getNode(), TR::treetop);
+  TR::Node::recreate(toStringTree->getNode(), TR::treetop);
   stringNode = toStringTree->getNode()->getFirstChild();
   stringNode->getFirstChild()->recursivelyDecReferenceCount();
-  TR::Node::recreateAndCopyValidProperties(stringNode, TR::acall);
+  TR::Node::recreate(stringNode, TR::acall);
   stringNode->setNumChildren(3);
   TR::SymbolReference *symRef = getStringCacheRef() ? comp()->getSymRefTab()->findOrCreateMethodSymbol(stringNode->getSymbolReference()->getOwningMethodIndex(), -1, getStringCacheRef()->getSymbol()->getResolvedMethodSymbol()->getResolvedMethod(), TR::MethodSymbol::Static) : 0;
   stringNode->setSymbolReference(symRef);
@@ -7124,7 +7124,7 @@ void TR_ValuePropagation::transformStringCtors(TR_VPTreeTopPair *treeTopPair)
   */
 
   treeTopPair->_treetop2->getNode()->getFirstChild()->getFirstChild()->decReferenceCount();
-  TR::Node::recreateAndCopyValidProperties(treeTopPair->_treetop2->getNode()->getFirstChild(), TR::acall);
+  TR::Node::recreate(treeTopPair->_treetop2->getNode()->getFirstChild(), TR::acall);
   treeTopPair->_treetop2->getNode()->getFirstChild()->setNumChildren(3);
   TR::SymbolReference *symRef = getStringCacheRef() ? comp()->getSymRefTab()->findOrCreateMethodSymbol(treeTopPair->_treetop2->getNode()->getFirstChild()->getSymbolReference()->getOwningMethodIndex(), -1, getStringCacheRef()->getSymbol()->getResolvedMethodSymbol()->getResolvedMethod(), TR::MethodSymbol::Static) : 0;
   treeTopPair->_treetop2->getNode()->getFirstChild()->setSymbolReference(symRef);
@@ -7686,7 +7686,7 @@ void TR_ValuePropagation::doDelayedTransformations()
    for (getComponentCallNode = nodesIt.getFirst();
         getComponentCallNode; getComponentCallNode = nodesIt.getNext())
       {
-      TR::Node::recreateAndCopyValidProperties(getComponentCallNode, TR::aloadi);
+      TR::Node::recreate(getComponentCallNode, TR::aloadi);
       getComponentCallNode->setSymbolReference(comp()->getSymRefTab()->findOrCreateArrayComponentTypeSymbolRef());
       if (getComponentCallNode->getNumChildren() > 1)
          {
@@ -7755,17 +7755,17 @@ void TR_ValuePropagation::doDelayedTransformations()
             }
          if (treeTop->getNode()->getOpCodeValue() == TR::NULLCHK)
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::PassThrough);
+            TR::Node::recreate(node, TR::PassThrough);
             treeTop = TR::TreeTop::create(comp(), treeTop, TR::Node::createWithSymRef(TR::astore, 1, 1, node->getFirstChild(), firstNode->getSymbolReference()));
             }
          else
             {
-            TR::Node::recreateAndCopyValidProperties(node, TR::astore);
+            TR::Node::recreate(node, TR::astore);
             node->setSymbolReference(firstNode->getSymbolReference());
             }
          }
       else if (!firstReferenceOfCatchObject)
-         TR::Node::recreateAndCopyValidProperties(node, node->getReferenceCount() == 0 ? TR::treetop : TR::PassThrough);
+         TR::Node::recreate(node, node->getReferenceCount() == 0 ? TR::treetop : TR::PassThrough);
       else
          firstTT = 0;
 
@@ -7964,7 +7964,7 @@ void TR_ValuePropagation::doDelayedTransformations()
                //  clnCallNode->setNumChildren(2);
                //  }
                clnCallNode->setAndIncChild(1, nullNode);
-               TR::Node::recreateAndCopyValidProperties(clnCallNode, TR::acall);
+               TR::Node::recreate(clnCallNode, TR::acall);
                clnCallNode->setSymbolReference(optClnClassSymRef);
                }
             }
@@ -8002,7 +8002,7 @@ void TR_ValuePropagation::doDelayedTransformations()
       else
          {
          TR::Block *newBlock = block->breakFallThrough(comp(), block, nextBlock);
-         TR::Node::recreateAndCopyValidProperties(ifNode, TR::ifacmpne);
+         TR::Node::recreate(ifNode, TR::ifacmpne);
 
          newBlock->getLastRealTreeTop()->getNode()->setBranchDestination(ifNode->getBranchDestination());
 

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -1711,7 +1711,7 @@ void TR_ValuePropagation::transformArrayCopyCall(TR::Node *node)
       TR::Node *stride = NULL;
 
       node->setNodeIsRecognizedArrayCopyCall(false); // flag conflicts with isForwardArrayCopy
-      TR::Node::recreateAndCopyValidProperties(node, TR::arraycopy);
+      TR::Node::recreate(node, TR::arraycopy);
 
       if (!comp()->generateArraylets())
          {
@@ -2252,7 +2252,7 @@ void TR_ValuePropagation::generateArrayTranslateNode(TR::TreeTop *callTree,TR::T
 
 /*
    TR::Node* arrayTranslateNode = arrayTranslateTree->getNode()->getFirstChild();
-   TR::Node::recreateAndCopyValidProperties(arrayTranslateNode, TR::arraytranslate);
+   TR::Node::recreate(arrayTranslateNode, TR::arraytranslate);
    arrayTranslateNode->setNumChildren(6);
 */
    arrayTranslateNode->setSymbolReference(comp()->getSymRefTab()->findOrCreateArrayTranslateSymbol());
@@ -2671,7 +2671,7 @@ void TR_ValuePropagation::generateRTArrayNodeWithoutFlags(TR_RealTimeArrayCopy *
    //   TR::Node* arraycopyNode = TR::Node::createArraycopy(srcOff, dstOff, len);
    TR::Node* arraycopyNode = dupArraycopyTree->getNode()->getFirstChild();
    arraycopyNode->setNodeIsRecognizedArrayCopyCall(false); // flag conflicts with isForwardArrayCopy
-   TR::Node::recreateAndCopyValidProperties(arraycopyNode, TR::arraycopy);
+   TR::Node::recreate(arraycopyNode, TR::arraycopy);
    if (primitive)
       {
       arraycopyNode->setAndIncChild(0, srcOff);
@@ -3464,7 +3464,7 @@ void TR_ValuePropagation::transformObjectCloneCall(TR::TreeTop *callTree, TR_Val
       TR_ASSERT(callTree->getNode()->getOpCodeValue() == TR::NULLCHK, "it only makes sense to do this object clone transform for checks with a NULLCHK - how did we get here otherwise??");
       TR::Node *passthrough = TR::Node::create(callNode, TR::PassThrough, 1, callNode->getChild(0));
       callTree->insertBefore(TR::TreeTop::create(comp(), TR::Node::createWithSymRef(callNode, callTree->getNode()->getOpCodeValue(), 1, passthrough, callTree->getNode()->getSymbolReference())));
-      TR::Node::recreateAndCopyValidProperties(callTree->getNode(), TR::treetop);
+      TR::Node::recreate(callTree->getNode(), TR::treetop);
       }
    else
       {
@@ -3562,7 +3562,7 @@ void TR_ValuePropagation::transformArrayCloneCall(TR::TreeTop *callTree, TR_Opaq
       TR_ASSERT(callTree->getNode()->getOpCodeValue() == TR::NULLCHK, "it only makes sense to do this array clone transform for checks with a NULLCHK - how did we get here otherwise??");
       TR::Node *passthrough = TR::Node::create(callNode, TR::PassThrough, 1, callNode->getChild(0));
       callTree->insertBefore(TR::TreeTop::create(comp(), TR::Node::createWithSymRef(callNode, callTree->getNode()->getOpCodeValue(), 1, passthrough, callTree->getNode()->getSymbolReference())));
-      TR::Node::recreateAndCopyValidProperties(callTree->getNode(), TR::treetop);
+      TR::Node::recreate(callTree->getNode(), TR::treetop);
       }
    else
       {
@@ -3760,7 +3760,7 @@ void TR_ValuePropagation::transformConverterCall(TR::TreeTop *callTree)
    TR::SymbolReference *symRefConvert =
       getSymRefTab()->createTemporary(comp()->getMethodSymbol(), callNode->getDataType(), false);
 
-   TR::Node::recreateAndCopyValidProperties(callNode, TR::iload);
+   TR::Node::recreate(callNode, TR::iload);
    callNode->setSymbolReference(symRefConvert);
    callNode->setFlags(0);
    callNode->removeAllChildren();

--- a/compiler/optimizer/VirtualGuardCoalescer.cpp
+++ b/compiler/optimizer/VirtualGuardCoalescer.cpp
@@ -898,7 +898,7 @@ void TR_VirtualGuardTailSplitter::remergeGuard(TR_BlockCloner &cloner, VGInfo *i
    //
    TR::TreeTop *ifTree = cloneG->getLastRealTreeTop();
    ifTree->getNode()->removeAllChildren();
-   TR::Node::recreateAndCopyValidProperties(ifTree->getNode(), TR::Goto);
+   TR::Node::recreate(ifTree->getNode(), TR::Goto);
 
    // Fix the if tree in G
    //
@@ -1166,7 +1166,7 @@ int32_t TR_VirtualGuardTailSplitter::rematerializeThis()
          #endif
 
          TR::Node *origThis = callNode->getFirstChild()->getFirstChild();
-         //TR::Node::recreateAndCopyValidProperties(origThis, thisExpr->getOpCodeValue());
+         //TR::Node::recreate(origThis, thisExpr->getOpCodeValue());
          //origThis->setSymbolReference(thisExpr->getSymbolReference());
 
          numGuardsChanged++;
@@ -1218,7 +1218,7 @@ int32_t TR_VirtualGuardTailSplitter::rematerializeThis()
          if (origThis != callNode->getSecondChild())
             {
             TR::Node *secondChild = callNode->getSecondChild();
-            TR::Node::recreateAndCopyValidProperties(secondChild, thisExpr->getOpCodeValue());
+            TR::Node::recreate(secondChild, thisExpr->getOpCodeValue());
             secondChild->setSymbolReference(thisExpr->getSymbolReference());
 
             int32_t i;
@@ -1265,7 +1265,7 @@ void TR_VirtualGuardTailSplitter::canonicalizeTree(TR::Node *node, List<TR_SymNo
          if (symRef == pair->_symRef)
             {
               //dumpOptDetails(comp(), "Matched for node %p\n", node);
-            TR::Node::recreateAndCopyValidProperties(node, pair->_node->getOpCodeValue());
+            TR::Node::recreate(node, pair->_node->getOpCodeValue());
             node->setSymbolReference(pair->_node->getSymbolReference());
              node->setNumChildren(pair->_node->getNumChildren());
             canonicalized = true;

--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -1346,14 +1346,14 @@ TR::Register *OMR::Power::TreeEvaluator::compareIntsForEquality(TR::InstOpCode::
        cannotInline = true;
        if(!(comp->isOptServer()))
           {
-          TR::Node::recreateAndCopyValidProperties(firstChild, TR::icall);
+          TR::Node::recreate(firstChild, TR::icall);
           }
        }
 
     src1Reg   = cg->evaluate(firstChild);
     if (cannotInline)
        {
-       TR::Node::recreateAndCopyValidProperties(firstChild, TR::instanceof);
+       TR::Node::recreate(firstChild, TR::instanceof);
        }
     condReg = cg->allocateRegister(TR_CCR);
 
@@ -1602,11 +1602,11 @@ TR::Register *OMR::Power::TreeEvaluator::compareLongsForEquality(TR::InstOpCode:
             secondChild->setRegister(secondShiftResultReg);
             if (node->getOpCode().isIf())
                {
-               TR::Node::recreateAndCopyValidProperties(node, node->getOpCode().isCompareTrueIfEqual() ? TR::ificmpeq : TR::ificmpne);
+               TR::Node::recreate(node, node->getOpCode().isCompareTrueIfEqual() ? TR::ificmpeq : TR::ificmpne);
                }
             else
                {
-               TR::Node::recreateAndCopyValidProperties(node, node->getOpCode().isCompareTrueIfEqual() ? TR::icmpeq : TR::icmpne);
+               TR::Node::recreate(node, node->getOpCode().isCompareTrueIfEqual() ? TR::icmpeq : TR::icmpne);
                }
             return compareIntsForEquality(branchOp, dstLabel, node, cg, isHint, likeliness);
             }
@@ -1788,15 +1788,15 @@ TR::Register *OMR::Power::TreeEvaluator::ifacmpeqEvaluator(TR::Node *node, TR::C
    {
    if (TR::Compiler->target.is64Bit())
       {
-      TR::Node::recreateAndCopyValidProperties(node, TR::iflcmpeq);
+      TR::Node::recreate(node, TR::iflcmpeq);
       iflcmpeqEvaluator(node, cg);
       }
    else
       {
-      TR::Node::recreateAndCopyValidProperties(node, TR::ificmpeq);
+      TR::Node::recreate(node, TR::ificmpeq);
       ificmpeqEvaluator(node, cg);
       }
-   TR::Node::recreateAndCopyValidProperties(node, TR::ifacmpeq);
+   TR::Node::recreate(node, TR::ifacmpeq);
    return NULL;
    }
 
@@ -1804,15 +1804,15 @@ TR::Register *OMR::Power::TreeEvaluator::ifacmpneEvaluator(TR::Node *node, TR::C
    {
    if (TR::Compiler->target.is64Bit())
       {
-      TR::Node::recreateAndCopyValidProperties(node, TR::iflcmpne);
+      TR::Node::recreate(node, TR::iflcmpne);
       iflcmpeqEvaluator(node, cg);
       }
    else
       {
-      TR::Node::recreateAndCopyValidProperties(node, TR::ificmpne);
+      TR::Node::recreate(node, TR::ificmpne);
       ificmpeqEvaluator(node, cg);
       }
-   TR::Node::recreateAndCopyValidProperties(node, TR::ifacmpne);
+   TR::Node::recreate(node, TR::ifacmpne);
    return NULL;
    }
 

--- a/compiler/p/codegen/FPTreeEvaluator.cpp
+++ b/compiler/p/codegen/FPTreeEvaluator.cpp
@@ -866,10 +866,10 @@ TR::Register *OMR::Power::TreeEvaluator::fstoreEvaluator(TR::Node *node, TR::Cod
          node->setAndIncChild(childIndex, child->getFirstChild());
       else
          node->setChild(childIndex, child->getFirstChild());
-      TR::Node::recreateAndCopyValidProperties(node, indirect?TR::istorei:TR::istore);
+      TR::Node::recreate(node, indirect?TR::istorei:TR::istore);
       istoreEvaluator(node, cg);
       node->setChild(childIndex, child);
-      TR::Node::recreateAndCopyValidProperties(node, indirect?TR::fstorei:TR::fstore);
+      TR::Node::recreate(node, indirect?TR::fstorei:TR::fstore);
       cg->decReferenceCount(child);
       return NULL;
       }
@@ -912,10 +912,10 @@ TR::Register* OMR::Power::TreeEvaluator::dstoreEvaluator(TR::Node *node, TR::Cod
          node->setAndIncChild(childIndex, child->getFirstChild());
       else
          node->setChild(childIndex, child->getFirstChild());
-      TR::Node::recreateAndCopyValidProperties(node, indirect?TR::lstorei:TR::lstore);
+      TR::Node::recreate(node, indirect?TR::lstorei:TR::lstore);
       lstoreEvaluator(node, cg);
       node->setChild(childIndex, child);
-      TR::Node::recreateAndCopyValidProperties(node, indirect?TR::dstorei:TR::dstore);
+      TR::Node::recreate(node, indirect?TR::dstorei:TR::dstore);
       cg->decReferenceCount(child);
       return NULL;
       }

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -944,18 +944,18 @@ TR::Register *OMR::Power::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::Cod
          if (node->getOpCode().isIndirect())
             {
             node->setChild(1, valueChild->getFirstChild());
-            TR::Node::recreateAndCopyValidProperties(node, TR::fstorei);
+            TR::Node::recreate(node, TR::fstorei);
             fstoreEvaluator(node, cg);
             node->setChild(1, valueChild);
-            TR::Node::recreateAndCopyValidProperties(node, TR::istorei);
+            TR::Node::recreate(node, TR::istorei);
             }
          else
             {
             node->setChild(0, valueChild->getFirstChild());
-            TR::Node::recreateAndCopyValidProperties(node, TR::fstore);
+            TR::Node::recreate(node, TR::fstore);
             fstoreEvaluator(node, cg);
             node->setChild(0, valueChild);
-            TR::Node::recreateAndCopyValidProperties(node, TR::istore);
+            TR::Node::recreate(node, TR::istore);
             }
          cg->decReferenceCount(valueChild);
          return NULL;
@@ -1125,18 +1125,18 @@ TR::Register *OMR::Power::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::Cod
          if (node->getOpCode().isIndirect())
             {
             node->setChild(1, valueChild->getFirstChild());
-            TR::Node::recreateAndCopyValidProperties(node, TR::dstorei);
+            TR::Node::recreate(node, TR::dstorei);
             dstoreEvaluator(node, cg);
             node->setChild(1, valueChild);
-            TR::Node::recreateAndCopyValidProperties(node, TR::lstorei);
+            TR::Node::recreate(node, TR::lstorei);
             }
          else
             {
             node->setChild(0, valueChild->getFirstChild());
-            TR::Node::recreateAndCopyValidProperties(node, TR::dstore);
+            TR::Node::recreate(node, TR::dstore);
             dstoreEvaluator(node, cg);
             node->setChild(0, valueChild);
-            TR::Node::recreateAndCopyValidProperties(node, TR::lstore);
+            TR::Node::recreate(node, TR::lstore);
             }
          cg->decReferenceCount(valueChild);
          return NULL;
@@ -2470,7 +2470,7 @@ TR::Register *OMR::Power::TreeEvaluator::vdlogEvaluator(TR::Node *node, TR::Code
     {
     TR::SymbolReference *helper = cg->comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_PPCVectorLogDouble, false, false, true);
     helper->getSymbol()->castToMethodSymbol()->setLinkage(TR_System);
-    TR::Node::recreateAndCopyValidProperties(node, TR::vcall);
+    TR::Node::recreate(node, TR::vcall);
     node->setSymbolReference(helper);
 
     return directCallEvaluator(node, cg);
@@ -4193,9 +4193,9 @@ TR::Register *OMR::Power::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::
    if (debug("noArrayCopy"))
       {
       TR::ILOpCodes opCode = node->getOpCodeValue();
-      TR::Node::recreateAndCopyValidProperties(node, TR::call);
+      TR::Node::recreate(node, TR::call);
       TR::Register *targetRegister = directCallEvaluator(node, cg);
-      TR::Node::recreateAndCopyValidProperties(node, opCode);
+      TR::Node::recreate(node, opCode);
       return targetRegister;
       }
 

--- a/compiler/p/codegen/UnaryEvaluator.cpp
+++ b/compiler/p/codegen/UnaryEvaluator.cpp
@@ -1019,21 +1019,21 @@ TR::Register *OMR::Power::TreeEvaluator::acmpleEvaluator(TR::Node *node, TR::Cod
 
 TR::Register *OMR::Power::TreeEvaluator::libmFuncEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::Node::recreateAndCopyValidProperties(node, TR::dcall);
+   TR::Node::recreate(node, TR::dcall);
    TR::Register *trgReg = directCallEvaluator(node, cg);
    return trgReg;
    }
 
 TR::Register *OMR::Power::TreeEvaluator::strcmpEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::Node::recreateAndCopyValidProperties(node, TR::icall);
+   TR::Node::recreate(node, TR::icall);
    TR::Register *trgReg = directCallEvaluator(node, cg);
    return trgReg;
    }
 
 TR::Register *OMR::Power::TreeEvaluator::strcFuncEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::Node::recreateAndCopyValidProperties(node, TR::acall);
+   TR::Node::recreate(node, TR::acall);
    TR::Register *trgReg = directCallEvaluator(node, cg);
    return trgReg;
    }

--- a/compiler/x/amd64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluator.cpp
@@ -90,18 +90,18 @@ TR::Register *OMR::X86::AMD64::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR
          if (node->getOpCode().isIndirect())
             {
             node->setChild(1, valueChild->getFirstChild());
-            TR::Node::recreateAndCopyValidProperties(node, TR::dstorei);
+            TR::Node::recreate(node, TR::dstorei);
             floatingPointStoreEvaluator(node, cg);
             node->setChild(1, valueChild);
-            TR::Node::recreateAndCopyValidProperties(node, TR::lstorei);
+            TR::Node::recreate(node, TR::lstorei);
             }
          else
             {
             node->setChild(0, valueChild->getFirstChild());
-            TR::Node::recreateAndCopyValidProperties(node, TR::dstore);
+            TR::Node::recreate(node, TR::dstore);
             floatingPointStoreEvaluator(node, cg);
             node->setChild(0, valueChild);
-            TR::Node::recreateAndCopyValidProperties(node, TR::lstore);
+            TR::Node::recreate(node, TR::lstore);
             }
          cg->decReferenceCount(valueChild);
          return NULL;

--- a/compiler/x/codegen/BinaryEvaluator.cpp
+++ b/compiler/x/codegen/BinaryEvaluator.cpp
@@ -2626,7 +2626,7 @@ TR::X86RegInstruction  *OMR::X86::TreeEvaluator::generateRegisterShift(TR::Node 
                 grandChild->getReferenceCount() == 1 &&
                 grandChild->getRegister() == 0)
                {
-               TR::Node::recreateAndCopyValidProperties(grandChild, TR::bloadi);
+               TR::Node::recreate(grandChild, TR::bloadi);
                secondChild->decReferenceCount();
                secondChild = grandChild;
                if (reportShiftAmount)
@@ -2637,7 +2637,7 @@ TR::X86RegInstruction  *OMR::X86::TreeEvaluator::generateRegisterShift(TR::Node 
                      grandChild->getReferenceCount() == 1 &&
                      grandChild->getRegister() == 0)
                {
-               TR::Node::recreateAndCopyValidProperties(grandChild, TR::bload);
+               TR::Node::recreate(grandChild, TR::bload);
                secondChild->decReferenceCount();
                secondChild = grandChild;
                if (reportShiftAmount)
@@ -2739,7 +2739,7 @@ TR::X86MemInstruction  *OMR::X86::TreeEvaluator::generateMemoryShift(TR::Node *n
                 grandChild->getReferenceCount() == 1 &&
                 grandChild->getRegister() == 0)
                {
-               TR::Node::recreateAndCopyValidProperties(grandChild, TR::bloadi);
+               TR::Node::recreate(grandChild, TR::bloadi);
                secondChild->decReferenceCount();
                secondChild = grandChild;
                if (reportShiftAmount)
@@ -2749,7 +2749,7 @@ TR::X86MemInstruction  *OMR::X86::TreeEvaluator::generateMemoryShift(TR::Node *n
                      grandChild->getReferenceCount() == 1 &&
                      grandChild->getRegister() == 0)
                {
-               TR::Node::recreateAndCopyValidProperties(grandChild, TR::bload);
+               TR::Node::recreate(grandChild, TR::bload);
                secondChild->decReferenceCount();
                secondChild = grandChild;
                if (reportShiftAmount)

--- a/compiler/x/codegen/CompareAnalyser.cpp
+++ b/compiler/x/codegen/CompareAnalyser.cpp
@@ -184,9 +184,9 @@ static TR::Register *optimizeIU2L(TR::Node *child, TR::ILOpCodes origOp, TR::Cod
       }
    if (op != TR::BadILOp)
       {
-      TR::Node::recreateAndCopyValidProperties(child, op);
+      TR::Node::recreate(child, op);
       reg = cg->evaluate(child);
-      TR::Node::recreateAndCopyValidProperties(child, origOp);
+      TR::Node::recreate(child, origOp);
       }
    else
       {

--- a/compiler/x/codegen/FPCompareAnalyser.cpp
+++ b/compiler/x/codegen/FPCompareAnalyser.cpp
@@ -310,7 +310,7 @@ TR::Register *TR_X86FPCompareAnalyser::fpCompareAnalyser(TR::Node       *root,
    if (getReversedOperands())
       {
       cmpOp = TR::ILOpCode(cmpOp).getOpCodeForSwapChildren();
-      TR::Node::recreateAndCopyValidProperties(root, cmpOp);
+      TR::Node::recreate(root, cmpOp);
       }
 
    if (useFCOMIInstructions && !targetRegisterForFTST)
@@ -683,7 +683,7 @@ TR::Register *TR_IA32XMMCompareAnalyser::xmmCompareAnalyser(TR::Node       *root
    if (getReversedOperands())
       {
       cmpOp = TR::ILOpCode(cmpOp).getOpCodeForSwapChildren();
-      TR::Node::recreateAndCopyValidProperties(root, cmpOp);
+      TR::Node::recreate(root, cmpOp);
       }
 
    return NULL;

--- a/compiler/x/codegen/FPTreeEvaluator.cpp
+++ b/compiler/x/codegen/FPTreeEvaluator.cpp
@@ -387,7 +387,7 @@ TR::Register *OMR::X86::TreeEvaluator::floatingPointStoreEvaluator(TR::Node *nod
       //
       TR::Node *integerValueChild = valueChild->getFirstChild();
       static TR::ILOpCodes integerOpCodes[2][2] = { {TR::istore, TR::lstore}, {TR::istorei, TR::lstorei} };
-      TR::Node::recreateAndCopyValidProperties(node, integerOpCodes[nodeIsIndirect][(valueChild->getOpCodeValue() == TR::ibits2f ? 0 : 1)]);
+      TR::Node::recreate(node, integerOpCodes[nodeIsIndirect][(valueChild->getOpCodeValue() == TR::ibits2f ? 0 : 1)]);
       node->setChild(nodeIsIndirect, integerValueChild);
       integerValueChild->incReferenceCount();
 
@@ -1141,7 +1141,7 @@ TR::Register *OMR::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::Symbo
       TR::Register *targetRegister = cg->allocateRegisterPair(lowReg, highReg);
       TR::SymbolReference *d2l = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_IA32double2LongSSE,false,false,false);
       d2l->getSymbol()->getMethodSymbol()->setLinkage(TR_Helper);
-      TR::Node::recreateAndCopyValidProperties(node, TR::lcall);
+      TR::Node::recreate(node, TR::lcall);
       node->setSymbolReference(d2l);
       TR_OutlinedInstructions *outlinedHelperCall = new (cg->trHeapMemory()) TR_OutlinedInstructions(node, TR::lcall, targetRegister, CallLabel, reStartLabel, cg);
       cg->getOutlinedInstructionsList().push_front(outlinedHelperCall);

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -1108,18 +1108,18 @@ TR::Register *OMR::X86::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::CodeG
          if (node->getOpCode().isIndirect())
             {
             node->setChild(1, valueChild->getFirstChild());
-            TR::Node::recreateAndCopyValidProperties(node, TR::fstorei);
+            TR::Node::recreate(node, TR::fstorei);
             floatingPointStoreEvaluator(node, cg);
             node->setChild(1, valueChild);
-            TR::Node::recreateAndCopyValidProperties(node, TR::istorei);
+            TR::Node::recreate(node, TR::istorei);
             }
          else
             {
             node->setChild(0, valueChild->getFirstChild());
-            TR::Node::recreateAndCopyValidProperties(node, TR::fstore);
+            TR::Node::recreate(node, TR::fstore);
             floatingPointStoreEvaluator(node, cg);
             node->setChild(0, valueChild);
-            TR::Node::recreateAndCopyValidProperties(node, TR::istore);
+            TR::Node::recreate(node, TR::istore);
             }
          cg->decReferenceCount(valueChild);
          return NULL;
@@ -3470,11 +3470,11 @@ OMR::X86::TreeEvaluator::performHelperCall(
       TR::CodeGenerator *cg)
    {
    TR::ILOpCodes opCode = node->getOpCodeValue();
-   TR::Node::recreateAndCopyValidProperties(node, helperCallOpCode);
+   TR::Node::recreate(node, helperCallOpCode);
    if(helperSymRef)
       node->setSymbolReference(helperSymRef);
    TR::Register *targetReg = performCall(node, false, spillFPRegs, cg);
-   TR::Node::recreateAndCopyValidProperties(node, opCode);
+   TR::Node::recreate(node, opCode);
    return targetReg;
    }
 

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -3602,7 +3602,7 @@ bool TR::X86FPCompareRegRegInstruction::swapOperands()
    // Communicate to FCMPEVAL what the new opcode is.
    // This cobbles the tree node; probably not a good idea if
    // the IL is still needed after register assignment.
-   TR::Node::recreateAndCopyValidProperties(node, swappedOp);
+   TR::Node::recreate(node, swappedOp);
 
    if (debug("dumpFPRA"))
       diagnostic("%s, ", node->getOpCode().getName());

--- a/compiler/x/codegen/UnaryEvaluator.cpp
+++ b/compiler/x/codegen/UnaryEvaluator.cpp
@@ -128,11 +128,11 @@ TR::Register *OMR::X86::TreeEvaluator::i2bEvaluator(TR::Node *node, TR::CodeGene
          {
          if (firstChild->getOpCode().isLoadIndirect())
             {
-            TR::Node::recreateAndCopyValidProperties(firstChild, TR::bloadi);
+            TR::Node::recreate(firstChild, TR::bloadi);
             }
          else
             {
-            TR::Node::recreateAndCopyValidProperties(firstChild, TR::bload);
+            TR::Node::recreate(firstChild, TR::bload);
             }
          }
       }

--- a/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
@@ -392,18 +392,18 @@ TR::Register *OMR::X86::i386::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR:
          if (node->getOpCode().isIndirect())
             {
             node->setChild(1, valueChild->getFirstChild());
-            TR::Node::recreateAndCopyValidProperties(node, TR::dstorei);
+            TR::Node::recreate(node, TR::dstorei);
             dstoreEvaluator(node, cg);
             node->setChild(1, valueChild);
-            TR::Node::recreateAndCopyValidProperties(node, TR::lstorei);
+            TR::Node::recreate(node, TR::lstorei);
             }
          else
             {
             node->setChild(0, valueChild->getFirstChild());
-            TR::Node::recreateAndCopyValidProperties(node, TR::dstore);
+            TR::Node::recreate(node, TR::dstore);
             dstoreEvaluator(node, cg);
             node->setChild(0, valueChild);
-            TR::Node::recreateAndCopyValidProperties(node, TR::lstore);
+            TR::Node::recreate(node, TR::lstore);
             }
          cg->decReferenceCount(valueChild);
          return NULL;
@@ -2552,9 +2552,9 @@ TR::Register *OMR::X86::i386::TreeEvaluator::l2iEvaluator(TR::Node *node, TR::Co
 
 TR::Register *OMR::X86::i386::TreeEvaluator::ifacmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::Node::recreateAndCopyValidProperties(node, TR::ificmpeq);
+   TR::Node::recreate(node, TR::ificmpeq);
    integerIfCmpeqEvaluator(node, cg);
-   TR::Node::recreateAndCopyValidProperties(node, TR::ifacmpeq);
+   TR::Node::recreate(node, TR::ifacmpeq);
    return NULL;
    }
 
@@ -2562,9 +2562,9 @@ TR::Register *OMR::X86::i386::TreeEvaluator::ifacmpeqEvaluator(TR::Node *node, T
 
 TR::Register *OMR::X86::i386::TreeEvaluator::acmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::Node::recreateAndCopyValidProperties(node, TR::icmpeq);
+   TR::Node::recreate(node, TR::icmpeq);
    TR::Register *targetRegister = integerCmpeqEvaluator(node, cg);
-   TR::Node::recreateAndCopyValidProperties(node, TR::acmpeq);
+   TR::Node::recreate(node, TR::acmpeq);
    return targetRegister;
    }
 
@@ -2992,7 +2992,7 @@ TR::Register *OMR::X86::i386::TreeEvaluator::dstoreEvaluator(TR::Node *node, TR:
       //
       TR::Node *longValueChild = valueChild->getFirstChild();
       static TR::ILOpCodes longOpCodes[2] = { TR::lstore, TR::lstorei };
-      TR::Node::recreateAndCopyValidProperties(node, longOpCodes[nodeIsIndirect]);
+      TR::Node::recreate(node, longOpCodes[nodeIsIndirect]);
       node->setChild(nodeIsIndirect, longValueChild);
       longValueChild->incReferenceCount();
 

--- a/compiler/z/codegen/FPTreeEvaluator.cpp
+++ b/compiler/z/codegen/FPTreeEvaluator.cpp
@@ -1639,7 +1639,7 @@ OMR::Z::TreeEvaluator::l2fEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 #else
    else
       {
-      TR::Node::recreateAndCopyValidProperties(node, TR::fcall);
+      TR::Node::recreate(node, TR::fcall);
       node->setSymbolReference(cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390jitMathHelperConvertLongToFloat, false, false, false));
       return cg->evaluate(node);
       }

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -3002,7 +3002,7 @@ tryGenerateConversionRXComparison(TR::Node *node, TR::CodeGenerator *cg, bool *i
 
    if (convertToSignExtension)
       {
-      TR::Node::recreateAndCopyValidProperties(regNode, TR::s2i);
+      TR::Node::recreate(regNode, TR::s2i);
       regNode->setUnneededConversion(false); // it is definitely needed now
       }
 
@@ -14743,9 +14743,9 @@ TR::Register *OMR::Z::TreeEvaluator::deallocaEvaluator(TR::Node *node, TR::CodeG
 TR::Register *OMR::Z::TreeEvaluator::libmFuncEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (node->getOpCode().isFloat())
-      TR::Node::recreateAndCopyValidProperties(node, TR::fcall);
+      TR::Node::recreate(node, TR::fcall);
    else if (node->getOpCode().isDouble())
-      TR::Node::recreateAndCopyValidProperties(node, TR::dcall);
+      TR::Node::recreate(node, TR::dcall);
    else
       TR_ASSERT(false, "Invalid type for libmFuncEvaluator.\n");
 
@@ -14783,7 +14783,7 @@ TR::Register *OMR::Z::TreeEvaluator::libxloptFuncEvaluator(TR::Node *node, TR::C
        }
      }
 
-   TR::Node::recreateAndCopyValidProperties(node, TR::ILOpCode::getDirectCall(node->getDataType()));
+   TR::Node::recreate(node, TR::ILOpCode::getDirectCall(node->getDataType()));
    node->setSymbolReference(callSymRef);
 
    // And finally evaluate the tree


### PR DESCRIPTION
As part of renaming `Node::recreateAndCopyValidProperties` to `Node::recreate`, redefine the current `recreate` as `recreateAndCopyValidProperties`. Also deprecate `recreateAndCopyValidProperties`, and change all uses of it to `recreate`.