### PR TITLE
Issue #73: Improve percolate start and subspace flipping for CS

### DIFF
--- a/gc/base/MemorySubSpaceSemiSpace.hpp
+++ b/gc/base/MemorySubSpaceSemiSpace.hpp
@@ -46,6 +46,14 @@ class MM_MemorySubSpaceSemiSpace : public MM_MemorySubSpace
 	/*
 	 * Data members
 	 */
+public:
+	enum Flip_step { 
+		set_evacuate,
+		set_allocate,
+		disable_allocation,
+		restore_allocation_and_set_survivor,
+		backout
+	};	 
 private:
 	MM_MemorySubSpace *_memorySubSpaceAllocate;
 	MM_MemorySubSpace *_memorySubSpaceSurvivor;
@@ -140,7 +148,7 @@ public:
 	virtual void systemGarbageCollect(MM_EnvironmentBase *env, uint32_t gcCode);
 
 	/* Type specific methods */
-	void flip(MM_EnvironmentBase *env, uintptr_t step);
+	void flip(MM_EnvironmentBase *env, Flip_step action);
 	
 	MMINLINE uintptr_t getSurvivorSpaceSizeRatio() const { return _survivorSpaceSizeRatio; }
 	MMINLINE void setSurvivorSpaceSizeRatio(uintptr_t size) { _survivorSpaceSizeRatio = size; }

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -32,8 +32,9 @@
 #include "CopyScanCacheStandard.hpp"
 #include "CycleState.hpp"
 #include "GCExtensionsBase.hpp"
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
 #include "MasterGCThread.hpp"
- 
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
 struct J9HookInterface;
 class GC_ObjectScanner;
 class MM_AllocateDescription;
@@ -499,6 +500,10 @@ public:
 	/* mutator thread */
 	void mutatorFinalReleaseCopyCaches(MM_EnvironmentBase *env, MM_EnvironmentBase *threadEnvironment);
 	void mutatorSetupForGC(MM_EnvironmentBase *env);
+	/**
+	 * trigger STW phase (either start or end) of a Concurrent Scavenger Cycle 
+	 */ 
+	void triggerConcurrentScavengerTransition(MM_EnvironmentBase *envBase, MM_AllocateDescription *allocDescription);
 
 	/* worker thread */
 	void workThreadProcessRoots(MM_EnvironmentStandard *env);


### PR DESCRIPTION
Ongoing improvements for Concurrent Scavenger:
- complete CS cycle before starting percolate Global GC
- clean up subspace flipping code and fix it for the case of aborted
Scavenge

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>