### PR TITLE
Move TR_S390*Instruction into TR namespace

### DIFF
--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -259,63 +259,63 @@ class TR_ARMStackCheckFailureSnippet;
 class TR_ARMRecompilationSnippet;
 class TR_ARMRegisterDependencyGroup;
 
-class TR_S390LabelInstruction;
-class TR_S390BranchInstruction;
-class TR_S390BranchOnCountInstruction;
-class TR_S390VirtualGuardNOPInstruction;
-class TR_S390BranchOnIndexInstruction;
-class TR_S390AnnotationInstruction;
-class TR_S390PseudoInstruction;
-class TR_S390ImmInstruction;
-class TR_S390ImmSnippetInstruction;
-class TR_S390ImmSymInstruction;
-class TR_S390Imm2Instruction;
-class TR_S390RegInstruction;
-class TR_S390RRInstruction;
-class TR_S390TranslateInstruction;
-class TR_S390RRFInstruction;
-class TR_S390RRRInstruction;
-class TR_S390RXFInstruction;
-class TR_S390RIInstruction;
-class TR_S390RILInstruction;
-class TR_S390RSInstruction;
-class TR_S390RSLInstruction;
-class TR_S390RSLbInstruction;
-class TR_S390RXEInstruction;
-class TR_S390RXInstruction;
-class TR_S390MemInstruction;
-class TR_S390SS1Instruction;
-class TR_S390MIIInstruction;
-class TR_S390SMIInstruction;
-class TR_S390SS2Instruction;
-class TR_S390SS4Instruction;
-class TR_S390SSEInstruction;
-class TR_S390SSFInstruction;
-class TR_S390VRIInstruction;
-class TR_S390VRIaInstruction;
-class TR_S390VRIbInstruction;
-class TR_S390VRIcInstruction;
-class TR_S390VRIdInstruction;
-class TR_S390VRIeInstruction;
-class TR_S390VRRInstruction;
-class TR_S390VRRaInstruction;
-class TR_S390VRRbInstruction;
-class TR_S390VRRcInstruction;
-class TR_S390VRRdInstruction;
-class TR_S390VRReInstruction;
-class TR_S390VRRfInstruction;
-class TR_S390VRSaInstruction;
-class TR_S390VRSbInstruction;
-class TR_S390VRScInstruction;
-class TR_S390VRVInstruction;
-class TR_S390VRXInstruction;
-class TR_S390VStorageInstruction;
-class TR_S390OpCodeOnlyInstruction;
-class TR_S390IInstruction;
-class TR_S390SInstruction;
-class TR_S390SIInstruction;
-class TR_S390SILInstruction;
-class TR_S390NOPInstruction;
+namespace TR { class S390LabelInstruction; }
+namespace TR { class S390BranchInstruction; }
+namespace TR { class S390BranchOnCountInstruction; }
+namespace TR { class S390VirtualGuardNOPInstruction; }
+namespace TR { class S390BranchOnIndexInstruction; }
+namespace TR { class S390AnnotationInstruction; }
+namespace TR { class S390PseudoInstruction; }
+namespace TR { class S390ImmInstruction; }
+namespace TR { class S390ImmSnippetInstruction; }
+namespace TR { class S390ImmSymInstruction; }
+namespace TR { class S390Imm2Instruction; }
+namespace TR { class S390RegInstruction; }
+namespace TR { class S390RRInstruction; }
+namespace TR { class S390TranslateInstruction; }
+namespace TR { class S390RRFInstruction; }
+namespace TR { class S390RRRInstruction; }
+namespace TR { class S390RXFInstruction; }
+namespace TR { class S390RIInstruction; }
+namespace TR { class S390RILInstruction; }
+namespace TR { class S390RSInstruction; }
+namespace TR { class S390RSLInstruction; }
+namespace TR { class S390RSLbInstruction; }
+namespace TR { class S390RXEInstruction; }
+namespace TR { class S390RXInstruction; }
+namespace TR { class S390MemInstruction; }
+namespace TR { class S390SS1Instruction; }
+namespace TR { class S390MIIInstruction; }
+namespace TR { class S390SMIInstruction; }
+namespace TR { class S390SS2Instruction; }
+namespace TR { class S390SS4Instruction; }
+namespace TR { class S390SSEInstruction; }
+namespace TR { class S390SSFInstruction; }
+namespace TR { class S390VRIInstruction; }
+namespace TR { class S390VRIaInstruction; }
+namespace TR { class S390VRIbInstruction; }
+namespace TR { class S390VRIcInstruction; }
+namespace TR { class S390VRIdInstruction; }
+namespace TR { class S390VRIeInstruction; }
+namespace TR { class S390VRRInstruction; }
+namespace TR { class S390VRRaInstruction; }
+namespace TR { class S390VRRbInstruction; }
+namespace TR { class S390VRRcInstruction; }
+namespace TR { class S390VRRdInstruction; }
+namespace TR { class S390VRReInstruction; }
+namespace TR { class S390VRRfInstruction; }
+namespace TR { class S390VRSaInstruction; }
+namespace TR { class S390VRSbInstruction; }
+namespace TR { class S390VRScInstruction; }
+namespace TR { class S390VRVInstruction; }
+namespace TR { class S390VRXInstruction; }
+namespace TR { class S390VStorageInstruction; }
+namespace TR { class S390OpCodeOnlyInstruction; }
+namespace TR { class S390IInstruction; }
+namespace TR { class S390SInstruction; }
+namespace TR { class S390SIInstruction; }
+namespace TR { class S390SILInstruction; }
+namespace TR { class S390NOPInstruction; }
 class TR_S390WarmToColdTrampolineSnippet;
 class TR_S390RestoreGPR7Snippet;
 class TR_S390CallSnippet;
@@ -329,10 +329,10 @@ class TR_S390JNICallDataSnippet;
 class TR_S390StackCheckFailureSnippet;
 class TR_S390HeapAllocSnippet;
 class TR_S390RegisterDependencyGroup;
-class TR_S390RRSInstruction;
-class TR_S390RIEInstruction;
-class TR_S390RISInstruction;
-class TR_S390IEInstruction;
+namespace TR { class S390RRSInstruction; }
+namespace TR { class S390RIEInstruction; }
+namespace TR { class S390RISInstruction; }
+namespace TR { class S390IEInstruction; }
 
 #ifdef J9_PROJECT_SPECIFIC
 class TR_S390ForceRecompilationSnippet;
@@ -993,54 +993,54 @@ public:
    void printAssocRegDirective(TR::FILE *pOutFile, TR::Instruction * instr);
    void printz(TR::FILE *, TR::Instruction *);
    void printz(TR::FILE *, TR::Instruction *, const char *);
-   void print(TR::FILE *, TR_S390LabelInstruction *);
-   void print(TR::FILE *, TR_S390BranchInstruction *);
-   void print(TR::FILE *, TR_S390BranchOnCountInstruction *);
+   void print(TR::FILE *, TR::S390LabelInstruction *);
+   void print(TR::FILE *, TR::S390BranchInstruction *);
+   void print(TR::FILE *, TR::S390BranchOnCountInstruction *);
 #ifdef J9_PROJECT_SPECIFIC
-   void print(TR::FILE *, TR_S390VirtualGuardNOPInstruction *);
+   void print(TR::FILE *, TR::S390VirtualGuardNOPInstruction *);
 #endif
-   void print(TR::FILE *, TR_S390BranchOnIndexInstruction *);
-   void print(TR::FILE *, TR_S390ImmInstruction *);
-   void print(TR::FILE *, TR_S390ImmSnippetInstruction *);
-   void print(TR::FILE *, TR_S390ImmSymInstruction *);
-   void print(TR::FILE *, TR_S390Imm2Instruction *);
-   void print(TR::FILE *, TR_S390RegInstruction *);
-   void print(TR::FILE *, TR_S390TranslateInstruction *);
-   void print(TR::FILE *, TR_S390RRInstruction *);
-   void print(TR::FILE *, TR_S390RRFInstruction *);
-   void print(TR::FILE *, TR_S390RRRInstruction *);
-   void print(TR::FILE *, TR_S390RIInstruction *);
-   void print(TR::FILE *, TR_S390RILInstruction *);
-   void print(TR::FILE *, TR_S390RSInstruction *);
-   void print(TR::FILE *, TR_S390RSLInstruction *);
-   void print(TR::FILE *, TR_S390RSLbInstruction *);
-   void print(TR::FILE *, TR_S390MemInstruction *);
-   void print(TR::FILE *, TR_S390SS1Instruction *);
-   void print(TR::FILE *, TR_S390SS2Instruction *);
-   void print(TR::FILE *, TR_S390SMIInstruction *);
-   void print(TR::FILE *, TR_S390MIIInstruction *);
-   void print(TR::FILE *, TR_S390SS4Instruction *);
-   void print(TR::FILE *, TR_S390SSFInstruction *);
-   void print(TR::FILE *, TR_S390SSEInstruction *);
-   void print(TR::FILE *, TR_S390SIInstruction *);
-   void print(TR::FILE *, TR_S390SILInstruction *);
-   void print(TR::FILE *, TR_S390SInstruction *);
-   void print(TR::FILE *, TR_S390RXInstruction *);
-   void print(TR::FILE *, TR_S390RXEInstruction *);
-   void print(TR::FILE *, TR_S390RXFInstruction *);
-   void print(TR::FILE *, TR_S390AnnotationInstruction *);
-   void print(TR::FILE *, TR_S390PseudoInstruction *);
-   void print(TR::FILE *, TR_S390NOPInstruction *);
+   void print(TR::FILE *, TR::S390BranchOnIndexInstruction *);
+   void print(TR::FILE *, TR::S390ImmInstruction *);
+   void print(TR::FILE *, TR::S390ImmSnippetInstruction *);
+   void print(TR::FILE *, TR::S390ImmSymInstruction *);
+   void print(TR::FILE *, TR::S390Imm2Instruction *);
+   void print(TR::FILE *, TR::S390RegInstruction *);
+   void print(TR::FILE *, TR::S390TranslateInstruction *);
+   void print(TR::FILE *, TR::S390RRInstruction *);
+   void print(TR::FILE *, TR::S390RRFInstruction *);
+   void print(TR::FILE *, TR::S390RRRInstruction *);
+   void print(TR::FILE *, TR::S390RIInstruction *);
+   void print(TR::FILE *, TR::S390RILInstruction *);
+   void print(TR::FILE *, TR::S390RSInstruction *);
+   void print(TR::FILE *, TR::S390RSLInstruction *);
+   void print(TR::FILE *, TR::S390RSLbInstruction *);
+   void print(TR::FILE *, TR::S390MemInstruction *);
+   void print(TR::FILE *, TR::S390SS1Instruction *);
+   void print(TR::FILE *, TR::S390SS2Instruction *);
+   void print(TR::FILE *, TR::S390SMIInstruction *);
+   void print(TR::FILE *, TR::S390MIIInstruction *);
+   void print(TR::FILE *, TR::S390SS4Instruction *);
+   void print(TR::FILE *, TR::S390SSFInstruction *);
+   void print(TR::FILE *, TR::S390SSEInstruction *);
+   void print(TR::FILE *, TR::S390SIInstruction *);
+   void print(TR::FILE *, TR::S390SILInstruction *);
+   void print(TR::FILE *, TR::S390SInstruction *);
+   void print(TR::FILE *, TR::S390RXInstruction *);
+   void print(TR::FILE *, TR::S390RXEInstruction *);
+   void print(TR::FILE *, TR::S390RXFInstruction *);
+   void print(TR::FILE *, TR::S390AnnotationInstruction *);
+   void print(TR::FILE *, TR::S390PseudoInstruction *);
+   void print(TR::FILE *, TR::S390NOPInstruction *);
    void print(TR::FILE *, TR::MemoryReference *, TR::Instruction *);
-   void print(TR::FILE *, TR_S390RRSInstruction *);
-   void print(TR::FILE *, TR_S390RIEInstruction *);
-   void print(TR::FILE *, TR_S390RISInstruction *);
-   void print(TR::FILE *, TR_S390OpCodeOnlyInstruction *);
-   void print(TR::FILE *, TR_S390IInstruction *);
-   void print(TR::FILE *, TR_S390IEInstruction *);
-   void print(TR::FILE *, TR_S390VRIInstruction *);
-   void print(TR::FILE *, TR_S390VRRInstruction *);
-   void print(TR::FILE *, TR_S390VStorageInstruction *);
+   void print(TR::FILE *, TR::S390RRSInstruction *);
+   void print(TR::FILE *, TR::S390RIEInstruction *);
+   void print(TR::FILE *, TR::S390RISInstruction *);
+   void print(TR::FILE *, TR::S390OpCodeOnlyInstruction *);
+   void print(TR::FILE *, TR::S390IInstruction *);
+   void print(TR::FILE *, TR::S390IEInstruction *);
+   void print(TR::FILE *, TR::S390VRIInstruction *);
+   void print(TR::FILE *, TR::S390VRRInstruction *);
+   void print(TR::FILE *, TR::S390VStorageInstruction *);
 
 
    const char * getS390RegisterName(uint32_t regNum, bool isVRF = false);

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -1065,7 +1065,7 @@ OMR::Z::TreeEvaluator::igotoEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    else
       cursor = generateS390RegInstruction(cg, TR::InstOpCode::BCR, node, dest);
 
-   ((TR_S390RegInstruction *)cursor)->setBranchCondition(TR::InstOpCode::COND_BCR);
+   ((TR::S390RegInstruction *)cursor)->setBranchCondition(TR::InstOpCode::COND_BCR);
 
    cg->decReferenceCount(child);
 
@@ -1150,13 +1150,13 @@ OMR::Z::TreeEvaluator::returnEvaluator(TR::Node * node, TR::CodeGenerator * cg)
          dependencies->addPostCondition(returnValRegister, linkage->getIntegerReturnRegister());
          comp->setReturnInfo(TR_IntReturn);
          if (linkage->isNeedsWidening())
-            new (cg->trHeapMemory()) TR_S390RRInstruction(TR::InstOpCode::LGFR, node, returnValRegister, returnValRegister, cg);
+            new (cg->trHeapMemory()) TR::S390RRInstruction(TR::InstOpCode::LGFR, node, returnValRegister, returnValRegister, cg);
          break;
       case TR::iureturn:
          comp->setReturnInfo(TR_IntReturn);
          dependencies->addPostCondition(returnValRegister, linkage->getIntegerReturnRegister());
          if (linkage->isNeedsWidening())
-            new (cg->trHeapMemory()) TR_S390RRInstruction(TR::InstOpCode::LLGFR, node, returnValRegister, returnValRegister, cg);
+            new (cg->trHeapMemory()) TR::S390RRInstruction(TR::InstOpCode::LLGFR, node, returnValRegister, returnValRegister, cg);
          break;
       case TR::lreturn:
       case TR::lureturn:
@@ -2320,14 +2320,14 @@ void OMR::Z::TreeEvaluator::tableEvaluatorCaseLabelHelper(TR::Node * node, TR::C
       TR_ASSERT(reg1, "Java must have allocated a temp reg");
       TR_ASSERT( tableKindToBeEvaluated == AddressTable32bit || tableKindToBeEvaluated == AddressTable64bitIntLookup || tableKindToBeEvaluated == AddressTable64bitLongLookup, "For Java, must be using Address Table");
 
-      new (cg->trHeapMemory()) TR_S390RIInstruction(TR::InstOpCode::BRAS, node, reg1, (4 + (sizeof(uintptrj_t) * numBranchTableEntries)) / 2, cg);
+      new (cg->trHeapMemory()) TR::S390RIInstruction(TR::InstOpCode::BRAS, node, reg1, (4 + (sizeof(uintptrj_t) * numBranchTableEntries)) / 2, cg);
 
       // Generate the data constants with the target label addresses.
       for (int32_t i = 0; i < numBranchTableEntries; ++i)
          {
          TR::Node * caseNode = node->getChild(i + 2);
          TR::LabelSymbol * label = caseNode->getBranchDestination()->getNode()->getLabel();
-         new (cg->trHeapMemory()) TR_S390LabelInstruction(TR::InstOpCode::DC, node, label, cg);
+         new (cg->trHeapMemory()) TR::S390LabelInstruction(TR::InstOpCode::DC, node, label, cg);
          }
 
       TR::MemoryReference * tempMR = generateS390MemoryReference(reg1, selectorReg, 0, cg);
@@ -2482,7 +2482,7 @@ OMR::Z::TreeEvaluator::tableEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    tableEvaluatorCaseLabelHelper(node,cg, tableKindToBeEvaluated, numBranchTableEntries, selectorReg, branchTableReg, reg1);
 
    TR::Instruction *cursor = generateS390RegInstruction(cg, TR::InstOpCode::BCR, node, selectorReg, deps);
-   ((TR_S390RegInstruction *)cursor)->setBranchCondition(TR::InstOpCode::COND_BCR);
+   ((TR::S390RegInstruction *)cursor)->setBranchCondition(TR::InstOpCode::COND_BCR);
 
 
    for (i = 0; i < node->getNumChildren(); ++i)
@@ -3214,7 +3214,7 @@ void OMR::Z::TreeEvaluator::createDAACondDeps(TR::Node * node, TR::RegisterDepen
       {
       case TR::Instruction::IsRX: //CVB, CVD
          {
-         TR_S390RXInstruction * instr = (TR_S390RXInstruction *)daaInstr;
+         TR::S390RXInstruction * instr = (TR::S390RXInstruction *)daaInstr;
          TR::MemoryReference * mr = instr->getMemoryReference();
 
          addToRegDep(daaDeps, instr->getRegisterOperand(1), false);
@@ -3228,7 +3228,7 @@ void OMR::Z::TreeEvaluator::createDAACondDeps(TR::Node * node, TR::RegisterDepen
          }
       case TR::Instruction::IsRXY: //CVBY, CVBG
          {
-         TR_S390RXYInstruction * instr = (TR_S390RXYInstruction *)daaInstr;
+         TR::S390RXYInstruction * instr = (TR::S390RXYInstruction *)daaInstr;
          TR::MemoryReference * mr = instr->getMemoryReference();
 
          addToRegDep(daaDeps, instr->getRegisterOperand(1), true);
@@ -3241,7 +3241,7 @@ void OMR::Z::TreeEvaluator::createDAACondDeps(TR::Node * node, TR::RegisterDepen
          }
       case TR::Instruction::IsSS2: //ZAP, Arithmetics
          {
-         TR_S390SS2Instruction * instr = (TR_S390SS2Instruction *)daaInstr;
+         TR::S390SS2Instruction * instr = (TR::S390SS2Instruction *)daaInstr;
          TR::MemoryReference * mr1 = instr->getMemoryReference ();
          TR::MemoryReference * mr2 = instr->getMemoryReference2();
 
@@ -3802,13 +3802,13 @@ TR::Instruction *generateAlwaysTrapSequence(TR::Node *node, TR::CodeGenerator *c
    // ** Generate a NOP LR R0,R0.  The signal handler has to walk backwards to pattern match
    // the trap instructions.  All trap instructions besides CRT/CLRT are 6-bytes in length.
    // Insert 2-byte NOP in front of the 4-byte CLRT to ensure we do not mismatch accidentally.
-   TR::Instruction *cursor = new (cg->trHeapMemory()) TR_S390NOPInstruction(TR::InstOpCode::NOP, 2, node, cg);
+   TR::Instruction *cursor = new (cg->trHeapMemory()) TR::S390NOPInstruction(TR::InstOpCode::NOP, 2, node, cg);
 
    TR::Register *zeroReg = cg->allocateRegister();
    TR::RegisterDependencyConditions *regDeps =
          new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 1, cg);
    regDeps->addPostCondition(zeroReg, TR::RealRegister::AssignAny);
-   cursor = new (cg->trHeapMemory()) TR_S390RRFInstruction(TR::InstOpCode::CLRT, node, zeroReg, zeroReg, getMaskForBranchCondition(TR::InstOpCode::COND_BERC)>>4, true, cg);
+   cursor = new (cg->trHeapMemory()) TR::S390RRFInstruction(TR::InstOpCode::CLRT, node, zeroReg, zeroReg, getMaskForBranchCondition(TR::InstOpCode::COND_BERC)>>4, true, cg);
    cursor->setDependencyConditions(regDeps);
 
    cg->stopUsingRegister(zeroReg);

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -1299,7 +1299,7 @@ OMR::Z::CodeGenerator::isUsing32BitEvaluator(TR::Node *node)
 TR::Instruction *
 OMR::Z::CodeGenerator::generateNop(TR::Node *n, TR::Instruction *preced, TR_NOPKind nopKind)
    {
-   return new (self()->trHeapMemory()) TR_S390NOPInstruction(TR::InstOpCode::NOP, 2, n, preced, self());
+   return new (self()->trHeapMemory()) TR::S390NOPInstruction(TR::InstOpCode::NOP, 2, n, preced, self());
    }
 
 void
@@ -1318,16 +1318,16 @@ OMR::Z::CodeGenerator::insertPad(TR::Node * theNode, TR::Instruction * insertion
    switch (padSize)
       {
       case 4:
-         (void) new (self()->trHeapMemory()) TR_S390NOPInstruction(TR::InstOpCode::NOP, 4, theNode, insertionPoint, self());
+         (void) new (self()->trHeapMemory()) TR::S390NOPInstruction(TR::InstOpCode::NOP, 4, theNode, insertionPoint, self());
          break;
 
       case 6:
-         (void) new (self()->trHeapMemory()) TR_S390NOPInstruction(TR::InstOpCode::NOP, 4, theNode, insertionPoint, self());
-         (void) new (self()->trHeapMemory()) TR_S390NOPInstruction(TR::InstOpCode::NOP, 2, theNode, insertionPoint, self());
+         (void) new (self()->trHeapMemory()) TR::S390NOPInstruction(TR::InstOpCode::NOP, 4, theNode, insertionPoint, self());
+         (void) new (self()->trHeapMemory()) TR::S390NOPInstruction(TR::InstOpCode::NOP, 2, theNode, insertionPoint, self());
          break;
 
       case 2:
-         (void) new (self()->trHeapMemory()) TR_S390NOPInstruction(TR::InstOpCode::NOP, 2, theNode, insertionPoint, self());
+         (void) new (self()->trHeapMemory()) TR::S390NOPInstruction(TR::InstOpCode::NOP, 2, theNode, insertionPoint, self());
          break;
 
       default:
@@ -1356,14 +1356,14 @@ OMR::Z::CodeGenerator::beginInstructionSelection()
         intptrj_t jniMethodTargetAddress = (intptrj_t)methodSymbol->getResolvedMethod()->startAddressForJNIMethod(self()->comp());
         if(TR::Compiler->target.is64Bit())
           {
-          cursor = new (self()->trHeapMemory()) TR_S390ImmInstruction(TR::InstOpCode::DC, startNode, UPPER_4_BYTES(jniMethodTargetAddress), cursor, self());
-          cursor = new (self()->trHeapMemory()) TR_S390ImmInstruction(TR::InstOpCode::DC, startNode, LOWER_4_BYTES(jniMethodTargetAddress), cursor, self());
+          cursor = new (self()->trHeapMemory()) TR::S390ImmInstruction(TR::InstOpCode::DC, startNode, UPPER_4_BYTES(jniMethodTargetAddress), cursor, self());
+          cursor = new (self()->trHeapMemory()) TR::S390ImmInstruction(TR::InstOpCode::DC, startNode, LOWER_4_BYTES(jniMethodTargetAddress), cursor, self());
           }
        else
-          cursor = new (self()->trHeapMemory()) TR_S390ImmInstruction(TR::InstOpCode::DC, startNode, UPPER_4_BYTES(jniMethodTargetAddress), cursor, self());
+          cursor = new (self()->trHeapMemory()) TR::S390ImmInstruction(TR::InstOpCode::DC, startNode, UPPER_4_BYTES(jniMethodTargetAddress), cursor, self());
        }
 
-      _returnTypeInfoInstruction = new (self()->trHeapMemory()) TR_S390ImmInstruction(TR::InstOpCode::DC, startNode, 0, NULL, cursor, self());
+      _returnTypeInfoInstruction = new (self()->trHeapMemory()) TR::S390ImmInstruction(TR::InstOpCode::DC, startNode, 0, NULL, cursor, self());
       generateS390PseudoInstruction(self(), TR::InstOpCode::PROC, startNode);
       }
    else
@@ -1784,7 +1784,7 @@ OMR::Z::CodeGenerator::insertInstructionPrefetchesForCalls(TR_BranchPreloadCallD
             TR::MemoryReference * tempMR;
             TR::Register * tempReg = self()->allocateRegister();
 
-            cursor =  new (self()->trHeapMemory()) TR_S390RILInstruction(TR::InstOpCode::LARL, node, tempReg, (data->_callSymRef)->getSymbol(),data->_callSymRef, cursor, self());
+            cursor =  new (self()->trHeapMemory()) TR::S390RILInstruction(TR::InstOpCode::LARL, node, tempReg, (data->_callSymRef)->getSymbol(),data->_callSymRef, cursor, self());
 
             tempMR = generateS390MemoryReference(tempReg, 0, self());
             cursor = generateS390BranchPredictionPreloadInstruction(self(), TR::InstOpCode::BPP, node, data->_callLabel, (int8_t) 0xD, tempMR, cursor);
@@ -1809,7 +1809,7 @@ OMR::Z::CodeGenerator::insertInstructionPrefetchesForCalls(TR_BranchPreloadCallD
          {
          TR::Register * tempReg = self()->allocateRegister();
 
-         cursor =  new (self()->trHeapMemory()) TR_S390RILInstruction(TR::InstOpCode::LARL, node, tempReg, (data->_callSymRef)->getSymbol(),  data->_callSymRef, cursor, self());
+         cursor =  new (self()->trHeapMemory()) TR::S390RILInstruction(TR::InstOpCode::LARL, node, tempReg, (data->_callSymRef)->getSymbol(),  data->_callSymRef, cursor, self());
          TR::MemoryReference * tempMR = generateS390MemoryReference(tempReg, 0, self());
          tempMR->setCreatedDuringInstructionSelection();
          cursor = generateS390BranchPredictionPreloadInstruction(self(), TR::InstOpCode::BPP, node, data->_callLabel, (int8_t) 0xD, tempMR, cursor);
@@ -1962,7 +1962,7 @@ OMR::Z::CodeGenerator::upgradeToHPRInstruction(TR::Instruction * inst)
          case TR::InstOpCode::AHI:
          case TR::InstOpCode::AFI:
             newOpCode = TR::InstOpCode::AIH;
-            immValue = ((TR_S390RIInstruction*)inst)->getSourceImmediate();
+            immValue = ((TR::S390RIInstruction*)inst)->getSourceImmediate();
             // signed extend 32-bit
             newInst = generateRILInstruction(self(), newOpCode, node, targetReg, immValue,inst->getPrev());
             targetReg->decTotalUseCount();
@@ -1970,7 +1970,7 @@ OMR::Z::CodeGenerator::upgradeToHPRInstruction(TR::Instruction * inst)
          case TR::InstOpCode::BRCT:
             newOpCode = TR::InstOpCode::BRCTH;
             //BRCTH has extended immediate
-            newInst= generateS390BranchInstruction(self(), TR::InstOpCode::BRCTH, node, targetReg, ((TR_S390LabeledInstruction*)inst)->getLabelSymbol(), inst->getPrev());
+            newInst= generateS390BranchInstruction(self(), TR::InstOpCode::BRCTH, node, targetReg, ((TR::S390LabeledInstruction*)inst)->getLabelSymbol(), inst->getPrev());
             targetReg->decTotalUseCount();
             break;
          case TR::InstOpCode::CR:
@@ -2001,7 +2001,7 @@ OMR::Z::CodeGenerator::upgradeToHPRInstruction(TR::Instruction * inst)
             break;
          case TR::InstOpCode::C:
          case TR::InstOpCode::CY:
-            mr = ((TR_S390RXInstruction *)inst)->getMemoryReference();
+            mr = ((TR::S390RXInstruction *)inst)->getMemoryReference();
             mr->resetMemRefUsedBefore();
             // mr re-use?
             newOpCode = TR::InstOpCode::CHF;
@@ -2019,7 +2019,7 @@ OMR::Z::CodeGenerator::upgradeToHPRInstruction(TR::Instruction * inst)
             break;
          case TR::InstOpCode::CL:
          case TR::InstOpCode::CLY:
-            mr = ((TR_S390RXInstruction *)inst)->getMemoryReference();
+            mr = ((TR::S390RXInstruction *)inst)->getMemoryReference();
             mr->resetMemRefUsedBefore();
             // mr re-use?
             newOpCode = TR::InstOpCode::CLHF;
@@ -2036,20 +2036,20 @@ OMR::Z::CodeGenerator::upgradeToHPRInstruction(TR::Instruction * inst)
                }
             break;
          case TR::InstOpCode::CFI:
-            immValue = ((TR_S390RILInstruction*)inst)->getSourceImmediate();
+            immValue = ((TR::S390RILInstruction*)inst)->getSourceImmediate();
             newOpCode = TR::InstOpCode::CIH;
             newInst = generateRILInstruction(self(), newOpCode, node, targetReg, immValue, inst->getPrev());
             targetReg->decTotalUseCount();
             break;
          case TR::InstOpCode::CLFI:
-            immValue = ((TR_S390RILInstruction*)inst)->getSourceImmediate();
+            immValue = ((TR::S390RILInstruction*)inst)->getSourceImmediate();
             newOpCode = TR::InstOpCode::CLIH;
             newInst = generateRILInstruction(self(), newOpCode, node, targetReg, immValue, inst->getPrev());
             targetReg->decTotalUseCount();
             break;
          case TR::InstOpCode::LB:
             newOpCode = TR::InstOpCode::LBH;
-            mr = ((TR_S390RXInstruction *)inst)->getMemoryReference();
+            mr = ((TR::S390RXInstruction *)inst)->getMemoryReference();
             mr->resetMemRefUsedBefore();
             // mr re-use?
             newInst = generateRXYInstruction(self(), newOpCode, node, targetReg, mr, inst->getPrev());
@@ -2067,7 +2067,7 @@ OMR::Z::CodeGenerator::upgradeToHPRInstruction(TR::Instruction * inst)
          case TR::InstOpCode::LH:
          case TR::InstOpCode::LHY:
             newOpCode = TR::InstOpCode::LHH;
-            mr = ((TR_S390RXInstruction *)inst)->getMemoryReference();
+            mr = ((TR::S390RXInstruction *)inst)->getMemoryReference();
             mr->resetMemRefUsedBefore();
             // mr re-use?
             newInst = generateRXYInstruction(self(), newOpCode, node, targetReg, mr, inst->getPrev());
@@ -2085,7 +2085,7 @@ OMR::Z::CodeGenerator::upgradeToHPRInstruction(TR::Instruction * inst)
          case TR::InstOpCode::L:
          case TR::InstOpCode::LY:
             newOpCode = TR::InstOpCode::LFH;
-            mr = ((TR_S390RXInstruction *)inst)->getMemoryReference();
+            mr = ((TR::S390RXInstruction *)inst)->getMemoryReference();
             mr->resetMemRefUsedBefore();
             // mr re-use?
             newInst = generateRXYInstruction(self(), newOpCode, node, targetReg, mr, inst->getPrev());
@@ -2102,7 +2102,7 @@ OMR::Z::CodeGenerator::upgradeToHPRInstruction(TR::Instruction * inst)
             break;
          case TR::InstOpCode::LAT:
             newOpCode = TR::InstOpCode::LFHAT;
-            mr = ((TR_S390RXInstruction *)inst)->getMemoryReference();
+            mr = ((TR::S390RXInstruction *)inst)->getMemoryReference();
             mr->resetMemRefUsedBefore();
             // mr re-use?
             newInst = generateRXYInstruction(self(), newOpCode, node, targetReg, mr, inst->getPrev());
@@ -2119,7 +2119,7 @@ OMR::Z::CodeGenerator::upgradeToHPRInstruction(TR::Instruction * inst)
             break;
          case TR::InstOpCode::LLC:
             newOpCode = TR::InstOpCode::LLCH;
-            mr = ((TR_S390RXInstruction *)inst)->getMemoryReference();
+            mr = ((TR::S390RXInstruction *)inst)->getMemoryReference();
             mr->resetMemRefUsedBefore();
             // mr re-use?
             newInst = generateRXYInstruction(self(), newOpCode, node, targetReg, mr, inst->getPrev());
@@ -2136,7 +2136,7 @@ OMR::Z::CodeGenerator::upgradeToHPRInstruction(TR::Instruction * inst)
             break;
          case TR::InstOpCode::LLH:
             newOpCode = TR::InstOpCode::LLHH;
-            mr = ((TR_S390RXInstruction *)inst)->getMemoryReference();
+            mr = ((TR::S390RXInstruction *)inst)->getMemoryReference();
             mr->resetMemRefUsedBefore();
             // mr re-use?
             newInst = generateRXYInstruction(self(), newOpCode, node, targetReg, mr, inst->getPrev());
@@ -2194,7 +2194,7 @@ OMR::Z::CodeGenerator::upgradeToHPRInstruction(TR::Instruction * inst)
          case TR::InstOpCode::LHI:
             //IIHF need to be sign-extend
             newOpCode = TR::InstOpCode::IIHF;
-            immValue = ((TR_S390RIInstruction*)inst)->getSourceImmediate();
+            immValue = ((TR::S390RIInstruction*)inst)->getSourceImmediate();
             newInst = generateRILInstruction(self(), newOpCode, node, targetReg, immValue, inst->getPrev());
             targetReg->decTotalUseCount();
             break;
@@ -2242,7 +2242,7 @@ OMR::Z::CodeGenerator::upgradeToHPRInstruction(TR::Instruction * inst)
          case TR::InstOpCode::ST:
          case TR::InstOpCode::STY:
             newOpCode = TR::InstOpCode::STFH;
-            mr = ((TR_S390RXInstruction *)inst)->getMemoryReference();
+            mr = ((TR::S390RXInstruction *)inst)->getMemoryReference();
             mr->resetMemRefUsedBefore();
             // mr re-use?
             newInst = generateRXYInstruction(self(), newOpCode, node, targetReg, mr, inst->getPrev());
@@ -2260,7 +2260,7 @@ OMR::Z::CodeGenerator::upgradeToHPRInstruction(TR::Instruction * inst)
          case TR::InstOpCode::STC:
          case TR::InstOpCode::STCY:
             newOpCode = TR::InstOpCode::STCH;
-            mr = ((TR_S390RXInstruction *)inst)->getMemoryReference();
+            mr = ((TR::S390RXInstruction *)inst)->getMemoryReference();
             mr->resetMemRefUsedBefore();
             // mr re-use?
             newInst = generateRXYInstruction(self(), newOpCode, node, targetReg, mr, inst->getPrev());
@@ -2278,7 +2278,7 @@ OMR::Z::CodeGenerator::upgradeToHPRInstruction(TR::Instruction * inst)
          case TR::InstOpCode::STH:
          case TR::InstOpCode::STHY:
             newOpCode = TR::InstOpCode::STHH;
-            mr = ((TR_S390RXInstruction *)inst)->getMemoryReference();
+            mr = ((TR::S390RXInstruction *)inst)->getMemoryReference();
             mr->resetMemRefUsedBefore();
             // mr re-use?
             newInst = generateRXYInstruction(self(), newOpCode, node, targetReg, mr, inst->getPrev());
@@ -2324,7 +2324,7 @@ OMR::Z::CodeGenerator::upgradeToHPRInstruction(TR::Instruction * inst)
          case TR::InstOpCode::SLFI:
             //ALSIH
             newOpCode = TR::InstOpCode::ALSIH;
-            immValue = ((TR_S390RILInstruction*)inst)->getSourceImmediate();
+            immValue = ((TR::S390RILInstruction*)inst)->getSourceImmediate();
             newInst = generateRILInstruction(self(), newOpCode, node, targetReg, -immValue, inst->getPrev());
             targetReg->decTotalUseCount();
             break;
@@ -2428,7 +2428,7 @@ static TR::Instruction *skipInternalControlFlow(TR::Instruction *insertInstr)
     // Track internal control flow on labels
     if (insertInstr->getOpCodeValue() == TR::InstOpCode::LABEL)
       {
-      TR_S390LabelInstruction *li = toS390LabelInstruction(insertInstr);
+      TR::S390LabelInstruction *li = toS390LabelInstruction(insertInstr);
       TR::LabelSymbol *ls=li->getLabelSymbol();
       if (ls->isStartInternalControlFlow())
         {
@@ -2672,7 +2672,7 @@ OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
         }
      else if(instructionCursor->getOpCodeValue() == TR::InstOpCode::TBEGIN || instructionCursor->getOpCodeValue() == TR::InstOpCode::TBEGINC)
         {
-        uint16_t immValue = ((TR_S390SILInstruction*)instructionCursor)->getSourceImmediate();
+        uint16_t immValue = ((TR::S390SILInstruction*)instructionCursor)->getSourceImmediate();
         uint8_t regMask = 0;
         for(int8_t i = TR::RealRegister::GPR0; i != TR::RealRegister::GPR15 + 1; i++)
            {
@@ -2680,7 +2680,7 @@ OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
               regMask |= (1 << (7 - ((i - 1) >> 1))); // bit 0 = GPR0/1, GPR0=1, GPR15=16. 'Or' with bit [(i-1)>>1]
            }
         immValue = immValue | (regMask<<8);
-        ((TR_S390SILInstruction*)instructionCursor)->setSourceImmediate(immValue);
+        ((TR::S390SILInstruction*)instructionCursor)->setSourceImmediate(immValue);
         }
 
       self()->tracePreRAInstruction(instructionCursor);
@@ -2725,7 +2725,7 @@ OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
       // Track internal control flow on labels
       if (instructionCursor->getOpCode().getOpCodeValue() == TR::InstOpCode::LABEL)
          {
-         TR_S390LabelInstruction *li = toS390LabelInstruction(instructionCursor);
+         TR::S390LabelInstruction *li = toS390LabelInstruction(instructionCursor);
 
          if (li->getLabelSymbol() != NULL)
             {
@@ -2940,8 +2940,8 @@ TR_S390Peephole::AGIReduction()
    if (disableRenaming!=NULL)
       return false;
 
-   TR::Register *lgrTargetReg = ((TR_S390RRInstruction*)_cursor)->getRegisterOperand(1);
-   TR::Register *lgrSourceReg = ((TR_S390RRInstruction*)_cursor)->getRegisterOperand(2);
+   TR::Register *lgrTargetReg = ((TR::S390RRInstruction*)_cursor)->getRegisterOperand(1);
+   TR::Register *lgrSourceReg = ((TR::S390RRInstruction*)_cursor)->getRegisterOperand(2);
 
    TR::RealRegister *gpr0 = _cg->machine()->getS390RealRegister(TR::RealRegister::GPR0);
 
@@ -3138,7 +3138,7 @@ TR_S390Peephole::ICMReduction()
    bool performed = false;
    bool isICMOpportunity = false;
 
-   TR_S390RXInstruction* load= (TR_S390RXInstruction*) _cursor;
+   TR::S390RXInstruction* load= (TR::S390RXInstruction*) _cursor;
 
    TR::MemoryReference* mem = load->getMemoryReference();
 
@@ -3156,7 +3156,7 @@ TR_S390Peephole::ICMReduction()
       //        LTR    GPRX, GPRY
       // it is wrong to transform the above sequence into
       //        ICM    GPRX, MEM
-      if (next->getRegisterOperand(1) != ((TR_S390RRInstruction*)next)->getRegisterOperand(2)) return false;
+      if (next->getRegisterOperand(1) != ((TR::S390RRInstruction*)next)->getRegisterOperand(2)) return false;
       isICMOpportunity = true;
       }
    else
@@ -3166,7 +3166,7 @@ TR_S390Peephole::ICMReduction()
       //      CHI  GPRX, '0'
       // reduce to:
       //      ICM GPRX,...
-      TR_S390RIInstruction* chi = (TR_S390RIInstruction*) next;
+      TR::S390RIInstruction* chi = (TR::S390RIInstruction*) next;
 
       // CHI must be comparing against '0' (i.e. NULLCHK) or else our
       // condition codes will be wrong.
@@ -3196,7 +3196,7 @@ TR_S390Peephole::ICMReduction()
          }
 
       // Do the reduction - create the icm instruction
-      TR_S390RSInstruction* icm = new (_cg->trHeapMemory()) TR_S390RSInstruction(TR::InstOpCode::ICM, load->getNode(), load->getRegisterOperand(1), 0xF, memcp, prev, _cg);
+      TR::S390RSInstruction* icm = new (_cg->trHeapMemory()) TR::S390RSInstruction(TR::InstOpCode::ICM, load->getNode(), load->getRegisterOperand(1), 0xF, memcp, prev, _cg);
       _cursor = icm;
 
       // Check if the load has an implicit NULLCHK.  If so, we need to ensure a GCmap is copied.
@@ -3286,8 +3286,8 @@ TR_S390Peephole::duplicateNILHReduction()
           (nb->getKind() == TR::Instruction::IsRI))
          {
          // NILH == generateRIInstruction
-         TR_S390RIInstruction * cast_na = (TR_S390RIInstruction *)na;
-         TR_S390RIInstruction * cast_nb = (TR_S390RIInstruction *)nb;
+         TR::S390RIInstruction * cast_na = (TR::S390RIInstruction *)na;
+         TR::S390RIInstruction * cast_nb = (TR::S390RIInstruction *)nb;
 
          if (cast_na->isImm() == cast_nb->isImm())
             {
@@ -3334,7 +3334,7 @@ TR_S390Peephole::clearsHighBitOfAddressInReg(TR::Instruction *inst, TR::Register
 
       if (inst->getOpCodeValue() == TR::InstOpCode::NILH)
          {
-         TR_S390RIInstruction * NILH_RI = (TR_S390RIInstruction *)inst;
+         TR::S390RIInstruction * NILH_RI = (TR::S390RIInstruction *)inst;
          if (NILH_RI->isImm() &&
              NILH_RI->getSourceImmediate() == 0x7FFF)
             {
@@ -3556,8 +3556,8 @@ TR_S390Peephole::LRReduction()
    //The _defRegs in the instruction records virtual def reg till now that needs to be reset to real reg.
    _cursor->setUseDefRegisters(false);
 
-   TR::Register *lgrSourceReg = ((TR_S390RRInstruction*)_cursor)->getRegisterOperand(2);
-   TR::Register *lgrTargetReg = ((TR_S390RRInstruction*)_cursor)->getRegisterOperand(1);
+   TR::Register *lgrSourceReg = ((TR::S390RRInstruction*)_cursor)->getRegisterOperand(2);
+   TR::Register *lgrTargetReg = ((TR::S390RRInstruction*)_cursor)->getRegisterOperand(1);
    TR::InstOpCode lgrOpCode = _cursor->getOpCode();
 
    if (lgrTargetReg == lgrSourceReg &&
@@ -3600,8 +3600,8 @@ TR_S390Peephole::LRReduction()
       if((prev->getOpCodeValue() == TR::InstOpCode::LR && lgrOpCode.getOpCodeValue() == TR::InstOpCode::LTR) ||
          (prev->getOpCodeValue() == TR::InstOpCode::LGR && lgrOpCode.getOpCodeValue() == TR::InstOpCode::LTGR))
         {
-        TR::Register *prevTargetReg = ((TR_S390RRInstruction*)prev)->getRegisterOperand(1);
-        TR::Register *prevSourceReg = ((TR_S390RRInstruction*)prev)->getRegisterOperand(2);
+        TR::Register *prevTargetReg = ((TR::S390RRInstruction*)prev)->getRegisterOperand(1);
+        TR::Register *prevSourceReg = ((TR::S390RRInstruction*)prev)->getRegisterOperand(2);
         if((lgrTargetReg == prevTargetReg || lgrTargetReg == prevSourceReg) &&
            performTransformation(comp(), "\nO^O S390 PEEPHOLE: Transforming load register into load and test register and removing current at %p\n", _cursor))
           {
@@ -3633,16 +3633,16 @@ TR_S390Peephole::LRReduction()
       //checks that the prev instruction is an add/sub logical operation that sets the same target register as the LTR/LTGR insn, and that we branch immediately after
       if (prev->getOpCode().setsCC() && prev->getOpCode().setsCarryFlag() && prev->getRegisterOperand(1) == lgrTargetReg && next->getOpCodeValue() == TR::InstOpCode::BRC)
          {
-         TR::InstOpCode::S390BranchCondition branchCond = ((TR_S390BranchInstruction *) next)->getBranchCondition();
+         TR::InstOpCode::S390BranchCondition branchCond = ((TR::S390BranchInstruction *) next)->getBranchCondition();
 
          if ((branchCond == TR::InstOpCode::COND_BERC || branchCond == TR::InstOpCode::COND_BNERC) &&
             performTransformation(comp(), "\nO^O S390 PEEPHOLE: Removing redundant Load and Test instruction at %p, because CC can be reused from logical instruction %p\n",_cursor, prev))
             {
             _cg->deleteInst(_cursor);
             if (branchCond == TR::InstOpCode::COND_BERC)
-               ((TR_S390BranchInstruction *) next)->setBranchCondition(TR::InstOpCode::COND_MASK10);
+               ((TR::S390BranchInstruction *) next)->setBranchCondition(TR::InstOpCode::COND_MASK10);
             else if (branchCond == TR::InstOpCode::COND_BNERC)
-               ((TR_S390BranchInstruction *) next)->setBranchCondition(TR::InstOpCode::COND_MASK5);
+               ((TR::S390BranchInstruction *) next)->setBranchCondition(TR::InstOpCode::COND_MASK5);
             performed = true;
             return performed;
             }
@@ -3659,7 +3659,7 @@ TR_S390Peephole::LRReduction()
    while ((current != NULL) &&
             !isBarrierToPeepHoleLookback(current) &&
            !(current->isBranchOp() && current->getKind() == TR::Instruction::IsRIL &&
-              ((TR_S390RILInstruction *)  current)->getTargetSnippet() ) &&
+              ((TR::S390RILInstruction *)  current)->getTargetSnippet() ) &&
            windowSize < maxWindowSize)
       {
 
@@ -3680,8 +3680,8 @@ TR_S390Peephole::LRReduction()
             ((curOpCode.is32bit() && lgrOpCode.is32bit()) ||
              (curOpCode.is64bit() && lgrOpCode.is64bit())))
          {
-         TR::Register *curTargetReg=((TR_S390RIInstruction*)current)->getRegisterOperand(1);
-         int32_t srcImm = ((TR_S390RIInstruction*)current)->getSourceImmediate();
+         TR::Register *curTargetReg=((TR::S390RIInstruction*)current)->getRegisterOperand(1);
+         int32_t srcImm = ((TR::S390RIInstruction*)current)->getSourceImmediate();
          if(curTargetReg == lgrTargetReg && (srcImm == 0) && !(setCC || useCC))
             {
             if (comp()->getOption(TR_TraceCG)) { printInfo("\n"); }
@@ -3719,8 +3719,8 @@ TR_S390Peephole::LRReduction()
       if (curOpCode.getOpCodeValue() == lgrOpCode.getOpCodeValue() &&
           current->getKind() == TR::Instruction::IsRR)
          {
-         TR::Register *curSourceReg = ((TR_S390RRInstruction*)current)->getRegisterOperand(2);
-         TR::Register *curTargetReg = ((TR_S390RRInstruction*)current)->getRegisterOperand(1);
+         TR::Register *curSourceReg = ((TR::S390RRInstruction*)current)->getRegisterOperand(2);
+         TR::Register *curTargetReg = ((TR::S390RRInstruction*)current)->getRegisterOperand(1);
 
          if ( ((curSourceReg == lgrTargetReg && curTargetReg == lgrSourceReg) ||
               (curSourceReg == lgrSourceReg && curTargetReg == lgrTargetReg)))
@@ -3803,10 +3803,10 @@ TR_S390Peephole::LLCReduction()
 
    if (curOpCode == TR::InstOpCode::LGFR || curOpCode == TR::InstOpCode::LLGTR)
       {
-      TR::Register *llcTgtReg = ((TR_S390RRInstruction *) _cursor)->getRegisterOperand(1);
+      TR::Register *llcTgtReg = ((TR::S390RRInstruction *) _cursor)->getRegisterOperand(1);
 
-      TR::Register *curSrcReg = ((TR_S390RRInstruction *) current)->getRegisterOperand(2);
-      TR::Register *curTgtReg = ((TR_S390RRInstruction *) current)->getRegisterOperand(1);
+      TR::Register *curSrcReg = ((TR::S390RRInstruction *) current)->getRegisterOperand(2);
+      TR::Register *curTgtReg = ((TR::S390RRInstruction *) current)->getRegisterOperand(1);
 
       if (llcTgtReg == curSrcReg && llcTgtReg == curTgtReg)
          {
@@ -3829,7 +3829,7 @@ TR_S390Peephole::LLCReduction()
             _cg->deleteInst(current);
             // Replace the LLC with LLGC
             TR::Instruction *oldCursor = _cursor;
-            TR::MemoryReference* memRef = ((TR_S390RXInstruction *) oldCursor)->getMemoryReference();
+            TR::MemoryReference* memRef = ((TR::S390RXInstruction *) oldCursor)->getMemoryReference();
             memRef->resetMemRefUsedBefore();
             _cursor = generateRXInstruction(_cg, TR::InstOpCode::LLGC, comp()->getStartTree()->getNode(), llcTgtReg, memRef, _cursor->getPrev());
             _cg->replaceInst(oldCursor, _cursor);
@@ -3864,8 +3864,8 @@ TR_S390Peephole::LGFRReduction()
 
    if (disableLGFRRemoval != NULL) return false;
 
-   TR::Register *lgrSourceReg = ((TR_S390RRInstruction*)_cursor)->getRegisterOperand(2);
-   TR::Register *lgrTargetReg = ((TR_S390RRInstruction*)_cursor)->getRegisterOperand(1);
+   TR::Register *lgrSourceReg = ((TR::S390RRInstruction*)_cursor)->getRegisterOperand(2);
+   TR::Register *lgrTargetReg = ((TR::S390RRInstruction*)_cursor)->getRegisterOperand(1);
 
    // We cannot do anything if both target and source are the same,
    // which can happen with LTR and LTGR
@@ -3876,8 +3876,8 @@ TR_S390Peephole::LGFRReduction()
 
    if (curOpCode == TR::InstOpCode::LGFR)
       {
-      TR::Register *curSourceReg=((TR_S390RRInstruction*)current)->getRegisterOperand(2);
-      TR::Register *curTargetReg=((TR_S390RRInstruction*)current)->getRegisterOperand(1);
+      TR::Register *curSourceReg=((TR::S390RRInstruction*)current)->getRegisterOperand(2);
+      TR::Register *curTargetReg=((TR::S390RRInstruction*)current)->getRegisterOperand(1);
 
       if (curSourceReg == lgrTargetReg && curTargetReg == lgrTargetReg)
          {
@@ -3893,7 +3893,7 @@ TR_S390Peephole::LGFRReduction()
                printInfo(tmp);
                }
 
-            ((TR_S390RRInstruction*)current)->setRegisterOperand(2,lgrSourceReg);
+            ((TR::S390RRInstruction*)current)->setRegisterOperand(2,lgrSourceReg);
 
             // Removing redundant LR.
             _cg->deleteInst(_cursor);
@@ -3929,7 +3929,7 @@ TR_S390Peephole::ConditionalBranchReduction(TR::InstOpCode::Mnemonic branchOPRep
    if (!_cg->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_z13) || disabled)
       return false;
 
-   TR_S390RIEInstruction* branchInst = static_cast<TR_S390RIEInstruction*> (_cursor);
+   TR::S390RIEInstruction* branchInst = static_cast<TR::S390RIEInstruction*> (_cursor);
 
    TR::Instruction* currInst = _cursor;
    TR::Instruction* nextInst = _cursor->getNext();
@@ -3967,7 +3967,7 @@ TR_S390Peephole::ConditionalBranchReduction(TR::InstOpCode::Mnemonic branchOPRep
             break;
 
          // Because of the previous checks, LHI or LGHI instruction is guaranteed to be here
-         TR_S390RIInstruction* RIInst = static_cast<TR_S390RIInstruction*> (currInst);
+         TR::S390RIInstruction* RIInst = static_cast<TR::S390RIInstruction*> (currInst);
 
          // Conditionalize from "Load Immediate" to "Load Immediate on Condition"
          _cg->replaceInst(RIInst, _cursor = generateRIEInstruction(_cg, RIInst->getOpCode().getOpCodeValue() == TR::InstOpCode::LHI ? TR::InstOpCode::LOCHI : TR::InstOpCode::LOCGHI, RIInst->getNode(), RIInst->getRegisterOperand(1), RIInst->getSourceImmediate(), cond, RIInst->getPrev()));
@@ -4033,8 +4033,8 @@ TR_S390Peephole::LoadAndMaskReduction(TR::InstOpCode::Mnemonic LZOpCode)
 
    if (_cursor->getNext()->getOpCodeValue() == TR::InstOpCode::NILL)
       {
-      TR_S390RXInstruction* loadInst = static_cast<TR_S390RXInstruction*> (_cursor);
-      TR_S390RIInstruction* nillInst = static_cast<TR_S390RIInstruction*> (_cursor->getNext());
+      TR::S390RXInstruction* loadInst = static_cast<TR::S390RXInstruction*> (_cursor);
+      TR::S390RIInstruction* nillInst = static_cast<TR::S390RIInstruction*> (_cursor->getNext());
 
       if (!nillInst->isImm() || nillInst->getSourceImmediate() != 0xFF00)
          return false;
@@ -4068,35 +4068,35 @@ bool swapOperands(TR::Register * trueReg, TR::Register * compReg, TR::Instructio
    switch (curr->getKind())
       {
       case TR::Instruction::IsRR:
-         branchCond = ((TR_S390RRInstruction *) curr)->getBranchCondition();
-         ((TR_S390RRInstruction *) curr)->setBranchCondition(getReverseBranchCondition(branchCond));
-         ((TR_S390RRInstruction *) curr)->setRegisterOperand(2,trueReg);
-         ((TR_S390RRInstruction *) curr)->setRegisterOperand(1,compReg);
+         branchCond = ((TR::S390RRInstruction *) curr)->getBranchCondition();
+         ((TR::S390RRInstruction *) curr)->setBranchCondition(getReverseBranchCondition(branchCond));
+         ((TR::S390RRInstruction *) curr)->setRegisterOperand(2,trueReg);
+         ((TR::S390RRInstruction *) curr)->setRegisterOperand(1,compReg);
          break;
       case TR::Instruction::IsRIE:
-         branchCond = ((TR_S390RIEInstruction *) curr)->getBranchCondition();
-         ((TR_S390RIEInstruction *) curr)->setBranchCondition(getReverseBranchCondition(branchCond));
-         ((TR_S390RIEInstruction *) curr)->setRegisterOperand(2,trueReg);
-         ((TR_S390RIEInstruction *) curr)->setRegisterOperand(1,compReg);
+         branchCond = ((TR::S390RIEInstruction *) curr)->getBranchCondition();
+         ((TR::S390RIEInstruction *) curr)->setBranchCondition(getReverseBranchCondition(branchCond));
+         ((TR::S390RIEInstruction *) curr)->setRegisterOperand(2,trueReg);
+         ((TR::S390RIEInstruction *) curr)->setRegisterOperand(1,compReg);
          break;
       case TR::Instruction::IsRRS:
-         branchCond = ((TR_S390RRSInstruction *) curr)->getBranchCondition();
-         ((TR_S390RRSInstruction *) curr)->setBranchCondition(getReverseBranchCondition(branchCond));
-         ((TR_S390RRSInstruction *) curr)->setRegisterOperand(2,trueReg);
-         ((TR_S390RRSInstruction *) curr)->setRegisterOperand(1,compReg);
+         branchCond = ((TR::S390RRSInstruction *) curr)->getBranchCondition();
+         ((TR::S390RRSInstruction *) curr)->setBranchCondition(getReverseBranchCondition(branchCond));
+         ((TR::S390RRSInstruction *) curr)->setRegisterOperand(2,trueReg);
+         ((TR::S390RRSInstruction *) curr)->setRegisterOperand(1,compReg);
          break;
       case TR::Instruction::IsRRD: // RRD is encoded use RRF
       case TR::Instruction::IsRRF:
-         branchCond = ((TR_S390RRFInstruction *) curr)->getBranchCondition();
-         ((TR_S390RRFInstruction *) curr)->setBranchCondition(getReverseBranchCondition(branchCond));
-         ((TR_S390RRFInstruction *) curr)->setRegisterOperand(2,trueReg);
-         ((TR_S390RRFInstruction *) curr)->setRegisterOperand(1,compReg);
+         branchCond = ((TR::S390RRFInstruction *) curr)->getBranchCondition();
+         ((TR::S390RRFInstruction *) curr)->setBranchCondition(getReverseBranchCondition(branchCond));
+         ((TR::S390RRFInstruction *) curr)->setRegisterOperand(2,trueReg);
+         ((TR::S390RRFInstruction *) curr)->setRegisterOperand(1,compReg);
          break;
       case TR::Instruction::IsRRF2:
-         mask = ((TR_S390RRFInstruction *) curr)->getMask3();
-         ((TR_S390RRFInstruction *) curr)->setMask3(getReverseBranchMask(mask));
-         ((TR_S390RRFInstruction *) curr)->setRegisterOperand(2,trueReg);
-         ((TR_S390RRFInstruction *) curr)->setRegisterOperand(1,compReg);
+         mask = ((TR::S390RRFInstruction *) curr)->getMask3();
+         ((TR::S390RRFInstruction *) curr)->setMask3(getReverseBranchMask(mask));
+         ((TR::S390RRFInstruction *) curr)->setRegisterOperand(2,trueReg);
+         ((TR::S390RRFInstruction *) curr)->setRegisterOperand(1,compReg);
          break;
       default:
          // unsupport instruction type, bail
@@ -4110,10 +4110,10 @@ void insertLoad(TR::Compilation * comp, TR::CodeGenerator * cg, TR::Instruction 
    switch(r->getKind())
      {
      case TR_FPR:
-       new (comp->trHeapMemory()) TR_S390RRInstruction(TR::InstOpCode::LDR, i->getNode(), r, r, i, cg);
+       new (comp->trHeapMemory()) TR::S390RRInstruction(TR::InstOpCode::LDR, i->getNode(), r, r, i, cg);
        break;
      default:
-       new (comp->trHeapMemory()) TR_S390RRInstruction(TR::InstOpCode::LR, i->getNode(), r, r, i, cg);
+       new (comp->trHeapMemory()) TR::S390RRInstruction(TR::InstOpCode::LR, i->getNode(), r, r, i, cg);
        break;
      }
    }
@@ -4175,7 +4175,7 @@ TR_S390Peephole::DAARemoveOutlinedLabelNop(bool hasPadding)
       if ((nextInst ->getOpCodeValue() == TR::InstOpCode::BRC || nextInst ->getOpCodeValue() == TR::InstOpCode::BRCL) &&
           (nextInst2->getOpCodeValue() == TR::InstOpCode::BRC || nextInst2->getOpCodeValue() == TR::InstOpCode::BRCL))
          {
-         TR_S390RegInstruction* OOLbranchInst = static_cast<TR_S390RegInstruction*> (nextInst2);
+         TR::S390RegInstruction* OOLbranchInst = static_cast<TR::S390RegInstruction*> (nextInst2);
 
          if (OOLbranchInst->getBranchCondition() == TR::InstOpCode::COND_MASK0)
             if (performTransformation(comp(), "O^O S390 PEEPHOLE: Eliminating redundant DAA NOP BRC/BRCL to OOL path %p.\n", OOLbranchInst))
@@ -4238,7 +4238,7 @@ TR_S390Peephole::DAAHandleMemoryReferenceSpill(bool hasPadding)
             currInst = _cursor;
             nextInst = _cursor->getNext();
 
-            TR_S390BranchInstruction* OOLbranchInst;
+            TR::S390BranchInstruction* OOLbranchInst;
 
             // Find the OOL Branch Instruction
             while (currInst != NULL)
@@ -4246,7 +4246,7 @@ TR_S390Peephole::DAAHandleMemoryReferenceSpill(bool hasPadding)
                if (currInst->getOpCodeValue() == TR::InstOpCode::BRC || currInst->getOpCodeValue() == TR::InstOpCode::BRCL)
                   {
                   // Convert the instruction to a Branch Instruction to access the Label Symbol
-                  OOLbranchInst = static_cast<TR_S390BranchInstruction*> (currInst);
+                  OOLbranchInst = static_cast<TR::S390BranchInstruction*> (currInst);
 
                   // We have found the correct BRC/BRCL
                   if (OOLbranchInst->getLabelSymbol()->isStartOfColdInstructionStream())
@@ -4309,7 +4309,7 @@ TR_S390Peephole::revertTo32BitShift()
          return false;
       }
 
-   TR_S390RSInstruction * instr = (TR_S390RSInstruction *) _cursor;
+   TR::S390RSInstruction * instr = (TR::S390RSInstruction *) _cursor;
 
    // The shift is supposed to be an integer shift when reducing 64bit shifts.
    // Note the NOT in front of second boolean expr. pair
@@ -4352,17 +4352,17 @@ TR_S390Peephole::revertTo32BitShift()
             break;
          }
 
-      TR_S390RSInstruction* newInstr = NULL;
+      TR::S390RSInstruction* newInstr = NULL;
 
       if (instr->getSourceImmediate())
          {
-         newInstr = new (_cg->trHeapMemory()) TR_S390RSInstruction(newOpCode, instr->getNode(), instr->getRegisterOperand(1), instr->getSourceImmediate(), instr->getPrev(), _cg);
+         newInstr = new (_cg->trHeapMemory()) TR::S390RSInstruction(newOpCode, instr->getNode(), instr->getRegisterOperand(1), instr->getSourceImmediate(), instr->getPrev(), _cg);
          }
       else if (instr->getMemoryReference())
          {
          TR::MemoryReference* memRef = instr->getMemoryReference();
          memRef->resetMemRefUsedBefore();
-         newInstr = new (_cg->trHeapMemory()) TR_S390RSInstruction(newOpCode, instr->getNode(), instr->getRegisterOperand(1), memRef, instr->getPrev(), _cg);
+         newInstr = new (_cg->trHeapMemory()) TR::S390RSInstruction(newOpCode, instr->getNode(), instr->getRegisterOperand(1), memRef, instr->getPrev(), _cg);
          }
       else
          {
@@ -4414,7 +4414,7 @@ TR_S390Peephole::inlineEXtargetHelper(TR::Instruction *inst, TR::Instruction * i
 
          if (iterator->getOpCodeValue() == TR::InstOpCode::LARL)
             {
-            TR_S390RILInstruction* LARLInst = reinterpret_cast<TR_S390RILInstruction*> (iterator);
+            TR::S390RILInstruction* LARLInst = reinterpret_cast<TR::S390RILInstruction*> (iterator);
 
             // Make sure the register we load the literal pool address in is the same register referenced by the EX instruction
             if (LARLInst->isLiteralPoolAddress() && LARLInst->getRegisterOperand(1) == _cursor->getMemoryReference()->getBaseRegister())
@@ -4444,7 +4444,7 @@ TR_S390Peephole::inlineEXtargetHelper(TR::Instruction *inst, TR::Instruction * i
       cnstDataInstr->setPrev(labelInstr);
 
       // generate EXRL
-      TR_S390RILInstruction * newEXRLInst = new (_cg->trHeapMemory()) TR_S390RILInstruction(TR::InstOpCode::EXRL, _cursor->getNode(), _cursor->getRegisterOperand(1), ssInstrLabel, _cursor->getPrev(), _cg);
+      TR::S390RILInstruction * newEXRLInst = new (_cg->trHeapMemory()) TR::S390RILInstruction(TR::InstOpCode::EXRL, _cursor->getNode(), _cursor->getRegisterOperand(1), ssInstrLabel, _cursor->getPrev(), _cg);
 
       // Replace the EX with EXRL
       TR::Instruction * oldCursor = _cursor;
@@ -4486,7 +4486,7 @@ TR_S390Peephole::inlineEXtarget()
 
          // check if the label is following an unconditional branch
          if (inst && inst->getOpCode().getOpCodeValue() == TR::InstOpCode::BRC &&
-             ((TR_S390BranchInstruction *)inst)->getBranchCondition() == TR::InstOpCode::COND_BRC)
+             ((TR::S390BranchInstruction *)inst)->getBranchCondition() == TR::InstOpCode::COND_BRC)
            {
            return inlineEXtargetHelper(inst,_cursor->getPrev());
            }
@@ -4669,13 +4669,13 @@ TR_S390Peephole::attemptZ7distinctOperants()
                   }
                case TR::InstOpCode::AHI:
                   {
-                  int16_t imm = ((TR_S390RIInstruction*)current)->getSourceImmediate();
+                  int16_t imm = ((TR::S390RIInstruction*)current)->getSourceImmediate();
                   newInstr = generateRIEInstruction(_cg, TR::InstOpCode::AHIK, node, lgrTargetReg, lgrSourceReg, imm, prevInstr);
                   break;
                   }
                case TR::InstOpCode::AGHI:
                   {
-                  int16_t imm = ((TR_S390RIInstruction*)current)->getSourceImmediate();
+                  int16_t imm = ((TR::S390RIInstruction*)current)->getSourceImmediate();
                   newInstr = generateRIEInstruction(_cg, TR::InstOpCode::AGHIK, node, lgrTargetReg, lgrSourceReg, imm, prevInstr);
                   break;
                   }
@@ -4711,8 +4711,8 @@ TR_S390Peephole::attemptZ7distinctOperants()
                   }
                case TR::InstOpCode::SLA:
                   {
-                  int16_t imm = ((TR_S390RSInstruction*)current)->getSourceImmediate();
-                  TR::MemoryReference * mf = ((TR_S390RSInstruction*)current)->getMemoryReference();
+                  int16_t imm = ((TR::S390RSInstruction*)current)->getSourceImmediate();
+                  TR::MemoryReference * mf = ((TR::S390RSInstruction*)current)->getMemoryReference();
                   if(mf != NULL)
                   {
                     mf->resetMemRefUsedBefore();
@@ -4724,8 +4724,8 @@ TR_S390Peephole::attemptZ7distinctOperants()
                   }
                case TR::InstOpCode::SLL:
                   {
-                  int16_t imm = ((TR_S390RSInstruction*)current)->getSourceImmediate();
-                  TR::MemoryReference * mf = ((TR_S390RSInstruction*)current)->getMemoryReference();
+                  int16_t imm = ((TR::S390RSInstruction*)current)->getSourceImmediate();
+                  TR::MemoryReference * mf = ((TR::S390RSInstruction*)current)->getMemoryReference();
                   if(mf != NULL)
                   {
                    mf->resetMemRefUsedBefore();
@@ -4738,8 +4738,8 @@ TR_S390Peephole::attemptZ7distinctOperants()
 
                case TR::InstOpCode::SRA:
                   {
-                  int16_t imm = ((TR_S390RSInstruction*)current)->getSourceImmediate();
-                  TR::MemoryReference * mf = ((TR_S390RSInstruction *)current)->getMemoryReference();
+                  int16_t imm = ((TR::S390RSInstruction*)current)->getSourceImmediate();
+                  TR::MemoryReference * mf = ((TR::S390RSInstruction *)current)->getMemoryReference();
                   if(mf != NULL)
                   {
                     mf->resetMemRefUsedBefore();
@@ -4751,8 +4751,8 @@ TR_S390Peephole::attemptZ7distinctOperants()
                   }
                case TR::InstOpCode::SRL:
                   {
-                  int16_t imm = ((TR_S390RSInstruction*)current)->getSourceImmediate();
-                  TR::MemoryReference * mf = ((TR_S390RSInstruction*)current)->getMemoryReference();
+                  int16_t imm = ((TR::S390RSInstruction*)current)->getSourceImmediate();
+                  TR::MemoryReference * mf = ((TR::S390RSInstruction*)current)->getMemoryReference();
                   if(mf != NULL)
                   {
                     mf->resetMemRefUsedBefore();
@@ -4869,7 +4869,7 @@ TR_S390Peephole::reloadLiteralPoolRegisterForCatchBlock()
       if ((_cg->getLinkage())->setupLiteralPoolRegister(firstSnippet) > 0)
          {
          // the imm. operand will be patched when the actual address of the literal pool is known at binary encoding phase
-         TR_S390RILInstruction * inst = (TR_S390RILInstruction *) generateRILInstruction(_cg, TR::InstOpCode::LARL, _cursor->getNode(), _cg->getLitPoolRealRegister(), 0xBABE, _cursor);
+         TR::S390RILInstruction * inst = (TR::S390RILInstruction *) generateRILInstruction(_cg, TR::InstOpCode::LARL, _cursor->getNode(), _cg->getLitPoolRealRegister(), 0xBABE, _cursor);
          inst->setIsLiteralPoolAddress();
          }
       }
@@ -4923,7 +4923,7 @@ TR_S390Peephole::tryMoveImmediate()
  */
 bool TR_S390Peephole::ReduceLHIToXR()
   {
-  TR_S390RIInstruction* lhiInstruction = static_cast<TR_S390RIInstruction*>(_cursor);
+  TR::S390RIInstruction* lhiInstruction = static_cast<TR::S390RIInstruction*>(_cursor);
 
   if (lhiInstruction->getSourceImmediate() == 0)
      {
@@ -5048,13 +5048,13 @@ TR_S390Peephole::perform()
          {
          case TR::InstOpCode::LOCK:
             {
-            int32_t regNum = ((TR_S390PseudoInstruction *)_cursor)->getLockedRegisterNumber();
+            int32_t regNum = ((TR::S390PseudoInstruction *)_cursor)->getLockedRegisterNumber();
             if (_cg->getCurrentlyRestrictedRegisters()) _cg->getCurrentlyRestrictedRegisters()->set(regNum);
             break;
             }
          case TR::InstOpCode::UNLOCK:
             {
-            int32_t regNum = ((TR_S390PseudoInstruction *)_cursor)->getLockedRegisterNumber();
+            int32_t regNum = ((TR::S390PseudoInstruction *)_cursor)->getLockedRegisterNumber();
             if (_cg->getCurrentlyRestrictedRegisters()) _cg->getCurrentlyRestrictedRegisters()->reset(regNum);
             break;
             }
@@ -5296,8 +5296,8 @@ TR_S390Peephole::perform()
                    (nb->getKind() == TR::Instruction::IsRIL))
                   {
                   // NILF == generateRILInstruction
-                  TR_S390RILInstruction * cast_na = (TR_S390RILInstruction *)na;
-                  TR_S390RILInstruction * cast_nb = (TR_S390RILInstruction *)nb;
+                  TR::S390RILInstruction * cast_na = (TR::S390RILInstruction *)na;
+                  TR::S390RILInstruction * cast_nb = (TR::S390RILInstruction *)nb;
 
                   bool instructionsMatch =
                      (cast_na->getTargetPtr() == cast_nb->getTargetPtr()) &&
@@ -5365,8 +5365,8 @@ TR_S390Peephole::perform()
                    (nb->getKind() == TR::Instruction::IsRS))
                   {
                   // SRL == SLL == generateRSInstruction
-                  TR_S390RSInstruction * cast_na = (TR_S390RSInstruction *)na;
-                  TR_S390RSInstruction * cast_nb = (TR_S390RSInstruction *)nb;
+                  TR::S390RSInstruction * cast_na = (TR::S390RSInstruction *)na;
+                  TR::S390RSInstruction * cast_nb = (TR::S390RSInstruction *)nb;
 
                   bool instrMatch =
                         (cast_na->getFirstRegister() == cast_nb->getFirstRegister()) &&
@@ -5752,7 +5752,7 @@ OMR::Z::CodeGenerator::doBinaryEncoding()
                      {
                      if (self()->comp()->getOption(TR_TraceLabelTargetNOPs))
                         traceMsg(self()->comp(),"\t\tepilogue inst %p (%s) setSkipForLabelTargetNOPs\n",s390Inst,self()->comp()->getDebug()->getOpCodeName(&s390Inst->getOpCode()));
-                     TR_S390LabelInstruction *labelInst = (TR_S390LabelInstruction*)s390Inst;
+                     TR::S390LabelInstruction *labelInst = (TR::S390LabelInstruction*)s390Inst;
                      labelInst->setSkipForLabelTargetNOPs();
                      }
                   }
@@ -5883,10 +5883,10 @@ OMR::Z::CodeGenerator::doBinaryEncoding()
 
          if (self()->comp()->cg()->isBranchInstruction(data.cursorInstruction))
             {
-            TR::LabelSymbol * branchLabelSymbol = ((TR_S390BranchInstruction *)data.cursorInstruction)->getLabelSymbol();
+            TR::LabelSymbol * branchLabelSymbol = ((TR::S390BranchInstruction *)data.cursorInstruction)->getLabelSymbol();
             if (data.cursorInstruction->getKind() == TR::Instruction::IsRIE &&
-                (toS390RIEInstruction(data.cursorInstruction)->getRieForm() == TR_S390RIEInstruction::RIE_RR ||
-                 toS390RIEInstruction(data.cursorInstruction)->getRieForm() == TR_S390RIEInstruction::RIE_RI8))
+                (toS390RIEInstruction(data.cursorInstruction)->getRieForm() == TR::S390RIEInstruction::RIE_RR ||
+                 toS390RIEInstruction(data.cursorInstruction)->getRieForm() == TR::S390RIEInstruction::RIE_RI8))
                {
                branchLabelSymbol = toS390RIEInstruction(data.cursorInstruction)->getBranchDestinationLabel();
                }
@@ -5898,16 +5898,16 @@ OMR::Z::CodeGenerator::doBinaryEncoding()
             }
          else if (data.cursorInstruction->getKind() == TR::Instruction::IsRIL) // e.g. LARL/EXRL
             {
-            if (((TR_S390RILInstruction *)data.cursorInstruction)->getTargetLabel() != NULL)
+            if (((TR::S390RILInstruction *)data.cursorInstruction)->getTargetLabel() != NULL)
                {
-               TR::LabelSymbol * targetLabel = ((TR_S390RILInstruction *)data.cursorInstruction)->getTargetLabel();
+               TR::LabelSymbol * targetLabel = ((TR::S390RILInstruction *)data.cursorInstruction)->getTargetLabel();
                TR_HashId hashIndex = 0;
                branchHashTable->add((void *)targetLabel, hashIndex, (void *)targetLabel);
                }
             }
          else if (self()->comp()->cg()->isLabelInstruction(data.cursorInstruction))
             {
-            TR::LabelSymbol * labelSymbol = ((TR_S390BranchInstruction *)data.cursorInstruction)->getLabelSymbol();
+            TR::LabelSymbol * labelSymbol = ((TR::S390BranchInstruction *)data.cursorInstruction)->getLabelSymbol();
             TR_HashId hashIndex = 0;
             labelHashTable->add((void *)labelSymbol, hashIndex, (void *)labelSymbol);
             }
@@ -8386,7 +8386,7 @@ OMR::Z::CodeGenerator::processInstruction(TR::Instruction *instr,
          }
       case TR::Instruction::IsRR:
          {
-         if (((TR_S390RRInstruction *)s390Instr)->getFirstConstant() >= 0)
+         if (((TR::S390RRInstruction *)s390Instr)->getFirstConstant() >= 0)
             ; //nothing to do
          else
             {
@@ -8410,11 +8410,11 @@ OMR::Z::CodeGenerator::processInstruction(TR::Instruction *instr,
                }
             }
 
-         if (((TR_S390RRInstruction *)s390Instr)->getSecondConstant() >= 0)
+         if (((TR::S390RRInstruction *)s390Instr)->getSecondConstant() >= 0)
             ; //nothing to do
          else
             {
-            TR::Register * sourceRegister = ((TR_S390RRInstruction *)instr)->getRegisterOperand(2);
+            TR::Register * sourceRegister = ((TR::S390RRInstruction *)instr)->getRegisterOperand(2);
             TR::RegisterPair *regPair = sourceRegister->getRegisterPair();
             int32_t srcRegNum = 0;
             if (regPair)
@@ -8465,7 +8465,7 @@ OMR::Z::CodeGenerator::processInstruction(TR::Instruction *instr,
       case TR::Instruction::IsRRF4:
       case TR::Instruction::IsRRF5:
          {
-         TR_S390RRFInstruction *s = (TR_S390RRFInstruction *)s390Instr;
+         TR::S390RRFInstruction *s = (TR::S390RRFInstruction *)s390Instr;
          int32_t tgtRegNum = toRealRegister(s->getRegisterOperand(1))->getRegisterNumber();
          if (traceIt)
             traceMsg(self()->comp(), "RRF instr [%p] USES register [%d]\n", s, tgtRegNum);
@@ -8485,7 +8485,7 @@ OMR::Z::CodeGenerator::processInstruction(TR::Instruction *instr,
          }
       case TR::Instruction::IsRRR:
          {
-         TR_S390RRRInstruction *s = (TR_S390RRRInstruction *)s390Instr;
+         TR::S390RRRInstruction *s = (TR::S390RRRInstruction *)s390Instr;
          int32_t tgtRegNum = toRealRegister(s->getRegisterOperand(1))->getRegisterNumber();
          registerUsageInfo[blockNum]->set(tgtRegNum);
 
@@ -8512,7 +8512,7 @@ OMR::Z::CodeGenerator::processInstruction(TR::Instruction *instr,
       case TR::Instruction::IsRS:
       case TR::Instruction::IsRSY:
          {
-         TR_S390RSInstruction *s = (TR_S390RSInstruction *)s390Instr;
+         TR::S390RSInstruction *s = (TR::S390RSInstruction *)s390Instr;
          if (s->getSourceImmediate())
             {
             if (s->getRegisterOperand(1)->getRegisterPair())
@@ -8782,7 +8782,7 @@ OMR::Z::CodeGenerator::processInstruction(TR::Instruction *instr,
          }
       case TR::Instruction::IsSS4:
          {
-         TR_S390SS4Instruction *s = (TR_S390SS4Instruction *)s390Instr;
+         TR::S390SS4Instruction *s = (TR::S390SS4Instruction *)s390Instr;
          int32_t lenRegNum = toRealRegister(s->getLengthReg())->getRegisterNumber();
          int32_t srcKeyRegNum = toRealRegister(s->getSourceKeyReg())->getRegisterNumber();
          registerUsageInfo[blockNum]->set(lenRegNum);
@@ -8808,7 +8808,7 @@ OMR::Z::CodeGenerator::processInstruction(TR::Instruction *instr,
          }
       case TR::Instruction::IsSSF:
          {
-         TR_S390SSFInstruction *s = (TR_S390SSFInstruction *)s390Instr;
+         TR::S390SSFInstruction *s = (TR::S390SSFInstruction *)s390Instr;
          int32_t firstRegNum = toRealRegister(s->getFirstRegister())->getRegisterNumber();
          registerUsageInfo[blockNum]->set(firstRegNum);
          if (traceIt)
@@ -8964,7 +8964,7 @@ OMR::Z::CodeGenerator::splitEdge(TR::Instruction *instr,
       newLabel = generateLabelSymbol(self());
    else
       {
-      newLabel = ((TR_S390LabelInstruction *)newSplitLabel)->getLabelSymbol();
+      newLabel = ((TR::S390LabelInstruction *)newSplitLabel)->getLabelSymbol();
       }
    TR::LabelSymbol *targetLabel = NULL;
    TR::Instruction *location = NULL;
@@ -8977,14 +8977,14 @@ OMR::Z::CodeGenerator::splitEdge(TR::Instruction *instr,
       // compare and branch
       if (instr->getKind() == TR::Instruction::IsRIE)
          {
-         TR_S390RIEInstruction *labelInstr = (TR_S390RIEInstruction *)instr;
+         TR::S390RIEInstruction *labelInstr = (TR::S390RIEInstruction *)instr;
          targetLabel = labelInstr->getBranchDestinationLabel();
          labelInstr->setBranchDestinationLabel(newLabel);
          location = targetLabel->getInstruction()->getPrev();
          }
       else
          {
-         TR_S390LabeledInstruction *labelInstr = (TR_S390LabeledInstruction *)instr;
+         TR::S390LabeledInstruction *labelInstr = (TR::S390LabeledInstruction *)instr;
          targetLabel = labelInstr->getLabelSymbol();
          labelInstr->setLabelSymbol(newLabel);
          location = targetLabel->getInstruction()->getPrev();
@@ -8994,7 +8994,7 @@ OMR::Z::CodeGenerator::splitEdge(TR::Instruction *instr,
       //
       for (auto jmpItr = jmpInstrs->begin(); jmpItr != jmpInstrs->end(); ++jmpItr)
          {
-         TR_S390LabeledInstruction *l = (TR_S390LabeledInstruction *)(*jmpItr);
+         TR::S390LabeledInstruction *l = (TR::S390LabeledInstruction *)(*jmpItr);
          if (l->getLabelSymbol() == targetLabel)
             {
             traceMsg(self()->comp(), "split edge fixing jmp instr %p\n", *jmpItr);
@@ -9078,7 +9078,7 @@ OMR::Z::CodeGenerator::updateSnippetMapWithRSD(TR::Instruction *instr, int32_t r
    // determine if it branches to a snippet and if so
    // mark the maps in the snippet with the right rsd
    //
-   TR_S390LabelInstruction *labelInstr = (TR_S390LabelInstruction *)instr;
+   TR::S390LabelInstruction *labelInstr = (TR::S390LabelInstruction *)instr;
    TR::LabelSymbol *targetLabel = labelInstr->getLabelSymbol();
 
    TR_S390OutOfLineCodeSection *oiCursor = self()->findOutLinedInstructionsFromLabel(targetLabel);
@@ -9120,7 +9120,7 @@ OMR::Z::CodeGenerator::findOutLinedInstructionsFromLabel(TR::LabelSymbol *label)
 bool
 OMR::Z::CodeGenerator::isTargetSnippetOrOutOfLine(TR::Instruction *instr, TR::Instruction **start, TR::Instruction **end)
    {
-   TR_S390LabelInstruction *labelInstr = (TR_S390LabelInstruction *)instr;
+   TR::S390LabelInstruction *labelInstr = (TR::S390LabelInstruction *)instr;
    TR::LabelSymbol *targetLabel = labelInstr->getLabelSymbol();
    TR_S390OutOfLineCodeSection *oiCursor = self()->findOutLinedInstructionsFromLabel(targetLabel);
    if (oiCursor)
@@ -10852,7 +10852,7 @@ bool TR_S390Peephole::forwardBranchTarget()
    TR::LabelSymbol *targetLabelSym = NULL;
    switch(_cursor->getOpCodeValue())
       {
-      case TR::InstOpCode::BRC: targetLabelSym = ((TR_S390BranchInstruction*)_cursor)->getLabelSymbol(); break;
+      case TR::InstOpCode::BRC: targetLabelSym = ((TR::S390BranchInstruction*)_cursor)->getLabelSymbol(); break;
       case TR::InstOpCode::CRJ:
       case TR::InstOpCode::CGRJ:
       case TR::InstOpCode::CIJ:
@@ -10875,14 +10875,14 @@ bool TR_S390Peephole::forwardBranchTarget()
       tmp = tmp->getNext();
    if (tmp->getOpCodeValue() == TR::InstOpCode::BRC)
       {
-      auto firstBranch = (TR_S390BranchInstruction*)tmp;
+      auto firstBranch = (TR::S390BranchInstruction*)tmp;
       if (firstBranch->getBranchCondition() == TR::InstOpCode::COND_BRC &&
           performTransformation(comp(), "\nO^O S390 PEEPHOLE: forwarding branch target in %p\n", _cursor))
          {
          auto newTargetLabelSym = firstBranch->getLabelSymbol();
          switch(_cursor->getOpCodeValue())
             {
-            case TR::InstOpCode::BRC: ((TR_S390BranchInstruction*)_cursor)->setLabelSymbol(newTargetLabelSym); break;
+            case TR::InstOpCode::BRC: ((TR::S390BranchInstruction*)_cursor)->setLabelSymbol(newTargetLabelSym); break;
             case TR::InstOpCode::CRJ:
             case TR::InstOpCode::CGRJ:
             case TR::InstOpCode::CIJ:

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -92,7 +92,7 @@ class TR_S390ConstantDataSnippet;
 class TR_S390ConstantInstructionSnippet;
 class TR_S390DeclTrampSnippet;
 class TR_S390EyeCatcherDataSnippet;
-class TR_S390ImmInstruction;
+namespace TR { class S390ImmInstruction; }
 class TR_S390LabelTableSnippet;
 class TR_S390LookupSwitchSnippet;
 class TR_S390OutOfLineCodeSection;
@@ -1140,7 +1140,7 @@ public:
     * on, due to user specified options.
     */
    TR_S390ProcessorInfo            _processorInfo;
-   TR_S390ImmInstruction          *_returnTypeInfoInstruction;
+   TR::S390ImmInstruction          *_returnTypeInfoInstruction;
    RegisterAssignmentDirection     assignmentDirection;
    int32_t                        _extentOfLitPool;  // excludes snippets
    uint64_t                       _availableHPRSpillMask;

--- a/compiler/z/codegen/OMRInstruction.cpp
+++ b/compiler/z/codegen/OMRInstruction.cpp
@@ -623,7 +623,7 @@ bool OMR::Z::Instruction::startOfLiveRange(TR::Register * reg)
      }
    if(self()->getOpCodeValue() == TR::InstOpCode::RISBG || self()->getOpCodeValue() == TR::InstOpCode::RISBGN || self()->getOpCodeValue() == TR::InstOpCode::RISBHG || self()->getOpCodeValue() == TR::InstOpCode::RISBLG)
      {
-      uint8_t endBit = ((TR_S390RIEInstruction* )self())->getSourceImmediate8Two();
+      uint8_t endBit = ((TR::S390RIEInstruction* )self())->getSourceImmediate8Two();
       if(_targetReg[0] == reg && (endBit & 128) != 0)
         return true;
       }
@@ -833,7 +833,7 @@ bool OMR::Z::Instruction::getUsedRegisters(TR::list<TR::Register *> &usedRegs)
         {
         if(i==0 && (self()->getOpCodeValue() == TR::InstOpCode::RISBG || self()->getOpCodeValue() == TR::InstOpCode::RISBGN || self()->getOpCodeValue() == TR::InstOpCode::RISBHG || self()->getOpCodeValue() == TR::InstOpCode::RISBLG))
           {
-          uint8_t endBit = ((TR_S390RIEInstruction* )self())->getSourceImmediate8Two();
+          uint8_t endBit = ((TR::S390RIEInstruction* )self())->getSourceImmediate8Two();
           if((endBit & 128) != 0)
             continue;       // Zeroing out unused bits therefore the first operand is not used
           else
@@ -1185,7 +1185,7 @@ static bool isInternalControlFlowOneEntryOneExit(TR::Instruction *regionEnd, TR:
     {
     if(curr->isBranchOp())
       {
-      TR_S390LabeledInstruction *labeledInstr=(TR_S390LabeledInstruction *)curr;
+      TR::S390LabeledInstruction *labeledInstr=(TR::S390LabeledInstruction *)curr;
       TR::LabelSymbol *targetLabel=labeledInstr->getLabelSymbol();
       int32_t i;
       bool found=false;
@@ -1213,7 +1213,7 @@ OMR::Z::Instruction::getOutOfLineEXInstr()
       {
       case TR::InstOpCode::EX:
       {
-         TR::MemoryReference * tempMR = ((TR_S390RXInstruction *)self())->getMemoryReference();
+         TR::MemoryReference * tempMR = ((TR::S390RXInstruction *)self())->getMemoryReference();
          TR_S390ConstantInstructionSnippet * cis = (TR_S390ConstantInstructionSnippet *) tempMR->getConstantDataSnippet();
          TR_ASSERT( cis != NULL, "Out of line EX instruction doesn't have a constantInstructionSnippet\n");
          return cis->getInstruction();
@@ -1221,7 +1221,7 @@ OMR::Z::Instruction::getOutOfLineEXInstr()
       case TR::InstOpCode::EXRL:
       {
          TR_S390ConstantInstructionSnippet * cis = (TR_S390ConstantInstructionSnippet *)
-            ((TR_S390RILInstruction *)self())->getTargetSnippet();
+            ((TR::S390RILInstruction *)self())->getTargetSnippet();
          TR_ASSERT( cis != NULL, "Out of line EXRL instruction doesn't have a constantInstructionSnippet\n");
          return cis->getInstruction();
       }
@@ -1281,7 +1281,7 @@ OMR::Z::Instruction::setupThrowsImplicitNullPointerException(TR::Node *n, TR::Me
 // The following safe virtual downcast method is only used in an assertion
 // check within "toS390ImmInstruction"
 #if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
-TR_S390ImmInstruction *
+TR::S390ImmInstruction *
 OMR::Z::Instruction::getS390ImmInstruction()
    {
    // *this    swipeable for debugging purposes
@@ -1459,8 +1459,8 @@ OMR::Z::Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
       // GRSM occupies the top 8 bits of the immediate field.  Need to
       // preserve the lower 8 bits, which has controls for AR, Floating
       // Point and Program Interruption Filtering.
-      uint16_t originalGRSM = ((TR_S390SILInstruction*)self())->getSourceImmediate();
-      ((TR_S390SILInstruction*)self())->setSourceImmediate((grsm << 8) | (originalGRSM & 0xFF));
+      uint16_t originalGRSM = ((TR::S390SILInstruction*)self())->getSourceImmediate();
+      ((TR::S390SILInstruction*)self())->setSourceImmediate((grsm << 8) | (originalGRSM & 0xFF));
       }
 
 
@@ -1593,9 +1593,9 @@ OMR::Z::Instruction::useSourceRegister(TR::Register * reg)
          {
          if (self()->getOpCodeValue() == TR::InstOpCode::RISBG || self()->getOpCodeValue() == TR::InstOpCode::RISBGN)
             {
-            uint8_t startBit = ((TR_S390RIEInstruction* )self())->getSourceImmediate8One();
-            uint8_t endBit = ((TR_S390RIEInstruction* )self())->getSourceImmediate8Two();
-            uint8_t rotateAmnt = ((TR_S390RIEInstruction* )self())->getSourceImmediate8();
+            uint8_t startBit = ((TR::S390RIEInstruction* )self())->getSourceImmediate8One();
+            uint8_t endBit = ((TR::S390RIEInstruction* )self())->getSourceImmediate8Two();
+            uint8_t rotateAmnt = ((TR::S390RIEInstruction* )self())->getSourceImmediate8();
             if ((startBit + rotateAmnt) < 32 &&
                 (endBit - rotateAmnt) > 63)
                {
@@ -1699,7 +1699,7 @@ bool OMR::Z::Instruction::containsRegister(TR::Register *reg)
       {
       if (self()->getOpCodeValue() == TR::InstOpCode::EX)
          {
-         TR::MemoryReference * tempMR = ((TR_S390RXInstruction *)self())->getMemoryReference();
+         TR::MemoryReference * tempMR = ((TR::S390RXInstruction *)self())->getMemoryReference();
          TR_S390ConstantInstructionSnippet * cis = (TR_S390ConstantInstructionSnippet *) tempMR->getConstantDataSnippet();
          TR_ASSERT( cis != NULL, "Out of line EX instruction doesn't have a constantInstructionSnippet\n");
          if (cis->getInstruction()->containsRegister(reg))
@@ -1707,7 +1707,7 @@ bool OMR::Z::Instruction::containsRegister(TR::Register *reg)
          }
       else if (self()->getOpCodeValue() == TR::InstOpCode::EXRL)
          {
-         TR_S390ConstantInstructionSnippet * cis = (TR_S390ConstantInstructionSnippet *) ((TR_S390RILInstruction *)self())->getTargetSnippet();
+         TR_S390ConstantInstructionSnippet * cis = (TR_S390ConstantInstructionSnippet *) ((TR::S390RILInstruction *)self())->getTargetSnippet();
          TR_ASSERT( cis != NULL, "Out of line EXRL instruction doesn't have a constantInstructionSnippet\n");
          if (cis->getInstruction()->containsRegister(reg))
             return true;
@@ -2005,8 +2005,8 @@ OMR::Z::Instruction::assignRegisterNoDependencies(TR::Register * reg)
       bool skipBookkeeping = false;
       if (self()->getOpCodeValue() == TR::InstOpCode::BCR &&
           toRealRegister(reg)->getRegisterNumber() == TR::RealRegister::GPR0 &&
-          (((TR_S390RegInstruction*)self())->getBranchCondition() == TR::InstOpCode::COND_MASK14 ||
-           ((TR_S390RegInstruction*)self())->getBranchCondition() == TR::InstOpCode::COND_MASK15))
+          (((TR::S390RegInstruction*)self())->getBranchCondition() == TR::InstOpCode::COND_MASK14 ||
+           ((TR::S390RegInstruction*)self())->getBranchCondition() == TR::InstOpCode::COND_MASK15))
          skipBookkeeping = true;
 
       if (!skipBookkeeping && realReg->getState() != TR::RealRegister::Locked &&
@@ -2352,7 +2352,7 @@ OMR::Z::Instruction::assignOrderedRegisters(TR_RegisterKinds kindToBeAssigned)
                {
                if (self()->getOpCodeValue() == TR::InstOpCode::RISBG || self()->getOpCodeValue() == TR::InstOpCode::RISBGN)
                   {
-                  uint8_t endBit = ((TR_S390RIEInstruction *)self())->getSourceImmediate8Two();
+                  uint8_t endBit = ((TR::S390RIEInstruction *)self())->getSourceImmediate8Two();
                   if (endBit & 0x80) // if the zero bit is set, target reg will be 64bit
                      {
                      _targetReg[i]->setIs64BitReg(true);
@@ -2364,9 +2364,9 @@ OMR::Z::Instruction::assignOrderedRegisters(TR_RegisterKinds kindToBeAssigned)
                   }
                }
             if ((self()->getOpCodeValue() == TR::InstOpCode::RISBLG || self()->getOpCodeValue() == TR::InstOpCode::RISBHG) &&
-                ((TR_S390RIEInstruction *)self())->getExtendedHighWordOpCode().getOpCodeValue() != TR::InstOpCode::BAD)
+                ((TR::S390RIEInstruction *)self())->getExtendedHighWordOpCode().getOpCodeValue() != TR::InstOpCode::BAD)
                {
-               if (((TR_S390RIEInstruction *)self())->getExtendedHighWordOpCode().isOperandHW(registerOperandNum))
+               if (((TR::S390RIEInstruction *)self())->getExtendedHighWordOpCode().isOperandHW(registerOperandNum))
                   _targetReg[i]->setAssignToHPR(true);
                else
                   _targetReg[i]->setAssignToHPR(false);
@@ -2463,9 +2463,9 @@ OMR::Z::Instruction::assignOrderedRegisters(TR_RegisterKinds kindToBeAssigned)
                {
                if (self()->getOpCodeValue() == TR::InstOpCode::RISBG || self()->getOpCodeValue() == TR::InstOpCode::RISBGN)
                   {
-                  uint8_t startBit = ((TR_S390RIEInstruction* )self())->getSourceImmediate8One();
-                  uint8_t endBit = ((TR_S390RIEInstruction* )self())->getSourceImmediate8Two();
-                  uint8_t rotateAmnt = ((TR_S390RIEInstruction* )self())->getSourceImmediate8();
+                  uint8_t startBit = ((TR::S390RIEInstruction* )self())->getSourceImmediate8One();
+                  uint8_t endBit = ((TR::S390RIEInstruction* )self())->getSourceImmediate8Two();
+                  uint8_t rotateAmnt = ((TR::S390RIEInstruction* )self())->getSourceImmediate8();
                   if ((startBit + rotateAmnt) < 32 &&
                       (endBit - rotateAmnt) > 63)
                      {
@@ -2480,9 +2480,9 @@ OMR::Z::Instruction::assignOrderedRegisters(TR_RegisterKinds kindToBeAssigned)
                }
 
             if ((self()->getOpCodeValue() == TR::InstOpCode::RISBLG || self()->getOpCodeValue() == TR::InstOpCode::RISBHG) &&
-                ((TR_S390RIEInstruction *)self())->getExtendedHighWordOpCode().getOpCodeValue() != TR::InstOpCode::BAD)
+                ((TR::S390RIEInstruction *)self())->getExtendedHighWordOpCode().getOpCodeValue() != TR::InstOpCode::BAD)
                {
-               firstNonPairSourceRegister->setAssignToHPR(((TR_S390RIEInstruction *)self())->getExtendedHighWordOpCode().isOperandHW(registerOperandNum));
+               firstNonPairSourceRegister->setAssignToHPR(((TR::S390RIEInstruction *)self())->getExtendedHighWordOpCode().isOperandHW(registerOperandNum));
                }
             else
                firstNonPairSourceRegister->setAssignToHPR(_opcode.isOperandHW(registerOperandNum));
@@ -2575,12 +2575,12 @@ OMR::Z::Instruction::assignRegistersAndDependencies(TR_RegisterKinds kindToBeAss
 
    // RIE for CompareAndBranch
    if (self()->getOpCode().isBranchOp() && self()->getKind() == IsRIE &&
-       ((TR_S390RIEInstruction*)self())->getLabelSymbol()->isStartOfColdInstructionStream())
+       ((TR::S390RIEInstruction*)self())->getLabelSymbol()->isStartOfColdInstructionStream())
       {
       // Switch to the outlined instruction stream and assign registers.
       //
-      TR_S390OutOfLineCodeSection *oi = self()->cg()->findS390OutOfLineCodeSectionFromLabel(((TR_S390RIEInstruction*)self())->getLabelSymbol());
-      TR_ASSERT(oi, "Could not find S390OutOfLineCodeSection stream from label.  instr=%p, label=%p\n", self(), ((TR_S390RIEInstruction*)self())->getLabelSymbol());
+      TR_S390OutOfLineCodeSection *oi = self()->cg()->findS390OutOfLineCodeSectionFromLabel(((TR::S390RIEInstruction*)self())->getLabelSymbol());
+      TR_ASSERT(oi, "Could not find S390OutOfLineCodeSection stream from label.  instr=%p, label=%p\n", self(), ((TR::S390RIEInstruction*)self())->getLabelSymbol());
       if (!oi->hasBeenRegisterAssigned())
          oi->assignRegisters(kindToBeAssigned);
       }

--- a/compiler/z/codegen/OMRInstruction.hpp
+++ b/compiler/z/codegen/OMRInstruction.hpp
@@ -46,7 +46,7 @@ namespace OMR { typedef OMR::Z::Instruction InstructionConnector; }
 #include "infra/Flags.hpp"                             // for flags16_t
 
 class TR_Debug;
-class TR_S390ImmInstruction;
+namespace TR { class S390ImmInstruction; }
 class TR_S390RegisterDependencyGroup;
 namespace TR { class CodeGenerator; }
 namespace TR { class Instruction; }
@@ -268,7 +268,7 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
 
    #if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
    /** The following safe virtual downcast method is used under debug only for assertion checking */
-   virtual TR_S390ImmInstruction *getS390ImmInstruction();
+   virtual TR::S390ImmInstruction *getS390ImmInstruction();
    #endif
 
 

--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -364,7 +364,7 @@ OMR::Z::Linkage::removeOSCOnSavedArgument(TR::Instruction* instr, TR::Register* 
 
       if (current->isLoad())
          {
-         TR::Register            *tReg    = ((TR_S390RXInstruction*)current)->getRegisterOperand(1);
+         TR::Register            *tReg    = ((TR::S390RXInstruction*)current)->getRegisterOperand(1);
          TR::MemoryReference *mr      = current->getMemoryReference();
          TR::SymbolReference     *symRef  = mr->getSymbolReference();
          TR::Symbol               *sym     = symRef->getSymbol();

--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -1441,8 +1441,8 @@ OMR::Z::Machine::assignBestRegisterSingle(TR::Register    *targetRegister,
            // special case for RISBG, we can change the rotate amount to shuffle low word/ high word
             if (currInst->getOpCodeValue() == TR::InstOpCode::RISBG || currInst->getOpCodeValue() == TR::InstOpCode::RISBGN)
                {
-               uint8_t rotateAmnt = ((TR_S390RIEInstruction* )currInst)->getSourceImmediate8();
-               ((TR_S390RIEInstruction* )currInst)->setSourceImmediate8(rotateAmnt+32);
+               uint8_t rotateAmnt = ((TR::S390RIEInstruction* )currInst)->getSourceImmediate8();
+               ((TR::S390RIEInstruction* )currInst)->setSourceImmediate8(rotateAmnt+32);
                }
             else
                {

--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -2669,7 +2669,7 @@ OMR::Z::MemoryReference::canUseTargetRegAsScratchReg (TR::Instruction * instr)
            {
            TR::RealRegister * base  = (memref->getBaseRegister() ? toRealRegister(memref->getBaseRegister()) : 0);
            TR::RealRegister * index = (memref->getIndexRegister() ? toRealRegister(memref->getIndexRegister()) : 0);
-           TR::RealRegister * targetReg = (TR::RealRegister * )((TR_S390RegInstruction *)instr)->getRegisterOperand(1);
+           TR::RealRegister * targetReg = (TR::RealRegister * )((TR::S390RegInstruction *)instr)->getRegisterOperand(1);
            if ( targetReg != base && targetReg != index && targetReg->getRegisterNumber() != TR::RealRegister::GPR0)
               return true;
            else
@@ -3109,7 +3109,7 @@ OMR::Z::MemoryReference::generateBinaryEncoding(uint8_t * cursor, TR::CodeGenera
          }
       else if (TR::MemoryReference::canUseTargetRegAsScratchReg(instr))
          {
-         scratchReg = (TR::RealRegister * )((TR_S390RegInstruction *)instr)->getRegisterOperand(1);
+         scratchReg = (TR::RealRegister * )((TR::S390RegInstruction *)instr)->getRegisterOperand(1);
          spillNeeded = false;
          }
       else
@@ -3510,7 +3510,7 @@ OMR::Z::MemoryReference::generateBinaryEncodingTouchUpForLongDisp(uint8_t *curso
       }
    else if (TR::MemoryReference::canUseTargetRegAsScratchReg(instr))
       {
-      scratchReg = (TR::RealRegister * )((TR_S390RegInstruction *)instr)->getRegisterOperand(1);
+      scratchReg = (TR::RealRegister * )((TR::S390RegInstruction *)instr)->getRegisterOperand(1);
       spillNeeded = false;
       }
    else

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -5805,7 +5805,7 @@ TR::Register *
 aloadHelper(TR::Node * node, TR::CodeGenerator * cg, TR::MemoryReference * tempMR)
    {
    TR::Snippet * firstSnippet = NULL;
-   TR_S390RILInstruction * LARLinst;
+   TR::S390RILInstruction * LARLinst;
    TR::Compilation *comp = cg->comp();
 
 
@@ -10652,7 +10652,7 @@ OMR::Z::TreeEvaluator::arraycmpHelper(TR::Node *node,
             source2MemRef= generateS390MemoryReference(source2Reg, 0, cg);
 
             if (!comp->getOption(TR_DisableInlineEXTarget))
-               cursor = new (cg->trHeapMemory()) TR_S390RILInstruction(TR::InstOpCode::EXRL, node, lengthReg, EXTargetLabel, cg);
+               cursor = new (cg->trHeapMemory()) TR::S390RILInstruction(TR::InstOpCode::EXRL, node, lengthReg, EXTargetLabel, cg);
             else
                {
                cursor = generateSS1Instruction(cg, TR::InstOpCode::CLC, node, 0, source1MemRef, source2MemRef);
@@ -11494,8 +11494,8 @@ OMR::Z::TreeEvaluator::loadaddrEvaluator(TR::Node * node, TR::CodeGenerator * cg
       TR_S390WritableDataSnippet * litpool = cg->CreateWritableConstant(node);
       litpool->setUnresolvedDataSnippet(uds);
 
-      TR_S390RILInstruction * LRLinst;
-      LRLinst = (TR_S390RILInstruction *) generateRILInstruction(cg, TR::InstOpCode::getLoadRelativeLongOpCode(), node, targetRegister, 0xBABE, 0);
+      TR::S390RILInstruction * LRLinst;
+      LRLinst = (TR::S390RILInstruction *) generateRILInstruction(cg, TR::InstOpCode::getLoadRelativeLongOpCode(), node, targetRegister, 0xBABE, 0);
       uds->setDataReferenceInstruction(LRLinst);
       LRLinst->setSymbolReference(uds->getDataSymbolReference());
       LRLinst->setTargetSnippet(litpool);
@@ -11567,7 +11567,7 @@ OMR::Z::TreeEvaluator::loadaddrEvaluator(TR::Node * node, TR::CodeGenerator * cg
          }
       else if (node->getSymbol()->isLabel() || node->getSymbol()->isMethod())
          {
-         new (cg->trHeapMemory()) TR_S390RILInstruction(TR::InstOpCode::LARL, node, targetRegister, symRef->getSymbol(), symRef, cg);
+         new (cg->trHeapMemory()) TR::S390RILInstruction(TR::InstOpCode::LARL, node, targetRegister, symRef->getSymbol(), symRef, cg);
          }
       else
          {
@@ -12652,7 +12652,7 @@ OMR::Z::TreeEvaluator::arraytranslateEvaluator(TR::Node * node, TR::CodeGenerato
    TR::LabelSymbol * afterLoop = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
    afterLoop->setEndInternalControlFlow();
 
-   new (cg->trHeapMemory()) TR_S390TranslateInstruction(opCode, node, outputPair, inputReg, tableReg, termCharReg, 0, cg, node->getTermCharNodeIsHint() && (opCode != TR::InstOpCode::TRTO) ? 1 : 0 );
+   new (cg->trHeapMemory()) TR::S390TranslateInstruction(opCode, node, outputPair, inputReg, tableReg, termCharReg, 0, cg, node->getTermCharNodeIsHint() && (opCode != TR::InstOpCode::TRTO) ? 1 : 0 );
 
    generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BORC, node, topOfLoop); // repeat if CPU-defined limit hit
    // LL: Only have to do this if not Golden Eagle when termination character is a guess.
@@ -17754,7 +17754,7 @@ TR::Register* inlineStringHashCodeUnrolled(TR::Node* node, TR::CodeGenerator* cg
    // Branch to the correct case label
    generateRXInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, tempRegister, generateS390MemoryReference(tempRegister, 0, cg));
 
-   static_cast <TR_S390RegInstruction*> (generateS390RegInstruction(cg, TR::InstOpCode::BCR, node, tempRegister))->setBranchCondition(TR::InstOpCode::COND_MASK15);
+   static_cast <TR::S390RegInstruction*> (generateS390RegInstruction(cg, TR::InstOpCode::BCR, node, tempRegister))->setBranchCondition(TR::InstOpCode::COND_MASK15);
 
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, switchTableLabel);
 

--- a/compiler/z/codegen/OpMemToMem.cpp
+++ b/compiler/z/codegen/OpMemToMem.cpp
@@ -1017,7 +1017,7 @@ MemToMemVarLenMacroOp::generateRemainder()
          {
          TR_ASSERT(_EXTargetLabel != NULL, "Assert: EXTarget label must not be NULL");
 
-         _cursor = new (_cg->trHeapMemory()) TR_S390RILInstruction(TR::InstOpCode::EXRL, _rootNode, _regLen, _EXTargetLabel, _cg);
+         _cursor = new (_cg->trHeapMemory()) TR::S390RILInstruction(TR::InstOpCode::EXRL, _rootNode, _regLen, _EXTargetLabel, _cg);
          }
          else
          {

--- a/compiler/z/codegen/S390Debug.cpp
+++ b/compiler/z/codegen/S390Debug.cpp
@@ -143,8 +143,8 @@ TR_Debug::printPrefix(TR::FILE *pOutFile, TR::Instruction * instr)
             if (instr->getKind() == TR::Instruction::IsSS1 || instr->getKind() == TR::Instruction::IsSS2)
                {
                TR::MemoryReference *memRef = (instr->getKind() == TR::Instruction::IsSS1) ?
-                                                   ((TR_S390SS1Instruction *)(instr))->getMemoryReference2() :
-                                                   ((TR_S390SS2Instruction *)(instr))->getMemoryReference2();
+                                                   ((TR::S390SS1Instruction *)(instr))->getMemoryReference2() :
+                                                   ((TR::S390SS2Instruction *)(instr))->getMemoryReference2();
                if (memRef && memRef->getSymbolReference() && instr->getNode()->getOpCodeValue() != TR::BBStart && instr->getRegisterOperand(0))
                   trfprintf(pOutFile, ", #%d (%s)", memRef->getSymbolReference()->getReferenceNumber(), instr->getRegisterOperand(0)->getRegisterName(TR::comp()));
                else if (memRef && memRef->getSymbolReference())
@@ -189,42 +189,42 @@ TR_Debug::printz(TR::FILE *pOutFile, TR::Instruction * instr)
    switch (instr->getKind())
       {
       case TR::Instruction::IsLabel:
-         print(pOutFile, (TR_S390LabelInstruction *) instr);
+         print(pOutFile, (TR::S390LabelInstruction *) instr);
          break;
       case TR::Instruction::IsBranch:
-         print(pOutFile, (TR_S390BranchInstruction *) instr);
+         print(pOutFile, (TR::S390BranchInstruction *) instr);
          break;
       case TR::Instruction::IsBranchOnCount:
-         print(pOutFile, (TR_S390BranchOnCountInstruction *) instr);
+         print(pOutFile, (TR::S390BranchOnCountInstruction *) instr);
          break;
       case TR::Instruction::IsBranchOnIndex:
-         print(pOutFile, (TR_S390BranchOnIndexInstruction *) instr);
+         print(pOutFile, (TR::S390BranchOnIndexInstruction *) instr);
          break;
       case TR::Instruction::IsImm:
-         print(pOutFile, (TR_S390ImmInstruction *) instr);
+         print(pOutFile, (TR::S390ImmInstruction *) instr);
          break;
       case TR::Instruction::IsImmSnippet:
-         print(pOutFile, (TR_S390ImmSnippetInstruction *) instr);
+         print(pOutFile, (TR::S390ImmSnippetInstruction *) instr);
          break;
       case TR::Instruction::IsImmSym:
-         print(pOutFile, (TR_S390ImmSymInstruction *) instr);
+         print(pOutFile, (TR::S390ImmSymInstruction *) instr);
          break;
       case TR::Instruction::IsImm2Byte:
-         print(pOutFile, (TR_S390Imm2Instruction *) instr);
+         print(pOutFile, (TR::S390Imm2Instruction *) instr);
          break;
       case TR::Instruction::IsReg:
-         print(pOutFile, (TR_S390RegInstruction *) instr);
+         print(pOutFile, (TR::S390RegInstruction *) instr);
          break;
       case TR::Instruction::IsRR:
-         print(pOutFile, (TR_S390RRInstruction *) instr);
+         print(pOutFile, (TR::S390RRInstruction *) instr);
          break;
       case TR::Instruction::IsRRE:
          {
          TR::InstOpCode::Mnemonic opCode = instr->getOpCodeValue();
          if (opCode == TR::InstOpCode::TROO || opCode == TR::InstOpCode::TRTO || opCode == TR::InstOpCode::TROT || opCode == TR::InstOpCode::TRTT)
-            print(pOutFile, (TR_S390TranslateInstruction *) instr);
+            print(pOutFile, (TR::S390TranslateInstruction *) instr);
          else
-            print(pOutFile, (TR_S390RRInstruction *) instr);
+            print(pOutFile, (TR::S390RRInstruction *) instr);
          break;
          }
       case TR::Instruction::IsRRD: // RRD is encoded use RRF
@@ -233,116 +233,116 @@ TR_Debug::printz(TR::FILE *pOutFile, TR::Instruction * instr)
       case TR::Instruction::IsRRF3:
       case TR::Instruction::IsRRF4:
       case TR::Instruction::IsRRF5:
-         print(pOutFile, (TR_S390RRFInstruction *) instr);
+         print(pOutFile, (TR::S390RRFInstruction *) instr);
          break;
       case TR::Instruction::IsRRR:
-         print(pOutFile, (TR_S390RRRInstruction *) instr);
+         print(pOutFile, (TR::S390RRRInstruction *) instr);
          break;
       case TR::Instruction::IsRI:
-         print(pOutFile, (TR_S390RIInstruction *) instr);
+         print(pOutFile, (TR::S390RIInstruction *) instr);
          break;
       case TR::Instruction::IsRIL:
-         print(pOutFile, (TR_S390RILInstruction *) instr);
+         print(pOutFile, (TR::S390RILInstruction *) instr);
          break;
       case TR::Instruction::IsRS:
-         print(pOutFile, (TR_S390RSInstruction *) instr);
+         print(pOutFile, (TR::S390RSInstruction *) instr);
          break;
       case TR::Instruction::IsRSL:
-         print(pOutFile, (TR_S390RSLInstruction *) instr);
+         print(pOutFile, (TR::S390RSLInstruction *) instr);
          break;
       case TR::Instruction::IsRSLb:
-         print(pOutFile, (TR_S390RSLbInstruction *) instr);
+         print(pOutFile, (TR::S390RSLbInstruction *) instr);
          break;
       case TR::Instruction::IsRSY:
-         print(pOutFile, (TR_S390RSInstruction *) instr);
+         print(pOutFile, (TR::S390RSInstruction *) instr);
          break;
       case TR::Instruction::IsRX:
-         print(pOutFile, (TR_S390RXInstruction *) instr);
+         print(pOutFile, (TR::S390RXInstruction *) instr);
          break;
       case TR::Instruction::IsRXE:
-         print(pOutFile, (TR_S390RXEInstruction *) instr);
+         print(pOutFile, (TR::S390RXEInstruction *) instr);
          break;
       case TR::Instruction::IsRXY:
-         print(pOutFile, (TR_S390RXInstruction *) instr);
+         print(pOutFile, (TR::S390RXInstruction *) instr);
          break;
       case TR::Instruction::IsRXYb:
-         print(pOutFile, (TR_S390MemInstruction *) instr);
+         print(pOutFile, (TR::S390MemInstruction *) instr);
          break;
       case TR::Instruction::IsRXF:
-         print(pOutFile, (TR_S390RXFInstruction *) instr);
+         print(pOutFile, (TR::S390RXFInstruction *) instr);
          break;
       case TR::Instruction::IsSMI:
-         print(pOutFile, (TR_S390SMIInstruction *) instr);
+         print(pOutFile, (TR::S390SMIInstruction *) instr);
          break;
       case TR::Instruction::IsMII:
-         print(pOutFile, (TR_S390MIIInstruction *) instr);
+         print(pOutFile, (TR::S390MIIInstruction *) instr);
          break;
       case TR::Instruction::IsMem:
-         print(pOutFile, (TR_S390MemInstruction *) instr);
+         print(pOutFile, (TR::S390MemInstruction *) instr);
          break;
       case TR::Instruction::IsSS1:
-         print(pOutFile, (TR_S390SS1Instruction *) instr);
+         print(pOutFile, (TR::S390SS1Instruction *) instr);
          break;
       case TR::Instruction::IsSS2:
-         print(pOutFile, (TR_S390SS2Instruction *) instr);
+         print(pOutFile, (TR::S390SS2Instruction *) instr);
          break;
       case TR::Instruction::IsSS4:
-         print(pOutFile, (TR_S390SS4Instruction *) instr);
+         print(pOutFile, (TR::S390SS4Instruction *) instr);
          break;
       case TR::Instruction::IsSSF:
-         print(pOutFile, (TR_S390SSFInstruction *) instr);
+         print(pOutFile, (TR::S390SSFInstruction *) instr);
          break;
       case TR::Instruction::IsSI:
       case TR::Instruction::IsSIY:
-         print(pOutFile, (TR_S390SIInstruction *) instr);
+         print(pOutFile, (TR::S390SIInstruction *) instr);
          break;
       case TR::Instruction::IsSIL:
-         print(pOutFile, (TR_S390SILInstruction *) instr);
+         print(pOutFile, (TR::S390SILInstruction *) instr);
          break;
       case TR::Instruction::IsS:
-         print(pOutFile, (TR_S390SInstruction *) instr);
+         print(pOutFile, (TR::S390SInstruction *) instr);
          break;
       case TR::Instruction::IsNOP:
-         print(pOutFile, (TR_S390NOPInstruction *) instr);
+         print(pOutFile, (TR::S390NOPInstruction *) instr);
          break;
 #ifdef J9_PROJECT_SPECIFIC
       case TR::Instruction::IsVirtualGuardNOP:
-         print(pOutFile, (TR_S390VirtualGuardNOPInstruction *) instr);
+         print(pOutFile, (TR::S390VirtualGuardNOPInstruction *) instr);
          break;
 #endif
       case TR::Instruction::IsAnnot:
-         print(pOutFile, (TR_S390AnnotationInstruction *) instr);
+         print(pOutFile, (TR::S390AnnotationInstruction *) instr);
          break;
       case TR::Instruction::IsPseudo:
-            print(pOutFile, (TR_S390PseudoInstruction *) instr);
+            print(pOutFile, (TR::S390PseudoInstruction *) instr);
          break;
       case TR::Instruction::IsRRS:
-            print(pOutFile, (TR_S390RRSInstruction *) instr);
+            print(pOutFile, (TR::S390RRSInstruction *) instr);
          break;
       case TR::Instruction::IsRIE:
-            print(pOutFile, (TR_S390RIEInstruction *) instr);
+            print(pOutFile, (TR::S390RIEInstruction *) instr);
          break;
       case TR::Instruction::IsRIS:
-            print(pOutFile, (TR_S390RISInstruction *) instr);
+            print(pOutFile, (TR::S390RISInstruction *) instr);
          break;
       case TR::Instruction::IsOpCodeOnly:
-            print(pOutFile, (TR_S390OpCodeOnlyInstruction *) instr);
+            print(pOutFile, (TR::S390OpCodeOnlyInstruction *) instr);
          break;
       case TR::Instruction::IsI:
-            print(pOutFile, (TR_S390IInstruction *) instr);
+            print(pOutFile, (TR::S390IInstruction *) instr);
          break;
       case TR::Instruction::IsSSE:
-            print(pOutFile, (TR_S390SSEInstruction *) instr);
+            print(pOutFile, (TR::S390SSEInstruction *) instr);
          break;
       case TR::Instruction::IsIE:
-            print(pOutFile, (TR_S390IEInstruction *) instr);
+            print(pOutFile, (TR::S390IEInstruction *) instr);
          break;
       case TR::Instruction::IsVRIa:
       case TR::Instruction::IsVRIb:
       case TR::Instruction::IsVRIc:
       case TR::Instruction::IsVRId:
       case TR::Instruction::IsVRIe:
-            print(pOutFile, (TR_S390VRIInstruction *) instr);
+            print(pOutFile, (TR::S390VRIInstruction *) instr);
          break;
       case TR::Instruction::IsVRRa:
       case TR::Instruction::IsVRRb:
@@ -350,14 +350,14 @@ TR_Debug::printz(TR::FILE *pOutFile, TR::Instruction * instr)
       case TR::Instruction::IsVRRd:
       case TR::Instruction::IsVRRe:
       case TR::Instruction::IsVRRf:
-            print(pOutFile, (TR_S390VRRInstruction *) instr);
+            print(pOutFile, (TR::S390VRRInstruction *) instr);
          break;
       case TR::Instruction::IsVRSa:
       case TR::Instruction::IsVRSb:
       case TR::Instruction::IsVRSc:
       case TR::Instruction::IsVRV:
       case TR::Instruction::IsVRX:
-            print(pOutFile, (TR_S390VStorageInstruction *) instr);
+            print(pOutFile, (TR::S390VStorageInstruction *) instr);
          break;
       default:
          TR_ASSERT( 0, "unexpected instruction kind");
@@ -407,14 +407,14 @@ TR_Debug::getOutlinedTargetIfAny(TR::Instruction *instr)
       {
 #ifdef J9_PROJECT_SPECIFIC
       case TR::Instruction::IsVirtualGuardNOP:
-         label = ((TR_S390VirtualGuardNOPInstruction *)instr)->getLabelSymbol();
+         label = ((TR::S390VirtualGuardNOPInstruction *)instr)->getLabelSymbol();
          break;
 #endif
       case TR::Instruction::IsBranch:
-         label = ((TR_S390BranchInstruction *)instr)->getLabelSymbol();
+         label = ((TR::S390BranchInstruction *)instr)->getLabelSymbol();
          break;
       case TR::Instruction::IsRIE:
-         label = ((TR_S390RIEInstruction *)instr)->getLabelSymbol();
+         label = ((TR::S390RIEInstruction *)instr)->getLabelSymbol();
          break;
       default:
          return NULL;
@@ -536,7 +536,7 @@ TR_Debug::printAssocRegDirective(TR::FILE *pOutFile, TR::Instruction * instr)
 
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390RRSInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390RRSInstruction * instr)
    {
    // *this    swipeable for debugging purposes
 
@@ -572,7 +572,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390RRSInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390IEInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390IEInstruction * instr)
    {
    // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
@@ -593,19 +593,19 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390IEInstruction * instr)
  *   "Opcode  R1,I2 (mask=)"
  */
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390RIEInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390RIEInstruction * instr)
    {
    // *this    swipeable for debugging purposes
 
 
 
    // let's determine what form of RIE we are dealing with
-   bool RIE1 = (instr->getRieForm() == TR_S390RIEInstruction::RIE_RR);
-   bool RIE2 = (instr->getRieForm() == TR_S390RIEInstruction::RIE_RI8);
-   bool RIE3 = (instr->getRieForm() == TR_S390RIEInstruction::RIE_RI16A);
-   bool RIE4 = (instr->getRieForm() == TR_S390RIEInstruction::RIE_RRI16);
-   bool RIE5 = (instr->getRieForm() == TR_S390RIEInstruction::RIE_IMM);
-   bool RIE6 = (instr->getRieForm() == TR_S390RIEInstruction::RIE_RI16G);
+   bool RIE1 = (instr->getRieForm() == TR::S390RIEInstruction::RIE_RR);
+   bool RIE2 = (instr->getRieForm() == TR::S390RIEInstruction::RIE_RI8);
+   bool RIE3 = (instr->getRieForm() == TR::S390RIEInstruction::RIE_RI16A);
+   bool RIE4 = (instr->getRieForm() == TR::S390RIEInstruction::RIE_RRI16);
+   bool RIE5 = (instr->getRieForm() == TR::S390RIEInstruction::RIE_IMM);
+   bool RIE6 = (instr->getRieForm() == TR::S390RIEInstruction::RIE_RI16G);
 
    // print the line prefix
    printPrefix(pOutFile, instr);
@@ -720,7 +720,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390RIEInstruction * instr)
  * Prints RIS format in "Opcode  R1,D4(B4),I2 (mask=)"
  */
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390RISInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390RISInstruction * instr)
    {
    // *this    swipeable for debugging purposes
 
@@ -751,7 +751,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390RISInstruction * instr)
 
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390LabelInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390LabelInstruction * instr)
    {
    // *this    swipeable for debugging purposes
 
@@ -805,7 +805,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390LabelInstruction * instr)
 
 #ifdef J9_PROJECT_SPECIFIC
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390VirtualGuardNOPInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390VirtualGuardNOPInstruction * instr)
    {
    // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
@@ -828,7 +828,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390VirtualGuardNOPInstruction * instr)
 #endif
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390BranchInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390BranchInstruction * instr)
    {
    // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
@@ -869,7 +869,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390BranchInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390BranchOnCountInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390BranchOnCountInstruction * instr)
    {
    // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
@@ -891,7 +891,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390BranchOnCountInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390BranchOnIndexInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390BranchOnIndexInstruction * instr)
    {
    printPrefix(pOutFile, instr);
 
@@ -926,7 +926,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390BranchOnIndexInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390AnnotationInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390AnnotationInstruction * instr)
    {
    // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
@@ -939,7 +939,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390AnnotationInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390PseudoInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390PseudoInstruction * instr)
    {
    // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
@@ -1009,7 +1009,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390PseudoInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390ImmInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390ImmInstruction * instr)
    {
    // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
@@ -1024,7 +1024,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390ImmInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390Imm2Instruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390Imm2Instruction * instr)
    {
    // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
@@ -1039,7 +1039,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390Imm2Instruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390ImmSnippetInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390ImmSnippetInstruction * instr)
    {
    // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
@@ -1052,7 +1052,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390ImmSnippetInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390ImmSymInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390ImmSymInstruction * instr)
    {
    // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
@@ -1061,7 +1061,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390ImmSymInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390RegInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390RegInstruction * instr)
    {
    // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
@@ -1094,7 +1094,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390RegInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390RRInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390RRInstruction * instr)
    {
    // *this    swipeable for debugging purposes
    int32_t i=1;
@@ -1153,7 +1153,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390RRInstruction * instr)
 
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390TranslateInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390TranslateInstruction * instr)
    {
    // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
@@ -1188,7 +1188,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390TranslateInstruction * instr)
 
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390RRFInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390RRFInstruction * instr)
    {
    // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
@@ -1223,7 +1223,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390RRFInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390RRRInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390RRRInstruction * instr)
    {
    // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
@@ -1240,7 +1240,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390RRRInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390RIInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390RIInstruction * instr)
    {
    // *this    swipeable for debugging purposes
    int16_t imm = instr->getSourceImmediate();
@@ -1259,7 +1259,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390RIInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390RILInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390RILInstruction * instr)
    {
    // *this    swipeable for debugging purposes
    uint8_t * cursor = (uint8_t *)instr->getBinaryEncoding();
@@ -1342,7 +1342,7 @@ bitString(int8_t val)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390RSLInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390RSLInstruction * instr)
    {
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%-*s", OPCODE_SPACING, getOpCodeName(&instr->getOpCode()));
@@ -1362,7 +1362,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390RSLInstruction * instr)
    }
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390RSLInstruction Class Definition
+// TR::S390RSLInstruction Class Definition
 //    ________ _______________________________________________
 //   | op     |     L1     |  B2 |   D2  |  R1 |  M3 |    op  |
 //   |________|____________|_____|_______|_____|_____|________|
@@ -1370,7 +1370,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390RSLInstruction * instr)
 //
 ////////////////////////////////////////////////////////////////////////////
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390RSLbInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390RSLbInstruction * instr)
    {
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%-*s", OPCODE_SPACING, getOpCodeName(&instr->getOpCode()));
@@ -1409,7 +1409,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390RSLbInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390RSInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390RSInstruction * instr)
    {
    // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
@@ -1475,7 +1475,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390RSInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390MemInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390MemInstruction * instr)
    {
    // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
@@ -1529,7 +1529,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390MemInstruction * instr)
  * Print SSE format in "Opcode  D1(B1),D2(B2)"
  */
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390SSEInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390SSEInstruction * instr)
    {
    // *this    swipeable for debugging purposes
 
@@ -1551,7 +1551,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390SSEInstruction * instr)
  * Print SS1 format in "Opcode  D1(L,B1),D2(B2)"
  */
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390SS1Instruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390SS1Instruction * instr)
    {
    // *this    swipeable for debugging purposes
 
@@ -1573,7 +1573,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390SS1Instruction * instr)
  * Print SS2 format in "Opcode  D1(L1,B1),D2(L2,B2)"
  */
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390SS2Instruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390SS2Instruction * instr)
    {
    // *this    swipeable for debugging purposes
 
@@ -1607,7 +1607,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390SS2Instruction * instr)
  * Print SS4 format in "Opcode  D1(R1,B1),D2(B2),R3"
  */
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390SS4Instruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390SS4Instruction * instr)
    {
    // *this    swipeable for debugging purposes
 
@@ -1673,7 +1673,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390SS4Instruction * instr)
  * Print SSF format in "Opcode  R3, D1(B1),D2(B2)"
  */
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390SSFInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390SSFInstruction * instr)
    {
    // *this    swipeable for debugging purposes
 
@@ -1699,7 +1699,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390SSFInstruction * instr)
  * Print SI format in "Opcode  D1(B1),imm"
  */
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390SIInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390SIInstruction * instr)
    {
    // *this    swipeable for debugging purposes
 
@@ -1738,7 +1738,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390SIInstruction * instr)
  * Prints SIL format in "Opcode  D1(B1),imm"
  */
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390SILInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390SILInstruction * instr)
    {
    // *this    swipeable for debugging purposes
 
@@ -1758,7 +1758,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390SILInstruction * instr)
  * Print S format in "Opcode  D1(B1)"
  */
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390SInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390SInstruction * instr)
    {
    // *this    swipeable for debugging purposes
 
@@ -1773,7 +1773,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390SInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390OpCodeOnlyInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390OpCodeOnlyInstruction * instr)
    {
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%-*s", OPCODE_SPACING, getOpCodeName(&instr->getOpCode()));
@@ -1781,7 +1781,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390OpCodeOnlyInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390IInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390IInstruction * instr)
    {
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%-*s%d", OPCODE_SPACING, getOpCodeName(&instr->getOpCode()), instr->getImmediateField());
@@ -1789,7 +1789,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390IInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390RXInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390RXInstruction * instr)
    {
    // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
@@ -1833,7 +1833,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390RXInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390RXEInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390RXEInstruction * instr)
    {
    // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
@@ -1846,7 +1846,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390RXEInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390RXFInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390RXFInstruction * instr)
    {
    // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
@@ -1861,7 +1861,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390RXFInstruction * instr)
 
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390MIIInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390MIIInstruction * instr)
    {
    // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
@@ -1891,7 +1891,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390MIIInstruction * instr)
 
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390SMIInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390SMIInstruction * instr)
    {
    // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
@@ -2243,7 +2243,7 @@ TR_Debug::printSymbolName(TR::FILE *pOutFile, TR::Symbol *sym,  TR::SymbolRefere
 
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390NOPInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390NOPInstruction * instr)
    {
    // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
@@ -3249,7 +3249,7 @@ TR_Debug::updateBranchName(const char * opCodeName, const char * brCondName)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390VRIInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390VRIInstruction * instr)
    {
    printPrefix(pOutFile, instr);
 
@@ -3273,19 +3273,19 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390VRIInstruction * instr)
          break;
       case TR::Instruction::IsVRIb:
          trfprintf(pOutFile, ",0x%x,0x%x",
-               maskHalf(((TR_S390VRIbInstruction*)instr)->getImmediateField2()),
-               maskHalf(((TR_S390VRIbInstruction*)instr)->getImmediateField3()));
+               maskHalf(((TR::S390VRIbInstruction*)instr)->getImmediateField2()),
+               maskHalf(((TR::S390VRIbInstruction*)instr)->getImmediateField3()));
          break;
       case TR::Instruction::IsVRIc:
          trfprintf(pOutFile, ",0x%x", maskHalf(instr->getImmediateField()));
          break;
       case TR::Instruction::IsVRId:
          trfprintf(pOutFile, ",0x%x",
-               maskHalf(((TR_S390VRIdInstruction*)instr)->getImmediateField4()));
+               maskHalf(((TR::S390VRIdInstruction*)instr)->getImmediateField4()));
          break;
       case TR::Instruction::IsVRIe:
          trfprintf(pOutFile, ",0x%x",
-               maskHalf(((TR_S390VRIeInstruction*)instr)->getImmediateField3()));
+               maskHalf(((TR::S390VRIeInstruction*)instr)->getImmediateField3()));
          break;
       default:
          TR_ASSERT(false, "Unknown VRI type");
@@ -3302,7 +3302,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390VRIInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390VRRInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390VRRInstruction * instr)
    {
    // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
@@ -3336,7 +3336,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390VRRInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390VStorageInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390VStorageInstruction * instr)
    {
    printPrefix(pOutFile, instr);
 

--- a/compiler/z/codegen/S390GenerateInstructions.cpp
+++ b/compiler/z/codegen/S390GenerateInstructions.cpp
@@ -82,9 +82,9 @@ generateS390LabelInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390LabelInstruction(op, n, sym, preced, cg);
+      return new (INSN_HEAP) TR::S390LabelInstruction(op, n, sym, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390LabelInstruction(op, n, sym, cg);
+   return new (INSN_HEAP) TR::S390LabelInstruction(op, n, sym, cg);
    }
 
 TR::Instruction *
@@ -93,9 +93,9 @@ generateS390LabelInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390LabelInstruction(op, n, sym, cond, preced, cg);
+      return new (INSN_HEAP) TR::S390LabelInstruction(op, n, sym, cond, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390LabelInstruction(op, n, sym, cond, cg);
+   return new (INSN_HEAP) TR::S390LabelInstruction(op, n, sym, cond, cg);
    }
 
 TR::Instruction *
@@ -104,9 +104,9 @@ generateS390LabelInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390LabelInstruction(op, n, s, cond, preced, cg);
+      return new (INSN_HEAP) TR::S390LabelInstruction(op, n, s, cond, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390LabelInstruction(op, n, s, cond, cg);
+   return new (INSN_HEAP) TR::S390LabelInstruction(op, n, s, cond, cg);
    }
 
 TR::Instruction *
@@ -114,9 +114,9 @@ generateS390LabelInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390LabelInstruction(op, n, s, preced, cg);
+      return new (INSN_HEAP) TR::S390LabelInstruction(op, n, s, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390LabelInstruction(op, n, s, cg);
+   return new (INSN_HEAP) TR::S390LabelInstruction(op, n, s, cg);
    }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -126,11 +126,11 @@ TR::Instruction *
 generateS390BranchInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::InstOpCode::S390BranchCondition brCond,
                               TR::Node * n, TR::LabelSymbol * sym, TR::Instruction * preced)
    {
-   TR_S390BranchInstruction * cursor ;
+   TR::S390BranchInstruction * cursor ;
    if (preced)
-      cursor = new (INSN_HEAP) TR_S390BranchInstruction(op, brCond, n, sym, preced, cg);
+      cursor = new (INSN_HEAP) TR::S390BranchInstruction(op, brCond, n, sym, preced, cg);
    else
-      cursor = new (INSN_HEAP) TR_S390BranchInstruction(op, brCond, n, sym, cg);
+      cursor = new (INSN_HEAP) TR::S390BranchInstruction(op, brCond, n, sym, cg);
    return cursor;
    }
 
@@ -148,9 +148,9 @@ generateS390BranchInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic o
       }
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390BranchOnCountInstruction(op, n, targetReg, sym, preced, cg);
+      return new (INSN_HEAP) TR::S390BranchOnCountInstruction(op, n, targetReg, sym, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390BranchOnCountInstruction(op, n, targetReg, sym, cg);
+   return new (INSN_HEAP) TR::S390BranchOnCountInstruction(op, n, targetReg, sym, cg);
    }
 
 TR::Instruction *
@@ -167,9 +167,9 @@ generateS390BranchInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic o
       }
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390BranchOnCountInstruction(op, n, targetReg, cond, sym, preced, cg);
+      return new (INSN_HEAP) TR::S390BranchOnCountInstruction(op, n, targetReg, cond, sym, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390BranchOnCountInstruction(op, n, targetReg, cond, sym, cg);
+   return new (INSN_HEAP) TR::S390BranchOnCountInstruction(op, n, targetReg, cond, sym, cg);
    }
 
 TR::Instruction *
@@ -178,9 +178,9 @@ generateS390BranchInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic o
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390BranchOnIndexInstruction(op, n, sourceReg, targetReg, sym, preced, cg);
+      return new (INSN_HEAP) TR::S390BranchOnIndexInstruction(op, n, sourceReg, targetReg, sym, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390BranchOnIndexInstruction(op, n, sourceReg, targetReg, sym, cg);
+   return new (INSN_HEAP) TR::S390BranchOnIndexInstruction(op, n, sourceReg, targetReg, sym, cg);
    }
 
 TR::Instruction *
@@ -189,20 +189,20 @@ generateS390BranchInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic o
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390BranchOnIndexInstruction(op, n, sourceReg, targetReg, sym, preced, cg);
+      return new (INSN_HEAP) TR::S390BranchOnIndexInstruction(op, n, sourceReg, targetReg, sym, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390BranchOnIndexInstruction(op, n, sourceReg, targetReg, sym, cg);
+   return new (INSN_HEAP) TR::S390BranchOnIndexInstruction(op, n, sourceReg, targetReg, sym, cg);
    }
 
 TR::Instruction *
 generateS390BranchInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::InstOpCode::S390BranchCondition brCond,
                               TR::Node * n, TR::LabelSymbol * sym, TR::RegisterDependencyConditions * cond, TR::Instruction * preced)
    {
-   TR_S390BranchInstruction * cursor ;
+   TR::S390BranchInstruction * cursor ;
    if (preced)
-      cursor = new (INSN_HEAP) TR_S390BranchInstruction(op, brCond, n, sym, cond, preced, cg);
+      cursor = new (INSN_HEAP) TR::S390BranchInstruction(op, brCond, n, sym, cond, preced, cg);
    else
-      cursor =  new (INSN_HEAP) TR_S390BranchInstruction(op, brCond, n, sym, cond, cg);
+      cursor =  new (INSN_HEAP) TR::S390BranchInstruction(op, brCond, n, sym, cond, cg);
    return cursor;
    }
 
@@ -210,11 +210,11 @@ TR::Instruction *
 generateS390BranchInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::InstOpCode::S390BranchCondition brCond,
                               TR::Node * n, TR::Snippet * s, TR::RegisterDependencyConditions * cond, TR::Instruction * preced)
    {
-   TR_S390BranchInstruction * cursor ;
+   TR::S390BranchInstruction * cursor ;
    if (preced)
-      cursor = new (INSN_HEAP) TR_S390BranchInstruction(op, brCond, n, s, cond, preced, cg);
+      cursor = new (INSN_HEAP) TR::S390BranchInstruction(op, brCond, n, s, cond, preced, cg);
    else
-      cursor = new (INSN_HEAP) TR_S390BranchInstruction(op, brCond, n, s, cond, cg);
+      cursor = new (INSN_HEAP) TR::S390BranchInstruction(op, brCond, n, s, cond, cg);
    return cursor;
    }
 
@@ -222,11 +222,11 @@ TR::Instruction *
 generateS390BranchInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::InstOpCode::S390BranchCondition brCond,
                               TR::Node * n, TR::Snippet * s, TR::Instruction * preced)
    {
-   TR_S390BranchInstruction * cursor ;
+   TR::S390BranchInstruction * cursor ;
    if (preced)
-      cursor = new (INSN_HEAP) TR_S390BranchInstruction(op, brCond, n, s, preced, cg);
+      cursor = new (INSN_HEAP) TR::S390BranchInstruction(op, brCond, n, s, preced, cg);
    else
-      cursor = new (INSN_HEAP) TR_S390BranchInstruction(op, brCond, n, s, cg);
+      cursor = new (INSN_HEAP) TR::S390BranchInstruction(op, brCond, n, s, cg);
    return cursor;
    }
 
@@ -312,13 +312,13 @@ generateS390CompareAndBranchInstruction(TR::CodeGenerator * cg,
            cg->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_zEC12))
       {
       // generate a compare and branch.
-      returnInstruction = (TR_S390RIEInstruction *)generateRIEInstruction(cg, replacementOpCode, node, first, second, branchDestination, bc);
+      returnInstruction = (TR::S390RIEInstruction *)generateRIEInstruction(cg, replacementOpCode, node, first, second, branchDestination, bc);
 
       // Generate a temporary warm trampoline for warm -> cold code cache branches.
       if (cg->getIsInWarmCodeCache() && targetIsFarAndCold)
          {
          TR_S390WarmToColdTrampolineSnippet * trampolineSnippet = new (INSN_HEAP) TR_S390WarmToColdTrampolineSnippet(cg, node,  TR::LabelSymbol::create(INSN_HEAP,cg), branchDestination);
-         ((TR_S390RIEInstruction*)returnInstruction)->setWarmToColdTrampolineSnippet(trampolineSnippet);
+         ((TR::S390RIEInstruction*)returnInstruction)->setWarmToColdTrampolineSnippet(trampolineSnippet);
          cg->addSnippet(trampolineSnippet);
          }
       }
@@ -414,12 +414,12 @@ generateS390CompareAndBranchInstruction(TR::CodeGenerator * cg,
            replacementOpCode != TR::InstOpCode::BAD &&
            cg->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_zEC12))
       {
-      cursor = (TR_S390RIEInstruction *)generateRIEInstruction(cg, replacementOpCode, node, first, (int8_t) second, branchDestination, bc, preced);
+      cursor = (TR::S390RIEInstruction *)generateRIEInstruction(cg, replacementOpCode, node, first, (int8_t) second, branchDestination, bc, preced);
       // Generate a temporary warm trampoline for warm -> cold code cache branches.
       if (cg->getIsInWarmCodeCache() && targetIsFarAndCold)
          {
          TR_S390WarmToColdTrampolineSnippet * trampolineSnippet = new (INSN_HEAP) TR_S390WarmToColdTrampolineSnippet(cg, node,  TR::LabelSymbol::create(INSN_HEAP,cg), branchDestination);
-         ((TR_S390RIEInstruction*)cursor)->setWarmToColdTrampolineSnippet(trampolineSnippet);
+         ((TR::S390RIEInstruction*)cursor)->setWarmToColdTrampolineSnippet(trampolineSnippet);
          cg->addSnippet(trampolineSnippet);
          }
       }
@@ -443,9 +443,9 @@ generateS390RegInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, 
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390RegInstruction(op, n, treg, preced, cg);
+      return new (INSN_HEAP) TR::S390RegInstruction(op, n, treg, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390RegInstruction(op, n, treg, cg);
+   return new (INSN_HEAP) TR::S390RegInstruction(op, n, treg, cg);
    }
 
 TR::Instruction *
@@ -454,9 +454,9 @@ generateS390RegInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, 
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390RegInstruction(op, n, treg, cond, preced, cg);
+      return new (INSN_HEAP) TR::S390RegInstruction(op, n, treg, cond, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390RegInstruction(op, n, treg, cond, cg);
+   return new (INSN_HEAP) TR::S390RegInstruction(op, n, treg, cond, cg);
    }
 
 TR::Instruction *
@@ -556,9 +556,9 @@ generateRRInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390RRInstruction(op, n, treg, sreg, preced, cg);
+      instr = new (INSN_HEAP) TR::S390RRInstruction(op, n, treg, sreg, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390RRInstruction(op, n, treg, sreg, cg);
+      instr = new (INSN_HEAP) TR::S390RRInstruction(op, n, treg, sreg, cg);
 
    return instr;
    }
@@ -569,9 +569,9 @@ generateRRInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390RRInstruction(op, n, treg, secondConstant, preced, cg);
+      return new (INSN_HEAP) TR::S390RRInstruction(op, n, treg, secondConstant, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390RRInstruction(op, n, treg, secondConstant, cg);
+   return new (INSN_HEAP) TR::S390RRInstruction(op, n, treg, secondConstant, cg);
    }
 
 TR::Instruction *
@@ -580,9 +580,9 @@ generateRRInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390RRInstruction(op, n, firstConstant, secondConstant, preced, cg);
+      return new (INSN_HEAP) TR::S390RRInstruction(op, n, firstConstant, secondConstant, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390RRInstruction(op, n, firstConstant, secondConstant, cg);
+   return new (INSN_HEAP) TR::S390RRInstruction(op, n, firstConstant, secondConstant, cg);
    }
 
 TR::Instruction *
@@ -591,9 +591,9 @@ generateRRInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390RRInstruction(op, n, firstConstant, sreg, preced, cg);
+      return new (INSN_HEAP) TR::S390RRInstruction(op, n, firstConstant, sreg, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390RRInstruction(op, n, firstConstant, sreg, cg);
+   return new (INSN_HEAP) TR::S390RRInstruction(op, n, firstConstant, sreg, cg);
    }
 
 TR::Instruction *
@@ -603,9 +603,9 @@ generateRRInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
    TR::Instruction *instr;
 
    if (preced)
-      instr = new (INSN_HEAP) TR_S390RRInstruction(op, n, treg, sreg, cond, preced, cg);
+      instr = new (INSN_HEAP) TR::S390RRInstruction(op, n, treg, sreg, cond, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390RRInstruction(op, n, treg, sreg, cond, cg);
+      instr = new (INSN_HEAP) TR::S390RRInstruction(op, n, treg, sreg, cond, cg);
 
    return instr;
    }
@@ -617,9 +617,9 @@ generateRRDInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
    bool encodeAsRRD = true;
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390RRFInstruction(encodeAsRRD, op, n, treg, sreg, sreg2, preced, cg);
+      return new (INSN_HEAP) TR::S390RRFInstruction(encodeAsRRD, op, n, treg, sreg, sreg2, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390RRFInstruction(encodeAsRRD, op, n, treg, sreg, sreg2, cg);
+   return new (INSN_HEAP) TR::S390RRFInstruction(encodeAsRRD, op, n, treg, sreg, sreg2, cg);
    }
 
 TR::Instruction *
@@ -628,37 +628,37 @@ generateRRFInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390RRFInstruction(op, n, treg, sreg, sreg2, preced, cg);
+      return new (INSN_HEAP) TR::S390RRFInstruction(op, n, treg, sreg, sreg2, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390RRFInstruction(op, n, treg, sreg, sreg2, cg);
+   return new (INSN_HEAP) TR::S390RRFInstruction(op, n, treg, sreg, sreg2, cg);
    }
 
 TR::Instruction *
 generateRRFInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * treg, TR::Register * sreg,
                        uint8_t mask, bool isMask3, TR::Instruction * preced)
    {
-   return new (INSN_HEAP) TR_S390RRFInstruction(op, n, treg, sreg, mask, isMask3, cg);
+   return new (INSN_HEAP) TR::S390RRFInstruction(op, n, treg, sreg, mask, isMask3, cg);
    }
 
 TR::Instruction *
 generateRRFInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * treg, TR::Register * sreg,
                        uint8_t mask, bool isMask3, TR::RegisterDependencyConditions * cond, TR::Instruction * preced)
    {
-   return new (INSN_HEAP) TR_S390RRFInstruction(op, n, treg, sreg, mask, isMask3, cond, cg);
+   return new (INSN_HEAP) TR::S390RRFInstruction(op, n, treg, sreg, mask, isMask3, cond, cg);
    }
 
 TR::Instruction *
 generateRRFInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * treg, TR::Register * sreg,
                        TR::Register * sreg2, uint8_t mask, TR::Instruction * preced)
    {
-   return new (INSN_HEAP) TR_S390RRFInstruction(op, n, treg, sreg, sreg2, mask, cg);
+   return new (INSN_HEAP) TR::S390RRFInstruction(op, n, treg, sreg, sreg2, mask, cg);
    }
 
 TR::Instruction *
 generateRRFInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * treg,
                        TR::Register * sreg, uint8_t mask3, uint8_t mask4, TR::Instruction * preced)
    {
-   return new (INSN_HEAP) TR_S390RRFInstruction(op, n, treg, sreg, mask3, mask4, cg);
+   return new (INSN_HEAP) TR::S390RRFInstruction(op, n, treg, sreg, mask3, mask4, cg);
    }
 
 TR::Instruction *
@@ -667,9 +667,9 @@ generateRRRInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390RRRInstruction(op, n, treg, sreg, sreg2, preced, cg);
+      return new (INSN_HEAP) TR::S390RRRInstruction(op, n, treg, sreg, sreg2, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390RRRInstruction(op, n, treg, sreg, sreg2, cg);
+   return new (INSN_HEAP) TR::S390RRRInstruction(op, n, treg, sreg, sreg2, cg);
    }
 
 /**
@@ -773,9 +773,9 @@ generateRXInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390RXInstruction(op, n, treg, mf, preced, cg);
+      instr = new (INSN_HEAP) TR::S390RXInstruction(op, n, treg, mf, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390RXInstruction(op, n, treg, mf, cg);
+      instr = new (INSN_HEAP) TR::S390RXInstruction(op, n, treg, mf, cg);
 
 #ifdef J9_PROJECT_SPECIFIC
    if (op == TR::InstOpCode::CVB || op == TR::InstOpCode::EX)
@@ -794,7 +794,7 @@ generateRXInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
          TR_S390RestoreGPR7Snippet * restoreSnippet =
                         new (INSN_HEAP) TR_S390RestoreGPR7Snippet(cg, n,  TR::LabelSymbol::create(INSN_HEAP,cg), label);
          cg->addSnippet(restoreSnippet);
-         TR::Instruction * nop = new (INSN_HEAP) TR_S390NOPInstruction(TR::InstOpCode::NOP, 2, n, cg);
+         TR::Instruction * nop = new (INSN_HEAP) TR::S390NOPInstruction(TR::InstOpCode::NOP, 2, n, cg);
          TR::Instruction* brcInstr = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_NOP, n, restoreSnippet->getSnippetLabel());
 
          //generate register deps for CVB so that we will not see spills between CVB and the following branch
@@ -813,9 +813,9 @@ generateRXInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
    {
    TR::Instruction * instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390RXInstruction(op, n, treg, constForMR, preced, cg);
+      instr = new (INSN_HEAP) TR::S390RXInstruction(op, n, treg, constForMR, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390RXInstruction(op, n, treg, constForMR, cg);
+      instr = new (INSN_HEAP) TR::S390RXInstruction(op, n, treg, constForMR, cg);
 
 #ifdef J9_PROJECT_SPECIFIC
    if (op == TR::InstOpCode::CVB || op == TR::InstOpCode::EX)
@@ -834,7 +834,7 @@ generateRXInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
          TR_S390RestoreGPR7Snippet * restoreSnippet =
                         new (INSN_HEAP) TR_S390RestoreGPR7Snippet(cg, n,  TR::LabelSymbol::create(INSN_HEAP,cg), label);
          cg->addSnippet(restoreSnippet);
-         TR::Instruction * nop = new (INSN_HEAP) TR_S390NOPInstruction(TR::InstOpCode::NOP, 2, n, cg);
+         TR::Instruction * nop = new (INSN_HEAP) TR::S390NOPInstruction(TR::InstOpCode::NOP, 2, n, cg);
          TR::Instruction* brcInstr = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_NOP, n, restoreSnippet->getSnippetLabel());
 
          //generate register deps for CVB so that we will not see spills between CVB and the following branch
@@ -852,9 +852,9 @@ generateRXEInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::N
    {
    TR::Instruction * instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390RXEInstruction(op, n, treg, mf, mask3, preced, cg);
+      instr = new (INSN_HEAP) TR::S390RXEInstruction(op, n, treg, mf, mask3, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390RXEInstruction(op, n, treg, mf, mask3, cg);
+      instr = new (INSN_HEAP) TR::S390RXEInstruction(op, n, treg, mf, mask3, cg);
 
    return instr;
    }
@@ -865,9 +865,9 @@ generateRXYInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
    {
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390RXYInstruction(op, n, regp, mf, preced, cg);
+      instr = new (INSN_HEAP) TR::S390RXYInstruction(op, n, regp, mf, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390RXYInstruction(op, n, regp, mf, cg);
+      instr = new (INSN_HEAP) TR::S390RXYInstruction(op, n, regp, mf, cg);
 
 #ifdef J9_PROJECT_SPECIFIC
    if (op == TR::InstOpCode::CVBY || op == TR::InstOpCode::CVBG)
@@ -937,9 +937,9 @@ generateRXYInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390RXYInstruction(op, n, treg, mf, preced, cg);
+      instr = new (INSN_HEAP) TR::S390RXYInstruction(op, n, treg, mf, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390RXYInstruction(op, n, treg, mf, cg);
+      instr = new (INSN_HEAP) TR::S390RXYInstruction(op, n, treg, mf, cg);
 
 #ifdef J9_PROJECT_SPECIFIC
    if (op == TR::InstOpCode::CVBY || op == TR::InstOpCode::CVBG)
@@ -975,9 +975,9 @@ generateRXYbInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR:
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390RXYbInstruction(op, n, mask, mf, preced, cg);
+      instr = new (INSN_HEAP) TR::S390RXYbInstruction(op, n, mask, mf, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390RXYbInstruction(op, n, mask, mf, cg);
+      instr = new (INSN_HEAP) TR::S390RXYbInstruction(op, n, mask, mf, cg);
 
    return instr;
    }
@@ -987,9 +987,9 @@ generateRXYInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
    {
    TR::Instruction * instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390RXYInstruction(op, n, treg, constForMR, preced, cg);
+      instr = new (INSN_HEAP) TR::S390RXYInstruction(op, n, treg, constForMR, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390RXYInstruction(op, n, treg, constForMR, cg);
+      instr = new (INSN_HEAP) TR::S390RXYInstruction(op, n, treg, constForMR, cg);
 
 #ifdef J9_PROJECT_SPECIFIC
    if (op == TR::InstOpCode::CVBY || op == TR::InstOpCode::CVBG)
@@ -1024,9 +1024,9 @@ generateRXFInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
    {
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390RXFInstruction(op, n, treg, sreg, mf, preced, cg);
+      instr = new (INSN_HEAP) TR::S390RXFInstruction(op, n, treg, sreg, mf, preced, cg);
    else
-   	  instr = new (INSN_HEAP) TR_S390RXFInstruction(op, n, treg, sreg, mf, cg);
+   	  instr = new (INSN_HEAP) TR::S390RXFInstruction(op, n, treg, sreg, mf, cg);
 
    return instr;
    }
@@ -1036,9 +1036,9 @@ generateRIInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
     {
     if (preced)
        {
-       return new (INSN_HEAP) TR_S390RIInstruction(op, n, preced, cg);
+       return new (INSN_HEAP) TR::S390RIInstruction(op, n, preced, cg);
        }
-    return new (INSN_HEAP) TR_S390RIInstruction(op, n, cg);
+    return new (INSN_HEAP) TR::S390RIInstruction(op, n, cg);
     }
 
 TR::Instruction *
@@ -1046,9 +1046,9 @@ generateRIInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
     {
     if (preced)
        {
-       return new (INSN_HEAP) TR_S390RIInstruction(op, n, treg, preced, cg);
+       return new (INSN_HEAP) TR::S390RIInstruction(op, n, treg, preced, cg);
        }
-    return new (INSN_HEAP) TR_S390RIInstruction(op, n, treg, cg);
+    return new (INSN_HEAP) TR::S390RIInstruction(op, n, treg, cg);
     }
 
 TR::Instruction *
@@ -1071,9 +1071,9 @@ generateRIInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
       }
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390RIInstruction(op, n, treg, imm, preced, cg);
+      return new (INSN_HEAP) TR::S390RIInstruction(op, n, treg, imm, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390RIInstruction(op, n, treg, imm, cg);
+   return new (INSN_HEAP) TR::S390RIInstruction(op, n, treg, imm, cg);
    }
 
 TR::Instruction *
@@ -1081,9 +1081,9 @@ generateRIInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
     {
     if (preced)
        {
-       return new (INSN_HEAP) TR_S390RIInstruction(op, n, treg, data, preced, cg);
+       return new (INSN_HEAP) TR::S390RIInstruction(op, n, treg, data, preced, cg);
        }
-    return new (INSN_HEAP) TR_S390RIInstruction(op, n, treg, data, cg);
+    return new (INSN_HEAP) TR::S390RIInstruction(op, n, treg, data, cg);
     }
 
 TR::Instruction *
@@ -1091,17 +1091,17 @@ generateRILInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390RILInstruction(op, n, treg, imm, sr, preced, cg);
+      return new (INSN_HEAP) TR::S390RILInstruction(op, n, treg, imm, sr, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390RILInstruction(op, n, treg, imm, sr, cg);
+   return new (INSN_HEAP) TR::S390RILInstruction(op, n, treg, imm, sr, cg);
    }
 
 TR::Instruction *
 generateRILInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * treg, TR::LabelSymbol * label, TR::Instruction * preced)
    {
    if (preced)
-      return new (INSN_HEAP) TR_S390RILInstruction(op, n, treg, label, preced, cg);
-   return new (INSN_HEAP) TR_S390RILInstruction(op, n, treg, label, cg);
+      return new (INSN_HEAP) TR::S390RILInstruction(op, n, treg, label, preced, cg);
+   return new (INSN_HEAP) TR::S390RILInstruction(op, n, treg, label, cg);
    }
 
 TR::Instruction *
@@ -1120,9 +1120,9 @@ generateRILInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
       }
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390RILInstruction(op, n, treg, imm, preced, cg);
+      return new (INSN_HEAP) TR::S390RILInstruction(op, n, treg, imm, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390RILInstruction(op, n, treg, imm, cg);
+   return new (INSN_HEAP) TR::S390RILInstruction(op, n, treg, imm, cg);
    }
 
 TR::Instruction *
@@ -1130,9 +1130,9 @@ generateRILInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::N
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390RILInstruction(op, n, treg, ts, preced, cg);
+      return new (INSN_HEAP) TR::S390RILInstruction(op, n, treg, ts, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390RILInstruction(op, n, treg, ts, cg);
+   return new (INSN_HEAP) TR::S390RILInstruction(op, n, treg, ts, cg);
    }
 
 
@@ -1141,9 +1141,9 @@ generateRSInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390RSInstruction(op, n, treg, imm, preced, cg);
+      return new (INSN_HEAP) TR::S390RSInstruction(op, n, treg, imm, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390RSInstruction(op, n, treg, imm, cg);
+   return new (INSN_HEAP) TR::S390RSInstruction(op, n, treg, imm, cg);
    }
 
 TR::Instruction *
@@ -1152,9 +1152,9 @@ generateRSInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390RSInstruction(op, n, treg, imm, cond, preced, cg);
+      return new (INSN_HEAP) TR::S390RSInstruction(op, n, treg, imm, cond, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390RSInstruction(op, n, treg, imm, cond, cg);
+   return new (INSN_HEAP) TR::S390RSInstruction(op, n, treg, imm, cond, cg);
    }
 
 TR::Instruction *
@@ -1166,9 +1166,9 @@ generateRSInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390RSInstruction(op, n, treg, mf, preced, cg);
+      instr = new (INSN_HEAP) TR::S390RSInstruction(op, n, treg, mf, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390RSInstruction(op, n, treg, mf, cg);
+      instr = new (INSN_HEAP) TR::S390RSInstruction(op, n, treg, mf, cg);
 
    return instr;
    }
@@ -1182,9 +1182,9 @@ generateRSInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390RSInstruction(op, n, treg, mask, mf, preced, cg);
+      instr = new (INSN_HEAP) TR::S390RSInstruction(op, n, treg, mask, mf, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390RSInstruction(op, n, treg, mask, mf, cg);
+      instr = new (INSN_HEAP) TR::S390RSInstruction(op, n, treg, mask, mf, cg);
 
    return instr;
    }
@@ -1198,9 +1198,9 @@ generateRSInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390RSInstruction(op, n, treg, sreg, mf, preced, cg);
+      instr = new (INSN_HEAP) TR::S390RSInstruction(op, n, treg, sreg, mf, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390RSInstruction(op, n, treg, sreg, mf, cg);
+      instr = new (INSN_HEAP) TR::S390RSInstruction(op, n, treg, sreg, mf, cg);
 
    return instr;
    }
@@ -1215,9 +1215,9 @@ generateRSInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390RSInstruction(op, n, freg, lreg, mf, preced, cg);
+      instr = new (INSN_HEAP) TR::S390RSInstruction(op, n, freg, lreg, mf, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390RSInstruction(op, n, freg, lreg, mf, cg);
+      instr = new (INSN_HEAP) TR::S390RSInstruction(op, n, freg, lreg, mf, cg);
 
    return instr;
    }
@@ -1231,9 +1231,9 @@ generateRSInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390RSInstruction(op, n, regp, mf, preced, cg);
+      instr = new (INSN_HEAP) TR::S390RSInstruction(op, n, regp, mf, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390RSInstruction(op, n, regp, mf, cg);
+      instr = new (INSN_HEAP) TR::S390RSInstruction(op, n, regp, mf, cg);
 
    return instr;
    }
@@ -1244,9 +1244,9 @@ generateRSInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390RSInstruction(op, n, treg, sreg, imm, preced, cg);
+      return new (INSN_HEAP) TR::S390RSInstruction(op, n, treg, sreg, imm, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390RSInstruction(op, n, treg, sreg, imm, cg);
+   return new (INSN_HEAP) TR::S390RSInstruction(op, n, treg, sreg, imm, cg);
    }
 
 
@@ -1259,9 +1259,9 @@ generateRSWithImplicitPairStoresInstruction(TR::CodeGenerator * cg, TR::InstOpCo
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390RSWithImplicitPairStoresInstruction(op, n, treg, sreg, mf, preced, cg);
+      instr = new (INSN_HEAP) TR::S390RSWithImplicitPairStoresInstruction(op, n, treg, sreg, mf, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390RSWithImplicitPairStoresInstruction(op, n, treg, sreg, mf, cg);
+      instr = new (INSN_HEAP) TR::S390RSWithImplicitPairStoresInstruction(op, n, treg, sreg, mf, cg);
 
    return instr;
    }
@@ -1275,9 +1275,9 @@ generateRSYInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390RSYInstruction(op, n, treg, mask, mf, preced, cg);
+      instr = new (INSN_HEAP) TR::S390RSYInstruction(op, n, treg, mask, mf, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390RSYInstruction(op, n, treg, mask, mf, cg);
+      instr = new (INSN_HEAP) TR::S390RSYInstruction(op, n, treg, mask, mf, cg);
 
    return instr;
    }
@@ -1290,9 +1290,9 @@ generateRRSInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390RRSInstruction(op, n, treg, sreg, branch, cond, preced, cg);
+      instr = new (INSN_HEAP) TR::S390RRSInstruction(op, n, treg, sreg, branch, cond, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390RRSInstruction(op, n, treg, sreg, branch, cond, cg);
+      instr = new (INSN_HEAP) TR::S390RRSInstruction(op, n, treg, sreg, branch, cond, cg);
 
    return instr;
    }
@@ -1303,9 +1303,9 @@ generateRREInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
    {
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390RREInstruction(op, n, treg, preced, cg);
+      instr = new (INSN_HEAP) TR::S390RREInstruction(op, n, treg, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390RREInstruction(op, n, treg, cg);
+      instr = new (INSN_HEAP) TR::S390RREInstruction(op, n, treg, cg);
    return instr;
    }
 
@@ -1315,9 +1315,9 @@ generateRREInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
    {
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390RREInstruction(op, n, treg, sreg, preced, cg);
+      instr = new (INSN_HEAP) TR::S390RREInstruction(op, n, treg, sreg, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390RREInstruction(op, n, treg, sreg, cg);
+      instr = new (INSN_HEAP) TR::S390RREInstruction(op, n, treg, sreg, cg);
 
 
    return instr;
@@ -1329,9 +1329,9 @@ generateRREInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
    {
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390RREInstruction(op, n, treg, sreg, cond, preced, cg);
+      instr = new (INSN_HEAP) TR::S390RREInstruction(op, n, treg, sreg, cond, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390RREInstruction(op, n, treg, sreg, cond, cg);
+      instr = new (INSN_HEAP) TR::S390RREInstruction(op, n, treg, sreg, cond, cg);
 
 
    return instr;
@@ -1341,45 +1341,45 @@ TR::Instruction * generateRIEInstruction(TR::CodeGenerator * cg, TR::InstOpCode:
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390RIEInstruction(op, n, treg, sreg, branch, mask, preced, cg);
+      return new (INSN_HEAP) TR::S390RIEInstruction(op, n, treg, sreg, branch, mask, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390RIEInstruction(op, n, treg, sreg, branch, mask, cg);
+   return new (INSN_HEAP) TR::S390RIEInstruction(op, n, treg, sreg, branch, mask, cg);
    }
 
 TR::Instruction * generateRIEInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * treg, int8_t immCompare, TR::LabelSymbol * branch, TR::InstOpCode::S390BranchCondition mask, TR::Instruction * preced)
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390RIEInstruction(op, n, treg, immCompare, branch, mask, preced, cg);
+      return new (INSN_HEAP) TR::S390RIEInstruction(op, n, treg, immCompare, branch, mask, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390RIEInstruction(op, n, treg, immCompare, branch, mask, cg);
+   return new (INSN_HEAP) TR::S390RIEInstruction(op, n, treg, immCompare, branch, mask, cg);
    }
 
 TR::Instruction * generateRIEInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * treg, TR::Register * sreg, int8_t immOne, int8_t immTwo, int8_t immThree, TR::Instruction * preced)
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390RIEInstruction(op, n, treg, sreg, immOne, immTwo, immThree, preced, cg);
+      return new (INSN_HEAP) TR::S390RIEInstruction(op, n, treg, sreg, immOne, immTwo, immThree, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390RIEInstruction(op, n, treg, sreg, immOne, immTwo, immThree, cg);
+   return new (INSN_HEAP) TR::S390RIEInstruction(op, n, treg, sreg, immOne, immTwo, immThree, cg);
    }
 
 TR::Instruction * generateRIEInstruction(TR::CodeGenerator* cg, TR::InstOpCode::Mnemonic op, TR::Node* n, TR::Register * treg, int16_t sourceImmediate, TR::InstOpCode::S390BranchCondition branchCondition, TR::Instruction * preced)
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390RIEInstruction(op, n, treg, sourceImmediate, branchCondition, preced, cg);
+      return new (INSN_HEAP) TR::S390RIEInstruction(op, n, treg, sourceImmediate, branchCondition, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390RIEInstruction(op, n, treg, sourceImmediate, branchCondition, cg);
+   return new (INSN_HEAP) TR::S390RIEInstruction(op, n, treg, sourceImmediate, branchCondition, cg);
    }
 
 TR::Instruction * generateRIEInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * treg, TR::Register * sreg, int16_t imm, TR::Instruction * preced)
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390RIEInstruction(op, n, treg, sreg, imm, preced, cg);
+      return new (INSN_HEAP) TR::S390RIEInstruction(op, n, treg, sreg, imm, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390RIEInstruction(op, n, treg, sreg, imm, cg);
+   return new (INSN_HEAP) TR::S390RIEInstruction(op, n, treg, sreg, imm, cg);
    }
 
 TR::Instruction * generateRISInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * leftSide, int8_t immCompare, TR::MemoryReference * branch, TR::InstOpCode::S390BranchCondition cond, TR::Instruction * preced)
@@ -1388,9 +1388,9 @@ TR::Instruction * generateRISInstruction(TR::CodeGenerator * cg, TR::InstOpCode:
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390RISInstruction(op, n, leftSide, immCompare, branch, cond, preced, cg);
+      instr = new (INSN_HEAP) TR::S390RISInstruction(op, n, leftSide, immCompare, branch, cond, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390RISInstruction(op, n, leftSide, immCompare, branch, cond, cg);
+      instr = new (INSN_HEAP) TR::S390RISInstruction(op, n, leftSide, immCompare, branch, cond, cg);
 
    return instr;
    }
@@ -1401,9 +1401,9 @@ generateS390MemInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, 
    {
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390MemInstruction(op, n, mf, preced, cg);
+      instr = new (INSN_HEAP) TR::S390MemInstruction(op, n, mf, preced, cg);
    else
-      instr =new (INSN_HEAP) TR_S390MemInstruction(op, n, mf, cg);
+      instr =new (INSN_HEAP) TR::S390MemInstruction(op, n, mf, cg);
 
    return instr;
    }
@@ -1414,9 +1414,9 @@ generateS390MemInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, 
    {
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390MemInstruction(op, n, memAccessMode, mf, preced, cg);
+      instr = new (INSN_HEAP) TR::S390MemInstruction(op, n, memAccessMode, mf, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390MemInstruction(op, n, memAccessMode, mf, cg);
+      instr = new (INSN_HEAP) TR::S390MemInstruction(op, n, memAccessMode, mf, cg);
 
    return instr;
    }
@@ -1427,9 +1427,9 @@ generateS390MemInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, 
    {
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390MemInstruction(op, n, constantField, memAccessMode, mf, preced, cg);
+      instr = new (INSN_HEAP) TR::S390MemInstruction(op, n, constantField, memAccessMode, mf, preced, cg);
    else
-   	  instr = new (INSN_HEAP) TR_S390MemInstruction(op, n, constantField, memAccessMode, mf, cg);
+   	  instr = new (INSN_HEAP) TR::S390MemInstruction(op, n, constantField, memAccessMode, mf, cg);
 
    return instr;
    }
@@ -1442,9 +1442,9 @@ generateRSLInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390RSLInstruction(op, n, len, mf1, preced, cg);
+      instr = new (INSN_HEAP) TR::S390RSLInstruction(op, n, len, mf1, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390RSLInstruction(op, n, len, mf1, cg);
+      instr = new (INSN_HEAP) TR::S390RSLInstruction(op, n, len, mf1, cg);
 
    return instr;
    }
@@ -1463,9 +1463,9 @@ generateRSLbInstruction(TR::CodeGenerator * cg,
 
    TR::Instruction *instr = NULL;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390RSLbInstruction(op, n, reg, length, mf1, mask, preced, cg);
+      instr = new (INSN_HEAP) TR::S390RSLbInstruction(op, n, reg, length, mf1, mask, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390RSLbInstruction(op, n, reg, length, mf1, mask, cg);
+      instr = new (INSN_HEAP) TR::S390RSLbInstruction(op, n, reg, length, mf1, mask, cg);
 
    return instr;
    }
@@ -1483,9 +1483,9 @@ generateSS1Instruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
       mf2->setBaseRegister(mf1->getBaseRegister(), cg);
 
    if (preced)
-      instr = new (INSN_HEAP) TR_S390SS1Instruction(op, n, len, mf1, mf2, preced, cg);
+      instr = new (INSN_HEAP) TR::S390SS1Instruction(op, n, len, mf1, mf2, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390SS1Instruction(op, n, len, mf1, mf2, cg);
+      instr = new (INSN_HEAP) TR::S390SS1Instruction(op, n, len, mf1, mf2, cg);
 
    return instr;
    }
@@ -1507,9 +1507,9 @@ generateSS1Instruction(TR::CodeGenerator * cg,
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390SS1Instruction(op, n, len, mf1, mf2, cond, preced, cg);
+      instr = new (INSN_HEAP) TR::S390SS1Instruction(op, n, len, mf1, mf2, cond, preced, cg);
    else
-   	  instr = new (INSN_HEAP) TR_S390SS1Instruction(op, n, len, mf1, mf2, cond, cg);
+   	  instr = new (INSN_HEAP) TR::S390SS1Instruction(op, n, len, mf1, mf2, cond, cg);
 
    return instr;
    }
@@ -1535,9 +1535,9 @@ generateSS1WithImplicitGPRsInstruction(TR::CodeGenerator * cg,
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390SS1WithImplicitGPRsInstruction(op, n, len, mf1, mf2, cond, preced, implicitRegSrc0, implicitRegSrc1, implicitRegTrg0, implicitRegTrg1, cg);
+      instr = new (INSN_HEAP) TR::S390SS1WithImplicitGPRsInstruction(op, n, len, mf1, mf2, cond, preced, implicitRegSrc0, implicitRegSrc1, implicitRegTrg0, implicitRegTrg1, cg);
    else
-      instr = new (INSN_HEAP) TR_S390SS1WithImplicitGPRsInstruction(op, n, len, mf1, mf2, cond, implicitRegSrc0, implicitRegSrc1, implicitRegTrg0, implicitRegTrg1, cg);
+      instr = new (INSN_HEAP) TR::S390SS1WithImplicitGPRsInstruction(op, n, len, mf1, mf2, cond, implicitRegSrc0, implicitRegSrc1, implicitRegTrg0, implicitRegTrg1, cg);
 
    return instr;
    }
@@ -1555,9 +1555,9 @@ generateSS2Instruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390SS2Instruction(op, n, len1, mf1, len2, mf2, preced, cg);
+      instr = new (INSN_HEAP) TR::S390SS2Instruction(op, n, len1, mf1, len2, mf2, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390SS2Instruction(op, n, len1, mf1, len2, mf2, cg);
+      instr = new (INSN_HEAP) TR::S390SS2Instruction(op, n, len1, mf1, len2, mf2, cg);
 
 #ifdef J9_PROJECT_SPECIFIC
    if (op == TR::InstOpCode::ZAP || op == TR::InstOpCode::CP || op == TR::InstOpCode::AP || op == TR::InstOpCode::SP || op == TR::InstOpCode::MP || op == TR::InstOpCode::DP)
@@ -1600,9 +1600,9 @@ generateSS3Instruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390SS2Instruction(op, n, len, mf1, roundAmount, mf2, preced, cg);
+      instr = new (INSN_HEAP) TR::S390SS2Instruction(op, n, len, mf1, roundAmount, mf2, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390SS2Instruction(op, n, len, mf1, roundAmount, mf2, cg);
+      instr = new (INSN_HEAP) TR::S390SS2Instruction(op, n, len, mf1, roundAmount, mf2, cg);
 
 #ifdef J9_PROJECT_SPECIFIC
    if (op == TR::InstOpCode::SRP)
@@ -1639,9 +1639,9 @@ generateSS3Instruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390SS2Instruction(op, n, len, mf1, shiftAmount, roundAmount, preced, cg);
+      instr = new (INSN_HEAP) TR::S390SS2Instruction(op, n, len, mf1, shiftAmount, roundAmount, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390SS2Instruction(op, n, len, mf1, shiftAmount, roundAmount, cg);
+      instr = new (INSN_HEAP) TR::S390SS2Instruction(op, n, len, mf1, shiftAmount, roundAmount, cg);
 #ifdef J9_PROJECT_SPECIFIC
    if (op == TR::InstOpCode::SRP)
       {
@@ -1682,9 +1682,9 @@ generateSS4Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::N
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390SS4Instruction(op, n, lengthReg, mf1, mf2, sourceKeyReg, preced, cg);
+      instr = new (INSN_HEAP) TR::S390SS4Instruction(op, n, lengthReg, mf1, mf2, sourceKeyReg, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390SS4Instruction(op, n, lengthReg, mf1, mf2, sourceKeyReg, cg);
+      instr = new (INSN_HEAP) TR::S390SS4Instruction(op, n, lengthReg, mf1, mf2, sourceKeyReg, cg);
 
    return instr;
    }
@@ -1732,9 +1732,9 @@ generateSS5WithImplicitGPRsInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mn
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390SS5WithImplicitGPRsInstruction(op, n, op1Reg, mf2, op3Reg, mf4, preced, implicitRegSrc0, implicitRegSrc1, implicitRegTrg0, implicitRegTrg1, cg);
+      instr = new (INSN_HEAP) TR::S390SS5WithImplicitGPRsInstruction(op, n, op1Reg, mf2, op3Reg, mf4, preced, implicitRegSrc0, implicitRegSrc1, implicitRegTrg0, implicitRegTrg1, cg);
    else
-      instr = new (INSN_HEAP) TR_S390SS5WithImplicitGPRsInstruction(op, n, op1Reg, mf2, op3Reg, mf4, implicitRegSrc0, implicitRegSrc1, implicitRegTrg0, implicitRegTrg1, cg);
+      instr = new (INSN_HEAP) TR::S390SS5WithImplicitGPRsInstruction(op, n, op1Reg, mf2, op3Reg, mf4, implicitRegSrc0, implicitRegSrc1, implicitRegTrg0, implicitRegTrg1, cg);
 
    return instr;
    }
@@ -1751,9 +1751,9 @@ generateSS5WithImplicitGPRsInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mn
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390SS5WithImplicitGPRsInstruction(op, n, op1Reg, mf2, NULL, NULL, preced, implicitRegSrc0, implicitRegSrc1, implicitRegTrg0, implicitRegTrg1, cg);
+      instr = new (INSN_HEAP) TR::S390SS5WithImplicitGPRsInstruction(op, n, op1Reg, mf2, NULL, NULL, preced, implicitRegSrc0, implicitRegSrc1, implicitRegTrg0, implicitRegTrg1, cg);
    else
-      instr = new (INSN_HEAP) TR_S390SS5WithImplicitGPRsInstruction(op, n, op1Reg, mf2, NULL, NULL, implicitRegSrc0, implicitRegSrc1, implicitRegTrg0, implicitRegTrg1, cg);
+      instr = new (INSN_HEAP) TR::S390SS5WithImplicitGPRsInstruction(op, n, op1Reg, mf2, NULL, NULL, implicitRegSrc0, implicitRegSrc1, implicitRegTrg0, implicitRegTrg1, cg);
 
    return instr;
    }
@@ -1777,9 +1777,9 @@ generateSS5WithImplicitGPRsInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mn
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390SS5WithImplicitGPRsInstruction(op, n, op1Reg, mf2, NULL, mf4, preced, implicitRegSrc0, implicitRegSrc1, implicitRegTrg0, implicitRegTrg1, cg);
+      instr = new (INSN_HEAP) TR::S390SS5WithImplicitGPRsInstruction(op, n, op1Reg, mf2, NULL, mf4, preced, implicitRegSrc0, implicitRegSrc1, implicitRegTrg0, implicitRegTrg1, cg);
    else
-      instr = new (INSN_HEAP) TR_S390SS5WithImplicitGPRsInstruction(op, n, op1Reg, mf2, NULL, mf4, implicitRegSrc0, implicitRegSrc1, implicitRegTrg0, implicitRegTrg1, cg);
+      instr = new (INSN_HEAP) TR::S390SS5WithImplicitGPRsInstruction(op, n, op1Reg, mf2, NULL, mf4, implicitRegSrc0, implicitRegSrc1, implicitRegTrg0, implicitRegTrg1, cg);
 
    return instr;
    }
@@ -1797,9 +1797,9 @@ generateSSEInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::N
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390SSEInstruction(op, n, mf1, mf2, preced, cg);
+      instr = new (INSN_HEAP) TR::S390SSEInstruction(op, n, mf1, mf2, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390SSEInstruction(op, n, mf1, mf2, cg);
+      instr = new (INSN_HEAP) TR::S390SSEInstruction(op, n, mf1, mf2, cg);
 
    return instr;
    }
@@ -1817,9 +1817,9 @@ generateSSFInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::N
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390SSFInstruction(op, n, regp, mf1, mf2, preced, cg);
+      instr = new (INSN_HEAP) TR::S390SSFInstruction(op, n, regp, mf1, mf2, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390SSFInstruction(op, n, regp, mf1, mf2, cg);
+      instr = new (INSN_HEAP) TR::S390SSFInstruction(op, n, regp, mf1, mf2, cg);
 
    return instr;
    }
@@ -1833,9 +1833,9 @@ generateSIInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390SIInstruction(op, n, mf, imm, preced, cg);
+      instr = new (INSN_HEAP) TR::S390SIInstruction(op, n, mf, imm, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390SIInstruction(op, n, mf, imm, cg);
+      instr = new (INSN_HEAP) TR::S390SIInstruction(op, n, mf, imm, cg);
 
    return instr;
    }
@@ -1848,9 +1848,9 @@ generateSIYInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390SIYInstruction(op, n, mf, imm, preced, cg);
+      instr = new (INSN_HEAP) TR::S390SIYInstruction(op, n, mf, imm, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390SIYInstruction(op, n, mf, imm, cg);
+      instr = new (INSN_HEAP) TR::S390SIYInstruction(op, n, mf, imm, cg);
 
    return instr;
    }
@@ -1873,9 +1873,9 @@ generateSILInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390SILInstruction(op, n, mf, imm, preced, cg);
+      instr = new (INSN_HEAP) TR::S390SILInstruction(op, n, mf, imm, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390SILInstruction(op, n, mf, imm, cg);
+      instr = new (INSN_HEAP) TR::S390SILInstruction(op, n, mf, imm, cg);
 
    return instr;
    }
@@ -1887,9 +1887,9 @@ generateSInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::No
 
    TR::Instruction *instr;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390SInstruction(op, n, mf, preced, cg);
+      instr = new (INSN_HEAP) TR::S390SInstruction(op, n, mf, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390SInstruction(op, n, mf, cg);
+      instr = new (INSN_HEAP) TR::S390SInstruction(op, n, mf, cg);
 
    return instr;
    }
@@ -1901,11 +1901,11 @@ generateSInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::No
 
    if (preced)
       {
-      instr = new (INSN_HEAP) TR_S390OpCodeOnlyInstruction(op, n, preced, cg);
+      instr = new (INSN_HEAP) TR::S390OpCodeOnlyInstruction(op, n, preced, cg);
       }
    else
       {
-      instr = new (INSN_HEAP) TR_S390OpCodeOnlyInstruction(op, n, cg);
+      instr = new (INSN_HEAP) TR::S390OpCodeOnlyInstruction(op, n, cg);
       }
 
    return instr;
@@ -1916,9 +1916,9 @@ generateRRInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::No
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390OpCodeOnlyInstruction(op, n, preced, cg);
+      return new (INSN_HEAP) TR::S390OpCodeOnlyInstruction(op, n, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390OpCodeOnlyInstruction(op, n, cg);
+   return new (INSN_HEAP) TR::S390OpCodeOnlyInstruction(op, n, cg);
    }
 
 /*********************************** Vector Instructions *******************************************/
@@ -1946,35 +1946,35 @@ TR::Instruction *
 generateVRIaInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * targetReg, uint16_t constantImm2 /* 16 bits */,
                         uint8_t mask3)
    {
-   return new (INSN_HEAP) TR_S390VRIaInstruction(cg, op, n, targetReg, constantImm2, mask3);
+   return new (INSN_HEAP) TR::S390VRIaInstruction(cg, op, n, targetReg, constantImm2, mask3);
    }
 
 TR::Instruction *
 generateVRIbInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * targetReg,
                         uint8_t constantImm2 /* 8 or 16 bits */, uint8_t constantImm3 /* 12 bits */, uint8_t mask4 /* 4 bits */)
    {
-   return new (INSN_HEAP) TR_S390VRIbInstruction(cg, op, n, targetReg, constantImm2, constantImm3, mask4);
+   return new (INSN_HEAP) TR::S390VRIbInstruction(cg, op, n, targetReg, constantImm2, constantImm3, mask4);
    }
 
 TR::Instruction *
 generateVRIcInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * targetReg, TR::Register * sourceReg3,
                         uint16_t constantImm2 /* 8 or 16 bits */, uint8_t mask4 /* 4 bits */)
    {
-   return new (INSN_HEAP) TR_S390VRIcInstruction(cg, op, n, targetReg, sourceReg3, constantImm2, mask4);
+   return new (INSN_HEAP) TR::S390VRIcInstruction(cg, op, n, targetReg, sourceReg3, constantImm2, mask4);
    }
 
 TR::Instruction *
 generateVRIdInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * targetReg, TR::Register * sourceReg2,
                         TR::Register * sourceReg3, uint8_t constantImm4 /* 8 bit */, uint8_t mask5 /* 4 bits */)
    {
-   return new (INSN_HEAP) TR_S390VRIdInstruction(cg, op, n, targetReg, sourceReg2, sourceReg3, constantImm4, mask5);
+   return new (INSN_HEAP) TR::S390VRIdInstruction(cg, op, n, targetReg, sourceReg2, sourceReg3, constantImm4, mask5);
    }
 
 TR::Instruction *
 generateVRIeInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * targetReg, TR::Register * sourceReg2,
                         uint16_t constantImm3 /* 12 bits */, uint8_t mask5 /* 4 bits */, uint8_t mask4 /* 4 bits */)
    {
-   return new (INSN_HEAP) TR_S390VRIeInstruction(cg, op, n, targetReg, sourceReg2, constantImm3, mask5, mask4);
+   return new (INSN_HEAP) TR::S390VRIeInstruction(cg, op, n, targetReg, sourceReg2, constantImm3, mask5, mask4);
    }
 
 /****** VRR ******/
@@ -1984,9 +1984,9 @@ generateVRRaInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR:
                         TR::Instruction * preced)
    {
    if (preced)
-      return new (INSN_HEAP) TR_S390VRRaInstruction(cg, op, n, targetReg, sourceReg2, mask5, mask4, mask3, preced);
+      return new (INSN_HEAP) TR::S390VRRaInstruction(cg, op, n, targetReg, sourceReg2, mask5, mask4, mask3, preced);
    else
-      return new (INSN_HEAP) TR_S390VRRaInstruction(cg, op, n, targetReg, sourceReg2, mask5, mask4, mask3);
+      return new (INSN_HEAP) TR::S390VRRaInstruction(cg, op, n, targetReg, sourceReg2, mask5, mask4, mask3);
    }
 
 TR::Instruction *
@@ -1994,37 +1994,37 @@ generateVRRaInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR:
                         TR::Instruction * preced)
    {
    if (preced)
-      return new (INSN_HEAP) TR_S390VRRaInstruction(cg, op, n, targetReg, sourceReg2, 0 /* mask5 */, 0 /* mask4 */, 0 /* mask3 */, preced);
+      return new (INSN_HEAP) TR::S390VRRaInstruction(cg, op, n, targetReg, sourceReg2, 0 /* mask5 */, 0 /* mask4 */, 0 /* mask3 */, preced);
    else
-      return new (INSN_HEAP) TR_S390VRRaInstruction(cg, op, n, targetReg, sourceReg2, 0 /* mask5 */, 0 /* mask4 */, 0 /* mask3 */);
+      return new (INSN_HEAP) TR::S390VRRaInstruction(cg, op, n, targetReg, sourceReg2, 0 /* mask5 */, 0 /* mask4 */, 0 /* mask3 */);
    }
 
 TR::Instruction *
 generateVRRbInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * targetReg, TR::Register * sourceReg2,
                         TR::Register * sourceReg3, uint8_t mask5 /* 4 bits */, uint8_t mask4 /* 4 bits */)
    {
-   return new (INSN_HEAP) TR_S390VRRbInstruction(cg, op, n, targetReg, sourceReg2, sourceReg3, mask5, mask4);
+   return new (INSN_HEAP) TR::S390VRRbInstruction(cg, op, n, targetReg, sourceReg2, sourceReg3, mask5, mask4);
    }
 
 TR::Instruction *
 generateVRRcInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * targetReg, TR::Register * sourceReg2,
                         TR::Register * sourceReg3, uint8_t mask6 /* 4 bits */, uint8_t mask5 /* 4 bits */, uint8_t mask4 /* 4 bits */)
    {
-   return new (INSN_HEAP) TR_S390VRRcInstruction(cg, op, n, targetReg, sourceReg2, sourceReg3, mask6, mask5, mask4);
+   return new (INSN_HEAP) TR::S390VRRcInstruction(cg, op, n, targetReg, sourceReg2, sourceReg3, mask6, mask5, mask4);
    }
 
 TR::Instruction *
 generateVRRcInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * targetReg, TR::Register * sourceReg2,
                         TR::Register * sourceReg3, uint8_t mask4 /* 4 bits */)
    {
-   return new (INSN_HEAP) TR_S390VRRcInstruction(cg, op, n, targetReg, sourceReg2, sourceReg3, 0, 0, mask4);
+   return new (INSN_HEAP) TR::S390VRRcInstruction(cg, op, n, targetReg, sourceReg2, sourceReg3, 0, 0, mask4);
    }
 
 TR::Instruction *
 generateVRRdInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * targetReg, TR::Register * sourceReg2,
                         TR::Register * sourceReg3, TR::Register * sourceReg4, uint8_t mask6 /* 4 bits */, uint8_t mask5 /* 4 bits */)
    {
-   return new (INSN_HEAP) TR_S390VRRdInstruction(cg, op, n, targetReg, sourceReg2, sourceReg3, sourceReg4, mask6, mask5);
+   return new (INSN_HEAP) TR::S390VRRdInstruction(cg, op, n, targetReg, sourceReg2, sourceReg3, sourceReg4, mask6, mask5);
    }
 
 TR::Instruction *
@@ -2032,14 +2032,14 @@ generateVRReInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR:
                         TR::Register * sourceReg3, TR::Register * sourceReg4, uint8_t mask6 /* 4 bits */, uint8_t mask5 /* 4 bits */)
 
    {
-   return new (INSN_HEAP) TR_S390VRReInstruction(cg, op, n, targetReg, sourceReg2, sourceReg3, sourceReg4, mask6, mask5);
+   return new (INSN_HEAP) TR::S390VRReInstruction(cg, op, n, targetReg, sourceReg2, sourceReg3, sourceReg4, mask6, mask5);
    }
 
 TR::Instruction *
 generateVRRfInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * targetReg, TR::Register * sourceReg2 /* GPR */,
                         TR::Register * sourceReg3 /* GPR */)
    {
-   return new (INSN_HEAP) TR_S390VRRfInstruction(cg, op, n, targetReg, sourceReg2, sourceReg3);
+   return new (INSN_HEAP) TR::S390VRRfInstruction(cg, op, n, targetReg, sourceReg2, sourceReg3);
    }
 
 /****** VRS ******/
@@ -2048,21 +2048,21 @@ TR::Instruction *
 generateVRSaInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * targetReg, TR::Register * sourceReg, TR::MemoryReference * mr,
                         uint8_t mask4 /* 4 bits */)
    {
-   return new (INSN_HEAP) TR_S390VRSaInstruction(cg, op, n, targetReg, sourceReg, mr, mask4);
+   return new (INSN_HEAP) TR::S390VRSaInstruction(cg, op, n, targetReg, sourceReg, mr, mask4);
    }
 
 TR::Instruction *
 generateVRSbInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * targetReg, TR::Register * sourceReg, TR::MemoryReference * mr,
                         uint8_t mask4 /* 4 bits */)
    {
-   return new (INSN_HEAP) TR_S390VRSbInstruction(cg, op, n, targetReg, sourceReg, mr, mask4);
+   return new (INSN_HEAP) TR::S390VRSbInstruction(cg, op, n, targetReg, sourceReg, mr, mask4);
    }
 
 TR::Instruction *
 generateVRScInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * targetReg, TR::Register * sourceReg, TR::MemoryReference * mr,
                         uint8_t mask4 /* 4 bits */)
    {
-   return new (INSN_HEAP) TR_S390VRScInstruction(cg, op, n, targetReg, sourceReg, mr, mask4);
+   return new (INSN_HEAP) TR::S390VRScInstruction(cg, op, n, targetReg, sourceReg, mr, mask4);
    }
 
 /****** VRV ******/
@@ -2070,7 +2070,7 @@ TR::Instruction *
 generateVRVInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register *sourceReg, TR::MemoryReference * mr,
                        uint8_t mask3 /* 4 bits */)
    {
-   return new (INSN_HEAP) TR_S390VRVInstruction(cg, op, n, sourceReg, mr, mask3);
+   return new (INSN_HEAP) TR::S390VRVInstruction(cg, op, n, sourceReg, mr, mask3);
    }
 
 /****** VRX ******/
@@ -2081,25 +2081,25 @@ generateVRXInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
    if (memRef) preced = memRef->enforceVRXFormatLimits(n, cg, preced);
 
    if (preced)
-      return new (INSN_HEAP) TR_S390VRXInstruction(cg, op, n, reg, memRef, mask3, preced);
+      return new (INSN_HEAP) TR::S390VRXInstruction(cg, op, n, reg, memRef, mask3, preced);
    else
-      return new (INSN_HEAP) TR_S390VRXInstruction(cg, op, n, reg, memRef, mask3);
+      return new (INSN_HEAP) TR::S390VRXInstruction(cg, op, n, reg, memRef, mask3);
    }
 
 /************************************************************ Misc Instructions ************************************************************/
 TR::Instruction *
 generateS390PseudoInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Node * fenceNode, TR::Instruction * preced)
    {
-   TR_S390PseudoInstruction *instr;
+   TR::S390PseudoInstruction *instr;
    TR::Compilation *comp = cg->comp();
 
    if (preced)
    {
-     instr= new (INSN_HEAP) TR_S390PseudoInstruction(op, n, fenceNode, preced, cg);
+     instr= new (INSN_HEAP) TR::S390PseudoInstruction(op, n, fenceNode, preced, cg);
    }
    else
    {
-     instr= new (INSN_HEAP) TR_S390PseudoInstruction(op, n, fenceNode, cg);
+     instr= new (INSN_HEAP) TR::S390PseudoInstruction(op, n, fenceNode, cg);
    }
 
 
@@ -2110,16 +2110,16 @@ TR::Instruction *
 generateS390PseudoInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::RegisterDependencyConditions * cond,
                               TR::Node * fenceNode, TR::Instruction * preced)
    {
-   TR_S390PseudoInstruction *instr;
+   TR::S390PseudoInstruction *instr;
    TR::Compilation *comp = cg->comp();
 
    if (preced)
       {
-      instr=new (INSN_HEAP) TR_S390PseudoInstruction(op, n, fenceNode, cond, preced, cg);
+      instr=new (INSN_HEAP) TR::S390PseudoInstruction(op, n, fenceNode, cond, preced, cg);
       }
    else
    	  {
-      instr= new (INSN_HEAP) TR_S390PseudoInstruction(op, n, fenceNode, cond, cg);
+      instr= new (INSN_HEAP) TR::S390PseudoInstruction(op, n, fenceNode, cond, cg);
       }
 
    return instr;
@@ -2145,9 +2145,9 @@ generateRegRegInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, T
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390RRInstruction(op, n, sreg, treg, cond, preced, cg);
+      return new (INSN_HEAP) TR::S390RRInstruction(op, n, sreg, treg, cond, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390RRInstruction(op, n, sreg, treg, cond, cg);
+   return new (INSN_HEAP) TR::S390RRInstruction(op, n, sreg, treg, cond, cg);
    }
 
 TR::Instruction *
@@ -2156,9 +2156,9 @@ generateS390ImmSymInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic o
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390ImmSymInstruction(op, n, imm, sr, cond, preced, cg);
+      return new (INSN_HEAP) TR::S390ImmSymInstruction(op, n, imm, sr, cond, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390ImmSymInstruction(op, n, imm, sr, cond, cg);
+   return new (INSN_HEAP) TR::S390ImmSymInstruction(op, n, imm, sr, cond, cg);
    }
 
 TR::Instruction *
@@ -2167,18 +2167,18 @@ generateLogicalImmediate(TR::CodeGenerator * cg, TR::Node * node, TR::InstOpCode
    {
    if ((imm & 0x0000FFFF) == 0x0000FFFF)
       {
-      return new (INSN_HEAP) TR_S390RIInstruction(lhOp, node, reg, ((imm & 0xFFFF0000) >> 16), cg);
+      return new (INSN_HEAP) TR::S390RIInstruction(lhOp, node, reg, ((imm & 0xFFFF0000) >> 16), cg);
       }
 
    if ((imm & 0xFFFF0000) == 0xFFFF0000)
       {
-      return new (INSN_HEAP) TR_S390RIInstruction(llOp, node, reg, imm, cg);
+      return new (INSN_HEAP) TR::S390RIInstruction(llOp, node, reg, imm, cg);
       }
 
    TR::MemoryReference * dataref = generateS390MemoryReference(imm, TR::Int32, cg, 0);
 
    TR::Instruction *instr;
-   instr = (new (INSN_HEAP) TR_S390RXInstruction(defaultOp, node, reg, dataref, cg));
+   instr = (new (INSN_HEAP) TR::S390RXInstruction(defaultOp, node, reg, dataref, cg));
 
    return instr;
    }
@@ -2200,11 +2200,11 @@ TR::Instruction *
 generateVirtualGuardNOPInstruction(TR::CodeGenerator * cg, TR::Node * n, TR_VirtualGuardSite * site,
                                    TR::RegisterDependencyConditions * cond, TR::LabelSymbol * sym, TR::Instruction * preced)
    {
-   TR_S390BranchInstruction * cursor ;
+   TR::S390BranchInstruction * cursor ;
    if (preced)
-      cursor = new (INSN_HEAP) TR_S390VirtualGuardNOPInstruction(n, site, cond, sym, preced, cg);
+      cursor = new (INSN_HEAP) TR::S390VirtualGuardNOPInstruction(n, site, cond, sym, preced, cg);
    else
-      cursor =  new (INSN_HEAP) TR_S390VirtualGuardNOPInstruction(n, site, cond, sym, cg);
+      cursor =  new (INSN_HEAP) TR::S390VirtualGuardNOPInstruction(n, site, cond, sym, cg);
    return cursor;
    }
 #endif
@@ -2262,7 +2262,7 @@ generateDirectCall(TR::CodeGenerator * cg, TR::Node * callNode, bool myself, TR:
    // instruction and calculate the address in generateBinary phase
    if (myself)
       {
-      TR::Instruction * instr = new (INSN_HEAP) TR_S390RILInstruction(TR::InstOpCode::BRASL, callNode, RegRA, sym, callSymRef, cg);
+      TR::Instruction * instr = new (INSN_HEAP) TR::S390RILInstruction(TR::InstOpCode::BRASL, callNode, RegRA, sym, callSymRef, cg);
       instr->setJITExit();
 
       return instr;
@@ -2287,8 +2287,8 @@ generateDirectCall(TR::CodeGenerator * cg, TR::Node * callNode, bool myself, TR:
 
          }
 
-      TR_S390RILInstruction *tempInst =
-            (new (INSN_HEAP) TR_S390RILInstruction(TR::InstOpCode::BRASL, callNode, RegRA, imm, callSymRef, cg));
+      TR::S390RILInstruction *tempInst =
+            (new (INSN_HEAP) TR::S390RILInstruction(TR::InstOpCode::BRASL, callNode, RegRA, imm, callSymRef, cg));
 
       AOTcgDiag1(comp, "\ntempInst=%p\n", tempInst);
       return tempInst;
@@ -2312,8 +2312,8 @@ generateDirectCall(TR::CodeGenerator * cg, TR::Node * callNode, bool myself, TR:
 
             }
 
-         TR_S390RILInstruction *tempInst =
-            new (INSN_HEAP) TR_S390RILInstruction(TR::InstOpCode::BRASL, callNode, RegRA, imm, cg);
+         TR::S390RILInstruction *tempInst =
+            new (INSN_HEAP) TR::S390RILInstruction(TR::InstOpCode::BRASL, callNode, RegRA, imm, cg);
          tempInst->setJITExit();
 
          if (isHelper)
@@ -2324,7 +2324,7 @@ generateDirectCall(TR::CodeGenerator * cg, TR::Node * callNode, bool myself, TR:
       else
          {
          genLoadAddressConstant(cg, callNode, imm, RegEP, preced, cond);
-         TR::Instruction * instr = new (INSN_HEAP) TR_S390RRInstruction(TR::InstOpCode::BASR, callNode, RegRA, RegEP, cg);
+         TR::Instruction * instr = new (INSN_HEAP) TR::S390RRInstruction(TR::InstOpCode::BASR, callNode, RegRA, RegEP, cg);
          instr->setJITExit();
 
          return instr;
@@ -2360,7 +2360,7 @@ generateSnippetCall(TR::CodeGenerator * cg, TR::Node * callNode, TR::Snippet * s
       // In particular, we use the this pointer reg, which  has a preDep to GPR1
       generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, callNode, TR::LabelSymbol::create(INSN_HEAP, cg), preDeps);
 
-      callInstr = new (INSN_HEAP) TR_S390RILInstruction(TR::InstOpCode::BRASL, callNode, killRegRA, s,
+      callInstr = new (INSN_HEAP) TR::S390RILInstruction(TR::InstOpCode::BRASL, callNode, killRegRA, s,
          postDeps, callSymRef, cg);
       callInstr->setJITExit();
 
@@ -2369,7 +2369,7 @@ generateSnippetCall(TR::CodeGenerator * cg, TR::Node * callNode, TR::Snippet * s
       }
    else
       {
-      callInstr = new (INSN_HEAP) TR_S390RILInstruction(TR::InstOpCode::BRASL, callNode, RegRA, s, cond, callSymRef, cg);
+      callInstr = new (INSN_HEAP) TR::S390RILInstruction(TR::InstOpCode::BRASL, callNode, RegRA, s, cond, callSymRef, cg);
       callInstr->setJITExit();
       }
 
@@ -2393,7 +2393,7 @@ generateLoadLiteralPoolAddress(TR::CodeGenerator * cg, TR::Node * node, TR::Regi
    TR::Instruction *cursor;
 
    //support f/w only so far
-   TR_S390RILInstruction *LARLinst = (TR_S390RILInstruction *) generateRILInstruction(cg, TR::InstOpCode::LARL, node, treg, 0xBABE, 0);
+   TR::S390RILInstruction *LARLinst = (TR::S390RILInstruction *) generateRILInstruction(cg, TR::InstOpCode::LARL, node, treg, 0xBABE, 0);
    LARLinst->setIsLiteralPoolAddress();
    cursor = LARLinst;
 
@@ -2419,13 +2419,13 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
    TR::Instruction * cursor;
    TR_S390ConstantDataSnippet * targetsnippet = 0;
    TR::MemoryReference * dataref = 0;
-   TR_S390RILInstruction *LRLinst = 0;
+   TR::S390RILInstruction *LRLinst = 0;
    if (cg->isLiteralPoolOnDemandOn() && (base == 0))
       {
       if (op == TR::InstOpCode::L)
          {
          targetsnippet = cg->findOrCreate4ByteConstant(node, imm);
-         LRLinst = (TR_S390RILInstruction *) generateRILInstruction(cg, TR::InstOpCode::LRL, node, treg, targetsnippet, 0);
+         LRLinst = (TR::S390RILInstruction *) generateRILInstruction(cg, TR::InstOpCode::LRL, node, treg, targetsnippet, 0);
          cursor = LRLinst;
          }
       else
@@ -2447,7 +2447,7 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
       {
       dataref = generateS390MemoryReference(imm, TR::Int32, cg, base);
       targetsnippet = dataref->getConstantDataSnippet();
-      cursor = new (INSN_HEAP) TR_S390RXInstruction(op, node, treg, dataref, cg);
+      cursor = new (INSN_HEAP) TR::S390RXInstruction(op, node, treg, dataref, cg);
       }
    // HCR in generateRegLitRefInstruction 32-bit: register const data snippet for common case
    if (comp->getOption(TR_EnableHCR) && isPICCandidate )
@@ -2507,7 +2507,7 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
       AOTcgDiag4(comp, "generateRegLitRefInstruction constantDataSnippet=%x symbolReference=%x symbol=%x reloType=%x\n",
          targetSnippet, targetSnippet->getSymbolReference(), targetSnippet->getSymbolReference()->getSymbol(), reloType);
 
-      cursor = (TR_S390RILInstruction *) generateRILInstruction(cg, (op == TR::InstOpCode::LG)?TR::InstOpCode::LGRL:TR::InstOpCode::LRL, node, treg, targetSnippet, preced);
+      cursor = (TR::S390RILInstruction *) generateRILInstruction(cg, (op == TR::InstOpCode::LG)?TR::InstOpCode::LGRL:TR::InstOpCode::LRL, node, treg, targetSnippet, preced);
       return cursor;
       }
 
@@ -2540,7 +2540,7 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
       dataref->getSymbolReference()->getSymbol(), reloType);
    dataref->getConstantDataSnippet()->setSymbolReference(dataref->getSymbolReference());
    dataref->getConstantDataSnippet()->setReloType(reloType);
-   cursor = new (INSN_HEAP) TR_S390RXInstruction(op, node, treg, dataref, cg);
+   cursor = new (INSN_HEAP) TR::S390RXInstruction(op, node, treg, dataref, cg);
    if (alloc)
       {
       cg->stopUsingRegister(base);
@@ -2575,7 +2575,7 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
       base = NULL;
       }
    TR::MemoryReference * dataref = generateS390MemoryReference(snippet, cg, base, node);
-   cursor = new (INSN_HEAP) TR_S390RXInstruction(op, node, treg, dataref, cg);
+   cursor = new (INSN_HEAP) TR::S390RXInstruction(op, node, treg, dataref, cg);
    if (alloc)
       {
       cg->stopUsingRegister(base);
@@ -2596,7 +2596,7 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
    TR::Instruction * cursor;
    TR_S390ConstantDataSnippet * targetsnippet = 0;
    TR::MemoryReference * dataref = 0;
-   TR_S390RILInstruction *LGRLinst = 0;
+   TR::S390RILInstruction *LGRLinst = 0;
    TR::Compilation *comp = cg->comp();
 
    if (TR::InstOpCode(op).getInstructionFormat() == RIL_FORMAT)
@@ -2627,7 +2627,7 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
             }
          }
 
-      cursor = new (INSN_HEAP) TR_S390RILInstruction(op, node, treg, constDataSnip, cg);
+      cursor = new (INSN_HEAP) TR::S390RILInstruction(op, node, treg, constDataSnip, cg);
 
       return cursor;
       }
@@ -2636,7 +2636,7 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
       if (op == TR::InstOpCode::LG)
          {
          targetsnippet = cg->findOrCreate8ByteConstant(node, imm);
-         LGRLinst = (TR_S390RILInstruction *) generateRILInstruction(cg, TR::InstOpCode::LGRL, node, treg, targetsnippet, 0);
+         LGRLinst = (TR::S390RILInstruction *) generateRILInstruction(cg, TR::InstOpCode::LGRL, node, treg, targetsnippet, 0);
          cursor = LGRLinst;
          }
       else
@@ -2684,7 +2684,7 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
       }
 
    if (!LGRLinst)
-      cursor = new (INSN_HEAP) TR_S390RXInstruction(op, node, treg, dataref, cg);
+      cursor = new (INSN_HEAP) TR::S390RXInstruction(op, node, treg, dataref, cg);
    if (alloc)
       {
       cg->stopUsingRegister(base);
@@ -2722,7 +2722,7 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
    {
 
    TR::MemoryReference * dataref = generateS390MemoryReference(imm, TR::Float, cg, node);
-   return new (INSN_HEAP) TR_S390RXInstruction(op, node, treg, dataref, cg);
+   return new (INSN_HEAP) TR::S390RXInstruction(op, node, treg, dataref, cg);
    }
 
 /**
@@ -2734,7 +2734,7 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
    {
 
    TR::MemoryReference * dataref = generateS390MemoryReference(imm, TR::Double, cg, node);
-   return new (INSN_HEAP) TR_S390RXInstruction(op, node, treg, dataref, cg);
+   return new (INSN_HEAP) TR::S390RXInstruction(op, node, treg, dataref, cg);
    }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2772,7 +2772,7 @@ generateRegUnresolvedSym(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR
 
    TR::Register * treg2 = (tempReg2->getRegisterPair() != NULL) ? tempReg2->getLowOrder() : tempReg2;
    //Since N3 instructions supportted, only need a single BRCL instr.
-   gcPoint = new (INSN_HEAP) TR_S390RILInstruction(TR::InstOpCode::BRCL, node, 0xF, uds, deps, cg);
+   gcPoint = new (INSN_HEAP) TR::S390RILInstruction(TR::InstOpCode::BRCL, node, 0xF, uds, deps, cg);
 
    gcPoint->setNeedsGCMap(0xFFFFFFFF);
    cg->stopUsingRegister(tempReg);
@@ -2953,9 +2953,9 @@ generateS390EInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390EInstruction(op, n, preced, cg);
+      return new (INSN_HEAP) TR::S390EInstruction(op, n, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390EInstruction(op, n,  cg);
+   return new (INSN_HEAP) TR::S390EInstruction(op, n,  cg);
    }
 
 TR::Instruction *
@@ -2965,9 +2965,9 @@ TR::RegisterDependencyConditions * cond, TR::Instruction * preced)
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390EInstruction(op, n, preced, cg, tgt, tgt2, src, src2 ,cond);
+      return new (INSN_HEAP) TR::S390EInstruction(op, n, preced, cg, tgt, tgt2, src, src2 ,cond);
       }
-   return new (INSN_HEAP) TR_S390EInstruction(op, n,  cg, tgt, tgt2, src, src2, cond);
+   return new (INSN_HEAP) TR::S390EInstruction(op, n,  cg, tgt, tgt2, src, src2, cond);
    }
 
 TR::Instruction *
@@ -2975,9 +2975,9 @@ generateS390IInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, uin
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390IInstruction(op, n, im, preced, cg);
+      return new (INSN_HEAP) TR::S390IInstruction(op, n, im, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390IInstruction(op,n,im,cg);
+   return new (INSN_HEAP) TR::S390IInstruction(op,n,im,cg);
    }
 
 TR::Instruction *
@@ -2985,14 +2985,14 @@ generateRuntimeInstrumentationInstruction(TR::CodeGenerator *cg, TR::InstOpCode:
    {
    if (preced != NULL)
       if (target != NULL)
-         return new (INSN_HEAP) TR_S390RIInstruction(op, node, target, preced, cg);
+         return new (INSN_HEAP) TR::S390RIInstruction(op, node, target, preced, cg);
       else
-         return new (INSN_HEAP) TR_S390RIInstruction(op, node, preced, cg);
+         return new (INSN_HEAP) TR::S390RIInstruction(op, node, preced, cg);
    else
       if (target != NULL)
-         return new (INSN_HEAP) TR_S390RIInstruction(op, node, target, cg);
+         return new (INSN_HEAP) TR::S390RIInstruction(op, node, target, cg);
       else
-         return new (INSN_HEAP) TR_S390RIInstruction(op, node, cg);
+         return new (INSN_HEAP) TR::S390RIInstruction(op, node, cg);
    }
 
 TR::Instruction *
@@ -3000,9 +3000,9 @@ generateS390IEInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, ui
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390IEInstruction(op, n, im1, im2, preced, cg);
+      return new (INSN_HEAP) TR::S390IEInstruction(op, n, im1, im2, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390IEInstruction(op, n, im1, im2, cg);
+   return new (INSN_HEAP) TR::S390IEInstruction(op, n, im1, im2, cg);
    }
 
 TR::Instruction *
@@ -3011,9 +3011,9 @@ generateS390BranchPredictionRelativePreloadInstruction(TR::CodeGenerator * cg, T
    {
    if (preced)
       {
-      return new (cg->trHeapMemory()) TR_S390MIIInstruction(op, n, mask, sym, sym3, preced, cg);
+      return new (cg->trHeapMemory()) TR::S390MIIInstruction(op, n, mask, sym, sym3, preced, cg);
       }
-   return new (cg->trHeapMemory()) TR_S390MIIInstruction(op, n, mask, sym, sym3, cg);
+   return new (cg->trHeapMemory()) TR::S390MIIInstruction(op, n, mask, sym, sym3, cg);
    }
 
 TR::Instruction *
@@ -3022,9 +3022,9 @@ generateS390BranchPredictionPreloadInstruction(TR::CodeGenerator * cg, TR::InstO
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR_S390SMIInstruction(op, n, mask, sym, mf3, preced, cg);
+      return new (INSN_HEAP) TR::S390SMIInstruction(op, n, mask, sym, mf3, preced, cg);
       }
-   return new (INSN_HEAP) TR_S390SMIInstruction(op, n, mask, sym, mf3, cg);
+   return new (INSN_HEAP) TR::S390SMIInstruction(op, n, mask, sym, mf3, cg);
    }
 
 TR::Instruction *
@@ -3041,9 +3041,9 @@ generateSerializationInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Inst
 
    TR::Instruction * instr = NULL;
    if (preced)
-      instr = new (INSN_HEAP) TR_S390RegInstruction(TR::InstOpCode::BCR, node, cond, gpr0, preced, cg);
+      instr = new (INSN_HEAP) TR::S390RegInstruction(TR::InstOpCode::BCR, node, cond, gpr0, preced, cg);
    else
-      instr = new (INSN_HEAP) TR_S390RegInstruction(TR::InstOpCode::BCR, node, cond, gpr0, cg);
+      instr = new (INSN_HEAP) TR::S390RegInstruction(TR::InstOpCode::BCR, node, cond, gpr0, cg);
 
    return instr;
    }
@@ -3224,7 +3224,7 @@ generateExtendedHighWordInstruction(TR::Node * node, TR::CodeGenerator *cg, TR::
             break;
          }
 
-      ((TR_S390RIEInstruction *)cursor)->setExtendedHighWordOpCode(op);
+      ((TR::S390RIEInstruction *)cursor)->setExtendedHighWordOpCode(op);
 
       if (debugObj)
          {

--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -72,7 +72,7 @@
 #include "z/codegen/S390OutOfLineCodeSection.hpp"
 
 void
-TR_S390RSInstruction::generateAdditionalSourceRegisters(TR::Register * fReg, TR::Register *lReg)
+TR::S390RSInstruction::generateAdditionalSourceRegisters(TR::Register * fReg, TR::Register *lReg)
    {
 
    int32_t firstRegNum = toRealRegister(fReg)->getRegisterNumber();
@@ -95,7 +95,7 @@ TR_S390RSInstruction::generateAdditionalSourceRegisters(TR::Register * fReg, TR:
    }
 
 uint8_t *
-TR_S390EInstruction::generateBinaryEncoding()
+TR::S390EInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -113,7 +113,7 @@ TR_S390EInstruction::generateBinaryEncoding()
    }
 
 uint8_t *
-TR_S390IEInstruction::generateBinaryEncoding()
+TR::S390IEInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -157,7 +157,7 @@ bool isLoopEntryAlignmentEnabled(TR::Compilation *comp)
  * Determines whether the given instruction should be aligned with NOPs.
  * Currently, it supports alignment of loop entry blocks.
  */
-bool TR_S390LabeledInstruction::isNopCandidate()
+bool TR::S390LabeledInstruction::isNopCandidate()
    {
    TR::Compilation *comp = cg()->comp();
    if (!isLoopEntryAlignmentEnabled(comp))
@@ -248,7 +248,7 @@ bool TR_S390LabeledInstruction::isNopCandidate()
 
 
 ////////////////////////////////////////////////////////
-// TR_S390LabelInstruction:: member functions
+// TR::S390LabelInstruction:: member functions
 ////////////////////////////////////////////////////////
 
 /**
@@ -262,7 +262,7 @@ bool TR_S390LabeledInstruction::isNopCandidate()
  *
  */
 uint8_t *
-TR_S390LabelInstruction::generateBinaryEncoding()
+TR::S390LabelInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -294,7 +294,7 @@ TR_S390LabelInstruction::generateBinaryEncoding()
             {
             TR::Instruction *thisInst = this;
             TR::Instruction *prevInst = getPrev();
-            traceMsg(comp,"\tTR_S390LabeledInstruction %p (%s) at cursor %p (skipThisOne=%s, offset = %p, codeStart %p)\n",
+            traceMsg(comp,"\tTR::S390LabeledInstruction %p (%s) at cursor %p (skipThisOne=%s, offset = %p, codeStart %p)\n",
                this,comp->getDebug()->getOpCodeName(&thisInst->getOpCode()),instructionStart,isSkipForLabelTargetNOPs()?"true":"false",
                offsetForLabelTargetNOPs,cg()->getCodeStart());
             traceMsg(comp,"\tprev %p (%s)\n",
@@ -431,21 +431,21 @@ TR_S390LabelInstruction::generateBinaryEncoding()
          uint8_t *curBeforeNOPs = cursor;
          if(offset<=250)
             {
-            instr = new (cg()->trHeapMemory()) TR_S390NOPInstruction(TR::InstOpCode::NOP, 6, getNode(), prevInstr, cg());
+            instr = new (cg()->trHeapMemory()) TR::S390NOPInstruction(TR::InstOpCode::NOP, 6, getNode(), prevInstr, cg());
             if (doUseLabelTargetNOPs && traceLabelTargetNOPs)
                traceMsg(comp,"\tgen 6 byte NOP at offset %lld\n",offset);
             instr->setEstimatedBinaryLength(6);
             }
          else if(offset<=252)
             {
-            instr = new (cg()->trHeapMemory()) TR_S390NOPInstruction(TR::InstOpCode::NOP, 4, getNode(), prevInstr, cg());
+            instr = new (cg()->trHeapMemory()) TR::S390NOPInstruction(TR::InstOpCode::NOP, 4, getNode(), prevInstr, cg());
             if (doUseLabelTargetNOPs && traceLabelTargetNOPs)
                traceMsg(comp,"\tgen 4 byte NOP at offset %lld\n",offset);
             instr->setEstimatedBinaryLength(4);
             }
          else if(offset<=254)
             {
-            instr = new (cg()->trHeapMemory()) TR_S390NOPInstruction(TR::InstOpCode::NOP, 2, getNode(), prevInstr, cg());
+            instr = new (cg()->trHeapMemory()) TR::S390NOPInstruction(TR::InstOpCode::NOP, 2, getNode(), prevInstr, cg());
             if (doUseLabelTargetNOPs && traceLabelTargetNOPs)
                traceMsg(comp,"\tgen 2 byte NOP at offset %lld\n",offset);
             instr->setEstimatedBinaryLength(2);
@@ -487,7 +487,7 @@ TR_S390LabelInstruction::generateBinaryEncoding()
    }
 
 bool
-TR_S390LabelInstruction::considerForLabelTargetNOPs(bool inEncodingPhase)
+TR::S390LabelInstruction::considerForLabelTargetNOPs(bool inEncodingPhase)
    {
    TR::Compilation *comp = cg()->comp();
    TR::Instruction *thisInst = this;
@@ -533,7 +533,7 @@ TR_S390LabelInstruction::considerForLabelTargetNOPs(bool inEncodingPhase)
 
 
 int32_t
-TR_S390LabelInstruction::estimateBinaryLength(int32_t  currentEstimate)
+TR::S390LabelInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
    // *this    swipeable for debugging purposes
    if (getLabelSymbol() != NULL)
@@ -592,7 +592,7 @@ TR_S390LabelInstruction::estimateBinaryLength(int32_t  currentEstimate)
    }
 
 void
-TR_S390LabelInstruction::assignRegistersAndDependencies(TR_RegisterKinds kindToBeAssigned)
+TR::S390LabelInstruction::assignRegistersAndDependencies(TR_RegisterKinds kindToBeAssigned)
    {
    // *this    swipeable for debugging purposes
    //
@@ -633,11 +633,11 @@ TR_S390LabelInstruction::assignRegistersAndDependencies(TR_RegisterKinds kindToB
    }
 
 ////////////////////////////////////////////////////////
-// TR_S390BranchInstruction:: member functions
+// TR::S390BranchInstruction:: member functions
 ////////////////////////////////////////////////////////
 
 void
-TR_S390BranchInstruction::assignRegistersAndDependencies(TR_RegisterKinds kindToBeAssigned)
+TR::S390BranchInstruction::assignRegistersAndDependencies(TR_RegisterKinds kindToBeAssigned)
    {
    // *this    swipeable for debugging purposes
    //
@@ -732,7 +732,7 @@ TR_S390BranchInstruction::assignRegistersAndDependencies(TR_RegisterKinds kindTo
  *     since they don't have long branch equivalents for themselves.
  */
 uint8_t *
-TR_S390BranchInstruction::generateBinaryEncoding()
+TR::S390BranchInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -830,7 +830,7 @@ TR_S390BranchInstruction::generateBinaryEncoding()
    }
 
 int32_t
-TR_S390BranchInstruction::estimateBinaryLength(int32_t  currentEstimate)
+TR::S390BranchInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
    // *this    swipeable for debugging purposes
    int32_t length = 6;
@@ -842,7 +842,7 @@ TR_S390BranchInstruction::estimateBinaryLength(int32_t  currentEstimate)
 
 
 ////////////////////////////////////////////////////////
-// TR_S390BranchOnCountInstruction:: member functions
+// TR::S390BranchOnCountInstruction:: member functions
 ////////////////////////////////////////////////////////
 
 /**
@@ -866,7 +866,7 @@ TR_S390BranchInstruction::estimateBinaryLength(int32_t  currentEstimate)
  *     BCRL 0xf, label
  */
 uint8_t *
-TR_S390BranchOnCountInstruction::generateBinaryEncoding()
+TR::S390BranchOnCountInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -974,7 +974,7 @@ TR_S390BranchOnCountInstruction::generateBinaryEncoding()
    }
 
 int32_t
-TR_S390BranchOnCountInstruction::estimateBinaryLength(int32_t  currentEstimate)
+TR::S390BranchOnCountInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
    // *this    swipeable for debugging purposes
    setEstimatedBinaryLength(getOpCode().getInstructionLength());
@@ -984,7 +984,7 @@ TR_S390BranchOnCountInstruction::estimateBinaryLength(int32_t  currentEstimate)
    }
 
 bool
-TR_S390BranchOnCountInstruction::refsRegister(TR::Register * reg)
+TR::S390BranchOnCountInstruction::refsRegister(TR::Register * reg)
    {
    // *this    swipeable for debugging purposes
    if (matchesAnyRegister(reg, getRegisterOperand(1)))
@@ -1018,7 +1018,7 @@ TR_S390BranchOnCountInstruction::refsRegister(TR::Register * reg)
  *     LD: could do better for long displacement on N3 and 64bit--TODO
  */
 uint8_t *
-TR_S390BranchOnIndexInstruction::generateBinaryEncoding()
+TR::S390BranchOnIndexInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -1067,7 +1067,7 @@ TR_S390BranchOnIndexInstruction::generateBinaryEncoding()
    else
       {
       TR_ASSERT(cg()->isExtCodeBaseFreeForAssignment() == false,
-         "TR_S390BranchOnIndexInstruction::generateBinaryEncoding -- Ext Code Base was wrongly released\n");
+         "TR::S390BranchOnIndexInstruction::generateBinaryEncoding -- Ext Code Base was wrongly released\n");
 
       TR::InstOpCode::Mnemonic opCode = getOpCodeValue();
       TR_ASSERT((opCode == TR::InstOpCode::BRXLE) || (opCode == TR::InstOpCode::BRXH) || (opCode == TR::InstOpCode::BRXLG) || (opCode == TR::InstOpCode::BRXHG),
@@ -1144,7 +1144,7 @@ TR_S390BranchOnIndexInstruction::generateBinaryEncoding()
    }
 
 int32_t
-TR_S390BranchOnIndexInstruction::estimateBinaryLength(int32_t  currentEstimate)
+TR::S390BranchOnIndexInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
    // *this    swipeable for debugging purposes
    setEstimatedBinaryLength(getOpCode().getInstructionLength());
@@ -1162,7 +1162,7 @@ TR_S390BranchOnIndexInstruction::estimateBinaryLength(int32_t  currentEstimate)
    }
 
 bool
-TR_S390BranchOnIndexInstruction::refsRegister(TR::Register * reg)
+TR::S390BranchOnIndexInstruction::refsRegister(TR::Register * reg)
    {
    // *this    swipeable for debugging purposes
    if (matchesAnyRegister(reg, getRegisterOperand(1), getRegisterOperand(2)))
@@ -1177,11 +1177,11 @@ TR_S390BranchOnIndexInstruction::refsRegister(TR::Register * reg)
    }
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390FenceInstruction:: member functions
+// TR::S390FenceInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
 
 uint8_t *
-TR_S390PseudoInstruction::generateBinaryEncoding()
+TR::S390PseudoInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -1261,7 +1261,7 @@ TR_S390PseudoInstruction::generateBinaryEncoding()
 
 
 int32_t
-TR_S390PseudoInstruction::estimateBinaryLength(int32_t currentEstimate)
+TR::S390PseudoInstruction::estimateBinaryLength(int32_t currentEstimate)
    {
    int32_t estimate = (getOpCodeValue() == TR::InstOpCode::XPCALLDESC) ? 18 : 0;
 
@@ -1269,13 +1269,13 @@ TR_S390PseudoInstruction::estimateBinaryLength(int32_t currentEstimate)
    return currentEstimate + estimate;
    }
 
-// TR_S390ImmInstruction:: member functions
+// TR::S390ImmInstruction:: member functions
 /**
  * This instruction is used to generate a constant value in JIT code
  * so the valid opcode is TR::InstOpCode::DC
  */
 uint8_t *
-TR_S390ImmInstruction::generateBinaryEncoding()
+TR::S390ImmInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -1332,21 +1332,21 @@ TR_S390ImmInstruction::generateBinaryEncoding()
  * The following safe virtual downcast method is only used in an assertion
  * check within "toS390ImmInstruction"
  */
-TR_S390ImmInstruction *
-TR_S390ImmInstruction::getS390ImmInstruction()
+TR::S390ImmInstruction *
+TR::S390ImmInstruction::getS390ImmInstruction()
    {
    // *this    swipeable for debugging purposes
    return this;
    }
 #endif
 
-// TR_S390ImmInstruction:: member functions
+// TR::S390ImmInstruction:: member functions
 /**
  * This instruction is used to generate a constant value in JIT code
  * so the valid opcode is TR::InstOpCode::DC
  */
 uint8_t *
-TR_S390Imm2Instruction::generateBinaryEncoding()
+TR::S390Imm2Instruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -1381,9 +1381,9 @@ TR_S390Imm2Instruction::generateBinaryEncoding()
    return cursor;
    }
 
-// TR_S390ImmSnippetInstruction:: member functions
+// TR::S390ImmSnippetInstruction:: member functions
 uint8_t *
-TR_S390ImmSnippetInstruction::generateBinaryEncoding()
+TR::S390ImmSnippetInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -1400,10 +1400,10 @@ TR_S390ImmSnippetInstruction::generateBinaryEncoding()
    }
 
 ///////////////////////////////////////////////////////////
-// TR_S390ImmSymInstruction:: member functions
+// TR::S390ImmSymInstruction:: member functions
 ///////////////////////////////////////////////////////////
 uint8_t *
-TR_S390ImmSymInstruction::generateBinaryEncoding()
+TR::S390ImmSymInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -1422,10 +1422,10 @@ TR_S390ImmSymInstruction::generateBinaryEncoding()
    }
 
 ///////////////////////////////////////////////////////
-// TR_S390RegInstruction:: member functions
+// TR::S390RegInstruction:: member functions
 ///////////////////////////////////////////////////////
 bool
-TR_S390RegInstruction::refsRegister(TR::Register * reg)
+TR::S390RegInstruction::refsRegister(TR::Register * reg)
    {
    // *this    swipeable for debugging purposes
    if (matchesTargetRegister(reg))
@@ -1440,7 +1440,7 @@ TR_S390RegInstruction::refsRegister(TR::Register * reg)
    }
 
 uint8_t *
-TR_S390RegInstruction::generateBinaryEncoding()
+TR::S390RegInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -1467,7 +1467,7 @@ TR_S390RegInstruction::generateBinaryEncoding()
    }
 
 void
-TR_S390RegInstruction::assignRegistersNoDependencies(TR_RegisterKinds kindToBeAssigned)
+TR::S390RegInstruction::assignRegistersNoDependencies(TR_RegisterKinds kindToBeAssigned)
    {
    TR::Machine *machine = cg()->machine();
    setRegisterOperand(1,machine->assignBestRegister(getRegisterOperand(1), this, BOOKKEEPING));
@@ -1475,10 +1475,10 @@ TR_S390RegInstruction::assignRegistersNoDependencies(TR_RegisterKinds kindToBeAs
    return;
    }
 
-// TR_S390RRInstruction:: member functions /////////////////////////////////////////
+// TR::S390RRInstruction:: member functions /////////////////////////////////////////
 
 bool
-TR_S390RRInstruction::refsRegister(TR::Register * reg)
+TR::S390RRInstruction::refsRegister(TR::Register * reg)
    {
    // *this    swipeable for debugging purposes
    if (matchesTargetRegister(reg) || matchesAnyRegister(reg, getRegisterOperand(2)))
@@ -1493,7 +1493,7 @@ TR_S390RRInstruction::refsRegister(TR::Register * reg)
    }
 
 uint8_t *
-TR_S390RRInstruction::generateBinaryEncoding()
+TR::S390RRInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -1546,7 +1546,7 @@ TR_S390RRInstruction::generateBinaryEncoding()
 //  TranslateInstruction
 
 bool
-TR_S390TranslateInstruction::refsRegister(TR::Register * reg)
+TR::S390TranslateInstruction::refsRegister(TR::Register * reg)
    {
    if (matchesAnyRegister(reg, getRegisterOperand(1)) ||
       matchesAnyRegister(reg, getTableRegister()) ||
@@ -1563,7 +1563,7 @@ TR_S390TranslateInstruction::refsRegister(TR::Register * reg)
    }
 
 uint8_t *
-TR_S390TranslateInstruction::generateBinaryEncoding()
+TR::S390TranslateInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -1590,10 +1590,10 @@ TR_S390TranslateInstruction::generateBinaryEncoding()
    }
 
 
-// TR_S390RRFInstruction:: member functions /////////////////////////////////////////
+// TR::S390RRFInstruction:: member functions /////////////////////////////////////////
 
 bool
-TR_S390RRFInstruction::refsRegister(TR::Register * reg)
+TR::S390RRFInstruction::refsRegister(TR::Register * reg)
    {
    // *this    swipeable for debugging purposes
    if (matchesTargetRegister(reg) || matchesAnyRegister(reg, getRegisterOperand(2)) ||
@@ -1609,7 +1609,7 @@ TR_S390RRFInstruction::refsRegister(TR::Register * reg)
    }
 
 uint8_t *
-TR_S390RRFInstruction::generateBinaryEncoding()
+TR::S390RRFInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -1748,10 +1748,10 @@ TR_S390RRFInstruction::generateBinaryEncoding()
    return cursor;
    }
 
-// TR_S390RRRInstruction:: member functions /////////////////////////////////////////
+// TR::S390RRRInstruction:: member functions /////////////////////////////////////////
 
 bool
-TR_S390RRRInstruction::refsRegister(TR::Register * reg)
+TR::S390RRRInstruction::refsRegister(TR::Register * reg)
    {
    // *this    swipeable for debugging purposes
    if (matchesTargetRegister(reg) || matchesAnyRegister(reg, getRegisterOperand(2)) ||
@@ -1767,7 +1767,7 @@ TR_S390RRRInstruction::refsRegister(TR::Register * reg)
    }
 
 uint8_t *
-TR_S390RRRInstruction::generateBinaryEncoding()
+TR::S390RRRInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -1805,7 +1805,7 @@ TR_S390RRRInstruction::generateBinaryEncoding()
    }
 
 ////////////////////////////////////////////////////////////////////////////
-// TR_S390RIInstruction:: member functions
+// TR::S390RIInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////
 
 /**
@@ -1817,7 +1817,7 @@ TR_S390RRRInstruction::generateBinaryEncoding()
  *
  */
 uint8_t *
-TR_S390RIInstruction::generateBinaryEncoding()
+TR::S390RIInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -1853,7 +1853,7 @@ TR_S390RIInstruction::generateBinaryEncoding()
    }
 
 ////////////////////////////////////////////////////////////////////////////
-// TR_S390RILInstruction:: member functions
+// TR::S390RILInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////
 
 /**
@@ -1864,7 +1864,7 @@ TR_S390RIInstruction::generateBinaryEncoding()
  *   0         8   12   16                            47
  */
 bool
-TR_S390RILInstruction::refsRegister(TR::Register * reg)
+TR::S390RILInstruction::refsRegister(TR::Register * reg)
    {
    // *this    swipeable for debugging purposes
    if (reg == getRegisterOperand(1))
@@ -1879,7 +1879,7 @@ TR_S390RILInstruction::refsRegister(TR::Register * reg)
    }
 
 int32_t
-TR_S390RILInstruction::estimateBinaryLength(int32_t  currentEstimate)
+TR::S390RILInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
    int32_t delta = 0;
    TR::Compilation *comp = cg()->comp();
@@ -1952,7 +1952,7 @@ TR_S390RILInstruction::estimateBinaryLength(int32_t  currentEstimate)
  * @return offset to target address in half words
  */
 int32_t
-TR_S390RILInstruction::adjustCallOffsetWithTrampoline(int32_t offset, uint8_t * currentInst)
+TR::S390RILInstruction::adjustCallOffsetWithTrampoline(int32_t offset, uint8_t * currentInst)
    {
    int32_t offsetHalfWords = offset;
 
@@ -1978,7 +1978,7 @@ TR_S390RILInstruction::adjustCallOffsetWithTrampoline(int32_t offset, uint8_t * 
    }
 
 uint8_t *
-TR_S390RILInstruction::generateBinaryEncoding()
+TR::S390RILInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -2053,14 +2053,14 @@ TR_S390RILInstruction::generateBinaryEncoding()
                   getOpCode().getOpCodeValue() == TR::InstOpCode::LGFRL  ||
                   getOpCode().getOpCodeValue() == TR::InstOpCode::LLGFRL )
             {
-            scratchReg = (TR::RealRegister * )((TR_S390RegInstruction *)this)->getRegisterOperand(1);
+            scratchReg = (TR::RealRegister * )((TR::S390RegInstruction *)this)->getRegisterOperand(1);
             }
          else if (getOpCode().getOpCodeValue() == TR::InstOpCode::STGRL ||
                   getOpCode().getOpCodeValue() == TR::InstOpCode::STRL ||
                   getOpCode().getOpCodeValue() == TR::InstOpCode::LRL)
             {
             scratchReg  = assignBestSpillRegister();
-            sourceReg  = (TR::RealRegister * )((TR_S390RegInstruction *)this)->getRegisterOperand(1);
+            sourceReg  = (TR::RealRegister * )((TR::S390RegInstruction *)this)->getRegisterOperand(1);
 
             spillNeeded = true;
             }
@@ -2507,7 +2507,7 @@ TR_S390RILInstruction::generateBinaryEncoding()
  *       targetReg => R1,                                            sourceImm => D2  ... (SLL,...)
  */
 int32_t
-TR_S390RSInstruction::estimateBinaryLength(int32_t  currentEstimate)
+TR::S390RSInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
    // *this    swipeable for debugging purposes
    if (getMemoryReference() != NULL)
@@ -2521,7 +2521,7 @@ TR_S390RSInstruction::estimateBinaryLength(int32_t  currentEstimate)
    }
 
 uint8_t *
-TR_S390RSInstruction::generateBinaryEncoding()
+TR::S390RSInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -2584,7 +2584,7 @@ TR_S390RSInstruction::generateBinaryEncoding()
    }
 
 
-// TR_S390RRSInstruction:: member functions
+// TR::S390RRSInstruction:: member functions
 
 /**
  * RRS Format
@@ -2594,7 +2594,7 @@ TR_S390RSInstruction::generateBinaryEncoding()
  * 0         8   12   16   20           32   36   40       47
  */
 uint8_t *
-TR_S390RRSInstruction::generateBinaryEncoding()
+TR::S390RRSInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
 
@@ -2650,7 +2650,7 @@ TR_S390RRSInstruction::generateBinaryEncoding()
    }
 
 
-// TR_S390RIEInstruction:: member functions
+// TR::S390RIEInstruction:: member functions
 /**
  *    RIE Format
  *
@@ -2690,7 +2690,7 @@ TR_S390RRSInstruction::generateBinaryEncoding()
  *    0         8   12   16                32  36    40       47
  */
 int32_t
-TR_S390RIEInstruction::estimateBinaryLength(int32_t  currentEstimate)
+TR::S390RIEInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
    // *this    swipeable for debugging purposes
    if (getBranchDestinationLabel())
@@ -2701,18 +2701,18 @@ TR_S390RIEInstruction::estimateBinaryLength(int32_t  currentEstimate)
    }
 
 uint8_t *
-TR_S390RIEInstruction::generateBinaryEncoding()
+TR::S390RIEInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
 
 
    // let's determine what form of RIE we are dealing with
-   bool RIE1 = (getRieForm() == TR_S390RIEInstruction::RIE_RR);
-   bool RIE2 = (getRieForm() == TR_S390RIEInstruction::RIE_RI8);
-   bool RIE3 = (getRieForm() == TR_S390RIEInstruction::RIE_RI16A);
-   bool RIE4 = (getRieForm() == TR_S390RIEInstruction::RIE_RRI16);
-   bool RIE5 = (getRieForm() == TR_S390RIEInstruction::RIE_IMM);
-   bool RIE6 = (getRieForm() == TR_S390RIEInstruction::RIE_RI16G);
+   bool RIE1 = (getRieForm() == TR::S390RIEInstruction::RIE_RR);
+   bool RIE2 = (getRieForm() == TR::S390RIEInstruction::RIE_RI8);
+   bool RIE3 = (getRieForm() == TR::S390RIEInstruction::RIE_RI16A);
+   bool RIE4 = (getRieForm() == TR::S390RIEInstruction::RIE_RRI16);
+   bool RIE5 = (getRieForm() == TR::S390RIEInstruction::RIE_IMM);
+   bool RIE6 = (getRieForm() == TR::S390RIEInstruction::RIE_RI16G);
 
    // acquire the current cursor location so we can start generating our
    // instruction there.
@@ -2994,7 +2994,7 @@ TR_S390RIEInstruction::generateBinaryEncoding()
  * like its done for JAVA
  */
 uint8_t *
-TR_S390RIEInstruction::splitIntoCompareAndLongBranch(void)
+TR::S390RIEInstruction::splitIntoCompareAndLongBranch(void)
    {
 
    //Generate equivalent Compare instruction
@@ -3089,7 +3089,7 @@ TR_S390RIEInstruction::splitIntoCompareAndLongBranch(void)
  * the combined compare and branch instruction.
  */
 void
-TR_S390RIEInstruction::splitIntoCompareAndBranch(TR::Instruction *insertBranchAfterThis)
+TR::S390RIEInstruction::splitIntoCompareAndBranch(TR::Instruction *insertBranchAfterThis)
    {
 
    //Generate equivalent Compare instruction
@@ -3163,7 +3163,7 @@ TR_S390RIEInstruction::splitIntoCompareAndBranch(TR::Instruction *insertBranchAf
    }
 
 
-// TR_S390RISInstruction:: member functions
+// TR::S390RISInstruction:: member functions
 /**
  *    RIS Format
  *
@@ -3173,7 +3173,7 @@ TR_S390RIEInstruction::splitIntoCompareAndBranch(TR::Instruction *insertBranchAf
  *    0         8   12   16   20           32        40       47
  */
 uint8_t *
-TR_S390RISInstruction::generateBinaryEncoding()
+TR::S390RISInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
 
@@ -3230,10 +3230,10 @@ TR_S390RISInstruction::generateBinaryEncoding()
 
 
 
-// TR_S390MemInstruction:: member functions
+// TR::S390MemInstruction:: member functions
 
 bool
-TR_S390MemInstruction::refsRegister(TR::Register * reg)
+TR::S390MemInstruction::refsRegister(TR::Register * reg)
    {
    // *this    swipeable for debugging purposes
    // 64bit mem refs clobber high word regs
@@ -3266,7 +3266,7 @@ TR_S390MemInstruction::refsRegister(TR::Register * reg)
    }
 
 uint8_t *
-TR_S390MemInstruction::generateBinaryEncoding()
+TR::S390MemInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -3289,9 +3289,9 @@ TR_S390MemInstruction::generateBinaryEncoding()
    return cursor;
    }
 
-// TR_S390RXInstruction:: member functions
+// TR::S390RXInstruction:: member functions
 bool
-TR_S390RXInstruction::refsRegister(TR::Register * reg)
+TR::S390RXInstruction::refsRegister(TR::Register * reg)
    {
    // *this    swipeable for debugging purposes
    // 64bit mem refs clobber high word regs
@@ -3328,7 +3328,7 @@ TR_S390RXInstruction::refsRegister(TR::Register * reg)
    }
 
 int32_t
-TR_S390RXInstruction::estimateBinaryLength(int32_t  currentEstimate)
+TR::S390RXInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
    if (getMemoryReference() != NULL)
       {
@@ -3341,7 +3341,7 @@ TR_S390RXInstruction::estimateBinaryLength(int32_t  currentEstimate)
    }
 
 uint8_t *
-TR_S390RXInstruction::generateBinaryEncoding()
+TR::S390RXInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -3359,7 +3359,7 @@ TR_S390RXInstruction::generateBinaryEncoding()
       }
    else
       {
-      TR_ASSERT( (getConstForMRField() & 0xFFF00000) == 0, "TR_S390RXInstruction::_constForMRField greater than 0x000FFFFF for instruction 0x%x", this);
+      TR_ASSERT( (getConstForMRField() & 0xFFF00000) == 0, "TR::S390RXInstruction::_constForMRField greater than 0x000FFFFF for instruction 0x%x", this);
       (*(uint32_t *) cursor) |= boi(0x000FFFFF & getConstForMRField());
       }
 
@@ -3390,7 +3390,7 @@ TR_S390RXInstruction::generateBinaryEncoding()
    }
 
 int32_t
-TR_S390RXEInstruction::estimateBinaryLength(int32_t  currentEstimate)
+TR::S390RXEInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
    if (getMemoryReference() != NULL)
       {
@@ -3403,7 +3403,7 @@ TR_S390RXEInstruction::estimateBinaryLength(int32_t  currentEstimate)
    }
 
 uint8_t *
-TR_S390RXEInstruction::generateBinaryEncoding()
+TR::S390RXEInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -3419,7 +3419,7 @@ TR_S390RXEInstruction::generateBinaryEncoding()
       }
    else
       {
-      TR_ASSERT( (getConstForMRField() & 0xFFF00000) == 0, "TR_S390RXEInstruction::_constForMRField greater than 0x000FFFFF");
+      TR_ASSERT( (getConstForMRField() & 0xFFF00000) == 0, "TR::S390RXEInstruction::_constForMRField greater than 0x000FFFFF");
       (*(uint32_t *) cursor) &= boi(0xFF000000);
       (*(uint32_t *) cursor) |= boi(0x000FFFFF & getConstForMRField());
       }
@@ -3440,7 +3440,7 @@ TR_S390RXEInstruction::generateBinaryEncoding()
    }
 
 int32_t
-TR_S390RXYInstruction::estimateBinaryLength(int32_t  currentEstimate)
+TR::S390RXYInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
    if (getMemoryReference() != NULL)
       {
@@ -3453,7 +3453,7 @@ TR_S390RXYInstruction::estimateBinaryLength(int32_t  currentEstimate)
    }
 
 uint8_t *
-TR_S390RXYInstruction::generateBinaryEncoding()
+TR::S390RXYInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -3470,7 +3470,7 @@ TR_S390RXYInstruction::generateBinaryEncoding()
       }
    else
       {
-      TR_ASSERT( (getConstForMRField() & 0xFFF00000) == 0, "TR_S390RXYInstruction::_constForMRField greater than 0x000FFFFF");
+      TR_ASSERT( (getConstForMRField() & 0xFFF00000) == 0, "TR::S390RXYInstruction::_constForMRField greater than 0x000FFFFF");
       (*(uint32_t *) cursor) &= boi(0xFF000000);
       (*(uint32_t *) cursor) |= boi(0x000FFFFF & getConstForMRField());
       }
@@ -3501,16 +3501,16 @@ TR_S390RXYInstruction::generateBinaryEncoding()
    return cursor;
    }
 
-// TR_S390RXFInstruction:: member functions /////////////////////////////////////////
+// TR::S390RXFInstruction:: member functions /////////////////////////////////////////
 
 int32_t
-TR_S390RXFInstruction::estimateBinaryLength(int32_t  currentEstimate)
+TR::S390RXFInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
    return getMemoryReference()->estimateBinaryLength(currentEstimate, cg(), this);
    }
 
 bool
-TR_S390RXFInstruction::refsRegister(TR::Register * reg)
+TR::S390RXFInstruction::refsRegister(TR::Register * reg)
    {
    // *this    swipeable for debugging purposes
    // 64bit mem refs clobber high word regs
@@ -3543,7 +3543,7 @@ TR_S390RXFInstruction::refsRegister(TR::Register * reg)
    }
 
 uint8_t *
-TR_S390RXFInstruction::generateBinaryEncoding()
+TR::S390RXFInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -3615,14 +3615,14 @@ getOpCodeName(TR::InstOpCode * opCode)
    return TR::InstOpCode::opCodeToNameMap[opCode->getOpCodeValue()];
    }
 
-TR_S390VInstruction::~TR_S390VInstruction()
+TR::S390VInstruction::~S390VInstruction()
    {
    if (_opCodeBuffer)
       TR::Instruction::jitPersistentFree((char *)_opCodeBuffer);
    }
 
 int32_t
-TR_S390VInstruction::estimateBinaryLength(int32_t  currentEstimate)
+TR::S390VInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
    setEstimatedBinaryLength(getOpCode().getInstructionLength());
 
@@ -3630,7 +3630,7 @@ TR_S390VInstruction::estimateBinaryLength(int32_t  currentEstimate)
    }
 
 char *
-TR_S390VInstruction::setOpCodeBuffer(char *c)
+TR::S390VInstruction::setOpCodeBuffer(char *c)
    {
    if (_opCodeBuffer)
       TR_ASSERT(false, "trying to set OpCodeBuffer after it has already been set!\n");
@@ -3641,7 +3641,7 @@ TR_S390VInstruction::setOpCodeBuffer(char *c)
 
 /**** VRI ***/
 const char *
-TR_S390VRIInstruction::getExtendedMnemonicName()
+TR::S390VRIInstruction::getExtendedMnemonicName()
    {
    if (getOpCodeBuffer())
       return getOpCodeBuffer();
@@ -3692,7 +3692,7 @@ TR_S390VRIInstruction::getExtendedMnemonicName()
    }
 
 uint8_t *
-TR_S390VRIInstruction::generateBinaryEncoding()
+TR::S390VRIInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -3736,47 +3736,47 @@ TR_S390VRIInstruction::generateBinaryEncoding()
  * VRI-a
  */
 uint8_t *
-TR_S390VRIaInstruction::generateBinaryEncoding()
+TR::S390VRIaInstruction::generateBinaryEncoding()
    {
    // Error Checking
    TR_ASSERT(getRegisterOperand(1) != NULL, "First Operand should not be NULL!");
 
    // Generate Binary Encoding
-   return TR_S390VRIInstruction::generateBinaryEncoding();
+   return TR::S390VRIInstruction::generateBinaryEncoding();
    }
 
 /**
  * VRI-b
  */
 uint8_t *
-TR_S390VRIbInstruction::generateBinaryEncoding()
+TR::S390VRIbInstruction::generateBinaryEncoding()
    {
    // Error Checking
    TR_ASSERT(getRegisterOperand(1) != NULL, "First Operand should not be NULL!");
 
    // Generate Binary Encoding
-   return TR_S390VRIInstruction::generateBinaryEncoding();
+   return TR::S390VRIInstruction::generateBinaryEncoding();
    }
 
 /**
  * VRI-c
  */
 uint8_t *
-TR_S390VRIcInstruction::generateBinaryEncoding()
+TR::S390VRIcInstruction::generateBinaryEncoding()
    {
    // Error Checking
    TR_ASSERT(getRegisterOperand(1) != NULL, "First Operand should not be NULL!");
    TR_ASSERT(getRegisterOperand(2) != NULL, "2nd Operand should not be NULL!");
 
    // Generate Binary Encoding
-   return TR_S390VRIInstruction::generateBinaryEncoding();
+   return TR::S390VRIInstruction::generateBinaryEncoding();
    }
 
 /**
  * VRI-d
  */
 uint8_t *
-TR_S390VRIdInstruction::generateBinaryEncoding()
+TR::S390VRIdInstruction::generateBinaryEncoding()
    {
    // Error Checking
    TR_ASSERT(getRegisterOperand(1) != NULL, "First Operand should not be NULL!");
@@ -3784,28 +3784,28 @@ TR_S390VRIdInstruction::generateBinaryEncoding()
    TR_ASSERT(getRegisterOperand(3) != NULL, "3rd Operand should not be NULL!");
 
    // Generate Binary Encoding
-   return TR_S390VRIInstruction::generateBinaryEncoding();
+   return TR::S390VRIInstruction::generateBinaryEncoding();
    }
 
 /**
  * VRI-e
  */
 uint8_t *
-TR_S390VRIeInstruction::generateBinaryEncoding()
+TR::S390VRIeInstruction::generateBinaryEncoding()
    {
    // Error Checking
    TR_ASSERT(getRegisterOperand(1) != NULL, "First Operand should not be NULL!");
    TR_ASSERT(getRegisterOperand(2) != NULL, "2nd Operand should not be NULL!");
 
    // Generate Binary Encoding
-   return TR_S390VRIInstruction::generateBinaryEncoding();
+   return TR::S390VRIInstruction::generateBinaryEncoding();
    }
 
 /**
  * VRR
  */
 const char *
-TR_S390VRRInstruction::getExtendedMnemonicName()
+TR::S390VRRInstruction::getExtendedMnemonicName()
    {
    if (getOpCodeBuffer())
       return getOpCodeBuffer();
@@ -3949,7 +3949,7 @@ TR_S390VRRInstruction::getExtendedMnemonicName()
    }
 
 uint8_t *
-TR_S390VRRInstruction::generateBinaryEncoding()
+TR::S390VRRInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -4001,21 +4001,21 @@ TR_S390VRRInstruction::generateBinaryEncoding()
  * VRR-a
  */
 uint8_t *
-TR_S390VRRaInstruction::generateBinaryEncoding()
+TR::S390VRRaInstruction::generateBinaryEncoding()
    {
    // Error Checking
    TR_ASSERT(getRegisterOperand(1) != NULL, "First Operand should not be NULL!");
    TR_ASSERT(getRegisterOperand(2) != NULL, "2nd Operand should not be NULL!");
 
    // Generate Binary Encoding
-   return TR_S390VRRInstruction::generateBinaryEncoding();
+   return TR::S390VRRInstruction::generateBinaryEncoding();
    }
 
 /**
  * VRR-b
  */
 uint8_t *
-TR_S390VRRbInstruction::generateBinaryEncoding()
+TR::S390VRRbInstruction::generateBinaryEncoding()
    {
    // Error Checking
    TR_ASSERT(getRegisterOperand(1) != NULL, "First Operand should not be NULL!");
@@ -4023,14 +4023,14 @@ TR_S390VRRbInstruction::generateBinaryEncoding()
    TR_ASSERT(getRegisterOperand(3) != NULL, "3rd Operand should not be NULL!");
 
    // Generate Binary Encoding
-   return TR_S390VRRInstruction::generateBinaryEncoding();
+   return TR::S390VRRInstruction::generateBinaryEncoding();
    }
 
 /**
  * VRR-c
  */
 uint8_t *
-TR_S390VRRcInstruction::generateBinaryEncoding()
+TR::S390VRRcInstruction::generateBinaryEncoding()
    {
    // Error Checking
    TR_ASSERT(getRegisterOperand(1) != NULL, "First Operand should not be NULL!");
@@ -4038,14 +4038,14 @@ TR_S390VRRcInstruction::generateBinaryEncoding()
    TR_ASSERT(getRegisterOperand(3) != NULL, "3rd Operand should not be NULL!");
 
    // Generate Binary Encoding
-   return TR_S390VRRInstruction::generateBinaryEncoding();
+   return TR::S390VRRInstruction::generateBinaryEncoding();
    }
 
 /**
  * VRR-d
  */
 uint8_t *
-TR_S390VRRdInstruction::generateBinaryEncoding()
+TR::S390VRRdInstruction::generateBinaryEncoding()
    {
    // Error Checking
    TR_ASSERT(getRegisterOperand(1) != NULL, "First Operand should not be NULL!");
@@ -4054,14 +4054,14 @@ TR_S390VRRdInstruction::generateBinaryEncoding()
    TR_ASSERT(getRegisterOperand(4) != NULL, "4th Operand should not be NULL!");
 
    // Generate Binary Encoding
-   return TR_S390VRRInstruction::generateBinaryEncoding();
+   return TR::S390VRRInstruction::generateBinaryEncoding();
    }
 
 /**
  * VRR-e
  */
 uint8_t *
-TR_S390VRReInstruction::generateBinaryEncoding()
+TR::S390VRReInstruction::generateBinaryEncoding()
    {
    // Error Checking
    TR_ASSERT(getRegisterOperand(1) != NULL, "First Operand should not be NULL!");
@@ -4070,14 +4070,14 @@ TR_S390VRReInstruction::generateBinaryEncoding()
    TR_ASSERT(getRegisterOperand(4) != NULL, "4th Operand should not be NULL!");
 
    // Generate Binary Encoding
-   return TR_S390VRRInstruction::generateBinaryEncoding();
+   return TR::S390VRRInstruction::generateBinaryEncoding();
    }
 
 /**
  * VRR-f
  */
 uint8_t *
-TR_S390VRRfInstruction::generateBinaryEncoding()
+TR::S390VRRfInstruction::generateBinaryEncoding()
    {
    // Error Checking
    TR_ASSERT(getRegisterOperand(1) != NULL, "First Operand should not be NULL!");
@@ -4085,14 +4085,14 @@ TR_S390VRRfInstruction::generateBinaryEncoding()
    TR_ASSERT(getRegisterOperand(3) != NULL, "3rd Operand should not be NULL!");
 
    // Generate Binary Encoding
-   return TR_S390VRRInstruction::generateBinaryEncoding();
+   return TR::S390VRRInstruction::generateBinaryEncoding();
    }
 
 /**
  * VStorage
  */
 const char *
-TR_S390VStorageInstruction::getExtendedMnemonicName()
+TR::S390VStorageInstruction::getExtendedMnemonicName()
    {
    if (getOpCodeBuffer())
       return getOpCodeBuffer();
@@ -4110,7 +4110,7 @@ TR_S390VStorageInstruction::getExtendedMnemonicName()
    }
 
 uint8_t *
-TR_S390VStorageInstruction::generateBinaryEncoding()
+TR::S390VStorageInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -4177,34 +4177,34 @@ TR_S390VStorageInstruction::generateBinaryEncoding()
  * VRS-a
  */
 uint8_t *
-TR_S390VRSaInstruction::generateBinaryEncoding()
+TR::S390VRSaInstruction::generateBinaryEncoding()
    {
-   return TR_S390VStorageInstruction::generateBinaryEncoding();
+   return TR::S390VStorageInstruction::generateBinaryEncoding();
    }
 
 /**
  * VRS-b
  */
 uint8_t *
-TR_S390VRSbInstruction::generateBinaryEncoding()
+TR::S390VRSbInstruction::generateBinaryEncoding()
    {
-   return TR_S390VStorageInstruction::generateBinaryEncoding();
+   return TR::S390VStorageInstruction::generateBinaryEncoding();
    }
 
 /**
  * VRS-c
  */
 uint8_t *
-TR_S390VRScInstruction::generateBinaryEncoding()
+TR::S390VRScInstruction::generateBinaryEncoding()
    {
-   return TR_S390VStorageInstruction::generateBinaryEncoding();
+   return TR::S390VStorageInstruction::generateBinaryEncoding();
    }
 
 /**** VRV ****/
 uint8_t *
-TR_S390VRVInstruction::generateBinaryEncoding()
+TR::S390VRVInstruction::generateBinaryEncoding()
    {
-   return TR_S390VStorageInstruction::generateBinaryEncoding();
+   return TR::S390VStorageInstruction::generateBinaryEncoding();
    }
 
 /**** VRX ***/
@@ -4212,13 +4212,13 @@ TR_S390VRVInstruction::generateBinaryEncoding()
 TR::Instruction * breakInst = NULL;
 
 uint8_t *
-TR_S390VRXInstruction::generateBinaryEncoding()
+TR::S390VRXInstruction::generateBinaryEncoding()
    {
-   return TR_S390VStorageInstruction::generateBinaryEncoding();
+   return TR::S390VStorageInstruction::generateBinaryEncoding();
    }
 
 int32_t
-TR_S390VRXInstruction::estimateBinaryLength(int32_t  currentEstimate)
+TR::S390VRXInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
    if (getMemoryReference() != NULL)
       {
@@ -4231,10 +4231,10 @@ TR_S390VRXInstruction::estimateBinaryLength(int32_t  currentEstimate)
    }
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390MemMemInstruction:: member functions
+// TR::S390MemMemInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
 int32_t
-TR_S390MemMemInstruction::estimateBinaryLength(int32_t  currentEstimate)
+TR::S390MemMemInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
    int32_t length = 0;
    if (getMemoryReference() != NULL)
@@ -4248,7 +4248,7 @@ TR_S390MemMemInstruction::estimateBinaryLength(int32_t  currentEstimate)
    }
 
 uint8_t *
-TR_S390MemMemInstruction::generateBinaryEncoding()
+TR::S390MemMemInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -4291,10 +4291,10 @@ TR_S390MemMemInstruction::generateBinaryEncoding()
    }
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390SS1Instruction:: member functions
+// TR::S390SS1Instruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
 int32_t
-TR_S390SS1Instruction::estimateBinaryLength(int32_t  currentEstimate)
+TR::S390SS1Instruction::estimateBinaryLength(int32_t  currentEstimate)
    {
    int32_t length = 0;
    if (getMemoryReference() != NULL)
@@ -4308,7 +4308,7 @@ TR_S390SS1Instruction::estimateBinaryLength(int32_t  currentEstimate)
    }
 
 uint8_t *
-TR_S390SS1Instruction::generateBinaryEncoding()
+TR::S390SS1Instruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -4362,10 +4362,10 @@ TR_S390SS1Instruction::generateBinaryEncoding()
    }
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390SS2Instruction:: member functions
+// TR::S390SS2Instruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
 uint8_t *
-TR_S390SS2Instruction::generateBinaryEncoding()
+TR::S390SS2Instruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -4430,10 +4430,10 @@ TR_S390SS2Instruction::generateBinaryEncoding()
    }
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390SS2Instruction:: member functions
+// TR::S390SS2Instruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
 uint8_t *
-TR_S390SS4Instruction::generateBinaryEncoding()
+TR::S390SS4Instruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -4488,10 +4488,10 @@ TR_S390SS4Instruction::generateBinaryEncoding()
    }
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390SSFInstruction:: member functions
+// TR::S390SSFInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
 bool
-TR_S390SSFInstruction::refsRegister(TR::Register * reg)
+TR::S390SSFInstruction::refsRegister(TR::Register * reg)
    {
    // *this    swipeable for debugging purposes
    // 64bit mem refs clobber high word regs
@@ -4535,7 +4535,7 @@ TR_S390SSFInstruction::refsRegister(TR::Register * reg)
    }
 
 int32_t
-TR_S390SSFInstruction::estimateBinaryLength(int32_t  currentEstimate)
+TR::S390SSFInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
    if (getMemoryReference() != NULL)
       {
@@ -4548,7 +4548,7 @@ TR_S390SSFInstruction::estimateBinaryLength(int32_t  currentEstimate)
    }
 
 uint8_t *
-TR_S390SSFInstruction::generateBinaryEncoding()
+TR::S390SSFInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -4592,10 +4592,10 @@ TR_S390SSFInstruction::generateBinaryEncoding()
    }
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390RSLInstruction:: member functions
+// TR::S390RSLInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
 int32_t
-TR_S390RSLInstruction::estimateBinaryLength(int32_t  currentEstimate)
+TR::S390RSLInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
    if (getMemoryReference() != NULL)
       {
@@ -4608,7 +4608,7 @@ TR_S390RSLInstruction::estimateBinaryLength(int32_t  currentEstimate)
    }
 
 uint8_t *
-TR_S390RSLInstruction::generateBinaryEncoding()
+TR::S390RSLInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -4650,10 +4650,10 @@ TR_S390RSLInstruction::generateBinaryEncoding()
    }
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390RSLbInstruction:: member functions
+// TR::S390RSLbInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
 int32_t
-TR_S390RSLbInstruction::estimateBinaryLength(int32_t  currentEstimate)
+TR::S390RSLbInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
    if (getMemoryReference() != NULL)
       {
@@ -4666,7 +4666,7 @@ TR_S390RSLbInstruction::estimateBinaryLength(int32_t  currentEstimate)
    }
 
 uint8_t *
-TR_S390RSLbInstruction::generateBinaryEncoding()
+TR::S390RSLbInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -4723,10 +4723,10 @@ TR_S390RSLbInstruction::generateBinaryEncoding()
    }
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390SIInstruction:: member functions
+// TR::S390SIInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
 int32_t
-TR_S390SIInstruction::estimateBinaryLength(int32_t  currentEstimate)
+TR::S390SIInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
    if (getMemoryReference() != NULL)
       {
@@ -4739,7 +4739,7 @@ TR_S390SIInstruction::estimateBinaryLength(int32_t  currentEstimate)
    }
 
 uint8_t *
-TR_S390SIInstruction::generateBinaryEncoding()
+TR::S390SIInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -4779,10 +4779,10 @@ TR_S390SIInstruction::generateBinaryEncoding()
    }
 
 ////////////////////////////////////////////////////////////////////////////////
-// LL: TR_S390SIYInstruction:: member functions
+// LL: TR::S390SIYInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
 int32_t
-TR_S390SIYInstruction::estimateBinaryLength(int32_t  currentEstimate)
+TR::S390SIYInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
    if (getMemoryReference() != NULL)
       {
@@ -4795,7 +4795,7 @@ TR_S390SIYInstruction::estimateBinaryLength(int32_t  currentEstimate)
    }
 
 uint8_t *
-TR_S390SIYInstruction::generateBinaryEncoding()
+TR::S390SIYInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -4833,11 +4833,11 @@ TR_S390SIYInstruction::generateBinaryEncoding()
    }
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390SILInstruction:: member functions
+// TR::S390SILInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
 
 int32_t
-TR_S390SILInstruction::estimateBinaryLength(int32_t  currentEstimate)
+TR::S390SILInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
    if (getMemoryReference() != NULL)
       {
@@ -4857,7 +4857,7 @@ TR_S390SILInstruction::estimateBinaryLength(int32_t  currentEstimate)
  *   0               16    20           32              47
  */
 uint8_t *
-TR_S390SILInstruction::generateBinaryEncoding()
+TR::S390SILInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -4896,10 +4896,10 @@ TR_S390SILInstruction::generateBinaryEncoding()
    }
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390SInstruction:: member functions
+// TR::S390SInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
 int32_t
-TR_S390SInstruction::estimateBinaryLength(int32_t  currentEstimate)
+TR::S390SInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
    if (getMemoryReference() != NULL)
       {
@@ -4912,7 +4912,7 @@ TR_S390SInstruction::estimateBinaryLength(int32_t  currentEstimate)
    }
 
 uint8_t *
-TR_S390SInstruction::generateBinaryEncoding()
+TR::S390SInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -4950,11 +4950,11 @@ TR_S390SInstruction::generateBinaryEncoding()
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390NOPInstruction:: member functions
+// TR::S390NOPInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
 
 int32_t
-TR_S390NOPInstruction::estimateBinaryLength(int32_t  currentEstimate)
+TR::S390NOPInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
    // could have 2 byte, 4 byte or 6 byte NOP
    setEstimatedBinaryLength(6);
@@ -4965,7 +4965,7 @@ TR_S390NOPInstruction::estimateBinaryLength(int32_t  currentEstimate)
    }
 
 uint8_t *
-TR_S390NOPInstruction::generateBinaryEncoding()
+TR::S390NOPInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
@@ -5039,7 +5039,7 @@ TR_S390NOPInstruction::generateBinaryEncoding()
    }
 
 // ////////////////////////////////////////////////////////////////////////////////
-// TR_S390MIIInstruction:: member functions
+// TR::S390MIIInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
 
 /**
@@ -5051,7 +5051,7 @@ TR_S390NOPInstruction::generateBinaryEncoding()
  *    0         8   12              24                       47
  */
 int32_t
-TR_S390MIIInstruction::estimateBinaryLength(int32_t  currentEstimate)
+TR::S390MIIInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
    //TODO:for now use instruction length (for case 0(R14), later need to add support for longer disposition
    //potentially reuse Memoryreference->estimateBinaryLength
@@ -5060,7 +5060,7 @@ TR_S390MIIInstruction::estimateBinaryLength(int32_t  currentEstimate)
    }
 
 uint8_t *
-TR_S390MIIInstruction::generateBinaryEncoding()
+TR::S390MIIInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
 
@@ -5130,7 +5130,7 @@ TR_S390MIIInstruction::generateBinaryEncoding()
    }
 
 // ////////////////////////////////////////////////////////////////////////////////
-// TR_S390SMIInstruction:: member functions
+// TR::S390SMIInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
 /**
  *    SMI Format
@@ -5140,7 +5140,7 @@ TR_S390MIIInstruction::generateBinaryEncoding()
  *    0         8   12   16   20           32        40       47
  */
 int32_t
-TR_S390SMIInstruction::estimateBinaryLength(int32_t  currentEstimate)
+TR::S390SMIInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
   //TODO:for now use instruction length (for case 0(R14), later need to add support for longer disposition
   //potentially reuse Memoryreference->estimateBinaryLength
@@ -5149,7 +5149,7 @@ TR_S390SMIInstruction::estimateBinaryLength(int32_t  currentEstimate)
    }
 
 uint8_t *
-TR_S390SMIInstruction::generateBinaryEncoding()
+TR::S390SMIInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
 
@@ -5218,7 +5218,7 @@ TR_S390SMIInstruction::generateBinaryEncoding()
  * BRC or BRCL depending on the range.
  */
 uint8_t *
-TR_S390VirtualGuardNOPInstruction::generateBinaryEncoding()
+TR::S390VirtualGuardNOPInstruction::generateBinaryEncoding()
    {
    // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();

--- a/compiler/z/codegen/S390Instruction.hpp
+++ b/compiler/z/codegen/S390Instruction.hpp
@@ -63,7 +63,7 @@ namespace TR { class SymbolReference; }
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_TR_S390Instruction Class Definition
+// TR::S390Instruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
 
 /**
@@ -74,17 +74,19 @@ inline uint32_t *toS390Cursor(uint8_t *i)
    return (uint32_t *)i;
    }
 
+namespace TR {
+
 ////////////////////////////////////////////////////////////////////////////////
-// TR_TR_S390LabeledInstruction Class Definition
+// TR::S390LabeledInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390LabeledInstruction : public TR::Instruction
+class S390LabeledInstruction : public TR::Instruction
    {
    TR::LabelSymbol *_symbol;
    TR::Snippet     *_snippet;
 
    public:
 
-   TR_S390LabeledInstruction(TR::InstOpCode::Mnemonic    op,
+   S390LabeledInstruction(TR::InstOpCode::Mnemonic    op,
                            TR::Node          *n,
                            TR::LabelSymbol    *sym,
                            TR::CodeGenerator *cg)
@@ -96,7 +98,7 @@ class TR_S390LabeledInstruction : public TR::Instruction
             clearCCInfo();
       }
 
-   TR_S390LabeledInstruction(TR::InstOpCode::Mnemonic    op,
+   S390LabeledInstruction(TR::InstOpCode::Mnemonic    op,
                            TR::Node          *n,
                            TR::LabelSymbol    *sym,
                            TR::RegisterDependencyConditions * cond,
@@ -109,7 +111,7 @@ class TR_S390LabeledInstruction : public TR::Instruction
             clearCCInfo();
       }
 
-   TR_S390LabeledInstruction(TR::InstOpCode::Mnemonic    op,
+   S390LabeledInstruction(TR::InstOpCode::Mnemonic    op,
                            TR::Node          *n,
                            TR::LabelSymbol    *sym,
                            TR::Instruction   *precedingInstruction,
@@ -122,7 +124,7 @@ class TR_S390LabeledInstruction : public TR::Instruction
             clearCCInfo();
       }
 
-   TR_S390LabeledInstruction(TR::InstOpCode::Mnemonic    op,
+   S390LabeledInstruction(TR::InstOpCode::Mnemonic    op,
                            TR::Node          *n,
                            TR::LabelSymbol    *sym,
                            TR::RegisterDependencyConditions * cond,
@@ -136,7 +138,7 @@ class TR_S390LabeledInstruction : public TR::Instruction
             clearCCInfo();
       }
 
-   TR_S390LabeledInstruction(TR::InstOpCode::Mnemonic     op,
+   S390LabeledInstruction(TR::InstOpCode::Mnemonic     op,
                            TR::Node           *n,
                            TR::Snippet        *s,
                            TR::CodeGenerator  *cg)
@@ -148,7 +150,7 @@ class TR_S390LabeledInstruction : public TR::Instruction
             clearCCInfo();
       }
 
-   TR_S390LabeledInstruction(TR::InstOpCode::Mnemonic     op,
+   S390LabeledInstruction(TR::InstOpCode::Mnemonic     op,
                            TR::Node           *n,
                            TR::Snippet        *s,
                            TR::RegisterDependencyConditions * cond,
@@ -161,7 +163,7 @@ class TR_S390LabeledInstruction : public TR::Instruction
             clearCCInfo();
       }
 
-   TR_S390LabeledInstruction(TR::InstOpCode::Mnemonic     op,
+   S390LabeledInstruction(TR::InstOpCode::Mnemonic     op,
                            TR::Node           *n,
                            TR::Snippet        *s,
                            TR::Instruction    *precedingInstruction,
@@ -174,7 +176,7 @@ class TR_S390LabeledInstruction : public TR::Instruction
             clearCCInfo();
       }
 
-   TR_S390LabeledInstruction(TR::InstOpCode::Mnemonic     op,
+   S390LabeledInstruction(TR::InstOpCode::Mnemonic     op,
                            TR::Node           *n,
                            TR::Snippet        *s,
                            TR::RegisterDependencyConditions * cond,
@@ -206,91 +208,91 @@ class TR_S390LabeledInstruction : public TR::Instruction
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390BranchInstruction Class Definition
+// S390BranchInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390BranchInstruction : public TR_S390LabeledInstruction
+class S390BranchInstruction : public TR::S390LabeledInstruction
    {
    TR::InstOpCode::S390BranchCondition _branchCondition;
 
    public:
 
-   TR_S390BranchInstruction(TR::InstOpCode::Mnemonic    op,
+   S390BranchInstruction(TR::InstOpCode::Mnemonic    op,
                            TR::InstOpCode::S390BranchCondition branchCondition,
                            TR::Node          *n,
                            TR::LabelSymbol    *sym,
                            TR::CodeGenerator *cg)
-      : TR_S390LabeledInstruction(op, n, sym, cg),
+      : S390LabeledInstruction(op, n, sym, cg),
         _branchCondition(branchCondition)
       {}
 
-   TR_S390BranchInstruction(TR::InstOpCode::Mnemonic    op,
+   S390BranchInstruction(TR::InstOpCode::Mnemonic    op,
                            TR::InstOpCode::S390BranchCondition branchCondition,
                            TR::Node          *n,
                            TR::LabelSymbol    *sym,
                            TR::RegisterDependencyConditions * cond,
                            TR::CodeGenerator *cg)
-      : TR_S390LabeledInstruction(op, n, sym, cond, cg),
+      : S390LabeledInstruction(op, n, sym, cond, cg),
         _branchCondition(branchCondition)
       {}
 
-   TR_S390BranchInstruction(TR::InstOpCode::Mnemonic    op,
+   S390BranchInstruction(TR::InstOpCode::Mnemonic    op,
                            TR::InstOpCode::S390BranchCondition branchCondition,
                            TR::Node          *n,
                            TR::LabelSymbol    *sym,
                            TR::Instruction   *precedingInstruction,
                            TR::CodeGenerator *cg)
-      : TR_S390LabeledInstruction(op, n, sym, precedingInstruction, cg),
+      : S390LabeledInstruction(op, n, sym, precedingInstruction, cg),
         _branchCondition(branchCondition)
       {}
 
-   TR_S390BranchInstruction(TR::InstOpCode::Mnemonic    op,
+   S390BranchInstruction(TR::InstOpCode::Mnemonic    op,
                            TR::InstOpCode::S390BranchCondition branchCondition,
                            TR::Node          *n,
                            TR::LabelSymbol    *sym,
                            TR::RegisterDependencyConditions * cond,
                            TR::Instruction   *precedingInstruction,
                            TR::CodeGenerator *cg)
-      : TR_S390LabeledInstruction(op, n, sym, cond, precedingInstruction, cg),
+      : S390LabeledInstruction(op, n, sym, cond, precedingInstruction, cg),
         _branchCondition(branchCondition)
       {}
 
-   TR_S390BranchInstruction(TR::InstOpCode::Mnemonic     op,
+   S390BranchInstruction(TR::InstOpCode::Mnemonic     op,
                            TR::InstOpCode::S390BranchCondition branchCondition,
                            TR::Node           *n,
                            TR::Snippet        *s,
                            TR::CodeGenerator  *cg)
-      : TR_S390LabeledInstruction(op, n, s, cg),
+      : S390LabeledInstruction(op, n, s, cg),
         _branchCondition(branchCondition)
       {}
 
-   TR_S390BranchInstruction(TR::InstOpCode::Mnemonic     op,
+   S390BranchInstruction(TR::InstOpCode::Mnemonic     op,
                            TR::InstOpCode::S390BranchCondition branchCondition,
                            TR::Node           *n,
                            TR::Snippet        *s,
                            TR::RegisterDependencyConditions * cond,
                            TR::CodeGenerator  *cg)
-      : TR_S390LabeledInstruction(op, n, s, cond, cg),
+      : S390LabeledInstruction(op, n, s, cond, cg),
         _branchCondition(branchCondition)
       {}
 
-   TR_S390BranchInstruction(TR::InstOpCode::Mnemonic     op,
+   S390BranchInstruction(TR::InstOpCode::Mnemonic     op,
                            TR::InstOpCode::S390BranchCondition branchCondition,
                            TR::Node           *n,
                            TR::Snippet        *s,
                            TR::Instruction    *precedingInstruction,
                            TR::CodeGenerator  *cg)
-      : TR_S390LabeledInstruction(op, n, s, precedingInstruction, cg),
+      : S390LabeledInstruction(op, n, s, precedingInstruction, cg),
         _branchCondition(branchCondition)
       {}
 
-   TR_S390BranchInstruction(TR::InstOpCode::Mnemonic     op,
+   S390BranchInstruction(TR::InstOpCode::Mnemonic     op,
                            TR::InstOpCode::S390BranchCondition branchCondition,
                            TR::Node           *n,
                            TR::Snippet        *s,
                            TR::RegisterDependencyConditions * cond,
                            TR::Instruction    *precedingInstruction,
                            TR::CodeGenerator  *cg)
-      : TR_S390LabeledInstruction(op, n, s, cond, precedingInstruction, cg),
+      : S390LabeledInstruction(op, n, s, cond, precedingInstruction, cg),
         _branchCondition(branchCondition)
       {}
 
@@ -316,29 +318,28 @@ class TR_S390BranchInstruction : public TR_S390LabeledInstruction
 ////////////////////////////////////////////////////////////////////////////////
 // For virtual guard nop instruction
 ////////////////////////////////////////////////////////////////////////////////
-class TR_VirtualGuardSite;
 
 #ifdef J9_PROJECT_SPECIFIC
-class TR_S390VirtualGuardNOPInstruction : public TR_S390BranchInstruction
+class S390VirtualGuardNOPInstruction : public TR::S390BranchInstruction
    {
    private:
    TR_VirtualGuardSite     *_site;
 
    public:
-   TR_S390VirtualGuardNOPInstruction(TR::Node                            *node,
+   S390VirtualGuardNOPInstruction(TR::Node                            *node,
                                     TR_VirtualGuardSite            *site,
                                     TR::RegisterDependencyConditions *cond,
                                     TR::LabelSymbol                       *label,
                                     TR::CodeGenerator                    *cg)
-      : TR_S390BranchInstruction(TR::InstOpCode::BRC, TR::InstOpCode::COND_VGNOP, node, label, cond, cg), _site(site) {}
+      : S390BranchInstruction(TR::InstOpCode::BRC, TR::InstOpCode::COND_VGNOP, node, label, cond, cg), _site(site) {}
 
-   TR_S390VirtualGuardNOPInstruction(TR::Node                            *node,
+   S390VirtualGuardNOPInstruction(TR::Node                            *node,
                                     TR_VirtualGuardSite            *site,
                                     TR::RegisterDependencyConditions *cond,
                                     TR::LabelSymbol                       *label,
                                     TR::Instruction                      *precedingInstruction,
                                     TR::CodeGenerator                    *cg)
-      : TR_S390BranchInstruction(TR::InstOpCode::BRC, TR::InstOpCode::COND_VGNOP, node, label, cond, precedingInstruction, cg), _site(site) {}
+      : S390BranchInstruction(TR::InstOpCode::BRC, TR::InstOpCode::COND_VGNOP, node, label, cond, precedingInstruction, cg), _site(site) {}
 
    virtual char *description() { return "S390VirtualGuardNOP"; }
    virtual Kind getKind() { return IsVirtualGuardNOP; }
@@ -352,47 +353,47 @@ class TR_S390VirtualGuardNOPInstruction : public TR_S390BranchInstruction
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390BranchOnCountInstruction Class Definition
+// S390BranchOnCountInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390BranchOnCountInstruction : public TR_S390LabeledInstruction
+class S390BranchOnCountInstruction : public TR::S390LabeledInstruction
    {
    #define br_targidx 0
 
    public:
-   TR_S390BranchOnCountInstruction(TR::InstOpCode::Mnemonic    op,
+   S390BranchOnCountInstruction(TR::InstOpCode::Mnemonic    op,
                            TR::Node          *n,
                            TR::Register      *targetReg,
                            TR::LabelSymbol    *sym,
                            TR::CodeGenerator *cg)
-      : TR_S390LabeledInstruction(op, n, sym, cg)
+      : S390LabeledInstruction(op, n, sym, cg)
       {useTargetRegister(targetReg);}
 
-   TR_S390BranchOnCountInstruction(TR::InstOpCode::Mnemonic    op,
+   S390BranchOnCountInstruction(TR::InstOpCode::Mnemonic    op,
                            TR::Node          *n,
                            TR::Register      *targetReg,
 						   TR::RegisterDependencyConditions * cond,
                            TR::LabelSymbol    *sym,
                            TR::CodeGenerator *cg)
-      : TR_S390LabeledInstruction(op, n, sym, cond, cg)
+      : S390LabeledInstruction(op, n, sym, cond, cg)
       {useTargetRegister(targetReg); }
 
-   TR_S390BranchOnCountInstruction(TR::InstOpCode::Mnemonic    op,
+   S390BranchOnCountInstruction(TR::InstOpCode::Mnemonic    op,
                            TR::Node          *n,
                            TR::Register      *targetReg,
                            TR::LabelSymbol    *sym,
                            TR::Instruction   *precedingInstruction,
                            TR::CodeGenerator *cg)
-      : TR_S390LabeledInstruction(op, n, sym, precedingInstruction, cg)
+      : S390LabeledInstruction(op, n, sym, precedingInstruction, cg)
          {useTargetRegister(targetReg); }
 
-   TR_S390BranchOnCountInstruction(TR::InstOpCode::Mnemonic    op,
+   S390BranchOnCountInstruction(TR::InstOpCode::Mnemonic    op,
                            TR::Node          *n,
                            TR::Register      *targetReg,
 						   TR::RegisterDependencyConditions * cond,
                            TR::LabelSymbol    *sym,
                            TR::Instruction   *precedingInstruction,
                            TR::CodeGenerator *cg)
-      : TR_S390LabeledInstruction(op, n, sym, precedingInstruction, cg)
+      : S390LabeledInstruction(op, n, sym, precedingInstruction, cg)
       {useTargetRegister(targetReg);}
 
    virtual char *description() { return "S390BranchOnCount"; }
@@ -405,50 +406,50 @@ class TR_S390BranchOnCountInstruction : public TR_S390LabeledInstruction
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390BranchOnCountInstruction Class Definition
+// S390BranchOnCountInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390BranchOnIndexInstruction : public TR_S390LabeledInstruction
+class S390BranchOnIndexInstruction : public TR::S390LabeledInstruction
    {
    #define br_srcidx 0
    #define br_targidx 0
 
    public:
-   TR_S390BranchOnIndexInstruction(TR::InstOpCode::Mnemonic    op,
+   S390BranchOnIndexInstruction(TR::InstOpCode::Mnemonic    op,
                            TR::Node          *n,
                            TR::Register      *sourceReg,
                            TR::Register      *targetReg,
                            TR::LabelSymbol    *sym,
                            TR::CodeGenerator *cg)
-      : TR_S390LabeledInstruction(op, n, sym, cg)
+      : S390LabeledInstruction(op, n, sym, cg)
       {useTargetRegister(targetReg); useSourceRegister(sourceReg); }
 
-   TR_S390BranchOnIndexInstruction(TR::InstOpCode::Mnemonic    op,
+   S390BranchOnIndexInstruction(TR::InstOpCode::Mnemonic    op,
                            TR::Node          *n,
                            TR::Register      *sourceReg,
                            TR::Register      *targetReg,
                            TR::LabelSymbol    *sym,
                            TR::Instruction   *precedingInstruction,
                            TR::CodeGenerator *cg)
-      : TR_S390LabeledInstruction(op, n, sym, precedingInstruction, cg)
+      : S390LabeledInstruction(op, n, sym, precedingInstruction, cg)
       {useTargetRegister(targetReg); useSourceRegister(sourceReg); }
 
-   TR_S390BranchOnIndexInstruction(TR::InstOpCode::Mnemonic    op,
+   S390BranchOnIndexInstruction(TR::InstOpCode::Mnemonic    op,
                            TR::Node          *n,
                            TR::RegisterPair  *sourceReg,
                            TR::Register      *targetReg,
                            TR::LabelSymbol    *sym,
                            TR::CodeGenerator *cg)
-      : TR_S390LabeledInstruction(op, n, sym, cg)
+      : S390LabeledInstruction(op, n, sym, cg)
       {useTargetRegister(targetReg); useSourceRegister(sourceReg);}
 
-   TR_S390BranchOnIndexInstruction(TR::InstOpCode::Mnemonic    op,
+   S390BranchOnIndexInstruction(TR::InstOpCode::Mnemonic    op,
                            TR::Node          *n,
                            TR::RegisterPair  *sourceReg,
                            TR::Register      *targetReg,
                            TR::LabelSymbol    *sym,
                            TR::Instruction   *precedingInstruction,
                            TR::CodeGenerator *cg)
-      : TR_S390LabeledInstruction(op, n, sym, precedingInstruction, cg)
+      : S390LabeledInstruction(op, n, sym, precedingInstruction, cg)
       {useTargetRegister(targetReg); useSourceRegister(sourceReg);}
 
    virtual char *description() { return "S390BranchOnIndex"; }
@@ -461,9 +462,9 @@ class TR_S390BranchOnIndexInstruction : public TR_S390LabeledInstruction
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390LabelInstruction Class Definition
+// S390LabelInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390LabelInstruction : public TR_S390LabeledInstruction
+class S390LabelInstruction : public TR::S390LabeledInstruction
    {
    flags8_t _flags;
 
@@ -477,109 +478,109 @@ class TR_S390LabelInstruction : public TR_S390LabeledInstruction
 
    public:
 
-   TR_S390LabelInstruction(TR::InstOpCode::Mnemonic    op,
+   S390LabelInstruction(TR::InstOpCode::Mnemonic    op,
                            TR::Node          *n,
                            TR::LabelSymbol    *sym,
                            TR::CodeGenerator *cg)
-      : TR_S390LabeledInstruction(op, n, sym, cg), _alignment(0), _handle(0), _flags(0)
+      : S390LabeledInstruction(op, n, sym, cg), _alignment(0), _handle(0), _flags(0)
       {
       if (op==TR::InstOpCode::LABEL)
          sym->setInstruction(this);
       cg->getNextAvailableBlockIndex();
       }
 
-   TR_S390LabelInstruction(TR::InstOpCode::Mnemonic    op,
-                           TR::Node          *n,
-                           TR::Register      *targetReg,
-                           TR::LabelSymbol    *sym,
-                           TR::CodeGenerator *cg)
-      : TR_S390LabeledInstruction(op, n, sym, cg), _alignment(0), _handle(0), _flags(0)
-      {
-      if (op==TR::InstOpCode::LABEL)
-         sym->setInstruction(this);
-      cg->getNextAvailableBlockIndex();
-      }
-
-   TR_S390LabelInstruction(TR::InstOpCode::Mnemonic    op,
+   S390LabelInstruction(TR::InstOpCode::Mnemonic    op,
                            TR::Node          *n,
                            TR::Register      *targetReg,
                            TR::LabelSymbol    *sym,
-                           TR::Instruction   *precedingInstruction,
                            TR::CodeGenerator *cg)
-      : TR_S390LabeledInstruction(op, n, sym, precedingInstruction, cg), _alignment(0), _handle(0), _flags(0)
+      : S390LabeledInstruction(op, n, sym, cg), _alignment(0), _handle(0), _flags(0)
       {
       if (op==TR::InstOpCode::LABEL)
          sym->setInstruction(this);
       cg->getNextAvailableBlockIndex();
       }
 
-   TR_S390LabelInstruction(TR::InstOpCode::Mnemonic    op,
+   S390LabelInstruction(TR::InstOpCode::Mnemonic    op,
+                           TR::Node          *n,
+                           TR::Register      *targetReg,
+                           TR::LabelSymbol    *sym,
+                           TR::Instruction   *precedingInstruction,
+                           TR::CodeGenerator *cg)
+      : S390LabeledInstruction(op, n, sym, precedingInstruction, cg), _alignment(0), _handle(0), _flags(0)
+      {
+      if (op==TR::InstOpCode::LABEL)
+         sym->setInstruction(this);
+      cg->getNextAvailableBlockIndex();
+      }
+
+   S390LabelInstruction(TR::InstOpCode::Mnemonic    op,
                            TR::Node          *n,
                            TR::LabelSymbol    *sym,
                            TR::RegisterDependencyConditions * cond,
                            TR::CodeGenerator *cg)
-      : TR_S390LabeledInstruction(op, n, sym, cond, cg), _alignment(0), _handle(0), _flags(0)
+      : S390LabeledInstruction(op, n, sym, cond, cg), _alignment(0), _handle(0), _flags(0)
       {
       if (op==TR::InstOpCode::LABEL)
          sym->setInstruction(this);
       cg->getNextAvailableBlockIndex();
       }
 
-   TR_S390LabelInstruction(TR::InstOpCode::Mnemonic    op,
+   S390LabelInstruction(TR::InstOpCode::Mnemonic    op,
                            TR::Node          *n,
                            TR::LabelSymbol    *sym,
                            TR::Instruction   *precedingInstruction,
                            TR::CodeGenerator *cg)
-      : TR_S390LabeledInstruction(op, n, sym, precedingInstruction, cg), _alignment(0), _handle(0), _flags(0)
+      : S390LabeledInstruction(op, n, sym, precedingInstruction, cg), _alignment(0), _handle(0), _flags(0)
       {
       if (op==TR::InstOpCode::LABEL)
          sym->setInstruction(this);
       cg->getNextAvailableBlockIndex();
       }
 
-   TR_S390LabelInstruction(TR::InstOpCode::Mnemonic    op,
+   S390LabelInstruction(TR::InstOpCode::Mnemonic    op,
                            TR::Node          *n,
                            TR::LabelSymbol    *sym,
                            TR::RegisterDependencyConditions * cond,
                            TR::Instruction   *precedingInstruction,
                            TR::CodeGenerator *cg)
-      : TR_S390LabeledInstruction(op, n, sym, cond, precedingInstruction, cg), _alignment(0), _handle(0), _flags(0)
+      : S390LabeledInstruction(op, n, sym, cond, precedingInstruction, cg), _alignment(0), _handle(0), _flags(0)
       {
       if (op==TR::InstOpCode::LABEL)
          sym->setInstruction(this);
       cg->getNextAvailableBlockIndex();
       }
 
-   TR_S390LabelInstruction(TR::InstOpCode::Mnemonic     op,
+   S390LabelInstruction(TR::InstOpCode::Mnemonic     op,
                            TR::Node           *n,
                            TR::Snippet        *s,
                            TR::CodeGenerator  *cg)
-      : TR_S390LabeledInstruction(op, n, s, cg), _alignment(0), _handle(0), _flags(0)
+      : S390LabeledInstruction(op, n, s, cg), _alignment(0), _handle(0), _flags(0)
       {}
 
-   TR_S390LabelInstruction(TR::InstOpCode::Mnemonic     op,
+   S390LabelInstruction(TR::InstOpCode::Mnemonic     op,
                            TR::Node           *n,
                            TR::Snippet        *s,
                            TR::RegisterDependencyConditions * cond,
                            TR::CodeGenerator  *cg)
-      : TR_S390LabeledInstruction(op, n, s, cond, cg), _alignment(0), _handle(0), _flags(0)
+      : S390LabeledInstruction(op, n, s, cond, cg), _alignment(0), _handle(0), _flags(0)
       {}
 
-   TR_S390LabelInstruction(TR::InstOpCode::Mnemonic     op,
+   S390LabelInstruction(TR::InstOpCode::Mnemonic     op,
                            TR::Node           *n,
                            TR::Snippet        *s,
                            TR::Instruction    *precedingInstruction,
                            TR::CodeGenerator  *cg)
-      : TR_S390LabeledInstruction(op, n, s, precedingInstruction, cg), _alignment(0), _handle(0), _flags(0)
+      : S390LabeledInstruction(op, n, s, precedingInstruction, cg), _alignment(0), _handle(0), _flags(0)
       {}
 
-   TR_S390LabelInstruction(TR::InstOpCode::Mnemonic     op,
+   S390LabelInstruction(TR::InstOpCode::Mnemonic     op,
                            TR::Node           *n,
                            TR::Snippet        *s,
                            TR::RegisterDependencyConditions * cond,
                            TR::Instruction    *precedingInstruction,
                            TR::CodeGenerator  *cg)
-      : TR_S390LabeledInstruction(op, n, s, cond, precedingInstruction, cg), _alignment(0), _handle(0), _flags(0)
+      : S390LabeledInstruction(op, n, s, cond, precedingInstruction, cg), _alignment(0), _handle(0), _flags(0)
       {}
 
    virtual char *description() { return "S390LabelInstruction"; }
@@ -609,9 +610,9 @@ class TR_S390LabelInstruction : public TR_S390LabeledInstruction
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390PseudoInstruction Class Definition
+// S390PseudoInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390PseudoInstruction : public TR::Instruction
+class S390PseudoInstruction : public TR::Instruction
    {
    TR::Node *_fenceNode;
 
@@ -632,7 +633,7 @@ class TR_S390PseudoInstruction : public TR::Instruction
 
    public:
 
-   TR_S390PseudoInstruction(TR::InstOpCode::Mnemonic op,
+   S390PseudoInstruction(TR::InstOpCode::Mnemonic op,
                            TR::Node *n,
                            TR::Node * fenceNode,
                            TR::CodeGenerator *cg)
@@ -645,7 +646,7 @@ class TR_S390PseudoInstruction : public TR::Instruction
         _asmDataEncodingLength(0),
         _shouldBeginNewLine(false){}
 
-   TR_S390PseudoInstruction(TR::InstOpCode::Mnemonic op,
+   S390PseudoInstruction(TR::InstOpCode::Mnemonic op,
                            TR::Node *n,
                            TR::Node * fenceNode,
                            TR::RegisterDependencyConditions * cond,
@@ -659,7 +660,7 @@ class TR_S390PseudoInstruction : public TR::Instruction
         _asmDataEncodingLength(0),
         _shouldBeginNewLine(false){}
 
-   TR_S390PseudoInstruction(TR::InstOpCode::Mnemonic  op,
+   S390PseudoInstruction(TR::InstOpCode::Mnemonic  op,
                             TR::Node * n,
                             TR::Node *fenceNode,
                             TR::Instruction *precedingInstruction,
@@ -673,7 +674,7 @@ class TR_S390PseudoInstruction : public TR::Instruction
         _asmDataEncodingLength(0),
         _shouldBeginNewLine(false){}
 
-   TR_S390PseudoInstruction(TR::InstOpCode::Mnemonic  op,
+   S390PseudoInstruction(TR::InstOpCode::Mnemonic  op,
                             TR::Node * n,
                             TR::Node *fenceNode,
                             TR::RegisterDependencyConditions * cond,
@@ -734,13 +735,13 @@ class TR_S390PseudoInstruction : public TR::Instruction
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390AnnotationInstruction Class Definition
+// S390AnnotationInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390AnnotationInstruction : public TR::Instruction
+class S390AnnotationInstruction : public TR::Instruction
    {
 public:
 
-   TR_S390AnnotationInstruction(TR::InstOpCode::Mnemonic    op,
+   S390AnnotationInstruction(TR::InstOpCode::Mnemonic    op,
                                 TR::Node          *n,
                                 int16_t regionNum,
                                 int32_t statementNum,
@@ -756,7 +757,7 @@ public:
       setRegionNumber(regionNum);
       }
 
-   TR_S390AnnotationInstruction(TR::InstOpCode::Mnemonic    op,
+   S390AnnotationInstruction(TR::InstOpCode::Mnemonic    op,
                                 TR::Node          *n,
                                 int16_t regionNum,
                                 int32_t statementNum,
@@ -773,7 +774,7 @@ public:
       setRegionNumber(regionNum);
       }
 
-   TR_S390AnnotationInstruction(TR::InstOpCode::Mnemonic    op,
+   S390AnnotationInstruction(TR::InstOpCode::Mnemonic    op,
                                 TR::Node          *n,
                                 int16_t regionNum,
                                 int32_t statementNum,
@@ -790,7 +791,7 @@ public:
       setRegionNumber(regionNum);
       }
 
-   TR_S390AnnotationInstruction(TR::InstOpCode::Mnemonic    op,
+   S390AnnotationInstruction(TR::InstOpCode::Mnemonic    op,
                                 TR::Node          *n,
                                 int16_t regionNum,
                                 int32_t statementNum,
@@ -822,22 +823,22 @@ private:
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390ImmInstruction Class Definition
+// S390ImmInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390ImmInstruction : public TR::Instruction
+class S390ImmInstruction : public TR::Instruction
    {
    uint32_t _sourceImmediate;
 
    public:
 
-   TR_S390ImmInstruction(TR::InstOpCode::Mnemonic    op,
+   S390ImmInstruction(TR::InstOpCode::Mnemonic    op,
                          TR::Node          *n,
                          uint32_t          imm,
                          TR::CodeGenerator *cg)
       : TR::Instruction(op, n, cg), _sourceImmediate(imm)
       {}
 
-   TR_S390ImmInstruction(TR::InstOpCode::Mnemonic    op,
+   S390ImmInstruction(TR::InstOpCode::Mnemonic    op,
                          TR::Node          *n,
                          uint32_t          imm,
                          TR::Instruction   *precedingInstruction,
@@ -845,7 +846,7 @@ class TR_S390ImmInstruction : public TR::Instruction
       : TR::Instruction(op, n, precedingInstruction, cg), _sourceImmediate(imm)
       {}
 
-   TR_S390ImmInstruction(TR::InstOpCode::Mnemonic    op,
+   S390ImmInstruction(TR::InstOpCode::Mnemonic    op,
                          TR::Node          *n,
                          uint32_t          imm,
                          TR::RegisterDependencyConditions *cond,
@@ -853,7 +854,7 @@ class TR_S390ImmInstruction : public TR::Instruction
       : TR::Instruction(op, n, cond, cg), _sourceImmediate(imm)
       {}
 
-   TR_S390ImmInstruction(TR::InstOpCode::Mnemonic    op,
+   S390ImmInstruction(TR::InstOpCode::Mnemonic    op,
                          TR::Node          *n,
                          uint32_t          imm,
                          TR::RegisterDependencyConditions *cond,
@@ -874,27 +875,27 @@ class TR_S390ImmInstruction : public TR::Instruction
 // The following safe virtual downcast method is used under debug only
 // for assertion checking
 #if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
-   virtual TR_S390ImmInstruction *getS390ImmInstruction();
+   virtual S390ImmInstruction *getS390ImmInstruction();
 #endif
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390Imm2Instruction (2-byte) Class Definition
+// S390Imm2Instruction (2-byte) Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390Imm2Instruction : public TR::Instruction
+class S390Imm2Instruction : public TR::Instruction
    {
    uint16_t _sourceImmediate;
 
    public:
 
-   TR_S390Imm2Instruction(TR::InstOpCode::Mnemonic    op,
+   S390Imm2Instruction(TR::InstOpCode::Mnemonic    op,
                           TR::Node          *n,
                           uint16_t          imm,
                           TR::CodeGenerator *cg)
       : TR::Instruction(op, n, cg), _sourceImmediate(imm)
       { setEstimatedBinaryLength(2); }
 
-   TR_S390Imm2Instruction(TR::InstOpCode::Mnemonic    op,
+   S390Imm2Instruction(TR::InstOpCode::Mnemonic    op,
                           TR::Node          *n,
                           uint16_t          imm,
                           TR::Instruction   *precedingInstruction,
@@ -902,7 +903,7 @@ class TR_S390Imm2Instruction : public TR::Instruction
       : TR::Instruction(op, n, precedingInstruction, cg), _sourceImmediate(imm)
       { setEstimatedBinaryLength(2); }
 
-   TR_S390Imm2Instruction(TR::InstOpCode::Mnemonic    op,
+   S390Imm2Instruction(TR::InstOpCode::Mnemonic    op,
                           TR::Node          *n,
                           uint16_t          imm,
                           TR::RegisterDependencyConditions *cond,
@@ -910,7 +911,7 @@ class TR_S390Imm2Instruction : public TR::Instruction
       : TR::Instruction(op, n, cond, cg), _sourceImmediate(imm)
       { setEstimatedBinaryLength(2); }
 
-   TR_S390Imm2Instruction(TR::InstOpCode::Mnemonic    op,
+   S390Imm2Instruction(TR::InstOpCode::Mnemonic    op,
                           TR::Node          *n,
                           uint16_t          imm,
                           TR::RegisterDependencyConditions *cond,
@@ -929,25 +930,25 @@ class TR_S390Imm2Instruction : public TR::Instruction
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390ImmSnippetInstruction Class Definition
+// S390ImmSnippetInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390ImmSnippetInstruction : public TR_S390ImmInstruction
+class S390ImmSnippetInstruction : public TR::S390ImmInstruction
    {
    TR::UnresolvedDataSnippet *_unresolvedSnippet;
    TR::Snippet                   *_snippet;
 
    public:
 
-   TR_S390ImmSnippetInstruction(TR::InstOpCode::Mnemonic                     op,
+   S390ImmSnippetInstruction(TR::InstOpCode::Mnemonic                     op,
                                 TR::Node                            *n,
                                 uint32_t                           imm,
                                 TR::UnresolvedDataSnippet       *us,
                                 TR::Snippet                         *s,
                                 TR::CodeGenerator                   *cg)
-      : TR_S390ImmInstruction(op, n,imm, cg), _unresolvedSnippet(us),
+      : S390ImmInstruction(op, n,imm, cg), _unresolvedSnippet(us),
         _snippet(s) {}
 
-   TR_S390ImmSnippetInstruction(
+   S390ImmSnippetInstruction(
                               TR::InstOpCode::Mnemonic                     op,
                               TR::Node                            *n,
                               uint32_t                           imm,
@@ -955,7 +956,7 @@ class TR_S390ImmSnippetInstruction : public TR_S390ImmInstruction
                               TR::Snippet                         *s,
                               TR::Instruction *precedingInstruction,
                               TR::CodeGenerator                   *cg)
-      : TR_S390ImmInstruction(op, n, imm, precedingInstruction, cg),
+      : S390ImmInstruction(op, n, imm, precedingInstruction, cg),
         _unresolvedSnippet(us), _snippet(s) {}
 
    virtual char *description() { return "S390ImmSnippetInstruction"; }
@@ -973,48 +974,48 @@ class TR_S390ImmSnippetInstruction : public TR_S390ImmInstruction
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390ImmSymInstruction Class Definition
+// S390ImmSymInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390ImmSymInstruction : public TR_S390ImmInstruction
+class S390ImmSymInstruction : public TR::S390ImmInstruction
    {
    TR::SymbolReference *_symbolReference;
 
    public:
 
-   TR_S390ImmSymInstruction(TR::InstOpCode::Mnemonic      op,
+   S390ImmSymInstruction(TR::InstOpCode::Mnemonic      op,
                             TR::Node            *node,
                             uint32_t            imm,
                             TR::SymbolReference *sr,
                             TR::CodeGenerator   *cg)
-      : TR_S390ImmInstruction(op, node, imm, cg), _symbolReference(sr)
+      : S390ImmInstruction(op, node, imm, cg), _symbolReference(sr)
       {}
 
-   TR_S390ImmSymInstruction(TR::InstOpCode::Mnemonic      op,
+   S390ImmSymInstruction(TR::InstOpCode::Mnemonic      op,
                             TR::Node            *node,
                             uint32_t            imm,
                             TR::SymbolReference *sr,
                             TR::Instruction     *precedingInstruction,
                             TR::CodeGenerator   *cg)
-      : TR_S390ImmInstruction(op, node, imm, precedingInstruction, cg), _symbolReference(sr)
+      : S390ImmInstruction(op, node, imm, precedingInstruction, cg), _symbolReference(sr)
       {}
 
-   TR_S390ImmSymInstruction(TR::InstOpCode::Mnemonic                       op,
+   S390ImmSymInstruction(TR::InstOpCode::Mnemonic                       op,
                             TR::Node                             *node,
                             uint32_t                             imm,
                             TR::SymbolReference                  *sr,
                             TR::RegisterDependencyConditions *cond,
                             TR::CodeGenerator                    *cg)
-      : TR_S390ImmInstruction(op, node, imm, cond, cg), _symbolReference(sr)
+      : S390ImmInstruction(op, node, imm, cond, cg), _symbolReference(sr)
       {}
 
-   TR_S390ImmSymInstruction(TR::InstOpCode::Mnemonic                       op,
+   S390ImmSymInstruction(TR::InstOpCode::Mnemonic                       op,
                             TR::Node                             *node,
                             uint32_t                             imm,
                             TR::SymbolReference                  *sr,
                             TR::RegisterDependencyConditions *cond,
                             TR::Instruction                      *precedingInstruction,
                             TR::CodeGenerator                    *cg)
-     : TR_S390ImmInstruction(op, node, imm, cond, precedingInstruction, cg), _symbolReference(sr)
+     : S390ImmInstruction(op, node, imm, cond, precedingInstruction, cg), _symbolReference(sr)
      {}
    virtual char *description() { return "S390ImmSymInstruction"; }
    virtual Kind getKind() { return IsImmSym; }
@@ -1030,9 +1031,9 @@ class TR_S390ImmSymInstruction : public TR_S390ImmInstruction
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390RegInstruction Class Definition
+// S390RegInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390RegInstruction : public TR::Instruction
+class S390RegInstruction : public TR::Instruction
    {
    protected:
 
@@ -1045,7 +1046,7 @@ class TR_S390RegInstruction : public TR::Instruction
 
    public:
 
-   TR_S390RegInstruction(TR::InstOpCode::Mnemonic    op,
+   S390RegInstruction(TR::InstOpCode::Mnemonic    op,
                          TR::Node          *n,
                          TR::Register      *reg,
                          TR::CodeGenerator *cg)
@@ -1070,14 +1071,14 @@ class TR_S390RegInstruction : public TR::Instruction
                 (_targetPairFlag)?"cannot":"should");
       }
 
-   TR_S390RegInstruction(TR::InstOpCode::Mnemonic    op,
+   S390RegInstruction(TR::InstOpCode::Mnemonic    op,
                          TR::Node          *n,
                          TR::CodeGenerator *cg)
       : TR::Instruction(op, n, cg), _branchCondition(TR::InstOpCode::COND_NOP), _firstConstant(-1), _targetPairFlag(false)
       {
       }
 
-   TR_S390RegInstruction(TR::InstOpCode::Mnemonic    op,
+   S390RegInstruction(TR::InstOpCode::Mnemonic    op,
                          TR::Node          *n,
                          TR::Instruction   *precedingInstruction,
                          TR::CodeGenerator *cg)
@@ -1085,7 +1086,7 @@ class TR_S390RegInstruction : public TR::Instruction
       {
       }
 
-   TR_S390RegInstruction(TR::InstOpCode::Mnemonic    op,
+   S390RegInstruction(TR::InstOpCode::Mnemonic    op,
                          TR::Node          *n,
                          int8_t           firstConstant,
                          TR::CodeGenerator *cg)
@@ -1093,7 +1094,7 @@ class TR_S390RegInstruction : public TR::Instruction
       {
       }
 
-   TR_S390RegInstruction(TR::InstOpCode::Mnemonic    op,
+   S390RegInstruction(TR::InstOpCode::Mnemonic    op,
                          TR::Node          *n,
                          int8_t           firstConstant,
                          TR::Instruction   *precedingInstruction,
@@ -1102,7 +1103,7 @@ class TR_S390RegInstruction : public TR::Instruction
       {
       }
 
-   TR_S390RegInstruction(TR::InstOpCode::Mnemonic    op,
+   S390RegInstruction(TR::InstOpCode::Mnemonic    op,
                          TR::Node          *n,
                          TR::Register      *reg,
                          TR::RegisterDependencyConditions * cond,
@@ -1128,7 +1129,7 @@ class TR_S390RegInstruction : public TR::Instruction
                 (_targetPairFlag)?"cannot":"should");
       }
 
-   TR_S390RegInstruction(TR::InstOpCode::Mnemonic    op,
+   S390RegInstruction(TR::InstOpCode::Mnemonic    op,
                          TR::Node          *n,
                          TR::Register      *reg,
                          TR::Instruction   *precedingInstruction,
@@ -1154,7 +1155,7 @@ class TR_S390RegInstruction : public TR::Instruction
                 (_targetPairFlag)?"cannot":"should");
       }
 
-   TR_S390RegInstruction(TR::InstOpCode::Mnemonic    op,
+   S390RegInstruction(TR::InstOpCode::Mnemonic    op,
                          TR::Node          *n,
                          TR::Register      *reg,
                          TR::RegisterDependencyConditions * cond,
@@ -1178,7 +1179,7 @@ class TR_S390RegInstruction : public TR::Instruction
                 (_targetPairFlag)?"cannot":"should");
       }
 
-   TR_S390RegInstruction(TR::InstOpCode::Mnemonic    op,
+   S390RegInstruction(TR::InstOpCode::Mnemonic    op,
                          TR::Node          *n,
                          TR::InstOpCode::S390BranchCondition brCond,
                          TR::Register      *reg,
@@ -1204,7 +1205,7 @@ class TR_S390RegInstruction : public TR::Instruction
                 (_targetPairFlag)?"cannot":"should");
       }
 
-   TR_S390RegInstruction(TR::InstOpCode::Mnemonic    op,
+   S390RegInstruction(TR::InstOpCode::Mnemonic    op,
                          TR::Node          *n,
                          TR::InstOpCode::S390BranchCondition brCond,
                          TR::Register      *reg,
@@ -1231,7 +1232,7 @@ class TR_S390RegInstruction : public TR::Instruction
                (_targetPairFlag)?"cannot":"should");
       }
 
-   TR_S390RegInstruction(TR::InstOpCode::Mnemonic    op,
+   S390RegInstruction(TR::InstOpCode::Mnemonic    op,
                          TR::Node          *n,
                          TR::InstOpCode::S390BranchCondition brCond,
                          TR::Register      *reg,
@@ -1258,7 +1259,7 @@ class TR_S390RegInstruction : public TR::Instruction
                 (_targetPairFlag)?"cannot":"should");
       }
 
-   TR_S390RegInstruction(TR::InstOpCode::Mnemonic    op,
+   S390RegInstruction(TR::InstOpCode::Mnemonic    op,
                          TR::Node          *n,
                          TR::InstOpCode::S390BranchCondition brCond,
                          TR::Register      *reg,
@@ -1403,29 +1404,29 @@ class TR_S390RegInstruction : public TR::Instruction
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390RRInstruction Class Definition
+// S390RRInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390RRInstruction : public TR_S390RegInstruction
+class S390RRInstruction : public TR::S390RegInstruction
    {
    flags32_t    _flagsRR;
    int8_t _secondConstant;
 
    public:
 
-   TR_S390RRInstruction(TR::InstOpCode::Mnemonic         op,
+   S390RRInstruction(TR::InstOpCode::Mnemonic         op,
                         TR::Node               *n,
                         TR::Register           *treg,
                         TR::CodeGenerator      *cg)
-      : TR_S390RegInstruction(op, n, treg, cg), _flagsRR(0), _secondConstant(-1)
+      : S390RegInstruction(op, n, treg, cg), _flagsRR(0), _secondConstant(-1)
       {
       }
 
-   TR_S390RRInstruction(TR::InstOpCode::Mnemonic         op,
+   S390RRInstruction(TR::InstOpCode::Mnemonic         op,
                         TR::Node               *n,
                         TR::Register           *treg,
                         TR::Register           *sreg,
                         TR::CodeGenerator      *cg)
-      : TR_S390RegInstruction(op, n, treg, cg), _flagsRR(0), _secondConstant(-1)
+      : S390RegInstruction(op, n, treg, cg), _flagsRR(0), _secondConstant(-1)
       {
       checkRegForGPR0Disable(op, sreg);
       if (!getOpCode().setsOperand2())
@@ -1434,13 +1435,13 @@ class TR_S390RRInstruction : public TR_S390RegInstruction
          useTargetRegister(sreg);
       }
 
-   TR_S390RRInstruction(TR::InstOpCode::Mnemonic         op,
+   S390RRInstruction(TR::InstOpCode::Mnemonic         op,
                         TR::Node               *n,
                         TR::Register           *treg,
                         TR::Register           *sreg,
                         TR::RegisterDependencyConditions * cond,
                         TR::CodeGenerator      *cg)
-      : TR_S390RegInstruction(op, n, treg, cond, cg), _flagsRR(0), _secondConstant(-1)
+      : S390RegInstruction(op, n, treg, cond, cg), _flagsRR(0), _secondConstant(-1)
       {
       checkRegForGPR0Disable(op, sreg);
       if (!getOpCode().setsOperand2())
@@ -1449,13 +1450,13 @@ class TR_S390RRInstruction : public TR_S390RegInstruction
          useTargetRegister(sreg);
       }
 
-   TR_S390RRInstruction(TR::InstOpCode::Mnemonic         op,
+   S390RRInstruction(TR::InstOpCode::Mnemonic         op,
                         TR::Node               *n,
                         TR::Register           *treg,
                         TR::Register           *sreg,
                         TR::Instruction        *precedingInstruction,
                         TR::CodeGenerator      *cg)
-      : TR_S390RegInstruction(op, n, treg, precedingInstruction, cg), _flagsRR(0), _secondConstant(-1)
+      : S390RegInstruction(op, n, treg, precedingInstruction, cg), _flagsRR(0), _secondConstant(-1)
       {
       checkRegForGPR0Disable(op, sreg);
       if (!getOpCode().setsOperand2())
@@ -1464,52 +1465,52 @@ class TR_S390RRInstruction : public TR_S390RegInstruction
          useTargetRegister(sreg);
       }
 
-   TR_S390RRInstruction(TR::InstOpCode::Mnemonic         op,
+   S390RRInstruction(TR::InstOpCode::Mnemonic         op,
                         TR::Node               *n,
                         TR::Register           *treg,
                         int8_t                secondConstant,
                         TR::Instruction        *precedingInstruction,
                         TR::CodeGenerator      *cg)
-      : TR_S390RegInstruction(op, n, treg, precedingInstruction, cg), _flagsRR(0), _secondConstant(secondConstant)
+      : S390RegInstruction(op, n, treg, precedingInstruction, cg), _flagsRR(0), _secondConstant(secondConstant)
       {
       }
 
-   TR_S390RRInstruction(TR::InstOpCode::Mnemonic         op,
+   S390RRInstruction(TR::InstOpCode::Mnemonic         op,
                         TR::Node               *n,
                         TR::Register           *treg,
                         int8_t                secondConstant,
                         TR::CodeGenerator      *cg)
-      : TR_S390RegInstruction(op, n, treg, cg), _flagsRR(0), _secondConstant(secondConstant)
+      : S390RegInstruction(op, n, treg, cg), _flagsRR(0), _secondConstant(secondConstant)
       {
       }
 
-   TR_S390RRInstruction(TR::InstOpCode::Mnemonic         op,
+   S390RRInstruction(TR::InstOpCode::Mnemonic         op,
                         TR::Node               *n,
                         int8_t                firstConstant,
                         int8_t                secondConstant,
                         TR::Instruction        *precedingInstruction,
                         TR::CodeGenerator      *cg)
-      : TR_S390RegInstruction(op, n, firstConstant, precedingInstruction, cg), _flagsRR(0), _secondConstant(secondConstant)
+      : S390RegInstruction(op, n, firstConstant, precedingInstruction, cg), _flagsRR(0), _secondConstant(secondConstant)
       {
       }
 
-   TR_S390RRInstruction(TR::InstOpCode::Mnemonic         op,
+   S390RRInstruction(TR::InstOpCode::Mnemonic         op,
                         TR::Node               *n,
                         int8_t                firstConstant,
                         int8_t                secondConstant,
                         TR::CodeGenerator      *cg)
-      : TR_S390RegInstruction(op, n, firstConstant, cg), _flagsRR(0), _secondConstant(secondConstant)
+      : S390RegInstruction(op, n, firstConstant, cg), _flagsRR(0), _secondConstant(secondConstant)
       {
       }
 
 
-   TR_S390RRInstruction(TR::InstOpCode::Mnemonic         op,
+   S390RRInstruction(TR::InstOpCode::Mnemonic         op,
                         TR::Node               *n,
                         int8_t                firstConstant,
                         TR::Register           *sreg,
                         TR::Instruction        *precedingInstruction,
                         TR::CodeGenerator      *cg)
-      : TR_S390RegInstruction(op, n, firstConstant, precedingInstruction, cg), _flagsRR(0), _secondConstant(-1)
+      : S390RegInstruction(op, n, firstConstant, precedingInstruction, cg), _flagsRR(0), _secondConstant(-1)
       {
       checkRegForGPR0Disable(op,sreg);
       if (!getOpCode().setsOperand2())
@@ -1518,12 +1519,12 @@ class TR_S390RRInstruction : public TR_S390RegInstruction
          useTargetRegister(sreg);
       }
 
-   TR_S390RRInstruction(TR::InstOpCode::Mnemonic         op,
+   S390RRInstruction(TR::InstOpCode::Mnemonic         op,
                         TR::Node               *n,
                         int8_t                firstConstant,
                         TR::Register           *sreg,
                         TR::CodeGenerator      *cg)
-      : TR_S390RegInstruction(op, n, firstConstant, cg),  _flagsRR(0), _secondConstant(-1)
+      : S390RegInstruction(op, n, firstConstant, cg),  _flagsRR(0), _secondConstant(-1)
       {
       checkRegForGPR0Disable(op,sreg);
       if (!getOpCode().setsOperand2())
@@ -1533,14 +1534,14 @@ class TR_S390RRInstruction : public TR_S390RegInstruction
       }
 
 
-   TR_S390RRInstruction(TR::InstOpCode::Mnemonic         op,
+   S390RRInstruction(TR::InstOpCode::Mnemonic         op,
                         TR::Node               *n,
                         TR::Register           *treg,
                         TR::Register           *sreg,
                         TR::RegisterDependencyConditions * cond,
                         TR::Instruction        *precedingInstruction,
                         TR::CodeGenerator      *cg)
-      : TR_S390RegInstruction(op, n, treg, cond, precedingInstruction, cg), _flagsRR(0), _secondConstant(-1)
+      : S390RegInstruction(op, n, treg, cond, precedingInstruction, cg), _flagsRR(0), _secondConstant(-1)
       {
       checkRegForGPR0Disable(op, sreg);
       if (!getOpCode().setsOperand2())
@@ -1549,12 +1550,12 @@ class TR_S390RRInstruction : public TR_S390RegInstruction
          useTargetRegister(sreg);
       }
 
-   TR_S390RRInstruction(TR::InstOpCode::Mnemonic         op,
+   S390RRInstruction(TR::InstOpCode::Mnemonic         op,
                         TR::Node               *n,
                         TR::Register           *treg,
                         TR::Instruction        *precedingInstruction,
                         TR::CodeGenerator      *cg)
-      : TR_S390RegInstruction(op, n, treg, precedingInstruction, cg), _flagsRR(0), _secondConstant(-1)
+      : S390RegInstruction(op, n, treg, precedingInstruction, cg), _flagsRR(0), _secondConstant(-1)
       {
       }
 
@@ -1599,10 +1600,10 @@ class TR_S390RRInstruction : public TR_S390RegInstruction
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390TranslateInstruction Class Definition
+// S390TranslateInstruction Class Definition
 // This currently includes TROO, TROT, TRTO, TRTT
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390TranslateInstruction : public TR::Instruction
+class S390TranslateInstruction : public TR::Instruction
    {
    private:
 
@@ -1620,7 +1621,7 @@ class TR_S390TranslateInstruction : public TR::Instruction
     * real register R0 and real register R1 will need to have been assigned to
     * _termCharRegister and _tableRegister respectively
     */
-   TR_S390TranslateInstruction(TR::InstOpCode::Mnemonic         op,
+   S390TranslateInstruction(TR::InstOpCode::Mnemonic         op,
                                TR::Node               *n,
                                TR::Register           *treg,
                                TR::Register           *sreg,
@@ -1640,7 +1641,7 @@ class TR_S390TranslateInstruction : public TR::Instruction
       }
 
    /** Add mask for ETF-2 TRxx instructions - RRE format */
-   TR_S390TranslateInstruction(TR::InstOpCode::Mnemonic         op,
+   S390TranslateInstruction(TR::InstOpCode::Mnemonic         op,
                                TR::Node               *n,
                                TR::Register           *treg,
                                TR::Register           *sreg,
@@ -1660,7 +1661,7 @@ class TR_S390TranslateInstruction : public TR::Instruction
       useSourceRegister(termCharReg);
       }
 
-   TR_S390TranslateInstruction(TR::InstOpCode::Mnemonic         op,
+   S390TranslateInstruction(TR::InstOpCode::Mnemonic         op,
                                TR::Node               *n,
                                TR::Register           *treg,
                                TR::Register           *sreg,
@@ -1706,23 +1707,23 @@ class TR_S390TranslateInstruction : public TR::Instruction
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390RRFInstruction Class Definition
+// S390RRFInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390RRFInstruction : public TR_S390RRInstruction
+class S390RRFInstruction : public TR::S390RRInstruction
    {
    bool _isMask3Present, _isMask4Present,  _isSourceReg2Present;
    bool _encodeAsRRD;
    uint8_t _mask3, _mask4;
    public:
 
-   TR_S390RRFInstruction(bool encodeAsRRD,
+   S390RRFInstruction(bool encodeAsRRD,
                         TR::InstOpCode::Mnemonic         op,
                         TR::Node               *n,
                         TR::Register           *treg,
                         TR::Register           *sreg,
                         TR::Register           *sreg2,
                         TR::CodeGenerator      *cg)
-      : TR_S390RRInstruction(op, n, treg, sreg, cg), _encodeAsRRD(encodeAsRRD),
+      : S390RRInstruction(op, n, treg, sreg, cg), _encodeAsRRD(encodeAsRRD),
         _isSourceReg2Present(true), _isMask3Present(false), _isMask4Present(false)
       {
       if (!getOpCode().setsOperand3())
@@ -1731,7 +1732,7 @@ class TR_S390RRFInstruction : public TR_S390RRInstruction
          useTargetRegister(sreg2);
       }
 
-   TR_S390RRFInstruction(bool encodeAsRRD,
+   S390RRFInstruction(bool encodeAsRRD,
                         TR::InstOpCode::Mnemonic         op,
                         TR::Node               *n,
                         TR::Register           *treg,
@@ -1739,7 +1740,7 @@ class TR_S390RRFInstruction : public TR_S390RRInstruction
                         TR::Register           *sreg2,
                         TR::Instruction        *precedingInstruction,
                         TR::CodeGenerator      *cg)
-      : TR_S390RRInstruction(op, n, treg, sreg, precedingInstruction, cg), _encodeAsRRD(encodeAsRRD),
+      : S390RRInstruction(op, n, treg, sreg, precedingInstruction, cg), _encodeAsRRD(encodeAsRRD),
        _isSourceReg2Present(true), _isMask3Present(false),_isMask4Present(false)
       {
       if (!getOpCode().setsOperand3())
@@ -1748,13 +1749,13 @@ class TR_S390RRFInstruction : public TR_S390RRInstruction
          useTargetRegister(sreg2);
       }
 
-   TR_S390RRFInstruction(TR::InstOpCode::Mnemonic         op,
+   S390RRFInstruction(TR::InstOpCode::Mnemonic         op,
                         TR::Node               *n,
                         TR::Register           *treg,
                         TR::Register           *sreg,
                         TR::Register           *sreg2,
                         TR::CodeGenerator      *cg)
-      : TR_S390RRInstruction(op, n, treg, sreg, cg), _encodeAsRRD(false),
+      : S390RRInstruction(op, n, treg, sreg, cg), _encodeAsRRD(false),
         _isSourceReg2Present(true), _isMask3Present(false), _isMask4Present(false)
       {
       if (!getOpCode().setsOperand3())
@@ -1763,14 +1764,14 @@ class TR_S390RRFInstruction : public TR_S390RRInstruction
          useTargetRegister(sreg2);
       }
 
-   TR_S390RRFInstruction(TR::InstOpCode::Mnemonic        op,
+   S390RRFInstruction(TR::InstOpCode::Mnemonic        op,
                         TR::Node               *n,
                         TR::Register           *treg,
                         TR::Register           *sreg,
                         uint8_t                 mask,
                         bool                   isMask3,
                         TR::CodeGenerator      *cg)
-      : TR_S390RRInstruction(op, n, treg, sreg, cg), _encodeAsRRD(false),
+      : S390RRInstruction(op, n, treg, sreg, cg), _encodeAsRRD(false),
         _isSourceReg2Present(false), _isMask3Present(isMask3),_isMask4Present(!isMask3)
       {
       if (isMask3)
@@ -1779,7 +1780,7 @@ class TR_S390RRFInstruction : public TR_S390RRInstruction
          _mask4 = mask;
       }
 
-   TR_S390RRFInstruction(TR::InstOpCode::Mnemonic        op,
+   S390RRFInstruction(TR::InstOpCode::Mnemonic        op,
                         TR::Node               *n,
                         TR::Register           *treg,
                         TR::Register           *sreg,
@@ -1787,7 +1788,7 @@ class TR_S390RRFInstruction : public TR_S390RRInstruction
                         bool                   isMask3,
                         TR::RegisterDependencyConditions * cond,
                         TR::CodeGenerator      *cg)
-      : TR_S390RRInstruction(op, n, treg, sreg, cond, cg), _encodeAsRRD(false),
+      : S390RRInstruction(op, n, treg, sreg, cond, cg), _encodeAsRRD(false),
         _isSourceReg2Present(false), _isMask3Present(isMask3),_isMask4Present(!isMask3)
       {
       if (isMask3)
@@ -1796,14 +1797,14 @@ class TR_S390RRFInstruction : public TR_S390RRInstruction
          _mask4 = mask;
       }
 
-   TR_S390RRFInstruction(TR::InstOpCode::Mnemonic        op,
+   S390RRFInstruction(TR::InstOpCode::Mnemonic        op,
                         TR::Node               *n,
                         TR::Register           *treg,
                         TR::Register           *sreg,
                         TR::Register           *sreg2,
                         uint8_t                 mask,
                         TR::CodeGenerator      *cg)
-      : TR_S390RRInstruction(op, n, treg, sreg, cg), _encodeAsRRD(false),
+      : S390RRInstruction(op, n, treg, sreg, cg), _encodeAsRRD(false),
         _isSourceReg2Present(true), _isMask3Present(false),_isMask4Present(true),_mask4(mask)
       {
       if (!getOpCode().setsOperand3())
@@ -1812,14 +1813,14 @@ class TR_S390RRFInstruction : public TR_S390RRInstruction
          useTargetRegister(sreg2);
       }
 
-   TR_S390RRFInstruction(TR::InstOpCode::Mnemonic         op,
+   S390RRFInstruction(TR::InstOpCode::Mnemonic         op,
                         TR::Node               *n,
                         TR::Register           *treg,
                         TR::Register           *sreg,
                         TR::Register           *sreg2,
                         TR::RegisterDependencyConditions * cond,
                         TR::CodeGenerator      *cg)
-      : TR_S390RRInstruction(op, n, treg, sreg, cond, cg), _encodeAsRRD(false),
+      : S390RRInstruction(op, n, treg, sreg, cond, cg), _encodeAsRRD(false),
         _isSourceReg2Present(true), _isMask3Present(false),_isMask4Present(false)
       {
       if (!getOpCode().setsOperand3())
@@ -1828,14 +1829,14 @@ class TR_S390RRFInstruction : public TR_S390RRInstruction
          useTargetRegister(sreg2);
       }
 
-   TR_S390RRFInstruction(TR::InstOpCode::Mnemonic         op,
+   S390RRFInstruction(TR::InstOpCode::Mnemonic         op,
                         TR::Node               *n,
                         TR::Register           *treg,
                         TR::Register           *sreg,
                         TR::Register           *sreg2,
                         TR::Instruction        *precedingInstruction,
                         TR::CodeGenerator      *cg)
-      : TR_S390RRInstruction(op, n, treg, sreg, precedingInstruction, cg), _encodeAsRRD(false),
+      : S390RRInstruction(op, n, treg, sreg, precedingInstruction, cg), _encodeAsRRD(false),
        _isSourceReg2Present(true), _isMask3Present(false),_isMask4Present(false)
       {
       if (!getOpCode().setsOperand3())
@@ -1844,7 +1845,7 @@ class TR_S390RRFInstruction : public TR_S390RRInstruction
          useTargetRegister(sreg2);
       }
 
-   TR_S390RRFInstruction(TR::InstOpCode::Mnemonic         op,
+   S390RRFInstruction(TR::InstOpCode::Mnemonic         op,
                         TR::Node               *n,
                         TR::Register           *treg,
                         TR::Register           *sreg,
@@ -1852,7 +1853,7 @@ class TR_S390RRFInstruction : public TR_S390RRInstruction
                         TR::RegisterDependencyConditions * cond,
                         TR::Instruction        *precedingInstruction,
                         TR::CodeGenerator      *cg)
-      : TR_S390RRInstruction(op, n, treg, sreg, cond, precedingInstruction, cg), _encodeAsRRD(false),
+      : S390RRInstruction(op, n, treg, sreg, cond, precedingInstruction, cg), _encodeAsRRD(false),
         _isSourceReg2Present(true), _isMask3Present(false),_isMask4Present(false)
       {
       if (!getOpCode().setsOperand3())
@@ -1861,14 +1862,14 @@ class TR_S390RRFInstruction : public TR_S390RRInstruction
          useTargetRegister(sreg2);
       }
 
-   TR_S390RRFInstruction(TR::InstOpCode::Mnemonic        op,
+   S390RRFInstruction(TR::InstOpCode::Mnemonic        op,
                         TR::Node               *n,
                         TR::Register           *treg,
                         TR::Register           *sreg,
                         uint8_t                 mask3,
                         uint8_t                 mask4,
                         TR::CodeGenerator      *cg)
-      : TR_S390RRInstruction(op, n, treg, sreg, cg),
+      : S390RRInstruction(op, n, treg, sreg, cg),
         _mask3(mask3),_mask4(mask4), _encodeAsRRD(false),
         _isSourceReg2Present(false), _isMask3Present(true),_isMask4Present(true)
       {
@@ -1919,20 +1920,20 @@ class TR_S390RRFInstruction : public TR_S390RRInstruction
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390RRRInstruction Class Definition
+// S390RRRInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390RRRInstruction : public TR_S390RRInstruction
+class S390RRRInstruction : public TR::S390RRInstruction
    {
    #define rrr_srcidx 1
    public:
 
-   TR_S390RRRInstruction(TR::InstOpCode::Mnemonic         op,
+   S390RRRInstruction(TR::InstOpCode::Mnemonic         op,
                          TR::Node               *n,
                          TR::Register           *treg,
                          TR::Register           *sreg,
                          TR::Register           *sreg2,
                          TR::CodeGenerator      *cg)
-      : TR_S390RRInstruction(op, n, treg, sreg, cg)
+      : S390RRInstruction(op, n, treg, sreg, cg)
       {
       if (!getOpCode().setsOperand3())
          useSourceRegister(sreg2);
@@ -1940,7 +1941,7 @@ class TR_S390RRRInstruction : public TR_S390RRInstruction
          useTargetRegister(sreg2);
       }
 
-   TR_S390RRRInstruction(TR::InstOpCode::Mnemonic         op,
+   S390RRRInstruction(TR::InstOpCode::Mnemonic         op,
                          TR::Node               *n,
                          TR::Register           *treg,
                          TR::Register           *sreg,
@@ -1948,7 +1949,7 @@ class TR_S390RRRInstruction : public TR_S390RRInstruction
                          TR::RegisterDependencyConditions * cond,
                          TR::Instruction        *precedingInstruction,
                          TR::CodeGenerator      *cg)
-      : TR_S390RRInstruction(op, n, treg, sreg, cond, precedingInstruction, cg)
+      : S390RRInstruction(op, n, treg, sreg, cond, precedingInstruction, cg)
       {
       if (!getOpCode().setsOperand3())
          useSourceRegister(sreg2);
@@ -1956,14 +1957,14 @@ class TR_S390RRRInstruction : public TR_S390RRInstruction
          useTargetRegister(sreg2);
       }
 
-   TR_S390RRRInstruction(TR::InstOpCode::Mnemonic         op,
+   S390RRRInstruction(TR::InstOpCode::Mnemonic         op,
                          TR::Node               *n,
                          TR::Register           *treg,
                          TR::Register           *sreg,
                          TR::Register           *sreg2,
                          TR::Instruction        *precedingInstruction,
                          TR::CodeGenerator      *cg)
-      : TR_S390RRInstruction(op, n, treg, sreg, precedingInstruction, cg)
+      : S390RRInstruction(op, n, treg, sreg, precedingInstruction, cg)
       {
       if (!getOpCode().setsOperand3())
          useSourceRegister(sreg2);
@@ -1988,9 +1989,9 @@ class TR_S390RRRInstruction : public TR_S390RRInstruction
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390RIInstruction Class Definition
+// S390RIInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390RIInstruction : public TR_S390RegInstruction
+class S390RIInstruction : public TR::S390RegInstruction
    {
    union
       {
@@ -2002,45 +2003,45 @@ class TR_S390RIInstruction : public TR_S390RegInstruction
 
    public:
 
-   TR_S390RIInstruction(TR::InstOpCode::Mnemonic op, TR::Node *n,
+   S390RIInstruction(TR::InstOpCode::Mnemonic op, TR::Node *n,
                             TR::CodeGenerator *cg)
-           : TR_S390RegInstruction(op, n, cg), _isImm(false), _sourceImmediate(0) {};
+           : S390RegInstruction(op, n, cg), _isImm(false), _sourceImmediate(0) {};
 
-   TR_S390RIInstruction(TR::InstOpCode::Mnemonic op, TR::Node *n,
+   S390RIInstruction(TR::InstOpCode::Mnemonic op, TR::Node *n,
                             TR::Instruction *precedingInstruction,
                             TR::CodeGenerator *cg)
-           : TR_S390RegInstruction(op, n, precedingInstruction, cg), _isImm(false), _sourceImmediate(0) {};
+           : S390RegInstruction(op, n, precedingInstruction, cg), _isImm(false), _sourceImmediate(0) {};
 
-   TR_S390RIInstruction(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register  *treg,
+   S390RIInstruction(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register  *treg,
                             TR::CodeGenerator *cg)
-           : TR_S390RegInstruction(op, n, treg, cg), _isImm(false), _sourceImmediate(0) {};
+           : S390RegInstruction(op, n, treg, cg), _isImm(false), _sourceImmediate(0) {};
 
-   TR_S390RIInstruction(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register  *treg,
+   S390RIInstruction(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register  *treg,
                             TR::Instruction *precedingInstruction,
                             TR::CodeGenerator *cg)
-           : TR_S390RegInstruction(op, n, treg, precedingInstruction, cg), _isImm(false), _sourceImmediate(0) {};
+           : S390RegInstruction(op, n, treg, precedingInstruction, cg), _isImm(false), _sourceImmediate(0) {};
 
-   TR_S390RIInstruction(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register  *treg,
+   S390RIInstruction(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register  *treg,
                             char *data,
                             TR::CodeGenerator *cg)
-           : TR_S390RegInstruction(op, n, treg, cg), _namedDataField(data), _isImm(false) {};
+           : S390RegInstruction(op, n, treg, cg), _namedDataField(data), _isImm(false) {};
 
-   TR_S390RIInstruction(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register  *treg,
+   S390RIInstruction(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register  *treg,
                             char *data,
                             TR::Instruction *precedingInstruction,
                             TR::CodeGenerator *cg)
-           : TR_S390RegInstruction(op, n, treg, precedingInstruction, cg), _namedDataField(data), _isImm(false)  {};
+           : S390RegInstruction(op, n, treg, precedingInstruction, cg), _namedDataField(data), _isImm(false)  {};
 
-   TR_S390RIInstruction(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register  *treg,
+   S390RIInstruction(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register  *treg,
                             int32_t     imm,
                             TR::CodeGenerator *cg)
-           : TR_S390RegInstruction(op, n, treg, cg), _sourceImmediate(imm), _isImm(true) {};
+           : S390RegInstruction(op, n, treg, cg), _sourceImmediate(imm), _isImm(true) {};
 
-   TR_S390RIInstruction(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register  *treg,
+   S390RIInstruction(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register  *treg,
                             int32_t       imm,
                             TR::Instruction *precedingInstruction,
                             TR::CodeGenerator *cg)
-           : TR_S390RegInstruction(op, n, treg, precedingInstruction, cg), _sourceImmediate(imm), _isImm(true) {};
+           : S390RegInstruction(op, n, treg, precedingInstruction, cg), _sourceImmediate(imm), _isImm(true) {};
 
    virtual char *description() { return "S390RIInstruction"; }
    virtual Kind getKind() { return IsRI; }
@@ -2055,9 +2056,9 @@ class TR_S390RIInstruction : public TR_S390RegInstruction
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390RILInstruction Class Definition
+// S390RILInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390RILInstruction : public TR::Instruction
+class S390RILInstruction : public TR::Instruction
    {
    uint32_t     _mask;
    uintptrj_t   _targetPtr;
@@ -2079,7 +2080,7 @@ class TR_S390RILInstruction : public TR::Instruction
 
    public:
 
-   TR_S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
+   S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
                          uintptrj_t     tp,
                          TR::CodeGenerator *cg)
       : TR::Instruction(op, n, cg), _targetSnippet(NULL), _targetSymbol(NULL), _flagsRIL(0), _mask(0xffffffff),  _targetLabel(NULL),_symbolReference(NULL)
@@ -2103,7 +2104,7 @@ class TR_S390RILInstruction : public TR::Instruction
          useTargetRegister(treg);
       }
 
-   TR_S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
+   S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
                          uintptrj_t     tp,
                          TR::SymbolReference *sr,
                          TR::CodeGenerator *cg)
@@ -2116,7 +2117,7 @@ class TR_S390RILInstruction : public TR::Instruction
          useTargetRegister(treg);
       }
 
-   TR_S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
+   S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
                          uintptrj_t     tp,
                          TR::SymbolReference *sr,
                          TR::Instruction *precedingInstruction,
@@ -2130,7 +2131,7 @@ class TR_S390RILInstruction : public TR::Instruction
          useTargetRegister(treg);
       }
 
-   TR_S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
+   S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
                          uintptrj_t     tp,
                          TR::Instruction *precedingInstruction,
                          TR::CodeGenerator *cg)
@@ -2155,7 +2156,7 @@ class TR_S390RILInstruction : public TR::Instruction
       }
 
    /** For TR::InstOpCode::BRCL */
-   TR_S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
+   S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
                          TR::Snippet *ts,
                          TR::CodeGenerator *cg)
       : TR::Instruction(op, n, cg), _targetPtr((uintptrj_t)NULL), _targetSnippet(ts), _targetSymbol(NULL), _flagsRIL(0), _mask(0xffffffff), _targetLabel(NULL),_symbolReference(NULL),_sourceImmediate(0)
@@ -2167,21 +2168,21 @@ class TR_S390RILInstruction : public TR::Instruction
          useTargetRegister(treg);
       }
 
-   TR_S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t mask,
+   S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t mask,
                          uintptrj_t targetPtr,
                          TR::CodeGenerator *cg)
       : TR::Instruction(op, n, cg), _targetPtr(targetPtr), _targetSnippet(NULL), _targetSymbol(NULL), _flagsRIL(0), _mask(mask),  _targetLabel(NULL),_symbolReference(NULL),_sourceImmediate(0)
       {
       }
 
-   TR_S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t mask,
+   S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t mask,
                          TR::Snippet *ts,
                          TR::CodeGenerator *cg)
       : TR::Instruction(op, n, cg), _targetPtr((uintptrj_t)NULL), _targetSnippet(ts), _targetSymbol(NULL), _flagsRIL(0), _mask(mask), _targetLabel(NULL),_symbolReference(NULL),_sourceImmediate(0)
       {
       }
 
-   TR_S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
+   S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
                          TR::Snippet *ts,
                          TR::Instruction *precedingInstruction,
                          TR::CodeGenerator *cg)
@@ -2194,7 +2195,7 @@ class TR_S390RILInstruction : public TR::Instruction
          useTargetRegister(treg);
       }
 
-   TR_S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t mask,
+   S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t mask,
                          uintptrj_t targetPtr,
                          TR::Instruction *precedingInstruction,
                          TR::CodeGenerator *cg)
@@ -2202,7 +2203,7 @@ class TR_S390RILInstruction : public TR::Instruction
       {
       }
    /** For TR::InstOpCode::BRASL */
-   TR_S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
+   S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
                          TR::Snippet *ts,
                          TR::RegisterDependencyConditions * cond,
                          TR::CodeGenerator *cg)
@@ -2215,7 +2216,7 @@ class TR_S390RILInstruction : public TR::Instruction
          useTargetRegister(treg);
       }
 
-   TR_S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
+   S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
                          TR::Snippet *ts,
                          TR::RegisterDependencyConditions * cond,
                          TR::SymbolReference *sr,
@@ -2229,7 +2230,7 @@ class TR_S390RILInstruction : public TR::Instruction
          useTargetRegister(treg);
       }
 
-   TR_S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t mask,
+   S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t mask,
                          TR::Snippet *ts,
                          TR::RegisterDependencyConditions * cond,
                          TR::CodeGenerator *cg)
@@ -2237,7 +2238,7 @@ class TR_S390RILInstruction : public TR::Instruction
       {
       }
 
-   TR_S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
+   S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
                          uintptrj_t     tp,
                          TR::RegisterDependencyConditions * cond,
                          TR::CodeGenerator *cg)
@@ -2250,7 +2251,7 @@ class TR_S390RILInstruction : public TR::Instruction
          useTargetRegister(treg);
       }
 
-   TR_S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
+   S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
                          TR::Symbol *sym,
                          TR::RegisterDependencyConditions * cond,
                          TR::CodeGenerator *cg)
@@ -2265,7 +2266,7 @@ class TR_S390RILInstruction : public TR::Instruction
          _targetLabel = sym->castToLabelSymbol();
       }
 
-   TR_S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
+   S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
                          TR::Symbol *sym,
                          TR::CodeGenerator *cg)
       : TR::Instruction(op, n, cg), _targetPtr((uintptrj_t)NULL), _targetSnippet(NULL),_targetSymbol(sym), _flagsRIL(0), _mask(0xffffffff), _targetLabel(NULL),_symbolReference(NULL),_sourceImmediate(0)
@@ -2276,7 +2277,7 @@ class TR_S390RILInstruction : public TR::Instruction
          _targetLabel = sym->castToLabelSymbol();
       }
 
-   TR_S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
+   S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
                          TR::Symbol *sym,
                          TR::SymbolReference *sr,
                          TR::CodeGenerator *cg)
@@ -2291,7 +2292,7 @@ class TR_S390RILInstruction : public TR::Instruction
          _targetLabel = sym->castToLabelSymbol();
       }
 
-   TR_S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
+   S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
                          TR::Symbol *sym,
                          TR::SymbolReference *sr,
                          TR::RegisterDependencyConditions * cond,
@@ -2307,7 +2308,7 @@ class TR_S390RILInstruction : public TR::Instruction
          _targetLabel = sym->castToLabelSymbol();
       }
 
-   TR_S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
+   S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
                          TR::Symbol *sym,
                          TR::SymbolReference *sr,
                          TR::Instruction *precedingInstruction,
@@ -2323,7 +2324,7 @@ class TR_S390RILInstruction : public TR::Instruction
          _targetLabel = sym->castToLabelSymbol();
       }
    /** For PFDRL */
-   TR_S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t mask,
+   S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t mask,
                          TR::Symbol *sym,
                          TR::SymbolReference *sr,
                          TR::CodeGenerator *cg)
@@ -2333,7 +2334,7 @@ class TR_S390RILInstruction : public TR::Instruction
          _targetLabel = sym->castToLabelSymbol();
       }
 
-   TR_S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t mask,
+   S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t mask,
                          TR::Symbol *sym,
                          TR::SymbolReference *sr,
                          TR::Instruction *precedingInstruction,
@@ -2344,7 +2345,7 @@ class TR_S390RILInstruction : public TR::Instruction
          _targetLabel = sym->castToLabelSymbol();
       }
 
-   TR_S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
+   S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
                          TR::LabelSymbol *label,
                          TR::CodeGenerator *cg)
       : TR::Instruction(op, n, cg), _targetPtr((uintptrj_t)NULL), _targetSnippet(NULL),_targetSymbol(NULL), _flagsRIL(0), _mask(0xffffffff),  _targetLabel(label),_symbolReference(NULL),_sourceImmediate(0)
@@ -2356,7 +2357,7 @@ class TR_S390RILInstruction : public TR::Instruction
          useTargetRegister(treg);
       }
 
-   TR_S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
+   S390RILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
                          TR::LabelSymbol *label,
                          TR::Instruction *precedingInstruction,
                          TR::CodeGenerator *cg)
@@ -2445,9 +2446,9 @@ class TR_S390RILInstruction : public TR::Instruction
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390RSInstruction Class Definition
+// S390RSInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390RSInstruction : public TR_S390RegInstruction
+class S390RSInstruction : public TR::S390RegInstruction
    {
    protected:
 
@@ -2465,12 +2466,12 @@ class TR_S390RSInstruction : public TR_S390RegInstruction
     * e.g. SLL   R1,12(0) - shifting R1 with constant value 12 and the value is < 4K
     * in this case, base register doesn't need to be set
     */
-   TR_S390RSInstruction(TR::InstOpCode::Mnemonic    op,
+   S390RSInstruction(TR::InstOpCode::Mnemonic    op,
                         TR::Node          *n,
                         TR::Register      *treg,
                         uint32_t          imm,
                         TR::CodeGenerator *cg)
-           : TR_S390RegInstruction(op, n, treg, cg), _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
+           : S390RegInstruction(op, n, treg, cg), _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
       {
       // 1 Register is specified - If it is not a register pair, make sure instruction doesn't take a range (i.e. STM).
       TR_ASSERT(treg->getRegisterPair() || !getOpCode().usesRegRangeForTarget(),
@@ -2478,13 +2479,13 @@ class TR_S390RSInstruction : public TR_S390RegInstruction
                 cg->getDebug()? cg->getDebug()->getOpCodeName(&this->getOpCode()) : "(unknown)");
       };
 
-   TR_S390RSInstruction(TR::InstOpCode::Mnemonic    op,
+   S390RSInstruction(TR::InstOpCode::Mnemonic    op,
                         TR::Node          *n,
                         TR::Register      *treg,
                         uint32_t          imm,
                         TR::Instruction   *precedingInstruction,
                         TR::CodeGenerator *cg)
-           : TR_S390RegInstruction(op, n, treg, precedingInstruction, cg), _kind(IsRS),
+           : S390RegInstruction(op, n, treg, precedingInstruction, cg), _kind(IsRS),
              _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMask(false)
       {
       // 1 Register is specified - If it is not a register pair, make sure instruction doesn't take a range (i.e. STM).
@@ -2493,13 +2494,13 @@ class TR_S390RSInstruction : public TR_S390RegInstruction
                 cg->getDebug()? cg->getDebug()->getOpCodeName(&this->getOpCode()) : "(unknown)");
       };
 
-   TR_S390RSInstruction(TR::InstOpCode::Mnemonic    op,
+   S390RSInstruction(TR::InstOpCode::Mnemonic    op,
                         TR::Node          *n,
                         TR::Register      *treg,
                         uint32_t          imm,
                         TR::RegisterDependencyConditions *_conditions,
                         TR::CodeGenerator *cg)
-           : TR_S390RegInstruction(op, n, treg, _conditions, cg), _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
+           : S390RegInstruction(op, n, treg, _conditions, cg), _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
 
       {
       // 1 Register is specified - If it is not a register pair, make sure instruction doesn't take a range (i.e. STM).
@@ -2508,14 +2509,14 @@ class TR_S390RSInstruction : public TR_S390RegInstruction
                 cg->getDebug()? cg->getDebug()->getOpCodeName(&this->getOpCode()) : "(unknown)");
       };
 
-   TR_S390RSInstruction(TR::InstOpCode::Mnemonic    op,
+   S390RSInstruction(TR::InstOpCode::Mnemonic    op,
                         TR::Node          *n,
                         TR::Register      *treg,
                         uint32_t          imm,
                         TR::RegisterDependencyConditions *_conditions,
                         TR::Instruction   *precedingInstruction,
                         TR::CodeGenerator *cg)
-           : TR_S390RegInstruction(op, n, treg, _conditions, precedingInstruction, cg), _kind(IsRS),
+           : S390RegInstruction(op, n, treg, _conditions, precedingInstruction, cg), _kind(IsRS),
              _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMask(false)
       {
       // 1 Register is specified - If it is not a register pair, make sure instruction doesn't take a range (i.e. STM).
@@ -2525,12 +2526,12 @@ class TR_S390RSInstruction : public TR_S390RegInstruction
       };
 
    // RS instruction with  R1,D2(B2) format
-   TR_S390RSInstruction(TR::InstOpCode::Mnemonic           op,
+   S390RSInstruction(TR::InstOpCode::Mnemonic           op,
                         TR::Node                 *n,
                         TR::Register             *treg,
                         TR::MemoryReference  *mf,
                         TR::CodeGenerator        *cg)
-           : TR_S390RegInstruction(op, n, treg, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
+           : S390RegInstruction(op, n, treg, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
       {
       useSourceMemoryReference(mf);
       setupThrowsImplicitNullPointerException(n,mf);
@@ -2543,13 +2544,13 @@ class TR_S390RSInstruction : public TR_S390RegInstruction
                 cg->getDebug()? cg->getDebug()->getOpCodeName(&this->getOpCode()) : "(unknown)");
       }
 
-   TR_S390RSInstruction(TR::InstOpCode::Mnemonic           op,
+   S390RSInstruction(TR::InstOpCode::Mnemonic           op,
                         TR::Node                 *n,
                         TR::Register             *treg,
                         TR::MemoryReference  *mf,
                         TR::Instruction          *precedingInstruction,
                         TR::CodeGenerator        *cg)
-           : TR_S390RegInstruction(op, n, treg, precedingInstruction, cg),
+           : S390RegInstruction(op, n, treg, precedingInstruction, cg),
              _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
       {
       useSourceMemoryReference(mf);
@@ -2564,14 +2565,14 @@ class TR_S390RSInstruction : public TR_S390RegInstruction
       }
 
    /** Used for ICM instruction */
-   TR_S390RSInstruction(TR::InstOpCode::Mnemonic op,
+   S390RSInstruction(TR::InstOpCode::Mnemonic op,
                         TR::Node                 *n,
                         TR::Register             *treg,
                         uint32_t                 mask,
                         TR::MemoryReference      *mf,
                         TR::Instruction          *precedingInstruction,
                         TR::CodeGenerator        *cg)
-           : TR_S390RegInstruction(op, n, treg, precedingInstruction, cg),
+           : S390RegInstruction(op, n, treg, precedingInstruction, cg),
              _sourceImmediate(0), _maskImmediate(mask), _idx(-1), _hasMask(true), _kind(IsRS)
       {
       useSourceMemoryReference(mf);
@@ -2586,13 +2587,13 @@ class TR_S390RSInstruction : public TR_S390RegInstruction
       }
 
    /** Used for ICM instruction */
-   TR_S390RSInstruction(TR::InstOpCode::Mnemonic op,
+   S390RSInstruction(TR::InstOpCode::Mnemonic op,
                         TR::Node                 *n,
                         TR::Register             *treg,
                         uint32_t                 mask,
                         TR::MemoryReference      *mf,
                         TR::CodeGenerator        *cg)
-           : TR_S390RegInstruction(op, n, treg, cg),
+           : S390RegInstruction(op, n, treg, cg),
              _sourceImmediate(0), _maskImmediate(mask), _idx(-1), _hasMask(true), _kind(IsRS)
       {
       useSourceMemoryReference(mf);
@@ -2606,13 +2607,13 @@ class TR_S390RSInstruction : public TR_S390RegInstruction
     * Used for range of registers STM R1,R2 (R2!=R1+1)
     * also for SLLG, SLAG, SRLG for 64bit codegen
     */
-   TR_S390RSInstruction(TR::InstOpCode::Mnemonic op,
+   S390RSInstruction(TR::InstOpCode::Mnemonic op,
                         TR::Node                 *n,
                         TR::Register             *freg,
                         TR::Register             *lreg,
                         TR::MemoryReference      *mf,
                         TR::CodeGenerator        *cg)
-           : TR_S390RegInstruction(op, n, freg, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
+           : S390RegInstruction(op, n, freg, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
       {
       if (getOpCode().setsOperand2())
          useTargetRegister(lreg);
@@ -2625,14 +2626,14 @@ class TR_S390RSInstruction : public TR_S390RegInstruction
          (mf->getUnresolvedSnippet())->setDataReferenceInstruction(this);
       }
 
-   TR_S390RSInstruction(TR::InstOpCode::Mnemonic op,
+   S390RSInstruction(TR::InstOpCode::Mnemonic op,
                         TR::Node                 *n,
                         TR::Register             *freg,
                         TR::Register             *lreg,
                         TR::MemoryReference      *mf,
                         TR::Instruction          *precedingInstruction,
                         TR::CodeGenerator        *cg)
-           : TR_S390RegInstruction(op, n, freg, precedingInstruction, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
+           : S390RegInstruction(op, n, freg, precedingInstruction, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
       {
 
       if (getOpCode().setsOperand2())
@@ -2648,12 +2649,12 @@ class TR_S390RSInstruction : public TR_S390RegInstruction
       }
 
    /** Used specifically for consecutive even-odd pairs (STM,LM) */
-   TR_S390RSInstruction(TR::InstOpCode::Mnemonic op,
+   S390RSInstruction(TR::InstOpCode::Mnemonic op,
                         TR::Node                 *n,
                         TR::RegisterPair         *regp,
                         TR::MemoryReference      *mf,
                         TR::CodeGenerator        *cg)
-           : TR_S390RegInstruction(op, n, regp, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
+           : S390RegInstruction(op, n, regp, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
      {
      useSourceMemoryReference(mf);
      setupThrowsImplicitNullPointerException(n,mf);
@@ -2661,13 +2662,13 @@ class TR_S390RSInstruction : public TR_S390RegInstruction
         (mf->getUnresolvedSnippet())->setDataReferenceInstruction(this);
      }
 
-   TR_S390RSInstruction(TR::InstOpCode::Mnemonic op,
+   S390RSInstruction(TR::InstOpCode::Mnemonic op,
                         TR::Node                 *n,
                         TR::RegisterPair         *regp,
                         TR::MemoryReference      *mf,
                         TR::Instruction          *precedingInstruction,
                         TR::CodeGenerator        *cg)
-           : TR_S390RegInstruction(op, n, regp, precedingInstruction, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
+           : S390RegInstruction(op, n, regp, precedingInstruction, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
       {
       useSourceMemoryReference(mf);
       setupThrowsImplicitNullPointerException(n,mf);
@@ -2676,13 +2677,13 @@ class TR_S390RSInstruction : public TR_S390RegInstruction
       }
 
    /** Used specifically for source/target consecutive even-odd pairs (CLCLE,MVCLE)*/
-   TR_S390RSInstruction(TR::InstOpCode::Mnemonic op,
+   S390RSInstruction(TR::InstOpCode::Mnemonic op,
                         TR::Node                 *n,
                         TR::RegisterPair         *regp,
                         TR::RegisterPair         *regp2,
                         TR::MemoryReference      *mf,
                         TR::CodeGenerator        *cg)
-           : TR_S390RegInstruction(op, n, regp, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
+           : S390RegInstruction(op, n, regp, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
 
      {
      if (getOpCode().setsOperand2())
@@ -2695,14 +2696,14 @@ class TR_S390RSInstruction : public TR_S390RegInstruction
         mf->getUnresolvedSnippet()->setDataReferenceInstruction(this);
      }
 
-   TR_S390RSInstruction(TR::InstOpCode::Mnemonic op,
+   S390RSInstruction(TR::InstOpCode::Mnemonic op,
                         TR::Node                 *n,
                         TR::RegisterPair         *regp,
                         TR::RegisterPair         *regp2,
                         TR::MemoryReference      *mf,
                         TR::Instruction          *precedingInstruction,
                         TR::CodeGenerator        *cg)
-           : TR_S390RegInstruction(op, n, regp, precedingInstruction, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
+           : S390RegInstruction(op, n, regp, precedingInstruction, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
       {
       if (getOpCode().setsOperand2())
          useTargetRegister(regp2);
@@ -2715,13 +2716,13 @@ class TR_S390RSInstruction : public TR_S390RegInstruction
       }
 
    /** For 64bit code-gen SLLG, SLAG, SRLG */
-   TR_S390RSInstruction(TR::InstOpCode::Mnemonic    op,
+   S390RSInstruction(TR::InstOpCode::Mnemonic    op,
                         TR::Node          *n,
                         TR::Register      *treg,
                         TR::Register      *sreg,
                         uint32_t          imm,
                         TR::CodeGenerator *cg)
-           : TR_S390RegInstruction(op, n, treg, cg), _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
+           : S390RegInstruction(op, n, treg, cg), _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
         {
         if (getOpCode().setsOperand2())
            useTargetRegister(sreg);
@@ -2729,14 +2730,14 @@ class TR_S390RSInstruction : public TR_S390RegInstruction
            useSourceRegister(sreg);
         };
 
-   TR_S390RSInstruction(TR::InstOpCode::Mnemonic    op,
+   S390RSInstruction(TR::InstOpCode::Mnemonic    op,
                         TR::Node          *n,
                         TR::Register      *treg,
                         TR::Register      *sreg,
                         uint32_t          imm,
                         TR::Instruction   *precedingInstruction,
                         TR::CodeGenerator *cg)
-           : TR_S390RegInstruction(op, n, treg, precedingInstruction, cg),
+           : S390RegInstruction(op, n, treg, precedingInstruction, cg),
              _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
         {
         if (getOpCode().setsOperand2())
@@ -2754,8 +2755,8 @@ class TR_S390RSInstruction : public TR_S390RegInstruction
    uint32_t setMaskImmediate(uint32_t mi)   {return _maskImmediate = mi;}
    bool     hasMask()                       {return _hasMask;}
 
-   TR::Register* getFirstRegister() { return isTargetPair()? TR_S390RegInstruction::getFirstRegister() : getRegisterOperand(1); }
-   TR::Register* getLastRegister()  { return isTargetPair()? TR_S390RegInstruction::getLastRegister()  : getRegisterOperand(2); }
+   TR::Register* getFirstRegister() { return isTargetPair()? S390RegInstruction::getFirstRegister() : getRegisterOperand(1); }
+   TR::Register* getLastRegister()  { return isTargetPair()? S390RegInstruction::getLastRegister()  : getRegisterOperand(2); }
 
    TR::Register* getSecondRegister() {return getRegisterOperand(2); }
 
@@ -2770,36 +2771,36 @@ class TR_S390RSInstruction : public TR_S390RegInstruction
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390RSWithImplicitPairStoresInstruction Class Definition
+// S390RSWithImplicitPairStoresInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
 
 /**
  * @todo complex source <-> target copies
  */
-class TR_S390RSWithImplicitPairStoresInstruction : public TR_S390RSInstruction
+class S390RSWithImplicitPairStoresInstruction : public TR::S390RSInstruction
    {
    public:
 
 
    /** Used specifically for source/target consecutive even-odd pairs (CLCLE,MVCLE)*/
-   TR_S390RSWithImplicitPairStoresInstruction(TR::InstOpCode::Mnemonic    op,
+   S390RSWithImplicitPairStoresInstruction(TR::InstOpCode::Mnemonic    op,
                         TR::Node          *n,
                         TR::RegisterPair  *regp,
                         TR::RegisterPair  *regp2,
                         TR::MemoryReference *mf,
                         TR::CodeGenerator *cg)
-           : TR_S390RSInstruction(op, n, regp, regp2, mf, cg)
+           : S390RSInstruction(op, n, regp, regp2, mf, cg)
       {
       }
 
-   TR_S390RSWithImplicitPairStoresInstruction(TR::InstOpCode::Mnemonic    op,
+   S390RSWithImplicitPairStoresInstruction(TR::InstOpCode::Mnemonic    op,
                         TR::Node          *n,
                         TR::RegisterPair  *regp,
                         TR::RegisterPair  *regp2,
                         TR::MemoryReference *mf,
                         TR::Instruction   *precedingInstruction,
                         TR::CodeGenerator *cg)
-           : TR_S390RSInstruction(op, n, regp, regp2, mf, precedingInstruction, cg)
+           : S390RSInstruction(op, n, regp, regp2, mf, precedingInstruction, cg)
       {
       }
 
@@ -2810,30 +2811,30 @@ class TR_S390RSWithImplicitPairStoresInstruction : public TR_S390RSInstruction
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390RSYInstruction Class Definition
+// S390RSYInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390RSYInstruction : public TR_S390RSInstruction
+class S390RSYInstruction : public TR::S390RSInstruction
    {
    public:
 
-   TR_S390RSYInstruction(TR::InstOpCode::Mnemonic    op,
+   S390RSYInstruction(TR::InstOpCode::Mnemonic    op,
                         TR::Node          *n,
                         TR::Register      *treg,
                         uint32_t          mask,
                         TR::MemoryReference *mf,
                         TR::CodeGenerator *cg)
-      : TR_S390RSInstruction(op, n, treg, mask, mf, cg)
+      : S390RSInstruction(op, n, treg, mask, mf, cg)
       {
       }
 
-   TR_S390RSYInstruction(TR::InstOpCode::Mnemonic    op,
+   S390RSYInstruction(TR::InstOpCode::Mnemonic    op,
                         TR::Node          *n,
                         TR::Register      *treg,
                         uint32_t          mask,
                         TR::MemoryReference *mf,
                         TR::Instruction   *preced,
                         TR::CodeGenerator *cg)
-      : TR_S390RSInstruction(op, n, treg, mask, mf, preced, cg)
+      : S390RSInstruction(op, n, treg, mask, mf, preced, cg)
       {
       }
 
@@ -2847,9 +2848,9 @@ class TR_S390RSYInstruction : public TR_S390RSInstruction
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390RRSInstruction Class Definition
+// S390RRSInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390RRSInstruction : public TR_S390RRInstruction
+class S390RRSInstruction : public TR::S390RRInstruction
    {
    TR::MemoryReference * _branchDestination;
    TR::InstOpCode::S390BranchCondition _branchCondition;
@@ -2859,14 +2860,14 @@ class TR_S390RRSInstruction : public TR_S390RRInstruction
    public:
 
    /** Construct a new RRS instruction with no preceding instruction */
-   TR_S390RRSInstruction(TR::InstOpCode::Mnemonic op,
+   S390RRSInstruction(TR::InstOpCode::Mnemonic op,
                          TR::Node * n,
                          TR::Register * targetRegister,
                          TR::Register * sourceRegister,
                          TR::MemoryReference * branchDestination,
                          TR::InstOpCode::S390BranchCondition branchCondition,
                          TR::CodeGenerator * cg)
-           : TR_S390RRInstruction(op, n, targetRegister, sourceRegister, cg),
+           : S390RRInstruction(op, n, targetRegister, sourceRegister, cg),
              _kind(IsRRS),
              _branchDestination(branchDestination),
              _branchCondition(branchCondition)
@@ -2875,7 +2876,7 @@ class TR_S390RRSInstruction : public TR_S390RRInstruction
    }
 
    /** Construct a new RRS instruction with preceding instruction */
-   TR_S390RRSInstruction(TR::InstOpCode::Mnemonic op,
+   S390RRSInstruction(TR::InstOpCode::Mnemonic op,
                          TR::Node * n,
                          TR::Register * targetRegister,
                          TR::Register * sourceRegister,
@@ -2883,7 +2884,7 @@ class TR_S390RRSInstruction : public TR_S390RRInstruction
                          TR::InstOpCode::S390BranchCondition branchCondition,
                          TR::Instruction * precedingInstruction,
                          TR::CodeGenerator * cg)
-           : TR_S390RRInstruction(op, n, targetRegister, sourceRegister, precedingInstruction, cg),
+           : S390RRInstruction(op, n, targetRegister, sourceRegister, precedingInstruction, cg),
              _kind(IsRRS),
              _branchDestination(branchDestination),
              _branchCondition(branchCondition)
@@ -2907,66 +2908,66 @@ class TR_S390RRSInstruction : public TR_S390RRInstruction
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390RREInstruction Class Definition
+// S390RREInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390RREInstruction : public TR_S390RRInstruction
+class S390RREInstruction : public TR::S390RRInstruction
    {
    public:
 
-   TR_S390RREInstruction(TR::InstOpCode::Mnemonic  op,
+   S390RREInstruction(TR::InstOpCode::Mnemonic  op,
                         TR::Node          *n,
                         TR::Register      *treg,
                         TR::CodeGenerator *cg)
-      : TR_S390RRInstruction(op, n, treg, cg)
+      : S390RRInstruction(op, n, treg, cg)
       {
       }
 
-   TR_S390RREInstruction(TR::InstOpCode::Mnemonic  op,
-                        TR::Node          *n,
-                        TR::Register      *treg,
-                        TR::Register      *sreg,
-                        TR::CodeGenerator *cg)
-      : TR_S390RRInstruction(op, n, treg, sreg, cg)
-      {
-      }
-
-   TR_S390RREInstruction(TR::InstOpCode::Mnemonic  op,
+   S390RREInstruction(TR::InstOpCode::Mnemonic  op,
                         TR::Node          *n,
                         TR::Register      *treg,
                         TR::Register      *sreg,
-                        TR::RegisterDependencyConditions * cond,
                         TR::CodeGenerator *cg)
-      : TR_S390RRInstruction(op, n, treg, sreg, cond, cg)
+      : S390RRInstruction(op, n, treg, sreg, cg)
       {
       }
 
-   TR_S390RREInstruction(TR::InstOpCode::Mnemonic  op,
+   S390RREInstruction(TR::InstOpCode::Mnemonic  op,
                         TR::Node          *n,
                         TR::Register      *treg,
                         TR::Register      *sreg,
                         TR::RegisterDependencyConditions * cond,
-                        TR::Instruction   *preced,
                         TR::CodeGenerator *cg)
-      : TR_S390RRInstruction(op, n, treg, sreg, cond, preced, cg)
+      : S390RRInstruction(op, n, treg, sreg, cond, cg)
       {
       }
 
-   TR_S390RREInstruction(TR::InstOpCode::Mnemonic  op,
+   S390RREInstruction(TR::InstOpCode::Mnemonic  op,
+                        TR::Node          *n,
+                        TR::Register      *treg,
+                        TR::Register      *sreg,
+                        TR::RegisterDependencyConditions * cond,
+                        TR::Instruction   *preced,
+                        TR::CodeGenerator *cg)
+      : S390RRInstruction(op, n, treg, sreg, cond, preced, cg)
+      {
+      }
+
+   S390RREInstruction(TR::InstOpCode::Mnemonic  op,
                         TR::Node          *n,
                         TR::Register      *treg,
                         TR::Register      *sreg,
                         TR::Instruction   *preced,
                         TR::CodeGenerator *cg)
-      : TR_S390RRInstruction(op, n, treg, sreg, preced, cg)
+      : S390RRInstruction(op, n, treg, sreg, preced, cg)
       {
       }
 
-   TR_S390RREInstruction(TR::InstOpCode::Mnemonic  op,
+   S390RREInstruction(TR::InstOpCode::Mnemonic  op,
                         TR::Node          *n,
                         TR::Register      *treg,
                         TR::Instruction   *preced,
                         TR::CodeGenerator *cg)
-      : TR_S390RRInstruction(op, n, treg,  preced, cg)
+      : S390RRInstruction(op, n, treg,  preced, cg)
       {
       }
 
@@ -2979,15 +2980,15 @@ class TR_S390RREInstruction : public TR_S390RRInstruction
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390IEInstruction Class Definition
+// S390IEInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390IEInstruction : public TR::Instruction
+class S390IEInstruction : public TR::Instruction
    {
    uint8_t                  _immediate1;
    uint8_t                  _immediate2;
    public:
 
-   TR_S390IEInstruction(TR::InstOpCode::Mnemonic op,
+   S390IEInstruction(TR::InstOpCode::Mnemonic op,
                          TR::Node *n,
                          uint8_t im1,
                          uint8_t im2,
@@ -2997,7 +2998,7 @@ class TR_S390IEInstruction : public TR::Instruction
 
            }
 
-   TR_S390IEInstruction(TR::InstOpCode::Mnemonic op,
+   S390IEInstruction(TR::InstOpCode::Mnemonic op,
                          TR::Node * n,
                          uint8_t im1,
                          uint8_t im2,
@@ -3018,7 +3019,7 @@ class TR_S390IEInstruction : public TR::Instruction
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390RIEInstruction Class Definition
+// S390RIEInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
 /**
  * There are 3 forms of RIE instructions.  one which compares Reg-Reg, one
@@ -3027,7 +3028,7 @@ class TR_S390IEInstruction : public TR::Instruction
  * Note that there is no distinction between source and target register for
  * a compare, this is just following convention.
  */
-class TR_S390RIEInstruction : public TR_S390RegInstruction
+class S390RIEInstruction : public TR::S390RegInstruction
    {
 
    TR::InstOpCode::S390BranchCondition _branchCondition;
@@ -3066,14 +3067,14 @@ class TR_S390RIEInstruction : public TR_S390RegInstruction
 
 
    /** Construct a Reg-Reg form RIE with no preceding instruction */
-   TR_S390RIEInstruction(TR::InstOpCode::Mnemonic op,
+   S390RIEInstruction(TR::InstOpCode::Mnemonic op,
                          TR::Node * n,
                          TR::Register * targetRegister,
                          TR::Register * sourceRegister,
                          TR::LabelSymbol * branchDestination,
                          TR::InstOpCode::S390BranchCondition branchCondition,
                          TR::CodeGenerator * cg)
-           : TR_S390RegInstruction(op, n, targetRegister, cg),
+           : S390RegInstruction(op, n, targetRegister, cg),
              _kind(IsRIE),
              _instructionFormat(RIE_RR),
              _branchDestination(branchDestination),
@@ -3081,12 +3082,12 @@ class TR_S390RIEInstruction : public TR_S390RegInstruction
              _warmToColdTrampolineSnippet(NULL)
       {
       // note that _targetRegister is registered for use via the
-      // TR_S390RegInstruction constructor call
+      // S390RegInstruction constructor call
       useSourceRegister(sourceRegister);
       }
 
    /** Construct a Reg-Reg form RIE with preceding instruction */
-   TR_S390RIEInstruction(TR::InstOpCode::Mnemonic op,
+   S390RIEInstruction(TR::InstOpCode::Mnemonic op,
                          TR::Node * n,
                          TR::Register * targetRegister,
                          TR::Register * sourceRegister,
@@ -3094,7 +3095,7 @@ class TR_S390RIEInstruction : public TR_S390RegInstruction
                          TR::InstOpCode::S390BranchCondition branchCondition,
                          TR::Instruction * precedingInstruction,
                          TR::CodeGenerator * cg)
-           : TR_S390RegInstruction(op, n, targetRegister, precedingInstruction, cg),
+           : S390RegInstruction(op, n, targetRegister, precedingInstruction, cg),
              _kind(IsRIE),
              _instructionFormat(RIE_RR),
              _branchDestination(branchDestination),
@@ -3102,19 +3103,19 @@ class TR_S390RIEInstruction : public TR_S390RegInstruction
              _warmToColdTrampolineSnippet(NULL)
       {
       // note that _targetRegister is registered for use via the
-      // TR_S390RegInstruction constructor call
+      // S390RegInstruction constructor call
       useSourceRegister(sourceRegister);
       }
 
    /** Construct a Reg-Imm8 form RIE with no preceding instruction */
-   TR_S390RIEInstruction(TR::InstOpCode::Mnemonic op,
+   S390RIEInstruction(TR::InstOpCode::Mnemonic op,
                          TR::Node * n,
                          TR::Register * targetRegister,
                          int8_t sourceImmediate,
                          TR::LabelSymbol * branchDestination,
                          TR::InstOpCode::S390BranchCondition branchCondition,
                          TR::CodeGenerator * cg)
-           : TR_S390RegInstruction(op, n, targetRegister, cg),
+           : S390RegInstruction(op, n, targetRegister, cg),
              _kind(IsRIE),
              _instructionFormat(RIE_RI8),
              _branchDestination(branchDestination),
@@ -3123,12 +3124,12 @@ class TR_S390RIEInstruction : public TR_S390RegInstruction
              _warmToColdTrampolineSnippet(NULL)
       {
       // note that _targetRegister is registered for use via the
-      // TR_S390RegInstruction constructor call
+      // S390RegInstruction constructor call
       }
 
 
    /** Construct a Reg-Imm8 form RIE with preceding instruction */
-   TR_S390RIEInstruction(TR::InstOpCode::Mnemonic op,
+   S390RIEInstruction(TR::InstOpCode::Mnemonic op,
                          TR::Node * n,
                          TR::Register * targetRegister,
                          int8_t sourceImmediate,
@@ -3136,7 +3137,7 @@ class TR_S390RIEInstruction : public TR_S390RegInstruction
                          TR::InstOpCode::S390BranchCondition branchCondition,
                          TR::Instruction * precedingInstruction,
                          TR::CodeGenerator * cg)
-           : TR_S390RegInstruction(op, n, targetRegister, precedingInstruction, cg),
+           : S390RegInstruction(op, n, targetRegister, precedingInstruction, cg),
               _kind(IsRIE),
               _instructionFormat(RIE_RI8),
              _branchDestination(branchDestination),
@@ -3145,11 +3146,11 @@ class TR_S390RIEInstruction : public TR_S390RegInstruction
              _warmToColdTrampolineSnippet(NULL)
       {
       // note that _targetRegister is registered for use via the
-      // TR_S390RegInstruction constructor call
+      // S390RegInstruction constructor call
       }
 
    /** Construct a Reg-Reg-Imm8-Imm8-Imm8 form RIE with no preceding instruction */
-   TR_S390RIEInstruction(TR::InstOpCode::Mnemonic op,
+   S390RIEInstruction(TR::InstOpCode::Mnemonic op,
                          TR::Node * n,
                          TR::Register * targetRegister,
                          TR::Register * sourceRegister,
@@ -3157,7 +3158,7 @@ class TR_S390RIEInstruction : public TR_S390RegInstruction
                          int8_t sourceImmediateTwo,
                          int8_t sourceImmediate,
                          TR::CodeGenerator * cg)
-           : TR_S390RegInstruction(op, n, targetRegister, cg),
+           : S390RegInstruction(op, n, targetRegister, cg),
              _kind(IsRIE),
              _instructionFormat(RIE_IMM),
              _extendedHighWordOpCode(TR::InstOpCode::BAD),
@@ -3170,18 +3171,18 @@ class TR_S390RIEInstruction : public TR_S390RegInstruction
       {
       useSourceRegister(sourceRegister);
       // note that _targetRegister is registered for use via the
-      // TR_S390RegInstruction constructor call
+      // S390RegInstruction constructor call
       if ((op == TR::InstOpCode::RISBG || op == TR::InstOpCode::RISBGN) &&
           cg->supportsHighWordFacility() && !cg->comp()->getOption(TR_DisableHighWordRA) &&
           sourceImmediateTwo & 0x80) // if the zero bit is set, target reg will be 64bit
          {
-         (TR_S390RegInstruction::getRegisterOperand(1))->setIs64BitReg(true);
+         (S390RegInstruction::getRegisterOperand(1))->setIs64BitReg(true);
          }
       }
 
 
    /** Construct a Reg-Reg-Imm8-Imm8-Imm8 form RIE with preceding instruction */
-   TR_S390RIEInstruction(TR::InstOpCode::Mnemonic op,
+   S390RIEInstruction(TR::InstOpCode::Mnemonic op,
                          TR::Node * n,
                          TR::Register * targetRegister,
                          TR::Register * sourceRegister,
@@ -3190,7 +3191,7 @@ class TR_S390RIEInstruction : public TR_S390RegInstruction
                          int8_t sourceImmediate,
                          TR::Instruction * precedingInstruction,
                          TR::CodeGenerator * cg)
-           : TR_S390RegInstruction(op, n, targetRegister, precedingInstruction, cg),
+           : S390RegInstruction(op, n, targetRegister, precedingInstruction, cg),
              _kind(IsRIE),
              _instructionFormat(RIE_IMM),
              _extendedHighWordOpCode(TR::InstOpCode::BAD),
@@ -3202,24 +3203,24 @@ class TR_S390RIEInstruction : public TR_S390RegInstruction
              _warmToColdTrampolineSnippet(NULL)
       {
       // note that _targetRegister is registered for use via the
-      // TR_S390RegInstruction constructor call
+      // S390RegInstruction constructor call
       useSourceRegister(sourceRegister);
       if ((op == TR::InstOpCode::RISBG || op == TR::InstOpCode::RISBGN) &&
           cg->supportsHighWordFacility() && !cg->comp()->getOption(TR_DisableHighWordRA) &&
           sourceImmediateTwo & 0x80) // if the zero bit is set, target reg will be 64bit
          {
-         (TR_S390RegInstruction::getRegisterOperand(1))->setIs64BitReg(true);
+         (S390RegInstruction::getRegisterOperand(1))->setIs64BitReg(true);
          }
       }
 
    /** Construct a Reg-Imm16 form RIE with no preceding instruction */
-   TR_S390RIEInstruction(TR::InstOpCode::Mnemonic op,
+   S390RIEInstruction(TR::InstOpCode::Mnemonic op,
                          TR::Node * n,
                          TR::Register * targetRegister,
                          int16_t sourceImmediate,
                          TR::InstOpCode::S390BranchCondition branchCondition,
                          TR::CodeGenerator * cg)
-           : TR_S390RegInstruction(op, n, targetRegister, cg),
+           : S390RegInstruction(op, n, targetRegister, cg),
               _kind(IsRIE),
               _instructionFormat(RIE_RI16A),
              _branchDestination(0),
@@ -3227,20 +3228,20 @@ class TR_S390RIEInstruction : public TR_S390RegInstruction
              _sourceImmediate16(sourceImmediate),
              _warmToColdTrampolineSnippet(NULL)
       {
-      // Note that _targetRegister is registered for use via the TR_S390RegInstruction constructor call
+      // Note that _targetRegister is registered for use via the S390RegInstruction constructor call
       if (op == TR::InstOpCode::LOCGHI || op == TR::InstOpCode::LOCHI || op == TR::InstOpCode::LOCHHI)
          _instructionFormat = RIE_RI16G;
       }
 
    /** Construct a Reg-Imm16 form RIE with preceding instruction */
-   TR_S390RIEInstruction(TR::InstOpCode::Mnemonic op,
+   S390RIEInstruction(TR::InstOpCode::Mnemonic op,
                          TR::Node * n,
                          TR::Register * targetRegister,
                          int16_t sourceImmediate,
                          TR::InstOpCode::S390BranchCondition branchCondition,
                          TR::Instruction * precedingInstruction,
                          TR::CodeGenerator * cg)
-           : TR_S390RegInstruction(op, n, targetRegister, precedingInstruction, cg),
+           : S390RegInstruction(op, n, targetRegister, precedingInstruction, cg),
               _kind(IsRIE),
               _instructionFormat(RIE_RI16A),
              _branchDestination(0),
@@ -3251,20 +3252,20 @@ class TR_S390RIEInstruction : public TR_S390RegInstruction
       if (isTrap())
          TR_ASSERT((sourceImmediate >> 8) != 0x00B9, "ASSERTION FAILURE: should not generate RIE trap instruction with imm field = B9XX!\n");
 
-      // Note that _targetRegister is registered for use via the TR_S390RegInstruction constructor call
+      // Note that _targetRegister is registered for use via the S390RegInstruction constructor call
       if (op == TR::InstOpCode::LOCGHI || op == TR::InstOpCode::LOCHI || op == TR::InstOpCode::LOCHHI)
          _instructionFormat = RIE_RI16G;
       }
 
       /** Construct a Reg-Reg-Imm16 form RIE with preceding instruction */
-   TR_S390RIEInstruction(TR::InstOpCode::Mnemonic op,
+   S390RIEInstruction(TR::InstOpCode::Mnemonic op,
                          TR::Node * n,
                          TR::Register * targetRegister,
                          TR::Register * sourceRegister,
                          int16_t sourceImmediate,
                          TR::Instruction * precedingInstruction,
                          TR::CodeGenerator * cg)
-      : TR_S390RegInstruction(op, n, targetRegister, precedingInstruction, cg),
+      : S390RegInstruction(op, n, targetRegister, precedingInstruction, cg),
         _kind(IsRIE),
         _instructionFormat(RIE_RRI16),
         _extendedHighWordOpCode(TR::InstOpCode::BAD),
@@ -3275,18 +3276,18 @@ class TR_S390RIEInstruction : public TR_S390RegInstruction
         _warmToColdTrampolineSnippet(NULL)
       {
       // note that _targetRegister is registered for use via the
-      // TR_S390RegInstruction constructor call
+      // S390RegInstruction constructor call
       useSourceRegister(sourceRegister);
       }
 
    /** Construct a Reg-Reg-Imm16 form RIE with no preceding instruction */
-   TR_S390RIEInstruction(TR::InstOpCode::Mnemonic op,
+   S390RIEInstruction(TR::InstOpCode::Mnemonic op,
                          TR::Node * n,
                          TR::Register * targetRegister,
                          TR::Register * sourceRegister,
                          int16_t sourceImmediate,
                          TR::CodeGenerator * cg)
-      : TR_S390RegInstruction(op, n, targetRegister, cg),
+      : S390RegInstruction(op, n, targetRegister, cg),
         _kind(IsRIE),
         _instructionFormat(RIE_RRI16),
         _extendedHighWordOpCode(TR::InstOpCode::BAD),
@@ -3297,7 +3298,7 @@ class TR_S390RIEInstruction : public TR_S390RegInstruction
         _warmToColdTrampolineSnippet(NULL)
       {
       // note that _targetRegister is registered for use via the
-      // TR_S390RegInstruction constructor call
+      // S390RegInstruction constructor call
       useSourceRegister(sourceRegister);
       }
 
@@ -3316,7 +3317,7 @@ class TR_S390RIEInstruction : public TR_S390RegInstruction
 
    // get register information
    //virtual TR::Register * getSourceRegister() { return (_sourceRegSize!=0) ? (sourceRegBase())[0] : NULL; }
-   //   virtual TR::Register * getTargetRegister() { return TR_S390RegInstruction::getTargetRegister(); }
+   //   virtual TR::Register * getTargetRegister() { return S390RegInstruction::getTargetRegister(); }
 
    // set register informtion
    //   virtual void setSourceRegister(TR::Register * reg) { assume0(_sourceRegSize==1); (sourceRegBase())[0] = reg; }
@@ -3365,9 +3366,9 @@ class TR_S390RIEInstruction : public TR_S390RegInstruction
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390SMIInstruction Class Definition
+// S390SMIInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390SMIInstruction : public TR::Instruction
+class S390SMIInstruction : public TR::Instruction
    {
    private:
    uint8_t _mask;
@@ -3375,7 +3376,7 @@ class TR_S390SMIInstruction : public TR::Instruction
 
    public:
 
-   TR_S390SMIInstruction(TR::InstOpCode::Mnemonic op,
+   S390SMIInstruction(TR::InstOpCode::Mnemonic op,
                          TR::Node                 *n,
                          uint8_t                  mask,
                          TR::LabelSymbol          *inst,
@@ -3386,7 +3387,7 @@ class TR_S390SMIInstruction : public TR::Instruction
       useSourceMemoryReference(mf3);
       }
 
-   TR_S390SMIInstruction(TR::InstOpCode::Mnemonic op,
+   S390SMIInstruction(TR::InstOpCode::Mnemonic op,
                          TR::Node                 *n,
                          uint8_t                  mask,
                          TR::LabelSymbol          *inst,
@@ -3398,7 +3399,7 @@ class TR_S390SMIInstruction : public TR::Instruction
       useSourceMemoryReference(mf3);
       }
 
-   TR_S390SMIInstruction(TR::InstOpCode::Mnemonic         op,
+   S390SMIInstruction(TR::InstOpCode::Mnemonic         op,
                          TR::Node                         * n,
                          uint8_t                          mask,
                          TR::LabelSymbol                  *inst,
@@ -3410,7 +3411,7 @@ class TR_S390SMIInstruction : public TR::Instruction
       useSourceMemoryReference(mf3);
       }
 
-   TR_S390SMIInstruction(TR::InstOpCode::Mnemonic         op,
+   S390SMIInstruction(TR::InstOpCode::Mnemonic         op,
                          TR::Node                         *n,
                          uint8_t                          mask,
                          TR::LabelSymbol                  *inst,
@@ -3440,9 +3441,9 @@ class TR_S390SMIInstruction : public TR::Instruction
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390MIIInstruction Class Definition
+// S390MIIInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390MIIInstruction : public TR::Instruction
+class S390MIIInstruction : public TR::Instruction
    {
    private:
    uint8_t _mask;
@@ -3450,7 +3451,7 @@ class TR_S390MIIInstruction : public TR::Instruction
    TR::SymbolReference * _callSymRef;
    public:
 
-   TR_S390MIIInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
+   S390MIIInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
                          uint8_t                mask,
                          TR::LabelSymbol          *inst2,
                          TR::SymbolReference         *inst3,
@@ -3458,7 +3459,7 @@ class TR_S390MIIInstruction : public TR::Instruction
    : TR::Instruction(op, n, cg), _mask(mask), _callSymRef(inst3), _branchInstruction(inst2)
       {
       }
-   TR_S390MIIInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
+   S390MIIInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
                          uint8_t                mask,
                          TR::LabelSymbol          *inst2,
                          TR::SymbolReference         *inst3,
@@ -3467,7 +3468,7 @@ class TR_S390MIIInstruction : public TR::Instruction
    : TR::Instruction(op, n, precedingInstruction, cg), _mask(mask), _callSymRef(inst3), _branchInstruction(inst2)
       {
       }
-   TR_S390MIIInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
+   S390MIIInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
                          uint8_t                mask,
                          TR::LabelSymbol          *inst2,
                          TR::SymbolReference         *inst3,
@@ -3476,7 +3477,7 @@ class TR_S390MIIInstruction : public TR::Instruction
    : TR::Instruction(op, n, cond, cg), _mask(mask), _callSymRef(inst3), _branchInstruction(inst2)
       {
       }
-   TR_S390MIIInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
+   S390MIIInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
                          uint8_t                mask,
                          TR::LabelSymbol          *inst2,
                          TR::SymbolReference         *inst3,
@@ -3505,9 +3506,9 @@ class TR_S390MIIInstruction : public TR::Instruction
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390RISInstruction Class Definition
+// S390RISInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390RISInstruction : public TR_S390RIInstruction
+class S390RISInstruction : public TR::S390RIInstruction
    {
    TR::MemoryReference * _branchDestination;
    TR::InstOpCode::S390BranchCondition _branchCondition;
@@ -3516,14 +3517,14 @@ class TR_S390RISInstruction : public TR_S390RIInstruction
    public:
 
    /** Construct a new RIS instruction with no preceding instruction */
-   TR_S390RISInstruction(TR::InstOpCode::Mnemonic op,
+   S390RISInstruction(TR::InstOpCode::Mnemonic op,
                          TR::Node * n,
                          TR::Register * targetRegister,
                          int8_t sourceImmediate,
                          TR::MemoryReference * branchDestination,
                          TR::InstOpCode::S390BranchCondition branchCondition,
                          TR::CodeGenerator *cg)
-           : TR_S390RIInstruction(op, n, targetRegister, sourceImmediate, cg),
+           : S390RIInstruction(op, n, targetRegister, sourceImmediate, cg),
              _kind(IsRIS),
              _branchDestination(branchDestination),
              _branchCondition(branchCondition)
@@ -3532,7 +3533,7 @@ class TR_S390RISInstruction : public TR_S390RIInstruction
       }
 
    /** Construct a new RIS instruction with preceding instruction */
-   TR_S390RISInstruction(TR::InstOpCode::Mnemonic op,
+   S390RISInstruction(TR::InstOpCode::Mnemonic op,
                          TR::Node * n,
                          TR::Register * targetRegister,
                          int8_t sourceImmediate,
@@ -3540,7 +3541,7 @@ class TR_S390RISInstruction : public TR_S390RIInstruction
                          TR::InstOpCode::S390BranchCondition branchCondition,
                          TR::Instruction * precedingInstruction,
                          TR::CodeGenerator *cg)
-           : TR_S390RIInstruction(op, n, targetRegister, sourceImmediate, precedingInstruction, cg),
+           : S390RIInstruction(op, n, targetRegister, sourceImmediate, precedingInstruction, cg),
              _kind(IsRIS),
              _branchDestination(branchDestination),
              _branchCondition(branchCondition)
@@ -3564,9 +3565,9 @@ class TR_S390RISInstruction : public TR_S390RIInstruction
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390MemInstruction Class Definition
+// S390MemInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390MemInstruction : public TR::Instruction
+class S390MemInstruction : public TR::Instruction
    {
    int8_t _memAccessMode;
    int8_t _constantField;
@@ -3574,7 +3575,7 @@ class TR_S390MemInstruction : public TR::Instruction
 
    public:
 
-   TR_S390MemInstruction(TR::InstOpCode::Mnemonic         op,
+   S390MemInstruction(TR::InstOpCode::Mnemonic         op,
                         TR::Node               *n,
                         TR::MemoryReference *mf,
                         TR::CodeGenerator       *cg,
@@ -3588,7 +3589,7 @@ class TR_S390MemInstruction : public TR::Instruction
          (mf->getUnresolvedSnippet())->setDataReferenceInstruction(this);
       }
 
-   TR_S390MemInstruction(TR::InstOpCode::Mnemonic         op,
+   S390MemInstruction(TR::InstOpCode::Mnemonic         op,
                          TR::Node               *n,
                          TR::MemoryReference *mf,
                          TR::RegisterDependencyConditions *cond,
@@ -3603,7 +3604,7 @@ class TR_S390MemInstruction : public TR::Instruction
          (mf->getUnresolvedSnippet())->setDataReferenceInstruction(this);
       }
 
-   TR_S390MemInstruction(TR::InstOpCode::Mnemonic         op,
+   S390MemInstruction(TR::InstOpCode::Mnemonic         op,
                          TR::Node               *n,
                          int8_t                memAccessMode,
                          TR::MemoryReference *mf,
@@ -3618,7 +3619,7 @@ class TR_S390MemInstruction : public TR::Instruction
          (mf->getUnresolvedSnippet())->setDataReferenceInstruction(this);
       }
 
-   TR_S390MemInstruction(TR::InstOpCode::Mnemonic         op,
+   S390MemInstruction(TR::InstOpCode::Mnemonic         op,
                         TR::Node               *n,
                         int8_t               constantField,
                         int8_t                memAccessMode,
@@ -3634,7 +3635,7 @@ class TR_S390MemInstruction : public TR::Instruction
          (mf->getUnresolvedSnippet())->setDataReferenceInstruction(this);
       }
 
-   TR_S390MemInstruction(TR::InstOpCode::Mnemonic         op,
+   S390MemInstruction(TR::InstOpCode::Mnemonic         op,
                          TR::Node               *n,
                          TR::MemoryReference *mf,
                          TR::Instruction        *precedingInstruction,
@@ -3650,7 +3651,7 @@ class TR_S390MemInstruction : public TR::Instruction
          (mf->getUnresolvedSnippet())->setDataReferenceInstruction(this);
       }
 
-   TR_S390MemInstruction(TR::InstOpCode::Mnemonic         op,
+   S390MemInstruction(TR::InstOpCode::Mnemonic         op,
                          TR::Node               *n,
                          TR::MemoryReference *mf,
                          TR::RegisterDependencyConditions *cond,
@@ -3667,7 +3668,7 @@ class TR_S390MemInstruction : public TR::Instruction
          (mf->getUnresolvedSnippet())->setDataReferenceInstruction(this);
       }
 
-   TR_S390MemInstruction(TR::InstOpCode::Mnemonic         op,
+   S390MemInstruction(TR::InstOpCode::Mnemonic         op,
                         TR::Node               *n,
                         int8_t                memAccessMode,
                         TR::MemoryReference *mf,
@@ -3684,7 +3685,7 @@ class TR_S390MemInstruction : public TR::Instruction
          (mf->getUnresolvedSnippet())->setDataReferenceInstruction(this);
       }
 
-   TR_S390MemInstruction(TR::InstOpCode::Mnemonic         op,
+   S390MemInstruction(TR::InstOpCode::Mnemonic         op,
                         TR::Node               *n,
                         int8_t                constantField,
                         int8_t                memAccessMode,
@@ -3715,9 +3716,9 @@ class TR_S390MemInstruction : public TR::Instruction
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390SIInstruction Class Definition
+// S390SIInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390SIInstruction : public TR_S390MemInstruction
+class S390SIInstruction : public TR::S390MemInstruction
    {
    uint8_t _sourceImmediate;
    Kind     _kind;
@@ -3725,19 +3726,19 @@ class TR_S390SIInstruction : public TR_S390MemInstruction
    public:
 
 
-   TR_S390SIInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::MemoryReference *mf,
+   S390SIInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::MemoryReference *mf,
                         uint8_t     imm,
                         TR::CodeGenerator *cg)
-           : TR_S390MemInstruction(op, n, mf, cg, false), _sourceImmediate(imm), _kind(IsSI)
+           : S390MemInstruction(op, n, mf, cg, false), _sourceImmediate(imm), _kind(IsSI)
       {
-      useSourceMemoryReference(mf); // need to call this *after* TR_S390SIInstruction constructor
+      useSourceMemoryReference(mf); // need to call this *after* S390SIInstruction constructor
       }
 
-   TR_S390SIInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::MemoryReference *mf,
+   S390SIInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::MemoryReference *mf,
                         uint8_t       imm,
                         TR::Instruction *precedingInstruction,
                         TR::CodeGenerator *cg)
-           : TR_S390MemInstruction(op, n, mf, precedingInstruction, cg, false), _sourceImmediate(imm), _kind(IsSI)
+           : S390MemInstruction(op, n, mf, precedingInstruction, cg, false), _sourceImmediate(imm), _kind(IsSI)
       {
       useSourceMemoryReference(mf);
       };
@@ -3754,22 +3755,22 @@ class TR_S390SIInstruction : public TR_S390MemInstruction
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390SIYInstruction Class Definition
+// S390SIYInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390SIYInstruction : public TR_S390SIInstruction
+class S390SIYInstruction : public TR::S390SIInstruction
    {
    public:
 
-   TR_S390SIYInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::MemoryReference *mf,
+   S390SIYInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::MemoryReference *mf,
                          uint8_t        imm,
                          TR::CodeGenerator *cg)
-           : TR_S390SIInstruction(op, n, mf, imm, cg) {};
+           : S390SIInstruction(op, n, mf, imm, cg) {};
 
-   TR_S390SIYInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::MemoryReference *mf,
+   S390SIYInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::MemoryReference *mf,
                          uint8_t        imm,
                          TR::Instruction *precedingInstruction,
                          TR::CodeGenerator *cg)
-           : TR_S390SIInstruction(op, n, mf, imm, precedingInstruction, cg) {};
+           : S390SIInstruction(op, n, mf, imm, precedingInstruction, cg) {};
 
    virtual char *description() { return "S390SIYInstruction"; }
    virtual Kind getKind() { return IsSIY; }
@@ -3780,30 +3781,30 @@ class TR_S390SIYInstruction : public TR_S390SIInstruction
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390SILInstruction Class Definition
+// S390SILInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390SILInstruction : public TR_S390MemInstruction
+class S390SILInstruction : public TR::S390MemInstruction
    {
    uint16_t _sourceImmediate;
 
    public:
 
-   TR_S390SILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
+   S390SILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
                          TR::MemoryReference *mf,
                          uint16_t imm,
                          TR::CodeGenerator *cg)
-           : TR_S390MemInstruction(op, n, mf, cg, false), _sourceImmediate(imm)
+           : S390MemInstruction(op, n, mf, cg, false), _sourceImmediate(imm)
       {
       if (op != TR::InstOpCode::TBEGINC)
          useSourceMemoryReference(mf);
       }
 
-   TR_S390SILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
+   S390SILInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
                          TR::MemoryReference *mf,
                          uint16_t imm,
                          TR::Instruction *precedingInstruction,
                          TR::CodeGenerator *cg)
-           : TR_S390MemInstruction(op, n, mf, precedingInstruction, cg, false), _sourceImmediate(imm)
+           : S390MemInstruction(op, n, mf, precedingInstruction, cg, false), _sourceImmediate(imm)
       {
       if (op != TR::InstOpCode::TBEGINC)
          useSourceMemoryReference(mf);
@@ -3820,20 +3821,20 @@ class TR_S390SILInstruction : public TR_S390MemInstruction
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390SInstruction Class Definition
+// S390SInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390SInstruction : public TR_S390MemInstruction
+class S390SInstruction : public TR::S390MemInstruction
    {
    public:
 
-   TR_S390SInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::MemoryReference *mf,
+   S390SInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::MemoryReference *mf,
                        TR::CodeGenerator *cg)
-           : TR_S390MemInstruction(op, n, mf, cg) {};
+           : S390MemInstruction(op, n, mf, cg) {};
 
-   TR_S390SInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::MemoryReference *mf,
+   S390SInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::MemoryReference *mf,
                        TR::Instruction *precedingInstruction,
                        TR::CodeGenerator *cg)
-           : TR_S390MemInstruction(op, n, mf, precedingInstruction, cg) {};
+           : S390MemInstruction(op, n, mf, precedingInstruction, cg) {};
 
    virtual char *description() { return "S390SInstruction"; }
    virtual Kind getKind() { return IsS; }
@@ -3844,7 +3845,7 @@ class TR_S390SInstruction : public TR_S390MemInstruction
 
 
 /**
- * TR_S390RSLInstruction Class Definition
+ * S390RSLInstruction Class Definition
  *    ________ _______ _________________________________
  *   |Op Code |   L1  |    |  B1 |   D1  |      | 'C0'  |
  *   |________|_______|____|_____|_______|______|_______|
@@ -3852,27 +3853,27 @@ class TR_S390SInstruction : public TR_S390MemInstruction
  *
  * First memory reference operand is inherited from base class 390MemInstruction
  */
-class TR_S390RSLInstruction : public TR_S390MemInstruction
+class S390RSLInstruction : public TR::S390MemInstruction
    {
 
    uint16_t _len; ///< length field
 
    public:
 
-   TR_S390RSLInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
+   S390RSLInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
                          uint16_t     len,
                          TR::MemoryReference *mf1,
                          TR::CodeGenerator *cg)
-           : TR_S390MemInstruction(op, n, mf1, cg), _len(len)
+           : S390MemInstruction(op, n, mf1, cg), _len(len)
       {
       }
 
-   TR_S390RSLInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
+   S390RSLInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
                         uint16_t       len,
                         TR::MemoryReference *mf1,
                         TR::Instruction *precedingInstruction,
                         TR::CodeGenerator *cg)
-           : TR_S390MemInstruction(op, n, mf1, precedingInstruction, cg), _len(len)
+           : S390MemInstruction(op, n, mf1, precedingInstruction, cg), _len(len)
       {
       }
 
@@ -3887,7 +3888,7 @@ class TR_S390RSLInstruction : public TR_S390MemInstruction
    };
 
 /**
- * TR_S390RSLInstruction Class Definition
+ * S390RSLInstruction Class Definition
  *    ________ _______________________________________________
  *   | op     |     L1     |  B2 |   D2  |  R1 |  M3 |    op  |
  *   |________|____________|_____|_______|_____|_____|________|
@@ -3896,20 +3897,20 @@ class TR_S390RSLInstruction : public TR_S390MemInstruction
  *
  * RSLb is actually very different in encoding and use then RSL so creating a new class
  */
-class TR_S390RSLbInstruction : public TR_S390RegInstruction
+class S390RSLbInstruction : public TR::S390RegInstruction
    {
    uint16_t _length;
    uint8_t _mask;
 
    public:
-   TR_S390RSLbInstruction(TR::InstOpCode::Mnemonic op,
+   S390RSLbInstruction(TR::InstOpCode::Mnemonic op,
                           TR::Node * n,
                           TR::Register *reg,
                           uint16_t length,
                           TR::MemoryReference *mf,
                           uint8_t mask,
                           TR::CodeGenerator *cg)
-            : TR_S390RegInstruction(op, n, reg, cg), _length(length), _mask(mask)
+            : S390RegInstruction(op, n, reg, cg), _length(length), _mask(mask)
       {
       useSourceMemoryReference(mf);
       setupThrowsImplicitNullPointerException(n,mf);
@@ -3917,7 +3918,7 @@ class TR_S390RSLbInstruction : public TR_S390RegInstruction
          (mf->getUnresolvedSnippet())->setDataReferenceInstruction(this);
       }
 
-   TR_S390RSLbInstruction(TR::InstOpCode::Mnemonic op,
+   S390RSLbInstruction(TR::InstOpCode::Mnemonic op,
                           TR::Node * n,
                           TR::Register *reg,
                           int16_t length,
@@ -3925,7 +3926,7 @@ class TR_S390RSLbInstruction : public TR_S390RegInstruction
                           int8_t mask,
                           TR::Instruction * preced,
                           TR::CodeGenerator *cg)
-            : TR_S390RegInstruction(op, n, reg, preced, cg), _length(length), _mask(mask)
+            : S390RegInstruction(op, n, reg, preced, cg), _length(length), _mask(mask)
       {
       useSourceMemoryReference(mf);
       setupThrowsImplicitNullPointerException(n,mf);
@@ -3951,15 +3952,15 @@ class TR_S390RSLbInstruction : public TR_S390RegInstruction
 /**
  * Common base class for instructions with two memory references (except SSF as this is also like an RX format instruction)
  */
-class TR_S390MemMemInstruction : public TR_S390MemInstruction
+class S390MemMemInstruction : public TR::S390MemInstruction
    {
    public:
 
-   TR_S390MemMemInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
+   S390MemMemInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
                             TR::MemoryReference *mf1,
                             TR::MemoryReference *mf2,
                             TR::CodeGenerator *cg)
-           : TR_S390MemInstruction(op, n, mf1, cg)
+           : S390MemInstruction(op, n, mf1, cg)
       {
       if (mf2)
          {
@@ -3969,12 +3970,12 @@ class TR_S390MemMemInstruction : public TR_S390MemInstruction
       setupThrowsImplicitNullPointerException(n,mf2);
       }
 
-   TR_S390MemMemInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
+   S390MemMemInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
                             TR::MemoryReference *mf1,
                             TR::MemoryReference *mf2,
                             TR::Instruction *precedingInstruction,
                             TR::CodeGenerator *cg)
-           : TR_S390MemInstruction(op, n, mf1, precedingInstruction, cg)
+           : S390MemInstruction(op, n, mf1, precedingInstruction, cg)
       {
       if (mf2)
          {
@@ -3984,12 +3985,12 @@ class TR_S390MemMemInstruction : public TR_S390MemInstruction
       setupThrowsImplicitNullPointerException(n,mf2);
       }
 
-   TR_S390MemMemInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
+   S390MemMemInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
                             TR::MemoryReference *mf1,
                             TR::MemoryReference *mf2,
                             TR::RegisterDependencyConditions *cond,
                             TR::CodeGenerator *cg)
-           : TR_S390MemInstruction(op, n, mf1, cond, cg)
+           : S390MemInstruction(op, n, mf1, cond, cg)
       {
       if (mf2)
          {
@@ -3999,13 +4000,13 @@ class TR_S390MemMemInstruction : public TR_S390MemInstruction
       setupThrowsImplicitNullPointerException(n,mf2);
       }
 
-   TR_S390MemMemInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
+   S390MemMemInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
                          TR::MemoryReference *mf1,
                          TR::MemoryReference *mf2,
                          TR::RegisterDependencyConditions *cond,
                          TR::Instruction *precedingInstruction,
                          TR::CodeGenerator *cg)
-           : TR_S390MemInstruction(op, n, mf1, cond, precedingInstruction, cg)
+           : S390MemInstruction(op, n, mf1, cond, precedingInstruction, cg)
       {
       if (mf2)
          {
@@ -4025,57 +4026,57 @@ class TR_S390MemMemInstruction : public TR_S390MemInstruction
    };
 
 /**
- * TR_S390SS1Instruction Class Definition
+ * S390SS1Instruction Class Definition
  *    ________ _______ ____________________________
  *   |Op Code |   L   | B1 |   D1  | B2 |   D2     |
  *   |________|_______|____|_______|____|__________|
  *   0         8     16   20       32  36          47
  *
  */
-class TR_S390SS1Instruction : public TR_S390MemMemInstruction
+class S390SS1Instruction : public TR::S390MemMemInstruction
    {
    uint16_t _len; ///< length field
    TR::LabelSymbol * _symbol;
 
    public:
 
-   TR_S390SS1Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
+   S390SS1Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
                          uint16_t     len,
                          TR::MemoryReference *mf1,
                          TR::MemoryReference *mf2,
                          TR::CodeGenerator *cg)
-           : TR_S390MemMemInstruction(op, n, mf1, mf2, cg), _symbol(NULL), _len(len)
+           : S390MemMemInstruction(op, n, mf1, mf2, cg), _symbol(NULL), _len(len)
       {
       }
 
-   TR_S390SS1Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
+   S390SS1Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
                         uint16_t       len,
                         TR::MemoryReference *mf1,
                         TR::MemoryReference *mf2,
                         TR::Instruction *precedingInstruction,
                         TR::CodeGenerator *cg)
-           : TR_S390MemMemInstruction(op, n, mf1, mf2, precedingInstruction, cg),  _symbol(NULL), _len(len)
+           : S390MemMemInstruction(op, n, mf1, mf2, precedingInstruction, cg),  _symbol(NULL), _len(len)
       {
       }
 
-   TR_S390SS1Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
+   S390SS1Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
                          uint16_t     len,
                          TR::MemoryReference *mf1,
                          TR::MemoryReference *mf2,
                          TR::RegisterDependencyConditions *cond,
                          TR::CodeGenerator *cg)
-           : TR_S390MemMemInstruction(op, n, mf1, mf2, cond, cg),  _symbol(NULL), _len(len)
+           : S390MemMemInstruction(op, n, mf1, mf2, cond, cg),  _symbol(NULL), _len(len)
       {
       }
 
-   TR_S390SS1Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
+   S390SS1Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
                          uint16_t       len,
                          TR::MemoryReference *mf1,
                          TR::MemoryReference *mf2,
                          TR::RegisterDependencyConditions *cond,
                          TR::Instruction *precedingInstruction,
                          TR::CodeGenerator *cg)
-           : TR_S390MemMemInstruction(op, n, mf1, mf2, cond, precedingInstruction, cg), _symbol(NULL), _len(len)
+           : S390MemMemInstruction(op, n, mf1, mf2, cond, precedingInstruction, cg), _symbol(NULL), _len(len)
       {
       }
 
@@ -4091,10 +4092,10 @@ class TR_S390SS1Instruction : public TR_S390MemMemInstruction
    virtual int32_t estimateBinaryLength(int32_t currentEstimate);
    };
 
-class TR_S390SS1WithImplicitGPRsInstruction : public TR_S390SS1Instruction
+class S390SS1WithImplicitGPRsInstruction : public TR::S390SS1Instruction
    {
    public:
-   TR_S390SS1WithImplicitGPRsInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
+   S390SS1WithImplicitGPRsInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
                                          uint16_t     len,
                                          TR::MemoryReference *mf1,
                                          TR::MemoryReference *mf2,
@@ -4104,7 +4105,7 @@ class TR_S390SS1WithImplicitGPRsInstruction : public TR_S390SS1Instruction
                                          TR::Register * implicitRegTrg0,
                                          TR::Register * implicitRegTrg1,
                                          TR::CodeGenerator *cg) :
-      TR_S390SS1Instruction(op, n, len, mf1, mf2, cond, cg)
+      S390SS1Instruction(op, n, len, mf1, mf2, cond, cg)
       {
       // Make sure memory references appear after registers in operands array
       int32_t i;
@@ -4121,7 +4122,7 @@ class TR_S390SS1WithImplicitGPRsInstruction : public TR_S390SS1Instruction
          _operands[i+nr]=vp[i];
       }
 
-   TR_S390SS1WithImplicitGPRsInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
+   S390SS1WithImplicitGPRsInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
                                          uint16_t       len,
                                          TR::MemoryReference *mf1,
                                          TR::MemoryReference *mf2,
@@ -4132,7 +4133,7 @@ class TR_S390SS1WithImplicitGPRsInstruction : public TR_S390SS1Instruction
                                          TR::Register * implicitRegTrg0,
                                          TR::Register * implicitRegTrg1,
                                          TR::CodeGenerator *cg) :
-      TR_S390SS1Instruction(op, n, len, mf1, mf2, cond, precedingInstruction, cg)
+      S390SS1Instruction(op, n, len, mf1, mf2, cond, precedingInstruction, cg)
       {
       // Make sure memory references appear after registers in operands array
       int32_t i;
@@ -4153,7 +4154,7 @@ class TR_S390SS1WithImplicitGPRsInstruction : public TR_S390SS1Instruction
    };
 
 /**
- * TR_S390SS2Instruction Class Definition
+ * S390SS2Instruction Class Definition
  *    ________ _____________ ______________________________
  *   |Op Code |  L1  |  L2  | B1 |   D1  |  B2  |   D2     |
  *   |________|______|______|____|_______|______|__________|
@@ -4161,52 +4162,52 @@ class TR_S390SS1WithImplicitGPRsInstruction : public TR_S390SS1Instruction
  *
  * Also used for SS3 where L2 is called I3
  */
-class TR_S390SS2Instruction : public TR_S390SS1Instruction
+class S390SS2Instruction : public TR::S390SS1Instruction
    {
    uint16_t _len2;       ///< length field, also used as imm3 for SS3 encoded SRP
    int32_t _shiftAmount; ///< For SS3 encoded SRP
 
    public:
 
-   TR_S390SS2Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
+   S390SS2Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
                          uint16_t     len1,
                          TR::MemoryReference *mf1,
                          uint16_t     len2,
                          TR::MemoryReference *mf2,
                          TR::CodeGenerator *cg)
-           : TR_S390SS1Instruction(op, n, len1, mf1, mf2, cg), _len2(len2), _shiftAmount(0)
+           : S390SS1Instruction(op, n, len1, mf1, mf2, cg), _len2(len2), _shiftAmount(0)
       {
       }
 
-   TR_S390SS2Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
+   S390SS2Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
                          uint16_t     len1,
                          TR::MemoryReference *mf1,
                          uint16_t     len2,
                          TR::MemoryReference *mf2,
                          TR::Instruction *precedingInstruction,
                          TR::CodeGenerator *cg)
-           : TR_S390SS1Instruction(op, n, len1, mf1, mf2, precedingInstruction, cg), _len2(len2), _shiftAmount(0)
+           : S390SS1Instruction(op, n, len1, mf1, mf2, precedingInstruction, cg), _len2(len2), _shiftAmount(0)
       {
       }
 
-   TR_S390SS2Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
+   S390SS2Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
                          uint32_t     len1,
                          TR::MemoryReference *mf1,
                          int32_t      shiftAmount,
                          uint32_t     roundAmount,
                          TR::CodeGenerator *cg)
-           : TR_S390SS1Instruction(op, n, len1, mf1, NULL, cg), _shiftAmount(shiftAmount), _len2(roundAmount)
+           : S390SS1Instruction(op, n, len1, mf1, NULL, cg), _shiftAmount(shiftAmount), _len2(roundAmount)
       {
       }
 
-   TR_S390SS2Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
+   S390SS2Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
                          uint32_t     len1,
                          TR::MemoryReference *mf1,
                          int32_t      shiftAmount,
                          uint32_t     roundAmount,
                          TR::Instruction *precedingInstruction,
                          TR::CodeGenerator *cg)
-           : TR_S390SS1Instruction(op, n, len1, mf1, NULL, precedingInstruction, cg), _shiftAmount(shiftAmount), _len2(roundAmount)
+           : S390SS1Instruction(op, n, len1, mf1, NULL, precedingInstruction, cg), _shiftAmount(shiftAmount), _len2(roundAmount)
       {
       }
 
@@ -4228,7 +4229,7 @@ class TR_S390SS2Instruction : public TR_S390SS1Instruction
    };
 
 /**
- * TR_S390SS4Instruction Class Definition
+ * S390SS4Instruction Class Definition
  *    ________ _____________ ______________________________
  *   |Op Code |  R1  |  R3  | B1 |   D1  |  B2  |   D2     |
  *   |________|______|______|____|_______|______|__________|
@@ -4237,19 +4238,19 @@ class TR_S390SS2Instruction : public TR_S390SS1Instruction
  *
  * Also used for an SS5 where B1(D1) is called B2(D2) and B2(D2) is called B4(D4)
  */
-class TR_S390SS4Instruction : public TR_S390SS1Instruction
+class S390SS4Instruction : public TR::S390SS1Instruction
    {
    int8_t      _ss4_lenidx;
    int8_t      _ss4_keyidx;
    public:
 
-   TR_S390SS4Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
+   S390SS4Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
                          TR::Register *     lengthReg,
                          TR::MemoryReference *mf1,
                          TR::MemoryReference *mf2,
                          TR::Register * sourceKeyReg,
                          TR::CodeGenerator *cg)
-           : TR_S390SS1Instruction(op, n, 0, mf1, mf2, cg), _ss4_lenidx(-1), _ss4_keyidx(-1)
+           : S390SS1Instruction(op, n, 0, mf1, mf2, cg), _ss4_lenidx(-1), _ss4_keyidx(-1)
       {
       // Make sure memory references appear after registers in operands array
       int32_t i;
@@ -4264,14 +4265,14 @@ class TR_S390SS4Instruction : public TR_S390SS1Instruction
          _operands[i+nr]=vp[i];
       }
 
-   TR_S390SS4Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
+   S390SS4Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
                          TR::Register *     lengthReg,
                          TR::MemoryReference *mf1,
                          TR::MemoryReference *mf2,
                          TR::Register * sourceKeyReg,
                          TR::Instruction * precedingInstruction,
                          TR::CodeGenerator *cg)
-           : TR_S390SS1Instruction(op, n, 0, mf1, mf2, precedingInstruction, cg), _ss4_lenidx(-1), _ss4_keyidx(-1)
+           : S390SS1Instruction(op, n, 0, mf1, mf2, precedingInstruction, cg), _ss4_lenidx(-1), _ss4_keyidx(-1)
       {
       // Make sure memory references appear after registers in operands array
       int32_t i;
@@ -4299,7 +4300,7 @@ class TR_S390SS4Instruction : public TR_S390SS1Instruction
    };
 
 /**
- * TR_S390SS5WithImplicitGPRsInstruction Class Definition
+ * S390SS5WithImplicitGPRsInstruction Class Definition
  *    ________ _____________ ______________________________
  *   |Op Code |  R1  |  R3  | B2 |   D2  |  B4  |   D4     |
  *   |________|______|______|____|_______|______|__________|
@@ -4307,10 +4308,10 @@ class TR_S390SS4Instruction : public TR_S390SS1Instruction
  *
  * Implicit GPR0 and/or GPR1
  */
-class TR_S390SS5WithImplicitGPRsInstruction : public TR_S390SS4Instruction
+class S390SS5WithImplicitGPRsInstruction : public TR::S390SS4Instruction
    {
    public:
-   TR_S390SS5WithImplicitGPRsInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
+   S390SS5WithImplicitGPRsInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
                                          TR::Register * op1,
                                          TR::MemoryReference *mf2,
                                          TR::Register * op3,
@@ -4320,7 +4321,7 @@ class TR_S390SS5WithImplicitGPRsInstruction : public TR_S390SS4Instruction
                                          TR::Register * implicitRegTrg0,
                                          TR::Register * implicitRegTrg1,
                                          TR::CodeGenerator *cg) :
-      TR_S390SS4Instruction(op, n, op1, mf2, mf4, op3, cg)
+      S390SS4Instruction(op, n, op1, mf2, mf4, op3, cg)
       {
       // Make sure memory references appear after registers in operands array
       int32_t i;
@@ -4341,7 +4342,7 @@ class TR_S390SS5WithImplicitGPRsInstruction : public TR_S390SS4Instruction
          _operands[i+explicitSourceRegSize+nr]=vp[i];
       }
 
-   TR_S390SS5WithImplicitGPRsInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
+   S390SS5WithImplicitGPRsInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
                                          TR::Register * op1,
                                          TR::MemoryReference *mf2,
                                          TR::Register * op3,
@@ -4352,7 +4353,7 @@ class TR_S390SS5WithImplicitGPRsInstruction : public TR_S390SS4Instruction
                                          TR::Register * implicitRegTrg0,
                                          TR::Register * implicitRegTrg1,
                                          TR::CodeGenerator *cg) :
-      TR_S390SS4Instruction(op, n, op1, mf2, mf4, op3, precedingInstruction, cg)
+      S390SS4Instruction(op, n, op1, mf2, mf4, op3, precedingInstruction, cg)
       {
       // Make sure memory references appear after registers in operands array
       int32_t i;
@@ -4375,31 +4376,31 @@ class TR_S390SS5WithImplicitGPRsInstruction : public TR_S390SS4Instruction
    };
 
 /**
- * TR_S390SSEInstruction Class Definition
+ * S390SSEInstruction Class Definition
  *    ______________ ____________________________
  *   |Op Code       | B1 |   D1  | B2 |   D2     |
  *   |______________|____|_______|____|__________|
  *   0             16   20       32  36          47
  *
  */
-class TR_S390SSEInstruction : public TR_S390MemMemInstruction
+class S390SSEInstruction : public TR::S390MemMemInstruction
    {
    public:
 
-   TR_S390SSEInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
+   S390SSEInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
                          TR::MemoryReference *mf1,
                          TR::MemoryReference *mf2,
                          TR::CodeGenerator *cg)
-           : TR_S390MemMemInstruction(op, n, mf1, mf2, cg)
+           : S390MemMemInstruction(op, n, mf1, mf2, cg)
       {
       }
 
-   TR_S390SSEInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
+   S390SSEInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
                          TR::MemoryReference *mf1,
                          TR::MemoryReference *mf2,
                          TR::Instruction *precedingInstruction,
                          TR::CodeGenerator *cg)
-           : TR_S390MemMemInstruction(op, n, mf1, mf2, precedingInstruction, cg)
+           : S390MemMemInstruction(op, n, mf1, mf2, precedingInstruction, cg)
       {
       }
 
@@ -4408,20 +4409,20 @@ class TR_S390SSEInstruction : public TR_S390MemMemInstruction
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390RXInstruction Class Definition
+// S390RXInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390RXInstruction : public TR_S390RegInstruction
+class S390RXInstruction : public TR::S390RegInstruction
    {
    uint32_t _constForMRField;
    Kind _kind;
 
    public:
 
-   TR_S390RXInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
+   S390RXInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
                         TR::Register            *treg,
                         TR::MemoryReference *mf,
                         TR::CodeGenerator       *cg)
-      : TR_S390RegInstruction(op, n, treg, cg), _kind(IsRX)
+      : S390RegInstruction(op, n, treg, cg), _kind(IsRX)
       {
       useSourceMemoryReference(mf);
       setupThrowsImplicitNullPointerException(n,mf);
@@ -4429,12 +4430,12 @@ class TR_S390RXInstruction : public TR_S390RegInstruction
          (mf->getUnresolvedSnippet())->setDataReferenceInstruction(this);
       }
 
-   TR_S390RXInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
+   S390RXInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
                         TR::Register            *treg,
                         TR::MemoryReference *mf,
                         TR::Instruction         *precedingInstruction,
                         TR::CodeGenerator       *cg)
-      : TR_S390RegInstruction(op, n, treg, precedingInstruction, cg), _kind(IsRX)
+      : S390RegInstruction(op, n, treg, precedingInstruction, cg), _kind(IsRX)
       {
       useSourceMemoryReference(mf);
       setupThrowsImplicitNullPointerException(n,mf);
@@ -4442,11 +4443,11 @@ class TR_S390RXInstruction : public TR_S390RegInstruction
          (mf->getUnresolvedSnippet())->setDataReferenceInstruction(this);
       }
 
-   TR_S390RXInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
+   S390RXInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
                         TR::RegisterPair        *regp,
                         TR::MemoryReference *mf,
                         TR::CodeGenerator       *cg)
-      : TR_S390RegInstruction(op, n, regp, cg), _kind(IsRX)
+      : S390RegInstruction(op, n, regp, cg), _kind(IsRX)
       {
       useSourceMemoryReference(mf);
       setupThrowsImplicitNullPointerException(n,mf);
@@ -4454,12 +4455,12 @@ class TR_S390RXInstruction : public TR_S390RegInstruction
          (mf->getUnresolvedSnippet())->setDataReferenceInstruction(this);
       }
 
-   TR_S390RXInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
+   S390RXInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
                         TR::RegisterPair        *regp,
                         TR::MemoryReference *mf,
                         TR::Instruction         *precedingInstruction,
                         TR::CodeGenerator       *cg)
-      : TR_S390RegInstruction(op, n, regp, precedingInstruction, cg), _kind(IsRX)
+      : S390RegInstruction(op, n, regp, precedingInstruction, cg), _kind(IsRX)
       {
       useSourceMemoryReference(mf);
       setupThrowsImplicitNullPointerException(n,mf);
@@ -4467,21 +4468,21 @@ class TR_S390RXInstruction : public TR_S390RegInstruction
          (mf->getUnresolvedSnippet())->setDataReferenceInstruction(this);
       }
 
-   TR_S390RXInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
+   S390RXInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
                         TR::Register            *treg,
                         uint32_t                constMR,
                         TR::CodeGenerator       *cg)
-      : TR_S390RegInstruction(op, n, treg, cg), _kind(IsRX),
+      : S390RegInstruction(op, n, treg, cg), _kind(IsRX),
         _constForMRField(constMR)
       {
       }
 
-   TR_S390RXInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
+   S390RXInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
                         TR::Register            *treg,
                         uint32_t                constMR,
                         TR::Instruction         *precedingInstruction,
                         TR::CodeGenerator       *cg)
-      : TR_S390RegInstruction(op, n, treg, precedingInstruction, cg), _kind(IsRX),
+      : S390RegInstruction(op, n, treg, precedingInstruction, cg), _kind(IsRX),
         _constForMRField(constMR)
       {
       }
@@ -4502,7 +4503,7 @@ class TR_S390RXInstruction : public TR_S390RegInstruction
    };
 
 /**
- * TR_S390RXEInstruction Class Definition
+ * S390RXEInstruction Class Definition
  *
  * RXE
  *    ________________________________________________________
@@ -4511,27 +4512,27 @@ class TR_S390RXInstruction : public TR_S390RegInstruction
  *   0        8    12   16   20             32   36   40      47
  *
  */
-class TR_S390RXEInstruction : public TR_S390RXInstruction
+class S390RXEInstruction : public TR::S390RXInstruction
    {
    uint8_t mask3;
    public:
-   TR_S390RXEInstruction(TR::InstOpCode::Mnemonic         op, TR::Node * n,
+   S390RXEInstruction(TR::InstOpCode::Mnemonic         op, TR::Node * n,
                          TR::Register            *treg,
                          TR::MemoryReference *mf,
                          uint8_t                m3,
                          TR::CodeGenerator       *cg)
-      : TR_S390RXInstruction(op, n, treg, mf, cg)
+      : S390RXInstruction(op, n, treg, mf, cg)
       {
       mask3 = m3;
       }
 
-   TR_S390RXEInstruction(TR::InstOpCode::Mnemonic         op, TR::Node * n,
+   S390RXEInstruction(TR::InstOpCode::Mnemonic         op, TR::Node * n,
                          TR::Register            *treg,
                          TR::MemoryReference *mf,
                          uint8_t                m3,
                          TR::Instruction     *precedingInstruction,
                          TR::CodeGenerator       *cg)
-      : TR_S390RXInstruction(op, n, treg, mf, precedingInstruction, cg)
+      : S390RXInstruction(op, n, treg, mf, precedingInstruction, cg)
       {
       mask3 = m3;
       }
@@ -4545,60 +4546,60 @@ class TR_S390RXEInstruction : public TR_S390RXInstruction
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390RXYInstruction Class Definition
+// S390RXYInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390RXYInstruction : public TR_S390RXInstruction
+class S390RXYInstruction : public TR::S390RXInstruction
    {
    public:
 
-   TR_S390RXYInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
+   S390RXYInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
                          TR::Register            *treg,
                          TR::MemoryReference *mf,
                          TR::CodeGenerator       *cg)
-      : TR_S390RXInstruction(op, n, treg, mf, cg)
+      : S390RXInstruction(op, n, treg, mf, cg)
       {
       }
 
-   TR_S390RXYInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
+   S390RXYInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
                          TR::Register            *treg,
                          TR::MemoryReference *mf,
                          TR::Instruction         *precedingInstruction,
                          TR::CodeGenerator       *cg)
-      : TR_S390RXInstruction(op, n, treg, mf, precedingInstruction, cg)
+      : S390RXInstruction(op, n, treg, mf, precedingInstruction, cg)
       {
       }
 
-   TR_S390RXYInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
+   S390RXYInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
                          TR::RegisterPair        *regp,
                          TR::MemoryReference *mf,
                          TR::CodeGenerator       *cg)
-      : TR_S390RXInstruction(op, n, regp, mf, cg)
+      : S390RXInstruction(op, n, regp, mf, cg)
       {
       }
 
-   TR_S390RXYInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
+   S390RXYInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
                          TR::RegisterPair        *regp,
                          TR::MemoryReference *mf,
                          TR::Instruction         *precedingInstruction,
                          TR::CodeGenerator       *cg)
-      : TR_S390RXInstruction(op, n, regp, mf, precedingInstruction, cg)
+      : S390RXInstruction(op, n, regp, mf, precedingInstruction, cg)
       {
       }
 
-   TR_S390RXYInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
+   S390RXYInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
                          TR::Register            *treg,
                          uint32_t                constMR,
                          TR::CodeGenerator       *cg)
-      : TR_S390RXInstruction(op, n, treg, constMR, cg)
+      : S390RXInstruction(op, n, treg, constMR, cg)
       {
       }
 
-   TR_S390RXYInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
+   S390RXYInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
                          TR::Register            *treg,
                          uint32_t                constMR,
                          TR::Instruction         *precedingInstruction,
                          TR::CodeGenerator       *cg)
-      : TR_S390RXInstruction(op, n, treg, constMR, precedingInstruction, cg)
+      : S390RXInstruction(op, n, treg, constMR, precedingInstruction, cg)
       {
       }
 
@@ -4611,26 +4612,26 @@ class TR_S390RXYInstruction : public TR_S390RXInstruction
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390RXYInstruction Class Definition
+// S390RXYInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390RXYbInstruction : public TR_S390MemInstruction
+class S390RXYbInstruction : public TR::S390MemInstruction
    {
    public:
 
-   TR_S390RXYbInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
+   S390RXYbInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
                           uint8_t                mask,
                           TR::MemoryReference *mf,
                           TR::CodeGenerator       *cg)
-      : TR_S390MemInstruction(op, n, mask, mf, cg)
+      : S390MemInstruction(op, n, mask, mf, cg)
       {
       }
 
-   TR_S390RXYbInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
+   S390RXYbInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
                           uint8_t                mask,
                           TR::MemoryReference *mf,
                           TR::Instruction        *precedingInstruction,
                           TR::CodeGenerator       *cg)
-      : TR_S390MemInstruction(op, n, mask, mf, precedingInstruction, cg)
+      : S390MemInstruction(op, n, mask, mf, precedingInstruction, cg)
       {
       }
 
@@ -4643,67 +4644,67 @@ class TR_S390RXYbInstruction : public TR_S390MemInstruction
 
 
 /**
- * TR_S390SSFInstruction Class Definition
+ * S390SSFInstruction Class Definition
  *    ________ _____________ ______________________________
  *   |Op Code |  R3  |  Op  | B1 |   D1  |  B2  |   D2     |
  *   |________|______|______|____|_______|______|__________|
  *   0        8      12     16   20      32     36         47
  *
  */
-class TR_S390SSFInstruction : public TR_S390RXInstruction
+class S390SSFInstruction : public TR::S390RXInstruction
    {
    // TR::MemoryReference *_memoryReference2;     // second memory reference operand
 
    public:
 
-   TR_S390SSFInstruction(TR::InstOpCode::Mnemonic          op,
+   S390SSFInstruction(TR::InstOpCode::Mnemonic          op,
                          TR::Node                * n,
                          TR::Register            *reg,
                          TR::MemoryReference *mf1,
                          TR::MemoryReference *mf2,
                          TR::CodeGenerator       *cg)
-      : TR_S390RXInstruction(op, n, reg, mf1, cg)
+      : S390RXInstruction(op, n, reg, mf1, cg)
       {
       useSourceMemoryReference(mf2);
       mf2->setIs2ndMemRef();
       setupThrowsImplicitNullPointerException(n,mf2);
       }
 
-   TR_S390SSFInstruction(TR::InstOpCode::Mnemonic          op,
+   S390SSFInstruction(TR::InstOpCode::Mnemonic          op,
                          TR::Node                * n,
                          TR::Register            *reg,
                          TR::MemoryReference *mf1,
                          TR::MemoryReference *mf2,
                          TR::Instruction         *precedingInstruction,
                          TR::CodeGenerator       *cg)
-      : TR_S390RXInstruction(op, n, reg, mf1, precedingInstruction, cg)
+      : S390RXInstruction(op, n, reg, mf1, precedingInstruction, cg)
       {
       useSourceMemoryReference(mf2);
       mf2->setIs2ndMemRef();
       setupThrowsImplicitNullPointerException(n,mf2);
       }
 
-   TR_S390SSFInstruction(TR::InstOpCode::Mnemonic          op,
+   S390SSFInstruction(TR::InstOpCode::Mnemonic          op,
                          TR::Node                * n,
                          TR::RegisterPair        *regp,
                          TR::MemoryReference *mf1,
                          TR::MemoryReference *mf2,
                          TR::CodeGenerator       *cg)
-      : TR_S390RXInstruction(op, n, regp, mf1, cg)
+      : S390RXInstruction(op, n, regp, mf1, cg)
       {
       useSourceMemoryReference(mf2);
       mf2->setIs2ndMemRef();
       setupThrowsImplicitNullPointerException(n,mf2);
       }
 
-   TR_S390SSFInstruction(TR::InstOpCode::Mnemonic          op,
+   S390SSFInstruction(TR::InstOpCode::Mnemonic          op,
                          TR::Node                * n,
                          TR::RegisterPair        *regp,
                          TR::MemoryReference *mf1,
                          TR::MemoryReference *mf2,
                          TR::Instruction         *precedingInstruction,
                          TR::CodeGenerator       *cg)
-      : TR_S390RXInstruction(op, n, regp, mf1, precedingInstruction, cg)
+      : S390RXInstruction(op, n, regp, mf1, precedingInstruction, cg)
       {
       useSourceMemoryReference(mf2);
       mf2->setIs2ndMemRef();
@@ -4721,56 +4722,56 @@ class TR_S390SSFInstruction : public TR_S390RXInstruction
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390RXFInstruction Class Definition
+// S390RXFInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390RXFInstruction : public TR_S390RRInstruction
+class S390RXFInstruction : public TR::S390RRInstruction
    {
 
    public:
 
-   TR_S390RXFInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
+   S390RXFInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
                          TR::Register            *treg,
                          TR::Register           *sreg,
                          TR::MemoryReference *mf,
                          TR::CodeGenerator       *cg)
-      : TR_S390RRInstruction(op, n, treg, sreg, cg)
+      : S390RRInstruction(op, n, treg, sreg, cg)
       {
       useSourceMemoryReference(mf);
       setupThrowsImplicitNullPointerException(n,mf);
       }
 
-   TR_S390RXFInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
+   S390RXFInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
                          TR::Register            *treg,
                          TR::Register           *sreg,
                          TR::MemoryReference *mf,
                          TR::Instruction         *precedingInstruction,
                          TR::CodeGenerator       *cg)
-      : TR_S390RRInstruction(op, n, treg, sreg, precedingInstruction, cg)
+      : S390RRInstruction(op, n, treg, sreg, precedingInstruction, cg)
       {
       useSourceMemoryReference(mf);
       setupThrowsImplicitNullPointerException(n,mf);
       }
 
-   TR_S390RXFInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
+   S390RXFInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
                          TR::Register            *treg,
                          TR::Register           *sreg,
                          TR::MemoryReference *mf,
                          TR::RegisterDependencyConditions * cond,
                          TR::CodeGenerator       *cg)
-      : TR_S390RRInstruction(op, n, treg, sreg, cond, cg)
+      : S390RRInstruction(op, n, treg, sreg, cond, cg)
       {
       useSourceMemoryReference(mf);
       setupThrowsImplicitNullPointerException(n,mf);
       }
 
-   TR_S390RXFInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
+   S390RXFInstruction(TR::InstOpCode::Mnemonic          op, TR::Node * n,
                          TR::Register            *treg,
                          TR::Register           *sreg,
                          TR::MemoryReference *mf,
                          TR::RegisterDependencyConditions * cond,
                          TR::Instruction         *precedingInstruction,
                          TR::CodeGenerator       *cg)
-      : TR_S390RRInstruction(op, n, treg, sreg, cond, precedingInstruction, cg)
+      : S390RRInstruction(op, n, treg, sreg, cond, precedingInstruction, cg)
       {
       useSourceMemoryReference(mf);
       setupThrowsImplicitNullPointerException(n,mf);
@@ -4788,38 +4789,38 @@ class TR_S390RXFInstruction : public TR_S390RRInstruction
    };
 
 /**
- * TR_S390VInstruction Class Definition
+ * S390VInstruction Class Definition
  *
  * Vector operation Generic class
  * Five subtypes: VRI, VRR, VRS, VRV, VRX
  */
-class TR_S390VInstruction : public TR_S390RegInstruction
+class S390VInstruction : public TR::S390RegInstruction
    {
    char        *_opCodeBuffer;
 
    protected:
-   TR_S390VInstruction(
+   S390VInstruction(
                        TR::CodeGenerator      * cg                    = NULL,
                        TR::InstOpCode::Mnemonic          op                    = TR::InstOpCode::BAD,
                        TR::Node               * n                     = NULL,
                        TR::Register           * reg1                  = NULL)
-   : TR_S390RegInstruction(op, n, reg1, cg)
+   : S390RegInstruction(op, n, reg1, cg)
       {
       _opCodeBuffer = NULL;
       }
 
-   TR_S390VInstruction(
+   S390VInstruction(
                        TR::CodeGenerator      * cg,
                        TR::InstOpCode::Mnemonic          op,
                        TR::Node               * n,
                        TR::Register           * reg1,
                        TR::Instruction    * precedingInstruction)
-   : TR_S390RegInstruction(op, n, reg1, precedingInstruction, cg)
+   : S390RegInstruction(op, n, reg1, precedingInstruction, cg)
       {
       _opCodeBuffer = NULL;
       }
 
-   ~TR_S390VInstruction();
+   ~S390VInstruction();
 
    /** Set mask field */
    virtual void setMaskField(uint32_t *instruction, uint8_t mask, int nField)
@@ -4841,12 +4842,12 @@ class TR_S390VInstruction : public TR_S390RegInstruction
    };
 
 /**
- * TR_S390VRIInstruction Class Definition
+ * S390VRIInstruction Class Definition
  *
  * Vector register-and-immediate operation with extended op-code field
  * Five subtypes: VRI-a to VRI-e
  */
-class TR_S390VRIInstruction : public TR_S390VInstruction
+class S390VRIInstruction : public TR::S390VInstruction
    {
    // masks starting from bit 28 to bit 35, 4 bits each field
    uint8_t     mask3;
@@ -4859,7 +4860,7 @@ class TR_S390VRIInstruction : public TR_S390VInstruction
    bool        _printM5;
    /* We want these to be called only by helper constructors */
    protected:
-   TR_S390VRIInstruction(
+   S390VRIInstruction(
                        TR::CodeGenerator      * cg               = NULL,
                        TR::InstOpCode::Mnemonic          op               = TR::InstOpCode::BAD,
                        TR::Node               * n                = NULL,
@@ -4868,7 +4869,7 @@ class TR_S390VRIInstruction : public TR_S390VInstruction
                        uint8_t                 m3               = 0,    /*  4 bits (28 - 31 bit) */
                        uint8_t                 m4               = 0,    /*  4 bits (28 - 31 bit) */
                        uint8_t                 m5               = 0)    /*  4 bits (32 - 35 bit) */
-   : TR_S390VInstruction(cg, op, n, targetReg),
+   : S390VInstruction(cg, op, n, targetReg),
      _constantImm(constantImm)
       {
       mask3 = m3;
@@ -4905,17 +4906,17 @@ class TR_S390VRIInstruction : public TR_S390VInstruction
  *   |________|____|____|___________________|____|____|_______|
  *   0        8    12   16                  32   36   40      47
  */
-class TR_S390VRIaInstruction : public TR_S390VRIInstruction
+class S390VRIaInstruction : public TR::S390VRIInstruction
    {
    public:
-   TR_S390VRIaInstruction(
+   S390VRIaInstruction(
                           TR::CodeGenerator      * cg            = NULL,
                           TR::InstOpCode::Mnemonic          op            = TR::InstOpCode::BAD,
                           TR::Node               * n             = NULL,
                           TR::Register           * targetReg     = NULL,
                           uint16_t                constantImm2  = 0,  /* 16 bits */
                           uint8_t                 mask3         = 0)     /*  4 bits */
-      : TR_S390VRIInstruction(cg, op, n, targetReg, constantImm2, mask3, 0, 0)
+      : S390VRIInstruction(cg, op, n, targetReg, constantImm2, mask3, 0, 0)
       {
       }
 
@@ -4933,10 +4934,10 @@ class TR_S390VRIaInstruction : public TR_S390VRIInstruction
  *   |________|____|____|_________|_________|____|____|_______|
  *   0        8    12   16        24   28   32   36   40      47
  */
-class TR_S390VRIbInstruction : public TR_S390VRIInstruction
+class S390VRIbInstruction : public TR::S390VRIInstruction
    {
    public:
-   TR_S390VRIbInstruction(
+   S390VRIbInstruction(
                           TR::CodeGenerator      * cg             = NULL,
                           TR::InstOpCode::Mnemonic          op             = TR::InstOpCode::BAD,
                           TR::Node               * n              = NULL,
@@ -4944,7 +4945,7 @@ class TR_S390VRIbInstruction : public TR_S390VRIInstruction
                           uint8_t                 constantImm2   = 0,    /*  8 bits */
                           uint8_t                 constantImm3   = 0,    /*  8 bits */
                           uint8_t                 mask4          = 0)    /*  4 bits */
-      : TR_S390VRIInstruction(cg, op, n, targetReg, CAT8TO16(constantImm2, constantImm3), 0, mask4, 0)
+      : S390VRIInstruction(cg, op, n, targetReg, CAT8TO16(constantImm2, constantImm3), 0, mask4, 0)
       {
       }
 
@@ -4961,10 +4962,10 @@ class TR_S390VRIbInstruction : public TR_S390VRIInstruction
  *   |________|____|____|___________________|____|____|_______|
  *   0        8    12   16                  32   36   40      47
  */
-class TR_S390VRIcInstruction : public TR_S390VRIInstruction
+class S390VRIcInstruction : public TR::S390VRIInstruction
    {
    public:
-   TR_S390VRIcInstruction(
+   S390VRIcInstruction(
                           TR::CodeGenerator      * cg               = NULL,
                           TR::InstOpCode::Mnemonic          op               = TR::InstOpCode::BAD,
                           TR::Node               * n                = NULL,
@@ -4972,7 +4973,7 @@ class TR_S390VRIcInstruction : public TR_S390VRIInstruction
                           TR::Register           * sourceReg3       = NULL,
                           uint16_t                constantImm2     = 0,    /* 8 or 16 bits */
                           uint8_t                 mask4            = 0)    /* 4 bits       */
-   : TR_S390VRIInstruction(cg, op, n, targetReg, constantImm2, 0, mask4, 0)
+   : S390VRIInstruction(cg, op, n, targetReg, constantImm2, 0, mask4, 0)
       {
       if(getOpCode().setsOperand2())
          useTargetRegister(sourceReg3);
@@ -4992,10 +4993,10 @@ class TR_S390VRIcInstruction : public TR_S390VRIInstruction
  *   |________|____|____|____|____|_________|____|____|_______|
  *   0        8    12   16   20   24        32   36   40      47
  */
-class TR_S390VRIdInstruction : public TR_S390VRIInstruction
+class S390VRIdInstruction : public TR::S390VRIInstruction
    {
    public:
-   TR_S390VRIdInstruction(
+   S390VRIdInstruction(
                           TR::CodeGenerator      * cg               = NULL,
                           TR::InstOpCode::Mnemonic          op               = TR::InstOpCode::BAD,
                           TR::Node               * n                = NULL,
@@ -5004,7 +5005,7 @@ class TR_S390VRIdInstruction : public TR_S390VRIInstruction
                           TR::Register           * sourceReg3       = NULL,
                           uint8_t                 constantImm4     = 0,    /* 8 bit  */
                           uint8_t                 mask5            = 0)    /* 4 bits */
-   : TR_S390VRIInstruction(cg, op, n, targetReg, CAT8TO16(0, constantImm4), 0, 0, mask5)
+   : S390VRIInstruction(cg, op, n, targetReg, CAT8TO16(0, constantImm4), 0, 0, mask5)
       {
       if (getOpCode().setsOperand2())
          useTargetRegister(sourceReg2);
@@ -5030,10 +5031,10 @@ class TR_S390VRIdInstruction : public TR_S390VRIInstruction
  *   |________|____|____|______________|____|____|____|_______|
  *   0        8    12   16             28   32   36   40      47
  */
-class TR_S390VRIeInstruction : public TR_S390VRIInstruction
+class S390VRIeInstruction : public TR::S390VRIInstruction
    {
    public:
-   TR_S390VRIeInstruction(
+   S390VRIeInstruction(
                           TR::CodeGenerator      * cg               = NULL,
                           TR::InstOpCode::Mnemonic          op               = TR::InstOpCode::BAD,
                           TR::Node               * n                = NULL,
@@ -5042,7 +5043,7 @@ class TR_S390VRIeInstruction : public TR_S390VRIInstruction
                           uint16_t                constantImm3     = 0,    /* 12 bits  */
                           uint8_t                 mask5            = 0,    /*  4 bits */
                           uint8_t                 mask4            = 0)    /*  4 bits */
-   : TR_S390VRIInstruction(cg, op, n, targetReg, (constantImm3 << 4), 0, mask4, mask5)
+   : S390VRIInstruction(cg, op, n, targetReg, (constantImm3 << 4), 0, mask4, mask5)
       {
       // Error Checking
       TR_ASSERT((constantImm3 & 0xf000) == 0, "Incorrect length in immediate value");
@@ -5059,13 +5060,13 @@ class TR_S390VRIeInstruction : public TR_S390VRIInstruction
    };
 
 /**
- * TR_S390VRRInstruction Class Definition
+ * S390VRRInstruction Class Definition
  *
  * Vector register-and-register operation with extended op-code field
  * Has 6 subtypes: VRR-a to VRR-f
  *
  */
-class TR_S390VRRInstruction : public TR_S390VInstruction
+class S390VRRInstruction : public TR::S390VInstruction
    {
    // masks at bit 20 to bit 35 (not necessarily in order), 4 bits each field
    uint8_t       mask3;
@@ -5097,7 +5098,7 @@ class TR_S390VRRInstruction : public TR_S390VInstruction
 
    /* We want these to be called only by helper constructors */
    protected:
-   TR_S390VRRInstruction(
+   S390VRRInstruction(
                          TR::CodeGenerator       * cg  = NULL,
                          TR::InstOpCode::Mnemonic           op  = TR::InstOpCode::BAD,
                          TR::Node                * n   = NULL,
@@ -5107,7 +5108,7 @@ class TR_S390VRRInstruction : public TR_S390VInstruction
                          uint8_t                  m4   = 0,     /* Mask4 */
                          uint8_t                  m5   = 0,     /* Mask5 */
                          uint8_t                  m6   = 0)     /* Mask6 */
-   : TR_S390VInstruction(cg, op, n, targetReg)
+   : S390VInstruction(cg, op, n, targetReg)
       {
       if (getOpCode().setsOperand2())
          useTargetRegister(sourceReg2);
@@ -5124,7 +5125,7 @@ class TR_S390VRRInstruction : public TR_S390VInstruction
       _printM6 = getOpCode().usesM6();
       }
 
-      TR_S390VRRInstruction(
+      S390VRRInstruction(
                          TR::CodeGenerator       * cg,
                          TR::InstOpCode::Mnemonic           op,
                          TR::Node                * n,
@@ -5135,7 +5136,7 @@ class TR_S390VRRInstruction : public TR_S390VInstruction
                          uint8_t                  m5,          /* Mask5 */
                          uint8_t                  m6,          /* Mask6 */
                          TR::Instruction     * precedingInstruction)
-   : TR_S390VInstruction(cg, op, n, targetReg, precedingInstruction)
+   : S390VInstruction(cg, op, n, targetReg, precedingInstruction)
       {
       if (getOpCode().setsOperand2())
          useTargetRegister(sourceReg2);
@@ -5162,10 +5163,10 @@ class TR_S390VRRInstruction : public TR_S390VInstruction
  *   |________|____|____|_________|____|____|____|____|_______|
  *   0        8    12   16        24   28   32   36   40      47
  */
-class TR_S390VRRaInstruction: public TR_S390VRRInstruction
+class S390VRRaInstruction: public TR::S390VRRInstruction
    {
    public:
-   TR_S390VRRaInstruction(
+   S390VRRaInstruction(
                           TR::CodeGenerator       * cg         = NULL,
                           TR::InstOpCode::Mnemonic           op         = TR::InstOpCode::BAD,
                           TR::Node                * n          = NULL,
@@ -5174,11 +5175,11 @@ class TR_S390VRRaInstruction: public TR_S390VRRInstruction
                           uint8_t                  mask5      = 0,     /* 4 bits */
                           uint8_t                  mask4      = 0,     /* 4 bits */
                           uint8_t                  mask3      = 0)     /* 4 bits */
-   : TR_S390VRRInstruction(cg, op, n, targetReg, sourceReg2, mask3, mask4, mask5, 0)
+   : S390VRRInstruction(cg, op, n, targetReg, sourceReg2, mask3, mask4, mask5, 0)
       {
       }
 
-   TR_S390VRRaInstruction(
+   S390VRRaInstruction(
                           TR::CodeGenerator       * cg,
                           TR::InstOpCode::Mnemonic           op,
                           TR::Node                * n,
@@ -5188,7 +5189,7 @@ class TR_S390VRRaInstruction: public TR_S390VRRInstruction
                           uint8_t                  mask4,                  /* 4 bits */
                           uint8_t                  mask3,                  /* 4 bits */
                           TR::Instruction     * precedingInstruction)
-   : TR_S390VRRInstruction(cg, op, n, targetReg, sourceReg2, mask3, mask4, mask5, 0, precedingInstruction)
+   : S390VRRInstruction(cg, op, n, targetReg, sourceReg2, mask3, mask4, mask5, 0, precedingInstruction)
       {
       }
 
@@ -5204,10 +5205,10 @@ class TR_S390VRRaInstruction: public TR_S390VRRInstruction
  *   |________|____|____|____|____|____|____|____|____|_______|
  *   0        8    12   16        24   28   32   36   40      47
  */
-class TR_S390VRRbInstruction: public TR_S390VRRInstruction
+class S390VRRbInstruction: public TR::S390VRRInstruction
    {
    public:
-   TR_S390VRRbInstruction(
+   S390VRRbInstruction(
                           TR::CodeGenerator       * cg         = NULL,
                           TR::InstOpCode::Mnemonic           op         = TR::InstOpCode::BAS,
                           TR::Node                * n          = NULL,
@@ -5216,7 +5217,7 @@ class TR_S390VRRbInstruction: public TR_S390VRRInstruction
                           TR::Register            * sourceReg3 = 0,
                           uint8_t                  mask5      = 0,     /* 4 bits */
                           uint8_t                  mask4      = 0)     /* 4 bits */
-   : TR_S390VRRInstruction(cg, op, n, targetReg, sourceReg2, 0, mask4, mask5, 0)
+   : S390VRRInstruction(cg, op, n, targetReg, sourceReg2, 0, mask4, mask5, 0)
       {
       if(getOpCode().setsOperand3())
          useTargetRegister(sourceReg3);
@@ -5236,10 +5237,10 @@ class TR_S390VRRbInstruction: public TR_S390VRRInstruction
  *   |________|____|____|____|____|____|____|____|____|_______|
  *   0        8    12   16        24   28   32   36   40      47
  */
-class TR_S390VRRcInstruction: public TR_S390VRRInstruction
+class S390VRRcInstruction: public TR::S390VRRInstruction
    {
    public:
-   TR_S390VRRcInstruction(
+   S390VRRcInstruction(
                           TR::CodeGenerator       * cg  = NULL,
                           TR::InstOpCode::Mnemonic           op  = TR::InstOpCode::BAD,
                           TR::Node                * n   = NULL,
@@ -5249,7 +5250,7 @@ class TR_S390VRRcInstruction: public TR_S390VRRInstruction
                           uint8_t                  mask6 = 0,     /* 4 bits */
                           uint8_t                  mask5 = 0,     /* 4 bits */
                           uint8_t                  mask4 = 0)     /* 4 bits */
-   : TR_S390VRRInstruction(cg, op, n, targetReg, sourceReg2, 0, mask4, mask5, mask6)
+   : S390VRRInstruction(cg, op, n, targetReg, sourceReg2, 0, mask4, mask5, mask6)
       {
       if (getOpCode().setsOperand3())
          useTargetRegister(sourceReg3);
@@ -5269,10 +5270,10 @@ class TR_S390VRRcInstruction: public TR_S390VRRInstruction
  *   |________|____|____|____|____|____|____|____|____|_______|
  *   0        8    12   16   20   24   28   32   36   40      47
  */
-class TR_S390VRRdInstruction: public TR_S390VRRInstruction
+class S390VRRdInstruction: public TR::S390VRRInstruction
    {
    public:
-   TR_S390VRRdInstruction(
+   S390VRRdInstruction(
                           TR::CodeGenerator       * cg  = NULL,
                           TR::InstOpCode::Mnemonic           op  = TR::InstOpCode::BAD,
                           TR::Node                * n   = NULL,
@@ -5282,7 +5283,7 @@ class TR_S390VRRdInstruction: public TR_S390VRRInstruction
                           TR::Register            * sourceReg4 = NULL,
                           uint8_t                  mask6 = 0,     /* 4 bits */
                           uint8_t                  mask5 = 0)     /* 4 bits */
-   : TR_S390VRRInstruction(cg, op, n, targetReg, sourceReg2, 0, 0, mask5, mask6)
+   : S390VRRInstruction(cg, op, n, targetReg, sourceReg2, 0, 0, mask5, mask6)
       {
       if (getOpCode().setsOperand3())
          useTargetRegister(sourceReg3);
@@ -5307,10 +5308,10 @@ class TR_S390VRRdInstruction: public TR_S390VRRInstruction
  *   |________|____|____|____|____|____|____|____|____|_______|
  *   0        8    12   16   20        28   32   36   40      47
  */
-class TR_S390VRReInstruction: public TR_S390VRRInstruction
+class S390VRReInstruction: public TR::S390VRRInstruction
    {
    public:
-   TR_S390VRReInstruction(
+   S390VRReInstruction(
                           TR::CodeGenerator       * cg  = NULL,
                           TR::InstOpCode::Mnemonic           op  = TR::InstOpCode::BAD,
                           TR::Node                * n   = NULL,
@@ -5320,7 +5321,7 @@ class TR_S390VRReInstruction: public TR_S390VRRInstruction
                           TR::Register            * sourceReg4 = NULL,
                           uint8_t                  mask6 = 0,     /* 4 bits */
                           uint8_t                  mask5 = 0)     /* 4 bits */
-   : TR_S390VRRInstruction(cg, op, n, targetReg, sourceReg2, 0, 0, mask5, mask6)
+   : S390VRRInstruction(cg, op, n, targetReg, sourceReg2, 0, 0, mask5, mask6)
       {
       if (getOpCode().setsOperand3())
          useTargetRegister(sourceReg3);
@@ -5345,17 +5346,17 @@ class TR_S390VRReInstruction: public TR_S390VRRInstruction
  *   |________|____|____|____|___________________|____|_______|
  *   0        8    12   16   20                  36   40      47
  */
-class TR_S390VRRfInstruction: public TR_S390VRRInstruction
+class S390VRRfInstruction: public TR::S390VRRInstruction
    {
    public:
-   TR_S390VRRfInstruction(
+   S390VRRfInstruction(
                           TR::CodeGenerator       * cg  = NULL,
                           TR::InstOpCode::Mnemonic           op  = TR::InstOpCode::BAD,
                           TR::Node                * n   = NULL,
                           TR::Register            * targetReg  = NULL,
                           TR::Register            * sourceReg2 = NULL, /* GPR */
                           TR::Register            * sourceReg3 = NULL) /* GPR */
-   : TR_S390VRRInstruction(cg, op, n, targetReg, sourceReg2, 0, 0, 0, 0)
+   : S390VRRInstruction(cg, op, n, targetReg, sourceReg2, 0, 0, 0, 0)
       {
       if (getOpCode().setsOperand3())
          useTargetRegister(sourceReg3);
@@ -5369,20 +5370,20 @@ class TR_S390VRRfInstruction: public TR_S390VRRInstruction
    };
 
 /**
- * TR_S390VStorageInstruction Class Definition
+ * S390VStorageInstruction Class Definition
  *
  * Vector Storage related operation with extended op-code field
  * Has 3 subtypes: VRS VRX and VRV
  *
  */
-class TR_S390VStorageInstruction: public TR_S390VInstruction
+class S390VStorageInstruction: public TR::S390VInstruction
    {
    uint16_t _displacement2;
    uint8_t  maskField;
    bool     _printMaskField;
 
    protected:
-   TR_S390VStorageInstruction(
+   S390VStorageInstruction(
                          TR::CodeGenerator       * cg           = NULL,
                          TR::InstOpCode::Mnemonic           op           = TR::InstOpCode::BAD,
                          TR::Node                * n            = NULL,
@@ -5390,7 +5391,7 @@ class TR_S390VStorageInstruction: public TR_S390VInstruction
                          TR::Register            * sourceReg    = NULL,   /* VRF or GPR */
                          TR::MemoryReference * mr           = NULL,
                          uint8_t                  mask         = 0)      /* 4 bits  */
-   : TR_S390VInstruction(cg, op, n, targetReg), _displacement2(0), maskField(mask)
+   : S390VInstruction(cg, op, n, targetReg), _displacement2(0), maskField(mask)
       {
       if (sourceReg)
          useSourceRegister(sourceReg);
@@ -5400,7 +5401,7 @@ class TR_S390VStorageInstruction: public TR_S390VInstruction
          (mr->getUnresolvedSnippet())->setDataReferenceInstruction(this);
       }
 
-   TR_S390VStorageInstruction(
+   S390VStorageInstruction(
                          TR::CodeGenerator       * cg,
                          TR::InstOpCode::Mnemonic           op,
                          TR::Node                * n,
@@ -5409,7 +5410,7 @@ class TR_S390VStorageInstruction: public TR_S390VInstruction
                          TR::MemoryReference * mr,
                          uint8_t                  mask,                    /* 4 bits  */
                          TR::Instruction     * precedingInstruction)
-   : TR_S390VInstruction(cg, op, n, targetReg, precedingInstruction), _displacement2(0), maskField(mask)
+   : S390VInstruction(cg, op, n, targetReg, precedingInstruction), _displacement2(0), maskField(mask)
       {
       if (sourceReg)
          useSourceRegister(sourceReg);
@@ -5433,16 +5434,16 @@ class TR_S390VStorageInstruction: public TR_S390VInstruction
    };
 
 /**
- * TR_S390VRSInstruction Class Definition
+ * S390VRSInstruction Class Definition
  *
  * Vector register-and-storage operation with extended op-code field
  * Has 3 subtypes: VRS-a to VRS-c
  */
-class TR_S390VRSInstruction : public TR_S390VInstruction
+class S390VRSInstruction : public TR::S390VInstruction
    {
    public:
-   TR::Register* getFirstRegister() { return isTargetPair()? TR_S390RegInstruction::getFirstRegister() : getRegisterOperand(1); }
-   TR::Register* getLastRegister()  { return isTargetPair()? TR_S390RegInstruction::getLastRegister()  : getRegisterOperand(2); }
+   TR::Register* getFirstRegister() { return isTargetPair()? S390RegInstruction::getFirstRegister() : getRegisterOperand(1); }
+   TR::Register* getLastRegister()  { return isTargetPair()? S390RegInstruction::getLastRegister()  : getRegisterOperand(2); }
 
    TR::Register* getSecondRegister() {return getRegisterOperand(2); }
 
@@ -5456,7 +5457,7 @@ class TR_S390VRSInstruction : public TR_S390VInstruction
 
    /* We want these to be called only by helper constructors */
    protected:
-   TR_S390VRSInstruction(
+   S390VRSInstruction(
                          TR::CodeGenerator       * cg           = NULL,
                          TR::InstOpCode::Mnemonic           op           = TR::InstOpCode::BAD,
                          TR::Node                * n            = NULL,
@@ -5465,7 +5466,7 @@ class TR_S390VRSInstruction : public TR_S390VInstruction
                          uint16_t                 displacement2= 0,      /* 12 bits */
                          uint8_t                  mask4        = 0,      /* 4 bits  */
                          uint8_t                  bitSet2      = 0)      /* 4 bits  */
-      : TR_S390VInstruction(cg, op, n)
+      : S390VInstruction(cg, op, n)
          {
          }
    };
@@ -5477,10 +5478,10 @@ class TR_S390VRSInstruction : public TR_S390VInstruction
  *   |________|____|____|____|_______________|____|____|_______|
  *   0        8    12   16   20              32   36   40      47
  */
-class TR_S390VRSaInstruction : public TR_S390VStorageInstruction
+class S390VRSaInstruction : public TR::S390VStorageInstruction
    {
    public:
-   TR_S390VRSaInstruction(
+   S390VRSaInstruction(
                          TR::CodeGenerator       * cg           = NULL,
                          TR::InstOpCode::Mnemonic           op           = TR::InstOpCode::BAD,
                          TR::Node                * n            = NULL,
@@ -5488,7 +5489,7 @@ class TR_S390VRSaInstruction : public TR_S390VStorageInstruction
                          TR::Register            * sourceReg    = NULL,   /* VRF */
                          TR::MemoryReference * mr           = NULL,
                          uint8_t                  mask4        = 0)      /*  4 bits */
-   : TR_S390VStorageInstruction(cg, op, n, targetReg, sourceReg, mr, mask4)
+   : S390VStorageInstruction(cg, op, n, targetReg, sourceReg, mr, mask4)
       {
       setPrintMaskField(getOpCode().usesM4());
       }
@@ -5503,10 +5504,10 @@ class TR_S390VRSaInstruction : public TR_S390VStorageInstruction
  *   |________|____|____|____|_______________|____|____|_______|
  *   0        8    12   16   20              32   36   40      47
  */
-class TR_S390VRSbInstruction : public TR_S390VStorageInstruction
+class S390VRSbInstruction : public TR::S390VStorageInstruction
    {
    public:
-   TR_S390VRSbInstruction(
+   S390VRSbInstruction(
                          TR::CodeGenerator       * cg           = NULL,
                          TR::InstOpCode::Mnemonic           op           = TR::InstOpCode::BAD,
                          TR::Node                * n            = NULL,
@@ -5514,7 +5515,7 @@ class TR_S390VRSbInstruction : public TR_S390VStorageInstruction
                          TR::Register            * sourceReg    = NULL,   /* GPR */
                          TR::MemoryReference * mr           = NULL,
                          uint8_t                  mask4        = 0)      /*  4 bits */
-   : TR_S390VStorageInstruction(cg, op, n, targetReg, sourceReg, mr, mask4)
+   : S390VStorageInstruction(cg, op, n, targetReg, sourceReg, mr, mask4)
       {
       setPrintMaskField(getOpCode().usesM4());
       }
@@ -5530,10 +5531,10 @@ class TR_S390VRSbInstruction : public TR_S390VStorageInstruction
  *   |________|____|____|____|_______________|____|____|_______|
  *   0        8    12   16   20              32   36   40      47
  */
-class TR_S390VRScInstruction : public TR_S390VStorageInstruction
+class S390VRScInstruction : public TR::S390VStorageInstruction
    {
    public:
-   TR_S390VRScInstruction(
+   S390VRScInstruction(
                          TR::CodeGenerator       * cg           = NULL,
                          TR::InstOpCode::Mnemonic           op           = TR::InstOpCode::BAD,
                          TR::Node                * n            = NULL,
@@ -5541,7 +5542,7 @@ class TR_S390VRScInstruction : public TR_S390VStorageInstruction
                          TR::Register            * sourceReg    = NULL,   /* VRF */
                          TR::MemoryReference * mr           = NULL,
                          uint8_t                  mask4        = 0)      /*  4 bits */
-   : TR_S390VStorageInstruction(cg, op, n, targetReg, sourceReg, mr, mask4)
+   : S390VStorageInstruction(cg, op, n, targetReg, sourceReg, mr, mask4)
       {
       setPrintMaskField(getOpCode().usesM4());
       }
@@ -5550,7 +5551,7 @@ class TR_S390VRScInstruction : public TR_S390VStorageInstruction
    };
 
 /**
- * TR_S390VRVInstruction Class Definition
+ * S390VRVInstruction Class Definition
  *    _________________________________________________________
  *   |Op Code | V1 | V2 | B2 |     D2        | M3*|RXB |Op Code|
  *   |________|____|____|____|_______________|____|____|_______|
@@ -5558,17 +5559,17 @@ class TR_S390VRScInstruction : public TR_S390VStorageInstruction
  *
  * Vector register-and-vector-index-storage operation with ext. op-code field
  */
-class TR_S390VRVInstruction : public TR_S390VStorageInstruction
+class S390VRVInstruction : public TR::S390VStorageInstruction
    {
    public:
-   TR_S390VRVInstruction(
+   S390VRVInstruction(
                          TR::CodeGenerator       * cg           = NULL,
                          TR::InstOpCode::Mnemonic           op           = TR::InstOpCode::BAD,
                          TR::Node                * n            = NULL,
                          TR::Register            * sourceReg    = NULL,   /* VRF */
                          TR::MemoryReference * mr           = NULL,
                          uint8_t                  mask3        = 0)      /*  4 bits */
-   : TR_S390VStorageInstruction(cg, op, n, sourceReg, sourceReg, mr, mask3)
+   : S390VStorageInstruction(cg, op, n, sourceReg, sourceReg, mr, mask3)
       {
       setPrintMaskField(getOpCode().usesM3());
       }
@@ -5577,7 +5578,7 @@ class TR_S390VRVInstruction : public TR_S390VStorageInstruction
    };
 
 /**
- * TR_S390VRXInstruction Class Definition
+ * S390VRXInstruction Class Definition
  *    ___________________________________________________________
  *   |Op Code |  V1  |  X2 | B2 |   D2   | M3* |  RXB | Op Code  |
  *   |________|______|_____|____|________|_____|______|__________|
@@ -5585,22 +5586,22 @@ class TR_S390VRVInstruction : public TR_S390VStorageInstruction
  *
  * Vector register-and-index-storage operation with extended op-code field
  */
-class TR_S390VRXInstruction : public TR_S390VStorageInstruction
+class S390VRXInstruction : public TR::S390VStorageInstruction
    {
    public:
-   TR_S390VRXInstruction(
+   S390VRXInstruction(
                          TR::CodeGenerator       * cg           = NULL,
                          TR::InstOpCode::Mnemonic           op           = TR::InstOpCode::BAD,
                          TR::Node              * n            = NULL,
                          TR::Register            * reg          = NULL,   /* GPR */
                          TR::MemoryReference * mr           = NULL,
                          uint8_t                  mask3        = 0)      /*  4 bits */
-   : TR_S390VStorageInstruction(cg, op, n, reg, NULL, mr, mask3)
+   : S390VStorageInstruction(cg, op, n, reg, NULL, mr, mask3)
       {
       setPrintMaskField(getOpCode().usesM3());
       }
 
-   TR_S390VRXInstruction(
+   S390VRXInstruction(
                          TR::CodeGenerator       * cg,
                          TR::InstOpCode::Mnemonic           op,
                          TR::Node              * n,
@@ -5608,7 +5609,7 @@ class TR_S390VRXInstruction : public TR_S390VStorageInstruction
                          TR::MemoryReference * mr,
                          uint8_t                  mask3,                /*  4 bits */
                          TR::Instruction     * precedingInstruction)
-   : TR_S390VStorageInstruction(cg, op, n, reg, NULL, mr, mask3, precedingInstruction)
+   : S390VStorageInstruction(cg, op, n, reg, NULL, mr, mask3, precedingInstruction)
       {
       setPrintMaskField(getOpCode().usesM3());
       }
@@ -5619,9 +5620,9 @@ class TR_S390VRXInstruction : public TR_S390VStorageInstruction
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390NOPInstruction Class Definition
+// S390NOPInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390NOPInstruction : public TR::Instruction
+class S390NOPInstruction : public TR::Instruction
    {
    /** Type of this special purpose NOP */
    enum KindNOP
@@ -5634,7 +5635,7 @@ class TR_S390NOPInstruction : public TR::Instruction
 
    // Following fields are used for specialized XPLink NOP following a call site
    TR::Snippet *_targetSnippet;
-   TR_S390PseudoInstruction *_callDescInstr;  ///<  This is the branch-around fix for JNI call descriptors on zOS-31.
+   S390PseudoInstruction *_callDescInstr;  ///<  This is the branch-around fix for JNI call descriptors on zOS-31.
    intptrj_t _estimatedOffset;                ///<  Save estimated offset for conservative distance calc to Call Descriptor Snippet (XPLINK zOS31).
    int8_t  _callType;                         ///<  call type for NOP
 
@@ -5642,7 +5643,7 @@ class TR_S390NOPInstruction : public TR::Instruction
    int32_t  _argumentsLengthOnCall;           ///< length of outgoing argument list
 
    public:
-   TR_S390NOPInstruction(TR::InstOpCode::Mnemonic op,
+   S390NOPInstruction(TR::InstOpCode::Mnemonic op,
                          int32_t numbytes,
                          TR::Node *n,
                          TR::CodeGenerator *cg)
@@ -5656,7 +5657,7 @@ class TR_S390NOPInstruction : public TR::Instruction
       setArgumentsLengthOnCall(0);
       }
 
-   TR_S390NOPInstruction(TR::InstOpCode::Mnemonic op,
+   S390NOPInstruction(TR::InstOpCode::Mnemonic op,
                          int32_t numbytes,
                          TR::Node * n,
                          TR::Instruction *precedingInstruction,
@@ -5672,7 +5673,7 @@ class TR_S390NOPInstruction : public TR::Instruction
       }
 
 
-   TR_S390NOPInstruction(TR::InstOpCode::Mnemonic op,
+   S390NOPInstruction(TR::InstOpCode::Mnemonic op,
                          int32_t numbytes,
                          TR::Snippet *ts,
                          TR::Node *n,
@@ -5687,7 +5688,7 @@ class TR_S390NOPInstruction : public TR::Instruction
       setArgumentsLengthOnCall(0);
       }
 
-   TR_S390NOPInstruction(TR::InstOpCode::Mnemonic op,
+   S390NOPInstruction(TR::InstOpCode::Mnemonic op,
                          int32_t numbytes,
                          TR::Snippet *ts,
                          TR::Node * n,
@@ -5704,7 +5705,7 @@ class TR_S390NOPInstruction : public TR::Instruction
       }
 
    /** Fastlink flavor */
-   TR_S390NOPInstruction(TR::InstOpCode::Mnemonic op,
+   S390NOPInstruction(TR::InstOpCode::Mnemonic op,
                          int32_t numbytes,
                          int32_t argumentsLengthOnCall,
                          TR::Node *n,
@@ -5727,9 +5728,9 @@ class TR_S390NOPInstruction : public TR::Instruction
    TR::Snippet *setTargetSnippet(TR::Snippet *ts)
       { return _targetSnippet = ts; }
 
-   TR_S390PseudoInstruction *getCallDescInstr()
+   S390PseudoInstruction *getCallDescInstr()
       { return _callDescInstr; }
-   TR_S390PseudoInstruction *setCallDescInstr(TR_S390PseudoInstruction *cdi)
+   S390PseudoInstruction *setCallDescInstr(S390PseudoInstruction *cdi)
       { return _callDescInstr = cdi; }
 
    int8_t getCallType()
@@ -5753,14 +5754,14 @@ class TR_S390NOPInstruction : public TR::Instruction
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390IInstruction Class Definition
+// S390IInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390IInstruction : public TR::Instruction
+class S390IInstruction : public TR::Instruction
    {
    uint8_t                  _immediate;
    public:
 
-   TR_S390IInstruction(TR::InstOpCode::Mnemonic op,
+   S390IInstruction(TR::InstOpCode::Mnemonic op,
                          TR::Node *n,
                          uint8_t im,
                          TR::CodeGenerator *cg)
@@ -5768,7 +5769,7 @@ class TR_S390IInstruction : public TR::Instruction
       {
       }
 
-   TR_S390IInstruction(TR::InstOpCode::Mnemonic op,
+   S390IInstruction(TR::InstOpCode::Mnemonic op,
                          TR::Node * n,
                          uint8_t im,
                          TR::Instruction *precedingInstruction,
@@ -5784,13 +5785,13 @@ class TR_S390IInstruction : public TR::Instruction
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390EInstruction Class Definition
+// S390EInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390EInstruction : public TR::Instruction
+class S390EInstruction : public TR::Instruction
    {
    public:
 
-   TR_S390EInstruction(TR::InstOpCode::Mnemonic op,
+   S390EInstruction(TR::InstOpCode::Mnemonic op,
                          TR::Node *n,
                          TR::CodeGenerator *cg)
       : TR::Instruction(op, n, cg)
@@ -5799,7 +5800,7 @@ class TR_S390EInstruction : public TR::Instruction
       setEstimatedBinaryLength(2);
       }
 
-   TR_S390EInstruction(TR::InstOpCode::Mnemonic op,
+   S390EInstruction(TR::InstOpCode::Mnemonic op,
                          TR::Node * n,
                          TR::Instruction *precedingInstruction,
                          TR::CodeGenerator                   *cg)
@@ -5814,7 +5815,7 @@ class TR_S390EInstruction : public TR::Instruction
     * FPR4/FPR6 and GPR0 are source registers;
     * they are implied by the opcode, purpose of adding these is to notify RA the reg use/def dependencies
     */
-   TR_S390EInstruction(TR::InstOpCode::Mnemonic op,
+   S390EInstruction(TR::InstOpCode::Mnemonic op,
                          TR::Node *n,
                          TR::CodeGenerator *cg,
                          TR::Register * tgt,
@@ -5832,7 +5833,7 @@ class TR_S390EInstruction : public TR::Instruction
       setEstimatedBinaryLength(2);
       }
 
-   TR_S390EInstruction(TR::InstOpCode::Mnemonic op,
+   S390EInstruction(TR::InstOpCode::Mnemonic op,
                          TR::Node * n,
                          TR::Instruction *precedingInstruction,
                          TR::CodeGenerator                   *cg,
@@ -5859,20 +5860,20 @@ class TR_S390EInstruction : public TR::Instruction
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390OpCodeOnlyInstruction Class Definition
+// S390OpCodeOnlyInstruction Class Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390OpCodeOnlyInstruction : public TR::Instruction
+class S390OpCodeOnlyInstruction : public TR::Instruction
    {
    public:
 
-   TR_S390OpCodeOnlyInstruction(TR::InstOpCode::Mnemonic op,
+   S390OpCodeOnlyInstruction(TR::InstOpCode::Mnemonic op,
                          TR::Node *n,
                          TR::CodeGenerator *cg)
       : TR::Instruction(op, n, cg)
       {
       }
 
-   TR_S390OpCodeOnlyInstruction(TR::InstOpCode::Mnemonic op,
+   S390OpCodeOnlyInstruction(TR::InstOpCode::Mnemonic op,
                          TR::Node * n,
                          TR::Instruction *precedingInstruction,
                          TR::CodeGenerator                   *cg)
@@ -5885,147 +5886,149 @@ class TR_S390OpCodeOnlyInstruction : public TR::Instruction
 
    };
 
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /*************************************************************************
  * Pseudo-safe downcast functions
  *
  *************************************************************************/
 
-inline TR_S390MemInstruction * toS390MemInstruction(TR::Instruction *i)
+inline TR::S390MemInstruction * toS390MemInstruction(TR::Instruction *i)
    {
-   return (TR_S390MemInstruction *)i;
+   return (TR::S390MemInstruction *)i;
    }
 
-inline TR_S390RIEInstruction * toS390RIEInstruction(TR::Instruction *i)
+inline TR::S390RIEInstruction * toS390RIEInstruction(TR::Instruction *i)
    {
-   return (TR_S390RIEInstruction *)i;
+   return (TR::S390RIEInstruction *)i;
    }
-inline TR_S390RRInstruction * toS390RRInstruction(TR::Instruction *i)
+inline TR::S390RRInstruction * toS390RRInstruction(TR::Instruction *i)
    {
-   return (TR_S390RRInstruction *)i;
-   }
-
-inline TR_S390RXInstruction * toS390RXInstruction(TR::Instruction *i)
-   {
-   return (TR_S390RXInstruction *)i;
+   return (TR::S390RRInstruction *)i;
    }
 
-inline TR_S390RXFInstruction * toS390RXFInstruction(TR::Instruction *i)
+inline TR::S390RXInstruction * toS390RXInstruction(TR::Instruction *i)
    {
-   return (TR_S390RXFInstruction *)i;
+   return (TR::S390RXInstruction *)i;
    }
 
-inline TR_S390LabelInstruction * toS390LabelInstruction(TR::Instruction *i)
+inline TR::S390RXFInstruction * toS390RXFInstruction(TR::Instruction *i)
    {
-   return (TR_S390LabelInstruction *)i;
+   return (TR::S390RXFInstruction *)i;
    }
 
-inline TR_S390RIInstruction * toS390RIInstruction(TR::Instruction *i)
+inline TR::S390LabelInstruction * toS390LabelInstruction(TR::Instruction *i)
    {
-   return (TR_S390RIInstruction *)i;
+   return (TR::S390LabelInstruction *)i;
    }
 
-inline TR_S390RILInstruction * toS390RILInstruction(TR::Instruction *i)
+inline TR::S390RIInstruction * toS390RIInstruction(TR::Instruction *i)
    {
-   return (TR_S390RILInstruction *)i;
+   return (TR::S390RIInstruction *)i;
    }
 
-inline TR_S390SS1Instruction * toS390SS1Instruction(TR::Instruction *i)
+inline TR::S390RILInstruction * toS390RILInstruction(TR::Instruction *i)
    {
-   return (TR_S390SS1Instruction *)i;
+   return (TR::S390RILInstruction *)i;
    }
 
-inline TR_S390SSEInstruction * toS390SSEInstruction(TR::Instruction *i)
+inline TR::S390SS1Instruction * toS390SS1Instruction(TR::Instruction *i)
    {
-   return (TR_S390SSEInstruction *)i;
+   return (TR::S390SS1Instruction *)i;
    }
 
-inline TR_S390SS2Instruction * toS390SS2Instruction(TR::Instruction *i)
+inline TR::S390SSEInstruction * toS390SSEInstruction(TR::Instruction *i)
    {
-   return (TR_S390SS2Instruction *)i;
+   return (TR::S390SSEInstruction *)i;
    }
 
-inline TR_S390SS4Instruction * toS390SS4Instruction(TR::Instruction *i)
+inline TR::S390SS2Instruction * toS390SS2Instruction(TR::Instruction *i)
    {
-   return (TR_S390SS4Instruction *)i;
+   return (TR::S390SS2Instruction *)i;
    }
 
-inline TR_S390SSFInstruction * toS390SSFInstruction(TR::Instruction *i)
+inline TR::S390SS4Instruction * toS390SS4Instruction(TR::Instruction *i)
    {
-   return (TR_S390SSFInstruction *)i;
+   return (TR::S390SS4Instruction *)i;
    }
 
-inline TR_S390RSInstruction * toS390RSInstruction(TR::Instruction *i)
+inline TR::S390SSFInstruction * toS390SSFInstruction(TR::Instruction *i)
    {
-   return (TR_S390RSInstruction *)i;
+   return (TR::S390SSFInstruction *)i;
    }
 
-inline TR_S390VRSInstruction * toS390VRSInstruction(TR::Instruction *i)
+inline TR::S390RSInstruction * toS390RSInstruction(TR::Instruction *i)
    {
-   return (TR_S390VRSInstruction *)i;
+   return (TR::S390RSInstruction *)i;
    }
 
-inline TR_S390VRRaInstruction * toS390VRRaInstruction(TR::Instruction *i)
+inline TR::S390VRSInstruction * toS390VRSInstruction(TR::Instruction *i)
    {
-   return (TR_S390VRRaInstruction *)i;
+   return (TR::S390VRSInstruction *)i;
    }
 
-inline TR_S390VRIaInstruction * toS390VRIaInstruction(TR::Instruction *i)
+inline TR::S390VRRaInstruction * toS390VRRaInstruction(TR::Instruction *i)
    {
-   return (TR_S390VRIaInstruction *)i;
+   return (TR::S390VRRaInstruction *)i;
    }
 
-inline TR_S390RSLInstruction * toS390RSLInstruction(TR::Instruction *i)
+inline TR::S390VRIaInstruction * toS390VRIaInstruction(TR::Instruction *i)
    {
-   return (TR_S390RSLInstruction *)i;
+   return (TR::S390VRIaInstruction *)i;
    }
 
-inline TR_S390RSLbInstruction * toS390RSLbInstruction(TR::Instruction *i)
+inline TR::S390RSLInstruction * toS390RSLInstruction(TR::Instruction *i)
    {
-   return (TR_S390RSLbInstruction *)i;
+   return (TR::S390RSLInstruction *)i;
    }
 
-inline TR_S390RRFInstruction * toS390RRFInstruction(TR::Instruction *i)
+inline TR::S390RSLbInstruction * toS390RSLbInstruction(TR::Instruction *i)
    {
-   return (TR_S390RRFInstruction *)i;
+   return (TR::S390RSLbInstruction *)i;
    }
 
-inline TR_S390ImmInstruction * toS390ImmInstruction(TR::Instruction *i)
+inline TR::S390RRFInstruction * toS390RRFInstruction(TR::Instruction *i)
+   {
+   return (TR::S390RRFInstruction *)i;
+   }
+
+inline TR::S390ImmInstruction * toS390ImmInstruction(TR::Instruction *i)
    {
 #if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
    TR_ASSERT(i->getS390ImmInstruction() != NULL, "trying to downcast to an S390ImmInstruction");
 #endif
-   return (TR_S390ImmInstruction *)i;
+   return (TR::S390ImmInstruction *)i;
    }
 
-inline TR_S390SMIInstruction * toS390SMIInstruction(TR::Instruction *i)
+inline TR::S390SMIInstruction * toS390SMIInstruction(TR::Instruction *i)
    {
-   return (TR_S390SMIInstruction *)i;
+   return (TR::S390SMIInstruction *)i;
    }
 
-inline TR_S390VRSaInstruction * toS390VRSaInstruction(TR::Instruction *i)
+inline TR::S390VRSaInstruction * toS390VRSaInstruction(TR::Instruction *i)
    {
-   return (TR_S390VRSaInstruction *)i;
+   return (TR::S390VRSaInstruction *)i;
    }
 
-inline TR_S390VRSbInstruction * toS390VRSbInstruction(TR::Instruction *i)
+inline TR::S390VRSbInstruction * toS390VRSbInstruction(TR::Instruction *i)
    {
-   return (TR_S390VRSbInstruction *)i;
+   return (TR::S390VRSbInstruction *)i;
    }
 
-inline TR_S390VRScInstruction * toS390VRScInstruction(TR::Instruction *i)
+inline TR::S390VRScInstruction * toS390VRScInstruction(TR::Instruction *i)
    {
-   return (TR_S390VRScInstruction *)i;
+   return (TR::S390VRScInstruction *)i;
    }
 
-inline TR_S390VRVInstruction * toS390VRVInstruction(TR::Instruction *i)
+inline TR::S390VRVInstruction * toS390VRVInstruction(TR::Instruction *i)
    {
-   return (TR_S390VRVInstruction *)i;
+   return (TR::S390VRVInstruction *)i;
    }
 
-inline TR_S390VRXInstruction * toS390VRXInstruction(TR::Instruction *i)
+inline TR::S390VRXInstruction * toS390VRXInstruction(TR::Instruction *i)
    {
-   return (TR_S390VRXInstruction *)i;
+   return (TR::S390VRXInstruction *)i;
    }
 
 TR::MemoryReference *getFirstReadWriteMemoryReference(TR::Instruction *i);

--- a/compiler/z/codegen/SystemLinkage.cpp
+++ b/compiler/z/codegen/SystemLinkage.cpp
@@ -1134,7 +1134,7 @@ TR_S390zLinuxSystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR:
          TR::SymbolReference *callSymRef = callNode->getSymbolReference();
          TR::Symbol *callSymbol = callSymRef->getSymbol();
          TR::Register * fpReg = systemReturnAddressRegister;
-         TR::Instruction * callInstr = new (trHeapMemory()) TR_S390RILInstruction(TR::InstOpCode::BRASL, callNode, fpReg, callSymbol, callSymRef, codeGen);
+         TR::Instruction * callInstr = new (trHeapMemory()) TR::S390RILInstruction(TR::InstOpCode::BRASL, callNode, fpReg, callSymbol, callSymRef, codeGen);
          callInstr->setDependencyConditions(deps);
          }
       }
@@ -2008,7 +2008,7 @@ void TR_S390SystemLinkage::createPrologue(TR::Instruction * cursor)
    // Literal Pool for Ruby and Python and test
    firstSnippet = cg()->getFirstSnippet();
    if ( cg()->isLiteralPoolOnDemandOn() != true && firstSnippet != NULL )
-      cursor = new (trHeapMemory()) TR_S390RILInstruction(TR::InstOpCode::LARL, firstNode, lpReg, firstSnippet, cursor, cg());
+      cursor = new (trHeapMemory()) TR::S390RILInstruction(TR::InstOpCode::LARL, firstNode, lpReg, firstSnippet, cursor, cg());
 #endif
 
 
@@ -2327,8 +2327,8 @@ void TR_S390SystemLinkage::createEpilogue(TR::Instruction * cursor)
 
    cursor = generateS390RegInstruction(cg(), TR::InstOpCode::BCR, nextNode,
           getS390RealRegister(REGNUM(TR::RealRegister::GPR14)), cursor);
-   ((TR_S390RegInstruction *)cursor)->setBranchCondition(TR::InstOpCode::COND_BCR);
-   ((TR_S390RegInstruction *)cursor)->setJITExit();
+   ((TR::S390RegInstruction *)cursor)->setBranchCondition(TR::InstOpCode::COND_BCR);
+   ((TR::S390RegInstruction *)cursor)->setJITExit();
    }
 
 void TR_S390SystemLinkage::notifyHasalloca()
@@ -2562,7 +2562,7 @@ void OMR::Z::Linkage::replaceCallWithJumpInstruction(TR::Instruction *callInstru
 
    TR::Instruction *replacementInst =0 ;
 
-   replacementInst = new (self()->trHeapMemory()) TR_S390RILInstruction(TR::InstOpCode::BRCL, node, (uint32_t)0xf, callSymbol, callSymRef, self()->cg());
+   replacementInst = new (self()->trHeapMemory()) TR::S390RILInstruction(TR::InstOpCode::BRCL, node, (uint32_t)0xf, callSymbol, callSymRef, self()->cg());
 
    if(self()->comp()->getOption(TR_TraceCG))
       traceMsg(self()->comp(), "Replacing instruction %p to a jump %p !\n",callInstruction, replacementInst);


### PR DESCRIPTION
Using the `TR_` prefix is deprecated, as it clutters the top level namespace. This moves classes named `TR_S390*Instruction` (eg. `TR_S390NOPInstruction`) to the TR namespace.