### PR TITLE
Rename SideTableIndex to LocalIndex

### DIFF
--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -125,8 +125,8 @@ OMR::CodeGenerator::estimateRegisterPressure(TR::Node *node, int32_t &registerPr
    {
    if (node->getVisitCount() == visitCount)
       {
-      node->setSideTableIndex(node->getSideTableIndex()-1);
-      if (node->getSideTableIndex() == 0)
+      node->setLocalIndex(node->getLocalIndex()-1);
+      if (node->getLocalIndex() == 0)
          {
 
          if (node->getOpCode().isLoadVar() &&
@@ -161,9 +161,9 @@ OMR::CodeGenerator::estimateRegisterPressure(TR::Node *node, int32_t &registerPr
 
    node->setVisitCount(visitCount);
    if (node->getReferenceCount() > 0)
-      node->setSideTableIndex(node->getReferenceCount()-1);
+      node->setLocalIndex(node->getReferenceCount()-1);
    else
-      node->setSideTableIndex(0);
+      node->setLocalIndex(0);
 
    int32_t childCount;
    for (childCount = node->getNumChildren()-1; childCount >= 0; childCount--)
@@ -191,7 +191,7 @@ OMR::CodeGenerator::estimateRegisterPressure(TR::Node *node, int32_t &registerPr
    // Allow these call-like opcodes in cold blocks
    // as we can afford to spill in cold blocks
    //
-   if (node->getSideTableIndex() > 0)
+   if (node->getLocalIndex() > 0)
       {
       if (node->getOpCode().isLoadVar() &&
           node->getSymbol()->isAutoOrParm() &&

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -446,11 +446,11 @@ OMR::CodeGenerator::lowerTreesPropagateBlockToNode(TR::Node *node)
 
    if (self()->comp()->getFlowGraph()->getNextNodeNumber() < SHRT_MAX)
       {
-      node->setSideTableIndex(self()->getCurrentBlock()->getNumber());
+      node->setLocalIndex(self()->getCurrentBlock()->getNumber());
       }
    else
       {
-      node->setSideTableIndex(-1);
+      node->setLocalIndex(-1);
       }
 
    }

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -151,7 +151,7 @@ OMR::Node::Node(TR::Node *originatingByteCodeNode, TR::ILOpCodes op, uint16_t nu
       self()->setNodePoolIndex(comp->getNodePool().getLastPoolIndex());
       self()->setReferenceCount(0);
       self()->setVisitCount(0);
-      self()->setSideTableIndex(0);
+      self()->setLocalIndex(0);
       memset( &(self()->getOptAttributes()->_unionA), 0, sizeof( self()->getOptAttributes()->_unionA ) );
       if (self()->getGlobalIndex() == MAX_NODE_COUNT)
          {
@@ -241,7 +241,7 @@ OMR::Node::Node(TR::Node * from, uint16_t numChildren)
    // opt attributes are separate, and need separate initialization.
    self()->setReferenceCount(from->getReferenceCount());
    self()->setVisitCount(from->getVisitCount());
-   self()->setSideTableIndex(from->getSideTableIndex());
+   self()->setLocalIndex(from->getLocalIndex());
    self()->getOptAttributes()->_unionA = from->getOptAttributes()->_unionA;
 
    if (self()->getGlobalIndex() == MAX_NODE_COUNT)

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -79,12 +79,12 @@ typedef uint32_t    ncount_t;
 typedef uint32_t    rcount_t;
 #define MAX_RCOUNT  UINT_MAX
 
-/// Node side table indexes
+/// Node local indexes
 ///
 typedef uint32_t    scount_t;
 #define MAX_SCOUNT  UINT_MAX
 #define SCOUNT_HIGH_BIT          0x80000000
-#define NULL_USEDEF_SYMBOL_INDEX 0xFFFF  //TODO: should be 0xFFFF until we change the date type of _sideTableIndex in Symbol.hpp
+#define NULL_USEDEF_SYMBOL_INDEX 0xFFFF  //TODO: should be 0xFFFF until we change the date type of _localIndex in Symbol.hpp
 
 /// Visit counts
 ///
@@ -678,13 +678,13 @@ public:
    rcount_t        recursivelyDecReferenceCount();
    void            recursivelyDecReferenceCountFromCodeGen();
 
-   inline scount_t getSideTableIndex();
-   inline scount_t setSideTableIndex(scount_t sti);
-   inline scount_t incSideTableIndex();
-   inline scount_t decSideTableIndex();
+   inline scount_t getLocalIndex();
+   inline scount_t setLocalIndex(scount_t li);
+   inline scount_t incLocalIndex();
+   inline scount_t decLocalIndex();
 
    inline scount_t getFutureUseCount();
-   inline scount_t setFutureUseCount(scount_t sti);
+   inline scount_t setFutureUseCount(scount_t li);
    inline scount_t incFutureUseCount();
    inline scount_t decFutureUseCount();
 

--- a/compiler/il/OMRNode_inlines.hpp
+++ b/compiler/il/OMRNode_inlines.hpp
@@ -309,26 +309,26 @@ OMR::Node::decReferenceCount()
    }
 
 scount_t
-OMR::Node::getSideTableIndex()
+OMR::Node::getLocalIndex()
    {
    return self()->getOptAttributes()->_localIndex;
    }
 
 scount_t
-OMR::Node::setSideTableIndex(scount_t sti)
+OMR::Node::setLocalIndex(scount_t li)
    {
-   return (self()->getOptAttributes()->_localIndex = sti);
+   return (self()->getOptAttributes()->_localIndex = li);
    }
 
 scount_t
-OMR::Node::incSideTableIndex()
+OMR::Node::incLocalIndex()
    {
    ++self()->getOptAttributes()->_localIndex;
    TR_ASSERT(self()->getOptAttributes()->_localIndex>0, "assertion failure"); return self()->getOptAttributes()->_localIndex;
    }
 
 scount_t
-OMR::Node::decSideTableIndex()
+OMR::Node::decLocalIndex()
    {
    TR_ASSERT(self()->getOptAttributes()->_localIndex > 0, "assertion failure"); return --self()->getOptAttributes()->_localIndex;
    }
@@ -340,9 +340,9 @@ OMR::Node::getFutureUseCount()
    }
 
 scount_t
-OMR::Node::setFutureUseCount(scount_t sti)
+OMR::Node::setFutureUseCount(scount_t li)
    {
-   return (self()->getOptAttributes()->_localIndex = (scount_t)sti);
+   return (self()->getOptAttributes()->_localIndex = (scount_t)li);
    }
 
 scount_t

--- a/compiler/il/symbol/OMRSymbol.cpp
+++ b/compiler/il/symbol/OMRSymbol.cpp
@@ -76,7 +76,7 @@ OMR::Symbol::Symbol(TR::DataTypes d) :
    _name(0),
    _flags(0),
    _flags2(0),
-   _sideTableIndex(0),
+   _localIndex(0),
    _restrictedRegisterNumber(-1)
    {
    self()->setDataType(d);
@@ -86,7 +86,7 @@ OMR::Symbol::Symbol(TR::DataTypes d, uint32_t size) :
    _name(0),
    _flags(0),
    _flags2(0),
-   _sideTableIndex(0),
+   _localIndex(0),
    _restrictedRegisterNumber(-1)
    {
    self()->setDataType(d);

--- a/compiler/il/symbol/OMRSymbol.hpp
+++ b/compiler/il/symbol/OMRSymbol.hpp
@@ -100,7 +100,7 @@ protected:
       _name(0),
       _flags(0),
       _flags2(0),
-      _sideTableIndex(0),
+      _localIndex(0),
       _restrictedRegisterNumber(-1)
    { }
 
@@ -198,8 +198,8 @@ public:
    uint32_t getFlags2()                     { return _flags2.getValue(); }
    void setFlagValue(uint32_t v, bool b)    { _flags.setValue(v, b); }
 
-   uint16_t getSideTableIndex()             { return _sideTableIndex; }
-   uint16_t setSideTableIndex(uint16_t sti) { return (_sideTableIndex = sti); }
+   uint16_t getLocalIndex()                 { return _localIndex; }
+   uint16_t setLocalIndex(uint16_t li)      { return (_localIndex = li); }
 
    uint8_t getRestrictedRegisterNumber()    { return _restrictedRegisterNumber; }
 
@@ -564,7 +564,7 @@ protected:
    const char *  _name;
    flags32_t     _flags;
    flags32_t     _flags2;
-   uint16_t      _sideTableIndex;
+   uint16_t      _localIndex;
    uint8_t       _restrictedRegisterNumber;
 
 

--- a/compiler/infra/ILWalk.hpp
+++ b/compiler/infra/ILWalk.hpp
@@ -367,7 +367,7 @@ class ILValidator
    class LiveNodeWindow
       {
       // This is like a NodeChecklist, but more compact.  Rather than track
-      // node global indexes, which can be sparse, this tracks side table
+      // node global indexes, which can be sparse, this tracks local
       // indexes, which are relatively dense.  Furthermore, the _basis field
       // allows us not to waste space on nodes we saw in prior blocks.
 

--- a/compiler/optimizer/CompactLocals.cpp
+++ b/compiler/optimizer/CompactLocals.cpp
@@ -158,7 +158,7 @@ int32_t TR_CompactLocals::perform()
 
    for (p = locals.getFirst(); p != NULL; p = locals.getNext())
       {
-      p->setSideTableIndex(0);
+      p->setLocalIndex(0);
       (*_localIndexToSymbolMap)[p->getLiveLocalIndex()] = p;
 
       if (eligibleLocal(p))
@@ -316,7 +316,7 @@ void TR_CompactLocals::processNodeInPreorder(TR::Node *node,
    if (node->getVisitCount() != visitCount)
       {
       node->setVisitCount(visitCount);
-      node->setSideTableIndex(node->getReferenceCount());
+      node->setLocalIndex(node->getReferenceCount());
       }
 
    if (trace())
@@ -341,7 +341,7 @@ void TR_CompactLocals::processNodeInPreorder(TR::Node *node,
          // This local is killed only if the live range of any loads of this symbol do not overlap
          // with this store.
          //
-         if (local->getSideTableIndex() == 0)
+         if (local->getLocalIndex() == 0)
             {
             _liveVars->reset(localIndex);
             if (trace())
@@ -362,12 +362,12 @@ void TR_CompactLocals::processNodeInPreorder(TR::Node *node,
 
          // First visit to this node.
          //
-         if (node->getSideTableIndex() == node->getReferenceCount())
+         if (node->getLocalIndex() == node->getReferenceCount())
             {
-            local->setSideTableIndex(local->getSideTableIndex() + node->getReferenceCount());
+            local->setLocalIndex(local->getLocalIndex() + node->getReferenceCount());
             }
 
-         if ((node->getSideTableIndex() == 1 || node->getOpCodeValue() == TR::loadaddr) && !_liveVars->isSet(localIndex))
+         if ((node->getLocalIndex() == 1 || node->getOpCodeValue() == TR::loadaddr) && !_liveVars->isSet(localIndex))
             {
             // First evaluation point of this node or loadaddr.
             //
@@ -389,14 +389,14 @@ void TR_CompactLocals::processNodeInPreorder(TR::Node *node,
                }
             }
 
-         local->setSideTableIndex(local->getSideTableIndex()-1);
-         node->setSideTableIndex(node->getSideTableIndex()-1);
+         local->setLocalIndex(local->getLocalIndex()-1);
+         node->setLocalIndex(node->getLocalIndex()-1);
 
          return;
          }
       }
    else if (node->exceptionsRaised() &&
-           (node->getSideTableIndex() <= 1))
+           (node->getLocalIndex() <= 1))
       {
       TR::Block *succ;
       for (auto edge = block->getExceptionSuccessors().begin(); edge != block->getExceptionSuccessors().end(); ++edge)
@@ -412,14 +412,14 @@ void TR_CompactLocals::processNodeInPreorder(TR::Node *node,
          createInterferenceBetween(_liveVars);
       }
 
-   if (node->getSideTableIndex() != 0)
+   if (node->getLocalIndex() != 0)
       {
-      node->setSideTableIndex(node->getSideTableIndex()-1);
+      node->setLocalIndex(node->getLocalIndex()-1);
       }
 
    // This is not the first evaluation point of this node.
    //
-   if (node->getSideTableIndex() > 0)
+   if (node->getLocalIndex() > 0)
       {
       return;
       }

--- a/compiler/optimizer/GeneralLoopUnroller.cpp
+++ b/compiler/optimizer/GeneralLoopUnroller.cpp
@@ -978,7 +978,7 @@ void TR_LoopUnroller::modifyOriginalLoop(TR_RegionStructure *loop, TR_StructureS
          TR::Node *gotoNode = TR::Node::create(branch, TR::Goto);
          TR::TreeTop *gotoTree = TR::TreeTop::create(comp(), gotoNode);
          gotoNode->setBranchDestination(destBlock->getEntry());
-         gotoNode->setSideTableIndex(CREATED_BY_GLU);
+         gotoNode->setLocalIndex(CREATED_BY_GLU);
 
          TR::TransformUtil::removeTree(comp(), branchBlock->getLastRealTreeTop());
          branchBlock->append(gotoTree);
@@ -2325,7 +2325,7 @@ void TR_LoopUnroller::generateSpillLoop(TR_RegionStructure *loop,
    TR::TreeTop *gotoTree = TR::TreeTop::create(comp(), gotoNode);
    clonedBranchBlock->append(gotoTree);
    gotoNode->setBranchDestination(newBranchBlock->getEntry());
-   gotoNode->setSideTableIndex(CREATED_BY_GLU);
+   gotoNode->setLocalIndex(CREATED_BY_GLU);
 
    processSwingQueue();
 
@@ -2418,7 +2418,7 @@ void TR_LoopUnroller::addEdgeForSpillLoop(TR_RegionStructure *region,
             {
             TR::Node *gotoNode = TR::Node::create(lastNode, TR::Goto);
             gotoNode->setBranchDestination(newTo->getEntry());
-            gotoNode->setSideTableIndex(CREATED_BY_GLU);
+            gotoNode->setLocalIndex(CREATED_BY_GLU);
             newFrom->append(TR::TreeTop::create(comp(), gotoNode));
             }
          }
@@ -2453,10 +2453,10 @@ void TR_LoopUnroller::addEdgeForSpillLoop(TR_RegionStructure *region,
             TR::Node *gotoNode = TR::Node::create(lastNode, TR::Goto);
             TR::TreeTop *gotoTree = TR::TreeTop::create(comp(), gotoNode);
             gotoNode->setBranchDestination(newTo->getEntry());
-            gotoNode->setSideTableIndex(CREATED_BY_GLU);
+            gotoNode->setLocalIndex(CREATED_BY_GLU);
             TR::Block *gotoBlock = TR::Block::createEmptyBlock(lastNode, comp(), newFrom->getFrequency(), newFrom);
             gotoBlock->append(gotoTree);
-            gotoBlock->getEntry()->getNode()->setSideTableIndex(CREATED_BY_GLU);
+            gotoBlock->getEntry()->getNode()->setLocalIndex(CREATED_BY_GLU);
             _cfg->addNode(gotoBlock);
 
 
@@ -2639,10 +2639,10 @@ void TR_LoopUnroller::addExitEdgeAndFixEverything(TR_RegionStructure *region,
                   TR::Node *gotoNode = TR::Node::create(lastNode, TR::Goto);
                   TR::TreeTop *gotoTree = TR::TreeTop::create(comp(), gotoNode);
                   gotoNode->setBranchDestination(newTo->getEntry());
-                  gotoNode->setSideTableIndex(CREATED_BY_GLU);
+                  gotoNode->setLocalIndex(CREATED_BY_GLU);
                   TR::Block *gotoBlock = TR::Block::createEmptyBlock(lastNode, comp(), newTo->getFrequency(), newTo);
                   gotoBlock->append(gotoTree);
-                  gotoBlock->getEntry()->getNode()->setSideTableIndex(CREATED_BY_GLU);
+                  gotoBlock->getEntry()->getNode()->setLocalIndex(CREATED_BY_GLU);
                   _cfg->addNode(gotoBlock);
 
                   //fix the tree tops: insert the goto block in place
@@ -2756,7 +2756,7 @@ void TR_LoopUnroller::addEdgeAndFixEverything(TR_RegionStructure *region,
             gotoTree->join(lastTreeTop->getNextTreeTop());
             lastTreeTop->join(gotoTree);
             gotoNode->setBranchDestination(newTo->getEntry());
-            gotoNode->setSideTableIndex(CREATED_BY_GLU);
+            gotoNode->setLocalIndex(CREATED_BY_GLU);
             }
          }
       //SWITCH
@@ -2829,8 +2829,8 @@ bool TR_LoopUnroller::cfgEdgeAlreadyExists(TR::Block *from, TR::Block *to, EdgeC
             // to the loop entry, so just checking the goto node is insufficient
             //
             if (dest->getNumber() == to->getNumber() &&
-                lastRealTree->getNode()->getSideTableIndex() == CREATED_BY_GLU &&
-                succ->getEntry()->getNode()->getSideTableIndex() == CREATED_BY_GLU)
+                lastRealTree->getNode()->getLocalIndex() == CREATED_BY_GLU &&
+                succ->getEntry()->getNode()->getLocalIndex() == CREATED_BY_GLU)
                return true;
             }
          }
@@ -3187,7 +3187,7 @@ TR_LoopUnroller::prepareLoopStructure(TR_RegionStructure *loop)
       {
       TR::TreeTop *tt = block->getLastRealTreeTop();
       if (tt->getNode()->getOpCodeValue() == TR::Goto)
-         tt->getNode()->setSideTableIndex(-1);
+         tt->getNode()->setLocalIndex(-1);
       }
    }
 

--- a/compiler/optimizer/GlobalAnticipatability.cpp
+++ b/compiler/optimizer/GlobalAnticipatability.cpp
@@ -173,7 +173,7 @@ static bool nodeCanSurvive(TR::Node *nextNode, TR::Node *lastNodeFirstChild, TR:
       TR::Node *firstChild = nextNode->getFirstChild();
       if (lastNodeFirstChild)
          {
-         if (lastNodeFirstChild->getFirstChild()->getSideTableIndex() == firstChild->getSideTableIndex())
+         if (lastNodeFirstChild->getFirstChild()->getLocalIndex() == firstChild->getLocalIndex())
             {
             similarOffset = lastNodeFirstChild->getSymbolReference()->getOffset();
             seenSimilarAccess = true;
@@ -182,7 +182,7 @@ static bool nodeCanSurvive(TR::Node *nextNode, TR::Node *lastNodeFirstChild, TR:
 
       if (lastNodeSecondChild)
          {
-         if (lastNodeSecondChild->getFirstChild()->getSideTableIndex() == firstChild->getSideTableIndex())
+         if (lastNodeSecondChild->getFirstChild()->getLocalIndex() == firstChild->getLocalIndex())
             {
             if (similarOffset < lastNodeSecondChild->getSymbolReference()->getOffset())
                similarOffset = lastNodeSecondChild->getSymbolReference()->getOffset();
@@ -249,8 +249,8 @@ bool TR_GlobalAnticipatability::isExceptionalInBlock(TR::Node * node, int32_t bl
          }
       }
 
-   if (node->getSideTableIndex() != -1 &&
-       alreadyInBlock->get(node->getSideTableIndex()))
+   if (node->getLocalIndex() != -1 &&
+       alreadyInBlock->get(node->getLocalIndex()))
       return false;
 
    if (isExceptional(comp(), node))

--- a/compiler/optimizer/InductionVariable.cpp
+++ b/compiler/optimizer/InductionVariable.cpp
@@ -936,7 +936,7 @@ int32_t TR_LoopStrider::detectCanonicalizedPredictableLoops(TR_Structure *loopSt
                }
 
             TR::Node *newStore = TR::Node::createWithSymRef(TR::astore, 1, 1, arrayRefNode, reassociatedAuto);
-            newStore->setSideTableIndex(~0);
+            newStore->setLocalIndex(~0);
             TR::TreeTop *newStoreTreeTop = TR::TreeTop::create(comp(), newStore);
             placeHolderTree->getPrevTreeTop()->join(newStoreTreeTop);
             newStoreTreeTop->join(placeHolderTree);
@@ -1004,7 +1004,7 @@ int32_t TR_LoopStrider::detectCanonicalizedPredictableLoops(TR_Structure *loopSt
                   }
 
                TR::Node *newStore = TR::Node::createWithSymRef(TR::astore, 1, 1, arrayRefNode, symRefPair->_derivedSymRef);
-               newStore->setSideTableIndex(~0);
+               newStore->setLocalIndex(~0);
                TR::TreeTop *newStoreTreeTop = TR::TreeTop::create(comp(), newStore);
                placeHolderTree->getPrevTreeTop()->join(newStoreTreeTop);
                newStoreTreeTop->join(placeHolderTree);
@@ -1248,8 +1248,8 @@ void TR_LoopStrider::changeLoopCondition(TR_BlockStructure *loopInvariantBlock, 
       mulNode = TR::Node::create(TR::imul, 2, secondChildOfLoopTestNode->duplicateTree(),
                 duplicateMulTermNode(bestCandidate, secondChildOfLoopTestNode, TR::Int32));
 
-   mulNode->setSideTableIndex(~0);
-   mulNode->getSecondChild()->setSideTableIndex(~0);
+   mulNode->setLocalIndex(~0);
+   mulNode->getSecondChild()->setLocalIndex(~0);
    TR::Node *addNode = NULL;
    if (getAdditiveTermNode(bestCandidate) != 0)
       {
@@ -1257,8 +1257,8 @@ void TR_LoopStrider::changeLoopCondition(TR_BlockStructure *loopInvariantBlock, 
       addNode = TR::Node::create(mulNode->getType().isInt64() ? TR::ladd : TR::iadd, 2, mulNode,
 	       	                duplicateAdditiveTermNode(bestCandidate, secondChildOfLoopTestNode,mulNode->getDataType()));
 
-      addNode->setSideTableIndex(~0);
-      addNode->getSecondChild()->setSideTableIndex(~0);
+      addNode->setLocalIndex(~0);
+      addNode->getSecondChild()->setLocalIndex(~0);
       }
    else
       addNode = mulNode;
@@ -1271,7 +1271,7 @@ void TR_LoopStrider::changeLoopCondition(TR_BlockStructure *loopInvariantBlock, 
        (comp()->getSymRefTab()->getNumInternalPointers() < maxInternalPointersAtPointTooLateToBackOff()))
       {
       TR::Node *newAload = TR::Node::createLoad(secondChildOfLoopTestNode, symRefTab->getSymRef((int32_t)_linearEquations[bestCandidate][4]));
-      newAload->setSideTableIndex(~0);
+      newAload->setLocalIndex(~0);
       if (usingAladd)
          addNode = TR::Node::create(TR::aladd, 2, newAload, addNode);
       else
@@ -1289,8 +1289,8 @@ void TR_LoopStrider::changeLoopCondition(TR_BlockStructure *loopInvariantBlock, 
             addNode->setPinningArrayPointer(newAload->getSymbolReference()->getSymbol()->castToInternalPointerAutoSymbol()->getPinningArrayPointer());
          }
 
-      addNode->setSideTableIndex(~0);
-      addNode->getSecondChild()->setSideTableIndex(~0);
+      addNode->setLocalIndex(~0);
+      addNode->getSecondChild()->setLocalIndex(~0);
       newSymbolReference = comp()->getSymRefTab()->createTemporary(comp()->getMethodSymbol(), TR::Address, true);
       _newTempsCreated = true;
       _numInternalPointers++;
@@ -1389,7 +1389,7 @@ void TR_LoopStrider::changeLoopCondition(TR_BlockStructure *loopInvariantBlock, 
          //else
       //secondChildOfLoopTestNode->recursivelyDecReferenceCount();
 
-      addNode->setSideTableIndex(~0);
+      addNode->setLocalIndex(~0);
       TR::Node *secondOperand = TR::Node::createWithSymRef(secondChildOfLoopTestNode, comp()->il.opCodeForDirectLoad(newStore->getDataType()), 0, newSymbolReference);
 
       if (firstOperand->getDataType() == TR::Address)
@@ -1532,7 +1532,7 @@ TR::Node* TR_LoopStrider::genLoad(TR::Node* node, TR::SymbolReference* symRef, b
       isInternalPointer ? TR::aload : (symRef->getSymbol()->getType().isInt64() ? TR::lload : TR::iload),
       0, symRef);
 
-   result->setSideTableIndex(~0);
+   result->setLocalIndex(~0);
    result->setReferenceCount(0);
    return result;
    }
@@ -1719,8 +1719,8 @@ void TR_LoopStrider::examineOpCodesForInductionVariableUse(TR::Node* node, TR::N
          mulNode->getFirstChild()->incReferenceCount();
          mulNode->setChild(1, constantNode);
          mulNode->getSecondChild()->setReferenceCount(1);
-         mulNode->setSideTableIndex(~0);
-         mulNode->getSecondChild()->setSideTableIndex(~0);
+         mulNode->setLocalIndex(~0);
+         mulNode->getSecondChild()->setLocalIndex(~0);
          adjustmentNode = mulNode;
          }
 
@@ -1734,8 +1734,8 @@ void TR_LoopStrider::examineOpCodesForInductionVariableUse(TR::Node* node, TR::N
                TR::Node *negateConstantNode = TR::Node::create(node, TR::lconst);
                negateConstantNode->setLongInt(-1);
                adjustmentNode = TR::Node::create(TR::lmul, 2, adjustmentNode, negateConstantNode);
-               adjustmentNode->setSideTableIndex(~0);
-               adjustmentNode->getSecondChild()->setSideTableIndex(~0);
+               adjustmentNode->setLocalIndex(~0);
+               adjustmentNode->getSecondChild()->setLocalIndex(~0);
                }
             TR::Node::recreate(replacingNode, TR::aladd);
             replacingNode->setIsInternalPointer(true);
@@ -1746,8 +1746,8 @@ void TR_LoopStrider::examineOpCodesForInductionVariableUse(TR::Node* node, TR::N
                {
                adjustmentNode = TR::Node::create(TR::imul, 2, adjustmentNode,
                   TR::Node::create(node, TR::iconst, 0, -1));
-               adjustmentNode->setSideTableIndex(~0);
-               adjustmentNode->getSecondChild()->setSideTableIndex(~0);
+               adjustmentNode->setLocalIndex(~0);
+               adjustmentNode->getSecondChild()->setLocalIndex(~0);
                }
             TR::Node::recreate(replacingNode, TR::aiadd);
             replacingNode->setIsInternalPointer(true);
@@ -1822,7 +1822,7 @@ void TR_LoopStrider::examineOpCodesForInductionVariableUse(TR::Node* node, TR::N
          {
          TR::SymbolReference *newLoopInvariant = comp()->getSymRefTab()->createTemporary(comp()->getMethodSymbol(), adjustmentNode->getDataType(), false);
          TR::Node *newLoad = TR::Node::createLoad(node, newLoopInvariant);
-         newLoad->setSideTableIndex(~0);
+         newLoad->setLocalIndex(~0);
          TR::Node *newStore = TR::Node::createWithSymRef(comp()->il.opCodeForDirectStore(adjustmentNode->getDataType()), 1, 1, adjustmentNode->duplicateTree(), newLoopInvariant);
 
          TR::TreeTop *placeHolderTree = loopInvariantBlock->getLastRealTreeTop();
@@ -1830,7 +1830,7 @@ void TR_LoopStrider::examineOpCodesForInductionVariableUse(TR::Node* node, TR::N
             placeHolderTree = loopInvariantBlock->getExit();
          TR::TreeTop *prevTree = placeHolderTree->getPrevTreeTop();
 
-         newStore->setSideTableIndex(~0);
+         newStore->setLocalIndex(~0);
          TR::TreeTop *newStoreTreeTop = TR::TreeTop::create(comp(), newStore);
          prevTree->join(newStoreTreeTop);
          newStoreTreeTop->join(placeHolderTree);
@@ -2011,9 +2011,9 @@ bool TR_LoopStrider::examineTreeForInductionVariableUse(TR::Block *loopInvariant
                      createParmAutoPair(comp()->getSymRefTab()->getSymRef(internalPointerSymbol), newPinningArray);
 
                      TR::Node *newAload = TR::Node::createLoad(node, comp()->getSymRefTab()->getSymRef(internalPointerSymbol));
-                     newAload->setSideTableIndex(~0);
+                     newAload->setLocalIndex(~0);
                      TR::Node *newStore = TR::Node::createWithSymRef(TR::astore, 1, 1, newAload, newPinningArray);
-                     newStore->setSideTableIndex(~0);
+                     newStore->setLocalIndex(~0);
                      internalPointerSymbol = newPinningArray->getReferenceNumber();
                      placeStore(newStore, loopInvariantBlock);
                      dumpOptDetails(comp(), "\nO^O INDUCTION VARIABLE ANALYSIS: Induction variable analysis inserted initialization tree : %p for new symRef #%d\n", newStore, newPinningArray->getReferenceNumber());
@@ -2137,10 +2137,10 @@ bool TR_LoopStrider::examineTreeForInductionVariableUse(TR::Block *loopInvariant
                createParmAutoPair(comp()->getSymRefTab()->getSymRef(internalPointerSymbol), newPinningArray);
 
                TR::Node *newAload = TR::Node::createLoad(node, comp()->getSymRefTab()->getSymRef(internalPointerSymbol));
-               newAload->setSideTableIndex(~0);
+               newAload->setLocalIndex(~0);
                TR::Node *newStore = TR::Node::createWithSymRef(TR::astore, 1, 1, newAload, newPinningArray);
                internalPointerSymbol = newPinningArray->getReferenceNumber();
-               newStore->setSideTableIndex(~0);
+               newStore->setLocalIndex(~0);
                placeStore(newStore, loopInvariantBlock);
                dumpOptDetails(comp(), "\nO^O INDUCTION VARIABLE ANALYSIS: Induction variable analysis inserted initialization tree : %p for new symRef #%d\n", newStore, newPinningArray->getReferenceNumber());
                _numInternalPointerOrPinningArrayTempsInitialized++;
@@ -2386,7 +2386,7 @@ TR::Node *TR_LoopStrider::placeInitializationTreeInLoopInvariantBlock(TR_BlockSt
 
    TR::Node *placeHolderNode = placeHolderTree->getNode();
    TR::Node *newLoad = TR::Node::createLoad(placeHolderNode, inductionVarSymRef);
-   newLoad->setSideTableIndex(~0);
+   newLoad->setLocalIndex(~0);
 
    // Create the multiply node first; e.g. 4*i
    //
@@ -2409,8 +2409,8 @@ TR::Node *TR_LoopStrider::placeInitializationTreeInLoopInvariantBlock(TR_BlockSt
       mulNode = TR::Node::create(newLoad->getType().isInt64() ? TR::lmul : TR::imul, 2, newLoad,
          duplicateMulTermNode(k, placeHolderNode, newLoad->getDataType()));
       }
-   mulNode->setSideTableIndex(~0);
-   mulNode->getSecondChild()->setSideTableIndex(~0);
+   mulNode->setLocalIndex(~0);
+   mulNode->getSecondChild()->setLocalIndex(~0);
    TR::Node *addNode = NULL;
    if (getAdditiveTermNode(k) != NULL)
       {
@@ -2424,8 +2424,8 @@ TR::Node *TR_LoopStrider::placeInitializationTreeInLoopInvariantBlock(TR_BlockSt
   	 addNode = TR::Node::create(mulNode->getType().isInt64() ? TR::ladd : TR::iadd, 2, mulNode,
                                    duplicateAdditiveTermNode(k, placeHolderNode, mulNode->getDataType()));
          }
-      addNode->setSideTableIndex(~0);
-      addNode->getSecondChild()->setSideTableIndex(~0);
+      addNode->setLocalIndex(~0);
+      addNode->getSecondChild()->setLocalIndex(~0);
       }
    else
       addNode = mulNode;
@@ -2436,7 +2436,7 @@ TR::Node *TR_LoopStrider::placeInitializationTreeInLoopInvariantBlock(TR_BlockSt
    if (_linearEquations[k][4] > -1)
       {
       TR::Node *newAload = TR::Node::createLoad(placeHolderNode, symRefTab->getSymRef((int32_t)_linearEquations[k][4]));
-      newAload->setSideTableIndex(~0);
+      newAload->setLocalIndex(~0);
       addNode = (usingAladd) ?
                    TR::Node::create(TR::aladd, 2, newAload, addNode) :
                    TR::Node::create(TR::aiadd, 2, newAload, addNode);
@@ -2453,8 +2453,8 @@ TR::Node *TR_LoopStrider::placeInitializationTreeInLoopInvariantBlock(TR_BlockSt
             addNode->setPinningArrayPointer(newAload->getSymbolReference()->getSymbol()->castToInternalPointerAutoSymbol()->getPinningArrayPointer());
          }
 
-      addNode->setSideTableIndex(~0);
-      addNode->getSecondChild()->setSideTableIndex(~0);
+      addNode->setLocalIndex(~0);
+      addNode->getSecondChild()->setLocalIndex(~0);
       newStore = TR::Node::createWithSymRef(TR::astore, 1, 1, addNode, newSymbolReference);
       }
    else
@@ -2465,7 +2465,7 @@ TR::Node *TR_LoopStrider::placeInitializationTreeInLoopInvariantBlock(TR_BlockSt
 
    // Insert the initialization tree
    //
-   newStore->setSideTableIndex(~0);
+   newStore->setLocalIndex(~0);
    TR::TreeTop *newStoreTreeTop = TR::TreeTop::create(comp(), newStore);
    placeHolderTree->getPrevTreeTop()->join(newStoreTreeTop);
    newStoreTreeTop->join(placeHolderTree);
@@ -2566,7 +2566,7 @@ TR::Node *TR_LoopStrider::placeNewInductionVariableIncrementTree(TR_BlockStructu
                newLoad = TR::Node::createLoad(placeHolderNode, newSymbolReference);
             else
                newLoad = TR::Node::createLoad(placeHolderNode, newSymbolReference);
-            newLoad->setSideTableIndex(~0);
+            newLoad->setLocalIndex(~0);
             // remember this load here in case the loop test tree needs to refer back to this load
             // instead of the new incremented/decremented value
 
@@ -2605,7 +2605,7 @@ TR::Node *TR_LoopStrider::placeNewInductionVariableIncrementTree(TR_BlockStructu
             newLoad = TR::Node::createLoad(placeHolderNode, newSymbolReference);
          else
             newLoad = TR::Node::createLoad(placeHolderNode, newSymbolReference);
-         newLoad->setSideTableIndex(~0);
+         newLoad->setLocalIndex(~0);
          // remember this load here in case the loop test tree needs to refer back to this load
          // instead of the new incremented/decremented value
          _loadUsedInNewLoopIncrement[k] = newLoad;
@@ -2661,7 +2661,7 @@ TR::Node *TR_LoopStrider::placeNewInductionVariableIncrementTree(TR_BlockStructu
          TR::Node::recreate(newConstNode, TR::i2l);
          }
       newMulNode = TR::Node::create(TR::lmul, 2, newConstNode, multiplicativeConstant);
-      newConstNode->setSideTableIndex(~0);
+      newConstNode->setLocalIndex(~0);
       //_constNode->incReferenceCount();
       }
    else
@@ -2670,9 +2670,9 @@ TR::Node *TR_LoopStrider::placeNewInductionVariableIncrementTree(TR_BlockStructu
          2, constNode, duplicateMulTermNode(k, placeHolderNode, newLoad->getDataType()));
       }
 
-   newMulNode->setSideTableIndex(~0);
-   constNode->setSideTableIndex(~0);
-   newMulNode->getSecondChild()->setSideTableIndex(~0);
+   newMulNode->setLocalIndex(~0);
+   constNode->setLocalIndex(~0);
+   newMulNode->getSecondChild()->setLocalIndex(~0);
 
    if (constNode->getOpCode().isLoadConst())
       {
@@ -2759,7 +2759,7 @@ TR::Node *TR_LoopStrider::placeNewInductionVariableIncrementTree(TR_BlockStructu
             {
             TR::ILOpCodes op = (usingAladd || newMulNode->getType().isInt64()) ? TR::lneg : TR::ineg;
             newMulNode = TR::Node::create(op, 1, newMulNode);
-            newMulNode->setSideTableIndex(~0);
+            newMulNode->setLocalIndex(~0);
             }
 
          //traceMsg(comp(), "constNode : %x has value %d\n", constNode, constNode->getInt());
@@ -2797,7 +2797,7 @@ TR::Node *TR_LoopStrider::placeNewInductionVariableIncrementTree(TR_BlockStructu
          }
       }
 
-   loopIncrementer->setSideTableIndex(~0);
+   loopIncrementer->setLocalIndex(~0);
 
    TR::Node *newStore = NULL;
    //
@@ -2811,7 +2811,7 @@ TR::Node *TR_LoopStrider::placeNewInductionVariableIncrementTree(TR_BlockStructu
       newStore = TR::Node::createWithSymRef(op, 1, 1, loopIncrementer, newSymbolReference);
       }
 
-   newStore->setSideTableIndex(~0);
+   newStore->setLocalIndex(~0);
    TR::TreeTop *newStoreTreeTop = TR::TreeTop::create(comp(), newStore);
    newStoreTreeTop->join(insertionTreeTop->getNextTreeTop());
    insertionTreeTop->join(newStoreTreeTop);
@@ -3202,7 +3202,7 @@ TR::Node *TR_LoopStrider::isExpressionLinearInInductionVariable(TR::Node *node, 
              else
                 returnedNode = TR::Node::create(node, TR::lload);
              }
-          returnedNode->setSideTableIndex(~0);
+          returnedNode->setLocalIndex(~0);
           }
        }
    else if ((node->getOpCodeValue() == TR::iadd) ||
@@ -3229,7 +3229,7 @@ TR::Node *TR_LoopStrider::isExpressionLinearInInductionVariable(TR::Node *node, 
                 else
                    returnedNode = TR::Node::create(node, TR::ladd, 2);
                 }
-             returnedNode->setSideTableIndex(~0);
+             returnedNode->setLocalIndex(~0);
              }
           }
        }
@@ -3257,7 +3257,7 @@ TR::Node *TR_LoopStrider::isExpressionLinearInInductionVariable(TR::Node *node, 
                 else
                    returnedNode = TR::Node::create(node, TR::lsub, 2);
                 }
-             returnedNode->setSideTableIndex(~0);
+             returnedNode->setLocalIndex(~0);
              }
           }
        }
@@ -3474,12 +3474,12 @@ bool TR_LoopStrider::reassociateAndHoistComputations(TR::Block *loopInvariantBlo
                createParmAutoPair(comp()->getSymRefTab()->getSymRef(internalPointerSymbol), newPinningArray);
 
                TR::Node *newAload = TR::Node::createLoad(node, comp()->getSymRefTab()->getSymRef(internalPointerSymbol));
-               newAload->setSideTableIndex(~0);
+               newAload->setLocalIndex(~0);
                TR::Node *newStore = TR::Node::createWithSymRef(TR::astore, 1, 1, newAload, newPinningArray);
                internalPointerSymbol = newPinningArray->getReferenceNumber();
                TR::TreeTop *placeHolderTree = loopInvariantBlock->getEntry();
                TR::TreeTop *nextTree = placeHolderTree->getNextTreeTop();
-               newStore->setSideTableIndex(~0);
+               newStore->setLocalIndex(~0);
                TR::TreeTop *newStoreTreeTop = TR::TreeTop::create(comp(), newStore);
                placeHolderTree->join(newStoreTreeTop);
                newStoreTreeTop->join(nextTree);
@@ -3535,7 +3535,7 @@ bool TR_LoopStrider::reassociateAndHoistComputations(TR::Block *loopInvariantBlo
          TR::Node::recreate(originalNode, TR::aload);
          originalNode->setSymbolReference(internalPointerSymRef);
          originalNode->setNumChildren(0);
-         originalNode->setSideTableIndex(~0);
+         originalNode->setLocalIndex(~0);
          reassociatedComputation = true;
          examineChildren = false;
          }
@@ -3578,12 +3578,12 @@ bool TR_LoopStrider::reassociateAndHoistComputations(TR::Block *loopInvariantBlo
                   createParmAutoPair(comp()->getSymRefTab()->getSymRef(internalPointerSymbol), newPinningArray);
 
                   TR::Node *newAload = TR::Node::createLoad(node, comp()->getSymRefTab()->getSymRef(internalPointerSymbol));
-                  newAload->setSideTableIndex(~0);
+                  newAload->setLocalIndex(~0);
                   TR::Node *newStore = TR::Node::createWithSymRef(TR::astore, 1, 1, newAload, newPinningArray);
                   internalPointerSymbol = newPinningArray->getReferenceNumber();
                   TR::TreeTop *placeHolderTree = loopInvariantBlock->getEntry();
                   TR::TreeTop *nextTree = placeHolderTree->getNextTreeTop();
-                  newStore->setSideTableIndex(~0);
+                  newStore->setLocalIndex(~0);
                   TR::TreeTop *newStoreTreeTop = TR::TreeTop::create(comp(), newStore);
                   placeHolderTree->join(newStoreTreeTop);
                   newStoreTreeTop->join(nextTree);
@@ -3625,7 +3625,7 @@ bool TR_LoopStrider::reassociateAndHoistComputations(TR::Block *loopInvariantBlo
                }
 
             TR::Node *newLoad = TR::Node::createWithSymRef(node, TR::aload, 0, internalPointerSymRef);
-            newLoad->setSideTableIndex(~0);
+            newLoad->setLocalIndex(~0);
             originalNode->setAndIncChild(0, newLoad);
             originalNode->setAndIncChild(1, node->getFirstChild());
             reassociatedComputation = true;
@@ -5370,7 +5370,7 @@ void TR_InductionVariableAnalysis::analyzeNaturalLoop(TR_RegionStructure *loop)
    loop->setPrimaryInductionVariable(NULL);
    loop->getBasicInductionVariables().init();
 
-   // For each of the candidates, assign a side table index
+   // For each of the candidates, assign a local index
    //
    int32_t index = 0;
    TR_BitVectorIterator it(*candidates);
@@ -5378,7 +5378,7 @@ void TR_InductionVariableAnalysis::analyzeNaturalLoop(TR_RegionStructure *loop)
       {
       int32_t i = it.getNextElement();
       TR::SymbolReference *symRef = comp()->getSymRefTab()->getSymRef(i);
-      symRef->getSymbol()->setSideTableIndex(index++);
+      symRef->getSymbol()->setLocalIndex(index++);
       }
 
    // Initialize empty info for the loop entry blocks
@@ -5407,14 +5407,14 @@ void TR_InductionVariableAnalysis::analyzeNaturalLoop(TR_RegionStructure *loop)
 
    analyzeLoopExpressions(loop, loopSet);
 
-   // For each of the candidates, clear the side table index to avoid polluting analyses of later loops
+   // For each of the candidates, clear the local index to avoid polluting analyses of later loops
    //
    TR_BitVectorIterator clear_it(*candidates);
    while (clear_it.hasMoreElements())
       {
       int32_t i = clear_it.getNextElement();
       TR::SymbolReference *symRef = comp()->getSymRefTab()->getSymRef(i);
-      symRef->getSymbol()->setSideTableIndex(~0);
+      symRef->getSymbol()->setLocalIndex(~0);
       }
 
    } // scope of the stack memory region
@@ -5503,7 +5503,7 @@ void TR_InductionVariableAnalysis::analyzeBlock(TR_BlockStructure *structure, TR
           {
           int32_t refNum = it.getNextElement();
           TR::SymbolReference *symRef = comp()->getSymRefTab()->getSymRef(refNum);
-          int32_t refIndex = symRef->getSymbol()->getSideTableIndex();
+          int32_t refIndex = symRef->getSymbol()->getLocalIndex();
           DeltaInfo *inSymbol = inSet[refIndex];
           traceMsg(comp(), "\t%d %d %p symRef=%p symbol=%p: ",
                   refNum, refIndex, inSymbol, symRef, symRef->getSymbol());
@@ -5530,7 +5530,7 @@ void TR_InductionVariableAnalysis::analyzeBlock(TR_BlockStructure *structure, TR
          {
          TR::SymbolReference *symRef = node->getSymbolReference();
          uint32_t refNum   = symRef->getReferenceNumber();
-         uint32_t refIndex = symRef->getSymbol()->getSideTableIndex();
+         uint32_t refIndex = symRef->getSymbol()->getLocalIndex();
 
          if (candidates->isSet(refNum))
             {
@@ -5612,7 +5612,7 @@ void TR_InductionVariableAnalysis::analyzeCyclicRegion(TR_RegionStructure *regio
       if (loopLocalDefs->isSet(refNum))
          {
          TR::SymbolReference *symRef = comp()->getSymRefTab()->getSymRef(refNum);
-         int32_t refIndex = symRef->getSymbol()->getSideTableIndex();
+         int32_t refIndex = symRef->getSymbol()->getLocalIndex();
 
          DeltaInfo *inSymbol = inSet[refIndex];
          if (!inSymbol)
@@ -5913,7 +5913,7 @@ TR_InductionVariableAnalysis::analyzeLoopExpressions(
       {
       int32_t refNum = it.getNextElement();
       TR::SymbolReference *symRef = comp()->getSymRefTab()->getSymRef(refNum);
-      int32_t refIndex = symRef->getSymbol()->getSideTableIndex();
+      int32_t refIndex = symRef->getSymbol()->getLocalIndex();
 
       DeltaInfo *info = loopSet[refIndex];
       //TR_ASSERT(info, "missing store/delta information for definitly written symref");
@@ -6271,7 +6271,7 @@ TR_InductionVariableAnalysis::analyzeExitEdges(TR_RegionStructure *loop,
 
       TR_ASSERT(kind != Geometric, "geometric not implemented yet");
 
-      int32_t index = symRef->getSymbol()->getSideTableIndex();
+      int32_t index = symRef->getSymbol()->getLocalIndex();
       TR_BasicInductionVariable *biv = basicIVs[index];
       if (!biv)
          {
@@ -6313,7 +6313,7 @@ TR_InductionVariableAnalysis::analyzeExitEdges(TR_RegionStructure *loop,
    TR_BasicInductionVariable * iv;
    for (iv = it.getFirst(); iv; iv = it.getNext())
       {
-      int32_t index = iv->getSymRef()->getSymbol()->getSideTableIndex();
+      int32_t index = iv->getSymRef()->getSymbol()->getLocalIndex();
       DeltaInfo *exitInfo = exitSet[index];
 
       if (!exitInfo)
@@ -6688,7 +6688,7 @@ TR_InductionVariableAnalysis::analyzeExitEdges(TR_RegionStructure *loop,
       {
       if (iv != piv)
          {
-         int32_t index = iv->getSymRef()->getSymbol()->getSideTableIndex();
+         int32_t index = iv->getSymRef()->getSymbol()->getLocalIndex();
          TR_DerivedInductionVariable *div = new (trHeapMemory()) TR_DerivedInductionVariable(comp(), iv, piv);
          basicIVs[index] = div;
 

--- a/compiler/optimizer/IsolatedStoreElimination.cpp
+++ b/compiler/optimizer/IsolatedStoreElimination.cpp
@@ -876,9 +876,9 @@ int32_t TR_IsolatedStoreElimination::performWithoutUseDefInfo()
          if (sym)
             {
             if (sym->isParm() || sym->isAuto())
-               sym->setSideTableIndex(numSymbols++);
+               sym->setLocalIndex(numSymbols++);
             else
-               sym->setSideTableIndex(0);
+               sym->setLocalIndex(0);
             }
          }
       }
@@ -904,7 +904,7 @@ int32_t TR_IsolatedStoreElimination::performWithoutUseDefInfo()
    for (i = _storeNodes->size()-1; i >= 0; --i)
       {
       TR::Node *node = _storeNodes->element(i);
-      if (node && _usedSymbols->get(node->getSymbolReference()->getSymbol()->getSideTableIndex()))
+      if (node && _usedSymbols->get(node->getSymbolReference()->getSymbol()->getLocalIndex()))
          _storeNodes->element(i) = NULL;
       }
 
@@ -928,7 +928,7 @@ void TR_IsolatedStoreElimination::examineNode(TR::Node *node, vcount_t visitCoun
       }
 
    // Now process this node. We are looking for stores or uses of a symbol to
-   // which we've assigned a non-zero side table index (i.e. a local or a parm)
+   // which we've assigned a non-zero local index (i.e. a local or a parm)
    //
    if (!node->getOpCode().hasSymbolReference())
       return;
@@ -936,14 +936,14 @@ void TR_IsolatedStoreElimination::examineNode(TR::Node *node, vcount_t visitCoun
    if (symRef == NULL)
       return;
    TR::Symbol *sym = symRef->getSymbol();
-   if (!sym || !sym->getSideTableIndex())
+   if (!sym || !sym->getLocalIndex())
       return;
 
    // This is a reference to a symbol we're interested in.
    //
    if (node->getOpCode().isStore())
       {
-      if (!_usedSymbols->get(sym->getSideTableIndex()))
+      if (!_usedSymbols->get(sym->getLocalIndex()))
          {
          // Store to a local or parm that is (as yet) unused
          //
@@ -959,7 +959,7 @@ void TR_IsolatedStoreElimination::examineNode(TR::Node *node, vcount_t visitCoun
           {
           // Use of a local or parm
           //
-          _usedSymbols->set(sym->getSideTableIndex());
+          _usedSymbols->set(sym->getLocalIndex());
           }
       //else
       //         printf("Ignoring load in same tree as store in %s\n", signature(comp()->getCurrentMethod()));

--- a/compiler/optimizer/LiveVariableInformation.cpp
+++ b/compiler/optimizer/LiveVariableInformation.cpp
@@ -274,7 +274,7 @@ void TR_LiveVariableInformation::initializeGenAndKillSetInfo(TR_BitVector **regu
             if (localIndex != INVALID_LIVENESS_INDEX)
                {
                if (traceLiveVarInfo())
-               traceMsg(comp(), "\n Killing symbol with side table index %d in block_%d\n", localIndex, blockNum);
+               traceMsg(comp(), "\n Killing symbol with local index %d in block_%d\n", localIndex, blockNum);
 
                if (regularKillSetInfo[blockNum] == NULL)
                   regularKillSetInfo[blockNum] = new (trStackMemory()) TR_BitVector(_numLocals,trMemory(), stackAlloc);
@@ -582,7 +582,7 @@ void TR_LiveVariableInformation::visitTreeForLocals(TR::Node *node, TR_BitVector
              //!blockKillSetInfo->get(localIndex))
             {
             if (traceLiveVarInfo() && local)
-               traceMsg(comp(), "            Gening symbol with side table index %d\n", localIndex);
+               traceMsg(comp(), "            Gening symbol with local index %d\n", localIndex);
 
             if (*blockGenSetInfo == NULL)
                *blockGenSetInfo = new (trStackMemory()) TR_BitVector(_numLocals,trMemory(), stackAlloc);

--- a/compiler/optimizer/LocalAnticipatability.cpp
+++ b/compiler/optimizer/LocalAnticipatability.cpp
@@ -176,7 +176,7 @@ void TR_LocalAnticipatability::analyzeBlock(TR::Block *block, vcount_t visitCoun
          if (currentTree->getNode()->getFirstChild()->getOpCode().isStore())
             {
             _isStoreTree = true;
-            if (currentTree->getNode()->getFirstChild()->getSideTableIndex() == MAX_SCOUNT)
+            if (currentTree->getNode()->getFirstChild()->getLocalIndex() == MAX_SCOUNT)
                storeTreeParticipatesInAnalysis = false;
             storeSymRef = currentTree->getNode()->getFirstChild()->getSymbolReference();
             storeSymRefNode = currentTree->getNode()->getFirstChild();
@@ -188,7 +188,7 @@ void TR_LocalAnticipatability::analyzeBlock(TR::Block *block, vcount_t visitCoun
          _checkTree = currentTree;
          if (currentTree->getNode()->getFirstChild()->getOpCode().isStore())
             {
-            if (currentTree->getNode()->getFirstChild()->getSideTableIndex() == MAX_SCOUNT)
+            if (currentTree->getNode()->getFirstChild()->getLocalIndex() == MAX_SCOUNT)
                storeTreeParticipatesInAnalysis = false;
             _isStoreTree = true;
             storeSymRef = currentTree->getNode()->getFirstChild()->getSymbolReference();
@@ -202,7 +202,7 @@ void TR_LocalAnticipatability::analyzeBlock(TR::Block *block, vcount_t visitCoun
          if (currentTree->getNode()->getFirstChild()->getOpCode().isStore())
             {
             _isStoreTree = true;
-             if (currentTree->getNode()->getFirstChild()->getSideTableIndex() == MAX_SCOUNT)
+             if (currentTree->getNode()->getFirstChild()->getLocalIndex() == MAX_SCOUNT)
              storeTreeParticipatesInAnalysis = false;
              storeSymRef = currentTree->getNode()->getFirstChild()->getSymbolReference();
              storeSymRefNode = currentTree->getNode()->getFirstChild();
@@ -212,7 +212,7 @@ void TR_LocalAnticipatability::analyzeBlock(TR::Block *block, vcount_t visitCoun
       else if (firstOpCodeInTree.isStore())
          {
          _isStoreTree = true;
-         if (currentTree->getNode()->getSideTableIndex() == MAX_SCOUNT)
+         if (currentTree->getNode()->getLocalIndex() == MAX_SCOUNT)
             storeTreeParticipatesInAnalysis = false;
          storeSymRef = currentTree->getNode()->getSymbolReference();
          storeSymRefNode = currentTree->getNode();
@@ -268,7 +268,7 @@ void TR_LocalAnticipatability::analyzeBlock(TR::Block *block, vcount_t visitCoun
                if (!tempContainer->isEmpty())
                   {
                   if (storeTreeParticipatesInAnalysis &&
-                      !storeNodes->get(node->getSideTableIndex()))
+                      !storeNodes->get(node->getLocalIndex()))
                       isCurrentTreeTopAnticipatable = false;
                   }
                }
@@ -287,42 +287,42 @@ void TR_LocalAnticipatability::analyzeBlock(TR::Block *block, vcount_t visitCoun
             {
              bool downwardExposed = true;
              if (node->getOpCode().isIndirect() &&
-                 ((node->getFirstChild()->getSideTableIndex() != MAX_SCOUNT && node->getFirstChild()->getSideTableIndex() != 0) &&
-                   ((_downwardExposedBeforeButNotAnymore->get(node->getFirstChild()->getSideTableIndex()) &&
+                 ((node->getFirstChild()->getLocalIndex() != MAX_SCOUNT && node->getFirstChild()->getLocalIndex() != 0) &&
+                   ((_downwardExposedBeforeButNotAnymore->get(node->getFirstChild()->getLocalIndex()) &&
                      _visitedNodes->get(node->getFirstChild()->getGlobalIndex())) ||
-                    !_info[block->getNumber()]._downwardExposedAnalysisInfo->get(node->getFirstChild()->getSideTableIndex()))))
+                    !_info[block->getNumber()]._downwardExposedAnalysisInfo->get(node->getFirstChild()->getLocalIndex()))))
                 downwardExposed = false;
 
             if (downwardExposed)
                {
-               _info[block->getNumber()]._downwardExposedStoreAnalysisInfo->set(node->getSideTableIndex());
+               _info[block->getNumber()]._downwardExposedStoreAnalysisInfo->set(node->getLocalIndex());
                if (trace())
-                  traceMsg(comp(), "\n11Store Definition #%d is computed in block_%d\n",node->getSideTableIndex(),block->getNumber());
+                  traceMsg(comp(), "\n11Store Definition #%d is computed in block_%d\n",node->getLocalIndex(),block->getNumber());
 
-               _info[block->getNumber()]._downwardExposedAnalysisInfo->set(node->getSideTableIndex());
+               _info[block->getNumber()]._downwardExposedAnalysisInfo->set(node->getLocalIndex());
                if (trace())
-                  traceMsg(comp(), "\n11Definition #%d is computed in block_%d\n",node->getSideTableIndex(),block->getNumber());
+                  traceMsg(comp(), "\n11Definition #%d is computed in block_%d\n",node->getLocalIndex(),block->getNumber());
                }
             }
 
          if (isCurrentTreeTopAnticipatable)
             {
-            if (!killedExpressions->get(node->getSideTableIndex()) ||
+            if (!killedExpressions->get(node->getLocalIndex()) ||
                 // if store appears in the block and is in its localTransparency set,
                 // it has to be locally anticipatable.
-                _localTransparency->getAnalysisInfo(block->getNumber())->get(node->getSideTableIndex()))
+                _localTransparency->getAnalysisInfo(block->getNumber())->get(node->getLocalIndex()))
                {
-               _info[block->getNumber()]._analysisInfo->set(node->getSideTableIndex());
+               _info[block->getNumber()]._analysisInfo->set(node->getLocalIndex());
                if (trace())
-                   traceMsg(comp(), "\n11Definition #%d is locally anticipatable in block_%d\n",node->getSideTableIndex(),block->getNumber());
+                   traceMsg(comp(), "\n11Definition #%d is locally anticipatable in block_%d\n",node->getLocalIndex(),block->getNumber());
                }
             }
          else if (storeTreeParticipatesInAnalysis)
             {
-            _info[block->getNumber()]._analysisInfo->reset(node->getSideTableIndex());
-            killedExpressions->set(node->getSideTableIndex());
+            _info[block->getNumber()]._analysisInfo->reset(node->getLocalIndex());
+            killedExpressions->set(node->getLocalIndex());
             if (trace())
-               traceMsg(comp(), "\n11Definition #%d is NOT locally anticipatable in block_%d\n",node->getSideTableIndex(),block->getNumber());
+               traceMsg(comp(), "\n11Definition #%d is NOT locally anticipatable in block_%d\n",node->getLocalIndex(),block->getNumber());
             }
 
          // Above we updated anticipatability info for the store; now we will
@@ -345,7 +345,7 @@ void TR_LocalAnticipatability::analyzeBlock(TR::Block *block, vcount_t visitCoun
                }
 
             TR::Node *nullCheckReference = treeTopNode->getNullCheckReference();
-            if ((nullCheckReference->getSideTableIndex() != MAX_SCOUNT) && (nullCheckReference->getSideTableIndex() != 0))
+            if ((nullCheckReference->getLocalIndex() != MAX_SCOUNT) && (nullCheckReference->getLocalIndex() != 0))
                {
                tempContainer->empty();
                *tempContainer |= *seenStoredSymbolReferences;
@@ -353,11 +353,11 @@ void TR_LocalAnticipatability::analyzeBlock(TR::Block *block, vcount_t visitCoun
                *tempContainer &= *allSymbolReferencesInNullCheckReference;
                if (!tempContainer->isEmpty())
                   {
-                  if (!storeNodes->get(nullCheckReference->getSideTableIndex()))
+                  if (!storeNodes->get(nullCheckReference->getLocalIndex()))
                      isCurrentTreeTopAnticipatable = false;
                   }
 
-               if (killedExpressions->get(nullCheckReference->getSideTableIndex()))
+               if (killedExpressions->get(nullCheckReference->getLocalIndex()))
                   isCurrentTreeTopAnticipatable = false;
                }
             else
@@ -367,34 +367,34 @@ void TR_LocalAnticipatability::analyzeBlock(TR::Block *block, vcount_t visitCoun
                }
 
             bool downwardExposed = true;
-            if (((nullCheckReference->getSideTableIndex() != MAX_SCOUNT) && (nullCheckReference->getSideTableIndex() != 0)) &&
-                ((_downwardExposedBeforeButNotAnymore->get(nullCheckReference->getSideTableIndex()) && _visitedNodes->get(nullCheckReference->getGlobalIndex())) ||
-                 _notDownwardExposed->get(nullCheckReference->getSideTableIndex()) ||
-                 !_info[block->getNumber()]._downwardExposedAnalysisInfo->get(nullCheckReference->getSideTableIndex())))
+            if (((nullCheckReference->getLocalIndex() != MAX_SCOUNT) && (nullCheckReference->getLocalIndex() != 0)) &&
+                ((_downwardExposedBeforeButNotAnymore->get(nullCheckReference->getLocalIndex()) && _visitedNodes->get(nullCheckReference->getGlobalIndex())) ||
+                 _notDownwardExposed->get(nullCheckReference->getLocalIndex()) ||
+                 !_info[block->getNumber()]._downwardExposedAnalysisInfo->get(nullCheckReference->getLocalIndex())))
                downwardExposed = false;
 
-            if (downwardExposed && !_downwardExposedBeforeButNotAnymore->get(treeTopNode->getSideTableIndex()) && !_notDownwardExposed->get(node->getSideTableIndex()))
+            if (downwardExposed && !_downwardExposedBeforeButNotAnymore->get(treeTopNode->getLocalIndex()) && !_notDownwardExposed->get(node->getLocalIndex()))
                {
-               _info[block->getNumber()]._downwardExposedAnalysisInfo->set(treeTopNode->getSideTableIndex());
+               _info[block->getNumber()]._downwardExposedAnalysisInfo->set(treeTopNode->getLocalIndex());
                if (trace())
-                  traceMsg(comp(), "\n11Definition #%d is computed in block_%d\n",node->getSideTableIndex(),block->getNumber());
+                  traceMsg(comp(), "\n11Definition #%d is computed in block_%d\n",node->getLocalIndex(),block->getNumber());
                }
 
             if (isCurrentTreeTopAnticipatable)
                {
-               if (!killedExpressions->get(treeTopNode->getSideTableIndex()))
+               if (!killedExpressions->get(treeTopNode->getLocalIndex()))
                   {
-                  _info[block->getNumber()]._analysisInfo->set(treeTopNode->getSideTableIndex());
+                  _info[block->getNumber()]._analysisInfo->set(treeTopNode->getLocalIndex());
                   if (trace())
-                     traceMsg(comp(), "\n11Definition #%d is locally anticipatable in block_%d\n",treeTopNode->getSideTableIndex(),block->getNumber());
+                     traceMsg(comp(), "\n11Definition #%d is locally anticipatable in block_%d\n",treeTopNode->getLocalIndex(),block->getNumber());
                   }
                }
             else
                {
-               killedExpressions->set(treeTopNode->getSideTableIndex());
-               _info[block->getNumber()]._analysisInfo->reset(treeTopNode->getSideTableIndex());
+               killedExpressions->set(treeTopNode->getLocalIndex());
+               _info[block->getNumber()]._analysisInfo->reset(treeTopNode->getLocalIndex());
                if (trace())
-                  traceMsg(comp(), "\n11Definition #%d is NOT locally anticipatable in block_%d\n",treeTopNode->getSideTableIndex(),block->getNumber());
+                  traceMsg(comp(), "\n11Definition #%d is NOT locally anticipatable in block_%d\n",treeTopNode->getLocalIndex(),block->getNumber());
                }
             }
          }
@@ -412,7 +412,7 @@ void TR_LocalAnticipatability::analyzeBlock(TR::Block *block, vcount_t visitCoun
          //
          bool isCurrentTreeTopAnticipatable = true;
 
-         //dumpOptDetails(comp(), "\nFor Check Node %p with side table index %d\n", node, node->getSideTableIndex());
+         //dumpOptDetails(comp(), "\nFor Check Node %p with local index %d\n", node, node->getLocalIndex());
          tempContainer->empty();
          *tempContainer |= *seenDefinedSymbolReferences;
          *tempContainer -= *_seenCallSymbolReferences;
@@ -428,9 +428,9 @@ void TR_LocalAnticipatability::analyzeBlock(TR::Block *block, vcount_t visitCoun
                for (childNum=0; childNum < node->getNumChildren(); childNum++)
                   {
                   TR::Node *child = node->getChild(childNum);
-                  if ((child->getSideTableIndex() != MAX_SCOUNT) && (child->getSideTableIndex() != 0))
+                  if ((child->getLocalIndex() != MAX_SCOUNT) && (child->getLocalIndex() != 0))
                      {
-                     if (killedExpressions->get(child->getSideTableIndex()))
+                     if (killedExpressions->get(child->getLocalIndex()))
                         {
                         isCurrentTreeTopAnticipatable = false;
                         break;
@@ -450,9 +450,9 @@ void TR_LocalAnticipatability::analyzeBlock(TR::Block *block, vcount_t visitCoun
             else
                {
                TR::Node *nullCheckReference = node->getNullCheckReference();
-               if ((nullCheckReference->getSideTableIndex() != MAX_SCOUNT) && (nullCheckReference->getSideTableIndex() != 0))
+               if ((nullCheckReference->getLocalIndex() != MAX_SCOUNT) && (nullCheckReference->getLocalIndex() != 0))
                    {
-                   if (killedExpressions->get(nullCheckReference->getSideTableIndex()))
+                   if (killedExpressions->get(nullCheckReference->getLocalIndex()))
                       isCurrentTreeTopAnticipatable = false;
                    }
                 else if (!nullCheckReference->getOpCode().isLoadConst())
@@ -469,11 +469,11 @@ void TR_LocalAnticipatability::analyzeBlock(TR::Block *block, vcount_t visitCoun
                {
                TR::Node *child = node->getChild(childNum);
                bool childIsDownwardExposed = true;
-               if ((child->getSideTableIndex() != MAX_SCOUNT) && (child->getSideTableIndex() != 0))
+               if ((child->getLocalIndex() != MAX_SCOUNT) && (child->getLocalIndex() != 0))
                    {
-                   if ((_downwardExposedBeforeButNotAnymore->get(child->getSideTableIndex()) && _visitedNodes->get(child->getGlobalIndex())) ||
-                       _notDownwardExposed->get(child->getSideTableIndex()) ||
-                       !_info[block->getNumber()]._downwardExposedAnalysisInfo->get(child->getSideTableIndex()))
+                   if ((_downwardExposedBeforeButNotAnymore->get(child->getLocalIndex()) && _visitedNodes->get(child->getGlobalIndex())) ||
+                       _notDownwardExposed->get(child->getLocalIndex()) ||
+                       !_info[block->getNumber()]._downwardExposedAnalysisInfo->get(child->getLocalIndex()))
                       childIsDownwardExposed = false;
                    }
 
@@ -488,35 +488,35 @@ void TR_LocalAnticipatability::analyzeBlock(TR::Block *block, vcount_t visitCoun
             {
             downwardExposed = true;
             TR::Node *nullCheckReference = node->getNullCheckReference();
-            if (((nullCheckReference->getSideTableIndex() != MAX_SCOUNT) && (nullCheckReference->getSideTableIndex() != 0)) &&
-                ((_downwardExposedBeforeButNotAnymore->get(nullCheckReference->getSideTableIndex()) && _visitedNodes->get(nullCheckReference->getGlobalIndex())) ||
-                 _notDownwardExposed->get(nullCheckReference->getSideTableIndex()) ||
-                 !_info[block->getNumber()]._downwardExposedAnalysisInfo->get(nullCheckReference->getSideTableIndex())))
+            if (((nullCheckReference->getLocalIndex() != MAX_SCOUNT) && (nullCheckReference->getLocalIndex() != 0)) &&
+                ((_downwardExposedBeforeButNotAnymore->get(nullCheckReference->getLocalIndex()) && _visitedNodes->get(nullCheckReference->getGlobalIndex())) ||
+                 _notDownwardExposed->get(nullCheckReference->getLocalIndex()) ||
+                 !_info[block->getNumber()]._downwardExposedAnalysisInfo->get(nullCheckReference->getLocalIndex())))
                downwardExposed = false;
             }
 
-         if (downwardExposed && !_downwardExposedBeforeButNotAnymore->get(node->getSideTableIndex()) && !_notDownwardExposed->get(node->getSideTableIndex()))
+         if (downwardExposed && !_downwardExposedBeforeButNotAnymore->get(node->getLocalIndex()) && !_notDownwardExposed->get(node->getLocalIndex()))
             {
-            _info[block->getNumber()]._downwardExposedAnalysisInfo->set(node->getSideTableIndex());
+            _info[block->getNumber()]._downwardExposedAnalysisInfo->set(node->getLocalIndex());
             if (trace())
-               traceMsg(comp(), "\n11Definition #%d is seen in block_%d\n",node->getSideTableIndex(),block->getNumber());
+               traceMsg(comp(), "\n11Definition #%d is seen in block_%d\n",node->getLocalIndex(),block->getNumber());
             }
 
          if (isCurrentTreeTopAnticipatable)
             {
-            if (!killedExpressions->get(node->getSideTableIndex()))
+            if (!killedExpressions->get(node->getLocalIndex()))
                {
-               _info[block->getNumber()]._analysisInfo->set(node->getSideTableIndex());
+               _info[block->getNumber()]._analysisInfo->set(node->getLocalIndex());
                if (trace())
-                  traceMsg(comp(), "\n22Definition #%d is locally anticipatable in block_%d\n",node->getSideTableIndex(),block->getNumber());
+                  traceMsg(comp(), "\n22Definition #%d is locally anticipatable in block_%d\n",node->getLocalIndex(),block->getNumber());
                }
             }
          else
             {
             if (trace())
-               traceMsg(comp(), "\n22Definition #%d is NOT locally anticipatable in block_%d\n",node->getSideTableIndex(),block->getNumber());
-            killedExpressions->set(node->getSideTableIndex());
-            _info[block->getNumber()]._analysisInfo->reset(node->getSideTableIndex());
+               traceMsg(comp(), "\n22Definition #%d is NOT locally anticipatable in block_%d\n",node->getLocalIndex(),block->getNumber());
+            killedExpressions->set(node->getLocalIndex());
+            _info[block->getNumber()]._analysisInfo->reset(node->getLocalIndex());
             }
          }
 
@@ -536,23 +536,23 @@ void TR_LocalAnticipatability::analyzeBlock(TR::Block *block, vcount_t visitCoun
    while (i < getNumNodes())
       {
       TR::Node *node = supportedNodesAsArray[i];
-      if (node && _info[block->getNumber()]._analysisInfo->get(node->getSideTableIndex()))
+      if (node && _info[block->getNumber()]._analysisInfo->get(node->getLocalIndex()))
          {
          int32_t numChildren = node->getNumChildren();
          int32_t j = 0;
          while (j < numChildren)
 	        {
 	        TR::Node *child = node->getChild(j);
-	        if ((child->getSideTableIndex() != MAX_SCOUNT) && (child->getSideTableIndex() != 0))
+	        if ((child->getLocalIndex() != MAX_SCOUNT) && (child->getLocalIndex() != 0))
  	           {
-	           if (killedExpressions->get(child->getSideTableIndex()) &&
+	           if (killedExpressions->get(child->getLocalIndex()) &&
                    // see comment about localTransparency above
-                   !_localTransparency->getAnalysisInfo(block->getNumber())->get(node->getSideTableIndex()))
+                   !_localTransparency->getAnalysisInfo(block->getNumber())->get(node->getLocalIndex()))
                   {
                   if (trace())
-                     traceMsg(comp(), "\n55Definition #%d is NOT locally anticipatable in block_%d\n",node->getSideTableIndex(),block->getNumber());
-                  killedExpressions->set(node->getSideTableIndex());
-                  _info[block->getNumber()]._analysisInfo->reset(node->getSideTableIndex());
+                     traceMsg(comp(), "\n55Definition #%d is NOT locally anticipatable in block_%d\n",node->getLocalIndex(),block->getNumber());
+                  killedExpressions->set(node->getLocalIndex());
+                  _info[block->getNumber()]._analysisInfo->reset(node->getLocalIndex());
                   break;
    	              }
                }
@@ -572,7 +572,7 @@ bool TR_LocalAnticipatability::updateAnticipatabilityForSupportedNodes(TR::Node 
 
    if (visitCount <= node->getVisitCount())
       {
-      if ((node->getSideTableIndex() != MAX_SCOUNT) && (node->getSideTableIndex() != 0) &&
+      if ((node->getLocalIndex() != MAX_SCOUNT) && (node->getLocalIndex() != 0) &&
           !(opCode.isStore() || opCode.isCheck()))
          {
          if (opCode.hasSymbolReference()  &&
@@ -582,7 +582,7 @@ bool TR_LocalAnticipatability::updateAnticipatabilityForSupportedNodes(TR::Node 
                return false;
             }
 
-         if (!_info[block->getNumber()]._analysisInfo->get(node->getSideTableIndex()))
+         if (!_info[block->getNumber()]._analysisInfo->get(node->getLocalIndex()))
             return false;
          }
       else
@@ -689,7 +689,7 @@ bool TR_LocalAnticipatability::updateAnticipatabilityForSupportedNodes(TR::Node 
       }
 
    bool flagToBeReturned = true;
-   if ((node->getSideTableIndex() != MAX_SCOUNT) && (node->getSideTableIndex() != 0) &&
+   if ((node->getLocalIndex() != MAX_SCOUNT) && (node->getLocalIndex() != 0) &&
        !(opCode.isStore() || opCode.isCheck()))
       {
       bool isCurrentTreeTopAnticipatable = true;
@@ -702,7 +702,7 @@ bool TR_LocalAnticipatability::updateAnticipatabilityForSupportedNodes(TR::Node 
 
          if (seenStoredSymbolReferences->get(node->getSymbolReference()->getReferenceNumber()))
              {
-             if (!storeNodes->get(node->getSideTableIndex()))
+             if (!storeNodes->get(node->getLocalIndex()))
                 isCurrentTreeTopAnticipatable = false;
              flagToBeReturned = false;
              }
@@ -714,11 +714,11 @@ bool TR_LocalAnticipatability::updateAnticipatabilityForSupportedNodes(TR::Node 
          {
          TR::Node *child = node->getChild(childNum);
          bool childIsDownwardExposed = true;
-         if ((child->getSideTableIndex() != MAX_SCOUNT) && (child->getSideTableIndex() != 0))
+         if ((child->getLocalIndex() != MAX_SCOUNT) && (child->getLocalIndex() != 0))
             {
-            if ((_downwardExposedBeforeButNotAnymore->get(child->getSideTableIndex()) && _visitedNodes->get(child->getGlobalIndex())) ||
-                _notDownwardExposed->get(child->getSideTableIndex()) ||
-                !_info[block->getNumber()]._downwardExposedAnalysisInfo->get(child->getSideTableIndex()))
+            if ((_downwardExposedBeforeButNotAnymore->get(child->getLocalIndex()) && _visitedNodes->get(child->getGlobalIndex())) ||
+                _notDownwardExposed->get(child->getLocalIndex()) ||
+                !_info[block->getNumber()]._downwardExposedAnalysisInfo->get(child->getLocalIndex()))
                 childIsDownwardExposed = false;
             }
 
@@ -729,36 +729,36 @@ bool TR_LocalAnticipatability::updateAnticipatabilityForSupportedNodes(TR::Node 
             }
          }
 
-      if (downwardExposed && !_downwardExposedBeforeButNotAnymore->get(node->getSideTableIndex()) && !_notDownwardExposed->get(node->getSideTableIndex()))
+      if (downwardExposed && !_downwardExposedBeforeButNotAnymore->get(node->getLocalIndex()) && !_notDownwardExposed->get(node->getLocalIndex()))
          {
-         _info[block->getNumber()]._downwardExposedAnalysisInfo->set(node->getSideTableIndex());
+         _info[block->getNumber()]._downwardExposedAnalysisInfo->set(node->getLocalIndex());
          if (trace())
-            traceMsg(comp(), "\n33Definition #%d is seen in block_%d\n",node->getSideTableIndex(),block->getNumber());
+            traceMsg(comp(), "\n33Definition #%d is seen in block_%d\n",node->getLocalIndex(),block->getNumber());
          }
 
       if (isCurrentTreeTopAnticipatable)
          {
-         if ((!killedExpressions->get(node->getSideTableIndex())) && flag)
+         if ((!killedExpressions->get(node->getLocalIndex())) && flag)
             {
-            _info[block->getNumber()]._analysisInfo->set(node->getSideTableIndex());
+            _info[block->getNumber()]._analysisInfo->set(node->getLocalIndex());
             if (trace())
-               traceMsg(comp(), "\n33Definition #%d is locally anticipatable in block_%d\n", node->getSideTableIndex(),block->getNumber());
+               traceMsg(comp(), "\n33Definition #%d is locally anticipatable in block_%d\n", node->getLocalIndex(),block->getNumber());
             }
          else if (!flag)
             {
-            killedExpressions->set(node->getSideTableIndex());
+            killedExpressions->set(node->getLocalIndex());
             if (trace())
-               traceMsg(comp(), "\n330Definition #%d is NOT locally anticipatable in block_%d\n", node->getSideTableIndex(),block->getNumber());
-            _info[block->getNumber()]._analysisInfo->reset(node->getSideTableIndex());
+               traceMsg(comp(), "\n330Definition #%d is NOT locally anticipatable in block_%d\n", node->getLocalIndex(),block->getNumber());
+            _info[block->getNumber()]._analysisInfo->reset(node->getLocalIndex());
             }
          }
       else
          {
          flag = false;
-         killedExpressions->set(node->getSideTableIndex());
+         killedExpressions->set(node->getLocalIndex());
          if (trace())
-            traceMsg(comp(), "\n331Definition #%d is NOT locally anticipatable in block_%d\n", node->getSideTableIndex(),block->getNumber());
-         _info[block->getNumber()]._analysisInfo->reset(node->getSideTableIndex());
+            traceMsg(comp(), "\n331Definition #%d is NOT locally anticipatable in block_%d\n", node->getLocalIndex(),block->getNumber());
+         _info[block->getNumber()]._analysisInfo->reset(node->getLocalIndex());
          }
       }
    else
@@ -772,7 +772,7 @@ bool TR_LocalAnticipatability::updateAnticipatabilityForSupportedNodes(TR::Node 
                 return false;
             if (seenStoredSymbolReferences->get(node->getSymbolReference()->getReferenceNumber()))
                {
-               if (!storeNodes->get(node->getSideTableIndex()))
+               if (!storeNodes->get(node->getLocalIndex()))
                   return false;
                flagToBeReturned = false;
                }
@@ -806,19 +806,19 @@ bool TR_LocalAnticipatability::adjustInfoForAddressAdd(TR::Node *node, TR::Node 
 
    TR::ILOpCode &childOpCode = child->getOpCode();
 
-   if ((child->getSideTableIndex() != MAX_SCOUNT) && (child->getSideTableIndex() != 0) &&
+   if ((child->getLocalIndex() != MAX_SCOUNT) && (child->getLocalIndex() != 0) &&
        !(childOpCode.isStore() || childOpCode.isCheck()))
       childHasSupportedOpCode = true;
 
    if (childHasSupportedOpCode)
       {
-      if (killedExpressions->get(child->getSideTableIndex()))
+      if (killedExpressions->get(child->getLocalIndex()))
          {
          if (trace())
             (TR::Compiler->target.is64Bit()
              ) ?
-               traceMsg(comp(), "\n330Definition #%d (aladd) is NOT locally anticipatable in block_%d because of child\n", node->getSideTableIndex(),block->getNumber())
-               : traceMsg(comp(), "\n330Definition #%d (aiadd) is NOT locally anticipatable in block_%d because of child\n", node->getSideTableIndex(),block->getNumber());
+               traceMsg(comp(), "\n330Definition #%d (aladd) is NOT locally anticipatable in block_%d because of child\n", node->getLocalIndex(),block->getNumber())
+               : traceMsg(comp(), "\n330Definition #%d (aiadd) is NOT locally anticipatable in block_%d because of child\n", node->getLocalIndex(),block->getNumber());
          return false;
          }
       }
@@ -831,15 +831,15 @@ bool TR_LocalAnticipatability::adjustInfoForAddressAdd(TR::Node *node, TR::Node 
             {
             if (seenDefinedSymbolReferences->get(child->getSymbolReference()->getReferenceNumber()) ||
                 (seenStoredSymbolReferences->get(child->getSymbolReference()->getReferenceNumber()) &&
-                 ((child->getSideTableIndex() == MAX_SCOUNT) ||
-                  (child->getSideTableIndex() == 0) ||
-                  !storeNodes->get(child->getSideTableIndex()))))
+                 ((child->getLocalIndex() == MAX_SCOUNT) ||
+                  (child->getLocalIndex() == 0) ||
+                  !storeNodes->get(child->getLocalIndex()))))
                {
                if (trace())
                   (TR::Compiler->target.is64Bit()
                    ) ?
-                  traceMsg(comp(), "\n330Definition #%d (aladd) is NOT locally anticipatable in block_%d because of child\n", node->getSideTableIndex(),block->getNumber())
-                  : traceMsg(comp(), "\n330Definition #%d (aiadd) is NOT locally anticipatable in block_%d because of child\n", node->getSideTableIndex(),block->getNumber());
+                  traceMsg(comp(), "\n330Definition #%d (aladd) is NOT locally anticipatable in block_%d because of child\n", node->getLocalIndex(),block->getNumber())
+                  : traceMsg(comp(), "\n330Definition #%d (aiadd) is NOT locally anticipatable in block_%d because of child\n", node->getLocalIndex(),block->getNumber());
                return false;
                }
             }
@@ -939,13 +939,13 @@ void TR_LocalAnticipatability::updateUsesAndDefs(TR::Node *node, TR::Block *bloc
                {
                if (!seenStoredSymbolReferences->get(symReference->getReferenceNumber()))
                   {
-                  if (node->getSideTableIndex() != MAX_SCOUNT)
-                     storeNodes->set(node->getSideTableIndex());
+                  if (node->getLocalIndex() != MAX_SCOUNT)
+                     storeNodes->set(node->getLocalIndex());
                   seenStoredSymbolReferences->set(symReference->getReferenceNumber());
                   }
                else
                   {
-                  if (!storeNodes->get(node->getSideTableIndex()))
+                  if (!storeNodes->get(node->getLocalIndex()))
                      seenDefinedSymbolReferences->set(symReference->getReferenceNumber());
                   }
 
@@ -967,7 +967,7 @@ void TR_LocalAnticipatability::updateUsesAndDefs(TR::Node *node, TR::Block *bloc
                }
             else
                {
-               storeNodes->set(node->getSideTableIndex());
+               storeNodes->set(node->getLocalIndex());
                seenStoredSymbolReferences->set(symReference->getReferenceNumber());
                killDownwardExposedExprs(block, node);
                }
@@ -986,12 +986,12 @@ void TR_LocalAnticipatability::killDownwardExposedExprs(TR::Block *block, Contai
    ContainerType::Cursor iter(*tempContainer);
    bool nodeBitShouldBeOn = false;
    bool storeNodeBitShouldBeOn = false;
-   if (node && (node->getSideTableIndex() != MAX_SCOUNT))
+   if (node && (node->getLocalIndex() != MAX_SCOUNT))
       {
-      if (_info[block->getNumber()]._downwardExposedAnalysisInfo->get(node->getSideTableIndex()))
+      if (_info[block->getNumber()]._downwardExposedAnalysisInfo->get(node->getLocalIndex()))
          nodeBitShouldBeOn = true;
 
-      if (_info[block->getNumber()]._downwardExposedStoreAnalysisInfo->get(node->getSideTableIndex()))
+      if (_info[block->getNumber()]._downwardExposedStoreAnalysisInfo->get(node->getLocalIndex()))
          storeNodeBitShouldBeOn = true;
       }
 
@@ -1006,10 +1006,10 @@ void TR_LocalAnticipatability::killDownwardExposedExprs(TR::Block *block, Contai
       }
 
    if (nodeBitShouldBeOn)
-     _info[block->getNumber()]._downwardExposedAnalysisInfo->set(node->getSideTableIndex());
+     _info[block->getNumber()]._downwardExposedAnalysisInfo->set(node->getLocalIndex());
 
    if (storeNodeBitShouldBeOn)
-      _info[block->getNumber()]._downwardExposedStoreAnalysisInfo->set(node->getSideTableIndex());
+      _info[block->getNumber()]._downwardExposedStoreAnalysisInfo->set(node->getLocalIndex());
 
    *_temp -= *(_info[block->getNumber()]._downwardExposedAnalysisInfo);
    *_downwardExposedBeforeButNotAnymore |= *_temp;
@@ -1021,12 +1021,12 @@ void TR_LocalAnticipatability::killDownwardExposedExprs(TR::Block *block, TR::No
    {
    bool nodeBitShouldBeOn = false;
    bool storeNodeBitShouldBeOn = false;
-   if (node && (node->getSideTableIndex() != MAX_SCOUNT))
+   if (node && (node->getLocalIndex() != MAX_SCOUNT))
       {
-      if (_info[block->getNumber()]._downwardExposedAnalysisInfo->get(node->getSideTableIndex()))
+      if (_info[block->getNumber()]._downwardExposedAnalysisInfo->get(node->getLocalIndex()))
          nodeBitShouldBeOn = true;
 
-      if (_info[block->getNumber()]._downwardExposedStoreAnalysisInfo->get(node->getSideTableIndex()))
+      if (_info[block->getNumber()]._downwardExposedStoreAnalysisInfo->get(node->getLocalIndex()))
           storeNodeBitShouldBeOn = true;
       }
 
@@ -1040,10 +1040,10 @@ void TR_LocalAnticipatability::killDownwardExposedExprs(TR::Block *block, TR::No
       }
 
    if (nodeBitShouldBeOn)
-      _info[block->getNumber()]._downwardExposedAnalysisInfo->set(node->getSideTableIndex());
+      _info[block->getNumber()]._downwardExposedAnalysisInfo->set(node->getLocalIndex());
 
    if (storeNodeBitShouldBeOn)
-      _info[block->getNumber()]._downwardExposedStoreAnalysisInfo->set(node->getSideTableIndex());
+      _info[block->getNumber()]._downwardExposedStoreAnalysisInfo->set(node->getLocalIndex());
 
    *_temp -= *(_info[block->getNumber()]._downwardExposedAnalysisInfo);
    *_downwardExposedBeforeButNotAnymore |= *_temp;

--- a/compiler/optimizer/LocalReordering.cpp
+++ b/compiler/optimizer/LocalReordering.cpp
@@ -290,12 +290,12 @@ void TR_LocalReordering::moveStoresEarlierIfRhsAnchored(TR::Block *block, TR::Tr
    {
    if (node->getVisitCount() >= visitCount)
       {
-      node->setSideTableIndex(node->getSideTableIndex()-1);
+      node->setLocalIndex(node->getLocalIndex()-1);
       return;
       }
 
    node->setVisitCount(visitCount);
-   node->setSideTableIndex(node->getReferenceCount()-1);
+   node->setLocalIndex(node->getReferenceCount()-1);
 
    if (node->getReferenceCount() > 1)
       {
@@ -335,7 +335,7 @@ void TR_LocalReordering::moveStoresEarlierIfRhsAnchored(TR::Block *block, TR::Tr
       {
       TR::Node *child = node->getChild(j);
       moveStoresEarlierIfRhsAnchored(block, treeTop, child, node, visitCount);
-      if ((child->getSideTableIndex() == 0) &&
+      if ((child->getLocalIndex() == 0) &&
           (child->getReferenceCount() > 1) &&
           (!child->getOpCode().isLoadConst()))
         {
@@ -366,9 +366,9 @@ void TR_LocalReordering::moveStoresEarlierIfRhsAnchored(TR::Block *block, TR::Tr
          (parent->getOpCodeValue() != TR::fadd || node->getOpCodeValue() != TR::fmul))) &&
        !noReordering)
       {
-      node->setSideTableIndex(node->getSideTableIndex()+1);
+      node->setLocalIndex(node->getLocalIndex()+1);
       TR::TreeTop *anchorTreeTop = TR::TreeTop::create(comp(), TR::Node::create(TR::treetop, 1, node));
-      anchorTreeTop->getNode()->setSideTableIndex(0);
+      anchorTreeTop->getNode()->setLocalIndex(0);
       TR::TreeTop *origPrev = treeTop->getPrevTreeTop();
       if (origPrev)
         origPrev->join(anchorTreeTop);

--- a/compiler/optimizer/LocalTransparency.cpp
+++ b/compiler/optimizer/LocalTransparency.cpp
@@ -196,7 +196,7 @@ TR_LocalTransparency::TR_LocalTransparency(TR_LocalAnalysisInfo &info, bool t)
          if (currentNode->getFirstChild()->getOpCode().isStore())
             {
             _isStoreTree = true;
-            if (currentNode->getFirstChild()->getSideTableIndex() == MAX_SCOUNT)
+            if (currentNode->getFirstChild()->getLocalIndex() == MAX_SCOUNT)
 	       storeTreeParticipatesInAnalysis = false;
             storeNode = currentNode->getFirstChild();
             }
@@ -207,7 +207,7 @@ TR_LocalTransparency::TR_LocalTransparency(TR_LocalAnalysisInfo &info, bool t)
          if (currentNode->getFirstChild()->getOpCode().isStore())
             {
             _isStoreTree = true;
-            if (currentNode->getFirstChild()->getSideTableIndex() == MAX_SCOUNT)
+            if (currentNode->getFirstChild()->getLocalIndex() == MAX_SCOUNT)
                storeTreeParticipatesInAnalysis = false;
             storeNode = currentNode->getFirstChild();
             }
@@ -218,7 +218,7 @@ TR_LocalTransparency::TR_LocalTransparency(TR_LocalAnalysisInfo &info, bool t)
          if (currentNode->getFirstChild()->getOpCode().isStore())
             {
             _isStoreTree = true;
-            if (currentNode->getFirstChild()->getSideTableIndex() == MAX_SCOUNT)
+            if (currentNode->getFirstChild()->getLocalIndex() == MAX_SCOUNT)
                storeTreeParticipatesInAnalysis = false;
             storeNode = currentNode->getFirstChild();
             }
@@ -226,7 +226,7 @@ TR_LocalTransparency::TR_LocalTransparency(TR_LocalAnalysisInfo &info, bool t)
       else if (firstOpCodeInTree.isStore())
          {
          _isStoreTree = true;
-         if (currentNode->getSideTableIndex() == MAX_SCOUNT)
+         if (currentNode->getLocalIndex() == MAX_SCOUNT)
 	    storeTreeParticipatesInAnalysis = false;
          storeNode = currentNode;
          }
@@ -261,7 +261,7 @@ TR_LocalTransparency::TR_LocalTransparency(TR_LocalAnalysisInfo &info, bool t)
             {
             TR_LocalAnalysisInfo::LAInfo *binfo = _info+(blockNumber);
             if (binfo->_block)
-               binfo->_analysisInfo->set(storeNode->getSideTableIndex());
+               binfo->_analysisInfo->set(storeNode->getLocalIndex());
             }
 
          ContainerType::Cursor bvi(*globalDefinedSymbolReferences);
@@ -278,9 +278,9 @@ TR_LocalTransparency::TR_LocalTransparency(TR_LocalAnalysisInfo &info, bool t)
                {
                if (allSymbolReferencesInStore->get(newDefinedSymbolReference))
                   {
-                  _transparencyInfo[newDefinedSymbolReference]->reset(storeNode->getSideTableIndex());
+                  _transparencyInfo[newDefinedSymbolReference]->reset(storeNode->getLocalIndex());
                   if (trace())
-                     traceMsg(comp(), "75757Expression %d killed (%x) by symRef #%d  %d\n", storeNode->getSideTableIndex(), storeNode, newDefinedSymbolReference, true);
+                     traceMsg(comp(), "75757Expression %d killed (%x) by symRef #%d  %d\n", storeNode->getLocalIndex(), storeNode, newDefinedSymbolReference, true);
                   }
                }
 
@@ -295,9 +295,9 @@ TR_LocalTransparency::TR_LocalTransparency(TR_LocalAnalysisInfo &info, bool t)
                   if (allSymbolReferencesInNullCheckReference->get(newDefinedSymbolReference))
                      {
                       if (trace())
-                         traceMsg(comp(), "76767Expression %d killed (%x) by symRef #%d  %d\n", currentNode->getSideTableIndex(), currentNode, newDefinedSymbolReference, true);
+                         traceMsg(comp(), "76767Expression %d killed (%x) by symRef #%d  %d\n", currentNode->getLocalIndex(), currentNode, newDefinedSymbolReference, true);
 
-                      _transparencyInfo[newDefinedSymbolReference]->reset(currentNode->getSideTableIndex());
+                      _transparencyInfo[newDefinedSymbolReference]->reset(currentNode->getLocalIndex());
                      }
                   }
                }
@@ -322,9 +322,9 @@ TR_LocalTransparency::TR_LocalTransparency(TR_LocalAnalysisInfo &info, bool t)
             if (symbolReferencesInCheck->get(newDefinedSymbolReference))
                {
                if (trace())
-                  traceMsg(comp(), "777Expression %d killed (%x) by symRef #%d  %d\n", currentNode->getSideTableIndex(), currentNode, newDefinedSymbolReference, true);
+                  traceMsg(comp(), "777Expression %d killed (%x) by symRef #%d  %d\n", currentNode->getLocalIndex(), currentNode, newDefinedSymbolReference, true);
 
-               _transparencyInfo[newDefinedSymbolReference]->reset(currentNode->getSideTableIndex());
+               _transparencyInfo[newDefinedSymbolReference]->reset(currentNode->getLocalIndex());
                }
             }
          }
@@ -412,9 +412,9 @@ TR_LocalTransparency::TR_LocalTransparency(TR_LocalAnalysisInfo &info, bool t)
                      if (supportedNodesAsArray[storeNode]->getOpCode().isIndirect())
                         {
                         TR::Node *child = supportedNodesAsArray[storeNode]->getFirstChild();
-                        if ((child->getSideTableIndex() != MAX_SCOUNT) && (child->getSideTableIndex() != 0))
+                        if ((child->getLocalIndex() != MAX_SCOUNT) && (child->getLocalIndex() != 0))
                            {
-                           if (!_transparencyInfo[nextDefinedSymbolReference]->get(child->getSideTableIndex()))
+                           if (!_transparencyInfo[nextDefinedSymbolReference]->get(child->getLocalIndex()))
                               childKilled = true;
                            }
                         else
@@ -678,32 +678,32 @@ void TR_LocalTransparency::updateInfoForSupportedNodes(TR::Node *node, Container
 
       updateInfoForSupportedNodes(child, allSymbolReferences, allSymbolReferencesInNullCheckReference, allSymbolReferencesInStore, seenDefinedSymbolReferences, seenStoredSymRefs, allStoredSymRefsInMethod, visitCount);
 
-      if (((node->getSideTableIndex() != MAX_SCOUNT) && (node->getSideTableIndex() != 0)) && (!(opCode.isStore() || opCode.isCheck())))
+      if (((node->getLocalIndex() != MAX_SCOUNT) && (node->getLocalIndex() != 0)) && (!(opCode.isStore() || opCode.isCheck())))
          {
          bool childHasSupportedOpCode = false;
          TR::ILOpCode &childOpCode = child->getOpCode();
 
-         if (((child->getSideTableIndex() != MAX_SCOUNT) && (child->getSideTableIndex() != 0)) && (!(childOpCode.isStore() || childOpCode.isCheck())))
+         if (((child->getLocalIndex() != MAX_SCOUNT) && (child->getLocalIndex() != 0)) && (!(childOpCode.isStore() || childOpCode.isCheck())))
             childHasSupportedOpCode = true;
 
          if (childHasSupportedOpCode)
             {
-            if (!_supportedNodes->get(child->getSideTableIndex()))
-               _supportedNodes->reset(node->getSideTableIndex());
+            if (!_supportedNodes->get(child->getLocalIndex()))
+               _supportedNodes->reset(node->getLocalIndex());
             else
                {
                int32_t i;
                for (i=0;i<comp()->getMaxAliasIndex();i++)
                   {
-                  if (!_transparencyInfo[i]->get(child->getSideTableIndex()) ||
+                  if (!_transparencyInfo[i]->get(child->getLocalIndex()) ||
                       (child->getOpCode().hasSymbolReference() &&
                        !child->getOpCode().isCall() &&
                        (i == child->getSymbolReference()->getReferenceNumber()) &&
                        seenStoredSymRefs->get(child->getSymbolReference()->getReferenceNumber())))
                      {
-                     _transparencyInfo[i]->reset(node->getSideTableIndex());
+                     _transparencyInfo[i]->reset(node->getLocalIndex());
                       if (trace())
-                         traceMsg(comp(), "Expression %d killed by symRef #%d because child %d is already killed by the symRef\n", node->getSideTableIndex(), i, child->getSideTableIndex());
+                         traceMsg(comp(), "Expression %d killed by symRef #%d because child %d is already killed by the symRef\n", node->getLocalIndex(), i, child->getLocalIndex());
                      }
                   }
                }
@@ -720,7 +720,7 @@ void TR_LocalTransparency::updateInfoForSupportedNodes(TR::Node *node, Container
                   if (seenDefinedSymbolReferences->get(childSymRefNum) ||
                       seenStoredSymRefs->get(childSymRefNum))
                      {
-                     _transparencyInfo[childSymRefNum]->reset(node->getSideTableIndex());
+                     _transparencyInfo[childSymRefNum]->reset(node->getLocalIndex());
 
                      TR::SparseBitVector aliases(comp()->allocator());
                      child->mayKill(true).getAliases(aliases);
@@ -729,14 +729,14 @@ void TR_LocalTransparency::updateInfoForSupportedNodes(TR::Node *node, Container
                      for (aliasesCursor.SetToFirstOne(); aliasesCursor.Valid(); aliasesCursor.SetToNextOne())
                         {
                         int32_t nextAlias = aliasesCursor;
-                        _transparencyInfo[nextAlias]->reset(node->getSideTableIndex());
+                        _transparencyInfo[nextAlias]->reset(node->getLocalIndex());
                         if (trace())
-                           traceMsg(comp(), "9999Expression %d killed (%x) by symRef #%d  %d\n", node->getSideTableIndex(), node, nextAlias, seenDefinedSymbolReferences->get(nextAlias));
+                           traceMsg(comp(), "9999Expression %d killed (%x) by symRef #%d  %d\n", node->getLocalIndex(), node, nextAlias, seenDefinedSymbolReferences->get(nextAlias));
 
                         }
 
                 if (trace())
-                        traceMsg(comp(), "Expression %d killed by symRef #%d (loaded in child)\n", node->getSideTableIndex(), childSymRefNum);
+                        traceMsg(comp(), "Expression %d killed by symRef #%d (loaded in child)\n", node->getLocalIndex(), childSymRefNum);
                      }
                   }
                }
@@ -751,9 +751,9 @@ void TR_LocalTransparency::updateInfoForSupportedNodes(TR::Node *node, Container
                   }
                else
                   {
-                  _supportedNodes->reset(node->getSideTableIndex());
+                  _supportedNodes->reset(node->getLocalIndex());
                   if (trace())
-                     traceMsg(comp(), "Expression %d killed (non supported opcode)\n", node->getSideTableIndex());
+                     traceMsg(comp(), "Expression %d killed (non supported opcode)\n", node->getLocalIndex());
                   }
                }
             }
@@ -807,7 +807,7 @@ void TR_LocalTransparency::updateInfoForSupportedNodes(TR::Node *node, Container
          _inStoreLhsTree = false;
       }
 
-   if (((node->getSideTableIndex() != MAX_SCOUNT) && (node->getSideTableIndex() != 0)) && (!(opCode.isStore() || opCode.isCheck())))
+   if (((node->getLocalIndex() != MAX_SCOUNT) && (node->getLocalIndex() != 0)) && (!(opCode.isStore() || opCode.isCheck())))
       {
       // If any symbol used in this subtree is defined in this block
       // then not transparent
@@ -820,8 +820,8 @@ void TR_LocalTransparency::updateInfoForSupportedNodes(TR::Node *node, Container
              seenStoredSymRefs->get(symRef->getReferenceNumber()))
             {
             if (trace())
-               traceMsg(comp(), "Expression %d killed (%x) by symRef #%d  %d\n", node->getSideTableIndex(), node, symRef->getReferenceNumber(), seenDefinedSymbolReferences->get(symRef->getReferenceNumber()));
-            _transparencyInfo[symRef->getReferenceNumber()]->reset(node->getSideTableIndex());
+               traceMsg(comp(), "Expression %d killed (%x) by symRef #%d  %d\n", node->getLocalIndex(), node, symRef->getReferenceNumber(), seenDefinedSymbolReferences->get(symRef->getReferenceNumber()));
+            _transparencyInfo[symRef->getReferenceNumber()]->reset(node->getLocalIndex());
 
             TR::SparseBitVector aliases(comp()->allocator());
             node->mayKill(true).getAliases(aliases);
@@ -830,9 +830,9 @@ void TR_LocalTransparency::updateInfoForSupportedNodes(TR::Node *node, Container
             for (aliasesCursor.SetToFirstOne(); aliasesCursor.Valid(); aliasesCursor.SetToNextOne())
                {
                int32_t nextAlias = aliasesCursor;
-               _transparencyInfo[nextAlias]->reset(node->getSideTableIndex());
+               _transparencyInfo[nextAlias]->reset(node->getLocalIndex());
                if (trace())
-                  traceMsg(comp(), "888Expression %d killed (%x) by symRef #%d  %d\n", node->getSideTableIndex(), node, nextAlias, seenDefinedSymbolReferences->get(nextAlias));
+                  traceMsg(comp(), "888Expression %d killed (%x) by symRef #%d  %d\n", node->getLocalIndex(), node, nextAlias, seenDefinedSymbolReferences->get(nextAlias));
 
                }
             }
@@ -849,27 +849,27 @@ void TR_LocalTransparency::adjustInfoForAddressAdd(TR::Node *node, TR::Node *chi
 
    TR::ILOpCode &childOpCode = child->getOpCode();
 
-   if (((child->getSideTableIndex() != MAX_SCOUNT) && (child->getSideTableIndex() != 0)) && (!(childOpCode.isStore() || childOpCode.isCheck())))
+   if (((child->getLocalIndex() != MAX_SCOUNT) && (child->getLocalIndex() != 0)) && (!(childOpCode.isStore() || childOpCode.isCheck())))
       childHasSupportedOpCode = true;
 
    if (childHasSupportedOpCode)
       {
-      if (!_supportedNodes->get(child->getSideTableIndex()))
-         _supportedNodes->reset(node->getSideTableIndex());
+      if (!_supportedNodes->get(child->getLocalIndex()))
+         _supportedNodes->reset(node->getLocalIndex());
       else
          {
          int32_t i;
          for (i=0;i<comp()->getMaxAliasIndex();i++)
             {
-            if (!_transparencyInfo[i]->get(child->getSideTableIndex()))
+            if (!_transparencyInfo[i]->get(child->getLocalIndex()))
                {
-               _transparencyInfo[i]->reset(node->getSideTableIndex());
+               _transparencyInfo[i]->reset(node->getLocalIndex());
                if (trace())
                   {
                   if (TR::Compiler->target.is64Bit())
-                     traceMsg(comp(), "Expression %d killed by symRef #%d because grandchild (child of aladd) %d is already killed by the symRef\n", node->getSideTableIndex(), i, child->getSideTableIndex());
+                     traceMsg(comp(), "Expression %d killed by symRef #%d because grandchild (child of aladd) %d is already killed by the symRef\n", node->getLocalIndex(), i, child->getLocalIndex());
                   else
-                     traceMsg(comp(), "Expression %d killed by symRef #%d because grandchild (child of aiadd) %d is already killed by the symRef\n", node->getSideTableIndex(), i, child->getSideTableIndex());
+                     traceMsg(comp(), "Expression %d killed by symRef #%d because grandchild (child of aiadd) %d is already killed by the symRef\n", node->getLocalIndex(), i, child->getLocalIndex());
                   }
                }
             }
@@ -886,7 +886,7 @@ void TR_LocalTransparency::adjustInfoForAddressAdd(TR::Node *node, TR::Node *chi
             if (seenDefinedSymbolReferences->get(childSymRef->getReferenceNumber()) ||
                 seenStoredSymRefs->get(childSymRef->getReferenceNumber()))
                {
-               _transparencyInfo[childSymRef->getReferenceNumber()]->reset(node->getSideTableIndex());
+               _transparencyInfo[childSymRef->getReferenceNumber()]->reset(node->getLocalIndex());
 
                TR::SparseBitVector aliases(comp()->allocator());
                child->mayKill(true).getAliases(aliases);
@@ -895,21 +895,21 @@ void TR_LocalTransparency::adjustInfoForAddressAdd(TR::Node *node, TR::Node *chi
                for (aliasesCursor.SetToFirstOne(); aliasesCursor.Valid(); aliasesCursor.SetToNextOne())
                   {
                   int32_t nextAlias = aliasesCursor;
-                  _transparencyInfo[nextAlias]->reset(node->getSideTableIndex());
+                  _transparencyInfo[nextAlias]->reset(node->getLocalIndex());
                   if (trace())
-                     traceMsg(comp(), "999Expression %d killed (%x) by symRef #%d  %d\n", node->getSideTableIndex(), node, nextAlias, seenDefinedSymbolReferences->get(nextAlias));
+                     traceMsg(comp(), "999Expression %d killed (%x) by symRef #%d  %d\n", node->getLocalIndex(), node, nextAlias, seenDefinedSymbolReferences->get(nextAlias));
 
                   }
                if (trace())
-                  traceMsg(comp(), "Expression %d killed by symRef #%d (loaded in grandchild)\n", node->getSideTableIndex(), childSymRef->getReferenceNumber());
+                  traceMsg(comp(), "Expression %d killed by symRef #%d (loaded in grandchild)\n", node->getLocalIndex(), childSymRef->getReferenceNumber());
                }
             }
          }
       else
          {
-         _supportedNodes->reset(node->getSideTableIndex());
+         _supportedNodes->reset(node->getLocalIndex());
          if (trace())
-            traceMsg(comp(), "Expression %d killed (non supported opcode)\n", node->getSideTableIndex());
+            traceMsg(comp(), "Expression %d killed (non supported opcode)\n", node->getLocalIndex());
          }
       }
    }

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -109,13 +109,13 @@ void printNode(TR::Node *node, TR_BitVector &visitedNodes, int32_t indentation)
    if (visitedNodes.isSet(node->getGlobalIndex()))
       {
       traceMsg(comp(), "\t\t\t%p %5d %*s ==>%s\n",  node,
-              node->getSideTableIndex(), indentation, " ",
+              node->getLocalIndex(), indentation, " ",
               comp()->getDebug()->getName(node->getOpCode()));
       }
    else
       {
       traceMsg(comp(), "\t\t\t%p %5d %*s %s %s\n", node,
-              node->getSideTableIndex(),
+              node->getLocalIndex(),
               indentation, " ", comp()->getDebug()->getName(node->getOpCode()),
               node->getOpCode().hasSymbolReference() ?
               comp()->getDebug()->getName(node->getSymbolReference()): "");

--- a/compiler/optimizer/OMRLocalCSE.cpp
+++ b/compiler/optimizer/OMRLocalCSE.cpp
@@ -846,7 +846,7 @@ void OMR::LocalCSE::doCommoningIfAvailable(TR::Node *node, TR::Node *parent, int
             doneCommoning = true;
             manager()->setAlteredCode(true);
 
-            if (node->getSideTableIndex() != REPLACE_MARKER)
+            if (node->getLocalIndex() != REPLACE_MARKER)
                collectAllReplacedNodes(node, availableExpression);
 
             if ((!parent->getOpCode().isResolveOrNullCheck() &&
@@ -913,7 +913,7 @@ void OMR::LocalCSE::doCommoningIfAvailable(TR::Node *node, TR::Node *parent, int
                }
             else
                {
-               if (node->getSideTableIndex() != REPLACE_MARKER)
+               if (node->getLocalIndex() != REPLACE_MARKER)
                   collectAllReplacedNodes(node, availableExpression);
 
                doneCommoning = true;
@@ -1205,7 +1205,7 @@ void OMR::LocalCSE::getNumberOfNodes(TR::Node *node)
       return;
    node->setVisitCount(comp()->getVisitCount());
 
-   node->setSideTableIndex(0);
+   node->setLocalIndex(0);
 
    if (node->getOpCode().hasSymbolReference())
       {
@@ -1952,7 +1952,7 @@ void OMR::LocalCSE::collectAllReplacedNodes(TR::Node *node, TR::Node *replacingN
       if (trace())
          traceMsg(comp(), "Replaced node : %p Replacing node : %p\n", node, replacingNode);
 
-      node->setSideTableIndex(REPLACE_MARKER);
+      node->setLocalIndex(REPLACE_MARKER);
       }
    }
 

--- a/compiler/optimizer/OSRDefAnalysis.cpp
+++ b/compiler/optimizer/OSRDefAnalysis.cpp
@@ -203,7 +203,7 @@ void TR_OSRDefInfo::addSharingInfo(AuxiliaryData &aux)
 
          for (TR::SymbolReference* symRef = ppsIt.getFirst(); symRef; symRef = ppsIt.getNext())
             {
-            uint16_t symIndex = symRef->getSymbol()->getSideTableIndex();
+            uint16_t symIndex = symRef->getSymbol()->getLocalIndex();
             const TR_UseDefInfo::BitVector &defs = aux._defsForSymbol[symIndex];
             unionDef |= defs;
             TR::DataTypes dt = symRef->getSymbol()->getDataType();
@@ -216,7 +216,7 @@ void TR_OSRDefInfo::addSharingInfo(AuxiliaryData &aux)
 
          for (TR::SymbolReference* symRef = ppsIt.getFirst(); symRef; symRef = ppsIt.getNext())
             {
-            uint16_t symIndex = symRef->getSymbol()->getSideTableIndex();
+            uint16_t symIndex = symRef->getSymbol()->getLocalIndex();
             // is assignment okay here, before it was reference only?
             aux._defsForSymbol[symIndex] = unionDef;
 
@@ -230,7 +230,7 @@ void TR_OSRDefInfo::addSharingInfo(AuxiliaryData &aux)
                   bool doesPrevTakesTwoSlots = prevdt == TR::Int64 || prevdt == TR::Double;
                   if (doesPrevTakesTwoSlots)
                      {
-                     uint16_t prevSymIndex = prevSymRef->getSymbol()->getSideTableIndex();
+                     uint16_t prevSymIndex = prevSymRef->getSymbol()->getLocalIndex();
                      aux._defsForSymbol[prevSymIndex] |= unionDef;
                      }
                   }
@@ -279,7 +279,7 @@ void TR_OSRDefInfo::addSharingInfo(AuxiliaryData &aux)
          twoSlotUnionDef.GrowTo(getBitVectorSize());
          for (TR::SymbolReference* symRef = autosIt.getFirst(); symRef; symRef = autosIt.getNext())
             {
-            uint16_t symIndex = symRef->getSymbol()->getSideTableIndex();
+            uint16_t symIndex = symRef->getSymbol()->getLocalIndex();
             const TR_UseDefInfo::BitVector &defs = aux._defsForSymbol[symIndex];
             unionDef |= defs;
             TR::DataTypes dt = symRef->getSymbol()->getDataType();
@@ -292,7 +292,7 @@ void TR_OSRDefInfo::addSharingInfo(AuxiliaryData &aux)
 
          for (TR::SymbolReference* symRef = autosIt.getFirst(); symRef; symRef = autosIt.getNext())
             {
-            uint16_t symIndex = symRef->getSymbol()->getSideTableIndex();
+            uint16_t symIndex = symRef->getSymbol()->getLocalIndex();
             // is assignment okay here, before it was reference only?
             aux._defsForSymbol[symIndex] = unionDef;
 
@@ -306,7 +306,7 @@ void TR_OSRDefInfo::addSharingInfo(AuxiliaryData &aux)
                   bool doesPrevTakesTwoSlots = prevdt == TR::Int64 || prevdt == TR::Double;
                   if (doesPrevTakesTwoSlots)
                      {
-                     uint16_t prevSymIndex = prevSymRef->getSymbol()->getSideTableIndex();
+                     uint16_t prevSymIndex = prevSymRef->getSymbol()->getLocalIndex();
                      aux._defsForSymbol[prevSymIndex] |= unionDef;
                      }
                   }
@@ -439,12 +439,12 @@ void TR_OSRDefInfo::buildOSRDefs(TR::Node *node, void *vanalysisInfo, TR_OSRPoin
       buildOSRDefs(node->getChild(i), analysisInfo, osrPoint, node, aux);
       }
 
-   scount_t expandedNodeIndex = node->getSideTableIndex(); //node->getUseDefIndex();
+   scount_t expandedNodeIndex = node->getLocalIndex(); //node->getUseDefIndex();
    if (expandedNodeIndex != NULL_USEDEF_SYMBOL_INDEX && expandedNodeIndex != 0)
       {
       TR::SymbolReference *symRef = node->getSymbolReference();
       TR::Symbol *sym = symRef->getSymbol();
-      uint16_t symIndex = sym->getSideTableIndex();
+      uint16_t symIndex = sym->getLocalIndex();
       TR_UseDefInfo::BitVector const &defsForSymbol = aux._defsForSymbol[symIndex];
       if (!defsForSymbol.IsZero() &&
          isExpandedDefIndex(expandedNodeIndex) &&
@@ -743,7 +743,7 @@ int32_t TR_OSRLiveRangeAnalysis::perform()
              !nextSymRef->getSymbol()->holdsMonitoredObject())
             {
             liveLocalIndexToSymRefNumberMap[nextSymRef->getSymbol()->castToAutoSymbol()->getLiveLocalIndex()] = nextSymRef->getReferenceNumber();
-            nextSymRef->getSymbol()->setSideTableIndex(0);
+            nextSymRef->getSymbol()->setLocalIndex(0);
             if (nextSymRef->getReferenceNumber() > maxSymRefNumber)
                maxSymRefNumber = nextSymRef->getReferenceNumber();
             }
@@ -764,7 +764,7 @@ int32_t TR_OSRLiveRangeAnalysis::perform()
             {
             liveLocalIndexToSymRefNumberMap[nextSymRef->getSymbol()->castToAutoSymbol()->getLiveLocalIndex()] = nextSymRef->getReferenceNumber();
             _pendingPushVars->set(nextSymRef->getSymbol()->castToAutoSymbol()->getLiveLocalIndex());
-            nextSymRef->getSymbol()->setSideTableIndex(0);
+            nextSymRef->getSymbol()->setLocalIndex(0);
             if (nextSymRef->getReferenceNumber() > maxSymRefNumber)
                maxSymRefNumber = nextSymRef->getReferenceNumber();
             }
@@ -854,7 +854,7 @@ void TR_OSRLiveRangeAnalysis::maintainLiveness(TR::Node *node,
    if (node->getVisitCount() != visitCount)
       {
       node->setVisitCount(visitCount);
-      node->setSideTableIndex(node->getReferenceCount());
+      node->setLocalIndex(node->getReferenceCount());
       }
 
    if (comp()->getOption(TR_TraceOSR))
@@ -873,7 +873,7 @@ void TR_OSRLiveRangeAnalysis::maintainLiveness(TR::Node *node,
          // This local is killed only if the live range of any loads of this symbol do not overlap
          // with this store.
          //
-         if (local->getSideTableIndex() == 0)
+         if (local->getLocalIndex() == 0)
             {
             if (_pendingPushVars->get(localIndex))
                {
@@ -887,7 +887,7 @@ void TR_OSRLiveRangeAnalysis::maintainLiveness(TR::Node *node,
                   if (node->getFirstChild()->getVisitCount() != visitCount)
                      {
                      node->getFirstChild()->setVisitCount(visitCount);
-                     node->getFirstChild()->setSideTableIndex(node->getFirstChild()->getReferenceCount());
+                     node->getFirstChild()->setLocalIndex(node->getFirstChild()->getReferenceCount());
 
                      if (node->getFirstChild()->getOpCode().hasSymbolReference() &&
                          node->getFirstChild()->getSymbolReference()->getSymbol()->isAuto())
@@ -897,7 +897,7 @@ void TR_OSRLiveRangeAnalysis::maintainLiveness(TR::Node *node,
                            {
                            int32_t rhsLocalIndex = rhsLocal->getLiveLocalIndex();
                            TR_ASSERT(rhsLocalIndex >= 0, "bad local index: %d\n", rhsLocalIndex);
-                           rhsLocal->setSideTableIndex(rhsLocal->getSideTableIndex() + node->getFirstChild()->getReferenceCount());
+                           rhsLocal->setLocalIndex(rhsLocal->getLocalIndex() + node->getFirstChild()->getReferenceCount());
                            }
                          }
                       }
@@ -935,9 +935,9 @@ void TR_OSRLiveRangeAnalysis::maintainLiveness(TR::Node *node,
 
          // First visit to this node.
          //
-         if (node->getSideTableIndex() == node->getReferenceCount())
+         if (node->getLocalIndex() == node->getReferenceCount())
             {
-            local->setSideTableIndex(local->getSideTableIndex() + node->getReferenceCount());
+            local->setLocalIndex(local->getLocalIndex() + node->getReferenceCount());
             }
 
          if (0 && _pendingPushVars->get(localIndex))
@@ -962,7 +962,7 @@ void TR_OSRLiveRangeAnalysis::maintainLiveness(TR::Node *node,
          static const char *disallowOSRPPS3 = feGetEnv("TR_DisallowOSRPPS3");
 
          if ((!disallowOSRPPS3 || !_pendingPushVars->get(localIndex)) &&
-             ((node->getSideTableIndex() == 1 || node->getOpCodeValue() == TR::loadaddr) && !liveVars->isSet(localIndex)))
+             ((node->getLocalIndex() == 1 || node->getOpCodeValue() == TR::loadaddr) && !liveVars->isSet(localIndex)))
             {
             // First evaluation point of this node or loadaddr.
             //
@@ -974,13 +974,13 @@ void TR_OSRLiveRangeAnalysis::maintainLiveness(TR::Node *node,
                }
             }
 
-         local->setSideTableIndex(local->getSideTableIndex()-1);
-         node->setSideTableIndex(node->getSideTableIndex()-1);
+         local->setLocalIndex(local->getLocalIndex()-1);
+         node->setLocalIndex(node->getLocalIndex()-1);
          return;
          }
       }
    else if (node->exceptionsRaised() &&
-           (node->getSideTableIndex() <= 1))
+           (node->getLocalIndex() <= 1))
       {
       TR::Block *succ;
       for (auto edge = block->getExceptionSuccessors().begin(); edge != block->getExceptionSuccessors().end(); ++edge)
@@ -990,14 +990,14 @@ void TR_OSRLiveRangeAnalysis::maintainLiveness(TR::Node *node,
          }
       }
 
-   if (node->getSideTableIndex() != 0)
+   if (node->getLocalIndex() != 0)
       {
-      node->setSideTableIndex(node->getSideTableIndex()-1);
+      node->setLocalIndex(node->getLocalIndex()-1);
       }
 
    // This is not the first evaluation point of this node.
    //
-   if (node->getSideTableIndex() > 0)
+   if (node->getLocalIndex() > 0)
       return;
 
    for (int32_t i = node->getNumChildren()-1; i >= 0; --i)

--- a/compiler/optimizer/PartialRedundancy.cpp
+++ b/compiler/optimizer/PartialRedundancy.cpp
@@ -973,7 +973,7 @@ TR::TreeTop *TR_PartialRedundancy::placeComputationsOptimally(TR::Block *block, 
                TR::Node *nextNode = placeToInsertOptimalComputations->getNode();
                if (nextNode->getOpCode().isCheck())
                    {
-                   if (nextNode->getSideTableIndex() == nextOptimalComputation)
+                   if (nextNode->getLocalIndex() == nextOptimalComputation)
                       {
                       if (nextNode->getOpCode().isNullCheck())
                          {
@@ -990,7 +990,7 @@ TR::TreeTop *TR_PartialRedundancy::placeComputationsOptimally(TR::Block *block, 
                             TR::Node *passThroughNode = TR::Node::create(TR::PassThrough, 1, nextNode->getNullCheckReference());
                             TR::Node *nodeInTreeTop = TR::Node::createWithSymRef(TR::NULLCHK, 1, 1, passThroughNode, newSymRef);
                             TR::TreeTop *duplicateOptimalTree = TR::TreeTop::create(comp(), nodeInTreeTop);
-                            nodeInTreeTop->setSideTableIndex(nextOptimalNode->getSideTableIndex());
+                            nodeInTreeTop->setLocalIndex(nextOptimalNode->getLocalIndex());
 
                             if (!shouldAllowLimitingOfOptimalPlacement(comp()) || performTransformation(comp(), "%sPlacing NULLCHK optimally : %p\n", OPT_DETAILS, nodeInTreeTop))
                                {
@@ -1039,7 +1039,7 @@ TR::TreeTop *TR_PartialRedundancy::placeComputationsOptimally(TR::Block *block, 
                   continue;
 
                 if (optimalNode &&
-                    ((optimalNode->getSideTableIndex() != nextOptimalComputation) ||
+                    ((optimalNode->getLocalIndex() != nextOptimalComputation) ||
                      rhsOfStore ||
                      !lastInsertionMade))
                    {
@@ -1133,7 +1133,7 @@ TR::TreeTop *TR_PartialRedundancy::placeComputationsOptimally(TR::Block *block, 
                       if (notLastInsertionInBlock)
                          TR::Node::recreate(notLastInsertionInBlock->getNode(), TR::treetop);
                       lastInsertionMade = placeToInsertOptimalComputations;
-                      if (optimalNode->getSideTableIndex() != nextOptimalComputation)
+                      if (optimalNode->getLocalIndex() != nextOptimalComputation)
                          lastInsertionCanBeRemoved = false;
                       else
                          lastInsertionCanBeRemoved = true;
@@ -1205,7 +1205,7 @@ TR::TreeTop *TR_PartialRedundancy::placeComputationsOptimally(TR::Block *block, 
          ////TR::TreeTop *duplicateOptimalTree = TR::TreeTop::create(comp(), duplicateOptimalNode, NULL, NULL);
          ////dumpOptDetails(comp(), "%sPlacing store optimally : %p\n", OPT_DETAILS, duplicateOptimalNode);
          ////setAlteredCode(true);
-         ////duplicateOptimalTree->getNode()->setSideTableIndex(nextOptimalNode->getSideTableIndex());
+         ////duplicateOptimalTree->getNode()->setLocalIndex(nextOptimalNode->getLocalIndex());
          ////TR::TreeTop *secondTreeInBlock = placeToInsertOptimalComputations->getNextTreeTop();
          ////placeToInsertOptimalComputations->join(duplicateOptimalTree);
          ////duplicateOptimalTree->join(secondTreeInBlock);
@@ -1250,18 +1250,18 @@ TR::TreeTop *TR_PartialRedundancy::placeComputationsOptimally(TR::Block *block, 
             TR::Node *nullCheckReferenceNode = nextOptimalNode->getNullCheckReference();
             if (isSupportedOpCode(nullCheckReferenceNode, NULL) && !nullCheckReferenceOpCode.isLoadVarDirect())
                {
-               if (((nullCheckReferenceNode->getSideTableIndex() != MAX_SCOUNT) && (nullCheckReferenceNode->getSideTableIndex() != 0)))
+               if (((nullCheckReferenceNode->getLocalIndex() != MAX_SCOUNT) && (nullCheckReferenceNode->getLocalIndex() != 0)))
                   {
-                  if ((_newSymbolsMap[nullCheckReferenceNode->getSideTableIndex()] > -1) &&
-                     (((!_unavailableSetInfo[block->getNumber()]->get(nullCheckReferenceNode->getSideTableIndex())) &&
-                        (_rednSetInfo[block->getNumber()]->get(nullCheckReferenceNode->getSideTableIndex()) || _optSetInfo[block->getNumber()]->get(nullCheckReferenceNode->getSideTableIndex()))) ||
+                  if ((_newSymbolsMap[nullCheckReferenceNode->getLocalIndex()] > -1) &&
+                     (((!_unavailableSetInfo[block->getNumber()]->get(nullCheckReferenceNode->getLocalIndex())) &&
+                        (_rednSetInfo[block->getNumber()]->get(nullCheckReferenceNode->getLocalIndex()) || _optSetInfo[block->getNumber()]->get(nullCheckReferenceNode->getLocalIndex()))) ||
                        (comp()->requiresSpineChecks() && nullCheckReferenceNode->getOpCode().hasSymbolReference() && nullCheckReferenceNode->getSymbol()->isArrayShadowSymbol())))
                      {
                      replacedNullCheckReference = true;
-                     TR::SymbolReference *newSymbolReference = _newSymbolReferences[nullCheckReferenceNode->getSideTableIndex()];
+                     TR::SymbolReference *newSymbolReference = _newSymbolReferences[nullCheckReferenceNode->getLocalIndex()];
                      TR::Node *newLoad = NULL;
                      newLoad = TR::Node::createWithSymRef(nullCheckReferenceNode, comp()->il.opCodeForDirectLoad(nullCheckReferenceDataType), 0, newSymbolReference);
-                     newLoad->setSideTableIndex(-1);
+                     newLoad->setLocalIndex(-1);
 
                      if (trace())
                         traceMsg(comp(), "Duplicate null check had its new null check reference %p replaced by %p with symRef #%d\n", duplicateOptimalNode, newLoad, newLoad->getSymbolReference()->getReferenceNumber());
@@ -1290,7 +1290,7 @@ TR::TreeTop *TR_PartialRedundancy::placeComputationsOptimally(TR::Block *block, 
             TR::Node *passThroughNode = TR::Node::create(TR::PassThrough, 1, duplicateOptimalNode);
             TR::Node *nodeInTreeTop = TR::Node::createWithSymRef(TR::NULLCHK, 1, 1, passThroughNode, newSymRef);
             TR::TreeTop *duplicateOptimalTree = TR::TreeTop::create(comp(), nodeInTreeTop);
-            nodeInTreeTop->setSideTableIndex(nextOptimalNode->getSideTableIndex());
+            nodeInTreeTop->setLocalIndex(nextOptimalNode->getLocalIndex());
 
             if (!shouldAllowLimitingOfOptimalPlacement(comp()) || performTransformation(comp(), "%sPlacing NULLCHK optimally : %p\n", OPT_DETAILS, duplicateOptimalNode))
                {
@@ -1352,7 +1352,7 @@ TR::TreeTop *TR_PartialRedundancy::placeComputationsOptimally(TR::Block *block, 
 
             duplicateOptimalNode->setReferenceCount(0);
             TR::TreeTop *duplicateOptimalTree = TR::TreeTop::create(comp(), duplicateOptimalNode, NULL, NULL);
-            duplicateOptimalNode->setSideTableIndex(nextOptimalNode->getSideTableIndex());
+            duplicateOptimalNode->setLocalIndex(nextOptimalNode->getLocalIndex());
 
             if (!shouldAllowLimitingOfOptimalPlacement(comp()) || performTransformation(comp(), "%sPlacing %s optimally : %p\n", OPT_DETAILS, duplicateOptimalTree->getNode()->getOpCode().getName(), duplicateOptimalTree->getNode()))
                {
@@ -1437,7 +1437,7 @@ TR::TreeTop *TR_PartialRedundancy::placeComputationsOptimally(TR::Block *block, 
 
          manager()->setAlteredCode(true);
 
-         convertedOptimalNode->setSideTableIndex(nextOptimalNode->getSideTableIndex());
+         convertedOptimalNode->setLocalIndex(nextOptimalNode->getLocalIndex());
 
          TR::TreeTop *secondTreeInBlock = placeToInsertOptimalComputations->getNextTreeTop();
 
@@ -1504,7 +1504,7 @@ TR::Node *TR_PartialRedundancy::getAlreadyPresentOptimalNode(TR::Node *node, int
 
    node->setVisitCount(visitCount);
 
-   if (node->getSideTableIndex() == nextOptimalComputation)
+   if (node->getLocalIndex() == nextOptimalComputation)
       {
       if (node->getOpCode().isStoreIndirect())
          {
@@ -1540,12 +1540,12 @@ static bool isExpressionRedundant(TR::Node *node, TR_PartialRedundancy::Containe
        preIndex2 = atoi(c1);
 
    if (redundantComputations &&
-       node->getSideTableIndex() != MAX_SCOUNT &&
-       node->getSideTableIndex() != 0 &&
-       redundantComputations->get(node->getSideTableIndex()) &&
-       (node->getOpCode().isStore() || anticipatable->get(node->getSideTableIndex())))
+       node->getLocalIndex() != MAX_SCOUNT &&
+       node->getLocalIndex() != 0 &&
+       redundantComputations->get(node->getLocalIndex()) &&
+       (node->getOpCode().isStore() || anticipatable->get(node->getLocalIndex())))
      {
-     if (node->getSideTableIndex() < preIndex2)
+     if (node->getLocalIndex() < preIndex2)
         return true;
      }
    return false;
@@ -1655,7 +1655,7 @@ void TR_PartialRedundancy::eliminateRedundantComputations(TR::Block *block, TR::
             //
             if (isExpressionRedundant(currentTree->getNode(), redundantComputations, anticipatabilityInfo))
                {
-               scount_t nodeIndex = currentTree->getNode()->getSideTableIndex();
+               scount_t nodeIndex = currentTree->getNode()->getLocalIndex();
                TR::Node *redundantNode = supportedNodesAsArray[nodeIndex];
 
                //
@@ -1673,7 +1673,7 @@ void TR_PartialRedundancy::eliminateRedundantComputations(TR::Block *block, TR::
                      if (firstOpCodeInTree.getOpCodeValue() == TR::ResolveCHK)
                         TR::Node::recreate(currentTree->getNode(), TR::treetop);
 
-                     currentTree->getNode()->setSideTableIndex(-1);
+                     currentTree->getNode()->setLocalIndex(-1);
                      currentTree->getNode()->setNumChildren(1);
 
                      //dumpOptDetails(comp(), "%sEliminating redundant check computation (resolve or null check) : %p\n", OPT_DETAILS, currentTree->getNode());
@@ -1717,7 +1717,7 @@ void TR_PartialRedundancy::eliminateRedundantComputations(TR::Block *block, TR::
                      if (storeForCommonedNode->getDataType() != TR::Address)
                         optimizer()->setRequestOptimization(OMR::loopVersionerGroup, true);
 
-                     storeForCommonedNode->setSideTableIndex(-1);
+                     storeForCommonedNode->setLocalIndex(-1);
                      currentTree->join(duplicateOptimalTree);
                      duplicateOptimalTree->join(nextTree);
                      currentTree = duplicateOptimalTree;
@@ -1730,7 +1730,7 @@ void TR_PartialRedundancy::eliminateRedundantComputations(TR::Block *block, TR::
                 isExpressionRedundant(currentTree->getNode()->getFirstChild(), redundantComputations, anticipatabilityInfo) &&
                 currentTree->getNode()->getFirstChild()->getOpCode().isStore())
               {
-              scount_t nodeIndex = currentTree->getNode()->getFirstChild()->getSideTableIndex();
+              scount_t nodeIndex = currentTree->getNode()->getFirstChild()->getLocalIndex();
               TR::Node *redundantNode = supportedNodesAsArray[nodeIndex];
 
               TR::SymbolReference *newSymbolReference = _newSymbolReferences[nodeIndex];
@@ -1767,7 +1767,7 @@ void TR_PartialRedundancy::eliminateRedundantComputations(TR::Block *block, TR::
                  if (storeForCommonedNode->getDataType() != TR::Address)
                     optimizer()->setRequestOptimization(OMR::loopVersionerGroup, true);
 
-                 storeForCommonedNode->setSideTableIndex(-1);
+                 storeForCommonedNode->setLocalIndex(-1);
                  currentTree->join(duplicateOptimalTree);
                  duplicateOptimalTree->join(nextTree);
                  currentTree = duplicateOptimalTree;
@@ -1949,7 +1949,7 @@ bool TR_PartialRedundancy::eliminateRedundantSupportedNodes(TR::Node *parent, TR
 #ifdef J9_PROJECT_SPECIFIC
       if (_profilingWalk &&
           ((_exceptionCheckMotion &&
-            _exceptionCheckMotion->getOptimisticRednSetInfo()[blockNum]->get(node->getSideTableIndex())) ||
+            _exceptionCheckMotion->getOptimisticRednSetInfo()[blockNum]->get(node->getLocalIndex())) ||
             isExpressionRedundant(node, redundantComputations, anticipatabilityInfo)))
          {
          // Nodes that can be commoned may be useful to profile as they may
@@ -2023,7 +2023,7 @@ bool TR_PartialRedundancy::eliminateRedundantSupportedNodes(TR::Node *parent, TR
 
       if (isExpressionRedundant(node, redundantComputations, anticipatabilityInfo))
          {
-         scount_t nodeIndex = node->getSideTableIndex();
+         scount_t nodeIndex = node->getLocalIndex();
          TR::Node *nextRedundantNode = supportedNodesAsArray[nodeIndex];
 
 
@@ -2167,7 +2167,7 @@ TR::TreeTop *TR_PartialRedundancy::replaceOptimalSubNodes(TR::TreeTop *curTree, 
       {
       if (trace())
          traceMsg(comp(), "Node %p has parent %p and we are considering replacing it\n", node, parent);
-      if (((node->getSideTableIndex() != MAX_SCOUNT) && (node->getSideTableIndex() != 0)) && !(isNullCheck && (_nullCheckNode->getNullCheckReference() == node)))
+      if (((node->getLocalIndex() != MAX_SCOUNT) && (node->getLocalIndex() != 0)) && !(isNullCheck && (_nullCheckNode->getNullCheckReference() == node)))
          {
          // We do not want to do optimal subnode replacement under tracePRE because it can cause spurious failures as a result
          // of earlier optimal node placement not having been done (because of opt transformation index) that interfere with last opt transformation index based search.
@@ -2178,15 +2178,15 @@ TR::TreeTop *TR_PartialRedundancy::replaceOptimalSubNodes(TR::TreeTop *curTree, 
          // optimal sub node replacement in the unlikely event that this is the cause of some failure)
          //
          if (shouldAllowOptimalSubNodeReplacement(comp()) &&
-             (((_newSymbolsMap[node->getSideTableIndex()] > -1)  && ((/* _optSetInfo[blockNum]->get(node->getSideTableIndex()) || */  ((!parent || !parent->getOpCode().isSpineCheck() || (childNum != 0)) && comp()->requiresSpineChecks() && node->getOpCode().hasSymbolReference() && node->getSymbol()->isArrayShadowSymbol()) || !_unavailableSetInfo[blockNum]->get(node->getSideTableIndex()))))))
+             (((_newSymbolsMap[node->getLocalIndex()] > -1)  && ((/* _optSetInfo[blockNum]->get(node->getLocalIndex()) || */  ((!parent || !parent->getOpCode().isSpineCheck() || (childNum != 0)) && comp()->requiresSpineChecks() && node->getOpCode().hasSymbolReference() && node->getSymbol()->isArrayShadowSymbol()) || !_unavailableSetInfo[blockNum]->get(node->getLocalIndex()))))))
             {
-            TR::SymbolReference *newSymbolReference = _newSymbolReferences[node->getSideTableIndex()];
+            TR::SymbolReference *newSymbolReference = _newSymbolReferences[node->getLocalIndex()];
             TR::Node *newLoad = TR::Node::createWithSymRef(node, comp()->il.opCodeForDirectLoad(nodeDataType), 0, newSymbolReference);
             if (fe()->dataTypeForLoadOrStore(node->getDataType()) != node->getDataType())
                newLoad = TR::Node::create(TR::ILOpCode::getProperConversion(newLoad->getDataType(), node->getDataType(), false /* !wantZeroExtension */), 1, newLoad);
 
             newLoad->setReferenceCount(1);
-            newLoad->setSideTableIndex(-1);
+            newLoad->setLocalIndex(-1);
             duplicateOptimalNode->recursivelyDecReferenceCount();
             duplicateParent->setChild(childNum, newLoad);
 
@@ -2566,8 +2566,8 @@ int32_t TR_ExceptionCheckMotion::perform()
                for (j=size;j<orderedListSize;j++)
                   {
                   if (trace())
-                     traceMsg(comp(), "Affected by order <%d>\n", nextElement->getData()->getSideTableIndex());
-                  _orderedOptNumbersList[i][j] = nextElement->getData()->getSideTableIndex();
+                     traceMsg(comp(), "Affected by order <%d>\n", nextElement->getData()->getLocalIndex());
+                  _orderedOptNumbersList[i][j] = nextElement->getData()->getLocalIndex();
                   nextElement = nextElement->getNextElement();
                   }
                TR_ASSERT(orderedListSize <= numElements2  , "Overwriting elements! orderedListSize = %d numElements2 = %d\n",orderedListSize,numElements2 );
@@ -2707,7 +2707,7 @@ void TR_ExceptionCheckMotion::composeLists(List<TR::Node> *targetList, List<TR::
       while (oldNode &&
              !oldNode->getData()->getOpCode().isCheck())
          {
-         _composeHelper->set(oldNode->getData()->getSideTableIndex());
+         _composeHelper->set(oldNode->getData()->getLocalIndex());
          if (!markerNode)
             markerNode = oldNode;
 
@@ -2727,7 +2727,7 @@ void TR_ExceptionCheckMotion::composeLists(List<TR::Node> *targetList, List<TR::
          while (newNode &&
                 !newNode->getData()->getOpCode().isCheck())
             {
-            if (!_composeHelper->get(newNode->getData()->getSideTableIndex()))
+            if (!_composeHelper->get(newNode->getData()->getLocalIndex()))
                {
                ListElement<TR::Node> *newSourceNode = (ListElement<TR::Node>*)trMemory()->allocateStackMemory(sizeof(ListElement<TR::Node>));
                newSourceNode->setNextElement(NULL);
@@ -2743,20 +2743,20 @@ void TR_ExceptionCheckMotion::composeLists(List<TR::Node> *targetList, List<TR::
                newSourceNode->setData(newNode->getData());
                }
             else
-               _definitelyNotKilled->set(newNode->getData()->getSideTableIndex());
+               _definitelyNotKilled->set(newNode->getData()->getLocalIndex());
             newNode = newNode->getNextElement();
             }
 
-         if ((oldNode == NULL) || (newNode ==  NULL) || (oldNode->getData()->getSideTableIndex() != newNode->getData()->getSideTableIndex()))
+         if ((oldNode == NULL) || (newNode ==  NULL) || (oldNode->getData()->getLocalIndex() != newNode->getData()->getLocalIndex()))
             {
             ListElement<TR::Node> *prevCursorNode = cutoffNode;
             ListElement<TR::Node> *cursorNode = cutoffNode ? cutoffNode->getNextElement() : markerNode;
             while (cursorNode)
                {
-               if (_definitelyNotKilled->get(cursorNode->getData()->getSideTableIndex()) ||
+               if (_definitelyNotKilled->get(cursorNode->getData()->getLocalIndex()) ||
                    ((cursorNode->getData()->getOpCode().isIndirect() ||
                      cursorNode->getData()->getOpCode().isArrayLength()) &&
-                    availableExprs->get(cursorNode->getData()->getFirstChild()->getSideTableIndex())))
+                    availableExprs->get(cursorNode->getData()->getFirstChild()->getLocalIndex())))
                   prevCursorNode = cursorNode;
                else
                   {
@@ -2777,12 +2777,12 @@ void TR_ExceptionCheckMotion::composeLists(List<TR::Node> *targetList, List<TR::
             while (oldNode &&
                    ((oldNode->getData()->getOpCode().isIndirect() ||
                      oldNode->getData()->getOpCode().isArrayLength()) &&
-                     availableExprs->get(oldNode->getData()->getFirstChild()->getSideTableIndex())))
+                     availableExprs->get(oldNode->getData()->getFirstChild()->getLocalIndex())))
                {
                ListElement<TR::Node> *nextOldNode = oldNode->getNextElement();
-               if (!_composeHelper->get(oldNode->getData()->getSideTableIndex()))
+               if (!_composeHelper->get(oldNode->getData()->getLocalIndex()))
                   {
-                  _composeHelper->set(oldNode->getData()->getSideTableIndex());
+                  _composeHelper->set(oldNode->getData()->getLocalIndex());
                   oldNode->setNextElement(NULL);
                   if (prevCursorNode)
                      {
@@ -2802,9 +2802,9 @@ void TR_ExceptionCheckMotion::composeLists(List<TR::Node> *targetList, List<TR::
             while (newNode &&
                    ((newNode->getData()->getOpCode().isIndirect() ||
                      newNode->getData()->getOpCode().isArrayLength()) &&
-                    availableExprs->get(newNode->getData()->getFirstChild()->getSideTableIndex())))
+                    availableExprs->get(newNode->getData()->getFirstChild()->getLocalIndex())))
                {
-               if (!_composeHelper->get(newNode->getData()->getSideTableIndex()))
+               if (!_composeHelper->get(newNode->getData()->getLocalIndex()))
                   {
                   ListElement<TR::Node> *newSourceNode = (ListElement<TR::Node>*)trMemory()->allocateStackMemory(sizeof(ListElement<TR::Node>));
                   newSourceNode->setNextElement(NULL);
@@ -2823,7 +2823,7 @@ void TR_ExceptionCheckMotion::composeLists(List<TR::Node> *targetList, List<TR::
             }
 
          prevNode = oldNode;
-         _composeHelper->set(oldNode->getData()->getSideTableIndex());
+         _composeHelper->set(oldNode->getData()->getLocalIndex());
          cutoffNode = oldNode;
          oldNode = oldNode->getNextElement();
          markerNode = oldNode;
@@ -2831,7 +2831,7 @@ void TR_ExceptionCheckMotion::composeLists(List<TR::Node> *targetList, List<TR::
          while (oldNode &&
                 !oldNode->getData()->getOpCode().isCheck())
             {
-            _composeHelper->set(oldNode->getData()->getSideTableIndex());
+            _composeHelper->set(oldNode->getData()->getLocalIndex());
             prevNode = oldNode;
             oldNode = oldNode->getNextElement();
             }
@@ -2855,10 +2855,10 @@ void TR_ExceptionCheckMotion::composeLists(List<TR::Node> *targetList, List<TR::
       while (oldNode &&
              ((oldNode->getData()->getOpCode().isIndirect() ||
                oldNode->getData()->getOpCode().isArrayLength()) &&
-               availableExprs->get(oldNode->getData()->getFirstChild()->getSideTableIndex())))
+               availableExprs->get(oldNode->getData()->getFirstChild()->getLocalIndex())))
          {
          ListElement<TR::Node> *nextOldNode = oldNode->getNextElement();
-         //if (!_composeHelper->get(oldNode->getData()->getSideTableIndex()))
+         //if (!_composeHelper->get(oldNode->getData()->getLocalIndex()))
             {
             oldNode->setNextElement(NULL);
             if (prevCursorNode)
@@ -2880,9 +2880,9 @@ void TR_ExceptionCheckMotion::composeLists(List<TR::Node> *targetList, List<TR::
       while (newNode &&
              ((newNode->getData()->getOpCode().isIndirect() ||
                newNode->getData()->getOpCode().isArrayLength()) &&
-               availableExprs->get(newNode->getData()->getFirstChild()->getSideTableIndex())))
+               availableExprs->get(newNode->getData()->getFirstChild()->getLocalIndex())))
          {
-           //if (!_composeHelper->get(newNode->getData()->getSideTableIndex()))
+           //if (!_composeHelper->get(newNode->getData()->getLocalIndex()))
             {
             ListElement<TR::Node> *newSourceNode = (ListElement<TR::Node>*)trMemory()->allocateStackMemory(sizeof(ListElement<TR::Node>));
             newSourceNode->setNextElement(NULL);
@@ -2922,13 +2922,13 @@ void TR_ExceptionCheckMotion::appendLists(List<TR::Node> *firstList, List<TR::No
       for (;firstNode != NULL;firstNode = firstNode->getNextElement())
           {
           lastElementInFirstList = firstNode;
-          _appendHelper->set(firstNode->getData()->getSideTableIndex());
+          _appendHelper->set(firstNode->getData()->getLocalIndex());
           }
 
       ListElement<TR::Node> *prevNode = lastElementInFirstList;
       for (;secondNode != NULL;)
          {
-         if (!_appendHelper->get(secondNode->getData()->getSideTableIndex()))
+         if (!_appendHelper->get(secondNode->getData()->getLocalIndex()))
             {
             newFirstNode = (ListElement<TR::Node>*)trMemory()->allocateStackMemory(sizeof(ListElement<TR::Node>));
             newFirstNode->setNextElement(NULL);
@@ -2938,7 +2938,7 @@ void TR_ExceptionCheckMotion::appendLists(List<TR::Node> *firstList, List<TR::No
                firstList->setListHead(newFirstNode);
 
             newFirstNode->setData(secondNode->getData());
-            _appendHelper->set(secondNode->getData()->getSideTableIndex());
+            _appendHelper->set(secondNode->getData()->getLocalIndex());
 
             prevNode = newFirstNode;
             }
@@ -2965,7 +2965,7 @@ bool TR_ExceptionCheckMotion::compareLists(List<TR::Node> *firstList, List<TR::N
          TR::Node *secondNode;
          for (secondNode = secondListIt.getFirst(); secondNode != NULL;)
             {
-            if (firstNode->getSideTableIndex() != secondNode->getSideTableIndex())
+            if (firstNode->getLocalIndex() != secondNode->getLocalIndex())
                {
                same = false;
                break;
@@ -3223,7 +3223,7 @@ void TR_ExceptionCheckMotion::initializeGenAndKillSetInfo()
             {
             ListElement<TR::Node> *listElem;
             for (listElem = _regularGenSetInfo[blockNum]->getListHead(); listElem != NULL; listElem = listElem->getNextElement())
-               traceMsg(comp(), "Expr %d (representative) Node %p in Block : %d\n", listElem->getData()->getSideTableIndex(), listElem->getData(), blockNum);
+               traceMsg(comp(), "Expr %d (representative) Node %p in Block : %d\n", listElem->getData()->getLocalIndex(), listElem->getData(), blockNum);
             }
          else
             traceMsg(comp(), "Block : %d has NO expr gened\n", blockNum);
@@ -3277,24 +3277,24 @@ void TR_ExceptionCheckMotion::analyzeNodeToInitializeGenAndKillSets(TR::TreeTop 
 
            if (!_atLeastOneExceptionPoint)
               {
-              if ((_optimisticRednSetInfo[blockNum]->get(node->getSideTableIndex()) ||
-                   _optimisticOptSetInfo[blockNum]->get(node->getSideTableIndex())) &&
-                    (!_actualRednSetInfo[blockNum]->get(node->getSideTableIndex())) &&
-                    (!_actualOptSetInfo[blockNum]->get(node->getSideTableIndex())) &&
-                    (!_genSetHelper->get(node->getSideTableIndex())))
+              if ((_optimisticRednSetInfo[blockNum]->get(node->getLocalIndex()) ||
+                   _optimisticOptSetInfo[blockNum]->get(node->getLocalIndex())) &&
+                    (!_actualRednSetInfo[blockNum]->get(node->getLocalIndex())) &&
+                    (!_actualOptSetInfo[blockNum]->get(node->getLocalIndex())) &&
+                    (!_genSetHelper->get(node->getLocalIndex())))
                  {
                  createAndAddListElement(node, blockNum);
                  //markNodeAsSurvivor(node->getNullCheckReference(), _indirectAccessesThatSurvive);
                  }
               }
 
-           if (((!_optimisticRednSetInfo[blockNum]->get(node->getSideTableIndex()) /* &&
-                !_optimisticOptSetInfo[blockNum]->get(node->getSideTableIndex()) */) ||
+           if (((!_optimisticRednSetInfo[blockNum]->get(node->getLocalIndex()) /* &&
+                !_optimisticOptSetInfo[blockNum]->get(node->getLocalIndex()) */) ||
                  _nullCheckKilled->get(blockNum) ||
                  nodeKilledByChild) &&
 	      !checkIfNodeCanSurvive(node->getNullCheckReference(), _indirectAccessesThatSurvive))
               {
-              _killedGenExprs[blockNum]->set(node->getSideTableIndex());
+              _killedGenExprs[blockNum]->set(node->getLocalIndex());
               _resolveCheckKilled->set(blockNum);
               _boundCheckKilled->set(blockNum);
               _divCheckKilled->set(blockNum);
@@ -3351,23 +3351,23 @@ void TR_ExceptionCheckMotion::analyzeNodeToInitializeGenAndKillSets(TR::TreeTop 
 
            if (!_atLeastOneExceptionPoint)
               {
-              if ((_optimisticRednSetInfo[blockNum]->get(node->getSideTableIndex()) ||
-                       _optimisticOptSetInfo[blockNum]->get(node->getSideTableIndex())) &&
-                    (!_actualRednSetInfo[blockNum]->get(node->getSideTableIndex())) &&
-                    (!_actualOptSetInfo[blockNum]->get(node->getSideTableIndex())) &&
-                    (!_genSetHelper->get(node->getSideTableIndex())))
+              if ((_optimisticRednSetInfo[blockNum]->get(node->getLocalIndex()) ||
+                       _optimisticOptSetInfo[blockNum]->get(node->getLocalIndex())) &&
+                    (!_actualRednSetInfo[blockNum]->get(node->getLocalIndex())) &&
+                    (!_actualOptSetInfo[blockNum]->get(node->getLocalIndex())) &&
+                    (!_genSetHelper->get(node->getLocalIndex())))
                  {
                  createAndAddListElement(node, blockNum);
                  //markNodeAsSurvivor(node->getFirstChild(), _unresolvedAccessesThatSurvive);
                  }
               }
 
-           if ((!_optimisticRednSetInfo[blockNum]->get(node->getSideTableIndex()) /* &&
-                                                                                     !_optimisticOptSetInfo[blockNum]->get(node->getSideTableIndex())*/ ||
+           if ((!_optimisticRednSetInfo[blockNum]->get(node->getLocalIndex()) /* &&
+                                                                                     !_optimisticOptSetInfo[blockNum]->get(node->getLocalIndex())*/ ||
                 _resolveCheckKilled->get(blockNum) ||
 		nodeKilledByChild))
               {
-              _killedGenExprs[blockNum]->set(node->getSideTableIndex());
+              _killedGenExprs[blockNum]->set(node->getLocalIndex());
               _nullCheckKilled->set(blockNum);
               _boundCheckKilled->set(blockNum);
               _divCheckKilled->set(blockNum);
@@ -3418,22 +3418,22 @@ void TR_ExceptionCheckMotion::analyzeNodeToInitializeGenAndKillSets(TR::TreeTop 
 
            if (!_atLeastOneExceptionPoint)
               {
-              if ((_optimisticRednSetInfo[blockNum]->get(node->getSideTableIndex()) ||
-                       _optimisticOptSetInfo[blockNum]->get(node->getSideTableIndex())) &&
-                    (!_actualRednSetInfo[blockNum]->get(node->getSideTableIndex())) &&
-                    (!_actualOptSetInfo[blockNum]->get(node->getSideTableIndex())) &&
-                    (!_genSetHelper->get(node->getSideTableIndex())))
+              if ((_optimisticRednSetInfo[blockNum]->get(node->getLocalIndex()) ||
+                       _optimisticOptSetInfo[blockNum]->get(node->getLocalIndex())) &&
+                    (!_actualRednSetInfo[blockNum]->get(node->getLocalIndex())) &&
+                    (!_actualOptSetInfo[blockNum]->get(node->getLocalIndex())) &&
+                    (!_genSetHelper->get(node->getLocalIndex())))
                  {
                  createAndAddListElement(node, blockNum);
                  }
               }
 
-           if ((!_optimisticRednSetInfo[blockNum]->get(node->getSideTableIndex()) /* &&
-                                                                                     !_optimisticOptSetInfo[blockNum]->get(node->getSideTableIndex()) */) ||
+           if ((!_optimisticRednSetInfo[blockNum]->get(node->getLocalIndex()) /* &&
+                                                                                     !_optimisticOptSetInfo[blockNum]->get(node->getLocalIndex()) */) ||
                  _boundCheckKilled->get(blockNum) ||
                  nodeKilledByChild)
               {
-              _killedGenExprs[blockNum]->set(node->getSideTableIndex());
+              _killedGenExprs[blockNum]->set(node->getLocalIndex());
               _nullCheckKilled->set(blockNum);
               _resolveCheckKilled->set(blockNum);
               _divCheckKilled->set(blockNum);
@@ -3463,24 +3463,24 @@ void TR_ExceptionCheckMotion::analyzeNodeToInitializeGenAndKillSets(TR::TreeTop 
 
            if (!_atLeastOneExceptionPoint)
               {
-              if ((_optimisticRednSetInfo[blockNum]->get(node->getSideTableIndex()) ||
-                       _optimisticOptSetInfo[blockNum]->get(node->getSideTableIndex())) &&
-                    (!_actualRednSetInfo[blockNum]->get(node->getSideTableIndex())) &&
-                    (!_actualOptSetInfo[blockNum]->get(node->getSideTableIndex())) &&
-                    (!_genSetHelper->get(node->getSideTableIndex())))
+              if ((_optimisticRednSetInfo[blockNum]->get(node->getLocalIndex()) ||
+                       _optimisticOptSetInfo[blockNum]->get(node->getLocalIndex())) &&
+                    (!_actualRednSetInfo[blockNum]->get(node->getLocalIndex())) &&
+                    (!_actualOptSetInfo[blockNum]->get(node->getLocalIndex())) &&
+                    (!_genSetHelper->get(node->getLocalIndex())))
                  {
                  createAndAddListElement(node, blockNum);
                  //markNodeAsSurvivor(node->getFirstChild()->getSecondChild(), _dividesThatSurvive);
                  }
               }
 
-           if ((!_optimisticRednSetInfo[blockNum]->get(node->getSideTableIndex()) /* &&
-                                                                                     !_optimisticOptSetInfo[blockNum]->get(node->getSideTableIndex()) */ ||
+           if ((!_optimisticRednSetInfo[blockNum]->get(node->getLocalIndex()) /* &&
+                                                                                     !_optimisticOptSetInfo[blockNum]->get(node->getLocalIndex()) */ ||
                  _divCheckKilled->get(blockNum) ||
                  nodeKilledByChild) &&
                 !checkIfNodeCanSurvive(node->getFirstChild()->getSecondChild(), _dividesThatSurvive))
               {
-              _killedGenExprs[blockNum]->set(node->getSideTableIndex());
+              _killedGenExprs[blockNum]->set(node->getLocalIndex());
               _nullCheckKilled->set(blockNum);
               _resolveCheckKilled->set(blockNum);
               _boundCheckKilled->set(blockNum);
@@ -3510,22 +3510,22 @@ void TR_ExceptionCheckMotion::analyzeNodeToInitializeGenAndKillSets(TR::TreeTop 
 
           if (!_atLeastOneExceptionPoint)
              {
-             if ((_optimisticRednSetInfo[blockNum]->get(node->getSideTableIndex()) ||
-                      _optimisticOptSetInfo[blockNum]->get(node->getSideTableIndex())) &&
-                   (!_actualRednSetInfo[blockNum]->get(node->getSideTableIndex())) &&
-                   (!_actualOptSetInfo[blockNum]->get(node->getSideTableIndex())) &&
-                   (!_genSetHelper->get(node->getSideTableIndex())))
+             if ((_optimisticRednSetInfo[blockNum]->get(node->getLocalIndex()) ||
+                      _optimisticOptSetInfo[blockNum]->get(node->getLocalIndex())) &&
+                   (!_actualRednSetInfo[blockNum]->get(node->getLocalIndex())) &&
+                   (!_actualOptSetInfo[blockNum]->get(node->getLocalIndex())) &&
+                   (!_genSetHelper->get(node->getLocalIndex())))
                 {
                 createAndAddListElement(node, blockNum);
                 }
              }
 
-          if ((!_optimisticRednSetInfo[blockNum]->get(node->getSideTableIndex()) /* &&
-                                                                                    !_optimisticOptSetInfo[blockNum]->get(node->getSideTableIndex()) */) ||
+          if ((!_optimisticRednSetInfo[blockNum]->get(node->getLocalIndex()) /* &&
+                                                                                    !_optimisticOptSetInfo[blockNum]->get(node->getLocalIndex()) */) ||
                 _arrayStoreCheckKilled->get(blockNum) ||
                 nodeKilledByChild)
              {
-             _killedGenExprs[blockNum]->set(node->getSideTableIndex());
+             _killedGenExprs[blockNum]->set(node->getLocalIndex());
              _resolveCheckKilled->set(blockNum);
              _nullCheckKilled->set(blockNum);
              _boundCheckKilled->set(blockNum);
@@ -3549,22 +3549,22 @@ void TR_ExceptionCheckMotion::analyzeNodeToInitializeGenAndKillSets(TR::TreeTop 
 
            if (!_atLeastOneExceptionPoint)
               {
-              if ((_optimisticRednSetInfo[blockNum]->get(node->getSideTableIndex()) ||
-                       _optimisticOptSetInfo[blockNum]->get(node->getSideTableIndex())) &&
-                    (!_actualRednSetInfo[blockNum]->get(node->getSideTableIndex())) &&
-                    (!_actualOptSetInfo[blockNum]->get(node->getSideTableIndex())) &&
-                    (!_genSetHelper->get(node->getSideTableIndex())))
+              if ((_optimisticRednSetInfo[blockNum]->get(node->getLocalIndex()) ||
+                       _optimisticOptSetInfo[blockNum]->get(node->getLocalIndex())) &&
+                    (!_actualRednSetInfo[blockNum]->get(node->getLocalIndex())) &&
+                    (!_actualOptSetInfo[blockNum]->get(node->getLocalIndex())) &&
+                    (!_genSetHelper->get(node->getLocalIndex())))
                  {
                  createAndAddListElement(node, blockNum);
                  }
               }
 
-           if ((!_optimisticRednSetInfo[blockNum]->get(node->getSideTableIndex()) /* &&
-                                                                                     !_optimisticOptSetInfo[blockNum]->get(node->getSideTableIndex()) */) ||
+           if ((!_optimisticRednSetInfo[blockNum]->get(node->getLocalIndex()) /* &&
+                                                                                     !_optimisticOptSetInfo[blockNum]->get(node->getLocalIndex()) */) ||
                  _arrayCheckKilled->get(blockNum) ||
                  nodeKilledByChild)
               {
-              _killedGenExprs[blockNum]->set(node->getSideTableIndex());
+              _killedGenExprs[blockNum]->set(node->getLocalIndex());
               _resolveCheckKilled->set(blockNum);
               _nullCheckKilled->set(blockNum);
               _boundCheckKilled->set(blockNum);
@@ -3588,23 +3588,23 @@ void TR_ExceptionCheckMotion::analyzeNodeToInitializeGenAndKillSets(TR::TreeTop 
 
            if (!_atLeastOneExceptionPoint)
               {
-              if ((_optimisticRednSetInfo[blockNum]->get(node->getSideTableIndex()) ||
-                       _optimisticOptSetInfo[blockNum]->get(node->getSideTableIndex())) &&
-                    (!_actualRednSetInfo[blockNum]->get(node->getSideTableIndex())) &&
-                    (!_actualOptSetInfo[blockNum]->get(node->getSideTableIndex())) &&
-                    (!_genSetHelper->get(node->getSideTableIndex())))
+              if ((_optimisticRednSetInfo[blockNum]->get(node->getLocalIndex()) ||
+                       _optimisticOptSetInfo[blockNum]->get(node->getLocalIndex())) &&
+                    (!_actualRednSetInfo[blockNum]->get(node->getLocalIndex())) &&
+                    (!_actualOptSetInfo[blockNum]->get(node->getLocalIndex())) &&
+                    (!_genSetHelper->get(node->getLocalIndex())))
                  {
                  createAndAddListElement(node, blockNum);
                  }
               }
 
            bool alreadyKilled = false;
-           if ((!_optimisticRednSetInfo[blockNum]->get(node->getSideTableIndex()) /* &&
-                                                                                     !_optimisticOptSetInfo[blockNum]->get(node->getSideTableIndex()) */) ||
+           if ((!_optimisticRednSetInfo[blockNum]->get(node->getLocalIndex()) /* &&
+                                                                                     !_optimisticOptSetInfo[blockNum]->get(node->getLocalIndex()) */) ||
                  _checkCastKilled->get(blockNum) ||
                  nodeKilledByChild)
               {
-              _killedGenExprs[blockNum]->set(node->getSideTableIndex());
+              _killedGenExprs[blockNum]->set(node->getLocalIndex());
               _resolveCheckKilled->set(blockNum);
               _nullCheckKilled->set(blockNum);
               _boundCheckKilled->set(blockNum);
@@ -3618,14 +3618,14 @@ void TR_ExceptionCheckMotion::analyzeNodeToInitializeGenAndKillSets(TR::TreeTop 
 
            if (node->getOpCodeValue() == TR::checkcastAndNULLCHK)
               {
-              if ((!_optimisticRednSetInfo[blockNum]->get(node->getSideTableIndex()) /* &&
-                                                                                        !_optimisticOptSetInfo[blockNum]->get(node->getSideTableIndex()) */) ||
+              if ((!_optimisticRednSetInfo[blockNum]->get(node->getLocalIndex()) /* &&
+                                                                                        !_optimisticOptSetInfo[blockNum]->get(node->getLocalIndex()) */) ||
                     _nullCheckKilled->get(blockNum) ||
                     nodeKilledByChild)
                  {
                  if (!alreadyKilled)
                     {
-                    _killedGenExprs[blockNum]->set(node->getSideTableIndex());
+                    _killedGenExprs[blockNum]->set(node->getLocalIndex());
                     _resolveCheckKilled->set(blockNum);
                     _boundCheckKilled->set(blockNum);
                     _divCheckKilled->set(blockNum);
@@ -3669,11 +3669,11 @@ void TR_ExceptionCheckMotion::analyzeNodeToInitializeGenAndKillSets(TR::TreeTop 
               (!node->getFirstChild()->isThisPointer() ||
                !node->getFirstChild()->isNonNull()))
               {
-              if ((_optimisticRednSetInfo[blockNum]->get(node->getSideTableIndex()) ||
-                       _optimisticOptSetInfo[blockNum]->get(node->getSideTableIndex())) &&
-                    (!_actualRednSetInfo[blockNum]->get(node->getSideTableIndex())) &&
-                    (!_actualOptSetInfo[blockNum]->get(node->getSideTableIndex())) &&
-                    (!_genSetHelper->get(node->getSideTableIndex())))
+              if ((_optimisticRednSetInfo[blockNum]->get(node->getLocalIndex()) ||
+                       _optimisticOptSetInfo[blockNum]->get(node->getLocalIndex())) &&
+                    (!_actualRednSetInfo[blockNum]->get(node->getLocalIndex())) &&
+                    (!_actualOptSetInfo[blockNum]->get(node->getLocalIndex())) &&
+                    (!_genSetHelper->get(node->getLocalIndex())))
                  {
                  createAndAddListElement(node, blockNum);
                  }
@@ -3710,26 +3710,26 @@ void TR_ExceptionCheckMotion::analyzeNodeToInitializeGenAndKillSets(TR::TreeTop 
                 (child->getVisitCount() != visitCount))
                {
                child->setVisitCount(visitCount);
-               if (((child->getSideTableIndex() != MAX_SCOUNT) && (child->getSideTableIndex() != 0)))
-                  _relevantNodes->set(child->getSideTableIndex());
+               if (((child->getLocalIndex() != MAX_SCOUNT) && (child->getLocalIndex() != 0)))
+                  _relevantNodes->set(child->getLocalIndex());
                }
             }
          }
       }
 
 #if 0
-   if (((node->getSideTableIndex() != MAX_SCOUNT) && (node->getSideTableIndex() != 0)) && node->getOpCode().isStore())
+   if (((node->getLocalIndex() != MAX_SCOUNT) && (node->getLocalIndex() != 0)) && node->getOpCode().isStore())
       {
       if (!childRelevant)
          {
-         _exprsUnaffectedByOrder->set(node->getSideTableIndex());
+         _exprsUnaffectedByOrder->set(node->getLocalIndex());
          //if (node->getOpCode().isIndirect())
-         //   _indirectAccessesThatSurvive->set(node->getFirstChild()->getSideTableIndex());
+         //   _indirectAccessesThatSurvive->set(node->getFirstChild()->getLocalIndex());
          //else
-         _indirectAccessesThatSurvive->set(node->getSideTableIndex());
-         _arrayAccessesThatSurvive->set(node->getSideTableIndex());
-         _unresolvedAccessesThatSurvive->set(node->getSideTableIndex());
-         _dividesThatSurvive->set(node->getSideTableIndex());
+         _indirectAccessesThatSurvive->set(node->getLocalIndex());
+         _arrayAccessesThatSurvive->set(node->getLocalIndex());
+         _unresolvedAccessesThatSurvive->set(node->getLocalIndex());
+         _dividesThatSurvive->set(node->getLocalIndex());
          }
       else
          {
@@ -3741,52 +3741,52 @@ void TR_ExceptionCheckMotion::analyzeNodeToInitializeGenAndKillSets(TR::TreeTop 
                 {
                TR::Node *firstChild = child->getFirstChild();
                TR::Node *secondChild = child->getSecondChild();
-               if (((firstChild->getSideTableIndex() != MAX_SCOUNT) && (firstChild->getSideTableIndex() != 0)) /* && (!firstChild->getOpCode().isStore()) */)
+               if (((firstChild->getLocalIndex() != MAX_SCOUNT) && (firstChild->getLocalIndex() != 0)) /* && (!firstChild->getOpCode().isStore()) */)
                   {
-                  if (_exprsContainingIndirectAccess->get(firstChild->getSideTableIndex()))
+                  if (_exprsContainingIndirectAccess->get(firstChild->getLocalIndex()))
                      containsIndirectAccess = true;
-                  if (_exprsContainingArrayAccess->get(firstChild->getSideTableIndex()))
+                  if (_exprsContainingArrayAccess->get(firstChild->getLocalIndex()))
                      containsArrayAccess = true;
-                  if (_exprsContainingDivide->get(firstChild->getSideTableIndex()))
+                  if (_exprsContainingDivide->get(firstChild->getLocalIndex()))
                      containsDivide = true;
-                  if (_exprsContainingUnresolvedAccess->get(firstChild->getSideTableIndex()))
+                  if (_exprsContainingUnresolvedAccess->get(firstChild->getLocalIndex()))
                      containsUnresolvedAccess = true;
                   }
 
-               if (((secondChild->getSideTableIndex() != MAX_SCOUNT) && (secondChild->getSideTableIndex() != 0)) /* && (!secondChild->getOpCode().isStore()) */)
+               if (((secondChild->getLocalIndex() != MAX_SCOUNT) && (secondChild->getLocalIndex() != 0)) /* && (!secondChild->getOpCode().isStore()) */)
                   {
-                  if (_exprsContainingIndirectAccess->get(secondChild->getSideTableIndex()))
+                  if (_exprsContainingIndirectAccess->get(secondChild->getLocalIndex()))
                      containsIndirectAccess = true;
-                  if (_exprsContainingArrayAccess->get(secondChild->getSideTableIndex()))
+                  if (_exprsContainingArrayAccess->get(secondChild->getLocalIndex()))
                      containsArrayAccess = true;
-                  if (_exprsContainingDivide->get(secondChild->getSideTableIndex()))
+                  if (_exprsContainingDivide->get(secondChild->getLocalIndex()))
                      containsDivide = true;
-                  if (_exprsContainingUnresolvedAccess->get(secondChild->getSideTableIndex()))
+                  if (_exprsContainingUnresolvedAccess->get(secondChild->getLocalIndex()))
                      containsUnresolvedAccess = true;
                   }
                }
             else
                {
-               if (_exprsContainingIndirectAccess->get(child->getSideTableIndex()))
+               if (_exprsContainingIndirectAccess->get(child->getLocalIndex()))
                   containsIndirectAccess = true;
-               if (_exprsContainingArrayAccess->get(child->getSideTableIndex()))
+               if (_exprsContainingArrayAccess->get(child->getLocalIndex()))
                   containsArrayAccess = true;
-               if (_exprsContainingDivide->get(child->getSideTableIndex()))
+               if (_exprsContainingDivide->get(child->getLocalIndex()))
                   containsDivide = true;
-               if (_exprsContainingUnresolvedAccess->get(child->getSideTableIndex()))
+               if (_exprsContainingUnresolvedAccess->get(child->getLocalIndex()))
                   containsUnresolvedAccess = true;
                }
             }
 
-         _relevantNodes->set(node->getSideTableIndex());
+         _relevantNodes->set(node->getLocalIndex());
          if (containsIndirectAccess)
-            _exprsContainingIndirectAccess->set(node->getSideTableIndex());
+            _exprsContainingIndirectAccess->set(node->getLocalIndex());
          if (containsArrayAccess)
-            _exprsContainingArrayAccess->set(node->getSideTableIndex());
+            _exprsContainingArrayAccess->set(node->getLocalIndex());
          if (containsDivide)
-           _exprsContainingDivide->set(node->getSideTableIndex());
+           _exprsContainingDivide->set(node->getLocalIndex());
          if (containsUnresolvedAccess)
-            _exprsContainingUnresolvedAccess->set(node->getSideTableIndex());
+            _exprsContainingUnresolvedAccess->set(node->getLocalIndex());
          }
       }
 #endif
@@ -3811,7 +3811,7 @@ void TR_ExceptionCheckMotion::createAndAddListElement(TR::Node *node, int32_t bl
    else
       _regularGenSetInfo[blockNum]->setListHead(newElement);
 
-   _genSetHelper->set(node->getSideTableIndex());
+   _genSetHelper->set(node->getLocalIndex());
    _lastGenSetElement = newElement;
    }
 
@@ -3826,11 +3826,11 @@ bool TR_ExceptionCheckMotion::isNodeKilledByChild(TR::Node *parent, TR::Node *ch
    {
    bool parentKilled = false;
 
-   if (((child->getSideTableIndex() != MAX_SCOUNT) && (child->getSideTableIndex() != 0)) /* && (!child->getOpCode().isStore()) */)
+   if (((child->getLocalIndex() != MAX_SCOUNT) && (child->getLocalIndex() != 0)) /* && (!child->getOpCode().isStore()) */)
       {
-      if (_exprsContainingIndirectAccess->get(child->getSideTableIndex()))
+      if (_exprsContainingIndirectAccess->get(child->getLocalIndex()))
          {
-         _exprsContainingIndirectAccess->set(parent->getSideTableIndex());
+         _exprsContainingIndirectAccess->set(parent->getLocalIndex());
          if (_indirectAccessesKilled->get(blockNum))
             {
             if (!checkIfNodeCanSomehowSurvive(child, _indirectAccessesThatSurvive))
@@ -3838,9 +3838,9 @@ bool TR_ExceptionCheckMotion::isNodeKilledByChild(TR::Node *parent, TR::Node *ch
             }
          }
 
-      if (_exprsContainingArrayAccess->get(child->getSideTableIndex()))
+      if (_exprsContainingArrayAccess->get(child->getLocalIndex()))
          {
-         _exprsContainingArrayAccess->set(parent->getSideTableIndex());
+         _exprsContainingArrayAccess->set(parent->getLocalIndex());
          if (_arrayAccessesKilled->get(blockNum))
             {
             if (!checkIfNodeCanSomehowSurvive(child, _arrayAccessesThatSurvive))
@@ -3848,9 +3848,9 @@ bool TR_ExceptionCheckMotion::isNodeKilledByChild(TR::Node *parent, TR::Node *ch
             }
          }
 
-      if (_exprsContainingDivide->get(child->getSideTableIndex()))
+      if (_exprsContainingDivide->get(child->getLocalIndex()))
          {
-         _exprsContainingDivide->set(parent->getSideTableIndex());
+         _exprsContainingDivide->set(parent->getLocalIndex());
          if (_dividesKilled->get(blockNum))
             {
             if (!checkIfNodeCanSomehowSurvive(child, _dividesThatSurvive))
@@ -3858,9 +3858,9 @@ bool TR_ExceptionCheckMotion::isNodeKilledByChild(TR::Node *parent, TR::Node *ch
             }
          }
 
-      if (_exprsContainingUnresolvedAccess->get(child->getSideTableIndex()))
+      if (_exprsContainingUnresolvedAccess->get(child->getLocalIndex()))
          {
-         _exprsContainingUnresolvedAccess->set(parent->getSideTableIndex());
+         _exprsContainingUnresolvedAccess->set(parent->getLocalIndex());
          if (_unresolvedAccessesKilled->get(blockNum))
             {
             if (!checkIfNodeCanSomehowSurvive(child, _unresolvedAccessesThatSurvive))
@@ -3885,24 +3885,24 @@ bool TR_ExceptionCheckMotion::includeRelevantNodes(TR::Node *node, vcount_t visi
    {
    if (node->getVisitCount() == visitCount)
       {
-      if (((node->getSideTableIndex() != MAX_SCOUNT) && (node->getSideTableIndex() != 0)) /* && (!node->getOpCode().isStore()) */)
+      if (((node->getLocalIndex() != MAX_SCOUNT) && (node->getLocalIndex() != 0)) /* && (!node->getOpCode().isStore()) */)
          {
-         if (_relevantNodes->get(node->getSideTableIndex()))
+         if (_relevantNodes->get(node->getLocalIndex()))
             return true;
          }
       else if (node->getOpCode().isTwoChildrenAddress())
          {
          TR::Node *firstChild = node->getFirstChild();
          TR::Node *secondChild = node->getSecondChild();
-         if (((firstChild->getSideTableIndex() != MAX_SCOUNT) && (firstChild->getSideTableIndex() != 0)) /* && (!firstChild->getOpCode().isStore()) */)
+         if (((firstChild->getLocalIndex() != MAX_SCOUNT) && (firstChild->getLocalIndex() != 0)) /* && (!firstChild->getOpCode().isStore()) */)
             {
-            if (_relevantNodes->get(firstChild->getSideTableIndex()))
+            if (_relevantNodes->get(firstChild->getLocalIndex()))
                return true;
             }
 
-         if (((secondChild->getSideTableIndex() != MAX_SCOUNT) && (secondChild->getSideTableIndex() != 0)) /* && (!secondChild->getOpCode().isStore()) */)
+         if (((secondChild->getLocalIndex() != MAX_SCOUNT) && (secondChild->getLocalIndex() != 0)) /* && (!secondChild->getOpCode().isStore()) */)
             {
-            if (_relevantNodes->get(secondChild->getSideTableIndex()))
+            if (_relevantNodes->get(secondChild->getLocalIndex()))
                return true;
             }
          }
@@ -3929,39 +3929,39 @@ bool TR_ExceptionCheckMotion::includeRelevantNodes(TR::Node *node, vcount_t visi
             {
             TR::Node *firstChild = child->getFirstChild();
             TR::Node *secondChild = child->getSecondChild();
-            if (((firstChild->getSideTableIndex() != MAX_SCOUNT) && (firstChild->getSideTableIndex() != 0)) /* && (!firstChild->getOpCode().isStore()) */)
+            if (((firstChild->getLocalIndex() != MAX_SCOUNT) && (firstChild->getLocalIndex() != 0)) /* && (!firstChild->getOpCode().isStore()) */)
                {
-               if (_exprsContainingIndirectAccess->get(firstChild->getSideTableIndex()))
+               if (_exprsContainingIndirectAccess->get(firstChild->getLocalIndex()))
                   containsIndirectAccess = true;
-               if (_exprsContainingArrayAccess->get(firstChild->getSideTableIndex()))
+               if (_exprsContainingArrayAccess->get(firstChild->getLocalIndex()))
                   containsArrayAccess = true;
-               if (_exprsContainingDivide->get(firstChild->getSideTableIndex()))
+               if (_exprsContainingDivide->get(firstChild->getLocalIndex()))
                   containsDivide = true;
-               if (_exprsContainingUnresolvedAccess->get(firstChild->getSideTableIndex()))
+               if (_exprsContainingUnresolvedAccess->get(firstChild->getLocalIndex()))
                   containsUnresolvedAccess = true;
                }
 
-            if (((secondChild->getSideTableIndex() != MAX_SCOUNT) && (secondChild->getSideTableIndex() != 0)) /* && (!secondChild->getOpCode().isStore()) */)
+            if (((secondChild->getLocalIndex() != MAX_SCOUNT) && (secondChild->getLocalIndex() != 0)) /* && (!secondChild->getOpCode().isStore()) */)
                {
-               if (_exprsContainingIndirectAccess->get(secondChild->getSideTableIndex()))
+               if (_exprsContainingIndirectAccess->get(secondChild->getLocalIndex()))
                   containsIndirectAccess = true;
-               if (_exprsContainingArrayAccess->get(secondChild->getSideTableIndex()))
+               if (_exprsContainingArrayAccess->get(secondChild->getLocalIndex()))
                   containsArrayAccess = true;
-               if (_exprsContainingDivide->get(secondChild->getSideTableIndex()))
+               if (_exprsContainingDivide->get(secondChild->getLocalIndex()))
                   containsDivide = true;
-               if (_exprsContainingUnresolvedAccess->get(secondChild->getSideTableIndex()))
+               if (_exprsContainingUnresolvedAccess->get(secondChild->getLocalIndex()))
                   containsUnresolvedAccess = true;
                }
             }
          else
             {
-            if (_exprsContainingIndirectAccess->get(child->getSideTableIndex()))
+            if (_exprsContainingIndirectAccess->get(child->getLocalIndex()))
                containsIndirectAccess = true;
-            if (_exprsContainingArrayAccess->get(child->getSideTableIndex()))
+            if (_exprsContainingArrayAccess->get(child->getLocalIndex()))
                containsArrayAccess = true;
-            if (_exprsContainingDivide->get(child->getSideTableIndex()))
+            if (_exprsContainingDivide->get(child->getLocalIndex()))
                containsDivide = true;
-            if (_exprsContainingUnresolvedAccess->get(child->getSideTableIndex()))
+            if (_exprsContainingUnresolvedAccess->get(child->getLocalIndex()))
                containsUnresolvedAccess = true;
             }
          }
@@ -3970,10 +3970,10 @@ bool TR_ExceptionCheckMotion::includeRelevantNodes(TR::Node *node, vcount_t visi
    TR::ILOpCode &opCode = node->getOpCode();
    TR::DataTypes nodeDataType = node->getDataType();
 
-   if (((node->getSideTableIndex() != MAX_SCOUNT) && (node->getSideTableIndex() != 0)) /* && (!opCode.isStore()) */)
+   if (((node->getLocalIndex() != MAX_SCOUNT) && (node->getLocalIndex() != 0)) /* && (!opCode.isStore()) */)
       {
-      if ((!_actualRednSetInfo[blockNum]->get(node->getSideTableIndex())) &&
-          (!_actualOptSetInfo[blockNum]->get(node->getSideTableIndex())) &&
+      if ((!_actualRednSetInfo[blockNum]->get(node->getLocalIndex())) &&
+          (!_actualOptSetInfo[blockNum]->get(node->getLocalIndex())) &&
           (childRelevant ||
            ((opCode.isIndirect() && (opCode.isLoadVar() || opCode.isStore()) &&
              (!(opCode.hasSymbolReference() &&
@@ -3985,11 +3985,11 @@ bool TR_ExceptionCheckMotion::includeRelevantNodes(TR::Node *node, vcount_t visi
               (opCode.hasSymbolReference() && node->getSymbolReference()->isUnresolved()) ||
               (opCode.isDiv() || opCode.isRem())))
          {
-         _relevantNodes->set(node->getSideTableIndex());
+         _relevantNodes->set(node->getLocalIndex());
          bool relevantNodeKilled = false;
          if (containsIndirectAccess || ((opCode.isIndirect() && (opCode.isLoadVar() || opCode.isStore())) || (opCode.isArrayLength())))
             {
-            _exprsContainingIndirectAccess->set(node->getSideTableIndex());
+            _exprsContainingIndirectAccess->set(node->getLocalIndex());
             if (_indirectAccessesKilled->get(blockNum))
                {
                if (!checkIfNodeCanSomehowSurvive(node, _indirectAccessesThatSurvive))
@@ -3999,7 +3999,7 @@ bool TR_ExceptionCheckMotion::includeRelevantNodes(TR::Node *node, vcount_t visi
 
          if (containsArrayAccess || node->getOpCode().isTwoChildrenAddress())
             {
-            _exprsContainingArrayAccess->set(node->getSideTableIndex());
+            _exprsContainingArrayAccess->set(node->getLocalIndex());
             if (_arrayAccessesKilled->get(blockNum))
                {
                //if (!checkIfNodeCanSomehowSurvive(node, _indirectAccessesThatSurvive))
@@ -4009,7 +4009,7 @@ bool TR_ExceptionCheckMotion::includeRelevantNodes(TR::Node *node, vcount_t visi
 
          if (containsDivide || (opCode.isDiv() || opCode.isRem()))
             {
-            _exprsContainingDivide->set(node->getSideTableIndex());
+            _exprsContainingDivide->set(node->getLocalIndex());
             if (_dividesKilled->get(blockNum))
                {
                if (!checkIfNodeCanSomehowSurvive(node, _dividesThatSurvive))
@@ -4019,7 +4019,7 @@ bool TR_ExceptionCheckMotion::includeRelevantNodes(TR::Node *node, vcount_t visi
 
          if (containsUnresolvedAccess || (opCode.hasSymbolReference() && node->getSymbolReference()->isUnresolved()))
             {
-            _exprsContainingUnresolvedAccess->set(node->getSideTableIndex());
+            _exprsContainingUnresolvedAccess->set(node->getLocalIndex());
             if (_unresolvedAccessesKilled->get(blockNum))
                {
                if (!checkIfNodeCanSomehowSurvive(node, _unresolvedAccessesThatSurvive))
@@ -4028,11 +4028,11 @@ bool TR_ExceptionCheckMotion::includeRelevantNodes(TR::Node *node, vcount_t visi
             }
 
          if (relevantNodeKilled)
-            _killedGenExprs[blockNum]->set(node->getSideTableIndex());
+            _killedGenExprs[blockNum]->set(node->getLocalIndex());
 
-         if  (!_genSetHelper->get(node->getSideTableIndex()) &&
-             (_optimisticRednSetInfo[blockNum]->get(node->getSideTableIndex()) ||
-              _optimisticOptSetInfo[blockNum]->get(node->getSideTableIndex())))
+         if  (!_genSetHelper->get(node->getLocalIndex()) &&
+             (_optimisticRednSetInfo[blockNum]->get(node->getLocalIndex()) ||
+              _optimisticOptSetInfo[blockNum]->get(node->getLocalIndex())))
             {
             ListElement<TR::Node> *newElement = (ListElement<TR::Node>*)trMemory()->allocateStackMemory(sizeof(ListElement<TR::Node>));
             newElement->setData(node);
@@ -4042,7 +4042,7 @@ bool TR_ExceptionCheckMotion::includeRelevantNodes(TR::Node *node, vcount_t visi
             else
                _regularGenSetInfo[blockNum]->setListHead(newElement);
 
-            _genSetHelper->set(node->getSideTableIndex());
+            _genSetHelper->set(node->getLocalIndex());
             _lastGenSetElement = newElement;
             }
          return true;
@@ -4059,30 +4059,30 @@ bool TR_ExceptionCheckMotion::includeRelevantNodes(TR::Node *node, vcount_t visi
              (opCode.hasSymbolReference() && node->getSymbolReference()->isUnresolved()) ||
              (opCode.isDiv() || opCode.isRem())))
             {
-            _exprsUnaffectedByOrder->set(node->getSideTableIndex());
+            _exprsUnaffectedByOrder->set(node->getLocalIndex());
 
             /*
             if (opCode.isIndirect())
-               _indirectAccessesThatSurvive->set(node->getFirstChild()->getSideTableIndex());
+               _indirectAccessesThatSurvive->set(node->getFirstChild()->getLocalIndex());
             else
-               _indirectAccessesThatSurvive->set(node->getSideTableIndex());
+               _indirectAccessesThatSurvive->set(node->getLocalIndex());
 
-            _arrayAccessesThatSurvive->set(node->getSideTableIndex());
-            _unresolvedAccessesThatSurvive->set(node->getSideTableIndex());
-            _dividesThatSurvive->set(node->getSideTableIndex());
+            _arrayAccessesThatSurvive->set(node->getLocalIndex());
+            _unresolvedAccessesThatSurvive->set(node->getLocalIndex());
+            _dividesThatSurvive->set(node->getLocalIndex());
             */
             }
          else
             {
-            _relevantNodes->set(node->getSideTableIndex());
+            _relevantNodes->set(node->getLocalIndex());
             if (containsIndirectAccess || ((opCode.isIndirect() && (opCode.isLoadVar() || opCode.isStore())) || opCode.isArrayLength()))
-               _exprsContainingIndirectAccess->set(node->getSideTableIndex());
+               _exprsContainingIndirectAccess->set(node->getLocalIndex());
             if (containsArrayAccess || node->getOpCode().isTwoChildrenAddress())
-               _exprsContainingArrayAccess->set(node->getSideTableIndex());
+               _exprsContainingArrayAccess->set(node->getLocalIndex());
             if (containsDivide || (opCode.isDiv() || opCode.isRem()))
-               _exprsContainingDivide->set(node->getSideTableIndex());
+               _exprsContainingDivide->set(node->getLocalIndex());
             if (containsUnresolvedAccess || (opCode.hasSymbolReference() && node->getSymbolReference()->isUnresolved()))
-               _exprsContainingUnresolvedAccess->set(node->getSideTableIndex());
+               _exprsContainingUnresolvedAccess->set(node->getLocalIndex());
 
             return true;
             }
@@ -4415,7 +4415,7 @@ bool TR_ExceptionCheckMotion::analyzeNodeIfSuccessorsAnalyzed(TR::CFGNode *cfgNo
                TR::Node *listNode;
                for (listNode = outListIt.getFirst(); listNode != NULL;)
                   {
-                  traceMsg(comp(), " ,%d ", listNode->getSideTableIndex());
+                  traceMsg(comp(), " ,%d ", listNode->getLocalIndex());
                   listNode = outListIt.getNext();
                   }
                traceMsg(comp(), "\n");
@@ -4430,7 +4430,7 @@ bool TR_ExceptionCheckMotion::analyzeNodeIfSuccessorsAnalyzed(TR::CFGNode *cfgNo
             TR::Node *listNode;
             for (listNode = inListIt.getFirst(); listNode != NULL;)
                {
-               traceMsg(comp(), " ,%d ", listNode->getSideTableIndex());
+               traceMsg(comp(), " ,%d ", listNode->getLocalIndex());
                listNode = inListIt.getNext();
                }
             traceMsg(comp(), "\n");
@@ -4532,7 +4532,7 @@ bool TR_ExceptionCheckMotion::analyzeBlockStructure(TR_BlockStructure *blockStru
 
       if (opCode.getOpCodeValue() == TR::NULLCHK)
          {
-         _composeHelper->set(nextAvailableNode->getNullCheckReference()->getSideTableIndex());
+         _composeHelper->set(nextAvailableNode->getNullCheckReference()->getLocalIndex());
          }
       }
 
@@ -4685,7 +4685,7 @@ bool TR_ExceptionCheckMotion::analyzeBlockStructure(TR_BlockStructure *blockStru
       // also mark this expression as one that will kill its parent (because it was
       // killed) if the parent is a check taking part in this analysis
       //
-      if (_exprsContainingIndirectAccess->get(node->getSideTableIndex()))
+      if (_exprsContainingIndirectAccess->get(node->getLocalIndex()))
          {
          if (indirectAccessesKilled)
             {
@@ -4700,7 +4700,7 @@ bool TR_ExceptionCheckMotion::analyzeBlockStructure(TR_BlockStructure *blockStru
 
       // Do the same as above for expressions containing unresolved access
       //
-      if (_exprsContainingUnresolvedAccess->get(node->getSideTableIndex()))
+      if (_exprsContainingUnresolvedAccess->get(node->getLocalIndex()))
          {
          if (unresolvedAccessesKilled)
             {
@@ -4715,7 +4715,7 @@ bool TR_ExceptionCheckMotion::analyzeBlockStructure(TR_BlockStructure *blockStru
 
       // Do the same as above for expressions containing array access
       //
-      if (_exprsContainingArrayAccess->get(node->getSideTableIndex()))
+      if (_exprsContainingArrayAccess->get(node->getLocalIndex()))
          {
          if (arrayAccessesKilled)
             {
@@ -4730,7 +4730,7 @@ bool TR_ExceptionCheckMotion::analyzeBlockStructure(TR_BlockStructure *blockStru
 
       // Do the same as above for expressions containing division
       //
-      if (_exprsContainingDivide->get(node->getSideTableIndex()))
+      if (_exprsContainingDivide->get(node->getLocalIndex()))
          {
          if (dividesKilled)
             {
@@ -4912,7 +4912,7 @@ bool TR_ExceptionCheckMotion::analyzeBlockStructure(TR_BlockStructure *blockStru
            TR::Node *listNode;
            for (listNode = workListIt.getFirst(); listNode != NULL;)
               {
-              traceMsg(comp(), " ,%d ", listNode->getSideTableIndex());
+              traceMsg(comp(), " ,%d ", listNode->getLocalIndex());
               listNode = workListIt.getNext();
               }
            traceMsg(comp(), "\n");
@@ -5079,7 +5079,7 @@ bool TR_ExceptionCheckMotion::analyzeBlockStructure(TR_BlockStructure *blockStru
          checkElement = true;
          }
 
-      if (!_optimisticOptSetInfo[blockNum]->get(node->getSideTableIndex()))
+      if (!_optimisticOptSetInfo[blockNum]->get(node->getLocalIndex()))
          {
          //
          // This expression is NOT an opt candidate for this block
@@ -5098,7 +5098,7 @@ bool TR_ExceptionCheckMotion::analyzeBlockStructure(TR_BlockStructure *blockStru
             // then kill this expression if it contains an indirect access as it is not
             // allowed to cross this block (it is not allowed to move past the check)
             //
-            if (_exprsContainingIndirectAccess->get(node->getSideTableIndex()))
+            if (_exprsContainingIndirectAccess->get(node->getLocalIndex()))
                {
                if (indirectAccessesKilled)
                   {
@@ -5113,7 +5113,7 @@ bool TR_ExceptionCheckMotion::analyzeBlockStructure(TR_BlockStructure *blockStru
 
             // Similar logic as above for resolve check and unresolved access
             //
-            if (_exprsContainingUnresolvedAccess->get(node->getSideTableIndex()))
+            if (_exprsContainingUnresolvedAccess->get(node->getLocalIndex()))
                {
                if (unresolvedAccessesKilled)
                   {
@@ -5128,7 +5128,7 @@ bool TR_ExceptionCheckMotion::analyzeBlockStructure(TR_BlockStructure *blockStru
 
             // Similar logic as above for array bound check and array access
             //
-            if (_exprsContainingArrayAccess->get(node->getSideTableIndex()))
+            if (_exprsContainingArrayAccess->get(node->getLocalIndex()))
                {
                if (arrayAccessesKilled)
                   {
@@ -5143,7 +5143,7 @@ bool TR_ExceptionCheckMotion::analyzeBlockStructure(TR_BlockStructure *blockStru
 
             // Similar logic as above for div check and division expression
             //
-            if (_exprsContainingDivide->get(node->getSideTableIndex()))
+            if (_exprsContainingDivide->get(node->getLocalIndex()))
                {
                if (dividesKilled)
                   {
@@ -5333,13 +5333,13 @@ bool TR_ExceptionCheckMotion::analyzeBlockStructure(TR_BlockStructure *blockStru
          // ACCESSKilled flags (which are really used to limit which expressions can stay
          // in the out list for this block eventually)
          //
-         if (_exprsContainingIndirectAccess->get(listElem->getData()->getSideTableIndex()) && optimalIndirectAccessesKilled)
+         if (_exprsContainingIndirectAccess->get(listElem->getData()->getLocalIndex()) && optimalIndirectAccessesKilled)
             canPlaceOptimally = false;
-         else if (_exprsContainingArrayAccess->get(listElem->getData()->getSideTableIndex()) && optimalArrayAccessesKilled)
+         else if (_exprsContainingArrayAccess->get(listElem->getData()->getLocalIndex()) && optimalArrayAccessesKilled)
             canPlaceOptimally = false;
-         else if (_exprsContainingDivide->get(listElem->getData()->getSideTableIndex()) && optimalDividesKilled)
+         else if (_exprsContainingDivide->get(listElem->getData()->getLocalIndex()) && optimalDividesKilled)
             canPlaceOptimally = false;
-         else if (_exprsContainingUnresolvedAccess->get(listElem->getData()->getSideTableIndex()) && optimalUnresolvedAccessesKilled)
+         else if (_exprsContainingUnresolvedAccess->get(listElem->getData()->getLocalIndex()) && optimalUnresolvedAccessesKilled)
             canPlaceOptimally = false;
 
          if (checkElement)
@@ -5426,11 +5426,11 @@ bool TR_ExceptionCheckMotion::analyzeBlockStructure(TR_BlockStructure *blockStru
          // Actually add this expression into the optimal list for this block
          // in the correct order
          //
-         if (canPlaceOptimally && !_actualOptSetInfo[blockNum]->get(listElem->getData()->getSideTableIndex()))
+         if (canPlaceOptimally && !_actualOptSetInfo[blockNum]->get(listElem->getData()->getLocalIndex()))
             {
             _tryAnotherIteration = true;
             if (trace())
-               traceMsg(comp(), "IN ORDER Expr %d (representative) Node %p (listElem %p) in Block : %d\n", listElem->getData()->getSideTableIndex(), listElem->getData(), listElem, blockNum);
+               traceMsg(comp(), "IN ORDER Expr %d (representative) Node %p (listElem %p) in Block : %d\n", listElem->getData()->getLocalIndex(), listElem->getData(), listElem, blockNum);
 
             if (checkElement)
                {
@@ -5513,7 +5513,7 @@ bool TR_ExceptionCheckMotion::analyzeBlockStructure(TR_BlockStructure *blockStru
                   }
                }
 
-            _actualOptSetInfo[blockNum]->set(listElem->getData()->getSideTableIndex());
+            _actualOptSetInfo[blockNum]->set(listElem->getData()->getLocalIndex());
 
             if (!_orderedOptList[blockNum])
                _orderedOptList[blockNum] = new (trStackMemory())TR_ScratchList<TR::Node>(trMemory());
@@ -5579,10 +5579,10 @@ bool TR_ExceptionCheckMotion::analyzeBlockStructure(TR_BlockStructure *blockStru
       TR::ILOpCode &opCode = listElem->getData()->getOpCode();
       bool checkKilledByChild = false;
       bool genExprThatIsKilled = false;
-      if (_killedGenExprs[blockNum]->get(listElem->getData()->getSideTableIndex()))
+      if (_killedGenExprs[blockNum]->get(listElem->getData()->getLocalIndex()))
          genExprThatIsKilled = true;
 
-      if (_exprsContainingIndirectAccess->get(listElem->getData()->getSideTableIndex()))
+      if (_exprsContainingIndirectAccess->get(listElem->getData()->getLocalIndex()))
          {
          if (indirectAccessesKilledByOptList ||
              genExprThatIsKilled)
@@ -5599,7 +5599,7 @@ bool TR_ExceptionCheckMotion::analyzeBlockStructure(TR_BlockStructure *blockStru
          }
 
 
-      if (_exprsContainingUnresolvedAccess->get(listElem->getData()->getSideTableIndex()))
+      if (_exprsContainingUnresolvedAccess->get(listElem->getData()->getLocalIndex()))
          {
          if (unresolvedAccessesKilledByOptList ||
              genExprThatIsKilled)
@@ -5616,7 +5616,7 @@ bool TR_ExceptionCheckMotion::analyzeBlockStructure(TR_BlockStructure *blockStru
          }
 
 
-      if (_exprsContainingArrayAccess->get(listElem->getData()->getSideTableIndex()))
+      if (_exprsContainingArrayAccess->get(listElem->getData()->getLocalIndex()))
          {
          if (arrayAccessesKilledByOptList ||
              genExprThatIsKilled)
@@ -5632,7 +5632,7 @@ bool TR_ExceptionCheckMotion::analyzeBlockStructure(TR_BlockStructure *blockStru
             }
          }
 
-      if (_exprsContainingDivide->get(listElem->getData()->getSideTableIndex()))
+      if (_exprsContainingDivide->get(listElem->getData()->getLocalIndex()))
          {
          if (dividesKilledByOptList ||
              genExprThatIsKilled)
@@ -5649,7 +5649,7 @@ bool TR_ExceptionCheckMotion::analyzeBlockStructure(TR_BlockStructure *blockStru
       if (opCode.getOpCodeValue() == TR::NULLCHK)
          {
          if (nullCheckKilledByOptList || checkKilledByChild || genExprThatIsKilled ||
-             _actualOptSetInfo[blockNum]->get(listElem->getData()->getSideTableIndex()))
+             _actualOptSetInfo[blockNum]->get(listElem->getData()->getLocalIndex()))
             {
             removeFromList(listElem, _blockInfo[blockNum], prevElem);
             boundCheckKilledByOptList = true;
@@ -5673,7 +5673,7 @@ bool TR_ExceptionCheckMotion::analyzeBlockStructure(TR_BlockStructure *blockStru
             }
 
          if (nodeKilledByOptList || checkKilledByChild || genExprThatIsKilled ||
-             _actualOptSetInfo[blockNum]->get(listElem->getData()->getSideTableIndex()))
+             _actualOptSetInfo[blockNum]->get(listElem->getData()->getLocalIndex()))
             {
             removeFromList(listElem, _blockInfo[blockNum], prevElem);
             boundCheckKilledByOptList = true;
@@ -5695,7 +5695,7 @@ bool TR_ExceptionCheckMotion::analyzeBlockStructure(TR_BlockStructure *blockStru
       else if (opCode.isBndCheck() || opCode.isSpineCheck())
          {
          if (boundCheckKilledByOptList || checkKilledByChild || genExprThatIsKilled ||
-             _actualOptSetInfo[blockNum]->get(listElem->getData()->getSideTableIndex()))
+             _actualOptSetInfo[blockNum]->get(listElem->getData()->getLocalIndex()))
             {
             removeFromList(listElem, _blockInfo[blockNum], prevElem);
             nullCheckKilledByOptList = true;
@@ -5710,7 +5710,7 @@ bool TR_ExceptionCheckMotion::analyzeBlockStructure(TR_BlockStructure *blockStru
       else if (opCode.getOpCodeValue() == TR::DIVCHK)
          {
          if (divCheckKilledByOptList || checkKilledByChild || genExprThatIsKilled ||
-             _actualOptSetInfo[blockNum]->get(listElem->getData()->getSideTableIndex()))
+             _actualOptSetInfo[blockNum]->get(listElem->getData()->getLocalIndex()))
             {
             removeFromList(listElem, _blockInfo[blockNum], prevElem);
             nullCheckKilledByOptList = true;
@@ -5727,7 +5727,7 @@ bool TR_ExceptionCheckMotion::analyzeBlockStructure(TR_BlockStructure *blockStru
       else if (opCode.getOpCodeValue() == TR::ArrayStoreCHK)
          {
          if (arrayStoreCheckKilledByOptList || checkKilledByChild || genExprThatIsKilled ||
-             _actualOptSetInfo[blockNum]->get(listElem->getData()->getSideTableIndex()))
+             _actualOptSetInfo[blockNum]->get(listElem->getData()->getLocalIndex()))
             {
             removeFromList(listElem, _blockInfo[blockNum], prevElem);
             nullCheckKilledByOptList = true;
@@ -5741,7 +5741,7 @@ bool TR_ExceptionCheckMotion::analyzeBlockStructure(TR_BlockStructure *blockStru
       else if (opCode.getOpCodeValue() == TR::ArrayCHK)
          {
          if (arrayStoreCheckKilledByOptList || checkKilledByChild || genExprThatIsKilled ||
-             _actualOptSetInfo[blockNum]->get(listElem->getData()->getSideTableIndex()))
+             _actualOptSetInfo[blockNum]->get(listElem->getData()->getLocalIndex()))
             {
             removeFromList(listElem, _blockInfo[blockNum], prevElem);
             nullCheckKilledByOptList = true;
@@ -5756,7 +5756,7 @@ bool TR_ExceptionCheckMotion::analyzeBlockStructure(TR_BlockStructure *blockStru
          {
    bool alreadyRemoved = false;
          if (checkCastKilledByOptList || checkKilledByChild || genExprThatIsKilled ||
-             _actualOptSetInfo[blockNum]->get(listElem->getData()->getSideTableIndex()))
+             _actualOptSetInfo[blockNum]->get(listElem->getData()->getLocalIndex()))
             {
             removeFromList(listElem, _blockInfo[blockNum], prevElem);
             nullCheckKilledByOptList = true;
@@ -5772,7 +5772,7 @@ bool TR_ExceptionCheckMotion::analyzeBlockStructure(TR_BlockStructure *blockStru
          if (opCode.getOpCodeValue() == TR::checkcastAndNULLCHK)
       {
             if (nullCheckKilledByOptList || checkKilledByChild || genExprThatIsKilled ||
-                _actualOptSetInfo[blockNum]->get(listElem->getData()->getSideTableIndex()))
+                _actualOptSetInfo[blockNum]->get(listElem->getData()->getLocalIndex()))
                {
          if (!alreadyRemoved)
       {
@@ -5818,7 +5818,7 @@ bool TR_ExceptionCheckMotion::analyzeBlockStructure(TR_BlockStructure *blockStru
          TR::Node *listNode;
          for (listNode = genListIt.getFirst(); listNode != NULL;)
             {
-            traceMsg(comp(), " ,%d ", listNode->getSideTableIndex());
+            traceMsg(comp(), " ,%d ", listNode->getLocalIndex());
             listNode = genListIt.getNext();
             }
          traceMsg(comp(), "\n");
@@ -5837,7 +5837,7 @@ bool TR_ExceptionCheckMotion::checkIfNodeCanSomehowSurvive(TR::Node *node, Conta
       return true;
       }
 
-   if (!_exprsUnaffectedByOrder->get(node->getSideTableIndex()))
+   if (!_exprsUnaffectedByOrder->get(node->getLocalIndex()))
       {
       TR::ILOpCode &opCode = node->getOpCode();
 
@@ -5882,7 +5882,7 @@ bool TR_ExceptionCheckMotion::checkIfNodeCanSomehowSurvive(TR::Node *node, Conta
          break;
          }
       /*
-      else if (!_exprsUnaffectedByOrder->get(node->getSideTableIndex()))
+      else if (!_exprsUnaffectedByOrder->get(node->getLocalIndex()))
          {
          if (!checkIfNodeCanSurvive(child, nodesThatSurvive))
             {
@@ -5901,7 +5901,7 @@ bool TR_ExceptionCheckMotion::checkIfNodeCanSomehowSurvive(TR::Node *node, Conta
    if ((allChildrenSurvive) &&
        (node->getNumChildren() > 0))
       {
-      nodesThatSurvive->set(node->getSideTableIndex());
+      nodesThatSurvive->set(node->getLocalIndex());
       }
 
    return allChildrenSurvive;
@@ -5911,7 +5911,7 @@ bool TR_ExceptionCheckMotion::checkIfNodeCanSomehowSurvive(TR::Node *node, Conta
 
 bool TR_ExceptionCheckMotion::checkIfNodeCanSurvive(TR::Node *node, ContainerType *nodesThatSurvive)
    {
-   if ((node->getSideTableIndex() != MAX_SCOUNT) && (node->getSideTableIndex() != 0))
+   if ((node->getLocalIndex() != MAX_SCOUNT) && (node->getLocalIndex() != 0))
       {
       //
       //Survival cannot guaranteed when divisor is 0;
@@ -5922,7 +5922,7 @@ bool TR_ExceptionCheckMotion::checkIfNodeCanSurvive(TR::Node *node, ContainerTyp
            node->getOpCode().isRem()) &&
            isNodeValueZero(node->getSecondChild()))
          return false;
-      else if (nodesThatSurvive->get(node->getSideTableIndex()))
+      else if (nodesThatSurvive->get(node->getLocalIndex()))
          {
          return true;
          }
@@ -5946,9 +5946,9 @@ bool TR_ExceptionCheckMotion::checkIfNodeCanSurvive(TR::Node *node, ContainerTyp
 
 void TR_ExceptionCheckMotion::markNodeAsSurvivor(TR::Node *node, ContainerType *nodesThatSurvive)
    {
-   if ((node->getSideTableIndex() != MAX_SCOUNT) && (node->getSideTableIndex() != 0))
+   if ((node->getLocalIndex() != MAX_SCOUNT) && (node->getLocalIndex() != 0))
       {
-      nodesThatSurvive->set(node->getSideTableIndex());
+      nodesThatSurvive->set(node->getLocalIndex());
       }
    }
 
@@ -6260,23 +6260,23 @@ bool TR_RedundantExpressionAdjustment::analyzeBlockStructure(TR_BlockStructure *
          // blocks where this expression is redundant
          //
          if (trace())
-               traceMsg(comp(), "CONSIDERING Expr %d (representative) Node %p (listElem %p) in Block : %d\n", listElem->getData()->getSideTableIndex(), listElem->getData(), listElem, blockNum);
-         if (/*_optSetHelper->get(listElem->getData()->getSideTableIndex()) || */
-             ((optimisticRednSetInfo[blockNum]->get(listElem->getData()->getSideTableIndex())) &&
-             (!_currentInSetInfo->get(listElem->getData()->getSideTableIndex())) &&
-             (!actualOptSetInfo[blockNum]->get(listElem->getData()->getSideTableIndex()))))
+               traceMsg(comp(), "CONSIDERING Expr %d (representative) Node %p (listElem %p) in Block : %d\n", listElem->getData()->getLocalIndex(), listElem->getData(), listElem, blockNum);
+         if (/*_optSetHelper->get(listElem->getData()->getLocalIndex()) || */
+             ((optimisticRednSetInfo[blockNum]->get(listElem->getData()->getLocalIndex())) &&
+             (!_currentInSetInfo->get(listElem->getData()->getLocalIndex())) &&
+             (!actualOptSetInfo[blockNum]->get(listElem->getData()->getLocalIndex()))))
             {
             if (trace())
-               traceMsg(comp(), "IN ORDER Expr %d (representative) Node %p (listElem %p) in Block : %d\n", listElem->getData()->getSideTableIndex(), listElem->getData(), listElem, blockNum);
+               traceMsg(comp(), "IN ORDER Expr %d (representative) Node %p (listElem %p) in Block : %d\n", listElem->getData()->getLocalIndex(), listElem->getData(), listElem, blockNum);
 
-            actualOptSetInfo[blockNum]->set(listElem->getData()->getSideTableIndex());
-            _regularGenSetInfo[blockNum]->set(listElem->getData()->getSideTableIndex());
-            _exceptionGenSetInfo[blockNum]->set(listElem->getData()->getSideTableIndex());
-            _optSetHelper->reset(listElem->getData()->getSideTableIndex());
+            actualOptSetInfo[blockNum]->set(listElem->getData()->getLocalIndex());
+            _regularGenSetInfo[blockNum]->set(listElem->getData()->getLocalIndex());
+            _exceptionGenSetInfo[blockNum]->set(listElem->getData()->getLocalIndex());
+            _optSetHelper->reset(listElem->getData()->getLocalIndex());
 
             if (trace())
-               traceMsg(comp(), "Affected by order <%d> will be at index %d\n", listElem->getData()->getSideTableIndex(), j);
-            orderedOptNumbersList[blockNum][j++] = listElem->getData()->getSideTableIndex();
+               traceMsg(comp(), "Affected by order <%d> will be at index %d\n", listElem->getData()->getLocalIndex(), j);
+            orderedOptNumbersList[blockNum][j++] = listElem->getData()->getLocalIndex();
             }
 
          if ((prevElem && (prevElem->getNextElement() == listElem)) || (genSetInfo[blockNum]->getListHead() == listElem))
@@ -6338,7 +6338,7 @@ bool TR_RedundantExpressionAdjustment::analyzeBlockStructure(TR_BlockStructure *
           (branch->getSecondChild()->getAddress() == 0))
          {
          TR::Node *nullCheckReference = branch->getFirstChild();
-         scount_t nullCheckReferenceIndex = nullCheckReference->getSideTableIndex();
+         scount_t nullCheckReferenceIndex = nullCheckReference->getLocalIndex();
          if (((nullCheckReferenceIndex != MAX_SCOUNT) && (nullCheckReferenceIndex != 0)))
             {
             if (_regularInfo->get(nullCheckReferenceIndex))
@@ -6351,7 +6351,7 @@ bool TR_RedundantExpressionAdjustment::analyzeBlockStructure(TR_BlockStructure *
                   TR::Node *nextOptimalNode = supportedNodesAsArray[j];
                   if (nextOptimalNode->getOpCodeValue() == TR::NULLCHK)
                      {
-                     if (nextOptimalNode->getNullCheckReference()->getSideTableIndex() == nullCheckReferenceIndex)
+                     if (nextOptimalNode->getNullCheckReference()->getLocalIndex() == nullCheckReferenceIndex)
                         {
                         nullCheckNumber = j;
                         if (branch->getOpCodeValue() == TR::ifacmpne)

--- a/compiler/optimizer/PartialRedundancy.hpp
+++ b/compiler/optimizer/PartialRedundancy.hpp
@@ -114,7 +114,7 @@ class TR_PartialRedundancy : public TR::Optimization
    bool _loadaddrPRE;
    bool _ignoreLoadaddrOfLitPool;
 
-   private: // side table index -> common node
+   private: // local index -> common node
 
   };
 

--- a/compiler/optimizer/ReachingDefinitions.cpp
+++ b/compiler/optimizer/ReachingDefinitions.cpp
@@ -190,7 +190,7 @@ void TR_ReachingDefinitions::initializeGenAndKillSetInfoForNode(TR::Node *node, 
       }
 
    bool irrelevantStore = false;
-   scount_t nodeIndex = node->getSideTableIndex();
+   scount_t nodeIndex = node->getLocalIndex();
    if (nodeIndex <= 0)
       {
       if (node->getOpCode().isStore() &&
@@ -226,7 +226,7 @@ void TR_ReachingDefinitions::initializeGenAndKillSetInfoForNode(TR::Node *node, 
       {
       symRef = node->getSymbolReference();
       sym = symRef->getSymbol();
-      symIndex = symRef->getSymbol()->getSideTableIndex();
+      symIndex = symRef->getSymbol()->getLocalIndex();
       num_aliases = _useDefInfo->getNumAliases(symRef, _aux);
       }
 
@@ -320,7 +320,7 @@ void TR_ReachingDefinitions::initializeGenAndKillSetInfoForNode(TR::Node *node, 
       }
    else // fake up the method entry def as the def index to "gen" to avoid a use without a def completely
       {
-      _regularGenSetInfo[blockNum]->set(sym->getSideTableIndex());
-      _exceptionGenSetInfo[blockNum]->set(sym->getSideTableIndex());
+      _regularGenSetInfo[blockNum]->set(sym->getLocalIndex());
+      _exceptionGenSetInfo[blockNum]->set(sym->getLocalIndex());
       }
    }

--- a/compiler/optimizer/RedundantAsyncCheckRemoval.cpp
+++ b/compiler/optimizer/RedundantAsyncCheckRemoval.cpp
@@ -1648,7 +1648,7 @@ uint32_t TR_LoopEstimator::estimateLoopIterationsUpperBound()
          //
          if (!candidates.isSet(refNum))
             {
-            symRef->getSymbol()->setSideTableIndex(index);
+            symRef->getSymbol()->setLocalIndex(index);
             candidates.set(refNum);
             index++;
             }
@@ -1659,7 +1659,7 @@ uint32_t TR_LoopEstimator::estimateLoopIterationsUpperBound()
 
          if (trace())
             traceMsg(comp(), "found candidate symbol #%d (%d) in condition block_%d\n",
-                        refNum, symRef->getSymbol()->getSideTableIndex(), edge->getFrom()->getNumber());
+                        refNum, symRef->getSymbol()->getLocalIndex(), edge->getFrom()->getNumber());
          }
       else
          {
@@ -1709,7 +1709,7 @@ uint32_t TR_LoopEstimator::estimateLoopIterationsUpperBound()
    for (ExitCondition *cond = it.getCurrent(); cond; cond = it.getNext())
       {
       uint32_t refNum = cond->_local->getReferenceNumber();
-      uint32_t refIndex = cond->_local->getSymbol()->getSideTableIndex();
+      uint32_t refIndex = cond->_local->getSymbol()->getLocalIndex();
 
       // make sure this is still a candidate
       //
@@ -1930,7 +1930,7 @@ void TR_LoopEstimator::processBlock(TR::Block *block, TR_BitVector &candidates)
          {
          TR::SymbolReference *symRef = node->getSymbolReference();
          uint32_t refNum = symRef->getReferenceNumber();
-         uint32_t refIndex = symRef->getSymbol()->getSideTableIndex();
+         uint32_t refIndex = symRef->getSymbol()->getLocalIndex();
 
          if (candidates.isSet(refNum))
             {

--- a/compiler/optimizer/Structure.cpp
+++ b/compiler/optimizer/Structure.cpp
@@ -2434,7 +2434,7 @@ TR_SequenceStructure::hoistInvariantsOutOfNestedLoops(
                            {
                            if (currentTree->getNode()->getOpCode().isCheck())
                               {
-                              if (currentTree->getNode()->getSideTableIndex() == nextOptimalComputation)
+                              if (currentTree->getNode()->getLocalIndex() == nextOptimalComputation)
                                  {
                                  treeToBeHoisted = currentTree;
                                  break;
@@ -2446,7 +2446,7 @@ TR_SequenceStructure::hoistInvariantsOutOfNestedLoops(
 
                               if (currentNode->getSymbolReference()->getSymbol()->isAuto())
                                  {
-                                 if (currentNode->getFirstChild()->getSideTableIndex() == nextOptimalComputation)
+                                 if (currentNode->getFirstChild()->getLocalIndex() == nextOptimalComputation)
                                     {
                                     treeToBeHoisted = currentTree;
                                     break;
@@ -2572,7 +2572,7 @@ TR_RegionStructure::hoistInvariantsOutOfNestedLoops(
                             {
                             if (currentTree->getNode()->getOpCode().isCheck())
                                {
-                               if (currentTree->getNode()->getSideTableIndex() == nextOptimalComputation)
+                               if (currentTree->getNode()->getLocalIndex() == nextOptimalComputation)
                                   {
                                   treeToBeHoisted = currentTree;
                                   break;
@@ -2584,7 +2584,7 @@ TR_RegionStructure::hoistInvariantsOutOfNestedLoops(
 
                                if (currentNode->getSymbolReference()->getSymbol()->isAuto())
                                    {
-                                  if (currentNode->getFirstChild()->getSideTableIndex() == nextOptimalComputation)
+                                  if (currentNode->getFirstChild()->getLocalIndex() == nextOptimalComputation)
                                      {
                                      treeToBeHoisted = currentTree;
                                      break;

--- a/compiler/optimizer/UseDefInfo.hpp
+++ b/compiler/optimizer/UseDefInfo.hpp
@@ -89,7 +89,7 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
              _onceWrittenSymbolsIndices(c->allocator("UseDefAux"), TR::SparseBitVector(c->allocator("UseDefAux"))),
              _onceReadSymbolsIndices(c->allocator("UseDefAux"), TR::SparseBitVector(c->allocator("UseDefAux"))),
              _nodeSideTableToSymRefNumMap(c->allocator("UseDefAux")),
-             _symRefToSideTableIndexMap(c->allocator("UseDefAux")),
+             _symRefToLocalIndexMap(c->allocator("UseDefAux")),
              _expandedAtoms(c->allocator("UseDefAux"), CS2::Pair<TR::Node *, TR::TreeTop *>(NULL, NULL)),
              _sideTableToUseDefMap(c->allocator("UseDefAux")),
              _numAliases(c->allocator("UseDefAux")),
@@ -102,7 +102,7 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
       CS2::ArrayOf<BitVector,TR::Allocator> _onceWrittenSymbols;
       // defsForSymbol are known definitions of the symbol
       CS2::ArrayOf<BitVector, TR::Allocator> _defsForSymbol;
-      CS2::ArrayOf<TR::SparseBitVector, TR::Allocator> _symsKilledByMustKills;    // symbol sideTableIndex killed by function call due to mustDef
+      CS2::ArrayOf<TR::SparseBitVector, TR::Allocator> _symsKilledByMustKills;    // symbol localIndex killed by function call due to mustDef
       TR::BitVector _neverReadSymbols;
       TR::BitVector _neverReferencedSymbols;
       TR::BitVector _neverWrittenSymbols;
@@ -111,7 +111,7 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
       CS2::ArrayOf<TR::SparseBitVector, TR::Allocator> _onceReadSymbolsIndices;
 
       CS2::ArrayOf<int32_t, TR::Allocator>             _nodeSideTableToSymRefNumMap;
-      CS2::ArrayOf<uint32_t, TR::Allocator>            _symRefToSideTableIndexMap;
+      CS2::ArrayOf<uint32_t, TR::Allocator>            _symRefToLocalIndexMap;
       CS2::ArrayOf<CS2::Pair<TR::Node *, TR::TreeTop *>, TR::Allocator> _expandedAtoms;    //TR::Node            **_expandedNodes;
 
 
@@ -364,9 +364,9 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
       {
       uint32_t         _size;
       uint32_t         _offset;
-      int32_t          _sideTableIndex;
+      int32_t          _localIndex;
 
-      MemorySymbol(uint32_t size, uint32_t offset, int32_t sideTableIndex) : _size(size), _offset(offset), _sideTableIndex(sideTableIndex) {}
+      MemorySymbol(uint32_t size, uint32_t offset, int32_t localIndex) : _size(size), _offset(offset), _localIndex(localIndex) {}
 
       friend class TR_UseDefInfo;
       };

--- a/compiler/optimizer/VirtualGuardCoalescer.cpp
+++ b/compiler/optimizer/VirtualGuardCoalescer.cpp
@@ -677,7 +677,7 @@ TR_VirtualGuardTailSplitter::VGInfo *TR_VirtualGuardTailSplitter::recognizeVirtu
    TR::list<TR::CFGEdge*> &succ = block->getSuccessors();
    if (!(succ.size() == 2))
       {
-      block->getLastRealTreeTop()->getNode()->setSideTableIndex(MALFORMED_GUARD);
+      block->getLastRealTreeTop()->getNode()->setLocalIndex(MALFORMED_GUARD);
       return 0;
       }
 
@@ -729,7 +729,7 @@ TR_VirtualGuardTailSplitter::VGInfo *TR_VirtualGuardTailSplitter::recognizeVirtu
 
       if (!allowSplit)
          {
-         guardNode->setSideTableIndex(MALFORMED_GUARD);
+         guardNode->setLocalIndex(MALFORMED_GUARD);
          return 0;
          }
       }
@@ -741,7 +741,7 @@ TR_VirtualGuardTailSplitter::VGInfo *TR_VirtualGuardTailSplitter::recognizeVirtu
    /////if (!call /* || !call->getExceptionSuccessors().empty() */)
    if (!call || !(call->getSuccessors().size() == 1))
       {
-      block->getLastRealTreeTop()->getNode()->setSideTableIndex(MALFORMED_GUARD);
+      block->getLastRealTreeTop()->getNode()->setLocalIndex(MALFORMED_GUARD);
       return 0;
       }
 
@@ -753,7 +753,7 @@ TR_VirtualGuardTailSplitter::VGInfo *TR_VirtualGuardTailSplitter::recognizeVirtu
    bool invalidMergeBlock = ( merge == _cfg->getEnd() || merge->getPredecessors().size() > 2);
    if (invalidMergeBlock)
       {
-      block->getLastRealTreeTop()->getNode()->setSideTableIndex(MALFORMED_GUARD);
+      block->getLastRealTreeTop()->getNode()->setLocalIndex(MALFORMED_GUARD);
       return 0;
       }
 
@@ -802,7 +802,7 @@ void TR_VirtualGuardTailSplitter::putGuard(uint32_t index, VGInfo *info)
    TR::Block *branch = info->getBranchBlock();
    TR::Node  *node   = branch->getLastRealTreeTop()->getNode();
 
-   node->setSideTableIndex(index);
+   node->setLocalIndex(index);
    _table[index] = info;
    }
 

--- a/compiler/optimizer/VirtualGuardCoalescer.hpp
+++ b/compiler/optimizer/VirtualGuardCoalescer.hpp
@@ -100,7 +100,7 @@ class TR_VirtualGuardTailSplitter : public TR::Optimization
 
       VGInfo *getParent() { return _parent; }
 
-      scount_t getIndex() { return _branch->getLastRealTreeTop()->getNode()->getSideTableIndex(); }
+      scount_t getIndex() { return _branch->getLastRealTreeTop()->getNode()->getLocalIndex(); }
       uint32_t getNumber() { return _branch->getNumber(); }
 
       private:
@@ -146,7 +146,7 @@ class TR_VirtualGuardTailSplitter : public TR::Optimization
    vcount_t  _visitCount;
    VGInfo *getGuard(uint32_t index)   { return index == MALFORMED_GUARD ? NULL : _table[index]; }
    VGInfo *getGuard(TR::Block *branch) { return getGuard(branch->getLastRealTreeTop()->getNode()); }
-   VGInfo *getGuard(TR::Node  *branch) { return getGuard(branch->getSideTableIndex()); }
+   VGInfo *getGuard(TR::Node  *branch) { return getGuard(branch->getLocalIndex()); }
    void    putGuard(uint32_t index, VGInfo *info);
    VGInfo **_table;
    bool _splitDone;

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -4626,7 +4626,7 @@ void TR_Debug::dumpSimulatedNode(TR::Node *node, char tagChar)
       }
    else if (node->getReferenceCount() >= 1)
       {
-      trfprintf(_file, "%2d/%-2d", node->getSideTableIndex(), node->getReferenceCount());
+      trfprintf(_file, "%2d/%-2d", node->getLocalIndex(), node->getReferenceCount());
       }
    else
       {

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -78,7 +78,7 @@ extern int32_t addressWidth;
 void
 TR_Debug::printTopLegend(TR::FILE *pOutFile)
    {
-   //-index--|--------------------------------------node---------------------------------------|--address---|-----bci-----|-rc-|-vc-|-vn-|--sti--|-udi-|-nc-|--sa--
+   //-index--|--------------------------------------node---------------------------------------|--address---|-----bci-----|-rc-|-vc-|-vn-|--li--|-udi-|-nc-|--sa--
 
    if (pOutFile == NULL) return;
 
@@ -104,7 +104,7 @@ TR_Debug::printBottomLegend(TR::FILE *pOutFile)
    trfprintf(pOutFile,    "rc:          reference count\n"
                               "vc:          visit count\n"
                               "vn:          value number\n"
-                              "sti:         side table index\n"
+                              "li:          local index\n"
                               "udi:         use/def index\n"
                               "nc:          number of children\n"
                               "addr:        address size in bytes\n"
@@ -1558,10 +1558,10 @@ TR_Debug::printBasicPostNodeInfo(TR::FILE *pOutFile, TR::Node * node, uint32_t i
    else
       output.append(" vn=-");
 
-   if ((node->hasOptAttributes()) && (node->getSideTableIndex()))
-      output.append(" sti=%d", node->getSideTableIndex());
+   if ((node->hasOptAttributes()) && (node->getLocalIndex()))
+      output.append(" li=%d", node->getLocalIndex());
    else
-      output.append(" sti=-");
+      output.append(" li=-");
 
    if (node->hasOptAttributes() && node->getUseDefIndex())
       output.append(" udi=%d", node->getUseDefIndex());
@@ -3607,7 +3607,7 @@ TR_Debug::verifyTrees(TR::ResolvedMethodSymbol *methodSymbol)
    for (tt = firstTree; tt; tt = tt->getNextTreeTop())
       {
       TR::Node * node = tt->getNode();
-      node->setSideTableIndex(0);
+      node->setLocalIndex(0);
       verifyTreesPass1(node);
       }
 
@@ -3623,7 +3623,7 @@ TR_Debug::verifyTrees(TR::ResolvedMethodSymbol *methodSymbol)
    }
 
 // Node verification. This is done in 2 passes. In pass 1 the reference count is
-// accumulated in the node's sideTableIndex. In pass 2 the reference count is checked.
+// accumulated in the node's localIndex. In pass 2 the reference count is checked.
 //
 void
 TR_Debug::verifyTreesPass1(TR::Node *node)
@@ -3641,12 +3641,12 @@ TR_Debug::verifyTreesPass1(TR::Node *node)
          if (_nodeChecklist.isSet(child->getGlobalIndex()))
             {
             // Just inc simulated ref count
-            child->incSideTableIndex();
+            child->incLocalIndex();
             }
          else
             {
             // Initialize simulated ref count and visit it
-            child->setSideTableIndex(1);
+            child->setLocalIndex(1);
             verifyTreesPass1(child);
             }
 
@@ -3697,7 +3697,7 @@ TR_Debug::verifyTreesPass2(TR::Node *node, bool isTreeTop)
    {
    // *this    swipeable for debugging purposes
 
-   // Verify the reference count. Pass 1 should have set the sideTableIndex to the
+   // Verify the reference count. Pass 1 should have set the localIndex to the
    // reference count.
    //
    if (!_nodeChecklist.isSet(node->getGlobalIndex()))
@@ -3728,15 +3728,15 @@ TR_Debug::verifyTreesPass2(TR::Node *node, bool isTreeTop)
          TR_ASSERT( debug("fixTrees"), "Tree verification error");
          }
 
-      if (node->getReferenceCount() != node->getSideTableIndex())
+      if (node->getReferenceCount() != node->getLocalIndex())
          {
          if (getFile() != NULL)
             trfprintf(getFile(), "TREE VERIFICATION ERROR -- node [%s] ref count is %d and should be %d\n",
-                 getName(node), node->getReferenceCount(), node->getSideTableIndex());
+                 getName(node), node->getReferenceCount(), node->getLocalIndex());
          TR_ASSERT(debug("fixTrees"), "Tree verification error");
          // if there is logging, don't fix the ref count!
          if (getFile() == NULL)
-            node->setReferenceCount(node->getSideTableIndex());
+            node->setReferenceCount(node->getLocalIndex());
          }
       }
    }
@@ -3820,13 +3820,13 @@ TR_Debug::verifyBlocks(TR::ResolvedMethodSymbol * methodSymbol)
          {
          TR_ASSERT( tt, "TreeTop problem in verifyBlocks");
          TR::Node *node = tt->getNode();
-         node->setSideTableIndex(node->getReferenceCount());
+         node->setLocalIndex(node->getReferenceCount());
          verifyBlocksPass1(node);
          }
 
       _nodeChecklist.empty();
 
-      // go back to the start of the block, and check the sideTableIndex to make sure it is 0
+      // go back to the start of the block, and check the localIndex to make sure it is 0
       // do not walk the tree backwards as this causes huge stack usage in verifyBlocksPass2
       _nodeChecklist.empty();
       for (tt = firstTreeTop; tt != exitTreeTop->getNextTreeTop(); tt = tt->getNextTreeTop())
@@ -3854,12 +3854,12 @@ TR_Debug::verifyBlocksPass1(TR::Node *node)
          if (_nodeChecklist.isSet(child->getGlobalIndex()))
             {
             // If the child has already been visited, decrement its verifyRefCount.
-            child->decSideTableIndex();
+            child->decLocalIndex();
             }
          else
             {
-            // If the child has not yet been visited, set its sideTableIndex and visit it
-            child->setSideTableIndex(child->getReferenceCount() - 1);
+            // If the child has not yet been visited, set its localIndex and visit it
+            child->setLocalIndex(child->getReferenceCount() - 1);
             verifyBlocksPass1(child);
             }
          }
@@ -3871,7 +3871,7 @@ TR_Debug::verifyBlocksPass2(TR::Node *node)
    {
    // *this    swipeable for debugging purposes
 
-   // Pass through and make sure that the sideTableIndex == 0 for each child
+   // Pass through and make sure that the localIndex == 0 for each child
    //
 
    if (!_nodeChecklist.isSet(node->getGlobalIndex()))
@@ -3880,11 +3880,11 @@ TR_Debug::verifyBlocksPass2(TR::Node *node)
       for (int32_t i = node->getNumChildren() - 1; i >= 0; --i)
          verifyBlocksPass2(node->getChild(i));
 
-      if (node->getSideTableIndex() != 0)
+      if (node->getLocalIndex() != 0)
          {
          char buffer[100];
          sprintf(buffer, "BLOCK VERIFICATION ERROR -- node [%s] accessed outside of its (extended) basic block: %d time(s)",
-                 getName(node), node->getSideTableIndex());
+                 getName(node), node->getLocalIndex());
          if (getFile() != NULL)
             trfprintf(getFile(), buffer);
          TR_ASSERT( debug("fixTrees"), buffer);


### PR DESCRIPTION
The SideTableIndex isn't actually used to index a side table
most of the time, but rather is  used to hold optimization-local
data.

Rename methods getSideTableIndex, setSideTableIndex,
incSideTableIndex, and decSideTableIndex (definitions and uses).

Rename SideTableIndex variables, comments, and TR_ASSERT messages.

Signed-off-by: Aman Kumar <amank@ca.ibm.com>