### PR TITLE
Remove "REMOVE_THIS_LATER" markers

### DIFF
--- a/compiler/codegen/FrontEnd.hpp
+++ b/compiler/codegen/FrontEnd.hpp
@@ -19,8 +19,8 @@
 #ifndef FRONTEND_INCL
 #define FRONTEND_INCL
 
-#include "infra/List.hpp" // REMOVE_THIS_LATER
-#include "infra/Random.hpp" // REMOVE_THIS_LATER
+#include "infra/List.hpp"
+#include "infra/Random.hpp"
 
 #include <stdarg.h>                              // for va_list
 #include <stddef.h>                              // for size_t

--- a/compiler/codegen/GCStackMap.hpp
+++ b/compiler/codegen/GCStackMap.hpp
@@ -19,7 +19,7 @@
 #ifndef GCSTACKMAP_INCL
 #define GCSTACKMAP_INCL
 
-#include "il/symbol/LabelSymbol.hpp" // REMOVE_THIS_LATER
+#include "il/symbol/LabelSymbol.hpp"
 
 #include <stddef.h>                         // for size_t
 #include <stdint.h>                         // for uint8_t

--- a/compiler/codegen/OMRGCStackAtlas.hpp
+++ b/compiler/codegen/OMRGCStackAtlas.hpp
@@ -28,7 +28,7 @@ namespace OMR { class GCStackAtlas; }
 namespace OMR { typedef OMR::GCStackAtlas GCStackAtlasConnector; }
 #endif
 
-#include "codegen/GCStackMap.hpp" // REMOVE_THIS_LATER
+#include "codegen/GCStackMap.hpp"
 
 #include <stddef.h>               // for NULL
 #include <stdint.h>               // for uint32_t, int32_t, uint8_t

--- a/compiler/codegen/OMRLinkage.hpp
+++ b/compiler/codegen/OMRLinkage.hpp
@@ -28,8 +28,8 @@ namespace OMR { class Linkage; }
 namespace OMR { typedef OMR::Linkage LinkageConnector; }
 #endif
 
-#include "infra/List.hpp" // REMOVE_THIS_LATER
-#include "il/symbol/ParameterSymbol.hpp" // REMOVE_THIS_LATER
+#include "infra/List.hpp"
+#include "il/symbol/ParameterSymbol.hpp"
 
 #include <stddef.h>                            // for NULL
 #include <stdint.h>                            // for uint32_t, uint8_t, etc

--- a/compiler/codegen/OMRSnippetGCMap.cpp
+++ b/compiler/codegen/OMRSnippetGCMap.cpp
@@ -17,7 +17,7 @@
  *******************************************************************************/
 
 #include <stdint.h>
-#include "codegen/GCStackAtlas.hpp" // REMOVE_THIS_LATER
+#include "codegen/GCStackAtlas.hpp"
 #include "codegen/SnippetGCMap.hpp"
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/Instruction.hpp"

--- a/compiler/codegen/Register.hpp
+++ b/compiler/codegen/Register.hpp
@@ -19,7 +19,7 @@
 #ifndef TR_REGISTER_INCL
 #define TR_REGISTER_INCL
 
-#include "infra/List.hpp" // REMOVE_THIS_LATER
+#include "infra/List.hpp"
 
 #include "codegen/OMRRegister.hpp"
 

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -67,7 +67,7 @@ namespace OMR { typedef OMR::Compilation CompilationConnector; }
 
 #include "omr.h"
 
-#include "il/symbol/ResolvedMethodSymbol.hpp" // REMOVE_THIS_LATER
+#include "il/symbol/ResolvedMethodSymbol.hpp"
 
 
 class TR_AOTGuardSite;

--- a/compiler/compile/OMRMethod.hpp
+++ b/compiler/compile/OMRMethod.hpp
@@ -19,7 +19,7 @@
 #ifndef METHOD_INCL
 #define METHOD_INCL
 
-#include "compile/InlineBlock.hpp" // REMOVE_THIS_LATER
+#include "compile/InlineBlock.hpp"
 
 #include <limits.h>                         // for INT_MAX
 #include <stddef.h>                         // for NULL, size_t

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -28,8 +28,8 @@ namespace OMR { class SymbolReferenceTable; }
 namespace OMR { typedef OMR::SymbolReferenceTable SymbolReferenceTableConnector; }
 #endif
 
-#include "infra/HashTab.hpp"  // REMOVE_THIS_LATER
-#include "il/symbol/ResolvedMethodSymbol.hpp"  // REMOVE_THIS_LATER
+#include "infra/HashTab.hpp"
+#include "il/symbol/ResolvedMethodSymbol.hpp"
 
 #include <stddef.h>                            // for NULL, size_t
 #include <stdint.h>                            // for int32_t, etc

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -46,7 +46,7 @@ namespace OMR { typedef OMR::Options OptionsConnector; }
 #include "optimizer/Optimizations.hpp"   // for Optimizations, etc
 #include "ras/DebugCounter.hpp"          // for TR::DebugCounter, etc
 
-namespace TR { class CFGNode; } // REMOVE_THIS_LATER
+namespace TR { class CFGNode; }
 
 class TR_CompilationFilters;
 class TR_Debug;

--- a/compiler/control/OptimizationPlan.hpp
+++ b/compiler/control/OptimizationPlan.hpp
@@ -19,7 +19,7 @@
 #ifndef OPTIMIZATION_PLAN_INCL
 #define OPTIMIZATION_PLAN_INCL
 
-#include "optimizer/Optimizer.hpp" // REMOVE_THIS_LATER
+#include "optimizer/Optimizer.hpp"
 
 #include <stddef.h>                      // for size_t
 #include <stdint.h>                      // for int32_t, uint32_t

--- a/compiler/env/ExceptionTable.hpp
+++ b/compiler/env/ExceptionTable.hpp
@@ -19,7 +19,7 @@
 #ifndef EXCEPTIONTABLE_INCL
 #define EXCEPTIONTABLE_INCL
 
-#include "infra/Array.hpp" // REMOVE_THIS_LATER
+#include "infra/Array.hpp"
 
 #include <stdint.h>          // for uint32_t, uint16_t, int32_t
 #include "env/TRMemory.hpp"  // for TR_Memory, etc

--- a/compiler/env/OMRIO.hpp
+++ b/compiler/env/OMRIO.hpp
@@ -33,7 +33,7 @@ namespace OMR { typedef OMR::IO IOConnector; }
 #include "env/FilePointerDecl.hpp"  // for FILE
 #include "infra/Annotations.hpp"    // for OMR_EXTENSIBLE
 
-#include "env/FilePointer.hpp" // REMOVE_THIS_LATER
+#include "env/FilePointer.hpp"
 
 /* All compilers now use the same format string for signed/unsigned 64-bit values.
  *

--- a/compiler/env/TRMemory.hpp
+++ b/compiler/env/TRMemory.hpp
@@ -68,11 +68,11 @@
 #include "infra/ReferenceWrapper.hpp"   // for reference_wrapper
 #include "env/Region.hpp"               // for Region
 
-#include <stdlib.h> // REMOVE_THIS_LATER
-#include "cs2/bitmanip.h" // REMOVE_THIS_LATER
-#include "cs2/hashtab.h" // REMOVE_THIS_LATER
-#include "cs2/llistof.h" // REMOVE_THIS_LATER
-#include "env/jittypes.h" // REMOVE_THIS_LATER
+#include <stdlib.h>
+#include "cs2/bitmanip.h"
+#include "cs2/hashtab.h"
+#include "cs2/llistof.h"
+#include "env/jittypes.h"
 
 #include "env/TypedAllocator.hpp"
 

--- a/compiler/infra/HashTab.hpp
+++ b/compiler/infra/HashTab.hpp
@@ -25,7 +25,7 @@
 #include "env/jittypes.h"    // for uintptrj_t, intptrj_t
 #include "infra/Assert.hpp"  // for TR_ASSERT
 
-#include "infra/Bit.hpp" // REMOVE_THIS_LATER
+#include "infra/Bit.hpp"
 
 class TR_HashTab;
 namespace TR { class Compilation; }

--- a/compiler/infra/Timer.hpp
+++ b/compiler/infra/Timer.hpp
@@ -24,7 +24,7 @@
 #include "env/TRMemory.hpp"  // for TR_Memory, etc
 #include "infra/Array.hpp"   // for TR_Array
 
-#include "infra/HashTab.hpp" //REMOVE_THIS_LATER
+#include "infra/HashTab.hpp"
 
 namespace TR { class Compilation; }
 

--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -30,7 +30,7 @@
 #ifndef INLINER_INCL
 #define INLINER_INCL
 
-#include "optimizer/CallInfo.hpp" // REMOVE_THIS_LATER
+#include "optimizer/CallInfo.hpp"
 
 #include <stddef.h>                            // for NULL
 #include <stdint.h>                            // for int32_t, uint32_t, etc

--- a/compiler/optimizer/Structure.hpp
+++ b/compiler/optimizer/Structure.hpp
@@ -38,7 +38,7 @@
 #include "infra/TRCfgEdge.hpp"      // for CFGEdge
 #include "infra/TRCfgNode.hpp"      // for CFGNode
 
-#include "optimizer/VPConstraint.hpp" // REMOVE_THIS_LATER
+#include "optimizer/VPConstraint.hpp"
 
 class TR_BasicInductionVariable;
 class TR_BlockStructure;

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -46,8 +46,8 @@ namespace OMR { typedef OMR::Power::CodeGenerator CodeGeneratorConnector; }
 #include "infra/TRlist.hpp"
 #include "optimizer/DataFlowAnalysis.hpp"
 
-#include "codegen/RegisterPair.hpp" // REMOVE_THIS_LATER
-#include "codegen/MemoryReference.hpp" // REMOVE_THIS_LATER
+#include "codegen/RegisterPair.hpp"
+#include "codegen/MemoryReference.hpp"
 
 class TR_BackingStore;
 class TR_PPCLoadLabelItem;

--- a/compiler/p/codegen/PPCHelperCallSnippet.hpp
+++ b/compiler/p/codegen/PPCHelperCallSnippet.hpp
@@ -26,7 +26,7 @@
 #include "codegen/RealRegister.hpp"  // for RealRegister, etc
 #include "il/SymbolReference.hpp"    // for SymbolReference
 
-#include "codegen/GCStackAtlas.hpp" // REMOVE_THIS_LATER
+#include "codegen/GCStackAtlas.hpp"
 
 namespace TR { class CodeGenerator; }
 namespace TR { class LabelSymbol; }

--- a/compiler/p/codegen/PPCInstruction.hpp
+++ b/compiler/p/codegen/PPCInstruction.hpp
@@ -44,7 +44,7 @@
 #include "p/codegen/PPCOpsDefines.hpp"           // for PPCOpProp_NoHint
 #include "runtime/Runtime.hpp"
 
-#include "codegen/GCStackMap.hpp" // REMOVE_THIS_LATER
+#include "codegen/GCStackMap.hpp"
 
 class TR_VirtualGuardSite;
 namespace TR { class SymbolReference; }

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -50,7 +50,7 @@
 #include "optimizer/Optimizations.hpp"      // for Optimizations
 #include "runtime/Runtime.hpp"              // for TR_CCPreLoadedCode
 
-#include "codegen/RegisterRematerializationInfo.hpp" // REMOVE_THIS_LATER
+#include "codegen/RegisterRematerializationInfo.hpp"
 
 class TR_Debug;
 class TR_BlockStructure;

--- a/compiler/ras/DebugCounter.hpp
+++ b/compiler/ras/DebugCounter.hpp
@@ -19,7 +19,7 @@
 #ifndef DEBUGCOUNTER_INCL
 #define DEBUGCOUNTER_INCL
 
-#include "ras/Debug.hpp" // REMOVE_THIS_LATER
+#include "ras/Debug.hpp"
 
 #include <stdarg.h>          // for va_list
 #include <stddef.h>          // for NULL

--- a/compiler/runtime/Runtime.hpp
+++ b/compiler/runtime/Runtime.hpp
@@ -23,7 +23,7 @@
 #include "env/defines.h"   // for TR_HOST_X86, TR_HOST_64BIT
 #include "env/jittypes.h"  // for intptrj_t
 
-#include "env/Processors.hpp" // REMOVE_THIS_LATER
+#include "env/Processors.hpp"
 
 #ifdef RUBY_PROJECT_SPECIFIC
 #include "ruby/config.h"

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -50,12 +50,12 @@ namespace OMR { typedef OMR::X86::CodeGenerator CodeGeneratorConnector; }
 #include <sys/time.h>                          // for timeval
 #endif
 
-#include "codegen/Instruction.hpp" // REMOVE_THIS_LATER
-#include "il/symbol/LabelSymbol.hpp" // REMOVE_THIS_LATER
-#include "il/symbol/StaticSymbol.hpp" // REMOVE_THIS_LATER
-#include "x/codegen/OutlinedInstructions.hpp" // REMOVE_THIS_LATER
-#include "codegen/GCStackMap.hpp" // REMOVE_THIS_LATER
-#include "codegen/GCStackAtlas.hpp" // REMOVE_THIS_LATER
+#include "codegen/Instruction.hpp"
+#include "il/symbol/LabelSymbol.hpp"
+#include "il/symbol/StaticSymbol.hpp"
+#include "x/codegen/OutlinedInstructions.hpp"
+#include "codegen/GCStackMap.hpp"
+#include "codegen/GCStackAtlas.hpp"
 
 class TR_GCStackMap;
 class TR_IA32ConstantDataSnippet;

--- a/compiler/x/codegen/OMRMemoryReference.hpp
+++ b/compiler/x/codegen/OMRMemoryReference.hpp
@@ -48,7 +48,7 @@ namespace OMR { typedef OMR::X86::MemoryReference MemoryReferenceConnector; }
 #include "infra/Flags.hpp"                         // for flags16_t
 #include "x/codegen/DataSnippet.hpp"
 
-#include "x/codegen/ConstantDataSnippet.hpp" // REMOVE_THIS_LATER
+#include "x/codegen/ConstantDataSnippet.hpp"
 
 #define HIGHEST_STRIDE_MULTIPLIER 8
 #define HIGHEST_STRIDE_SHIFT      3

--- a/compiler/z/codegen/CallSnippet.hpp
+++ b/compiler/z/codegen/CallSnippet.hpp
@@ -26,7 +26,7 @@
 #include "runtime/Runtime.hpp"        // for TR_RuntimeHelper
 #include "codegen/Snippet.hpp"  // for TR_S390Snippet, etc
 
-#include "z/codegen/S390Instruction.hpp" // REMOVE_THIS_LATER
+#include "z/codegen/S390Instruction.hpp"
 
 namespace TR { class CodeGenerator; }
 namespace TR { class Instruction; }

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -77,10 +77,10 @@ namespace OMR { typedef OMR::Z::CodeGenerator CodeGeneratorConnector; }
 #include "env/IO.hpp"
 
 
-#include "il/symbol/LabelSymbol.hpp" // REMOVE_THIS_LATER
-#include "z/codegen/S390OutOfLineCodeSection.hpp" // REMOVE_THIS_LATER
-#include "codegen/BackingStore.hpp" // REMOVE_THIS_LATER
-#include "codegen/Relocation.hpp" // REMOVE_THIS_LATER
+#include "il/symbol/LabelSymbol.hpp"
+#include "z/codegen/S390OutOfLineCodeSection.hpp"
+#include "codegen/BackingStore.hpp"
+#include "codegen/Relocation.hpp"
 
 #include "infra/TRlist.hpp"
 class TR_BackingStore;

--- a/compiler/z/codegen/OMRLinkage.hpp
+++ b/compiler/z/codegen/OMRLinkage.hpp
@@ -43,7 +43,7 @@ namespace OMR { typedef OMR::Z::Linkage LinkageConnector; }
 #include "il/DataTypes.hpp"                    // for TR::DataType, DataTypes
 #include "infra/Assert.hpp"                    // for TR_ASSERT
 
-#include "codegen/RegisterDependency.hpp" // REMOVE_THIS_LATER
+#include "codegen/RegisterDependency.hpp"
 
 class TR_FrontEnd;
 class TR_S390JNICallDataSnippet;

--- a/compiler/z/codegen/S390GenerateInstructions.hpp
+++ b/compiler/z/codegen/S390GenerateInstructions.hpp
@@ -26,7 +26,7 @@
 #include "env/jittypes.h"          // for uintptrj_t
 #include "il/Symbol.hpp"           // for Symbol, etc
 
-#include "z/codegen/S390Instruction.hpp" // REMOVE_THIS_LATER
+#include "z/codegen/S390Instruction.hpp"
 
 class TR_VirtualGuardSite;
 namespace TR { class CodeGenerator; }

--- a/compiler/z/codegen/S390Instruction.hpp
+++ b/compiler/z/codegen/S390Instruction.hpp
@@ -41,7 +41,7 @@
 #include "infra/Flags.hpp"                    // for flags8_t, flags32_t
 #include "ras/Debug.hpp"                      // for TR_DebugBase
 
-#include "codegen/RegisterDependency.hpp" // REMOVE_THIS_LATER
+#include "codegen/RegisterDependency.hpp"
 
 class TR_AsmData;
 class TR_VirtualGuardSite;


### PR DESCRIPTION
These includes are marked as "REMOVE_THIS_LATER". However, some of these includes are required. Instead of manually determining which of these can be removed, `include-what-you-use` will be run some time in the near future.