### PR TITLE
Move TR_Compilation* classes into TR namespace

### DIFF
--- a/compiler/control/CompilationController.cpp
+++ b/compiler/control/CompilationController.cpp
@@ -32,22 +32,22 @@
 #include "infra/Monitor.hpp"                  // for Monitor
 #include "infra/ThreadLocal.h"                // for tlsAlloc, tlsFree
 
-class TR_CompilationInfo;
+namespace TR { class CompilationInfo; }
 
-int32_t                 TR_CompilationController::_verbose = 0;
-TR_CompilationStrategy *TR_CompilationController::_compilationStrategy = NULL;
-TR_CompilationInfo *    TR_CompilationController::_compInfo = 0;
-bool                    TR_CompilationController::_useController = false;
+int32_t                 TR::CompilationController::_verbose = 0;
+TR::CompilationStrategy *TR::CompilationController::_compilationStrategy = NULL;
+TR::CompilationInfo *    TR::CompilationController::_compInfo = 0;
+bool                    TR::CompilationController::_useController = false;
 
 
-bool TR_CompilationController::init(TR_CompilationInfo *compInfo)
+bool TR::CompilationController::init(TR::CompilationInfo *compInfo)
    {
    TR::Options *options = TR::Options::getCmdLineOptions();
    char *strategyName = options->getCompilationStrategyName();
 
       {
       _compInfo = compInfo;
-      _compilationStrategy = new (PERSISTENT_NEW) TR_DefaultCompilationStrategy();
+      _compilationStrategy = new (PERSISTENT_NEW) TR::DefaultCompilationStrategy();
 
          {
          TR_OptimizationPlan::_optimizationPlanMonitor = TR::Monitor::create("OptimizationPlanMonitor");
@@ -68,7 +68,7 @@ bool TR_CompilationController::init(TR_CompilationInfo *compInfo)
    return _useController;
    }
 
-void TR_CompilationController::shutdown()
+void TR::CompilationController::shutdown()
    {
    tlsFree(OMR::compilation);
    if (!_useController)
@@ -86,7 +86,7 @@ void TR_CompilationController::shutdown()
    }
 
 TR_OptimizationPlan *
-TR_DefaultCompilationStrategy::processEvent(TR_MethodEvent *event, bool *newPlanCreated)
+TR::DefaultCompilationStrategy::processEvent(TR_MethodEvent *event, bool *newPlanCreated)
    {
    TR_OptimizationPlan *plan = NULL;
    return plan;

--- a/compiler/control/CompilationController.hpp
+++ b/compiler/control/CompilationController.hpp
@@ -25,14 +25,18 @@
 class TR_MethodEvent;
 namespace TR { class Recompilation; }
 
-class TR_DefaultCompilationStrategy : public TR_CompilationStrategy
+namespace TR
+{
+
+class DefaultCompilationStrategy : public TR::CompilationStrategy
    {
    public:
    TR_PERSISTENT_ALLOC(TR_Memory::PersistentInfo);
-   TR_DefaultCompilationStrategy() {}
+   DefaultCompilationStrategy() {}
    TR_OptimizationPlan *processEvent(TR_MethodEvent *event, bool *newPlanCreated);
    void shutdown() {}
    virtual bool enableSwitchToProfiling() { return true; }
    };
 
+} // namesapce TR
 #endif

--- a/compiler/control/CompileMethod.cpp
+++ b/compiler/control/CompileMethod.cpp
@@ -134,7 +134,7 @@ int32_t commonJitInit(OMR::FrontEnd &fe, char *cmdLineOptions)
    TR_VerboseLog::initialize(jitConfig);
    TR::Options::setCanJITCompile(true);
    TR::Options::getCmdLineOptions()->setOption(TR_NoRecompile);
-   TR_CompilationController::init(NULL);
+   TR::CompilationController::init(NULL);
 
    void *pseudoTOC = NULL;
 #if defined(TR_TARGET_POWER)

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -48,7 +48,7 @@ namespace OMR { typedef OMR::Options OptionsConnector; }
 
 namespace TR { class CFGNode; }
 
-class TR_CompilationFilters;
+namespace TR { class CompilationFilters; }
 class TR_Debug;
 class TR_Debug;
 class TR_MCTLogs;
@@ -1386,11 +1386,14 @@ public:
 
    // Sub group filters
    //
-   TR_CompilationFilters * subGroup;
+   TR::CompilationFilters * subGroup;
 
    };
 
-class TR_CompilationFilters
+namespace TR
+{
+
+class CompilationFilters
    {
 public:
    #define FILTER_HASH_SIZE 211
@@ -1437,7 +1440,7 @@ public:
    void setHasRegexFilter()         {flags |= HasRegexFilter;}
    void setDefaultExclude(bool b)   {if (b) flags |= DefaultExclude;else flags &= ~DefaultExclude;}
    };
-
+} //namespace TR
 
 // Compilation options - each compilation has a pointer to one of these objects
 // to represent the options used for that compilation. There is a single

--- a/compiler/control/OptimizationPlan.cpp
+++ b/compiler/control/OptimizationPlan.cpp
@@ -133,7 +133,7 @@ int32_t TR_OptimizationPlan::freeEntirePool()
       _totalNumAllocatedPlans--;
       }
    TR_ASSERT(_poolSize==0, "Some error regarding optimization plan accounting\n");
-   if (TR_CompilationController::verbose() >= TR_CompilationController::LEVEL1)
+   if (TR::CompilationController::verbose() >= TR::CompilationController::LEVEL1)
       fprintf(stderr, "TR_OptimizationPlan allocations=%lu releases=%lu\n", _numAllocOp, _numFreeOp);
    remainingPlans = _totalNumAllocatedPlans;
    _optimizationPlanMonitor->exit();

--- a/compiler/control/OptimizationPlan.hpp
+++ b/compiler/control/OptimizationPlan.hpp
@@ -30,7 +30,7 @@
 #include "infra/Assert.hpp"              // for TR_ASSERT
 #include "infra/Flags.hpp"               // for flags32_t
 
-class TR_CompilationInfo;
+namespace TR { class CompilationInfo; }
 class TR_MethodEvent;
 namespace TR { class Recompilation; }
 namespace TR { class Monitor; }
@@ -247,11 +247,13 @@ class TR_OptimizationPlan
    };
 
 
-//---------------------------- TR_CompilationStrategy ---------------------------
+//---------------------------- TR::CompilationStrategy ---------------------------
 // Abstract class. Must derive strategies from it. The only pure virtual method
 // is processEevent() which needs to be defined in the derived classes.
 //-------------------------------------------------------------------------------
-class TR_CompilationStrategy
+namespace TR
+{
+class CompilationStrategy
    {
    public:
    virtual TR_OptimizationPlan *processEvent(TR_MethodEvent *event, bool *newPlanCreated) = 0;
@@ -261,30 +263,32 @@ class TR_CompilationStrategy
    virtual void shutdown() {} // called at shutdown time; useful for stats
    virtual bool enableSwitchToProfiling() { return false; } // turn profiling on during optimizations
    };
+} // namespace TR
 
-
-//------------------------------- TR_CompilationController ------------------------
+//------------------------------- TR::CompilationController ------------------------
 // All methods and fields are static. The most important field is _compilationStrategy
 // that store the compilation strategy in use.
 //---------------------------------------------------------------------------------
-class TR_CompilationController
+namespace TR
+{
+class CompilationController
    {
    public:
    enum {LEVEL1=1, LEVEL2, LEVEL3}; // verbosity levels;
    enum {DEFAULT, THRESHOLD}; // strategy codes
-   static bool    init(TR_CompilationInfo *);
+   static bool    init(TR::CompilationInfo *);
    static void    shutdown();
    static bool    useController() { return _useController; }
    static int32_t verbose() { return _verbose; }
    static void    setVerbose(int32_t v) { _verbose = v; }
-   static TR_CompilationStrategy * getCompilationStrategy() { return _compilationStrategy; }
-   static TR_CompilationInfo     * getCompilationInfo() { return _compInfo; }
+   static TR::CompilationStrategy * getCompilationStrategy() { return _compilationStrategy; }
+   static TR::CompilationInfo     * getCompilationInfo() { return _compInfo; }
    private:
-   static TR_CompilationStrategy *_compilationStrategy;
-   static TR_CompilationInfo     *_compInfo;        // stored here for convenience
+   static TR::CompilationStrategy *_compilationStrategy;
+   static TR::CompilationInfo     *_compInfo;        // stored here for convenience
    static int32_t                 _verbose;
    static bool                    _useController;
    };
 
-
+} // namespace TR
 #endif

--- a/compiler/env/TRMemory.cpp
+++ b/compiler/env/TRMemory.cpp
@@ -281,8 +281,8 @@ const char * objectName[] =
    "TR::Instruction",
 
    "TR_ArtifactManager",
-   "TR_CompilationInfo",
-   "TR_CompilationInfoPerThreadBase",
+   "CompilationInfo",
+   "CompilationInfoPerThreadBase",
    "TR_DebuggingCounters",
    "TR_Pattern",
    "TR_UseNodeInfo",

--- a/compiler/env/TRMemory.hpp
+++ b/compiler/env/TRMemory.hpp
@@ -429,8 +429,8 @@ public:
       S390Instruction,
 
       ArtifactManager,
-      TR_CompilationInfo,
-      TR_CompilationInfoPerThreadBase,
+      CompilationInfo,
+      CompilationInfoPerThreadBase,
       TR_DebuggingCounters,
       TR_Pattern,
       TR_UseNodeInfo,

--- a/compiler/optimizer/CallInfo.hpp
+++ b/compiler/optimizer/CallInfo.hpp
@@ -38,7 +38,7 @@
 #include "infra/List.hpp"                      // for List, etc
 #include "optimizer/InlinerFailureReason.hpp"
 
-class TR_CompilationFilters;
+namespace TR { class CompilationFilters;}
 class TR_FrontEnd;
 class TR_InlineBlocks;
 class TR_InlinerBase;
@@ -116,7 +116,7 @@ class TR_CallStack : public TR_Link<TR_CallStack>
       List<TR::SymbolReference>  _temps;
       List<TR::SymbolReference>  _injectedBasicBlockTemps;
       TR_InnerPreexistenceInfo *_innerPrexInfo;
-      TR_CompilationFilters *   _inlineFilters;
+      TR::CompilationFilters *   _inlineFilters;
       int32_t                   _maxCallSize;
       bool                      _inALoop;
       bool                      _alwaysCalled;

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -720,7 +720,7 @@ OMR_InlinerPolicy::tryToInlineGeneral(TR_CallTarget * calltarget, TR_CallStack *
    if (callStack && callStack->_inlineFilters)
       {
       TR_FilterBST *filterInfo = NULL;
-      TR_CompilationFilters * inlineFilters = NULL;
+      TR::CompilationFilters * inlineFilters = NULL;
 
       inlineFilters=callStack->_inlineFilters;
 
@@ -744,7 +744,7 @@ OMR_InlinerPolicy::tryToInlineGeneral(TR_CallTarget * calltarget, TR_CallStack *
       if (!toInline)
          {
          TR_FilterBST *filterInfo = NULL;
-         TR_CompilationFilters * inlineFilters = NULL;
+         TR::CompilationFilters * inlineFilters = NULL;
 
          if (TR::Options::getDebug())
             {
@@ -798,7 +798,7 @@ TR_CallStack::TR_CallStack(
      _safeToAddSymRefs(safeToAddSymRefs)
    {
    TR_FilterBST *filterInfo = NULL;
-   TR_CompilationFilters * inlineFilters = NULL;
+   TR::CompilationFilters * inlineFilters = NULL;
 
    if (!nextCallStack)
       {

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -55,7 +55,7 @@
 class TR_Debug;
 class TR_BlockStructure;
 class TR_CHTable;
-class TR_CompilationFilters;
+namespace TR { class CompilationFilters; }
 class TR_FilterBST;
 class TR_FrontEnd;
 class TR_GCStackMap;
@@ -366,7 +366,7 @@ public:
    virtual void newInstruction(TR::Instruction *);
    virtual void addInstructionComment(TR::Instruction *, char*, ...);
 
-   virtual TR_CompilationFilters * getInlineFilters() { return _inlineFilters; }
+   virtual TR::CompilationFilters * getInlineFilters() { return _inlineFilters; }
 
    virtual TR_FrontEnd *fe() { return _fe; }
    virtual TR::Compilation *comp() { return _comp; }
@@ -407,19 +407,19 @@ public:
    virtual bool            methodSigCanBeCompiled(const char *, TR_FilterBST * & , TR_Method::Type methodType);
    virtual bool            methodSigCanBeRelocated(const char *, TR_FilterBST * & );
    virtual bool            methodSigCanBeCompiledOrRelocated(const char *, TR_FilterBST * &, bool isRelocation, TR_Method::Type methodType);
-   virtual bool            methodCanBeFound(TR_Memory *, TR_ResolvedMethod *, TR_CompilationFilters *, TR_FilterBST * &);
-   virtual bool            methodSigCanBeFound(const char *, TR_CompilationFilters *, TR_FilterBST * &, TR_Method::Type methodType);
-   virtual TR_CompilationFilters * getCompilationFilters() { return _compilationFilters; }
-   virtual TR_CompilationFilters * getRelocationFilters() { return _relocationFilters; }
-   virtual void            clearFilters(TR_CompilationFilters *);
+   virtual bool            methodCanBeFound(TR_Memory *, TR_ResolvedMethod *, TR::CompilationFilters *, TR_FilterBST * &);
+   virtual bool            methodSigCanBeFound(const char *, TR::CompilationFilters *, TR_FilterBST * &, TR_Method::Type methodType);
+   virtual TR::CompilationFilters * getCompilationFilters() { return _compilationFilters; }
+   virtual TR::CompilationFilters * getRelocationFilters() { return _relocationFilters; }
+   virtual void            clearFilters(TR::CompilationFilters *);
    void                    clearFilters(bool loadLimit);
-   virtual bool            scanInlineFilters(FILE *, int32_t &, TR_CompilationFilters *);
-   virtual TR_FilterBST *  addFilter(char * &, int32_t, int32_t, int32_t, TR_CompilationFilters *);
+   virtual bool            scanInlineFilters(FILE *, int32_t &, TR::CompilationFilters *);
+   virtual TR_FilterBST *  addFilter(char * &, int32_t, int32_t, int32_t, TR::CompilationFilters *);
    virtual TR_FilterBST *  addFilter(char * &, int32_t, int32_t, int32_t, bool loadLimit);
    virtual TR_FilterBST *  addExcludedMethodFilter(bool loadLimit);
    virtual bool            addSamplingPoint(char *, TR_FilterBST * &, bool loadLimit);
    virtual int32_t         scanFilterName(char *, TR_FilterBST *);
-   virtual void            printFilters(TR_CompilationFilters *);
+   virtual void            printFilters(TR::CompilationFilters *);
    virtual void            printFilters();
    virtual void            print(TR_FilterBST * filter);
    virtual void            printSamplingPoints();
@@ -687,8 +687,8 @@ public:
    void printLoadConst(TR::FILE *, TR::Node *);
    void printLoadConst(TR::Node *, TR_PrettyPrinterString&);
 
-   TR_CompilationFilters * findOrCreateFilters(TR_CompilationFilters *);
-   TR_CompilationFilters * findOrCreateFilters(bool loadLimit);
+   TR::CompilationFilters * findOrCreateFilters(TR::CompilationFilters *);
+   TR::CompilationFilters * findOrCreateFilters(bool loadLimit);
 
    void printFilterTree(TR_FilterBST *root);
 
@@ -1099,9 +1099,9 @@ protected:
    uint32_t                   _nextInstructionNumber;
    uint32_t                   _nextStructureNumber;
    uint32_t                   _nextVariableSizeSymbolNumber;
-   TR_CompilationFilters    * _compilationFilters;
-   TR_CompilationFilters    * _relocationFilters;
-   TR_CompilationFilters    * _inlineFilters;
+   TR::CompilationFilters    * _compilationFilters;
+   TR::CompilationFilters    * _relocationFilters;
+   TR::CompilationFilters    * _inlineFilters;
    bool                       _usesSingleAllocMetaData;
    TR_BitVector               _nodeChecklist;
    TR_BitVector               _structureChecklist;

--- a/compiler/ras/LimitFile.cpp
+++ b/compiler/ras/LimitFile.cpp
@@ -47,15 +47,15 @@
 
 #define FILTER_POOL_CHUNK_SIZE 32768
 
-#define FILTER_SIZE (sizeof(TR_CompilationFilters) + sizeof(TR_FilterBST*) * FILTER_HASH_SIZE)
+#define FILTER_SIZE (sizeof(TR::CompilationFilters) + sizeof(TR_FilterBST*) * FILTER_HASH_SIZE)
 void
-TR_Debug::clearFilters(TR_CompilationFilters * filters)
+TR_Debug::clearFilters(TR::CompilationFilters * filters)
    {
    char *buf = (char*) findOrCreateFilters(filters);
    int32_t size = FILTER_SIZE;
    memset(buf, 0, size);
 
-   filters->filterHash = (TR_FilterBST **)(buf + sizeof(TR_CompilationFilters));
+   filters->filterHash = (TR_FilterBST **)(buf + sizeof(TR::CompilationFilters));
    filters->setDefaultExclude(false);
    filters->excludedMethodFilter = NULL;
    }
@@ -69,24 +69,24 @@ TR_Debug::clearFilters(bool loadLimit)
       clearFilters(_compilationFilters);
    }
 
-TR_CompilationFilters *
-TR_Debug::findOrCreateFilters(TR_CompilationFilters * filters)
+TR::CompilationFilters *
+TR_Debug::findOrCreateFilters(TR::CompilationFilters * filters)
    {
    if (filters)
       return filters;
    else
       {
-      int32_t size = sizeof(TR_CompilationFilters) + sizeof(TR_FilterBST*) * FILTER_HASH_SIZE;
+      int32_t size = sizeof(TR::CompilationFilters) + sizeof(TR_FilterBST*) * FILTER_HASH_SIZE;
 
       char * buf = (char *)(TR::Compiler->regionAllocator.allocate(size));
 
-      filters = (TR_CompilationFilters *)buf;
+      filters = (TR::CompilationFilters *)buf;
       clearFilters(filters);
       return filters;
       }
   }
 
-TR_CompilationFilters *
+TR::CompilationFilters *
 TR_Debug::findOrCreateFilters(bool loadLimit)
    {
    if (loadLimit)
@@ -98,13 +98,13 @@ TR_Debug::findOrCreateFilters(bool loadLimit)
    }
 
 TR_FilterBST *
-TR_Debug::addFilter(char * & filterString, int32_t scanningExclude, int32_t optionSetIndex, int32_t lineNum, TR_CompilationFilters * anyFilters)
+TR_Debug::addFilter(char * & filterString, int32_t scanningExclude, int32_t optionSetIndex, int32_t lineNum, TR::CompilationFilters * anyFilters)
    {
    uint32_t filterType = scanningExclude ? TR_FILTER_EXCLUDE_NAME_ONLY : TR_FILTER_NAME_ONLY;
 
    // Allocate the filter hash table, if it hasn't been already.
    //
-   TR_CompilationFilters * filters = findOrCreateFilters(anyFilters);
+   TR::CompilationFilters * filters = findOrCreateFilters(anyFilters);
 
    TR_FilterBST * filterBST = new (TR::Compiler->regionAllocator) TR_FilterBST(filterType, optionSetIndex, lineNum);
 
@@ -250,7 +250,7 @@ TR_Debug::addSamplingPoint(char * filterString, TR_FilterBST * & lastSamplingPoi
       return false;
    p += 2;
 
-   TR_CompilationFilters *filters = findOrCreateFilters(loadLimit);
+   TR::CompilationFilters *filters = findOrCreateFilters(loadLimit);
    TR_FilterBST * filterBST = new (TR::Compiler->regionAllocator) TR_FilterBST(type, tickCount);
    if (!scanFilterName(methodName, filterBST))
       return false;
@@ -298,7 +298,7 @@ TR_Debug::addSamplingPoint(char * filterString, TR_FilterBST * & lastSamplingPoi
    }
 
 bool
-TR_Debug::scanInlineFilters(FILE * inlineFile, int32_t & lineNumber, TR_CompilationFilters * filters)
+TR_Debug::scanInlineFilters(FILE * inlineFile, int32_t & lineNumber, TR::CompilationFilters * filters)
    {
    char          limitReadBuffer[1024];
    bool          inlineFileError = false;
@@ -424,7 +424,7 @@ TR_Debug::inlinefileOption(char *option, void *base, TR::OptionTable *entry, TR:
       // initializing _inlineFilters using the new interface
       //
       _inlineFilters = findOrCreateFilters(_inlineFilters);
-      TR_CompilationFilters * filters = _inlineFilters;
+      TR::CompilationFilters * filters = _inlineFilters;
 
       filters->setDefaultExclude(true);
 
@@ -485,7 +485,7 @@ TR_Debug::limitfileOption(char *option, void *base, TR::OptionTable *entry, TR::
    FILE *limitFile = fopen(limitFileName, "r");
    if (limitFile)
       {
-      TR_CompilationFilters * filters = findOrCreateFilters(loadLimit);
+      TR::CompilationFilters * filters = findOrCreateFilters(loadLimit);
       if (!cmdLineOptions->getOption(TR_OrderCompiles))
          filters->setDefaultExclude(true);
 
@@ -901,7 +901,7 @@ TR_Debug::print(TR_FilterBST * filter)
    }
 
 void
-TR_Debug::printFilters(TR_CompilationFilters * filters)
+TR_Debug::printFilters(TR::CompilationFilters * filters)
    {
    int32_t i;
    if (filters)
@@ -1125,7 +1125,7 @@ TR_Debug::methodSigCanBeRelocated(const char *methodSig, TR_FilterBST * & filter
    }
 
 bool
-TR_Debug::methodSigCanBeFound(const char *methodSig, TR_CompilationFilters * filters, TR_FilterBST * & filter, TR_Method::Type methodType)
+TR_Debug::methodSigCanBeFound(const char *methodSig, TR::CompilationFilters * filters, TR_FilterBST * & filter, TR_Method::Type methodType)
    {
    const char *methodClass, *methodName, *methodSignature;
    uint32_t methodClassLen, methodNameLen, methodSignatureLen;
@@ -1240,7 +1240,7 @@ TR_Debug::methodSigCanBeFound(const char *methodSig, TR_CompilationFilters * fil
    }
 
 bool
-TR_Debug::methodCanBeFound(TR_Memory *trMemory, TR_ResolvedMethod *method, TR_CompilationFilters * filters, TR_FilterBST * & filter)
+TR_Debug::methodCanBeFound(TR_Memory *trMemory, TR_ResolvedMethod *method, TR::CompilationFilters * filters, TR_FilterBST * & filter)
    {
    const char * methodSig = method->signature(trMemory);
    return methodSigCanBeFound(methodSig, filters, filter, method->convertToMethod()->methodType());
@@ -1249,7 +1249,7 @@ TR_Debug::methodCanBeFound(TR_Memory *trMemory, TR_ResolvedMethod *method, TR_Co
 bool
 TR_Debug::methodSigCanBeCompiledOrRelocated(const char *methodSig, TR_FilterBST * & filter, bool loadLimit, TR_Method::Type methodType)
    {
-   TR_CompilationFilters *compOrReloFilter = NULL;
+   TR::CompilationFilters *compOrReloFilter = NULL;
 
    if (loadLimit)
       {


### PR DESCRIPTION
This is part of moving all classes from using TR_prefix
to using the TR namespace.