### PR TITLE
Fix DataType warnings

### DIFF
--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -1163,7 +1163,7 @@ OMR::CodeGenerator::TR_RegisterPressureState::updateRegisterPressure(TR::Symbol 
    if (symbol->getType().isAggregate())
       {
       dt = TR::comp()->cg()->getDataTypeFromSymbolMap(symbol);
-      traceMsg(TR::comp(), "\nxxx2, rcSymbol %p is aggregate but found better dt = %d\n",symbol,dt);
+      traceMsg(TR::comp(), "\nxxx2, rcSymbol %p is aggregate but found better dt = %s\n",symbol,dt.toString());
       }
 
    if (dt == TR::NoType)

--- a/compiler/il/OMRDataTypes.cpp
+++ b/compiler/il/OMRDataTypes.cpp
@@ -281,8 +281,8 @@ OMR::DataType::getFloatTypeFromSize(int32_t size)
 TR::ILOpCodes
 OMR::DataType::getDataTypeConversion(TR::DataType t1, TR::DataType t2)
    {
-   TR_ASSERT(t1 < TR::NumOMRTypes, "conversion opcode from unexpected datatype %d requested", t1);
-   TR_ASSERT(t2 < TR::NumOMRTypes, "conversion opcode to unexpected datatype %d requested", t2);
+   TR_ASSERT(t1 < TR::NumOMRTypes, "conversion opcode from unexpected datatype %s requested", t1.toString());
+   TR_ASSERT(t2 < TR::NumOMRTypes, "conversion opcode to unexpected datatype %s requested", t2.toString());
    return OMR::conversionMap[t1][t2];
    }
 
@@ -348,6 +348,12 @@ OMR::DataType::getName(TR::DataType dt)
    {
    TR_ASSERT(dt < TR::NumOMRTypes, "Name requested for unknown datatype");
    return OMRDataTypeNames[dt];
+   }
+
+const char *
+OMR::DataType::toString() const
+   {
+   return TR::DataType::getName(getDataType());
    }
 
 

--- a/compiler/il/OMRDataTypes.hpp
+++ b/compiler/il/OMRDataTypes.hpp
@@ -286,7 +286,7 @@ namespace OMR
 class DataType
    {
 public:
-   DataType() : _type(TR::DataTypes::NoType) { }
+   DataType() : _type(TR::NoType) { }
    DataType(TR::DataTypes t) : _type(t) { }
 
    TR::DataTypes getDataType() const { return _type; }
@@ -338,6 +338,8 @@ public:
 
    TR::DataType vectorToScalar();
    TR::DataType scalarToVector();
+
+   const char * toString() const;
 
    static TR::DataType getIntegralTypeFromPrecision(int32_t precision);
 

--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -664,7 +664,7 @@ public:
          case TR::Int64:   return TR::labs;
          case TR::Float:   return TR::fabs;
          case TR::Double:  return TR::dabs;
-         default: TR_ASSERT(false, "no abs opcode for this datatype %d",type);
+         default: TR_ASSERT(false, "no abs opcode for this datatype %s",type.toString());
          }
       return TR::BadILOp;
       }
@@ -777,7 +777,7 @@ public:
          case TR::Int16:  return TR::sand;
          case TR::Int32:  return TR::iand;
          case TR::Int64:  return TR::land;
-         default: TR_ASSERT(false, "no and opcode for datatype %d",type);
+         default: TR_ASSERT(false, "no and opcode for datatype %s",type.toString());
          }
       return TR::BadILOp;
       }
@@ -790,7 +790,7 @@ public:
          case TR::Int16:  return TR::sor;
          case TR::Int32:  return TR::ior;
          case TR::Int64:  return TR::lor;
-         default: TR_ASSERT(false, "no or opcode for datatype %d",type);
+         default: TR_ASSERT(false, "no or opcode for datatype %s",type.toString());
          }
       return TR::BadILOp;
       }
@@ -803,7 +803,7 @@ public:
          case TR::Int16:  return TR::sxor;
          case TR::Int32:  return TR::ixor;
          case TR::Int64:  return TR::lxor;
-         default: TR_ASSERT(false, "no xor opcode for datatype %d",type);
+         default: TR_ASSERT(false, "no xor opcode for datatype %s",type.toString());
          }
       return TR::BadILOp;
       }
@@ -816,7 +816,7 @@ public:
          case TR::Int16:  return TR::sshl;
          case TR::Int32:  return TR::ishl;
          case TR::Int64:  return TR::lshl;
-         default: TR_ASSERT(false, "no shl opcode for datatype %d",type);
+         default: TR_ASSERT(false, "no shl opcode for datatype %s",type.toString());
          }
       return TR::BadILOp;
       }
@@ -827,7 +827,7 @@ public:
          {
          case TR::Int32:  return TR::iushl;
          case TR::Int64:  return TR::lushl;
-         default: TR_ASSERT(false, "no ushl opcode for datatype %d",type);
+         default: TR_ASSERT(false, "no ushl opcode for datatype %s",type.toString());
          }
       return TR::BadILOp;
       }
@@ -840,7 +840,7 @@ public:
          case TR::Int16:  return TR::sshr;
          case TR::Int32:  return TR::ishr;
          case TR::Int64:  return TR::lshr;
-         default: TR_ASSERT(false, "no shr opcode for datatype %d",type);
+         default: TR_ASSERT(false, "no shr opcode for datatype %s",type.toString());
          }
       return TR::BadILOp;
       }
@@ -851,7 +851,7 @@ public:
          {
          case TR::Int32:  return TR::iushr;
          case TR::Int64:  return TR::lushr;
-         default: TR_ASSERT(false, "no ushr opcode for datatype %d",type);
+         default: TR_ASSERT(false, "no ushr opcode for datatype %s",type.toString());
          }
       return TR::BadILOp;
       }
@@ -1011,7 +1011,7 @@ public:
          case TR::Address:  return TR::ifacmpeq;
          case TR::Float:    return TR::iffcmpeq;
          case TR::Double:   return TR::ifdcmpeq;
-         default: TR_ASSERT(0, "no ifcmpeq opcode for this datatype %d",type);
+         default: TR_ASSERT(0, "no ifcmpeq opcode for this datatype %s",type.toString());
          }
       return TR::BadILOp;
       }
@@ -1027,7 +1027,7 @@ public:
          case TR::Address:  return TR::ifacmpne;
          case TR::Float:    return TR::iffcmpne;
          case TR::Double:   return TR::ifdcmpne;
-         default: TR_ASSERT(0, "no ifcmpne opcode for this datatype %d",type);
+         default: TR_ASSERT(0, "no ifcmpne opcode for this datatype %s",type.toString());
          }
       return TR::BadILOp;
       }
@@ -1043,7 +1043,7 @@ public:
          case TR::Address:  return TR::acmpeq;
          case TR::Float:    return TR::fcmpeq;
          case TR::Double:   return TR::dcmpeq;
-         default: TR_ASSERT(0, "no cmpeq opcode for this datatype %d",type);
+         default: TR_ASSERT(0, "no cmpeq opcode for this datatype %s",type.toString());
          }
       return TR::BadILOp;
       }
@@ -1091,7 +1091,7 @@ public:
          case TR::Address:  return TR::aconst;
          case TR::Float:    return TR::fconst;
          case TR::Double:   return TR::dconst;
-         default: TR_ASSERT(0, "no const opcode for this datatype %d",type);
+         default: TR_ASSERT(0, "no const opcode for this datatype %s",type.toString());
          }
       return TR::BadILOp;
       }

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -1436,7 +1436,7 @@ OMR::Node::createConstZeroValue(TR::Node *originatingByteCodeNode, TR::DataType 
          break;
          }
       default:
-         TR_ASSERT_SAFE_FATAL(false, "datatype %d not supported for createConstZeroValue\n", dt);
+         TR_ASSERT_SAFE_FATAL(false, "datatype %s not supported for createConstZeroValue\n", dt.toString());
       }
    return constZero;
    }
@@ -1472,7 +1472,7 @@ OMR::Node::createConstOne(TR::Node *originatingByteCodeNode, TR::DataType dt)
          constOne->setUnsignedLongInt(DOUBLE_ONE);
          break;
       default:
-         TR_ASSERT_SAFE_FATAL(false, "datatype %d not supported for createConstOne\n", dt);
+         TR_ASSERT_SAFE_FATAL(false, "datatype %s not supported for createConstOne\n", dt.toString());
       }
    return constOne;
    }
@@ -1514,7 +1514,7 @@ OMR::Node::createConstDead(TR::Node *originatingByteCodeNode, TR::DataType dt, i
          result->setDouble(*(double*)(&dead64));
          break;
       default:
-         TR_ASSERT_SAFE_FATAL(false, "datatype %d not supported for createConstDead\n", dt);
+         TR_ASSERT_SAFE_FATAL(false, "datatype %s not supported for createConstDead\n", dt.toString());
       }
    return result;
    }
@@ -4383,7 +4383,7 @@ OMR::Node::get32bitIntegralValue()
       return self()->getByte();
    else
       {
-      TR_ASSERT(false, "Must be an <= size 4 integral but it is type %d", self()->getDataType());
+      TR_ASSERT(false, "Must be an <= size 4 integral but it is type %s", self()->getDataType().toString());
       return 0;
       }
    }
@@ -4425,7 +4425,7 @@ OMR::Node::get64bitIntegralValue()
       return self()->getAddress(); //TR::Compiler->target.is64Bit() ? getUnsignedLongInt() : getUnsignedInt();
    else
       {
-      TR_ASSERT(false, "Must be an integral or address but it is type %d on node %p\n", self()->getDataType(), self());
+      TR_ASSERT(false, "Must be an integral or address but it is type %s on node %p\n", self()->getDataType().toString(), self());
       return 0;
       }
 
@@ -4454,7 +4454,7 @@ OMR::Node::set64bitIntegralValue(int64_t value)
       }
    else
       {
-      TR_ASSERT(false, "Must be an integral value but it is type %d", self()->getDataType());
+      TR_ASSERT(false, "Must be an integral value but it is type %s", self()->getDataType().toString());
       }
    }
 
@@ -4475,7 +4475,7 @@ OMR::Node::get64bitIntegralValueAsUnsigned()
       return TR::Compiler->target.is64Bit() ? self()->getUnsignedLongInt() : self()->getUnsignedInt();
    else
       {
-      TR_ASSERT(false, "Must be an integral or address but it is type %d", self()->getDataType());
+      TR_ASSERT(false, "Must be an integral or address but it is type %s", self()->getDataType().toString());
       return 0;
       }
 

--- a/compiler/optimizer/CopyPropagation.cpp
+++ b/compiler/optimizer/CopyPropagation.cpp
@@ -311,9 +311,9 @@ class TR_ExpressionPropagation
                   {
                   TR::ILOpCodes modPrecOp = TR::ILOpCode::modifyPrecisionOpCode(_parentOfTargetNode->getChild(_targetChildIndex)->getDataType());
 
-                  TR_ASSERT(modPrecOp != TR::BadILOp, "no bcd modify precision opcode found for node %p type %d\n",
+                  TR_ASSERT(modPrecOp != TR::BadILOp, "no bcd modify precision opcode found for node %p type %s\n",
                           _parentOfTargetNode->getChild(_targetChildIndex),
-                          _parentOfTargetNode->getChild(_targetChildIndex)->getDataType());
+                          _parentOfTargetNode->getChild(_targetChildIndex)->getDataType().toString());
 
                   TR::Node * pdModPrecNode = TR::Node::create(modPrecOp, 1, _parentOfTargetNode->getChild(_targetChildIndex));
                   pdModPrecNode->setDecimalPrecision(oldPrecision); // set to existing node's precision
@@ -325,9 +325,9 @@ class TR_ExpressionPropagation
                   {
                   TR::ILOpCodes cleanOp = TR::ILOpCode::cleanOpCode(_parentOfTargetNode->getChild(_targetChildIndex)->getDataType());
 
-                  TR_ASSERT(cleanOp != TR::BadILOp, "no bcd clean opcode found for node %p type %d\n",
+                  TR_ASSERT(cleanOp != TR::BadILOp, "no bcd clean opcode found for node %p type %s\n",
                           _parentOfTargetNode->getChild(_targetChildIndex),
-                          _parentOfTargetNode->getChild(_targetChildIndex)->getDataType());
+                          _parentOfTargetNode->getChild(_targetChildIndex)->getDataType().toString());
 
                   TR::Node * pdCleanNode = TR::Node::create(cleanOp, 1, _parentOfTargetNode->getChild(_targetChildIndex));
 
@@ -348,8 +348,8 @@ class TR_ExpressionPropagation
             //                                                     /* source */            /* target */
             TR::ILOpCodes convOp = TR::ILOpCode::getProperConversion(newNode->getDataType(), oldNode->getDataType(), true);
 
-            TR_ASSERT(convOp != TR::BadILOp, "no conversion opcode found for old type %d to new type %d!\n",
-                    oldNode->getDataType(), newNode->getDataType());
+            TR_ASSERT(convOp != TR::BadILOp, "no conversion opcode found for old type %s to new type %s!\n",
+                    oldNode->getDataType().toString(), newNode->getDataType().toString());
 
             TR::Node * convNode = TR::Node::create(convOp, 1, _parentOfTargetNode->getChild(_targetChildIndex));
 
@@ -527,8 +527,8 @@ int32_t TR_CopyPropagation::perform()
 #ifdef J9_PROJECT_SPECIFIC
                   if (prevDefNode->getType().isBCD())
                      {
-                     TR_ASSERT(defNode->getType().isBCD(),"expecting defNode to be a BCD type (dt=%d) when prevDefNode is a BCD type (dt=%d)\n",
-                        defNode->getDataType(),prevDefNode->getDataType());
+                     TR_ASSERT(defNode->getType().isBCD(),"expecting defNode to be a BCD type (dt=%s) when prevDefNode is a BCD type (dt=%s)\n",
+                        defNode->getDataType().toString(),prevDefNode->getDataType().toString());
                      if (defNode->getType().isBCD() &&
                          defNode->getDataType() == prevDefNode->getDataType() &&
                          prevDefNode->getDecimalPrecision() == defNode->getDecimalPrecision() &&
@@ -1289,7 +1289,7 @@ void TR_CopyPropagation::replaceCopySymbolReferenceByOriginalIn(TR::SymbolRefere
                   if (needsPrecisionCorrection)
                      {
                      TR::ILOpCodes modPrecOp = TR::ILOpCode::modifyPrecisionOpCode(nodeCopy->getDataType());
-                     TR_ASSERT(modPrecOp != TR::BadILOp,"no bcd modify precision opcode found\n",nodeCopy,nodeCopy->getDataType());
+                     TR_ASSERT(modPrecOp != TR::BadILOp,"no bcd modify precision opcode found for node %p with type %s\n",nodeCopy,nodeCopy->getDataType().toString());
                      if (needsClean) // i.e. if a clean will be generated below then do not modify node op yet, let the top level op (the coming clean) do this
                         {
                         TR::Node *pdModPrecNode = TR::Node::create(modPrecOp, 1, nodeCopy);
@@ -1314,7 +1314,7 @@ void TR_CopyPropagation::replaceCopySymbolReferenceByOriginalIn(TR::SymbolRefere
                   if (needsClean)
                      {
                      TR::ILOpCodes cleanOp = TR::ILOpCode::cleanOpCode(nodeCopy->getDataType());
-                     TR_ASSERT(cleanOp != TR::BadILOp,"no bcd modify precision cleanOp found for node %p with type %d\n",nodeCopy,nodeCopy->getDataType());
+                     TR_ASSERT(cleanOp != TR::BadILOp,"no bcd modify precision cleanOp found for node %p with type %s\n",nodeCopy,nodeCopy->getDataType().toString());
                      // can only clean up to maxPackedPrec -- case allow should have been guaranteed by isCorrectToPropagate
                      TR_ASSERT(node->getDecimalPrecision() <= TR::DataType::getMaxPackedDecimalPrecision(),
                              "node %p prec %d must be <= max %d\n", node, node->getDecimalPrecision(), TR::DataType::getMaxPackedDecimalPrecision());

--- a/compiler/optimizer/LoopReducer.cpp
+++ b/compiler/optimizer/LoopReducer.cpp
@@ -980,8 +980,8 @@ TR_LoopReducer::generateArraycopy(TR_InductionVariable * indVar, TR::Block * loo
    if (storeNode->getType().isBCD() &&
        !(storeSize == 1 || storeSize == 2 || storeSize == 4 || storeSize == 8))
       {
-      dumpOptDetails(comp(), "arraycopy storeNode %p is a BCD type (%d) and the storeSize (%d) is not 1,2,4 or 8 so do not reduce arraycopy\n",
-         storeNode,storeNode->getDataType(),storeSize);
+      dumpOptDetails(comp(), "arraycopy storeNode %p is a BCD type (%s) and the storeSize (%d) is not 1,2,4 or 8 so do not reduce arraycopy\n",
+         storeNode,storeNode->getDataType().toString(),storeSize);
       return false;
       }
 #endif

--- a/compiler/optimizer/OMRLocalCSE.cpp
+++ b/compiler/optimizer/OMRLocalCSE.cpp
@@ -1144,8 +1144,8 @@ TR::Node *OMR::LocalCSE::replaceCopySymbolReferenceByOriginalIn(TR::SymbolRefere
                    defNode->getOpCode().isStore() &&
                    defNode->mustCleanSignInPDStoreEvaluator())
                   {
-                  TR_ASSERT(rhsOfStoreDefNode->getDataType() == TR::PackedDecimal,"rhsOfStoreDefNode %p (type %d) must be pd type if defNode %p is pd\n",
-                     rhsOfStoreDefNode,rhsOfStoreDefNode->getDataType(),defNode);
+                  TR_ASSERT(rhsOfStoreDefNode->getDataType() == TR::PackedDecimal,"rhsOfStoreDefNode %p (type %s) must be pd type if defNode %p is pd\n",
+                     rhsOfStoreDefNode,rhsOfStoreDefNode->getDataType().toString(),defNode);
                   // clean should only have been folded into defNode if rhsOfStoreDefNode prec <= 31
                   TR_ASSERT(rhsOfStoreDefNode->getDecimalPrecision() <= TR::DataType::getMaxPackedDecimalPrecision(),
                      "rhsOfStoreDefNode %p prec %d must be <= max %d\n", rhsOfStoreDefNode, rhsOfStoreDefNode->getDecimalPrecision(), TR::DataType::getMaxPackedDecimalPrecision());

--- a/compiler/optimizer/OMRSimplifier.cpp
+++ b/compiler/optimizer/OMRSimplifier.cpp
@@ -680,8 +680,8 @@ OMR::Simplifier::unaryCancelOutWithChild(TR::Node * node, TR::Node * firstChild,
             {
             TR::Node *origGrandChild = grandChild;
             TR::ILOpCodes setSignOp = TR::ILOpCode::setSignOpCode(grandChild->getDataType());
-            TR_ASSERT(setSignOp != TR::BadILOp,"could not find setSignOp for type %d on %s (%p)\n",
-                    grandChild->getDataType(),grandChild->getOpCode().getName(),grandChild);
+            TR_ASSERT(setSignOp != TR::BadILOp,"could not find setSignOp for type %s on %s (%p)\n",
+                    grandChild->getDataType().toString(),grandChild->getOpCode().getName(),grandChild);
             grandChild = TR::Node::create(setSignOp, 2,
                                          origGrandChild,
                                          TR::Node::iconst(origGrandChild, TR::DataType::getValue(alwaysGeneratedSign)));

--- a/compiler/optimizer/OMRSimplifierHelpers.cpp
+++ b/compiler/optimizer/OMRSimplifierHelpers.cpp
@@ -513,7 +513,7 @@ bool isNZDoublePowerOfTwo(double value)
 // instead of base ** 255
 bool isIntegralExponentInRange(TR::Node *parent, TR::Node *exponent, int64_t maxNegativeExponent, int64_t maxPositiveExponent, TR::Simplifier * s)
    {
-   TR_ASSERT(exponent->getType().isIntegral(),"isIntegralExponentInRange only valid for integral exponents and not type %d\n",exponent->getDataType());
+   TR_ASSERT(exponent->getType().isIntegral(),"isIntegralExponentInRange only valid for integral exponents and not type %s\n",exponent->getDataType().toString());
    TR_ASSERT(parent->getOpCode().isExponentiation(),"isIntegralExponentInRange only valid for exponentiation operations\n");
    bool exponentInRange = false;
    bool isUnsignedExpOp = parent->getOpCode().isUnsignedExponentiation();
@@ -747,7 +747,7 @@ TR::Node *replaceExpWithMult(TR::Node *node,TR::Node *valueNode,TR::Node *expone
                   }
                default:
                   {
-                  TR_ASSERT(false,"unexpected exponent datatype %d\n",node->getDataType());
+                  TR_ASSERT(false,"unexpected exponent datatype %s\n",node->getDataType().toString());
                   }
                }
             return node;

--- a/compiler/optimizer/OMRTransformUtil.cpp
+++ b/compiler/optimizer/OMRTransformUtil.cpp
@@ -246,7 +246,7 @@ OMR::TransformUtil::scalarizeAddressParameter(
             ref->getSymbol()->getDataType() == dataType)
       {
       if (comp->getOption(TR_TraceScalarizeSSOps))
-         traceMsg(comp,"\n\tscalarizeAddressParameter auto direct case: address %p, dt %d\n",address,dataType);
+         traceMsg(comp,"\n\tscalarizeAddressParameter auto direct case: address %p, dt %s\n",address,dataType.toString());
 
       TR::ILOpCodes opcode = store ? comp->il.opCodeForDirectStore(dataType)
                                   : comp->il.opCodeForDirectLoad(dataType);

--- a/compiler/optimizer/RegisterCandidate.cpp
+++ b/compiler/optimizer/RegisterCandidate.cpp
@@ -319,7 +319,7 @@ TR_RegisterCandidates::findOrCreate(TR::SymbolReference * symRef)
    if (_candidateForSymRefs)
       _candidateForSymRefs[GET_INDEX_FOR_CANDIDATE_FOR_SYMREF(symRef)] = rc;
 
-   TR_ASSERT(comp()->cg()->considerTypeForGRA(symRef),"should create a registerCandidate for symRef #%d with datatype %d\n",symRef->getReferenceNumber(),rc->getDataType());
+   TR_ASSERT(comp()->cg()->considerTypeForGRA(symRef),"should create a registerCandidate for symRef #%d with datatype %s\n",symRef->getReferenceNumber(),rc->getDataType().toString());
 
    return rc;
    }

--- a/compiler/p/codegen/OMRConstantDataSnippet.cpp
+++ b/compiler/p/codegen/OMRConstantDataSnippet.cpp
@@ -149,7 +149,7 @@ int32_t OMR::ConstantDataSnippet::addConstantRequest(void              *v,
          break;
 
       default:
-         TR_ASSERT(0, "Only float and address constants are supported. Data type is %d.\n", type);
+         TR_ASSERT(0, "Only float and address constants are supported. Data type is %s.\n", type.toString());
       }
 
    return(ret);

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -1514,7 +1514,7 @@ TR::Register *OMR::Power::TreeEvaluator::vloadEvaluator(TR::Node *node, TR::Code
 	kind = TR_VSX_VECTOR;
 	break;
      default:
-	TR_ASSERT(false, "unknown vector load TRIL: unrecognized vector type %i\n", node->getDataType()); return NULL;
+	TR_ASSERT(false, "unknown vector load TRIL: unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
      }
 
    TR::Register *dstReg = cg->allocateRegister(kind);
@@ -1554,7 +1554,7 @@ TR::Register *OMR::Power::TreeEvaluator::vstoreEvaluator(TR::Node *node, TR::Cod
      case TR::VectorInt64:
      case TR::VectorDouble:
              opcode = TR::InstOpCode::stxvd2x; break;
-     default: TR_ASSERT(false, "unknown vector store TRIL: unrecognized vector type %i\n", node->getDataType()); return NULL;
+     default: TR_ASSERT(false, "unknown vector store TRIL: unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
      }
 
    TR::Node *valueChild = node->getOpCode().isStoreDirect() ? node->getFirstChild() : node->getSecondChild();
@@ -1818,7 +1818,7 @@ TR::Register *OMR::Power::TreeEvaluator::getvelemEvaluator(TR::Node *node, TR::C
       {
       case TR::VectorInt8:
       case TR::VectorInt16:
-         TR_ASSERT(false, "unsupported vector type %i in getvelemEvaluator.\n", firstChild->getDataType());
+         TR_ASSERT(false, "unsupported vector type %s in getvelemEvaluator.\n", firstChild->getDataType().toString());
          break;
       case TR::VectorInt32:
          elementCount = 4;
@@ -1846,7 +1846,7 @@ TR::Register *OMR::Power::TreeEvaluator::getvelemEvaluator(TR::Node *node, TR::C
          vecStoreOpCode = TR::InstOpCode::stxvd2x;
          break;
       default:
-         TR_ASSERT(false, "unrecognized vector type %i\n", firstChild->getDataType());
+         TR_ASSERT(false, "unrecognized vector type %s\n", firstChild->getDataType().toString());
       }
 
    TR::Register *vectorReg = cg->evaluate(firstChild);
@@ -2182,7 +2182,7 @@ TR::Register *OMR::Power::TreeEvaluator::vaddEvaluator(TR::Node *node, TR::CodeG
      case TR::VectorInt32:  return inlineVectorBinaryOp(node, cg, TR::InstOpCode::vadduwm);
      case TR::VectorFloat: return inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvaddsp);
      case TR::VectorDouble: return inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvadddp);
-     default: TR_ASSERT(false, "unrecognized vector type %i\n", node->getDataType()); return NULL;
+     default: TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
      }
    }
 
@@ -2194,7 +2194,7 @@ TR::Register *OMR::Power::TreeEvaluator::vsubEvaluator(TR::Node *node, TR::CodeG
      case TR::VectorInt32:  return inlineVectorBinaryOp(node, cg, TR::InstOpCode::vsubuwm);
      case TR::VectorFloat: return inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvsubsp);
      case TR::VectorDouble: return inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvsubdp);
-     default: TR_ASSERT(false, "unrecognized vector type %i\n", node->getDataType()); return NULL;
+     default: TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
      }
    }
 
@@ -2209,7 +2209,7 @@ TR::Register *OMR::Power::TreeEvaluator::vnegEvaluator(TR::Node *node, TR::CodeG
      case TR::VectorDouble:
        return vnegDoubleHelper(node,cg);
      default:
-       TR_ASSERT(false, "unrecognized vector type %i\n", node->getDataType()); return NULL;
+       TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
      }
    }
 
@@ -2252,7 +2252,7 @@ TR::Register *OMR::Power::TreeEvaluator::vmulEvaluator(TR::Node *node, TR::CodeG
      case TR::VectorDouble:
        return vmulDoubleHelper(node,cg);
      default:
-       TR_ASSERT(false, "unrecognized vector type %i\n", node->getDataType()); return NULL;
+       TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
      }
    }
 
@@ -2316,7 +2316,7 @@ TR::Register *OMR::Power::TreeEvaluator::vdivEvaluator(TR::Node *node, TR::CodeG
      case TR::VectorDouble:
 	return vdivDoubleHelper(node, cg);
      default:
-       TR_ASSERT(false, "unrecognized vector type %i\n", node->getDataType()); return NULL;
+       TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
      }
    }
 

--- a/compiler/p/codegen/PPCSystemLinkage.cpp
+++ b/compiler/p/codegen/PPCSystemLinkage.cpp
@@ -963,7 +963,7 @@ int32_t TR_PPCSystemLinkage::buildArgs(TR::Node *callNode,
             }
             break;
          default:
-            TR_ASSERT(false, "Argument type %d is not supported\n", child->getDataType());
+            TR_ASSERT(false, "Argument type %s is not supported\n", child->getDataType().toString());
          }
       }
 

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -293,7 +293,7 @@ TR_Debug::printLoadConst(TR::Node *node, TR_PrettyPrinterString& output)
          break;
 
       default:
-         output.append(" Bad Type %d", node->getDataType());
+         output.append(" Bad Type %s", node->getDataType().toString());
          break;
       }
    }

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -10096,7 +10096,7 @@ OMR::Z::CodeGenerator::biasDecimalFloatFrac(TR::DataType dt, int32_t frac)
       case TR::DecimalDouble:     return TR_DECIMAL_DOUBLE_BIAS-frac;
       case TR::DecimalLongDouble: return TR_DECIMAL_LONG_DOUBLE_BIAS-frac;
 #endif
-      default: TR_ASSERT(0, "unexpected biasDecimalFloatFrac dt %d",dt);
+      default: TR_ASSERT(0, "unexpected biasDecimalFloatFrac dt %s",dt.toString());
       }
    return 0;
    }

--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -646,7 +646,7 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node * rootLoadOrStore, TR::CodeGen
          else
             {
             TR_ASSERT(rootLoadOrStore->getDataType() == TR::Address || rootLoadOrStore->getOpCode().isLoadConst(),
-               "rootLoadOrStore %s %p should be an address type or const op and not dt %d\n", rootLoadOrStore->getOpCode().getName(), rootLoadOrStore,rootLoadOrStore->getDataType());
+               "rootLoadOrStore %s %p should be an address type or const op and not dt %s\n", rootLoadOrStore->getOpCode().getName(), rootLoadOrStore,rootLoadOrStore->getDataType().toString());
             //TR_ASSERT(rootLoadOrStore->getDataType() == TR::Address,
             //   "rootLoadOrStore %s %p should be an address type and not dt %d\n",rootLoadOrStore->getOpCode().getName(),rootLoadOrStore,rootLoadOrStore->getDataType());
 

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -12892,7 +12892,7 @@ OMR::Z::TreeEvaluator::arraysetEvaluator(TR::Node * node, TR::CodeGenerator * cg
                }
 
          default:
-            TR_ASSERT(0, "Unexpected copy datatype %d encountered on arrayset", constType);
+            TR_ASSERT(0, "Unexpected copy datatype %s encountered on arrayset", constType.toString());
             break;
          }
       }
@@ -18209,7 +18209,7 @@ int32_t getVectorElementSize(TR::Node *node)
       case TR::VectorFloat: return 4;
       case TR::VectorInt64:
       case TR::VectorDouble: return 8;
-      default: TR_ASSERT(false, "Unknown vector node type %i for element size\n", node->getDataType()); return 0;
+      default: TR_ASSERT(false, "Unknown vector node type %s for element size\n", node->getDataType().toString()); return 0;
       }
    }
 
@@ -18223,7 +18223,7 @@ int32_t getVectorElementSizeMask(TR::Node *node)
       case TR::VectorFloat: return 2;
       case TR::VectorInt64:
       case TR::VectorDouble: return 3;
-      default: TR_ASSERT(false, "Unknown vector node type %i for Element Size Control Mask\n", node->getDataType()); return 0;
+      default: TR_ASSERT(false, "Unknown vector node type %s for Element Size Control Mask\n", node->getDataType().toString()); return 0;
       }
    }
 
@@ -18281,7 +18281,7 @@ OMR::Z::TreeEvaluator::vnegEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       case TR::VectorInt32:
       case TR::VectorInt64: return inlineVectorUnaryOp(node, cg, TR::InstOpCode::VLC);
       case TR::VectorDouble: return inlineVectorUnaryOp(node, cg, TR::InstOpCode::VFPSO);
-      default: TR_ASSERT(false, "unrecognized vector type %i\n", node->getDataType()); return NULL;
+      default: TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
       }
    }
 
@@ -18403,7 +18403,7 @@ OMR::Z::TreeEvaluator::vaddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
          case TR::VectorInt32:
          case TR::VectorInt64: return inlineVectorBinaryOp(node, cg, TR::InstOpCode::VA);
          case TR::VectorDouble: return inlineVectorBinaryOp(node, cg, TR::InstOpCode::VFA);
-         default: TR_ASSERT(false, "unrecognized vector type %i\n", node->getDataType()); return NULL;
+         default: TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
          }
       }
    }
@@ -18429,7 +18429,7 @@ OMR::Z::TreeEvaluator::vsubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
          case TR::VectorInt32:
          case TR::VectorInt64: return inlineVectorBinaryOp(node, cg, TR::InstOpCode::VS);
          case TR::VectorDouble: return inlineVectorBinaryOp(node, cg, TR::InstOpCode::VFS);
-         default: TR_ASSERT(false, "unrecognized vector type %i\n", node->getDataType()); return NULL;
+         default: TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
          }
       }
    }
@@ -18489,7 +18489,7 @@ OMR::Z::TreeEvaluator::vmulEvaluator(TR::Node *node, TR::CodeGenerator *cg)
          return returnReg;
          }
       case TR::VectorDouble: return inlineVectorBinaryOp(node, cg, TR::InstOpCode::VFM);
-      default: TR_ASSERT(false, "unrecognized vector type %i\n", node->getDataType()); return NULL;
+      default: TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
       }
    }
 
@@ -18588,7 +18588,7 @@ OMR::Z::TreeEvaluator::vdivEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       case TR::VectorInt32:
       case TR::VectorInt64: return vDivOrRemHelper(node, cg, true);
       case TR::VectorDouble: return inlineVectorBinaryOp(node, cg, TR::InstOpCode::VFD);
-      default: TR_ASSERT(false, "unrecognized vector type %i\n", node->getDataType()); return NULL;
+      default: TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
       }
    }
 
@@ -18702,7 +18702,7 @@ OMR::Z::TreeEvaluator::vcmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       case TR::VectorInt32:
       case TR::VectorInt64: return inlineVectorBinaryOp(node, cg, TR::InstOpCode::VCEQ);
       case TR::VectorDouble: return inlineVectorBinaryOp(node, cg, TR::InstOpCode::VFCE);
-      default: TR_ASSERT(false, "unrecognized vector type %i\n", node->getDataType()); return NULL;
+      default: TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
       }
    }
 
@@ -18717,7 +18717,7 @@ OMR::Z::TreeEvaluator::vcmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       case TR::VectorInt32:
       case TR::VectorInt64: targetReg = inlineVectorBinaryOp(node, cg, TR::InstOpCode::VCEQ); break;
       case TR::VectorDouble: targetReg = inlineVectorBinaryOp(node, cg, TR::InstOpCode::VFCE); break;
-      default: TR_ASSERT(false, "unrecognized vector type %i\n", node->getDataType()); break;
+      default: TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); break;
       }
 
    // vector nor with zero vector
@@ -18747,7 +18747,7 @@ OMR::Z::TreeEvaluator::vcmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       case TR::VectorInt32:
       case TR::VectorInt64: return inlineVectorBinaryOp(node, cg, op);
       case TR::VectorDouble: return inlineVectorBinaryOp(node, cg, TR::InstOpCode::VFCH);
-      default: TR_ASSERT(false, "unrecognized vector type %i\n", node->getDataType()); return NULL;
+      default: TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
       }
    }
 


### PR DESCRIPTION
Silence warnings about "Cannot pass an argument of non-POD class type "TR::DataType" through ellipsis." This also changes these outputs from an integer based on an enum to a string.