### PR TITLE
Add DataType operators and use where possible

### DIFF
--- a/compiler/arm/codegen/ConstantDataSnippet.cpp
+++ b/compiler/arm/codegen/ConstantDataSnippet.cpp
@@ -35,7 +35,7 @@
 #include "runtime/Runtime.hpp"
 
 int32_t TR_ARMConstantDataSnippet::addConstantRequest(void              *v,
-                                                  TR::DataTypes       type,
+                                                  TR::DataType       type,
                                                   TR::Instruction *nibble0,
                                                   TR::Instruction *nibble1,
                                                   TR::Instruction *nibble2,

--- a/compiler/arm/codegen/ConstantDataSnippet.hpp
+++ b/compiler/arm/codegen/ConstantDataSnippet.hpp
@@ -93,7 +93,7 @@ class TR_ARMConstantDataSnippet
    uint8_t *setSnippetBinaryStart(uint8_t *p) {return _snippetBinaryStart=p;}
 
    int32_t addConstantRequest(void              *v,
-                           TR::DataTypes       type,
+                           TR::DataType       type,
                            TR::Instruction *nibble0,
                            TR::Instruction *nibble1,
                            TR::Instruction *nibble2,

--- a/compiler/arm/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/arm/codegen/ControlFlowEvaluator.cpp
@@ -1778,7 +1778,7 @@ TR::Register *OMR::ARM::TreeEvaluator::ArrayCHKEvaluator(TR::Node *node, TR::Cod
 static TR::Register *generateMaxMin(TR::Node *node, TR::CodeGenerator *cg, bool max)
    {
    TR::Node *child  = node->getFirstChild();
-   TR::DataTypes data_type = child->getDataType();
+   TR::DataType data_type = child->getDataType();
    TR::DataType type = child->getType();
    bool two_reg = type.isInt64();
    bool isUnsigned = false;

--- a/compiler/arm/codegen/FPTreeEvaluator.cpp
+++ b/compiler/arm/codegen/FPTreeEvaluator.cpp
@@ -2496,7 +2496,7 @@ TR::Register *OMR::ARM::TreeEvaluator::fRegStoreEvaluator(TR::Node *node, TR::Co
 static TR::Register *generateFloatMaxMin(TR::Node *node, TR::CodeGenerator *cg, bool max)
    {
    TR::Node *firstChild  = node->getFirstChild();
-   TR::DataTypes data_type = firstChild->getDataType();
+   TR::DataType data_type = firstChild->getDataType();
    TR::DataType type = firstChild->getType();
    TR::Instruction *cursor;
    TR::Register *trgReg, *trgFloatReg;

--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -681,7 +681,7 @@ void OMR::ARM::CodeGenerator::dumpDataSnippets(TR::FILE *outFile, bool isWarm)
    }
 #endif
 
-int32_t OMR::ARM::CodeGenerator::findOrCreateAddressConstant(void *v, TR::DataTypes t,
+int32_t OMR::ARM::CodeGenerator::findOrCreateAddressConstant(void *v, TR::DataType t,
                              TR::Instruction *n0, TR::Instruction *n1,
                              TR::Instruction *n2, TR::Instruction *n3,
                              TR::Instruction *n4,
@@ -924,7 +924,7 @@ int32_t OMR::ARM::CodeGenerator::getMaximumNumberOfFPRsAllowedAcrossEdge(TR::Nod
    }
 
 #if 1
-TR_GlobalRegisterNumber OMR::ARM::CodeGenerator::getLinkageGlobalRegisterNumber(int8_t linkageRegisterIndex, TR::DataTypes type)
+TR_GlobalRegisterNumber OMR::ARM::CodeGenerator::getLinkageGlobalRegisterNumber(int8_t linkageRegisterIndex, TR::DataType type)
    {
    TR_GlobalRegisterNumber result;
    if (type == TR::Float || type == TR::Double)
@@ -955,7 +955,7 @@ int32_t OMR::ARM::CodeGenerator::getMaximumNumbersOfAssignableFPRs()
    return TR::RealRegister::LastFPR - TR::RealRegister::FirstFPR  + 1;
    }
 
-bool OMR::ARM::CodeGenerator::isGlobalRegisterAvailable(TR_GlobalRegisterNumber i, TR::DataTypes dt)
+bool OMR::ARM::CodeGenerator::isGlobalRegisterAvailable(TR_GlobalRegisterNumber i, TR::DataType dt)
    {
    return self()->machine()->getARMRealRegister((TR::RealRegister::RegNum)self()->getGlobalRegister(i))->getState() == TR::RealRegister::Free;
    }

--- a/compiler/arm/codegen/OMRCodeGenerator.hpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.hpp
@@ -136,7 +136,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    TR::Instruction *generateSwitchToInterpreterPrePrologue(TR::Instruction *cursor, TR::Node *node);
 
-   int32_t findOrCreateAddressConstant(void *v, TR::DataTypes t,
+   int32_t findOrCreateAddressConstant(void *v, TR::DataType t,
                   TR::Instruction *n0, TR::Instruction *n1,
                   TR::Instruction *n2, TR::Instruction *n3,
                   TR::Instruction *n4,
@@ -183,12 +183,12 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    using OMR::CodeGenerator::getMaximumNumberOfGPRsAllowedAcrossEdge;
    int32_t getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Node *);
    int32_t getMaximumNumberOfFPRsAllowedAcrossEdge(TR::Node *);
-   bool isGlobalRegisterAvailable(TR_GlobalRegisterNumber i, TR::DataTypes dt);
+   bool isGlobalRegisterAvailable(TR_GlobalRegisterNumber i, TR::DataType dt);
    TR_BitVector _globalRegisterBitVectors[TR_numSpillKinds];
    virtual TR_BitVector *getGlobalRegisters(TR_SpillKinds kind, TR_LinkageConventions lc){ return &_globalRegisterBitVectors[kind]; }
 
    TR_GlobalRegisterNumber _gprLinkageGlobalRegisterNumbers[TR::RealRegister::NumRegisters], _fprLinkageGlobalRegisterNumbers[TR::RealRegister::NumRegisters]; // these could be smaller
-   TR_GlobalRegisterNumber getLinkageGlobalRegisterNumber(int8_t linkageRegisterIndex, TR::DataTypes type);
+   TR_GlobalRegisterNumber getLinkageGlobalRegisterNumber(int8_t linkageRegisterIndex, TR::DataType type);
 
    int32_t getMaximumNumbersOfAssignableGPRs();
    int32_t getMaximumNumbersOfAssignableFPRs();

--- a/compiler/arm/codegen/OMRLinkage.cpp
+++ b/compiler/arm/codegen/OMRLinkage.cpp
@@ -499,7 +499,7 @@ int32_t OMR::ARM::Linkage::buildARMLinkageArgs(TR::Node                         
    uint32_t  numFloatArgs = 0;
    uint32_t  numMemArgs = 0;
    uint32_t  firstArgumentChild = callNode->getFirstArgumentIndex();
-   TR::DataTypes callNodeDataType = callNode->getDataType();
+   TR::DataType callNodeDataType = callNode->getDataType();
    TR::DataType resType = callNode->getType();
    TR::MethodSymbol *callSymbol = callNode->getSymbol()->castToMethodSymbol();
 
@@ -641,7 +641,7 @@ printf("%s: numIntegerArgs %d numMemArgs %d\n", sig,  numIntegerArgs, numMemArgs
    for (i = from; (isHelper && i > to) || (!isHelper && i < to); i += step)
       {
       TR::Node               *child = callNode->getChild(i);
-      TR::DataTypes           childType = child->getDataType();
+      TR::DataType            childType = child->getDataType();
       TR::Register           *reg;
       TR::Register           *tempReg;
       TR::MemoryReference *tempMR;

--- a/compiler/codegen/CodeGenPrep.cpp
+++ b/compiler/codegen/CodeGenPrep.cpp
@@ -361,7 +361,7 @@ OMR::CodeGenerator::lowerTreeIfNeeded(
  * will be thrownaway as part of the store.  Thus, we can mark the convert an unneeded.  Codegen can then
  * avoid generating the associated code.
  */
-void OMR::CodeGenerator::identifyUnneededByteConvNodes(TR::Node * parent, TR::TreeTop * treeTop, vcount_t visitCount, TR::DataTypes storeType)
+void OMR::CodeGenerator::identifyUnneededByteConvNodes(TR::Node * parent, TR::TreeTop * treeTop, vcount_t visitCount, TR::DataType storeType)
    {
    // *this    swipeable for debugging purposes
    parent->setVisitCount(visitCount);

--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -207,7 +207,7 @@ OMR::CodeGenerator::estimateRegisterPressure(TR::Node *node, int32_t &registerPr
          if (!node->getOpCode().isLoadConst())
             {
             bool gprCandidate = true;
-            TR::DataTypes dtype = node->getDataType();
+            TR::DataType dtype = node->getDataType();
             if (dtype == TR::Float
                 || dtype == TR::Double
 #ifdef J9_PROJECT_SPECIFIC
@@ -1158,7 +1158,7 @@ static bool blockIsIgnorablyCold(TR::Block *block, TR::CodeGenerator *cg)
 void
 OMR::CodeGenerator::TR_RegisterPressureState::updateRegisterPressure(TR::Symbol *symbol)
    {
-   TR::DataTypes dt = TR::NoType;
+   TR::DataType dt = TR::NoType;
 
    if (symbol->getType().isAggregate())
       {
@@ -1239,7 +1239,7 @@ OMR::CodeGenerator::pickRegister(TR_RegisterCandidate     *rc,
       // Register pressure simulation algorithm
 
       TR::Symbol *rcSymbol = rc->getSymbolReference()->getSymbol();
-      TR::DataTypes dtype = rc->getDataType();
+      TR::DataType dtype = rc->getDataType();
 
       const bool usesFPR = (dtype == TR::Float
                            || dtype == TR::Double
@@ -1250,7 +1250,7 @@ OMR::CodeGenerator::pickRegister(TR_RegisterCandidate     *rc,
 #endif
                            );
 
-      const bool usesVRF = isVectorType(dtype);
+      const bool usesVRF = dtype.isVector();
 
       if (self()->terseSimulateTreeEvaluation())
          {
@@ -1428,7 +1428,7 @@ OMR::CodeGenerator::pickRegister(TR_RegisterCandidate     *rc,
                   TR_RegisterPressureSummary summary(state._gprPressure, state._fprPressure, state._vrfPressure);
                   if (enableHighWordGRA)
                      {
-                     TR::DataTypes dtype = rc->getSymbolReference()->getSymbol()->getDataType();
+                     TR::DataType dtype = rc->getSymbolReference()->getSymbol()->getDataType();
                      if (dtype == TR::Int8 ||
                          dtype == TR::Int16 ||
                          dtype == TR::Int32)
@@ -1776,7 +1776,7 @@ OMR::CodeGenerator::pickRegister(TR_RegisterCandidate     *rc,
          // if any HPR candidate is present
          if (remainingRegisters.intersects(HPRMasks))
             {
-            TR::DataTypes dtype = rc->getSymbolReference()->getSymbol()->getDataType();
+            TR::DataType dtype = rc->getSymbolReference()->getSymbol()->getDataType();
             if (hprSimulated && !hprColdBlockSkipped)
                {
                if (self()->traceSimulateTreeEvaluation())
@@ -1860,7 +1860,7 @@ OMR::CodeGenerator::pickRegister(TR_RegisterCandidate     *rc,
 
    if(1)
       {
-      TR::DataTypes dtype = rc->getDataType();
+      TR::DataType dtype = rc->getDataType();
       uint8_t regsWithheld =
          (dtype == TR::Float
           || dtype == TR::Double

--- a/compiler/codegen/FrontEnd.hpp
+++ b/compiler/codegen/FrontEnd.hpp
@@ -192,7 +192,7 @@ public:
    // J9 Classes / VM?
    // --------------------------------------------------------------------------
 
-   virtual TR::DataTypes dataTypeForLoadOrStore(TR::DataTypes dt) { return dt; }
+   virtual TR::DataType dataTypeForLoadOrStore(TR::DataType dt) { return dt; }
 
    virtual TR_OpaqueClassBlock * getClassClassPointer(TR_OpaqueClassBlock *objectClassPointer);
    virtual TR_OpaqueClassBlock * getClassFromMethodBlock(TR_OpaqueMethodBlock *mb);

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -841,16 +841,16 @@ OMR::CodeGenerator::trPersistentMemory()
    }
 
 void
-OMR::CodeGenerator::addSymbolAndDataTypeToMap(TR::Symbol *symbol, TR::DataTypes dt)
+OMR::CodeGenerator::addSymbolAndDataTypeToMap(TR::Symbol *symbol, TR::DataType dt)
    {
    _symbolDataTypeMap.Add(symbol,dt);
    }
-TR::DataTypes
+TR::DataType
 OMR::CodeGenerator::getDataTypeFromSymbolMap(TR::Symbol *symbol)
    {
    CS2::HashIndex hi;
 
-   TR::DataTypes dt = TR::NoType;
+   TR::DataType dt = TR::NoType;
 
    if(_symbolDataTypeMap.Locate(symbol,hi))
       {
@@ -2980,7 +2980,7 @@ OMR::CodeGenerator::lookUpSnippet(int32_t snippetKind, TR::SymbolReference *symR
    }
 
 TR::SymbolReference *
-OMR::CodeGenerator::allocateLocalTemp(TR::DataTypes dt, bool isInternalPointer)
+OMR::CodeGenerator::allocateLocalTemp(TR::DataType dt, bool isInternalPointer)
    {
    // *this    swipeable for debugging purposes
    //

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -392,7 +392,7 @@ class OMR_EXTENSIBLE CodeGenerator
    bool hasComplexAddressingMode() { return false; } // no virt, default
    void removeUnusedLocals();
 
-   void identifyUnneededByteConvNodes(TR::Node*, TR::TreeTop *, vcount_t, TR::DataTypes);
+   void identifyUnneededByteConvNodes(TR::Node*, TR::TreeTop *, vcount_t, TR::DataType);
    void identifyUnneededByteConvNodes();
 
    bool afterRA() { return _afterRA; }
@@ -846,8 +846,8 @@ class OMR_EXTENSIBLE CodeGenerator
    // --------------------------------------------------------------------------
    // GRA
    //
-   void addSymbolAndDataTypeToMap(TR::Symbol *symbol, TR::DataTypes dt);
-   TR::DataTypes getDataTypeFromSymbolMap(TR::Symbol *symbol);
+   void addSymbolAndDataTypeToMap(TR::Symbol *symbol, TR::DataType dt);
+   TR::DataType getDataTypeFromSymbolMap(TR::Symbol *symbol);
 
    bool prepareForGRA(); // no virt, cast
 
@@ -935,7 +935,7 @@ class OMR_EXTENSIBLE CodeGenerator
 
    bool is8BitGlobalGPR(TR_GlobalRegisterNumber n) {return n <= _last8BitGlobalGPR;}
 
-   TR_GlobalRegisterNumber getLinkageGlobalRegisterNumber(int8_t linkageRegisterIndex, TR::DataTypes type){ return -1; } // no virt, cast
+   TR_GlobalRegisterNumber getLinkageGlobalRegisterNumber(int8_t linkageRegisterIndex, TR::DataType type){ return -1; } // no virt, cast
    TR_BitVector *getGlobalGPRsPreservedAcrossCalls(){ return NULL; } // no virt, cast
    TR_BitVector *getGlobalFPRsPreservedAcrossCalls(){ return NULL; } // no virt, cast
 
@@ -957,7 +957,7 @@ class OMR_EXTENSIBLE CodeGenerator
    int32_t getMaximumNumbersOfAssignableFPRs() { return INT_MAX; } // no virt, cast
    int32_t getMaximumNumbersOfAssignableVRs()  { return INT_MAX; } // no virt, cast
    virtual bool willBeEvaluatedAsCallByCodeGen(TR::Node *node, TR::Compilation *comp){ return true;}
-   bool isGlobalRegisterAvailable(TR_GlobalRegisterNumber, TR::DataTypes) { return true; } // no virt
+   bool isGlobalRegisterAvailable(TR_GlobalRegisterNumber, TR::DataType) { return true; } // no virt
 
    bool areAssignableGPRsScarce(); // no virt, 1 impl
 
@@ -978,7 +978,7 @@ class OMR_EXTENSIBLE CodeGenerator
    bool needToAvoidCommoningInGRA() {return false;} // no virt
 
    bool considerTypeForGRA(TR::Node *node) {return true;} // no virt
-   bool considerTypeForGRA(TR::DataTypes dt) {return true;} // no virt
+   bool considerTypeForGRA(TR::DataType dt) {return true;} // no virt
    bool considerTypeForGRA(TR::SymbolReference *symRef) {return true;} // no virt
 
    void enableLiteralPoolRegisterForGRA () {} // no virt
@@ -1082,7 +1082,7 @@ class OMR_EXTENSIBLE CodeGenerator
 
 
 
-   TR::SymbolReference * allocateLocalTemp(TR::DataTypes dt = TR::Int32, bool isInternalPointer = false);
+   TR::SymbolReference * allocateLocalTemp(TR::DataType dt = TR::Int32, bool isInternalPointer = false);
 
    // --------------------------------------------------------------------------
    // Relocations
@@ -1387,7 +1387,7 @@ class OMR_EXTENSIBLE CodeGenerator
    bool supportsNativeLongOperations();
 
 
-   TR::DataTypes IntJ() { return TR::Compiler->target.is64Bit() ? TR::Int64 : TR::Int32; }
+   TR::DataType IntJ() { return TR::Compiler->target.is64Bit() ? TR::Int64 : TR::Int32; }
 
    // will a BCD left shift always leave the sign code unchanged and thus allow it to be propagated through and upwards
    bool propagateSignThroughBCDLeftShift(TR::DataType type) { return false; } // no virt
@@ -1563,7 +1563,7 @@ class OMR_EXTENSIBLE CodeGenerator
    bool getSupportsAutoSIMD() { return _flags4.testAny(SupportsAutoSIMD);}
    void setSupportsAutoSIMD() { _flags4.set(SupportsAutoSIMD);}
 
-   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataTypes) { return false; }
+   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataType) { return false; }
 
    bool removeRegisterHogsInLowerTreesWalk() { return _flags3.testAny(RemoveRegisterHogsInLowerTreesWalk);}
    void setRemoveRegisterHogsInLowerTreesWalk() { _flags3.set(RemoveRegisterHogsInLowerTreesWalk);}
@@ -2063,7 +2063,7 @@ class OMR_EXTENSIBLE CodeGenerator
 
    TR_Stack<TR::Node *> _stackOfArtificiallyInflatedNodes;
 
-   CS2::HashTable<TR::Symbol*, TR::DataTypes, TR::Allocator> _symbolDataTypeMap;
+   CS2::HashTable<TR::Symbol*, TR::DataType, TR::Allocator> _symbolDataTypeMap;
    };
 
 }

--- a/compiler/codegen/RegisterConstants.hpp
+++ b/compiler/codegen/RegisterConstants.hpp
@@ -76,7 +76,7 @@ enum TR_RegisterSizes
 
 enum TR_RematerializableTypes
    {
-   // TODO:AMD64: We should just use TR::DataTypes for this and simplify everything
+   // TODO:AMD64: We should just use TR::DataType for this and simplify everything
    TR_Unrematerializable       = -1,
    TR_RematerializableByte     = 0,
    TR_RematerializableShort    = 1,

--- a/compiler/compile/Method.cpp
+++ b/compiler/compile/Method.cpp
@@ -257,10 +257,10 @@ bool TR_ResolvedMethod::isDAAIntrinsicMethod()
 #define notImplemented(A) TR_ASSERT(0, "TR_Method::%s is undefined", (A) )
 
 uint32_t              TR_Method::numberOfExplicitParameters() { notImplemented("numberOfExplicitParameters"); return 0; }
-TR::DataTypes        TR_Method::parmType(uint32_t)           { notImplemented("parmType"); return TR::NoType; }
+TR::DataType        TR_Method::parmType(uint32_t)           { notImplemented("parmType"); return TR::NoType; }
 TR::ILOpCodes          TR_Method::directCallOpCode()           { notImplemented("directCallOpCode"); return TR::BadILOp; }
 TR::ILOpCodes          TR_Method::indirectCallOpCode()         { notImplemented("indirectCallOpCode"); return TR::BadILOp; }
-TR::DataTypes        TR_Method::returnType()                 { notImplemented("returnType"); return TR::NoType; }
+TR::DataType        TR_Method::returnType()                 { notImplemented("returnType"); return TR::NoType; }
 bool                  TR_Method::returnTypeIsUnsigned()       { notImplemented("returnTypeIsUnsigned"); return TR::NoType;}
 uint32_t              TR_Method::returnTypeWidth()            { notImplemented("returnTypeWidth"); return 0; }
 TR::ILOpCodes          TR_Method::returnOpCode()               { notImplemented("returnOpCode"); return TR::BadILOp; }
@@ -316,10 +316,10 @@ TR_Method::isBigDecimalConvertersMethod(TR::Compilation * comp)
 TR_Method *  TR_ResolvedMethod::convertToMethod()                          { notImplemented("convertToMethod"); return 0; }
 uint32_t     TR_ResolvedMethod::numberOfParameters()                       { notImplemented("numberOfParameters"); return 0; }
 uint32_t     TR_ResolvedMethod::numberOfExplicitParameters()               { notImplemented("numberOfExplicitParameters"); return 0; }
-TR::DataTypes TR_ResolvedMethod::parmType(uint32_t)                         { notImplemented("parmType"); return TR::NoType; }
+TR::DataType TR_ResolvedMethod::parmType(uint32_t)                         { notImplemented("parmType"); return TR::NoType; }
 TR::ILOpCodes TR_ResolvedMethod::directCallOpCode()                         { notImplemented("directCallOpCode"); return TR::BadILOp; }
 TR::ILOpCodes TR_ResolvedMethod::indirectCallOpCode()                       { notImplemented("indirectCallOpCode"); return TR::BadILOp; }
-TR::DataTypes TR_ResolvedMethod::returnType()                               { notImplemented("returnType"); return TR::NoType; }
+TR::DataType TR_ResolvedMethod::returnType()                               { notImplemented("returnType"); return TR::NoType; }
 uint32_t     TR_ResolvedMethod::returnTypeWidth()                          { notImplemented("returnTypeWidth"); return 0; }
 bool         TR_ResolvedMethod::returnTypeIsUnsigned()                     { notImplemented("returnTypeIsUnsigned"); return 0; }
 TR::ILOpCodes TR_ResolvedMethod::returnOpCode()                             { notImplemented("returnOpCode"); return TR::BadILOp; }
@@ -373,7 +373,7 @@ uint32_t     TR_ResolvedMethod::maxBytecodeIndex()                         { not
 void *       TR_ResolvedMethod::ramConstantPool()                          { notImplemented("ramConstantPool"); return 0; }
 void *       TR_ResolvedMethod::constantPool()                             { notImplemented("constantPool"); return 0; }
 
-TR::DataTypes TR_ResolvedMethod::getLDCType(int32_t)                        { notImplemented("getLDCType"); return TR::NoType; }
+TR::DataType TR_ResolvedMethod::getLDCType(int32_t)                        { notImplemented("getLDCType"); return TR::NoType; }
 bool         TR_ResolvedMethod::isClassConstant(int32_t cpIndex)           { notImplemented("isClassConstant"); return false; }
 bool         TR_ResolvedMethod::isStringConstant(int32_t cpIndex)          { notImplemented("isStringConstant"); return false; }
 bool         TR_ResolvedMethod::isMethodTypeConstant(int32_t cpIndex)      { notImplemented("isMethodTypeConstant"); return false; }
@@ -453,14 +453,14 @@ TR_ResolvedMethod::getUnresolvedVirtualMethodInCP(int32_t)
    }
 
 bool
-TR_ResolvedMethod::fieldAttributes(TR::Compilation *, int32_t, uint32_t *, TR::DataTypes *, bool *, bool *, bool *, bool, bool *, bool)
+TR_ResolvedMethod::fieldAttributes(TR::Compilation *, int32_t, uint32_t *, TR::DataType *, bool *, bool *, bool *, bool, bool *, bool)
    {
    notImplemented("fieldAttributes");
    return false;
    }
 
 bool
-TR_ResolvedMethod::staticAttributes(TR::Compilation *, int32_t, void * *, TR::DataTypes *, bool *, bool *, bool *, bool, bool *, bool)
+TR_ResolvedMethod::staticAttributes(TR::Compilation *, int32_t, void * *, TR::DataType *, bool *, bool *, bool *, bool, bool *, bool)
    {
    notImplemented("staticAttributes");
    return false;
@@ -574,7 +574,7 @@ void TR_ResolvedMethod::makeParameterList(TR::ResolvedMethodSymbol *methodSym)
    uint32_t parmSlots = numberOfParameterSlots();
    for (int32_t parmIndex = 0; slot < parmSlots; ++parmIndex)
       {
-      TR::DataTypes type = parmType(parmIndex);
+      TR::DataType type = parmType(parmIndex);
       int32_t size = methodSym->convertTypeToSize(type);
       if (size < 4) type = TR::Int32;
 

--- a/compiler/compile/OMRMethod.hpp
+++ b/compiler/compile/OMRMethod.hpp
@@ -94,7 +94,7 @@ class TR_MethodParameterIterator
    {
 public:
    TR_ALLOC(TR_Memory::Method)
-   virtual TR::DataTypes getDataType() = 0;
+   virtual TR::DataType getDataType() = 0;
    virtual TR_OpaqueClassBlock * getOpaqueClass() = 0; //  if getDataType() == TR::Aggregate
    virtual bool isArray() = 0; // refines getOpaqueClass
    virtual bool isClass() = 0; // refines getOpaqueClass
@@ -116,12 +116,12 @@ class TR_Method
    enum Type {J9, Python, Ruby, Test, JitBuilder};
 
 
-   virtual TR::DataTypes parmType(uint32_t parmNumber); // returns the type of the parmNumber'th parameter (0-based)
+   virtual TR::DataType parmType(uint32_t parmNumber); // returns the type of the parmNumber'th parameter (0-based)
    virtual bool isConstructor(); // returns true if this method is object constructor.
    virtual TR::ILOpCodes directCallOpCode();
    virtual TR::ILOpCodes indirectCallOpCode();
 
-   virtual TR::DataTypes returnType();
+   virtual TR::DataType returnType();
    virtual uint32_t returnTypeWidth();
    virtual bool returnTypeIsUnsigned();
    virtual TR::ILOpCodes returnOpCode();

--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -362,7 +362,7 @@ OMR::SymbolReferenceTable::findOrCreateOSRReturnAddressSymbolRef()
 
 
 TR::SymbolReference *
-OMR::SymbolReferenceTable::findOrCreateArrayletShadowSymbolRef(TR::DataTypes type)
+OMR::SymbolReferenceTable::findOrCreateArrayletShadowSymbolRef(TR::DataType type)
    {
    int32_t index = getArrayletShadowIndex(TR::Address);
    if (!baseArray.element(index))
@@ -382,7 +382,7 @@ OMR::SymbolReferenceTable::findOrCreateArrayletShadowSymbolRef(TR::DataTypes typ
    }
 
 TR::SymbolReference *
-OMR::SymbolReferenceTable::findOrCreateArrayShadowSymbolRef(TR::DataTypes type, TR::Node * baseArrayAddress)
+OMR::SymbolReferenceTable::findOrCreateArrayShadowSymbolRef(TR::DataType type, TR::Node * baseArrayAddress)
    {
    int32_t index = getArrayShadowIndex(type);
    if (!baseArray.element(index))
@@ -398,7 +398,7 @@ OMR::SymbolReferenceTable::findOrCreateArrayShadowSymbolRef(TR::DataTypes type, 
    }
 
 TR::SymbolReference *
-OMR::SymbolReferenceTable::findOrCreateArrayShadowSymbolRef(TR::DataTypes type, TR::Node * baseArrayAddress, int32_t size, TR_FrontEnd * fe)
+OMR::SymbolReferenceTable::findOrCreateArrayShadowSymbolRef(TR::DataType type, TR::Node * baseArrayAddress, int32_t size, TR_FrontEnd * fe)
    {
 
    int32_t index = getArrayShadowIndex(type);
@@ -426,7 +426,7 @@ bool OMR::SymbolReferenceTable::isRefinedArrayShadow(TR::SymbolReference *symRef
 
 
 TR::SymbolReference *
-OMR::SymbolReferenceTable::createRefinedArrayShadowSymbolRef(TR::DataTypes type)
+OMR::SymbolReferenceTable::createRefinedArrayShadowSymbolRef(TR::DataType type)
    {
    TR::SymbolReference * symRef = getSymRef(getArrayShadowIndex(type));
    symRef->setReallySharesSymbol();
@@ -438,7 +438,7 @@ OMR::SymbolReferenceTable::createRefinedArrayShadowSymbolRef(TR::DataTypes type)
 
 //TODO: to be changed to a special sym ref to be used by intrinsics
 TR::SymbolReference *
-OMR::SymbolReferenceTable::createRefinedArrayShadowSymbolRef(TR::DataTypes type, TR::Symbol *sym)
+OMR::SymbolReferenceTable::createRefinedArrayShadowSymbolRef(TR::DataType type, TR::Symbol *sym)
    {
    const bool trace=false;
    sym->setArrayShadowSymbol();
@@ -630,7 +630,7 @@ OMR::SymbolReferenceTable::findOrCreateCurrentTimeMaxPrecisionSymbol()
 
 
 TR::SymbolReference *
-OMR::SymbolReferenceTable::createKnownStaticDataSymbolRef(void *dataAddress, TR::DataTypes type)
+OMR::SymbolReferenceTable::createKnownStaticDataSymbolRef(void *dataAddress, TR::DataType type)
    {
    TR::StaticSymbol * sym = TR::StaticSymbol::create(trHeapMemory(),type);
    sym->setStaticAddress(dataAddress);
@@ -639,7 +639,7 @@ OMR::SymbolReferenceTable::createKnownStaticDataSymbolRef(void *dataAddress, TR:
    }
 
 TR::SymbolReference *
-OMR::SymbolReferenceTable::createKnownStaticDataSymbolRef(void *dataAddress, TR::DataTypes type, TR::KnownObjectTable::Index knownObjectIndex)
+OMR::SymbolReferenceTable::createKnownStaticDataSymbolRef(void *dataAddress, TR::DataType type, TR::KnownObjectTable::Index knownObjectIndex)
    {
    TR::StaticSymbol * sym = TR::StaticSymbol::create(trHeapMemory(),type);
    sym->setStaticAddress(dataAddress);
@@ -1203,9 +1203,9 @@ void OMR::SymbolReferenceTable::initRegisterSymbols(TR::ResolvedMethodSymbol *ow
 #endif
   }
 
-TR::SymbolReference * OMR::SymbolReferenceTable::createRegisterSymbol(TR::ResolvedMethodSymbol *owningMethodSymbol, TR_RegisterKinds regKind, TR::DataTypes dataType, TR_GlobalRegisterNumber grn)
+TR::SymbolReference * OMR::SymbolReferenceTable::createRegisterSymbol(TR::ResolvedMethodSymbol *owningMethodSymbol, TR_RegisterKinds regKind, TR::DataType dataType, TR_GlobalRegisterNumber grn)
   {
-  TR::DataTypes dt;
+  TR::DataType dt(dataType);
   int32_t size;
 
   switch (regKind)
@@ -1264,7 +1264,7 @@ TR::SymbolReference * OMR::SymbolReferenceTable::getRegisterSymbol(TR_GlobalRegi
 
 
 TR::SymbolReference *
-OMR::SymbolReferenceTable::findStaticSymbol(TR_ResolvedMethod * owningMethod, int32_t cpIndex, TR::DataTypes type)
+OMR::SymbolReferenceTable::findStaticSymbol(TR_ResolvedMethod * owningMethod, int32_t cpIndex, TR::DataType type)
    {
    TR::SymbolReference * symRef;
    TR_SymRefIterator i(type == TR::Address ? aliasBuilder.addressStaticSymRefs() :
@@ -1336,7 +1336,7 @@ OMR::SymbolReferenceTable::findOrCreateClassSymbol(
 
 TR::SymbolReference *
 OMR::SymbolReferenceTable::findOrCreateCPSymbol(
-   TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex, TR::DataTypes dataType, bool resolved, void * dataAddress)
+   TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex, TR::DataType dataType, bool resolved, void * dataAddress)
    {
    TR::StaticSymbol *sym;
    TR_SymRefIterator i(aliasBuilder.cpSymRefs(), self());
@@ -1476,7 +1476,7 @@ OMR::SymbolReferenceTable::findOrCreateMethodSymbol(
 
 
 TR::SymbolReference *
-OMR::SymbolReferenceTable::findOrCreateAutoSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataTypes type, bool isReference, bool isInternalPointer, bool reuseAuto, bool isAdjunct, size_t size)
+OMR::SymbolReferenceTable::findOrCreateAutoSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataType type, bool isReference, bool isInternalPointer, bool reuseAuto, bool isAdjunct, size_t size)
    {
    mcount_t owningMethodIndex = owningMethodSymbol->getResolvedMethodIndex();
    int32_t numberOfParms = owningMethodSymbol->getNumParameterSlots();
@@ -1625,7 +1625,7 @@ OMR::SymbolReferenceTable::findOrCreateAutoSymbol(TR::ResolvedMethodSymbol * own
 
 
 TR::SymbolReference *
-OMR::SymbolReferenceTable::findAvailableAuto(TR::DataTypes type, bool behavesLikeTemp, bool isAdjunct)
+OMR::SymbolReferenceTable::findAvailableAuto(TR::DataType type, bool behavesLikeTemp, bool isAdjunct)
    {
    return findAvailableAuto(_availableAutos, type, behavesLikeTemp, isAdjunct);
    }
@@ -1633,7 +1633,7 @@ OMR::SymbolReferenceTable::findAvailableAuto(TR::DataTypes type, bool behavesLik
 
 TR::SymbolReference *
 OMR::SymbolReferenceTable::findAvailableAuto(List<TR::SymbolReference> & availableAutos,
-                                           TR::DataTypes type, bool behavesLikeTemp, bool isAdjunct)
+                                           TR::DataType type, bool behavesLikeTemp, bool isAdjunct)
    {
    // Disable sharing of autos in IL gen now as autos compaction based on
    // liveness information has been implemented as a pass before codegen is
@@ -1683,7 +1683,7 @@ static bool parmSlotCameFromExpandingAnArchetypeArgPlaceholder(int32_t slot, TR:
 
 TR::ParameterSymbol *
 OMR::SymbolReferenceTable::createParameterSymbol(
-   TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataTypes type, bool isUnsigned)
+   TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataType type, bool isUnsigned)
    {
    TR::ParameterSymbol * sym = TR::ParameterSymbol::create(trHeapMemory(),type,isUnsigned,slot);
 
@@ -1703,17 +1703,17 @@ OMR::SymbolReferenceTable::createParameterSymbol(
 
 
 TR::SymbolReference *
-OMR::SymbolReferenceTable::createTemporary(TR::ResolvedMethodSymbol * owningMethodSymbol, TR::DataTypes type, bool isInternalPointer, size_t size)
+OMR::SymbolReferenceTable::createTemporary(TR::ResolvedMethodSymbol * owningMethodSymbol, TR::DataType type, bool isInternalPointer, size_t size)
    {
 #ifdef J9_PROJECT_SPECIFIC
-   TR_ASSERT(!isBCDType(type) || size,"binary coded decimal types must provide a size\n");
+   TR_ASSERT(!type.isBCD() || size,"binary coded decimal types must provide a size\n");
 #endif
 
    return findOrCreateAutoSymbol(owningMethodSymbol, owningMethodSymbol->incTempIndex(fe()), type, true, isInternalPointer, false, false, size);
    }
 
 TR::SymbolReference *
-OMR::SymbolReferenceTable::createCoDependententTemporary(TR::ResolvedMethodSymbol *owningMethodSymbol, TR::DataTypes type, bool isInternalPointer, size_t size, TR::Symbol *coDependent, int32_t offset)
+OMR::SymbolReferenceTable::createCoDependententTemporary(TR::ResolvedMethodSymbol *owningMethodSymbol, TR::DataType type, bool isInternalPointer, size_t size, TR::Symbol *coDependent, int32_t offset)
    {
    TR::SymbolReference *tempSymRef = findOrCreateAutoSymbol(owningMethodSymbol, offset, type, true, isInternalPointer, false, false, size);
    return tempSymRef;
@@ -1722,10 +1722,10 @@ OMR::SymbolReferenceTable::createCoDependententTemporary(TR::ResolvedMethodSymbo
 
 TR::SymbolReference *
 OMR::SymbolReferenceTable::findOrCreatePendingPushTemporary(
-   TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataTypes type, size_t size)
+   TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataType type, size_t size)
    {
 #ifdef J9_PROJECT_SPECIFIC
-   TR_ASSERT(!isBCDType(type) || size,"binary coded decimal types must provide a size\n");
+   TR_ASSERT(!type.isBCD() || size,"binary coded decimal types must provide a size\n");
 #endif
    return findOrCreateAutoSymbol(owningMethodSymbol, -(slot + 1), type, true, false, false, false, size);
    }
@@ -1778,7 +1778,7 @@ OMR::SymbolReferenceTable::createLocalPrimArray(int32_t objectSize, TR::Resolved
 
 
 TR::SymbolReference *
-OMR::SymbolReferenceTable::findOrCreateCounterSymRef(char *name, TR::DataTypes d, void *address)
+OMR::SymbolReferenceTable::findOrCreateCounterSymRef(char *name, TR::DataType d, void *address)
    {
    ListIterator<TR::SymbolReference> i(&_debugCounterSymbolRefs);
    TR::SymbolReference *result;

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -209,8 +209,8 @@ class SymbolReferenceTable
    int32_t getNumUnresolvedSymbols()                  { return _numUnresolvedSymbols; }
    int32_t getNonhelperIndex(CommonNonhelperSymbol s);
    int32_t getNumHelperSymbols()                      { return _numHelperSymbols; }
-   int32_t getArrayShadowIndex(TR::DataTypes t)        { return _numHelperSymbols + firstArrayShadowSymbol + t; }
-   int32_t getArrayletShadowIndex(TR::DataTypes t) { return _numHelperSymbols + firstArrayShadowSymbol + TR::NumTypes + t; }
+   int32_t getArrayShadowIndex(TR::DataType t)        { return _numHelperSymbols + firstArrayShadowSymbol + t; }
+   int32_t getArrayletShadowIndex(TR::DataType t) { return _numHelperSymbols + firstArrayShadowSymbol + TR::NumTypes + t; }
 
    template <class BitVector>
    void getAllSymRefs(BitVector &allSymRefs)
@@ -234,19 +234,19 @@ class SymbolReferenceTable
    TR::SymbolReference * createRuntimeHelper(TR_RuntimeHelper, bool = false, bool = false, bool preservesAllRegisters = false);
    TR::SymbolReference * findOrCreateRuntimeHelper(TR_RuntimeHelper, bool, bool, bool preservesAllRegisters);
 
-   TR::ParameterSymbol * createParameterSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataTypes, bool isUnsigned);
-   TR::SymbolReference * findOrCreateAutoSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataTypes, bool isReference = true,
+   TR::ParameterSymbol * createParameterSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataType, bool isUnsigned);
+   TR::SymbolReference * findOrCreateAutoSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataType, bool isReference = true,
          bool isInternalPointer = false, bool reuseAuto = true, bool isAdjunct = false, size_t size = 0);
-   TR::SymbolReference * createTemporary(TR::ResolvedMethodSymbol * owningMethodSymbol, TR::DataTypes, bool isInternalPointer = false, size_t size = 0);
-   TR::SymbolReference * createCoDependententTemporary(TR::ResolvedMethodSymbol * owningMethodSymbol, TR::DataTypes, bool isInternalPointer, size_t size,
+   TR::SymbolReference * createTemporary(TR::ResolvedMethodSymbol * owningMethodSymbol, TR::DataType, bool isInternalPointer = false, size_t size = 0);
+   TR::SymbolReference * createCoDependententTemporary(TR::ResolvedMethodSymbol * owningMethodSymbol, TR::DataType, bool isInternalPointer, size_t size,
          TR::Symbol *coDependent, int32_t offset);
-   TR::SymbolReference * findStaticSymbol(TR_ResolvedMethod * owningMethod, int32_t cpIndex, TR::DataTypes);
+   TR::SymbolReference * findStaticSymbol(TR_ResolvedMethod * owningMethod, int32_t cpIndex, TR::DataType);
 
    // --------------------------------------------------------------------------
    // OMR
    // --------------------------------------------------------------------------
 
-   TR::SymbolReference * findOrCreatePendingPushTemporary(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t stackDepth, TR::DataTypes, size_t size = 0);
+   TR::SymbolReference * findOrCreatePendingPushTemporary(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t stackDepth, TR::DataType, size_t size = 0);
    TR::SymbolReference * createLocalPrimArray(int32_t objectSize, TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t arrayType);
    TR::Symbol           * findOrCreateGenericIntShadowSymbol();
    TR::Symbol           * findGenericIntShadowSymbol() { return _genericIntShadowSymbol; }
@@ -264,8 +264,8 @@ class SymbolReferenceTable
 
    bool isVtableEntrySymbolRef(TR::SymbolReference * s) { return _vtableEntrySymbolRefs.find(s); }
 
-   TR::SymbolReference * createKnownStaticDataSymbolRef(void *counterAddress, TR::DataTypes type);
-   TR::SymbolReference * createKnownStaticDataSymbolRef(void *counterAddress, TR::DataTypes type, TR::KnownObjectTable::Index knownObjectIndex);
+   TR::SymbolReference * createKnownStaticDataSymbolRef(void *counterAddress, TR::DataType type);
+   TR::SymbolReference * createKnownStaticDataSymbolRef(void *counterAddress, TR::DataType type, TR::KnownObjectTable::Index knownObjectIndex);
    TR::SymbolReference * findOrCreateTransactionEntrySymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);
    TR::SymbolReference * findOrCreateTransactionExitSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);
    TR::SymbolReference * findOrCreateTransactionAbortSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);
@@ -330,8 +330,8 @@ class SymbolReferenceTable
    TR::SymbolReference * findOrCreateNewObjectSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);
    TR::SymbolReference * findOrCreateNewObjectNoZeroInitSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);
    TR::SymbolReference * findOrCreateArrayStoreExceptionSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);
-   TR::SymbolReference * findOrCreateArrayShadowSymbolRef(TR::DataTypes, TR::Node * baseAddress = 0);
-   TR::SymbolReference * findOrCreateArrayletShadowSymbolRef(TR::DataTypes type);
+   TR::SymbolReference * findOrCreateArrayShadowSymbolRef(TR::DataType, TR::Node * baseAddress = 0);
+   TR::SymbolReference * findOrCreateArrayletShadowSymbolRef(TR::DataType type);
    TR::SymbolReference * findOrCreateAsyncCheckSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol = 0);
    TR::SymbolReference * findOrCreateExcpSymbolRef();
    TR::SymbolReference * findOrCreateANewArrayNoZeroInitSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);
@@ -376,12 +376,12 @@ class SymbolReferenceTable
    TR::SymbolReference * findOrCreateArrayCmpSymbol();
 
    TR::SymbolReference * findOrCreateClassSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex, void * classObject, bool cpIndexOfStatic = false);
-   TR::SymbolReference * findOrCreateArrayShadowSymbolRef(TR::DataTypes type, TR::Node * baseArrayAddress, int32_t size, TR_FrontEnd * fe);
+   TR::SymbolReference * findOrCreateArrayShadowSymbolRef(TR::DataType type, TR::Node * baseArrayAddress, int32_t size, TR_FrontEnd * fe);
 
    TR::SymbolReference * findOrCreateCounterAddressSymbolRef();
-   TR::SymbolReference * findOrCreateCounterSymRef(char *name, TR::DataTypes d, void *address);
-   TR::SymbolReference * createRefinedArrayShadowSymbolRef(TR::DataTypes);
-   TR::SymbolReference * createRefinedArrayShadowSymbolRef(TR::DataTypes, TR::Symbol *); // TODO: to be changed to a special sym ref
+   TR::SymbolReference * findOrCreateCounterSymRef(char *name, TR::DataType d, void *address);
+   TR::SymbolReference * createRefinedArrayShadowSymbolRef(TR::DataType);
+   TR::SymbolReference * createRefinedArrayShadowSymbolRef(TR::DataType, TR::Symbol *); // TODO: to be changed to a special sym ref
    bool                 isRefinedArrayShadow(TR::SymbolReference *symRef);
 
 
@@ -391,7 +391,7 @@ class SymbolReferenceTable
    // life of a procedure. A set of hardware registers is pre-created for each method.
    //
    void initRegisterSymbols(TR::ResolvedMethodSymbol *);
-   TR::SymbolReference * createRegisterSymbol(TR::ResolvedMethodSymbol *, TR_RegisterKinds, TR::DataTypes, TR_GlobalRegisterNumber grn);
+   TR::SymbolReference * createRegisterSymbol(TR::ResolvedMethodSymbol *, TR_RegisterKinds, TR::DataType, TR_GlobalRegisterNumber grn);
    TR::SymbolReference * getRegisterSymbol(TR_GlobalRegisterNumber grn);
 
    /*
@@ -399,13 +399,13 @@ class SymbolReferenceTable
     */
 
    void makeAutoAvailableForIlGen(TR::SymbolReference * a);
-   TR::SymbolReference * findAvailableAuto(TR::DataTypes dataType, bool behavesLikeTemp, bool isAdjunct = false);
-   TR::SymbolReference * findAvailableAuto(List<TR::SymbolReference> &, TR::DataTypes dataType, bool behavesLikeTemp, bool isAdjunct = false);
+   TR::SymbolReference * findAvailableAuto(TR::DataType dataType, bool behavesLikeTemp, bool isAdjunct = false);
+   TR::SymbolReference * findAvailableAuto(List<TR::SymbolReference> &, TR::DataType dataType, bool behavesLikeTemp, bool isAdjunct = false);
    void clearAvailableAutos() { _availableAutos.init(); }
 
    protected:
 
-   TR::SymbolReference * findOrCreateCPSymbol(TR::ResolvedMethodSymbol *, int32_t, TR::DataTypes, bool, void *);
+   TR::SymbolReference * findOrCreateCPSymbol(TR::ResolvedMethodSymbol *, int32_t, TR::DataType, bool, void *);
 
    bool shouldMarkBlockAsCold(TR_ResolvedMethod * owningMethod, bool isUnresolvedInCP);
    void markBlockAsCold();

--- a/compiler/compile/ResolvedMethod.hpp
+++ b/compiler/compile/ResolvedMethod.hpp
@@ -52,10 +52,10 @@ public:
 
    virtual uint32_t numberOfParameters();
    virtual uint32_t numberOfExplicitParameters(); // excludes receiver if any
-   virtual TR::DataTypes parmType(uint32_t parmNumber); // returns the type of the parmNumber'th parameter (0-based)
+   virtual TR::DataType parmType(uint32_t parmNumber); // returns the type of the parmNumber'th parameter (0-based)
    virtual TR::ILOpCodes directCallOpCode();
    virtual TR::ILOpCodes indirectCallOpCode();
-   virtual TR::DataTypes returnType();
+   virtual TR::DataType returnType();
    virtual uint32_t returnTypeWidth();
    virtual bool returnTypeIsUnsigned();
    virtual TR::ILOpCodes returnOpCode();
@@ -118,7 +118,7 @@ public:
    virtual TR_OpaqueClassBlock * getClassFromConstantPool(TR::Compilation *, uint32_t cpIndex, bool returnClassForAot = false);
    virtual bool canAlwaysShareSymbolDespiteOwningMethod(TR_ResolvedMethod *other) { return false; }
    virtual char *getClassNameFromConstantPool(uint32_t cpIndex, uint32_t &length);
-   virtual TR::DataTypes getLDCType(int32_t cpIndex);
+   virtual TR::DataType getLDCType(int32_t cpIndex);
    virtual bool isClassConstant(int32_t cpIndex);
    virtual bool isStringConstant(int32_t cpIndex);
    virtual bool isMethodTypeConstant(int32_t cpIndex);
@@ -163,8 +163,8 @@ public:
 
    // --------------------------------------------------------------------------
 
-   virtual bool fieldAttributes (TR::Compilation *, int32_t cpIndex, uint32_t * fieldOffset, TR::DataTypes * type, bool * volatileP, bool * isFinal, bool *isPrivate, bool isStore, bool * unresolvedInCP = 0, bool needAOTValidation=true);
-   virtual bool staticAttributes(TR::Compilation *, int32_t cpIndex, void * *, TR::DataTypes * type, bool * volatileP, bool * isFinal, bool *isPrivate, bool isStore, bool * unresolvedInCP = 0, bool needAOTValidation=true);
+   virtual bool fieldAttributes (TR::Compilation *, int32_t cpIndex, uint32_t * fieldOffset, TR::DataType * type, bool * volatileP, bool * isFinal, bool *isPrivate, bool isStore, bool * unresolvedInCP = 0, bool needAOTValidation=true);
+   virtual bool staticAttributes(TR::Compilation *, int32_t cpIndex, void * *, TR::DataType * type, bool * volatileP, bool * isFinal, bool *isPrivate, bool isStore, bool * unresolvedInCP = 0, bool needAOTValidation=true);
 
    virtual char *classNameOfFieldOrStatic(int32_t cpIndex, int32_t & len);
    virtual char *classSignatureOfFieldOrStatic(int32_t cpIndex, int32_t & len);

--- a/compiler/il/Aliases.cpp
+++ b/compiler/il/Aliases.cpp
@@ -623,18 +623,18 @@ OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool includeGCSafePo
 #endif
 
          // alias vector arrays shadows  with corresponding scalar array shadows
-         if (_symbol->isArrayShadowSymbol() && isVectorType(_symbol->getDataType()))
+         if (_symbol->isArrayShadowSymbol() && _symbol->getDataType().isVector())
             {
             if (!aliases)
                aliases = new (comp->trHeapMemory()) TR_BitVector(symRefTab->getNumSymRefs(), comp->trMemory(), heapAlloc, growable);
-            aliases->set(symRefTab->getArrayShadowIndex(vectorToScalar(_symbol->getDataType())));
+            aliases->set(symRefTab->getArrayShadowIndex(_symbol->getDataType().vectorToScalar()));
             }
          // the other way around
-         if (_symbol->isArrayShadowSymbol() && !isVectorType(_symbol->getDataType()))
+         if (_symbol->isArrayShadowSymbol() && !_symbol->getDataType().isVector())
             {
             if (!aliases)
                aliases = new (comp->trHeapMemory()) TR_BitVector(symRefTab->getNumSymRefs(), comp->trMemory(), heapAlloc, growable);
-            aliases->set(symRefTab->getArrayShadowIndex(scalarToVector(_symbol->getDataType())));
+            aliases->set(symRefTab->getArrayShadowIndex(_symbol->getDataType().scalarToVector()));
             }
 
 
@@ -645,7 +645,7 @@ OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool includeGCSafePo
             if (!aliases)
                aliases = new (comp->trHeapMemory()) TR_BitVector(symRefTab->getNumSymRefs(), comp->trMemory(), heapAlloc, growable);
 
-            TR::DataTypes type = _symbol->getDataType();
+            TR::DataType type = _symbol->getDataType();
             TR_BitVectorIterator bvi(symRefTab->aliasBuilder.arrayElementSymRefs());
             int32_t symRefNum;
             while (bvi.hasMoreElements())
@@ -854,7 +854,7 @@ addVeryRefinedCallAliasSets(TR::ResolvedMethodSymbol * methodSymbol, TR_BitVecto
          {
          TR::SymbolReference * symRefInCallee = node->getSymbolReference(), * symRefInCaller;
          TR::Symbol * symInCallee = symRefInCallee->getSymbol();
-         TR::DataTypes type = symInCallee->getDataType();
+         TR::DataType type = symInCallee->getDataType();
          if (symInCallee->isShadow())
             {
             if (symInCallee->isArrayShadowSymbol())

--- a/compiler/il/DataTypes.hpp
+++ b/compiler/il/DataTypes.hpp
@@ -28,6 +28,7 @@ class DataType : public OMR::DataTypeConnector
    { 
 
 public:
+   DataType() : OMR::DataTypeConnector() { }
    DataType(TR::DataTypes t) : OMR::DataTypeConnector(t) { }
 
    };

--- a/compiler/il/OMRDataTypes.cpp
+++ b/compiler/il/OMRDataTypes.cpp
@@ -23,6 +23,7 @@
 #include <stdint.h>                   // for int32_t, intptrj_t
 #include <string.h>                   // for strlen
 #include "env/jittypes.h"             // for intptrj_t
+#include "il/DataTypes.hpp"           // for DataType
 #include "infra/Assert.hpp"           // for TR_ASSERT
 
 // When adding new types also update pDataTypeNames[] in ras/Tree.cpp
@@ -55,31 +56,96 @@ static TR::ILOpCodes conversionMap[TR::NumOMRTypes][TR::NumOMRTypes] =
 
 } // namespace OMR
 
-TR::ILOpCodes
-OMR::DataType::getDataTypeConversion(TR::DataTypes t1, TR::DataTypes t2)
+TR::DataType&
+OMR::DataType::operator=(const TR::DataType& rhs)
    {
-   TR_ASSERT(t1 < TR::NumOMRTypes, "conversion opcode from unexpected datatype %d requested", t1);
-   TR_ASSERT(t2 < TR::NumOMRTypes, "conversion opcode to unexpected datatype %d requested", t2);
-   return OMR::conversionMap[t1][t2];
+   _type = rhs._type;
+   return *(static_cast<TR::DataType *>(this));
    }
 
-TR::DataTypes
-OMR::DataType::getFloatTypeFromSize(int32_t size)
+TR::DataType&
+OMR::DataType::operator=(TR::DataTypes rhs)
    {
-   TR::DataTypes type = TR::NoType;
-   switch (size)
-      {
-      case 4:  type = TR::Float; break;
-      case 8:  type = TR::Double; break;
-      default: TR_ASSERT(false,"unexpected size %d for float type\n",size);
-      }
-   return type;
+   _type = rhs;
+   return *(static_cast<TR::DataType *>(this));
    }
 
 bool
-OMR::DataType::canGetMaxPrecisionFromType(TR::DataTypes type)
+OMR::DataType::operator==(const TR::DataType& rhs)
    {
-   switch (type)
+   return _type == rhs._type;
+   }
+
+bool
+OMR::DataType::operator==(TR::DataTypes rhs)
+   {
+   return _type == rhs;
+   }
+
+bool
+OMR::DataType::operator!=(const TR::DataType& rhs)
+   {
+   return _type != rhs._type;
+   }
+
+bool
+OMR::DataType::operator!=(TR::DataTypes rhs)
+   {
+   return _type != rhs;
+   }
+
+bool
+OMR::DataType::operator<=(const TR::DataType& rhs)
+   {
+   return _type <= rhs._type;
+   }
+
+bool
+OMR::DataType::operator<=(TR::DataTypes rhs)
+   {
+   return _type <= rhs;
+   }
+
+bool
+OMR::DataType::operator<(const TR::DataType& rhs)
+   {
+   return _type < rhs._type;
+   }
+
+bool
+OMR::DataType::operator<(TR::DataTypes rhs)
+   {
+   return _type < rhs;
+   }
+
+bool
+OMR::DataType::operator>=(const TR::DataType& rhs)
+   {
+   return _type >= rhs._type;
+   }
+
+bool
+OMR::DataType::operator>=(TR::DataTypes rhs)
+   {
+   return _type >= rhs;
+   }
+
+bool
+OMR::DataType::operator>(const TR::DataType& rhs)
+   {
+   return _type > rhs._type;
+   }
+
+bool
+OMR::DataType::operator>(TR::DataTypes rhs)
+   {
+   return _type > rhs;
+   }
+
+bool
+OMR::DataType::canGetMaxPrecisionFromType()
+   {
+   switch (getDataType())
       {
       case TR::Int8:
       case TR::Int16:
@@ -92,9 +158,9 @@ OMR::DataType::canGetMaxPrecisionFromType(TR::DataTypes type)
    }
 
 int32_t
-OMR::DataType::getMaxPrecisionFromType(TR::DataTypes type)
+OMR::DataType::getMaxPrecisionFromType()
    {
-   switch (type)
+   switch (getDataType())
       {
       case TR::Int8: return TR::getMaxSignedPrecision<TR::Int8>();
       case TR::Int16: return TR::getMaxSignedPrecision<TR::Int16>();
@@ -104,6 +170,120 @@ OMR::DataType::getMaxPrecisionFromType(TR::DataTypes type)
          TR_ASSERT(false, "Unsupported data type in getMaxPrecisionFromType\n");
          return 0;
       }
+   }
+
+TR::DataType
+OMR::DataType::getVectorIntegralType()
+   {
+   switch(getDataType())
+      {
+      case TR::VectorInt8:
+      case TR::VectorInt16:
+      case TR::VectorInt32:
+      case TR::VectorInt64: return getDataType();
+      case TR::VectorFloat: return TR::VectorInt32;
+      case TR::VectorDouble: return TR::VectorInt64;
+      default:
+         return TR::NoType;
+         break;
+      }
+   }
+
+TR::DataType
+OMR::DataType::getVectorElementType()
+   {
+   switch(getDataType())
+      {
+      case TR::VectorInt8: return TR::Int8;
+      case TR::VectorInt16: return TR::Int16;
+      case TR::VectorInt32: return TR::Int32;
+      case TR::VectorInt64: return TR::Int64;
+      case TR::VectorFloat: return TR::Float;
+      case TR::VectorDouble: return TR::Double;
+      default:
+         return TR::NoType;
+         break;
+      }
+   }
+
+TR::DataType
+OMR::DataType::vectorToScalar()
+   {
+   switch (getDataType())
+      {
+      case TR::VectorInt8:
+         return TR::Int8;
+      case TR::VectorInt16:
+         return TR::Int16;
+      case TR::VectorInt32:
+         return TR::Int32;
+      case TR::VectorInt64:
+         return TR::Int64;
+      case TR::VectorFloat:
+         return TR::Float;
+      case TR::VectorDouble:
+         return TR::Double;
+      default:
+         return TR::NoType;
+      }
+   }
+
+TR::DataType
+OMR::DataType::scalarToVector()
+   {
+   switch (getDataType())
+      {
+      case TR::Int8:
+         return TR::VectorInt8;
+      case TR::Int16:
+         return TR::VectorInt16;
+      case TR::Int32:
+         return TR::VectorInt32;
+      case TR::Int64:
+         return TR::VectorInt64;
+      case TR::Float:
+         return TR::VectorFloat;
+      case TR::Double:
+         return TR::VectorDouble;
+      default:
+         return TR::NoType;
+      }
+   }
+
+TR::DataType
+OMR::DataType::getIntegralTypeFromPrecision(int32_t precision)
+   {
+   if (precision < 1 || precision >= TR::getMaxSignedPrecision<TR::Int64>())
+      return TR::NoType;
+   else if (precision < TR::getMaxSignedPrecision<TR::Int8>())
+      return TR::Int8;
+   else if (precision < TR::getMaxSignedPrecision<TR::Int16>())
+      return TR::Int16;
+   else if (precision < TR::getMaxSignedPrecision<TR::Int32>())
+      return TR::Int32;
+   else
+      return TR::Int64;
+   }
+
+TR::DataType
+OMR::DataType::getFloatTypeFromSize(int32_t size)
+   {
+   TR::DataType type = TR::NoType;
+   switch (size)
+      {
+      case 4:  type = TR::Float; break;
+      case 8:  type = TR::Double; break;
+      default: TR_ASSERT(false,"unexpected size %d for float type\n",size);
+      }
+   return type;
+   }
+
+TR::ILOpCodes
+OMR::DataType::getDataTypeConversion(TR::DataType t1, TR::DataType t2)
+   {
+   TR_ASSERT(t1 < TR::NumOMRTypes, "conversion opcode from unexpected datatype %d requested", t1);
+   TR_ASSERT(t2 < TR::NumOMRTypes, "conversion opcode to unexpected datatype %d requested", t2);
+   return OMR::conversionMap[t1][t2];
    }
 
 static int32_t OMRDataTypeSizes[] =
@@ -128,14 +308,14 @@ static int32_t OMRDataTypeSizes[] =
 static_assert(TR::NumOMRTypes == (sizeof(OMRDataTypeSizes) / sizeof(OMRDataTypeSizes[0])), "OMRDataTypeSizes is not the correct size");
 
 const int32_t
-OMR::DataType::getSize(TR::DataTypes dt)
+OMR::DataType::getSize(TR::DataType dt)
    {
    TR_ASSERT(dt < TR::NumOMRTypes, "dataTypeSizeMap called on unrecognized data type");
    return OMRDataTypeSizes[dt];
    }
 
 void
-OMR::DataType::setSize(TR::DataTypes dt, int32_t newSize)
+OMR::DataType::setSize(TR::DataType dt, int32_t newSize)
    {
    TR_ASSERT(dt < TR::NumOMRTypes, "setDataTypeSizeInMap called on unrecognized data type");
    OMRDataTypeSizes[dt] = newSize;
@@ -164,7 +344,7 @@ static const char * OMRDataTypeNames[] =
 static_assert(TR::NumOMRTypes == (sizeof(OMRDataTypeNames) / sizeof(OMRDataTypeNames[0])), "OMRDataTypeNames is not the correct size");
 
 const char *
-OMR::DataType::getName(TR::DataTypes dt)
+OMR::DataType::getName(TR::DataType dt)
    {
    TR_ASSERT(dt < TR::NumOMRTypes, "Name requested for unknown datatype");
    return OMRDataTypeNames[dt];
@@ -193,7 +373,7 @@ static const char *OMRDataTypePrefixes[] =
 static_assert(TR::NumOMRTypes == (sizeof(OMRDataTypePrefixes) / sizeof(OMRDataTypePrefixes[0])), "OMRDataTypePrefixes is not the correct size");
 
 const char *
-OMR::DataType::getPrefix(TR::DataTypes dt)
+OMR::DataType::getPrefix(TR::DataType dt)
    {
    TR_ASSERT(dt < TR::NumOMRTypes, "Prefix requested for unknown datatype");
    return OMRDataTypePrefixes[dt];

--- a/compiler/il/OMRDataTypes.hpp
+++ b/compiler/il/OMRDataTypes.hpp
@@ -225,11 +225,6 @@ enum DataTypes
    };
 }
 
-inline bool isAnyIntegralType(TR::DataTypes type)              { return (type == TR::Int8 || type == TR::Int16 || type == TR::Int32 || type == TR::Int64); }
-inline bool isAnyAggregateType(TR::DataTypes type)             { return (type == TR::Aggregate); }
-inline bool isVectorType(TR::DataTypes type)                   { return (type == TR::VectorInt8 || type == TR::VectorInt16 || type == TR::VectorInt32 || type == TR::VectorInt64 ||
-                                                                          type == TR::VectorFloat || type == TR::VectorDouble); }
-
 /**
  * @name OMRDataTypeIntegerLimits
  *
@@ -291,82 +286,69 @@ namespace OMR
 class DataType
    {
 public:
+   DataType() : _type(TR::DataTypes::NoType) { }
    DataType(TR::DataTypes t) : _type(t) { }
 
-   TR::DataTypes getDataType() { return _type; }
+   TR::DataTypes getDataType() const { return _type; }
 
-   bool isInt8()  { return _type == TR::Int8; }
-   bool isInt16() { return _type == TR::Int16; }
-   bool isInt32() { return _type == TR::Int32; }
-   bool isInt64() { return _type == TR::Int64; }
+   TR::DataType& operator=(const TR::DataType& rhs);
+   TR::DataType& operator=(TR::DataTypes rhs);
+
+   bool operator==(const TR::DataType& rhs);
+   bool operator==(TR::DataTypes rhs);
+
+   bool operator!=(const TR::DataType& rhs);
+   bool operator!=(TR::DataTypes rhs);
+
+   bool operator<=(const TR::DataType& rhs);
+   bool operator<=(TR::DataTypes rhs);
+
+   bool operator<(const TR::DataType& rhs);
+   bool operator<(TR::DataTypes rhs);
+
+   bool operator>=(const TR::DataType& rhs);
+   bool operator>=(TR::DataTypes rhs);
+
+   bool operator>(const TR::DataType& rhs);
+   bool operator>(TR::DataTypes rhs);
+
+   operator int() { return getDataType(); }
+
+   bool isInt8()  { return getDataType() == TR::Int8; }
+   bool isInt16() { return getDataType() == TR::Int16; }
+   bool isInt32() { return getDataType() == TR::Int32; }
+   bool isInt64() { return getDataType() == TR::Int64; }
 
    bool isIntegral() { return isInt8() || isInt16() || isInt32() || isInt64(); }
 
    bool isFloatingPoint() { return isBFPorHFP(); }
-   bool isVector() { return _type == TR::VectorInt8 || _type == TR::VectorInt16 || _type == TR::VectorInt32 || _type == TR::VectorInt64 ||
-                            _type == TR::VectorFloat || _type == TR::VectorDouble; }
-   bool isBFPorHFP() { return _type == TR::Float || _type == TR::Double; }
-   bool isDouble() { return _type == TR::Double; }
+   bool isVector() { return getDataType() == TR::VectorInt8 || getDataType() == TR::VectorInt16 || getDataType() == TR::VectorInt32 || getDataType() == TR::VectorInt64 ||
+                            getDataType() == TR::VectorFloat || getDataType() == TR::VectorDouble; }
+   bool isBFPorHFP() { return getDataType() == TR::Float || getDataType() == TR::Double; }
+   bool isDouble() { return getDataType() == TR::Double; }
 
-   bool isAddress() { return _type == TR::Address; }
-   bool isAggregate() { return _type == TR::Aggregate; }
+   bool isAddress() { return getDataType() == TR::Address; }
+   bool isAggregate() { return getDataType() == TR::Aggregate; }
 
-   static TR::DataTypes getIntegralTypeFromPrecision(int32_t precision)
-      {
-      if (precision < 1 || precision >= TR::getMaxSignedPrecision<TR::Int64>())
-         return  TR::NoType;
-      else if (precision < TR::getMaxSignedPrecision<TR::Int8>())
-         return  TR::Int8;
-      else if (precision < TR::getMaxSignedPrecision<TR::Int16>())
-         return  TR::Int16;
-      else if (precision < TR::getMaxSignedPrecision<TR::Int32>())
-         return  TR::Int32;
-      else
-         return  TR::Int64;
-      }
+   bool canGetMaxPrecisionFromType();
+   int32_t getMaxPrecisionFromType();
 
-   static bool canGetMaxPrecisionFromType(TR::DataTypes type);
-   static int32_t getMaxPrecisionFromType(TR::DataTypes type);
+   TR::DataType getVectorIntegralType();
+   TR::DataType getVectorElementType();
 
-   static TR::DataTypes getVectorIntegralType(TR::DataTypes dt)
-      {
-      switch(dt)
-         {
-         case TR::VectorInt8:
-         case TR::VectorInt16:
-         case TR::VectorInt32:
-         case TR::VectorInt64: return dt;
-         case TR::VectorFloat: return TR::VectorInt32;
-         case TR::VectorDouble: return TR::VectorInt64;
-         default:
-            return TR::NoType;
-            break;
-         }
-      }
+   TR::DataType vectorToScalar();
+   TR::DataType scalarToVector();
 
-   static TR::DataTypes getVectorElementType(TR::DataTypes dt)
-      {
-      switch(dt)
-         {
-         case TR::VectorInt8: return TR::Int8;
-         case TR::VectorInt16: return TR::Int16;
-         case TR::VectorInt32: return TR::Int32;
-         case TR::VectorInt64: return TR::Int64;
-         case TR::VectorFloat: return TR::Float;
-         case TR::VectorDouble: return TR::Double;
-         default:
-            return TR::NoType;
-            break;
-         }
-      }
-    static TR::DataTypes getFloatTypeFromSize(int32_t size);
+   static TR::DataType getIntegralTypeFromPrecision(int32_t precision);
 
-   static const char    * getName(TR::DataTypes dt);
-   static const int32_t   getSize(TR::DataTypes dt);
-   static void            setSize(TR::DataTypes dt, int32_t newValue);
-   static const char    * getPrefix(TR::DataTypes dt);
+   static TR::DataType getFloatTypeFromSize(int32_t size);
 
-   static TR::ILOpCodes getDataTypeConversion(TR::DataTypes t1, TR::DataTypes t2);
+   static TR::ILOpCodes getDataTypeConversion(TR::DataType t1, TR::DataType t2);
+
+   static const char    * getName(TR::DataType dt);
+   static const int32_t   getSize(TR::DataType dt);
+   static void            setSize(TR::DataType dt, int32_t newValue);
+   static const char    * getPrefix(TR::DataType dt);
 
    template <typename T> static bool isSignedInt8()  { return false; }
    template <typename T> static bool isSignedInt16() { return false; }
@@ -397,47 +379,5 @@ template <> inline bool OMR::DataType::isUnsignedInt32<uint32_t>() { return true
 template <> inline bool OMR::DataType::isUnsignedInt64<uint64_t>() { return true; }
 
 } // namespace OMR
-
-inline TR::DataTypes vectorToScalar(TR::DataTypes type)
-   {
-   switch (type)
-      {
-      case TR::VectorInt8:
-         return TR::Int8;
-      case TR::VectorInt16:
-         return TR::Int16;
-      case TR::VectorInt32:
-         return TR::Int32;
-      case TR::VectorInt64:
-         return TR::Int64;
-      case TR::VectorFloat:
-         return TR::Float;
-      case TR::VectorDouble:
-         return TR::Double;
-      default:
-         return TR::NoType;
-      }
-   }
-
-inline TR::DataTypes scalarToVector(TR::DataTypes type)
-   {
-   switch (type)
-      {
-      case TR::Int8:
-         return TR::VectorInt8;
-      case TR::Int16:
-         return TR::VectorInt16;
-      case TR::Int32:
-         return TR::VectorInt32;
-      case TR::Int64:
-         return TR::VectorInt64;
-      case TR::Float:
-         return TR::VectorFloat;
-      case TR::Double:
-         return TR::VectorDouble;
-      default:
-         return TR::NoType;
-      }
-   }
 
 #endif

--- a/compiler/il/OMRIL.cpp
+++ b/compiler/il/OMRIL.cpp
@@ -453,7 +453,7 @@ OMR::IL::opCodeForCorrespondingIndirectStore(TR::ILOpCodes storeOpCode)
 
 
 TR::ILOpCodes
-OMR::IL::opCodeForConst(TR::DataTypes dt)
+OMR::IL::opCodeForConst(TR::DataType dt)
    {
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -461,7 +461,7 @@ OMR::IL::opCodeForConst(TR::DataTypes dt)
    }
 
 TR::ILOpCodes
-OMR::IL::opCodeForDirectLoad(TR::DataTypes dt)
+OMR::IL::opCodeForDirectLoad(TR::DataType dt)
    {
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -469,7 +469,7 @@ OMR::IL::opCodeForDirectLoad(TR::DataTypes dt)
    }
 
 TR::ILOpCodes
-OMR::IL::opCodeForDirectStore(TR::DataTypes dt)
+OMR::IL::opCodeForDirectStore(TR::DataType dt)
    {
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -477,7 +477,7 @@ OMR::IL::opCodeForDirectStore(TR::DataTypes dt)
    }
 
 TR::ILOpCodes
-OMR::IL::opCodeForIndirectLoad(TR::DataTypes dt)
+OMR::IL::opCodeForIndirectLoad(TR::DataType dt)
    {
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -485,7 +485,7 @@ OMR::IL::opCodeForIndirectLoad(TR::DataTypes dt)
    }
 
 TR::ILOpCodes
-OMR::IL::opCodeForIndirectStore(TR::DataTypes dt)
+OMR::IL::opCodeForIndirectStore(TR::DataType dt)
    {
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -493,7 +493,7 @@ OMR::IL::opCodeForIndirectStore(TR::DataTypes dt)
    }
 
 TR::ILOpCodes
-OMR::IL::opCodeForIndirectArrayLoad(TR::DataTypes dt)
+OMR::IL::opCodeForIndirectArrayLoad(TR::DataType dt)
    {
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -501,7 +501,7 @@ OMR::IL::opCodeForIndirectArrayLoad(TR::DataTypes dt)
    }
 
 TR::ILOpCodes
-OMR::IL::opCodeForIndirectArrayStore(TR::DataTypes dt)
+OMR::IL::opCodeForIndirectArrayStore(TR::DataType dt)
    {
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -509,7 +509,7 @@ OMR::IL::opCodeForIndirectArrayStore(TR::DataTypes dt)
    }
 
 TR::ILOpCodes
-OMR::IL::opCodeForRegisterLoad(TR::DataTypes dt)
+OMR::IL::opCodeForRegisterLoad(TR::DataType dt)
    {
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -517,7 +517,7 @@ OMR::IL::opCodeForRegisterLoad(TR::DataTypes dt)
    }
 
 TR::ILOpCodes
-OMR::IL::opCodeForRegisterStore(TR::DataTypes dt)
+OMR::IL::opCodeForRegisterStore(TR::DataType dt)
    {
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -525,7 +525,7 @@ OMR::IL::opCodeForRegisterStore(TR::DataTypes dt)
    }
 
 TR::ILOpCodes
-OMR::IL::opCodeForCompareEquals(TR::DataTypes dt)
+OMR::IL::opCodeForCompareEquals(TR::DataType dt)
    {
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -533,7 +533,7 @@ OMR::IL::opCodeForCompareEquals(TR::DataTypes dt)
    }
 
 TR::ILOpCodes
-OMR::IL::opCodeForIfCompareEquals(TR::DataTypes dt)
+OMR::IL::opCodeForIfCompareEquals(TR::DataType dt)
    {
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -541,7 +541,7 @@ OMR::IL::opCodeForIfCompareEquals(TR::DataTypes dt)
    }
 
 TR::ILOpCodes
-OMR::IL::opCodeForCompareNotEquals(TR::DataTypes dt)
+OMR::IL::opCodeForCompareNotEquals(TR::DataType dt)
    {
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -549,7 +549,7 @@ OMR::IL::opCodeForCompareNotEquals(TR::DataTypes dt)
    }
 
 TR::ILOpCodes
-OMR::IL::opCodeForIfCompareNotEquals(TR::DataTypes dt)
+OMR::IL::opCodeForIfCompareNotEquals(TR::DataType dt)
    {
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -557,7 +557,7 @@ OMR::IL::opCodeForIfCompareNotEquals(TR::DataTypes dt)
    }
 
 TR::ILOpCodes
-OMR::IL::opCodeForCompareLessThan(TR::DataTypes dt)
+OMR::IL::opCodeForCompareLessThan(TR::DataType dt)
    {
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -565,7 +565,7 @@ OMR::IL::opCodeForCompareLessThan(TR::DataTypes dt)
    }
 
 TR::ILOpCodes
-OMR::IL::opCodeForIfCompareLessThan(TR::DataTypes dt)
+OMR::IL::opCodeForIfCompareLessThan(TR::DataType dt)
    {
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -573,7 +573,7 @@ OMR::IL::opCodeForIfCompareLessThan(TR::DataTypes dt)
    }
 
 TR::ILOpCodes
-OMR::IL::opCodeForCompareGreaterThan(TR::DataTypes dt)
+OMR::IL::opCodeForCompareGreaterThan(TR::DataType dt)
    {
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -581,7 +581,7 @@ OMR::IL::opCodeForCompareGreaterThan(TR::DataTypes dt)
    }
 
 TR::ILOpCodes
-OMR::IL::opCodeForIfCompareGreaterThan(TR::DataTypes dt)
+OMR::IL::opCodeForIfCompareGreaterThan(TR::DataType dt)
    {
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 

--- a/compiler/il/OMRIL.hpp
+++ b/compiler/il/OMRIL.hpp
@@ -61,23 +61,23 @@ class OMR_EXTENSIBLE IL
    TR::ILOpCodes opCodeForCorrespondingIndirectLoad(TR::ILOpCodes loadOpCode);
    TR::ILOpCodes opCodeForCorrespondingIndirectStore(TR::ILOpCodes storeOpCode);
 
-   TR::ILOpCodes opCodeForConst(TR::DataTypes dt);
-   TR::ILOpCodes opCodeForDirectLoad(TR::DataTypes dt);
-   TR::ILOpCodes opCodeForDirectStore(TR::DataTypes dt);
-   TR::ILOpCodes opCodeForIndirectLoad(TR::DataTypes dt);
-   TR::ILOpCodes opCodeForIndirectStore(TR::DataTypes dt);
-   TR::ILOpCodes opCodeForIndirectArrayLoad(TR::DataTypes dt);
-   TR::ILOpCodes opCodeForIndirectArrayStore(TR::DataTypes dt);
-   TR::ILOpCodes opCodeForRegisterLoad(TR::DataTypes dt);
-   TR::ILOpCodes opCodeForRegisterStore(TR::DataTypes dt);
-   TR::ILOpCodes opCodeForCompareEquals(TR::DataTypes dt);
-   TR::ILOpCodes opCodeForIfCompareEquals(TR::DataTypes dt);
-   TR::ILOpCodes opCodeForCompareNotEquals(TR::DataTypes dt);
-   TR::ILOpCodes opCodeForIfCompareNotEquals(TR::DataTypes dt);
-   TR::ILOpCodes opCodeForCompareLessThan(TR::DataTypes dt);
-   TR::ILOpCodes opCodeForIfCompareLessThan(TR::DataTypes dt);
-   TR::ILOpCodes opCodeForCompareGreaterThan(TR::DataTypes dt);
-   TR::ILOpCodes opCodeForIfCompareGreaterThan(TR::DataTypes dt);
+   TR::ILOpCodes opCodeForConst(TR::DataType dt);
+   TR::ILOpCodes opCodeForDirectLoad(TR::DataType dt);
+   TR::ILOpCodes opCodeForDirectStore(TR::DataType dt);
+   TR::ILOpCodes opCodeForIndirectLoad(TR::DataType dt);
+   TR::ILOpCodes opCodeForIndirectStore(TR::DataType dt);
+   TR::ILOpCodes opCodeForIndirectArrayLoad(TR::DataType dt);
+   TR::ILOpCodes opCodeForIndirectArrayStore(TR::DataType dt);
+   TR::ILOpCodes opCodeForRegisterLoad(TR::DataType dt);
+   TR::ILOpCodes opCodeForRegisterStore(TR::DataType dt);
+   TR::ILOpCodes opCodeForCompareEquals(TR::DataType dt);
+   TR::ILOpCodes opCodeForIfCompareEquals(TR::DataType dt);
+   TR::ILOpCodes opCodeForCompareNotEquals(TR::DataType dt);
+   TR::ILOpCodes opCodeForIfCompareNotEquals(TR::DataType dt);
+   TR::ILOpCodes opCodeForCompareLessThan(TR::DataType dt);
+   TR::ILOpCodes opCodeForIfCompareLessThan(TR::DataType dt);
+   TR::ILOpCodes opCodeForCompareGreaterThan(TR::DataType dt);
+   TR::ILOpCodes opCodeForIfCompareGreaterThan(TR::DataType dt);
 
    };
 

--- a/compiler/il/OMRILOps.cpp
+++ b/compiler/il/OMRILOps.cpp
@@ -91,113 +91,10 @@ OMR::ILOpCode::setTarget()
    }
 
 
-#if !defined(_MSC_VER)
-// the microsoft compiler cannot handle these templates
-namespace
-   {
-   enum signedUnsigned
-      {
-      isSigned,
-      isUnSigned
-      };
-   // originally, getCompareOp0, getCompareOp1 and getCompareOp2
-   // were all called getCompareOp.  However, this caused a
-   // compiler crash on AIX.
-   //
-   template<enum signedUnsigned>
-   class getCompareOpCodeHelper_
-      {
-      public:
-      template<enum TR::DataTypes, enum TR_ComparisonTypes>
-         static TR::ILOpCodes getCompareOp0();
-      template<enum TR::DataTypes>
-      static TR::ILOpCodes getCompareOp1(enum TR_ComparisonTypes ct);
-      static TR::ILOpCodes getCompareOp2(enum TR::DataTypes dt,
-                                        enum TR_ComparisonTypes ct);
-      };
-
-   template<enum signedUnsigned s>
-   template<enum TR::DataTypes, enum TR_ComparisonTypes>
-   inline TR::ILOpCodes getCompareOpCodeHelper_<s>::
-      getCompareOp0() { return TR::BadILOp; }
-
-#define declCmp0(S, DT, CT, OP) \
-   template<> template<> inline TR::ILOpCodes \
-   getCompareOpCodeHelper_<S>::getCompareOp0<DT, CT>() { return OP; }
-#define declCmp1(S, DT, OPBase) \
-   declCmp0(S, DT, TR_cmpEQ, OPBase ## eq) \
-   declCmp0(S, DT, TR_cmpNE, OPBase ## ne) \
-   declCmp0(S, DT, TR_cmpLT, OPBase ## lt) \
-   declCmp0(S, DT, TR_cmpLE, OPBase ## le) \
-   declCmp0(S, DT, TR_cmpGT, OPBase ## gt) \
-   declCmp0(S, DT, TR_cmpGE, OPBase ## ge)
-#define declCmp2(DT, sOPBase, uOPBase) \
-   declCmp1(isSigned, DT, sOPBase) \
-   declCmp1(isUnSigned, DT, uOPBase)
-#define declCmp3(DT, OPBase) declCmp1(isSigned, DT, OPBase)
-declCmp2(TR::Int8,    TR::bcmp, TR::bucmp)
-declCmp2(TR::Int16,   TR::scmp, TR::sucmp)
-declCmp2(TR::Int32,   TR::icmp, TR::iucmp)
-declCmp2(TR::Int64,   TR::lcmp, TR::lucmp)
-declCmp3(TR::Float,   TR::fcmp)
-declCmp3(TR::Double,  TR::dcmp)
-declCmp3(TR::Address, TR::acmp)
-#undef declCmp3
-#undef declCmp2
-#undef declCmp1
-#undef declCmp0
-
-   template<signedUnsigned s>
-   template<TR::DataTypes DT>
-   inline TR::ILOpCodes getCompareOpCodeHelper_<s>::getCompareOp1(TR_ComparisonTypes ct)
-      {
-      switch (ct)
-         {
-         case TR_cmpEQ: return getCompareOp0<DT, TR_cmpEQ>();
-         case TR_cmpNE: return getCompareOp0<DT, TR_cmpNE>();
-         case TR_cmpLT: return getCompareOp0<DT, TR_cmpLT>();
-         case TR_cmpLE: return getCompareOp0<DT, TR_cmpLE>();
-         case TR_cmpGT: return getCompareOp0<DT, TR_cmpGT>();
-         case TR_cmpGE: return getCompareOp0<DT, TR_cmpGE>();
-         default: return TR::BadILOp;
-         }
-      }
-
-   template<enum signedUnsigned s> inline
-      TR::ILOpCodes getCompareOpCodeHelper_<s>::
-      getCompareOp2(enum TR::DataTypes dt,
-                    enum TR_ComparisonTypes ct)
-      {
-      switch (dt)
-         {
-         case TR::Int8:    return getCompareOp1<TR::Int8>(ct);
-         case TR::Int16:   return getCompareOp1<TR::Int16>(ct);
-         case TR::Int32:   return getCompareOp1<TR::Int32>(ct);
-         case TR::Int64:   return getCompareOp1<TR::Int64>(ct);
-         case TR::Float:   return getCompareOp1<TR::Float>(ct);
-         case TR::Double:  return getCompareOp1<TR::Double>(ct);
-         case TR::Address: return getCompareOp1<TR::Address>(ct);
-         default: return TR::BadILOp;
-         }
-      }
-   }
-
 TR::ILOpCodes
-OMR::ILOpCode::compareOpCode(enum TR::DataTypes dt,
-                                        enum TR_ComparisonTypes ct,
-                                        bool unsignedCompare)
-   {
-   return unsignedCompare ?
-      getCompareOpCodeHelper_<isUnSigned>::getCompareOp2(dt, ct) :
-      getCompareOpCodeHelper_<isSigned>::getCompareOp2(dt, ct);
-   }
-
-#else
-// version for the microsoft compiler
-TR::ILOpCodes
-OMR::ILOpCode::compareOpCode(enum TR::DataTypes dt,
-                                        enum TR_ComparisonTypes ct,
-                                        bool unsignedCompare)
+OMR::ILOpCode::compareOpCode(TR::DataType dt,
+                             enum TR_ComparisonTypes ct,
+                             bool unsignedCompare)
    {
    if (unsignedCompare)
       {
@@ -393,5 +290,4 @@ OMR::ILOpCode::compareOpCode(enum TR::DataTypes dt,
       }
    return TR::BadILOp;
    }
-#endif
 

--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -50,7 +50,7 @@ struct OpCodeProperties
    uint32_t            properties3; // all those trivial flags32_t constructor calls
    uint32_t            properties4;
 
-   TR::DataTypes       dataType;
+   TR::DataType        dataType;
    uint32_t            typeProperties;
    TR::ILOpCodes       swapChildrenOpCode;
    TR::ILOpCodes       reverseBranchOpCode;
@@ -102,8 +102,8 @@ public:
    TR::ILOpCodes convertCmpToIfCmp()
       { return _opCodeProperties[_opCode].ifCompareOpCode; }
 
-   TR::DataTypes getDataType() const                  { return _opCodeProperties[_opCode].dataType; }
-   static TR::DataTypes getDataType(TR::ILOpCodes op) { return _opCodeProperties[op].dataType; }
+   TR::DataType getDataType() const                  { return _opCodeProperties[_opCode].dataType; }
+   static TR::DataType getDataType(TR::ILOpCodes op) { return _opCodeProperties[op].dataType; }
 
    TR::DataType getType() const                  { return _opCodeProperties[_opCode].dataType; }
    static TR::DataType getType(TR::ILOpCodes op) { return _opCodeProperties[op].dataType; }
@@ -383,7 +383,7 @@ public:
              getOpCodeValue() == TR::arraycopy;
       }
 
-   static TR::ILOpCodes getProperConversion(TR::DataTypes sourceDataType, TR::DataTypes targetDataType, bool needUnsignedConversion)
+   static TR::ILOpCodes getProperConversion(TR::DataType sourceDataType, TR::DataType targetDataType, bool needUnsignedConversion)
       {
       TR::ILOpCodes op = TR::DataType::getDataTypeConversion(sourceDataType, targetDataType);
       if (!needUnsignedConversion) return op;
@@ -489,7 +489,7 @@ public:
          }
       }
 
-   static TR::ILOpCodes compareOpCode(enum TR::DataTypes dt, enum TR_ComparisonTypes ct, bool unsignedCompare = false);
+   static TR::ILOpCodes compareOpCode(TR::DataType dt, enum TR_ComparisonTypes ct, bool unsignedCompare = false);
 
    static bool isStrictlyLessThanCmp(TR::ILOpCodes op)
       {
@@ -639,7 +639,7 @@ public:
          }
       }
 
-   static TR::ILOpCodes indirectLoadOpCode(TR::DataTypes type)
+   static TR::ILOpCodes indirectLoadOpCode(TR::DataType type)
       {
       switch(type)
          {
@@ -655,7 +655,7 @@ public:
       return TR::BadILOp;
       }
 
-   static TR::ILOpCodes absOpCode(TR::DataTypes type)
+   static TR::ILOpCodes absOpCode(TR::DataType type)
       {
       switch(type)
          {
@@ -668,7 +668,7 @@ public:
       return TR::BadILOp;
       }
 
-   static TR::ILOpCodes addOpCode(TR::DataTypes type, bool is64Bit)
+   static TR::ILOpCodes addOpCode(TR::DataType type, bool is64Bit)
       {
       switch(type)
          {
@@ -690,7 +690,7 @@ public:
       return TR::BadILOp;
       }
 
-   static TR::ILOpCodes subtractOpCode(TR::DataTypes type)
+   static TR::ILOpCodes subtractOpCode(TR::DataType type)
       {
       switch(type)
          {
@@ -711,7 +711,7 @@ public:
       return TR::BadILOp;
       }
 
-   static TR::ILOpCodes multiplyOpCode(TR::DataTypes type)
+   static TR::ILOpCodes multiplyOpCode(TR::DataType type)
       {
       switch(type)
          {
@@ -732,7 +732,7 @@ public:
       return TR::BadILOp;
       }
 
-   static TR::ILOpCodes divideOpCode(TR::DataTypes type)
+   static TR::ILOpCodes divideOpCode(TR::DataType type)
       {
       switch(type)
          {
@@ -753,7 +753,7 @@ public:
       return TR::BadILOp;
       }
 
-   static TR::ILOpCodes remainderOpCode(TR::DataTypes type)
+   static TR::ILOpCodes remainderOpCode(TR::DataType type)
       {
       switch(type)
          {
@@ -768,7 +768,7 @@ public:
       return TR::BadILOp;
       }
 
-   static TR::ILOpCodes andOpCode(TR::DataTypes type)
+   static TR::ILOpCodes andOpCode(TR::DataType type)
       {
       switch(type)
          {
@@ -781,7 +781,7 @@ public:
       return TR::BadILOp;
       }
 
-   static TR::ILOpCodes orOpCode(TR::DataTypes type)
+   static TR::ILOpCodes orOpCode(TR::DataType type)
       {
       switch(type)
          {
@@ -794,7 +794,7 @@ public:
       return TR::BadILOp;
       }
 
-   static TR::ILOpCodes xorOpCode(TR::DataTypes type)
+   static TR::ILOpCodes xorOpCode(TR::DataType type)
       {
       switch(type)
          {
@@ -807,7 +807,7 @@ public:
       return TR::BadILOp;
       }
 
-   static TR::ILOpCodes shiftLeftOpCode(TR::DataTypes type)
+   static TR::ILOpCodes shiftLeftOpCode(TR::DataType type)
       {
       switch(type)
          {
@@ -820,7 +820,7 @@ public:
       return TR::BadILOp;
       }
 
-   static TR::ILOpCodes unsignedShiftLeftOpCode(TR::DataTypes type)
+   static TR::ILOpCodes unsignedShiftLeftOpCode(TR::DataType type)
       {
       switch(type)
          {
@@ -831,7 +831,7 @@ public:
       return TR::BadILOp;
       }
 
-   static TR::ILOpCodes shiftRightOpCode(TR::DataTypes type)
+   static TR::ILOpCodes shiftRightOpCode(TR::DataType type)
       {
       switch(type)
          {
@@ -844,7 +844,7 @@ public:
       return TR::BadILOp;
       }
 
-   static TR::ILOpCodes unsignedShiftRightOpCode(TR::DataTypes type)
+   static TR::ILOpCodes unsignedShiftRightOpCode(TR::DataType type)
       {
       switch(type)
          {
@@ -855,7 +855,7 @@ public:
       return TR::BadILOp;
       }
 
-   static TR::ILOpCodes negateOpCode(TR::DataTypes type)
+   static TR::ILOpCodes negateOpCode(TR::DataType type)
       {
       switch(type)
          {
@@ -935,7 +935,7 @@ public:
       return false;
       }
 
-   static TR::ILOpCodes ifcmpgeOpCode(TR::DataTypes type, bool isUnsigned)
+   static TR::ILOpCodes ifcmpgeOpCode(TR::DataType type, bool isUnsigned)
       {
       switch(type)
          {
@@ -951,7 +951,7 @@ public:
       return TR::BadILOp;
       }
 
-   static TR::ILOpCodes ifcmpleOpCode(TR::DataTypes type, bool isUnsigned)
+   static TR::ILOpCodes ifcmpleOpCode(TR::DataType type, bool isUnsigned)
       {
       switch(type)
          {
@@ -967,7 +967,7 @@ public:
       return TR::BadILOp;
       }
 
-   static TR::ILOpCodes ifcmpgtOpCode(TR::DataTypes type, bool isUnsigned)
+   static TR::ILOpCodes ifcmpgtOpCode(TR::DataType type, bool isUnsigned)
       {
       switch(type)
          {
@@ -983,7 +983,7 @@ public:
       return TR::BadILOp;
       }
 
-   static TR::ILOpCodes ifcmpltOpCode(TR::DataTypes type, bool isUnsigned)
+   static TR::ILOpCodes ifcmpltOpCode(TR::DataType type, bool isUnsigned)
       {
       switch(type)
          {
@@ -999,7 +999,7 @@ public:
       return TR::BadILOp;
       }
 
-   static TR::ILOpCodes ifcmpeqOpCode(TR::DataTypes type)
+   static TR::ILOpCodes ifcmpeqOpCode(TR::DataType type)
       {
       switch(type)
          {
@@ -1015,7 +1015,7 @@ public:
       return TR::BadILOp;
       }
 
-   static TR::ILOpCodes ifcmpneOpCode(TR::DataTypes type)
+   static TR::ILOpCodes ifcmpneOpCode(TR::DataType type)
       {
       switch(type)
          {
@@ -1031,7 +1031,7 @@ public:
       return TR::BadILOp;
       }
 
-   static TR::ILOpCodes cmpeqOpCode(TR::DataTypes type)
+   static TR::ILOpCodes cmpeqOpCode(TR::DataType type)
       {
       switch(type)
          {
@@ -1079,7 +1079,7 @@ public:
          }
       }
 
-   static TR::ILOpCodes constOpCode(TR::DataTypes type)
+   static TR::ILOpCodes constOpCode(TR::DataType type)
       {
       switch(type)
          {
@@ -1145,7 +1145,7 @@ public:
             }
          }
 
-   static TR::ILOpCodes returnOpCode(TR::DataTypes type)
+   static TR::ILOpCodes returnOpCode(TR::DataType type)
       {
       switch(type)
          {
@@ -1179,7 +1179,7 @@ public:
       return TR::BadILOp;
       }
 
-   static TR::ILOpCodes getDirectCall(TR::DataTypes type)
+   static TR::ILOpCodes getDirectCall(TR::DataType type)
       {
       switch (type)
          {
@@ -1300,7 +1300,7 @@ public:
       return TR::BadILOp;
       }
 
-   static TR::ILOpCodes getRotateOpCodeFromDt(TR::DataTypes type)
+   static TR::ILOpCodes getRotateOpCodeFromDt(TR::DataType type)
       {
       switch (type)
          {
@@ -1314,16 +1314,6 @@ public:
       return TR::BadILOp;
       }
 
-   static TR::ILOpCodes getCorrespondingNonAggregateOp(TR::ILOpCodes op, TR::DataTypes type)
-      {
-      switch (op)
-         {
-         default: return TR::BadILOp;
-         }
-
-      return TR::BadILOp;
-      }
-
    bool isSqrt()
       {
       auto op = getOpCodeValue();
@@ -1331,7 +1321,6 @@ public:
          return true;
       return false;
       }
-
 
 
    template <typename T> static TR::ILOpCodes getConstOpCode();

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -1412,7 +1412,7 @@ OMR::Node::aconst(uintptrj_t val)
 
 
 TR::Node *
-OMR::Node::createConstZeroValue(TR::Node *originatingByteCodeNode, TR::DataTypes dt)
+OMR::Node::createConstZeroValue(TR::Node *originatingByteCodeNode, TR::DataType dt)
    {
    TR::Node *constZero = NULL;
    switch (dt)
@@ -1451,7 +1451,7 @@ OMR::Node::createConstZeroValue(TR::Node *originatingByteCodeNode, TR::DataTypes
    }
 
 TR::Node *
-OMR::Node::createConstOne(TR::Node *originatingByteCodeNode, TR::DataTypes dt)
+OMR::Node::createConstOne(TR::Node *originatingByteCodeNode, TR::DataType dt)
    {
    TR::Node *constOne = NULL;
    char buf[20];
@@ -1487,7 +1487,7 @@ OMR::Node::createConstOne(TR::Node *originatingByteCodeNode, TR::DataTypes dt)
    }
 
 TR::Node *
-OMR::Node::createConstDead(TR::Node *originatingByteCodeNode, TR::DataTypes dt, intptrj_t extraData)
+OMR::Node::createConstDead(TR::Node *originatingByteCodeNode, TR::DataType dt, intptrj_t extraData)
    {
    TR::Node *result = NULL;
    const int8_t dead8 = (int8_t)((extraData << 4) | 0xD);
@@ -1576,7 +1576,7 @@ OMR::Node::createLiteralPoolAddress(TR::Node *node, size_t offset)
 
 
 TR::Node *
-OMR::Node::createVectorConst(TR::Node *originatingByteCodeNode, TR::DataTypes dt)
+OMR::Node::createVectorConst(TR::Node *originatingByteCodeNode, TR::DataType dt)
    {
    TR::Node *node = TR::Node::createInternal(originatingByteCodeNode, TR::vconst, 0, NULL);
    node->setDataType(dt);
@@ -1585,7 +1585,7 @@ OMR::Node::createVectorConst(TR::Node *originatingByteCodeNode, TR::DataTypes dt
 
 // v2v is vector conversion that preserves bit-pattern, effectively a noop that only changes datatype.
 TR::Node *
-OMR::Node::createVectorConversion(TR::Node *src, TR::DataTypes trgType)
+OMR::Node::createVectorConversion(TR::Node *src, TR::DataType trgType)
    {
    TR::Node *node = TR::Node::createWithoutSymRef(TR::v2v, 1, 1, src);
    node->setDataType(trgType);
@@ -4592,7 +4592,7 @@ OMR::Node::freeExtensionIfExists()
 
 
 
-TR::DataTypes
+TR::DataType
 OMR::Node::getArrayCopyElementType()
    {
    TR::Compilation * comp = TR::comp();
@@ -4600,7 +4600,7 @@ OMR::Node::getArrayCopyElementType()
 
    if (_numChildren==3 || _numChildren==4 || _numChildren==6)
       {
-       return _unionBase._extension.getExtensionPtr()->getElem<TR::DataTypes>(_numChildren);
+       return (TR::DataTypes)_unionBase._extension.getExtensionPtr()->getElem<uint32_t>(_numChildren);
       }
 
    TR_ASSERT(comp, "Query only valid during compilation\n");
@@ -4610,7 +4610,7 @@ OMR::Node::getArrayCopyElementType()
    }
 
 void
-OMR::Node::setArrayCopyElementType(TR::DataTypes type)
+OMR::Node::setArrayCopyElementType(TR::DataType type)
    {
    TR_ASSERT(self()->getOpCodeValue() == TR::arraycopy || self()->getOpCodeValue() == TR::arrayset, "assertion failure");
 
@@ -5057,7 +5057,7 @@ OMR::Node::setPinningArrayPointer(TR::AutomaticSymbol *s)
    return (_unionPropertyA._pinningArrayPointer = s);
    }
 
-TR::DataTypes
+TR::DataType
 OMR::Node::computeDataType()
    {
    // If opcode has SymRef, must get DataType from SymRef, since _dataType member is union-aliased with SymRef.
@@ -5082,19 +5082,19 @@ OMR::Node::computeDataType()
          {
          // Vector comparison returning resultant vector should return vector bool int type, WCode ACR 265
          if (_opCode.isBooleanCompare())
-            _unionPropertyA._dataType = TR::DataType::getVectorIntegralType(self()->getFirstChild()->getDataType());
+            _unionPropertyA._dataType = self()->getFirstChild()->getDataType().getVectorIntegralType().getDataType();
          else if (_opCode.isVectorReduction())
-            _unionPropertyA._dataType = TR::DataType::getVectorElementType(self()->getFirstChild()->getDataType());
+            _unionPropertyA._dataType = self()->getFirstChild()->getDataType().getVectorElementType().getDataType();
          else if (_opCode.getOpCodeValue() == TR::vsplats)
-            _unionPropertyA._dataType = scalarToVector(self()->getFirstChild()->getDataType());
+            _unionPropertyA._dataType = self()->getFirstChild()->getDataType().scalarToVector().getDataType();
          else
-            _unionPropertyA._dataType = self()->getFirstChild()->getDataType();
+            _unionPropertyA._dataType = self()->getFirstChild()->getDataType().getDataType();
 
          return _unionPropertyA._dataType;
          }
 
       if (_opCode.getOpCodeValue() == TR::getvelem)
-         return _unionPropertyA._dataType = vectorToScalar(self()->getFirstChild()->getDataType());
+         return _unionPropertyA._dataType = self()->getFirstChild()->getDataType().vectorToScalar().getDataType();
       }
    TR_ASSERT(false, "Unsupported typeless opcode in node %p\n", self());
    return TR::NoType;

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -308,17 +308,17 @@ public:
    static TR::Node *aconst(TR::Node *originatingByteCodeNode, uintptrj_t val, uint8_t precision);
    static TR::Node *aconst(uintptrj_t val);
 
-   static TR::Node *createConstZeroValue(TR::Node *originatingByteCodeNode, TR::DataTypes dt);
-   static TR::Node *createConstOne(TR::Node *originatingByteCodeNode, TR::DataTypes dt);
-   static TR::Node *createConstDead(TR::Node *originatingByteCodeNode, TR::DataTypes dt, intptrj_t extraData=0);
+   static TR::Node *createConstZeroValue(TR::Node *originatingByteCodeNode, TR::DataType dt);
+   static TR::Node *createConstOne(TR::Node *originatingByteCodeNode, TR::DataType dt);
+   static TR::Node *createConstDead(TR::Node *originatingByteCodeNode, TR::DataType dt, intptrj_t extraData=0);
 
    static TR::Node *createCompressedRefsAnchor(TR::Node *firstChild);
 
    static TR::Node *createAddConstantToAddress(TR::Node * addr, intptr_t value, TR::Node * parent = NULL);
    static TR::Node *createLiteralPoolAddress(TR::Node *node, size_t offset);
 
-   static TR::Node *createVectorConst(TR::Node *originatingByteCodeNode, TR::DataTypes dt);
-   static TR::Node *createVectorConversion(TR::Node *src, TR::DataTypes trgType);
+   static TR::Node *createVectorConst(TR::Node *originatingByteCodeNode, TR::DataType dt);
+   static TR::Node *createVectorConversion(TR::Node *src, TR::DataType trgType);
 
 /**
  * Private constructor helpers
@@ -786,8 +786,8 @@ public:
     */
    void                    freeExtensionIfExists();
 
-   TR::DataTypes           getArrayCopyElementType();
-   void                    setArrayCopyElementType(TR::DataTypes type);
+   TR::DataType           getArrayCopyElementType();
+   void                    setArrayCopyElementType(TR::DataType type);
 
    TR_OpaqueClassBlock *   getArrayStoreClassInNode();
    void                    setArrayStoreClassInNode(TR_OpaqueClassBlock *o);
@@ -865,9 +865,9 @@ public:
    TR::AutomaticSymbol * getPinningArrayPointer();
    TR::AutomaticSymbol * setPinningArrayPointer(TR::AutomaticSymbol *s);
 
-   inline TR::DataTypes   getDataType();
-   inline TR::DataTypes   setDataType(TR::DataTypes dt);
-   TR::DataTypes          computeDataType();
+   inline TR::DataType   getDataType();
+   inline TR::DataType   setDataType(TR::DataType dt);
+   TR::DataType          computeDataType();
 
    /**
     * UnionPropertyA functions end
@@ -1659,7 +1659,7 @@ protected:
       TR::Block             *_block;                        ///< hasBlock()
       int32_t                _arrayStride;                  ///< hasArrayStride()
       TR::AutomaticSymbol  *_pinningArrayPointer;          ///< hasPinningArrayPointer()
-      TR::DataTypes          _dataType;                     ///< hasDataType()
+      TR::DataTypes         _dataType;                     ///< hasDataType()  TODO: Change to TR::DataType once all target compilers support it
 
       UnionPropertyA()
          {

--- a/compiler/il/OMRNode_inlines.hpp
+++ b/compiler/il/OMRNode_inlines.hpp
@@ -688,7 +688,7 @@ OMR::Node::setBranchDestination(TR::TreeTop * p)
    return (_unionPropertyA._branchDestinationNode = p);
    }
 
-TR::DataTypes
+TR::DataType
 OMR::Node::getDataType()
    {
    if (!_opCode.hasNoDataType())
@@ -696,11 +696,11 @@ OMR::Node::getDataType()
    return self()->computeDataType();
    }
 
-TR::DataTypes
-OMR::Node::setDataType(TR::DataTypes dt)
+TR::DataType
+OMR::Node::setDataType(TR::DataType dt)
    {
    TR_ASSERT(self()->hasDataType(), "attempting to access _dataType field for node %s %p that does not have it", self()->getOpCode().getName(), this);
-   return (_unionPropertyA._dataType = dt);
+   return (_unionPropertyA._dataType = dt.getDataType());
    }
 
 /**

--- a/compiler/il/OMRTreeTop.cpp
+++ b/compiler/il/OMRTreeTop.cpp
@@ -71,7 +71,7 @@ TR::TreeTop *
 OMR::TreeTop::createIncTree(TR::Compilation * comp, TR::Node *node, TR::SymbolReference * symRef, int32_t incAmount, TR::TreeTop *precedingTreeTop, bool isRecompCounter)
    {
    TR::StaticSymbol * symbol = symRef->getSymbol()->castToStaticSymbol();
-   TR::DataTypes type = symbol->getDataType();
+   TR::DataType type = symbol->getDataType();
    TR::Node * storeNode;
    if (comp->cg()->getAccessStaticsIndirectly() && !symRef->isUnresolved() && type != TR::Address)
       {
@@ -100,7 +100,7 @@ TR::TreeTop *
 OMR::TreeTop::createResetTree(TR::Compilation * comp, TR::Node *node, TR::SymbolReference * symRef, int32_t resetAmount, TR::TreeTop *precedingTreeTop, bool isRecompCounter)
    {
    TR::StaticSymbol * symbol = symRef->getSymbol()->castToStaticSymbol();
-   TR::DataTypes type = symbol->getDataType();
+   TR::DataType type = symbol->getDataType();
    TR::Node * storeNode;
    if (comp->cg()->getAccessStaticsIndirectly() && !symRef->isUnresolved() && type != TR::Address)
       {

--- a/compiler/il/Symbol.hpp
+++ b/compiler/il/Symbol.hpp
@@ -60,10 +60,10 @@ public:
    Symbol() :
       OMR::SymbolConnector() {}
 
-   Symbol(TR::DataTypes d) :
+   Symbol(TR::DataType d) :
       OMR::SymbolConnector(d) {}
 
-   Symbol(TR::DataTypes d, uint32_t s) :
+   Symbol(TR::DataType d, uint32_t s) :
       OMR::SymbolConnector(d,s) {}
 
    };

--- a/compiler/il/symbol/AutomaticSymbol.hpp
+++ b/compiler/il/symbol/AutomaticSymbol.hpp
@@ -37,13 +37,13 @@ protected:
    AutomaticSymbol(int32_t o = 0) :
       OMR::AutomaticSymbolConnector() { }
 
-   AutomaticSymbol(TR::DataTypes d) :
+   AutomaticSymbol(TR::DataType d) :
       OMR::AutomaticSymbolConnector(d) { }
 
-   AutomaticSymbol(TR::DataTypes d, uint32_t s) :
+   AutomaticSymbol(TR::DataType d, uint32_t s) :
       OMR::AutomaticSymbolConnector(d, s) { }
 
-   AutomaticSymbol(TR::DataTypes d, uint32_t s, const char * name) :
+   AutomaticSymbol(TR::DataType d, uint32_t s, const char * name) :
       OMR::AutomaticSymbolConnector(d, s, name) { }
 
 private:

--- a/compiler/il/symbol/OMRAutomaticSymbol.cpp
+++ b/compiler/il/symbol/OMRAutomaticSymbol.cpp
@@ -40,19 +40,19 @@ OMR::AutomaticSymbol::AutomaticSymbol() :
    self()->init();
    }
 
-OMR::AutomaticSymbol::AutomaticSymbol(TR::DataTypes d) :
+OMR::AutomaticSymbol::AutomaticSymbol(TR::DataType d) :
    TR::RegisterMappedSymbol(d)
    {
    self()->init();
    }
 
-OMR::AutomaticSymbol::AutomaticSymbol(TR::DataTypes d, uint32_t s) :
+OMR::AutomaticSymbol::AutomaticSymbol(TR::DataType d, uint32_t s) :
    TR::RegisterMappedSymbol(d, s)
    {
    self()->init();
    }
 
-OMR::AutomaticSymbol::AutomaticSymbol(TR::DataTypes d, uint32_t s, const char *name) :
+OMR::AutomaticSymbol::AutomaticSymbol(TR::DataType d, uint32_t s, const char *name) :
    TR::RegisterMappedSymbol(d, s)
    {
    self()->init(); _name = name;
@@ -117,19 +117,19 @@ TR::AutomaticSymbol * OMR::AutomaticSymbol::create(AllocatorType t)
    }
 
 template <typename AllocatorType>
-TR::AutomaticSymbol * OMR::AutomaticSymbol::create(AllocatorType t,  TR::DataTypes d)
+TR::AutomaticSymbol * OMR::AutomaticSymbol::create(AllocatorType t,  TR::DataType d)
    {
    return new (t) TR::AutomaticSymbol(d);
    }
 
 template <typename AllocatorType>
-TR::AutomaticSymbol * OMR::AutomaticSymbol::create(AllocatorType t,  TR::DataTypes d, uint32_t s)
+TR::AutomaticSymbol * OMR::AutomaticSymbol::create(AllocatorType t,  TR::DataType d, uint32_t s)
    {
    return new (t) TR::AutomaticSymbol(d,s);
    }
 
 template <typename AllocatorType>
-TR::AutomaticSymbol * OMR::AutomaticSymbol::create(AllocatorType t,  TR::DataTypes d, uint32_t s, const char * n)
+TR::AutomaticSymbol * OMR::AutomaticSymbol::create(AllocatorType t,  TR::DataType d, uint32_t s, const char * n)
    {
    return new (t) TR::AutomaticSymbol(d,s,n);
    }
@@ -144,7 +144,7 @@ TR::AutomaticSymbol * OMR::AutomaticSymbol::createMarker(AllocatorType m, const 
    }
 
 template <typename AllocatorType>
-TR::AutomaticSymbol * OMR::AutomaticSymbol::createRegisterSymbol(AllocatorType m, TR_RegisterKinds regKind, uint32_t globalRegNum, TR::DataTypes d, uint32_t s, TR_FrontEnd * fe)
+TR::AutomaticSymbol * OMR::AutomaticSymbol::createRegisterSymbol(AllocatorType m, TR_RegisterKinds regKind, uint32_t globalRegNum, TR::DataType d, uint32_t s, TR_FrontEnd * fe)
    {
    TR::AutomaticSymbol * sym = new (m) TR::AutomaticSymbol(d,s);
    sym->_regKind = regKind;
@@ -154,7 +154,7 @@ TR::AutomaticSymbol * OMR::AutomaticSymbol::createRegisterSymbol(AllocatorType m
    }
 
 template <typename AllocatorType>
-TR::AutomaticSymbol * OMR::AutomaticSymbol::createLocalObject(AllocatorType m, int32_t arrayType, TR::DataTypes d, uint32_t s, TR_FrontEnd * fe)
+TR::AutomaticSymbol * OMR::AutomaticSymbol::createLocalObject(AllocatorType m, int32_t arrayType, TR::DataType d, uint32_t s, TR_FrontEnd * fe)
    {
    TR::AutomaticSymbol * sym   = new (m) TR::AutomaticSymbol(d, s);
 
@@ -168,7 +168,7 @@ TR::AutomaticSymbol * OMR::AutomaticSymbol::createLocalObject(AllocatorType m, i
 
 
 template <typename AllocatorType>
-TR::AutomaticSymbol * OMR::AutomaticSymbol::createLocalObject(AllocatorType m, TR::ILOpCodes kind, TR::SymbolReference * classSymRef, TR::DataTypes d, uint32_t s, TR_FrontEnd * fe)
+TR::AutomaticSymbol * OMR::AutomaticSymbol::createLocalObject(AllocatorType m, TR::ILOpCodes kind, TR::SymbolReference * classSymRef, TR::DataType d, uint32_t s, TR_FrontEnd * fe)
    {
    TR_ASSERT(kind == TR::newarray     ||
              kind == TR::New          ||
@@ -192,7 +192,7 @@ TR::AutomaticSymbol * OMR::AutomaticSymbol::createInternalPointer(AllocatorType 
    }
 
 template <typename AllocatorType>
-TR::AutomaticSymbol * OMR::AutomaticSymbol::createInternalPointer(AllocatorType m, TR::DataTypes d, TR::AutomaticSymbol *pinningArrayPointer)
+TR::AutomaticSymbol * OMR::AutomaticSymbol::createInternalPointer(AllocatorType m, TR::DataType d, TR::AutomaticSymbol *pinningArrayPointer)
    {
    TR::AutomaticSymbol * sym = new (m) TR::AutomaticSymbol(d);
    sym->setInternalPointer();
@@ -201,7 +201,7 @@ TR::AutomaticSymbol * OMR::AutomaticSymbol::createInternalPointer(AllocatorType 
    }
 
 template <typename AllocatorType>
-TR::AutomaticSymbol * OMR::AutomaticSymbol::createInternalPointer(AllocatorType m, TR::DataTypes d, uint32_t s, TR_FrontEnd * fe)
+TR::AutomaticSymbol * OMR::AutomaticSymbol::createInternalPointer(AllocatorType m, TR::DataType d, uint32_t s, TR_FrontEnd * fe)
    {
    TR::AutomaticSymbol * sym = new (m) TR::AutomaticSymbol(d,s);
    sym->setInternalPointer();
@@ -226,44 +226,44 @@ TR::AutomaticSymbol * OMR::AutomaticSymbol::createVariableSized(AllocatorType m,
 
 
 template TR::AutomaticSymbol * OMR::AutomaticSymbol::createMarker(TR_HeapMemory m, const char * name) ;
-template TR::AutomaticSymbol * OMR::AutomaticSymbol::createRegisterSymbol(TR_HeapMemory m, TR_RegisterKinds regKind, uint32_t globalRegNum, TR::DataTypes d, uint32_t s, TR_FrontEnd * fe) ;
-template TR::AutomaticSymbol * OMR::AutomaticSymbol::createLocalObject(TR_HeapMemory m, int32_t arrayType, TR::DataTypes d, uint32_t s, TR_FrontEnd * fe);
-template TR::AutomaticSymbol * OMR::AutomaticSymbol::createLocalObject(TR_HeapMemory m, TR::ILOpCodes kind, TR::SymbolReference * classSymRef, TR::DataTypes d, uint32_t s, TR_FrontEnd * fe);
+template TR::AutomaticSymbol * OMR::AutomaticSymbol::createRegisterSymbol(TR_HeapMemory m, TR_RegisterKinds regKind, uint32_t globalRegNum, TR::DataType d, uint32_t s, TR_FrontEnd * fe) ;
+template TR::AutomaticSymbol * OMR::AutomaticSymbol::createLocalObject(TR_HeapMemory m, int32_t arrayType, TR::DataType d, uint32_t s, TR_FrontEnd * fe);
+template TR::AutomaticSymbol * OMR::AutomaticSymbol::createLocalObject(TR_HeapMemory m, TR::ILOpCodes kind, TR::SymbolReference * classSymRef, TR::DataType d, uint32_t s, TR_FrontEnd * fe);
 template TR::AutomaticSymbol * OMR::AutomaticSymbol::createInternalPointer(TR_HeapMemory m, TR::AutomaticSymbol *pinningArrayPointer);
-template TR::AutomaticSymbol * OMR::AutomaticSymbol::createInternalPointer(TR_HeapMemory m, TR::DataTypes d, TR::AutomaticSymbol *pinningArrayPointer);
-template TR::AutomaticSymbol * OMR::AutomaticSymbol::createInternalPointer(TR_HeapMemory m, TR::DataTypes d, uint32_t s, TR_FrontEnd * fe);
+template TR::AutomaticSymbol * OMR::AutomaticSymbol::createInternalPointer(TR_HeapMemory m, TR::DataType d, TR::AutomaticSymbol *pinningArrayPointer);
+template TR::AutomaticSymbol * OMR::AutomaticSymbol::createInternalPointer(TR_HeapMemory m, TR::DataType d, uint32_t s, TR_FrontEnd * fe);
 template TR::AutomaticSymbol * OMR::AutomaticSymbol::createVariableSized(TR_HeapMemory m, uint32_t s);
 
 template TR::AutomaticSymbol * OMR::AutomaticSymbol::createMarker(TR_StackMemory m, const char * name) ;
-template TR::AutomaticSymbol * OMR::AutomaticSymbol::createRegisterSymbol(TR_StackMemory m, TR_RegisterKinds regKind, uint32_t globalRegNum, TR::DataTypes d, uint32_t s, TR_FrontEnd * fe) ;
-template TR::AutomaticSymbol * OMR::AutomaticSymbol::createLocalObject(TR_StackMemory m, int32_t arrayType, TR::DataTypes   d, uint32_t s, TR_FrontEnd * fe);
-template TR::AutomaticSymbol * OMR::AutomaticSymbol::createLocalObject(TR_StackMemory m, TR::ILOpCodes kind, TR::SymbolReference * classSymRef, TR::DataTypes d, uint32_t s, TR_FrontEnd * fe);
+template TR::AutomaticSymbol * OMR::AutomaticSymbol::createRegisterSymbol(TR_StackMemory m, TR_RegisterKinds regKind, uint32_t globalRegNum, TR::DataType d, uint32_t s, TR_FrontEnd * fe) ;
+template TR::AutomaticSymbol * OMR::AutomaticSymbol::createLocalObject(TR_StackMemory m, int32_t arrayType, TR::DataType   d, uint32_t s, TR_FrontEnd * fe);
+template TR::AutomaticSymbol * OMR::AutomaticSymbol::createLocalObject(TR_StackMemory m, TR::ILOpCodes kind, TR::SymbolReference * classSymRef, TR::DataType d, uint32_t s, TR_FrontEnd * fe);
 template TR::AutomaticSymbol * OMR::AutomaticSymbol::createInternalPointer(TR_StackMemory m, TR::AutomaticSymbol *pinningArrayPointer);
-template TR::AutomaticSymbol * OMR::AutomaticSymbol::createInternalPointer(TR_StackMemory m, TR::DataTypes d, TR::AutomaticSymbol *pinningArrayPointer);
-template TR::AutomaticSymbol * OMR::AutomaticSymbol::createInternalPointer(TR_StackMemory m, TR::DataTypes d, uint32_t s, TR_FrontEnd * fe);
+template TR::AutomaticSymbol * OMR::AutomaticSymbol::createInternalPointer(TR_StackMemory m, TR::DataType d, TR::AutomaticSymbol *pinningArrayPointer);
+template TR::AutomaticSymbol * OMR::AutomaticSymbol::createInternalPointer(TR_StackMemory m, TR::DataType d, uint32_t s, TR_FrontEnd * fe);
 template TR::AutomaticSymbol * OMR::AutomaticSymbol::createVariableSized(TR_StackMemory m, uint32_t s);
 
 template TR::AutomaticSymbol * OMR::AutomaticSymbol::createMarker(PERSISTENT_NEW_DECLARE m, const char * name) ;
-template TR::AutomaticSymbol * OMR::AutomaticSymbol::createRegisterSymbol(PERSISTENT_NEW_DECLARE m, TR_RegisterKinds regKind, uint32_t globalRegNum, TR::DataTypes d, uint32_t s, TR_FrontEnd * fe) ;
-template TR::AutomaticSymbol * OMR::AutomaticSymbol::createLocalObject(PERSISTENT_NEW_DECLARE m, int32_t arrayType, TR::DataTypes d, uint32_t s, TR_FrontEnd * fe);
-template TR::AutomaticSymbol * OMR::AutomaticSymbol::createLocalObject(PERSISTENT_NEW_DECLARE m, TR::ILOpCodes kind, TR::SymbolReference * classSymRef, TR::DataTypes d, uint32_t s, TR_FrontEnd * fe);
+template TR::AutomaticSymbol * OMR::AutomaticSymbol::createRegisterSymbol(PERSISTENT_NEW_DECLARE m, TR_RegisterKinds regKind, uint32_t globalRegNum, TR::DataType d, uint32_t s, TR_FrontEnd * fe) ;
+template TR::AutomaticSymbol * OMR::AutomaticSymbol::createLocalObject(PERSISTENT_NEW_DECLARE m, int32_t arrayType, TR::DataType d, uint32_t s, TR_FrontEnd * fe);
+template TR::AutomaticSymbol * OMR::AutomaticSymbol::createLocalObject(PERSISTENT_NEW_DECLARE m, TR::ILOpCodes kind, TR::SymbolReference * classSymRef, TR::DataType d, uint32_t s, TR_FrontEnd * fe);
 template TR::AutomaticSymbol * OMR::AutomaticSymbol::createInternalPointer(PERSISTENT_NEW_DECLARE m, TR::AutomaticSymbol *pinningArrayPointer);
-template TR::AutomaticSymbol * OMR::AutomaticSymbol::createInternalPointer(PERSISTENT_NEW_DECLARE m, TR::DataTypes d, TR::AutomaticSymbol *pinningArrayPointer);
-template TR::AutomaticSymbol * OMR::AutomaticSymbol::createInternalPointer(PERSISTENT_NEW_DECLARE m, TR::DataTypes d, uint32_t s, TR_FrontEnd * fe);
+template TR::AutomaticSymbol * OMR::AutomaticSymbol::createInternalPointer(PERSISTENT_NEW_DECLARE m, TR::DataType d, TR::AutomaticSymbol *pinningArrayPointer);
+template TR::AutomaticSymbol * OMR::AutomaticSymbol::createInternalPointer(PERSISTENT_NEW_DECLARE m, TR::DataType d, uint32_t s, TR_FrontEnd * fe);
 template TR::AutomaticSymbol * OMR::AutomaticSymbol::createVariableSized(PERSISTENT_NEW_DECLARE m, uint32_t s);
 
 
 template TR::AutomaticSymbol * OMR::AutomaticSymbol::create(TR_StackMemory);
-template TR::AutomaticSymbol * OMR::AutomaticSymbol::create(TR_StackMemory,  TR::DataTypes);
-template TR::AutomaticSymbol * OMR::AutomaticSymbol::create(TR_StackMemory,  TR::DataTypes, uint32_t);
-template TR::AutomaticSymbol * OMR::AutomaticSymbol::create(TR_StackMemory,  TR::DataTypes, uint32_t, const char *);
+template TR::AutomaticSymbol * OMR::AutomaticSymbol::create(TR_StackMemory,  TR::DataType);
+template TR::AutomaticSymbol * OMR::AutomaticSymbol::create(TR_StackMemory,  TR::DataType, uint32_t);
+template TR::AutomaticSymbol * OMR::AutomaticSymbol::create(TR_StackMemory,  TR::DataType, uint32_t, const char *);
 
 template TR::AutomaticSymbol * OMR::AutomaticSymbol::create(TR_HeapMemory);
-template TR::AutomaticSymbol * OMR::AutomaticSymbol::create(TR_HeapMemory,  TR::DataTypes);
-template TR::AutomaticSymbol * OMR::AutomaticSymbol::create(TR_HeapMemory,  TR::DataTypes, uint32_t);
-template TR::AutomaticSymbol * OMR::AutomaticSymbol::create(TR_HeapMemory,  TR::DataTypes, uint32_t, const char *);
+template TR::AutomaticSymbol * OMR::AutomaticSymbol::create(TR_HeapMemory,  TR::DataType);
+template TR::AutomaticSymbol * OMR::AutomaticSymbol::create(TR_HeapMemory,  TR::DataType, uint32_t);
+template TR::AutomaticSymbol * OMR::AutomaticSymbol::create(TR_HeapMemory,  TR::DataType, uint32_t, const char *);
 
 template TR::AutomaticSymbol * OMR::AutomaticSymbol::create(PERSISTENT_NEW_DECLARE);
-template TR::AutomaticSymbol * OMR::AutomaticSymbol::create(PERSISTENT_NEW_DECLARE,  TR::DataTypes);
-template TR::AutomaticSymbol * OMR::AutomaticSymbol::create(PERSISTENT_NEW_DECLARE,  TR::DataTypes, uint32_t);
-template TR::AutomaticSymbol * OMR::AutomaticSymbol::create(PERSISTENT_NEW_DECLARE,  TR::DataTypes, uint32_t, const char *);
+template TR::AutomaticSymbol * OMR::AutomaticSymbol::create(PERSISTENT_NEW_DECLARE,  TR::DataType);
+template TR::AutomaticSymbol * OMR::AutomaticSymbol::create(PERSISTENT_NEW_DECLARE,  TR::DataType, uint32_t);
+template TR::AutomaticSymbol * OMR::AutomaticSymbol::create(PERSISTENT_NEW_DECLARE,  TR::DataType, uint32_t, const char *);

--- a/compiler/il/symbol/OMRAutomaticSymbol.hpp
+++ b/compiler/il/symbol/OMRAutomaticSymbol.hpp
@@ -55,23 +55,23 @@ public:
    static TR::AutomaticSymbol * create(AllocatorType);
 
    template <typename AllocatorType>
-   static TR::AutomaticSymbol * create(AllocatorType, TR::DataTypes);
+   static TR::AutomaticSymbol * create(AllocatorType, TR::DataType);
 
    template <typename AllocatorType>
-   static TR::AutomaticSymbol * create(AllocatorType, TR::DataTypes, uint32_t);
+   static TR::AutomaticSymbol * create(AllocatorType, TR::DataType, uint32_t);
 
    template <typename AllocatorType>
-   static TR::AutomaticSymbol * create(AllocatorType, TR::DataTypes, uint32_t, const char *);
+   static TR::AutomaticSymbol * create(AllocatorType, TR::DataType, uint32_t, const char *);
 
 protected:
 
    AutomaticSymbol();
 
-   AutomaticSymbol(TR::DataTypes d);
+   AutomaticSymbol(TR::DataType d);
 
-   AutomaticSymbol(TR::DataTypes d, uint32_t s);
+   AutomaticSymbol(TR::DataType d, uint32_t s);
 
-   AutomaticSymbol(TR::DataTypes d, uint32_t s, const char *name);
+   AutomaticSymbol(TR::DataType d, uint32_t s, const char *name);
 
    void init();
 
@@ -129,7 +129,7 @@ public:
  *
  */
    template <typename AllocatorType>
-   static TR::AutomaticSymbol * createRegisterSymbol(AllocatorType m, TR_RegisterKinds regKind, uint32_t globalRegNum, TR::DataTypes d, uint32_t s, TR_FrontEnd * fe);
+   static TR::AutomaticSymbol * createRegisterSymbol(AllocatorType m, TR_RegisterKinds regKind, uint32_t globalRegNum, TR::DataType d, uint32_t s, TR_FrontEnd * fe);
 
    TR_RegisterKinds  getRegisterKind() const                { return _regKind;                        }
    void              setGlobalRegisterNumber(uint32_t grn)  { _globalRegisterNumber = grn;            }
@@ -158,7 +158,7 @@ public:
    template <typename AllocatorType>
    static TR::AutomaticSymbol * createLocalObject(AllocatorType  m,
                                                  int32_t          arrayType,
-                                                 TR::DataTypes    d,
+                                                 TR::DataType    d,
                                                  uint32_t         s,
                                                  TR_FrontEnd *    fe);
 
@@ -172,7 +172,7 @@ public:
    static TR::AutomaticSymbol * createLocalObject(AllocatorType          m,
                                                    TR::ILOpCodes          kind,
                                                    TR::SymbolReference *  classSymRef,
-                                                   TR::DataTypes          d,
+                                                   TR::DataType          d,
                                                    uint32_t               s,
                                                    TR_FrontEnd *          fe);
 
@@ -223,10 +223,10 @@ public:
    static TR::AutomaticSymbol * createInternalPointer(AllocatorType m, TR::AutomaticSymbol *pinningArrayPointer = 0);
 
    template <typename AllocatorType>
-   static TR::AutomaticSymbol * createInternalPointer(AllocatorType m, TR::DataTypes d, TR::AutomaticSymbol *pinningArrayPointer = 0);
+   static TR::AutomaticSymbol * createInternalPointer(AllocatorType m, TR::DataType d, TR::AutomaticSymbol *pinningArrayPointer = 0);
 
    template <typename AllocatorType>
-   static TR::AutomaticSymbol * createInternalPointer(AllocatorType m, TR::DataTypes d, uint32_t s, TR_FrontEnd * fe);
+   static TR::AutomaticSymbol * createInternalPointer(AllocatorType m, TR::DataType d, uint32_t s, TR_FrontEnd * fe);
 
    TR::AutomaticSymbol *getPinningArrayPointer()
       {

--- a/compiler/il/symbol/OMRParameterSymbol.cpp
+++ b/compiler/il/symbol/OMRParameterSymbol.cpp
@@ -34,7 +34,7 @@ OMR::ParameterSymbol::self()
    return static_cast<TR::ParameterSymbol*>(this);
    }
 
-OMR::ParameterSymbol::ParameterSymbol(TR::DataTypes d, bool isUnsigned, int32_t slot) :
+OMR::ParameterSymbol::ParameterSymbol(TR::DataType d, bool isUnsigned, int32_t slot) :
    TR::RegisterMappedSymbol(d),
    _registerIndex(-1),
    _allocatedHigh(-1),
@@ -49,7 +49,7 @@ OMR::ParameterSymbol::ParameterSymbol(TR::DataTypes d, bool isUnsigned, int32_t 
    self()->setOffset(slot * TR::ParameterSymbol::convertTypeToSize(TR::Address));
    }
 
-OMR::ParameterSymbol::ParameterSymbol(TR::DataTypes d, bool isUnsigned, int32_t slot, size_t size) :
+OMR::ParameterSymbol::ParameterSymbol(TR::DataType d, bool isUnsigned, int32_t slot, size_t size) :
    TR::RegisterMappedSymbol(d, (uint32_t)size), // cast argument size explicitly \TODO: Document why?
    _registerIndex(-1),
    _allocatedHigh(-1),
@@ -77,21 +77,21 @@ OMR::ParameterSymbol::getSlot()
    }
 
 template <typename AllocatorType>
-TR::ParameterSymbol * OMR::ParameterSymbol::create(AllocatorType m, TR::DataTypes d, bool isUnsigned, int32_t slot)
+TR::ParameterSymbol * OMR::ParameterSymbol::create(AllocatorType m, TR::DataType d, bool isUnsigned, int32_t slot)
    {
    return new (m) TR::ParameterSymbol(d, isUnsigned, slot);
    }
 
 template <typename AllocatorType>
-TR::ParameterSymbol * OMR::ParameterSymbol::create(AllocatorType m, TR::DataTypes d, bool isUnsigned, int32_t slot, size_t size)
+TR::ParameterSymbol * OMR::ParameterSymbol::create(AllocatorType m, TR::DataType d, bool isUnsigned, int32_t slot, size_t size)
    {
    return new (m) TR::ParameterSymbol(d, isUnsigned, slot, size);
    }
 
 
-template TR::ParameterSymbol * OMR::ParameterSymbol::create(TR_StackMemory, TR::DataTypes, bool, int32_t);
-template TR::ParameterSymbol * OMR::ParameterSymbol::create(TR_StackMemory, TR::DataTypes, bool, int32_t, size_t);
-template TR::ParameterSymbol * OMR::ParameterSymbol::create(TR_HeapMemory, TR::DataTypes, bool, int32_t);
-template TR::ParameterSymbol * OMR::ParameterSymbol::create(TR_HeapMemory, TR::DataTypes, bool, int32_t, size_t);
-template TR::ParameterSymbol * OMR::ParameterSymbol::create(PERSISTENT_NEW_DECLARE, TR::DataTypes, bool, int32_t);
-template TR::ParameterSymbol * OMR::ParameterSymbol::create(PERSISTENT_NEW_DECLARE, TR::DataTypes, bool, int32_t, size_t);
+template TR::ParameterSymbol * OMR::ParameterSymbol::create(TR_StackMemory, TR::DataType, bool, int32_t);
+template TR::ParameterSymbol * OMR::ParameterSymbol::create(TR_StackMemory, TR::DataType, bool, int32_t, size_t);
+template TR::ParameterSymbol * OMR::ParameterSymbol::create(TR_HeapMemory, TR::DataType, bool, int32_t);
+template TR::ParameterSymbol * OMR::ParameterSymbol::create(TR_HeapMemory, TR::DataType, bool, int32_t, size_t);
+template TR::ParameterSymbol * OMR::ParameterSymbol::create(PERSISTENT_NEW_DECLARE, TR::DataType, bool, int32_t);
+template TR::ParameterSymbol * OMR::ParameterSymbol::create(PERSISTENT_NEW_DECLARE, TR::DataType, bool, int32_t, size_t);

--- a/compiler/il/symbol/OMRParameterSymbol.hpp
+++ b/compiler/il/symbol/OMRParameterSymbol.hpp
@@ -33,7 +33,7 @@ namespace OMR { typedef OMR::ParameterSymbol ParameterSymbolConnector; }
 #include <stddef.h>                  // for size_t
 #include <stdint.h>                  // for int32_t, int8_t, etc
 #include "env/KnownObjectTable.hpp"  // for KnownObjectTable, etc
-#include "il/DataTypes.hpp"          // for DataTypes
+#include "il/DataTypes.hpp"          // for DataType
 
 namespace TR { class ParameterSymbol; }
 
@@ -45,19 +45,19 @@ class OMR_EXTENSIBLE ParameterSymbol : public TR::RegisterMappedSymbol
 
 protected:
 
-   ParameterSymbol(TR::DataTypes d, bool isUnsigned, int32_t slot);
+   ParameterSymbol(TR::DataType d, bool isUnsigned, int32_t slot);
 
-   ParameterSymbol(TR::DataTypes d, bool isUnsigned, int32_t slot, size_t size);
+   ParameterSymbol(TR::DataType d, bool isUnsigned, int32_t slot, size_t size);
 
    TR::ParameterSymbol * self();
 
 public:
 
    template <typename AllocatorType>
-   static TR::ParameterSymbol * create(AllocatorType, TR::DataTypes, bool, int32_t);
+   static TR::ParameterSymbol * create(AllocatorType, TR::DataType, bool, int32_t);
 
    template <typename AllocatorType>
-   static TR::ParameterSymbol * create(AllocatorType, TR::DataTypes, bool, int32_t, size_t);
+   static TR::ParameterSymbol * create(AllocatorType, TR::DataType, bool, int32_t, size_t);
 
    int32_t  getParameterOffset()               { return _mappedOffset; }
    void     setParameterOffset(int32_t o);

--- a/compiler/il/symbol/OMRRegisterMappedSymbol.cpp
+++ b/compiler/il/symbol/OMRRegisterMappedSymbol.cpp
@@ -36,13 +36,13 @@ TR::RegisterMappedSymbol * OMR::RegisterMappedSymbol::create(AllocatorType m, in
    }
 
 template <typename AllocatorType>
-TR::RegisterMappedSymbol * OMR::RegisterMappedSymbol::create(AllocatorType m, TR::DataTypes d)
+TR::RegisterMappedSymbol * OMR::RegisterMappedSymbol::create(AllocatorType m, TR::DataType d)
    {
    return new (m) TR::RegisterMappedSymbol(d);
    }
 
 template <typename AllocatorType>
-TR::RegisterMappedSymbol * OMR::RegisterMappedSymbol::create(AllocatorType m, TR::DataTypes d, uint32_t s)
+TR::RegisterMappedSymbol * OMR::RegisterMappedSymbol::create(AllocatorType m, TR::DataType d, uint32_t s)
    {
    return new (m) TR::RegisterMappedSymbol(d,s);
    }
@@ -55,7 +55,7 @@ OMR::RegisterMappedSymbol::RegisterMappedSymbol(int32_t o) :
    self()->setLiveLocalIndexUninitialized();
    }
 
-OMR::RegisterMappedSymbol::RegisterMappedSymbol(TR::DataTypes d) :
+OMR::RegisterMappedSymbol::RegisterMappedSymbol(TR::DataType d) :
    TR::Symbol(d),
    _mappedOffset(0),
    _GCMapIndex(-1)
@@ -63,7 +63,7 @@ OMR::RegisterMappedSymbol::RegisterMappedSymbol(TR::DataTypes d) :
    self()->setLiveLocalIndexUninitialized();
    }
 
-OMR::RegisterMappedSymbol::RegisterMappedSymbol(TR::DataTypes d, uint32_t s) :
+OMR::RegisterMappedSymbol::RegisterMappedSymbol(TR::DataType d, uint32_t s) :
    TR::Symbol(d, s),
    _mappedOffset(0),
    _GCMapIndex(-1)
@@ -116,16 +116,16 @@ OMR::RegisterMappedSymbol::createMethodMetaDataSymbol(AllocatorType m, const cha
  */
 
 template TR::RegisterMappedSymbol * OMR::RegisterMappedSymbol::create(TR_HeapMemory m, int32_t o);
-template TR::RegisterMappedSymbol * OMR::RegisterMappedSymbol::create(TR_HeapMemory m, TR::DataTypes d);
-template TR::RegisterMappedSymbol * OMR::RegisterMappedSymbol::create(TR_HeapMemory m, TR::DataTypes d, uint32_t s);
+template TR::RegisterMappedSymbol * OMR::RegisterMappedSymbol::create(TR_HeapMemory m, TR::DataType d);
+template TR::RegisterMappedSymbol * OMR::RegisterMappedSymbol::create(TR_HeapMemory m, TR::DataType d, uint32_t s);
 
 template TR::RegisterMappedSymbol * OMR::RegisterMappedSymbol::create(TR_StackMemory m, int32_t o);
-template TR::RegisterMappedSymbol * OMR::RegisterMappedSymbol::create(TR_StackMemory m, TR::DataTypes d);
-template TR::RegisterMappedSymbol * OMR::RegisterMappedSymbol::create(TR_StackMemory m, TR::DataTypes d, uint32_t s);
+template TR::RegisterMappedSymbol * OMR::RegisterMappedSymbol::create(TR_StackMemory m, TR::DataType d);
+template TR::RegisterMappedSymbol * OMR::RegisterMappedSymbol::create(TR_StackMemory m, TR::DataType d, uint32_t s);
 
 template TR::RegisterMappedSymbol * OMR::RegisterMappedSymbol::create(PERSISTENT_NEW_DECLARE m, int32_t o);
-template TR::RegisterMappedSymbol * OMR::RegisterMappedSymbol::create(PERSISTENT_NEW_DECLARE m, TR::DataTypes d);
-template TR::RegisterMappedSymbol * OMR::RegisterMappedSymbol::create(PERSISTENT_NEW_DECLARE m, TR::DataTypes d, uint32_t s);
+template TR::RegisterMappedSymbol * OMR::RegisterMappedSymbol::create(PERSISTENT_NEW_DECLARE m, TR::DataType d);
+template TR::RegisterMappedSymbol * OMR::RegisterMappedSymbol::create(PERSISTENT_NEW_DECLARE m, TR::DataType d, uint32_t s);
 
 template TR::RegisterMappedSymbol * OMR::RegisterMappedSymbol::createMethodMetaDataSymbol(TR_HeapMemory m, const char *name, TR_MethodMetaDataType type);
 template TR::RegisterMappedSymbol * OMR::RegisterMappedSymbol::createMethodMetaDataSymbol(TR_StackMemory m, const char *name, TR_MethodMetaDataType type);

--- a/compiler/il/symbol/OMRRegisterMappedSymbol.hpp
+++ b/compiler/il/symbol/OMRRegisterMappedSymbol.hpp
@@ -66,9 +66,9 @@ protected:
 
    RegisterMappedSymbol(int32_t o = 0);
 
-   RegisterMappedSymbol(TR::DataTypes d);
+   RegisterMappedSymbol(TR::DataType d);
 
-   RegisterMappedSymbol(TR::DataTypes d, uint32_t s);
+   RegisterMappedSymbol(TR::DataType d, uint32_t s);
 
    TR::RegisterMappedSymbol * self();
 
@@ -78,10 +78,10 @@ public:
    static TR::RegisterMappedSymbol * create(AllocatorType t, int32_t o = 0);
 
    template <typename AllocatorType>
-   static TR::RegisterMappedSymbol * create(AllocatorType m, TR::DataTypes d);
+   static TR::RegisterMappedSymbol * create(AllocatorType m, TR::DataType d);
 
    template <typename AllocatorType>
-   static TR::RegisterMappedSymbol * create(AllocatorType m, TR::DataTypes d, uint32_t s);
+   static TR::RegisterMappedSymbol * create(AllocatorType m, TR::DataType d, uint32_t s);
 
    int32_t getOffset()          {return _mappedOffset;}
    void    setOffset(int32_t o) {_mappedOffset = o;}

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -964,7 +964,7 @@ OMR::ResolvedMethodSymbol::sharesStackSlot(TR::SymbolReference *symRef)
    int32_t slot = symRef->getCPIndex();
    if (slot >= self()->getFirstJitTempIndex())
       return false; // Jit temps don't share slots
-   TR::DataTypes dt = symRef->getSymbol()->getDataType();
+   TR::DataType dt = symRef->getSymbol()->getDataType();
    bool takesTwoSlots = dt == TR::Int64 || dt == TR::Double;
 
    List<TR::SymbolReference> *listForPrevSlot, *list, *listForNextSlot;
@@ -1301,7 +1301,7 @@ OMR::ResolvedMethodSymbol::sharesStackSlots(TR::Compilation *comp)
       bool takesTwoSlots = false;
       for (TR::SymbolReference* symRef = ppsIt.getFirst(); symRef; symRef = ppsIt.getNext())
          {
-         TR::DataTypes dt = symRef->getSymbol()->getDataType();
+         TR::DataType dt = symRef->getSymbol()->getDataType();
          takesTwoSlots = dt == TR::Int64 || dt == TR::Double;
          if (takesTwoSlots)
             break;
@@ -1341,7 +1341,7 @@ OMR::ResolvedMethodSymbol::sharesStackSlots(TR::Compilation *comp)
 
       for (; symRef; symRef = autosIt.getNext())
          {
-         TR::DataTypes dt = symRef->getSymbol()->getDataType();
+         TR::DataType dt = symRef->getSymbol()->getDataType();
          takesTwoSlots = dt == TR::Int64 || dt == TR::Double;
          if (takesTwoSlots)
             break;

--- a/compiler/il/symbol/OMRStaticSymbol.cpp
+++ b/compiler/il/symbol/OMRStaticSymbol.cpp
@@ -24,20 +24,20 @@
 #include "il/symbol/StaticSymbol.hpp"  // for StaticSymbolBase, etc
 
 template <typename AllocatorType>
-TR::StaticSymbol * OMR::StaticSymbol::create(AllocatorType m, TR::DataTypes d)
+TR::StaticSymbol * OMR::StaticSymbol::create(AllocatorType m, TR::DataType d)
    {
    return new (m) TR::StaticSymbol(d);
    }
 
 template <typename AllocatorType>
-TR::StaticSymbol * OMR::StaticSymbol::createWithAddress(AllocatorType m, TR::DataTypes d, void * address)
+TR::StaticSymbol * OMR::StaticSymbol::createWithAddress(AllocatorType m, TR::DataType d, void * address)
    {
    //Explict cast to disambiguate constructor!
    return new (m) TR::StaticSymbol(d, (void*)address);
    }
 
 template <typename AllocatorType>
-TR::StaticSymbol * OMR::StaticSymbol::createWithSize(AllocatorType m, TR::DataTypes d, uint32_t size)
+TR::StaticSymbol * OMR::StaticSymbol::createWithSize(AllocatorType m, TR::DataType d, uint32_t size)
    {
    //Explict cast to disambiguate constructor!
    return new (m) TR::StaticSymbol(d, (uint32_t)size);
@@ -45,7 +45,7 @@ TR::StaticSymbol * OMR::StaticSymbol::createWithSize(AllocatorType m, TR::DataTy
 
 
 template <typename AllocatorType>
-TR::StaticSymbol * OMR::StaticSymbol::createNamed(AllocatorType m, TR::DataTypes d, const char * name)
+TR::StaticSymbol * OMR::StaticSymbol::createNamed(AllocatorType m, TR::DataType d, const char * name)
    {
    TR::StaticSymbol * sym = new (m) TR::StaticSymbol(d);
    sym->makeNamed(name);
@@ -53,7 +53,7 @@ TR::StaticSymbol * OMR::StaticSymbol::createNamed(AllocatorType m, TR::DataTypes
    }
 
 template <typename AllocatorType>
-TR::StaticSymbol * OMR::StaticSymbol::createNamed(AllocatorType m, TR::DataTypes d, void * addr, const char * name)
+TR::StaticSymbol * OMR::StaticSymbol::createNamed(AllocatorType m, TR::DataType d, void * addr, const char * name)
    {
    TR::StaticSymbol * sym = new (m) TR::StaticSymbol(d,addr);
    sym->makeNamed(name);
@@ -62,25 +62,25 @@ TR::StaticSymbol * OMR::StaticSymbol::createNamed(AllocatorType m, TR::DataTypes
 
 
 //Explicit Instantiations
-template TR::StaticSymbol * OMR::StaticSymbol::createNamed(TR_HeapMemory m, TR::DataTypes d, const char * name) ;
-template TR::StaticSymbol * OMR::StaticSymbol::createNamed(TR_HeapMemory m, TR::DataTypes d, void * addr, const char * name) ;
+template TR::StaticSymbol * OMR::StaticSymbol::createNamed(TR_HeapMemory m, TR::DataType d, const char * name) ;
+template TR::StaticSymbol * OMR::StaticSymbol::createNamed(TR_HeapMemory m, TR::DataType d, void * addr, const char * name) ;
 
-template TR::StaticSymbol * OMR::StaticSymbol::createNamed(TR_StackMemory m, TR::DataTypes d, const char * name) ;
-template TR::StaticSymbol * OMR::StaticSymbol::createNamed(TR_StackMemory m, TR::DataTypes d, void * addr, const char * name) ;
+template TR::StaticSymbol * OMR::StaticSymbol::createNamed(TR_StackMemory m, TR::DataType d, const char * name) ;
+template TR::StaticSymbol * OMR::StaticSymbol::createNamed(TR_StackMemory m, TR::DataType d, void * addr, const char * name) ;
 
-template TR::StaticSymbol * OMR::StaticSymbol::createNamed(PERSISTENT_NEW_DECLARE m, TR::DataTypes d, const char * name) ;
-template TR::StaticSymbol * OMR::StaticSymbol::createNamed(PERSISTENT_NEW_DECLARE m, TR::DataTypes d, void * addr, const char * name) ;
+template TR::StaticSymbol * OMR::StaticSymbol::createNamed(PERSISTENT_NEW_DECLARE m, TR::DataType d, const char * name) ;
+template TR::StaticSymbol * OMR::StaticSymbol::createNamed(PERSISTENT_NEW_DECLARE m, TR::DataType d, void * addr, const char * name) ;
 
-template TR::StaticSymbol * OMR::StaticSymbol::create(TR_HeapMemory, TR::DataTypes);
-template TR::StaticSymbol * OMR::StaticSymbol::create(TR_StackMemory, TR::DataTypes);
-template TR::StaticSymbol * OMR::StaticSymbol::create(TR_PersistentMemory*, TR::DataTypes);
-template TR::StaticSymbol * OMR::StaticSymbol::create(PERSISTENT_NEW_DECLARE, TR::DataTypes);
+template TR::StaticSymbol * OMR::StaticSymbol::create(TR_HeapMemory, TR::DataType);
+template TR::StaticSymbol * OMR::StaticSymbol::create(TR_StackMemory, TR::DataType);
+template TR::StaticSymbol * OMR::StaticSymbol::create(TR_PersistentMemory*, TR::DataType);
+template TR::StaticSymbol * OMR::StaticSymbol::create(PERSISTENT_NEW_DECLARE, TR::DataType);
 
-template TR::StaticSymbol * OMR::StaticSymbol::createWithAddress(TR_HeapMemory, TR::DataTypes, void *);
-template TR::StaticSymbol * OMR::StaticSymbol::createWithAddress(TR_StackMemory, TR::DataTypes, void *);
-template TR::StaticSymbol * OMR::StaticSymbol::createWithAddress(PERSISTENT_NEW_DECLARE, TR::DataTypes, void*);
+template TR::StaticSymbol * OMR::StaticSymbol::createWithAddress(TR_HeapMemory, TR::DataType, void *);
+template TR::StaticSymbol * OMR::StaticSymbol::createWithAddress(TR_StackMemory, TR::DataType, void *);
+template TR::StaticSymbol * OMR::StaticSymbol::createWithAddress(PERSISTENT_NEW_DECLARE, TR::DataType, void*);
 
-template TR::StaticSymbol * OMR::StaticSymbol::createWithSize(TR_HeapMemory, TR::DataTypes, uint32_t);
-template TR::StaticSymbol * OMR::StaticSymbol::createWithSize(TR_StackMemory, TR::DataTypes, uint32_t);
-template TR::StaticSymbol * OMR::StaticSymbol::createWithSize(TR_PersistentMemory*, TR::DataTypes, uint32_t);
-template TR::StaticSymbol * OMR::StaticSymbol::createWithSize(PERSISTENT_NEW_DECLARE, TR::DataTypes, uint32_t);
+template TR::StaticSymbol * OMR::StaticSymbol::createWithSize(TR_HeapMemory, TR::DataType, uint32_t);
+template TR::StaticSymbol * OMR::StaticSymbol::createWithSize(TR_StackMemory, TR::DataType, uint32_t);
+template TR::StaticSymbol * OMR::StaticSymbol::createWithSize(TR_PersistentMemory*, TR::DataType, uint32_t);
+template TR::StaticSymbol * OMR::StaticSymbol::createWithSize(PERSISTENT_NEW_DECLARE, TR::DataType, uint32_t);

--- a/compiler/il/symbol/OMRStaticSymbol.hpp
+++ b/compiler/il/symbol/OMRStaticSymbol.hpp
@@ -50,17 +50,17 @@ class OMR_EXTENSIBLE StaticSymbol : public TR::Symbol
 public:
 
    template <typename AllocatorType>
-   static TR::StaticSymbol * create(AllocatorType t, TR::DataTypes d);
+   static TR::StaticSymbol * create(AllocatorType t, TR::DataType d);
 
    template <typename AllocatorType>
-   static TR::StaticSymbol * createWithAddress(AllocatorType t, TR::DataTypes d, void * address);
+   static TR::StaticSymbol * createWithAddress(AllocatorType t, TR::DataType d, void * address);
 
    template <typename AllocatorType>
-   static TR::StaticSymbol * createWithSize(AllocatorType t, TR::DataTypes d, uint32_t s);
+   static TR::StaticSymbol * createWithSize(AllocatorType t, TR::DataType d, uint32_t s);
 
 protected:
 
-   StaticSymbol(TR::DataTypes d) :
+   StaticSymbol(TR::DataType d) :
       TR::Symbol(d),
       _staticAddress(0),
       _assignedTOCIndex(0)
@@ -68,7 +68,7 @@ protected:
       _flags.setValue(KindMask, IsStatic);
       }
 
-   StaticSymbol(TR::DataTypes d, void * address) :
+   StaticSymbol(TR::DataType d, void * address) :
       TR::Symbol(d),
       _staticAddress(address),
       _assignedTOCIndex(0)
@@ -76,7 +76,7 @@ protected:
       _flags.setValue(KindMask, IsStatic);
       }
 
-   StaticSymbol(TR::DataTypes d, uint32_t s) :
+   StaticSymbol(TR::DataType d, uint32_t s) :
       TR::Symbol(d, s),
       _staticAddress(0),
       _assignedTOCIndex(0)
@@ -117,10 +117,10 @@ private:
 public:
 
    template <typename AllocatorType>
-   static TR::StaticSymbol * createNamed(AllocatorType m, TR::DataTypes d, const char * name);
+   static TR::StaticSymbol * createNamed(AllocatorType m, TR::DataType d, const char * name);
 
    template <typename AllocatorType>
-   static TR::StaticSymbol * createNamed(AllocatorType m, TR::DataTypes d, void * addr, const char * name);
+   static TR::StaticSymbol * createNamed(AllocatorType m, TR::DataType d, void * addr, const char * name);
 
    const char *getName()
       {

--- a/compiler/il/symbol/OMRSymbol.cpp
+++ b/compiler/il/symbol/OMRSymbol.cpp
@@ -60,18 +60,18 @@ TR::Symbol * OMR::Symbol::create(AllocatorType m)
    }
 
 template <typename AllocatorType>
-TR::Symbol * OMR::Symbol::create(AllocatorType m, TR::DataTypes d)
+TR::Symbol * OMR::Symbol::create(AllocatorType m, TR::DataType d)
    {
    return new (m) TR::Symbol(d);
    }
 
 template <typename AllocatorType>
-TR::Symbol * OMR::Symbol::create(AllocatorType m, TR::DataTypes d, uint32_t s)
+TR::Symbol * OMR::Symbol::create(AllocatorType m, TR::DataType d, uint32_t s)
    {
    return new (m) TR::Symbol(d,s);
    }
 
-OMR::Symbol::Symbol(TR::DataTypes d) :
+OMR::Symbol::Symbol(TR::DataType d) :
    _size(0),
    _name(0),
    _flags(0),
@@ -82,7 +82,7 @@ OMR::Symbol::Symbol(TR::DataTypes d) :
    self()->setDataType(d);
    }
 
-OMR::Symbol::Symbol(TR::DataTypes d, uint32_t size) :
+OMR::Symbol::Symbol(TR::DataType d, uint32_t size) :
    _name(0),
    _flags(0),
    _flags2(0),
@@ -118,7 +118,7 @@ OMR::Symbol::getNumberOfSlots()
    return (numSlots? numSlots : 1);
    }
 
-TR::DataTypes
+TR::DataType
 OMR::Symbol::convertSigCharToType(char sigChar)
    {
    switch (sigChar)
@@ -143,7 +143,7 @@ OMR::Symbol::convertSigCharToType(char sigChar)
  * from the data type.
  */
 void
-OMR::Symbol::setDataType(TR::DataTypes dt)
+OMR::Symbol::setDataType(TR::DataType dt)
    {
    uint32_t inferredSize = TR::DataType::getSize(dt);
    if (inferredSize)
@@ -161,14 +161,14 @@ OMR::Symbol::getRoundedSize()
    }
 
 uint32_t
-OMR::Symbol::convertTypeToSize(TR::DataTypes dt)
+OMR::Symbol::convertTypeToSize(TR::DataType dt)
    {
    //TR_ASSERT(dt != TR::Aggregate, "Cannot be called for aggregates");
    return TR::DataType::getSize(dt);
    }
 
 uint32_t
-OMR::Symbol::convertTypeToNumberOfSlots(TR::DataTypes dt)
+OMR::Symbol::convertTypeToNumberOfSlots(TR::DataType dt)
    {
    return (dt == TR::Int64 || dt == TR::Double)? 2 : 1;
    }
@@ -948,7 +948,7 @@ TR::Symbol * OMR::Symbol::createShadow(AllocatorType m)
    }
 
 template <typename AllocatorType>
-TR::Symbol * OMR::Symbol::createShadow(AllocatorType m, TR::DataTypes d)
+TR::Symbol * OMR::Symbol::createShadow(AllocatorType m, TR::DataType d)
    {
    TR::Symbol * sym = new (m) TR::Symbol(d);
    sym->_flags.setValue(KindMask, IsShadow);
@@ -956,7 +956,7 @@ TR::Symbol * OMR::Symbol::createShadow(AllocatorType m, TR::DataTypes d)
    }
 
 template <typename AllocatorType>
-TR::Symbol * OMR::Symbol::createShadow(AllocatorType m, TR::DataTypes d, uint32_t s)
+TR::Symbol * OMR::Symbol::createShadow(AllocatorType m, TR::DataType d, uint32_t s)
    {
    TR::Symbol * sym = new (m) TR::Symbol(d,s);
    sym->_flags.setValue(KindMask, IsShadow);
@@ -964,7 +964,7 @@ TR::Symbol * OMR::Symbol::createShadow(AllocatorType m, TR::DataTypes d, uint32_
    }
 
 template <typename AllocatorType>
-TR::Symbol * OMR::Symbol::createNamedShadow(AllocatorType m, TR::DataTypes d, uint32_t s, char *name)
+TR::Symbol * OMR::Symbol::createNamedShadow(AllocatorType m, TR::DataType d, uint32_t s, char *name)
    {
    auto * sym = createShadow(m,d,s);
    sym->_name = name;
@@ -980,26 +980,26 @@ template TR::Symbol * OMR::Symbol::create(TR_StackMemory);
 template TR::Symbol * OMR::Symbol::create(TR_HeapMemory);
 template TR::Symbol * OMR::Symbol::create(PERSISTENT_NEW_DECLARE);
 
-template TR::Symbol * OMR::Symbol::create(TR_StackMemory, TR::DataTypes);
-template TR::Symbol * OMR::Symbol::create(TR_HeapMemory, TR::DataTypes);
-template TR::Symbol * OMR::Symbol::create(PERSISTENT_NEW_DECLARE, TR::DataTypes);
+template TR::Symbol * OMR::Symbol::create(TR_StackMemory, TR::DataType);
+template TR::Symbol * OMR::Symbol::create(TR_HeapMemory, TR::DataType);
+template TR::Symbol * OMR::Symbol::create(PERSISTENT_NEW_DECLARE, TR::DataType);
 
-template TR::Symbol * OMR::Symbol::create(TR_StackMemory, TR::DataTypes, uint32_t);
-template TR::Symbol * OMR::Symbol::create(TR_HeapMemory, TR::DataTypes, uint32_t);
-template TR::Symbol * OMR::Symbol::create(PERSISTENT_NEW_DECLARE, TR::DataTypes, uint32_t);
+template TR::Symbol * OMR::Symbol::create(TR_StackMemory, TR::DataType, uint32_t);
+template TR::Symbol * OMR::Symbol::create(TR_HeapMemory, TR::DataType, uint32_t);
+template TR::Symbol * OMR::Symbol::create(PERSISTENT_NEW_DECLARE, TR::DataType, uint32_t);
 
 template TR::Symbol * OMR::Symbol::createShadow(TR_StackMemory);
 template TR::Symbol * OMR::Symbol::createShadow(TR_HeapMemory);
 template TR::Symbol * OMR::Symbol::createShadow(PERSISTENT_NEW_DECLARE);
 
-template TR::Symbol * OMR::Symbol::createShadow(TR_StackMemory,         TR::DataTypes);
-template TR::Symbol * OMR::Symbol::createShadow(TR_HeapMemory,          TR::DataTypes);
-template TR::Symbol * OMR::Symbol::createShadow(PERSISTENT_NEW_DECLARE, TR::DataTypes);
+template TR::Symbol * OMR::Symbol::createShadow(TR_StackMemory,         TR::DataType);
+template TR::Symbol * OMR::Symbol::createShadow(TR_HeapMemory,          TR::DataType);
+template TR::Symbol * OMR::Symbol::createShadow(PERSISTENT_NEW_DECLARE, TR::DataType);
 
-template TR::Symbol * OMR::Symbol::createShadow(TR_StackMemory,         TR::DataTypes, uint32_t);
-template TR::Symbol * OMR::Symbol::createShadow(TR_HeapMemory,          TR::DataTypes, uint32_t);
-template TR::Symbol * OMR::Symbol::createShadow(PERSISTENT_NEW_DECLARE, TR::DataTypes, uint32_t);
+template TR::Symbol * OMR::Symbol::createShadow(TR_StackMemory,         TR::DataType, uint32_t);
+template TR::Symbol * OMR::Symbol::createShadow(TR_HeapMemory,          TR::DataType, uint32_t);
+template TR::Symbol * OMR::Symbol::createShadow(PERSISTENT_NEW_DECLARE, TR::DataType, uint32_t);
 
-template TR::Symbol * OMR::Symbol::createNamedShadow(TR_StackMemory,         TR::DataTypes, uint32_t, char *);
-template TR::Symbol * OMR::Symbol::createNamedShadow(TR_HeapMemory,          TR::DataTypes, uint32_t, char *);
-template TR::Symbol * OMR::Symbol::createNamedShadow(PERSISTENT_NEW_DECLARE, TR::DataTypes, uint32_t, char *);
+template TR::Symbol * OMR::Symbol::createNamedShadow(TR_StackMemory,         TR::DataType, uint32_t, char *);
+template TR::Symbol * OMR::Symbol::createNamedShadow(TR_HeapMemory,          TR::DataType, uint32_t, char *);
+template TR::Symbol * OMR::Symbol::createNamedShadow(PERSISTENT_NEW_DECLARE, TR::DataType, uint32_t, char *);

--- a/compiler/il/symbol/OMRSymbol.hpp
+++ b/compiler/il/symbol/OMRSymbol.hpp
@@ -85,10 +85,10 @@ public:
    static TR::Symbol * create(AllocatorType);
 
    template <typename AllocatorType>
-   static TR::Symbol * create(AllocatorType, TR::DataTypes);
+   static TR::Symbol * create(AllocatorType, TR::DataType);
 
    template <typename AllocatorType>
-   static TR::Symbol * create(AllocatorType, TR::DataTypes, uint32_t);
+   static TR::Symbol * create(AllocatorType, TR::DataType, uint32_t);
 
 protected:
 
@@ -108,13 +108,13 @@ protected:
     * Create symbol of specified data type, inferring size
     * from type.
     */
-   Symbol(TR::DataTypes d);
+   Symbol(TR::DataType d);
 
    /**
     * Create symbol of specified data type, inferring size
     * from type.
     */
-   Symbol(TR::DataTypes d, uint32_t size);
+   Symbol(TR::DataType d, uint32_t size);
 
 public:
    /**
@@ -177,11 +177,11 @@ public:
 
    bool isReferenced();
 
-   static uint32_t convertTypeToSize(TR::DataTypes dt);
+   static uint32_t convertTypeToSize(TR::DataType dt);
 
-   static uint32_t convertTypeToNumberOfSlots(TR::DataTypes dt);
+   static uint32_t convertTypeToNumberOfSlots(TR::DataType dt);
 
-   static TR::DataTypes convertSigCharToType(char sigChar);
+   static TR::DataType convertSigCharToType(char sigChar);
 
    /**
     * Field functions
@@ -207,8 +207,8 @@ public:
     * Flag functions
     */
 
-   void          setDataType(TR::DataTypes dt);
-   TR::DataTypes getDataType() { return (TR::DataTypes)_flags.getValue(DataTypeMask);}
+   void          setDataType(TR::DataType dt);
+   TR::DataType  getDataType() { return (TR::DataTypes)_flags.getValue(DataTypeMask);}
    TR::DataType  getType();
 
    int32_t getKind()             { return _flags.getValue(KindMask);}
@@ -579,10 +579,10 @@ public:
    static TR::Symbol * createShadow(AllocatorType m);
 
    template <typename AllocatorType>
-   static TR::Symbol * createShadow(AllocatorType m, TR::DataTypes d);
+   static TR::Symbol * createShadow(AllocatorType m, TR::DataType d);
 
    template <typename AllocatorType>
-   static TR::Symbol * createShadow(AllocatorType m, TR::DataTypes d, uint32_t );
+   static TR::Symbol * createShadow(AllocatorType m, TR::DataType d, uint32_t );
 
    /**
     * TR_NamedShadowSymbol
@@ -594,7 +594,7 @@ public:
 public:
 
    template <typename AllocatorType>
-   static TR::Symbol * createNamedShadow(AllocatorType m, TR::DataTypes d, uint32_t s, char *name = NULL);
+   static TR::Symbol * createNamedShadow(AllocatorType m, TR::DataType d, uint32_t s, char *name = NULL);
 
    /** @} */
 

--- a/compiler/il/symbol/ParameterSymbol.hpp
+++ b/compiler/il/symbol/ParameterSymbol.hpp
@@ -33,10 +33,10 @@ class OMR_EXTENSIBLE ParameterSymbol : public OMR::ParameterSymbolConnector
 
 protected:
 
-   ParameterSymbol(TR::DataTypes d, bool isUnsigned, int32_t slot) :
+   ParameterSymbol(TR::DataType d, bool isUnsigned, int32_t slot) :
       OMR::ParameterSymbolConnector(d, isUnsigned, slot) { }
 
-   ParameterSymbol(TR::DataTypes d, bool isUnsigned, int32_t slot, size_t size) :
+   ParameterSymbol(TR::DataType d, bool isUnsigned, int32_t slot, size_t size) :
       OMR::ParameterSymbolConnector(d, isUnsigned, slot, size) { }
 
 private:

--- a/compiler/il/symbol/RegisterMappedSymbol.hpp
+++ b/compiler/il/symbol/RegisterMappedSymbol.hpp
@@ -35,10 +35,10 @@ protected:
    RegisterMappedSymbol(int32_t o = 0) :
       OMR::RegisterMappedSymbolConnector() { }
 
-   RegisterMappedSymbol(TR::DataTypes d) :
+   RegisterMappedSymbol(TR::DataType d) :
       OMR::RegisterMappedSymbolConnector(d) { }
 
-   RegisterMappedSymbol(TR::DataTypes d, uint32_t s) :
+   RegisterMappedSymbol(TR::DataType d, uint32_t s) :
       OMR::RegisterMappedSymbolConnector(d, s) { }
 
 private:

--- a/compiler/il/symbol/StaticSymbol.hpp
+++ b/compiler/il/symbol/StaticSymbol.hpp
@@ -35,13 +35,13 @@ class OMR_EXTENSIBLE StaticSymbol : public OMR::StaticSymbolConnector
 
 protected:
 
-   StaticSymbol(TR::DataTypes d) :
+   StaticSymbol(TR::DataType d) :
       OMR::StaticSymbolConnector(d) { }
 
-   StaticSymbol(TR::DataTypes d, void * address) :
+   StaticSymbol(TR::DataType d, void * address) :
       OMR::StaticSymbolConnector(d,address) { }
 
-   StaticSymbol(TR::DataTypes d, uint32_t s) :
+   StaticSymbol(TR::DataType d, uint32_t s) :
       OMR::StaticSymbolConnector(d, s) { }
 
 private:

--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -242,7 +242,7 @@ IlBuilder::defineValue(const char *name, TR::IlType *dt)
    }
 
 TR::IlValue *
-IlBuilder::newValue(TR::DataTypes dt)
+IlBuilder::newValue(TR::DataType dt)
    {
    TR::SymbolReference *newSymRef = symRefTab()->createTemporary(methodSymbol(), dt);
    char *name = (char *) _comp->trMemory()->allocateHeapMemory(5 * sizeof(char));
@@ -425,7 +425,7 @@ IlBuilder::connectTrees()
    }
 
 TR::Node *
-IlBuilder::zero(TR::DataTypes dt)
+IlBuilder::zero(TR::DataType dt)
    {
    switch (dt)
       {
@@ -556,7 +556,7 @@ IlBuilder::storeNode(TR::IlValue *dest, TR::Node *v)
 void
 IlBuilder::indirectStoreNode(TR::Node *addr, TR::Node *v)
    {
-   TR::DataTypes dt = v->getDataType();
+   TR::DataType dt = v->getDataType();
    TR::SymbolReference *storeSymRef = symRefTab()->findOrCreateArrayShadowSymbolRef(dt, addr);
    TR::ILOpCodes storeOp = comp()->il.opCodeForIndirectArrayStore(dt);
    genTreeTop(TR::Node::createWithSymRef(storeOp, 2, addr, v, 0, storeSymRef));
@@ -567,10 +567,10 @@ IlBuilder::indirectLoadNode(TR::IlType *dt, TR::Node *addr, bool isVectorLoad)
    {
    TR_ASSERT(dt->isPointer(), "indirectLoadNode must apply to pointer type");
    TR::IlType *baseType = dt->baseType();
-   TR::DataTypes primType = baseType->getPrimitiveType();
-   TR::DataTypes symRefType = primType;
+   TR::DataType primType = baseType->getPrimitiveType();
+   TR::DataType symRefType = primType;
    if (isVectorLoad)
-      symRefType = scalarToVector(symRefType);
+      symRefType = symRefType.scalarToVector();
 
    TR::SymbolReference *storeSymRef = symRefTab()->findOrCreateArrayShadowSymbolRef(symRefType, addr);
 
@@ -607,11 +607,11 @@ IlBuilder::VectorStore(const char *varName, TR::IlValue *value)
    ILB_REPLAY("%s->Store(\"%s\", %s);", REPLAY_BUILDER(this), varName, REPLAY_VALUE(value));
 
    TR::Node *valueNode = loadValue(value);
-   TR::DataTypes dt = valueNode->getDataType();
-   if (!isVectorType(dt))
+   TR::DataType dt = valueNode->getDataType();
+   if (!dt.isVector())
       {
       valueNode = TR::Node::create(TR::vsplats, 1, valueNode);
-      dt = scalarToVector(dt);
+      dt = dt.scalarToVector();
       }
 
    if (!_methodBuilder->symbolDefined(varName))
@@ -644,7 +644,7 @@ IlBuilder::VectorStoreAt(TR::IlType *dt, TR::IlValue *address, TR::IlValue *valu
 
    TR::Node *valueNode = loadValue(value);
 
-   if (!isVectorType(valueNode->getDataType()))
+   if (!valueNode->getDataType().isVector())
       valueNode = TR::Node::create(TR::vsplats, 1, valueNode);
 
    indirectStoreNode(loadValue(address), valueNode);
@@ -696,7 +696,7 @@ IlBuilder::StoreIndirect(const char *type, const char *field, TR::IlValue *objec
   ILB_REPLAY("%s->StoreIndirect(\"%s\", \"%s\", %s, %s);", REPLAY_BUILDER(this), type, field, REPLAY_VALUE(object), REPLAY_VALUE(value));
 
   TR::SymbolReference *symRef = (TR::SymbolReference*)_types->FieldReference(type, field);
-  TR::DataTypes fieldType = symRef->getSymbol()->getDataType();
+  TR::DataType fieldType = symRef->getSymbol()->getDataType();
   TraceIL("IlBuilder[ %p ]::StoreIndirect %s.%s (%d) into (%d)\n", this, type, field, value->getCPIndex(), object->getCPIndex());
   TR::ILOpCodes storeOp = comp()->il.opCodeForIndirectStore(fieldType);
   genTreeTop(TR::Node::createWithSymRef(storeOp, 2, loadValue(object), loadValue(value), 0, symRef));
@@ -722,8 +722,8 @@ IlBuilder::VectorLoad(const char *name)
    {
    TR::IlValue *nameSymRef = lookupSymbol(name);
    appendBlock();
-   TR::DataTypes returnType = nameSymRef->getSymbol()->getDataType();
-   TR_ASSERT(isVectorType(returnType), "VectorLoad must load symbol with a vector type");
+   TR::DataType returnType = nameSymRef->getSymbol()->getDataType();
+   TR_ASSERT(returnType.isVector(), "VectorLoad must load symbol with a vector type");
    TR::IlValue *returnValue = newValue(returnType);
    TraceIL("IlBuilder[ %p ]::%d is VectorLoad %s (%d)\n", this, returnValue->getCPIndex(), name, nameSymRef->getCPIndex());
 
@@ -738,7 +738,7 @@ TR::IlValue *
 IlBuilder::LoadIndirect(const char *type, const char *field, TR::IlValue *object)
    {
    TR::SymbolReference *symRef = (TR::SymbolReference *)_types->FieldReference(type, field);
-   TR::DataTypes fieldType = symRef->getSymbol()->getDataType();
+   TR::DataType fieldType = symRef->getSymbol()->getDataType();
    TR::IlValue *returnValue = newValue(fieldType);
    TraceIL("IlBuilder[ %p ]::%d is LoadIndirect %s.%s from (%d)\n", this, returnValue->getCPIndex(), type, field, object->getCPIndex());
    storeNode(returnValue, TR::Node::createWithSymRef(comp()->il.opCodeForIndirectLoad(fieldType), 1, loadValue(object), 0, symRef));
@@ -776,7 +776,7 @@ IlBuilder::IndexAt(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index)
    TR::Node *indexNode = TR::Node::createLoad(index);
    TR::Node *elemSizeNode;
    TR::ILOpCodes addOp, mulOp;
-   TR::DataTypes indexType = indexNode->getSymbol()->getDataType();
+   TR::DataType indexType = indexNode->getSymbol()->getDataType();
    if (TR::Compiler->target.is64Bit())
       {
       if (indexType != TR::Int64)
@@ -790,7 +790,7 @@ IlBuilder::IndexAt(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index)
       }
    else
       {
-      TR::DataTypes targetType = TR::Int32;
+      TR::DataType targetType = TR::Int32;
       if (indexType != targetType)
          {
          TR::ILOpCodes op = TR::DataType::getDataTypeConversion(indexType, targetType);
@@ -899,8 +899,8 @@ IlBuilder::ConvertTo(TR::IlType *t, TR::IlValue *v)
    {
    appendBlock();
    TR::IlValue *convertedValue = newValue(t);
-   TR::DataTypes t1 = v->getSymbol()->getDataType();
-   TR::DataTypes t2 = t->getPrimitiveType();
+   TR::DataType t1 = v->getSymbol()->getDataType();
+   TR::DataType t2 = t->getPrimitiveType();
    TR::ILOpCodes convertOp = TR::DataType::getDataTypeConversion(v->getSymbol()->getDataType(), t->getPrimitiveType());
    TR::Node *result = TR::Node::create(convertOp, 1, loadValue(v));
    storeNode(convertedValue, result);
@@ -923,15 +923,15 @@ void
 IlBuilder::doVectorConversions(TR::Node **leftPtr, TR::Node **rightPtr)
    {
    TR::Node *    left  = *leftPtr;
-   TR::DataTypes lType = left->getDataType();
+   TR::DataType lType = left->getDataType();
 
    TR::Node *    right = *rightPtr;
-   TR::DataTypes rType = right->getDataType();
+   TR::DataType rType = right->getDataType();
 
-   if (isVectorType(lType) && !isVectorType(rType))
+   if (lType.isVector() && !rType.isVector())
       *rightPtr = TR::Node::create(TR::vsplats, 1, right);
 
-   if (!isVectorType(lType) && isVectorType(rType))
+   if (!lType.isVector() && rType.isVector())
       *leftPtr = TR::Node::create(TR::vsplats, 1, left);
    }
 
@@ -940,8 +940,8 @@ IlBuilder::binaryOpFromNodes(TR::ILOpCodes op,
                              TR::Node *leftNode,
                              TR::Node *rightNode)
    {
-   TR::DataTypes leftType = leftNode->getDataType();
-   TR::DataTypes rightType = rightNode->getDataType();
+   TR::DataType leftType = leftNode->getDataType();
+   TR::DataType rightType = rightNode->getDataType();
    bool isAddressBump = ((leftType == TR::Address) &&
                             (rightType == TR::Int32 || rightType == TR::Int64));
    bool isRevAddressBump = ((rightType == TR::Address) &&
@@ -973,7 +973,7 @@ IlBuilder::binaryOpFromOpMap(OpCodeMapper mapOp,
 
    doVectorConversions(&leftNode, &rightNode);
 
-   TR::DataTypes leftType = leftNode->getDataType();
+   TR::DataType leftType = leftNode->getDataType();
    return binaryOpFromNodes(mapOp(leftType), leftNode, rightNode);
    }
 
@@ -1055,7 +1055,7 @@ IlBuilder::Sub(TR::IlValue *left, TR::IlValue *right)
    return returnValue;
    }
 
-static TR::ILOpCodes addOpCode(TR::DataTypes type)
+static TR::ILOpCodes addOpCode(TR::DataType type)
    {
    return TR::ILOpCode::addOpCode(type, TR::Compiler->target.is64Bit());
    }
@@ -1194,7 +1194,7 @@ IlBuilder::Call(const char *functionName, int32_t numArgs, TR::IlValue ** argVal
    appendBlock();
 
    TR::ResolvedMethod *resolvedMethod = _methodBuilder->lookupFunction(functionName);
-   TR::DataTypes returnType = resolvedMethod->returnType();
+   TR::DataType returnType = resolvedMethod->returnType();
 
    // treat as "Static" (so no receiver expected) and use a direct call opcode
    TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateMethodSymbol(JITTED_METHOD_INDEX, -1, resolvedMethod, TR::MethodSymbol::Static);

--- a/compiler/ilgen/IlBuilder.hpp
+++ b/compiler/ilgen/IlBuilder.hpp
@@ -50,7 +50,7 @@ template <class T> class ListAppender;
 namespace OMR
 {
 
-typedef TR::ILOpCodes (*OpCodeMapper)(TR::DataTypes);
+typedef TR::ILOpCodes (*OpCodeMapper)(TR::DataType);
 
 
 class IlBuilder : public TR::IlInjector
@@ -304,7 +304,7 @@ protected:
 
    TR::IlValue *lookupSymbol(const char *name);
    void defineSymbol(const char *name, TR::IlValue *v);
-   TR::IlValue *newValue(TR::DataTypes dt);
+   TR::IlValue *newValue(TR::DataType dt);
    TR::IlValue *newValue(TR::IlType *dt);
    void defineValue(const char *name, TR::IlType *dt);
 
@@ -313,7 +313,7 @@ protected:
    void indirectStoreNode(TR::Node *addr, TR::Node *v);
    TR::IlValue *indirectLoadNode(TR::IlType *dt, TR::Node *addr, bool isVectorLoad=false);
 
-   TR::Node *zero(TR::DataTypes dt);
+   TR::Node *zero(TR::DataType dt);
    TR::Node *zero(TR::IlType *dt);
    TR::Node *zeroNodeForValue(TR::IlValue *v);
    TR::IlValue *zeroForValue(TR::IlValue *v);

--- a/compiler/ilgen/MethodBuilder.cpp
+++ b/compiler/ilgen/MethodBuilder.cpp
@@ -346,7 +346,7 @@ MethodBuilder::lookupSymbol(const char *name)
    TR_HashId typesID;
    _symbolTypes->locate(name, typesID);
 
-   TR::DataTypes type = ((TR::IlType *)(_symbolTypes->getData(typesID)))->getPrimitiveType();
+   TR::DataType type = ((TR::IlType *)(_symbolTypes->getData(typesID)))->getPrimitiveType();
 
    TR_HashId slotID;
    if (_parameterSlot->locate(name, slotID))

--- a/compiler/ilgen/TypeDictionary.cpp
+++ b/compiler/ilgen/TypeDictionary.cpp
@@ -49,7 +49,7 @@ static const char *signatureNameForType[] =
 char *
 IlType::getSignatureName()
    {
-   TR::DataTypes dt = getPrimitiveType();
+   TR::DataType dt = getPrimitiveType();
    if (dt == TR::Address)
       return (char *)_name;
    return (char *) signatureNameForType[dt];
@@ -88,12 +88,12 @@ class PrimitiveType : public TR::IlType
 public:
    TR_ALLOC(TR_Memory::IlGenerator)
 
-   PrimitiveType(const char * name, TR::DataTypes type) :
+   PrimitiveType(const char * name, TR::DataType type) :
       TR::IlType(name),
       _type(type)
       { }
 
-   virtual TR::DataTypes getPrimitiveType()
+   virtual TR::DataType getPrimitiveType()
       {
       return _type;
       }
@@ -101,7 +101,7 @@ public:
   virtual char *getSignatureName() { return (char *) signatureNameForType[_type]; }
 
 protected:
-   TR::DataTypes _type;
+   TR::DataType _type;
    };
 
 
@@ -124,7 +124,7 @@ public:
 
    TR::IlType *getType()                         { return _type; }
 
-   TR::DataTypes getPrimitiveType()             { return _type->getPrimitiveType(); }
+   TR::DataType getPrimitiveType()             { return _type->getPrimitiveType(); }
 
    uint32_t getOffset()                          { return _offset; }
 
@@ -153,7 +153,7 @@ public:
       _closed(false)
       { }
 
-   TR::DataTypes getPrimitiveType()                 { return TR::Address; }
+   TR::DataType getPrimitiveType()                 { return TR::Address; }
    void Close()                                      { _closed = true; };
 
    void AddField(const char *name, TR::IlType *fieldType);
@@ -178,7 +178,7 @@ StructType::AddField(const char *name, TR::IlType *typeInfo)
    if (_closed)
       return;
 
-   TR::DataTypes primitiveType = typeInfo->getPrimitiveType();
+   TR::DataType primitiveType = typeInfo->getPrimitiveType();
    uint32_t align = primitiveTypeAlignment[primitiveType] - 1;
    _size = (_size + align) & (~align);
 
@@ -225,7 +225,7 @@ StructType::getFieldSymRef(const char *fieldName)
       {
       TR::Compilation *comp = TR::comp();
 
-      TR::DataTypes type = info->getPrimitiveType();
+      TR::DataType type = info->getPrimitiveType();
 
       TR::Symbol *symbol = NULL;
       if (TR::Int32 == type)
@@ -285,7 +285,7 @@ public:
 
    virtual const char *getName() { return _name; }
 
-   virtual TR::DataTypes getPrimitiveType() { return TR::Address; }
+   virtual TR::DataType getPrimitiveType() { return TR::Address; }
 
    TR::SymbolReference *getSymRef();
 

--- a/compiler/ilgen/TypeDictionary.hpp
+++ b/compiler/ilgen/TypeDictionary.hpp
@@ -61,7 +61,7 @@ public:
    const char *getName() { return _name; }
    virtual char *getSignatureName();
 
-   virtual TR::DataTypes getPrimitiveType() { return TR::NoType; }
+   virtual TR::DataType getPrimitiveType() { return TR::NoType; }
 
    virtual bool isArray() { return false; }
    virtual bool isPointer() { return false; }
@@ -89,7 +89,7 @@ public:
    void CloseStruct(const char *structName);
    TR::IlType * GetFieldType(const char *structName, const char *fieldName);
 
-   TR::IlType *PrimitiveType(TR::DataTypes primitiveType)
+   TR::IlType *PrimitiveType(TR::DataType primitiveType)
       {
       return _primitiveType[primitiveType];
       }
@@ -98,7 +98,7 @@ public:
 
    TR::IlType *PointerTo(TR::IlType *baseType);
    TR::IlType *PointerTo(const char *structName);
-   TR::IlType *PointerTo(TR::DataTypes baseType)  { return PointerTo(_primitiveType[baseType]); }
+   TR::IlType *PointerTo(TR::DataType baseType)  { return PointerTo(_primitiveType[baseType]); }
 
    TR::IlReference *FieldReference(const char *structName, const char *fieldName);
    TR_Memory *trMemory() { return _trMemory; }

--- a/compiler/optimizer/CopyPropagation.cpp
+++ b/compiler/optimizer/CopyPropagation.cpp
@@ -269,7 +269,7 @@ class TR_ExpressionPropagation
                oldPrecision = oldNode->getDecimalPrecision();
                int32_t oldSize = oldNode->getSize();
 
-               TR::DataTypes newDataType = newNode->getOpCode().hasSymbolReference() ? newNode->getSymbolReference()->getSymbol()->getDataType() : newNode->getDataType();
+               TR::DataType newDataType = newNode->getOpCode().hasSymbolReference() ? newNode->getSymbolReference()->getSymbol()->getDataType() : newNode->getDataType();
                int32_t      newSymSize  = newNode->getOpCode().hasSymbolReference() ? newNode->getSymbolReference()->getSymbol()->getSize() : newNode->getSize();
                newPrecision = TR::DataType::getBCDPrecisionFromSize(newDataType, newSymSize);
 

--- a/compiler/optimizer/FieldPrivatizer.cpp
+++ b/compiler/optimizer/FieldPrivatizer.cpp
@@ -715,7 +715,7 @@ void TR_FieldPrivatizer::privatizeFields(TR::Node *node, bool postDominatesEntry
 
    TR::ILOpCode &opCode = node->getOpCode();
    TR::DataType nodeType = node->getType();
-   TR::DataTypes nodeDataType = node->getDataType();
+   TR::DataType nodeDataType = node->getDataType();
 
    // privatize
    if (opCode.isStore() || opCode.isLoadVar())
@@ -1569,7 +1569,7 @@ void TR_FieldPrivatizer::privatizeElementCandidates()
          tempMap.Add(candidate.valueNum,tempSymRef);
          }
 
-      TR::DataTypes storedt = candidate.node->getDataType();
+      TR::DataType storedt = candidate.node->getDataType();
 
       // step 1, anchor the original store address calculation child
 

--- a/compiler/optimizer/GlobalRegisterAllocator.cpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.cpp
@@ -239,7 +239,7 @@ bool TR_GlobalRegisterAllocator::isSymRefAvailable(TR::SymbolReference *symRef, 
    return true;
    }
 
-bool TR_GlobalRegisterAllocator::allocateForType(TR::DataTypes dt)
+bool TR_GlobalRegisterAllocator::allocateForType(TR::DataType dt)
    {
    return true;
    }
@@ -971,7 +971,7 @@ TR_GlobalRegisterAllocator::transformBlock(TR::TreeTop * tt)
 
 
 TR::Node *
-TR_GlobalRegisterAllocator::resolveTypeMismatch(TR::DataTypes oldType, TR::Node *newNode)
+TR_GlobalRegisterAllocator::resolveTypeMismatch(TR::DataType oldType, TR::Node *newNode)
    {
    return resolveTypeMismatch(oldType, NULL, newNode);
    }
@@ -983,7 +983,7 @@ TR_GlobalRegisterAllocator::resolveTypeMismatch(TR::Node *oldNode, TR::Node *new
    }
 
 TR::Node *
-TR_GlobalRegisterAllocator::resolveTypeMismatch(TR::DataTypes inputOldType, TR::Node *oldNode, TR::Node *newNode)
+TR_GlobalRegisterAllocator::resolveTypeMismatch(TR::DataType inputOldType, TR::Node *oldNode, TR::Node *newNode)
    {
    return newNode;
    }
@@ -1524,7 +1524,7 @@ TR_GlobalRegisterAllocator::transformNode(
                TR::Node * child = node->getFirstChild();
                TR::Node *newNode = NULL;
                   {
-                  TR::DataTypes regStoreType = node->getDataType();
+                  TR::DataType regStoreType = node->getDataType();
                   newNode = TR::Node::create(comp()->il.opCodeForRegisterStore(regStoreType), 1, child);
                   newNode->setRegLoadStoreSymbolReference(symRef);
                   }
@@ -1546,7 +1546,7 @@ TR_GlobalRegisterAllocator::transformNode(
                {
                origStoreToMetaData = NULL;
                   {
-                  TR::DataTypes regStoreType = node->getDataType();
+                  TR::DataType regStoreType = node->getDataType();
                   TR::Node::recreate(node, comp()->il.opCodeForRegisterStore(regStoreType));
                   }
 
@@ -2988,7 +2988,7 @@ TR::Node *
 TR_GlobalRegister::createLoadFromRegister(TR::Node * n, TR::Compilation *comp)
    {
    TR_RegisterCandidate * rc = getCurrentRegisterCandidate();
-   TR::DataTypes dt = rc->getDataType();
+   TR::DataType dt = rc->getDataType();
    if (dt == TR::Aggregate)
       {
       switch (rc->getSymbol()->getSize())
@@ -3028,7 +3028,7 @@ TR_GlobalRegister::createStoreToRegister(TR::TreeTop * prevTreeTop, TR::Node *no
    TR_RegisterCandidate * rc = getCurrentRegisterCandidate();
    TR::Node * load = NULL;
 
-   TR::DataTypes dt = rc->getDataType();
+   TR::DataType dt = rc->getDataType();
    if (dt == TR::Aggregate)
       {
       switch (rc->getSymbol()->getSize())
@@ -5278,7 +5278,7 @@ TR_LiveRangeSplitter::splitLiveRanges(TR_StructureSubGraphNode *structureNode)
 
                if (candidateIsLiveOnExit)
                   {
-                  TR::DataTypes dt = symRef->getSymbol()->getDataType();
+                  TR::DataType dt = symRef->getSymbol()->getDataType();
                   bool isFloat = (dt == TR::Float
                                   || dt == TR::Double
 #ifdef J9_PROJECT_SPECIFIC
@@ -5388,7 +5388,7 @@ TR_LiveRangeSplitter::replaceAutosUsedIn(
          TR::SymbolReference *origSymRef = symRef;
          if (!correspondingSymRefCandidate)
             {
-            TR::DataTypes dt = symRef->getSymbol()->getDataType();
+            TR::DataType dt = symRef->getSymbol()->getDataType();
             bool isFloat = (dt == TR::Float
                             || dt == TR::Double
 #ifdef J9_PROJECT_SPECIFIC

--- a/compiler/optimizer/GlobalRegisterAllocator.hpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.hpp
@@ -163,9 +163,9 @@ public:
          _signExtAdjustmentNotReqd->reset(regNum);
       }
 
-   TR::Node *           resolveTypeMismatch(TR::DataTypes oldType, TR::Node *newNode);
+   TR::Node *           resolveTypeMismatch(TR::DataType oldType, TR::Node *newNode);
    TR::Node *           resolveTypeMismatch(TR::Node *oldNode, TR::Node *newNode);
-   TR::Node *           resolveTypeMismatch(TR::DataTypes inputOldType, TR::Node *oldNode, TR::Node *newNode);
+   TR::Node *           resolveTypeMismatch(TR::DataType inputOldType, TR::Node *oldNode, TR::Node *newNode);
 
 private:
 
@@ -186,7 +186,7 @@ private:
    bool                allocateForSymRef(TR::SymbolReference *symRef);
    bool                isSymRefAvailable(TR::SymbolReference *symRef);
    bool                isSymRefAvailable(TR::SymbolReference *symRef, List<TR::Block> *blocksInLoop);
-   bool                allocateForType(TR::DataTypes dt);
+   bool                allocateForType(TR::DataType dt);
    bool                isNodeAvailable(TR::Node *node);
    bool                isTypeAvailable(TR::SymbolReference *symref);
 

--- a/compiler/optimizer/InductionVariable.cpp
+++ b/compiler/optimizer/InductionVariable.cpp
@@ -1999,7 +1999,7 @@ bool TR_LoopStrider::examineTreeForInductionVariableUse(TR::Block *loopInvariant
 
                if (canCreateNewSymRef)
                   {
-                  TR::DataTypes dataType = findDataType(replacingNode, usingAladd, isInternalPointer);
+                  TR::DataType dataType = findDataType(replacingNode, usingAladd, isInternalPointer);
                   TR_ASSERT(dataType, "dataType cannot be NoType\n");
 
                   *newSymbolReference = comp()->getSymRefTab()->createTemporary(comp()->getMethodSymbol(), dataType, isInternalPointer);
@@ -2125,7 +2125,7 @@ bool TR_LoopStrider::examineTreeForInductionVariableUse(TR::Block *loopInvariant
          if (canCreateNewSymRef)
             {
 
-            TR::DataTypes dataType = findDataType(replacingNode, usingAladd, isInternalPointer);
+            TR::DataType dataType = findDataType(replacingNode, usingAladd, isInternalPointer);
             TR_ASSERT(dataType, "dataType cannot be TR::NoType\n");
 
             *newSymbolReference = comp()->getSymRefTab()->createTemporary(comp()->getMethodSymbol(), dataType, isInternalPointer);
@@ -2310,9 +2310,9 @@ TR::Node *TR_LoopStrider::findReplacingNode(TR::Node *node, bool usingAladd, int
    }
 
 
-TR::DataTypes TR_LoopStrider::findDataType(TR::Node *node, bool usingAladd, bool isInternalPointer)
+TR::DataType TR_LoopStrider::findDataType(TR::Node *node, bool usingAladd, bool isInternalPointer)
    {
-   TR::DataTypes dataType = TR::NoType;
+   TR::DataType dataType = TR::NoType;
    if (!isInternalPointer)
       {
       // generate long symRefs if on 64-bit
@@ -4293,7 +4293,7 @@ void TR_LoopStrider::detectLoopsForIndVarConversion(
                // Only consider 32-bit integer autos. In particular note that
                // any temps newly created by the above recursive calls are
                // Int64, and their stores are all lstore.
-               TR::DataTypes ivType = storeTree->getNode()->getDataType();
+               TR::DataType ivType = storeTree->getNode()->getDataType();
                if (ivType != TR::Int32)
                   continue;
 
@@ -5171,7 +5171,7 @@ bool TR_LoopStrider::isAdditiveTermEquivalentTo(int32_t k, TR::Node * node)
    }
 
 
-TR::Node *TR_LoopStrider::duplicateMulTermNode(int32_t k, TR::Node *node, TR::DataTypes type)
+TR::Node *TR_LoopStrider::duplicateMulTermNode(int32_t k, TR::Node *node, TR::DataType type)
    {
    TR_ASSERT(k < _numberOfLinearExprs, "index k %d exceeds _numberOfLinearExprs %d!\n",k,_numberOfLinearExprs);
    TR::Node *new_node = ((TR::Node*)(intptrj_t)_linearEquations[k][2])->duplicateTree();
@@ -6774,7 +6774,7 @@ TR_InductionVariableAnalysis::getEntryValue(TR::Block *block,
       {
       if (comp()->isLoopTransferDone())
          {
-         TR::DataTypes dataType = symRef->getSymbol()->getDataType();
+         TR::DataType dataType = symRef->getSymbol()->getDataType();
 
          TR::Node *dummyNode = TR::Node::create(NULL,
                                                 ((dataType == TR::Int32) ? TR::iconst : TR::lconst),

--- a/compiler/optimizer/InductionVariable.hpp
+++ b/compiler/optimizer/InductionVariable.hpp
@@ -166,7 +166,7 @@ class TR_LoopStrider : public TR_LoopTransformer
    void createParmAutoPair(TR::SymbolReference *parmSymRef, TR::SymbolReference *autoSymRef);
 
    TR::Node *findReplacingNode(TR::Node *node, bool usingAladd, int32_t k);
-   TR::DataTypes findDataType(TR::Node *node, bool usingAladd, bool isInternalPointer);
+   TR::DataType findDataType(TR::Node *node, bool usingAladd, bool isInternalPointer);
    void placeStore(TR::Node *newStore, TR::Block *loopInvariantBlock);
    void setInternalPointer(TR::Symbol *symbol, TR::AutomaticSymbol *pinningArrayPointer);
    void populateLinearEquation(TR::Node *node, int32_t loopDrivingInductionVar, int32_t derivedInductionVar, int32_t internalPointerSymbol, TR::Node *invariantMultiplicationTerm);
@@ -241,7 +241,7 @@ class TR_LoopStrider : public TR_LoopTransformer
 
    void    setAdditiveTermNode (TR::Node *node, int32_t k) { TR_ASSERT(k < _numberOfLinearExprs, "index k %d exceeds _numberOfLinearExprs %d!\n",k,_numberOfLinearExprs); _linearEquations[k][3] = (intptrj_t) node; }
    TR::Node *getAdditiveTermNode(int32_t k) { TR_ASSERT(k < _numberOfLinearExprs, "index k %d exceeds _numberOfLinearExprs %d!\n",k,_numberOfLinearExprs); return (TR::Node*)(intptrj_t)_linearEquations[k][3]; }
-   TR::Node *duplicateAdditiveTermNode(int32_t k, TR::Node *node, TR::DataTypes type)
+   TR::Node *duplicateAdditiveTermNode(int32_t k, TR::Node *node, TR::DataType type)
       {
       TR_ASSERT(k < _numberOfLinearExprs, "index k %d exceeds _numberOfLinearExprs %d!\n",k,_numberOfLinearExprs);
       TR::Node *new_node = ((TR::Node*)(intptrj_t)_linearEquations[k][3])->duplicateTree();
@@ -266,7 +266,7 @@ class TR_LoopStrider : public TR_LoopTransformer
 
    void    setMulTermNode (TR::Node *node, int32_t k) { TR_ASSERT(k < _numberOfLinearExprs, "index k %d exceeds _numberOfLinearExprs %d!\n",k,_numberOfLinearExprs); _linearEquations[k][2] = (intptrj_t) node; }
    TR::Node *getMulTermNode(int32_t k) { TR_ASSERT(k < _numberOfLinearExprs, "index k %d exceeds _numberOfLinearExprs %d!\n",k,_numberOfLinearExprs); return (TR::Node*)(intptrj_t)_linearEquations[k][2]; }
-   TR::Node *duplicateMulTermNode(int32_t k, TR::Node *node, TR::DataTypes type);
+   TR::Node *duplicateMulTermNode(int32_t k, TR::Node *node, TR::DataType type);
    bool isMulTermConst(int32_t k)
       {
       TR_ASSERT(k < _numberOfLinearExprs, "index k %d exceeds _numberOfLinearExprs %d!\n",

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -182,9 +182,9 @@ OMR_InlinerPolicy::getInitialBytecodeSize(TR_ResolvedMethod *feMethod, TR::Resol
    return size;
    }
 
-TR::DataTypes getStoreType(TR::Node *store, TR::Symbol *addrSymbol, TR::Compilation *comp)
+TR::DataType getStoreType(TR::Node *store, TR::Symbol *addrSymbol, TR::Compilation *comp)
    {
-   TR::DataTypes storeType = addrSymbol->getDataType();
+   TR::DataType storeType = addrSymbol->getDataType();
    return storeType;
    }
 
@@ -2772,7 +2772,7 @@ TR_TransformInlinedFunction::transform()
    // walking the trees [this is possible, for example if the callee ends with a 'throw'
    // instead of returning a value]; then create a zero const node (of the return type of the
    // callee) and make this the result
-   TR::DataTypes returnType = _calleeSymbol->getMethod()->returnType();
+   TR::DataType returnType = _calleeSymbol->getMethod()->returnType();
    if (!_resultNode && returnType != TR::NoType && !_simpleCallReferenceTreeTop &&
          _callNode->getReferenceCount() > 1)
       {
@@ -3131,7 +3131,7 @@ TR_HandleInjectedBasicBlock::createTemps(bool replaceAllReferences)
    for (MultiplyReferencedNode * ref = _multiplyReferencedNodes.getFirst(); ref; ref = ref->getNext())
       {
       TR::ILOpCode opcode = ref->_node->getOpCode();
-      TR::DataTypes nodeDataType = ref->_node->getDataType();
+      TR::DataType nodeDataType = ref->_node->getDataType();
 
       ref->_replacementSymRef = 0;
       ref->_isConst = false;
@@ -3343,7 +3343,7 @@ TR::TreeTop * OMR_InlinerUtil::storeValueInATemp(
    List<TR::SymbolReference> * availableTemps2, bool behavesLikeTemp, TR::TreeTop ** newStoreValueTreeTop,
    bool isIndirect, int32_t offset)
    {
-   TR::DataTypes dataType = value->getDataType();
+   TR::DataType dataType = value->getDataType();
 
    bool internalPtrHasPinningArrayPtr = false;
 

--- a/compiler/optimizer/LoopCanonicalizer.cpp
+++ b/compiler/optimizer/LoopCanonicalizer.cpp
@@ -2085,7 +2085,7 @@ bool TR_LoopCanonicalizer::replaceInductionVariableComputationsInExits(TR_Struct
       if (!structure->contains(block->getStructureOf()))
          {
          TR::Block *newBlock = (*edge)->getFrom()->asBlock()->splitEdge((*edge)->getFrom()->asBlock(), block, comp());
-         TR::DataTypes dataType = newSymbolReference->getSymbol()->getDataType();
+         TR::DataType dataType = newSymbolReference->getSymbol()->getDataType();
          TR::Node *subNode = TR::Node::create((dataType == TR::Int32) ? TR::iadd : TR::ladd, 2,
                                                 TR::Node::createWithSymRef(node, comp()->il.opCodeForDirectLoad(dataType), 0, newSymbolReference),
                                                 TR::Node::createWithSymRef(node, comp()->il.opCodeForDirectLoad(dataType), 0, primaryInductionVar));
@@ -2138,7 +2138,7 @@ bool TR_LoopCanonicalizer::replaceInductionVariableComputationsInExits(TR_Struct
       if (!structure->contains(block->getStructureOf()))
          {
          TR::Block *newBlock = (*edge)->getFrom()->asBlock()->splitEdge((*edge)->getFrom()->asBlock(), block, comp());
-         TR::DataTypes dataType = newSymbolReference->getSymbol()->getDataType();
+         TR::DataType dataType = newSymbolReference->getSymbol()->getDataType();
          TR::Node *subNode = TR::Node::create((dataType == TR::Int32) ? TR::iadd : TR::ladd, 2,
                                                 TR::Node::createWithSymRef(node, comp()->il.opCodeForDirectLoad(dataType), 0, newSymbolReference),
                                                 TR::Node::createWithSymRef(node, comp()->il.opCodeForDirectLoad(dataType), 0, primaryInductionVar));
@@ -2537,7 +2537,7 @@ bool TR_LoopCanonicalizer::examineTreeForInductionVariableUse(TR::Block *loopInv
       if ((node->getSymbolReference() == _symRefBeingReplaced) &&
           performTransformation(comp(), "Replacing use %p of sym ref #%d by sym ref #%d\n", node, node->getSymbolReference()->getReferenceNumber(), _primaryInductionVariable->getReferenceNumber()))
          {
-         TR::DataTypes dataType = node->getDataType();
+         TR::DataType dataType = node->getDataType();
          if (!(*newSymbolReference))
            *newSymbolReference = comp()->getSymRefTab()->createTemporary(comp()->getMethodSymbol(), dataType, false);
 
@@ -2737,7 +2737,7 @@ bool TR_LoopCanonicalizer::examineTreeForInductionVariableUse(TR::Block *loopInv
 
 void TR_LoopCanonicalizer::placeInitializationTreeInLoopPreHeader(TR::Block *b, TR::Node *node, TR::SymbolReference *newSymbolReference, TR::SymbolReference *primaryInductionVar, TR::SymbolReference *derivedInductionVar)
    {
-   TR::DataTypes dataType = newSymbolReference->getSymbol()->getDataType();
+   TR::DataType dataType = newSymbolReference->getSymbol()->getDataType();
    TR::Node *subNode = TR::Node::create((dataType == TR::Int32) ? TR::isub : TR::lsub, 2,
                                             TR::Node::createWithSymRef(node, comp()->il.opCodeForDirectLoad(dataType), 0, derivedInductionVar),
                                             TR::Node::createWithSymRef(node, comp()->il.opCodeForDirectLoad(dataType), 0, primaryInductionVar));

--- a/compiler/optimizer/LoopReducer.cpp
+++ b/compiler/optimizer/LoopReducer.cpp
@@ -1051,9 +1051,9 @@ TR_LoopReducer::generateArraycopy(TR_InductionVariable * indVar, TR::Block * loo
          src = TR::Node::create(op_add, 2, src, TR::Node::create(src, op_const, 0, offset));
 
       arraycopy = TR::Node::createArraycopy(src, dst, imul->duplicateTree());
-      TR::DataTypes arraycopyElementType = storeNode->getDataType();
+      TR::DataType arraycopyElementType = storeNode->getDataType();
 #ifdef J9_PROJECT_SPECIFIC
-      if (isBCDType(arraycopyElementType))
+      if (arraycopyElementType.isBCD())
          {
          switch (storeNode->getSize())
             {

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -5228,7 +5228,7 @@ bool TR_LoopVersioner::buildLoopInvariantTree(List<TR::TreeTop> *nullCheckTrees,
          {
          TR::Node *duplicateNode = invariantNode->duplicateTree();
 
-         TR::DataTypes dataType = invariantNode->getDataType();
+         TR::DataType dataType = invariantNode->getDataType();
          TR::SymbolReference *newSymbolReference = comp()->getSymRefTab()->createTemporary(comp()->getMethodSymbol(), dataType);
 
          if (invariantNode->getOpCode().hasSymbolReference() && invariantNode->getSymbolReference()->getSymbol()->isNotCollected())
@@ -6028,7 +6028,7 @@ void TR_LoopVersioner::buildSpineCheckComparisonsTree(List<TR::TreeTop> *nullChe
          //       iconst strideShift
 
          bool is64BitTarget = TR::Compiler->target.is64Bit() ? true : false;
-         TR::DataTypes type =  spineCheckNode->getChild(0)->getDataType();
+         TR::DataType type =  spineCheckNode->getChild(0)->getDataType();
          uint32_t elementSize = TR::Symbol::convertTypeToSize(type);
          if (comp()->useCompressedPointers() && (type == TR::Address))
             elementSize = TR::Compiler->om.sizeofReferenceField();

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -2500,7 +2500,7 @@ bool OMR::Optimizer::areNodesEquivalent(TR::Node *node1, TR::Node *node2,  TR::C
             default:
                {
 #ifdef J9_PROJECT_SPECIFIC
-               if (isBCDType(node1->getDataType()))
+               if (node1->getDataType().isBCD())
                   {
                   if (!areBCDAggrConstantNodesEquivalent(node1, node2, _comp))
                      return false;
@@ -2647,8 +2647,8 @@ bool OMR::Optimizer::areNodesEquivalent(TR::Node *node1, TR::Node *node2,  TR::C
 #ifdef J9_PROJECT_SPECIFIC
 bool OMR::Optimizer::areBCDAggrConstantNodesEquivalent(TR::Node *node1, TR::Node *node2,  TR::Compilation *_comp)
    {
-   size_t size1 = (isBCDType(node1->getDataType())) ? node1->getDecimalPrecision() : 0;
-   size_t size2 = (isBCDType(node2->getDataType())) ? node2->getDecimalPrecision() : 0;
+   size_t size1 = (node1->getDataType().isBCD()) ? node1->getDecimalPrecision() : 0;
+   size_t size2 = (node2->getDataType().isBCD()) ? node2->getDecimalPrecision() : 0;
 
    if (size1 != size2)
       {

--- a/compiler/optimizer/OMRSimplifier.cpp
+++ b/compiler/optimizer/OMRSimplifier.cpp
@@ -553,8 +553,8 @@ OMR::Simplifier::unaryCancelOutWithChild(TR::Node * node, TR::Node * firstChild,
 
       if (node->hasSourcePrecision())
          childP = node->getSourcePrecision();
-      else if (TR::DataType::canGetMaxPrecisionFromType(firstChild->getDataType()))
-         childP = TR::DataType::getMaxPrecisionFromType(firstChild->getDataType());
+      else if (firstChild->getDataType().canGetMaxPrecisionFromType())
+         childP = firstChild->getDataType().getMaxPrecisionFromType();
 
       if (childP < nodeP && childP < grandChildP)
          {
@@ -570,8 +570,8 @@ OMR::Simplifier::unaryCancelOutWithChild(TR::Node * node, TR::Node * firstChild,
       //   l2dd
       //     lX
       // Folding could give an incorrect result because the max precision of a dd is 16 and the max precision of an l is 19
-      if (TR::DataType::canGetMaxPrecisionFromType(node->getDataType()) && TR::DataType::canGetMaxPrecisionFromType(firstChild->getDataType()) &&
-          TR::DataType::getMaxPrecisionFromType(node->getDataType()) > TR::DataType::getMaxPrecisionFromType(firstChild->getDataType()))
+      if (node->getDataType().canGetMaxPrecisionFromType() && firstChild->getDataType().canGetMaxPrecisionFromType() &&
+          node->getDataType().getMaxPrecisionFromType() > firstChild->getDataType().getMaxPrecisionFromType())
          {
          if (trace())
             traceMsg(comp(),"disallow unaryCancel of node %p and firstChild %p due to intermediate truncation of node\n",node,firstChild);
@@ -709,9 +709,9 @@ OMR::Simplifier::unaryCancelOutWithChild(TR::Node * node, TR::Node * firstChild,
          int32_t childP = firstChild->getDecimalPrecision();
          int32_t grandChildP = TR::DataType::getMaxPackedDecimalPrecision();
 
-         if (TR::DataType::canGetMaxPrecisionFromType(node->getDataType()))
+         if (node->getDataType().canGetMaxPrecisionFromType())
             {
-            nodeP = TR::DataType::getMaxPrecisionFromType(node->getDataType());
+            nodeP = node->getDataType().getMaxPrecisionFromType();
             grandChildP = nodeP;
             }
          if (firstChild->hasSourcePrecision())

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -1768,7 +1768,7 @@ static bool reduceLongOp(TR::Node * node, TR::Block * block, TR::Simplifier * s,
    return true;
    }
 
-static void fold2SmallerIntConstant(TR::Node * node, TR::Node *child, TR::DataTypes sdt, TR::DataTypes tdt, TR::Simplifier * s)
+static void fold2SmallerIntConstant(TR::Node * node, TR::Node *child, TR::DataType sdt, TR::DataType tdt, TR::Simplifier * s)
    {
    int32_t val;
    switch (sdt)
@@ -1807,7 +1807,7 @@ static TR::Node *intDemoteSimplifier(TR::Node * node, TR::Block * block, TR::Sim
 
    TR::ILOpCode op = node->getOpCode();
 
-   TR::DataTypes sourceDataType, targetDataType;
+   TR::DataType sourceDataType(TR::DataTypes::NoType), targetDataType(TR::DataTypes::NoType);
 
    if (!decodeConversionOpcode(op, node->getDataType(), sourceDataType, targetDataType))
       return node;
@@ -1857,14 +1857,13 @@ static TR::Node *intDemoteSimplifier(TR::Node * node, TR::Block * block, TR::Sim
    // TODO: do we really need Tx to be 64 bit?
 
    TR::ILOpCode childOp = firstChild->getOpCode();
-   TR::DataTypes childSourceDataType, childTargetDataType;
+   TR::DataType childSourceDataType(TR::DataTypes::NoType), childTargetDataType(TR::DataTypes::NoType);
 
    if (sourceIs64Bit && decodeConversionOpcode(childOp, firstChild->getDataType(), childSourceDataType, childTargetDataType) && (childSourceDataType != targetDataType))
       {
       bool wantZeroExtension = childOp.isZeroExtension();
-      TR::DataType childSourceType = childSourceDataType;
       uint32_t childSourceSize = TR::ILOpCode::getSize(TR::ILOpCode::getProperConversion(childTargetDataType, childSourceDataType, wantZeroExtension));  // size of childSourceDataType (hack)
-      if (childSourceType.isIntegral() && (childSourceSize < sourceSize))
+      if (childSourceDataType.isIntegral() && (childSourceSize < sourceSize))
          {
          bool wantZeroExtension = childOp.isZeroExtension();
          TR::ILOpCodes foldOp =  TR::ILOpCode::getProperConversion(childSourceDataType, targetDataType, wantZeroExtension);
@@ -5178,7 +5177,7 @@ static void bitTestingOp(TR::Node * node, TR::Simplifier *s)
   firstChild->setAndIncChild(0, shift->getFirstChild());
   shift->recursivelyDecReferenceCount();
 
-  TR::DataTypes dt = node->getFirstChild()->getDataType();
+  TR::DataType dt = node->getFirstChild()->getDataType();
 
   switch (dt)
      {
@@ -5702,11 +5701,11 @@ TR::Node *indirectLoadSimplifier(TR::Node * node, TR::Block * block, TR::Simplif
        !s->comp()->cg()->getLinkage()->isArgumentListSymbol(firstChild->getSymbolReference()->getSymbol(), s->comp())) // argList symbol can grow later on
        {
        bool newOType = false;
-       TR::DataTypes loadDataType = newOType ? node->getDataType() : node->getSymbolReference()->getSymbol()->getDataType();
+       TR::DataType loadDataType = newOType ? node->getDataType() : node->getSymbolReference()->getSymbol()->getDataType();
        intptrj_t loadSize = newOType ? node->getSize() : node->getSymbolReference()->getSymbol()->getSize();
        intptrj_t loadSymSize = node->getSymbolReference()->getSymbol()->getSize();
 
-       TR::DataTypes addrDataType = firstChild->getSymbolReference()->getSymbol()->getDataType();
+       TR::DataType addrDataType = firstChild->getSymbolReference()->getSymbol()->getDataType();
        intptrj_t addrSize = firstChild->getSymbolReference()->getSymbol()->getSize();
        TR::Symbol* addrSymbol = firstChild->getSymbolReference()->getSymbol();
        bool localStatic = false;
@@ -5837,11 +5836,11 @@ TR::Node *indirectStoreSimplifier(TR::Node * node, TR::Block * block, TR::Simpli
        {
        bool newOType = false;
 
-       TR::DataTypes storeDataType = newOType ? node->getDataType() : node->getSymbolReference()->getSymbol()->getDataType();
+       TR::DataType storeDataType = newOType ? node->getDataType() : node->getSymbolReference()->getSymbol()->getDataType();
        intptrj_t storeSize = newOType ? node->getSize() : node->getSymbolReference()->getSymbol()->getSize();
        intptrj_t storeSymSize = node->getSymbolReference()->getSymbol()->getSize();
 
-       TR::DataTypes addrDataType = firstChild->getSymbolReference()->getSymbol()->getDataType();
+       TR::DataType addrDataType = firstChild->getSymbolReference()->getSymbol()->getDataType();
        intptrj_t addrSize = firstChild->getSymbolReference()->getSymbol()->getSize();
        TR::Symbol *addrSymbol = firstChild->getSymbolReference()->getSymbol();
 
@@ -17155,7 +17154,7 @@ TR::Node *bndchkwithspinechkSimplifier(TR::Node * node, TR::Block * block, TR::S
       // We need to determine the element size in order to prove the spine
       // check is not necessary.  Derive it from the array element node.
       //
-      TR::DataTypes dt = node->getFirstChild()->getDataType();
+      TR::DataType dt = node->getFirstChild()->getDataType();
 
       int32_t elementSize = (dt == TR::Address) ?
                               TR::Compiler->om.sizeofReferenceField() :

--- a/compiler/optimizer/OMRSimplifierHelpers.cpp
+++ b/compiler/optimizer/OMRSimplifierHelpers.cpp
@@ -1036,7 +1036,7 @@ TR::Node *removeOperandWidening(TR::Node *node, TR::Node *parent, TR::Block *blo
 #endif
 
 // NOTE: This function only (and should only) decodes opcodes found in conversionMap table!!!
-bool decodeConversionOpcode(TR::ILOpCode op, TR::DataTypes nodeDataType, TR::DataTypes &sourceDataType, TR::DataTypes &targetDataType)
+bool decodeConversionOpcode(TR::ILOpCode op, TR::DataType nodeDataType, TR::DataType &sourceDataType, TR::DataType &targetDataType)
    {
    if (!op.isConversion())
       {

--- a/compiler/optimizer/OMRSimplifierHelpers.hpp
+++ b/compiler/optimizer/OMRSimplifierHelpers.hpp
@@ -107,7 +107,7 @@ void convertStringToZonedSeparate(char *result, int32_t resultLen, char *source,
 void convertStringToUnicode(char *result, int32_t resultLen, char *source, int32_t sourceLen);
 void convertStringToUnicodeSeparate(char *result, int32_t resultLen, char *source, int32_t sourceLen, uint32_t signCode, bool signLeading);
 TR::Node *removeOperandWidening(TR::Node *node, TR::Node *parent, TR::Block *block, TR::Simplifier * s);
-bool decodeConversionOpcode(TR::ILOpCode op, TR::DataTypes nodeDataType, TR::DataTypes &sourceDataType, TR::DataTypes &targetDataType);
+bool decodeConversionOpcode(TR::ILOpCode op, TR::DataType nodeDataType, TR::DataType &sourceDataType, TR::DataType &targetDataType);
 int32_t floatToInt(float value, bool roundUp);
 int32_t doubleToInt(double value, bool roundUp);
 void removePaddingNode(TR::Node *node, TR::Simplifier *s);

--- a/compiler/optimizer/OMRTransformUtil.cpp
+++ b/compiler/optimizer/OMRTransformUtil.cpp
@@ -85,10 +85,10 @@ OMR::TransformUtil::scalarizeArrayCopy(
       {
       return node;
       }
-   TR::DataTypes dataType = TR::Aggregate;
+   TR::DataType dataType = TR::Aggregate;
 
    // Get the element datatype from the (hidden) 4th child
-   TR::DataTypes elementType = node->getArrayCopyElementType();
+   TR::DataType elementType = node->getArrayCopyElementType();
    int32_t elementSize = TR::Symbol::convertTypeToSize(elementType);
 
    if (byteLen == elementSize)
@@ -159,8 +159,8 @@ OMR::TransformUtil::scalarizeArrayCopy(
       return node;
       }
 #ifdef J9_PROJECT_SPECIFIC
-   if (isBCDType(targetRef->getSymbol()->getDataType()) ||
-       isBCDType(sourceRef->getSymbol()->getDataType()))
+   if (targetRef->getSymbol()->getDataType().isBCD() ||
+       sourceRef->getSymbol()->getDataType().isBCD())
       {
       return node;
       }
@@ -215,7 +215,7 @@ OMR::TransformUtil::scalarizeAddressParameter(
       TR::Compilation *comp,
       TR::Node *address,
       size_t byteLengthOrPrecision, // precision for BCD types and byteLength for all other types
-      TR::DataTypes dataType,
+      TR::DataType dataType,
       TR::SymbolReference *ref,
       bool store)
    {
@@ -224,7 +224,7 @@ OMR::TransformUtil::scalarizeAddressParameter(
    TR::Node * loadOrStore = NULL;
 
 #ifdef J9_PROJECT_SPECIFIC
-   size_t byteLength = isBCDType(dataType) ? TR::DataType::getSizeFromBCDPrecision(dataType, byteLengthOrPrecision) : byteLengthOrPrecision;
+   size_t byteLength = dataType.isBCD() ? TR::DataType::getSizeFromBCDPrecision(dataType, byteLengthOrPrecision) : byteLengthOrPrecision;
 #else
    size_t byteLength = byteLengthOrPrecision;
 #endif

--- a/compiler/optimizer/OMRTransformUtil.hpp
+++ b/compiler/optimizer/OMRTransformUtil.hpp
@@ -67,7 +67,7 @@ class OMR_EXTENSIBLE TransformUtil
          TR::Compilation *comp,
          TR::Node *address,
          size_t byteLengthOrPrecision,
-         TR::DataTypes dataType,
+         TR::DataType dataType,
          TR::SymbolReference *ref,
          bool store);
 

--- a/compiler/optimizer/OSRDefAnalysis.cpp
+++ b/compiler/optimizer/OSRDefAnalysis.cpp
@@ -134,7 +134,7 @@ void TR_OSRDefInfo::performFurtherAnalysis(AuxiliaryData &aux)
             int32_t slot = defSymRef->getCPIndex();
             if (slot >= methodSymbol->getFirstJitTempIndex()) continue;
             int32_t symRefNum = defSymRef->getReferenceNumber();
-            TR::DataTypes dt = defSymRef->getSymbol()->getDataType();
+            TR::DataType dt = defSymRef->getSymbol()->getDataType();
             bool takesTwoSlots = dt == TR::Int64 || dt == TR::Double;
 
             if (methodSymbol->sharesStackSlot(defSymRef))
@@ -183,7 +183,7 @@ void TR_OSRDefInfo::addSharingInfo(AuxiliaryData &aux)
       bool isTwoSlotSymRefAtThisSlot = false;
       for (TR::SymbolReference* symRef = ppsIt.getFirst(); symRef; symRef = ppsIt.getNext())
          {
-         TR::DataTypes dt = symRef->getSymbol()->getDataType();
+         TR::DataType dt = symRef->getSymbol()->getDataType();
          bool takesTwoSlots = dt == TR::Int64 || dt == TR::Double;
          if (takesTwoSlots)
             {
@@ -206,7 +206,7 @@ void TR_OSRDefInfo::addSharingInfo(AuxiliaryData &aux)
             uint16_t symIndex = symRef->getSymbol()->getSideTableIndex();
             const TR_UseDefInfo::BitVector &defs = aux._defsForSymbol[symIndex];
             unionDef |= defs;
-            TR::DataTypes dt = symRef->getSymbol()->getDataType();
+            TR::DataType dt = symRef->getSymbol()->getDataType();
             bool takesTwoSlots = dt == TR::Int64 || dt == TR::Double;
             if (takesTwoSlots)
                twoSlotUnionDef |= defs;
@@ -226,7 +226,7 @@ void TR_OSRDefInfo::addSharingInfo(AuxiliaryData &aux)
                ListIterator<TR::SymbolReference> prevppsIt(&prevppsList);
                for (TR::SymbolReference* prevSymRef = prevppsIt.getFirst(); prevSymRef; prevSymRef = prevppsIt.getNext())
                   {
-                  TR::DataTypes prevdt = prevSymRef->getSymbol()->getDataType();
+                  TR::DataType prevdt = prevSymRef->getSymbol()->getDataType();
                   bool doesPrevTakesTwoSlots = prevdt == TR::Int64 || prevdt == TR::Double;
                   if (doesPrevTakesTwoSlots)
                      {
@@ -258,7 +258,7 @@ void TR_OSRDefInfo::addSharingInfo(AuxiliaryData &aux)
       bool isTwoSlotSymRefAtThisSlot = false;
       for (TR::SymbolReference* symRef = autosIt.getFirst(); symRef; symRef = autosIt.getNext())
          {
-         TR::DataTypes dt = symRef->getSymbol()->getDataType();
+         TR::DataType dt = symRef->getSymbol()->getDataType();
          bool takesTwoSlots = dt == TR::Int64 || dt == TR::Double;
          if (takesTwoSlots)
             {
@@ -282,7 +282,7 @@ void TR_OSRDefInfo::addSharingInfo(AuxiliaryData &aux)
             uint16_t symIndex = symRef->getSymbol()->getSideTableIndex();
             const TR_UseDefInfo::BitVector &defs = aux._defsForSymbol[symIndex];
             unionDef |= defs;
-            TR::DataTypes dt = symRef->getSymbol()->getDataType();
+            TR::DataType dt = symRef->getSymbol()->getDataType();
             bool takesTwoSlots = dt == TR::Int64 || dt == TR::Double;
             if (takesTwoSlots)
                twoSlotUnionDef |= defs;
@@ -302,7 +302,7 @@ void TR_OSRDefInfo::addSharingInfo(AuxiliaryData &aux)
                ListIterator<TR::SymbolReference> prevautosIt(&prevautosList);
                for (TR::SymbolReference* prevSymRef = prevautosIt.getFirst(); prevSymRef; prevSymRef = prevautosIt.getNext())
                   {
-                  TR::DataTypes prevdt = prevSymRef->getSymbol()->getDataType();
+                  TR::DataType prevdt = prevSymRef->getSymbol()->getDataType();
                   bool doesPrevTakesTwoSlots = prevdt == TR::Int64 || prevdt == TR::Double;
                   if (doesPrevTakesTwoSlots)
                      {

--- a/compiler/optimizer/PartialRedundancy.cpp
+++ b/compiler/optimizer/PartialRedundancy.cpp
@@ -538,7 +538,7 @@ int32_t TR_PartialRedundancy::perform()
                   traceMsg(comp(), "Creating new symbol for optimal expr number %d node %p\n", nextOptimalComputation, nextOptimalNode);
 
                   }
-               TR::DataTypes dataType = nextOptimalNode->getDataType();
+               TR::DataType dataType = nextOptimalNode->getDataType();
                // set the datatype of the temporary created below to
                // be at least OMR::Int ; otherwise the opcode used to create
                // the store (to initialize) and the datatype on the symbol
@@ -1245,7 +1245,7 @@ TR::TreeTop *TR_PartialRedundancy::placeComputationsOptimally(TR::Block *block, 
             // optimally.
             //
             TR::ILOpCode &nullCheckReferenceOpCode = duplicateOptimalNode->getOpCode();
-            TR::DataTypes nullCheckReferenceDataType = duplicateOptimalNode->getDataType();
+            TR::DataType nullCheckReferenceDataType = duplicateOptimalNode->getDataType();
 
             TR::Node *nullCheckReferenceNode = nextOptimalNode->getNullCheckReference();
             if (isSupportedOpCode(nullCheckReferenceNode, NULL) && !nullCheckReferenceOpCode.isLoadVarDirect())
@@ -1421,7 +1421,7 @@ TR::TreeTop *TR_PartialRedundancy::placeComputationsOptimally(TR::Block *block, 
             convertedOptimalNode = TR::Node::create(conversionOpCode, 1, duplicateOptimalNode);
             }
 
-         TR::DataTypes type = nextOptimalNode->getDataType();
+         TR::DataType type = nextOptimalNode->getDataType();
          TR::ILOpCodes storeOp = type == TR::NoType ? TR::treetop : comp()->il.opCodeForDirectStore(type);
 
          TR::Node *storeForCommonedNode = TR::Node::createWithSymRef(storeOp, 1, 1, convertedOptimalNode, newSymbolReference);
@@ -1933,7 +1933,7 @@ bool TR_PartialRedundancy::eliminateRedundantSupportedNodes(TR::Node *parent, TR
 
    bool flag = firstComputation;
    TR::ILOpCode &opCode = node->getOpCode();
-   TR::DataTypes nodeDataType = node->getDataType();
+   TR::DataType nodeDataType = node->getDataType();
 
    int32_t i;
    for (i = 0; i < node->getNumChildren(); i++)
@@ -2158,7 +2158,7 @@ TR::TreeTop *TR_PartialRedundancy::replaceOptimalSubNodes(TR::TreeTop *curTree, 
    node->setVisitCount(visitCount);
 
    TR::ILOpCode &opCode = node->getOpCode();
-   TR::DataTypes nodeDataType = node->getDataType();
+   TR::DataType nodeDataType = node->getDataType();
 
    if (isSupportedOpCode(node, parent) &&
        (!(opCode.isLoadVarDirect() &&
@@ -3968,7 +3968,7 @@ bool TR_ExceptionCheckMotion::includeRelevantNodes(TR::Node *node, vcount_t visi
       }
 
    TR::ILOpCode &opCode = node->getOpCode();
-   TR::DataTypes nodeDataType = node->getDataType();
+   TR::DataType nodeDataType = node->getDataType();
 
    if (((node->getSideTableIndex() != MAX_SCOUNT) && (node->getSideTableIndex() != 0)) /* && (!opCode.isStore()) */)
       {

--- a/compiler/optimizer/RegisterCandidate.cpp
+++ b/compiler/optimizer/RegisterCandidate.cpp
@@ -218,11 +218,11 @@ TR_RegisterCandidate::getType()
    {
    return getSymbol()->getType();
    }
-TR::DataTypes
+TR::DataType
 TR_RegisterCandidate::getDataType()
    {
    TR::Symbol *rcSymbol = getSymbol();
-   TR::DataTypes dtype = rcSymbol->getDataType();
+   TR::DataType dtype = rcSymbol->getDataType();
 
    return dtype;
    }
@@ -230,7 +230,7 @@ TR_RegisterCandidate::getDataType()
 TR_RegisterKinds
 TR_RegisterCandidate::getRegisterKinds()
   {
-  TR::DataTypes dt = getDataType();
+  TR::DataType dt = getDataType();
   if(dt == TR::Float
      || dt == TR::Double
 #ifdef J9_PROJECT_SPECIFIC
@@ -240,7 +240,7 @@ TR_RegisterCandidate::getRegisterKinds()
 #endif
      )
     return TR_FPR;
-  else if (isVectorType(dt))
+  else if (dt.isVector())
     return TR_VRF;
   else
     return TR_GPR;
@@ -2467,7 +2467,7 @@ TR_RegisterCandidates::assign(TR::Block ** cfgBlocks, int32_t numberOfBlocks, in
                       || rc->getDataType() == TR::DecimalLongDouble
 #endif
                       );
-      bool isVector = isVectorType(rc->getDataType());
+      bool isVector = rc->getDataType().isVector();
       bool needs2Regs = false;
       bool isARCandidate = false;
 
@@ -2679,7 +2679,7 @@ TR_RegisterCandidates::assign(TR::Block ** cfgBlocks, int32_t numberOfBlocks, in
          }
 
       TR::DataType type = rc->getType();
-      TR::DataTypes dt = rc->getDataType();
+      TR::DataType dt = rc->getDataType();
 
       if (type.isInt64() && cg->getDisableLongGRA())
          {
@@ -2712,7 +2712,7 @@ TR_RegisterCandidates::assign(TR::Block ** cfgBlocks, int32_t numberOfBlocks, in
          continue;
          }
 
-      if (isVectorType(dt) && !comp()->cg()->hasGlobalVRF())
+      if (dt.isVector() && !comp()->cg()->hasGlobalVRF())
          {
          if (trace)
             traceMsg(comp(),"Leaving candidate because it has vector type but no global vector registers provided\n");
@@ -2755,7 +2755,7 @@ TR_RegisterCandidates::assign(TR::Block ** cfgBlocks, int32_t numberOfBlocks, in
                       || dt == TR::DecimalLongDouble
 #endif
                       );
-      bool isVector = isVectorType(dt);
+      bool isVector = dt.isVector();
       int32_t firstRegister, lastRegister;
       bool isARCandidate = false;
 

--- a/compiler/optimizer/RegisterCandidate.hpp
+++ b/compiler/optimizer/RegisterCandidate.hpp
@@ -227,7 +227,7 @@ public:
    TR_BitVector &          getBlocksLiveWithinGenSetsOnly() { return _liveWithinGenSetsOnly; }
    TR::Symbol *            getSymbol();
 
-   TR::DataTypes           getDataType();
+   TR::DataType           getDataType();
    TR::DataType            getType();
    bool                    rcNeeds2Regs(TR::Compilation *);
    TR_RegisterKinds        getRegisterKinds();

--- a/compiler/optimizer/StripMiner.cpp
+++ b/compiler/optimizer/StripMiner.cpp
@@ -1767,7 +1767,7 @@ void TR_StripMiner::examineNode(LoopInfo *li, TR::Node *parent, TR::Node *node,
             }
          if (foundArrayAccess)
             {
-            TR::DataTypes type = symbol->getDataType();
+            TR::DataType type = symbol->getDataType();
             intptrj_t dataSize = TR::Symbol::convertTypeToSize(type);
             if (comp()->useCompressedPointers() && (type == TR::Address))
                dataSize = TR::Compiler->om.sizeofReferenceField();

--- a/compiler/optimizer/VPConstraint.cpp
+++ b/compiler/optimizer/VPConstraint.cpp
@@ -561,7 +561,7 @@ TR_VPObjectLocation *TR_VPObjectLocation::getObjectLocation()
    return this;
    }
 
-TR::DataTypes TR_VPClassType::getPrimitiveArrayDataType()
+TR::DataType TR_VPClassType::getPrimitiveArrayDataType()
    {
    if (_sig[0] != '[')
       return TR::NoType;
@@ -1003,7 +1003,7 @@ TR_VPIntConstraint *TR_VPIntRange::create(TR_ValuePropagation *vp, TR::DataTypes
    return TR_VPIntRange::createWithPrecision(vp, dt, VP_UNDEFINED_PRECISION, isUnsigned);
    }
 
-TR_VPIntConstraint *TR_VPIntRange::createWithPrecision(TR_ValuePropagation *vp, TR::DataTypes dt, int32_t precision, TR_YesNoMaybe isUnsigned, bool isNonNegative)
+TR_VPIntConstraint *TR_VPIntRange::createWithPrecision(TR_ValuePropagation *vp, TR::DataType dt, int32_t precision, TR_YesNoMaybe isUnsigned, bool isNonNegative)
    {
    TR_ASSERT(dt > TR::NoType && dt < TR::Int64, "Bad range for datatype in integerLoad constant propagation\n");
 
@@ -1468,7 +1468,7 @@ TR_VPArrayInfo *TR_VPArrayInfo::create(TR_ValuePropagation *vp, int32_t lowBound
 TR_VPArrayInfo *TR_VPArrayInfo::create(TR_ValuePropagation *vp, char *sig)
    {
    TR_ASSERT(*sig == '[', "expecting array signature");
-   TR::DataTypes d = TR::Symbol::convertSigCharToType(sig[1]);
+   TR::DataType d = TR::Symbol::convertSigCharToType(sig[1]);
    int32_t stride;
    if (d == TR::Address)
       stride = TR::Compiler->om.sizeofReferenceField();
@@ -4432,17 +4432,17 @@ TR_VPConstraint *TR_VPEqual::intersect1(TR_VPConstraint *other, TR_ValuePropagat
 
 
 
-TR_VPConstraint *TR_VPConstraint::add(TR_VPConstraint *other, TR::DataTypes type, TR_ValuePropagation *vp)
+TR_VPConstraint *TR_VPConstraint::add(TR_VPConstraint *other, TR::DataType type, TR_ValuePropagation *vp)
    {
    return NULL;
    }
 
-TR_VPConstraint *TR_VPConstraint::subtract(TR_VPConstraint *other, TR::DataTypes type, TR_ValuePropagation *vp)
+TR_VPConstraint *TR_VPConstraint::subtract(TR_VPConstraint *other, TR::DataType type, TR_ValuePropagation *vp)
    {
    return NULL;
    }
 
-TR_VPConstraint *TR_VPShortConstraint::add(TR_VPConstraint *other, TR::DataTypes dt, TR_ValuePropagation *vp)
+TR_VPConstraint *TR_VPShortConstraint::add(TR_VPConstraint *other, TR::DataType dt, TR_ValuePropagation *vp)
    {
     TR_VPShortConstraint *otherShort = other->asShortConstraint();
     if(!otherShort)
@@ -4464,7 +4464,7 @@ TR_VPConstraint *TR_VPShortConstraint::add(TR_VPConstraint *other, TR::DataTypes
    return getRange(low, high, lowOverflow, highOverflow, vp);
    }
 
-TR_VPConstraint *TR_VPIntConstraint::add(TR_VPConstraint *other, TR::DataTypes dt, TR_ValuePropagation *vp)
+TR_VPConstraint *TR_VPIntConstraint::add(TR_VPConstraint *other, TR::DataType dt, TR_ValuePropagation *vp)
    {
    // TODO - handle add and subtract for merged constraints
    //
@@ -4549,7 +4549,7 @@ TR_VPConstraint *TR_VPIntConstraint::add(TR_VPConstraint *other, TR::DataTypes d
 //    return range;
 //    }
 
-TR_VPConstraint *TR_VPShortConstraint::subtract(TR_VPConstraint *other, TR::DataTypes dt, TR_ValuePropagation * vp)
+TR_VPConstraint *TR_VPShortConstraint::subtract(TR_VPConstraint *other, TR::DataType dt, TR_ValuePropagation * vp)
    {
    TR_VPShortConstraint *otherShort = other->asShortConstraint();
 
@@ -4572,7 +4572,7 @@ TR_VPConstraint *TR_VPShortConstraint::subtract(TR_VPConstraint *other, TR::Data
    return getRange(low, high, lowOverflow, highOverflow, vp);
    }
 
-TR_VPConstraint *TR_VPIntConstraint::subtract(TR_VPConstraint *other, TR::DataTypes dt, TR_ValuePropagation *vp)
+TR_VPConstraint *TR_VPIntConstraint::subtract(TR_VPConstraint *other, TR::DataType dt, TR_ValuePropagation *vp)
    {
    TR_VPIntConstraint *otherInt = other->asIntConstraint();
    if (!otherInt)
@@ -4673,7 +4673,7 @@ TR_VPConstraint *TR_VPIntConstraint::getRange(int32_t low, int32_t high, bool lo
    return TR_VPIntRange::create(vp, low, high, TR_no);
    }
 
-TR_VPConstraint *TR_VPLongConstraint::add(TR_VPConstraint *other, TR::DataTypes dt, TR_ValuePropagation *vp)
+TR_VPConstraint *TR_VPLongConstraint::add(TR_VPConstraint *other, TR::DataType dt, TR_ValuePropagation *vp)
    {
    // TODO - handle add and subtract for merged constraints
    //
@@ -4696,7 +4696,7 @@ TR_VPConstraint *TR_VPLongConstraint::add(TR_VPConstraint *other, TR::DataTypes 
    return getRange(low, high, lowOverflow, highOverflow, vp);
    }
 
-TR_VPConstraint *TR_VPLongConstraint::subtract(TR_VPConstraint *other, TR::DataTypes dt, TR_ValuePropagation *vp)
+TR_VPConstraint *TR_VPLongConstraint::subtract(TR_VPConstraint *other, TR::DataType dt, TR_ValuePropagation *vp)
    {
    TR_VPLongConstraint *otherLong = other->asLongConstraint();
    if (!otherLong)

--- a/compiler/optimizer/VPConstraint.hpp
+++ b/compiler/optimizer/VPConstraint.hpp
@@ -115,8 +115,8 @@ class TR_VPConstraint
 
    // Arithmetic operations
    //
-   virtual TR_VPConstraint *add(TR_VPConstraint *other, TR::DataTypes type, TR_ValuePropagation *vp);
-   virtual TR_VPConstraint *subtract(TR_VPConstraint *other, TR::DataTypes type, TR_ValuePropagation *vp);
+   virtual TR_VPConstraint *add(TR_VPConstraint *other, TR::DataType type, TR_ValuePropagation *vp);
+   virtual TR_VPConstraint *subtract(TR_VPConstraint *other, TR::DataType type, TR_ValuePropagation *vp);
    virtual TR_YesNoMaybe canOverflow();
    virtual void setCanOverflow(TR_YesNoMaybe v) {}
 
@@ -330,8 +330,8 @@ class TR_VPShortConstraint: public TR_VPConstraint
    virtual bool mustBeLessThan (TR_VPConstraint * other, TR_ValuePropagation *vp);
    virtual bool mustBeLessThanOrEqual (TR_VPConstraint * other, TR_ValuePropagation *vp);
 
-   virtual TR_VPConstraint *add(TR_VPConstraint * other, TR::DataTypes type, TR_ValuePropagation *vp);
-   virtual TR_VPConstraint *subtract(TR_VPConstraint *other, TR::DataTypes type, TR_ValuePropagation * vp);
+   virtual TR_VPConstraint *add(TR_VPConstraint * other, TR::DataType type, TR_ValuePropagation *vp);
+   virtual TR_VPConstraint *subtract(TR_VPConstraint *other, TR::DataType type, TR_ValuePropagation * vp);
 
    virtual TR_YesNoMaybe canOverflow() {return _overflow;}
    virtual void setCanOverflow(TR_YesNoMaybe v) {_overflow = v;}
@@ -405,8 +405,8 @@ class TR_VPIntConstraint : public TR_VPConstraint
    virtual bool mustBeLessThan(TR_VPConstraint *other, TR_ValuePropagation *vp);
    virtual bool mustBeLessThanOrEqual(TR_VPConstraint *other, TR_ValuePropagation *vp);
 
-   virtual TR_VPConstraint *add(TR_VPConstraint *other, TR::DataTypes type, TR_ValuePropagation *vp);
-   virtual TR_VPConstraint *subtract(TR_VPConstraint *other, TR::DataTypes type, TR_ValuePropagation *vp);
+   virtual TR_VPConstraint *add(TR_VPConstraint *other, TR::DataType type, TR_ValuePropagation *vp);
+   virtual TR_VPConstraint *subtract(TR_VPConstraint *other, TR::DataType type, TR_ValuePropagation *vp);
    // unsigned add
    //TR_VPConstraint *add(TR_VPIntConstraint *other, TR_ValuePropagation *vp, bool isUnsigned);
    // unsigned subtract
@@ -449,8 +449,8 @@ class TR_VPIntRange : public TR_VPIntConstraint
    TR_VPIntRange(int32_t low, int32_t high) : TR_VPIntConstraint(low), _high(high) {}
    //static TR_VPIntConstraint *create(TR_ValuePropagation *vp, int32_t low, int32_t high);
    static TR_VPIntConstraint *create(TR_ValuePropagation *vp, int32_t low, int32_t high, TR_YesNoMaybe canOverflow = TR_no);
-   static TR_VPIntConstraint *create(TR_ValuePropagation *vp, TR::DataTypes dt, TR_YesNoMaybe isUnsigned);
-   static TR_VPIntConstraint *createWithPrecision(TR_ValuePropagation *vp, TR::DataTypes dt, int32_t precision, TR_YesNoMaybe isUnsigned, bool isNonNegative = false);
+   static TR_VPIntConstraint *create(TR_ValuePropagation *vp, TR::DataTypes dt, TR_YesNoMaybe isUnsigned); // Takes a TR::DataTypes instead of TR::DataType to work around ambiguous overloads
+   static TR_VPIntConstraint *createWithPrecision(TR_ValuePropagation *vp, TR::DataType dt, int32_t precision, TR_YesNoMaybe isUnsigned, bool isNonNegative = false);
    virtual TR_VPIntRange *asIntRange();
    virtual int32_t getHigh() {return _high;}
 
@@ -483,8 +483,8 @@ class TR_VPLongConstraint : public TR_VPConstraint
    virtual bool mustBeLessThan(TR_VPConstraint *other, TR_ValuePropagation *vp);
    virtual bool mustBeLessThanOrEqual(TR_VPConstraint *other, TR_ValuePropagation *vp);
 
-   virtual TR_VPConstraint *add(TR_VPConstraint *other, TR::DataTypes type, TR_ValuePropagation *vp);
-   virtual TR_VPConstraint *subtract(TR_VPConstraint *other, TR::DataTypes type, TR_ValuePropagation *vp);
+   virtual TR_VPConstraint *add(TR_VPConstraint *other, TR::DataType type, TR_ValuePropagation *vp);
+   virtual TR_VPConstraint *subtract(TR_VPConstraint *other, TR::DataType type, TR_ValuePropagation *vp);
 
    virtual TR_YesNoMaybe canOverflow() {return _overflow;}
    virtual void setCanOverflow(TR_YesNoMaybe v) {_overflow = v;}
@@ -606,7 +606,7 @@ class TR_VPClassType : public TR_VPConstraint
    virtual bool isCloneableOrSerializable();
 
 
-   TR::DataTypes getPrimitiveArrayDataType();
+   TR::DataType getPrimitiveArrayDataType();
 
    virtual TR_YesNoMaybe isClassObject();
    virtual TR_YesNoMaybe isJavaLangClassObject();

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -482,7 +482,7 @@ static bool findConstant(TR_ValuePropagation *vp, TR::Node *node)
    TR_VPConstraint *constraint = vp->getConstraint(node, isGlobal);
    if (constraint)
       {
-      TR::DataTypes type = node->getDataType();
+      TR::DataType type = node->getDataType();
       switch (type)
          {
          case TR::Int64:
@@ -1074,7 +1074,7 @@ TR::Node *constrainBCDAggrLoad(TR_ValuePropagation *vp, TR::Node *node)
 
 TR::Node *constrainAnyIntLoad(TR_ValuePropagation *vp, TR::Node *node)
    {
-   TR::DataTypes dataType = node->getDataType();
+   TR::DataType dataType = node->getDataType();
 
    // Optimize characters being loaded out of the values array of a constant string
    //
@@ -1513,7 +1513,7 @@ TR::Node *constrainAload(TR_ValuePropagation *vp, TR::Node *node)
             if (sym->isStatic() && sym->isFinal())
                {
                TR::StaticSymbol * symbol = sym->castToStaticSymbol();
-               TR::DataTypes type = symbol->getDataType();
+               TR::DataType type = symbol->getDataType();
                TR_OpaqueClassBlock * classOfStatic = symRef->getOwningMethod(vp->comp())->classOfStatic(symRef->getCPIndex());
                if (classOfStatic == NULL)
                   {
@@ -2281,7 +2281,7 @@ TR::Node *constrainIaload(TR_ValuePropagation *vp, TR::Node *node)
             if (sym->isStatic() && sym->isFinal())
                {
                TR::StaticSymbol * symbol = sym->castToStaticSymbol();
-               TR::DataTypes type = symbol->getDataType();
+               TR::DataType type = symbol->getDataType();
                TR_OpaqueClassBlock * classOfStatic = symRef->getOwningMethod(vp->comp())->classOfStatic(symRef->getCPIndex());
                bool isClassInitialized = false;
                TR_PersistentClassInfo * classInfo =
@@ -5174,7 +5174,7 @@ TR::Node *constrainCall(TR_ValuePropagation *vp, TR::Node *node)
       TR_Method *method = node->getSymbol()->castToMethodSymbol()->getMethod();
       if (method)
          {
-         TR::DataTypes dataType = method->returnType();
+         TR::DataType dataType = method->returnType();
 
          if (dataType == TR::Int8 || dataType == TR::Int16 || dataType == TR::Int32 || dataType == TR::Int64)
             {
@@ -8263,7 +8263,7 @@ void replaceWithSmallerType(TR_ValuePropagation *vp, TR::Node *node)
       return;
       }
 
-   TR::DataTypes newType = node->getDataType();
+   TR::DataType newType = node->getDataType();
    TR::Node *load = node->getFirstChild();
 
    TR::Compilation *comp = vp->comp();
@@ -12669,7 +12669,7 @@ TR::Node *constrainArraycopy(TR_ValuePropagation *vp, TR::Node *node)
       TR_VPConstraint *dst = vp->getConstraint(dstObjNode, isGlobal);
       TR_VPClassType *srcType = src ? src->getClassType() : NULL;
       TR_VPClassType *dstType = dst ? dst->getClassType() : NULL;
-      TR::DataTypes elementType = TR::NoType;
+      TR::DataType elementType = TR::NoType;
       if (srcType && srcType->isPrimitiveArray(vp->comp()))
          elementType = srcType->getPrimitiveArrayDataType();
       else if (dstType && dstType->isPrimitiveArray(vp->comp()))

--- a/compiler/optimizer/ValuePropagation.cpp
+++ b/compiler/optimizer/ValuePropagation.cpp
@@ -2722,7 +2722,7 @@ void TR_ValuePropagation::replaceByConstant(TR::Node *node, TR_VPConstraint *con
    invalidateValueNumberInfo();
    invalidateUseDefInfo();
 
-   TR::DataTypes type = node->getDataType();
+   TR::DataType type = node->getDataType();
    TR_VPConstraint * shortConstraint = constraint->asShortConstraint();
    switch (type)
       {
@@ -3943,7 +3943,7 @@ void TR_ValuePropagation::getParmValues()
    for ( ; p; p = parms.getNext())
       {
       TR_ASSERT(!parmIterator->atEnd(), "Ran out of parameters unexpectedly.");
-      TR::DataTypes dataType = parmIterator->getDataType();
+      TR::DataType dataType = parmIterator->getDataType();
       if ((dataType == TR::Int8 || dataType == TR::Int16)
           && comp()->getOption(TR_AllowVPRangeNarrowingBasedOnDeclaredType))
          {
@@ -8068,7 +8068,7 @@ void TR_ValuePropagation::doDelayedTransformations()
 
      if (!recognizedStatic)
         {
-        TR::DataTypes dataType = origFirst->getDataType();
+        TR::DataType dataType = origFirst->getDataType();
         TR::SymbolReference *newSymbolReference = comp()->getSymRefTab()->createTemporary(comp()->getMethodSymbol(), dataType, false, 0);
 
         TR::Node *astoreNode = TR::Node::createWithSymRef(TR::astore, 1, 1, ifNode->getFirstChild(), newSymbolReference);

--- a/compiler/optimizer/ValuePropagation.hpp
+++ b/compiler/optimizer/ValuePropagation.hpp
@@ -107,7 +107,7 @@ class TR_ArraycopyTransformation : public TR::Optimization
    int64_t arraycopyHighFrequencySpecificLength(TR::Node* byteLenNode);
    TR::TreeTop* createPointerCompareNode(TR::Node* node, TR::SymbolReference* srcRef, TR::SymbolReference* dstRef);
    TR::TreeTop* createRangeCompareNode(TR::Node* node, TR::SymbolReference* srcRef, TR::SymbolReference* dstRef, TR::SymbolReference* lenRef);
-//   int shiftAmount(TR::DataTypes type, TR::Node* node);
+//   int shiftAmount(TR::DataType type, TR::Node* node);
 
    TR::TreeTop* createMultipleArrayNodes(TR::TreeTop* arrayTreeTop, TR::Node* node);
    TR::TreeTop* tryToSpecializeForLength(TR::TreeTop *tt, TR::Node *arraycopyNode);
@@ -522,7 +522,7 @@ class TR_ValuePropagation : public TR::Optimization
    void mustTakeException();
    void processTrees(TR::TreeTop *startTree, TR::TreeTop *endTree);
    void transformArrayCopyCall(TR::Node *node);
-   bool canTransformArrayCopyCallForSmall(TR::Node *node, int32_t &srcLength, int32_t &dstLength, int32_t &stride, TR::DataTypes &type );
+   bool canTransformArrayCopyCallForSmall(TR::Node *node, int32_t &srcLength, int32_t &dstLength, int32_t &stride, TR::DataType &type );
    int32_t getPrimitiveArrayType(char primitiveArrayChar);
 
    bool canRunTransformToArrayCopy();
@@ -600,13 +600,13 @@ class TR_ValuePropagation : public TR::Optimization
       {
       TR_ALLOC(TR_Memory::ValuePropagation)
 
-      TR_RealTimeArrayCopy(TR::TreeTop *vcall, TR::DataTypes type, uint8_t b)
+      TR_RealTimeArrayCopy(TR::TreeTop *vcall, TR::DataType type, uint8_t b)
          : _treetop(vcall), _flag(b), _type(type)
          {}
 
       TR::TreeTop  *_treetop;
       uint8_t      _flag;
-      TR::DataTypes _type;
+      TR::DataType _type;
       };
 
    struct TR_ArrayCopySpineCheck
@@ -947,12 +947,12 @@ class TR_ValuePropagation : public TR::Optimization
  #if (defined(LINUX) && ( defined(TR_TARGET_X86) || defined(TR_TARGET_S390)))
   #if __GNUC__ > 4 || \
    (__GNUC__ == 4 && __GNUC_MINOR__ >= 4)
-   TR_VP_BCDSign **getBCDSignConstraints(TR::DataTypes dt) __attribute__((optimize(1)));
+   TR_VP_BCDSign **getBCDSignConstraints(TR::DataType dt) __attribute__((optimize(1)));
   #else
-   TR_VP_BCDSign **getBCDSignConstraints(TR::DataTypes dt);
+   TR_VP_BCDSign **getBCDSignConstraints(TR::DataType dt);
   #endif
  #else
-   TR_VP_BCDSign **getBCDSignConstraints(TR::DataTypes dt);
+   TR_VP_BCDSign **getBCDSignConstraints(TR::DataType dt);
  #endif
    TR_UseDefInfo      *_useDefInfo;      // Cached use/def info
    TR_ValueNumberInfo *_valueNumberInfo; // Cached value number info
@@ -1098,7 +1098,7 @@ class TR_LocalValuePropagation : public TR_ValuePropagation
    TR::TreeTop *processBlock(TR::TreeTop *start);
    };
 
-TR::Node *generateArrayletAddressTree(TR::Compilation* comp, TR::Node *vcallNode, TR::DataTypes type, TR::Node *off,TR::Node *obj, TR::Node *spineShiftNode,TR::Node *shiftNode,TR::Node *strideShiftNode, TR::Node *hdrSize);
+TR::Node *generateArrayletAddressTree(TR::Compilation* comp, TR::Node *vcallNode, TR::DataType type, TR::Node *off,TR::Node *obj, TR::Node *spineShiftNode,TR::Node *shiftNode,TR::Node *strideShiftNode, TR::Node *hdrSize);
 TR::Node *generateArrayAddressTree(TR::Compilation* comp, TR::Node *node, int32_t offHigh, TR::Node *offNode, TR::Node *objNode, int32_t elementSize, TR::Node * &stride, TR::Node *hdrSize);
 TR::Node * createHdrSizeNode(TR::Compilation *comp, TR::Node *n);
 

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -700,7 +700,7 @@ int32_t TR_ValuePropagation::getPrimitiveArrayType(char primitiveArrayChar)
       }
    }
 
-bool TR_ValuePropagation::canTransformArrayCopyCallForSmall(TR::Node *node, int32_t &srcLength, int32_t &dstLength, int32_t &elementSize, TR::DataTypes &type )
+bool TR_ValuePropagation::canTransformArrayCopyCallForSmall(TR::Node *node, int32_t &srcLength, int32_t &dstLength, int32_t &elementSize, TR::DataType &type )
    {
    TR::Node *srcArrayNode = node->getFirstChild();
    TR::Node *srcOffsetNode = node->getSecondChild();
@@ -711,7 +711,7 @@ bool TR_ValuePropagation::canTransformArrayCopyCallForSmall(TR::Node *node, int3
    int32_t srcSigLength, srcType;
    int32_t dstSigLength, dstType;
    static uint8_t primitiveArrayTypeToElementSize[] = {1, 2, 4, 8, 1, 2, 4, 8};
-   static TR::DataTypes primitiveArrayToTRDataType[] = {TR::Int8, TR::Int16, TR::Float, TR::Double, TR::Int8, TR::Int16, TR::Int32, TR::Int64};
+   static TR::DataType primitiveArrayToTRDataType[] = {TR::Int8, TR::Int16, TR::Float, TR::Double, TR::Int8, TR::Int16, TR::Int32, TR::Int64};
 
    const char *srcSig = srcArrayNode->getTypeSignature(srcSigLength);
    const char *dstSig = dstArrayNode->getTypeSignature(dstSigLength);
@@ -1057,7 +1057,7 @@ void TR_ValuePropagation::transformArrayCopyCall(TR::Node *node)
    int32_t dstLength = -1;
    int32_t elementSize = 0;
    int32_t arraySpineShift = 0;
-   TR::DataTypes type = TR::NoType;
+   TR::DataType type = TR::NoType;
 
    bool transformTheCall = false;
    bool primitiveArray1 = false;
@@ -1903,7 +1903,7 @@ void TR_ValuePropagation::transformArrayCopyCall(TR::Node *node)
          else if (srcArrayInfo)
             {
              // Default to NoType to prevent puting garbage in element datatype
-            TR::DataTypes newType = TR::NoType;
+            TR::DataType newType = TR::NoType;
             // Java spec says arraycopies need to be atomic for the element size
             // So we need to make sure we set the element datatype appropriately to enforce that
             switch (srcArrayInfo->elementSize())
@@ -2561,7 +2561,7 @@ TR::TreeTop *TR_ValuePropagation::buildSameLeafTest(TR::Node *offset,TR::Node *l
    }
 
 
-TR::Node *generateArrayletAddressTree(TR::Compilation* comp, TR::Node *vcallNode, TR::DataTypes type, TR::Node *off,TR::Node *obj, TR::Node *spineShiftNode,TR::Node *shiftNode, TR::Node *strideShiftNode, TR::Node *hdrSize)
+TR::Node *generateArrayletAddressTree(TR::Compilation* comp, TR::Node *vcallNode, TR::DataType type, TR::Node *off,TR::Node *obj, TR::Node *spineShiftNode,TR::Node *shiftNode, TR::Node *strideShiftNode, TR::Node *hdrSize)
    {
    bool is64BitTarget = TR::Compiler->target.is64Bit() ? true : false;
 
@@ -2603,7 +2603,7 @@ TR::Node *generateArrayletAddressTree(TR::Compilation* comp, TR::Node *vcallNode
 
 void TR_ValuePropagation::generateRTArrayNodeWithoutFlags(TR_RealTimeArrayCopy *rtArrayCopy,TR::TreeTop *dupArraycopyTree, TR::SymbolReference *srcRef, TR::SymbolReference *dstRef, TR::SymbolReference *srcOffRef, TR::SymbolReference *dstOffRef, TR::SymbolReference *lenRef, bool primitive)
    {
-   TR::DataTypes type = rtArrayCopy->_type;
+   TR::DataType type = rtArrayCopy->_type;
    uint32_t elementSize = TR::Symbol::convertTypeToSize(type);
    if (comp()->useCompressedPointers() && (type == TR::Address))
       elementSize = TR::Compiler->om.sizeofReferenceField();
@@ -3047,7 +3047,7 @@ void TR_ValuePropagation::transformRealTimeArrayCopy(TR_RealTimeArrayCopy *rtArr
       return;
 
    TR::Block *origCallBlock = rtArrayCopyTree->_treetop->getEnclosingBlock();
-   TR::DataTypes type = rtArrayCopyTree->_type;
+   TR::DataType type = rtArrayCopyTree->_type;
    uint32_t elementSize = TR::Symbol::convertTypeToSize(type);
    if (comp()->useCompressedPointers() && (type == TR::Address))
       elementSize = TR::Compiler->om.sizeofReferenceField();
@@ -3370,7 +3370,7 @@ void TR_ValuePropagation::transformRTMultiLeafArrayCopy(TR_RealTimeArrayCopy *rt
       traceMsg(comp(), "Transforming multi-leaf array copy: %p\n", vcallNode);
 
    TR::TreeTop *prevTree = vcallTree->getPrevTreeTop();
-   TR::DataTypes type = rtArrayCopyTree->_type;
+   TR::DataType type = rtArrayCopyTree->_type;
    intptrj_t elementSize = TR::Symbol::convertTypeToSize(type);
    intptrj_t leafSize = comp()->fe()->getArrayletMask(elementSize) + 1;
 

--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -4081,7 +4081,7 @@ static bool virtualGuardHelper(TR::Node *node, TR::CodeGenerator *cg)
 static TR::Register *generateMaxMin(TR::Node *node, TR::CodeGenerator *cg, bool max)
    {
    TR::Node *child  = node->getFirstChild();
-   TR::DataTypes data_type = child->getDataType();
+   TR::DataType data_type = child->getDataType();
    TR::DataType type = child->getType();
    TR::InstOpCode::Mnemonic move_op = type.isIntegral() ? TR::InstOpCode::mr : TR::InstOpCode::fmr;
    TR::InstOpCode::Mnemonic cmp_op;

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -2409,7 +2409,7 @@ void OMR::Power::CodeGenerator::buildRegisterMapForInstruction(TR_GCStackMap *ma
    }
 
 
-int32_t OMR::Power::CodeGenerator::findOrCreateFloatConstant(void *v, TR::DataTypes t,
+int32_t OMR::Power::CodeGenerator::findOrCreateFloatConstant(void *v, TR::DataType t,
                              TR::Instruction *n0, TR::Instruction *n1,
                              TR::Instruction *n2, TR::Instruction *n3)
    {
@@ -2418,7 +2418,7 @@ int32_t OMR::Power::CodeGenerator::findOrCreateFloatConstant(void *v, TR::DataTy
    return(_constantData->addConstantRequest(v, t, n0, n1, n2, n3, NULL, false));
    }
 
-int32_t OMR::Power::CodeGenerator::findOrCreateAddressConstant(void *v, TR::DataTypes t,
+int32_t OMR::Power::CodeGenerator::findOrCreateAddressConstant(void *v, TR::DataType t,
                              TR::Instruction *n0, TR::Instruction *n1,
                              TR::Instruction *n2, TR::Instruction *n3,
                              TR::Node *node, bool isUnloadablePicSite)
@@ -2634,7 +2634,7 @@ TR_GlobalRegisterNumber OMR::Power::CodeGenerator::pickRegister(TR_RegisterCandi
    bool gprCandidate = true;
    if ((sym->getDataType() == TR::Float) ||
        (sym->getDataType() == TR::Double) ||
-       isVectorType(sym->getDataType()))
+       sym->getDataType().isVector())
       gprCandidate = false;
 
    if (gprCandidate)
@@ -2692,7 +2692,7 @@ TR_GlobalRegisterNumber OMR::Power::CodeGenerator::pickRegister(TR_RegisterCandi
             bool gprCandidate = true;
             if ((prev->getSymbol()->getDataType() == TR::Float) ||
                 (prev->getSymbol()->getDataType() == TR::Double) ||
-                isVectorType(sym->getDataType()))
+                sym->getDataType().isVector())
                gprCandidate = false;
             if (gprCandidate && prev->getBlocksLiveOnEntry().get(liveBlockNum))
                {
@@ -2854,7 +2854,7 @@ int32_t OMR::Power::CodeGenerator::getMaximumNumberOfFPRsAllowedAcrossEdge(TR::N
    return 32; // pickRegister will ensure that the number of free registers isn't exceeded
    }
 
-TR_GlobalRegisterNumber OMR::Power::CodeGenerator::getLinkageGlobalRegisterNumber(int8_t linkageRegisterIndex, TR::DataTypes type)
+TR_GlobalRegisterNumber OMR::Power::CodeGenerator::getLinkageGlobalRegisterNumber(int8_t linkageRegisterIndex, TR::DataType type)
    {
    TR_GlobalRegisterNumber result;
    if (type == TR::Float || type == TR::Double)
@@ -2864,7 +2864,7 @@ TR_GlobalRegisterNumber OMR::Power::CodeGenerator::getLinkageGlobalRegisterNumbe
       else
          result = _fprLinkageGlobalRegisterNumbers[linkageRegisterIndex];
       }
-   else if (isVectorType(type))
+   else if (type.isVector())
       TR_ASSERT(false, "assertion failure");    // TODO
    else
       {
@@ -3459,7 +3459,7 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
    }
 
 
-bool OMR::Power::CodeGenerator::isGlobalRegisterAvailable(TR_GlobalRegisterNumber i, TR::DataTypes dt)
+bool OMR::Power::CodeGenerator::isGlobalRegisterAvailable(TR_GlobalRegisterNumber i, TR::DataType dt)
    {
    return self()->machine()->getPPCRealRegister((TR::RealRegister::RegNum)self()->getGlobalRegister(i))->getState() == TR::RealRegister::Free;
    }
@@ -3516,7 +3516,7 @@ OMR::Power::CodeGenerator::freeAndResetTransientLongs()
 
 
 
-bool OMR::Power::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR::DataTypes dt)
+bool OMR::Power::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR::DataType dt)
    {
 
    // alignment issues

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -204,10 +204,10 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    int32_t maxPositiveDisplacement() { return UPPER_IMMED; }
    int32_t maxNegativeDisplacement() { return LOWER_IMMED; }
 
-   int32_t findOrCreateFloatConstant(void *v, TR::DataTypes t,
+   int32_t findOrCreateFloatConstant(void *v, TR::DataType t,
                   TR::Instruction *n0, TR::Instruction *n1,
                   TR::Instruction *n2, TR::Instruction *n3);
-   int32_t findOrCreateAddressConstant(void *v, TR::DataTypes t,
+   int32_t findOrCreateAddressConstant(void *v, TR::DataType t,
                   TR::Instruction *n0, TR::Instruction *n1,
                   TR::Instruction *n2, TR::Instruction *n3,
                   TR::Node *node, bool isUnloadablePicSite);
@@ -271,7 +271,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
       return false;
       }
 
-   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataTypes);
+   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataType);
 
    bool getSupportsEncodeUtf16LittleWithSurrogateTest();
 
@@ -385,13 +385,13 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    using OMR::CodeGenerator::getMaximumNumberOfGPRsAllowedAcrossEdge;
    int32_t getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Node *);
    int32_t getMaximumNumberOfFPRsAllowedAcrossEdge(TR::Node *);
-   bool isGlobalRegisterAvailable(TR_GlobalRegisterNumber i, TR::DataTypes dt);
+   bool isGlobalRegisterAvailable(TR_GlobalRegisterNumber i, TR::DataType dt);
 
    TR_BitVector _globalRegisterBitVectors[TR_numSpillKinds];
    virtual TR_BitVector *getGlobalRegisters(TR_SpillKinds kind, TR_LinkageConventions lc){ return &_globalRegisterBitVectors[kind]; }
 
    TR_GlobalRegisterNumber _gprLinkageGlobalRegisterNumbers[TR::RealRegister::NumRegisters], _fprLinkageGlobalRegisterNumbers[TR::RealRegister::NumRegisters]; // these could be smaller
-   TR_GlobalRegisterNumber getLinkageGlobalRegisterNumber(int8_t linkageRegisterIndex, TR::DataTypes type);
+   TR_GlobalRegisterNumber getLinkageGlobalRegisterNumber(int8_t linkageRegisterIndex, TR::DataType type);
 
    virtual void simulateNodeEvaluation(TR::Node *node, TR_RegisterPressureState *state, TR_RegisterPressureSummary *summary);
 

--- a/compiler/p/codegen/OMRConstantDataSnippet.cpp
+++ b/compiler/p/codegen/OMRConstantDataSnippet.cpp
@@ -35,7 +35,7 @@
 #include "runtime/Runtime.hpp"
 
 int32_t OMR::ConstantDataSnippet::addConstantRequest(void              *v,
-                                                  TR::DataTypes       type,
+                                                  TR::DataType       type,
                                                   TR::Instruction *nibble0,
                                                   TR::Instruction *nibble1,
                                                   TR::Instruction *nibble2,

--- a/compiler/p/codegen/OMRConstantDataSnippet.hpp
+++ b/compiler/p/codegen/OMRConstantDataSnippet.hpp
@@ -108,7 +108,7 @@ class ConstantDataSnippet
    uint8_t *setSnippetBinaryStart(uint8_t *p) {return _snippetBinaryStart=p;}
 
    int32_t addConstantRequest(void              *v,
-                           TR::DataTypes       type,
+                           TR::DataType       type,
                            TR::Instruction *nibble0,
                            TR::Instruction *nibble1,
                            TR::Instruction *nibble2,

--- a/compiler/p/codegen/OMRLinkage.cpp
+++ b/compiler/p/codegen/OMRLinkage.cpp
@@ -796,7 +796,7 @@ OMR::Power::Linkage::numArgumentRegisters(TR_RegisterKinds kind)
       }
    }
 
-TR_ReturnInfo OMR::Power::Linkage::getReturnInfoFromReturnType(TR::DataTypes returnType)
+TR_ReturnInfo OMR::Power::Linkage::getReturnInfoFromReturnType(TR::DataType returnType)
    {
    switch (returnType)
       {

--- a/compiler/p/codegen/OMRLinkage.hpp
+++ b/compiler/p/codegen/OMRLinkage.hpp
@@ -438,7 +438,7 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
    //
    virtual uintptr_t calculateParameterRegisterOffset(uintptr_t o, TR::ParameterSymbol& p) { return o; }
 
-   TR_ReturnInfo getReturnInfoFromReturnType(TR::DataTypes);
+   TR_ReturnInfo getReturnInfoFromReturnType(TR::DataType);
 
 protected:
 

--- a/compiler/p/codegen/PPCSystemLinkage.cpp
+++ b/compiler/p/codegen/PPCSystemLinkage.cpp
@@ -982,12 +982,12 @@ int32_t TR_PPCSystemLinkage::buildArgs(TR::Node *callNode,
    for (i = firstArgumentChild; i < callNode->getNumChildren(); i++)
       {
       TR::MemoryReference *mref=NULL;
-      TR::Register           *argRegister;
-      bool                   checkSplit = true;
-      TR::DataTypes           childType;
+      TR::Register        *argRegister;
+      bool                 checkSplit = true;
 
       child = callNode->getChild(i);
-      childType = child->getDataType();
+      TR::DataType childType = child->getDataType();
+
       switch (childType)
          {
          case TR::Int8:

--- a/compiler/p/codegen/TreeEvaluatorVMX.cpp
+++ b/compiler/p/codegen/TreeEvaluatorVMX.cpp
@@ -229,7 +229,7 @@ TR::Register *OMR::Power::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
    TR::Node *fillNode = node->getSecondChild();
    TR::Node *lenNode = node->getChild(2);
    uint32_t fillNodeSize = fillNode->getSize();
-   TR::DataTypes fillNodeType = fillNode->getDataType();
+   TR::DataType fillNodeType = fillNode->getDataType();
    bool constLength = lenNode->getOpCode().isLoadConst();
    int32_t length = constLength ? lenNode->getInt() : 0;
    bool constFill = fillNode->getOpCode().isLoadConst();
@@ -894,7 +894,7 @@ static void arraysetConstLen(TR::Node *node, TR::Node *addrNode, TR::Node *elemN
    TR::Register *elemReg;
    int elemSize = getElementSize(elemNode, cg);
    int elemIsConst = elemNode->getOpCode().isLoadConst();
-   TR::DataTypes data_type = elemNode->getDataType();
+   TR::DataType data_type = elemNode->getDataType();
    TR::DataType type = elemNode->getType();
    if (data_type == TR::Address)
       data_type = TR::Compiler->target.is64Bit() ? TR_SInt64 : TR_SInt32;
@@ -1132,7 +1132,7 @@ static void arraysetConstElemAlign8(TR::Node *node, TR::Node *addrNode, TR::Node
    TR::Register *fp2Reg = cg->allocateRegister(TR_FPR);
    TR::Register *constBaseReg = cg->allocateRegister(TR_GPR);
 
-   TR::DataTypes data_type = elemNode->getDataType();
+   TR::DataType data_type = elemNode->getDataType();
    TR::DataType type = elemNode->getType();
    if (data_type == TR::Address)
       data_type = TR::Compiler->target.is64Bit() ? TR_SInt64 : TR_SInt32;
@@ -1352,7 +1352,7 @@ static void arraysetGeneric(TR::Node *node, TR::Node *addrNode, TR::Node *elemNo
    TR::Register *cndReg = cg->allocateRegister(TR_CCR);
    TR::Register *tmpReg=cg->allocateRegister();
 
-   TR::DataTypes data_type = elemNode->getDataType();
+   TR::DataType data_type = elemNode->getDataType();
    TR::DataType type = elemNode->getType();
    if (data_type == TR::Address)
       data_type = TR::Compiler->target.is64Bit() ? TR_SInt64 : TR_SInt32;
@@ -6823,7 +6823,7 @@ static int arraycmpEstimateElementSize(TR::Node *lenNode, TR::CodeGenerator *cg)
 static int getElementSize(TR::Node *elemNode, TR::CodeGenerator *cg)
    {
    int sz;
-   TR::DataTypes data_type = elemNode->getDataType();
+   TR::DataType data_type = elemNode->getDataType();
    if (data_type == TR::Address)
       data_type = TR::Compiler->target.is64Bit() ? TR_SInt64 : TR_SInt32;
    switch (data_type)

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -437,7 +437,7 @@ public:
 
    virtual const char * getName(TR::ILOpCode);
    virtual const char * getName(TR::ILOpCodes);
-   virtual const char * getName(TR::DataTypes);
+   virtual const char * getName(TR::DataType);
    virtual const char * getName(TR_RawBCDSignCode);
    virtual const char * getName(TR::LabelSymbol *);
    virtual const char * getName(TR::SymbolReference *);

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -1755,7 +1755,7 @@ TR_Debug::printNodeInfo(TR::Node * node, TR_PrettyPrinterString& output, bool pr
       bool isParentGlRegDep = getCurrentParent() ? (getCurrentParent()->getOpCodeValue() == TR::GlRegDeps) : false;
       if (isParentGlRegDep)
          {
-         TR::DataTypes t = node->getDataType();
+         TR::DataType t = node->getDataType();
          // This is a half-hearted attempt at getting better register sizes, I know
          TR_RegisterSizes size;
          if (t == TR::Int8)       size = TR_ByteReg;
@@ -2292,7 +2292,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_VPConstraint *info)
    }
 
 const char *
-TR_Debug::getName(TR::DataTypes type)
+TR_Debug::getName(TR::DataType type)
    {
    return TR::DataType::getName(type);
    }
@@ -3671,7 +3671,7 @@ TR_Debug::verifyTreesPass1(TR::Node *node)
             // Temporarily allow known cases to succeed
             //
             TR::ILOpCodes conversionOp = TR::BadILOp;
-            TR::DataTypes childType = child->getDataType();
+            TR::DataType childType = child->getDataType();
             if (childType != expectedType &&
                 childType != TR::NoType &&
                 !((node->getOpCodeValue() == TR::imul || node->getOpCodeValue() == TR::ishl) && child->getOpCodeValue() == TR::loadaddr))
@@ -3679,11 +3679,11 @@ TR_Debug::verifyTreesPass1(TR::Node *node)
                if (getFile() != NULL)
                   {
                   trfprintf(getFile(),
-                                "TREE VERIFICATION ERROR -- node [%s] has wrong type for child [%s] (%s), expected %s\n",
-                                getName(node),
-                                getName(child),
-                                getName(childType),
-                                getName((TR::DataTypes)expectedType));
+                            "TREE VERIFICATION ERROR -- node [%s] has wrong type for child [%s] (%s), expected %s\n",
+                            getName(node),
+                            getName(child),
+                            getName(childType),
+                            getName((TR::DataTypes)expectedType));
                   }
                TR_ASSERT( debug("fixTrees"), "Tree verification error");
                }

--- a/compiler/x/amd64/codegen/AMD64SystemLinkage.cpp
+++ b/compiler/x/amd64/codegen/AMD64SystemLinkage.cpp
@@ -908,7 +908,7 @@ static const TR::RealRegister::RegNum NOT_ASSIGNED = (TR::RealRegister::RegNum)-
 
 
 uint32_t
-TR_AMD64SystemLinkage::getAlignment(TR::DataTypes type)
+TR_AMD64SystemLinkage::getAlignment(TR::DataType type)
    {
    switch(type)
       {
@@ -989,7 +989,7 @@ TR_AMD64ABILinkage::mapIncomingParms(
 
 bool
 TR_AMD64SystemLinkage::layoutTypeInRegs(
-      TR::DataTypes type,
+      TR::DataType type,
       uint16_t &intArgs,
       uint16_t &floatArgs,
       parmLayoutResult &layoutResult)

--- a/compiler/x/amd64/codegen/AMD64SystemLinkage.hpp
+++ b/compiler/x/amd64/codegen/AMD64SystemLinkage.hpp
@@ -43,7 +43,7 @@ class TR_AMD64SystemLinkage : public TR_X86SystemLinkage
 
    virtual int32_t layoutParm(TR::Node *parmNode, int32_t &dataCursor, uint16_t &intReg, uint16_t &floatReg, parmLayoutResult &layoutResult);
    virtual int32_t layoutParm(TR::ParameterSymbol *paramSymbol, int32_t &dataCursor, uint16_t &intReg, uint16_t &floatRrgs, parmLayoutResult&);
-   virtual uint32_t getAlignment(TR::DataTypes type);
+   virtual uint32_t getAlignment(TR::DataType type);
 
    virtual int32_t buildArgs(TR::Node *callNode, TR::RegisterDependencyConditions *deps);
 
@@ -52,7 +52,7 @@ class TR_AMD64SystemLinkage : public TR_X86SystemLinkage
 
    TR::Register *buildVolatileAndReturnDependencies(TR::Node *callNode, TR::RegisterDependencyConditions *deps);
    private:
-   bool layoutTypeInRegs(TR::DataTypes type, uint16_t &intReg, uint16_t &floatReg, parmLayoutResult&);
+   bool layoutTypeInRegs(TR::DataType type, uint16_t &intReg, uint16_t &floatReg, parmLayoutResult&);
 
    };
 

--- a/compiler/x/amd64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/amd64/codegen/OMRCodeGenerator.cpp
@@ -132,7 +132,7 @@ OMR::X86::AMD64::CodeGenerator::longClobberEvaluate(TR::Node *node)
 TR_GlobalRegisterNumber
 OMR::X86::AMD64::CodeGenerator::getLinkageGlobalRegisterNumber(
       int8_t linkageRegisterIndex,
-      TR::DataTypes type)
+      TR::DataType type)
    {
 
    TR_GlobalRegisterNumber result;

--- a/compiler/x/amd64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/amd64/codegen/OMRCodeGenerator.hpp
@@ -55,7 +55,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::X86::CodeGenerator
 
    virtual TR::Register *longClobberEvaluate(TR::Node *node);
 
-   TR_GlobalRegisterNumber getLinkageGlobalRegisterNumber(int8_t linkageRegisterIndex, TR::DataTypes type);
+   TR_GlobalRegisterNumber getLinkageGlobalRegisterNumber(int8_t linkageRegisterIndex, TR::DataType type);
    TR_BitVector *getGlobalGPRsPreservedAcrossCalls(){ return &_globalGPRsPreservedAcrossCalls; }
    TR_BitVector *getGlobalFPRsPreservedAcrossCalls(){ return &_globalFPRsPreservedAcrossCalls; }
 

--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -525,7 +525,7 @@ TR::Register *OMR::X86::TreeEvaluator::tableEvaluator(TR::Node *node, TR::CodeGe
 TR::Register *OMR::X86::TreeEvaluator::minmaxEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node *child  = node->getFirstChild();
-   TR::DataTypes data_type = child->getDataType();
+   TR::DataType data_type = child->getDataType();
    TR::DataType type = child->getType();
    TR_X86OpCodes  move_op = MOVRegReg(TR::Compiler->target.is64Bit() && type.isInt64());
    TR_X86OpCodes  cmp_op = CMPRegReg(TR::Compiler->target.is64Bit() && type.isInt64());

--- a/compiler/x/codegen/FPTreeEvaluator.cpp
+++ b/compiler/x/codegen/FPTreeEvaluator.cpp
@@ -146,7 +146,7 @@ void OMR::X86::TreeEvaluator::insertPrecisionAdjustment(TR::Register      *reg,
                                                     TR::Node          *root,
                                                     TR::CodeGenerator *cg)
    {
-   TR::DataTypes    dt;
+   TR::DataType    dt;
    TR_X86OpCodes  opStore, opLoad;
    TR::Node        *node = root;
 

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -3875,7 +3875,7 @@ void OMR::X86::CodeGenerator::dumpPostGPRegisterAssignment(TR::Instruction * ins
 #endif
 
 bool
-OMR::X86::CodeGenerator::useSSEFor(TR::DataTypes type)
+OMR::X86::CodeGenerator::useSSEFor(TR::DataType type)
    {
    if (type == TR::Float)
       return self()->useSSEForSinglePrecision();

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -760,7 +760,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
       return _flags.testAll(UseSSEForSinglePrecision | UseSSEForDoublePrecision);
       }
 
-   bool useSSEFor(TR::DataTypes type);
+   bool useSSEFor(TR::DataType type);
 
    bool useGPRsForWin32CTMConversion()
       {

--- a/compiler/x/codegen/OMRLinkage.hpp
+++ b/compiler/x/codegen/OMRLinkage.hpp
@@ -342,7 +342,7 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
 
    TR_RegisterKinds movRegisterKind(TR_MovDataTypes mdt);
 
-   TR_MovDataTypes movType(TR::DataTypes type)
+   TR_MovDataTypes movType(TR::DataType type)
       {
       switch(type)
          {

--- a/compiler/x/codegen/OMRMachine.cpp
+++ b/compiler/x/codegen/OMRMachine.cpp
@@ -2332,7 +2332,7 @@ void OMR::X86::Machine::purgeDeadRegistersFromRegisterFile()
 // These reusable temporaries are intended for use whenever a temporary store to a
 // memory location is required.
 
-TR::MemoryReference *OMR::X86::Machine::getDummyLocalMR(TR::DataTypes dt)
+TR::MemoryReference *OMR::X86::Machine::getDummyLocalMR(TR::DataType dt)
    {
    if (_dummyLocal[dt] == NULL)
       {

--- a/compiler/x/codegen/OMRMachine.hpp
+++ b/compiler/x/codegen/OMRMachine.hpp
@@ -218,7 +218,7 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
    TR_X86OpCodes fpDeterminePopOpCode(TR_X86OpCodes op);
    TR_X86OpCodes fpDetermineReverseOpCode(TR_X86OpCodes op);
 
-   TR::MemoryReference  *getDummyLocalMR(TR::DataTypes dt);
+   TR::MemoryReference  *getDummyLocalMR(TR::DataType dt);
 
    TR::RealRegister *fpMapToStackRelativeRegister(TR::Register *vreg);
 

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -1002,7 +1002,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerStoreEvaluator(TR::Node *node, TR:
                {
                TR_RematerializableTypes type;
 
-               // This is why we should use TR::DataTypes in place of TR_RematerializableTypes...
+               // This is why we should use TR::DataType in place of TR_RematerializableTypes...
                //
                switch (node->getDataType())
                   {
@@ -2730,7 +2730,7 @@ TR::Register *OMR::X86::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Co
 
    // Call the appropriate helper entry point
    //
-   TR::DataTypes dt = node->getArrayCopyElementType();
+   TR::DataType dt = node->getArrayCopyElementType();
    uint32_t elementSize;
    if (dt == TR::Address)
       elementSize = TR::Compiler->om.sizeofReferenceField();

--- a/compiler/x/codegen/X86Debug.cpp
+++ b/compiler/x/codegen/X86Debug.cpp
@@ -2226,7 +2226,7 @@ const char callRegName32[][5] =
 
 static const char*
 getInterpretedMethodNameHelper(TR::MethodSymbol *methodSymbol,
-                               TR::DataTypes     type){
+                               TR::DataType     type){
    if (methodSymbol->isVMInternalNative() || methodSymbol->isJITInternalNative())
       return "icallVMprJavaSendNativeStatic";
 
@@ -2282,10 +2282,9 @@ TR_Debug::print(TR::FILE *pOutFile, TR_X86CallSnippet  * snippet)
          {
             TR::Node       *child   = callNode->getChild(count);
             TR::DataType    type    = child->getType();
-            TR::DataTypes   dt      = type.getDataType();
 
 
-            switch (dt)
+            switch (type)
                {
                case TR::Float:
                case TR::Int8:
@@ -2307,7 +2306,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_X86CallSnippet  * snippet)
                   bufferPos+=5;
                   break;
                default:
-                  TR_ASSERT(0, "unknown data type: %d", dt);
+                  TR_ASSERT(0, "unknown data type: %d", type);
                   break;
                }
 

--- a/compiler/x/codegen/X86SystemLinkage.cpp
+++ b/compiler/x/codegen/X86SystemLinkage.cpp
@@ -840,7 +840,7 @@ TR_X86SystemLinkage::getParameterStartingPos(
 
 int32_t
 TR_X86SystemLinkage::layoutTypeOnStack(
-      TR::DataTypes type,
+      TR::DataType type,
       int32_t &dataCursor,
       parmLayoutResult &layoutResult)
    {

--- a/compiler/x/codegen/X86SystemLinkage.hpp
+++ b/compiler/x/codegen/X86SystemLinkage.hpp
@@ -73,9 +73,9 @@ class TR_X86SystemLinkage : public TR::Linkage
 
    int32_t computeMemoryArgSize(TR::Node *callNode, int32_t first, int32_t last, int8_t direction);
    int32_t getParameterStartingPos(int32_t &dataCursor, uint32_t align);
-   int32_t layoutTypeOnStack(TR::DataTypes, int32_t&, parmLayoutResult&);
+   int32_t layoutTypeOnStack(TR::DataType, int32_t&, parmLayoutResult&);
    virtual int32_t buildArgs(TR::Node *callNode, TR::RegisterDependencyConditions *deps) = 0;
-   virtual uint32_t getAlignment(TR::DataTypes) = 0;
+   virtual uint32_t getAlignment(TR::DataType) = 0;
    virtual int32_t layoutParm(TR::Node *parmNode, int32_t &dataCursor, uint16_t &intReg, uint16_t &floatReg, parmLayoutResult &layoutResult) = 0;
    virtual int32_t layoutParm(TR::ParameterSymbol *paramSymbol, int32_t &dataCursor, uint16_t &intReg, uint16_t &floatRrgs, parmLayoutResult&) = 0;
 

--- a/compiler/x/i386/codegen/IA32SystemLinkage.cpp
+++ b/compiler/x/i386/codegen/IA32SystemLinkage.cpp
@@ -152,7 +152,7 @@ TR_IA32SystemLinkage::TR_IA32SystemLinkage(
    }
 
 uint32_t
-TR_IA32SystemLinkage::getAlignment(TR::DataTypes type)
+TR_IA32SystemLinkage::getAlignment(TR::DataType type)
    {
    switch(type)
       {

--- a/compiler/x/i386/codegen/IA32SystemLinkage.hpp
+++ b/compiler/x/i386/codegen/IA32SystemLinkage.hpp
@@ -44,7 +44,7 @@ class TR_IA32SystemLinkage : public TR_X86SystemLinkage
    int32_t layoutParm(TR::ParameterSymbol*, int32_t&, uint16_t&, uint16_t&, parmLayoutResult&);
    virtual TR::Register *buildVolatileAndReturnDependencies(TR::Node *callNode, TR::RegisterDependencyConditions *deps);
    private:
-   virtual uint32_t getAlignment(TR::DataTypes);
+   virtual uint32_t getAlignment(TR::DataType);
    };
 
 #if 0

--- a/compiler/z/codegen/BinaryEvaluator.cpp
+++ b/compiler/z/codegen/BinaryEvaluator.cpp
@@ -688,7 +688,7 @@ generic32BitAddEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    else
       {
       TR_S390BinaryCommutativeAnalyser temp(cg);
-      TR::DataTypes type = node->getDataType();
+      TR::DataType type = node->getDataType();
       temp.integerAddAnalyser(node, TR::InstOpCode::AR, type == TR::Int16 ? TR::InstOpCode::AH : TR::InstOpCode::A, TR::InstOpCode::LR);
       targetRegister = node->getRegister();
       }
@@ -768,7 +768,7 @@ generic32BitSubEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    else // The second child of the sub node isn't a loadConstant type.
       {
       TR_S390BinaryAnalyser temp(cg);
-      TR::DataTypes type = node->getDataType();
+      TR::DataType type = node->getDataType();
       temp.intBinaryAnalyser(node, TR::InstOpCode::SR, type == TR::Int16 ? TR::InstOpCode::SH : TR::InstOpCode::S);
       targetRegister = node->getRegister();
       }

--- a/compiler/z/codegen/CallSnippet.cpp
+++ b/compiler/z/codegen/CallSnippet.cpp
@@ -278,7 +278,7 @@ TR_S390CallSnippet::getCallRA()
 
 
 TR_RuntimeHelper
-TR_S390CallSnippet::getHelper(TR::MethodSymbol * methodSymbol, TR::DataTypes type, TR::CodeGenerator * cg)
+TR_S390CallSnippet::getHelper(TR::MethodSymbol * methodSymbol, TR::DataType type, TR::CodeGenerator * cg)
    {
    bool synchronised = methodSymbol->isSynchronised();
 
@@ -381,7 +381,7 @@ TR_S390CallSnippet::getHelper(TR::MethodSymbol * methodSymbol, TR::DataTypes typ
 
 TR_RuntimeHelper TR_S390CallSnippet::getInterpretedDispatchHelper(
    TR::SymbolReference *methodSymRef,
-   TR::DataTypes        type)
+   TR::DataType        type)
    {
    TR::Compilation *comp = cg()->comp();
    TR::MethodSymbol * methodSymbol = methodSymRef->getSymbol()->castToMethodSymbol();

--- a/compiler/z/codegen/CallSnippet.hpp
+++ b/compiler/z/codegen/CallSnippet.hpp
@@ -44,7 +44,7 @@ class TR_S390CallSnippet : public TR::Snippet
    protected:
    TR::SymbolReference * _realMethodSymbolReference;
    TR_RuntimeHelper getInterpretedDispatchHelper(TR::SymbolReference *methodSymRef,
-                                                 TR::DataTypes        type);
+                                                 TR::DataType        type);
    public:
 
    TR_S390CallSnippet(TR::CodeGenerator *cg, TR::Node *c, TR::LabelSymbol *lab, int32_t s)
@@ -81,7 +81,7 @@ class TR_S390CallSnippet : public TR::Snippet
    uint8_t *setUpArgumentsInRegister(uint8_t *buffer, TR::Node *callNode, int32_t argSize);
 
 
-   static TR_RuntimeHelper getHelper(TR::MethodSymbol *, TR::DataTypes, TR::CodeGenerator *);
+   static TR_RuntimeHelper getHelper(TR::MethodSymbol *, TR::DataType, TR::CodeGenerator *);
 
    static uint8_t *storeArgumentItem(TR::InstOpCode::Mnemonic op, uint8_t *buffer, TR::RealRegister *reg, int32_t offset, TR::CodeGenerator *cg);
    static uint8_t *S390flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32_t argSize, TR::CodeGenerator *cg);

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -1150,11 +1150,11 @@ OMR::Z::CodeGenerator::considerTypeForGRA(TR::Node *node)
    }
 
 bool
-OMR::Z::CodeGenerator::considerTypeForGRA(TR::DataTypes dt)
+OMR::Z::CodeGenerator::considerTypeForGRA(TR::DataType dt)
    {
    if (
 #ifdef J9_PROJECT_SPECIFIC
-       isBCDType(dt) ||
+       dt.isBCD() ||
 #endif
        dt == TR::Aggregate)
       return false;
@@ -1174,7 +1174,7 @@ OMR::Z::CodeGenerator::considerTypeForGRA(TR::SymbolReference *symRef)
       if (self()->isAddressOfPrivateStaticSymRefWithLockedReg(symRef))
          return false;
 #ifdef J9_PROJECT_SPECIFIC
-      if (isBCDType(symRef->getSymbol()->getDataType()))
+      if (symRef->getSymbol()->getDataType().isBCD())
          return false;
       else
 #endif
@@ -6380,7 +6380,7 @@ OMR::Z::CodeGenerator::getSmallestPosConstThatMustBeMaterialized()
 ////////////////////////////////////////////////////////////////////////////////
 //  Tactical GRA
 TR_GlobalRegisterNumber
-OMR::Z::CodeGenerator::getLinkageGlobalRegisterNumber(int8_t linkageRegisterIndex, TR::DataTypes type)
+OMR::Z::CodeGenerator::getLinkageGlobalRegisterNumber(int8_t linkageRegisterIndex, TR::DataType type)
    {
    TR_GlobalRegisterNumber result;
    bool isFloat = (type == TR::Float
@@ -6408,7 +6408,7 @@ OMR::Z::CodeGenerator::getLinkageGlobalRegisterNumber(int8_t linkageRegisterInde
       {
       result = self()->machine()->getLastLinkageFPR() - linkageRegisterIndex;
       }
-   else if (isVectorType(type))
+   else if (type.isVector())
       {
       result = self()->machine()->getLastGlobalVRFRegisterNumber() - linkageRegisterIndex;
       }
@@ -6553,7 +6553,7 @@ OMR::Z::CodeGenerator::getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Node * node)
 
    if (node->getOpCode().isIf() && node->getNumChildren() > 0 && !node->getOpCode().isCompBranchOnly())
       {
-      TR::DataTypes dt = node->getFirstChild()->getDataType();
+      TR::DataType dt = node->getFirstChild()->getDataType();
 
       isFloat = (dt == TR::Float
                  || dt == TR::Double
@@ -6700,7 +6700,7 @@ OMR::Z::CodeGenerator::setRealRegisterAssociation(TR::Register * reg, TR::RealRe
    }
 
 bool
-OMR::Z::CodeGenerator::isGlobalRegisterAvailable(TR_GlobalRegisterNumber i, TR::DataTypes dt)
+OMR::Z::CodeGenerator::isGlobalRegisterAvailable(TR_GlobalRegisterNumber i, TR::DataType dt)
    {
    if ((self()->getGlobalRegister(i) != TR::RealRegister::GPR0) || (dt != TR::Address))
      return true;
@@ -7868,7 +7868,7 @@ OMR::Z::CodeGenerator::emitDataSnippets(bool isWarm)
 
 
 TR_S390ConstantDataSnippet *
-OMR::Z::CodeGenerator::create64BitLiteralPoolSnippet(TR::DataTypes dt, int64_t value)
+OMR::Z::CodeGenerator::create64BitLiteralPoolSnippet(TR::DataType dt, int64_t value)
    {
    TR_ASSERT( dt == TR::Int64, "create64BitLiteralPoolSnippet is only for data constants\n");
 
@@ -10115,7 +10115,7 @@ OMR::Z::CodeGenerator::genCopyFromLiteralPool(TR::Node *node, int32_t bytesToCop
    }
 
 int32_t
-OMR::Z::CodeGenerator::biasDecimalFloatFrac(TR::DataTypes dt, int32_t frac)
+OMR::Z::CodeGenerator::biasDecimalFloatFrac(TR::DataType dt, int32_t frac)
    {
    switch (dt)
       {
@@ -10806,7 +10806,7 @@ bool OMR::Z::CodeGenerator::isDispInRange(int64_t disp)
    return (MINLONGDISP <= disp) && (disp <= MAXLONGDISP);
    }
 
-bool OMR::Z::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR::DataTypes dt)
+bool OMR::Z::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR::DataType dt)
    {
 
    if (dt == TR::Float) return false;

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -472,7 +472,7 @@ public:
    void genMemClear(TR::MemoryReference *targetMR, TR::Node *targetNode, int64_t clearSize);
 
    void genCopyFromLiteralPool(TR::Node *node, int32_t bytesToCopy, TR::MemoryReference *targetMR, size_t litPoolOffset, TR::InstOpCode::Mnemonic op = TR::InstOpCode::MVC);
-   int32_t biasDecimalFloatFrac(TR::DataTypes dt, int32_t frac);
+   int32_t biasDecimalFloatFrac(TR::DataType dt, int32_t frac);
 
 
    bool isMemcpyWithPadIfFoldable(TR::Node *node, TR_MemCpyPadTypes type);
@@ -640,7 +640,7 @@ public:
    // GRA
    //
    bool prepareForGRA();
-   TR_GlobalRegisterNumber getLinkageGlobalRegisterNumber(int8_t linkageRegisterIndex, TR::DataTypes type);
+   TR_GlobalRegisterNumber getLinkageGlobalRegisterNumber(int8_t linkageRegisterIndex, TR::DataType type);
 
    TR_BitVector _globalRegisterBitVectors[TR_numSpillKinds];
    virtual TR_BitVector *getGlobalRegisters(TR_SpillKinds kind, TR_LinkageConventions lc){ return &_globalRegisterBitVectors[kind]; }
@@ -653,7 +653,7 @@ public:
    TR_GlobalRegisterNumber getGlobalGPRFromHPR (TR_GlobalRegisterNumber n);
 
    bool considerTypeForGRA(TR::Node *node);
-   bool considerTypeForGRA(TR::DataTypes dt);
+   bool considerTypeForGRA(TR::DataType dt);
    bool considerTypeForGRA(TR::SymbolReference *symRef);
 
    // Number of assignable GPRs
@@ -671,7 +671,7 @@ public:
    bool allowGlobalRegisterAcrossBranch(TR_RegisterCandidate *, TR::Node *);
    void setRealRegisterAssociation(TR::Register     *reg,
                                    TR::RealRegister::RegNum realNum);
-   bool isGlobalRegisterAvailable(TR_GlobalRegisterNumber i, TR::DataTypes dt);
+   bool isGlobalRegisterAvailable(TR_GlobalRegisterNumber i, TR::DataType dt);
    void registerSymbolSetup();
 
    // Used to model register liveness without Future Use Count.
@@ -887,7 +887,7 @@ public:
    TR_S390ConstantDataSnippet * getConstantDataSnippet(CS2::HashIndex hi) { return _constantHash.DataAt(hi);}
 
 
-   TR_S390ConstantDataSnippet * create64BitLiteralPoolSnippet(TR::DataTypes dt, int64_t value);
+   TR_S390ConstantDataSnippet * create64BitLiteralPoolSnippet(TR::DataType dt, int64_t value);
    TR_S390ConstantDataSnippet * createLiteralPoolSnippet(TR::Node * node);
    TR_S390ConstantInstructionSnippet *createConstantInstruction(TR::CodeGenerator * cg, TR::Node *node, TR::Instruction * instr);
    TR_S390ConstantDataSnippet *findOrCreateConstant(TR::Node *, void *c, uint16_t size, bool isWarm = 0);
@@ -1100,7 +1100,7 @@ public:
    bool constLoadNeedsLiteralFromPool(TR::Node *node);
    virtual bool isDispInRange(int64_t disp);
 
-   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataTypes);
+   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataType);
 
    bool canOptimizeEdit(uint8_t *parm, int32_t length);
    bool parseEditParm(uint8_t *parm,

--- a/compiler/z/codegen/OMRLinkage.hpp
+++ b/compiler/z/codegen/OMRLinkage.hpp
@@ -304,7 +304,7 @@ protected:
 
    bool alreadySaved(TR::RealRegister::RegNum regNum) { return false; }
 
-   static bool needsAlignment(TR::DataTypes dt, TR::CodeGenerator * cg);
+   static bool needsAlignment(TR::DataType dt, TR::CodeGenerator * cg);
    static int32_t getFirstMaskedBit(int16_t mask, int32_t from , int32_t to);
    static int32_t getLastMaskedBit(int16_t mask, int32_t from , int32_t to);
    static int32_t getFirstMaskedBit(int16_t mask);
@@ -425,8 +425,8 @@ enum TR_DispatchType
    virtual int64_t addFECustomizedReturnRegDependency(int64_t killMask, TR::Linkage* linkage, TR::DataType resType, TR::RegisterDependencyConditions * dependencies) {return killMask; }
    virtual int32_t buildArgs(TR::Node * callNode, TR::RegisterDependencyConditions * dependencies, bool isFastJNI, int64_t killMask, TR::Register* &vftReg, bool PassReceiver = true);
    TR::Instruction * storeArgumentOnStack(TR::Node * callNode, TR::InstOpCode::Mnemonic opCode, TR::Register * argReg, int32_t *stackOffsetPtr, TR::Register* stackRegister);
-   TR::Instruction * storeLongDoubleArgumentOnStack(TR::Node * callNode, TR::DataTypes argType, TR::InstOpCode::Mnemonic opCode, TR::Register * argReg, int32_t *stackOffsetPtr, TR::Register* stackRegister);
-   void loadIntArgumentsFromStack(TR::Node *callNode, TR::RegisterDependencyConditions *dependencies, TR::DataTypes argType, int32_t stackOffset, int32_t argsSize, int32_t numIntegerArgs, TR::Register* stackRegister);
+   TR::Instruction * storeLongDoubleArgumentOnStack(TR::Node * callNode, TR::DataType argType, TR::InstOpCode::Mnemonic opCode, TR::Register * argReg, int32_t *stackOffsetPtr, TR::Register* stackRegister);
+   void loadIntArgumentsFromStack(TR::Node *callNode, TR::RegisterDependencyConditions *dependencies, TR::DataType argType, int32_t stackOffset, int32_t argsSize, int32_t numIntegerArgs, TR::Register* stackRegister);
 
    void setStrictestAutoSymbolAlignment(int32_t alignment, bool force=false)
       {
@@ -451,7 +451,7 @@ enum TR_DispatchType
    virtual bool isAggregateReturnedInIntRegistersAndMemory(int32_t aggregateLenth)   { return false; }
    virtual bool isAggregateReturnedInRegistersAndMemoryCall(TR::Node *callNode) { return false; }
 
-   virtual bool canDataTypeBePassedByReference(TR::DataTypes type);
+   virtual bool canDataTypeBePassedByReference(TR::DataType type);
    virtual bool isSymbolPassedByReference(TR::Symbol *sym);
 
    int32_t  isSpecialArgumentRegisters() { return ((_properties & SpecialArgumentRegisters) != 0) && (_numSpecialArgumentRegisters > 0); }

--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -3650,7 +3650,7 @@ generateS390MemoryReference(TR::CodeGenerator * cg)
    }
 
 TR::MemoryReference *
-generateS390MemoryReference(int32_t iValue, TR::DataTypes type, TR::CodeGenerator * cg, TR::Register * treg, TR::Node *node)
+generateS390MemoryReference(int32_t iValue, TR::DataType type, TR::CodeGenerator * cg, TR::Register * treg, TR::Node *node)
    {
    TR_S390ConstantDataSnippet * targetsnippet = cg->findOrCreate4ByteConstant(node, iValue);
 
@@ -3658,14 +3658,14 @@ generateS390MemoryReference(int32_t iValue, TR::DataTypes type, TR::CodeGenerato
    }
 
 TR::MemoryReference *
-generateS390MemoryReference(int64_t iValue, TR::DataTypes type, TR::CodeGenerator * cg, TR::Register * treg, TR::Node *node)
+generateS390MemoryReference(int64_t iValue, TR::DataType type, TR::CodeGenerator * cg, TR::Register * treg, TR::Node *node)
    {
    TR_S390ConstantDataSnippet * targetsnippet = cg->findOrCreate8ByteConstant(node, iValue);
    return generateS390MemoryReference(targetsnippet, cg, treg, node);
    }
 
 TR::MemoryReference *
-generateS390MemoryReference(float fValue, TR::DataTypes type, TR::CodeGenerator * cg, TR::Node * node)
+generateS390MemoryReference(float fValue, TR::DataType type, TR::CodeGenerator * cg, TR::Node * node)
    {
    union
       {
@@ -3678,7 +3678,7 @@ generateS390MemoryReference(float fValue, TR::DataTypes type, TR::CodeGenerator 
    }
 
 TR::MemoryReference *
-generateS390MemoryReference(double dValue, TR::DataTypes type, TR::CodeGenerator * cg, TR::Node * node)
+generateS390MemoryReference(double dValue, TR::DataType type, TR::CodeGenerator * cg, TR::Node * node)
    {
    union
       {

--- a/compiler/z/codegen/OMRMemoryReference.hpp
+++ b/compiler/z/codegen/OMRMemoryReference.hpp
@@ -464,10 +464,10 @@ TR::MemoryReference * generateS390MemoryReference(TR::MemoryReference &, int32_t
 TR::MemoryReference * generateS390MemoryReference(TR::Node *, TR::SymbolReference *, TR::CodeGenerator *);
 TR::MemoryReference * generateS390MemoryReference(TR::Snippet *, TR::CodeGenerator *, TR::Register *, TR::Node *);
 TR::MemoryReference * generateS390MemoryReference(TR::Snippet *, TR::Register *, int32_t, TR::CodeGenerator *);
-TR::MemoryReference * generateS390MemoryReference(int32_t, enum TR::DataTypes, TR::CodeGenerator *, TR::Register *, TR::Node *node = NULL);
-TR::MemoryReference * generateS390MemoryReference(int64_t, enum TR::DataTypes, TR::CodeGenerator *, TR::Register *, TR::Node *node = NULL);
-TR::MemoryReference * generateS390MemoryReference(float  , enum TR::DataTypes, TR::CodeGenerator *, TR::Node *);
-TR::MemoryReference * generateS390MemoryReference(double , enum TR::DataTypes, TR::CodeGenerator *, TR::Node *);
+TR::MemoryReference * generateS390MemoryReference(int32_t, TR::DataType, TR::CodeGenerator *, TR::Register *, TR::Node *node = NULL);
+TR::MemoryReference * generateS390MemoryReference(int64_t, TR::DataType, TR::CodeGenerator *, TR::Register *, TR::Node *node = NULL);
+TR::MemoryReference * generateS390MemoryReference(float  , TR::DataType, TR::CodeGenerator *, TR::Node *);
+TR::MemoryReference * generateS390MemoryReference(double , TR::DataType, TR::CodeGenerator *, TR::Node *);
 TR::MemoryReference * generateS390MemoryReference(TR::CodeGenerator * cg, TR::Node *, TR::Node *, int32_t disp=0, bool forSS=false);
 
 TR::MemoryReference * generateS390ConstantAreaMemoryReference(TR::Register *br, int32_t disp, TR::Node *node, TR::CodeGenerator *cg, bool forSS);

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -1875,7 +1875,7 @@ generateS390FloatCompareAndBranchOps(TR::Node *node,
                                      TR::InstOpCode::S390BranchCondition &retBranchOpCond,
                                      TR::LabelSymbol *branchTarget)
    {
-   TR::DataTypes dataType = node->getFirstChild()->getDataType();
+   TR::DataType dataType = node->getFirstChild()->getDataType();
    TR_ASSERT(dataType == TR::Float ||
            dataType == TR::Double,
            "only floats are supported by this function");
@@ -2132,7 +2132,7 @@ generateS390DFPLongDoubleCompareAndBranchOps(TR::Node * node, TR::CodeGenerator 
    TR::Compilation *comp = cg->comp();
    bool isBranchGenerated = false;
 
-   TR::DataTypes dataType = node->getFirstChild()->getDataType();
+   TR::DataType dataType = node->getFirstChild()->getDataType();
    TR::InstOpCode::Mnemonic cmpOp = TR::InstOpCode::BAD;
    if (dataType == TR::DecimalDouble)
       cmpOp = TR::InstOpCode::CDTR;
@@ -3043,7 +3043,7 @@ generateS390CompareAndBranchOpsHelper(TR::Node * node, TR::CodeGenerator * cg, T
    TR::Instruction * returnInstruction = NULL;
    bool isBranchGenerated = false;
 
-   TR::DataTypes dataType = firstChild->getDataType();
+   TR::DataType dataType = firstChild->getDataType();
 
    if (TR::Float == dataType || TR::Double == dataType)
       return generateS390FloatCompareAndBranchOps(node, cg, fBranchOpCond, rBranchOpCond, retBranchOpCond, branchTarget);
@@ -3120,7 +3120,7 @@ generateS390CompareAndBranchOpsHelper(TR::Node * node, TR::CodeGenerator * cg, T
          isForward = true;
          }
 
-      TR::DataTypes constType = constNode->getDataType();
+      TR::DataType constType = constNode->getDataType();
 
       bool byteAddress = false;
       bool is64BitData = dataType == TR::Int64;
@@ -3477,7 +3477,7 @@ generateS390CompareAndBranchOpsHelper(TR::Node * node, TR::CodeGenerator * cg, T
       // Answer:The only case where it can be different is in the compressed refs
       // build. an aload of a class pointer is 32-bits only.
       //
-      TR::DataTypes childType = secondChild->getDataType();
+      TR::DataType childType = secondChild->getDataType();
       if (childType == TR::Address)
          {
          isUnsignedCmp = true;
@@ -3706,7 +3706,7 @@ generateS390CompareBool(TR::Node * node, TR::CodeGenerator * cg, TR::InstOpCode:
    }
 
 TR::InstOpCode::Mnemonic
-getOpCodeIfSuitableForCompareAndBranch(TR::CodeGenerator * cg, TR::Node * node, TR::DataTypes dataType, bool canUseImm8 )
+getOpCodeIfSuitableForCompareAndBranch(TR::CodeGenerator * cg, TR::Node * node, TR::DataType dataType, bool canUseImm8 )
    {
    // be pessimistic and signal we can't use compare and branch until we
    // determine otherwise.
@@ -3809,7 +3809,7 @@ genCompareAndBranchInstructionIfPossible(TR::CodeGenerator * cg, TR::Node * node
    if (isBranchToNodeWithDifferentHotnessLevel)
       return NULL;
 
-   TR::DataTypes dataType = constNode->getDataType();
+   TR::DataType dataType = constNode->getDataType();
    if (canUseImm8)
         {
 
@@ -4662,7 +4662,7 @@ generateS390CompareBranch(TR::Node * node, TR::CodeGenerator * cg, TR::InstOpCod
          {
          opBranchCond = generateS390CompareOps(node, cg, fBranchOpCond, rBranchOpCond);
          }
-      TR::DataTypes dataType = node->getFirstChild()->getDataType();
+      TR::DataType dataType = node->getFirstChild()->getDataType();
 
       // take care of global reg deps if we have them
       if (thirdChild)
@@ -11775,7 +11775,7 @@ OMR::Z::TreeEvaluator::BBStartEvaluator(TR::Node * node, TR::CodeGenerator * cg)
             TR::ParameterSymbol * sym = child->getChild(i)->getSymbol()->getParmSymbol();
             if (sym != NULL)
                {
-               TR::DataTypes dt = sym->getDataType();
+               TR::DataType dt = sym->getDataType();
                TR::DataType type = dt;
 
                if ((TR::Compiler->target.is64Bit() || cg->use64BitRegsOn32Bit() || !type.isInt64()) &&
@@ -12814,7 +12814,7 @@ OMR::Z::TreeEvaluator::arraysetEvaluator(TR::Node * node, TR::CodeGenerator * cg
       return NULL;
       }
 
-   TR::DataTypes constType = constExpr->getDataType();
+   TR::DataType constType = constExpr->getDataType();
 
 
    if (constType == TR::Address)
@@ -19243,7 +19243,7 @@ OMR::Z::TreeEvaluator::getvelemEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 
    generateVRScInstruction(cg, TR::InstOpCode::VLGV, node, returnReg, vectorReg, memRef, getVectorElementSizeMask(vectorChild));
 
-   TR::DataTypes dt = vectorChild->getDataType();
+   TR::DataType dt = vectorChild->getDataType();
    bool isUnsigned = (!node->getType().isInt64() && node->isUnsigned());
    if (dt == TR::VectorDouble)
       {

--- a/compiler/z/codegen/OpMemToMem.cpp
+++ b/compiler/z/codegen/OpMemToMem.cpp
@@ -2638,7 +2638,7 @@ MemCpyAtomicMacroOp::generateLoop()
 
    return cursor;
    }
-MemCpyAtomicMacroOp::MemCpyAtomicMacroOp(TR::Node* rootNode, TR::Node* dstNode, TR::Node* srcNode, TR::CodeGenerator* cg, TR::DataTypes destType, TR::Register* lenReg, TR::Node * lenNode, bool isForward , bool unroll , int32_t constLength): MemToMemTypedVarLenMacroOp(rootNode, dstNode, srcNode, cg, destType, lenReg, lenNode, isForward)
+MemCpyAtomicMacroOp::MemCpyAtomicMacroOp(TR::Node* rootNode, TR::Node* dstNode, TR::Node* srcNode, TR::CodeGenerator* cg, TR::DataType destType, TR::Register* lenReg, TR::Node * lenNode, bool isForward , bool unroll , int32_t constLength): MemToMemTypedVarLenMacroOp(rootNode, dstNode, srcNode, cg, destType, lenReg, lenNode, isForward)
    {
       static char * unrollFactor = feGetEnv("TR_ArrayCopyUnrollFactor");
       static char * trace = feGetEnv("TR_ArrayCopyTrace");

--- a/compiler/z/codegen/OpMemToMem.hpp
+++ b/compiler/z/codegen/OpMemToMem.hpp
@@ -548,7 +548,7 @@ class MemToMemTypedMacroOp
       TR::RegisterDependencyConditions* getDependencies() { return _macroDependencies; }
 
    protected:
-      MemToMemTypedMacroOp(TR::Node* rootNode, TR::Node* dstNode, TR::Node* srcNode, TR::CodeGenerator * cg, TR::DataTypes destType, TR::Node * lenNode, bool isForward)
+      MemToMemTypedMacroOp(TR::Node* rootNode, TR::Node* dstNode, TR::Node* srcNode, TR::CodeGenerator * cg, TR::DataType destType, TR::Node * lenNode, bool isForward)
          : _rootNode(rootNode), _dstNode(dstNode), _srcNode(srcNode), _cg(cg), _destType(destType),
            _startReg(0), _endReg(0), _srcReg(0), _bxhReg(0), _strideReg(0), _macroDependencies(NULL), _lenNode(lenNode), _isForward(isForward)
          {}
@@ -566,7 +566,7 @@ class MemToMemTypedMacroOp
       TR::Register* _startReg;
       TR::Register* _endReg;
       TR::Register* _strideReg;
-      TR::DataTypes _destType;
+      TR::DataType _destType;
       bool _applyDepLocally;
       bool _isForward;
       TR::RegisterDependencyConditions* _macroDependencies;
@@ -608,7 +608,7 @@ class MemToMemTypedVarLenMacroOp : public MemToMemTypedMacroOp
    {
    public:
    protected:
-      MemToMemTypedVarLenMacroOp(TR::Node* rootNode, TR::Node* dstNode, TR::Node* srcNode, TR::CodeGenerator * cg, TR::DataTypes destType, TR::Register* lenReg, TR::Node * lenNode, bool isForward = false)
+      MemToMemTypedVarLenMacroOp(TR::Node* rootNode, TR::Node* dstNode, TR::Node* srcNode, TR::CodeGenerator * cg, TR::DataType destType, TR::Register* lenReg, TR::Node * lenNode, bool isForward = false)
          : MemToMemTypedMacroOp(rootNode, dstNode, srcNode, cg, destType, lenNode, isForward), _lenReg(lenReg)
          {}
       virtual TR::Instruction* generateLoop();
@@ -626,7 +626,7 @@ class MemToMemTypedVarLenMacroOp : public MemToMemTypedMacroOp
 class MemInitVarLenTypedMacroOp : public MemToMemTypedVarLenMacroOp
    {
    public:
-      MemInitVarLenTypedMacroOp(TR::Node* rootNode, TR::Node* dstNode, TR::CodeGenerator * cg, TR::DataTypes destType, TR::Register* lenReg, TR::Register* initReg, TR::Node * lenNode, bool isForward = false)
+      MemInitVarLenTypedMacroOp(TR::Node* rootNode, TR::Node* dstNode, TR::CodeGenerator * cg, TR::DataType destType, TR::Register* lenReg, TR::Register* initReg, TR::Node * lenNode, bool isForward = false)
          : MemToMemTypedVarLenMacroOp(rootNode, dstNode, dstNode, cg, destType, lenReg, lenNode, isForward), _initReg(initReg)
          {}
    protected:
@@ -640,7 +640,7 @@ class MemInitVarLenTypedMacroOp : public MemToMemTypedVarLenMacroOp
 class MemCpyVarLenTypedMacroOp : public MemToMemTypedVarLenMacroOp
    {
    public:
-      MemCpyVarLenTypedMacroOp(TR::Node* rootNode, TR::Node* dstNode, TR::Node* srcNode, TR::CodeGenerator * cg, TR::DataTypes destType, TR::Register* lenReg, TR::Node * lenNode, bool isForward = false)
+      MemCpyVarLenTypedMacroOp(TR::Node* rootNode, TR::Node* dstNode, TR::Node* srcNode, TR::CodeGenerator * cg, TR::DataType destType, TR::Register* lenReg, TR::Node * lenNode, bool isForward = false)
          : MemToMemTypedVarLenMacroOp(rootNode, dstNode, srcNode, cg, destType, lenReg, lenNode, isForward)
          {
          allocWorkReg();
@@ -664,7 +664,7 @@ class MemCpyAtomicMacroOp: public MemToMemTypedVarLenMacroOp
    {
 public:
 
-   MemCpyAtomicMacroOp(TR::Node* rootNode, TR::Node* dstNode, TR::Node* srcNode, TR::CodeGenerator * cg, TR::DataTypes destType, TR::Register* lenReg, TR::Node * lenNode, bool isForward=false, bool unroll=false, int32_t constLength=-1);
+   MemCpyAtomicMacroOp(TR::Node* rootNode, TR::Node* dstNode, TR::Node* srcNode, TR::CodeGenerator * cg, TR::DataType destType, TR::Register* lenReg, TR::Node * lenNode, bool isForward=false, bool unroll=false, int32_t constLength=-1);
    // Add getters for registers, so that can be shared with MVC routine in arraycopyEvaluator
    TR::Register * getAlignedReg() { return _alignedReg; };
    TR::Register * getWorkReg() { return _workReg; };

--- a/compiler/z/codegen/SystemLinkage.cpp
+++ b/compiler/z/codegen/SystemLinkage.cpp
@@ -571,7 +571,7 @@ TR_S390zOSSystemLinkage::calculateInterfaceMappingFlags(TR::ResolvedMethodSymbol
    // Bits 3-7 inclusive
    //
 
-   TR::DataTypes dataType = TR::NoType;
+   TR::DataType dataType = TR::NoType;
    int32_t aggregateLength = 0;
       TR_ASSERT( 0, "dont know how to get datatype of non-WCode method");
    uint32_t rva = calculateReturnValueAdjustFlag(dataType, aggregateLength);
@@ -599,7 +599,7 @@ TR_S390zOSSystemLinkage::calculateInterfaceMappingFlags(TR::ResolvedMethodSymbol
    while ((parmCursor != NULL) && !done)
       {
       TR::Symbol *parmSymbol = parmCursor;
-      TR::DataTypes dataType = parmSymbol->getDataType();
+      TR::DataType dataType = parmSymbol->getDataType();
       int32_t argSize = parmSymbol->getSize();
 
       done = updateFloatParmDescriptorFlags(&parmDescriptorFields, funcSymbol, parmCount, argSize, dataType, &floatParmNum, &lastFloatParmAreaOffset, &parmAreaOffset);
@@ -617,7 +617,7 @@ TR_S390zOSSystemLinkage::calculateInterfaceMappingFlags(TR::ResolvedMethodSymbol
  * Calculate "Return value adjust" component of XPLink call descriptor
  */
 uint32_t
-TR_S390zOSSystemLinkage::calculateReturnValueAdjustFlag(TR::DataTypes dataType, int32_t aggregateLength)
+TR_S390zOSSystemLinkage::calculateReturnValueAdjustFlag(TR::DataType dataType, int32_t aggregateLength)
    {
    // 5 bit values for "return value adjust" field of XPLink descriptor
    #define XPLINK_RVA_RETURN_VOID_OR_UNUSED    0x00
@@ -697,7 +697,7 @@ TR_S390zOSSystemLinkage::calculateReturnValueAdjustFlag(TR::DataTypes dataType, 
  * determined.
  */
 bool
-TR_S390zOSSystemLinkage::updateFloatParmDescriptorFlags(uint32_t *parmDescriptorFields, TR::Symbol *funcSymbol, int32_t parmCount, int32_t argSize, TR::DataTypes dataType, int32_t *floatParmNum, uint32_t *lastFloatParmAreaOffset, uint32_t *parmAreaOffset)
+TR_S390zOSSystemLinkage::updateFloatParmDescriptorFlags(uint32_t *parmDescriptorFields, TR::Symbol *funcSymbol, int32_t parmCount, int32_t argSize, TR::DataType dataType, int32_t *floatParmNum, uint32_t *lastFloatParmAreaOffset, uint32_t *parmAreaOffset)
    {
    uint32_t gprSize = cg()->machine()->getGPRSize();
 
@@ -1266,12 +1266,12 @@ TR_S390zLinuxSystemLinkage::initParamOffset(TR::ResolvedMethodSymbol * method, i
       {
       int32_t previousIndex=parmCursor->getLinkageRegisterIndex();
       parmCursor->setLinkageRegisterIndex(-1);
-      TR::DataTypes originalDataType=parmCursor->getDataType();
+      TR::DataType originalDataType=parmCursor->getDataType();
 
       if ( parmCursor->getDataType()==TR::Aggregate)
          {
          TR_ASSERT(0, "should not reach here due to folding of getDataTypeOfAggregateMember()");
-         TR::DataTypes dt = TR::NoType;
+         TR::DataType dt = TR::NoType;
          if(dt != TR::NoType) parmCursor->setDataType(dt);
          else if (parmCursor->getSize() > 8) parmCursor->setDataType(TR::Address);
          else if (parmCursor->getSize() == 8) parmCursor->setDataType(TR::Int64);
@@ -2573,9 +2573,9 @@ void OMR::Z::Linkage::replaceCallWithJumpInstruction(TR::Instruction *callInstru
    }
 
 
-bool OMR::Z::Linkage::canDataTypeBePassedByReference(TR::DataTypes type) { return false; }
+bool OMR::Z::Linkage::canDataTypeBePassedByReference(TR::DataType type) { return false; }
 
-bool TR_S390zLinuxSystemLinkage::canDataTypeBePassedByReference(TR::DataTypes type)
+bool TR_S390zLinuxSystemLinkage::canDataTypeBePassedByReference(TR::DataType type)
    {
 
    if (type == TR::Aggregate)
@@ -2598,7 +2598,7 @@ bool TR_S390zLinuxSystemLinkage::isSymbolPassedByReference(TR::Symbol *sym)
    int32_t symSize = sym->getSize();
    TR_ASSERT(0, "should not reach here due to folding of getDataTypeOfAggregateMember()");
 
-   TR::DataTypes aggrMemberDataType = TR::NoType;
+   TR::DataType aggrMemberDataType = TR::NoType;
    bool isVectorAggregate = (TR::DataType(aggrMemberDataType).isVector() && cg()->getSupportsVectorRegisters());
 
    if ((symSize > gprSize) && !(gprSize == 4 && symSize == 8) && !isVectorAggregate)
@@ -2653,7 +2653,7 @@ TR_S390zOSSystemLinkage::calculateCallDescriptorFlags(TR::Node *callNode)
    // Bits 3-7 inclusive
    //
 
-   TR::DataTypes dataType;
+   TR::DataType dataType;
    TR::ILOpCodes opcode;
    int32_t aggregateLength = 0;
 
@@ -2736,7 +2736,7 @@ TR_S390zOSSystemLinkage::calculateCallDescriptorFlags(TR::Node *callNode)
    for (int32_t i = firstArgumentChild; (i <= to) && !done; i++, parmCount++)
       {
       TR::Node *child = callNode->getChild(i);
-      TR::DataTypes dataType = child->getDataType();
+      TR::DataType dataType = child->getDataType();
       TR::SymbolReference *parmSymRef = child->getOpCode().hasSymbolReference() ? child->getSymbolReference() : NULL;
       int32_t argSize = 0;
 

--- a/compiler/z/codegen/TRSystemLinkage.hpp
+++ b/compiler/z/codegen/TRSystemLinkage.hpp
@@ -109,10 +109,10 @@ public:
    uint32_t calculateInterfaceMappingFlags(TR::ResolvedMethodSymbol *method);
 
    static uint32_t shiftFloatParmDescriptorFlag(uint32_t fieldVal, int32_t floatParmNum)  { return (fieldVal) << (6*(3-floatParmNum)); } // accepts floatParmNum values 0,1,2,3
-   bool updateFloatParmDescriptorFlags(uint32_t *parmDescriptorFields, TR::Symbol *funcSymbol, int32_t parmCount, int32_t argSize, TR::DataTypes dataType, int32_t *floatParmNum, uint32_t *lastFloatParmAreaOffset, uint32_t *parmAreaOffset);
+   bool updateFloatParmDescriptorFlags(uint32_t *parmDescriptorFields, TR::Symbol *funcSymbol, int32_t parmCount, int32_t argSize, TR::DataType dataType, int32_t *floatParmNum, uint32_t *lastFloatParmAreaOffset, uint32_t *parmAreaOffset);
 
    static uint32_t getFloatParmDescriptorFlag(uint32_t descriptorFields, int32_t floatParmNum)  { return  (descriptorFields >> (6*(3-floatParmNum))) & 0x3F; }
-   uint32_t calculateReturnValueAdjustFlag(TR::DataTypes dataType, int32_t aggregateLength);
+   uint32_t calculateReturnValueAdjustFlag(TR::DataType dataType, int32_t aggregateLength);
    static uint32_t isFloatDescriptorFlagUnprototyped(uint32_t flag)  { return flag == 0; }
 
    virtual bool isEnvironmentSpecialArgumentRegister(int8_t linkageRegisterIndex)
@@ -173,7 +173,7 @@ public:
 
    virtual FrameType checkLeafRoutine(int32_t stackFrameSize, TR::Instruction **callInstruction = 0);
 
-   virtual bool canDataTypeBePassedByReference(TR::DataTypes type);
+   virtual bool canDataTypeBePassedByReference(TR::DataType type);
    virtual bool isSymbolPassedByReference(TR::Symbol *sym);
    };
 

--- a/fvtest/compilertest/compile/Method.cpp
+++ b/fvtest/compilertest/compile/Method.cpp
@@ -79,7 +79,7 @@ ResolvedMethod::signature(TR_Memory * trMemory, TR_AllocationKind allocKind)
       return _signature;
    }
 
-TR::DataTypes
+TR::DataType
 ResolvedMethod::parmType(uint32_t slot)
    {
    TR_ASSERT((slot < _numParms), "Invalid slot provided for Parameter Type");
@@ -128,7 +128,7 @@ ResolvedMethod::makeParameterList(TR::ResolvedMethodSymbol *methodSym)
    for (int32_t parmIndex = 0; parmIndex < parmSlots; ++parmIndex)
       {
       TR::IlType *type = _parmTypes[parmIndex];
-      TR::DataTypes dt = type->getPrimitiveType();
+      TR::DataType dt = type->getPrimitiveType();
       int32_t size = methodSym->convertTypeToSize(dt);
 
       parmSymbol = methodSym->comp()->getSymRefTab()->createParameterSymbol(methodSym, slot, type->getPrimitiveType(), false);
@@ -184,7 +184,7 @@ ResolvedMethod::getInjector (TR::IlGeneratorMethodDetails * details,
    return _ilInjector;
    }
 
-TR::DataTypes
+TR::DataType
 ResolvedMethod::returnType()
    {
    return _returnType->getPrimitiveType();

--- a/fvtest/compilertest/compile/Method.hpp
+++ b/fvtest/compilertest/compile/Method.hpp
@@ -137,7 +137,7 @@ class ResolvedMethod : public ResolvedMethodBase, public Method
    virtual void                * resolvedMethodAddress()                    { return (void *)_ilInjector; }
 
    virtual uint16_t              numberOfParameterSlots()                   { return _numParms; }
-   virtual TR::DataTypes         parmType(uint32_t slot);
+   virtual TR::DataType         parmType(uint32_t slot);
    virtual uint16_t              numberOfTemps()                            { return 0; }
 
    virtual void                * startAddressForJittedMethod()              { return (getEntryPoint()); }
@@ -150,7 +150,7 @@ class ResolvedMethod : public ResolvedMethodBase, public Method
 
    const char                  * getLineNumber()                            { return _lineNumber;}
    char                        * getSignature()                             { return _signature;}
-   TR::DataTypes                 returnType();
+   TR::DataType                 returnType();
    TR::IlType                  * returnIlType()                             { return _returnType; }
    int32_t                       getNumArgs()                               { return _numParms;}
    void                          setEntryPoint(void *ep)                    { _entryPoint = ep; }

--- a/fvtest/compilertest/ilgen/OpIlInjector.hpp
+++ b/fvtest/compilertest/ilgen/OpIlInjector.hpp
@@ -57,7 +57,8 @@ class OpIlInjector : public TR::IlInjector
       : TR::IlInjector(types, test),
         _opCode(opCode),
         _numOptArgs(0),
-        _conditionalDataType(TR::NoType)
+        _dataType(TR::DataTypes::NoType),
+        _conditionalDataType(TR::DataTypes::NoType)
       {
       setDataType();
       }
@@ -128,8 +129,8 @@ class OpIlInjector : public TR::IlInjector
       }
 
    TR::ILOpCodes _opCode;
-   TR::DataTypes _dataType; // datatype of OpCode child/children
-   TR::DataTypes _conditionalDataType; // return type of Ternary opcodes
+   TR::DataType _dataType; // datatype of OpCode child/children
+   TR::DataType _conditionalDataType; // return type of Ternary opcodes
 
    ParmNode **_optArgs;  // holds args that are not on stack params
    uint32_t _numOptArgs;

--- a/fvtest/compilertest/tests/OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/OpCodesTest.cpp
@@ -126,37 +126,37 @@ const uintptrj_t OpCodesTest::ADDRESS_PLACEHOLDER_1 = (uintptrj_t)100;
 const uintptrj_t OpCodesTest::ADDRESS_PLACEHOLDER_2 = (uintptrj_t)200;
 const uintptrj_t OpCodesTest::ADDRESS_PLACEHOLDER_3 = (uintptrj_t)300;
 
-TR::DataTypes OpCodesTest::_argTypesUnaryByte[_numberOfUnaryArgs] = {TR::Int8};
-TR::DataTypes OpCodesTest::_argTypesUnaryShort[_numberOfUnaryArgs] = {TR::Int16};
-TR::DataTypes OpCodesTest::_argTypesUnaryInt[_numberOfUnaryArgs] = {TR::Int32};
-TR::DataTypes OpCodesTest::_argTypesUnaryLong[_numberOfUnaryArgs] = {TR::Int64};
-TR::DataTypes OpCodesTest::_argTypesUnaryFloat[_numberOfUnaryArgs] = {TR::Float};
-TR::DataTypes OpCodesTest::_argTypesUnaryDouble[_numberOfUnaryArgs] = {TR::Double};
-TR::DataTypes OpCodesTest::_argTypesUnaryAddress[_numberOfUnaryArgs] = {TR::Address};
+TR::DataType OpCodesTest::_argTypesUnaryByte[_numberOfUnaryArgs] = {TR::Int8};
+TR::DataType OpCodesTest::_argTypesUnaryShort[_numberOfUnaryArgs] = {TR::Int16};
+TR::DataType OpCodesTest::_argTypesUnaryInt[_numberOfUnaryArgs] = {TR::Int32};
+TR::DataType OpCodesTest::_argTypesUnaryLong[_numberOfUnaryArgs] = {TR::Int64};
+TR::DataType OpCodesTest::_argTypesUnaryFloat[_numberOfUnaryArgs] = {TR::Float};
+TR::DataType OpCodesTest::_argTypesUnaryDouble[_numberOfUnaryArgs] = {TR::Double};
+TR::DataType OpCodesTest::_argTypesUnaryAddress[_numberOfUnaryArgs] = {TR::Address};
 
-TR::DataTypes OpCodesTest::_argTypesBinaryByte[_numberOfBinaryArgs] = {TR::Int8, TR::Int8};
-TR::DataTypes OpCodesTest::_argTypesBinaryShort[_numberOfBinaryArgs] = {TR::Int16, TR::Int16};
-TR::DataTypes OpCodesTest::_argTypesBinaryInt[_numberOfBinaryArgs] = {TR::Int32, TR::Int32};
-TR::DataTypes OpCodesTest::_argTypesBinaryLong[_numberOfBinaryArgs] = {TR::Int64, TR::Int64};
-TR::DataTypes OpCodesTest::_argTypesBinaryFloat[_numberOfBinaryArgs] = {TR::Float, TR::Float};
-TR::DataTypes OpCodesTest::_argTypesBinaryDouble[_numberOfBinaryArgs] = {TR::Double, TR::Double};
-TR::DataTypes OpCodesTest::_argTypesBinaryAddress[_numberOfBinaryArgs] = {TR::Address, TR::Address};
+TR::DataType OpCodesTest::_argTypesBinaryByte[_numberOfBinaryArgs] = {TR::Int8, TR::Int8};
+TR::DataType OpCodesTest::_argTypesBinaryShort[_numberOfBinaryArgs] = {TR::Int16, TR::Int16};
+TR::DataType OpCodesTest::_argTypesBinaryInt[_numberOfBinaryArgs] = {TR::Int32, TR::Int32};
+TR::DataType OpCodesTest::_argTypesBinaryLong[_numberOfBinaryArgs] = {TR::Int64, TR::Int64};
+TR::DataType OpCodesTest::_argTypesBinaryFloat[_numberOfBinaryArgs] = {TR::Float, TR::Float};
+TR::DataType OpCodesTest::_argTypesBinaryDouble[_numberOfBinaryArgs] = {TR::Double, TR::Double};
+TR::DataType OpCodesTest::_argTypesBinaryAddress[_numberOfBinaryArgs] = {TR::Address, TR::Address};
 
-TR::DataTypes OpCodesTest::_argTypesTernaryByte[_numberOfTernaryArgs] = {TR::Int32,TR::Int8, TR::Int8};
-TR::DataTypes OpCodesTest::_argTypesTernaryShort[_numberOfTernaryArgs] = {TR::Int32,TR::Int16, TR::Int16};
-TR::DataTypes OpCodesTest::_argTypesTernaryInt[_numberOfTernaryArgs] = {TR::Int32,TR::Int32, TR::Int32};
-TR::DataTypes OpCodesTest::_argTypesTernaryLong[_numberOfTernaryArgs] = {TR::Int32,TR::Int64, TR::Int64};
-TR::DataTypes OpCodesTest::_argTypesTernaryFloat[_numberOfTernaryArgs] = {TR::Int32,TR::Float, TR::Float};
-TR::DataTypes OpCodesTest::_argTypesTernaryDouble[_numberOfTernaryArgs] = {TR::Int32,TR::Double, TR::Double};
-TR::DataTypes OpCodesTest::_argTypesTernaryAddress[_numberOfTernaryArgs] = {TR::Int32,TR::Address, TR::Address};
+TR::DataType OpCodesTest::_argTypesTernaryByte[_numberOfTernaryArgs] = {TR::Int32,TR::Int8, TR::Int8};
+TR::DataType OpCodesTest::_argTypesTernaryShort[_numberOfTernaryArgs] = {TR::Int32,TR::Int16, TR::Int16};
+TR::DataType OpCodesTest::_argTypesTernaryInt[_numberOfTernaryArgs] = {TR::Int32,TR::Int32, TR::Int32};
+TR::DataType OpCodesTest::_argTypesTernaryLong[_numberOfTernaryArgs] = {TR::Int32,TR::Int64, TR::Int64};
+TR::DataType OpCodesTest::_argTypesTernaryFloat[_numberOfTernaryArgs] = {TR::Int32,TR::Float, TR::Float};
+TR::DataType OpCodesTest::_argTypesTernaryDouble[_numberOfTernaryArgs] = {TR::Int32,TR::Double, TR::Double};
+TR::DataType OpCodesTest::_argTypesTernaryAddress[_numberOfTernaryArgs] = {TR::Int32,TR::Address, TR::Address};
 
-TR::DataTypes OpCodesTest::_argTypesBinaryAddressByte[_numberOfBinaryArgs] = {TR::Address, TR::Int32};
-TR::DataTypes OpCodesTest::_argTypesBinaryAddressShort[_numberOfBinaryArgs] = {TR::Address,TR::Int16};
-TR::DataTypes OpCodesTest::_argTypesBinaryAddressInt[_numberOfBinaryArgs] = {TR::Address, TR::Int32};
-TR::DataTypes OpCodesTest::_argTypesBinaryAddressLong[_numberOfBinaryArgs] = {TR::Address, TR::Int64};
-TR::DataTypes OpCodesTest::_argTypesBinaryAddressFloat[_numberOfBinaryArgs] = {TR::Address, TR::Float};
-TR::DataTypes OpCodesTest::_argTypesBinaryAddressDouble[_numberOfBinaryArgs] = {TR::Address, TR::Double};
-TR::DataTypes OpCodesTest::_argTypesBinaryAddressAddress[_numberOfBinaryArgs] = {TR::Address, TR::Address};
+TR::DataType OpCodesTest::_argTypesBinaryAddressByte[_numberOfBinaryArgs] = {TR::Address, TR::Int32};
+TR::DataType OpCodesTest::_argTypesBinaryAddressShort[_numberOfBinaryArgs] = {TR::Address,TR::Int16};
+TR::DataType OpCodesTest::_argTypesBinaryAddressInt[_numberOfBinaryArgs] = {TR::Address, TR::Int32};
+TR::DataType OpCodesTest::_argTypesBinaryAddressLong[_numberOfBinaryArgs] = {TR::Address, TR::Int64};
+TR::DataType OpCodesTest::_argTypesBinaryAddressFloat[_numberOfBinaryArgs] = {TR::Address, TR::Float};
+TR::DataType OpCodesTest::_argTypesBinaryAddressDouble[_numberOfBinaryArgs] = {TR::Address, TR::Double};
+TR::DataType OpCodesTest::_argTypesBinaryAddressAddress[_numberOfBinaryArgs] = {TR::Address, TR::Address};
 
 //Neg
 signatureCharB_B_testMethodType  * OpCodesTest::_bNeg = 0;
@@ -548,8 +548,8 @@ uint8_t *
 OpCodesTest::compileOpCodeMethod(int32_t opCodeArgsNum,
       TR::ILOpCodes opCode,
       char * resolvedMethodName,
-      TR::DataTypes * argTypes,
-      TR::DataTypes returnType,
+      TR::DataType * argTypes,
+      TR::DataType returnType,
       int32_t & returnCode,
       uint16_t numArgs,
       ...)
@@ -688,8 +688,8 @@ OpCodesTest::compileDirectCallOpCodeMethod(int32_t opCodeArgsNum,
       TR::ILOpCodes opCode,
       char * compileeResolvedMethodName,
       char * testResolvedMethodName,
-      TR::DataTypes * argTypes,
-      TR::DataTypes returnType,
+      TR::DataType * argTypes,
+      TR::DataType returnType,
       int32_t & returnCode)
    {
    TR::TypeDictionary types;
@@ -743,8 +743,8 @@ void
 OpCodesTest::addUnsupportedOpCodeTest(int32_t opCodeArgsNum,
       TR::ILOpCodes opCode,
       char * resolvedMethodName,
-      TR::DataTypes * argTypes,
-      TR::DataTypes returnType)
+      TR::DataType * argTypes,
+      TR::DataType returnType)
    {
    int32_t returnCode = 0;
    compileOpCodeMethod(opCodeArgsNum, opCode, resolvedMethodName, argTypes, returnType, returnCode);
@@ -752,7 +752,7 @@ OpCodesTest::addUnsupportedOpCodeTest(int32_t opCodeArgsNum,
    }
 
 TR::ResolvedMethod *
-OpCodesTest::resolvedMethod(TR::DataTypes dataType)
+OpCodesTest::resolvedMethod(TR::DataType dataType)
    {
    switch (dataType)
       {

--- a/fvtest/compilertest/tests/OpCodesTest.hpp
+++ b/fvtest/compilertest/tests/OpCodesTest.hpp
@@ -175,8 +175,8 @@ class OpCodesTest : public TestDriver
    compileOpCodeMethod(int32_t opCodeArgsNum,
          TR::ILOpCodes opCode,
          char * resolvedMethodName,
-         TR::DataTypes * argTypes,
-         TR::DataTypes returnType,
+         TR::DataType * argTypes,
+         TR::DataType returnType,
          int32_t & returnCode,
          uint16_t numArgs = 0,
          ...);
@@ -187,18 +187,18 @@ class OpCodesTest : public TestDriver
          TR::ILOpCodes opCode,
          char * compileeResolvedMethodName,
          char * testResolvedMethodName,
-         TR::DataTypes * argTypes,
-         TR::DataTypes returnType,
+         TR::DataType * argTypes,
+         TR::DataType returnType,
          int32_t & returnCode);
 
    void
    addUnsupportedOpCodeTest(int32_t opCodeArgsNum,
          TR::ILOpCodes opCode,
          char * resolvedMethodName,
-         TR::DataTypes * argTypes,
-         TR::DataTypes returnType);
+         TR::DataType * argTypes,
+         TR::DataType returnType);
 
-   static TR::ResolvedMethod * resolvedMethod(TR::DataTypes dataType);
+   static TR::ResolvedMethod * resolvedMethod(TR::DataType dataType);
 
    //number of arguments for datatypes
    static const int32_t RESOLVED_METHOD_NAME_LENGTH = 50;
@@ -655,37 +655,37 @@ class OpCodesTest : public TestDriver
    static signatureCharLL_I_testMethodType *_ifacmpgt;
    static signatureCharILL_L_testMethodType *_aternary;
 
-   static TR::DataTypes _argTypesUnaryByte[_numberOfUnaryArgs];
-   static TR::DataTypes _argTypesUnaryShort[_numberOfUnaryArgs];
-   static TR::DataTypes _argTypesUnaryInt[_numberOfUnaryArgs];
-   static TR::DataTypes _argTypesUnaryLong[_numberOfUnaryArgs];
-   static TR::DataTypes _argTypesUnaryFloat[_numberOfUnaryArgs];
-   static TR::DataTypes _argTypesUnaryDouble[_numberOfUnaryArgs];
-   static TR::DataTypes _argTypesUnaryAddress[_numberOfUnaryArgs];
+   static TR::DataType _argTypesUnaryByte[_numberOfUnaryArgs];
+   static TR::DataType _argTypesUnaryShort[_numberOfUnaryArgs];
+   static TR::DataType _argTypesUnaryInt[_numberOfUnaryArgs];
+   static TR::DataType _argTypesUnaryLong[_numberOfUnaryArgs];
+   static TR::DataType _argTypesUnaryFloat[_numberOfUnaryArgs];
+   static TR::DataType _argTypesUnaryDouble[_numberOfUnaryArgs];
+   static TR::DataType _argTypesUnaryAddress[_numberOfUnaryArgs];
 
-   static TR::DataTypes _argTypesBinaryByte[_numberOfBinaryArgs];
-   static TR::DataTypes _argTypesBinaryShort[_numberOfBinaryArgs];
-   static TR::DataTypes _argTypesBinaryInt[_numberOfBinaryArgs];
-   static TR::DataTypes _argTypesBinaryLong[_numberOfBinaryArgs];
-   static TR::DataTypes _argTypesBinaryFloat[_numberOfBinaryArgs];
-   static TR::DataTypes _argTypesBinaryDouble[_numberOfBinaryArgs];
-   static TR::DataTypes _argTypesBinaryAddress[_numberOfBinaryArgs];
+   static TR::DataType _argTypesBinaryByte[_numberOfBinaryArgs];
+   static TR::DataType _argTypesBinaryShort[_numberOfBinaryArgs];
+   static TR::DataType _argTypesBinaryInt[_numberOfBinaryArgs];
+   static TR::DataType _argTypesBinaryLong[_numberOfBinaryArgs];
+   static TR::DataType _argTypesBinaryFloat[_numberOfBinaryArgs];
+   static TR::DataType _argTypesBinaryDouble[_numberOfBinaryArgs];
+   static TR::DataType _argTypesBinaryAddress[_numberOfBinaryArgs];
 
-   static TR::DataTypes _argTypesTernaryByte[_numberOfTernaryArgs];
-   static TR::DataTypes _argTypesTernaryShort[_numberOfTernaryArgs];
-   static TR::DataTypes _argTypesTernaryInt[_numberOfTernaryArgs];
-   static TR::DataTypes _argTypesTernaryLong[_numberOfTernaryArgs];
-   static TR::DataTypes _argTypesTernaryFloat[_numberOfTernaryArgs];
-   static TR::DataTypes _argTypesTernaryDouble[_numberOfTernaryArgs];
-   static TR::DataTypes _argTypesTernaryAddress[_numberOfTernaryArgs];
+   static TR::DataType _argTypesTernaryByte[_numberOfTernaryArgs];
+   static TR::DataType _argTypesTernaryShort[_numberOfTernaryArgs];
+   static TR::DataType _argTypesTernaryInt[_numberOfTernaryArgs];
+   static TR::DataType _argTypesTernaryLong[_numberOfTernaryArgs];
+   static TR::DataType _argTypesTernaryFloat[_numberOfTernaryArgs];
+   static TR::DataType _argTypesTernaryDouble[_numberOfTernaryArgs];
+   static TR::DataType _argTypesTernaryAddress[_numberOfTernaryArgs];
 
-   static TR::DataTypes _argTypesBinaryAddressByte[_numberOfBinaryArgs];
-   static TR::DataTypes _argTypesBinaryAddressShort[_numberOfBinaryArgs];
-   static TR::DataTypes _argTypesBinaryAddressInt[_numberOfBinaryArgs];
-   static TR::DataTypes _argTypesBinaryAddressLong[_numberOfBinaryArgs];
-   static TR::DataTypes _argTypesBinaryAddressFloat[_numberOfBinaryArgs];
-   static TR::DataTypes _argTypesBinaryAddressDouble[_numberOfBinaryArgs];
-   static TR::DataTypes _argTypesBinaryAddressAddress[_numberOfBinaryArgs];
+   static TR::DataType _argTypesBinaryAddressByte[_numberOfBinaryArgs];
+   static TR::DataType _argTypesBinaryAddressShort[_numberOfBinaryArgs];
+   static TR::DataType _argTypesBinaryAddressInt[_numberOfBinaryArgs];
+   static TR::DataType _argTypesBinaryAddressLong[_numberOfBinaryArgs];
+   static TR::DataType _argTypesBinaryAddressFloat[_numberOfBinaryArgs];
+   static TR::DataType _argTypesBinaryAddressDouble[_numberOfBinaryArgs];
+   static TR::DataType _argTypesBinaryAddressAddress[_numberOfBinaryArgs];
 
    // straight C(++) implementations of testMethodType for initial test validation purposes
    template <typename T> static T neg(T a) { return -a;}

--- a/jitbuilder/compile/Method.cpp
+++ b/jitbuilder/compile/Method.cpp
@@ -78,7 +78,7 @@ ResolvedMethod::signature(TR_Memory * trMemory, TR_AllocationKind allocKind)
       return _signature;
    }
 
-TR::DataTypes
+TR::DataType
 ResolvedMethod::parmType(uint32_t slot)
    {
    TR_ASSERT((slot < _numParms), "Invalid slot provided for Parameter Type");
@@ -127,7 +127,7 @@ ResolvedMethod::makeParameterList(TR::ResolvedMethodSymbol *methodSym)
    for (int32_t parmIndex = 0; parmIndex < parmSlots; ++parmIndex)
       {
       TR::IlType *type = _parmTypes[parmIndex];
-      TR::DataTypes dt = type->getPrimitiveType();
+      TR::DataType dt = type->getPrimitiveType();
       int32_t size = methodSym->convertTypeToSize(dt);
 
       parmSymbol = methodSym->comp()->getSymRefTab()->createParameterSymbol(methodSym, slot, type->getPrimitiveType(), false);
@@ -183,7 +183,7 @@ ResolvedMethod::getInjector (TR::IlGeneratorMethodDetails * details,
    return _ilInjector;
    }
 
-TR::DataTypes
+TR::DataType
 ResolvedMethod::returnType()
    {
    return _returnType->getPrimitiveType();

--- a/jitbuilder/compile/Method.hpp
+++ b/jitbuilder/compile/Method.hpp
@@ -137,7 +137,7 @@ class ResolvedMethod : public ResolvedMethodBase, public Method
    virtual void                * resolvedMethodAddress()                    { return (void *)_ilInjector; }
 
    virtual uint16_t              numberOfParameterSlots()                   { return _numParms; }
-   virtual TR::DataTypes         parmType(uint32_t slot);
+   virtual TR::DataType         parmType(uint32_t slot);
    virtual uint16_t              numberOfTemps()                            { return 0; }
 
    virtual void                * startAddressForJittedMethod()              { return (getEntryPoint()); }
@@ -150,7 +150,7 @@ class ResolvedMethod : public ResolvedMethodBase, public Method
 
    const char                  * getLineNumber()                            { return _lineNumber;}
    char                        * getSignature()                             { return _signature;}
-   TR::DataTypes                 returnType();
+   TR::DataType                 returnType();
    TR::IlType                  * returnIlType()                             { return _returnType; }
    int32_t                       getNumArgs()                               { return _numParms;}
    void                          setEntryPoint(void *ep)                    { _entryPoint = ep; }


### PR DESCRIPTION
Currently, there is TR::DataTypes and TR::DataType. In a given situation, it is not clear which data type to use.

These changes are meant to make TR::DataType behave the same way as TR::DataTypes by adding operators, so that TR::DataType should be used over TR::DataTypes whenever possible.

The only times TR::DataTypes should be used is when the enum constants are needed, or to create a TR::DataType from a value stored directly as an int.