### PR TITLE
Remove MethodEnterHook and MethodExitHook Opcodes

### DIFF
--- a/compiler/arm/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/arm/codegen/TreeEvaluatorTable.hpp
@@ -491,8 +491,6 @@
    TR::TreeEvaluator::badILOpEvaluator,     // TR::fternary
    TR::TreeEvaluator::badILOpEvaluator,     // TR::dternary
    TR::TreeEvaluator::treetopEvaluator,     // TR::treetop
-   TR::TreeEvaluator::badILOpEvaluator,     // TR::MethodEnterHook
-   TR::TreeEvaluator::badILOpEvaluator,     // TR::MethodExitHook
    TR::TreeEvaluator::passThroughEvaluator, // TR::PassThrough
    TR::TreeEvaluator::badILOpEvaluator,     // TR::compressedRefs
 

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -3033,8 +3033,10 @@ OMR::CodeGenerator::treeContainsCall(TR::TreeTop * treeTop)
        l1OpCode == TR::checkcast       ||
        l1OpCode == TR::instanceof      ||
        l1OpCode == TR::ArrayStoreCHK   ||
+#ifdef J9_PROJECT_SPECIFIC
        l1OpCode == TR::MethodEnterHook ||
        l1OpCode == TR::MethodExitHook  ||
+#endif
        l1OpCode == TR::New             ||
        l1OpCode == TR::newarray        ||
        l1OpCode == TR::anewarray       ||

--- a/compiler/il/ILOpCodeProperties.hpp
+++ b/compiler/il/ILOpCodeProperties.hpp
@@ -5556,36 +5556,6 @@
    },
 
    {
-   /* .opcode               = */ TR::MethodEnterHook,
-   /* .name                 = */ "MethodEnterHook",
-   /* .properties1          = */ ILProp1::TreeTop | ILProp1::HasSymbolRef,
-   /* .properties2          = */ ILProp2::MustBeLowered | ILProp2::MayUseVMThread | ILProp2::MayUseSystemStack,
-   /* .properties3          = */ 0,
-   /* .properties4          = */ 0,
-   /* .dataType             = */ TR::NoType,
-   /* .typeProperties       = */ 0,
-   /* .swapChildrenOpCode   = */ TR::BadILOp,
-   /* .reverseBranchOpCode  = */ TR::BadILOp,
-   /* .booleanCompareOpCode = */ TR::BadILOp,
-   /* .ifCompareOpCode      = */ TR::BadILOp,
-   },
-
-   {
-   /* .opcode               = */ TR::MethodExitHook,
-   /* .name                 = */ "MethodExitHook",
-   /* .properties1          = */ ILProp1::TreeTop | ILProp1::HasSymbolRef,
-   /* .properties2          = */ ILProp2::MustBeLowered | ILProp2::MayUseVMThread | ILProp2::MayUseSystemStack,
-   /* .properties3          = */ 0,
-   /* .properties4          = */ 0,
-   /* .dataType             = */ TR::NoType,
-   /* .typeProperties       = */ 0,
-   /* .swapChildrenOpCode   = */ TR::BadILOp,
-   /* .reverseBranchOpCode  = */ TR::BadILOp,
-   /* .booleanCompareOpCode = */ TR::BadILOp,
-   /* .ifCompareOpCode      = */ TR::BadILOp,
-   },
-
-   {
    /* .opcode               = */ TR::PassThrough,
    /* .name                 = */ "PassThrough",
    /* .properties1          = */ 0,

--- a/compiler/il/OMRILOpCodesEnum.hpp
+++ b/compiler/il/OMRILOpCodesEnum.hpp
@@ -423,8 +423,6 @@
    fternary,   //
    dternary,   //
    treetop,  // tree top to anchor subtrees with side-effects
-   MethodEnterHook, // called after a frame is built, temps initialized, and monitor acquired (if necessary)
-   MethodExitHook,  // called immediately before returning, frame not yet collapsed, monitor released (if necessary)
    PassThrough, // Dummy node that represents its single child.
    compressedRefs,   // no-op anchor providing optimizable subexpressions used for compression/decompression.  First child is address load/store, second child is heap base displacement
    BBStart,  // Start of Basic Block

--- a/compiler/optimizer/OMRLocalCSE.cpp
+++ b/compiler/optimizer/OMRLocalCSE.cpp
@@ -1631,6 +1631,8 @@ void OMR::LocalCSE::killAvailableExpressionsAtGCSafePoints(TR::Node *node, TR::N
    if (parent != NULL)
       return;
 
+#ifdef J9_PROJECT_SPECIFIC
+
    if ((node->getOpCodeValue() == TR::MethodEnterHook) ||
        (node->getOpCodeValue() == TR::MethodExitHook))
       {
@@ -1667,6 +1669,8 @@ void OMR::LocalCSE::killAvailableExpressionsAtGCSafePoints(TR::Node *node, TR::N
          _hashTableWithCalls._buckets[i] = NULL;
       return;
       }
+
+#endif
 
    if (node->canGCandReturn())
       {

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -17733,16 +17733,15 @@ TR::Node *NewSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
 // Used by MethodEnter/ExitHook
 TR::Node *lowerTreeSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    {
+#ifdef J9_PROJECT_SPECIFIC
    if(node->getOpCodeValue() == TR::MethodExitHook)
       {
       s->_performLowerTreeSimplifier = s->_curTree;
       s->_performLowerTreeNode = node;
       return node;
       }
-   else
-      {
-      return postWalkLowerTreeSimplifier(s->_curTree,node, block,s);
-      }
+#endif
+   return postWalkLowerTreeSimplifier(s->_curTree,node, block,s);
    }
 
 // Simplification of arrayLength operator

--- a/compiler/optimizer/OMRSimplifierTableEnum.hpp
+++ b/compiler/optimizer/OMRSimplifierTableEnum.hpp
@@ -402,8 +402,6 @@
    ternarySimplifier,       // TR::fternary
    ternarySimplifier,       // TR::dternary
    treetopSimplifier,       // TR::treetop
-   lowerTreeSimplifier,     // TR::MethodEnterHook
-   lowerTreeSimplifier,     // TR::MethodExitHook
    passThroughSimplifier,   // TR::PassThrough
    anchorSimplifier,        // TR::compressedRefs
 

--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -542,8 +542,6 @@ const ValuePropagationPtr constraintHandlers[] =
    constrainChildrenFirstToLast,        // TR::fternary
    constrainChildrenFirstToLast,        // TR::dternary
    constrainChildren,        // TR::treetop
-   constrainChildren,        // TR::MethodEnterHook
-   constrainChildren,        // TR::MethodExitHook
    constrainChildren,        // TR::PassThrough
    constrainChildren,        // TR::compressedRefs
 
@@ -998,6 +996,9 @@ const ValuePropagationPtr constraintHandlers[] =
    constrainChildren,           // TR::dfModifyPrecision
    constrainChildren,           // TR::ddModifyPrecision
    constrainChildren,           // TR::deModifyPrecision
+
+   constrainChildren,           // TR::MethodEnterHook
+   constrainChildren,           // TR::MethodExitHook
 
    constrainChildren,           // TR::i2df
    constrainChildren,           // TR::iu2df

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -2484,8 +2484,10 @@ inline static bool callInTree(TR::TreeTop *treeTop)
        l1OpCode == TR::checkcast       ||
        l1OpCode == TR::instanceof      ||
        l1OpCode == TR::ArrayStoreCHK   ||
+#ifdef J9_PROJECT_SPECIFIC
        l1OpCode == TR::MethodEnterHook ||
        l1OpCode == TR::MethodExitHook  ||
+#endif
        l1OpCode == TR::New             ||
        l1OpCode == TR::newarray        ||
        l1OpCode == TR::anewarray       ||

--- a/compiler/p/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/TreeEvaluatorTable.hpp
@@ -387,8 +387,6 @@
    TR::TreeEvaluator::iternaryEvaluator,                // TR::fternary
    TR::TreeEvaluator::iternaryEvaluator,                // TR::dternary
    TR::TreeEvaluator::treetopEvaluator,                 // TR::treetop
-   TR::TreeEvaluator::badILOpEvaluator,                    // TR::MethodEnterHook (J9)
-   TR::TreeEvaluator::badILOpEvaluator,                    // TR::MethodExitHook (J9)
    TR::TreeEvaluator::passThroughEvaluator,             // TR::PassThrough
    TR::TreeEvaluator::compressedRefsEvaluator,          // TR::compressedRefs
    TR::TreeEvaluator::BBStartEvaluator,                 // TR::BBStart

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -2707,8 +2707,6 @@ int32_t childTypes[] =
    TR::Float | (TR::Int32<<8),     // TR::fternary
    TR::Double | (TR::Int32<<8),    // TR::dternary
    TR::NoType,                     // TR::treetop
-   TR::NoType,                     // TR::MethodEnterHook
-   TR::NoType,                     // TR::MethodExitHook
    TR::NoType,                     // TR::PassThrough
    TR::Address,                   // TR::compressedRefs   FIXME:IL: shouldn't second arg be TR::Int64?  Type info should be like TR::aladd
    TR::NoType,                     // TR::BBStart
@@ -3161,6 +3159,9 @@ int32_t childTypes[] =
    TR::DecimalDouble | (TR::Int32<<16),                      // TR::ddModifyPrecision
    TR::DecimalLongDouble | (TR::Int32<<16),                  // TR::deModifyPrecision
 
+   TR::NoType,                                               // TR::MethodEnterHook
+   TR::NoType,                                               // TR::MethodExitHook
+ 
    TR::Int32,                                                // TR::i2df
    TR::Int32,                                                // TR::iu2df
    TR::Int64,                                                // TR::l2df

--- a/compiler/x/amd64/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/x/amd64/codegen/TreeEvaluatorTable.hpp
@@ -388,8 +388,6 @@
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::fternary
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::dternary
    TR::TreeEvaluator::treetopEvaluator,                 // TR::treetop
-   TR::TreeEvaluator::badILOpEvaluator,                    // TR::MethodEnterHook (J9)
-   TR::TreeEvaluator::badILOpEvaluator,                    // TR::MethodExitHook (J9)
    TR::TreeEvaluator::passThroughEvaluator,             // TR::PassThrough
    TR::TreeEvaluator::compressedRefsEvaluator,          // TR::compressedRefs
    TR::TreeEvaluator::BBStartEvaluator,                 // TR::BBStart

--- a/compiler/x/i386/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/x/i386/codegen/TreeEvaluatorTable.hpp
@@ -388,8 +388,6 @@
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::fternary
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::dternary
    TR::TreeEvaluator::treetopEvaluator,                 // TR::treetop
-   TR::TreeEvaluator::badILOpEvaluator,                    // TR::MethodEnterHook (J9)
-   TR::TreeEvaluator::badILOpEvaluator,                    // TR::MethodExitHook (J9)
    TR::TreeEvaluator::passThroughEvaluator,             // TR::PassThrough
    TR::TreeEvaluator::compressedRefsEvaluator,          // TR::compressedRefs
    TR::TreeEvaluator::BBStartEvaluator,                 // TR::BBStart

--- a/compiler/z/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/z/codegen/TreeEvaluatorTable.hpp
@@ -417,8 +417,6 @@
    TR::TreeEvaluator::ternaryEvaluator,     // TR::fternary
    TR::TreeEvaluator::dternaryEvaluator,     // TR::dternary
    TR::TreeEvaluator::treetopEvaluator,     // TR::treetop
-   TR::TreeEvaluator::badILOpEvaluator,     // TR::MethodEnterHook
-   TR::TreeEvaluator::badILOpEvaluator,     // TR::MethodExitHook
    TR::TreeEvaluator::passThroughEvaluator, // TR::PassThrough
    TR::TreeEvaluator::compressedRefsEvaluator,  // TR::compressedRefs
    TR::TreeEvaluator::BBStartEvaluator,     // TR::BBStart


### PR DESCRIPTION
Remove the Op codes from all tables  since these Op codes are
J9 specific.

Where deletion is not trivial, guard usage of these Op codes
by using #ifdef J9_PROJECT_SPECIFIC.

Signed-off-by: Aman Kumar <amank@ca.ibm.com>