### PR TITLE
WIP: Fix doOSR check condition

### DIFF
--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -1227,7 +1227,7 @@ OMR::ResolvedMethodSymbol::genIL(TR_FrontEnd * fe, TR::Compilation * comp, TR::S
          //
          bool doOSR =
             comp->getOption(TR_EnableOSR) &&
-            !comp->isPeekingMethod()  && (comp->getOption(TR_EnableNextGenHCR) || !comp->getOption(TR_EnableHCR)) ;
+            !comp->isPeekingMethod();
 
          TR::Optimizer *optimizer = NULL;
          TR::Optimizer *previousOptimizer = NULL;


### PR DESCRIPTION
**TR_EnableOSR is** always set when **TR_EnableNextGenHCR** or
**TR_EnableHCR** is set according to **compiler/compile/OMRCompilation.cpp**
So only checking **TR_EnableOSR** should be enough. The original
code checks for conditions that's either mutually exclusive or redundant

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>