### PR TITLE
Expose Scavenger Evacuate boundaries

### DIFF
--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -541,6 +541,18 @@ public:
 		/* check if the object in cached allocate (from GC perspective, evacuate) ranges */
 		return ((void *)objectPtr >= _evacuateSpaceBase) && ((void *)objectPtr < _evacuateSpaceTop);
 	}
+	
+	MMINLINE void *
+	getEvacuateBase()
+	{
+		return _evacuateSpaceBase;
+	}
+	
+	MMINLINE void *
+	getEvacuateTop()
+	{
+		return _evacuateSpaceTop;
+	}
 
 	void workThreadGarbageCollect(MM_EnvironmentStandard *env);
 


### PR DESCRIPTION
Implementations of the concurrent scavenger object access barrier will need to know the actual address range for evacuate space.  For performance reasons the barriers need to be implemented in multiple components, and we cannot just rely on existing isObjectInEvacuateMemory() API. The exact evacuate address range needs to be publicly available.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>