### PR TITLE
OMR_OMRSIG_HAS_SIGVEC never defined in omrsig.h

### DIFF
--- a/include_core/omrsig.h
+++ b/include_core/omrsig.h
@@ -28,6 +28,12 @@
 extern "C" {
 #endif /* __cplusplus */
 
+#if defined(__GLIBC__) && (__GLIBC__ >= 2) && (__GLIBC_MINOR__ >= 21)
+#undef OMR_OMRSIG_HAS_SIGVEC
+#else /* defined(__GLIBC__) && (__GLIBC__ >= 2) && (__GLIBC_MINOR__ >= 21) */
+#define OMR_OMRSIG_HAS_SIGVEC
+#endif /* defined(__GLIBC__) && (__GLIBC__ >= 2) && (__GLIBC_MINOR__ >= 21) */
+
 #if defined(OSX)
 #define __THROW
 #endif /* defined(OSX) */

--- a/omrsigcompat/omrsig.cpp
+++ b/omrsigcompat/omrsig.cpp
@@ -38,12 +38,6 @@
 #include "omrsig.h"
 #include "omrsig_internal.hpp"
 
-#if defined(__GLIBC__) && (__GLIBC__ >= 2) && (__GLIBC_MINOR__ >= 21)
-#undef OMR_OMRSIG_HAS_SIGVEC
-#else /* defined(__GLIBC__) && (__GLIBC__ >= 2) && (__GLIBC_MINOR__ >= 21) */
-#define OMR_OMRSIG_HAS_SIGVEC
-#endif /* defined(__GLIBC__) && (__GLIBC__ >= 2) && (__GLIBC_MINOR__ >= 21) */
-
 extern "C" {
 
 static OMR_SigData sigData[NSIG];


### PR DESCRIPTION
The fix for #266 resolves the compile error but leaves omrsig.h in a
state where OMR_OMRSIG_HAS_SIGVEC can never be true in the header file
as it is only set in /omrsigcompat/omrsig.cpp.

The GLIBC check should be moved from the cpp file into the .h.

fix #345