### PR TITLE
Clarify prerequisites for building compiler tests

### DIFF
--- a/fvtest/compilertest/README.md
+++ b/fvtest/compilertest/README.md
@@ -7,11 +7,13 @@ language independent compiler tests for the Testarossa compiler technology.
 Building
 --------
 
-To build the Test compiler, typing `make` in this directory
-(`omr/fvtest/compilertest`) should suffice. A binary called 
-`testjit` will be produced in `../../objs/compilertest_$(BUILD_CONFIG)/`
 
-BUILD_CONFIG defaults to prod. 
+After running `./configure --enable-fvtest --enable-OMR_JIT,`To build the Test
+compiler, typing `make` in this directory (`omr/fvtest/compilertest`) should
+suffice. A binary called `testjit` will be produced in
+`../../objs/compilertest_$(BUILD_CONFIG)/`
+
+`BUILD_CONFIG` defaults to `prod`. 
 
 In the case where `guess-platform.sh` is incorrect, you can set the `PLATFORM`
 environment variables to one of the supported ones, listed in


### PR DESCRIPTION
Buiding the compiler tests requires that OMR be configured first, as
their makefiles depend on it.

[skip ci] Documentation change.

Signed-off-by: Matthew Gaudet magaudet@ca.ibm.com
