### PR TITLE
Remove the deprecated Compilation::removeTree

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -2267,15 +2267,6 @@ OMR::Compilation::getSymRefCount()
    return self()->getSymRefTab()->getNumSymRefs();
    }
 
-/**
-  * @deprecated Use TransformUtil::removeTree
-  */
-void
-OMR::Compilation::removeTree(TR::TreeTop * tt)
-   {
-   _methodSymbol->removeTree(tt);
-   }
-
 void
 OMR::Compilation::setStartTree(TR::TreeTop * tt)
    {

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -965,7 +965,6 @@ public:
 #endif
 
    // To TransformUtil
-   void removeTree(TR::TreeTop * tt);
    void setStartTree(TR::TreeTop * tt);
 
 


### PR DESCRIPTION
This function is no longer used, so it can be removed.