### PR TITLE
Add JIT build artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ omrmakefiles/configure.mk
 omrmakefiles/toolconfigure.mk
 omrsigcompat/omrsig.exportlist
 
+TRBuildName.cpp
+
 J9TraceFormat.dat
 OMRTestTraceFormat.dat
 OMRTraceFormat.dat
@@ -61,6 +63,7 @@ omrthreadtest
 omrtraceoptiontest
 omrutiltest
 omrvmtest
+testjit
 utTrcCounters
 
 # hook generation tool
@@ -113,6 +116,11 @@ Testing/
 *.exe
 *.out
 *.app
+
+# Misc Build Artifacts
+*.o.depend.mk
+*.o.s
+*.pyc
 
 # Visual Studio
 *.dir/

--- a/jitbuilder/release/.gitignore
+++ b/jitbuilder/release/.gitignore
@@ -1,0 +1,33 @@
+###############################################################################
+#
+# (c) Copyright IBM Corp. 2016, 2016
+#
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License v1.0 and
+#  Apache License v2.0 which accompanies this distribution.
+#
+#      The Eclipse Public License is available at
+#      http://www.eclipse.org/legal/epl-v10.html
+#
+#      The Apache License v2.0 is available at
+#      http://www.opensource.org/licenses/apache2.0.php
+#
+# Contributors:
+#    Multiple authors (IBM Corp.) - initial implementation and documentation
+###############################################################################
+
+include/compiler/
+
+call
+dotproduct
+iterfib
+jitbuilder.tgz
+linkedlist
+localarray
+mandelbrot
+nestedloop
+pointer
+pow2
+recfib
+simple
+switch


### PR DESCRIPTION
These files are generated by the Test compiler and JitBuilder, and should not be tracked in Git.