### PR TITLE
Start replacing CS2 ArrayOf containers

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -38,7 +38,6 @@
 #include "control/Options_inlines.hpp"
 #include "control/Recompilation.hpp"
 #include "cs2/allocator.h"                     // for shared_allocator
-#include "cs2/arrayof.h"                       // for ArrayOf, etc
 #include "cs2/bitvectr.h"                      // for ABitVector, etc
 #include "cs2/hashtab.h"                       // for HashTable<>::Cursor, etc
 #include "cs2/sparsrbit.h"

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -40,7 +40,6 @@ namespace OMR { typedef OMR::SymbolReferenceTable SymbolReferenceTableConnector;
 #include "codegen/RegisterConstants.hpp"
 #include "compile/AliasBuilder.hpp"            // for AliasBuilder
 #include "compile/Method.hpp"                  // for mcount_t
-#include "cs2/arrayof.h"                       // for ArrayOf
 #include "cs2/hashtab.h"                       // for HashTable, etc
 #include "env/jittypes.h"                      // for intptrj_t, uintptrj_t
 #include "il/DataTypes.hpp"                    // for DataTypes, etc

--- a/compiler/ilgen/ByteCodeIterator.hpp
+++ b/compiler/ilgen/ByteCodeIterator.hpp
@@ -41,6 +41,19 @@ public:
 
    struct TryCatchInfo : TR_Link<TryCatchInfo>
       {
+      void *operator new(size_t s, void *p) { return p; }
+
+      TryCatchInfo(uint16_t s, uint16_t e, uint16_t h, uint32_t c) :
+         _startIndex(s),
+         _endIndex(e),
+         _handlerIndex(h),
+         _catchType(c),
+         _firstBlock(0),
+         _lastBlock(0),
+         _catchBlock(0)
+         {
+         }
+
       void initialize(uint16_t s, uint16_t e, uint16_t h, uint32_t c)
          {
          _startIndex = s;
@@ -48,6 +61,7 @@ public:
          _handlerIndex = h;
          _catchType = c;
          }
+
       bool operator==(TryCatchInfo & o)
          {
          return _handlerIndex == o._handlerIndex && _catchType == o._catchType;

--- a/compiler/ilgen/ByteCodeIteratorWithState.hpp
+++ b/compiler/ilgen/ByteCodeIteratorWithState.hpp
@@ -22,7 +22,7 @@
 #include "compile/Compilation.hpp"      // for Compilation
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
-#include "cs2/arrayof.h"                // for ArrayOf
+#include "infra/deque.hpp"              // for TR::deque
 #include "env/TRMemory.hpp"             // for Allocator
 #include "il/Block.hpp"                 // for Block
 #include "infra/Assert.hpp"             // for TR_ASSERT
@@ -190,7 +190,8 @@ protected:
       genBBStart(end + 1);
       genBBStart(handler);
 
-      _tryCatchInfo[index].initialize(start, end, handler, type);
+      TR_ASSERT(_tryCatchInfo.begin() + index == _tryCatchInfo.end(), "Unexpected insertion order");
+      _tryCatchInfo.insert(_tryCatchInfo.begin() + index, typename ByteCodeIterator::TryCatchInfo(start, end, handler, type));
 
       for (int32_t j = start; j <= end; ++j)
          setIsInExceptionRange(j);
@@ -424,5 +425,5 @@ protected:
    flags8_t *                                     _flags;
 
    uint8_t                                        _unimplementedOpcode;  ///< (255 if opcode unknown)
-   CS2::ArrayOf<class ByteCodeIterator::TryCatchInfo, TR::Allocator> _tryCatchInfo;
+   TR::deque<class ByteCodeIterator::TryCatchInfo> _tryCatchInfo;
    };

--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -46,6 +46,7 @@
 #include "infra/Assert.hpp"                    // for TR_ASSERT
 #include "infra/Cfg.hpp"                       // for CFG
 #include "infra/CfgFrequencyCompletion.hpp"
+#include "infra/deque.hpp"
 #include "infra/Link.hpp"                      // for TR_LinkHead1
 #include "infra/List.hpp"                      // for ListIterator, List
 #include "infra/Stack.hpp"                     // for TR_Stack
@@ -1375,7 +1376,7 @@ class LoopInfo
 void OMR::CFG::findLoopingBlocks(TR::BitVector &loopingBlocks)
    {
    int32_t numberOfBlocks = getNextNodeNumber();
-   CS2::ArrayOf<int32_t, TR::Allocator> seenIndex(numberOfBlocks, comp()->allocator());
+   TR::deque<int32_t> seenIndex(numberOfBlocks, comp()->allocator());
    CS2::ArrayOf<TR::Block *, TR::Allocator> stack(256, comp()->allocator());
    CS2::TableOf<LoopInfo, TR::Allocator> loops(8, comp()->allocator());
    int32_t i, j;

--- a/compiler/infra/deque.hpp
+++ b/compiler/infra/deque.hpp
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#ifndef DEQUE_HPP
+#define DEQUE_HPP
+
+#pragma once
+
+#include <deque>
+#include "env/TypedAllocator.hpp"
+#include "env/TRMemory.hpp"
+
+namespace TR {
+
+template <typename T>
+class deque : public std::deque<T, typed_allocator<T, Allocator> >
+   {
+public:
+   typedef typed_allocator<T, Allocator> allocator_type;
+   typedef std::deque<T, typed_allocator<T, Allocator> > container_type;
+   typedef typename allocator_type::value_type value_type;
+   typedef typename allocator_type::reference reference;
+   typedef typename allocator_type::const_reference const_reference;
+   /*
+    * This would ideally use the parent deque's size_type.  However, such usage
+    * runs into two-phase lookup problems when compiling with MSVC++ 2010.
+    */
+   typedef std::size_t size_type;
+
+   explicit deque(const Allocator &allocator);
+   explicit deque(size_type size, const Allocator &allocator);
+   explicit deque(size_type size, const T& initialValue, const Allocator &allocator);
+   template <typename InputIterator> deque(InputIterator first, InputIterator last, const Allocator &allocator);
+   deque(const deque<T> &x);
+   ~deque();
+
+   reference operator[](size_type index);
+   const_reference operator[](size_type index) const;
+   };
+
+}
+
+template <typename T>
+TR::deque<T>::deque(const Allocator &allocator) :
+   container_type(allocator_type(allocator))
+   {
+   }
+
+template <typename T>
+TR::deque<T>::deque(size_type size, const Allocator &allocator) :
+   container_type(size, T(), allocator_type(allocator))
+   {
+   }
+
+template <typename T>
+TR::deque<T>::deque(size_type size, const T& initialValue, const Allocator &allocator) :
+   container_type(size, initialValue, allocator_type(allocator))
+   {
+   }
+
+template <typename T>
+template <typename InputIterator>
+TR::deque<T>::deque(InputIterator first, InputIterator last, const Allocator &allocator) :
+   container_type(first, last, allocator_type(allocator))
+   {
+   }
+
+template <typename T>
+TR::deque<T>::deque(const deque<T> &other) :
+   container_type(other)
+   {
+   }
+
+template <typename T>
+TR::deque<T>::~deque()
+   {
+   }
+
+template <typename T>
+typename TR::deque<T>::reference
+TR::deque<T>::operator [](size_type index)
+   {
+   return this->at(index);
+   }
+
+template <typename T>
+typename TR::deque<T>::const_reference
+TR::deque<T>::operator [](size_type index) const
+   {
+   return this->at(index);
+   }
+
+#endif // DEQUE_HPP

--- a/compiler/optimizer/LocalDeadStoreElimination.hpp
+++ b/compiler/optimizer/LocalDeadStoreElimination.hpp
@@ -21,9 +21,9 @@
 
 #include <stdint.h>                           // for int32_t
 #include "env/TRMemory.hpp"                   // for Allocator, etc
-#include "cs2/arrayof.h"                      // for ArrayOf<>::iterator, etc
 #include "cs2/tableof.h"                      // for TableOf
 #include "il/Node.hpp"                        // for vcount_t, rcount_t
+#include "infra/deque.hpp"
 #include "optimizer/Optimization.hpp"         // for Optimization
 #include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
 
@@ -80,7 +80,7 @@ class LocalDeadStoreElimination : public TR::Optimization
    typedef TR::Node *StoreNode;
 
    typedef CS2::TableOf<PendingIdentityStore, TR::Allocator> PendingIdentityStoreTable;
-   typedef CS2::ArrayOf<StoreNode, TR::Allocator> StoreNodeTable;
+   typedef TR::deque<StoreNode> StoreNodeTable;
    typedef TR::BitVector LDSBitVector;
 
    inline TR::LocalDeadStoreElimination *self();

--- a/compiler/optimizer/StructuralAnalysis.hpp
+++ b/compiler/optimizer/StructuralAnalysis.hpp
@@ -26,6 +26,7 @@
 #include "env/TRMemory.hpp"         // for Allocator, TR_Memory, etc
 #include "il/Block.hpp"             // for Block
 #include "infra/Cfg.hpp"            // for CFG
+#include "infra/deque.hpp"
 
 class TR_Dominators;
 class TR_RegionStructure;
@@ -59,7 +60,7 @@ class TR_RegionAnalysis
    typedef CS2::TableOf<StructInfo, TR::Allocator> InfoTable;
    typedef TR::SparseBitVector SparseBitVector;
    typedef TR::BitVector WorkBitVector;
-   typedef CS2::StaticArrayOf<TR_StructureSubGraphNode*, TR::Allocator> SubGraphNodes;
+   typedef TR::deque<TR_StructureSubGraphNode*> SubGraphNodes;
 
    void simpleIterator(TR_Stack<int32_t>& workStack,
                        SparseBitVector& vector,


### PR DESCRIPTION
Start the process of eliminating uses of CS2 ArrayOf.  Given that the C++ standard library container closest in behaviour to CS2::ArrayOf is std::deque, use it as a default replacement.