### PR TITLE
af-start/af-end stanzas missing from verbosegc logs

### DIFF
--- a/gc/base/AllocateInitialization.hpp
+++ b/gc/base/AllocateInitialization.hpp
@@ -192,12 +192,11 @@ public:
 				env->restoreObjects(&objectPtr);
 #endif /* OMR_GC_ALLOCATION_TAX */
 			}
-		} else if (isGCAllowed()) {
-			/* gc was allowed but allocation failed -- issue Allocation Failure Report if required */
-			env->allocationFailureEndReportIfRequired(&_allocateDescription);
 		}
 
 		if (isGCAllowed()) {
+			/* issue Allocation Failure Report if required */
+			env->allocationFailureEndReportIfRequired(&_allocateDescription);
 			/* Done allocation - successful or not */
 			env->unwindExclusiveVMAccessForGC();
 		}


### PR DESCRIPTION
Call MM_EnvironmentBase::allocationFailureEndReportIfRequired() from
MM_AllocateInitialization::allocateAndInitializeObject() for successful
allocations (previously only called for failed allocations).

@amicic Please review.

Issue: #362
Signed-off-by: Kim Briggs <briggs@ca.ibm.com>