### PR TITLE
Remove `Node::recreateAndCopyValidProperties`

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -495,15 +495,6 @@ OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op)
    return TR::Node::recreateAndCopyValidPropertiesImpl(originalNode, op, NULL);
    }
 
-/**
-  * @deprecated Use TR::Node::recreate instead
-  */
-TR::Node *
-OMR::Node::recreateAndCopyValidProperties(TR::Node *originalNode, TR::ILOpCodes op)
-   {
-   return TR::Node::recreate(originalNode, op);
-   }
-
 TR::Node *
 OMR::Node::recreateWithSymRefAndCopyValidProperties(TR::Node *originalNode, TR::ILOpCodes op, TR::SymbolReference *newSymRef)
    {

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -164,7 +164,6 @@ public:
    static TR::Node *copy(TR::Node *, int32_t numChildren);
 
    static TR::Node *recreate(TR::Node *originalNode, TR::ILOpCodes op);
-   static TR::Node *recreateAndCopyValidProperties(TR::Node *originalNode, TR::ILOpCodes op);
    static TR::Node *recreateWithSymRefAndCopyValidProperties(TR::Node *originalNode, TR::ILOpCodes op, TR::SymbolReference *newSymRef);
 
    // create methods from everywhere other than the ilGenerator need


### PR DESCRIPTION
This method is deprecated in favour of `Node::recreate`, and no downstream projects use it. It can be safely removed.