### PR TITLE
Support glueless compiler builds.

### DIFF
--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -64,8 +64,11 @@ namespace OMR { typedef OMR::Compilation CompilationConnector; }
 #include "ras/Debug.hpp"                      // for TR_DebugBase
 #include "ras/DebugCounter.hpp"               // for TR_DebugCounter, etc
 
-
+#ifdef GLUELESS
+struct OMR_VMThread;
+#else
 #include "omr.h"
+#endif
 
 #include "il/symbol/ResolvedMethodSymbol.hpp" // REMOVE_THIS_LATER
 

--- a/compiler/control/CompileMethod.cpp
+++ b/compiler/control/CompileMethod.cpp
@@ -47,8 +47,13 @@
 #include "ilgen/IlGeneratorMethodDetails.hpp"
 #include "infra/Assert.hpp"                    // for TR_ASSERT
 #include "ras/Debug.hpp"                       // for createDebugObject, etc
-#include "omr.h"
 #include "env/SystemSegmentProvider.hpp"
+
+#ifdef GLUELESS
+struct OMR_VMThread;
+#else
+#include "omr.h"
+#endif 
 
 static void
 writePerfToolEntry(void *start, uint32_t size, const char *name)

--- a/compiler/env/OMRCPU.cpp
+++ b/compiler/env/OMRCPU.cpp
@@ -20,7 +20,10 @@
 #include "env/CompilerEnv.hpp"
 #include "infra/Assert.hpp"
 #include "env/defines.h"
+
+#ifndef GLUELESS
 #include "omrcfg.h"
+#endif
 
 TR::CPU *
 OMR::CPU::self()
@@ -33,17 +36,17 @@ void
 OMR::CPU::initializeByHostQuery()
    {
 
+   char SwapTest[2] = { 1, 0 };
+   bool isHostLittleEndian = (*(short *)SwapTest == 1);
+
+#ifndef GLUELESS
 #ifdef OMR_ENV_LITTLE_ENDIAN
    _endianness = TR::endian_little;
 #else
    _endianness = TR::endian_big;
 #endif
-
    // Validate host endianness #define with an additional compile-time test
    //
-   char SwapTest[2] = { 1, 0 };
-   bool isHostLittleEndian = (*(short *)SwapTest == 1);
-
    if (_endianness == TR::endian_little)
       {
       TR_ASSERT(isHostLittleEndian, "expecting host to be little endian");
@@ -52,6 +55,12 @@ OMR::CPU::initializeByHostQuery()
       {
       TR_ASSERT(!isHostLittleEndian, "expecting host to be big endian");
       }
+#else 
+   // Don't have OMR glue, so we're not relying on OMR's processor detection,
+   // so we just use the computed endianness
+   
+   _endianness = isHostLittleEndian ? TR::endian_little : TR::endian_big; 
+#endif
 
 #if defined(TR_HOST_X86)
    _majorArch = TR::arch_x86;


### PR DESCRIPTION
By including including omr.h and omrcfg.h we assume we've connected up a
glue for OMR. This isn't actually necessary right now for the OMR JIT.
We get by just fine without actually having an OMR glue with a few minor
modifications to the JIT code.

Adds a new `#define` flag `GLUELESS` to enable this functionality. 