### PR TITLE
Created C wrappers for C++ atomic functions

### DIFF
--- a/include_core/omrutilbase.h
+++ b/include_core/omrutilbase.h
@@ -33,6 +33,8 @@ uint32_t compareAndSwapU32NoSpinlock(uint32_t *location, uint32_t oldValue, uint
 void issueReadBarrier(void);
 void issueReadWriteBarrier(void);
 void issueWriteBarrier(void);
+uintptr_t addAtomic(volatile uintptr_t *address, uintptr_t addend);
+uintptr_t subtractAtomic(volatile uintptr_t *address, uintptr_t value);
 
 /* ---------------- cas8help.s ---------------- */
 #if !defined(OMR_ENV_DATA64) && (defined(AIXPPC) || defined(LINUXPPC))

--- a/util/omrutil/AtomicFunctions.cpp
+++ b/util/omrutil/AtomicFunctions.cpp
@@ -60,3 +60,15 @@ issueWriteBarrier(void)
 {
 	VM_AtomicSupport::writeBarrier();
 }
+ 
+uintptr_t
+addAtomic(volatile uintptr_t *address, uintptr_t addend)
+{
+	return VM_AtomicSupport::add(address, addend);
+}
+
+uintptr_t
+subtractAtomic(volatile uintptr_t *address, uintptr_t value)
+{
+	return VM_AtomicSupport::subtract(address, value);
+}


### PR DESCRIPTION
Created C wrappers for atomic add and subtract functions, which are
currently written in C++ within AtomicSupport.hpp. Currently, the C++
atomic add and subtract functions can not be called from C code. The C
wrappers allow the atomic add and subtract functions to be called from C
code.

Issue: #354
Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>