### PR TITLE
Expose Scavenger Nursery boundaries

### DIFF
--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -553,6 +553,18 @@ public:
 	{
 		return _evacuateSpaceTop;
 	}
+	
+	MMINLINE void *
+	getSurvivorBase()
+	{
+		return _survivorSpaceBase;
+	}
+	
+	MMINLINE void *
+	getSurvivorTop()
+	{
+		return _survivorSpaceTop;
+	}
 
 	void workThreadGarbageCollect(MM_EnvironmentStandard *env);
 


### PR DESCRIPTION
Implementations of the concurrent scavenger object access barrier will
need to know the actual address range not only for Evacuate boundaries,
but for total Nursery boundaries, too. Nursery boundaries can be derived
from Evacuate and Survivor boundaries. Thus, this change will expose
just Survivor boundaries, since Evacuate had recently been exposed.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>