### PR TITLE
Remove TR_EnableSCSSRelocations

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -707,7 +707,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"enableRubyTieredCompilation",        "O\tEnable Tiered Compilation on Ruby", SET_OPTION_BIT(TR_EnableRubyTieredCompilation), "F", NOT_IN_SUBSET},
    {"enableSCHint=","R<nnn>\tOverride default SC Hints to user-specified hints", TR::Options::set32BitHexadecimal, offsetof(OMR::Options, _enableSCHintFlags), 0, "F%d"},
    {"enableScorchInterpBlkFreqProfiling",   "R\tenable profiling blocks in the jit", SET_OPTION_BIT(TR_EnableScorchInterpBlockFrequencyProfiling), "F"},
-   {"enableSCSSRelocations",              "O\tenable relocations in sequential constant store simplification sequences", SET_OPTION_BIT(TR_EnableSCSSRelocations), "F"},
    {"enableSelectiveEnterExitHooks",      "O\tadd method-specific test to JVMTI method enter and exit hooks", SET_OPTION_BIT(TR_EnableSelectiveEnterExitHooks), "F"},
    {"enableSelfTuningScratchMemoryUsageBeforeCompile", "O\tEnable self tuning scratch memory usage", SET_OPTION_BIT(TR_EnableSelfTuningScratchMemoryUsageBeforeCompile), "F", NOT_IN_SUBSET},
    {"enableSelfTuningScratchMemoryUsageInTrMemory", "O\tEnable self tuning scratch memory usage", SET_OPTION_BIT(TR_EnableSelfTuningScratchMemoryUsageInTrMemory), "F", NOT_IN_SUBSET},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -642,11 +642,9 @@ enum TR_CompilationOptions
    // Available                                       = 0x00000400 + 18,
    // Available                                       = 0x00000800 + 18,
    // Available                                       = 0x00001000 + 18,
-   // Available                                       = 0x00002000 + 18, // trace sequentialConstantStoreSimplification
    // Available                                       = 0x00004000 + 18,
    // Available                                       = 0x00008000 + 18,
    // Available                                       = 0x00010000 + 18,
-   TR_EnableSCSSRelocations                           = 0x00020000 + 18, // enable relocations in sequentialConstantStoreSimplification sequences
    // Available                                       = 0x00040000 + 18,
    TR_DisableProloguePushes                           = 0x00080000 + 18, // Use stores instead of pushes in x86 prologues
    TR_EnableOutlinedPrologues                         = 0x00100000 + 18, // Call a helper to do some of the prologue logic


### PR DESCRIPTION
The Option bit sequentialConstantStoreSimplification was used in a
project that existed prior to this code being contributed and is
not relevant to the open source code base.

Signed-off-by: Aman Kumar <amank@ca.ibm.com>