### PR TITLE
Add `lint` make target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ addons:
        - bison
        - gcc-multilib
        - g++-multilib
+       - clang-3.4
+       - libclang-3.4-dev
+       - llvm-3.4
 
 before_script:
   - ulimit -c unlimited
@@ -62,5 +65,5 @@ matrix:
 
 script:
   - make -f run_configure.mk OMRGLUE=./example/glue
-  - make && make test
+  - make && make test && ([ "$SPEC" != "linux_x86-64" ] || make lint)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,8 @@ will help us to merge your pull requests smoothly:
 3. Follow the coding style and format of the code you are modifying (see the
    [coding standards](doc/CodingStandard.md)).
 4. Follow the commit guidelines found below.
-5. Ensure that "make test" passes all tests before you submit a Pull Request.
+5. Ensure that `make test` passes all tests and `make lint` passes before you
+   submit a Pull Request.
 
 ## Commit Guidelines
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -33,6 +33,7 @@ help:
 	@echo "all    Build OMR."
 	@echo "clean  Clean OMR build artifacts."
 	@echo "test   Run functional verification tests."
+	@echo "lint   Run the OMR linter."
 .PHONY: help
 
 ###
@@ -261,6 +262,10 @@ clean: $(targets_clean) hook_definition_sentinel_clean
 $(targets_clean)::
 	$(MAKE) -C $(patsubst %_clean,%,$@) clean
 .PHONY: $(targets_clean)
+
+lint:
+	$(MAKE) -C fvtest/compilertest -f linter.mk
+.PHONY: lint
 
 test:
 ifeq (yes,$(ENABLE_FVTEST))


### PR DESCRIPTION
Add an `lint` make target. This target builds and runs the OMR linter.

The OMR linter checks for common pitfalls, such as not using `self()->` when accessing methods of extensible classes from within another method of the class. Enabling the linter as a make target allows the linter to be more easily run, and can be easily integrated into continuous integration systems.

This PR also enables running the linter in Travis CI. It is currently only run on one build, since I do not believe linting the small amount of code different between x86-64 and x86 is worth slowing down more Travis CI builds for.