### PR TITLE
Fix overflow errors in options processing

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1048,7 +1048,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"stopOnFailure",      "D\tstop compilation if exceed memory threshold", SET_OPTION_BIT(TR_StopOnFailure), "P"},
    {"stopThrottlingTime=", "M<nnn>\tTime when compilation throttling should stop (ms since JVM start)",
                              TR::Options::setStaticNumeric, (intptrj_t)&OMR::Options::_stopThrottlingTime, 0, "F%d", NOT_IN_SUBSET },
-   {"storeSinkingLastOpt=", "C<nnn>\tLast store sinking optimization to perform", TR::Options::set32BitNumeric, offsetof(OMR::Options, _storeSinkingLastOpt), -1 , "F%d"},
+   {"storeSinkingLastOpt=", "C<nnn>\tLast store sinking optimization to perform", TR::Options::set32BitNumeric, offsetof(OMR::Options, _storeSinkingLastOpt), static_cast<uintptrj_t>(-1) , "F%d"},
    {"strictFPCompares",   "C\tassume strictFP semantics for floating point compares only", SET_OPTION_BIT(TR_StrictFPCompares), "F" },
    {"subtractLoopyMethodCounts",   "C\tSubtract loopy method counts instead of dividing", SET_OPTION_BIT(TR_SubtractLoopyMethodCounts), "F", NOT_IN_SUBSET},
    {"subtractMethodCountsWhenIprofilerIsOff",   "C\tSubtract method counts instead of dividing when Iprofiler is off", SET_OPTION_BIT(TR_SubtractMethodCountsWhenIprofilerIsOff), "F", NOT_IN_SUBSET},

--- a/compiler/control/OptionsUtil.hpp
+++ b/compiler/control/OptionsUtil.hpp
@@ -87,7 +87,7 @@ struct OptionTable
     * Parameters to be passed to the processing method.
     */
    intptrj_t parm1;
-   intptrj_t parm2;
+   uintptrj_t parm2;
 
    /**
     * Message information to be printed if this option is in effect


### PR DESCRIPTION
The JIT fails to compile for IA32 with newer versions of GCC (tested on
GCC 6.2.1). The failures occur because we use values greater than
0x80000000 to set option flag bits.  Changing OptionTable::parm2 to be
unsigned fixes most of the problem, however the storeSinkingLastOpt
option attempts to set parm2 to -1.

Because storeSinkingLastOpt is unique in attempting to use parm2 as a
signed value, change parm2 to be unsigned, and use a static_cast to
coerce the field into accepting storeSinkingLastOpt's -1 value.

Signed-off-by: Luc des Trois Maisons <lmaisons@ca.ibm.com>