### PR TITLE
Add byteClobberEvaluator on x86

### DIFF
--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -2084,6 +2084,12 @@ TR::Register *OMR::X86::CodeGenerator::shortClobberEvaluate(TR::Node * node)
    return self()->gprClobberEvaluate(node, MOV2RegReg);
    }
 
+TR::Register *OMR::X86::CodeGenerator::byteClobberEvaluate(TR::Node * node)
+   {
+   TR_ASSERT(node->getOpCode().is1Byte(), "only use byteClobberEvaluate for byte");
+   return self()->gprClobberEvaluate(node, MOV1RegReg);
+   }
+
 TR::Register *OMR::X86::CodeGenerator::floatClobberEvaluate(TR::Node * node)
    {
 

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -356,6 +356,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    void processClobberingInstructions(TR_ClobberingInstruction * clobInstructionCursor, TR::Instruction *instructionCursor);
 
    // different from evaluateNode in that it returns a clobberable register
+   TR::Register *byteClobberEvaluate(TR::Node *node);
    TR::Register *shortClobberEvaluate(TR::Node *node);
    TR::Register *intClobberEvaluate(TR::Node *node);
    virtual TR::Register *longClobberEvaluate(TR::Node *node)=0;


### PR DESCRIPTION
There are int/long/short clobberEvaluate already and
this changeset just adds one more for byte.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>