### PR TITLE
Repair TreeEvaluatorVMX.cpp merge conflict

### DIFF
--- a/compiler/p/codegen/TreeEvaluatorVMX.cpp
+++ b/compiler/p/codegen/TreeEvaluatorVMX.cpp
@@ -471,9 +471,3 @@ TR::Register *OMR::Power::TreeEvaluator::arraytranslateAndTestEvaluator(TR::Node
    {
    return NULL;
    }
-
-
-TR::Register *OMR::Power::TreeEvaluator::countDigitsEvaluator(TR::Node * node, TR::CodeGenerator * cg)
-   {
-   return NULL;
-   }


### PR DESCRIPTION
Remove 'countDigitsEvaluator()' again to fix build issues on Power.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>