### PR TITLE
Move TR_*Instruction into TR namespace

### DIFF
--- a/compiler/arm/codegen/ARMBinaryEncoding.cpp
+++ b/compiler/arm/codegen/ARMBinaryEncoding.cpp
@@ -88,7 +88,7 @@ uint32_t encodeHelperBranch(bool isBranchAndLink, TR::SymbolReference *symRef, u
    return (isBranchAndLink ? 0x0B000000 : 0x0A000000) | encodeBranchDistance((uintptr_t) cursor, target) | (((uint32_t) cc) << 28);
    }
 
-uint8_t *TR_ARMLabelInstruction::generateBinaryEncoding()
+uint8_t *TR::ARMLabelInstruction::generateBinaryEncoding()
    {
    uint8_t        *instructionStart = cg()->getBinaryBufferCursor();
    TR::LabelSymbol *label            = getLabelSymbol();
@@ -128,7 +128,7 @@ uint8_t *TR_ARMLabelInstruction::generateBinaryEncoding()
    return cursor;
    }
 
-int32_t TR_ARMLabelInstruction::estimateBinaryLength(int32_t currentEstimate)
+int32_t TR::ARMLabelInstruction::estimateBinaryLength(int32_t currentEstimate)
    {
    if (getOpCode().isLabel()) // LABEL
       {
@@ -145,17 +145,17 @@ int32_t TR_ARMLabelInstruction::estimateBinaryLength(int32_t currentEstimate)
 // Conditional branches are just like label instructions but have their
 // CC set - for now, simply forward - TODO remove entirely.
 
-uint8_t *TR_ARMConditionalBranchInstruction::generateBinaryEncoding()
+uint8_t *TR::ARMConditionalBranchInstruction::generateBinaryEncoding()
    {
-   return TR_ARMLabelInstruction::generateBinaryEncoding();
+   return TR::ARMLabelInstruction::generateBinaryEncoding();
    }
 
-int32_t TR_ARMConditionalBranchInstruction::estimateBinaryLength(int32_t currentEstimate)
+int32_t TR::ARMConditionalBranchInstruction::estimateBinaryLength(int32_t currentEstimate)
    {
-   return TR_ARMLabelInstruction::estimateBinaryLength(currentEstimate);
+   return TR::ARMLabelInstruction::estimateBinaryLength(currentEstimate);
    }
 
-uint8_t *TR_ARMAdminInstruction::generateBinaryEncoding()
+uint8_t *TR::ARMAdminInstruction::generateBinaryEncoding()
    {
    uint8_t  *instructionStart = cg()->getBinaryBufferCursor();
    uint32_t i;
@@ -196,13 +196,13 @@ uint8_t *TR_ARMAdminInstruction::generateBinaryEncoding()
    return instructionStart;
    }
 
-int32_t TR_ARMAdminInstruction::estimateBinaryLength(int32_t currentEstimate)
+int32_t TR::ARMAdminInstruction::estimateBinaryLength(int32_t currentEstimate)
    {
    setEstimatedBinaryLength(0);
    return currentEstimate;
    }
 
-uint8_t *TR_ARMImmInstruction::generateBinaryEncoding()
+uint8_t *TR::ARMImmInstruction::generateBinaryEncoding()
    {
    TR::Compilation *comp = cg()->comp();
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
@@ -244,7 +244,7 @@ uint8_t *TR_ARMImmInstruction::generateBinaryEncoding()
    return cursor;
    }
 
-uint8_t *TR_ARMImmSymInstruction::generateBinaryEncoding()
+uint8_t *TR::ARMImmSymInstruction::generateBinaryEncoding()
    {
    TR::Compilation *comp = TR::comp();
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
@@ -359,7 +359,7 @@ uint8_t *TR_ARMImmSymInstruction::generateBinaryEncoding()
    return cursor;
    }
 
-int32_t TR_ARMImmSymInstruction::estimateBinaryLength(int32_t currentEstimate)
+int32_t TR::ARMImmSymInstruction::estimateBinaryLength(int32_t currentEstimate)
    {
    // *this   swipeable for debugging purposes
    int32_t length;
@@ -375,7 +375,7 @@ int32_t TR_ARMImmSymInstruction::estimateBinaryLength(int32_t currentEstimate)
    return(currentEstimate + length);
    }
 
-uint8_t *TR_ARMTrg1Instruction::generateBinaryEncoding()
+uint8_t *TR::ARMTrg1Instruction::generateBinaryEncoding()
    {
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
@@ -388,7 +388,7 @@ uint8_t *TR_ARMTrg1Instruction::generateBinaryEncoding()
    return cursor;
    }
 
-uint8_t *TR_ARMTrg1Src2Instruction::generateBinaryEncoding()
+uint8_t *TR::ARMTrg1Src2Instruction::generateBinaryEncoding()
    {
    TR::Compilation *comp = cg()->comp();
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
@@ -416,7 +416,7 @@ uint8_t *TR_ARMTrg1Src2Instruction::generateBinaryEncoding()
    return cursor;
    }
 
-uint8_t *TR_ARMLoadStartPCInstruction::generateBinaryEncoding()
+uint8_t *TR::ARMLoadStartPCInstruction::generateBinaryEncoding()
    {
    /* Calculates the offset from the current instruction to startPCAddr, then set it to the operand2 */
    uint8_t *startPCAddr = (uint8_t *)getSymbolReference()->getSymbol()->getStaticSymbol()->getStaticAddress();
@@ -434,7 +434,7 @@ uint8_t *TR_ARMLoadStartPCInstruction::generateBinaryEncoding()
       getNext()->remove();
       getNext()->remove();
 
-      return TR_ARMTrg1Src2Instruction::generateBinaryEncoding();
+      return TR::ARMTrg1Src2Instruction::generateBinaryEncoding();
       }
    else
       {
@@ -447,14 +447,14 @@ uint8_t *TR_ARMLoadStartPCInstruction::generateBinaryEncoding()
          TR_ARMOperand2 *op2_1 = new (cg()->trHeapMemory()) TR_ARMOperand2((base >> 8) & 0x000000FF, 8 + bitTrailing);
          TR_ARMOperand2 *op2_0 = new (cg()->trHeapMemory()) TR_ARMOperand2(base & 0x000000FF, bitTrailing);
          setSource2Operand(op2_1);
-         TR_ARMTrg1Src2Instruction *secondInstruction = (TR_ARMTrg1Src2Instruction *)getNext();
+         TR::ARMTrg1Src2Instruction *secondInstruction = (TR::ARMTrg1Src2Instruction *)getNext();
          secondInstruction->setSource2Operand(op2_0);
 
          /* Remove the trailing 2 Trg1Src2Instructions */
          secondInstruction->getNext()->remove();
          secondInstruction->getNext()->remove();
 
-         return TR_ARMTrg1Src2Instruction::generateBinaryEncoding();
+         return TR::ARMTrg1Src2Instruction::generateBinaryEncoding();
          }
       else
          {
@@ -465,22 +465,22 @@ uint8_t *TR_ARMLoadStartPCInstruction::generateBinaryEncoding()
          TR_ARMOperand2 *op2_0 = new (cg()->trHeapMemory()) TR_ARMOperand2(localVal.getByte0(), 0);
 
          setSource2Operand(op2_3);
-         TR_ARMTrg1Src2Instruction *secondInstruction = (TR_ARMTrg1Src2Instruction *)getNext();
+         TR::ARMTrg1Src2Instruction *secondInstruction = (TR::ARMTrg1Src2Instruction *)getNext();
          secondInstruction->setSource2Operand(op2_2);
 
-         TR_ARMTrg1Src2Instruction *thirdInstruction = (TR_ARMTrg1Src2Instruction *)secondInstruction->getNext();
+         TR::ARMTrg1Src2Instruction *thirdInstruction = (TR::ARMTrg1Src2Instruction *)secondInstruction->getNext();
          thirdInstruction->setSource2Operand(op2_1);
 
-         TR_ARMTrg1Src2Instruction *fourthInstruction = (TR_ARMTrg1Src2Instruction *)thirdInstruction->getNext();
+         TR::ARMTrg1Src2Instruction *fourthInstruction = (TR::ARMTrg1Src2Instruction *)thirdInstruction->getNext();
          fourthInstruction->setSource2Operand(op2_0);
 
-         return TR_ARMTrg1Src2Instruction::generateBinaryEncoding();
+         return TR::ARMTrg1Src2Instruction::generateBinaryEncoding();
          }
       }
    }
 
 #if defined(__VFP_FP__) && !defined(__SOFTFP__)
-uint8_t *TR_ARMTrg2Src1Instruction::generateBinaryEncoding()
+uint8_t *TR::ARMTrg2Src1Instruction::generateBinaryEncoding()
    {
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
@@ -496,7 +496,7 @@ uint8_t *TR_ARMTrg2Src1Instruction::generateBinaryEncoding()
    }
 #endif
 
-uint8_t *TR_ARMMulInstruction::generateBinaryEncoding()
+uint8_t *TR::ARMMulInstruction::generateBinaryEncoding()
    {
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
@@ -511,7 +511,7 @@ uint8_t *TR_ARMMulInstruction::generateBinaryEncoding()
    return cursor;
    }
 
-uint8_t *TR_ARMMemInstruction::generateBinaryEncoding()
+uint8_t *TR::ARMMemInstruction::generateBinaryEncoding()
    {
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
@@ -525,13 +525,13 @@ uint8_t *TR_ARMMemInstruction::generateBinaryEncoding()
    return cursor;
    }
 
-int32_t TR_ARMMemInstruction::estimateBinaryLength(int32_t currentEstimate)
+int32_t TR::ARMMemInstruction::estimateBinaryLength(int32_t currentEstimate)
    {
    setEstimatedBinaryLength(getMemoryReference()->estimateBinaryLength(getOpCodeValue()));
    return(currentEstimate + getEstimatedBinaryLength());
    }
 
-uint8_t *TR_ARMTrg1MemSrc1Instruction::generateBinaryEncoding()
+uint8_t *TR::ARMTrg1MemSrc1Instruction::generateBinaryEncoding()
    {
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
@@ -546,7 +546,7 @@ uint8_t *TR_ARMTrg1MemSrc1Instruction::generateBinaryEncoding()
    return cursor;
    }
 
-uint8_t *TR_ARMControlFlowInstruction::generateBinaryEncoding()
+uint8_t *TR::ARMControlFlowInstruction::generateBinaryEncoding()
    {
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
@@ -556,7 +556,7 @@ uint8_t *TR_ARMControlFlowInstruction::generateBinaryEncoding()
    return cursor;
    }
 
-int32_t TR_ARMControlFlowInstruction::estimateBinaryLength(int32_t currentEstimate)
+int32_t TR::ARMControlFlowInstruction::estimateBinaryLength(int32_t currentEstimate)
    {
    switch(getOpCodeValue())
       {
@@ -581,7 +581,7 @@ int32_t TR_ARMControlFlowInstruction::estimateBinaryLength(int32_t currentEstima
    return currentEstimate + getEstimatedBinaryLength();
    }
 
-uint8_t *TR_ARMMultipleMoveInstruction::generateBinaryEncoding()
+uint8_t *TR::ARMMultipleMoveInstruction::generateBinaryEncoding()
    {
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
@@ -602,7 +602,7 @@ uint8_t *TR_ARMMultipleMoveInstruction::generateBinaryEncoding()
    }
 
 #ifdef J9_PROJECT_SPECIFIC
-uint8_t *TR_ARMVirtualGuardNOPInstruction::generateBinaryEncoding()
+uint8_t *TR::ARMVirtualGuardNOPInstruction::generateBinaryEncoding()
    {
    uint8_t    *cursor           = cg()->getBinaryBufferCursor();
    TR::LabelSymbol *label        = getLabelSymbol();
@@ -645,7 +645,7 @@ uint8_t *TR_ARMVirtualGuardNOPInstruction::generateBinaryEncoding()
    return cursor+length;
    }
 
-int32_t TR_ARMVirtualGuardNOPInstruction::estimateBinaryLength(int32_t currentEstimate)
+int32_t TR::ARMVirtualGuardNOPInstruction::estimateBinaryLength(int32_t currentEstimate)
    {
    // This is a conservative estimation for reserving NOP space.
    setEstimatedBinaryLength(ARM_INSTRUCTION_LENGTH);

--- a/compiler/arm/codegen/ARMDebug.cpp
+++ b/compiler/arm/codegen/ARMDebug.cpp
@@ -183,58 +183,58 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Instruction * instr)
    switch (instr->getKind())
       {
       case OMR::Instruction::IsImm:
-         print(pOutFile, (TR_ARMImmInstruction *)instr);
+         print(pOutFile, (TR::ARMImmInstruction *)instr);
          break;
       case OMR::Instruction::IsImmSym:
-         print(pOutFile, (TR_ARMImmSymInstruction *)instr);
+         print(pOutFile, (TR::ARMImmSymInstruction *)instr);
          break;
       case OMR::Instruction::IsLabel:
-         print(pOutFile, (TR_ARMLabelInstruction *)instr);
+         print(pOutFile, (TR::ARMLabelInstruction *)instr);
          break;
       case OMR::Instruction::IsConditionalBranch:
-         print(pOutFile, (TR_ARMConditionalBranchInstruction *)instr);
+         print(pOutFile, (TR::ARMConditionalBranchInstruction *)instr);
          break;
 #ifdef J9_PROJECT_SPECIFIC
       case OMR::Instruction::IsVirtualGuardNOP:
-         print(pOutFile, (TR_ARMVirtualGuardNOPInstruction *)instr);
+         print(pOutFile, (TR::ARMVirtualGuardNOPInstruction *)instr);
          break;
 #endif
       case OMR::Instruction::IsAdmin:
-         print(pOutFile, (TR_ARMAdminInstruction *)instr);
+         print(pOutFile, (TR::ARMAdminInstruction *)instr);
          break;
       case OMR::Instruction::IsTrg1Src2:
       case OMR::Instruction::IsSrc2:
       case OMR::Instruction::IsTrg1Src1:
-         print(pOutFile, (TR_ARMTrg1Src2Instruction *)instr);
+         print(pOutFile, (TR::ARMTrg1Src2Instruction *)instr);
          break;
       case OMR::Instruction::IsTrg1:
-         print(pOutFile, (TR_ARMTrg1Instruction *)instr);
+         print(pOutFile, (TR::ARMTrg1Instruction *)instr);
          break;
       case OMR::Instruction::IsMem:
-         print(pOutFile, (TR_ARMMemInstruction *)instr);
+         print(pOutFile, (TR::ARMMemInstruction *)instr);
          break;
       case OMR::Instruction::IsMemSrc1:
-         print(pOutFile, (TR_ARMMemSrc1Instruction *)instr);
+         print(pOutFile, (TR::ARMMemSrc1Instruction *)instr);
          break;
       case OMR::Instruction::IsTrg1Mem:
-         print(pOutFile, (TR_ARMTrg1MemInstruction *)instr);
+         print(pOutFile, (TR::ARMTrg1MemInstruction *)instr);
          break;
       case OMR::Instruction::IsTrg1MemSrc1:
-         print(pOutFile, (TR_ARMTrg1MemSrc1Instruction *)instr);
+         print(pOutFile, (TR::ARMTrg1MemSrc1Instruction *)instr);
          break;
 #if defined(__VFP_FP__) && !defined(__SOFTFP__)
       case OMR::Instruction::IsTrg2Src1:
-         print(pOutFile, (TR_ARMTrg2Src1Instruction *)instr);
+         print(pOutFile, (TR::ARMTrg2Src1Instruction *)instr);
          break;
 #endif
       case OMR::Instruction::IsMul:
-         print(pOutFile, (TR_ARMMulInstruction *)instr);
+         print(pOutFile, (TR::ARMMulInstruction *)instr);
          break;
       case OMR::Instruction::IsControlFlow:
-         print(pOutFile, (TR_ARMControlFlowInstruction *)instr);
+         print(pOutFile, (TR::ARMControlFlowInstruction *)instr);
          break;
       case OMR::Instruction::IsMultipleMove:
-         print(pOutFile, (TR_ARMMultipleMoveInstruction *)instr);
+         print(pOutFile, (TR::ARMMultipleMoveInstruction *)instr);
          break;
       default:
          TR_ASSERT( 0, "unexpected instruction kind");
@@ -303,7 +303,7 @@ TR_Debug::dumpDependencies(TR::FILE *pOutFile, TR::Instruction *instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_ARMLabelInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::ARMLabelInstruction * instr)
    {
    printPrefix(pOutFile, instr);
 
@@ -344,7 +344,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_ARMLabelInstruction * instr)
 
 #ifdef J9_PROJECT_SPECIFIC
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_ARMVirtualGuardNOPInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::ARMVirtualGuardNOPInstruction * instr)
    {
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s Site:" POINTER_PRINTF_FORMAT ", ", getOpCodeName(&instr->getOpCode()), instr->getSite());
@@ -356,7 +356,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_ARMVirtualGuardNOPInstruction * instr)
 #endif
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_ARMAdminInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::ARMAdminInstruction * instr)
    {
    // Omit admin instructions from post-binary dumps unless they mark basic block boundaries.
    if (instr->getBinaryEncoding() &&
@@ -397,7 +397,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_ARMAdminInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_ARMImmInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::ARMImmInstruction * instr)
    {
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s\t0x%08x", fullOpCodeName(instr), instr->getSourceImmediate());
@@ -406,7 +406,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_ARMImmInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_ARMImmSymInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::ARMImmSymInstruction * instr)
    {
    uint8_t *bufferPos = instr->getBinaryEncoding();
    int32_t  imm       = instr->getSourceImmediate();
@@ -466,7 +466,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_ARMImmSymInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_ARMTrg1Src2Instruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::ARMTrg1Src2Instruction * instr)
    {
 #if (defined(__VFP_FP__) && !defined(__SOFTFP__))
    TR_RegisterSizes targetSize = instr->doubleFPOp() ? TR_DoubleReg : TR_WordReg;
@@ -567,7 +567,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_ARMTrg1Src2Instruction * instr)
 
 #if (defined(__VFP_FP__) && !defined(__SOFTFP__))
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_ARMTrg2Src1Instruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::ARMTrg2Src1Instruction * instr)
    {
    // fmrrd
    TR_RegisterSizes size = TR_WordReg;
@@ -593,7 +593,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_ARMTrg2Src1Instruction * instr)
 #endif
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_ARMMulInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::ARMMulInstruction * instr)
    {
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s\t", fullOpCodeName(instr));
@@ -615,7 +615,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_ARMMulInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_ARMMemSrc1Instruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::ARMMemSrc1Instruction * instr)
    {
    if(instr->getBinaryEncoding() &&
       instr->getMemoryReference()->hasDelayedOffset() &&
@@ -650,7 +650,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_ARMMemSrc1Instruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_ARMTrg1Instruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::ARMTrg1Instruction * instr)
    {
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s\t", fullOpCodeName(instr));
@@ -660,7 +660,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_ARMTrg1Instruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_ARMMemInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::ARMMemInstruction * instr)
    {
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s\t", fullOpCodeName(instr));
@@ -670,7 +670,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_ARMMemInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_ARMTrg1MemInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::ARMTrg1MemInstruction * instr)
    {
    if(instr->getBinaryEncoding() &&
       instr->getMemoryReference()->hasDelayedOffset() &&
@@ -715,7 +715,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_ARMTrg1MemInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_ARMTrg1MemSrc1Instruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::ARMTrg1MemSrc1Instruction * instr)
    {
    // strex
    printPrefix(pOutFile, instr);
@@ -730,7 +730,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_ARMTrg1MemSrc1Instruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_ARMControlFlowInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::ARMControlFlowInstruction * instr)
    {
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s\t", fullOpCodeName(instr));
@@ -768,7 +768,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_ARMControlFlowInstruction * instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_ARMMultipleMoveInstruction * instr)
+TR_Debug::print(TR::FILE *pOutFile, TR::ARMMultipleMoveInstruction * instr)
    {
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s\t", fullOpCodeName(instr));
@@ -1537,7 +1537,7 @@ TR_Debug::printARM(TR::FILE *pOutFile, uint8_t* instrStart, uint8_t* instrEnd)
    }
 
 void
-TR_Debug::printARMDelayedOffsetInstructions(TR::FILE *pOutFile, TR_ARMMemInstruction *instr)
+TR_Debug::printARMDelayedOffsetInstructions(TR::FILE *pOutFile, TR::ARMMemInstruction *instr)
    {
    bool regSpilled;
    uint8_t *bufferPos   = instr->getBinaryEncoding();

--- a/compiler/arm/codegen/ARMGenerateInstructions.cpp
+++ b/compiler/arm/codegen/ARMGenerateInstructions.cpp
@@ -39,9 +39,9 @@ TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg,
                                          TR::Instruction   *prev)
    {
    if (prev)
-      return new (cg->trHeapMemory()) TR_ARMAdminInstruction(prev, op, node, fenceNode, cg);
+      return new (cg->trHeapMemory()) TR::ARMAdminInstruction(prev, op, node, fenceNode, cg);
    else
-      return new (cg->trHeapMemory()) TR_ARMAdminInstruction(op, node, fenceNode, cg);
+      return new (cg->trHeapMemory()) TR::ARMAdminInstruction(op, node, fenceNode, cg);
    }
 
 TR::Instruction *generateAdminInstruction(TR::CodeGenerator                   *cg,
@@ -52,9 +52,9 @@ TR::Instruction *generateAdminInstruction(TR::CodeGenerator                   *c
                                          TR::Instruction                     *prev)
    {
    if (prev)
-      return new (cg->trHeapMemory()) TR_ARMAdminInstruction(prev, op, node, fenceNode, cond, cg);
+      return new (cg->trHeapMemory()) TR::ARMAdminInstruction(prev, op, node, fenceNode, cond, cg);
    else
-      return new (cg->trHeapMemory()) TR_ARMAdminInstruction(op, node, fenceNode, cond, cg);
+      return new (cg->trHeapMemory()) TR::ARMAdminInstruction(op, node, fenceNode, cond, cg);
    }
 
 TR::Instruction *generateImmInstruction(TR::CodeGenerator                   *cg,
@@ -66,9 +66,9 @@ TR::Instruction *generateImmInstruction(TR::CodeGenerator                   *cg,
 
    {
    if (prev)
-      return new (cg->trHeapMemory()) TR_ARMImmInstruction(prev, op, node, cond, imm, cg);
+      return new (cg->trHeapMemory()) TR::ARMImmInstruction(prev, op, node, cond, imm, cg);
    else
-      return new (cg->trHeapMemory()) TR_ARMImmInstruction(op, node, cond, imm, cg);
+      return new (cg->trHeapMemory()) TR::ARMImmInstruction(op, node, cond, imm, cg);
    }
 
 TR::Instruction *generateImmInstruction(TR::CodeGenerator                   *cg,
@@ -79,9 +79,9 @@ TR::Instruction *generateImmInstruction(TR::CodeGenerator                   *cg,
 
    {
    if (prev)
-      return new (cg->trHeapMemory()) TR_ARMImmInstruction(prev, op, node, imm, cg);
+      return new (cg->trHeapMemory()) TR::ARMImmInstruction(prev, op, node, imm, cg);
    else
-      return new (cg->trHeapMemory()) TR_ARMImmInstruction(op, node, imm, cg);
+      return new (cg->trHeapMemory()) TR::ARMImmInstruction(op, node, imm, cg);
    }
 
 TR::Instruction *generateImmInstruction(TR::CodeGenerator                   *cg,
@@ -92,9 +92,9 @@ TR::Instruction *generateImmInstruction(TR::CodeGenerator                   *cg,
                                           TR::Instruction                     *prev)
    {
    if (prev)
-      return new (cg->trHeapMemory()) TR_ARMImmInstruction(prev, op, node, imm, relocationKind, cg);
+      return new (cg->trHeapMemory()) TR::ARMImmInstruction(prev, op, node, imm, relocationKind, cg);
    else
-      return new (cg->trHeapMemory()) TR_ARMImmInstruction(op, node, imm, relocationKind, cg);
+      return new (cg->trHeapMemory()) TR::ARMImmInstruction(op, node, imm, relocationKind, cg);
    }
 
 TR::Instruction *generateImmInstruction(TR::CodeGenerator                   *cg,
@@ -106,9 +106,9 @@ TR::Instruction *generateImmInstruction(TR::CodeGenerator                   *cg,
                                           TR::Instruction                     *prev)
    {
    if (prev)
-      return new (cg->trHeapMemory()) TR_ARMImmInstruction(prev, op, node, imm, relocationKind, sr, cg);
+      return new (cg->trHeapMemory()) TR::ARMImmInstruction(prev, op, node, imm, relocationKind, sr, cg);
    else
-      return new (cg->trHeapMemory()) TR_ARMImmInstruction(op, node, imm, relocationKind, sr, cg);
+      return new (cg->trHeapMemory()) TR::ARMImmInstruction(op, node, imm, relocationKind, sr, cg);
    }
 
 TR::Instruction *generateImmSymInstruction(TR::CodeGenerator                   *cg,
@@ -122,9 +122,9 @@ TR::Instruction *generateImmSymInstruction(TR::CodeGenerator                   *
                                           TR_ARMConditionCode                 cc)
    {
    if (prev)
-      return new (cg->trHeapMemory()) TR_ARMImmSymInstruction(prev, op, node, imm, cond, sr, cg, s, cc);
+      return new (cg->trHeapMemory()) TR::ARMImmSymInstruction(prev, op, node, imm, cond, sr, cg, s, cc);
    else
-      return new (cg->trHeapMemory()) TR_ARMImmSymInstruction(op, node, imm, cond, sr, cg, s, cc);
+      return new (cg->trHeapMemory()) TR::ARMImmSymInstruction(op, node, imm, cond, sr, cg, s, cc);
    }
 
 TR::Instruction *generateMemSrc1Instruction(TR::CodeGenerator      *cg,
@@ -143,9 +143,9 @@ TR::Instruction *generateMemSrc1Instruction(TR::CodeGenerator      *cg,
 #endif
 
    if (prev)
-      return new (cg->trHeapMemory()) TR_ARMMemSrc1Instruction(prev, op, node, mf, sreg, cg);
+      return new (cg->trHeapMemory()) TR::ARMMemSrc1Instruction(prev, op, node, mf, sreg, cg);
    else
-      return new (cg->trHeapMemory()) TR_ARMMemSrc1Instruction(op, node, mf, sreg, cg);
+      return new (cg->trHeapMemory()) TR::ARMMemSrc1Instruction(op, node, mf, sreg, cg);
    }
 
 TR::Instruction *generateTrg1MemInstruction(TR::CodeGenerator      *cg,
@@ -164,9 +164,9 @@ TR::Instruction *generateTrg1MemInstruction(TR::CodeGenerator      *cg,
 #endif
 
    if (prev)
-      return new (cg->trHeapMemory()) TR_ARMTrg1MemInstruction(prev, op, node, treg, mf, cg);
+      return new (cg->trHeapMemory()) TR::ARMTrg1MemInstruction(prev, op, node, treg, mf, cg);
    else
-      return new (cg->trHeapMemory()) TR_ARMTrg1MemInstruction(op, node, treg, mf, cg);
+      return new (cg->trHeapMemory()) TR::ARMTrg1MemInstruction(op, node, treg, mf, cg);
    }
 
 TR::Instruction *generateTrg1MemSrc1Instruction(TR::CodeGenerator      *cg,
@@ -178,9 +178,9 @@ TR::Instruction *generateTrg1MemSrc1Instruction(TR::CodeGenerator      *cg,
                                                TR::Instruction        *prev)
    {
    if (prev)
-      return new (cg->trHeapMemory()) TR_ARMTrg1MemSrc1Instruction(prev, op, node, treg, mf, sreg, cg);
+      return new (cg->trHeapMemory()) TR::ARMTrg1MemSrc1Instruction(prev, op, node, treg, mf, sreg, cg);
    else
-      return new (cg->trHeapMemory()) TR_ARMTrg1MemSrc1Instruction(op, node, treg, mf, sreg, cg);
+      return new (cg->trHeapMemory()) TR::ARMTrg1MemSrc1Instruction(op, node, treg, mf, sreg, cg);
    }
 
 TR::Instruction *generateTrg1ImmInstruction(TR::CodeGenerator *cg,
@@ -193,9 +193,9 @@ TR::Instruction *generateTrg1ImmInstruction(TR::CodeGenerator *cg,
    {
    TR_ARMOperand2 *operand = new (cg->trHeapMemory()) TR_ARMOperand2(base, rotate);
    if (prev)
-      return new (cg->trHeapMemory()) TR_ARMTrg1Src1Instruction(prev, op, node, treg, operand, cg);
+      return new (cg->trHeapMemory()) TR::ARMTrg1Src1Instruction(prev, op, node, treg, operand, cg);
    else
-      return new (cg->trHeapMemory()) TR_ARMTrg1Src1Instruction(op, node, treg, operand, cg);
+      return new (cg->trHeapMemory()) TR::ARMTrg1Src1Instruction(op, node, treg, operand, cg);
    }
 
 TR::Instruction *generateSrc1ImmInstruction(TR::CodeGenerator *cg,
@@ -211,16 +211,16 @@ TR::Instruction *generateSrc1ImmInstruction(TR::CodeGenerator *cg,
    if (opCode.isVFPOp())
       {
       if (prev)
-         return new (cg->trHeapMemory()) TR_ARMTrg1Src1Instruction(prev, op, node, s1reg, operand, cg);
+         return new (cg->trHeapMemory()) TR::ARMTrg1Src1Instruction(prev, op, node, s1reg, operand, cg);
       else
-         return new (cg->trHeapMemory()) TR_ARMTrg1Src1Instruction(op, node, s1reg, operand, cg);
+         return new (cg->trHeapMemory()) TR::ARMTrg1Src1Instruction(op, node, s1reg, operand, cg);
       }
    else
       {
       if (prev)
-         return new (cg->trHeapMemory()) TR_ARMSrc2Instruction(prev, op, node, s1reg, operand, cg);
+         return new (cg->trHeapMemory()) TR::ARMSrc2Instruction(prev, op, node, s1reg, operand, cg);
       else
-         return new (cg->trHeapMemory()) TR_ARMSrc2Instruction(op, node, s1reg, operand, cg);
+         return new (cg->trHeapMemory()) TR::ARMSrc2Instruction(op, node, s1reg, operand, cg);
       }
    }
 
@@ -236,16 +236,16 @@ TR::Instruction *generateSrc2Instruction(TR::CodeGenerator *cg,
    if (opCode.isVFPOp())
       {
       if (prev)
-         return new (cg->trHeapMemory()) TR_ARMTrg1Src1Instruction(prev, op, node, s1reg, operand, cg);
+         return new (cg->trHeapMemory()) TR::ARMTrg1Src1Instruction(prev, op, node, s1reg, operand, cg);
       else
-         return new (cg->trHeapMemory()) TR_ARMTrg1Src1Instruction(op, node, s1reg, operand, cg);
+         return new (cg->trHeapMemory()) TR::ARMTrg1Src1Instruction(op, node, s1reg, operand, cg);
       }
    else
       {
       if (prev)
-         return new (cg->trHeapMemory()) TR_ARMSrc2Instruction(prev, op, node, s1reg, operand, cg);
+         return new (cg->trHeapMemory()) TR::ARMSrc2Instruction(prev, op, node, s1reg, operand, cg);
       else
-         return new (cg->trHeapMemory()) TR_ARMSrc2Instruction(op, node, s1reg, operand, cg);
+         return new (cg->trHeapMemory()) TR::ARMSrc2Instruction(op, node, s1reg, operand, cg);
       }
    }
 
@@ -257,9 +257,9 @@ TR::Instruction *generateTrg1Src1Instruction(TR::CodeGenerator *cg,
                                             TR::Instruction   *prev)
    {
    if (prev)
-      return new (cg->trHeapMemory()) TR_ARMTrg1Src1Instruction(prev, op, node, treg, s1op, cg);
+      return new (cg->trHeapMemory()) TR::ARMTrg1Src1Instruction(prev, op, node, treg, s1op, cg);
    else
-      return new (cg->trHeapMemory()) TR_ARMTrg1Src1Instruction(op, node, treg, s1op, cg);
+      return new (cg->trHeapMemory()) TR::ARMTrg1Src1Instruction(op, node, treg, s1op, cg);
    }
 
 TR::Instruction *generateTrg1Src1Instruction(TR::CodeGenerator *cg,
@@ -273,17 +273,17 @@ TR::Instruction *generateTrg1Src1Instruction(TR::CodeGenerator *cg,
       {
       TR_ARMOperand2 *operand = new (cg->trHeapMemory()) TR_ARMOperand2(0, 0);
       if (prev)
-         return new (cg->trHeapMemory()) TR_ARMTrg1Src2Instruction(prev, op, node, (op==ARMOp_fmrs)?treg:s1reg, (op==ARMOp_fmrs)?s1reg:treg, operand, cg);
+         return new (cg->trHeapMemory()) TR::ARMTrg1Src2Instruction(prev, op, node, (op==ARMOp_fmrs)?treg:s1reg, (op==ARMOp_fmrs)?s1reg:treg, operand, cg);
       else
-         return new (cg->trHeapMemory()) TR_ARMTrg1Src2Instruction(op, node, (op==ARMOp_fmrs)?treg:s1reg, (op==ARMOp_fmrs)?s1reg:treg, operand, cg);
+         return new (cg->trHeapMemory()) TR::ARMTrg1Src2Instruction(op, node, (op==ARMOp_fmrs)?treg:s1reg, (op==ARMOp_fmrs)?s1reg:treg, operand, cg);
       }
    else
       {
       TR_ARMOperand2 *operand = new (cg->trHeapMemory()) TR_ARMOperand2(ARMOp2Reg, s1reg);
       if (prev)
-         return new (cg->trHeapMemory()) TR_ARMTrg1Src1Instruction(prev, op, node, treg, operand, cg);
+         return new (cg->trHeapMemory()) TR::ARMTrg1Src1Instruction(prev, op, node, treg, operand, cg);
       else
-         return new (cg->trHeapMemory()) TR_ARMTrg1Src1Instruction(op, node, treg, operand, cg);
+         return new (cg->trHeapMemory()) TR::ARMTrg1Src1Instruction(op, node, treg, operand, cg);
       }
    }
 
@@ -298,9 +298,9 @@ TR::Instruction *generateTrg1Src1ImmInstruction(TR::CodeGenerator *cg,
    {
    TR_ARMOperand2 *operand = new (cg->trHeapMemory()) TR_ARMOperand2(base, rotate);
    if (prev)
-      return new (cg->trHeapMemory()) TR_ARMTrg1Src2Instruction(prev, op, node, treg, s1reg, operand, cg);
+      return new (cg->trHeapMemory()) TR::ARMTrg1Src2Instruction(prev, op, node, treg, s1reg, operand, cg);
    else
-      return new (cg->trHeapMemory()) TR_ARMTrg1Src2Instruction(op, node, treg, s1reg, operand, cg);
+      return new (cg->trHeapMemory()) TR::ARMTrg1Src2Instruction(op, node, treg, s1reg, operand, cg);
    }
 
 TR::Instruction *generateLoadStartPCInstruction(TR::CodeGenerator *cg,
@@ -310,9 +310,9 @@ TR::Instruction *generateLoadStartPCInstruction(TR::CodeGenerator *cg,
                                                TR::Instruction   *prev = NULL)
    {
    if (prev)
-      return new (cg->trHeapMemory()) TR_ARMLoadStartPCInstruction(prev, node, treg, sr, cg);
+      return new (cg->trHeapMemory()) TR::ARMLoadStartPCInstruction(prev, node, treg, sr, cg);
    else
-	   return new (cg->trHeapMemory()) TR_ARMLoadStartPCInstruction(node, treg, sr, cg);
+	   return new (cg->trHeapMemory()) TR::ARMLoadStartPCInstruction(node, treg, sr, cg);
    }
 
 TR::Instruction *generateTrg1Src2Instruction(TR::CodeGenerator *cg,
@@ -324,9 +324,9 @@ TR::Instruction *generateTrg1Src2Instruction(TR::CodeGenerator *cg,
                                             TR::Instruction   *prev)
    {
    if (prev)
-      return new (cg->trHeapMemory()) TR_ARMTrg1Src2Instruction(prev, op, node, treg, s1reg, s2op, cg);
+      return new (cg->trHeapMemory()) TR::ARMTrg1Src2Instruction(prev, op, node, treg, s1reg, s2op, cg);
    else
-      return new (cg->trHeapMemory()) TR_ARMTrg1Src2Instruction(op, node, treg, s1reg, s2op, cg);
+      return new (cg->trHeapMemory()) TR::ARMTrg1Src2Instruction(op, node, treg, s1reg, s2op, cg);
    }
 
 TR::Instruction *generateTrg1Src2Instruction(TR::CodeGenerator *cg,
@@ -342,17 +342,17 @@ TR::Instruction *generateTrg1Src2Instruction(TR::CodeGenerator *cg,
       // fmdrr   Dm, Rd, Rn
       TR_ARMOperand2 *toperand = new (cg->trHeapMemory()) TR_ARMOperand2(ARMOp2Reg, treg);
       if (prev)
-         return new (cg->trHeapMemory()) TR_ARMTrg1Src2Instruction(prev, op, node, s1reg, s2reg, toperand, cg);
+         return new (cg->trHeapMemory()) TR::ARMTrg1Src2Instruction(prev, op, node, s1reg, s2reg, toperand, cg);
       else
-         return new (cg->trHeapMemory()) TR_ARMTrg1Src2Instruction(op, node, s1reg, s2reg, toperand, cg);
+         return new (cg->trHeapMemory()) TR::ARMTrg1Src2Instruction(op, node, s1reg, s2reg, toperand, cg);
       }
    else
       {
       TR_ARMOperand2 *operand = new (cg->trHeapMemory()) TR_ARMOperand2(ARMOp2Reg, s2reg);
       if (prev)
-         return new (cg->trHeapMemory()) TR_ARMTrg1Src2Instruction(prev, op, node, treg, s1reg, operand, cg);
+         return new (cg->trHeapMemory()) TR::ARMTrg1Src2Instruction(prev, op, node, treg, s1reg, operand, cg);
       else
-         return new (cg->trHeapMemory()) TR_ARMTrg1Src2Instruction(op, node, treg, s1reg, operand, cg);
+         return new (cg->trHeapMemory()) TR::ARMTrg1Src2Instruction(op, node, treg, s1reg, operand, cg);
       }
    }
 
@@ -366,9 +366,9 @@ TR::Instruction *generateTrg2Src1Instruction(TR::CodeGenerator *cg,
                                             TR::Instruction   *prev)
    {
    if (prev)
-      return new (cg->trHeapMemory()) TR_ARMTrg2Src1Instruction(prev, op, node, t1reg, t2reg, sreg, cg);
+      return new (cg->trHeapMemory()) TR::ARMTrg2Src1Instruction(prev, op, node, t1reg, t2reg, sreg, cg);
    else
-      return new (cg->trHeapMemory()) TR_ARMTrg2Src1Instruction(op, node, t1reg, t2reg, sreg, cg);
+      return new (cg->trHeapMemory()) TR::ARMTrg2Src1Instruction(op, node, t1reg, t2reg, sreg, cg);
    }
 #endif
 
@@ -381,9 +381,9 @@ TR::Instruction *generateTrg1Src2MulInstruction(TR::CodeGenerator *cg,
                                                TR::Instruction   *prev)
    {
    if (prev)
-      return new (cg->trHeapMemory()) TR_ARMMulInstruction(prev, op, node, treg, s1reg, s2reg, cg);
+      return new (cg->trHeapMemory()) TR::ARMMulInstruction(prev, op, node, treg, s1reg, s2reg, cg);
    else
-      return new (cg->trHeapMemory()) TR_ARMMulInstruction(op, node, treg, s1reg, s2reg, cg);
+      return new (cg->trHeapMemory()) TR::ARMMulInstruction(op, node, treg, s1reg, s2reg, cg);
    }
 
 TR::Instruction *generateTrg2Src2MulInstruction(TR::CodeGenerator *cg,
@@ -396,9 +396,9 @@ TR::Instruction *generateTrg2Src2MulInstruction(TR::CodeGenerator *cg,
                                                TR::Instruction   *prev)
    {
    if (prev)
-      return new (cg->trHeapMemory()) TR_ARMMulInstruction(prev, op, node, tregHi, tregLo, s1reg, s2reg, cg);
+      return new (cg->trHeapMemory()) TR::ARMMulInstruction(prev, op, node, tregHi, tregLo, s1reg, s2reg, cg);
    else
-      return new (cg->trHeapMemory()) TR_ARMMulInstruction(op, node, tregHi, tregLo, s1reg, s2reg, cg);
+      return new (cg->trHeapMemory()) TR::ARMMulInstruction(op, node, tregHi, tregLo, s1reg, s2reg, cg);
    }
 
 TR::Instruction *generateShiftLeftImmediate(TR::CodeGenerator  *cg,
@@ -459,9 +459,9 @@ TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg,
                                          TR::Register      *src1Reg)
    {
    if (prev)
-      return new (cg->trHeapMemory()) TR_ARMLabelInstruction(prev, op, node, sym, cg, trgReg, src1Reg);
+      return new (cg->trHeapMemory()) TR::ARMLabelInstruction(prev, op, node, sym, cg, trgReg, src1Reg);
    else
-      return new (cg->trHeapMemory()) TR_ARMLabelInstruction(op, node, sym, cg, trgReg, src1Reg);
+      return new (cg->trHeapMemory()) TR::ARMLabelInstruction(op, node, sym, cg, trgReg, src1Reg);
    }
 
 TR::Instruction *generateLabelInstruction(TR::CodeGenerator                   *cg,
@@ -472,9 +472,9 @@ TR::Instruction *generateLabelInstruction(TR::CodeGenerator                   *c
                                          TR::Instruction                     *prev)
    {
    if (prev)
-      return new (cg->trHeapMemory()) TR_ARMLabelInstruction(prev, op, node, cond, sym, cg);
+      return new (cg->trHeapMemory()) TR::ARMLabelInstruction(prev, op, node, cond, sym, cg);
    else
-      return new (cg->trHeapMemory()) TR_ARMLabelInstruction(op, node, cond, sym, cg);
+      return new (cg->trHeapMemory()) TR::ARMLabelInstruction(op, node, cond, sym, cg);
    }
 
 TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator    *cg,
@@ -484,9 +484,9 @@ TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator    *cg,
                                                      TR::Instruction      *prev)
    {
    if (prev)
-      return new (cg->trHeapMemory()) TR_ARMConditionalBranchInstruction(prev, ARMOp_b, node, sym, cc, cg);
+      return new (cg->trHeapMemory()) TR::ARMConditionalBranchInstruction(prev, ARMOp_b, node, sym, cc, cg);
    else
-      return new (cg->trHeapMemory()) TR_ARMConditionalBranchInstruction(ARMOp_b, node, sym, cc, cg);
+      return new (cg->trHeapMemory()) TR::ARMConditionalBranchInstruction(ARMOp_b, node, sym, cc, cg);
    }
 
 TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator                   *cg,
@@ -497,20 +497,20 @@ TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator         
                                                      TR::Instruction                     *prev)
    {
    if (prev)
-      return new (cg->trHeapMemory()) TR_ARMConditionalBranchInstruction(prev, ARMOp_b, node, cond, sym, cc, cg);
+      return new (cg->trHeapMemory()) TR::ARMConditionalBranchInstruction(prev, ARMOp_b, node, cond, sym, cc, cg);
    else
-      return new (cg->trHeapMemory()) TR_ARMConditionalBranchInstruction(ARMOp_b, node, cond, sym, cc, cg);
+      return new (cg->trHeapMemory()) TR::ARMConditionalBranchInstruction(ARMOp_b, node, cond, sym, cc, cg);
    }
 
-TR_ARMControlFlowInstruction *generateControlFlowInstruction(TR::CodeGenerator                   *cg,
+TR::ARMControlFlowInstruction *generateControlFlowInstruction(TR::CodeGenerator                   *cg,
                                                              TR_ARMOpCodes                       op,
                                                              TR::Node                            *node,
                                                              TR::RegisterDependencyConditions *cond)
    {
    if (cond)
-      return new (cg->trHeapMemory()) TR_ARMControlFlowInstruction(op, node, cond, cg);
+      return new (cg->trHeapMemory()) TR::ARMControlFlowInstruction(op, node, cond, cg);
    else
-      return new (cg->trHeapMemory()) TR_ARMControlFlowInstruction(op, node, cg);
+      return new (cg->trHeapMemory()) TR::ARMControlFlowInstruction(op, node, cg);
    }
 
 TR::Instruction *generatePreIncLoadInstruction(TR::CodeGenerator *cg,
@@ -523,9 +523,9 @@ TR::Instruction *generatePreIncLoadInstruction(TR::CodeGenerator *cg,
    TR::MemoryReference *updateMR = new (cg->trHeapMemory()) TR::MemoryReference(baseReg, offset, cg);
    updateMR->setImmediatePreIndexed(); // write the updated EA back into baseReg
    if (prev)
-      return new (cg->trHeapMemory()) TR_ARMTrg1MemInstruction(prev, ARMOp_ldr, node, treg, updateMR, cg);
+      return new (cg->trHeapMemory()) TR::ARMTrg1MemInstruction(prev, ARMOp_ldr, node, treg, updateMR, cg);
    else
-      return new (cg->trHeapMemory()) TR_ARMTrg1MemInstruction(ARMOp_ldr, node, treg, updateMR, cg);
+      return new (cg->trHeapMemory()) TR::ARMTrg1MemInstruction(ARMOp_ldr, node, treg, updateMR, cg);
    }
 
 #ifdef J9_PROJECT_SPECIFIC
@@ -533,7 +533,7 @@ TR::Instruction *generateVirtualGuardNOPInstruction(TR::CodeGenerator *cg,  TR::
    TR::RegisterDependencyConditions *cond, TR::LabelSymbol *sym, TR::Instruction *preced)
    {
    if (preced)
-      return new (cg->trHeapMemory()) TR_ARMVirtualGuardNOPInstruction(n, site, cond, sym, preced, cg);
-   return new (cg->trHeapMemory()) TR_ARMVirtualGuardNOPInstruction(n, site, cond, sym, cg);
+      return new (cg->trHeapMemory()) TR::ARMVirtualGuardNOPInstruction(n, site, cond, sym, preced, cg);
+   return new (cg->trHeapMemory()) TR::ARMVirtualGuardNOPInstruction(n, site, cond, sym, cg);
    }
 #endif

--- a/compiler/arm/codegen/ARMInstruction.hpp
+++ b/compiler/arm/codegen/ARMInstruction.hpp
@@ -32,9 +32,9 @@
 
 class TR_VirtualGuardSite;
 
-class TR_ARMDepImmInstruction;
-class TR_ARMImmInstruction;
-class TR_ARMConditionalBranchInstruction;
+namespace TR { class ARMDepImmInstruction; }
+namespace TR { class ARMImmInstruction; }
+namespace TR { class ARMConditionalBranchInstruction; }
 
 #define ARM_INSTRUCTION_LENGTH 4
 
@@ -93,7 +93,9 @@ inline bool isSinglePrecision(TR::RealRegister::RegNum registerNumber)
 #endif
    }
 
-class TR_ARMImmInstruction : public TR::Instruction
+namespace TR {
+
+class ARMImmInstruction : public TR::Instruction
    {
    uint32_t _sourceImmediate;
    TR_ExternalRelocationTargetKind _reloKind;
@@ -101,81 +103,81 @@ class TR_ARMImmInstruction : public TR::Instruction
 
    public:
 
-   TR_ARMImmInstruction(TR::Node *node, TR::CodeGenerator *cg) : TR::Instruction(node, cg) {}
+   ARMImmInstruction(TR::Node *node, TR::CodeGenerator *cg) : TR::Instruction(node, cg) {}
 
-   TR_ARMImmInstruction(TR_ARMOpCodes op, TR::Node *node, uint32_t imm, TR::CodeGenerator *cg)
+   ARMImmInstruction(TR_ARMOpCodes op, TR::Node *node, uint32_t imm, TR::CodeGenerator *cg)
       : TR::Instruction(node, cg), _sourceImmediate(imm), _reloKind(TR_NoRelocation), _symbolReference(NULL)
       {
       setOpCodeValue(op);
       }
 
-   TR_ARMImmInstruction(TR_ARMOpCodes                       op,
-                        TR::Node                            *node,
-                        TR::RegisterDependencyConditions *cond,
-                        uint32_t                            imm,
-                        TR::CodeGenerator                   *cg)
+   ARMImmInstruction(TR_ARMOpCodes                       op,
+                     TR::Node                            *node,
+                     TR::RegisterDependencyConditions *cond,
+                     uint32_t                            imm,
+                     TR::CodeGenerator                   *cg)
       : TR::Instruction(op, node, cond, cg), _sourceImmediate(imm), _reloKind(TR_NoRelocation), _symbolReference(NULL)
       {
       }
 
-   TR_ARMImmInstruction(TR::Instruction   *precedingInstruction,
-                        TR_ARMOpCodes     op,
-                        TR::Node          *node,
-                        uint32_t          imm,
-                        TR::CodeGenerator *cg)
+   ARMImmInstruction(TR::Instruction   *precedingInstruction,
+                     TR_ARMOpCodes     op,
+                     TR::Node          *node,
+                     uint32_t          imm,
+                     TR::CodeGenerator *cg)
       : TR::Instruction(precedingInstruction, op, node, cg), _sourceImmediate(imm), _reloKind(TR_NoRelocation), _symbolReference(NULL)
       {
       }
 
-   TR_ARMImmInstruction(TR::Instruction                     *precedingInstruction,
-                        TR_ARMOpCodes                       op,
-                        TR::Node                            *node,
-                        TR::RegisterDependencyConditions *cond,
-                        uint32_t                            imm,
-                        TR::CodeGenerator *cg)
+   ARMImmInstruction(TR::Instruction                     *precedingInstruction,
+                     TR_ARMOpCodes                       op,
+                     TR::Node                            *node,
+                     TR::RegisterDependencyConditions *cond,
+                     uint32_t                            imm,
+                     TR::CodeGenerator *cg)
       : TR::Instruction(precedingInstruction, op, node, cond, cg), _sourceImmediate(imm), _reloKind(TR_NoRelocation), _symbolReference(NULL)
       {
       }
 
-   TR_ARMImmInstruction(TR_ARMOpCodes     op,
-                        TR::Node          *node,
-                        uint32_t          imm,
-                        TR_ExternalRelocationTargetKind relocationKind,
-                        TR::CodeGenerator *cg)
+   ARMImmInstruction(TR_ARMOpCodes     op,
+                     TR::Node          *node,
+                     uint32_t          imm,
+                     TR_ExternalRelocationTargetKind relocationKind,
+                     TR::CodeGenerator *cg)
       : TR::Instruction(op, node, cg), _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(NULL)
       {
       setNeedsAOTRelocation(true);
       }
 
-   TR_ARMImmInstruction(TR::Instruction   *precedingInstruction,
-                        TR_ARMOpCodes     op,
-                        TR::Node          *node,
-                        uint32_t          imm,
-                        TR_ExternalRelocationTargetKind relocationKind,
-                        TR::CodeGenerator *cg)
+   ARMImmInstruction(TR::Instruction   *precedingInstruction,
+                     TR_ARMOpCodes     op,
+                     TR::Node          *node,
+                     uint32_t          imm,
+                     TR_ExternalRelocationTargetKind relocationKind,
+                     TR::CodeGenerator *cg)
       : TR::Instruction(precedingInstruction, op, node, cg), _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(NULL)
       {
       setNeedsAOTRelocation(true);
       }
 
-   TR_ARMImmInstruction(TR_ARMOpCodes     op,
-                        TR::Node          *node,
-                        uint32_t          imm,
-                        TR_ExternalRelocationTargetKind relocationKind,
-                        TR::SymbolReference *sr,
-                        TR::CodeGenerator *cg)
+   ARMImmInstruction(TR_ARMOpCodes     op,
+                     TR::Node          *node,
+                     uint32_t          imm,
+                     TR_ExternalRelocationTargetKind relocationKind,
+                     TR::SymbolReference *sr,
+                     TR::CodeGenerator *cg)
       : TR::Instruction(op, node, cg), _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(sr)
       {
       setNeedsAOTRelocation(true);
       }
 
-   TR_ARMImmInstruction(TR::Instruction   *precedingInstruction,
-                        TR_ARMOpCodes     op,
-                        TR::Node          *node,
-                        uint32_t          imm,
-                        TR_ExternalRelocationTargetKind relocationKind,
-                        TR::SymbolReference *sr,
-                        TR::CodeGenerator *cg)
+   ARMImmInstruction(TR::Instruction   *precedingInstruction,
+                     TR_ARMOpCodes     op,
+                     TR::Node          *node,
+                     uint32_t          imm,
+                     TR_ExternalRelocationTargetKind relocationKind,
+                     TR::SymbolReference *sr,
+                     TR::CodeGenerator *cg)
       : TR::Instruction(precedingInstruction, op, node, cg), _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(sr)
       {
       setNeedsAOTRelocation(true);
@@ -205,12 +207,12 @@ class TR_ARMImmInstruction : public TR::Instruction
 // The following safe virtual downcast method is used under debug only
 // for assertion checking
 #if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
-   virtual TR_ARMImmInstruction *getARMImmInstruction();
+   virtual TR::ARMImmInstruction *getARMImmInstruction();
 #endif
    };
 
 
-class TR_ARMLabelInstruction : public TR::Instruction
+class ARMLabelInstruction : public TR::Instruction
    {
    TR::LabelSymbol *_symbol;
    TR::Register    *_t1reg;
@@ -218,11 +220,11 @@ class TR_ARMLabelInstruction : public TR::Instruction
 
    public:
 
-   TR_ARMLabelInstruction(TR::Node *node, TR::CodeGenerator *cg)
+   ARMLabelInstruction(TR::Node *node, TR::CodeGenerator *cg)
       : TR::Instruction(node, cg), _symbol(NULL), _t1reg(NULL), _s1reg(NULL) {}
 
-   TR_ARMLabelInstruction(TR_ARMOpCodes op, TR::Node *node, TR::LabelSymbol *sym, TR::CodeGenerator *cg,
-                          TR::Register *t1reg = NULL, TR::Register *s1reg = NULL)
+   ARMLabelInstruction(TR_ARMOpCodes op, TR::Node *node, TR::LabelSymbol *sym, TR::CodeGenerator *cg,
+                       TR::Register *t1reg = NULL, TR::Register *s1reg = NULL)
       : TR::Instruction(node, cg), _symbol(sym), _t1reg(t1reg), _s1reg(s1reg)
       {
       setOpCodeValue(op);
@@ -232,24 +234,24 @@ class TR_ARMLabelInstruction : public TR::Instruction
          sym->setInstruction(this);
       }
 
-   TR_ARMLabelInstruction(TR_ARMOpCodes                       op,
-                          TR::Node                            *node,
-                          TR::RegisterDependencyConditions *cond,
-                          TR::LabelSymbol                     *sym,
-                          TR::CodeGenerator                   *cg)
+   ARMLabelInstruction(TR_ARMOpCodes                       op,
+                       TR::Node                            *node,
+                       TR::RegisterDependencyConditions *cond,
+                       TR::LabelSymbol                     *sym,
+                       TR::CodeGenerator                   *cg)
       : TR::Instruction(op, node, cond, cg), _symbol(sym), _t1reg(NULL), _s1reg(NULL)
       {
       if (sym!=NULL && op==ARMOp_label)
          sym->setInstruction(this);
       }
 
-   TR_ARMLabelInstruction(TR::Instruction   *precedingInstruction,
-                          TR_ARMOpCodes     op,
-                          TR::Node          *node,
-                          TR::LabelSymbol   *sym,
-                          TR::CodeGenerator *cg,
-                          TR::Register      *t1reg = NULL,
-                          TR::Register      *s1reg = NULL)
+   ARMLabelInstruction(TR::Instruction   *precedingInstruction,
+                       TR_ARMOpCodes     op,
+                       TR::Node          *node,
+                       TR::LabelSymbol   *sym,
+                       TR::CodeGenerator *cg,
+                       TR::Register      *t1reg = NULL,
+                       TR::Register      *s1reg = NULL)
       : TR::Instruction(precedingInstruction, op, node, cg), _symbol(sym), _t1reg(t1reg), _s1reg(s1reg)
       {
       if (t1reg) t1reg->incTotalUseCount();
@@ -258,12 +260,12 @@ class TR_ARMLabelInstruction : public TR::Instruction
          sym->setInstruction(this);
       }
 
-   TR_ARMLabelInstruction(TR::Instruction                     *precedingInstruction,
-                          TR_ARMOpCodes                       op,
-                          TR::Node                            *node,
-                          TR::RegisterDependencyConditions *cond,
-                          TR::LabelSymbol                     *sym,
-                          TR::CodeGenerator                   *cg)
+   ARMLabelInstruction(TR::Instruction                     *precedingInstruction,
+                       TR_ARMOpCodes                       op,
+                       TR::Node                            *node,
+                       TR::RegisterDependencyConditions *cond,
+                       TR::LabelSymbol                     *sym,
+                       TR::CodeGenerator                   *cg)
       : TR::Instruction(precedingInstruction, op, node, cond, cg), _symbol(sym), _t1reg(NULL), _s1reg(NULL)
       {
       if (sym!=NULL && op==ARMOp_label)
@@ -299,68 +301,68 @@ class TR_ARMLabelInstruction : public TR::Instruction
    };
 
 
-class TR_ARMConditionalBranchInstruction : public TR_ARMLabelInstruction
+class ARMConditionalBranchInstruction : public TR::ARMLabelInstruction
    {
    int32_t             _estimatedBinaryLocation;
    bool                _farRelocation;
 
    public:
 
-   TR_ARMConditionalBranchInstruction(TR::Node *node, TR::CodeGenerator *cg)
-      : TR_ARMLabelInstruction(node, cg),
+   ARMConditionalBranchInstruction(TR::Node *node, TR::CodeGenerator *cg)
+      : TR::ARMLabelInstruction(node, cg),
         _estimatedBinaryLocation(0),
         _farRelocation(false)
       {
       setConditionCode(ARMConditionCodeIllegal);
       }
 
-   TR_ARMConditionalBranchInstruction(TR_ARMOpCodes        op,
-                                      TR::Node             *node,
-                                      TR::LabelSymbol      *sym,
-                                      TR_ARMConditionCode  cc,
-                                      TR::CodeGenerator    *cg)
-      : TR_ARMLabelInstruction(op, node, sym, cg),
+   ARMConditionalBranchInstruction(TR_ARMOpCodes        op,
+                                   TR::Node             *node,
+                                   TR::LabelSymbol      *sym,
+                                   TR_ARMConditionCode  cc,
+                                   TR::CodeGenerator    *cg)
+      : TR::ARMLabelInstruction(op, node, sym, cg),
         _estimatedBinaryLocation(0),
         _farRelocation(false)
       {
       setConditionCode(cc);
       }
 
-   TR_ARMConditionalBranchInstruction(TR_ARMOpCodes                       op,
-                                      TR::Node                            *node,
-                                      TR::RegisterDependencyConditions *cond,
-                                      TR::LabelSymbol                     *sym,
-                                      TR_ARMConditionCode                 cc,
-                                      TR::CodeGenerator                   *cg)
-      : TR_ARMLabelInstruction(op, node, cond, sym, cg),
+   ARMConditionalBranchInstruction(TR_ARMOpCodes                       op,
+                                   TR::Node                            *node,
+                                   TR::RegisterDependencyConditions *cond,
+                                   TR::LabelSymbol                     *sym,
+                                   TR_ARMConditionCode                 cc,
+                                   TR::CodeGenerator                   *cg)
+      : TR::ARMLabelInstruction(op, node, cond, sym, cg),
         _estimatedBinaryLocation(0),
         _farRelocation(false)
       {
       setConditionCode(cc);
       }
 
-   TR_ARMConditionalBranchInstruction(TR::Instruction      *precedingInstruction,
-                                      TR_ARMOpCodes        op,
-                                      TR::Node             *node,
-                                      TR::LabelSymbol      *sym,
-                                      TR_ARMConditionCode  cc,
-                                      TR::CodeGenerator    *cg)
+   ARMConditionalBranchInstruction(TR::Instruction      *precedingInstruction,
+                                   TR_ARMOpCodes        op,
+                                   TR::Node             *node,
+                                   TR::LabelSymbol      *sym,
+                                   TR_ARMConditionCode  cc,
+                                   TR::CodeGenerator    *cg)
 
-      : TR_ARMLabelInstruction(precedingInstruction, op, node, sym, cg),
+      : TR::ARMLabelInstruction(precedingInstruction, op, node, sym, cg),
         _estimatedBinaryLocation(0),
         _farRelocation(false)
       {
       setConditionCode(cc);
       }
 
-   TR_ARMConditionalBranchInstruction(TR::Instruction                     *precedingInstruction,
-                                      TR_ARMOpCodes                       op,
-                                      TR::Node                            *node,
-                                      TR::RegisterDependencyConditions *cond,
-                                      TR::LabelSymbol                     *sym,
-                                      TR_ARMConditionCode                 cc,
-                                      TR::CodeGenerator                   *cg)
-      : TR_ARMLabelInstruction(precedingInstruction, op, node, cond, sym, cg),
+   ARMConditionalBranchInstruction(TR::Instruction                     *precedingInstruction,
+                                   TR_ARMOpCodes                       op,
+                                   TR::Node                            *node,
+                                   TR::RegisterDependencyConditions *cond,
+                                   TR::LabelSymbol                     *sym,
+                                   TR_ARMConditionCode                 cc,
+                                   TR::CodeGenerator                   *cg)
+      : TR::ARMLabelInstruction(precedingInstruction, op, node, cond, sym, cg),
         _estimatedBinaryLocation(0),
         _farRelocation(false)
       {
@@ -377,7 +379,7 @@ class TR_ARMConditionalBranchInstruction : public TR_ARMLabelInstruction
    bool getFarRelocation() {return _farRelocation;}
    bool setFarRelocation(bool b) {return (_farRelocation = b);}
 
-   virtual TR_ARMConditionalBranchInstruction *getARMConditionalBranchInstruction();
+   virtual TR::ARMConditionalBranchInstruction *getARMConditionalBranchInstruction();
 
    virtual void assignRegisters(TR_RegisterKinds kindToBeAssigned);
 
@@ -393,30 +395,30 @@ class TR_ARMConditionalBranchInstruction : public TR_ARMLabelInstruction
    };
 
 #ifdef J9_PROJECT_SPECIFIC
-class TR_ARMVirtualGuardNOPInstruction : public TR_ARMLabelInstruction
+class ARMVirtualGuardNOPInstruction : public TR::ARMLabelInstruction
    {
    private:
    TR_VirtualGuardSite     *_site;
 
    public:
 
-   TR_ARMVirtualGuardNOPInstruction(TR::Node                         *node,
-                                    TR_VirtualGuardSite              *site,
-                                    TR::RegisterDependencyConditions *cond,
-                                    TR::LabelSymbol                  *sym,
-                                    TR::CodeGenerator                *cg)
-      : TR_ARMLabelInstruction(ARMOp_vgdnop, node, cond, sym, cg),
+   ARMVirtualGuardNOPInstruction(TR::Node                         *node,
+                                 TR_VirtualGuardSite              *site,
+                                 TR::RegisterDependencyConditions *cond,
+                                 TR::LabelSymbol                  *sym,
+                                 TR::CodeGenerator                *cg)
+      : TR::ARMLabelInstruction(ARMOp_vgdnop, node, cond, sym, cg),
         _site(site)
       {
       }
 
-   TR_ARMVirtualGuardNOPInstruction(TR::Node                         *node,
-                                    TR_VirtualGuardSite              *site,
-                                    TR::RegisterDependencyConditions *cond,
-                                    TR::LabelSymbol                  *sym,
-                                    TR::Instruction                *precedingInstruction,
-                                    TR::CodeGenerator                *cg)
-      : TR_ARMLabelInstruction(precedingInstruction, ARMOp_vgdnop, node, cond, sym, cg),
+   ARMVirtualGuardNOPInstruction(TR::Node                         *node,
+                                 TR_VirtualGuardSite              *site,
+                                 TR::RegisterDependencyConditions *cond,
+                                 TR::LabelSymbol                  *sym,
+                                 TR::Instruction                *precedingInstruction,
+                                 TR::CodeGenerator                *cg)
+      : TR::ARMLabelInstruction(precedingInstruction, ARMOp_vgdnop, node, cond, sym, cg),
         _site(site)
       {
       }
@@ -432,38 +434,38 @@ class TR_ARMVirtualGuardNOPInstruction : public TR_ARMLabelInstruction
    };
 #endif
 
-class TR_ARMAdminInstruction : public TR::Instruction
+class ARMAdminInstruction : public TR::Instruction
    {
    TR::Node *_fenceNode;
 
    public:
 
-   TR_ARMAdminInstruction(TR_ARMOpCodes     op,
-                          TR::Node          *node,
-                          TR::Node          *fenceNode,
-                          TR::CodeGenerator *cg)
+   ARMAdminInstruction(TR_ARMOpCodes     op,
+                       TR::Node          *node,
+                       TR::Node          *fenceNode,
+                       TR::CodeGenerator *cg)
       : TR::Instruction(op, node, cg), _fenceNode(fenceNode) {}
 
-   TR_ARMAdminInstruction(TR_ARMOpCodes                       op,
-                          TR::Node                            *node,
-                          TR::Node                            *fenceNode,
-                          TR::RegisterDependencyConditions *cond,
-                          TR::CodeGenerator                   *cg)
+   ARMAdminInstruction(TR_ARMOpCodes                       op,
+                       TR::Node                            *node,
+                       TR::Node                            *fenceNode,
+                       TR::RegisterDependencyConditions *cond,
+                       TR::CodeGenerator                   *cg)
       : TR::Instruction(op, node, cond, cg), _fenceNode(fenceNode) {}
 
-   TR_ARMAdminInstruction(TR::Instruction   *precedingInstruction,
-                          TR_ARMOpCodes     op,
-                          TR::Node          *node,
-                          TR::Node          *fenceNode,
-                          TR::CodeGenerator *cg)
+   ARMAdminInstruction(TR::Instruction   *precedingInstruction,
+                       TR_ARMOpCodes     op,
+                       TR::Node          *node,
+                       TR::Node          *fenceNode,
+                       TR::CodeGenerator *cg)
       : TR::Instruction(precedingInstruction, op, node, cg), _fenceNode(fenceNode) {}
 
-   TR_ARMAdminInstruction(TR::Instruction                     *precedingInstruction,
-                          TR_ARMOpCodes                       op,
-                          TR::Node                            *node,
-                          TR::Node                            *fenceNode,
-                          TR::RegisterDependencyConditions *cond,
-                          TR::CodeGenerator                   *cg)
+   ARMAdminInstruction(TR::Instruction                     *precedingInstruction,
+                       TR_ARMOpCodes                       op,
+                       TR::Node                            *node,
+                       TR::Node                            *fenceNode,
+                       TR::RegisterDependencyConditions *cond,
+                       TR::CodeGenerator                   *cg)
       : TR::Instruction(precedingInstruction, op, node, cond, cg), _fenceNode(fenceNode) {}
 
    TR::Node *getFenceNode() { return _fenceNode; }
@@ -476,33 +478,33 @@ class TR_ARMAdminInstruction : public TR::Instruction
    };
 
 
-class TR_ARMImmSymInstruction : public TR_ARMImmInstruction
+class ARMImmSymInstruction : public TR::ARMImmInstruction
    {
    TR::SymbolReference *_symbolReference;
    TR::Snippet         *_snippet;
 
    public:
 
-   TR_ARMImmSymInstruction(TR::Node *node, TR::CodeGenerator *cg) : TR_ARMImmInstruction(node, cg), _symbolReference(NULL), _snippet(NULL) {}
+   ARMImmSymInstruction(TR::Node *node, TR::CodeGenerator *cg) : TR::ARMImmInstruction(node, cg), _symbolReference(NULL), _snippet(NULL) {}
 
-   TR_ARMImmSymInstruction(TR_ARMOpCodes                          op,
-                              TR::Node                            *node,
-                              uint32_t                            imm,
-                              TR::RegisterDependencyConditions *cond,
-                              TR::SymbolReference                 *sr,
-                              TR::CodeGenerator                   *cg,
-                              TR::Snippet                         *s=NULL,
-                              TR_ARMConditionCode                cc=ARMConditionCodeAL);
+   ARMImmSymInstruction(TR_ARMOpCodes                          op,
+                        TR::Node                            *node,
+                        uint32_t                            imm,
+                        TR::RegisterDependencyConditions *cond,
+                        TR::SymbolReference                 *sr,
+                        TR::CodeGenerator                   *cg,
+                        TR::Snippet                         *s=NULL,
+                        TR_ARMConditionCode                cc=ARMConditionCodeAL);
 
-   TR_ARMImmSymInstruction(TR::Instruction                        *precedingInstruction,
-                              TR_ARMOpCodes                       op,
-                              TR::Node                            *node,
-                              uint32_t                            imm,
-                              TR::RegisterDependencyConditions *cond,
-                              TR::SymbolReference                 *sr,
-                              TR::CodeGenerator                   *cg,
-                              TR::Snippet                         *s=NULL,
-                              TR_ARMConditionCode                cc=ARMConditionCodeAL);
+   ARMImmSymInstruction(TR::Instruction                        *precedingInstruction,
+                        TR_ARMOpCodes                       op,
+                        TR::Node                            *node,
+                        uint32_t                            imm,
+                        TR::RegisterDependencyConditions *cond,
+                        TR::SymbolReference                 *sr,
+                        TR::CodeGenerator                   *cg,
+                        TR::Snippet                         *s=NULL,
+                        TR_ARMConditionCode                cc=ARMConditionCodeAL);
 
    virtual Kind getKind() { return IsImmSym; }
 
@@ -519,7 +521,7 @@ class TR_ARMImmSymInstruction : public TR_ARMImmInstruction
    virtual int32_t estimateBinaryLength(int32_t currentEstimate);
    };
 
-class TR_ARMTrg1Src2Instruction : public TR::Instruction
+class ARMTrg1Src2Instruction : public TR::Instruction
    {
    TR::Register    *_target1Register;
    TR::Register    *_source1Register;
@@ -527,35 +529,35 @@ class TR_ARMTrg1Src2Instruction : public TR::Instruction
 
    public:
 
-   TR_ARMTrg1Src2Instruction(TR::Node *node, TR::CodeGenerator *cg) : TR::Instruction(node, cg) {}
+   ARMTrg1Src2Instruction(TR::Node *node, TR::CodeGenerator *cg) : TR::Instruction(node, cg) {}
 
-   TR_ARMTrg1Src2Instruction(TR_ARMOpCodes op, TR::Node *node, TR::CodeGenerator *cg)
+   ARMTrg1Src2Instruction(TR_ARMOpCodes op, TR::Node *node, TR::CodeGenerator *cg)
       : TR::Instruction(op, node, cg), _target1Register(0), _source1Register(0), _source2Operand(0)
       {
       }
 
-   TR_ARMTrg1Src2Instruction(TR::Instruction   *precedingInstruction,
-                             TR_ARMOpCodes     op,
-                             TR::Node          *node,
-                             TR::CodeGenerator *cg)
+   ARMTrg1Src2Instruction(TR::Instruction   *precedingInstruction,
+                          TR_ARMOpCodes     op,
+                          TR::Node          *node,
+                          TR::CodeGenerator *cg)
       : TR::Instruction(precedingInstruction, op, node, cg), _target1Register(0), _source1Register(0), _source2Operand(0)
       {
       }
 
-   TR_ARMTrg1Src2Instruction(TR_ARMOpCodes                       op,
-                             TR::Node                            *node,
-                             TR::RegisterDependencyConditions *cond,
-                             TR::CodeGenerator                   *cg)
+   ARMTrg1Src2Instruction(TR_ARMOpCodes                       op,
+                          TR::Node                            *node,
+                          TR::RegisterDependencyConditions *cond,
+                          TR::CodeGenerator                   *cg)
       : TR::Instruction(op, node, cond, cg), _target1Register(0), _source1Register(0), _source2Operand(0)
       {
       }
 
-   TR_ARMTrg1Src2Instruction(TR_ARMOpCodes    op,
-                             TR::Node          *node,
-                             TR::Register      *treg,
-                             TR::Register      *s1reg,
-                             TR_ARMOperand2   *s2op,
-                             TR::CodeGenerator *cg)
+   ARMTrg1Src2Instruction(TR_ARMOpCodes    op,
+                          TR::Node          *node,
+                          TR::Register      *treg,
+                          TR::Register      *s1reg,
+                          TR_ARMOperand2   *s2op,
+                          TR::CodeGenerator *cg)
       : TR::Instruction(op, node, cg), _target1Register(treg), _source1Register(s1reg), _source2Operand(s2op)
       {
       treg->incTotalUseCount();
@@ -563,13 +565,13 @@ class TR_ARMTrg1Src2Instruction : public TR::Instruction
       s2op->incTotalUseCount();
       }
 
-   TR_ARMTrg1Src2Instruction(TR::Instruction   *precedingInstruction,
-                             TR_ARMOpCodes     op,
-                             TR::Node          *node,
-                             TR::Register      *treg,
-                             TR::Register      *s1reg,
-                             TR_ARMOperand2   *s2op,
-                             TR::CodeGenerator *cg)
+   ARMTrg1Src2Instruction(TR::Instruction   *precedingInstruction,
+                          TR_ARMOpCodes     op,
+                          TR::Node          *node,
+                          TR::Register      *treg,
+                          TR::Register      *s1reg,
+                          TR_ARMOperand2   *s2op,
+                          TR::CodeGenerator *cg)
       : TR::Instruction(precedingInstruction, op, node, cg),  _target1Register(treg), _source1Register(s1reg), _source2Operand(s2op)
       {
       treg->incTotalUseCount();
@@ -579,12 +581,12 @@ class TR_ARMTrg1Src2Instruction : public TR::Instruction
 
 // The following are for convenience so one doesn't need to build a
 // TR_ARMOperand2 by hand each time
-   TR_ARMTrg1Src2Instruction(TR_ARMOpCodes     op,
-                             TR::Node          *node,
-                             TR::Register      *treg,
-                             TR::Register      *s1reg,
-                             TR::Register      *s2reg,
-                             TR::CodeGenerator *cg)
+   ARMTrg1Src2Instruction(TR_ARMOpCodes     op,
+                          TR::Node          *node,
+                          TR::Register      *treg,
+                          TR::Register      *s1reg,
+                          TR::Register      *s2reg,
+                          TR::CodeGenerator *cg)
       : TR::Instruction(op, node, cg), _target1Register(treg), _source1Register(s1reg)
       {
       TR_ARMOperand2 *s2op = new (cg->trHeapMemory()) TR_ARMOperand2(ARMOp2Reg, s2reg);
@@ -594,13 +596,13 @@ class TR_ARMTrg1Src2Instruction : public TR::Instruction
       s2op->incTotalUseCount();
       }
 
-   TR_ARMTrg1Src2Instruction(TR::Instruction   *precedingInstruction,
-                             TR_ARMOpCodes     op,
-                             TR::Node          *node,
-                             TR::Register      *treg,
-                             TR::Register      *s1reg,
-                             TR::Register      *s2reg,
-                             TR::CodeGenerator *cg)
+   ARMTrg1Src2Instruction(TR::Instruction   *precedingInstruction,
+                          TR_ARMOpCodes     op,
+                          TR::Node          *node,
+                          TR::Register      *treg,
+                          TR::Register      *s1reg,
+                          TR::Register      *s2reg,
+                          TR::CodeGenerator *cg)
       : TR::Instruction(precedingInstruction, op, node, cg), _target1Register(treg), _source1Register(s1reg)
       {
       TR_ARMOperand2 *s2op = new (cg->trHeapMemory()) TR_ARMOperand2(ARMOp2Reg, s2reg);
@@ -688,27 +690,27 @@ class TR_ARMTrg1Src2Instruction : public TR::Instruction
    virtual bool defsRealRegister(TR::Register *reg);
    };
 
-class TR_ARMLoadStartPCInstruction : public TR_ARMTrg1Src2Instruction
+class ARMLoadStartPCInstruction : public TR::ARMTrg1Src2Instruction
    {
    TR::SymbolReference           *_symbolReference;
 
    public:
-   TR_ARMLoadStartPCInstruction(TR::Node          *node,
+   ARMLoadStartPCInstruction(TR::Node          *node,
                              TR::Register      *treg,
                              TR::SymbolReference *symRef,
                              TR::CodeGenerator *cg)
-      : TR_ARMTrg1Src2Instruction(ARMOp_sub, node, treg, cg->machine()->getARMRealRegister(TR::RealRegister::gr15),
+      : TR::ARMTrg1Src2Instruction(ARMOp_sub, node, treg, cg->machine()->getARMRealRegister(TR::RealRegister::gr15),
          new (cg->trHeapMemory()) TR_ARMOperand2(0xde, 24), cg), /* The value 0xde does not mean anything. It will be replaced in the binary encoding phase. */
         _symbolReference(symRef)
       {
       }
 
-   TR_ARMLoadStartPCInstruction(TR::Instruction   *precedingInstruction,
+   ARMLoadStartPCInstruction(TR::Instruction   *precedingInstruction,
                              TR::Node          *node,
                              TR::Register      *treg,
                              TR::SymbolReference *symRef,
                              TR::CodeGenerator *cg)
-      : TR_ARMTrg1Src2Instruction(precedingInstruction, ARMOp_sub, node, treg, cg->machine()->getARMRealRegister(TR::RealRegister::gr15),
+      : TR::ARMTrg1Src2Instruction(precedingInstruction, ARMOp_sub, node, treg, cg->machine()->getARMRealRegister(TR::RealRegister::gr15),
          new (cg->trHeapMemory()) TR_ARMOperand2(0xde, 0), cg),  /* The value 0xde does not mean anything. It will be replaced in the binary encoding phase. */
         _symbolReference(symRef)
       {
@@ -718,19 +720,19 @@ class TR_ARMLoadStartPCInstruction : public TR_ARMTrg1Src2Instruction
    virtual uint8_t *generateBinaryEncoding();
    };
 
-class TR_ARMSrc2Instruction : public TR_ARMTrg1Src2Instruction
+class ARMSrc2Instruction : public TR::ARMTrg1Src2Instruction
    {
 
    public:
 
-   TR_ARMSrc2Instruction(TR::Node *node, TR::CodeGenerator *cg) : TR_ARMTrg1Src2Instruction(node, cg) {}
+   ARMSrc2Instruction(TR::Node *node, TR::CodeGenerator *cg) : TR::ARMTrg1Src2Instruction(node, cg) {}
 
-   TR_ARMSrc2Instruction(TR_ARMOpCodes     op,
-                         TR::Node          *node,
-                         TR::Register      *s1reg,
-                         TR_ARMOperand2   *s2op,
-                         TR::CodeGenerator *cg)
-      : TR_ARMTrg1Src2Instruction(op, node, cg)
+   ARMSrc2Instruction(TR_ARMOpCodes     op,
+                      TR::Node          *node,
+                      TR::Register      *s1reg,
+                      TR_ARMOperand2   *s2op,
+                      TR::CodeGenerator *cg)
+      : TR::ARMTrg1Src2Instruction(op, node, cg)
       {
       setSource1Register(s1reg);
       setSource2Operand(s2op);
@@ -738,13 +740,13 @@ class TR_ARMSrc2Instruction : public TR_ARMTrg1Src2Instruction
       s2op->incTotalUseCount();
       }
 
-   TR_ARMSrc2Instruction(TR::Instruction   *precedingInstruction,
-                         TR_ARMOpCodes     op,
-                         TR::Node          *node,
-                         TR::Register      *s1reg,
-                         TR_ARMOperand2   *s2op,
-                         TR::CodeGenerator *cg)
-      : TR_ARMTrg1Src2Instruction(precedingInstruction, op, node, cg)
+   ARMSrc2Instruction(TR::Instruction   *precedingInstruction,
+                      TR_ARMOpCodes     op,
+                      TR::Node          *node,
+                      TR::Register      *s1reg,
+                      TR_ARMOperand2   *s2op,
+                      TR::CodeGenerator *cg)
+      : TR::ARMTrg1Src2Instruction(precedingInstruction, op, node, cg)
       {
       setSource1Register(s1reg);
       setSource2Operand(s2op);
@@ -756,19 +758,19 @@ class TR_ARMSrc2Instruction : public TR_ARMTrg1Src2Instruction
    };
 
 
-class TR_ARMTrg1Src1Instruction : public TR_ARMTrg1Src2Instruction
+class ARMTrg1Src1Instruction : public TR::ARMTrg1Src2Instruction
    {
 
    public:
 
-   TR_ARMTrg1Src1Instruction(TR::Node *node, TR::CodeGenerator *cg) : TR_ARMTrg1Src2Instruction(node, cg) {}
+   ARMTrg1Src1Instruction(TR::Node *node, TR::CodeGenerator *cg) : TR::ARMTrg1Src2Instruction(node, cg) {}
 
-   TR_ARMTrg1Src1Instruction(TR_ARMOpCodes     op,
-                             TR::Node          *node,
-                             TR::Register      *treg,
-                             TR_ARMOperand2   *sop,
-                             TR::CodeGenerator *cg)
-      : TR_ARMTrg1Src2Instruction(op, node, cg)
+   ARMTrg1Src1Instruction(TR_ARMOpCodes     op,
+                          TR::Node          *node,
+                          TR::Register      *treg,
+                          TR_ARMOperand2   *sop,
+                          TR::CodeGenerator *cg)
+      : TR::ARMTrg1Src2Instruction(op, node, cg)
       {
       setTarget1Register(treg);
       setSource2Operand(sop);
@@ -776,13 +778,13 @@ class TR_ARMTrg1Src1Instruction : public TR_ARMTrg1Src2Instruction
       sop->incTotalUseCount();
       }
 
-   TR_ARMTrg1Src1Instruction(TR_ARMOpCodes                       op,
-                             TR::Node                            *node,
-                             TR::RegisterDependencyConditions *cond,
-                             TR::Register                        *treg,
-                             TR_ARMOperand2                     *sop,
-                             TR::CodeGenerator                   *cg)
-      : TR_ARMTrg1Src2Instruction(op, node, cond, cg)
+   ARMTrg1Src1Instruction(TR_ARMOpCodes                       op,
+                          TR::Node                            *node,
+                          TR::RegisterDependencyConditions *cond,
+                          TR::Register                        *treg,
+                          TR_ARMOperand2                     *sop,
+                          TR::CodeGenerator                   *cg)
+      : TR::ARMTrg1Src2Instruction(op, node, cond, cg)
       {
       setTarget1Register(treg);
       setSource2Operand(sop);
@@ -790,13 +792,13 @@ class TR_ARMTrg1Src1Instruction : public TR_ARMTrg1Src2Instruction
       sop->incTotalUseCount();
       }
 
-   TR_ARMTrg1Src1Instruction(TR::Instruction   *precedingInstruction,
-                             TR_ARMOpCodes     op,
-                             TR::Node          *node,
-                             TR::Register      *treg,
-                             TR_ARMOperand2   *sop,
-                             TR::CodeGenerator *cg)
-      : TR_ARMTrg1Src2Instruction(precedingInstruction, op, node, cg)
+   ARMTrg1Src1Instruction(TR::Instruction   *precedingInstruction,
+                          TR_ARMOpCodes     op,
+                          TR::Node          *node,
+                          TR::Register      *treg,
+                          TR_ARMOperand2   *sop,
+                          TR::CodeGenerator *cg)
+      : TR::ARMTrg1Src2Instruction(precedingInstruction, op, node, cg)
       {
       setTarget1Register(treg);
       setSource2Operand(sop);
@@ -806,13 +808,13 @@ class TR_ARMTrg1Src1Instruction : public TR_ARMTrg1Src2Instruction
 
    // The following are for convenience so one doesn't need to build a
    // TR_ARMOperand2 by hand each time
-   TR_ARMTrg1Src1Instruction(TR::Instruction   *precedingInstruction,
-                             TR_ARMOpCodes     op,
-                             TR::Node          *node,
-                             TR::Register      *treg,
-                             TR::Register      *sreg,
-                             TR::CodeGenerator *cg)
-      : TR_ARMTrg1Src2Instruction(precedingInstruction, op, node, cg)
+   ARMTrg1Src1Instruction(TR::Instruction   *precedingInstruction,
+                          TR_ARMOpCodes     op,
+                          TR::Node          *node,
+                          TR::Register      *treg,
+                          TR::Register      *sreg,
+                          TR::CodeGenerator *cg)
+      : TR::ARMTrg1Src2Instruction(precedingInstruction, op, node, cg)
       {
       TR_ARMOperand2 *sop = new (cg->trHeapMemory()) TR_ARMOperand2(ARMOp2Reg, sreg);
       setTarget1Register(treg);
@@ -821,12 +823,12 @@ class TR_ARMTrg1Src1Instruction : public TR_ARMTrg1Src2Instruction
       sop->incTotalUseCount();
       }
 
-   TR_ARMTrg1Src1Instruction(TR_ARMOpCodes     op,
-                             TR::Node          *node,
-                             TR::Register      *treg,
-                             TR::Register      *sreg,
-                             TR::CodeGenerator *cg)
-      : TR_ARMTrg1Src2Instruction(op, node, cg)
+   ARMTrg1Src1Instruction(TR_ARMOpCodes     op,
+                          TR::Node          *node,
+                          TR::Register      *treg,
+                          TR::Register      *sreg,
+                          TR::CodeGenerator *cg)
+      : TR::ARMTrg1Src2Instruction(op, node, cg)
       {
       TR_ARMOperand2 *sop = new (cg->trHeapMemory()) TR_ARMOperand2(ARMOp2Reg, sreg);
       setTarget1Register(treg);
@@ -835,13 +837,13 @@ class TR_ARMTrg1Src1Instruction : public TR_ARMTrg1Src2Instruction
       sop->incTotalUseCount();
       }
 
-   TR_ARMTrg1Src1Instruction(TR_ARMOpCodes                       op,
-                             TR::Node                            *node,
-                             TR::RegisterDependencyConditions *cond,
-                             TR::Register                        *treg,
-                             TR::Register                        *sreg,
-                             TR::CodeGenerator                   *cg)
-      : TR_ARMTrg1Src2Instruction(op, node, cond, cg)
+   ARMTrg1Src1Instruction(TR_ARMOpCodes                       op,
+                          TR::Node                            *node,
+                          TR::RegisterDependencyConditions *cond,
+                          TR::Register                        *treg,
+                          TR::Register                        *sreg,
+                          TR::CodeGenerator                   *cg)
+      : TR::ARMTrg1Src2Instruction(op, node, cond, cg)
       {
       TR_ARMOperand2 *sop = new (cg->trHeapMemory()) TR_ARMOperand2(ARMOp2Reg, sreg);
       setTarget1Register(treg);
@@ -854,30 +856,30 @@ class TR_ARMTrg1Src1Instruction : public TR_ARMTrg1Src2Instruction
    };
 
 
-class TR_ARMTrg1Instruction : public TR::Instruction
+class ARMTrg1Instruction : public TR::Instruction
    {
    TR::Register *_target1Register;
 
    public:
 
-   TR_ARMTrg1Instruction(TR::Node *node, TR::CodeGenerator *cg) : TR::Instruction(node, cg) {}
+   ARMTrg1Instruction(TR::Node *node, TR::CodeGenerator *cg) : TR::Instruction(node, cg) {}
 
 
-   TR_ARMTrg1Instruction(TR_ARMOpCodes     op,
-                         TR::Node          *node,
-                         TR::Register      *treg,
-                         TR::CodeGenerator *cg)
+   ARMTrg1Instruction(TR_ARMOpCodes     op,
+                      TR::Node          *node,
+                      TR::Register      *treg,
+                      TR::CodeGenerator *cg)
       : TR::Instruction(op, node, cg),
         _target1Register(treg)
       {
       treg->incTotalUseCount();
       }
 
-   TR_ARMTrg1Instruction(TR::Instruction   *precedingInstruction,
-                         TR_ARMOpCodes     op,
-                         TR::Node          *node,
-                         TR::Register      *treg,
-                         TR::CodeGenerator *cg)
+   ARMTrg1Instruction(TR::Instruction   *precedingInstruction,
+                      TR_ARMOpCodes     op,
+                      TR::Node          *node,
+                      TR::Register      *treg,
+                      TR::CodeGenerator *cg)
       : TR::Instruction(precedingInstruction, op, node, cg),
         _target1Register(treg)
       {
@@ -917,22 +919,22 @@ class TR_ARMTrg1Instruction : public TR::Instruction
    };
 
 #if (defined(__VFP_FP__) && !defined(__SOFTFP__))
-class TR_ARMTrg2Src1Instruction : public TR_ARMTrg1Src2Instruction
+class ARMTrg2Src1Instruction : public TR::ARMTrg1Src2Instruction
    {
    // For fmrrd
    TR::Register *_target2Register;
 
    public:
 
-   TR_ARMTrg2Src1Instruction(TR::Node *node, TR::CodeGenerator *cg) : TR_ARMTrg1Src2Instruction(node, cg), _target2Register(0) {}
+   ARMTrg2Src1Instruction(TR::Node *node, TR::CodeGenerator *cg) : TR::ARMTrg1Src2Instruction(node, cg), _target2Register(0) {}
 
-   TR_ARMTrg2Src1Instruction(TR_ARMOpCodes     op,
-                             TR::Node          *node,
-                             TR::Register      *t1reg,
-                             TR::Register      *t2reg,
-                             TR::Register      *sreg,
-                             TR::CodeGenerator *cg)
-      : TR_ARMTrg1Src2Instruction(op, node, cg), _target2Register(t2reg)
+   ARMTrg2Src1Instruction(TR_ARMOpCodes     op,
+                          TR::Node          *node,
+                          TR::Register      *t1reg,
+                          TR::Register      *t2reg,
+                          TR::Register      *sreg,
+                          TR::CodeGenerator *cg)
+      : TR::ARMTrg1Src2Instruction(op, node, cg), _target2Register(t2reg)
       {
       setTarget1Register(t1reg);
       setSource1Register(sreg);
@@ -941,14 +943,14 @@ class TR_ARMTrg2Src1Instruction : public TR_ARMTrg1Src2Instruction
       sreg->incTotalUseCount();
       }
 
-   TR_ARMTrg2Src1Instruction(TR::Instruction   *precedingInstruction,
-                             TR_ARMOpCodes     op,
-                             TR::Node          *node,
-                             TR::Register      *t1reg,
-                             TR::Register      *t2reg,
-                             TR::Register      *sreg,
-                             TR::CodeGenerator *cg)
-      : TR_ARMTrg1Src2Instruction(precedingInstruction, op, node, cg), _target2Register(t2reg)
+   ARMTrg2Src1Instruction(TR::Instruction   *precedingInstruction,
+                          TR_ARMOpCodes     op,
+                          TR::Node          *node,
+                          TR::Register      *t1reg,
+                          TR::Register      *t2reg,
+                          TR::Register      *sreg,
+                          TR::CodeGenerator *cg)
+      : TR::ARMTrg1Src2Instruction(precedingInstruction, op, node, cg), _target2Register(t2reg)
       {
       setTarget1Register(t1reg);
       setSource1Register(sreg);
@@ -991,7 +993,7 @@ class TR_ARMTrg2Src1Instruction : public TR_ARMTrg1Src2Instruction
    };
 #endif
 
-class TR_ARMMulInstruction : public TR::Instruction
+class ARMMulInstruction : public TR::Instruction
    {
    TR::Register    *_targetLoRegister;  // for mul only targetLoRegister is used
    TR::Register    *_targetHiRegister;  // for mull instructions only, NULL for mul instructions
@@ -1000,11 +1002,11 @@ class TR_ARMMulInstruction : public TR::Instruction
 
    public:
 
-   TR_ARMMulInstruction(TR::Node *node, TR::CodeGenerator *cg) : TR::Instruction(node, cg) {}
+   ARMMulInstruction(TR::Node *node, TR::CodeGenerator *cg) : TR::Instruction(node, cg) {}
 
-   TR_ARMMulInstruction(TR_ARMOpCodes     op,
-                        TR::Node          *node,
-                        TR::CodeGenerator *cg)
+   ARMMulInstruction(TR_ARMOpCodes     op,
+                     TR::Node          *node,
+                     TR::CodeGenerator *cg)
          : TR::Instruction(op, node, cg),
            _targetLoRegister(0),
            _targetHiRegister(0),
@@ -1013,10 +1015,10 @@ class TR_ARMMulInstruction : public TR::Instruction
          {
          }
 
-   TR_ARMMulInstruction(TR::Instruction   *precedingInstruction,
-                        TR_ARMOpCodes     op,
-                        TR::Node          *node,
-                        TR::CodeGenerator *cg)
+   ARMMulInstruction(TR::Instruction   *precedingInstruction,
+                     TR_ARMOpCodes     op,
+                     TR::Node          *node,
+                     TR::CodeGenerator *cg)
          : TR::Instruction(precedingInstruction, op, node, cg),
            _targetLoRegister(0),
            _targetHiRegister(0),
@@ -1025,10 +1027,10 @@ class TR_ARMMulInstruction : public TR::Instruction
          {
          }
 
-   TR_ARMMulInstruction(TR_ARMOpCodes                       op,
-                        TR::Node                            *node,
-                        TR::RegisterDependencyConditions *cond,
-                        TR::CodeGenerator                   *cg)
+   ARMMulInstruction(TR_ARMOpCodes                       op,
+                     TR::Node                            *node,
+                     TR::RegisterDependencyConditions *cond,
+                     TR::CodeGenerator                   *cg)
          : TR::Instruction(op, node, cond, cg),
            _targetLoRegister(0),
            _targetHiRegister(0),
@@ -1037,12 +1039,12 @@ class TR_ARMMulInstruction : public TR::Instruction
          {
          }
 
-   TR_ARMMulInstruction(TR_ARMOpCodes     op,
-                        TR::Node          *node,
-                        TR::Register      *tregLo,
-                        TR::Register      *s1reg,
-                        TR::Register      *s2reg,
-                        TR::CodeGenerator *cg)
+   ARMMulInstruction(TR_ARMOpCodes     op,
+                     TR::Node          *node,
+                     TR::Register      *tregLo,
+                     TR::Register      *s1reg,
+                     TR::Register      *s2reg,
+                     TR::CodeGenerator *cg)
          : TR::Instruction(op, node, cg),
            _targetLoRegister(tregLo),
            _targetHiRegister(0),
@@ -1054,13 +1056,13 @@ class TR_ARMMulInstruction : public TR::Instruction
          s2reg->incTotalUseCount();
          }
 
-   TR_ARMMulInstruction(TR::Instruction   *precedingInstruction,
-                        TR_ARMOpCodes     op,
-                        TR::Node          *node,
-                        TR::Register      *tregLo,
-                        TR::Register      *s1reg,
-                        TR::Register      *s2reg,
-                        TR::CodeGenerator *cg)
+   ARMMulInstruction(TR::Instruction   *precedingInstruction,
+                     TR_ARMOpCodes     op,
+                     TR::Node          *node,
+                     TR::Register      *tregLo,
+                     TR::Register      *s1reg,
+                     TR::Register      *s2reg,
+                     TR::CodeGenerator *cg)
          : TR::Instruction(precedingInstruction, op, node, cg),
            _targetLoRegister(tregLo),
            _targetHiRegister(0),
@@ -1072,13 +1074,13 @@ class TR_ARMMulInstruction : public TR::Instruction
          s2reg->incTotalUseCount();
          }
 // below 2 for mull instructions
- TR_ARMMulInstruction(TR_ARMOpCodes       op,
-                        TR::Node          *node,
-                        TR::Register      *tregHi,
-                        TR::Register      *tregLo,
-                        TR::Register      *s1reg,
-                        TR::Register      *s2reg,
-                        TR::CodeGenerator *cg)
+   ARMMulInstruction(TR_ARMOpCodes       op,
+                     TR::Node          *node,
+                     TR::Register      *tregHi,
+                     TR::Register      *tregLo,
+                     TR::Register      *s1reg,
+                     TR::Register      *s2reg,
+                     TR::CodeGenerator *cg)
          : TR::Instruction(op, node, cg),
            _targetLoRegister(tregLo),
            _targetHiRegister(tregHi),
@@ -1091,14 +1093,14 @@ class TR_ARMMulInstruction : public TR::Instruction
          s2reg->incTotalUseCount();
          }
 
-   TR_ARMMulInstruction(TR::Instruction   *precedingInstruction,
-                        TR_ARMOpCodes     op,
-                        TR::Node          *node,
-                        TR::Register      *tregHi,
-                        TR::Register      *tregLo,
-                        TR::Register      *s1reg,
-                        TR::Register      *s2reg,
-                        TR::CodeGenerator *cg)
+   ARMMulInstruction(TR::Instruction   *precedingInstruction,
+                     TR_ARMOpCodes     op,
+                     TR::Node          *node,
+                     TR::Register      *tregHi,
+                     TR::Register      *tregLo,
+                     TR::Register      *s1reg,
+                     TR::Register      *s2reg,
+                     TR::CodeGenerator *cg)
          : TR::Instruction(precedingInstruction, op, node, cg),
            _targetLoRegister(tregLo),
            _targetHiRegister(tregHi),
@@ -1165,34 +1167,34 @@ class TR_ARMMulInstruction : public TR::Instruction
    };
 
 // superclass of both ldr and str
-class TR_ARMMemInstruction : public TR_ARMTrg1Instruction
+class ARMMemInstruction : public TR::ARMTrg1Instruction
    {
    TR::MemoryReference *_memoryReference;
    bool                   _memoryRead;
 
    public:
 
-   TR_ARMMemInstruction(TR::Node *node, TR::CodeGenerator *cg) : TR_ARMTrg1Instruction(node, cg) {}
+   ARMMemInstruction(TR::Node *node, TR::CodeGenerator *cg) : TR::ARMTrg1Instruction(node, cg) {}
 
-   TR_ARMMemInstruction(TR_ARMOpCodes          op,
-                        TR::Node               *node,
-                        TR::Register           *treg,
-                        TR::MemoryReference *mf,
-                        bool                   memRead,
-                        TR::CodeGenerator *cg)
-         : TR_ARMTrg1Instruction(op, node, treg, cg), _memoryReference(mf), _memoryRead(memRead)
+   ARMMemInstruction(TR_ARMOpCodes          op,
+                     TR::Node               *node,
+                     TR::Register           *treg,
+                     TR::MemoryReference *mf,
+                     bool                   memRead,
+                     TR::CodeGenerator *cg)
+         : TR::ARMTrg1Instruction(op, node, treg, cg), _memoryReference(mf), _memoryRead(memRead)
       {
       mf->incRegisterTotalUseCounts(cg);
       }
 
-   TR_ARMMemInstruction(TR::Instruction         *precedingInstruction,
-                        TR_ARMOpCodes          op,
-                        TR::Node                *node,
-                        TR::Register            *treg,
-                        TR::MemoryReference  *mf,
-                        bool                   memRead,
-                        TR::CodeGenerator *cg)
-         : TR_ARMTrg1Instruction(precedingInstruction, op, node, treg, cg), _memoryReference(mf), _memoryRead(memRead)
+   ARMMemInstruction(TR::Instruction         *precedingInstruction,
+                     TR_ARMOpCodes          op,
+                     TR::Node                *node,
+                     TR::Register            *treg,
+                     TR::MemoryReference  *mf,
+                     bool                   memRead,
+                     TR::CodeGenerator *cg)
+         : TR::ARMTrg1Instruction(precedingInstruction, op, node, treg, cg), _memoryReference(mf), _memoryRead(memRead)
       {
       mf->incRegisterTotalUseCounts(cg);
       }
@@ -1221,28 +1223,28 @@ class TR_ARMMemInstruction : public TR_ARMTrg1Instruction
    virtual bool usesRegister(TR::Register *reg);
    };
 
-class TR_ARMMemSrc1Instruction : public TR_ARMMemInstruction
+class ARMMemSrc1Instruction : public TR::ARMMemInstruction
    {
    public:
 
-   TR_ARMMemSrc1Instruction(TR::Node *node, TR::CodeGenerator *cg) : TR_ARMMemInstruction(node, cg) {}
+   ARMMemSrc1Instruction(TR::Node *node, TR::CodeGenerator *cg) : TR::ARMMemInstruction(node, cg) {}
 
-   TR_ARMMemSrc1Instruction(TR_ARMOpCodes         op,
-                            TR::Node               *node,
-                            TR::MemoryReference *mf,
-                            TR::Register           *sreg,
-                            TR::CodeGenerator *cg)
-         : TR_ARMMemInstruction(op, node, sreg, mf, true, cg)
+   ARMMemSrc1Instruction(TR_ARMOpCodes         op,
+                         TR::Node               *node,
+                         TR::MemoryReference *mf,
+                         TR::Register           *sreg,
+                         TR::CodeGenerator *cg)
+         : TR::ARMMemInstruction(op, node, sreg, mf, true, cg)
       {
       }
 
-   TR_ARMMemSrc1Instruction(TR::Instruction        *precedingInstruction,
-                            TR_ARMOpCodes         op,
-                            TR::Node               *node,
-                            TR::MemoryReference *mf,
-                            TR::Register           *sreg,
-                            TR::CodeGenerator *cg)
-         : TR_ARMMemInstruction(precedingInstruction, op, node, sreg, mf, true, cg)
+   ARMMemSrc1Instruction(TR::Instruction        *precedingInstruction,
+                         TR_ARMOpCodes         op,
+                         TR::Node               *node,
+                         TR::MemoryReference *mf,
+                         TR::Register           *sreg,
+                         TR::CodeGenerator *cg)
+         : TR::ARMMemInstruction(precedingInstruction, op, node, sreg, mf, true, cg)
       {
       }
 
@@ -1262,27 +1264,27 @@ class TR_ARMMemSrc1Instruction : public TR_ARMMemInstruction
    };
 
 
-class TR_ARMTrg1MemInstruction : public TR_ARMMemInstruction
+class ARMTrg1MemInstruction : public TR::ARMMemInstruction
    {
    public:
 
 
-   TR_ARMTrg1MemInstruction(TR::Node *node, TR::CodeGenerator *cg) : TR_ARMMemInstruction(node, cg) {}
+   ARMTrg1MemInstruction(TR::Node *node, TR::CodeGenerator *cg) : TR::ARMMemInstruction(node, cg) {}
 
-   TR_ARMTrg1MemInstruction(TR_ARMOpCodes          op,
-                            TR::Node               *node,
-                            TR::Register           *sreg,
-                            TR::MemoryReference *mf,
-                            TR::CodeGenerator      *cg)
-      : TR_ARMMemInstruction(op, node, sreg, mf, false, cg) {}
+   ARMTrg1MemInstruction(TR_ARMOpCodes          op,
+                         TR::Node               *node,
+                         TR::Register           *sreg,
+                         TR::MemoryReference *mf,
+                         TR::CodeGenerator      *cg)
+      : TR::ARMMemInstruction(op, node, sreg, mf, false, cg) {}
 
-   TR_ARMTrg1MemInstruction(TR::Instruction        *precedingInstruction,
-                            TR_ARMOpCodes          op,
-                            TR::Node               *node,
-                            TR::Register           *sreg,
-                            TR::MemoryReference *mf,
-                            TR::CodeGenerator      *cg)
-      : TR_ARMMemInstruction(precedingInstruction, op, node, sreg, mf, false, cg) {}
+   ARMTrg1MemInstruction(TR::Instruction        *precedingInstruction,
+                         TR_ARMOpCodes          op,
+                         TR::Node               *node,
+                         TR::Register           *sreg,
+                         TR::MemoryReference *mf,
+                         TR::CodeGenerator      *cg)
+      : TR::ARMMemInstruction(precedingInstruction, op, node, sreg, mf, false, cg) {}
 
    virtual Kind getKind() { return IsTrg1Mem; }
 
@@ -1293,30 +1295,30 @@ class TR_ARMTrg1MemInstruction : public TR_ARMMemInstruction
    virtual bool usesRegister(TR::Register *reg);
    };
 
-class TR_ARMTrg1MemSrc1Instruction : public TR_ARMMemInstruction
+class ARMTrg1MemSrc1Instruction : public TR::ARMMemInstruction
    {
    TR::Register *_source1Register;
 
    public:
 
-   TR_ARMTrg1MemSrc1Instruction(TR::Node *node, TR::CodeGenerator *cg) : TR_ARMMemInstruction(node, cg) {}
+   ARMTrg1MemSrc1Instruction(TR::Node *node, TR::CodeGenerator *cg) : TR::ARMMemInstruction(node, cg) {}
 
-   TR_ARMTrg1MemSrc1Instruction(TR_ARMOpCodes          op,
-                                TR::Node               *node,
-                                TR::Register           *treg,
-                                TR::MemoryReference *mf,
-                                TR::Register           *sreg,
-                                TR::CodeGenerator      *cg)
-      : TR_ARMMemInstruction(op, node, treg, mf, false, cg), _source1Register(sreg) {}
+   ARMTrg1MemSrc1Instruction(TR_ARMOpCodes          op,
+                             TR::Node               *node,
+                             TR::Register           *treg,
+                             TR::MemoryReference *mf,
+                             TR::Register           *sreg,
+                             TR::CodeGenerator      *cg)
+      : TR::ARMMemInstruction(op, node, treg, mf, false, cg), _source1Register(sreg) {}
 
-   TR_ARMTrg1MemSrc1Instruction(TR::Instruction        *precedingInstruction,
-                                TR_ARMOpCodes          op,
-                                TR::Node               *node,
-                                TR::Register           *treg,
-                                TR::MemoryReference *mf,
-                                TR::Register           *sreg,
-                                TR::CodeGenerator      *cg)
-      : TR_ARMMemInstruction(precedingInstruction, op, node, treg, mf, false, cg), _source1Register(sreg) {}
+   ARMTrg1MemSrc1Instruction(TR::Instruction        *precedingInstruction,
+                             TR_ARMOpCodes          op,
+                             TR::Node               *node,
+                             TR::Register           *treg,
+                             TR::MemoryReference *mf,
+                             TR::Register           *sreg,
+                             TR::CodeGenerator      *cg)
+      : TR::ARMMemInstruction(precedingInstruction, op, node, treg, mf, false, cg), _source1Register(sreg) {}
 
    virtual Kind getKind() { return IsTrg1MemSrc1; }
 
@@ -1337,10 +1339,10 @@ class TR_ARMTrg1MemSrc1Instruction : public TR_ARMMemInstruction
    };
 
 // If we are using a register allocator that cannot handle registers being alive across basic block
-// boundaries then we use TR_ARMControlFlowInstruction as a placeholder.  It contains a summary of
+// boundaries then we use TR::ARMControlFlowInstruction as a placeholder.  It contains a summary of
 // register usage information and enough other information to generate the correct instruction
 // sequence.
-class TR_ARMControlFlowInstruction : public TR::Instruction
+class ARMControlFlowInstruction : public TR::Instruction
    {
    TR::Register *_sourceRegisters[8];
    TR::Register *_targetRegisters[5];
@@ -1353,13 +1355,13 @@ class TR_ARMControlFlowInstruction : public TR::Instruction
 
    public:
 
-   TR_ARMControlFlowInstruction(TR::Node *node, TR::CodeGenerator *cg) : TR::Instruction(node, cg) {}
-   TR_ARMControlFlowInstruction(TR_ARMOpCodes  op, TR::Node *node, TR::CodeGenerator *cg)
+   ARMControlFlowInstruction(TR::Node *node, TR::CodeGenerator *cg) : TR::Instruction(node, cg) {}
+   ARMControlFlowInstruction(TR_ARMOpCodes  op, TR::Node *node, TR::CodeGenerator *cg)
       : TR::Instruction(op, node, cg), _numSources(0), _numTargets(0), _label(NULL), _opCode2(ARMOp_bad)
       {
       }
 
-   TR_ARMControlFlowInstruction(TR_ARMOpCodes  op, TR::Node *node, TR::RegisterDependencyConditions *deps, TR::CodeGenerator *cg)
+   ARMControlFlowInstruction(TR_ARMOpCodes  op, TR::Node *node, TR::RegisterDependencyConditions *deps, TR::CodeGenerator *cg)
       : TR::Instruction(op, node, deps, cg), _numSources(0), _numTargets(0), _label(NULL), _opCode2(ARMOp_bad)
       {
       }
@@ -1423,7 +1425,7 @@ class TR_ARMControlFlowInstruction : public TR::Instruction
    virtual bool defsRealRegister(TR::Register *reg);
    };
 
-class TR_ARMMultipleMoveInstruction : public TR::Instruction
+class ARMMultipleMoveInstruction : public TR::Instruction
    {
    TR::Register    *_memoryBaseRegister;
    uint16_t       _registerList;
@@ -1433,45 +1435,45 @@ class TR_ARMMultipleMoveInstruction : public TR::Instruction
 
    public:
 
-   TR_ARMMultipleMoveInstruction(TR::Node *node, TR::CodeGenerator *cg) : TR::Instruction(node, cg) {}
+   ARMMultipleMoveInstruction(TR::Node *node, TR::CodeGenerator *cg) : TR::Instruction(node, cg) {}
 
-   TR_ARMMultipleMoveInstruction(TR_ARMOpCodes op, TR::Node *node, TR::CodeGenerator *cg)
+   ARMMultipleMoveInstruction(TR_ARMOpCodes op, TR::Node *node, TR::CodeGenerator *cg)
          : TR::Instruction(op, node, cg), _memoryBaseRegister(0), _registerList(0), _writeBack(false), _increment(false), _preIndex(false)
          {
          }
 
-   TR_ARMMultipleMoveInstruction(TR::Instruction * precedingInstruction,
-                                 TR_ARMOpCodes    op,
-                                 TR::Node *node,
-                                 TR::CodeGenerator *cg)
+   ARMMultipleMoveInstruction(TR::Instruction * precedingInstruction,
+                              TR_ARMOpCodes    op,
+                              TR::Node *node,
+                              TR::CodeGenerator *cg)
          : TR::Instruction(precedingInstruction, op, node, cg), _memoryBaseRegister(0), _registerList(0), _writeBack(false), _increment(false), _preIndex(false)
          {
          }
 
-   TR_ARMMultipleMoveInstruction(TR_ARMOpCodes                        op,
-                                 TR::Node                            * node,
-                                 TR::RegisterDependencyConditions * cond,
-                                 TR::CodeGenerator *cg)
+   ARMMultipleMoveInstruction(TR_ARMOpCodes                        op,
+                              TR::Node                            * node,
+                              TR::RegisterDependencyConditions * cond,
+                              TR::CodeGenerator *cg)
          : TR::Instruction(op, node, cond, cg), _memoryBaseRegister(0), _registerList(0), _writeBack(false), _increment(false), _preIndex(false)
          {
          }
 
-   TR_ARMMultipleMoveInstruction(TR_ARMOpCodes    op,
-                                 TR::Node        * node,
-                                 TR::Register    * mbr,
-                                 uint16_t         rl,
-                                 TR::CodeGenerator *cg)
+   ARMMultipleMoveInstruction(TR_ARMOpCodes    op,
+                              TR::Node        * node,
+                              TR::Register    * mbr,
+                              uint16_t         rl,
+                              TR::CodeGenerator *cg)
          : TR::Instruction(op, node, cg), _memoryBaseRegister(mbr), _registerList(rl), _writeBack(false), _increment(false), _preIndex(false)
          {
          mbr->incTotalUseCount();
          }
 
-   TR_ARMMultipleMoveInstruction(TR::Instruction * precedingInstruction,
-                                 TR_ARMOpCodes    op,
-                                 TR::Node        * node,
-                                 TR::Register    * mbr,
-                                 uint16_t         rl,
-                                 TR::CodeGenerator *cg)
+   ARMMultipleMoveInstruction(TR::Instruction * precedingInstruction,
+                              TR_ARMOpCodes    op,
+                              TR::Node        * node,
+                              TR::Register    * mbr,
+                              uint16_t         rl,
+                              TR::CodeGenerator *cg)
          : TR::Instruction(precedingInstruction, op, node, cg), _memoryBaseRegister(mbr), _registerList(rl), _writeBack(false), _increment(false), _preIndex(false)
          {
          mbr->incTotalUseCount();
@@ -1526,5 +1528,27 @@ class TR_ARMMultipleMoveInstruction : public TR::Instruction
 
    virtual bool defsRealRegister(TR::Register *reg);
    };
+
+}
+
+typedef TR::ARMImmInstruction TR_ARMImmInstruction;
+typedef TR::ARMLabelInstruction TR_ARMLabelInstruction;
+typedef TR::ARMConditionalBranchInstruction TR_ARMConditionalBranchInstruction;
+typedef TR::ARMVirtualGuardNOPInstruction TR_ARMVirtualGuardNOPInstruction;
+typedef TR::ARMAdminInstruction TR_ARMAdminInstruction;
+typedef TR::ARMImmSymInstruction TR_ARMImmSymInstruction;
+typedef TR::ARMTrg1Src2Instruction TR_ARMTrg1Src2Instruction;
+typedef TR::ARMLoadStartPCInstruction TR_ARMLoadStartPCInstruction;
+typedef TR::ARMSrc2Instruction TR_ARMSrc2Instruction;
+typedef TR::ARMTrg1Src1Instruction TR_ARMTrg1Src1Instruction;
+typedef TR::ARMTrg1Instruction TR_ARMTrg1Instruction;
+typedef TR::ARMTrg2Src1Instruction TR_ARMTrg2Src1Instruction;
+typedef TR::ARMMulInstruction TR_ARMMulInstruction;
+typedef TR::ARMMemInstruction TR_ARMMemInstruction;
+typedef TR::ARMMemSrc1Instruction TR_ARMMemSrc1Instruction;
+typedef TR::ARMTrg1MemInstruction TR_ARMTrg1MemInstruction;
+typedef TR::ARMTrg1MemSrc1Instruction TR_ARMTrg1MemSrc1Instruction;
+typedef TR::ARMControlFlowInstruction TR_ARMControlFlowInstruction;
+typedef TR::ARMMultipleMoveInstruction TR_ARMMultipleMoveInstruction;
 
 #endif

--- a/compiler/arm/codegen/BinaryCommutativeAnalyser.cpp
+++ b/compiler/arm/codegen/BinaryCommutativeAnalyser.cpp
@@ -62,39 +62,39 @@ void TR_ARMBinaryCommutativeAnalyser::genericAnalyser(TR::Node       *root,
 
    if (getOpReg1Reg2())
       {
-//      new TR_ARMRegRegInstruction(regToRegOpCode, firstRegister, secondRegister);
+//      new TR::ARMRegRegInstruction(regToRegOpCode, firstRegister, secondRegister);
 //      root->setRegister(firstRegister);
       }
    else if (getOpReg2Reg1())
       {
-//      new TR_ARMRegRegInstruction(regToRegOpCode, secondRegister, firstRegister);
+//      new TR::ARMRegRegInstruction(regToRegOpCode, secondRegister, firstRegister);
 //      root->setRegister(secondRegister);
 //      notReversedOperands();
       }
    else if (getCopyReg1())
       {
 //      TR::Register *tempReg = root->setRegister(cg()->allocateRegister());
-//      new TR_ARMRegRegInstruction(copyOpCode, tempReg, firstRegister);
-//      new TR_ARMRegRegInstruction(regToRegOpCode, tempReg, secondRegister);
+//      new TR::ARMRegRegInstruction(copyOpCode, tempReg, firstRegister);
+//      new TR::ARMRegRegInstruction(regToRegOpCode, tempReg, secondRegister);
       }
    else if (getCopyReg2())
       {
 //      TR::Register *tempReg = root->setRegister(cg()->allocateRegister());
-//      new TR_ARMRegRegInstruction(copyOpCode, tempReg, secondRegister);
-//      new TR_ARMRegRegInstruction(regToRegOpCode, tempReg, firstRegister);
+//      new TR::ARMRegRegInstruction(copyOpCode, tempReg, secondRegister);
+//      new TR::ARMRegRegInstruction(regToRegOpCode, tempReg, firstRegister);
 //      notReversedOperands();
       }
    else if (getOpReg1Mem2())
       {
 //      TR_ARMMemoryReference *tempMR = new TR_ARMMemoryReference(secondChild);
-//      new TR_ARMRegMemInstruction(memToRegOpCode, firstRegister, tempMR);
+//      new TR::ARMRegMemInstruction(memToRegOpCode, firstRegister, tempMR);
 //      tempMR->decNodeReferenceCounts();
 //      root->setRegister(firstRegister);
       }
    else
       {
 //      TR_ARMMemoryReference *tempMR = new TR_ARMMemoryReference(firstChild);
-//      new TR_ARMRegMemInstruction(memToRegOpCode, secondRegister, tempMR);
+//      new TR::ARMRegMemInstruction(memToRegOpCode, secondRegister, tempMR);
 //      tempMR->decNodeReferenceCounts();
 //      root->setRegister(secondRegister);
 //      notReversedOperands();
@@ -147,20 +147,20 @@ void TR_ARMBinaryCommutativeAnalyser::genericLongAnalyser(TR::Node       *root,
 
    if (getOpReg1Reg2())
       {
-//      new TR_ARMRegRegInstruction(lowRegToRegOpCode,
+//      new TR::ARMRegRegInstruction(lowRegToRegOpCode,
 //                                  firstRegister->getLowOrder(),
 //                                  secondRegister->getLowOrder());
-//      new TR_ARMRegRegInstruction(highRegToRegOpCode,
+//      new TR::ARMRegRegInstruction(highRegToRegOpCode,
 //                                  firstRegister->getHighOrder(),
 //                                  secondRegister->getHighOrder());
 //      root->setRegister(firstRegister);
       }
    else if (getOpReg2Reg1())
       {
-//      new TR_ARMRegRegInstruction(lowRegToRegOpCode,
+//      new TR::ARMRegRegInstruction(lowRegToRegOpCode,
 //                                  secondRegister->getLowOrder(),
 //                                  firstRegister->getLowOrder());
-//      new TR_ARMRegRegInstruction(highRegToRegOpCode,
+//      new TR::ARMRegRegInstruction(highRegToRegOpCode,
 //                                  secondRegister->getHighOrder(),
 //                                  firstRegister->getHighOrder());
 //      root->setRegister(secondRegister);
@@ -169,32 +169,32 @@ void TR_ARMBinaryCommutativeAnalyser::genericLongAnalyser(TR::Node       *root,
    else if (getCopyReg1())
       {
 //      TR::Register *tempReg = root->setRegister(cg()->allocateRegisterPair());
-//      new TR_ARMRegRegInstruction(copyOpCode,
+//      new TR::ARMRegRegInstruction(copyOpCode,
 //                                  tempReg->getLowOrder(),
 //                                  firstRegister->getLowOrder());
-//      new TR_ARMRegRegInstruction(copyOpCode,
+//      new TR::ARMRegRegInstruction(copyOpCode,
 //                                  tempReg->getHighOrder(),
 //                                  firstRegister->getHighOrder());
-//      new TR_ARMRegRegInstruction(lowRegToRegOpCode,
+//      new TR::ARMRegRegInstruction(lowRegToRegOpCode,
 //                                  tempReg->getLowOrder(),
 //                                  secondRegister->getLowOrder());
-//      new TR_ARMRegRegInstruction(highRegToRegOpCode,
+//      new TR::ARMRegRegInstruction(highRegToRegOpCode,
 //                                  tempReg->getHighOrder(),
 //                                  secondRegister->getHighOrder());
       }
    else if (getCopyReg2())
       {
 //      TR::Register *tempReg = root->setRegister(cg()->allocateRegisterPair());
-//      new TR_ARMRegRegInstruction(copyOpCode,
+//      new TR::ARMRegRegInstruction(copyOpCode,
 //                                  tempReg->getLowOrder(),
 //                                  secondRegister->getLowOrder());
-//      new TR_ARMRegRegInstruction(copyOpCode,
+//      new TR::ARMRegRegInstruction(copyOpCode,
 //                                  tempReg->getHighOrder(),
 //                                  secondRegister->getHighOrder());
-//      new TR_ARMRegRegInstruction(lowRegToRegOpCode,
+//      new TR::ARMRegRegInstruction(lowRegToRegOpCode,
 //                                  tempReg->getLowOrder(),
 //                                  firstRegister->getLowOrder());
-//      new TR_ARMRegRegInstruction(highRegToRegOpCode,
+//      new TR::ARMRegRegInstruction(highRegToRegOpCode,
 //                                  tempReg->getHighOrder(),
 //                                  firstRegister->getHighOrder());
 //      notReversedOperands();
@@ -203,10 +203,10 @@ void TR_ARMBinaryCommutativeAnalyser::genericLongAnalyser(TR::Node       *root,
       {
 //      TR_ARMMemoryReference *lowMR  = new TR_ARMMemoryReference(secondChild);
 //      TR_ARMMemoryReference *highMR = new TR_ARMMemoryReference(*lowMR, 4);
-//      new TR_ARMRegMemInstruction(lowMemToRegOpCode,
+//      new TR::ARMRegMemInstruction(lowMemToRegOpCode,
 //                                  firstRegister->getLowOrder(),
 //                                  lowMR);
-//      new TR_ARMRegMemInstruction(highMemToRegOpCode,
+//      new TR::ARMRegMemInstruction(highMemToRegOpCode,
 //                                  firstRegister->getHighOrder(),
 //                                  highMR);
 //      lowMR->decNodeReferenceCounts();
@@ -216,10 +216,10 @@ void TR_ARMBinaryCommutativeAnalyser::genericLongAnalyser(TR::Node       *root,
       {
 //      TR_ARMMemoryReference *lowMR  = new TR_ARMMemoryReference(firstChild);
 //      TR_ARMMemoryReference *highMR = new TR_ARMMemoryReference(*lowMR, 4);
-//      new TR_ARMRegMemInstruction(lowMemToRegOpCode,
+//      new TR::ARMRegMemInstruction(lowMemToRegOpCode,
 //                                  secondRegister->getLowOrder(),
 //                                  lowMR);
-//      new TR_ARMRegMemInstruction(highMemToRegOpCode,
+//      new TR::ARMRegMemInstruction(highMemToRegOpCode,
 //                                  secondRegister->getHighOrder(),
 //                                  highMR);
 //      lowMR->decNodeReferenceCounts();
@@ -271,12 +271,12 @@ void TR_ARMBinaryCommutativeAnalyser::integerAddAnalyser(TR::Node       *root,
 
    if (getOpReg1Reg2())
       {
-//      new TR_ARMRegRegInstruction(regToRegOpCode, firstRegister, secondRegister);
+//      new TR::ARMRegRegInstruction(regToRegOpCode, firstRegister, secondRegister);
 //      root->setRegister(firstRegister);
       }
    else if (getOpReg2Reg1())
       {
-//      new TR_ARMRegRegInstruction(regToRegOpCode, secondRegister, firstRegister);
+//      new TR::ARMRegRegInstruction(regToRegOpCode, secondRegister, firstRegister);
 //      root->setRegister(secondRegister);
 //      notReversedOperands();
       }
@@ -286,19 +286,19 @@ void TR_ARMBinaryCommutativeAnalyser::integerAddAnalyser(TR::Node       *root,
 //      TR_ARMMemoryReference *tempMR = new TR_ARMMemoryReference();
 //      tempMR->setBaseRegister(firstRegister);
 //      tempMR->setIndexRegister(secondRegister);
-//      new TR_ARMRegMemInstruction(LEA4RegMem, tempReg, tempMR);
+//      new TR::ARMRegMemInstruction(LEA4RegMem, tempReg, tempMR);
       }
    else if (getOpReg1Mem2())
       {
 //      TR_ARMMemoryReference *tempMR = new TR_ARMMemoryReference(secondChild);
-//      new TR_ARMRegMemInstruction(memToRegOpCode, firstRegister, tempMR);
+//      new TR::ARMRegMemInstruction(memToRegOpCode, firstRegister, tempMR);
 //      tempMR->decNodeReferenceCounts();
 //      root->setRegister(firstRegister);
       }
    else
       {
 //      TR_ARMMemoryReference *tempMR = new TR_ARMMemoryReference(firstChild);
-//      new TR_ARMRegMemInstruction(memToRegOpCode, secondRegister, tempMR);
+//      new TR::ARMRegMemInstruction(memToRegOpCode, secondRegister, tempMR);
 //      tempMR->decNodeReferenceCounts();
 //      root->setRegister(secondRegister);
 //      notReversedOperands();
@@ -345,14 +345,14 @@ void TR_ARMBinaryCommutativeAnalyser::longAddAnalyser(TR::Node *root)
 
    if (getOpReg1Reg2())
       {
-//      new TR_ARMRegRegInstruction(ADD4RegReg, firstRegister->getLowOrder(), secondRegister->getLowOrder());
-//      new TR_ARMRegRegInstruction(ADC4RegReg, firstRegister->getHighOrder(), secondRegister->getHighOrder());
+//      new TR::ARMRegRegInstruction(ADD4RegReg, firstRegister->getLowOrder(), secondRegister->getLowOrder());
+//      new TR::ARMRegRegInstruction(ADC4RegReg, firstRegister->getHighOrder(), secondRegister->getHighOrder());
 //      root->setRegister(firstRegister);
       }
    else if (getOpReg2Reg1())
       {
-//      new TR_ARMRegRegInstruction(ADD4RegReg, secondRegister->getLowOrder(), firstRegister->getLowOrder());
-//      new TR_ARMRegRegInstruction(ADC4RegReg, secondRegister->getHighOrder(), firstRegister->getHighOrder());
+//      new TR::ARMRegRegInstruction(ADD4RegReg, secondRegister->getLowOrder(), firstRegister->getLowOrder());
+//      new TR::ARMRegRegInstruction(ADC4RegReg, secondRegister->getHighOrder(), firstRegister->getHighOrder());
 //      root->setRegister(secondRegister);
 //      notReversedOperands();
       }
@@ -362,18 +362,18 @@ void TR_ARMBinaryCommutativeAnalyser::longAddAnalyser(TR::Node *root)
 //      TR::Register     *highRegister = cg()->allocateRegister();
 //      TR_RegisterPair *tempReg      = cg()->allocateRegisterPair(lowRegister, highRegister);
 //      root->setRegister(tempReg);
-//      new TR_ARMRegRegInstruction(MOV4RegReg, lowRegister, firstRegister->getLowOrder());
-//      new TR_ARMRegRegInstruction(MOV4RegReg, highRegister, firstRegister->getHighOrder());
-//      new TR_ARMRegRegInstruction(ADD4RegReg, tempReg->getLowOrder(), secondRegister->getLowOrder());
-//      new TR_ARMRegRegInstruction(ADC4RegReg, tempReg->getHighOrder(), secondRegister->getHighOrder());
+//      new TR::ARMRegRegInstruction(MOV4RegReg, lowRegister, firstRegister->getLowOrder());
+//      new TR::ARMRegRegInstruction(MOV4RegReg, highRegister, firstRegister->getHighOrder());
+//      new TR::ARMRegRegInstruction(ADD4RegReg, tempReg->getLowOrder(), secondRegister->getLowOrder());
+//      new TR::ARMRegRegInstruction(ADC4RegReg, tempReg->getHighOrder(), secondRegister->getHighOrder());
 //      root->setRegister(tempReg);
       }
    else if (getOpReg1Mem2())
       {
 //      TR_ARMMemoryReference *lowMR  = new TR_ARMMemoryReference(secondChild);
 //      TR_ARMMemoryReference *highMR = new TR_ARMMemoryReference(*lowMR, 4);
-//      new TR_ARMRegMemInstruction(ADD4RegMem, firstRegister->getLowOrder(), lowMR);
-//      new TR_ARMRegMemInstruction(ADC4RegMem, firstRegister->getHighOrder(), highMR);
+//      new TR::ARMRegMemInstruction(ADD4RegMem, firstRegister->getLowOrder(), lowMR);
+//      new TR::ARMRegMemInstruction(ADC4RegMem, firstRegister->getHighOrder(), highMR);
 //      lowMR->decNodeReferenceCounts();
 //      root->setRegister(firstRegister);
       }
@@ -381,8 +381,8 @@ void TR_ARMBinaryCommutativeAnalyser::longAddAnalyser(TR::Node *root)
       {
 //      TR_ARMMemoryReference *lowMR  = new TR_ARMMemoryReference(firstChild);
 //      TR_ARMMemoryReference *highMR = new TR_ARMMemoryReference(*lowMR, 4);
-//      new TR_ARMRegMemInstruction(ADD4RegMem, secondRegister->getLowOrder(), lowMR);
-//      new TR_ARMRegMemInstruction(ADC4RegMem, secondRegister->getHighOrder(), highMR);
+//      new TR::ARMRegMemInstruction(ADD4RegMem, secondRegister->getLowOrder(), lowMR);
+//      new TR::ARMRegMemInstruction(ADC4RegMem, secondRegister->getHighOrder(), highMR);
 //      lowMR->decNodeReferenceCounts();
 //      root->setRegister(secondRegister);
 //      notReversedOperands();

--- a/compiler/arm/codegen/BinaryEvaluator.cpp
+++ b/compiler/arm/codegen/BinaryEvaluator.cpp
@@ -933,7 +933,7 @@ static TR::Register *longRightShiftEvaluator(TR::Node *node, bool isLogical, TR:
             }
          else
             {
-            new (cg->trHeapMemory()) TR_ARMTrg1Src1Instruction(ARMOp_mov, node, trgReg->getHighOrder(), new (cg->trHeapMemory()) TR_ARMOperand2(shiftType, srcHighReg, 31), cg);
+            new (cg->trHeapMemory()) TR::ARMTrg1Src1Instruction(ARMOp_mov, node, trgReg->getHighOrder(), new (cg->trHeapMemory()) TR_ARMOperand2(shiftType, srcHighReg, 31), cg);
             }
          if (shiftAmount == 32)
             {
@@ -941,7 +941,7 @@ static TR::Register *longRightShiftEvaluator(TR::Node *node, bool isLogical, TR:
             }
          else
             {
-            new (cg->trHeapMemory()) TR_ARMTrg1Src1Instruction(ARMOp_mov, node, trgReg->getLowOrder(), new (cg->trHeapMemory()) TR_ARMOperand2(shiftType, srcHighReg, shiftAmount-32), cg);
+            new (cg->trHeapMemory()) TR::ARMTrg1Src1Instruction(ARMOp_mov, node, trgReg->getLowOrder(), new (cg->trHeapMemory()) TR_ARMOperand2(shiftType, srcHighReg, shiftAmount-32), cg);
             }
          }
       else // (shiftAmount < 32)
@@ -1161,13 +1161,13 @@ static inline TR::Register *lbooleanTypeEvaluator(TR::Node *node,
          {
          trgLow = cg->allocateRegister();
          armLoadConstant(node, (int32_t)imm64, trgLow, cg);
-         new (cg->trHeapMemory()) TR_ARMTrg1Src2Instruction(regOp, node, trgLow, src1Reg->getLowOrder(), trgLow, cg);
+         new (cg->trHeapMemory()) TR::ARMTrg1Src2Instruction(regOp, node, trgLow, src1Reg->getLowOrder(), trgLow, cg);
          }
       if (!(trgHigh = ibooleanTypeImmediateEvaluator(firstChild, regOp, src1Reg->getHighOrder(), (int32_t)(imm64>>32), cg)))
          {
          trgHigh = cg->allocateRegister();
          armLoadConstant(node, (int32_t)(imm64>>32), trgHigh, cg);
-         new (cg->trHeapMemory()) TR_ARMTrg1Src2Instruction(regOp, node, trgHigh, src1Reg->getHighOrder(), trgHigh, cg);
+         new (cg->trHeapMemory()) TR::ARMTrg1Src2Instruction(regOp, node, trgHigh, src1Reg->getHighOrder(), trgHigh, cg);
          }
       trgReg = cg->allocateRegisterPair(trgLow, trgHigh);
       }
@@ -1176,8 +1176,8 @@ static inline TR::Register *lbooleanTypeEvaluator(TR::Node *node,
       trgReg = cg->allocateRegisterPair(cg->allocateRegister(), cg->allocateRegister());
       src2Reg = cg->evaluate(secondChild);
 
-      new (cg->trHeapMemory()) TR_ARMTrg1Src2Instruction(regOp, node, trgReg->getLowOrder(), src2Reg->getLowOrder(), src1Reg->getLowOrder(), cg);
-      new (cg->trHeapMemory()) TR_ARMTrg1Src2Instruction(regOp, node, trgReg->getHighOrder(), src2Reg->getHighOrder(), src1Reg->getHighOrder(), cg);
+      new (cg->trHeapMemory()) TR::ARMTrg1Src2Instruction(regOp, node, trgReg->getLowOrder(), src2Reg->getLowOrder(), src1Reg->getLowOrder(), cg);
+      new (cg->trHeapMemory()) TR::ARMTrg1Src2Instruction(regOp, node, trgReg->getHighOrder(), src2Reg->getHighOrder(), src1Reg->getHighOrder(), cg);
       }
    node->setRegister(trgReg);
    firstChild->decReferenceCount();

--- a/compiler/arm/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/arm/codegen/ControlFlowEvaluator.cpp
@@ -506,7 +506,7 @@ static TR::Register *compareLongAndSetOrderedBoolean(TR_ARMConditionCode branchO
    if (true)
       {
       TR::Register   *src2Reg = cg->evaluate(secondChild);
-      TR_ARMControlFlowInstruction *cfop = generateControlFlowInstruction(cg, ARMOp_setblong, node, deps);
+      TR::ARMControlFlowInstruction *cfop = generateControlFlowInstruction(cg, ARMOp_setblong, node, deps);
       cfop->addTargetRegister(trgReg);
       cfop->addTargetRegister(tempReg);
       cfop->addSourceRegister(src1Reg->getLowOrder());
@@ -545,7 +545,7 @@ static TR::Register *compareLongsForOrder(TR_ARMConditionCode branchOp, TR::Node
    TR::Register *src2Reg = cg->evaluate(secondChild);
    if (/* isSmall() || */ TR::comp()->getOption(TR_DisableOOL) || disableOOLForLongCompares)
       {
-      TR_ARMControlFlowInstruction *cfop = generateControlFlowInstruction(cg, ARMOp_iflong, node, deps);
+      TR::ARMControlFlowInstruction *cfop = generateControlFlowInstruction(cg, ARMOp_iflong, node, deps);
       cfop->addSourceRegister(src1Reg->getHighOrder());
       cfop->addSourceRegister(src1Reg->getLowOrder());
       cfop->addSourceRegister(src2Reg->getHighOrder());
@@ -929,7 +929,7 @@ TR::Register *OMR::ARM::TreeEvaluator::lcmpEvaluator(TR::Node *node, TR::CodeGen
    // can handle registers being alive across basic block boundaries.
    // For now we just generate pessimistic code.
    TR::Register   *src2Reg = cg->evaluate(secondChild);
-   TR_ARMControlFlowInstruction *cfop = generateControlFlowInstruction(cg, ARMOp_lcmp, node, deps);
+   TR::ARMControlFlowInstruction *cfop = generateControlFlowInstruction(cg, ARMOp_lcmp, node, deps);
    cfop->addTargetRegister(trgReg);
    cfop->addSourceRegister(src1Reg->getLowOrder());
    cfop->addSourceRegister(src1Reg->getHighOrder());
@@ -1332,16 +1332,16 @@ static void lookupScheme4(TR::Node *node, TR::CodeGenerator *cg)
 
    generateLabelInstruction(node, cg, ARMOp_label, backLabel);
    generateTrg1Src2Instruction(node, cg, ARMOp_add, pivotRegister, highRegister, lowRegister);
-   new (cg->trHeapMemory()) TR_ARMTrg1Src1Imm2Instruction(0xfffffffc, 31, pivotRegister, pivotRegister, ARMOp_rlwinm, cg);
+   new (cg->trHeapMemory()) TR::ARMTrg1Src1Imm2Instruction(0xfffffffc, 31, pivotRegister, pivotRegister, ARMOp_rlwinm, cg);
    generateTrg1MemInstruction(cg, ARMOp_lwzx, dataRegister, new (cg->trHeapMemory()) TR_ARMMemoryReference(addrRegister, pivotRegister, cg));
    generateTrg1Src2Instruction(node, cg, ARMOp_cmp4, cndRegister, dataRegister, selector);
    generateConditionalBranchInstruction(node, cg, ARMOp_bne, searchLabel, cndRegister);
    generateLabelInstruction(node, cg, ARMOp_bl, linkLabel);
    generateLabelInstruction(node, cg, ARMOp_label, linkLabel);
-   new (cg->trHeapMemory()) TR_ARMTrg1Instruction(ARMOp_mflr, dataRegister, cg);
+   new (cg->trHeapMemory()) TR::ARMTrg1Instruction(ARMOp_mflr, dataRegister, cg);
    generateTrg1Src1ImmInstruction(node, cg, ARMOp_addi, pivotRegister, pivotRegister, 20);
    generateTrg1Src2Instruction(node, cg, ARMOp_add, dataRegister, pivotRegister, dataRegister);
-   new (cg->trHeapMemory()) TR_ARMSrc1Instruction(ARMOp_mtctr, dataRegister, cg);
+   new (cg->trHeapMemory()) TR::ARMSrc1Instruction(ARMOp_mtctr, dataRegister, cg);
    new (cg->trHeapMemory()) TR::Instruction(ARMOp_bctr, cg);
    for (int32_t ii=2; ii<total; ii++)
       {
@@ -1359,7 +1359,7 @@ static void lookupScheme4(TR::Node *node, TR::CodeGenerator *cg)
    generateTrg1Src2Instruction(node, cg, ARMOp_cmp4, cndRegister, pivotRegister, lowRegister);
    generateConditionalBranchInstruction(node, cg, ARMOp_beq, node->getSecondChild()->getBranchDestination()->getNode()->getLabel(), cndRegister);
    generateTrg1Src1ImmInstruction(node, cg, ARMOp_addi, highRegister, pivotRegister, -4);
-   new (cg->trHeapMemory()) TR_ARMDepLabelInstruction(ARMOp_b, backLabel, conditions, cg);
+   new (cg->trHeapMemory()) TR::ARMDepLabelInstruction(ARMOp_b, backLabel, conditions, cg);
    */
    }
 

--- a/compiler/arm/codegen/GenerateInstructions.hpp
+++ b/compiler/arm/codegen/GenerateInstructions.hpp
@@ -298,7 +298,7 @@ TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator         
                                                      TR::RegisterDependencyConditions *cond,
                                                      TR::Instruction                     *prev = NULL);
 
-TR_ARMControlFlowInstruction *generateControlFlowInstruction(TR::CodeGenerator                   *cg,
+TR::ARMControlFlowInstruction *generateControlFlowInstruction(TR::CodeGenerator                   *cg,
                                                              TR_ARMOpCodes                       op,
                                                              TR::Node                            *node,
                                                              TR::RegisterDependencyConditions *cond);

--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -290,7 +290,7 @@ TR::Instruction *OMR::ARM::CodeGenerator::generateSwitchToInterpreterPrePrologue
    uintptrj_t             helperAddr = (uintptrj_t)helperSymRef->getMethodAddress();
 
    // gr4 must contain the saved LR; see Recompilation.s
-   cursor = new (self()->trHeapMemory()) TR_ARMTrg1Src1Instruction(cursor, ARMOp_mov, node, gr4, lr, self());
+   cursor = new (self()->trHeapMemory()) TR::ARMTrg1Src1Instruction(cursor, ARMOp_mov, node, gr4, lr, self());
    cursor = self()->getLinkage()->flushArguments(cursor);
    cursor = generateImmSymInstruction(self(), ARMOp_bl, node, (uintptrj_t)revertToInterpreterSymRef->getMethodAddress(), new (self()->trHeapMemory()) TR::RegisterDependencyConditions((uint8_t)0,0, self()->trMemory()), revertToInterpreterSymRef, NULL, cursor);
    cursor = generateImmInstruction(self(), ARMOp_dd, node, (int32_t)ramMethod, TR_RamMethod, cursor);
@@ -313,7 +313,7 @@ static void removeGhostRegistersFromGCMaps(TR::CodeGenerator *cg, TR::Instructio
    // If there are any GC points between the top of the hot path and the first use the real reg holding the virtual will be included,
    // so we need to fix this.
    TR::Instruction *instr = branchOOL->getNext();
-   while (!instr->isLabel() || !((TR_ARMLabelInstruction*)instr)->getLabelSymbol()->isEndOfColdInstructionStream())
+   while (!instr->isLabel() || !((TR::ARMLabelInstruction*)instr)->getLabelSymbol()->isEndOfColdInstructionStream())
       {
       if (instr->needsGCMap())
          {
@@ -360,17 +360,17 @@ void OMR::ARM::CodeGenerator::beginInstructionSelection()
       if (methodSymbol->isJNI())
          {
          uintptrj_t JNIMethodAddress = (uintptrj_t) methodSymbol->getResolvedMethod()->startAddressForJNIMethod(comp);
-         cursor = new (self()->trHeapMemory()) TR_ARMImmInstruction(cursor, ARMOp_dd, startNode, (int32_t)JNIMethodAddress, self());
+         cursor = new (self()->trHeapMemory()) TR::ARMImmInstruction(cursor, ARMOp_dd, startNode, (int32_t)JNIMethodAddress, self());
          }
 
-      _returnTypeInfoInstruction = new (self()->trHeapMemory()) TR_ARMImmInstruction(cursor, ARMOp_dd, startNode, 0, self());
-      new (self()->trHeapMemory()) TR_ARMAdminInstruction(_returnTypeInfoInstruction, ARMOp_proc, startNode, NULL, self());
+      _returnTypeInfoInstruction = new (self()->trHeapMemory()) TR::ARMImmInstruction(cursor, ARMOp_dd, startNode, 0, self());
+      new (self()->trHeapMemory()) TR::ARMAdminInstruction(_returnTypeInfoInstruction, ARMOp_proc, startNode, NULL, self());
 
       }
    else
       {
       _returnTypeInfoInstruction = NULL;
-      new (self()->trHeapMemory()) TR_ARMAdminInstruction((TR::Instruction *)NULL, ARMOp_proc, startNode, NULL, self());
+      new (self()->trHeapMemory()) TR::ARMAdminInstruction((TR::Instruction *)NULL, ARMOp_proc, startNode, NULL, self());
       }
    }
 
@@ -415,7 +415,7 @@ void OMR::ARM::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssig
       // Track internal control flow on labels
       if (instructionCursor->isLabel())
          {
-         TR_ARMLabelInstruction *li = (TR_ARMLabelInstruction *)instructionCursor;
+         TR::ARMLabelInstruction *li = (TR::ARMLabelInstruction *)instructionCursor;
 
          if (li->getLabelSymbol() != NULL)
             {
@@ -431,7 +431,7 @@ void OMR::ARM::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssig
          }
       else if (instructionCursor->getKind() == TR::Instruction::IsConditionalBranch)
          {
-         TR_ARMConditionalBranchInstruction *bi = (TR_ARMConditionalBranchInstruction *)instructionCursor;
+         TR::ARMConditionalBranchInstruction *bi = (TR::ARMConditionalBranchInstruction *)instructionCursor;
 
          if (bi->getLabelSymbol() && bi->getLabelSymbol()->isStartOfColdInstructionStream())
             {
@@ -610,7 +610,7 @@ void OMR::ARM::CodeGenerator::doBinaryEncoding()
          {
          uint32_t magicWord = ((self()->getBinaryBufferCursor()-self()->getCodeStart())<<16) | static_cast<uint32_t>(comp->getReturnInfo());
          TR_ASSERT(_returnTypeInfoInstruction && _returnTypeInfoInstruction->getOpCodeValue() == ARMOp_dd, "assertion failure");
-         ((TR_ARMImmInstruction *)_returnTypeInfoInstruction)->setSourceImmediate(magicWord);
+         ((TR::ARMImmInstruction *)_returnTypeInfoInstruction)->setSourceImmediate(magicWord);
          *(uint32_t *)(_returnTypeInfoInstruction->getBinaryEncoding()) = magicWord;
 
 #ifdef J9_PROJECT_SPECIFIC
@@ -726,12 +726,12 @@ TR::Register *OMR::ARM::CodeGenerator::gprClobberEvaluate(TR::Node *node)
 
 static int32_t identifyFarConditionalBranches(int32_t estimate, TR::CodeGenerator *cg)
    {
-   TR_Array<TR_ARMConditionalBranchInstruction *> candidateBranches(cg->trMemory(), 256);
+   TR_Array<TR::ARMConditionalBranchInstruction *> candidateBranches(cg->trMemory(), 256);
    TR::Instruction *cursorInstruction = TR::comp()->getFirstInstruction();
 
    while (cursorInstruction)
       {
-      TR_ARMConditionalBranchInstruction *branch = cursorInstruction->getARMConditionalBranchInstruction();
+      TR::ARMConditionalBranchInstruction *branch = cursorInstruction->getARMConditionalBranchInstruction();
       if (branch != NULL)
          {
          if (abs(branch->getEstimatedBinaryLocation() - branch->getLabelSymbol()->getEstimatedCodeLocation()) > 16384)

--- a/compiler/arm/codegen/OMRCodeGenerator.hpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.hpp
@@ -84,7 +84,7 @@ class TR_BackingStore;
 namespace TR { class Machine; }
 namespace TR { class CodeGenerator; }
 struct TR_ARMLinkageProperties;
-class TR_ARMImmInstruction;
+namespace TR { class ARMImmInstruction; }
 class TR_ARMOpCode;
 class TR_ARMConstantDataSnippet;
 class TR_ARMLoadLabelItem;
@@ -227,7 +227,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    uint32_t                         _numFPR;
    TR::RealRegister            *_frameRegister;
    TR::RealRegister            *_methodMetaDataRegister;
-   TR_ARMImmInstruction          *_returnTypeInfoInstruction;
+   TR::ARMImmInstruction          *_returnTypeInfoInstruction;
    TR_ARMConstantDataSnippet       *_constantData;
    TR_ARMLinkageProperties   *_linkageProperties;
    List<TR_ARMOutOfLineCodeSection> _outOfLineCodeSectionList;

--- a/compiler/arm/codegen/OMRInstruction.cpp
+++ b/compiler/arm/codegen/OMRInstruction.cpp
@@ -119,7 +119,7 @@ bool OMR::ARM::Instruction::dependencyRefsRegister(TR::Register *reg)
    return false;
    }
 
-TR_ARMConditionalBranchInstruction *
+TR::ARMConditionalBranchInstruction *
 OMR::ARM::Instruction::getARMConditionalBranchInstruction()
    {
    return NULL;
@@ -128,7 +128,7 @@ OMR::ARM::Instruction::getARMConditionalBranchInstruction()
 // The following safe virtual downcast method is only used in an assertion
 // check within "toARMImmInstruction"
 #if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
-TR_ARMImmInstruction *OMR::ARM::Instruction::getARMImmInstruction()
+TR::ARMImmInstruction *OMR::ARM::Instruction::getARMImmInstruction()
    {
    return NULL;
    }
@@ -151,13 +151,13 @@ void OMR::ARM::Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
       }
    }
 
-// TR_ARMConditionalBranchInstruction member functions
-TR_ARMConditionalBranchInstruction *TR_ARMConditionalBranchInstruction::getARMConditionalBranchInstruction()
+// TR::ARMConditionalBranchInstruction member functions
+TR::ARMConditionalBranchInstruction *TR::ARMConditionalBranchInstruction::getARMConditionalBranchInstruction()
    {
    return this;
    }
 
-void TR_ARMConditionalBranchInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
+void TR::ARMConditionalBranchInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
    if (getDependencyConditions())
       {
@@ -186,72 +186,72 @@ void TR_ARMConditionalBranchInstruction::assignRegisters(TR_RegisterKinds kindTo
       }
    }
 
-bool TR_ARMConditionalBranchInstruction::refsRegister(TR::Register *reg)
+bool TR::ARMConditionalBranchInstruction::refsRegister(TR::Register *reg)
    {
    return false;
    }
 
-bool TR_ARMConditionalBranchInstruction::defsRegister(TR::Register *reg)
+bool TR::ARMConditionalBranchInstruction::defsRegister(TR::Register *reg)
    {
    return false;
    }
 
-bool TR_ARMConditionalBranchInstruction::defsRealRegister(TR::Register *reg)
+bool TR::ARMConditionalBranchInstruction::defsRealRegister(TR::Register *reg)
    {
    return false;
    }
 
-bool TR_ARMConditionalBranchInstruction::usesRegister(TR::Register *reg)
+bool TR::ARMConditionalBranchInstruction::usesRegister(TR::Register *reg)
    {
    return false;
    }
 
-// TR_ARMImmInstruction:: member functions
+// TR::ARMImmInstruction:: member functions
 
 
 // The following safe virtual downcast method is only used in an assertion
 // check within "toARMImmInstruction"
 #if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
-TR_ARMImmInstruction *TR_ARMImmInstruction::getARMImmInstruction()
+TR::ARMImmInstruction *TR::ARMImmInstruction::getARMImmInstruction()
    {
    return this;
    }
 #endif // defined(DEBUG) || defined(PROD_WITH_ASSUMES)
 
-// TR_ARMImmSymInstruction:: member functions
+// TR::ARMImmSymInstruction:: member functions
 
-TR_ARMImmSymInstruction::TR_ARMImmSymInstruction(TR_ARMOpCodes                       op,
-                                                 TR::Node                            *node,
-                                                 uint32_t                            imm,
-                                                 TR::RegisterDependencyConditions *cond,
-                                                 TR::SymbolReference                 *sr,
-                                                 TR::CodeGenerator                   *cg,
-                                                 TR::Snippet                         *s,
-                                                 TR_ARMConditionCode                 cc)
-   : TR_ARMImmInstruction(op, node, cond, imm, cg),
+TR::ARMImmSymInstruction::ARMImmSymInstruction(TR_ARMOpCodes                       op,
+                                               TR::Node                            *node,
+                                               uint32_t                            imm,
+                                               TR::RegisterDependencyConditions *cond,
+                                               TR::SymbolReference                 *sr,
+                                               TR::CodeGenerator                   *cg,
+                                               TR::Snippet                         *s,
+                                               TR_ARMConditionCode                 cc)
+   : TR::ARMImmInstruction(op, node, cond, imm, cg),
      _symbolReference(sr),
      _snippet(s)
    {
    setConditionCode(cc);
    }
 
-TR_ARMImmSymInstruction::TR_ARMImmSymInstruction(TR::Instruction                           *precedingInstruction,
-                                                       TR_ARMOpCodes                       op,
-                                                       TR::Node                            *node,
-                                                       uint32_t                            imm,
-                                                       TR::RegisterDependencyConditions *cond,
-                                                       TR::SymbolReference                 *sr,
-                                                       TR::CodeGenerator                   *cg,
-                                                       TR::Snippet                         *s,
-                                                       TR_ARMConditionCode                 cc)
-   : TR_ARMImmInstruction(precedingInstruction, op, node, cond, imm, cg),
+TR::ARMImmSymInstruction::ARMImmSymInstruction(TR::Instruction                           *precedingInstruction,
+                                               TR_ARMOpCodes                       op,
+                                               TR::Node                            *node,
+                                               uint32_t                            imm,
+                                               TR::RegisterDependencyConditions *cond,
+                                               TR::SymbolReference                 *sr,
+                                               TR::CodeGenerator                   *cg,
+                                               TR::Snippet                         *s,
+                                               TR_ARMConditionCode                 cc)
+   : TR::ARMImmInstruction(precedingInstruction, op, node, cond, imm, cg),
      _symbolReference(sr),
      _snippet(s)
    {
    setConditionCode(cc);
    }
 
-void TR_ARMLabelInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
+void TR::ARMLabelInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
    TR::Compilation *comp = TR::comp();
    TR::Machine  *machine        = cg()->machine();
@@ -316,30 +316,30 @@ void TR_ARMLabelInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
       }
    }
 
-// TR_ARMTrg1Src2Instruction:: member functions
-bool TR_ARMTrg1Src2Instruction::refsRegister(TR::Register *reg)
+// TR::ARMTrg1Src2Instruction:: member functions
+bool TR::ARMTrg1Src2Instruction::refsRegister(TR::Register *reg)
    {
    return (reg == getTarget1Register() ||
            reg == getSource1Register() ||
            getSource2Operand()->refsRegister(reg));
    }
 
-bool TR_ARMTrg1Src2Instruction::defsRegister(TR::Register *reg)
+bool TR::ARMTrg1Src2Instruction::defsRegister(TR::Register *reg)
    {
    return (reg == getTarget1Register());
    }
 
-bool TR_ARMTrg1Src2Instruction::defsRealRegister(TR::Register *reg)
+bool TR::ARMTrg1Src2Instruction::defsRealRegister(TR::Register *reg)
    {
    return (reg == getTarget1Register()->getAssignedRegister());
    }
 
-bool TR_ARMTrg1Src2Instruction::usesRegister(TR::Register *reg)
+bool TR::ARMTrg1Src2Instruction::usesRegister(TR::Register *reg)
    {
    return (reg == getSource1Register() || getSource2Operand()->refsRegister(reg));
    }
 
-void TR_ARMTrg1Src2Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
+void TR::ARMTrg1Src2Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
    TR::Machine  *machine        = cg()->machine();
    TR::Register    *target1Virtual = getTarget1Register();
@@ -387,30 +387,30 @@ void TR_ARMTrg1Src2Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigne
    }
 
 #if (defined(__VFP_FP__) && !defined(__SOFTFP__))
-// TR_ARMTrg2Src1Instruction:: member functions
-bool TR_ARMTrg2Src1Instruction::refsRegister(TR::Register *reg)
+// TR::ARMTrg2Src1Instruction:: member functions
+bool TR::ARMTrg2Src1Instruction::refsRegister(TR::Register *reg)
    {
    return (reg == getTarget1Register() ||
            reg == getTarget2Register() ||
            reg == getSource1Register() );
    }
 
-bool TR_ARMTrg2Src1Instruction::defsRegister(TR::Register *reg)
+bool TR::ARMTrg2Src1Instruction::defsRegister(TR::Register *reg)
    {
    return (reg == getTarget1Register() || reg == getTarget2Register());
    }
 
-bool TR_ARMTrg2Src1Instruction::defsRealRegister(TR::Register *reg)
+bool TR::ARMTrg2Src1Instruction::defsRealRegister(TR::Register *reg)
    {
    return (reg == getTarget1Register()->getAssignedRegister() || reg == getTarget2Register()->getAssignedRegister());
    }
 
-bool TR_ARMTrg2Src1Instruction::usesRegister(TR::Register *reg)
+bool TR::ARMTrg2Src1Instruction::usesRegister(TR::Register *reg)
    {
    return (reg == getSource1Register());
    }
 
-void TR_ARMTrg2Src1Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
+void TR::ARMTrg2Src1Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
    TR::Machine  *machine        = cg()->machine();
    TR::Register    *target1Virtual = getTarget1Register();
@@ -462,7 +462,7 @@ void TR_ARMTrg2Src1Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigne
    }
 #endif
 
-bool TR_ARMMulInstruction::refsRegister(TR::Register *reg)
+bool TR::ARMMulInstruction::refsRegister(TR::Register *reg)
    {
    return (reg == getTargetLoRegister() ||
            reg == getTargetHiRegister() ||
@@ -470,25 +470,25 @@ bool TR_ARMMulInstruction::refsRegister(TR::Register *reg)
            reg == getSource2Register());
    }
 
-bool TR_ARMMulInstruction::defsRegister(TR::Register *reg)
+bool TR::ARMMulInstruction::defsRegister(TR::Register *reg)
    {
    return (reg == getTargetLoRegister() ||
            reg == getTargetHiRegister());
    }
 
-bool TR_ARMMulInstruction::defsRealRegister(TR::Register *reg)
+bool TR::ARMMulInstruction::defsRealRegister(TR::Register *reg)
    {
    return (reg == getTargetLoRegister()->getAssignedRegister() ||
            reg == getTargetHiRegister()->getAssignedRegister());
    }
 
-bool TR_ARMMulInstruction::usesRegister(TR::Register *reg)
+bool TR::ARMMulInstruction::usesRegister(TR::Register *reg)
    {
    return (reg == getSource1Register() ||
            reg == getSource2Register());
    }
 
-void TR_ARMMulInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
+void TR::ARMMulInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
    TR::Machine *machine         = cg()->machine();
    TR::Register   *targetLoVirtual = getTargetLoRegister();
@@ -547,23 +547,23 @@ void TR_ARMMulInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    setSource2Register(assignedSource2Register);
    }
 
-TR::Register *TR_ARMMemInstruction::getMemoryDataRegister()
+TR::Register *TR::ARMMemInstruction::getMemoryDataRegister()
    {
    return getTargetRegister();
    }
 
 
-bool TR_ARMMemInstruction::refsRegister(TR::Register *reg)
+bool TR::ARMMemInstruction::refsRegister(TR::Register *reg)
    {
    return getMemoryReference()->refsRegister(reg);
    }
 
-bool TR_ARMMemInstruction::usesRegister(TR::Register *reg)
+bool TR::ARMMemInstruction::usesRegister(TR::Register *reg)
    {
    return getMemoryReference()->refsRegister(reg);
    }
 
-void TR_ARMMemInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
+void TR::ARMMemInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
    if (getDependencyConditions())
       getDependencyConditions()->assignPostConditionRegisters(this, kindToBeAssigned, cg());
@@ -574,29 +574,29 @@ void TR_ARMMemInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
       getDependencyConditions()->assignPreConditionRegisters(this->getPrev(), kindToBeAssigned, cg());
    }
 
-// TR_ARMMemSrc1Instruction:: member functions
+// TR::ARMMemSrc1Instruction:: member functions
 
-bool TR_ARMMemSrc1Instruction::refsRegister(TR::Register *reg)
+bool TR::ARMMemSrc1Instruction::refsRegister(TR::Register *reg)
    {
    return (getMemoryReference()->refsRegister(reg) || reg == getSourceRegister());
    }
 
-bool TR_ARMMemSrc1Instruction::defsRegister(TR::Register *reg)
+bool TR::ARMMemSrc1Instruction::defsRegister(TR::Register *reg)
    {
    return false;
    }
 
-bool TR_ARMMemSrc1Instruction::defsRealRegister(TR::Register *reg)
+bool TR::ARMMemSrc1Instruction::defsRealRegister(TR::Register *reg)
    {
    return false;
    }
 
-bool TR_ARMMemSrc1Instruction::usesRegister(TR::Register *reg)
+bool TR::ARMMemSrc1Instruction::usesRegister(TR::Register *reg)
    {
    return (getMemoryReference()->refsRegister(reg) || reg == getSourceRegister());
    }
 
-void TR_ARMMemSrc1Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
+void TR::ARMMemSrc1Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
    TR::Machine *machine       = cg()->machine();
    TR::Register   *sourceVirtual = getSourceRegister();
@@ -650,29 +650,29 @@ void TR_ARMMemSrc1Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned
       getDependencyConditions()->assignPreConditionRegisters(this->getPrev(), kindToBeAssigned, cg());
    }
 
-// TR_ARMTrg1Instruction:: member functions
+// TR::ARMTrg1Instruction:: member functions
 
-bool TR_ARMTrg1Instruction::refsRegister(TR::Register *reg)
+bool TR::ARMTrg1Instruction::refsRegister(TR::Register *reg)
    {
    return (reg == getTargetRegister());
    }
 
-bool TR_ARMTrg1Instruction::usesRegister(TR::Register *reg)
+bool TR::ARMTrg1Instruction::usesRegister(TR::Register *reg)
    {
    return false;
    }
 
-bool TR_ARMTrg1Instruction::defsRegister(TR::Register *reg)
+bool TR::ARMTrg1Instruction::defsRegister(TR::Register *reg)
    {
    return (reg == getTargetRegister());
    }
 
-bool TR_ARMTrg1Instruction::defsRealRegister(TR::Register *reg)
+bool TR::ARMTrg1Instruction::defsRealRegister(TR::Register *reg)
    {
    return (reg == getTargetRegister()->getAssignedRegister());
    }
 
-void TR_ARMTrg1Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
+void TR::ARMTrg1Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
    if (getDependencyConditions())
       getDependencyConditions()->assignPostConditionRegisters(this, kindToBeAssigned, cg());
@@ -685,19 +685,19 @@ void TR_ARMTrg1Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
       getDependencyConditions()->assignPreConditionRegisters(this->getPrev(), kindToBeAssigned, cg());
    }
 
-// TR_ARMTrg1MemInstruction:: member functions
+// TR::ARMTrg1MemInstruction:: member functions
 
-bool TR_ARMTrg1MemInstruction::refsRegister(TR::Register *reg)
+bool TR::ARMTrg1MemInstruction::refsRegister(TR::Register *reg)
    {
    return (reg == getTargetRegister() || getMemoryReference()->refsRegister(reg));
    }
 
-bool TR_ARMTrg1MemInstruction::usesRegister(TR::Register *reg)
+bool TR::ARMTrg1MemInstruction::usesRegister(TR::Register *reg)
    {
    return getMemoryReference()->refsRegister(reg);
    }
 
-void TR_ARMTrg1MemInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
+void TR::ARMTrg1MemInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
    TR::Register *targetVirtual = getTargetRegister();
    TR::Register *mBaseVirtual  = getMemoryReference()->getModBase();
@@ -724,18 +724,18 @@ void TR_ARMTrg1MemInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned
       getDependencyConditions()->assignPreConditionRegisters(this->getPrev(), kindToBeAssigned, cg());
    }
 
-// TR_ARMTrg1MemSrc1Instruction:: member functions
-bool TR_ARMTrg1MemSrc1Instruction::refsRegister(TR::Register *reg)
+// TR::ARMTrg1MemSrc1Instruction:: member functions
+bool TR::ARMTrg1MemSrc1Instruction::refsRegister(TR::Register *reg)
    {
    return (reg == getTargetRegister() || getMemoryReference()->refsRegister(reg) || reg == getSourceRegister());
    }
 
-bool TR_ARMTrg1MemSrc1Instruction::usesRegister(TR::Register *reg)
+bool TR::ARMTrg1MemSrc1Instruction::usesRegister(TR::Register *reg)
    {
    return (getMemoryReference()->refsRegister(reg) || reg == getSourceRegister());
    }
 
-void TR_ARMTrg1MemSrc1Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
+void TR::ARMTrg1MemSrc1Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
    TR::Register *targetVirtual = getTargetRegister();
    TR::Register *mBaseVirtual  = getMemoryReference()->getModBase();
@@ -773,9 +773,9 @@ void TR_ARMTrg1MemSrc1Instruction::assignRegisters(TR_RegisterKinds kindToBeAssi
       getDependencyConditions()->assignPreConditionRegisters(this->getPrev(), kindToBeAssigned, cg());
    }
 
-// TR_ARMControlFlowInstruction:: member functions
+// TR::ARMControlFlowInstruction:: member functions
 
-bool TR_ARMControlFlowInstruction::refsRegister(TR::Register *reg)
+bool TR::ARMControlFlowInstruction::refsRegister(TR::Register *reg)
    {
    int i;
    for (i = 0; i < getNumTargets(); i++)
@@ -791,7 +791,7 @@ bool TR_ARMControlFlowInstruction::refsRegister(TR::Register *reg)
    return false;
    }
 
-bool TR_ARMControlFlowInstruction::defsRegister(TR::Register *reg)
+bool TR::ARMControlFlowInstruction::defsRegister(TR::Register *reg)
    {
    for (int i = 0; i < getNumTargets(); i++)
       {
@@ -801,7 +801,7 @@ bool TR_ARMControlFlowInstruction::defsRegister(TR::Register *reg)
    return false;
    }
 
-bool TR_ARMControlFlowInstruction::defsRealRegister(TR::Register *reg)
+bool TR::ARMControlFlowInstruction::defsRealRegister(TR::Register *reg)
    {
    for (int i = 0; i < getNumTargets(); i++)
       {
@@ -811,7 +811,7 @@ bool TR_ARMControlFlowInstruction::defsRealRegister(TR::Register *reg)
    return false;
    }
 
-bool TR_ARMControlFlowInstruction::usesRegister(TR::Register *reg)
+bool TR::ARMControlFlowInstruction::usesRegister(TR::Register *reg)
    {
    for (int i = 0; i < getNumSources(); i++)
       {
@@ -844,7 +844,7 @@ static TR::Instruction *expandBlongLessThan(TR::Node          *node,
    return cursor;
 }
 
-void TR_ARMControlFlowInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
+void TR::ARMControlFlowInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
    TR::Machine    *machine = cg()->machine();
    TR::Node          *currentNode = getNode();
@@ -1008,22 +1008,22 @@ void TR_ARMControlFlowInstruction::assignRegisters(TR_RegisterKinds kindToBeAssi
       case ARMOp_setbool:
          TR_ASSERT(0, "implement setbool");
          /*
-         cursor = new (cg()->trHeapMemory()) TR_ARMTrg1Src2Instruction(cursor, getCmpOpValue(), currentNode, getTargetRegister(0), getSourceRegister(0), getSourceRegister(1), cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMTrg1ImmInstruction(cursor, ARMOp_li, currentNode, getTargetRegister(1), 1, cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMConditionalBranchInstruction(cursor, getOpCode2Value(), currentNode, label2, getTargetRegister(0), cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMTrg1ImmInstruction(cursor, ARMOp_li, currentNode, getTargetRegister(1), 0, cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMLabelInstruction(cursor, ARMOp_label, currentNode, label2, cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMTrg1Src2Instruction(cursor, getCmpOpValue(), currentNode, getTargetRegister(0), getSourceRegister(0), getSourceRegister(1), cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMTrg1ImmInstruction(cursor, ARMOp_li, currentNode, getTargetRegister(1), 1, cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMConditionalBranchInstruction(cursor, getOpCode2Value(), currentNode, label2, getTargetRegister(0), cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMTrg1ImmInstruction(cursor, ARMOp_li, currentNode, getTargetRegister(1), 0, cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMLabelInstruction(cursor, ARMOp_label, currentNode, label2, cg());
          break;
          */
       case ARMOp_setbflt:
          TR_ASSERT(0, "implement setbflt");
          /*
-         cursor = new (cg()->trHeapMemory()) TR_ARMTrg1Src2Instruction(cursor, getCmpOpValue(), currentNode, getTargetRegister(0), getSourceRegister(0), getSourceRegister(1), cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMTrg1ImmInstruction(cursor, ARMOp_li, currentNode, getTargetRegister(1), 1, cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMConditionalBranchInstruction(cursor, getOpCode2Value(), currentNode, label2, getTargetRegister(0), cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMConditionalBranchInstruction(cursor, getOpCode3Value(), currentNode, label2, getTargetRegister(0), cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMTrg1ImmInstruction(cursor, ARMOp_li, currentNode, getTargetRegister(1), 0, cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMLabelInstruction(cursor, ARMOp_label, currentNode, label2, cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMTrg1Src2Instruction(cursor, getCmpOpValue(), currentNode, getTargetRegister(0), getSourceRegister(0), getSourceRegister(1), cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMTrg1ImmInstruction(cursor, ARMOp_li, currentNode, getTargetRegister(1), 1, cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMConditionalBranchInstruction(cursor, getOpCode2Value(), currentNode, label2, getTargetRegister(0), cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMConditionalBranchInstruction(cursor, getOpCode3Value(), currentNode, label2, getTargetRegister(0), cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMTrg1ImmInstruction(cursor, ARMOp_li, currentNode, getTargetRegister(1), 0, cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMLabelInstruction(cursor, ARMOp_label, currentNode, label2, cg());
          break;
          */
       case ARMOp_lcmp:
@@ -1062,39 +1062,39 @@ void TR_ARMControlFlowInstruction::assignRegisters(TR_RegisterKinds kindToBeAssi
          break;
 /*
       case ARMOp_flcmpl:
-         cursor = new (cg()->trHeapMemory()) TR_ARMTrg1Src2Instruction(cursor, ARMOp_fcmpu, currentNode, getTargetRegister(0), getSourceRegister(0), getSourceRegister(2), cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMTrg1ImmInstruction(cursor, ARMOp_li, currentNode, getTargetRegister(1), 1, cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMConditionalBranchInstruction(cursor, ARMOp_bgt, currentNode, label2, getTargetRegister(0), cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMTrg1ImmInstruction(cursor, ARMOp_li, currentNode, getTargetRegister(1), 0, cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMConditionalBranchInstruction(cursor, ARMOp_beq, currentNode, label2, getTargetRegister(0), cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMTrg1ImmInstruction(cursor, ARMOp_li, currentNode, getTargetRegister(1), -1, cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMLabelInstruction(cursor, ARMOp_label, currentNode, label2, cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMTrg1Src2Instruction(cursor, ARMOp_fcmpu, currentNode, getTargetRegister(0), getSourceRegister(0), getSourceRegister(2), cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMTrg1ImmInstruction(cursor, ARMOp_li, currentNode, getTargetRegister(1), 1, cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMConditionalBranchInstruction(cursor, ARMOp_bgt, currentNode, label2, getTargetRegister(0), cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMTrg1ImmInstruction(cursor, ARMOp_li, currentNode, getTargetRegister(1), 0, cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMConditionalBranchInstruction(cursor, ARMOp_beq, currentNode, label2, getTargetRegister(0), cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMTrg1ImmInstruction(cursor, ARMOp_li, currentNode, getTargetRegister(1), -1, cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMLabelInstruction(cursor, ARMOp_label, currentNode, label2, cg());
          break;
       case ARMOp_flcmpg:
-         cursor = new (cg()->trHeapMemory()) TR_ARMTrg1Src2Instruction(cursor, ARMOp_fcmpu, currentNode, getTargetRegister(0), getSourceRegister(0), getSourceRegister(2), cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMTrg1ImmInstruction(cursor, ARMOp_li, currentNode, getTargetRegister(1), -1, cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMConditionalBranchInstruction(cursor, ARMOp_blt, currentNode, label2, getTargetRegister(0), cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMTrg1ImmInstruction(cursor, ARMOp_li, currentNode, getTargetRegister(1), 0, cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMConditionalBranchInstruction(cursor, ARMOp_beq, currentNode, label2, getTargetRegister(0), cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMTrg1ImmInstruction(cursor, ARMOp_li, currentNode, getTargetRegister(1), 1, cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMLabelInstruction(cursor, ARMOp_label, currentNode, label2, cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMTrg1Src2Instruction(cursor, ARMOp_fcmpu, currentNode, getTargetRegister(0), getSourceRegister(0), getSourceRegister(2), cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMTrg1ImmInstruction(cursor, ARMOp_li, currentNode, getTargetRegister(1), -1, cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMConditionalBranchInstruction(cursor, ARMOp_blt, currentNode, label2, getTargetRegister(0), cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMTrg1ImmInstruction(cursor, ARMOp_li, currentNode, getTargetRegister(1), 0, cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMConditionalBranchInstruction(cursor, ARMOp_beq, currentNode, label2, getTargetRegister(0), cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMTrg1ImmInstruction(cursor, ARMOp_li, currentNode, getTargetRegister(1), 1, cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMLabelInstruction(cursor, ARMOp_label, currentNode, label2, cg());
          break;
       case ARMOp_idiv:
-         cursor = new (cg()->trHeapMemory()) TR_ARMTrg1Src2Instruction(cursor, ARMOp_eqv, currentNode, getTargetRegister(2), getTargetRegister(1), getSourceRegister(1), cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMTrg1Src2Instruction(cursor, ARMOp_and, currentNode, getTargetRegister(2), getSourceRegister(2), getTargetRegister(2), cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMTrg1Src1ImmInstruction(cursor, ARMOp_cmpi4, currentNode, getTargetRegister(0), getTargetRegister(2), -1, cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMConditionalBranchInstruction(cursor, ARMOp_beq, currentNode, label2, getTargetRegister(0), cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMTrg1Src2Instruction(cursor, ARMOp_divw, currentNode, getTargetRegister(1), getSourceRegister(1), getSourceRegister(2), cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMLabelInstruction(cursor, ARMOp_label, currentNode, label2, cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMTrg1Src2Instruction(cursor, ARMOp_eqv, currentNode, getTargetRegister(2), getTargetRegister(1), getSourceRegister(1), cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMTrg1Src2Instruction(cursor, ARMOp_and, currentNode, getTargetRegister(2), getSourceRegister(2), getTargetRegister(2), cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMTrg1Src1ImmInstruction(cursor, ARMOp_cmpi4, currentNode, getTargetRegister(0), getTargetRegister(2), -1, cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMConditionalBranchInstruction(cursor, ARMOp_beq, currentNode, label2, getTargetRegister(0), cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMTrg1Src2Instruction(cursor, ARMOp_divw, currentNode, getTargetRegister(1), getSourceRegister(1), getSourceRegister(2), cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMLabelInstruction(cursor, ARMOp_label, currentNode, label2, cg());
          break;
       case ARMOp_irem:
-         cursor = new (cg()->trHeapMemory()) TR_ARMTrg1Src1ImmInstruction(cursor, ARMOp_cmpi4, currentNode, getTargetRegister(0), getSourceRegister(2), -1, cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMTrg1ImmInstruction(cursor, ARMOp_li, currentNode, getTargetRegister(1), 0, cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMConditionalBranchInstruction(cursor, ARMOp_beq, currentNode, label2, getTargetRegister(0), cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMTrg1Src2Instruction(cursor, ARMOp_divw, currentNode, getTargetRegister(2), getSourceRegister(1), getSourceRegister(2), cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMTrg1Src2Instruction(cursor, ARMOp_mullw, currentNode, getTargetRegister(2), getSourceRegister(2), getTargetRegister(2), cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMTrg1Src2Instruction(cursor, ARMOp_subf, currentNode, getTargetRegister(1), getTargetRegister(2), getSourceRegister(1), cg());
-         cursor = new (cg()->trHeapMemory()) TR_ARMLabelInstruction(cursor, ARMOp_label, currentNode, label2, cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMTrg1Src1ImmInstruction(cursor, ARMOp_cmpi4, currentNode, getTargetRegister(0), getSourceRegister(2), -1, cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMTrg1ImmInstruction(cursor, ARMOp_li, currentNode, getTargetRegister(1), 0, cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMConditionalBranchInstruction(cursor, ARMOp_beq, currentNode, label2, getTargetRegister(0), cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMTrg1Src2Instruction(cursor, ARMOp_divw, currentNode, getTargetRegister(2), getSourceRegister(1), getSourceRegister(2), cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMTrg1Src2Instruction(cursor, ARMOp_mullw, currentNode, getTargetRegister(2), getSourceRegister(2), getTargetRegister(2), cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMTrg1Src2Instruction(cursor, ARMOp_subf, currentNode, getTargetRegister(1), getTargetRegister(2), getSourceRegister(1), cg());
+         cursor = new (cg()->trHeapMemory()) TR::ARMLabelInstruction(cursor, ARMOp_label, currentNode, label2, cg());
          break;
 */
       default:
@@ -1104,27 +1104,27 @@ void TR_ARMControlFlowInstruction::assignRegisters(TR_RegisterKinds kindToBeAssi
       getDependencyConditions()->assignPreConditionRegisters(this->getPrev(), kindToBeAssigned, cg());
    }
 
-bool TR_ARMMultipleMoveInstruction::refsRegister(TR::Register *reg)
+bool TR::ARMMultipleMoveInstruction::refsRegister(TR::Register *reg)
    {
    return (reg == getMemoryBaseRegister());
    }
 
-bool TR_ARMMultipleMoveInstruction::defsRegister(TR::Register *reg)
+bool TR::ARMMultipleMoveInstruction::defsRegister(TR::Register *reg)
    {
    return (reg == getMemoryBaseRegister());
    }
 
-bool TR_ARMMultipleMoveInstruction::defsRealRegister(TR::Register *reg)
+bool TR::ARMMultipleMoveInstruction::defsRealRegister(TR::Register *reg)
    {
    return (reg == getMemoryBaseRegister()->getAssignedRegister());
    }
 
-bool TR_ARMMultipleMoveInstruction::usesRegister(TR::Register *reg)
+bool TR::ARMMultipleMoveInstruction::usesRegister(TR::Register *reg)
    {
    return (reg == getMemoryBaseRegister());
    }
 
-void TR_ARMMultipleMoveInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
+void TR::ARMMultipleMoveInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
    if (getDependencyConditions())
       getDependencyConditions()->assignPostConditionRegisters(this, kindToBeAssigned, cg());

--- a/compiler/arm/codegen/OMRInstruction.hpp
+++ b/compiler/arm/codegen/OMRInstruction.hpp
@@ -37,9 +37,9 @@
 #include "codegen/GCStackMap.hpp"
 #include "codegen/RegisterConstants.hpp"
 
-class TR_ARMConditionalBranchInstruction;
-class TR_ARMDepImmInstruction;
-class TR_ARMImmInstruction;
+namespace TR { class ARMConditionalBranchInstruction; }
+namespace TR { class ARMDepImmInstruction; }
+namespace TR { class ARMImmInstruction; }
 namespace TR { class CodeGenerator; }
 namespace TR { class MemoryReference; }
 namespace TR { class RegisterDependencyConditions; }
@@ -112,14 +112,14 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
 
    virtual bool dependencyRefsRegister(TR::Register *reg);
 
-   virtual TR_ARMConditionalBranchInstruction *getARMConditionalBranchInstruction();
+   virtual TR::ARMConditionalBranchInstruction *getARMConditionalBranchInstruction();
 
    virtual TR::Register *getPrimaryTargetRegister() {return NULL;}
 
 // The following safe virtual downcast method is used under debug only
 // for assertion checking
 #if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
-   virtual TR_ARMImmInstruction *getARMImmInstruction();
+   virtual TR::ARMImmInstruction *getARMImmInstruction();
 #endif
 
 

--- a/compiler/arm/codegen/OMRMachine.cpp
+++ b/compiler/arm/codegen/OMRMachine.cpp
@@ -379,7 +379,7 @@ TR::RealRegister *OMR::ARM::Machine::reverseSpillState(TR::Instruction      *cur
          bool isOOLentryReverseSpill = false;
          if (currentInstruction->isLabel())
             {
-            if (((TR_ARMLabelInstruction*)currentInstruction)->getLabelSymbol()->isStartOfColdInstructionStream())
+            if (((TR::ARMLabelInstruction*)currentInstruction)->getLabelSymbol()->isStartOfColdInstructionStream())
                {
                // indicates that we are at OOL entry point post conditions. Since
                // we are now exiting the OOL cold path (going reverse order)
@@ -836,7 +836,7 @@ static void registerCopy(TR::Instruction     *precedingInstruction,
    switch (rk)
       {
       case TR_GPR:
-         new (cg->trHeapMemory()) TR_ARMTrg1Src1Instruction(precedingInstruction, ARMOp_mov, node, targetReg, sourceReg, cg);
+         new (cg->trHeapMemory()) TR::ARMTrg1Src1Instruction(precedingInstruction, ARMOp_mov, node, targetReg, sourceReg, cg);
          break;
       case TR_FPR:
          bool isTargetSinglePrecision = isSinglePrecision(targetReg->getRegisterNumber());
@@ -845,7 +845,7 @@ static void registerCopy(TR::Instruction     *precedingInstruction,
             {
             if (isSourceSinglePrecision)
                {
-                new (cg->trHeapMemory()) TR_ARMTrg1Src1Instruction(precedingInstruction, ARMOp_fcpys, node, targetReg, sourceReg, cg);
+                new (cg->trHeapMemory()) TR::ARMTrg1Src1Instruction(precedingInstruction, ARMOp_fcpys, node, targetReg, sourceReg, cg);
                }
             else
                {
@@ -860,7 +860,7 @@ static void registerCopy(TR::Instruction     *precedingInstruction,
                }
             else
                {
-               new (cg->trHeapMemory()) TR_ARMTrg1Src1Instruction(precedingInstruction, ARMOp_fcpyd, node, targetReg, sourceReg, cg);
+               new (cg->trHeapMemory()) TR::ARMTrg1Src1Instruction(precedingInstruction, ARMOp_fcpyd, node, targetReg, sourceReg, cg);
                }
            }
          break;
@@ -885,9 +885,9 @@ static void registerExchange(TR::Instruction     *precedingInstruction,
       }
    else
       {
-      new (cg->trHeapMemory()) TR_ARMTrg1Src2Instruction(precedingInstruction, ARMOp_eor, node, targetReg, targetReg, sourceReg, cg);
-      new (cg->trHeapMemory()) TR_ARMTrg1Src2Instruction(precedingInstruction, ARMOp_eor, node, sourceReg, targetReg, sourceReg, cg);
-      new (cg->trHeapMemory()) TR_ARMTrg1Src2Instruction(precedingInstruction, ARMOp_eor, node, targetReg, targetReg, sourceReg, cg);
+      new (cg->trHeapMemory()) TR::ARMTrg1Src2Instruction(precedingInstruction, ARMOp_eor, node, targetReg, targetReg, sourceReg, cg);
+      new (cg->trHeapMemory()) TR::ARMTrg1Src2Instruction(precedingInstruction, ARMOp_eor, node, sourceReg, targetReg, sourceReg, cg);
+      new (cg->trHeapMemory()) TR::ARMTrg1Src2Instruction(precedingInstruction, ARMOp_eor, node, targetReg, targetReg, sourceReg, cg);
       }
    }
 

--- a/compiler/arm/codegen/OMRMemoryReference.cpp
+++ b/compiler/arm/codegen/OMRMemoryReference.cpp
@@ -573,7 +573,7 @@ void OMR::ARM::MemoryReference::consolidateRegisters(TR::Register *srcReg, TR::N
             tempTargetRegister = cg->allocateCollectedReferenceRegister();
          else
             tempTargetRegister = cg->allocateRegister();
-         new (cg->trHeapMemory()) TR_ARMTrg1Src2Instruction(ARMOp_add, srcTree, tempTargetRegister, _indexRegister, srcReg, cg);
+         new (cg->trHeapMemory()) TR::ARMTrg1Src2Instruction(ARMOp_add, srcTree, tempTargetRegister, _indexRegister, srcReg, cg);
          if (_indexRegister != tempTargetRegister)
             {
             if (_indexNode != NULL)
@@ -610,7 +610,7 @@ void OMR::ARM::MemoryReference::consolidateRegisters(TR::Register *srcReg, TR::N
             tempTargetRegister = cg->allocateCollectedReferenceRegister();
          else
             tempTargetRegister = cg->allocateRegister();
-         new (cg->trHeapMemory()) TR_ARMTrg1Src2Instruction(ARMOp_add, srcTree, tempTargetRegister, _baseRegister, _indexRegister, cg);
+         new (cg->trHeapMemory()) TR::ARMTrg1Src2Instruction(ARMOp_add, srcTree, tempTargetRegister, _baseRegister, _indexRegister, cg);
          if (_baseRegister != tempTargetRegister)
             {
             self()->decNodeReferenceCounts();
@@ -637,7 +637,7 @@ void OMR::ARM::MemoryReference::consolidateRegisters(TR::Register *srcReg, TR::N
             tempTargetRegister = cg->allocateCollectedReferenceRegister();
          else
             tempTargetRegister = cg->allocateRegister();
-         new (cg->trHeapMemory()) TR_ARMTrg1Src2Instruction(ARMOp_add, srcTree, tempTargetRegister, _baseRegister, srcReg, cg);
+         new (cg->trHeapMemory()) TR::ARMTrg1Src2Instruction(ARMOp_add, srcTree, tempTargetRegister, _baseRegister, srcReg, cg);
          if (_baseRegister != tempTargetRegister)
             {
             self()->decNodeReferenceCounts();

--- a/compiler/arm/codegen/OMRRegisterDependency.cpp
+++ b/compiler/arm/codegen/OMRRegisterDependency.cpp
@@ -383,7 +383,7 @@ void TR_ARMRegisterDependencyGroup::assignRegisters(TR::Instruction  *currentIns
          // we also need to free up all locked backing storage if we are exiting the OOL during backwards RA assignment
          else if (currentInstruction->isLabel() && virtReg->getAssignedRealRegister())
             {
-            TR_ARMLabelInstruction *labelInstr = (TR_ARMLabelInstruction *)currentInstruction;
+            TR::ARMLabelInstruction *labelInstr = (TR::ARMLabelInstruction *)currentInstruction;
             TR_BackingStore *location = virtReg->getBackingStorage();
             TR_RegisterKinds rk = virtReg->getKind();
             int32_t dataSize;

--- a/compiler/arm/codegen/SubtractAnalyser.cpp
+++ b/compiler/arm/codegen/SubtractAnalyser.cpp
@@ -54,25 +54,25 @@ void TR_ARMSubtractAnalyser::integerSubtractAnalyser(TR::Node       *root,
       TR::Register *thirdReg = root->setRegister(cg()->allocateRegister());
       if (getSubReg3Reg2())
          {
-         new (cg()->trHeapMemory()) TR_ARMTrg1Src2Instruction(ARMOp_sub, root, thirdReg, secondRegister, firstRegister, cg());
+         new (cg()->trHeapMemory()) TR::ARMTrg1Src2Instruction(ARMOp_sub, root, thirdReg, secondRegister, firstRegister, cg());
          }
       else // assert getSubReg3Mem2() == true
          {
 //         TR_ARMMemoryReference *tempMR = new (cg()->trHeapMemory()) TR_ARMMemoryReference(secondChild);
-//         new (cg()->trHeapMemory()) TR_ARMRegMemInstruction(memToRegOpCode, thirdReg, tempMR, cg());
+//         new (cg()->trHeapMemory()) TR::ARMRegMemInstruction(memToRegOpCode, thirdReg, tempMR, cg());
 //         tempMR->decNodeReferenceCounts();
          }
       root->setRegister(thirdReg);
       }
    else if (getSubReg1Reg2())
       {
-      new (cg()->trHeapMemory()) TR_ARMTrg1Src1Instruction(ARMOp_sub, root, firstRegister, secondRegister, cg());
+      new (cg()->trHeapMemory()) TR::ARMTrg1Src1Instruction(ARMOp_sub, root, firstRegister, secondRegister, cg());
       root->setRegister(firstRegister);
       }
    else // assert getSubReg1Mem2() == true
       {
 //      TR_ARMMemoryReference *tempMR = new (cg()->trHeapMemory()) TR_ARMMemoryReference(secondChild);
-//      new (cg()->trHeapMemory()) TR_ARMRegMemInstruction(memToRegOpCode, firstRegister, tempMR, cg());
+//      new (cg()->trHeapMemory()) TR::ARMRegMemInstruction(memToRegOpCode, firstRegister, tempMR, cg());
 //      tempMR->decNodeReferenceCounts();
 //      root->setRegister(firstRegister);
       }
@@ -112,35 +112,35 @@ void TR_ARMSubtractAnalyser::longSubtractAnalyser(TR::Node *root)
       TR::Register     *highThird = cg()->allocateRegister();
       TR::RegisterPair *thirdReg  = cg()->allocateRegisterPair(lowThird, highThird);
       root->setRegister(thirdReg);
-      new (cg()->trHeapMemory()) TR_ARMTrg1Src1Instruction(ARMOp_mov, root, lowThird, firstRegister->getLowOrder(), cg());
-      new (cg()->trHeapMemory()) TR_ARMTrg1Src1Instruction(ARMOp_mov, root, highThird, firstRegister->getHighOrder(), cg());
+      new (cg()->trHeapMemory()) TR::ARMTrg1Src1Instruction(ARMOp_mov, root, lowThird, firstRegister->getLowOrder(), cg());
+      new (cg()->trHeapMemory()) TR::ARMTrg1Src1Instruction(ARMOp_mov, root, highThird, firstRegister->getHighOrder(), cg());
       if (getSubReg3Reg2())
          {
-         new (cg()->trHeapMemory()) TR_ARMTrg1Src1Instruction(ARMOp_sub, root, lowThird, secondRegister->getLowOrder(), cg());
-//         new (cg()->trHeapMemory()) TR_ARMTrg1Src1Instruction(SBB4RegReg, root, highThird, secondRegister->getHighOrder(), cg());
+         new (cg()->trHeapMemory()) TR::ARMTrg1Src1Instruction(ARMOp_sub, root, lowThird, secondRegister->getLowOrder(), cg());
+//         new (cg()->trHeapMemory()) TR::ARMTrg1Src1Instruction(SBB4RegReg, root, highThird, secondRegister->getHighOrder(), cg());
          }
       else // assert getSubReg3Mem2() == true
          {
 //         TR_ARMMemoryReference *lowMR = new (cg()->trHeapMemory()) TR_ARMMemoryReference(secondChild);
-//         new (cg()->trHeapMemory()) TR_ARMRegMemInstruction(SUB4RegMem, lowThird, lowMR, cg());
+//         new (cg()->trHeapMemory()) TR::ARMRegMemInstruction(SUB4RegMem, lowThird, lowMR, cg());
 //         TR_ARMMemoryReference *highMR = new (cg()->trHeapMemory()) TR_ARMMemoryReference(*lowMR, 4);
-//         new (cg()->trHeapMemory()) TR_ARMRegMemInstruction(SBB4RegMem, highThird, highMR, cg());
+//         new (cg()->trHeapMemory()) TR::ARMRegMemInstruction(SBB4RegMem, highThird, highMR, cg());
 //         lowMR->decNodeReferenceCounts();
          }
       root->setRegister(thirdReg);
       }
    else if (getSubReg1Reg2())
       {
-//      new (cg()->trHeapMemory()) TR_ARMTrg1Src2Instruction(root, ARMOp_subf, firstRegister->getLowOrder(), secondRegister->getLowOrder(), cg());
-//      new (cg()->trHeapMemory()) TR_ARMRegRegInstruction(SBB4RegReg, firstRegister->getHighOrder(), secondRegister->getHighOrder(), cg());
+//      new (cg()->trHeapMemory()) TR::ARMTrg1Src2Instruction(root, ARMOp_subf, firstRegister->getLowOrder(), secondRegister->getLowOrder(), cg());
+//      new (cg()->trHeapMemory()) TR::ARMRegRegInstruction(SBB4RegReg, firstRegister->getHighOrder(), secondRegister->getHighOrder(), cg());
       root->setRegister(firstRegister);
       }
    else // assert getSubReg1Mem2() == true
       {
 //      TR_ARMMemoryReference *lowMR = new (cg()->trHeapMemory()) TR_ARMMemoryReference(secondChild);
-//      new (cg()->trHeapMemory()) TR_ARMRegMemInstruction(SUB4RegMem, firstRegister->getLowOrder(), lowMR, cg());
+//      new (cg()->trHeapMemory()) TR::ARMRegMemInstruction(SUB4RegMem, firstRegister->getLowOrder(), lowMR, cg());
 //      TR_ARMMemoryReference *highMR = new (cg()->trHeapMemory()) TR_ARMMemoryReference(*lowMR, 4);
-//      new (cg()->trHeapMemory()) TR_ARMRegMemInstruction(SBB4RegMem, firstRegister->getHighOrder(), highMR, cg());
+//      new (cg()->trHeapMemory()) TR::ARMRegMemInstruction(SBB4RegMem, firstRegister->getHighOrder(), highMR, cg());
 //      lowMR->decNodeReferenceCounts();
 //      root->setRegister(firstRegister);
       }

--- a/compiler/p/codegen/PPCInstruction.cpp
+++ b/compiler/p/codegen/PPCInstruction.cpp
@@ -48,7 +48,7 @@
 namespace TR { class SymbolReference; }
 
 
-// TR_LabelInstruction function
+// TR::LabelInstruction function
 void TR::PPCLabelInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
    TR::Compilation *comp = cg()->comp();

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -228,22 +228,22 @@ class TR_PPCCallSnippet;
 
 
 class TR_ARMOpCode;
-class TR_ARMLabelInstruction;
-class TR_ARMConditionalBranchInstruction;
-class TR_ARMVirtualGuardNOPInstruction;
-class TR_ARMAdminInstruction;
-class TR_ARMImmInstruction;
-class TR_ARMImmSymInstruction;
-class TR_ARMTrg1Src2Instruction;
-class TR_ARMTrg2Src1Instruction;
-class TR_ARMMulInstruction;
-class TR_ARMMemSrc1Instruction;
-class TR_ARMTrg1Instruction;
-class TR_ARMMemInstruction;
-class TR_ARMTrg1MemInstruction;
-class TR_ARMTrg1MemSrc1Instruction;
-class TR_ARMControlFlowInstruction;
-class TR_ARMMultipleMoveInstruction;
+namespace TR { class ARMLabelInstruction; }
+namespace TR { class ARMConditionalBranchInstruction; }
+namespace TR { class ARMVirtualGuardNOPInstruction; }
+namespace TR { class ARMAdminInstruction; }
+namespace TR { class ARMImmInstruction; }
+namespace TR { class ARMImmSymInstruction; }
+namespace TR { class ARMTrg1Src2Instruction; }
+namespace TR { class ARMTrg2Src1Instruction; }
+namespace TR { class ARMMulInstruction; }
+namespace TR { class ARMMemSrc1Instruction; }
+namespace TR { class ARMTrg1Instruction; }
+namespace TR { class ARMMemInstruction; }
+namespace TR { class ARMTrg1MemInstruction; }
+namespace TR { class ARMTrg1MemSrc1Instruction; }
+namespace TR { class ARMControlFlowInstruction; }
+namespace TR { class ARMMultipleMoveInstruction; }
 class TR_ARMMemoryReference;
 class TR_ARMOperand2;
 class TR_ARMRealRegister;
@@ -585,7 +585,7 @@ public:
    void print(TR::FILE *, TR_PPCHelperCallSnippet *);
 #endif
 #if defined(TR_TARGET_ARM)
-   virtual void printARMDelayedOffsetInstructions(TR::FILE *pOutFile, TR_ARMMemInstruction *instr);
+   virtual void printARMDelayedOffsetInstructions(TR::FILE *pOutFile, TR::ARMMemInstruction *instr);
    virtual void printARMHelperBranch(TR::SymbolReference *symRef, uint8_t *cursor, TR::FILE *outFile, const char * opcodeName = "bl");
    virtual const char * getOpCodeName(TR_ARMOpCode *);
    const char * getName(TR::RealRegister *, TR_RegisterSizes size = TR_WordReg);
@@ -940,23 +940,23 @@ public:
    void printBinaryPrefix(char *prefixBuffer, TR::Instruction *);
    void dumpDependencyGroup(TR::FILE *pOutFile, TR_ARMRegisterDependencyGroup *group, int32_t numConditions, char *prefix, bool omitNullDependencies);
    void dumpDependencies(TR::FILE *, TR::Instruction *);
-   void print(TR::FILE *, TR_ARMLabelInstruction *);
+   void print(TR::FILE *, TR::ARMLabelInstruction *);
 #ifdef J9_PROJECT_SPECIFIC
-   void print(TR::FILE *, TR_ARMVirtualGuardNOPInstruction *);
+   void print(TR::FILE *, TR::ARMVirtualGuardNOPInstruction *);
 #endif
-   void print(TR::FILE *, TR_ARMAdminInstruction *);
-   void print(TR::FILE *, TR_ARMImmInstruction *);
-   void print(TR::FILE *, TR_ARMImmSymInstruction *);
-   void print(TR::FILE *, TR_ARMTrg1Src2Instruction *);
-   void print(TR::FILE *, TR_ARMTrg2Src1Instruction *);
-   void print(TR::FILE *, TR_ARMMulInstruction *);
-   void print(TR::FILE *, TR_ARMMemSrc1Instruction *);
-   void print(TR::FILE *, TR_ARMTrg1Instruction *);
-   void print(TR::FILE *, TR_ARMMemInstruction *);
-   void print(TR::FILE *, TR_ARMTrg1MemInstruction *);
-   void print(TR::FILE *, TR_ARMTrg1MemSrc1Instruction *);
-   void print(TR::FILE *, TR_ARMControlFlowInstruction *);
-   void print(TR::FILE *, TR_ARMMultipleMoveInstruction *);
+   void print(TR::FILE *, TR::ARMAdminInstruction *);
+   void print(TR::FILE *, TR::ARMImmInstruction *);
+   void print(TR::FILE *, TR::ARMImmSymInstruction *);
+   void print(TR::FILE *, TR::ARMTrg1Src2Instruction *);
+   void print(TR::FILE *, TR::ARMTrg2Src1Instruction *);
+   void print(TR::FILE *, TR::ARMMulInstruction *);
+   void print(TR::FILE *, TR::ARMMemSrc1Instruction *);
+   void print(TR::FILE *, TR::ARMTrg1Instruction *);
+   void print(TR::FILE *, TR::ARMMemInstruction *);
+   void print(TR::FILE *, TR::ARMTrg1MemInstruction *);
+   void print(TR::FILE *, TR::ARMTrg1MemSrc1Instruction *);
+   void print(TR::FILE *, TR::ARMControlFlowInstruction *);
+   void print(TR::FILE *, TR::ARMMultipleMoveInstruction *);
 
    void print(TR::FILE *, TR::MemoryReference *);
 

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -474,7 +474,7 @@ OMR::X86::CodeGenerator::CodeGenerator() :
    _spilledIntRegisters(getTypedAllocator<TR::Register*>(TR::comp()->allocator())),
    _liveDiscardableRegisters(getTypedAllocator<TR::Register*>(TR::comp()->allocator())),
    _dependentDiscardableRegisters(getTypedAllocator<TR::Register*>(TR::comp()->allocator())),
-   _clobberingInstructions(getTypedAllocator<TR_ClobberingInstruction*>(TR::comp()->allocator())),
+   _clobberingInstructions(getTypedAllocator<TR::ClobberingInstruction*>(TR::comp()->allocator())),
    _outlinedInstructionsList(getTypedAllocator<TR_OutlinedInstructions*>(TR::comp()->allocator())),
    _deferredSplits(getTypedAllocator<TR::X86LabelInstruction*>(TR::comp()->allocator())),
    _flags(0)
@@ -712,7 +712,7 @@ void OMR::X86::CodeGenerator::clobberLiveDiscardableRegisters(
 
    if (symbol)
       {
-      TR_ClobberingInstruction  * clob = NULL;
+      TR::ClobberingInstruction  * clob = NULL;
       TR_IGNode                 *IGNodeSym = NULL;
 
       if (self()->getLocalsIG())
@@ -735,7 +735,7 @@ void OMR::X86::CodeGenerator::clobberLiveDiscardableRegisters(
                {
                if (!clob)
                   {
-                  clob = new (self()->trHeapMemory()) TR_ClobberingInstruction(instr, self()->trMemory());
+                  clob = new (self()->trHeapMemory()) TR::ClobberingInstruction(instr, self()->trMemory());
                   self()->addClobberingInstruction(clob);
                   }
 
@@ -762,7 +762,7 @@ void OMR::X86::CodeGenerator::clobberLiveDiscardableRegisters(
                   {
                   if (!clob)
                      {
-                     clob = new (self()->trHeapMemory()) TR_ClobberingInstruction(instr, self()->trMemory());
+                     clob = new (self()->trHeapMemory()) TR::ClobberingInstruction(instr, self()->trMemory());
                      self()->addClobberingInstruction(clob);
                      }
 
@@ -807,7 +807,7 @@ void OMR::X86::CodeGenerator::clobberLiveDiscardableRegisters(
 // register, we iteratively deactivate all registers that depend on registers
 // that have been clobbered/deactivated.
 //
-void OMR::X86::CodeGenerator::clobberLiveDependentDiscardableRegisters(TR_ClobberingInstruction * clob,
+void OMR::X86::CodeGenerator::clobberLiveDependentDiscardableRegisters(TR::ClobberingInstruction * clob,
                                                                     TR::Register              * baseReg)
    {
    TR_Stack<TR::Register *> worklist(self()->trMemory());
@@ -1324,7 +1324,7 @@ void OMR::X86::CodeGenerator::prepareForNonLinearRegisterAssignmentAtMerge(
    }
 
 
-void OMR::X86::CodeGenerator::processClobberingInstructions(TR_ClobberingInstruction * clobInstructionCursor, TR::Instruction *instructionCursor)
+void OMR::X86::CodeGenerator::processClobberingInstructions(TR::ClobberingInstruction * clobInstructionCursor, TR::Instruction *instructionCursor)
    {
    // Activate any discardable registers that this instruction may have clobbered.
    //
@@ -1453,7 +1453,7 @@ void OMR::X86::CodeGenerator::doBackwardsRegisterAssignment(
          self()->dumpPostGPRegisterAssignment(instructionCursor, origNextInstruction);
 #endif
       self()->tracePostRAInstruction(instructionCursor);
-      TR_ClobberingInstruction * clobInst;
+      TR::ClobberingInstruction * clobInst;
       if(_clobIterator == self()->getClobberingInstructions().end())
     	  clobInst = 0;
       else

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -71,7 +71,9 @@ namespace TR { class X86ScratchRegisterManager; }
 namespace TR { class X86VFPSaveInstruction;     }
 struct TR_X86LinkageProperties;
 
-class TR_ClobberingInstruction
+namespace TR {
+
+class ClobberingInstruction
    {
    TR::Instruction *_instruction;
    TR::list<TR::Register*> _clobberedRegisters;
@@ -79,14 +81,18 @@ class TR_ClobberingInstruction
 public:
    TR_ALLOC(TR_Memory::ClobberingInstruction)
 
-   TR_ClobberingInstruction(TR_Memory * m) : _instruction(0), _clobberedRegisters(getTypedAllocator<TR::Register*>(TR::comp()->allocator())) {};
-   TR_ClobberingInstruction(TR::Instruction *instr, TR_Memory * m) : _instruction(instr), _clobberedRegisters(getTypedAllocator<TR::Register*>(TR::comp()->allocator())) {}
+   ClobberingInstruction(TR_Memory * m) : _instruction(0), _clobberedRegisters(getTypedAllocator<TR::Register*>(TR::comp()->allocator())) {};
+   ClobberingInstruction(TR::Instruction *instr, TR_Memory * m) : _instruction(instr), _clobberedRegisters(getTypedAllocator<TR::Register*>(TR::comp()->allocator())) {}
 
    TR::Instruction *getInstruction() {return _instruction;}
    TR::Instruction *setInstruction(TR::Instruction *i) {return (_instruction = i);}
    TR::list<TR::Register*> &getClobberedRegisters() {return _clobberedRegisters;}
    void addClobberedRegister(TR::Register *reg) {_clobberedRegisters.push_front(reg);}
    };
+
+}
+
+typedef TR::ClobberingInstruction TR_ClobberingInstruction;
 
 struct TR_BetterSpillPlacement
    {
@@ -353,7 +359,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    void performNonLinearRegisterAssignmentAtBranch(TR::X86LabelInstruction *branchInstruction, TR_RegisterKinds kindsToBeAssigned);
    void prepareForNonLinearRegisterAssignmentAtMerge(TR::X86LabelInstruction *mergeInstruction);
 
-   void processClobberingInstructions(TR_ClobberingInstruction * clobInstructionCursor, TR::Instruction *instructionCursor);
+   void processClobberingInstructions(TR::ClobberingInstruction * clobInstructionCursor, TR::Instruction *instructionCursor);
 
    // different from evaluateNode in that it returns a clobberable register
    TR::Register *shortClobberEvaluate(TR::Node *node);
@@ -425,12 +431,12 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    TR::list<TR::Register*> &getDependentDiscardableRegisters() {return _dependentDiscardableRegisters;}
    void addDependentDiscardableRegister(TR::Register *reg) {_dependentDiscardableRegisters.push_front(reg);}
-   void clobberLiveDependentDiscardableRegisters(TR_ClobberingInstruction *instr, TR::Register *baseReg);
+   void clobberLiveDependentDiscardableRegisters(TR::ClobberingInstruction *instr, TR::Register *baseReg);
    void reactivateDependentDiscardableRegisters(TR::Register *baseReg);
    void deactivateDependentDiscardableRegisters(TR::Register *baseReg);
 
-   TR::list<TR_ClobberingInstruction*> &getClobberingInstructions() {return _clobberingInstructions;}
-   void addClobberingInstruction(TR_ClobberingInstruction *i)  {_clobberingInstructions.push_front(i);}
+   TR::list<TR::ClobberingInstruction*> &getClobberingInstructions() {return _clobberingInstructions;}
+   void addClobberingInstruction(TR::ClobberingInstruction *i)  {_clobberingInstructions.push_front(i);}
 
    TR::list<TR_OutlinedInstructions*> &getOutlinedInstructionsList() {return _outlinedInstructionsList;}
 
@@ -656,8 +662,8 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    TR::list<TR::Register*>               _spilledIntRegisters;
    TR::list<TR::Register*>               _liveDiscardableRegisters;
    TR::list<TR::Register*>               _dependentDiscardableRegisters;
-   TR::list<TR_ClobberingInstruction*>  _clobberingInstructions;
-   std::list<TR_ClobberingInstruction*, TR::typed_allocator<TR_ClobberingInstruction*, TR::Allocator> >::iterator _clobIterator;
+   TR::list<TR::ClobberingInstruction*>  _clobberingInstructions;
+   std::list<TR::ClobberingInstruction*, TR::typed_allocator<TR::ClobberingInstruction*, TR::Allocator> >::iterator _clobIterator;
    TR::list<TR::X86LabelInstruction*>    _deferredSplits;
    TR::list<TR_OutlinedInstructions*>   _outlinedInstructionsList;
 

--- a/compiler/x/codegen/OMRInstruction.cpp
+++ b/compiler/x/codegen/OMRInstruction.cpp
@@ -344,7 +344,7 @@ void OMR::X86::Instruction::clobberRegsForRematerialisation()
       // Check the live discardable register list to see if this is the first
       // instruction that kills the rematerialisable range of a register.
       //
-      TR_ClobberingInstruction *clob = NULL;
+      TR::ClobberingInstruction *clob = NULL;
       TR_X86RegisterDependencyGroup *post = self()->getDependencyConditions()->getPostConditions();
       for (uint32_t i = 0; i < self()->getDependencyConditions()->getNumPostConditions(); i++)
          {
@@ -353,7 +353,7 @@ void OMR::X86::Instruction::clobberRegsForRematerialisation()
             {
             if (!clob)
                {
-               clob = new (self()->cg()->trHeapMemory()) TR_ClobberingInstruction(self(), self()->cg()->trMemory());
+               clob = new (self()->cg()->trHeapMemory()) TR::ClobberingInstruction(self(), self()->cg()->trMemory());
                self()->cg()->addClobberingInstruction(clob);
                }
             clob->addClobberedRegister(reg);

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -4193,7 +4193,7 @@ TR::Register *OMR::X86::TreeEvaluator::BBEndEvaluator(TR::Node *node, TR::CodeGe
          if (debug("dumpRemat"))
             diagnostic("\n---> Deleting surviving discardable registers at BBEnd [" POINTER_PRINTF_FORMAT "]", node);
 
-         TR_ClobberingInstruction  *clob = NULL;
+         TR::ClobberingInstruction  *clob = NULL;
          if (debug("dumpRemat"))
             diagnostic(":");
          auto iterator = cg->getLiveDiscardableRegisters().begin();
@@ -4202,7 +4202,7 @@ TR::Register *OMR::X86::TreeEvaluator::BBEndEvaluator(TR::Node *node, TR::CodeGe
             TR::Register* regCursor = *iterator;
             if (!clob)
             {
-               clob = new (cg->trHeapMemory()) TR_ClobberingInstruction(instr, cg->trMemory());
+               clob = new (cg->trHeapMemory()) TR::ClobberingInstruction(instr, cg->trMemory());
                cg->addClobberingInstruction(clob);
             }
             clob->addClobberedRegister(regCursor);

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -699,7 +699,7 @@ TR::X86RegInstruction::X86RegInstruction(TR_X86OpCodes op,
        reg->isDiscardable() &&
        getOpCode().modifiesTarget())
       {
-      TR_ClobberingInstruction *clob = new (cg->trHeapMemory()) TR_ClobberingInstruction(this, cg->trMemory());
+      TR::ClobberingInstruction *clob = new (cg->trHeapMemory()) TR::ClobberingInstruction(this, cg->trMemory());
       clob->addClobberedRegister(reg);
       cg->addClobberingInstruction(clob);
       cg->removeLiveDiscardableRegister(reg);
@@ -742,7 +742,7 @@ TR::X86RegInstruction::X86RegInstruction(TR_X86OpCodes                       op,
        reg->isDiscardable() &&
        getOpCode().modifiesTarget())
       {
-      TR_ClobberingInstruction *clob = new (cg->trHeapMemory()) TR_ClobberingInstruction(this, cg->trMemory());
+      TR::ClobberingInstruction *clob = new (cg->trHeapMemory()) TR::ClobberingInstruction(this, cg->trMemory());
       clob->addClobberedRegister(reg);
       cg->addClobberingInstruction(clob);
       cg->removeLiveDiscardableRegister(reg);
@@ -3702,7 +3702,7 @@ void TR::X86FPCompareEvalInstruction::assignRegisters(TR_RegisterKinds kindsToBe
          case TR::fcmple:
          case TR::dcmpgtu:
          case TR::fcmpgtu:
-            TR_ASSERT(0, "TR_X86FPCompareEvalRegInstruction::assignRegisters() ==> shouldn't be able to generate this condition!\n" );
+            TR_ASSERT(0, "TR::X86FPCompareEvalRegInstruction::assignRegisters() ==> shouldn't be able to generate this condition!\n" );
             break;
 
          case TR::ifdcmpltu:
@@ -3749,7 +3749,7 @@ void TR::X86FPCompareEvalInstruction::assignRegisters(TR_RegisterKinds kindsToBe
             break;
 
          default:
-            TR_ASSERT(0, "TR_X86FPCompareEvalRegInstruction::assignRegisters() ==> invalid comparison op: %d\n", cmpOp);
+            TR_ASSERT(0, "TR::X86FPCompareEvalRegInstruction::assignRegisters() ==> invalid comparison op: %d\n", cmpOp);
             break;
          }
 

--- a/compiler/x/codegen/OMRX86Instruction.hpp
+++ b/compiler/x/codegen/OMRX86Instruction.hpp
@@ -791,7 +791,7 @@ class X86RegInstruction : public TR::Instruction
           reg->isDiscardable() &&
           getOpCode().modifiesTarget())
          {
-         TR_ClobberingInstruction *clob = new (cg->trHeapMemory()) TR_ClobberingInstruction(this, cg->trMemory());
+         TR::ClobberingInstruction *clob = new (cg->trHeapMemory()) TR::ClobberingInstruction(this, cg->trMemory());
          clob->addClobberedRegister(reg);
          cg->addClobberingInstruction(clob);
          cg->removeLiveDiscardableRegister(reg);
@@ -833,7 +833,7 @@ class X86RegInstruction : public TR::Instruction
           reg->isDiscardable() &&
           getOpCode().modifiesTarget())
          {
-         TR_ClobberingInstruction *clob = new (cg->trHeapMemory()) TR_ClobberingInstruction(this, cg->trMemory());
+         TR::ClobberingInstruction *clob = new (cg->trHeapMemory()) TR::ClobberingInstruction(this, cg->trMemory());
          clob->addClobberedRegister(reg);
          cg->addClobberingInstruction(clob);
          cg->removeLiveDiscardableRegister(reg);


### PR DESCRIPTION
This is part of moving all classes from using the TR_ prefix to the TR namespace. Typedefs are added since some downstream projects still use the old types. They will be removed in the near future.