### PR TITLE
Fix strncat warning in OMROptions

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -3744,8 +3744,8 @@ void OMR::Options::openLogFile(int32_t idSuffix)
             getTRPID(buf);
             sprintf(filename, "%s.%s", fn, buf);
             getTimeInSeconds(buf);
-            strncat(filename, ".", 1025);
-            strncat(filename, buf, 1025);
+            strncat(filename, ".", 1);
+            strncat(filename, buf, 20);
             fn = filename;
             }
 


### PR DESCRIPTION
Fix strncat overflow warning by passing the actual size of the
source strings as an input to strncat instead of passing in 1025.

Signed-off-by: Aman Kumar <amank@ca.ibm.com>