### PR TITLE
Add the option enableAggressiveLiveness

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -596,6 +596,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"dumpInitialMethodNamesAndCounts",    "O\tDebug Printing of Method Names and Initial Counts.", SET_OPTION_BIT(TR_DumpInitialMethodNamesAndCounts), "F"},
    {"dumpIprofilerMethodNamesAndCounts",  "O\tDebug Printing of Method Names and Persisted Counts.", SET_OPTION_BIT(TR_DumpPersistedIProfilerMethodNamesAndCounts), "F"},
    {"dynamicThreadPriority",              "M\tenable dynamic changing of compilation thread priority", SET_OPTION_BIT(TR_DynamicThreadPriority), "F", NOT_IN_SUBSET},
+   {"enableAggressiveLiveness",           "I\tenable globalLiveVariablesForGC below warm", SET_OPTION_BIT(TR_EnableAggressiveLiveness), "F"},
    {"enableAllocationOfScratchBTL",       "M\tAllow the allocation scratch memory below the line (zOS 31-bit)", RESET_OPTION_BIT(TR_DontAllocateScratchBTL), "F", NOT_IN_SUBSET },
    {"enableAllocationSinking",            "O\tdelay object allocations until immediately before the corresponding constructor calls", TR::Options::enableOptimization, allocationSinking, 0, "P"},
    {EnableAnnotations,                    "O\tenable annotation support",                      SET_OPTION_BIT(TR_EnableAnnotations), "F"},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -988,6 +988,7 @@ enum TR_CompilationOptions
    TR_DisableVMCSProfiling                            = 0x00100000 + 30,
    TR_EnableHardwareProfileIndirectDispatch           = 0x00200000 + 30,
    TR_DisableCompareAndBranchInstruction              = 0x00400000 + 30,
+   TR_EnableAggressiveLiveness                        = 0x00010000 + 30,
    TR_EnableMetadataBytecodePCToIAMap                 = 0x00800000 + 30,
    TR_DisableHardwareProfilerReducedWarmUpgrades      = 0x01000000 + 30,
    TR_DontAddHWPDataToIProfiler                       = 0x02000000 + 30,

--- a/compiler/optimizer/GlobalRegisterAllocator.cpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.cpp
@@ -415,6 +415,14 @@ TR_GlobalRegisterAllocator::perform()
          for (a = locals.getFirst(); a != NULL; a = locals.getNext())
             ++numLocals;
 
+         if (comp()->getOption(TR_EnableAggressiveLiveness))
+            {
+            TR::ParameterSymbol *p;
+            ListIterator<TR::ParameterSymbol> parms(&comp()->getMethodSymbol()->getParameterList());
+            for (p = parms.getFirst(); p != NULL; p = parms.getNext())
+               ++numLocals;
+            }
+
          ListIterator<TR::RegisterMappedSymbol> methodMetaDataSymbols(&comp()->getMethodSymbol()->getMethodMetaDataList());
          if (comp()->allocateAtThisOptLevel())
             {
@@ -434,7 +442,7 @@ TR_GlobalRegisterAllocator::perform()
             // Perform liveness analysis
             //
             TR_Liveness liveLocals(comp(), optimizer(), comp()->getFlowGraph()->getStructure(),
-               false, NULL, false, false);
+               false, NULL, false, comp()->getOption(TR_EnableAggressiveLiveness));
             if (comp()->getVisitCount() > HIGH_VISIT_COUNT)
                {
                comp()->resetVisitCounts(1);

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -1494,7 +1494,14 @@ int32_t OMR::Optimizer::performOptimization(const OptimizationStrategy *optimiza
             }
          break;
          }
-
+      case IfAggressiveLiveness:
+         {
+         if (comp()->getOption(TR_EnableAggressiveLiveness))
+            {
+            doThisOptimization = true;
+            }
+         break;
+         }
       case MarkLastRun:
          doThisOptimization = true;
          TR_ASSERT(optNum < OMR::numOpts ,"No current support for marking groups as last (optNum=%d,numOpt=%d\n",optNum,OMR::numOpts); //make sure we didn't mark groups

--- a/compiler/optimizer/OMROptimizer.hpp
+++ b/compiler/optimizer/OMROptimizer.hpp
@@ -125,6 +125,7 @@ enum
    IfEAOpportunities,
    IfEAOpportunitiesMarkLastRun,
    IfEAOpportunitiesAndNotOptServer,
+   IfAggressiveLiveness,
    MarkLastRun
    };
 


### PR DESCRIPTION
This new option will enable object liveness analysis at low
optimization levels to allow early deallocation of dead objects to get
more memory at the cost of compilation time

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>