### PR TITLE
Annotate Symbol hierarchy as extensible

### DIFF
--- a/compiler/compile/Compilation.hpp
+++ b/compiler/compile/Compilation.hpp
@@ -33,7 +33,7 @@ struct OMR_VMThread;
 
 namespace TR
 {
-class Compilation : public OMR::CompilationConnector
+class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
    {
    public:
 

--- a/compiler/il/Symbol.hpp
+++ b/compiler/il/Symbol.hpp
@@ -52,7 +52,7 @@
 namespace TR
 {
 
-class Symbol : public OMR::SymbolConnector
+class OMR_EXTENSIBLE Symbol : public OMR::SymbolConnector
    {
 
 public:

--- a/compiler/il/symbol/AutomaticSymbol.hpp
+++ b/compiler/il/symbol/AutomaticSymbol.hpp
@@ -29,7 +29,7 @@ namespace TR { class Compilation; }
 namespace TR
 {
 
-class AutomaticSymbol : public OMR::AutomaticSymbolConnector
+class OMR_EXTENSIBLE AutomaticSymbol : public OMR::AutomaticSymbolConnector
    {
 
 protected:

--- a/compiler/il/symbol/LabelSymbol.hpp
+++ b/compiler/il/symbol/LabelSymbol.hpp
@@ -26,7 +26,7 @@ namespace TR { class CodeGenerator; }
 
 namespace TR {
 
-class LabelSymbol : public OMR::LabelSymbolConnector
+class OMR_EXTENSIBLE LabelSymbol : public OMR::LabelSymbolConnector
    {
 
 protected:

--- a/compiler/il/symbol/MethodSymbol.hpp
+++ b/compiler/il/symbol/MethodSymbol.hpp
@@ -29,7 +29,7 @@ class TR_Method;
 namespace TR
 {
 
-class MethodSymbol : public OMR::MethodSymbolConnector
+class OMR_EXTENSIBLE MethodSymbol : public OMR::MethodSymbolConnector
    {
 
 protected:

--- a/compiler/il/symbol/OMRAutomaticSymbol.cpp
+++ b/compiler/il/symbol/OMRAutomaticSymbol.cpp
@@ -34,19 +34,49 @@ class TR_FrontEnd;
 namespace TR { class Node; }
 namespace TR { class SymbolReference; }
 
+OMR::AutomaticSymbol::AutomaticSymbol() :
+   TR::RegisterMappedSymbol()
+   {
+   self()->init();
+   }
+
+OMR::AutomaticSymbol::AutomaticSymbol(TR::DataTypes d) :
+   TR::RegisterMappedSymbol(d)
+   {
+   self()->init();
+   }
+
+OMR::AutomaticSymbol::AutomaticSymbol(TR::DataTypes d, uint32_t s) :
+   TR::RegisterMappedSymbol(d, s)
+   {
+   self()->init();
+   }
+
+OMR::AutomaticSymbol::AutomaticSymbol(TR::DataTypes d, uint32_t s, const char *name) :
+   TR::RegisterMappedSymbol(d, s)
+   {
+   self()->init(); _name = name;
+   }
+
+TR::AutomaticSymbol *
+OMR::AutomaticSymbol::self()
+   {
+   return static_cast<TR::AutomaticSymbol*>(this);
+   }
+
 rcount_t
 OMR::AutomaticSymbol::setReferenceCount(rcount_t i)
    {
-   if (isVariableSizeSymbol() && i > 0)
-      castToVariableSizeSymbol()->setIsReferenced();
+   if (self()->isVariableSizeSymbol() && i > 0)
+      self()->castToVariableSizeSymbol()->setIsReferenced();
    return (_referenceCount = i);
    }
 
 rcount_t
 OMR::AutomaticSymbol::incReferenceCount()
    {
-   if (isVariableSizeSymbol())
-      castToVariableSizeSymbol()->setIsReferenced();
+   if (self()->isVariableSizeSymbol())
+      self()->castToVariableSizeSymbol()->setIsReferenced();
    return ++_referenceCount;
    }
 

--- a/compiler/il/symbol/OMRAutomaticSymbol.hpp
+++ b/compiler/il/symbol/OMRAutomaticSymbol.hpp
@@ -46,7 +46,7 @@ namespace TR { class SymbolReference; }
 namespace OMR
 {
 
-class AutomaticSymbol : public TR::RegisterMappedSymbol
+class OMR_EXTENSIBLE AutomaticSymbol : public TR::RegisterMappedSymbol
    {
 
 public:
@@ -65,23 +65,17 @@ public:
 
 protected:
 
-   AutomaticSymbol() :
-      TR::RegisterMappedSymbol()
-      { init(); }
+   AutomaticSymbol();
 
-   AutomaticSymbol(TR::DataTypes d) :
-      TR::RegisterMappedSymbol(d)
-      { init(); }
+   AutomaticSymbol(TR::DataTypes d);
 
-   AutomaticSymbol(TR::DataTypes d, uint32_t s) :
-      TR::RegisterMappedSymbol(d, s)
-      { init(); }
+   AutomaticSymbol(TR::DataTypes d, uint32_t s);
 
-   AutomaticSymbol(TR::DataTypes d, uint32_t s, const char *name) :
-      TR::RegisterMappedSymbol(d, s)
-      { init(); _name = name; }
+   AutomaticSymbol(TR::DataTypes d, uint32_t s, const char *name);
 
    void init();
+
+   TR::AutomaticSymbol * self();
 
 public:
 

--- a/compiler/il/symbol/OMRLabelSymbol.cpp
+++ b/compiler/il/symbol/OMRLabelSymbol.cpp
@@ -132,11 +132,11 @@ OMR::LabelSymbol::makeRelativeLabelSymbol(intptr_t offset)
    // Is this assert here purely to ensure that the label size doesn't blow the buffer?
    TR_ASSERT(offset*2 > -9999999 && offset*2 < +9999999, "assertion failure");
 
-   setRelativeLabel();
+   self()->setRelativeLabel();
    _offset = offset;
    char * name = (char*)calloc(10,sizeof(char));  // FIXME: Leaked.
    sprintf(name, "%d", (int)(offset*2));
-   setName(name);
+   self()->setName(name);
    }
 
 TR::LabelSymbol *

--- a/compiler/il/symbol/OMRLabelSymbol.hpp
+++ b/compiler/il/symbol/OMRLabelSymbol.hpp
@@ -58,7 +58,7 @@ namespace OMR
  *
  * A label has an instruction, a code location...
  */
-class LabelSymbol : public TR::Symbol
+class OMR_EXTENSIBLE LabelSymbol : public TR::Symbol
    {
 public:
    TR::LabelSymbol * self();

--- a/compiler/il/symbol/OMRMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRMethodSymbol.cpp
@@ -35,7 +35,7 @@ OMR::MethodSymbol::MethodSymbol(TR_LinkageConventions lc, TR_Method * m) :
 bool
 OMR::MethodSymbol::firstArgumentIsReceiver()
    {
-   if (isSpecial() || isVirtual() || isInterface() || isComputedVirtual())
+   if (self()->isSpecial() || self()->isVirtual() || self()->isInterface() || self()->isComputedVirtual())
       return true;
 
    return false;
@@ -48,6 +48,11 @@ OMR::MethodSymbol::self()
    return static_cast<TR::MethodSymbol *>(this);
    }
 
+bool
+OMR::MethodSymbol::isComputed()
+   {
+   return self()->isComputedStatic() || self()->isComputedVirtual();
+   }
 
 /**
  * Method Symbol Factory.

--- a/compiler/il/symbol/OMRMethodSymbol.hpp
+++ b/compiler/il/symbol/OMRMethodSymbol.hpp
@@ -45,7 +45,7 @@ namespace OMR
 /**
  * Symbol for methods, along with information about the method
  */
-class MethodSymbol : public TR::Symbol
+class OMR_EXTENSIBLE MethodSymbol : public TR::Symbol
    {
 
 protected:
@@ -133,7 +133,7 @@ public:
 
    bool isComputedStatic()                     { return _methodFlags.testValue(MethodKindMask, ComputedStatic);}
    bool isComputedVirtual()                    { return _methodFlags.testValue(MethodKindMask, ComputedVirtual);}
-   bool isComputed()                           { return isComputedStatic() || isComputedVirtual(); }
+   bool isComputed();
 
    void setStatic()                            { _methodFlags.setValue(MethodKindMask, Static);}
    bool isStatic()                             { return _methodFlags.testValue(MethodKindMask, Static);}

--- a/compiler/il/symbol/OMRParameterSymbol.cpp
+++ b/compiler/il/symbol/OMRParameterSymbol.cpp
@@ -28,6 +28,12 @@
 #include "il/symbol/ParameterSymbol.hpp"  // for ParameterSymbol
 #include "infra/Flags.hpp"                // for flags32_t
 
+TR::ParameterSymbol *
+OMR::ParameterSymbol::self()
+   {
+   return static_cast<TR::ParameterSymbol*>(this);
+   }
+
 OMR::ParameterSymbol::ParameterSymbol(TR::DataTypes d, bool isUnsigned, int32_t slot) :
    TR::RegisterMappedSymbol(d),
    _registerIndex(-1),
@@ -39,8 +45,8 @@ OMR::ParameterSymbol::ParameterSymbol(TR::DataTypes d, bool isUnsigned, int32_t 
    _knownObjectIndex(TR::KnownObjectTable::UNKNOWN)
    {
    _flags.setValue(KindMask, IsParameter);
-   _addressSize = convertTypeToSize(TR::Address);
-   setOffset(slot * convertTypeToSize(TR::Address));
+   _addressSize = TR::ParameterSymbol::convertTypeToSize(TR::Address);
+   self()->setOffset(slot * TR::ParameterSymbol::convertTypeToSize(TR::Address));
    }
 
 OMR::ParameterSymbol::ParameterSymbol(TR::DataTypes d, bool isUnsigned, int32_t slot, size_t size) :
@@ -54,10 +60,21 @@ OMR::ParameterSymbol::ParameterSymbol(TR::DataTypes d, bool isUnsigned, int32_t 
    _knownObjectIndex(TR::KnownObjectTable::UNKNOWN)
    {
    _flags.setValue(KindMask, IsParameter);
-   _addressSize = convertTypeToSize(TR::Address);
-   setOffset(slot * convertTypeToSize(TR::Address));
+   _addressSize = TR::ParameterSymbol::convertTypeToSize(TR::Address);
+   self()->setOffset(slot * TR::ParameterSymbol::convertTypeToSize(TR::Address));
    }
 
+void
+OMR::ParameterSymbol::setParameterOffset(int32_t o)
+   {
+   self()->setOffset(o);
+   }
+
+int32_t
+OMR::ParameterSymbol::getSlot()
+   {
+   return self()->getParameterOffset() / (uint32_t)_addressSize; // cast _addressSize explicity
+   }
 
 template <typename AllocatorType>
 TR::ParameterSymbol * OMR::ParameterSymbol::create(AllocatorType m, TR::DataTypes d, bool isUnsigned, int32_t slot)

--- a/compiler/il/symbol/OMRParameterSymbol.hpp
+++ b/compiler/il/symbol/OMRParameterSymbol.hpp
@@ -40,7 +40,7 @@ namespace TR { class ParameterSymbol; }
 namespace OMR
 {
 
-class ParameterSymbol : public TR::RegisterMappedSymbol
+class OMR_EXTENSIBLE ParameterSymbol : public TR::RegisterMappedSymbol
    {
 
 protected:
@@ -48,6 +48,8 @@ protected:
    ParameterSymbol(TR::DataTypes d, bool isUnsigned, int32_t slot);
 
    ParameterSymbol(TR::DataTypes d, bool isUnsigned, int32_t slot, size_t size);
+
+   TR::ParameterSymbol * self();
 
 public:
 
@@ -58,9 +60,9 @@ public:
    static TR::ParameterSymbol * create(AllocatorType, TR::DataTypes, bool, int32_t, size_t);
 
    int32_t  getParameterOffset()               { return _mappedOffset; }
-   void     setParameterOffset(int32_t o)      { setOffset(o); }
+   void     setParameterOffset(int32_t o);
 
-   int32_t  getSlot()                          { return getParameterOffset() / (uint32_t)_addressSize;} // cast _addressSize explicity
+   int32_t  getSlot();
 
    int32_t  getOrdinal()                       { return _ordinal; }
    void     setOrdinal(int32_t o)              { _ordinal = o; }

--- a/compiler/il/symbol/OMRRegisterMappedSymbol.cpp
+++ b/compiler/il/symbol/OMRRegisterMappedSymbol.cpp
@@ -47,11 +47,41 @@ TR::RegisterMappedSymbol * OMR::RegisterMappedSymbol::create(AllocatorType m, TR
    return new (m) TR::RegisterMappedSymbol(d,s);
    }
 
+OMR::RegisterMappedSymbol::RegisterMappedSymbol(int32_t o) :
+   TR::Symbol(),
+   _mappedOffset(o),
+   _GCMapIndex(-1)
+   {
+   self()->setLiveLocalIndexUninitialized();
+   }
+
+OMR::RegisterMappedSymbol::RegisterMappedSymbol(TR::DataTypes d) :
+   TR::Symbol(d),
+   _mappedOffset(0),
+   _GCMapIndex(-1)
+   {
+   self()->setLiveLocalIndexUninitialized();
+   }
+
+OMR::RegisterMappedSymbol::RegisterMappedSymbol(TR::DataTypes d, uint32_t s) :
+   TR::Symbol(d, s),
+   _mappedOffset(0),
+   _GCMapIndex(-1)
+   {
+   self()->setLiveLocalIndexUninitialized();
+   }
+
+TR::RegisterMappedSymbol *
+OMR::RegisterMappedSymbol::self()
+   {
+   return static_cast<TR::RegisterMappedSymbol*>(this);
+   }
+
 void
 OMR::RegisterMappedSymbol::setLiveLocalIndex(uint16_t i, TR_FrontEnd * fe)
    {
    _liveLocalIndex = i;
-   if (isLiveLocalIndexUninitialized())
+   if (self()->isLiveLocalIndexUninitialized())
       {
       TR_ASSERT(0, "OMR::RegisterMappedSymbol::_liveLocalIndex == USHRT_MAX");
       fe->outOfMemory(0, "OMR::RegisterMappedSymbol::_liveLocalIndex == USHRT_MAX");

--- a/compiler/il/symbol/OMRRegisterMappedSymbol.hpp
+++ b/compiler/il/symbol/OMRRegisterMappedSymbol.hpp
@@ -59,34 +59,18 @@ namespace OMR
  *
  * \todo Concept doesn't have the best name, and should likely be renamed
  */
-class RegisterMappedSymbol : public TR::Symbol
+class OMR_EXTENSIBLE RegisterMappedSymbol : public TR::Symbol
    {
 
 protected:
 
-   RegisterMappedSymbol(int32_t o = 0) :
-      TR::Symbol(),
-      _mappedOffset(o),
-      _GCMapIndex(-1)
-      {
-      setLiveLocalIndexUninitialized();
-      }
+   RegisterMappedSymbol(int32_t o = 0);
 
-   RegisterMappedSymbol(TR::DataTypes d) :
-      TR::Symbol(d),
-      _mappedOffset(0),
-      _GCMapIndex(-1)
-      {
-      setLiveLocalIndexUninitialized();
-      }
+   RegisterMappedSymbol(TR::DataTypes d);
 
-   RegisterMappedSymbol(TR::DataTypes d, uint32_t s) :
-      TR::Symbol(d, s),
-      _mappedOffset(0),
-      _GCMapIndex(-1)
-      {
-      setLiveLocalIndexUninitialized();
-      }
+   RegisterMappedSymbol(TR::DataTypes d, uint32_t s);
+
+   TR::RegisterMappedSymbol * self();
 
 public:
 

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -96,11 +96,11 @@ TR::TreeTop *findEndTreeTop(TR::ResolvedMethodSymbol *rms)
 void
 OMR::ResolvedMethodSymbol::initForCompilation(TR::Compilation *comp)
    {
-   getParameterList()._trMemory = comp->trMemory();
-   getAutomaticList()._trMemory = comp->trMemory();
+   self()->getParameterList()._trMemory = comp->trMemory();
+   self()->getAutomaticList()._trMemory = comp->trMemory();
 
-   getVariableSizeSymbolList()._trMemory = comp->trMemory();
-   getTrivialDeadTreeBlocksList()._trMemory = comp->trMemory();
+   self()->getVariableSizeSymbolList()._trMemory = comp->trMemory();
+   self()->getTrivialDeadTreeBlocksList()._trMemory = comp->trMemory();
    }
 
 
@@ -137,13 +137,13 @@ OMR::ResolvedMethodSymbol::ResolvedMethodSymbol(TR_ResolvedMethod * method, TR::
 
    if (comp->isGPUCompileCPUCode())
       {
-      setLinkage(TR_System);
+      self()->setLinkage(TR_System);
       }
 
     _methodIndex = comp->addOwningMethod(self());
    if (comp->getOption(TR_TraceMethodIndex))
       traceMsg(comp, "-- New symbol for method: M%p index: %d owningMethod: M%p sig: %s\n",
-         method, (int)_methodIndex.value(), method->owningMethod(), signature(comp->trMemory()));
+         method, (int)_methodIndex.value(), method->owningMethod(), self()->signature(comp->trMemory()));
 
    if (_methodIndex >= MAX_CALLER_INDEX)
       {
@@ -152,7 +152,7 @@ OMR::ResolvedMethodSymbol::ResolvedMethodSymbol(TR_ResolvedMethod * method, TR::
       }
 
    if (_resolvedMethod->isSynchronized())
-      setSynchronised();
+      self()->setSynchronised();
 
    // Set the interpreted flag for an interpreted method unless we're calling
    // the method that's being jitted
@@ -161,11 +161,11 @@ OMR::ResolvedMethodSymbol::ResolvedMethodSymbol(TR_ResolvedMethod * method, TR::
       {
       if (_resolvedMethod->isInterpreted())
          {
-         setInterpreted();
-         setMethodAddress(_resolvedMethod->resolvedMethodAddress());
+         self()->setInterpreted();
+         self()->setMethodAddress(_resolvedMethod->resolvedMethodAddress());
          }
       else
-         setMethodAddress(_resolvedMethod->startAddressForJittedMethod());
+         self()->setMethodAddress(_resolvedMethod->startAddressForJittedMethod());
       }
 
 #ifdef J9_PROJECT_SPECIFIC
@@ -271,24 +271,24 @@ OMR::ResolvedMethodSymbol::ResolvedMethodSymbol(TR_ResolvedMethod * method, TR::
 #endif // J9_PROJECT_SPECIFIC
       if (_resolvedMethod->isNative())
       {
-      if (!isInterpreted() && _resolvedMethod->isJITInternalNative())
+      if (!self()->isInterpreted() && _resolvedMethod->isJITInternalNative())
          {
-         setMethodAddress(_resolvedMethod->startAddressForJITInternalNativeMethod());
-         setJITInternalNative();
+         self()->setMethodAddress(_resolvedMethod->startAddressForJITInternalNativeMethod());
+         self()->setJITInternalNative();
          }
       else
          {
-         setVMInternalNative();
+         self()->setVMInternalNative();
          }
       }
 
    if (_resolvedMethod->isFinal())
-      setFinal();
+      self()->setFinal();
 
    if (_resolvedMethod->isStatic())
-      setStatic();
+      self()->setStatic();
 
-   setParameterList();
+   self()->setParameterList();
 
    _properties.set(CanSkipNullChecks                   , self()->safeToSkipNullChecks());
    _properties.set(CanSkipBoundChecks                  , self()->safeToSkipBoundChecks());
@@ -304,24 +304,24 @@ int32_t
 OMR::ResolvedMethodSymbol::getSyncObjectTempIndex()
    {
    int32_t delta = 0;
-   if (comp()->getOption(TR_MimicInterpreterFrameShape))
+   if (self()->comp()->getOption(TR_MimicInterpreterFrameShape))
       {
       delta++;
       }
 
-   return getFirstJitTempIndex() - delta;
+   return self()->getFirstJitTempIndex() - delta;
    }
 
 int32_t
 OMR::ResolvedMethodSymbol::getThisTempForObjectCtorIndex()
    {
    int32_t delta = 0;
-   if (comp()->getOption(TR_MimicInterpreterFrameShape))
+   if (self()->comp()->getOption(TR_MimicInterpreterFrameShape))
       {
       delta++;
       }
 
-   return getFirstJitTempIndex() - delta;
+   return self()->getFirstJitTempIndex() - delta;
    }
 
 List<TR::ParameterSymbol>&
@@ -332,7 +332,7 @@ OMR::ResolvedMethodSymbol::getLogicalParameterList(TR::Compilation *comp)
       List<TR::ParameterSymbol>* l = comp->cg()->getLinkage()->getMainBodyLogicalParameterList();
       if (l == NULL)
          {
-         return getParameterList();
+         return self()->getParameterList();
          }
       else
          {
@@ -341,7 +341,7 @@ OMR::ResolvedMethodSymbol::getLogicalParameterList(TR::Compilation *comp)
       }
    else
       {
-      return getParameterList();
+      return self()->getParameterList();
       }
    }
 
@@ -431,47 +431,47 @@ bcIndexForFakeInduce(TR::Compilation* comp, int16_t* callSiteInsertionPoint,
 bool
 OMR::ResolvedMethodSymbol::canInjectInduceOSR(TR::Node* node)
    {
-   bool trace = comp()->getOption(TR_TraceOSR);
+   bool trace = self()->comp()->getOption(TR_TraceOSR);
    if (node->getOpCodeValue() != TR::treetop
        && node->getOpCodeValue() != TR::NULLCHK
        && node->getOpCodeValue() != TR::ResolveAndNULLCHK)
       {
       if (trace)
-         traceMsg(comp(), "node doesn't have a treetop, NULLCHK, or ResolveAndNULLCHK root\n");
+         traceMsg(self()->comp(), "node doesn't have a treetop, NULLCHK, or ResolveAndNULLCHK root\n");
       return false;
       }
    if (node->getNumChildren() != 1
        || !node->getChild(0)->getOpCode().isCall())
       {
       if (trace)
-         traceMsg(comp(), "there is no call under the treetop\n");
+         traceMsg(self()->comp(), "there is no call under the treetop\n");
       return false;
       }
    TR::Node* callNode = node->getChild(0);
    if (callNode->getReferenceCount() != 1 && node->getOpCodeValue() == TR::treetop)
       {
       if (trace)
-         traceMsg(comp(), "call node has a refcount larger than 1 and is under a treetop\n");
+         traceMsg(self()->comp(), "call node has a refcount larger than 1 and is under a treetop\n");
       return false;
       }
-   const char* rootSignature = comp()->signature();
+   const char* rootSignature = self()->comp()->signature();
    if (!strncmp(rootSignature, "java/lang/Object.newInstancePrototype", 37))
       {
       if (trace)
-         traceMsg(comp(), "root method is a java/lang/Object.newInstancePrototype method\n");
+         traceMsg(self()->comp(), "root method is a java/lang/Object.newInstancePrototype method\n");
       return false;
       }
    if (!strncmp(rootSignature, "java/lang/Class.newInstancePrototype", 36))
       {
       if (trace)
-         traceMsg(comp(), "root method is a java/lang/Class.newInstancePrototype method\n");
+         traceMsg(self()->comp(), "root method is a java/lang/Class.newInstancePrototype method\n");
       return false;
       }
-   const char* currentSignature = self()->signature(comp()->trMemory());
+   const char* currentSignature = self()->signature(self()->comp()->trMemory());
    if (!strncmp(currentSignature, "com/ibm/jit/JITHelpers", 22))
       {
       if (trace)
-         traceMsg(comp(), "node is a com/ibm/jit/jit helper method\n");
+         traceMsg(self()->comp(), "node is a com/ibm/jit/jit helper method\n");
       return false;
       }
 
@@ -484,18 +484,18 @@ OMR::ResolvedMethodSymbol::canInjectInduceOSR(TR::Node* node)
           methSym->getMethodKind() == TR::MethodSymbol::Special)
          {
          if (trace)
-            traceMsg(comp(), "node is a helper, native, or a special call\n");
+            traceMsg(self()->comp(), "node is a helper, native, or a special call\n");
          return false;
          }
       }
    if (sym->isResolvedMethod())
       {
       auto * methSym = sym->castToResolvedMethodSymbol();
-      const char* signature = methSym->signature(comp()->trMemory());
+      const char* signature = methSym->signature(self()->comp()->trMemory());
       if (!strncmp(signature, "com/ibm/jit/JITHelpers", 22))
          {
          if (trace)
-            traceMsg(comp(), "node is a com/ibm/jit/jit helper method\n");
+            traceMsg(self()->comp(), "node is a com/ibm/jit/jit helper method\n");
          return false;
          }
       }
@@ -516,18 +516,18 @@ OMR::ResolvedMethodSymbol::genInduceOSRCallNode(TR::TreeTop* insertionPoint,
    //and that method gets inlined
    //there is no guarantee that the future block containing the induceOSR call still will have an exception
    //edge to the OSR catch block.
-   TR::SymbolReferenceTable* symRefTab = comp()->getSymRefTab();
+   TR::SymbolReferenceTable* symRefTab = self()->comp()->getSymRefTab();
    TR::SymbolReference *induceOSRSymRef = symRefTab->findOrCreateRuntimeHelper(TR_induceOSRAtCurrentPC, true, true, true);
    // treat jitInduceOSR like an interpreted call so that each platform's codegen generate a snippet for it
    induceOSRSymRef->getSymbol()->getMethodSymbol()->setInterpreted();
    TR::Node *refNode = insertionPoint->getNode();
 
-   if (comp()->getOption(TR_TraceOSR))
-     traceMsg(comp(), "O^O OSR: Inject induceOSR call for [%p] at %3d:%d\n", refNode, refNode->getInlinedSiteIndex(), refNode->getByteCodeIndex());
+   if (self()->comp()->getOption(TR_TraceOSR))
+     traceMsg(self()->comp(), "O^O OSR: Inject induceOSR call for [%p] at %3d:%d\n", refNode, refNode->getInlinedSiteIndex(), refNode->getByteCodeIndex());
 
    TR::Block * firstHalfBlock = insertionPoint->getEnclosingBlock();
    if (shouldSplitBlock)
-       firstHalfBlock->split(insertionPoint, comp()->getFlowGraph(), true);
+       firstHalfBlock->split(insertionPoint, self()->comp()->getFlowGraph(), true);
 
    int32_t firstArgIndex = 0;
    if ((refNode->getNumChildren() > 0) &&
@@ -553,11 +553,11 @@ OMR::ResolvedMethodSymbol::genInduceOSRCallNode(TR::TreeTop* insertionPoint,
       induceOSRCallNode->setNumChildren(0);
       }
 
-   if (comp()->getOptions()->getVerboseOption(TR_VerboseOSRDetails))
-      TR_VerboseLog::writeLineLocked(TR_Vlog_OSRD, "Injected induceOSR call at %3d:%d in %s", refNode->getInlinedSiteIndex(), refNode->getByteCodeIndex(), comp()->signature());
+   if (self()->comp()->getOptions()->getVerboseOption(TR_VerboseOSRDetails))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_OSRD, "Injected induceOSR call at %3d:%d in %s", refNode->getInlinedSiteIndex(), refNode->getByteCodeIndex(), self()->comp()->signature());
 
    TR::Node *induceOSRTreeTopNode = TR::Node::create(TR::treetop, 1, induceOSRCallNode);
-   insertionPoint->insertBefore(TR::TreeTop::create(comp(), induceOSRTreeTopNode));
+   insertionPoint->insertBefore(TR::TreeTop::create(self()->comp(), induceOSRTreeTopNode));
    return insertionPoint->getPrevTreeTop();
    }
 
@@ -567,9 +567,9 @@ OMR::ResolvedMethodSymbol::induceOSRAfter(TR::TreeTop *insertionPoint, TR_ByteCo
    {
    TR::Block *block = insertionPoint->getEnclosingBlock();
 
-   if (supportsInduceOSR(induceBCI, insertionPoint->getNode(), block, NULL, comp()))
+   if (self()->supportsInduceOSR(induceBCI, insertionPoint->getNode(), block, NULL, self()->comp()))
       {
-      TR::CFG *cfg = comp()->getFlowGraph();
+      TR::CFG *cfg = self()->comp()->getFlowGraph();
       cfg->setStructure(NULL);
       TR::TreeTop *remainderTree = insertionPoint->getNextTreeTop();
       if (remainderTree->getNode()->getOpCodeValue() != TR::BBEnd)
@@ -578,19 +578,19 @@ OMR::ResolvedMethodSymbol::induceOSRAfter(TR::TreeTop *insertionPoint, TR_ByteCo
             {
             TR::Block *remainderBlock = block->split(remainderTree, cfg, false, true);
             remainderBlock->setIsExtensionOfPreviousBlock(true);
-            if (comp()->getOption(TR_TraceOSR))
-               traceMsg(comp(), "  Split of block_%d at n%dn produced block_%d which is an extension\n", block->getNumber(), remainderTree->getNode()->getGlobalIndex(), remainderBlock->getNumber());
+            if (self()->comp()->getOption(TR_TraceOSR))
+               traceMsg(self()->comp(), "  Split of block_%d at n%dn produced block_%d which is an extension\n", block->getNumber(), remainderTree->getNode()->getGlobalIndex(), remainderBlock->getNumber());
             }
          else
             {
             TR::Block *remainderBlock = block->split(remainderTree, cfg, true, true);
-            if (comp()->getOption(TR_TraceOSR))
-               traceMsg(comp(), "  Split of block_%d at n%dn produced block_%d\n", block->getNumber(), remainderTree->getNode()->getGlobalIndex(), remainderBlock->getNumber());
+            if (self()->comp()->getOption(TR_TraceOSR))
+               traceMsg(self()->comp(), "  Split of block_%d at n%dn produced block_%d\n", block->getNumber(), remainderTree->getNode()->getGlobalIndex(), remainderBlock->getNumber());
             }
          }
 
       // create a block that will be the target of the branch with BCI for the induceOSR
-      TR::Block *osrBlock = TR::Block::createEmptyBlock(comp(), MAX_COLD_BLOCK_COUNT);
+      TR::Block *osrBlock = TR::Block::createEmptyBlock(self()->comp(), MAX_COLD_BLOCK_COUNT);
       osrBlock->setIsCold();
       osrBlock->getEntry()->getNode()->setByteCodeInfo(induceBCI);
       osrBlock->getExit()->getNode()->setByteCodeInfo(induceBCI);
@@ -599,15 +599,15 @@ OMR::ResolvedMethodSymbol::induceOSRAfter(TR::TreeTop *insertionPoint, TR_ByteCo
       cfg->addNode(osrBlock);
       cfg->addEdge(block, osrBlock);
 
-      if (comp()->getOption(TR_TraceOSR))
-         traceMsg(comp(), "  Created OSR block_%d and inserting it at the end of the method\n", osrBlock->getNumber());
+      if (self()->comp()->getOption(TR_TraceOSR))
+         traceMsg(self()->comp(), "  Created OSR block_%d and inserting it at the end of the method\n", osrBlock->getNumber());
 
       branch->getNode()->setBranchDestination(osrBlock->getEntry());
       block->append(branch);
       cfg->copyExceptionSuccessors(block, osrBlock);
 
       // induce OSR in the new block
-      genInduceOSRCallAndCleanUpFollowingTreesImmediately(osrBlock->getExit(), induceBCI, false, false, comp());
+      self()->genInduceOSRCallAndCleanUpFollowingTreesImmediately(osrBlock->getExit(), induceBCI, false, false, self()->comp());
       return true;
       }
    return false;
@@ -616,10 +616,10 @@ OMR::ResolvedMethodSymbol::induceOSRAfter(TR::TreeTop *insertionPoint, TR_ByteCo
 TR::TreeTop *
 OMR::ResolvedMethodSymbol::induceImmediateOSRWithoutChecksBefore(TR::TreeTop *insertionPoint)
    {
-   if (supportsInduceOSR(insertionPoint->getNode()->getByteCodeInfo(), insertionPoint->getNode(), insertionPoint->getEnclosingBlock(), NULL, comp()))
-      return genInduceOSRCallAndCleanUpFollowingTreesImmediately(insertionPoint, insertionPoint->getNode()->getByteCodeInfo(), false, false, comp());
-   if (comp()->getOption(TR_TraceOSR))
-      traceMsg(comp(), "induceImmediateOSRWithoutChecksBefore n%dn failed - supportsInduceOSR returned false\n", insertionPoint->getNode()->getGlobalIndex());
+   if (self()->supportsInduceOSR(insertionPoint->getNode()->getByteCodeInfo(), insertionPoint->getNode(), insertionPoint->getEnclosingBlock(), NULL, self()->comp()))
+      return self()->genInduceOSRCallAndCleanUpFollowingTreesImmediately(insertionPoint, insertionPoint->getNode()->getByteCodeInfo(), false, false, self()->comp());
+   if (self()->comp()->getOption(TR_TraceOSR))
+      traceMsg(self()->comp(), "induceImmediateOSRWithoutChecksBefore n%dn failed - supportsInduceOSR returned false\n", insertionPoint->getNode()->getGlobalIndex());
    return NULL;
    }
 
@@ -639,7 +639,7 @@ OMR::ResolvedMethodSymbol::genInduceOSRCallAndCleanUpFollowingTreesImmediately(T
       numChildrenOfInduceCall = numOfChildren - firstArgChild;
       }
 
-   TR::TreeTop *induceOSRCallTree = genInduceOSRCall(insertionPoint, induceBCI.getCallerIndex(), numChildrenOfInduceCall, copyChildren, shouldSplitBlock);
+   TR::TreeTop *induceOSRCallTree = self()->genInduceOSRCall(insertionPoint, induceBCI.getCallerIndex(), numChildrenOfInduceCall, copyChildren, shouldSplitBlock);
 
    if (induceOSRCallTree)
       {
@@ -676,15 +676,15 @@ OMR::ResolvedMethodSymbol::genInduceOSRCallForGuardedCallee(TR::TreeTop* inserti
                                                           bool copyChildren,
                                                           bool shouldSplitBlock)
    {
-   if (comp()->getOption(TR_TraceOSR))
+   if (self()->comp()->getOption(TR_TraceOSR))
       {
-      const char * mSignature = calleeSymbol->signature(comp()->trMemory());
-      traceMsg(comp(), "induce %p generated for %s index %d\n",
+      const char * mSignature = calleeSymbol->signature(self()->comp()->trMemory());
+      traceMsg(self()->comp(), "induce %p generated for %s index %d\n",
                       insertionPoint->getNode(), mSignature, insertionPoint->getNode()->getByteCodeInfo().getCallerIndex());
       }
 
-   TR_OSRMethodData *osrMethodData = comp()->getOSRCompilationData()->findCallerOSRMethodData(comp()->getOSRCompilationData()->findOrCreateOSRMethodData(comp()->getCurrentInlinedSiteIndex(), calleeSymbol));
-   return genInduceOSRCall(insertionPoint, comp()->getCurrentInlinedSiteIndex(), osrMethodData, calleeSymbol, numChildren, copyChildren, shouldSplitBlock);
+   TR_OSRMethodData *osrMethodData = self()->comp()->getOSRCompilationData()->findCallerOSRMethodData(self()->comp()->getOSRCompilationData()->findOrCreateOSRMethodData(self()->comp()->getCurrentInlinedSiteIndex(), calleeSymbol));
+   return self()->genInduceOSRCall(insertionPoint, self()->comp()->getCurrentInlinedSiteIndex(), osrMethodData, calleeSymbol, numChildren, copyChildren, shouldSplitBlock);
    }
 
 
@@ -692,8 +692,8 @@ TR::TreeTop *
 OMR::ResolvedMethodSymbol::genInduceOSRCall(TR::TreeTop* insertionPoint, int32_t inlinedSiteIndex,
                         int32_t numChildren, bool copyChildren, bool shouldSplitBlock)
    {
-   TR_OSRMethodData *osrMethodData = comp()->getOSRCompilationData()->findOrCreateOSRMethodData(inlinedSiteIndex, self());
-   return genInduceOSRCall(insertionPoint, inlinedSiteIndex, osrMethodData, NULL, numChildren, copyChildren, shouldSplitBlock);
+   TR_OSRMethodData *osrMethodData = self()->comp()->getOSRCompilationData()->findOrCreateOSRMethodData(inlinedSiteIndex, self());
+   return self()->genInduceOSRCall(insertionPoint, inlinedSiteIndex, osrMethodData, NULL, numChildren, copyChildren, shouldSplitBlock);
    }
 
 
@@ -706,15 +706,15 @@ OMR::ResolvedMethodSymbol::genInduceOSRCall(TR::TreeTop* insertionPoint,
                                           bool copyChildren,
                                           bool shouldSplitBlock)
    {
-   TR::CFG * callerCFG = comp()->getFlowGraph();
+   TR::CFG * callerCFG = self()->comp()->getFlowGraph();
    TR::Node *insertionPointNode = insertionPoint->getNode();
-   if (comp()->getOption(TR_TraceOSR))
-      traceMsg(comp(), "Osr point added for %p, callerIndex=%d, bcindex=%d\n",
+   if (self()->comp()->getOption(TR_TraceOSR))
+      traceMsg(self()->comp(), "Osr point added for %p, callerIndex=%d, bcindex=%d\n",
               insertionPointNode, insertionPointNode->getByteCodeInfo().getCallerIndex(),
               insertionPointNode->getByteCodeInfo().getByteCodeIndex());
 
    TR::Block * OSRCatchBlock = osrMethodData->getOSRCatchBlock();
-   TR::TreeTop *induceOSRCallTree = genInduceOSRCallNode(insertionPoint, numChildren, copyChildren, shouldSplitBlock);
+   TR::TreeTop *induceOSRCallTree = self()->genInduceOSRCallNode(insertionPoint, numChildren, copyChildren, shouldSplitBlock);
 
    TR::Block *enclosingBlock = insertionPoint->getEnclosingBlock();
    if (!enclosingBlock->getLastRealTreeTop()->getNode()->getOpCode().isReturn())
@@ -740,7 +740,7 @@ OMR::ResolvedMethodSymbol::genInduceOSRCall(TR::TreeTop* insertionPoint,
       }
 
    TR::SymbolReference * tempSymRef = 0;
-   TR::Node * loadExcpSymbol = TR::Node::createWithSymRef(insertionPointNode, TR::aload, 0, comp()->getSymRefTab()->findOrCreateExcpSymbolRef());
+   TR::Node * loadExcpSymbol = TR::Node::createWithSymRef(insertionPointNode, TR::aload, 0, self()->comp()->getSymRefTab()->findOrCreateExcpSymbolRef());
 
    TR::TreeTop *lastTreeInEnclosingBlock = enclosingBlock->getLastRealTreeTop();
    if (lastTreeInEnclosingBlock != enclosingBlock->getLastNonControlFlowTreeTop())
@@ -751,11 +751,11 @@ OMR::ResolvedMethodSymbol::genInduceOSRCall(TR::TreeTop* insertionPoint,
       lastTreeInEnclosingBlock->getNode()->recursivelyDecReferenceCount();
       }
 
-   enclosingBlock->append(TR::TreeTop::create(comp(), TR::Node::createWithSymRef(TR::athrow, 1, 1, loadExcpSymbol, comp()->getSymRefTab()->findOrCreateAThrowSymbolRef(self()))));
+   enclosingBlock->append(TR::TreeTop::create(self()->comp(), TR::Node::createWithSymRef(TR::athrow, 1, 1, loadExcpSymbol, self()->comp()->getSymRefTab()->findOrCreateAThrowSymbolRef(self()))));
    enclosingBlock->getLastRealTreeTop()->getNode()->setThrowInsertedByOSR(true);
 
    bool firstOSRPoint = false;
-   if (getOSRPoints().isEmpty())
+   if (self()->getOSRPoints().isEmpty())
       firstOSRPoint = true;
 
    if (firstOSRPoint)
@@ -763,15 +763,15 @@ OMR::ResolvedMethodSymbol::genInduceOSRCall(TR::TreeTop* insertionPoint,
       TR::Block *OSRCodeBlock = osrMethodData->getOSRCodeBlock();
       TR::Block *OSRCatchBlock = osrMethodData->getOSRCatchBlock();
 
-      if (comp()->getOption(TR_TraceOSR))
-         traceMsg(comp(), "code %p %d catch %p %d\n", OSRCodeBlock, OSRCodeBlock->getNumber(), OSRCatchBlock, OSRCatchBlock->getNumber());
+      if (self()->comp()->getOption(TR_TraceOSR))
+         traceMsg(self()->comp(), "code %p %d catch %p %d\n", OSRCodeBlock, OSRCodeBlock->getNumber(), OSRCatchBlock, OSRCatchBlock->getNumber());
 
-      getLastTreeTop()->insertTreeTopsAfterMe(OSRCatchBlock->getEntry(), OSRCodeBlock->getExit());
-      genOSRHelperCall(inlinedSiteIndex, comp()->getSymRefTab());
+      self()->getLastTreeTop()->insertTreeTopsAfterMe(OSRCatchBlock->getEntry(), OSRCodeBlock->getExit());
+      self()->genOSRHelperCall(inlinedSiteIndex, self()->comp()->getSymRefTab());
       }
 
-   self()->insertStoresForDeadStackSlotsBeforeInducingOSR(comp(), inlinedSiteIndex, induceOSRCallTree, callSymbolForDeadSlots);
-   traceMsg(comp(), "last real tree n%dn\n", enclosingBlock->getLastRealTreeTop()->getNode()->getGlobalIndex());
+   self()->insertStoresForDeadStackSlotsBeforeInducingOSR(self()->comp(), inlinedSiteIndex, induceOSRCallTree, callSymbolForDeadSlots);
+   traceMsg(self()->comp(), "last real tree n%dn\n", enclosingBlock->getLastRealTreeTop()->getNode()->getGlobalIndex());
    return induceOSRCallTree;
    }
 
@@ -804,7 +804,7 @@ OMR::ResolvedMethodSymbol::matchInduceOSRCall(TR::TreeTop* insertionPoint,
       if ((callerIndex != -3 && refNode->getInlinedSiteIndex() != callerIndex) ||
           (byteCodeIndex != -3 && refNode->getByteCodeIndex() != byteCodeIndex))
          return 0;
-      if (canInjectInduceOSR(refNode))
+      if (self()->canInjectInduceOSR(refNode))
          return 1;
       else
          {
@@ -817,11 +817,11 @@ OMR::ResolvedMethodSymbol::matchInduceOSRCall(TR::TreeTop* insertionPoint,
    else if (childPath[0] == 'r')
       {
       if (callerIndex == -2) return 0;
-      if (!canInjectInduceOSR(refNode)) return 0;
-      int32_t random = comp()->adhocRandom().getRandom();
-      if (comp()->getOption(TR_TraceOSR))
-         traceMsg(comp(), "Random fake induceOSR injection: caller=%d bc=%x random=%d\n", callerIndex, byteCodeIndex, random);
-      if (comp()->adhocRandom().getRandom() % recipProb != 0) return 0;
+      if (!self()->canInjectInduceOSR(refNode)) return 0;
+      int32_t random = self()->comp()->adhocRandom().getRandom();
+      if (self()->comp()->getOption(TR_TraceOSR))
+         traceMsg(self()->comp(), "Random fake induceOSR injection: caller=%d bc=%x random=%d\n", callerIndex, byteCodeIndex, random);
+      if (self()->comp()->adhocRandom().getRandom() % recipProb != 0) return 0;
       return 1;
       }
    else if (childPath[0] == 'g')
@@ -829,7 +829,7 @@ OMR::ResolvedMethodSymbol::matchInduceOSRCall(TR::TreeTop* insertionPoint,
       if ((callerIndex != -3 && refNode->getInlinedSiteIndex() != callerIndex) ||
           (byteCodeIndex != -3 && refNode->getByteCodeIndex() < byteCodeIndex))
          return 0;
-      if (canInjectInduceOSR(refNode))
+      if (self()->canInjectInduceOSR(refNode))
          return 1;
       else
          return 0;
@@ -842,36 +842,36 @@ OMR::ResolvedMethodSymbol::matchInduceOSRCall(TR::TreeTop* insertionPoint,
 void
 OMR::ResolvedMethodSymbol::genAndAttachOSRCodeBlocks(int32_t currentInlinedSiteIndex)
    {
-   bool trace = comp()->getOption(TR_TraceOSR);
-   TR_ASSERT(getFirstTreeTop(), "the method doesn't have any trees\n");
+   bool trace = self()->comp()->getOption(TR_TraceOSR);
+   TR_ASSERT(self()->getFirstTreeTop(), "the method doesn't have any trees\n");
    int16_t callSiteInsertionPoint, bcIndexInsertionPoint;
    char childPath[10];
    childPath[0] = '\0';
-   bcIndexForFakeInduce(comp(), &callSiteInsertionPoint, &bcIndexInsertionPoint, childPath);
-   const char * mSignature = signature(comp()->trMemory());
+   bcIndexForFakeInduce(self()->comp(), &callSiteInsertionPoint, &bcIndexInsertionPoint, childPath);
+   const char * mSignature = self()->signature(self()->comp()->trMemory());
 
    TR::TreeTop *lastTreeTop = NULL;
-   TR_OSRMethodData *osrMethodData = comp()->getOSRCompilationData()->findOrCreateOSRMethodData(currentInlinedSiteIndex, self());
+   TR_OSRMethodData *osrMethodData = self()->comp()->getOSRCompilationData()->findOrCreateOSRMethodData(currentInlinedSiteIndex, self());
    //Using this flag we avoid processing twice a call before which we are injecting an induceOSR
    bool skipNextTT = false;
-   for (TR::TreeTop* tt = getFirstTreeTop(); tt; tt = tt->getNextTreeTop())
+   for (TR::TreeTop* tt = self()->getFirstTreeTop(); tt; tt = tt->getNextTreeTop())
       {
       TR::Node* ttnode = tt->getNode();
       if (!skipNextTT)
          {
-         int matchCode = matchInduceOSRCall(tt, callSiteInsertionPoint, bcIndexInsertionPoint, childPath);
+         int matchCode = self()->matchInduceOSRCall(tt, callSiteInsertionPoint, bcIndexInsertionPoint, childPath);
          if (matchCode > 0)
             {
             TR::Node *refNode = tt->getNode()->getFirstChild();
             int32_t numChildren   = refNode->getNumChildren();
             int32_t firstArgIndex = refNode->getFirstArgumentIndex();
-            genInduceOSRCallNode(tt, (numChildren - firstArgIndex), matchCode == 1);
+            self()->genInduceOSRCallNode(tt, (numChildren - firstArgIndex), matchCode == 1);
             tt = tt->getPrevTreeTop();
             ttnode = tt->getNode();
             if (trace)
                {
-               const char * mSignature = signature(comp()->trMemory());
-               traceMsg(comp(), "fake induce %p generated for %s at callsite %d bytecode %x\n",
+               const char * mSignature = self()->signature(self()->comp()->trMemory());
+               traceMsg(self()->comp(), "fake induce %p generated for %s at callsite %d bytecode %x\n",
                        ttnode, mSignature, callSiteInsertionPoint, bcIndexInsertionPoint);
                }
             skipNextTT = true;
@@ -881,15 +881,15 @@ OMR::ResolvedMethodSymbol::genAndAttachOSRCodeBlocks(int32_t currentInlinedSiteI
          skipNextTT = false;
       // check potential OSR point using a node to avoid a check for the exception successor
       // which we are responsible for creating if we decide to continue with this OSR point
-      if (comp()->isPotentialOSRPoint(NULL, tt->getNode()))
+      if (self()->comp()->isPotentialOSRPoint(NULL, tt->getNode()))
          {
          TR::Block * block = tt->getEnclosingBlock();
          // Add the OSR point to the list
          TR::Block * OSRCatchBlock = osrMethodData->findOrCreateOSRCatchBlock(ttnode);
-         TR_OSRPoint *osrPoint = new (comp()->trHeapMemory()) TR_OSRPoint(ttnode, osrMethodData, comp()->trMemory());
-         osrPoint->setOSRIndex(addOSRPoint(osrPoint));
-         if (comp()->getOption(TR_TraceOSR))
-            traceMsg(comp(), "osr point added for [%p] at %d:%d\n",
+         TR_OSRPoint *osrPoint = new (self()->comp()->trHeapMemory()) TR_OSRPoint(ttnode, osrMethodData, self()->comp()->trMemory());
+         osrPoint->setOSRIndex(self()->addOSRPoint(osrPoint));
+         if (self()->comp()->getOption(TR_TraceOSR))
+            traceMsg(self()->comp(), "osr point added for [%p] at %d:%d\n",
                ttnode, ttnode->getByteCodeInfo().getCallerIndex(),
                ttnode->getByteCodeInfo().getByteCodeIndex());
 
@@ -903,7 +903,7 @@ OMR::ResolvedMethodSymbol::genAndAttachOSRCodeBlocks(int32_t currentInlinedSiteI
             }
 
          if (edge == block->getExceptionSuccessors().end())
-            comp()->getFlowGraph()->addEdge( TR::CFGEdge::createExceptionEdge(block, OSRCatchBlock, comp()->trMemory()));
+            self()->comp()->getFlowGraph()->addEdge( TR::CFGEdge::createExceptionEdge(block, OSRCatchBlock, self()->comp()->trMemory()));
          }
       if (tt->getNextTreeTop() == NULL)
          lastTreeTop = tt;
@@ -911,9 +911,9 @@ OMR::ResolvedMethodSymbol::genAndAttachOSRCodeBlocks(int32_t currentInlinedSiteI
 
    //if an OSR code block has been created, attach its treetops and osr catch block's
    //treetops to the method's treetops
-   if (!getOSRPoints().isEmpty())
+   if (!self()->getOSRPoints().isEmpty())
       {
-      TR_OSRMethodData *osrMethodData = comp()->getOSRCompilationData()->findOrCreateOSRMethodData(currentInlinedSiteIndex, self());
+      TR_OSRMethodData *osrMethodData = self()->comp()->getOSRCompilationData()->findOrCreateOSRMethodData(currentInlinedSiteIndex, self());
       TR::Block *OSRCodeBlock = osrMethodData->getOSRCodeBlock();
       TR::Block *OSRCatchBlock = osrMethodData->getOSRCatchBlock();
       lastTreeTop->insertTreeTopsAfterMe(OSRCatchBlock->getEntry(), OSRCodeBlock->getExit());
@@ -962,16 +962,16 @@ OMR::ResolvedMethodSymbol::sharesStackSlot(TR::SymbolReference *symRef)
    {
    TR_ASSERT(symRef->getSymbol()->isAutoOrParm(), "sharesStackSlot requires #%d to be on the stack", symRef->getReferenceNumber());
    int32_t slot = symRef->getCPIndex();
-   if (slot >= getFirstJitTempIndex())
+   if (slot >= self()->getFirstJitTempIndex())
       return false; // Jit temps don't share slots
    TR::DataTypes dt = symRef->getSymbol()->getDataType();
    bool takesTwoSlots = dt == TR::Int64 || dt == TR::Double;
 
    List<TR::SymbolReference> *listForPrevSlot, *list, *listForNextSlot;
    if (slot < 0)
-      getNeighboringSymRefLists(-slot - 1, getPendingPushSymRefs(), &listForPrevSlot, &list, &listForNextSlot);
+      getNeighboringSymRefLists(-slot - 1, self()->getPendingPushSymRefs(), &listForPrevSlot, &list, &listForNextSlot);
    else
-      getNeighboringSymRefLists(slot, getAutoSymRefs(), &listForPrevSlot, &list, &listForNextSlot);
+      getNeighboringSymRefLists(slot, self()->getAutoSymRefs(), &listForPrevSlot, &list, &listForNextSlot);
 
    if (list->isMultipleEntry())
       return true;
@@ -986,13 +986,13 @@ OMR::ResolvedMethodSymbol::sharesStackSlot(TR::SymbolReference *symRef)
 void
 OMR::ResolvedMethodSymbol::genOSRHelperCall(int32_t currentInlinedSiteIndex, TR::SymbolReferenceTable* symRefTab)
    {
-   bool trace = comp()->getOption(TR_TraceOSR);
+   bool trace = self()->comp()->getOption(TR_TraceOSR);
    // Use first node of the method for bytecode info
-   TR_ASSERT(getFirstTreeTop(), "first tree top is NULL in %s", signature(comp()->trMemory()));
-   TR::Node *firstNode = getFirstTreeTop()->getNode();
+   TR_ASSERT(self()->getFirstTreeTop(), "first tree top is NULL in %s", signature(self()->comp()->trMemory()));
+   TR::Node *firstNode = self()->getFirstTreeTop()->getNode();
 
    // Create the OSR helper symbol reference
-   TR::Node *vmThread = TR::Node::createWithSymRef(firstNode, TR::loadaddr, 0, new (comp()->trHeapMemory()) TR::SymbolReference(symRefTab, TR::RegisterMappedSymbol::createMethodMetaDataSymbol(comp()->trHeapMemory(), "vmThread")));
+   TR::Node *vmThread = TR::Node::createWithSymRef(firstNode, TR::loadaddr, 0, new (self()->comp()->trHeapMemory()) TR::SymbolReference(symRefTab, TR::RegisterMappedSymbol::createMethodMetaDataSymbol(self()->comp()->trHeapMemory(), "vmThread")));
    TR::SymbolReference *osrHelper = symRefTab->findOrCreateRuntimeHelper(TR_prepareForOSR, false, false, true);
 #if defined(TR_TARGET_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM)
    osrHelper->getSymbol()->castToMethodSymbol()->setLinkage(TR_System);
@@ -1001,10 +1001,10 @@ OMR::ResolvedMethodSymbol::genOSRHelperCall(int32_t currentInlinedSiteIndex, TR:
    osrHelper->getSymbol()->castToMethodSymbol()->setSystemLinkageDispatch();
 #endif
 
-   TR_OSRMethodData *osrMethodData = comp()->getOSRCompilationData()->findOrCreateOSRMethodData(currentInlinedSiteIndex, self());
+   TR_OSRMethodData *osrMethodData = self()->comp()->getOSRCompilationData()->findOrCreateOSRMethodData(currentInlinedSiteIndex, self());
 
    // Create children to the OSR helper call node and save them to a list
-   TR_Array<TR::Node*> loadNodes(comp()->trMemory());
+   TR_Array<TR::Node*> loadNodes(self()->comp()->trMemory());
    loadNodes.add(vmThread);
    loadNodes.add(TR::Node::iconst(firstNode, osrMethodData->getInlinedSiteIndex()));
    TR::Node *loadNode = NULL;
@@ -1014,7 +1014,7 @@ OMR::ResolvedMethodSymbol::genOSRHelperCall(int32_t currentInlinedSiteIndex, TR:
    bool alreadyLoadedThisTempForObjectCtor = false;
 
    // Pending push temporaries
-   TR_Array<List<TR::SymbolReference> > *ppsListArray = getPendingPushSymRefs();
+   TR_Array<List<TR::SymbolReference> > *ppsListArray = self()->getPendingPushSymRefs();
    for (i = 0; ppsListArray && i < ppsListArray->size(); ++i)
       {
       List<TR::SymbolReference> ppsList = (*ppsListArray)[i];
@@ -1022,21 +1022,21 @@ OMR::ResolvedMethodSymbol::genOSRHelperCall(int32_t currentInlinedSiteIndex, TR:
       int symRefOrder = 0;
       for (TR::SymbolReference* symRef = ppsIt.getFirst(); symRef; symRef = ppsIt.getNext(), symRefOrder++)
          {
-         bool sharesSlot = sharesStackSlot(symRef);
+         bool sharesSlot = self()->sharesStackSlot(symRef);
          if (sharesSlot)
             {
             if (trace)
-               traceMsg(comp(), "#%d shares pending push slot\n", symRef->getReferenceNumber());
-            if (comp()->getOption(TR_DisableOSRSharedSlots))
+               traceMsg(self()->comp(), "#%d shares pending push slot\n", symRef->getReferenceNumber());
+            if (self()->comp()->getOption(TR_DisableOSRSharedSlots))
               {
-               comp()->setErrorCode(COMPILATION_IL_GEN_FAILURE);
-               comp()->fe()->outOfMemory(comp(), "Pending push slot sharing detected");
+               self()->comp()->setErrorCode(COMPILATION_IL_GEN_FAILURE);
+               self()->comp()->fe()->outOfMemory(self()->comp(), "Pending push slot sharing detected");
                }
             }
 
-         if (getSyncObjectTemp() == symRef)
+         if (self()->getSyncObjectTemp() == symRef)
             alreadyLoadedSyncObjectTemp = true;
-         else if (getThisTempForObjectCtor() == symRef)
+         else if (self()->getThisTempForObjectCtor() == symRef)
             alreadyLoadedThisTempForObjectCtor = true;
 
          loadNodes.add(TR::Node::createLoad(firstNode, symRef));
@@ -1046,7 +1046,7 @@ OMR::ResolvedMethodSymbol::genOSRHelperCall(int32_t currentInlinedSiteIndex, TR:
       }
 
    //  parameters and autos
-   TR_Array<List<TR::SymbolReference> > *autosListArray = getAutoSymRefs();
+   TR_Array<List<TR::SymbolReference> > *autosListArray = self()->getAutoSymRefs();
    for (i = 0; autosListArray && i < autosListArray->size(); ++i)
       {
       List<TR::SymbolReference> autosList = (*autosListArray)[i];
@@ -1054,28 +1054,28 @@ OMR::ResolvedMethodSymbol::genOSRHelperCall(int32_t currentInlinedSiteIndex, TR:
       int symRefOrder = 0;
       for (TR::SymbolReference* symRef = autosIt.getFirst(); symRef; symRef = autosIt.getNext(), symRefOrder++)
          {
-         bool sharesSlot = sharesStackSlot(symRef);
+         bool sharesSlot = self()->sharesStackSlot(symRef);
          if (sharesSlot)
             {
             if (trace)
-               traceMsg(comp(), "#%d shares auto slot\n", symRef->getReferenceNumber());
-            if (comp()->getOption(TR_DisableOSRSharedSlots))
+               traceMsg(self()->comp(), "#%d shares auto slot\n", symRef->getReferenceNumber());
+            if (self()->comp()->getOption(TR_DisableOSRSharedSlots))
                {
-               comp()->setErrorCode(COMPILATION_IL_GEN_FAILURE);
-               comp()->fe()->outOfMemory(comp(), "Auto/parm slot sharing detected");
+               self()->comp()->setErrorCode(COMPILATION_IL_GEN_FAILURE);
+               self()->comp()->fe()->outOfMemory(self()->comp(), "Auto/parm slot sharing detected");
                }
             }
          // Certain special temps go into the OSR buffer, but most don't
          //
-         if (getSyncObjectTemp() == symRef)
+         if (self()->getSyncObjectTemp() == symRef)
             alreadyLoadedSyncObjectTemp = true;
-         else if (getThisTempForObjectCtor() == symRef)
+         else if (self()->getThisTempForObjectCtor() == symRef)
             alreadyLoadedThisTempForObjectCtor = true;
-         else if (symRef->getCPIndex() >= getFirstJitTempIndex())
+         else if (symRef->getCPIndex() >= self()->getFirstJitTempIndex())
             continue;
          TR::Symbol *sym = symRef->getSymbol();
          if (trace)
-            traceMsg(comp(), "symref # %d is %s\n", symRef->getReferenceNumber(), (sym->isAuto()?"auto":(sym->isParm()?"parm":"not auto or parm")));
+            traceMsg(self()->comp(), "symref # %d is %s\n", symRef->getReferenceNumber(), (sym->isAuto()?"auto":(sym->isParm()?"parm":"not auto or parm")));
 
          loadNodes.add(TR::Node::createLoad(firstNode, symRef));
          loadNodes.add(TR::Node::iconst(firstNode, symRef->getReferenceNumber()));
@@ -1084,17 +1084,17 @@ OMR::ResolvedMethodSymbol::genOSRHelperCall(int32_t currentInlinedSiteIndex, TR:
 
       }
 
-   if (!alreadyLoadedSyncObjectTemp && (getSyncObjectTemp() != NULL))
+   if (!alreadyLoadedSyncObjectTemp && (self()->getSyncObjectTemp() != NULL))
       {
-      loadNodes.add(TR::Node::createLoad(firstNode, getSyncObjectTemp()));
-      loadNodes.add(TR::Node::iconst(firstNode, getSyncObjectTemp()->getReferenceNumber()));
+      loadNodes.add(TR::Node::createLoad(firstNode, self()->getSyncObjectTemp()));
+      loadNodes.add(TR::Node::iconst(firstNode, self()->getSyncObjectTemp()->getReferenceNumber()));
       loadNodes.add(TR::Node::iconst(firstNode, -1));
       }
 
-   if (!alreadyLoadedThisTempForObjectCtor && (getThisTempForObjectCtor() != NULL))
+   if (!alreadyLoadedThisTempForObjectCtor && (self()->getThisTempForObjectCtor() != NULL))
       {
-      loadNodes.add(TR::Node::createLoad(firstNode, getThisTempForObjectCtor()));
-      loadNodes.add(TR::Node::iconst(firstNode, getThisTempForObjectCtor()->getReferenceNumber()));
+      loadNodes.add(TR::Node::createLoad(firstNode, self()->getThisTempForObjectCtor()));
+      loadNodes.add(TR::Node::iconst(firstNode, self()->getThisTempForObjectCtor()->getReferenceNumber()));
       loadNodes.add(TR::Node::iconst(firstNode, -1));
       }
 
@@ -1113,47 +1113,47 @@ OMR::ResolvedMethodSymbol::genOSRHelperCall(int32_t currentInlinedSiteIndex, TR:
    // Add the call to the OSR Block
    TR::Node *osrNode = TR::Node::create(TR::treetop, 1, osrCall);
    TR::Block *OSRCodeBlock = osrMethodData->getOSRCodeBlock();
-   TR::TreeTop *osrTT = TR::TreeTop::create(comp(), osrNode);
+   TR::TreeTop *osrTT = TR::TreeTop::create(self()->comp(), osrNode);
    OSRCodeBlock->append(osrTT);
 
    bool disableOSRwithTM = feGetEnv("TR_disableOSRwithTM") ? true: false;
-   if (comp()->cg()->getSupportsTM() && !comp()->getOption(TR_DisableTLE) && !disableOSRwithTM)
+   if (self()->comp()->cg()->getSupportsTM() && !self()->comp()->getOption(TR_DisableTLE) && !disableOSRwithTM)
       {
       TR::Node *tabortNode = TR::Node::create(osrNode, TR::tabort, 0, 0);
-      TR::TreeTop *tabortTT = TR::TreeTop::create(comp(),tabortNode, NULL,NULL);
-      tabortNode->setSymbolReference(comp()->getSymRefTab()->findOrCreateTransactionAbortSymbolRef(comp()->getMethodSymbol()));
+      TR::TreeTop *tabortTT = TR::TreeTop::create(self()->comp(),tabortNode, NULL,NULL);
+      tabortNode->setSymbolReference(self()->comp()->getSymRefTab()->findOrCreateTransactionAbortSymbolRef(self()->comp()->getMethodSymbol()));
       if (trace)
-         traceMsg(comp(), "adding tabortNode %p, tabortTT %p, osrNode %p\n", tabortNode, tabortTT, osrNode);
+         traceMsg(self()->comp(), "adding tabortNode %p, tabortTT %p, osrNode %p\n", tabortNode, tabortTT, osrNode);
       osrTT->insertBefore(tabortTT);
       if (trace)
-         traceMsg(comp(), "osrNode->getPrevTreeTop()->getNode() %p\n", osrTT->getPrevTreeTop()->getNode());
+         traceMsg(self()->comp(), "osrNode->getPrevTreeTop()->getNode() %p\n", osrTT->getPrevTreeTop()->getNode());
       }
 
-   if (comp()->getCurrentInlinedSiteIndex() == -1)
+   if (self()->comp()->getCurrentInlinedSiteIndex() == -1)
       {
       //I'm compiling the top-level caller, so put a TR::igoto to vmThread->osrReturnAddress
       //to get the control back to the VM after we fill the OSR buffer
-      TR::Node* osrReturnAddress = TR::Node::createLoad(firstNode , comp()->getSymRefTab()->findOrCreateOSRReturnAddressSymbolRef());
+      TR::Node* osrReturnAddress = TR::Node::createLoad(firstNode , self()->comp()->getSymRefTab()->findOrCreateOSRReturnAddressSymbolRef());
       TR::Node* igotoNode = TR::Node::create(firstNode, TR::igoto, 1);
       igotoNode->setChild(0, osrReturnAddress);
       osrReturnAddress->incReferenceCount();
-      OSRCodeBlock->append(TR::TreeTop::create(comp(), igotoNode));
+      OSRCodeBlock->append(TR::TreeTop::create(self()->comp(), igotoNode));
       }
    else
       {
       //create an appropritely-typed return node and append it to the OSR code block and add
       //the corresponding cfg edge
-      bool voidReturn = getResolvedMethod()->returnOpCode() == TR::Return;
-      TR::Node *retNode = TR::Node::create(firstNode, getResolvedMethod()->returnOpCode(), voidReturn?0:1);
+      bool voidReturn = self()->getResolvedMethod()->returnOpCode() == TR::Return;
+      TR::Node *retNode = TR::Node::create(firstNode, self()->getResolvedMethod()->returnOpCode(), voidReturn?0:1);
       if (!voidReturn)
          {
-         TR::Node *retValNode = TR::Node::create(firstNode, comp()->il.opCodeForConst(getResolvedMethod()->returnType()), 0);
+         TR::Node *retValNode = TR::Node::create(firstNode, self()->comp()->il.opCodeForConst(self()->getResolvedMethod()->returnType()), 0);
          retValNode->setLongInt(0);
          retNode->setAndIncChild(0, retValNode);
          }
-      OSRCodeBlock->append(TR::TreeTop::create(comp(), retNode));
+      OSRCodeBlock->append(TR::TreeTop::create(self()->comp(), retNode));
       }
-   comp()->getFlowGraph()->addEdge(OSRCodeBlock, comp()->getFlowGraph()->getEnd());
+   self()->comp()->getFlowGraph()->addEdge(OSRCodeBlock, self()->comp()->getFlowGraph()->getEnd());
    }
 
 
@@ -1205,7 +1205,7 @@ OMR::ResolvedMethodSymbol::genIL(TR_FrontEnd * fe, TR::Compilation * comp, TR::S
          }
 
       if (_tempIndex == -1)
-         setParameterList();
+         self()->setParameterList();
       _tempIndex = _firstJitTempIndex;
       //_automaticList.setListHead(0); // what's the point ? sym ref tab can use the sym refs anyway by using methodSymbol's auto sym refs and pending push sym refs list; this only confuses analyses into thinking these autos cannot be used when they actually can be
 
@@ -1217,7 +1217,7 @@ OMR::ResolvedMethodSymbol::genIL(TR_FrontEnd * fe, TR::Compilation * comp, TR::S
          {
          if (!comp->isPeekingMethod())
             {
-            if (catchBlocksHaveRealPredecessors(comp->getFlowGraph(), comp))
+            if (self()->catchBlocksHaveRealPredecessors(comp->getFlowGraph(), comp))
                comp->fe()->outOfMemory(comp, "Catch blocks have real predecessors");
             }
 
@@ -1239,23 +1239,23 @@ OMR::ResolvedMethodSymbol::genIL(TR_FrontEnd * fe, TR::Compilation * comp, TR::S
             comp->setOptimizer(optimizer);
             }
 
-         detectInternalCycles(comp->getFlowGraph(), comp);
+         self()->detectInternalCycles(comp->getFlowGraph(), comp);
 
          if (doOSR)
             {
             TR_ASSERT(comp->getOSRCompilationData(), "OSR compilation data is NULL\n");
             if (comp->canAffordOSRControlFlow())
                {
-               genAndAttachOSRCodeBlocks(comp->getCurrentInlinedSiteIndex());
-               if (!getOSRPoints().isEmpty())
+               self()->genAndAttachOSRCodeBlocks(comp->getCurrentInlinedSiteIndex());
+               if (!self()->getOSRPoints().isEmpty())
                   {
-                  genOSRHelperCall(comp->getCurrentInlinedSiteIndex(), symRefTab);
+                  self()->genOSRHelperCall(comp->getCurrentInlinedSiteIndex(), symRefTab);
                   if (comp->getOption(TR_TraceOSR))
                      comp->dumpMethodTrees("Trees after OSR in genIL", self());
                   }
 
                if (!comp->isOutermostMethod())
-                  cleanupUnreachableOSRBlocks(comp->getCurrentInlinedSiteIndex(), comp);
+                  self()->cleanupUnreachableOSRBlocks(comp->getCurrentInlinedSiteIndex(), comp);
                }
             }
 
@@ -1375,7 +1375,7 @@ OMR::ResolvedMethodSymbol::getNumberOfBackEdges()
    {
    int32_t numBackEdges = 0;
    bool inColdBlock = false;
-   for (TR::TreeTop *tt = getFirstTreeTop();
+   for (TR::TreeTop *tt = self()->getFirstTreeTop();
         tt;
         tt = tt->getNextTreeTop())
       {
@@ -1399,12 +1399,12 @@ void
 OMR::ResolvedMethodSymbol::resetLiveLocalIndices()
    {
    TR::ParameterSymbol *p1;
-   ListIterator<TR::ParameterSymbol> parms(&getParameterList());
+   ListIterator<TR::ParameterSymbol> parms(&self()->getParameterList());
    for (p1 = parms.getFirst(); p1 != NULL; p1 = parms.getNext())
       p1->setLiveLocalIndexUninitialized();
 
    TR::AutomaticSymbol *p2;
-   ListIterator<TR::AutomaticSymbol> locals(&getAutomaticList());
+   ListIterator<TR::AutomaticSymbol> locals(&self()->getAutomaticList());
    for (p2 = locals.getFirst(); p2 != NULL; p2 = locals.getNext())
       p2->setLiveLocalIndexUninitialized();
    }
@@ -1419,7 +1419,7 @@ OMR::ResolvedMethodSymbol::supportsInduceOSR(TR_ByteCodeInfo bci,
    if (!comp->supportsInduceOSR())
       return false;
 
-   if (cannotAttemptOSR(bci, nodeToOSRAt, blockToOSRAt, calleeSymbolIfCallNode, comp))
+   if (self()->cannotAttemptOSR(bci, nodeToOSRAt, blockToOSRAt, calleeSymbolIfCallNode, comp))
       return false;
 
    return true;
@@ -1608,7 +1608,7 @@ OMR::ResolvedMethodSymbol::cleanupUnreachableOSRBlocks(int32_t inlinedSiteIndex,
 
             while (!CallerOSRCatchBlock->getExceptionPredecessors().empty())
                {
-               getFlowGraph()->removeEdge(CallerOSRCatchBlock->getExceptionPredecessors().front());
+               self()->getFlowGraph()->removeEdge(CallerOSRCatchBlock->getExceptionPredecessors().front());
                }
             }
          else
@@ -1712,9 +1712,9 @@ OMR::ResolvedMethodSymbol::addAutomatic(TR::AutomaticSymbol *p)
    {
    if (!_automaticList.find(p))
       {
-      bool compiledMethod = comp()->getMethodSymbol() == self();
+      bool compiledMethod = self()->comp()->getMethodSymbol() == self();
 
-      TR::CodeGenerator *cg = comp()->cg();
+      TR::CodeGenerator *cg = self()->comp()->cg();
       if (cg->getMappingAutomatics() && compiledMethod)
          cg->getLinkage()->mapSingleAutomatic(p, self()->getLocalMappingCursor());
 
@@ -1750,16 +1750,16 @@ OMR::ResolvedMethodSymbol::addTrivialDeadTreeBlock(TR::Block *b)
 ncount_t
 OMR::ResolvedMethodSymbol::generateAccurateNodeCount()
    {
-   TR::TreeTop *tt = getFirstTreeTop();
+   TR::TreeTop *tt = self()->getFirstTreeTop();
 
-   comp()->incOrResetVisitCount();
+   self()->comp()->incOrResetVisitCount();
 
    ncount_t count=0;
 
    for (; tt; tt = tt->getNextTreeTop())
       {
       TR::Node *node = tt->getNode();
-      count += recursivelyCountChildren(node);
+      count += self()->recursivelyCountChildren(node);
       }
    return count;
    }
@@ -1769,15 +1769,15 @@ OMR::ResolvedMethodSymbol::recursivelyCountChildren(TR::Node *node)
    {
    ncount_t count=1;
 
-   if( node->getVisitCount() >= comp()->getVisitCount() )
+   if( node->getVisitCount() >= self()->comp()->getVisitCount() )
       return 0;
 
-   node->setVisitCount(comp()->getVisitCount());
+   node->setVisitCount(self()->comp()->getVisitCount());
 
    for(int32_t i=0 ; i < node->getNumChildren(); i++)
       {
       if( node->getChild(i) )
-         count += recursivelyCountChildren(node->getChild(i));
+         count += self()->recursivelyCountChildren(node->getChild(i));
       }
 
    return count;
@@ -1786,10 +1786,10 @@ OMR::ResolvedMethodSymbol::recursivelyCountChildren(TR::Node *node)
 List<TR::SymbolReference> &
 OMR::ResolvedMethodSymbol::getAutoSymRefs(int32_t slot)
    {
-   TR_Memory * m = comp()->trMemory();
+   TR_Memory * m = self()->comp()->trMemory();
    if (!_autoSymRefs)
       {
-      if (comp()->getMethodSymbol() == self())
+      if (self()->comp()->getMethodSymbol() == self())
          _autoSymRefs = new (m->trHeapMemory()) TR_Array<List<TR::SymbolReference> >(m, 100, true);
       else
          _autoSymRefs = new (m->trHeapMemory()) TR_Array<List<TR::SymbolReference> >(m, _resolvedMethod->numberOfParameterSlots() + _resolvedMethod->numberOfTemps() + 5, true);
@@ -1811,14 +1811,14 @@ void
 OMR::ResolvedMethodSymbol::setParmSymRef(int32_t slot, TR::SymbolReference *symRef)
    {
    if (!_parmSymRefs)
-      _parmSymRefs = new (comp()->trHeapMemory()) TR_Array<TR::SymbolReference*>(comp()->trMemory(), getNumParameterSlots());
+      _parmSymRefs = new (self()->comp()->trHeapMemory()) TR_Array<TR::SymbolReference*>(self()->comp()->trMemory(), self()->getNumParameterSlots());
    (*_parmSymRefs)[slot] = symRef;
    }
 
 List<TR::SymbolReference> &
 OMR::ResolvedMethodSymbol::getPendingPushSymRefs(int32_t slot)
    {
-   TR_Memory * m = comp()->trMemory();
+   TR_Memory * m = self()->comp()->trMemory();
    if (!_pendingPushSymRefs)
       {
       _pendingPushSymRefs = new (m->trHeapMemory()) TR_Array<List<TR::SymbolReference> >(m, 10, true);
@@ -1836,8 +1836,8 @@ OMR::ResolvedMethodSymbol::removeTree(TR::TreeTop *tt)
    if (node != NULL)
       {
       node->recursivelyDecReferenceCount();
-      if (comp()->getOption(TR_TraceAddAndRemoveEdge))
-         traceMsg(comp(), "remove [%s]\n", node->getName(comp()->getDebug()));
+      if (self()->comp()->getOption(TR_TraceAddAndRemoveEdge))
+         traceMsg(self()->comp(), "remove [%s]\n", node->getName(self()->comp()->getDebug()));
       }
 
    TR::TreeTop *prev = tt->getPrevTreeTop();
@@ -1867,11 +1867,11 @@ OMR::ResolvedMethodSymbol::getLastTreeTop(TR::Block * b)
 TR::Block *
 OMR::ResolvedMethodSymbol::prependEmptyFirstBlock()
    {
-   TR::Node * firstNode = getFirstTreeTop()->getNode();
+   TR::Node * firstNode = self()->getFirstTreeTop()->getNode();
    TR::Block * firstBlock = firstNode->getBlock();
 
    TR::Block * newBlock = TR::Block::createEmptyBlock(firstNode, _flowGraph->comp(), firstBlock->getFrequency());
-   setFirstTreeTop(newBlock->getEntry());
+   self()->setFirstTreeTop(newBlock->getEntry());
 
    _flowGraph->insertBefore(newBlock, firstBlock);
    _flowGraph->addEdge(_flowGraph->getStart(), newBlock);
@@ -2026,9 +2026,9 @@ OMR::ResolvedMethodSymbol::removeUnusedLocals()
    uint32_t removedSize = 0;
 #endif
 
-   bool compiledMethod = (comp()->getMethodSymbol() == self());
+   bool compiledMethod = (self()->comp()->getMethodSymbol() == self());
 
-   TR_BitVector *liveButMaybeUnreferencedLocals = comp()->cg()->getLiveButMaybeUnreferencedLocals();
+   TR_BitVector *liveButMaybeUnreferencedLocals = self()->comp()->cg()->getLiveButMaybeUnreferencedLocals();
 
    while (cursor)
       {
@@ -2073,11 +2073,36 @@ OMR::ResolvedMethodSymbol::removeUnusedLocals()
                   afterTotalSize,
                   removedSize,
                   removedTotalSize,
-                  comp()->signature());
+                  self()->comp()->signature());
       }
 #endif
    }
 
+int32_t
+OMR::ResolvedMethodSymbol::incTempIndex(TR_FrontEnd * fe)
+   {
+   return self()->setTempIndex(_tempIndex+1, fe);
+   }
+
+bool
+OMR::ResolvedMethodSymbol::hasEscapeAnalysisOpportunities()
+   {
+   return self()->hasNews() || self()->hasDememoizationOpportunities();
+   }
+
+bool
+OMR::ResolvedMethodSymbol::doJSR292PerfTweaks()
+   {
+   return self()->hasMethodHandleInvokes();
+   }
+
+int32_t
+OMR::ResolvedMethodSymbol::getArrayCopyTempSlot(TR_FrontEnd * fe)
+   {
+   if (_arrayCopyTempSlot == -1)
+      _arrayCopyTempSlot = self()->incTempIndex(fe);
+   return _arrayCopyTempSlot;
+   }
 
 //Explicit instantiations
 

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
@@ -67,7 +67,7 @@ namespace OMR
 /**
  * Class for resolved method symbols
  */
-class ResolvedMethodSymbol : public TR::MethodSymbol
+class OMR_EXTENSIBLE ResolvedMethodSymbol : public TR::MethodSymbol
    {
 
 protected:
@@ -162,8 +162,7 @@ public:
    bool induceOSRAfter(TR::TreeTop *insertionPoint, TR_ByteCodeInfo induceBCI, TR::TreeTop* branch, bool extendRemainder);
    TR::TreeTop *induceImmediateOSRWithoutChecksBefore(TR::TreeTop *insertionPoint);
 
-   int32_t incTempIndex(TR_FrontEnd * fe)
-      { return setTempIndex(_tempIndex+1, fe); }
+   int32_t incTempIndex(TR_FrontEnd * fe);
 
    void setFirstJitTempIndex(int32_t index) { _firstJitTempIndex = index; }
    int32_t getFirstJitTempIndex() { TR_ASSERT(_tempIndex >= 0, "assertion failure"); return _firstJitTempIndex; }
@@ -221,7 +220,7 @@ public:
    bool hasDememoizationOpportunities()      {return _methodFlags2.testAny(HasDememoizationOpportunities); }
    void setHasDememoizationOpportunities(bool b) { _methodFlags2.set(HasDememoizationOpportunities, b); }
 
-   bool hasEscapeAnalysisOpportunities()     { return hasNews() || hasDememoizationOpportunities(); }
+   bool hasEscapeAnalysisOpportunities();
 
    bool mayHaveIndirectCalls()               { return _methodFlags.testAny(MayHaveIndirectCalls); }
    void setMayHaveIndirectCalls(bool b)      { _methodFlags.set(MayHaveIndirectCalls, b); }
@@ -231,7 +230,7 @@ public:
 
    bool hasMethodHandleInvokes()             {return _methodFlags2.testAny(HasMethodHandleInvokes); }
    void setHasMethodHandleInvokes(bool b)    { _methodFlags2.set(HasMethodHandleInvokes, b); }
-   bool doJSR292PerfTweaks()                 { return hasMethodHandleInvokes(); }
+   bool doJSR292PerfTweaks();
 
    bool hasCheckCasts()                      { return _methodFlags2.testAny(HasCheckCasts); }
    void setHasCheckCasts(bool b)             { _methodFlags2.set(HasCheckCasts, b); }
@@ -294,12 +293,7 @@ public:
       }
 
    int32_t getTempIndex() { return _tempIndex; }
-   int32_t getArrayCopyTempSlot(TR_FrontEnd * fe)
-      {
-      if (_arrayCopyTempSlot == -1)
-         _arrayCopyTempSlot = incTempIndex(fe);
-      return _arrayCopyTempSlot;
-      }
+   int32_t getArrayCopyTempSlot(TR_FrontEnd * fe);
 
    TR::SymbolReference *getPythonConstsSymbolRef() { return _pythonConstsSymRef; }
 

--- a/compiler/il/symbol/OMRStaticSymbol.hpp
+++ b/compiler/il/symbol/OMRStaticSymbol.hpp
@@ -44,7 +44,7 @@ namespace OMR
 /**
  * A symbol with an adress
  */
-class StaticSymbol : public TR::Symbol
+class OMR_EXTENSIBLE StaticSymbol : public TR::Symbol
    {
 
 public:

--- a/compiler/il/symbol/OMRSymbol.cpp
+++ b/compiler/il/symbol/OMRSymbol.cpp
@@ -71,17 +71,39 @@ TR::Symbol * OMR::Symbol::create(AllocatorType m, TR::DataTypes d, uint32_t s)
    return new (m) TR::Symbol(d,s);
    }
 
+OMR::Symbol::Symbol(TR::DataTypes d) :
+   _size(0),
+   _name(0),
+   _flags(0),
+   _flags2(0),
+   _sideTableIndex(0),
+   _restrictedRegisterNumber(-1)
+   {
+   self()->setDataType(d);
+   }
+
+OMR::Symbol::Symbol(TR::DataTypes d, uint32_t size) :
+   _name(0),
+   _flags(0),
+   _flags2(0),
+   _sideTableIndex(0),
+   _restrictedRegisterNumber(-1)
+   {
+   self()->setDataType(d);
+   _size = size;
+   }
+
 bool
 OMR::Symbol::isReferenced()
    {
-   return isVariableSizeSymbol() && castToVariableSizeSymbol()->isReferenced();
+   return self()->isVariableSizeSymbol() && self()->castToVariableSizeSymbol()->isReferenced();
    }
 
 bool
 OMR::Symbol::dontEliminateStores(TR::Compilation *comp, bool isForLocalDeadStore)
    {
-   return (isAuto() && _flags.testAny(PinningArrayPointer)) ||
-          (isParm() && _flags.testAny(ReinstatedReceiver)) ||
+   return (self()->isAuto() && _flags.testAny(PinningArrayPointer)) ||
+          (self()->isParm() && _flags.testAny(ReinstatedReceiver)) ||
           _flags.testAny(HoldsMonitoredObject) ||
           (comp->getSymRefTab()->findThisRangeExtensionSymRef() && (self() == comp->getSymRefTab()->findThisRangeExtensionSymRef()->getSymbol()));
    }
@@ -89,7 +111,7 @@ OMR::Symbol::dontEliminateStores(TR::Compilation *comp, bool isForLocalDeadStore
 uint32_t
 OMR::Symbol::getNumberOfSlots()
    {
-   uint32_t numSlots = getRoundedSize()/convertTypeToSize(TR::Address);
+   uint32_t numSlots = self()->getRoundedSize()/self()->convertTypeToSize(TR::Address);
 
    // We should always give at least 1 slot.
    //  This is specifically for the case of an int type on 64bit pltfrms
@@ -134,7 +156,7 @@ OMR::Symbol::setDataType(TR::DataTypes dt)
 uint32_t
 OMR::Symbol::getRoundedSize()
    {
-   int32_t roundedSize = (int32_t)((getSize()+3)&(~3)); // cast explicitly
+   int32_t roundedSize = (int32_t)((self()->getSize()+3)&(~3)); // cast explicitly
    return roundedSize ? roundedSize : 4;
    }
 
@@ -154,7 +176,7 @@ OMR::Symbol::convertTypeToNumberOfSlots(TR::DataTypes dt)
 int32_t
 OMR::Symbol::getOffset()
    {
-   TR::RegisterMappedSymbol * r = getRegisterMappedSymbol();
+   TR::RegisterMappedSymbol * r = self()->getRegisterMappedSymbol();
    return r ? r->getOffset() : 0;
    }
 
@@ -165,77 +187,77 @@ OMR::Symbol::getOffset()
 bool
 OMR::Symbol::isCollectedReference()
    {
-   return (getDataType()==TR::Address || isLocalObject()) && !isNotCollected();
+   return (self()->getDataType()==TR::Address || self()->isLocalObject()) && !self()->isNotCollected();
    }
 
 bool
 OMR::Symbol::isInternalPointerAuto()
    {
-   return (isInternalPointer() && isAuto());
+   return (self()->isInternalPointer() && self()->isAuto());
    }
 
 bool
 OMR::Symbol::isNamed()
    {
-   return isStatic() && _flags.testAny(IsNamed);
+   return self()->isStatic() && _flags.testAny(IsNamed);
    }
 
 void
 OMR::Symbol::setSpillTempAuto()
    {
-   TR_ASSERT(isAuto(), "assertion failure");
+   TR_ASSERT(self()->isAuto(), "assertion failure");
    _flags.set(SpillTemp);
    }
 
 bool
 OMR::Symbol::isSpillTempAuto()
    {
-   return isAuto() && _flags.testAny(SpillTemp);
+   return self()->isAuto() && _flags.testAny(SpillTemp);
    }
 
 void
 OMR::Symbol::setLocalObject()
    {
-   TR_ASSERT(isAuto(), "assertion failure");
+   TR_ASSERT(self()->isAuto(), "assertion failure");
    _flags.set(IsLocalObject);
    }
 
 bool
 OMR::Symbol::isLocalObject()
    {
-   return isAuto() && _flags.testAny(IsLocalObject);
+   return self()->isAuto() && _flags.testAny(IsLocalObject);
    }
 
 void
 OMR::Symbol::setBehaveLikeNonTemp()
    {
-   TR_ASSERT(isAuto(), "assertion failure");
+   TR_ASSERT(self()->isAuto(), "assertion failure");
    _flags.set(BehaveLikeNonTemp);
    }
 
 bool
 OMR::Symbol::behaveLikeNonTemp()
    {
-   return isAuto() && _flags.testAny(BehaveLikeNonTemp);
+   return self()->isAuto() && _flags.testAny(BehaveLikeNonTemp);
    }
 
 void
 OMR::Symbol::setPinningArrayPointer()
    {
-   TR_ASSERT(isAuto(), "assertion failure");
+   TR_ASSERT(self()->isAuto(), "assertion failure");
    _flags.set(PinningArrayPointer);
    }
 
 bool
 OMR::Symbol::isPinningArrayPointer()
    {
-   return isAuto() && _flags.testAny(PinningArrayPointer);
+   return self()->isAuto() && _flags.testAny(PinningArrayPointer);
    }
 
 bool
 OMR::Symbol::isRegisterSymbol()
    {
-   return isAuto() && _flags.testAny(RegisterAuto);
+   return self()->isAuto() && _flags.testAny(RegisterAuto);
    }
 
 void
@@ -247,99 +269,99 @@ OMR::Symbol::setIsRegisterSymbol()
 void
 OMR::Symbol::setAutoAddressTaken()
    {
-   TR_ASSERT(isAuto(), "assertion failure");
+   TR_ASSERT(self()->isAuto(), "assertion failure");
    _flags.set(AutoAddressTaken);
    }
 
 bool
 OMR::Symbol::isAutoAddressTaken()
    {
-   return isAuto() && _flags.testAny(AutoAddressTaken);
+   return self()->isAuto() && _flags.testAny(AutoAddressTaken);
    }
 
 void
 OMR::Symbol::setSpillTempLoaded()
    {
-   if (isAuto()) // For non auto spills (ie. to original location) we can't optimize removing spills
+   if (self()->isAuto()) // For non auto spills (ie. to original location) we can't optimize removing spills
      _flags.set(SpillTempLoaded);
    }
 
 bool
 OMR::Symbol::isSpillTempLoaded()
    {
-   return isSpillTempAuto() && _flags.testAny(SpillTempLoaded);
+   return self()->isSpillTempAuto() && _flags.testAny(SpillTempLoaded);
    }
 
 void
 OMR::Symbol::setAutoMarkerSymbol()
    {
-   TR_ASSERT(isAuto(), "assertion failure");
+   TR_ASSERT(self()->isAuto(), "assertion failure");
    _flags.set(AutoMarkerSymbol);
    }
 
 bool
 OMR::Symbol::isAutoMarkerSymbol()
    {
-   return (isAuto() && _flags.testAny(AutoMarkerSymbol));
+   return (self()->isAuto() && _flags.testAny(AutoMarkerSymbol));
    }
 
 void
 OMR::Symbol::setVariableSizeSymbol()
    {
-   TR_ASSERT(isAuto(), "assertion failure");
+   TR_ASSERT(self()->isAuto(), "assertion failure");
    _flags.set(VariableSizeSymbol);
    }
 
 bool
 OMR::Symbol::isVariableSizeSymbol()
    {
-   return (isAuto() && _flags.testAny(VariableSizeSymbol));
+   return (self()->isAuto() && _flags.testAny(VariableSizeSymbol));
    }
 
 void
 OMR::Symbol::setThisTempForObjectCtor()
    {
-   TR_ASSERT(isAuto(), "assertion failure");
+   TR_ASSERT(self()->isAuto(), "assertion failure");
    _flags.set(ThisTempForObjectCtor);
    }
 
 bool
 OMR::Symbol::isThisTempForObjectCtor()
    {
-   return isAuto() && _flags.testAny(ThisTempForObjectCtor);
+   return self()->isAuto() && _flags.testAny(ThisTempForObjectCtor);
    }
 
 void
 OMR::Symbol::setParmHasToBeOnStack()
    {
-   TR_ASSERT(isParm(), "assertion failure");
+   TR_ASSERT(self()->isParm(), "assertion failure");
    _flags.set(ParmHasToBeOnStack);
    }
 
 bool
 OMR::Symbol::isParmHasToBeOnStack()
    {
-   return isParm() && _flags.testAny(ParmHasToBeOnStack);
+   return self()->isParm() && _flags.testAny(ParmHasToBeOnStack);
    }
 
 void
 OMR::Symbol::setReferencedParameter()
    {
-   TR_ASSERT(isParm(), "assertion failure");
+   TR_ASSERT(self()->isParm(), "assertion failure");
    _flags.set(ReferencedParameter);
    }
 
 void
 OMR::Symbol::resetReferencedParameter()
    {
-   TR_ASSERT(isParm(), "assertion failure");
+   TR_ASSERT(self()->isParm(), "assertion failure");
    _flags.reset(ReferencedParameter);
    }
 
 bool
 OMR::Symbol::isReferencedParameter()
    {
-   return isParm() && _flags.testAny(ReferencedParameter);
+   return self()->isParm() && _flags.testAny(ReferencedParameter);
    }
 
 void
@@ -352,279 +374,279 @@ OMR::Symbol::setReinstatedReceiver()
 bool
 OMR::Symbol::isReinstatedReceiver()
    {
-   return isParm() && _flags.testAny(ReinstatedReceiver);
+   return self()->isParm() && _flags.testAny(ReinstatedReceiver);
    }
 
 void
 OMR::Symbol::setConstString()
    {
-   TR_ASSERT(isStatic(), "assertion failure");
+   TR_ASSERT(self()->isStatic(), "assertion failure");
    _flags.set(ConstString);
    }
 
 bool
 OMR::Symbol::isConstString()
    {
-   return isStatic() && _flags.testAny(ConstString);
+   return self()->isStatic() && _flags.testAny(ConstString);
    }
 
 void
 OMR::Symbol::setAddressIsCPIndexOfStatic(bool b)
    {
-   TR_ASSERT(isStatic(), "assertion failure");
+   TR_ASSERT(self()->isStatic(), "assertion failure");
    _flags.set(AddressIsCPIndexOfStatic, b);
    }
 
 bool
 OMR::Symbol::addressIsCPIndexOfStatic()
    {
-   return isStatic() && _flags.testAny(AddressIsCPIndexOfStatic);
+   return self()->isStatic() && _flags.testAny(AddressIsCPIndexOfStatic);
    }
 
 bool
 OMR::Symbol::isRecognizedStatic()
    {
-   return isStatic() && _flags.testAny(RecognizedStatic);
+   return self()->isStatic() && _flags.testAny(RecognizedStatic);
    }
 
 void
 OMR::Symbol::setCompiledMethod()
    {
-   TR_ASSERT(isStatic(), "assertion failure");
+   TR_ASSERT(self()->isStatic(), "assertion failure");
    _flags.set(CompiledMethod);
    }
 
 bool
 OMR::Symbol::isCompiledMethod()
    {
-   return isStatic() && _flags.testAny(CompiledMethod);
+   return self()->isStatic() && _flags.testAny(CompiledMethod);
    }
 
 void
 OMR::Symbol::setStartPC()
    {
-   TR_ASSERT(isStatic(), "assertion failure");
+   TR_ASSERT(self()->isStatic(), "assertion failure");
    _flags.set(StartPC);
    }
 
 bool
 OMR::Symbol::isStartPC()
    {
-   return isStatic() && _flags.testAny(StartPC);
+   return self()->isStatic() && _flags.testAny(StartPC);
    }
 
 void
 OMR::Symbol::setCountForRecompile()
    {
-   TR_ASSERT(isStatic(), "assertion failure");
+   TR_ASSERT(self()->isStatic(), "assertion failure");
    _flags.set(CountForRecompile);
    }
 
 bool
 OMR::Symbol::isCountForRecompile()
    {
-   return isStatic() && _flags.testAny(CountForRecompile);
+   return self()->isStatic() && _flags.testAny(CountForRecompile);
    }
 
 void
 OMR::Symbol::setRecompilationCounter()
    {
-   TR_ASSERT(isStatic(), "assertion failure");
+   TR_ASSERT(self()->isStatic(), "assertion failure");
    _flags.set(RecompilationCounter);
    }
 
 bool
 OMR::Symbol::isRecompilationCounter()
    {
-   return isStatic() && _flags.testAny(RecompilationCounter);
+   return self()->isStatic() && _flags.testAny(RecompilationCounter);
    }
 
 void
 OMR::Symbol::setGCRPatchPoint()
    {
-   TR_ASSERT(isStatic(), "assertion failure");
+   TR_ASSERT(self()->isStatic(), "assertion failure");
    _flags.set(GCRPatchPoint);
    }
 
 bool
 OMR::Symbol::isGCRPatchPoint()
    {
-   return isStatic() && _flags.testAny(GCRPatchPoint);
+   return self()->isStatic() && _flags.testAny(GCRPatchPoint);
    }
 
 bool
 OMR::Symbol::isJittedMethod()
    {
-   return isResolvedMethod() && _flags.testAny(IsJittedMethod);
+   return self()->isResolvedMethod() && _flags.testAny(IsJittedMethod);
    }
 
 void
 OMR::Symbol::setArrayShadowSymbol()
    {
-   TR_ASSERT(isShadow(), "assertion failure");
+   TR_ASSERT(self()->isShadow(), "assertion failure");
    _flags.set(ArrayShadow);
    }
 
 bool
 OMR::Symbol::isArrayShadowSymbol()
    {
-   return isShadow() && _flags.testAny(ArrayShadow);
+   return self()->isShadow() && _flags.testAny(ArrayShadow);
    }
 
 bool
 OMR::Symbol::isRecognizedShadow()
    {
-   return isShadow() && _flags.testAny(RecognizedShadow);
+   return self()->isShadow() && _flags.testAny(RecognizedShadow);
    }
 
 void
 OMR::Symbol::setArrayletShadowSymbol()
    {
-   TR_ASSERT(isShadow(), "assertion failure");
+   TR_ASSERT(self()->isShadow(), "assertion failure");
    _flags.set(ArrayletShadow);
    }
 
 bool
 OMR::Symbol::isArrayletShadowSymbol()
    {
-   return isShadow() && _flags.testAny(ArrayletShadow);
+   return self()->isShadow() && _flags.testAny(ArrayletShadow);
    }
 
 void
 OMR::Symbol::setPythonLocalVariableShadowSymbol()
    {
-   TR_ASSERT(isShadow(), "assertion failure");
+   TR_ASSERT(self()->isShadow(), "assertion failure");
    _flags.set(PythonLocalVariable);
    }
 
 bool
 OMR::Symbol::isPythonLocalVariableShadowSymbol()
    {
-   return isShadow() && _flags.testAny(PythonLocalVariable);
+   return self()->isShadow() && _flags.testAny(PythonLocalVariable);
    }
 
 void
 OMR::Symbol::setGlobalFragmentShadowSymbol()
    {
-   TR_ASSERT(isShadow(), "assertion failure");
+   TR_ASSERT(self()->isShadow(), "assertion failure");
    _flags.set(GlobalFragmentShadow);
    }
 
 bool
 OMR::Symbol::isGlobalFragmentShadowSymbol()
    {
-   return isShadow() && _flags.testAny(GlobalFragmentShadow);
+   return self()->isShadow() && _flags.testAny(GlobalFragmentShadow);
    }
 
 void
 OMR::Symbol::setMemoryTypeShadowSymbol()
    {
-   TR_ASSERT(isShadow(), "assertion failure");
+   TR_ASSERT(self()->isShadow(), "assertion failure");
    _flags.set(MemoryTypeShadow);
    }
 
 bool
 OMR::Symbol::isMemoryTypeShadowSymbol()
    {
-   return isShadow() && _flags.testAny(MemoryTypeShadow);
+   return self()->isShadow() && _flags.testAny(MemoryTypeShadow);
    }
 
 void
 OMR::Symbol::setPythonConstantShadowSymbol()
    {
-   TR_ASSERT(isShadow(), "assertion failure");
+   TR_ASSERT(self()->isShadow(), "assertion failure");
    _flags.set(PythonConstant);
    }
 
 bool
 OMR::Symbol::isPythonConstantShadowSymbol()
    {
-   return isShadow() && _flags.testAny(PythonConstant);
+   return self()->isShadow() && _flags.testAny(PythonConstant);
    }
 
 void
 OMR::Symbol::setPythonNameShadowSymbol()
    {
-   TR_ASSERT(isShadow(), "assertion failure");
+   TR_ASSERT(self()->isShadow(), "assertion failure");
    _flags.set(PythonName);
    }
 
 bool
 OMR::Symbol::isPythonNameShadowSymbol()
    {
-   return isShadow() && _flags.testAny(PythonName);
+   return self()->isShadow() && _flags.testAny(PythonName);
    }
 
 void
 OMR::Symbol::setStartOfColdInstructionStream()
    {
-   TR_ASSERT(isLabel(), "assertion failure"); _flags.set(StartOfColdInstructionStream);
+   TR_ASSERT(self()->isLabel(), "assertion failure"); _flags.set(StartOfColdInstructionStream);
    }
 
 bool
 OMR::Symbol::isStartOfColdInstructionStream()
    {
-   return isLabel() && _flags.testAny(StartOfColdInstructionStream);
+   return self()->isLabel() && _flags.testAny(StartOfColdInstructionStream);
    }
 
 void
 OMR::Symbol::setStartInternalControlFlow()
    {
-   TR_ASSERT(isLabel(), "assertion failure"); _flags.set(StartInternalControlFlow);
+   TR_ASSERT(self()->isLabel(), "assertion failure"); _flags.set(StartInternalControlFlow);
    }
 
 bool
 OMR::Symbol::isStartInternalControlFlow()
    {
-   return isLabel() && _flags.testAny(StartInternalControlFlow) && !isGlobalLabel();
+   return self()->isLabel() && _flags.testAny(StartInternalControlFlow) && !self()->isGlobalLabel();
    }
 
 void
 OMR::Symbol::setEndInternalControlFlow()
    {
-   TR_ASSERT(isLabel(), "assertion failure"); _flags.set(EndInternalControlFlow);
+   TR_ASSERT(self()->isLabel(), "assertion failure"); _flags.set(EndInternalControlFlow);
    }
 
 bool
 OMR::Symbol::isEndInternalControlFlow()
    {
-   return isLabel() && !isGlobalLabel() && _flags.testAny(EndInternalControlFlow) && !isGlobalLabel();
+   return self()->isLabel() && !self()->isGlobalLabel() && _flags.testAny(EndInternalControlFlow) && !self()->isGlobalLabel();
    }
 
 void
 OMR::Symbol::setVMThreadLive()
    {
-   TR_ASSERT(isLabel(), "assertion failure"); _flags.set(IsVMThreadLive);
+   TR_ASSERT(self()->isLabel(), "assertion failure"); _flags.set(IsVMThreadLive);
    }
 
 bool
 OMR::Symbol::isVMThreadLive()
    {
-   return isLabel() && _flags.testAny(IsVMThreadLive);
+   return self()->isLabel() && _flags.testAny(IsVMThreadLive);
    }
 
 void
 OMR::Symbol::setInternalControlFlowMerge()
    {
-   TR_ASSERT(isLabel(), "assertion failure"); _flags.set(InternalControlFlowMerge);
+   TR_ASSERT(self()->isLabel(), "assertion failure"); _flags.set(InternalControlFlowMerge);
    }
 
 bool
 OMR::Symbol::isInternalControlFlowMerge()
    {
-   return isLabel() && _flags.testAny(InternalControlFlowMerge);
+   return self()->isLabel() && _flags.testAny(InternalControlFlowMerge);
    }
 
 void
 OMR::Symbol::setEndOfColdInstructionStream()
    {
-   TR_ASSERT(isLabel(), "assertion failure"); _flags.set(EndOfColdInstructionStream);
+   TR_ASSERT(self()->isLabel(), "assertion failure"); _flags.set(EndOfColdInstructionStream);
    }
 
 bool
 OMR::Symbol::isEndOfColdInstructionStream()
    {
-   return isLabel() && _flags.testAny(EndOfColdInstructionStream);
+   return self()->isLabel() && _flags.testAny(EndOfColdInstructionStream);
    }
 
 void
@@ -636,75 +658,75 @@ OMR::Symbol::setNonLinear()
 bool
 OMR::Symbol::isNonLinear()
    {
-   return (isLabel() && _flags.testValue(OOLMask, (StartOfColdInstructionStream|NonLinear)));
+   return (self()->isLabel() && _flags.testValue(OOLMask, (StartOfColdInstructionStream|NonLinear)));
    }
 
 void
 OMR::Symbol::setGlobalLabel()
    {
-   TR_ASSERT(isLabel(), "assertion failure"); _flags.setValue(LabelKindMask, IsGlobalLabel);
+   TR_ASSERT(self()->isLabel(), "assertion failure"); _flags.setValue(LabelKindMask, IsGlobalLabel);
    }
 
 bool
 OMR::Symbol::isGlobalLabel()
    {
-   return isLabel() && _flags.testValue(LabelKindMask, IsGlobalLabel);
+   return self()->isLabel() && _flags.testValue(LabelKindMask, IsGlobalLabel);
    }
 
 void
 OMR::Symbol::setRelativeLabel()
    {
-   TR_ASSERT(isLabel(), "assertion failure"); _flags2.set(RelativeLabel);
+   TR_ASSERT(self()->isLabel(), "assertion failure"); _flags2.set(RelativeLabel);
    }
 
 bool
 OMR::Symbol::isRelativeLabel()
    {
-   return isLabel() && _flags2.testAny(RelativeLabel);
+   return self()->isLabel() && _flags2.testAny(RelativeLabel);
    }
 
 void
 OMR::Symbol::setConstMethodType()
    {
-   TR_ASSERT(isStatic(), "assertion failure");
+   TR_ASSERT(self()->isStatic(), "assertion failure");
    _flags2.set(ConstMethodType);
    }
 
 bool
 OMR::Symbol::isConstMethodType()
    {
-   return isStatic() && _flags2.testAny(ConstMethodType);
+   return self()->isStatic() && _flags2.testAny(ConstMethodType);
    }
 
 void
 OMR::Symbol::setConstMethodHandle()
    {
-   TR_ASSERT(isStatic(), "assertion failure");
+   TR_ASSERT(self()->isStatic(), "assertion failure");
    _flags2.set(ConstMethodHandle);
    }
 
 bool
 OMR::Symbol::isConstMethodHandle()
    {
-   return isStatic() && _flags2.testAny(ConstMethodHandle);
+   return self()->isStatic() && _flags2.testAny(ConstMethodHandle);
    }
 
 bool
 OMR::Symbol::isConstObjectRef()
    {
-   return isStatic() && (_flags.testAny(ConstString) || _flags2.testAny(ConstMethodType|ConstMethodHandle));
+   return self()->isStatic() && (_flags.testAny(ConstString) || _flags2.testAny(ConstMethodType|ConstMethodHandle));
    }
 
 bool
 OMR::Symbol::isStaticField()
    {
-   return isStatic() && !(isConstObjectRef() || isClassObject() || isAddressOfClassObject() || isConst());
+   return self()->isStatic() && !(self()->isConstObjectRef() || self()->isClassObject() || self()->isAddressOfClassObject() || self()->isConst());
    }
 
 bool
 OMR::Symbol::isFixedObjectRef()
    {
-   return isConstObjectRef() || isCallSiteTableEntry() || isMethodTypeTableEntry();
+   return self()->isConstObjectRef() || self()->isCallSiteTableEntry() || self()->isMethodTypeTableEntry();
    }
 
 void
@@ -717,57 +739,201 @@ OMR::Symbol::setCallSiteTableEntry()
 bool
 OMR::Symbol::isCallSiteTableEntry()
    {
-   return isStatic() && _flags2.testAny(CallSiteTableEntry);
+   return self()->isStatic() && _flags2.testAny(CallSiteTableEntry);
    }
 
 void
 OMR::Symbol::setMethodTypeTableEntry()
    {
-   TR_ASSERT(isStatic(), "assertion failure");
+   TR_ASSERT(self()->isStatic(), "assertion failure");
    _flags2.set(MethodTypeTableEntry);
    }
 
 bool
 OMR::Symbol::isMethodTypeTableEntry()
    {
-   return isStatic() && _flags2.testAny(MethodTypeTableEntry);
+   return self()->isStatic() && _flags2.testAny(MethodTypeTableEntry);
    }
 
 void
 OMR::Symbol::setNotDataAddress()
    {
-   TR_ASSERT(isStatic(), "assertion failure");
+   TR_ASSERT(self()->isStatic(), "assertion failure");
    _flags2.set(NotDataAddress);
    }
 
 bool
 OMR::Symbol::isNotDataAddress()
    {
-   return isStatic() && _flags2.testAny(NotDataAddress);
+   return self()->isStatic() && _flags2.testAny(NotDataAddress);
    }
 
 void
 OMR::Symbol::setUnsafeShadowSymbol()
    {
-   TR_ASSERT(isShadow(), "assertion failure"); _flags2.set(UnsafeShadow);
+   TR_ASSERT(self()->isShadow(), "assertion failure"); _flags2.set(UnsafeShadow);
    }
 
 bool
 OMR::Symbol::isUnsafeShadowSymbol()
    {
-   return isShadow() && _flags2.testAny(UnsafeShadow);
+   return self()->isShadow() && _flags2.testAny(UnsafeShadow);
    }
 
 void
 OMR::Symbol::setNamedShadowSymbol()
    {
-   TR_ASSERT(isShadow(), "assertion failure"); _flags2.set(NamedShadow);
+   TR_ASSERT(self()->isShadow(), "assertion failure"); _flags2.set(NamedShadow);
    }
 
 bool
 OMR::Symbol::isNamedShadowSymbol()
    {
-   return isShadow() && _flags2.testAny(NamedShadow);
+   return self()->isShadow() && _flags2.testAny(NamedShadow);
+   }
+
+TR::DataType
+OMR::Symbol::getType()
+   {
+   return self()->getDataType();
+   }
+
+bool
+OMR::Symbol::isMethod()
+   {
+   return self()->getKind() == IsMethod || self()->getKind() == IsResolvedMethod;
+   }
+
+bool
+OMR::Symbol::isRegisterMappedSymbol()
+   {
+   return self()->getKind() <= LastRegisterMapped;
+   }
+
+bool
+OMR::Symbol::isAutoOrParm()
+   {
+   return self()->getKind() <= IsParameter;
+   }
+
+bool
+OMR::Symbol::isRegularShadow()
+   {
+   return self()->isShadow() && !self()->isAutoField() && !self()->isParmField();
+   }
+
+bool
+OMR::Symbol::isSyncVolatile()
+   {
+   return self()->isVolatile();
+   }
+
+TR::RegisterMappedSymbol *
+OMR::Symbol::getRegisterMappedSymbol()
+   {
+   return self()->isRegisterMappedSymbol() ? (TR::RegisterMappedSymbol *)this : 0;
+   }
+
+TR::AutomaticSymbol *
+OMR::Symbol::getAutoSymbol()
+   {
+   return self()->isAuto() ? (TR::AutomaticSymbol *)this : 0;
+   }
+
+TR::ParameterSymbol *
+OMR::Symbol::getParmSymbol()
+   {
+   return self()->isParm() ? (TR::ParameterSymbol *)this : 0;
+   }
+
+TR::AutomaticSymbol *
+OMR::Symbol::getInternalPointerAutoSymbol()
+   {
+   return self()->isInternalPointerAuto() ? (TR::AutomaticSymbol *)this : 0;
+   }
+
+TR::AutomaticSymbol *
+OMR::Symbol::getLocalObjectSymbol()
+   {
+   return self()->isLocalObject() ? (TR::AutomaticSymbol *)this : 0;
+   }
+
+TR::StaticSymbol *
+OMR::Symbol::getStaticSymbol()
+   {
+   return self()->isStatic() ? (TR::StaticSymbol *)this : 0;
+   }
+
+TR::MethodSymbol *
+OMR::Symbol::getMethodSymbol()
+   {
+   return self()->isMethod() ? (TR::MethodSymbol *)this : 0;
+   }
+
+TR::ResolvedMethodSymbol *
+OMR::Symbol::getResolvedMethodSymbol()
+   {
+   return self()->isResolvedMethod() ? (TR::ResolvedMethodSymbol *)this : 0;
+   }
+
+TR::Symbol *
+OMR::Symbol::getShadowSymbol()
+   {
+   return self()->isShadow() ? (TR::Symbol *)this : 0;
+   }
+
+TR::RegisterMappedSymbol *
+OMR::Symbol::getMethodMetaDataSymbol()
+   {
+   return self()->isMethodMetaData() ? (TR::RegisterMappedSymbol *)this : 0;
+   }
+
+TR::LabelSymbol *
+OMR::Symbol::getLabelSymbol()
+   {
+   return self()->isLabel() ? (TR::LabelSymbol *)this : 0;
+   }
+
+TR::ResolvedMethodSymbol *
+OMR::Symbol::getJittedMethodSymbol()
+   {
+   return self()->isJittedMethod() ? (TR::ResolvedMethodSymbol *)this : 0;
+   }
+
+TR::StaticSymbol *
+OMR::Symbol::getCallSiteTableEntrySymbol()
+   {
+   return self()->isCallSiteTableEntry()? self()->castToCallSiteTableEntrySymbol() : NULL;
+   }
+
+TR::StaticSymbol *
+OMR::Symbol::getMethodTypeTableEntrySymbol()
+   {
+   return self()->isMethodTypeTableEntry()? self()->castToMethodTypeTableEntrySymbol() : NULL;
+   }
+
+TR::Symbol *
+OMR::Symbol::getNamedShadowSymbol()
+   {
+   return self()->isNamedShadowSymbol() ? (TR::Symbol *)this : 0;
+   }
+
+TR::AutomaticSymbol *
+OMR::Symbol::getRegisterSymbol()
+   {
+   return self()->isRegisterSymbol() ? (TR::AutomaticSymbol *)this : 0;
+   }
+
+TR::StaticSymbol *
+OMR::Symbol::getRecognizedStaticSymbol()
+   {
+   return self()->isRecognizedStatic() ? (TR::StaticSymbol*)this : 0;
+   }
+
+TR::AutomaticSymbol *
+OMR::Symbol::getVariableSizeSymbol()
+   {
+   return self()->isVariableSizeSymbol() ? (TR::AutomaticSymbol *)this : 0;
    }
 
 /*

--- a/compiler/il/symbol/OMRSymbol.hpp
+++ b/compiler/il/symbol/OMRSymbol.hpp
@@ -44,6 +44,7 @@ namespace OMR { typedef OMR::Symbol SymbolConnector; }
 
 #include <stddef.h>                 // for size_t
 #include <stdint.h>                 // for uint32_t, uint16_t, uint8_t, etc
+#include "infra/Annotations.hpp"    // for OMR_EXTENSIBLE
 #include "env/TRMemory.hpp"         // for TR_Memory, etc
 #include "il/DataTypes.hpp"         // for TR::DataType, DataTypes
 #include "infra/Assert.hpp"         // for TR_ASSERT
@@ -69,7 +70,7 @@ namespace OMR {
  * A Symbol object contains data type, size and attribute
  * information for a symbol.
  */
-class Symbol
+class OMR_EXTENSIBLE Symbol
    {
 
 public:
@@ -107,31 +108,13 @@ protected:
     * Create symbol of specified data type, inferring size
     * from type.
     */
-   Symbol(TR::DataTypes d) :
-      _size(0),
-      _name(0),
-      _flags(0),
-      _flags2(0),
-      _sideTableIndex(0),
-      _restrictedRegisterNumber(-1)
-      {
-      setDataType(d);
-      }
+   Symbol(TR::DataTypes d);
 
    /**
     * Create symbol of specified data type, inferring size
     * from type.
     */
-   Symbol(TR::DataTypes d, uint32_t size) :
-      _name(0),
-      _flags(0),
-      _flags2(0),
-      _sideTableIndex(0),
-      _restrictedRegisterNumber(-1)
-      {
-      setDataType(d);
-      _size = size;
-      }
+   Symbol(TR::DataTypes d, uint32_t size);
 
 public:
    /**
@@ -140,27 +123,28 @@ public:
     */
    virtual ~Symbol() {}
 
-   // If the symbol is of the correct type the inline get method downcasts the
-   // symbol to the correct type otherwise it returns 0.
-   //
-   inline TR::RegisterMappedSymbol            *getRegisterMappedSymbol();
-   inline TR::AutomaticSymbol                 *getAutoSymbol();
-   inline TR::ParameterSymbol                 *getParmSymbol();
-   inline TR::AutomaticSymbol                 *getInternalPointerAutoSymbol();
-   inline TR::AutomaticSymbol                 *getLocalObjectSymbol();
-   inline TR::StaticSymbol                    *getStaticSymbol();
-   inline TR::ResolvedMethodSymbol            *getResolvedMethodSymbol();
-   inline TR::MethodSymbol                    *getMethodSymbol();
-   inline TR::Symbol                          *getShadowSymbol();
-   inline TR::Symbol                          *getNamedShadowSymbol();
-   inline TR::RegisterMappedSymbol            *getMethodMetaDataSymbol();
-   inline TR::LabelSymbol                     *getLabelSymbol();
-   inline TR::ResolvedMethodSymbol            *getJittedMethodSymbol();
-   inline TR::StaticSymbol                    *getRecognizedStaticSymbol();
-   inline TR::AutomaticSymbol                 *getVariableSizeSymbol();
-   inline TR::StaticSymbol                    *getCallSiteTableEntrySymbol();
-   inline TR::StaticSymbol                    *getMethodTypeTableEntrySymbol();
-   inline TR::AutomaticSymbol                 *getRegisterSymbol();
+   /**
+    * If the symbol is of the correct type the get method downcasts the
+    * symbol to the correct type otherwise it returns 0.
+    */
+   TR::RegisterMappedSymbol                   *getRegisterMappedSymbol();
+   TR::AutomaticSymbol                        *getAutoSymbol();
+   TR::ParameterSymbol                        *getParmSymbol();
+   TR::AutomaticSymbol                        *getInternalPointerAutoSymbol();
+   TR::AutomaticSymbol                        *getLocalObjectSymbol();
+   TR::StaticSymbol                           *getStaticSymbol();
+   TR::ResolvedMethodSymbol                   *getResolvedMethodSymbol();
+   TR::MethodSymbol                           *getMethodSymbol();
+   TR::Symbol                                 *getShadowSymbol();
+   TR::Symbol                                 *getNamedShadowSymbol();
+   TR::RegisterMappedSymbol                   *getMethodMetaDataSymbol();
+   TR::LabelSymbol                            *getLabelSymbol();
+   TR::ResolvedMethodSymbol                   *getJittedMethodSymbol();
+   TR::StaticSymbol                           *getRecognizedStaticSymbol();
+   TR::AutomaticSymbol                        *getVariableSizeSymbol();
+   TR::StaticSymbol                           *getCallSiteTableEntrySymbol();
+   TR::StaticSymbol                           *getMethodTypeTableEntrySymbol();
+   TR::AutomaticSymbol                        *getRegisterSymbol();
 
    // The inline To methods perform an explicit (debug) assume that the symbol is a correct type
    // and then return the symbol explicitly cast to the type.
@@ -225,7 +209,7 @@ public:
 
    void          setDataType(TR::DataTypes dt);
    TR::DataTypes getDataType() { return (TR::DataTypes)_flags.getValue(DataTypeMask);}
-   TR::DataType  getType()     { return getDataType(); }
+   TR::DataType  getType();
 
    int32_t getKind()             { return _flags.getValue(KindMask);}
 
@@ -233,19 +217,19 @@ public:
    bool isParm()                 { return _flags.testValue(KindMask, IsParameter); }
    bool isMethodMetaData()       { return _flags.testValue(KindMask, IsMethodMetaData); }
    bool isResolvedMethod()       { return _flags.testValue(KindMask, IsResolvedMethod); }
-   bool isMethod()               { return getKind() == IsMethod || getKind() == IsResolvedMethod; }
+   bool isMethod();
    bool isStatic()               { return _flags.testValue(KindMask, IsStatic); }
    bool isShadow()               { return _flags.testValue(KindMask, IsShadow); }
    bool isLabel()                { return _flags.testValue(KindMask, IsLabel); }
    void setIsLabel()             { _flags.setValue(KindMask, IsLabel);}
 
-   bool isRegisterMappedSymbol() { return getKind() <= LastRegisterMapped; }
+   bool isRegisterMappedSymbol();
 
-   bool isAutoOrParm()           { return getKind() <= IsParameter; }
+   bool isAutoOrParm();
    bool isAutoField()            { return false; }
    bool isParmField()            { return false; }
    bool isWeakSymbol()           { return false; }
-   bool isRegularShadow()        { return isShadow() && !isAutoField() && !isParmField(); }
+   bool isRegularShadow();
 
    void setIsInGlobalRegister(bool b)       { _flags.set(IsInGlobalRegister, b); }
    bool isInGlobalRegister()                { return _flags.testAny(IsInGlobalRegister); }
@@ -256,7 +240,7 @@ public:
    void setVolatile()                       { _flags.set(Volatile); }
    void resetVolatile()                     { _flags.reset(Volatile); }
    bool isVolatile()                        { return _flags.testAny(Volatile); }
-   bool isSyncVolatile()                    { return isVolatile(); }
+   bool isSyncVolatile();
 
    void setInitializedReference()           { _flags.set(InitializedReference); }
    void setUninitializedReference()         { _flags.reset(InitializedReference); }
@@ -618,20 +602,10 @@ public:
 }
 
 // If these implementations are to be moved, they need to be un-defined as inline.
-TR::RegisterMappedSymbol * OMR::Symbol::getRegisterMappedSymbol()
-   {
-   return isRegisterMappedSymbol() ? (TR::RegisterMappedSymbol *)this : 0;
-   }
-
 TR::RegisterMappedSymbol * OMR::Symbol::castToRegisterMappedSymbol()
    {
    TR_ASSERT(isRegisterMappedSymbol(), "OMR::Symbol::castToRegisterMappedSymbol, symbol is not a register mapped symbol");
    return (TR::RegisterMappedSymbol *)this;
-   }
-
-TR::AutomaticSymbol * OMR::Symbol::getAutoSymbol()
-   {
-   return isAuto() ? (TR::AutomaticSymbol *)this : 0;
    }
 
 TR::AutomaticSymbol * OMR::Symbol::castToAutoSymbol()
@@ -640,20 +614,10 @@ TR::AutomaticSymbol * OMR::Symbol::castToAutoSymbol()
    return (TR::AutomaticSymbol *)this;
    }
 
-TR::ParameterSymbol * OMR::Symbol::getParmSymbol()
-   {
-   return isParm() ? (TR::ParameterSymbol *)this : 0;
-   }
-
 TR::ParameterSymbol * OMR::Symbol::castToParmSymbol()
    {
    TR_ASSERT(isParm(), "OMR::Symbol::castToParmSymbol, symbol is not a parameter symbol");
    return (TR::ParameterSymbol *)this;
-   }
-
-TR::AutomaticSymbol * OMR::Symbol::getInternalPointerAutoSymbol()
-   {
-   return isInternalPointerAuto() ? (TR::AutomaticSymbol *)this : 0;
    }
 
 TR::AutomaticSymbol * OMR::Symbol::castToInternalPointerAutoSymbol()
@@ -662,20 +626,10 @@ TR::AutomaticSymbol * OMR::Symbol::castToInternalPointerAutoSymbol()
    return (TR::AutomaticSymbol *)this;
    }
 
-TR::AutomaticSymbol * OMR::Symbol::getLocalObjectSymbol()
-   {
-   return isLocalObject() ? (TR::AutomaticSymbol *)this : 0;
-   }
-
 TR::AutomaticSymbol * OMR::Symbol::castToLocalObjectSymbol()
    {
    TR_ASSERT(isLocalObject(), "OMR::Symbol::castToLocalObjectSymbol, symbol is not an internal pointer automatic symbol");
    return (TR::AutomaticSymbol *)this;
-   }
-
-TR::StaticSymbol * OMR::Symbol::getStaticSymbol()
-   {
-   return isStatic() ? (TR::StaticSymbol *)this : 0;
    }
 
 TR::StaticSymbol * OMR::Symbol::castToStaticSymbol()
@@ -690,21 +644,11 @@ TR::StaticSymbol * OMR::Symbol::castToNamedStaticSymbol()
    return (TR::StaticSymbol *)this;
    }
 
-TR::MethodSymbol * OMR::Symbol::getMethodSymbol()
-   {
-   return isMethod() ? (TR::MethodSymbol *)this : 0;
-   }
-
 TR::MethodSymbol * OMR::Symbol::castToMethodSymbol()
    {
    TR_ASSERT(isMethod(), "OMR::Symbol::castToMethodSymbol, symbol[%p] is not a method symbol",
          this);
    return (TR::MethodSymbol *)this;
-   }
-
-TR::ResolvedMethodSymbol * OMR::Symbol::getResolvedMethodSymbol()
-   {
-   return isResolvedMethod() ? (TR::ResolvedMethodSymbol *)this : 0;
    }
 
 TR::ResolvedMethodSymbol * OMR::Symbol::castToResolvedMethodSymbol()
@@ -713,20 +657,10 @@ TR::ResolvedMethodSymbol * OMR::Symbol::castToResolvedMethodSymbol()
    return (TR::ResolvedMethodSymbol *)this;
    }
 
-TR::Symbol * OMR::Symbol::getShadowSymbol()
-   {
-   return isShadow() ? (TR::Symbol *)this : 0;
-   }
-
 TR::Symbol * OMR::Symbol::castToShadowSymbol()
    {
    TR_ASSERT(isShadow(), "OMR::Symbol::castToShadowSymbol, symbol is not a shadow symbol");
    return (TR::Symbol *)this;
-   }
-
-TR::RegisterMappedSymbol * OMR::Symbol::getMethodMetaDataSymbol()
-   {
-   return isMethodMetaData() ? (TR::RegisterMappedSymbol *)this : 0;
    }
 
 TR::RegisterMappedSymbol * OMR::Symbol::castToMethodMetaDataSymbol()
@@ -735,20 +669,10 @@ TR::RegisterMappedSymbol * OMR::Symbol::castToMethodMetaDataSymbol()
    return (TR::RegisterMappedSymbol *)this;
    }
 
-TR::LabelSymbol * OMR::Symbol::getLabelSymbol()
-   {
-   return isLabel() ? (TR::LabelSymbol *)this : 0;
-   }
-
 TR::LabelSymbol * OMR::Symbol::castToLabelSymbol()
    {
    TR_ASSERT(isLabel(), "OMR::Symbol::castToLabelSymbol, symbol is not a label symbol");
    return (TR::LabelSymbol *)this;
-   }
-
-TR::ResolvedMethodSymbol * OMR::Symbol::getJittedMethodSymbol()
-   {
-   return isJittedMethod() ? (TR::ResolvedMethodSymbol *)this : 0;
    }
 
 TR::ResolvedMethodSymbol * OMR::Symbol::castToJittedMethodSymbol()
@@ -763,32 +687,12 @@ TR::StaticSymbol *OMR::Symbol::castToCallSiteTableEntrySymbol()
    return (TR::StaticSymbol*)this;
    }
 
-TR::StaticSymbol *OMR::Symbol::getCallSiteTableEntrySymbol()
-   {
-   return isCallSiteTableEntry()? castToCallSiteTableEntrySymbol() : NULL;
-   }
-
 TR::StaticSymbol *OMR::Symbol::castToMethodTypeTableEntrySymbol()
    {
    TR_ASSERT(isMethodTypeTableEntry(), "OMR::Symbol::castToMethodTypeTableEntrySymbol expected a method type table entry symbol");
    return (TR::StaticSymbol*)this;
    }
 
-TR::StaticSymbol *OMR::Symbol::getMethodTypeTableEntrySymbol()
-   {
-   return isMethodTypeTableEntry()? castToMethodTypeTableEntrySymbol() : NULL;
-   }
-
-
-TR::Symbol * OMR::Symbol::getNamedShadowSymbol()
-   {
-   return isNamedShadowSymbol() ? (TR::Symbol *)this : 0;
-   }
-
-TR::AutomaticSymbol * OMR::Symbol::getRegisterSymbol()
-   {
-   return isRegisterSymbol() ? (TR::AutomaticSymbol *)this : 0;
-   }
 
 TR::AutomaticSymbol *OMR::Symbol::castToRegisterSymbol()
    {
@@ -796,20 +700,10 @@ TR::AutomaticSymbol *OMR::Symbol::castToRegisterSymbol()
    return (TR::AutomaticSymbol*)this;
    }
 
-TR::StaticSymbol * OMR::Symbol::getRecognizedStaticSymbol()
-   {
-   return isRecognizedStatic() ? (TR::StaticSymbol*)this : 0;
-   }
-
 TR::AutomaticSymbol * OMR::Symbol::castToAutoMarkerSymbol()
    {
    TR_ASSERT(isAutoMarkerSymbol(), "OMR::Symbol::castToAutoMarkerSymbol, symbol is not a auto marker symbol");
    return (TR::AutomaticSymbol *)this;
-   }
-
-TR::AutomaticSymbol * OMR::Symbol::getVariableSizeSymbol()
-   {
-   return isVariableSizeSymbol() ? (TR::AutomaticSymbol *)this : 0;
    }
 
 TR::AutomaticSymbol * OMR::Symbol::castToVariableSizeSymbol()

--- a/compiler/il/symbol/ParameterSymbol.hpp
+++ b/compiler/il/symbol/ParameterSymbol.hpp
@@ -28,7 +28,7 @@
 namespace TR
 {
 
-class ParameterSymbol : public OMR::ParameterSymbolConnector
+class OMR_EXTENSIBLE ParameterSymbol : public OMR::ParameterSymbolConnector
    {
 
 protected:

--- a/compiler/il/symbol/RegisterMappedSymbol.hpp
+++ b/compiler/il/symbol/RegisterMappedSymbol.hpp
@@ -27,7 +27,7 @@
 namespace TR
 {
 
-class RegisterMappedSymbol : public OMR::RegisterMappedSymbolConnector
+class OMR_EXTENSIBLE RegisterMappedSymbol : public OMR::RegisterMappedSymbolConnector
    {
 
 protected:

--- a/compiler/il/symbol/ResolvedMethodSymbol.hpp
+++ b/compiler/il/symbol/ResolvedMethodSymbol.hpp
@@ -27,7 +27,7 @@ namespace TR { class Compilation; }
 namespace TR
 {
 
-class ResolvedMethodSymbol : public OMR::ResolvedMethodSymbolConnector
+class OMR_EXTENSIBLE ResolvedMethodSymbol : public OMR::ResolvedMethodSymbolConnector
    {
 
 protected:

--- a/compiler/il/symbol/StaticSymbol.hpp
+++ b/compiler/il/symbol/StaticSymbol.hpp
@@ -30,7 +30,7 @@
 namespace TR
 {
 
-class StaticSymbol : public OMR::StaticSymbolConnector
+class OMR_EXTENSIBLE StaticSymbol : public OMR::StaticSymbolConnector
    {
 
 protected:


### PR DESCRIPTION
Add the `OMR_EXTENSIBLE` annotation to the Symbol hierarchy. There were also a few extensible class anti-patterns that were fixed, including adding a `self()` method to a few classes, and adding `self()->` when accessing member functions.

In this process, a few methods needed to be outlined. If this causes performance problems, they can be re-inlined.