### PR TITLE
JitBuilder improvements

### DIFF
--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -892,6 +892,17 @@ IlBuilder::ConstDouble(double value)
    return returnValue;
    }
 
+TR::IlValue *
+IlBuilder::ConstAddress(void* value)
+   {
+   appendBlock();
+   TR::IlValue *returnValue = newValue(Address);
+   storeNode(returnValue, TR::Node::aconst((uintptrj_t)value));
+   TraceIL("IlBuilder[ %p ]::%d is ConstAddress %p\n", this, returnValue->getCPIndex(), value);
+   ILB_REPLAY("%s = %s->ConstAddress(%p);", REPLAY_VALUE(returnValue), REPLAY_BUILDER(this), value);
+   return returnValue;
+   }
+
 
 TR::IlValue *
 IlBuilder::ConvertTo(TR::IlType *t, TR::IlValue *v)

--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -673,7 +673,7 @@ TR::IlValue *
 IlBuilder::CreateLocalStruct(TR::IlType *structType)
    {
    //similar to CreateLocalArray except writing a method in StructType to get the struct size
-   uint32_t size = structType->getStructSize();
+   uint32_t size = structType->getSize();
    TR::SymbolReference *localStructSymRef = symRefTab()->createLocalPrimArray(size,
                                                                              methodSymbol(),
                                                                              8 /*FIXME: JVM-specific - byte*/);
@@ -783,7 +783,7 @@ IlBuilder::IndexAt(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index)
          TR::ILOpCodes op = TR::DataType::getDataTypeConversion(indexType, TR::Int64);
          indexNode = TR::Node::create(op, 1, indexNode);
          }
-      elemSizeNode = TR::Node::lconst(TR::DataType::getSize(elemType->getPrimitiveType()));
+      elemSizeNode = TR::Node::lconst(elemType->getSize());
       addOp = TR::aladd;
       mulOp = TR::lmul;
       }
@@ -795,7 +795,7 @@ IlBuilder::IndexAt(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index)
          TR::ILOpCodes op = TR::DataType::getDataTypeConversion(indexType, targetType);
          indexNode = TR::Node::create(op, 1, indexNode);
          }
-      elemSizeNode = TR::Node::iconst(TR::DataType::getSize(elemType->getPrimitiveType()));
+      elemSizeNode = TR::Node::iconst(elemType->getSize());
       addOp = TR::aiadd;
       mulOp = TR::imul;
       }

--- a/compiler/ilgen/IlBuilder.hpp
+++ b/compiler/ilgen/IlBuilder.hpp
@@ -144,6 +144,7 @@ public:
    TR::IlValue *ConstInt64(int64_t value);
    TR::IlValue *ConstFloat(float value);
    TR::IlValue *ConstDouble(double value);
+   TR::IlValue *ConstAddress(void* value);
    TR::IlValue *ConstString(const char *value);
    TR::IlValue *ConstzeroValueForValue(TR::IlValue *v);
 

--- a/compiler/ilgen/TypeDictionary.cpp
+++ b/compiler/ilgen/TypeDictionary.cpp
@@ -56,9 +56,9 @@ IlType::getSignatureName()
    }
 
 size_t
-IlType::getStructSize()
+IlType::getSize()
    {
-   TR_ASSERT(0, "The input type is not a StructType\n");
+   TR_ASSERT(0, "The input type does not have a defined size\n");
    return 0;
    }
 
@@ -100,7 +100,9 @@ public:
       return _type;
       }
 
-  virtual char *getSignatureName() { return (char *) signatureNameForType[_type]; }
+   virtual char *getSignatureName() { return (char *) signatureNameForType[_type]; }
+
+   virtual size_t getSize() { return TR::DataType::getSize(_type); }
 
 protected:
    TR::DataType _type;
@@ -163,7 +165,7 @@ public:
 
    TR::SymbolReference *getFieldSymRef(const char *name);
    bool isStruct() { return true; }
-   size_t getStructSize();
+   virtual size_t getSize();
 
 protected:
    FieldInfo * findField(const char *fieldName);
@@ -255,7 +257,7 @@ StructType::getFieldSymRef(const char *fieldName)
    }
 
 size_t
-StructType::getStructSize()
+StructType::getSize()
    {
    size_t size = 0;
    FieldInfo *currentField = _firstField;

--- a/compiler/ilgen/TypeDictionary.cpp
+++ b/compiler/ilgen/TypeDictionary.cpp
@@ -64,22 +64,24 @@ IlType::getStructSize()
 
 const uint8_t primitiveTypeAlignment[TR::NumOMRTypes] =
    {
-   1,
-   1,
-   2,
-   4,
-   8,
+   1,  // NoType
+   1,  // Int8
+   2,  // Int16
+   4,  // Int32
+   8,  // Int64
+   4,  // Float
+   8,  // Double
 #if TR_TARGET_64BIT // HOST?
-   4,
+   4,  // Address/Word
 #else
-   8,
+   8,  // Address/Word
 #endif
-   16,
-   16,
-   16,
-   16,
-   16,
-   16
+   16, // VectorInt8
+   16, // VectorInt16
+   16, // VectorInt32
+   16, // VectorInt64
+   16, // VectorFloat
+   16  // VectorDouble
    };
 
 

--- a/compiler/ilgen/TypeDictionary.hpp
+++ b/compiler/ilgen/TypeDictionary.hpp
@@ -68,7 +68,7 @@ public:
    virtual TR::IlType *baseType() { return NULL; }
 
    virtual bool isStruct() {return false; }
-   virtual size_t getStructSize(); 
+   virtual size_t getSize();
 
 protected:
    const char *_name;


### PR DESCRIPTION
Fix alignment table issue in JitBuilder as reported in #358.

Generalize the `getSize` method in `IlBuilder` to return both the size of structs and primitive types. This has the side effect of making the `IndexAt` function also work on arrays of structs, not just arrays of primitives.

Create the function `ConstAddress()` for creating constant address values for use with pointer types.