### PR TITLE
Change parameter types in DefineFunction()

### DIFF
--- a/compiler/ilgen/MethodBuilder.cpp
+++ b/compiler/ilgen/MethodBuilder.cpp
@@ -460,9 +460,9 @@ MethodBuilder::DefineReturnType(TR::IlType *dt)
    }
 
 void
-MethodBuilder::DefineFunction(char           * name,
-                              char           * fileName,
-                              char           * lineNumber,
+MethodBuilder::DefineFunction(const char* const name,
+                              const char* const fileName,
+                              const char* const lineNumber,
                               void           * entryPoint,
                               TR::IlType     * returnType,
                               int32_t          numParms,
@@ -481,17 +481,17 @@ MethodBuilder::DefineFunction(char           * name,
    }
 
 void
-MethodBuilder::DefineFunction(char           * name,
-                              char           * fileName,
-                              char           * lineNumber,
+MethodBuilder::DefineFunction(const char* const name,
+                              const char* const fileName,
+                              const char* const lineNumber,
                               void           * entryPoint,
                               TR::IlType     * returnType,
                               int32_t          numParms,
                               TR::IlType     ** parmTypes)
    {   
-   MB_REPLAY("DefineFunction((char*)\"%s\",", name);
-   MB_REPLAY("               (char*)\"%s\",", fileName);
-   MB_REPLAY("               (char*)\"%s\",", lineNumber);
+   MB_REPLAY("DefineFunction((const char* const)\"%s\",", name);
+   MB_REPLAY("               (const char* const)\"%s\",", fileName);
+   MB_REPLAY("               (const char* const)\"%s\",", lineNumber);
    MB_REPLAY("               " REPLAY_POINTER_FMT ",", REPLAY_POINTER(entryPoint, name));
    MB_REPLAY("               %s,", REPLAY_TYPE(returnType));
    MB_REPLAY_NONL("               %d", numParms);
@@ -502,9 +502,9 @@ MethodBuilder::DefineFunction(char           * name,
       }   
    MB_REPLAY(");");
 
-   TR::ResolvedMethod *method = new (PERSISTENT_NEW) TR::ResolvedMethod(fileName,
-                                                                        lineNumber,
-                                                                        name,
+   TR::ResolvedMethod *method = new (PERSISTENT_NEW) TR::ResolvedMethod((char*)fileName,
+                                                                        (char*)lineNumber,
+                                                                        (char*)name,
                                                                         numParms,
                                                                         parmTypes,
                                                                         returnType,

--- a/compiler/ilgen/MethodBuilder.hpp
+++ b/compiler/ilgen/MethodBuilder.hpp
@@ -93,16 +93,16 @@ class MethodBuilder : public TR::IlBuilder
    void DefineReturnType(TR::IlType *dt);
    void DefineLocal(const char *name, TR::IlType *dt);
    void DefineMemory(const char *name, TR::IlType *dt, void *location);
-   void DefineFunction(char           * name,
-                       char           * fileName,
-                       char           * lineNumber,
+   void DefineFunction(const char* const name,
+                       const char* const fileName,
+                       const char* const lineNumber,
                        void           * entryPoint,
                        TR::IlType     * returnType,
                        int32_t          numParms,
                        ...);
-   void DefineFunction(char           * name,
-                       char           * fileName,
-                       char           * lineNumber,
+   void DefineFunction(const char* const name,
+                       const char* const fileName,
+                       const char* const lineNumber,
                        void           * entryPoint,
                        TR::IlType     * returnType,
                        int32_t          numParms,


### PR DESCRIPTION
In order to eliminate the warning: ISO C++11 does not allow conversion
from string literal to `char *` [-Wwritable-strings] when passing string
parameter in `DefineFunction()`, change the type of `name`,
`fileName`,`lineNumber` taking `char*` to `const char* const`.

Signed-off-by: Shuyu Li <shuyuli@ca.ibm.com>