### PR TITLE
Support method limiting in Test Compiler

### DIFF
--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -123,6 +123,7 @@ typedef TR::SparseBitVector SharedSparseBitVector;
 // Return codes from the compilation. Any non-zero return code will abort the
 // compilation.
 #define COMPILATION_SUCCEEDED          0
+#define COMPILATION_REQUESTED          1
 #define COMPILATION_IL_GEN_FAILURE     8
 #define COMPILATION_UNIMPL_OPCODE     12
 #define COMPILATION_METADATA_CREATION_FAILURE 24

--- a/compiler/control/CompileMethod.cpp
+++ b/compiler/control/CompileMethod.cpp
@@ -228,6 +228,9 @@ compileMethodFromDetails(
 
    TR::CompileIlGenRequest request(details);
 
+   // initialize return code before compilation starts
+   rc = COMPILATION_REQUESTED;
+
    uint8_t *startPC = 0;
 
    TR_FilterBST *filterInfo = 0;

--- a/fvtest/compilertest/tests/BuilderTest.cpp
+++ b/fvtest/compilertest/tests/BuilderTest.cpp
@@ -24,6 +24,7 @@
 #include "ilgen/IlGeneratorMethodDetails_inlines.hpp"
 #include "ilgen/TypeDictionary.hpp"
 #include "tests/BuilderTest.hpp"
+#include "OpCodesTest.hpp"
 
 namespace TestCompiler
 {
@@ -650,9 +651,9 @@ BuilderTest::invokeTests()
    {
    for(uint32_t i = 0; i <= 20 ; i++)
       {
-   	EXPECT_EQ(iterativeFib(i), _iterativeFibMethod(i));
+   	OMR_CT_EXPECT_EQ(_iterativeFibMethod, iterativeFib(i), _iterativeFibMethod(i));
 #if (defined(TR_TARGET_X86) && defined(TR_TARGET_64BIT)) || defined(TR_TARGET_S390)
-   	EXPECT_EQ(recursiveFib(i), _recursiveFibMethod(i));
+   	OMR_CT_EXPECT_EQ(_recursiveFibMethod, recursiveFib(i), _recursiveFibMethod(i));
 #endif
       }
    }
@@ -670,18 +671,16 @@ BuilderTest::invokeControlFlowTests()
 
    for(uint32_t i = 0; i < sizeof(basicForLoopParms) / sizeof(basicForLoopParms[0]); ++i)
       {
-      EXPECT_EQ(basicForLoop(basicForLoopParms[i][0], basicForLoopParms[i][1], basicForLoopParms[i][2], true),
-               _basicForLoopUpMethod(basicForLoopParms[i][0], basicForLoopParms[i][1], basicForLoopParms[i][2]));
+      OMR_CT_EXPECT_EQ(_basicForLoopUpMethod, basicForLoop(basicForLoopParms[i][0], basicForLoopParms[i][1], basicForLoopParms[i][2], true), _basicForLoopUpMethod(basicForLoopParms[i][0], basicForLoopParms[i][1], basicForLoopParms[i][2]));
 
-      EXPECT_EQ(basicForLoop(basicForLoopParms[i][0], basicForLoopParms[i][1], basicForLoopParms[i][2], false),
-               _basicForLoopDownMethod(basicForLoopParms[i][0], basicForLoopParms[i][1], basicForLoopParms[i][2]));
+      OMR_CT_EXPECT_EQ(_basicForLoopDownMethod, basicForLoop(basicForLoopParms[i][0], basicForLoopParms[i][1], basicForLoopParms[i][2], false), _basicForLoopDownMethod(basicForLoopParms[i][0], basicForLoopParms[i][1], basicForLoopParms[i][2]));
       }
 
    int32_t nestedLoopParms[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 16, 20};
 
    for(uint32_t i = 0; i < sizeof(nestedLoopParms) / sizeof(nestedLoopParms[0]); ++i)
       {
-      EXPECT_EQ(shootoutNestedLoop(nestedLoopParms[i]), _shootoutNestedLoopMethod(nestedLoopParms[i]));
+      OMR_CT_EXPECT_EQ(_shootoutNestedLoopMethod, shootoutNestedLoop(nestedLoopParms[i]), _shootoutNestedLoopMethod(nestedLoopParms[i]));
       }
 
    int32_t absDiffParms[][2] =
@@ -693,7 +692,7 @@ BuilderTest::invokeControlFlowTests()
 
    for(uint32_t i = 0; i < sizeof(absDiffParms) / sizeof(absDiffParms[0]); ++i)
       {
-      EXPECT_EQ(absDiff(absDiffParms[i][0], absDiffParms[i][1]), _absDiffIfThenElseMethod(absDiffParms[i][0], absDiffParms[i][1]));
+      OMR_CT_EXPECT_EQ(_absDiffIfThenElseMethod, absDiff(absDiffParms[i][0], absDiffParms[i][1]), _absDiffIfThenElseMethod(absDiffParms[i][0], absDiffParms[i][1]));
       }
 
    int32_t maxIfThenParms[][2] =
@@ -706,7 +705,7 @@ BuilderTest::invokeControlFlowTests()
 
    for(uint32_t i = 0; i < sizeof(maxIfThenParms) / sizeof(maxIfThenParms[0]); ++i)
       {
-      EXPECT_EQ(maxIfThen(maxIfThenParms[i][0], maxIfThenParms[i][1]), _maxIfThenMethod(maxIfThenParms[i][0], maxIfThenParms[i][1]));
+      OMR_CT_EXPECT_EQ(_maxIfThenMethod, maxIfThen(maxIfThenParms[i][0], maxIfThenParms[i][1]), _maxIfThenMethod(maxIfThenParms[i][0], maxIfThenParms[i][1]));
       }
 
    const int64_t LONG_NEG = -9;
@@ -720,23 +719,23 @@ BuilderTest::invokeControlFlowTests()
 
    for(uint32_t i = 0; i < sizeof(subIfFalseThenParms) / sizeof(subIfFalseThenParms[0]); ++i)
       {
-      EXPECT_EQ(subIfFalseThen(subIfFalseThenParms[i][0], subIfFalseThenParms[i][1]), _subIfFalseThenMethod(subIfFalseThenParms[i][0], subIfFalseThenParms[i][1]));
+      OMR_CT_EXPECT_EQ(_subIfFalseThenMethod, subIfFalseThen(subIfFalseThenParms[i][0], subIfFalseThenParms[i][1]), _subIfFalseThenMethod(subIfFalseThenParms[i][0], subIfFalseThenParms[i][1]));
       }
 
    int32_t loopN[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20};
    for(uint32_t i = 0; i < sizeof(loopN) / sizeof(loopN[0]); ++i)
       {
-      EXPECT_EQ(doWhileFib(loopN[i]), _doWhileFibMethod(loopN[i]));
-      EXPECT_EQ(whileDoFib(loopN[i]), _whileDoFibMethod(loopN[i]));
-      EXPECT_EQ(forLoopContinue(loopN[i]), _forLoopContinueMethod(loopN[i]));
-      EXPECT_EQ(forLoopBreak(loopN[i]), _forLoopBreakMethod(loopN[i]));
-      EXPECT_EQ(forLoopBreakAndContinue(loopN[i]), _forLoopBreakAndContinueMethod(loopN[i]));
-      EXPECT_EQ(doWhileWithBreak(loopN[i]), _doWhileWithBreakMethod(loopN[i]));
-      EXPECT_EQ(doWhileWithContinue(loopN[i]), _doWhileWithContinueMethod(loopN[i]));
-      EXPECT_EQ(doWhileWithBreakAndContinue(loopN[i]), _doWhileWithBreakAndContinueMethod(loopN[i]));
-      EXPECT_EQ(whileDoWithBreak(loopN[i]), _whileDoWithBreakMethod(loopN[i]));
-      EXPECT_EQ(whileDoWithContinue(loopN[i]), _whileDoWithContinueMethod(loopN[i])) << i;
-      EXPECT_EQ(whileDoWithBreakAndContinue(loopN[i]), _whileDoWithBreakAndContinueMethod(loopN[i]));
+      OMR_CT_EXPECT_EQ(_doWhileFibMethod, doWhileFib(loopN[i]), _doWhileFibMethod(loopN[i]));
+      OMR_CT_EXPECT_EQ(_whileDoFibMethod, whileDoFib(loopN[i]), _whileDoFibMethod(loopN[i]));
+      OMR_CT_EXPECT_EQ(_forLoopContinueMethod, forLoopContinue(loopN[i]), _forLoopContinueMethod(loopN[i]));
+      OMR_CT_EXPECT_EQ(_forLoopBreakMethod, forLoopBreak(loopN[i]), _forLoopBreakMethod(loopN[i]));
+      OMR_CT_EXPECT_EQ(_forLoopBreakAndContinueMethod, forLoopBreakAndContinue(loopN[i]), _forLoopBreakAndContinueMethod(loopN[i]));
+      OMR_CT_EXPECT_EQ(_doWhileWithBreakMethod, doWhileWithBreak(loopN[i]), _doWhileWithBreakMethod(loopN[i]));
+      OMR_CT_EXPECT_EQ(_doWhileWithContinueMethod, doWhileWithContinue(loopN[i]), _doWhileWithContinueMethod(loopN[i]));
+      OMR_CT_EXPECT_EQ(_doWhileWithBreakAndContinueMethod, doWhileWithBreakAndContinue(loopN[i]), _doWhileWithBreakAndContinueMethod(loopN[i]));
+      OMR_CT_EXPECT_EQ(_whileDoWithBreakMethod, whileDoWithBreak(loopN[i]), _whileDoWithBreakMethod(loopN[i]));
+      OMR_CT_EXPECT_EQ(_whileDoWithContinueMethod, whileDoWithContinue(loopN[i]), _whileDoWithContinueMethod(loopN[i])) << i;
+      OMR_CT_EXPECT_EQ(_whileDoWithBreakAndContinueMethod, whileDoWithBreakAndContinue(loopN[i]), _whileDoWithBreakAndContinueMethod(loopN[i]));
       }
    }
 
@@ -777,28 +776,25 @@ BuilderTest::invokeNestedControlFlowLoopTests()
    arrSize = sizeof(loopIfThenElseArr) / sizeof(loopIfThenElseArr[0]);
    for(uint32_t i = 0; i < arrSize; ++i)
       {
-      EXPECT_EQ(forLoopIfThenElse(loopIfThenElseArr[i][0], loopIfThenElseArr[i][1], loopIfThenElseArr[i][2], loopIfThenElseArr[i][3]),
-               _forLoopUpIfThenElseMethod(loopIfThenElseArr[i][0], loopIfThenElseArr[i][1], loopIfThenElseArr[i][2], loopIfThenElseArr[i][3]));
+      OMR_CT_EXPECT_EQ(_forLoopUpIfThenElseMethod, forLoopIfThenElse(loopIfThenElseArr[i][0], loopIfThenElseArr[i][1], loopIfThenElseArr[i][2], loopIfThenElseArr[i][3]), _forLoopUpIfThenElseMethod(loopIfThenElseArr[i][0], loopIfThenElseArr[i][1], loopIfThenElseArr[i][2], loopIfThenElseArr[i][3]));
       }
 
    arrSize = sizeof(loopIfThenElseArr) / sizeof(loopIfThenElseArr[0]);
    for(uint32_t i = 0; i < arrSize; ++i)
       {
-      EXPECT_EQ(whileDoIfThenElse(loopIfThenElseArr[i][0], loopIfThenElseArr[i][1], loopIfThenElseArr[i][2], loopIfThenElseArr[i][3]),
-               _whileDoIfThenElseMethod(loopIfThenElseArr[i][0], loopIfThenElseArr[i][1], loopIfThenElseArr[i][2], loopIfThenElseArr[i][3]));
+      OMR_CT_EXPECT_EQ(_whileDoIfThenElseMethod, whileDoIfThenElse(loopIfThenElseArr[i][0], loopIfThenElseArr[i][1], loopIfThenElseArr[i][2], loopIfThenElseArr[i][3]), _whileDoIfThenElseMethod(loopIfThenElseArr[i][0], loopIfThenElseArr[i][1], loopIfThenElseArr[i][2], loopIfThenElseArr[i][3]));
       }
 
    arrSize = sizeof(loopIfThenElseArr) / sizeof(loopIfThenElseArr[0]);
    for(uint32_t i = 0; i < arrSize; ++i)
       {
-      EXPECT_EQ(doWhileIfThenElse(loopIfThenElseArr[i][0], loopIfThenElseArr[i][1], loopIfThenElseArr[i][2], loopIfThenElseArr[i][3]),
-               _doWhileIfThenElseMethod(loopIfThenElseArr[i][0], loopIfThenElseArr[i][1], loopIfThenElseArr[i][2], loopIfThenElseArr[i][3]));
+      OMR_CT_EXPECT_EQ(_doWhileIfThenElseMethod, doWhileIfThenElse(loopIfThenElseArr[i][0], loopIfThenElseArr[i][1], loopIfThenElseArr[i][2], loopIfThenElseArr[i][3]), _doWhileIfThenElseMethod(loopIfThenElseArr[i][0], loopIfThenElseArr[i][1], loopIfThenElseArr[i][2], loopIfThenElseArr[i][3]));
       }
 
    arrSize = sizeof(ifThenElseLoopArr) / sizeof(ifThenElseLoopArr[0]);
    for(int32_t i = 0; i < arrSize; i++)
       {
-      EXPECT_EQ(ifThenElseLoop(ifThenElseLoopArr[i][0], ifThenElseLoopArr[i][1]), _ifThenElseLoopMethod(ifThenElseLoopArr[i][0], ifThenElseLoopArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifThenElseLoopMethod, ifThenElseLoop(ifThenElseLoopArr[i][0], ifThenElseLoopArr[i][1]), _ifThenElseLoopMethod(ifThenElseLoopArr[i][0], ifThenElseLoopArr[i][1]));
       }
    }
 

--- a/fvtest/compilertest/tests/FooBarTest.cpp
+++ b/fvtest/compilertest/tests/FooBarTest.cpp
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include "compile/Method.hpp"
 #include "ilgen/TypeDictionary.hpp"
+#include "OpCodesTest.hpp"
 #include "tests/FooBarTest.hpp"
 #include "tests/BarIlInjector.hpp"
 #include "tests/FooIlInjector.hpp"
@@ -103,17 +104,17 @@ FooBarTest::invokeTests()
       _dataArray[i] = _dataArraySize - i;
 
    int32_t testID = 0, result;
-   ASSERT_EQ(-1, _foo(0));
+   OMR_CT_EXPECT_EQ(_foo, -1, _foo(0));
 
    for (i = 1; i < _dataArraySize;i++,testID++)
       {
-      ASSERT_EQ(i, _foo(i));
+      OMR_CT_EXPECT_EQ(_foo, i, _foo(i));
       }
 
    // Second set of tests should map i to N-i
    for (i = 0; i < _dataArraySize;i++/*,testID++*/)
       {
-      ASSERT_EQ(_dataArraySize - i, _bar(i));
+      OMR_CT_EXPECT_EQ(_bar, _dataArraySize - i, _bar(i));
       }
 
    // Third set of tests should map i to 1
@@ -121,13 +122,13 @@ FooBarTest::invokeTests()
       _dataArray[i] = 1;
    for (i = 0;i < _dataArraySize;i++,testID++)
       {
-      ASSERT_EQ(1, _foo(i));
+      OMR_CT_EXPECT_EQ(_foo, 1, _foo(i));
       }
 
-   ASSERT_EQ(-1, _foo(-1));
-   ASSERT_EQ(-1, _foo(INT_MIN));
-   ASSERT_EQ(-1, _foo(_dataArraySize));
-   ASSERT_EQ(-1, _foo(INT_MAX));
+   OMR_CT_EXPECT_EQ(_foo, -1, _foo(-1));
+   OMR_CT_EXPECT_EQ(_foo, -1, _foo(INT_MIN));
+   OMR_CT_EXPECT_EQ(_foo, -1, _foo(_dataArraySize));
+   OMR_CT_EXPECT_EQ(_foo, -1, _foo(INT_MAX));
    }
 
 } // namespace TestCompiler

--- a/fvtest/compilertest/tests/OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/OpCodesTest.cpp
@@ -679,6 +679,10 @@ OpCodesTest::compileOpCodeMethod(int32_t opCodeArgsNum,
    TR::ResolvedMethod opCodeCompilee(__FILE__, LINETOSTR(__LINE__), resolvedMethodName, opCodeArgsNum, argIlTypes, types.PrimitiveType(returnType), 0, opCodeInjector);
    TR::IlGeneratorMethodDetails opCodeDetails(&opCodeCompilee);
    uint8_t *startPC= compileMethod(opCodeDetails, warm, returnCode);
+   EXPECT_TRUE(COMPILATION_SUCCEEDED == returnCode || 
+               COMPILATION_IL_GEN_FAILURE == returnCode || 
+               COMPILATION_REQUESTED == returnCode) 
+      << "compileOpCodeMethod: Compiling method " << resolvedMethodName << " failed unexpectedly";
    return startPC;
    }
 
@@ -731,11 +735,15 @@ OpCodesTest::compileDirectCallOpCodeMethod(int32_t opCodeArgsNum,
       default:
          TR_ASSERT(0, "compilee dataType should be int32, int64, double, float or address");
       }
+   EXPECT_TRUE(COMPILATION_SUCCEEDED == returnCode || COMPILATION_REQUESTED == returnCode) 
+      << "Compiling callee method " << compileeResolvedMethodName << " failed unexpectedly";
 
    CallIlInjector callIlInjector(&types, this, opCode);
    TR::ResolvedMethod callCompilee(__FILE__, LINETOSTR(__LINE__), testResolvedMethodName, opCodeArgsNum, argIlTypes, types.PrimitiveType(returnType), 0, &callIlInjector);
    TR::IlGeneratorMethodDetails callDetails(&callCompilee);
    uint8_t *startPC = compileMethod(callDetails, warm, returnCode);
+   EXPECT_TRUE(COMPILATION_SUCCEEDED == returnCode || COMPILATION_REQUESTED == returnCode) 
+      << "Compiling test method " << testResolvedMethodName << " failed unexpectedly";
    return startPC;
    }
 
@@ -748,7 +756,8 @@ OpCodesTest::addUnsupportedOpCodeTest(int32_t opCodeArgsNum,
    {
    int32_t returnCode = 0;
    compileOpCodeMethod(opCodeArgsNum, opCode, resolvedMethodName, argTypes, returnType, returnCode);
-   EXPECT_EQ(COMPILATION_IL_GEN_FAILURE, returnCode) << resolvedMethodName << " is " << returnCode << ", expected is " << COMPILATION_IL_GEN_FAILURE;
+   EXPECT_TRUE(COMPILATION_IL_GEN_FAILURE == returnCode || COMPILATION_REQUESTED == returnCode) 
+      << resolvedMethodName << " is " << returnCode << ", expected is 0 or " << COMPILATION_IL_GEN_FAILURE;
    }
 
 TR::ResolvedMethod *
@@ -993,66 +1002,66 @@ OpCodesTest::invokeIntegerArithmeticTests()
    testCaseArrLength = sizeof(intAddArr) / sizeof(intAddArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(add(intAddArr[i][0], intAddArr[i][1]), _iAdd(intAddArr[i][0], intAddArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iAdd, add(intAddArr[i][0], intAddArr[i][1]), _iAdd(intAddArr[i][0], intAddArr[i][1]));
 
       sprintf(resolvedMethodName, "iAddConst1_Testcase%d", i);
       iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iadd,
             resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &intAddArr[i][0], 2, &intAddArr[i][1]));
-      EXPECT_EQ(add(intAddArr[i][0], intAddArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iBinaryCons, add(intAddArr[i][0], intAddArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iAddConst2_Testcase%d", i);
       iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iadd,
             resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &intAddArr[i][0]));
-      EXPECT_EQ(add(intAddArr[i][0], intAddArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, intAddArr[i][1]));
+      OMR_CT_EXPECT_EQ(iBinaryCons, add(intAddArr[i][0], intAddArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, intAddArr[i][1]));
 
       sprintf(resolvedMethodName, "iAddConst3_Testcase%d", i);
       iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iadd,
             resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &intAddArr[i][1]));
-      EXPECT_EQ(add(intAddArr[i][0], intAddArr[i][1]), iBinaryCons(intAddArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iBinaryCons, add(intAddArr[i][0], intAddArr[i][1]), iBinaryCons(intAddArr[i][0], INT_PLACEHOLDER_2));
       }
 
    //isub
    testCaseArrLength = sizeof(intSubArr) / sizeof(intSubArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(sub(intSubArr[i][0], intSubArr[i][1]), _iSub(intSubArr[i][0], intSubArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iSub, sub(intSubArr[i][0], intSubArr[i][1]), _iSub(intSubArr[i][0], intSubArr[i][1]));
 
       sprintf(resolvedMethodName, "iSubConst1_Testcase%d", i);
       iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::isub,
             resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &intSubArr[i][0], 2, &intSubArr[i][1]));
-      EXPECT_EQ(sub(intSubArr[i][0], intSubArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iBinaryCons, sub(intSubArr[i][0], intSubArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iSubConst2_Testcase%d", i);
       iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::isub,
             resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &intSubArr[i][0]));
-      EXPECT_EQ(sub(intSubArr[i][0], intSubArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, intSubArr[i][1]));
+      OMR_CT_EXPECT_EQ(iBinaryCons, sub(intSubArr[i][0], intSubArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, intSubArr[i][1]));
 
       sprintf(resolvedMethodName, "iSubConst3_Testcase%d", i);
       iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::isub,
             resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &intSubArr[i][1]));
-      EXPECT_EQ(sub(intSubArr[i][0], intSubArr[i][1]), iBinaryCons(intSubArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iBinaryCons, sub(intSubArr[i][0], intSubArr[i][1]), iBinaryCons(intSubArr[i][0], INT_PLACEHOLDER_2));
       }
 
    //imul
    testCaseArrLength = sizeof(intMulArr) / sizeof(intMulArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(mul(intMulArr[i][0], intMulArr[i][1]), _iMul(intMulArr[i][0], intMulArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iMul, mul(intMulArr[i][0], intMulArr[i][1]), _iMul(intMulArr[i][0], intMulArr[i][1]));
 
       sprintf(resolvedMethodName, "iMulConst1_Testcase%d", i);
       iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::imul,
             resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &intMulArr[i][0], 2, &intMulArr[i][1]));
-      EXPECT_EQ(mul(intMulArr[i][0], intMulArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iBinaryCons, mul(intMulArr[i][0], intMulArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iMulConst2_Testcase%d", i);
       iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::imul,
             resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &intMulArr[i][0]));
-      EXPECT_EQ(mul(intMulArr[i][0], intMulArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, intMulArr[i][1]));
+      OMR_CT_EXPECT_EQ(iBinaryCons, mul(intMulArr[i][0], intMulArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, intMulArr[i][1]));
 
       sprintf(resolvedMethodName, "iMulConst3_Testcase%d", i);
       iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::imul,
             resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &intMulArr[i][1]));
-      EXPECT_EQ(mul(intMulArr[i][0], intMulArr[i][1]), iBinaryCons(intMulArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iBinaryCons, mul(intMulArr[i][0], intMulArr[i][1]), iBinaryCons(intMulArr[i][0], INT_PLACEHOLDER_2));
       }
 
    //idiv
@@ -1061,22 +1070,22 @@ OpCodesTest::invokeIntegerArithmeticTests()
    testCaseArrLength = sizeof(intDivArr) / sizeof(intDivArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(div(intDivArr[i][0], intDivArr[i][1]), _iDiv(intDivArr[i][0], intDivArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iDiv, div(intDivArr[i][0], intDivArr[i][1]), _iDiv(intDivArr[i][0], intDivArr[i][1]));
 
       sprintf(resolvedMethodName, "iDivConst1_Testcase%d", i);
       iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::idiv,
             resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &intDivArr[i][0], 2, &intDivArr[i][1]));
-      EXPECT_EQ(div(intDivArr[i][0], intDivArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iBinaryCons, div(intDivArr[i][0], intDivArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iDivConst2_Testcase%d", i);
       iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::idiv,
             resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &intDivArr[i][0]));
-      EXPECT_EQ(div(intDivArr[i][0], intDivArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, intDivArr[i][1]));
+      OMR_CT_EXPECT_EQ(iBinaryCons, div(intDivArr[i][0], intDivArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, intDivArr[i][1]));
 
       sprintf(resolvedMethodName, "iDivConst3_Testcase%d", i);
       iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::idiv,
             resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &intDivArr[i][1]));
-      EXPECT_EQ(div(intDivArr[i][0], intDivArr[i][1]), iBinaryCons(intDivArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iBinaryCons, div(intDivArr[i][0], intDivArr[i][1]), iBinaryCons(intDivArr[i][0], INT_PLACEHOLDER_2));
       }
 
    //irem
@@ -1085,22 +1094,22 @@ OpCodesTest::invokeIntegerArithmeticTests()
    testCaseArrLength = sizeof(intRemArr) / sizeof(intRemArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(rem(intRemArr[i][0], intRemArr[i][1]), _iRem(intRemArr[i][0], intRemArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iRem, rem(intRemArr[i][0], intRemArr[i][1]), _iRem(intRemArr[i][0], intRemArr[i][1]));
 
       sprintf(resolvedMethodName, "iRemConst1_Testcase%d", i);
       iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::irem,
             resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &intRemArr[i][0], 2, &intRemArr[i][1]));
-      EXPECT_EQ(rem(intRemArr[i][0], intRemArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iBinaryCons, rem(intRemArr[i][0], intRemArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iRemConst2_Testcase%d", i);
       iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::irem,
             resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &intRemArr[i][0]));
-      EXPECT_EQ(rem(intRemArr[i][0], intRemArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, intRemArr[i][1]));
+      OMR_CT_EXPECT_EQ(iBinaryCons, rem(intRemArr[i][0], intRemArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, intRemArr[i][1]));
 
       sprintf(resolvedMethodName, "iRemConst3_Testcase%d", i);
       iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::irem,
             resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &intRemArr[i][1]));
-      EXPECT_EQ(rem(intRemArr[i][0], intRemArr[i][1]), iBinaryCons(intRemArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iBinaryCons, rem(intRemArr[i][0], intRemArr[i][1]), iBinaryCons(intRemArr[i][0], INT_PLACEHOLDER_2));
       }
    }
 
@@ -1108,29 +1117,29 @@ void
 OpCodesTest::invokeMemoryOperationTests()
    {
    //iload
-   EXPECT_EQ(INT_ZERO, _iLoad(INT_ZERO));
-   EXPECT_EQ(INT_NEG, _iLoad(INT_NEG));
-   EXPECT_EQ(INT_POS, _iLoad(INT_POS));
-   EXPECT_EQ(INT_MAXIMUM, _iLoad(INT_MAXIMUM));
-   EXPECT_EQ(INT_MINIMUM, _iLoad(INT_MINIMUM));
+   OMR_CT_EXPECT_EQ(_iLoad, INT_ZERO, _iLoad(INT_ZERO));
+   OMR_CT_EXPECT_EQ(_iLoad, INT_NEG, _iLoad(INT_NEG));
+   OMR_CT_EXPECT_EQ(_iLoad, INT_POS, _iLoad(INT_POS));
+   OMR_CT_EXPECT_EQ(_iLoad, INT_MAXIMUM, _iLoad(INT_MAXIMUM));
+   OMR_CT_EXPECT_EQ(_iLoad, INT_MINIMUM, _iLoad(INT_MINIMUM));
 
-   EXPECT_EQ(LONG_ZERO, _lLoad(LONG_ZERO));
-   EXPECT_EQ(LONG_NEG, _lLoad(LONG_NEG));
-   EXPECT_EQ(LONG_POS, _lLoad(LONG_POS));
-   EXPECT_EQ(LONG_MAXIMUM, _lLoad(LONG_MAXIMUM));
-   EXPECT_EQ(LONG_MINIMUM, _lLoad(LONG_MINIMUM));
+   OMR_CT_EXPECT_EQ(_lLoad, LONG_ZERO, _lLoad(LONG_ZERO));
+   OMR_CT_EXPECT_EQ(_lLoad, LONG_NEG, _lLoad(LONG_NEG));
+   OMR_CT_EXPECT_EQ(_lLoad, LONG_POS, _lLoad(LONG_POS));
+   OMR_CT_EXPECT_EQ(_lLoad, LONG_MAXIMUM, _lLoad(LONG_MAXIMUM));
+   OMR_CT_EXPECT_EQ(_lLoad, LONG_MINIMUM, _lLoad(LONG_MINIMUM));
 
-   EXPECT_DOUBLE_EQ(DOUBLE_ZERO, _dLoad(DOUBLE_ZERO));
-   EXPECT_DOUBLE_EQ(DOUBLE_NEG, _dLoad(DOUBLE_NEG));
-   EXPECT_DOUBLE_EQ(DOUBLE_POS, _dLoad(DOUBLE_POS));
-   EXPECT_DOUBLE_EQ(DOUBLE_MAXIMUM, _dLoad(DOUBLE_MAXIMUM));
-   EXPECT_DOUBLE_EQ(DOUBLE_MINIMUM, _dLoad(DOUBLE_MINIMUM));
+   OMR_CT_EXPECT_DOUBLE_EQ(_dLoad, DOUBLE_ZERO, _dLoad(DOUBLE_ZERO));
+   OMR_CT_EXPECT_DOUBLE_EQ(_dLoad, DOUBLE_NEG, _dLoad(DOUBLE_NEG));
+   OMR_CT_EXPECT_DOUBLE_EQ(_dLoad, DOUBLE_POS, _dLoad(DOUBLE_POS));
+   OMR_CT_EXPECT_DOUBLE_EQ(_dLoad, DOUBLE_MAXIMUM, _dLoad(DOUBLE_MAXIMUM));
+   OMR_CT_EXPECT_DOUBLE_EQ(_dLoad, DOUBLE_MINIMUM, _dLoad(DOUBLE_MINIMUM));
 
-   EXPECT_FLOAT_EQ(FLOAT_ZERO, _fLoad(FLOAT_ZERO));
-   EXPECT_FLOAT_EQ(FLOAT_NEG, _fLoad(FLOAT_NEG));
-   EXPECT_FLOAT_EQ(FLOAT_POS, _fLoad(FLOAT_POS));
-   EXPECT_FLOAT_EQ(FLOAT_MAXIMUM, _fLoad(FLOAT_MAXIMUM));
-   EXPECT_FLOAT_EQ(FLOAT_MINIMUM, _fLoad(FLOAT_MINIMUM));
+   OMR_CT_EXPECT_FLOAT_EQ(_fLoad, FLOAT_ZERO, _fLoad(FLOAT_ZERO));
+   OMR_CT_EXPECT_FLOAT_EQ(_fLoad, FLOAT_NEG, _fLoad(FLOAT_NEG));
+   OMR_CT_EXPECT_FLOAT_EQ(_fLoad, FLOAT_POS, _fLoad(FLOAT_POS));
+   OMR_CT_EXPECT_FLOAT_EQ(_fLoad, FLOAT_MAXIMUM, _fLoad(FLOAT_MAXIMUM));
+   OMR_CT_EXPECT_FLOAT_EQ(_fLoad, FLOAT_MINIMUM, _fLoad(FLOAT_MINIMUM));
 
    int32_t intDataArray[] = {INT_NEG, INT_POS, INT_MAXIMUM, INT_MINIMUM, INT_ZERO};
    int16_t shortDataArray[] = {SHORT_NEG, SHORT_POS, SHORT_MAXIMUM, SHORT_MINIMUM, SHORT_ZERO};
@@ -1151,51 +1160,51 @@ OpCodesTest::invokeMemoryOperationTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "iStoreConst%d", i + 1);
-      EXPECT_EQ(intDataArray[i], _iStore(intDataArray[i]));
+      OMR_CT_EXPECT_EQ(_iStore, intDataArray[i], _iStore(intDataArray[i]));
       iMemCons = (signatureCharI_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::istore, resolvedMethodName, _argTypesUnaryInt, TR::Int32, rc, 2, 1, &(intDataArray[i])));
-      EXPECT_EQ(intDataArray[i], iMemCons(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(iMemCons, intDataArray[i], iMemCons(INT_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(intDataArray) / sizeof(intDataArray[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(intDataArray[i], _iLoadi((uintptrj_t)(&intDataArray[i])));
+      OMR_CT_EXPECT_EQ(_iLoadi, intDataArray[i], _iLoadi((uintptrj_t)(&intDataArray[i])));
       }
 
    testCaseNum = sizeof(shortDataArray) / sizeof(shortDataArray[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(shortDataArray[i], _sLoadi((uintptrj_t)(&shortDataArray[i])));
+      OMR_CT_EXPECT_EQ(_sLoadi, shortDataArray[i], _sLoadi((uintptrj_t)(&shortDataArray[i])));
       }
 
    testCaseNum = sizeof(byteDataArray) / sizeof(byteDataArray[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(byteDataArray[i], _bLoadi((uintptrj_t)(&byteDataArray[i])));
+      OMR_CT_EXPECT_EQ(_bLoadi, byteDataArray[i], _bLoadi((uintptrj_t)(&byteDataArray[i])));
       }
 
    testCaseNum = sizeof(longDataArray) / sizeof(longDataArray[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(longDataArray[i], _lLoadi((uintptrj_t)(&longDataArray[i])));
+      OMR_CT_EXPECT_EQ(_lLoadi, longDataArray[i], _lLoadi((uintptrj_t)(&longDataArray[i])));
       }
 
    testCaseNum = sizeof(doubleDataArray) / sizeof(doubleDataArray[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(doubleDataArray[i], _dLoadi((uintptrj_t)(&doubleDataArray[i])));
+      OMR_CT_EXPECT_EQ(_dLoadi, doubleDataArray[i], _dLoadi((uintptrj_t)(&doubleDataArray[i])));
       }
 
    testCaseNum = sizeof(floatDataArray) / sizeof(floatDataArray[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(floatDataArray[i], _fLoadi((uintptrj_t)(&floatDataArray[i])));
+      OMR_CT_EXPECT_EQ(_fLoadi, floatDataArray[i], _fLoadi((uintptrj_t)(&floatDataArray[i])));
       }
 
    testCaseNum = sizeof(addressDataArray) / sizeof(addressDataArray[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(addressDataArray[i], _aLoadi((uintptrj_t)(&addressDataArray[i])));
+      OMR_CT_EXPECT_EQ(_aLoadi, addressDataArray[i], _aLoadi((uintptrj_t)(&addressDataArray[i])));
       }
    }
 
@@ -1243,66 +1252,66 @@ OpCodesTest::invokeShiftOrRolTests()
    testCaseNum = sizeof(ishlDataArr) / sizeof(ishlDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shl(ishlDataArr[i][0], ishlDataArr[i][1]), _iShl(ishlDataArr[i][0], ishlDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iShl, shl(ishlDataArr[i][0], ishlDataArr[i][1]), _iShl(ishlDataArr[i][0], ishlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iShlConst1_TestCase%d", i + 1);
       iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ishl, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &ishlDataArr[i][0], 2, &ishlDataArr[i][1]));
-      EXPECT_EQ(shl(ishlDataArr[i][0], ishlDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iShiftOrRolConst, shl(ishlDataArr[i][0], ishlDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iShlConst2_TestCase%d", i + 1);
       iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ishl, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &ishlDataArr[i][0]));
-      EXPECT_EQ(shl(ishlDataArr[i][0], ishlDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, ishlDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iShiftOrRolConst, shl(ishlDataArr[i][0], ishlDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, ishlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iShlConst3_TestCase%d", i + 1);
       iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ishl, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &ishlDataArr[i][1]));
-      EXPECT_EQ(shl(ishlDataArr[i][0], ishlDataArr[i][1]), iShiftOrRolConst(ishlDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iShiftOrRolConst, shl(ishlDataArr[i][0], ishlDataArr[i][1]), iShiftOrRolConst(ishlDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    //ishr
    testCaseNum = sizeof(ishrDataArr) / sizeof(ishrDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shr(ishrDataArr[i][0], ishrDataArr[i][1]), _iShr(ishrDataArr[i][0],ishrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iShr, shr(ishrDataArr[i][0], ishrDataArr[i][1]), _iShr(ishrDataArr[i][0],ishrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iShrConst1_TestCase%d", i + 1);
       iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ishr, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &ishrDataArr[i][0], 2, &ishrDataArr[i][1]));
-      EXPECT_EQ(shr(ishrDataArr[i][0], ishrDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iShiftOrRolConst, shr(ishrDataArr[i][0], ishrDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iShrConst2_TestCase%d", i + 1);
       iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ishr, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &ishrDataArr[i][0]));
-      EXPECT_EQ(shr(ishrDataArr[i][0], ishrDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, ishrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iShiftOrRolConst, shr(ishrDataArr[i][0], ishrDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, ishrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iShrConst3_TestCase%d", i + 1);
       iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ishr, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &ishrDataArr[i][1]));
-      EXPECT_EQ(shr(ishrDataArr[i][0], ishrDataArr[i][1]), iShiftOrRolConst(ishrDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iShiftOrRolConst, shr(ishrDataArr[i][0], ishrDataArr[i][1]), iShiftOrRolConst(ishrDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    //iushr
    testCaseNum = sizeof(iushrDataArr) / sizeof(iushrDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shr(iushrDataArr[i][0], iushrDataArr[i][1]), _iuShr(iushrDataArr[i][0],iushrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iuShr, shr(iushrDataArr[i][0], iushrDataArr[i][1]), _iuShr(iushrDataArr[i][0],iushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuShrConst1_TestCase%d", i + 1);
       iuShiftOrRolConst = (unsignedSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iushr, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &iushrDataArr[i][0], 2, &iushrDataArr[i][1]));
-      EXPECT_EQ(shr(iushrDataArr[i][0], iushrDataArr[i][1]), iuShiftOrRolConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuShiftOrRolConst, shr(iushrDataArr[i][0], iushrDataArr[i][1]), iuShiftOrRolConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iuShrConst2_TestCase%d", i + 1);
       iuShiftOrRolConst = (unsignedSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iushr, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &iushrDataArr[i][0]));
-      EXPECT_EQ(shr(iushrDataArr[i][0], iushrDataArr[i][1]), iuShiftOrRolConst(INT_PLACEHOLDER_1, iushrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iuShiftOrRolConst, shr(iushrDataArr[i][0], iushrDataArr[i][1]), iuShiftOrRolConst(INT_PLACEHOLDER_1, iushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuShrConst3_TestCase%d", i + 1);
       iuShiftOrRolConst = (unsignedSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iushr, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &iushrDataArr[i][1]));
-      EXPECT_EQ(shr(iushrDataArr[i][0], iushrDataArr[i][1]), iuShiftOrRolConst(iushrDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuShiftOrRolConst, shr(iushrDataArr[i][0], iushrDataArr[i][1]), iuShiftOrRolConst(iushrDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    }
@@ -1350,22 +1359,22 @@ OpCodesTest::invokeUnaryTests()
    testCaseNum = sizeof(intDataArray) / sizeof(intDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(neg(intDataArray[i]), _iNeg(intDataArray[i]));
+      OMR_CT_EXPECT_EQ(_iNeg, neg(intDataArray[i]), _iNeg(intDataArray[i]));
       sprintf(resolvedMethodName, "iNegConst%d", i + 1);
       iUnaryCons = (signatureCharI_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::ineg,
             resolvedMethodName, _argTypesUnaryInt, TR::Int32, rc, 2, 1, &intDataArray[i]));
-      EXPECT_EQ(neg(intDataArray[i]), iUnaryCons(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(iUnaryCons, neg(intDataArray[i]), iUnaryCons(INT_PLACEHOLDER_1));
       }
 
    //iabs
    testCaseNum = sizeof(intDataArray) / sizeof(intDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(abs(intDataArray[i]), _iAbs(intDataArray[i]));
+      OMR_CT_EXPECT_EQ(_iAbs, abs(intDataArray[i]), _iAbs(intDataArray[i]));
       sprintf(resolvedMethodName, "iAbsConst%d", i + 1);
       iUnaryCons = (signatureCharI_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iabs,
             resolvedMethodName, _argTypesUnaryInt, TR::Int32, rc, 2, 1, &intDataArray[i]));
-      EXPECT_EQ(abs(intDataArray[i]), iUnaryCons(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(iUnaryCons, abs(intDataArray[i]), iUnaryCons(INT_PLACEHOLDER_1));
       }
 
    //return group
@@ -1373,9 +1382,9 @@ OpCodesTest::invokeUnaryTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "iReturnCons%d", i + 1);
-      EXPECT_EQ(intDataArray[i], _iReturn(intDataArray[i]));
+      OMR_CT_EXPECT_EQ(_iReturn, intDataArray[i], _iReturn(intDataArray[i]));
       iUnaryCons = (signatureCharI_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::ireturn, resolvedMethodName, _argTypesUnaryInt, TR::Int32, rc, 2, 1, &(intDataArray[i])));
-      EXPECT_EQ(intDataArray[i], iUnaryCons(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(iUnaryCons, intDataArray[i], iUnaryCons(INT_PLACEHOLDER_1));
       }
 
    //const
@@ -1384,7 +1393,7 @@ OpCodesTest::invokeUnaryTests()
       {
       sprintf(resolvedMethodName, "iConst%d", i + 1);
       iUnaryCons = (signatureCharI_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iconst, resolvedMethodName, _argTypesUnaryInt, TR::Int32, rc, 2, 1, &(intDataArray[i])));
-      EXPECT_EQ(intDataArray[i], iUnaryCons(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(iUnaryCons, intDataArray[i], iUnaryCons(INT_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(byteDataArray) / sizeof(byteDataArray[0]);
@@ -1392,7 +1401,7 @@ OpCodesTest::invokeUnaryTests()
       {
       sprintf(resolvedMethodName, "bConst%d", i + 1);
       bUnaryCons = (signatureCharB_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bconst, resolvedMethodName, _argTypesUnaryByte, TR::Int8, rc, 2, 1, &(byteDataArray[i])));
-      EXPECT_EQ(byteDataArray[i], bUnaryCons(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(bUnaryCons, byteDataArray[i], bUnaryCons(BYTE_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(shortDataArray) / sizeof(shortDataArray[0]);
@@ -1400,56 +1409,56 @@ OpCodesTest::invokeUnaryTests()
       {
       sprintf(resolvedMethodName, "sConst%d", i + 1);
       sUnaryCons = (signatureCharS_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::sconst, resolvedMethodName, _argTypesUnaryShort, TR::Int16, rc, 2, 1, &(shortDataArray[i])));
-      EXPECT_EQ(shortDataArray[i], sUnaryCons(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(sUnaryCons, shortDataArray[i], sUnaryCons(SHORT_PLACEHOLDER_1));
       }
 
    //int 2 l,b,s
    testCaseNum = sizeof(intDataArray) / sizeof(intDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(intDataArray[i], BYTE_POS), _i2b(intDataArray[i]));
-      EXPECT_EQ(convert(intDataArray[i], SHORT_POS), _i2s(intDataArray[i]));
-      EXPECT_EQ(convert(intDataArray[i], LONG_POS), _i2l(intDataArray[i]));
+      OMR_CT_EXPECT_EQ(_i2b, convert(intDataArray[i], BYTE_POS), _i2b(intDataArray[i]));
+      OMR_CT_EXPECT_EQ(_i2s, convert(intDataArray[i], SHORT_POS), _i2s(intDataArray[i]));
+      OMR_CT_EXPECT_EQ(_i2l, convert(intDataArray[i], LONG_POS), _i2l(intDataArray[i]));
 
       sprintf(resolvedMethodName, "i2bConst%d", i + 1);
       i2bConst = (signatureCharI_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::i2b,
             resolvedMethodName, _argTypesUnaryInt, TR::Int8, rc, 2, 1, &intDataArray[i]));
-      EXPECT_EQ(convert(intDataArray[i], BYTE_POS), i2bConst(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(i2bConst, convert(intDataArray[i], BYTE_POS), i2bConst(INT_PLACEHOLDER_1));
 
 
       sprintf(resolvedMethodName, "i2sConst%d", i + 1);
       i2sConst = (signatureCharI_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::i2s,
             resolvedMethodName, _argTypesUnaryInt, TR::Int16, rc, 2, 1, &intDataArray[i]));
-      EXPECT_EQ(convert(intDataArray[i], SHORT_POS), i2sConst(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(i2sConst, convert(intDataArray[i], SHORT_POS), i2sConst(INT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "i2lConst%d", i + 1);
       i2lConst = (signatureCharI_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::i2l,
             resolvedMethodName, _argTypesUnaryInt, TR::Int64, rc, 2, 1, &intDataArray[i]));
-      EXPECT_EQ(convert(intDataArray[i], LONG_POS), i2lConst(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(i2lConst, convert(intDataArray[i], LONG_POS), i2lConst(INT_PLACEHOLDER_1));
       }
 
    //l 2 i,b,s
    testCaseNum = sizeof(longDataArray) / sizeof(longDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(longDataArray[i], BYTE_POS), _l2b(longDataArray[i]));
-      EXPECT_EQ(convert(longDataArray[i], SHORT_POS), _l2s(longDataArray[i]));
-      EXPECT_EQ(convert(longDataArray[i], INT_POS), _l2i(longDataArray[i]));
+      OMR_CT_EXPECT_EQ(_l2b, convert(longDataArray[i], BYTE_POS), _l2b(longDataArray[i]));
+      OMR_CT_EXPECT_EQ(_l2s, convert(longDataArray[i], SHORT_POS), _l2s(longDataArray[i]));
+      OMR_CT_EXPECT_EQ(_l2i, convert(longDataArray[i], INT_POS), _l2i(longDataArray[i]));
 
       sprintf(resolvedMethodName, "l2bConst%d", i + 1);
       l2bConst = (signatureCharJ_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::l2b,
             resolvedMethodName, _argTypesUnaryLong, TR::Int8, rc, 2, 1, &longDataArray[i]));
-      EXPECT_EQ(convert(longDataArray[i], BYTE_POS), l2bConst(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(l2bConst, convert(longDataArray[i], BYTE_POS), l2bConst(LONG_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "l2sConst%d", i + 1);
       l2sConst = (signatureCharJ_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::l2s,
             resolvedMethodName, _argTypesUnaryLong, TR::Int16, rc, 2, 1, &longDataArray[i]));
-      EXPECT_EQ(convert(longDataArray[i], SHORT_POS), l2sConst(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(l2sConst, convert(longDataArray[i], SHORT_POS), l2sConst(LONG_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "l2iConst%d", i + 1);
       l2iConst = (signatureCharJ_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::l2i,
             resolvedMethodName, _argTypesUnaryLong, TR::Int32, rc, 2, 1, &longDataArray[i]));
-      EXPECT_EQ(convert(longDataArray[i], INT_POS), l2iConst(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(l2iConst, convert(longDataArray[i], INT_POS), l2iConst(LONG_PLACEHOLDER_1));
       }
 
    //f2i
@@ -1461,12 +1470,12 @@ OpCodesTest::invokeUnaryTests()
    //back to the loop above.
    for (uint32_t i = 0; i < 3; ++i)
       {
-      EXPECT_EQ(convert(floatDataArray[i], INT_POS), _f2i(floatDataArray[i]));
+      OMR_CT_EXPECT_EQ(_f2i, convert(floatDataArray[i], INT_POS), _f2i(floatDataArray[i]));
 
       sprintf(resolvedMethodName, "f2iConst%d", i + 1);
       f2iConst = (signatureCharF_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2i,
             resolvedMethodName, _argTypesUnaryFloat, TR::Int32, rc, 2, 1, &floatDataArray[i]));
-      EXPECT_EQ(convert(floatDataArray[i], INT_POS), f2iConst(FLOAT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(f2iConst, convert(floatDataArray[i], INT_POS), f2iConst(FLOAT_PLACEHOLDER_1));
       }
 
    //d2i
@@ -1478,12 +1487,12 @@ OpCodesTest::invokeUnaryTests()
    //back to the loop above.
    for (uint32_t i = 0; i < 3; ++i)
       {
-      EXPECT_EQ(convert(doubleDataArray[i], INT_POS), _d2i(doubleDataArray[i]));
+      OMR_CT_EXPECT_EQ(_d2i, convert(doubleDataArray[i], INT_POS), _d2i(doubleDataArray[i]));
 
       sprintf(resolvedMethodName, "d2iConst%d", i + 1);
       d2iConst = (signatureCharD_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2i,
             resolvedMethodName, _argTypesUnaryDouble, TR::Int32, rc, 2, 1, &doubleDataArray[i]));
-      EXPECT_EQ(convert(doubleDataArray[i], INT_POS), d2iConst(DOUBLE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(d2iConst, convert(doubleDataArray[i], INT_POS), d2iConst(DOUBLE_PLACEHOLDER_1));
       }
 
    }
@@ -1539,66 +1548,66 @@ OpCodesTest::invokeBitwiseTests()
    testCaseNum = sizeof(intAndArr) / sizeof(intAndArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(tand(intAndArr[i][0], intAndArr[i][1]), _iAnd(intAndArr[i][0], intAndArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iAnd, tand(intAndArr[i][0], intAndArr[i][1]), _iAnd(intAndArr[i][0], intAndArr[i][1]));
 
       sprintf(resolvedMethodName, "iAndConst1_TestCase%d", i + 1);
       iBitwiseConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iand, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(intAndArr[i][0]), 2, &(intAndArr[i][1])));
-      EXPECT_EQ(tand(intAndArr[i][0], intAndArr[i][1]), iBitwiseConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iBitwiseConst, tand(intAndArr[i][0], intAndArr[i][1]), iBitwiseConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iAndConst2_TestCase%d", i + 1);
       iBitwiseConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iand, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(intAndArr[i][0])));
-      EXPECT_EQ(tand(intAndArr[i][0], intAndArr[i][1]), iBitwiseConst(INT_PLACEHOLDER_1, intAndArr[i][1]));
+      OMR_CT_EXPECT_EQ(iBitwiseConst, tand(intAndArr[i][0], intAndArr[i][1]), iBitwiseConst(INT_PLACEHOLDER_1, intAndArr[i][1]));
 
       sprintf(resolvedMethodName, "iAndConst3_TestCase%d", i + 1);
       iBitwiseConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iand, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(intAndArr[i][1])));
-      EXPECT_EQ(tand(intAndArr[i][0], intAndArr[i][1]), iBitwiseConst(intAndArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iBitwiseConst, tand(intAndArr[i][0], intAndArr[i][1]), iBitwiseConst(intAndArr[i][0], INT_PLACEHOLDER_2));
      }
 
    //ior
    testCaseNum = sizeof(intOrArr) / sizeof(intOrArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(tor(intOrArr[i][0], intOrArr[i][1]), _iOr(intOrArr[i][0], intOrArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iOr, tor(intOrArr[i][0], intOrArr[i][1]), _iOr(intOrArr[i][0], intOrArr[i][1]));
 
       sprintf(resolvedMethodName, "iOrConst1_TestCase%d", i + 1);
       iBitwiseConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ior, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(intOrArr[i][0]), 2, &(intOrArr[i][1])));
-      EXPECT_EQ(tor(intOrArr[i][0], intOrArr[i][1]), iBitwiseConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iBitwiseConst, tor(intOrArr[i][0], intOrArr[i][1]), iBitwiseConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iOrConst2_TestCase%d", i + 1);
       iBitwiseConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ior, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(intOrArr[i][0])));
-      EXPECT_EQ(tor(intOrArr[i][0], intOrArr[i][1]), iBitwiseConst(INT_PLACEHOLDER_1, intOrArr[i][1]));
+      OMR_CT_EXPECT_EQ(iBitwiseConst, tor(intOrArr[i][0], intOrArr[i][1]), iBitwiseConst(INT_PLACEHOLDER_1, intOrArr[i][1]));
 
       sprintf(resolvedMethodName, "iOrConst3_TestCase%d", i + 1);
       iBitwiseConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ior, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(intOrArr[i][1])));
-      EXPECT_EQ(tor(intOrArr[i][0], intOrArr[i][1]), iBitwiseConst(intOrArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iBitwiseConst, tor(intOrArr[i][0], intOrArr[i][1]), iBitwiseConst(intOrArr[i][0], INT_PLACEHOLDER_2));
      }
 
    //ixor
    testCaseNum = sizeof(intXorArr) / sizeof(intXorArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(txor(intXorArr[i][0], intXorArr[i][1]), _iXor(intXorArr[i][0], intXorArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iXor, txor(intXorArr[i][0], intXorArr[i][1]), _iXor(intXorArr[i][0], intXorArr[i][1]));
 
       sprintf(resolvedMethodName, "iXorConst1_TestCase%d", i + 1);
       iBitwiseConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ixor, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(intXorArr[i][0]), 2, &(intXorArr[i][1])));
-      EXPECT_EQ(txor(intXorArr[i][0], intXorArr[i][1]), iBitwiseConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iBitwiseConst, txor(intXorArr[i][0], intXorArr[i][1]), iBitwiseConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iXorConst2_TestCase%d", i + 1);
       iBitwiseConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ixor, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(intXorArr[i][0])));
-      EXPECT_EQ(txor(intXorArr[i][0], intXorArr[i][1]), iBitwiseConst(INT_PLACEHOLDER_1, intXorArr[i][1]));
+      OMR_CT_EXPECT_EQ(iBitwiseConst, txor(intXorArr[i][0], intXorArr[i][1]), iBitwiseConst(INT_PLACEHOLDER_1, intXorArr[i][1]));
 
       sprintf(resolvedMethodName, "iXorConst3_TestCase%d", i + 1);
       iBitwiseConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ixor, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(intXorArr[i][1])));
-      EXPECT_EQ(txor(intXorArr[i][0], intXorArr[i][1]), iBitwiseConst(intXorArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iBitwiseConst, txor(intXorArr[i][0], intXorArr[i][1]), iBitwiseConst(intXorArr[i][0], INT_PLACEHOLDER_2));
      }
    }
 
@@ -1607,17 +1616,17 @@ OpCodesTest::invokeDisabledOpCodesTests()
    {
 
    //frem
-   EXPECT_FLOAT_EQ(remainderf(FLOAT_MINIMUM, FLOAT_MINIMUM), _fRem(FLOAT_MINIMUM, FLOAT_MINIMUM));
-   EXPECT_FLOAT_EQ(remainderf(FLOAT_ZERO, FLOAT_MAXIMUM), _fRem(FLOAT_ZERO, FLOAT_MAXIMUM));
-   EXPECT_FLOAT_EQ(remainderf(FLOAT_POS, FLOAT_NEG), _fRem(FLOAT_POS, FLOAT_NEG));
-   EXPECT_FLOAT_EQ(remainderf(FLOAT_MAXIMUM, FLOAT_POS), _fRem(FLOAT_MAXIMUM, FLOAT_POS));
+   OMR_CT_EXPECT_FLOAT_EQ(_fRem, remainderf(FLOAT_MINIMUM, FLOAT_MINIMUM), _fRem(FLOAT_MINIMUM, FLOAT_MINIMUM));
+   OMR_CT_EXPECT_FLOAT_EQ(_fRem, remainderf(FLOAT_ZERO, FLOAT_MAXIMUM), _fRem(FLOAT_ZERO, FLOAT_MAXIMUM));
+   OMR_CT_EXPECT_FLOAT_EQ(_fRem, remainderf(FLOAT_POS, FLOAT_NEG), _fRem(FLOAT_POS, FLOAT_NEG));
+   OMR_CT_EXPECT_FLOAT_EQ(_fRem, remainderf(FLOAT_MAXIMUM, FLOAT_POS), _fRem(FLOAT_MAXIMUM, FLOAT_POS));
 
 
    //drem
-   EXPECT_DOUBLE_EQ(remainder(DOUBLE_MINIMUM, DOUBLE_MINIMUM), _dRem(DOUBLE_MINIMUM, DOUBLE_MINIMUM));
-   EXPECT_DOUBLE_EQ(remainder(DOUBLE_ZERO, DOUBLE_MAXIMUM), _dRem(DOUBLE_ZERO, DOUBLE_MAXIMUM));
-   EXPECT_DOUBLE_EQ(remainder(DOUBLE_POS, DOUBLE_NEG), _dRem(DOUBLE_POS, DOUBLE_NEG));
-   EXPECT_DOUBLE_EQ(remainder(DOUBLE_MAXIMUM, DOUBLE_POS), _dRem(DOUBLE_MAXIMUM, DOUBLE_POS));
+   OMR_CT_EXPECT_DOUBLE_EQ(_dRem, remainder(DOUBLE_MINIMUM, DOUBLE_MINIMUM), _dRem(DOUBLE_MINIMUM, DOUBLE_MINIMUM));
+   OMR_CT_EXPECT_DOUBLE_EQ(_dRem, remainder(DOUBLE_ZERO, DOUBLE_MAXIMUM), _dRem(DOUBLE_ZERO, DOUBLE_MAXIMUM));
+   OMR_CT_EXPECT_DOUBLE_EQ(_dRem, remainder(DOUBLE_POS, DOUBLE_NEG), _dRem(DOUBLE_POS, DOUBLE_NEG));
+   OMR_CT_EXPECT_DOUBLE_EQ(_dRem, remainder(DOUBLE_MAXIMUM, DOUBLE_POS), _dRem(DOUBLE_MAXIMUM, DOUBLE_POS));
    }
 
 void
@@ -1886,727 +1895,727 @@ OpCodesTest::invokeCompareTests()
    testCaseNum = sizeof(iCmpeqDataArr) / sizeof(iCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(iCmpeqDataArr[i][0], iCmpeqDataArr[i][1]), _iCmpeq(iCmpeqDataArr[i][0], iCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iCmpeq, compareEQ(iCmpeqDataArr[i][0], iCmpeqDataArr[i][1]), _iCmpeq(iCmpeqDataArr[i][0], iCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iCmpeqConst1_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::icmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iCmpeqDataArr[i][0]), 2, &(iCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(iCmpeqDataArr[i][0], iCmpeqDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareEQ(iCmpeqDataArr[i][0], iCmpeqDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iCmpeqConst2_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::icmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(iCmpeqDataArr[i][0], iCmpeqDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, iCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareEQ(iCmpeqDataArr[i][0], iCmpeqDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, iCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iCmpeqConst3_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::icmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(iCmpeqDataArr[i][0], iCmpeqDataArr[i][1]), iCompareConst(iCmpeqDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareEQ(iCmpeqDataArr[i][0], iCmpeqDataArr[i][1]), iCompareConst(iCmpeqDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(iCmpneDataArr) / sizeof(iCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(iCmpneDataArr[i][0], iCmpneDataArr[i][1]), _iCmpne(iCmpneDataArr[i][0], iCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iCmpne, compareNE(iCmpneDataArr[i][0], iCmpneDataArr[i][1]), _iCmpne(iCmpneDataArr[i][0], iCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iCmpneConst1_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::icmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iCmpneDataArr[i][0]), 2, &(iCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(iCmpneDataArr[i][0], iCmpneDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareNE(iCmpneDataArr[i][0], iCmpneDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iCmpneConst2_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::icmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(iCmpneDataArr[i][0], iCmpneDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, iCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareNE(iCmpneDataArr[i][0], iCmpneDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, iCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iCmpneConst3_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::icmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(iCmpneDataArr[i][0], iCmpneDataArr[i][1]), iCompareConst(iCmpneDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareNE(iCmpneDataArr[i][0], iCmpneDataArr[i][1]), iCompareConst(iCmpneDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(iCmpgtDataArr) / sizeof(iCmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(iCmpgtDataArr[i][0], iCmpgtDataArr[i][1]), _iCmpgt(iCmpgtDataArr[i][0], iCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iCmpgt, compareGT(iCmpgtDataArr[i][0], iCmpgtDataArr[i][1]), _iCmpgt(iCmpgtDataArr[i][0], iCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iCmpgtConst1_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::icmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iCmpgtDataArr[i][0]), 2, &(iCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(iCmpgtDataArr[i][0], iCmpgtDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareGT(iCmpgtDataArr[i][0], iCmpgtDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iCmpgtConst2_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::icmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iCmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(iCmpgtDataArr[i][0], iCmpgtDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, iCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareGT(iCmpgtDataArr[i][0], iCmpgtDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, iCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iCmpgtConst3_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::icmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(iCmpgtDataArr[i][0], iCmpgtDataArr[i][1]), iCompareConst(iCmpgtDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareGT(iCmpgtDataArr[i][0], iCmpgtDataArr[i][1]), iCompareConst(iCmpgtDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(iCmpltDataArr) / sizeof(iCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(iCmpltDataArr[i][0], iCmpltDataArr[i][1]), _iCmplt(iCmpltDataArr[i][0], iCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iCmplt, compareLT(iCmpltDataArr[i][0], iCmpltDataArr[i][1]), _iCmplt(iCmpltDataArr[i][0], iCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iCmpltConst1_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::icmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iCmpltDataArr[i][0]), 2, &(iCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(iCmpltDataArr[i][0], iCmpltDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareLT(iCmpltDataArr[i][0], iCmpltDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iCmpltConst2_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::icmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(iCmpltDataArr[i][0], iCmpltDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, iCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareLT(iCmpltDataArr[i][0], iCmpltDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, iCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iCmpltConst3_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::icmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(iCmpltDataArr[i][0], iCmpltDataArr[i][1]), iCompareConst(iCmpltDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareLT(iCmpltDataArr[i][0], iCmpltDataArr[i][1]), iCompareConst(iCmpltDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(iCmpgeDataArr) / sizeof(iCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(iCmpgeDataArr[i][0], iCmpgeDataArr[i][1]), _iCmpge(iCmpgeDataArr[i][0], iCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iCmpge, compareGE(iCmpgeDataArr[i][0], iCmpgeDataArr[i][1]), _iCmpge(iCmpgeDataArr[i][0], iCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iCmpgeConst1_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::icmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iCmpgeDataArr[i][0]), 2, &(iCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(iCmpgeDataArr[i][0], iCmpgeDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareGE(iCmpgeDataArr[i][0], iCmpgeDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iCmpgeConst2_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::icmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(iCmpgeDataArr[i][0], iCmpgeDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, iCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareGE(iCmpgeDataArr[i][0], iCmpgeDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, iCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iCmpgeConst3_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::icmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(iCmpgeDataArr[i][0], iCmpgeDataArr[i][1]), iCompareConst(iCmpgeDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareGE(iCmpgeDataArr[i][0], iCmpgeDataArr[i][1]), iCompareConst(iCmpgeDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(iCmpleDataArr) / sizeof(iCmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(iCmpleDataArr[i][0], iCmpleDataArr[i][1]), _iCmple(iCmpleDataArr[i][0], iCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iCmple, compareLE(iCmpleDataArr[i][0], iCmpleDataArr[i][1]), _iCmple(iCmpleDataArr[i][0], iCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iCmpleConst1_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::icmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iCmpleDataArr[i][0]), 2, &(iCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(iCmpleDataArr[i][0], iCmpleDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareLE(iCmpleDataArr[i][0], iCmpleDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iCmpleConst2_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::icmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iCmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(iCmpleDataArr[i][0], iCmpleDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, iCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareLE(iCmpleDataArr[i][0], iCmpleDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, iCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iCmpleConst3_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::icmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(iCmpleDataArr[i][0], iCmpleDataArr[i][1]), iCompareConst(iCmpleDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareLE(iCmpleDataArr[i][0], iCmpleDataArr[i][1]), iCompareConst(iCmpleDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    //lCompare
    testCaseNum = sizeof(lCmpneDataArr) / sizeof(lCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(lCmpneDataArr[i][0], lCmpneDataArr[i][1]), _lCmpne(lCmpneDataArr[i][0], lCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lCmpne, compareNE(lCmpneDataArr[i][0], lCmpneDataArr[i][1]), _lCmpne(lCmpneDataArr[i][0], lCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpneConst1_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpneDataArr[i][0]), 2, &(lCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(lCmpneDataArr[i][0], lCmpneDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareNE(lCmpneDataArr[i][0], lCmpneDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
 #ifndef TR_TARGET_POWER
       sprintf(resolvedMethodName, "lCmpneConst2_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(lCmpneDataArr[i][0], lCmpneDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareNE(lCmpneDataArr[i][0], lCmpneDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpneConst3_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(lCmpneDataArr[i][0], lCmpneDataArr[i][1]), lCompareConst(lCmpneDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareNE(lCmpneDataArr[i][0], lCmpneDataArr[i][1]), lCompareConst(lCmpneDataArr[i][0], LONG_PLACEHOLDER_2));
 #endif
       }
 
    testCaseNum = sizeof(lCmpgtDataArr) / sizeof(lCmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(lCmpgtDataArr[i][0], lCmpgtDataArr[i][1]), _lCmpgt(lCmpgtDataArr[i][0], lCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lCmpgt, compareGT(lCmpgtDataArr[i][0], lCmpgtDataArr[i][1]), _lCmpgt(lCmpgtDataArr[i][0], lCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpgtConst1_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpgtDataArr[i][0]), 2, &(lCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(lCmpgtDataArr[i][0], lCmpgtDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareGT(lCmpgtDataArr[i][0], lCmpgtDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
 #ifndef TR_TARGET_POWER
       sprintf(resolvedMethodName, "lCmpgtConst2_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(lCmpgtDataArr[i][0], lCmpgtDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareGT(lCmpgtDataArr[i][0], lCmpgtDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpgtConst3_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(lCmpgtDataArr[i][0], lCmpgtDataArr[i][1]), lCompareConst(lCmpgtDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareGT(lCmpgtDataArr[i][0], lCmpgtDataArr[i][1]), lCompareConst(lCmpgtDataArr[i][0], LONG_PLACEHOLDER_2));
 #endif
       }
 
    testCaseNum = sizeof(lCmpgeDataArr) / sizeof(lCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(lCmpgeDataArr[i][0], lCmpgeDataArr[i][1]), _lCmpge(lCmpgeDataArr[i][0], lCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lCmpge, compareGE(lCmpgeDataArr[i][0], lCmpgeDataArr[i][1]), _lCmpge(lCmpgeDataArr[i][0], lCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpgeConst1_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpgeDataArr[i][0]), 2, &(lCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(lCmpgeDataArr[i][0], lCmpgeDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareGE(lCmpgeDataArr[i][0], lCmpgeDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lCmpgeConst2_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(lCmpgeDataArr[i][0], lCmpgeDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareGE(lCmpgeDataArr[i][0], lCmpgeDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpgeConst3_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(lCmpgeDataArr[i][0], lCmpgeDataArr[i][1]), lCompareConst(lCmpgeDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareGE(lCmpgeDataArr[i][0], lCmpgeDataArr[i][1]), lCompareConst(lCmpgeDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(lCmpleDataArr) / sizeof(lCmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(lCmpleDataArr[i][0], lCmpleDataArr[i][1]), _lCmple(lCmpleDataArr[i][0], lCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lCmple, compareLE(lCmpleDataArr[i][0], lCmpleDataArr[i][1]), _lCmple(lCmpleDataArr[i][0], lCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpleConst1_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpleDataArr[i][0]), 2, &(lCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(lCmpleDataArr[i][0], lCmpleDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareLE(lCmpleDataArr[i][0], lCmpleDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lCmpleConst2_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(lCmpleDataArr[i][0], lCmpleDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareLE(lCmpleDataArr[i][0], lCmpleDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpleConst3_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(lCmpleDataArr[i][0], lCmpleDataArr[i][1]), lCompareConst(lCmpleDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareLE(lCmpleDataArr[i][0], lCmpleDataArr[i][1]), lCompareConst(lCmpleDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //iuCompare
    testCaseNum = sizeof(iuCmpgtDataArr) / sizeof(iuCmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(iuCmpgtDataArr[i][0], iuCmpgtDataArr[i][1]), _iuCmpgt(iuCmpgtDataArr[i][0], iuCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iuCmpgt, compareGT(iuCmpgtDataArr[i][0], iuCmpgtDataArr[i][1]), _iuCmpgt(iuCmpgtDataArr[i][0], iuCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpgtConst1_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpgtDataArr[i][0]), 2, &(iuCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(iuCmpgtDataArr[i][0], iuCmpgtDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareGT(iuCmpgtDataArr[i][0], iuCmpgtDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iuCmpgtConst2_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(iuCmpgtDataArr[i][0], iuCmpgtDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareGT(iuCmpgtDataArr[i][0], iuCmpgtDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpgtConst3_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(iuCmpgtDataArr[i][0], iuCmpgtDataArr[i][1]), iuCompareConst(iuCmpgtDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareGT(iuCmpgtDataArr[i][0], iuCmpgtDataArr[i][1]), iuCompareConst(iuCmpgtDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(iuCmpltDataArr) / sizeof(iuCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(iuCmpltDataArr[i][0], iuCmpltDataArr[i][1]), _iuCmplt(iuCmpltDataArr[i][0], iuCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iuCmplt, compareLT(iuCmpltDataArr[i][0], iuCmpltDataArr[i][1]), _iuCmplt(iuCmpltDataArr[i][0], iuCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpltConst1_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpltDataArr[i][0]), 2, &(iuCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(iuCmpltDataArr[i][0], iuCmpltDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareLT(iuCmpltDataArr[i][0], iuCmpltDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iuCmpltConst2_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(iuCmpltDataArr[i][0], iuCmpltDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareLT(iuCmpltDataArr[i][0], iuCmpltDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpltConst3_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(iuCmpltDataArr[i][0], iuCmpltDataArr[i][1]), iuCompareConst(iuCmpltDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareLT(iuCmpltDataArr[i][0], iuCmpltDataArr[i][1]), iuCompareConst(iuCmpltDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(iuCmpleDataArr) / sizeof(iuCmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(iuCmpleDataArr[i][0], iuCmpleDataArr[i][1]), _iuCmple(iuCmpleDataArr[i][0], iuCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iuCmple, compareLE(iuCmpleDataArr[i][0], iuCmpleDataArr[i][1]), _iuCmple(iuCmpleDataArr[i][0], iuCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpleConst1_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpleDataArr[i][0]), 2, &(iuCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(iuCmpleDataArr[i][0], iuCmpleDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareLE(iuCmpleDataArr[i][0], iuCmpleDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iuCmpleConst2_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(iuCmpleDataArr[i][0], iuCmpleDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareLE(iuCmpleDataArr[i][0], iuCmpleDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpleConst3_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(iuCmpleDataArr[i][0], iuCmpleDataArr[i][1]), iuCompareConst(iuCmpleDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareLE(iuCmpleDataArr[i][0], iuCmpleDataArr[i][1]), iuCompareConst(iuCmpleDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    //luCompare
    testCaseNum = sizeof(luCmpeqDataArr) / sizeof(luCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(luCmpeqDataArr[i][0], luCmpeqDataArr[i][1]), _luCmpeq(luCmpeqDataArr[i][0], luCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_luCmpeq, compareEQ(luCmpeqDataArr[i][0], luCmpeqDataArr[i][1]), _luCmpeq(luCmpeqDataArr[i][0], luCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luCmpeqConst1_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lucmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(luCmpeqDataArr[i][0]), 2, &(luCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(luCmpeqDataArr[i][0], luCmpeqDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareEQ(luCmpeqDataArr[i][0], luCmpeqDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "luCmpeqConst2_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lucmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(luCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(luCmpeqDataArr[i][0], luCmpeqDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, luCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareEQ(luCmpeqDataArr[i][0], luCmpeqDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, luCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luCmpeqConst3_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lucmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(luCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(luCmpeqDataArr[i][0], luCmpeqDataArr[i][1]), luCompareConst(luCmpeqDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareEQ(luCmpeqDataArr[i][0], luCmpeqDataArr[i][1]), luCompareConst(luCmpeqDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(luCmpneDataArr) / sizeof(luCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(luCmpneDataArr[i][0], luCmpneDataArr[i][1]), _luCmpne(luCmpneDataArr[i][0], luCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_luCmpne, compareNE(luCmpneDataArr[i][0], luCmpneDataArr[i][1]), _luCmpne(luCmpneDataArr[i][0], luCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luCmpneConst1_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lucmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(luCmpneDataArr[i][0]), 2, &(luCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(luCmpneDataArr[i][0], luCmpneDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareNE(luCmpneDataArr[i][0], luCmpneDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "luCmpneConst2_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lucmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(luCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(luCmpneDataArr[i][0], luCmpneDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, luCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareNE(luCmpneDataArr[i][0], luCmpneDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, luCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luCmpneConst3_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lucmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(luCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(luCmpneDataArr[i][0], luCmpneDataArr[i][1]), luCompareConst(luCmpneDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareNE(luCmpneDataArr[i][0], luCmpneDataArr[i][1]), luCompareConst(luCmpneDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(luCmpgtDataArr) / sizeof(luCmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(luCmpgtDataArr[i][0], luCmpgtDataArr[i][1]), _luCmpgt(luCmpgtDataArr[i][0], luCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_luCmpgt, compareGT(luCmpgtDataArr[i][0], luCmpgtDataArr[i][1]), _luCmpgt(luCmpgtDataArr[i][0], luCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luCmpgtConst1_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lucmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(luCmpgtDataArr[i][0]), 2, &(luCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(luCmpgtDataArr[i][0], luCmpgtDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareGT(luCmpgtDataArr[i][0], luCmpgtDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "luCmpgtConst2_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lucmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(luCmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(luCmpgtDataArr[i][0], luCmpgtDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, luCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareGT(luCmpgtDataArr[i][0], luCmpgtDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, luCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luCmpgtConst3_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lucmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(luCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(luCmpgtDataArr[i][0], luCmpgtDataArr[i][1]), luCompareConst(luCmpgtDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareGT(luCmpgtDataArr[i][0], luCmpgtDataArr[i][1]), luCompareConst(luCmpgtDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(luCmpltDataArr) / sizeof(luCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(luCmpltDataArr[i][0], luCmpltDataArr[i][1]), _luCmplt(luCmpltDataArr[i][0], luCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_luCmplt, compareLT(luCmpltDataArr[i][0], luCmpltDataArr[i][1]), _luCmplt(luCmpltDataArr[i][0], luCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luCmpltConst1_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lucmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(luCmpltDataArr[i][0]), 2, &(luCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(luCmpltDataArr[i][0], luCmpltDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareLT(luCmpltDataArr[i][0], luCmpltDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "luCmpltConst2_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lucmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(luCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(luCmpltDataArr[i][0], luCmpltDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, luCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareLT(luCmpltDataArr[i][0], luCmpltDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, luCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luCmpltConst3_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lucmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(luCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(luCmpltDataArr[i][0], luCmpltDataArr[i][1]), luCompareConst(luCmpltDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareLT(luCmpltDataArr[i][0], luCmpltDataArr[i][1]), luCompareConst(luCmpltDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(luCmpgeDataArr) / sizeof(luCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(luCmpgeDataArr[i][0], luCmpgeDataArr[i][1]), _luCmpge(luCmpgeDataArr[i][0], luCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_luCmpge, compareGE(luCmpgeDataArr[i][0], luCmpgeDataArr[i][1]), _luCmpge(luCmpgeDataArr[i][0], luCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luCmpgeConst1_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lucmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(luCmpgeDataArr[i][0]), 2, &(luCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(luCmpgeDataArr[i][0], luCmpgeDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareGE(luCmpgeDataArr[i][0], luCmpgeDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "luCmpgeConst2_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lucmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(luCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(luCmpgeDataArr[i][0], luCmpgeDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, luCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareGE(luCmpgeDataArr[i][0], luCmpgeDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, luCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luCmpgeConst3_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lucmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(luCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(luCmpgeDataArr[i][0], luCmpgeDataArr[i][1]), luCompareConst(luCmpgeDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareGE(luCmpgeDataArr[i][0], luCmpgeDataArr[i][1]), luCompareConst(luCmpgeDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(luCmpleDataArr) / sizeof(luCmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(luCmpleDataArr[i][0], luCmpleDataArr[i][1]), _luCmple(luCmpleDataArr[i][0], luCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_luCmple, compareLE(luCmpleDataArr[i][0], luCmpleDataArr[i][1]), _luCmple(luCmpleDataArr[i][0], luCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luCmpleConst1_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lucmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(luCmpleDataArr[i][0]), 2, &(luCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(luCmpleDataArr[i][0], luCmpleDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareLE(luCmpleDataArr[i][0], luCmpleDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "luCmpleConst2_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lucmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(luCmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(luCmpleDataArr[i][0], luCmpleDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, luCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareLE(luCmpleDataArr[i][0], luCmpleDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, luCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luCmpleConst3_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lucmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(luCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(luCmpleDataArr[i][0], luCmpleDataArr[i][1]), luCompareConst(luCmpleDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareLE(luCmpleDataArr[i][0], luCmpleDataArr[i][1]), luCompareConst(luCmpleDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //ifiCompare
    testCaseNum = sizeof(ifIcmpeqDataArr) / sizeof(ifIcmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(ifIcmpeqDataArr[i][0], ifIcmpeqDataArr[i][1]), _ifIcmpeq(ifIcmpeqDataArr[i][0], ifIcmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifIcmpeq, compareEQ(ifIcmpeqDataArr[i][0], ifIcmpeqDataArr[i][1]), _ifIcmpeq(ifIcmpeqDataArr[i][0], ifIcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIcmpeqConst1_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ificmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIcmpeqDataArr[i][0]), 2, &(ifIcmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifIcmpeqDataArr[i][0], ifIcmpeqDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareEQ(ifIcmpeqDataArr[i][0], ifIcmpeqDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifIcmpeqConst2_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ificmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIcmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifIcmpeqDataArr[i][0], ifIcmpeqDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, ifIcmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareEQ(ifIcmpeqDataArr[i][0], ifIcmpeqDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, ifIcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIcmpeqConst3_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ificmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIcmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifIcmpeqDataArr[i][0], ifIcmpeqDataArr[i][1]), iCompareConst(ifIcmpeqDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareEQ(ifIcmpeqDataArr[i][0], ifIcmpeqDataArr[i][1]), iCompareConst(ifIcmpeqDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifIcmpneDataArr) / sizeof(ifIcmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(ifIcmpneDataArr[i][0], ifIcmpneDataArr[i][1]), _ifIcmpne(ifIcmpneDataArr[i][0], ifIcmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifIcmpne, compareNE(ifIcmpneDataArr[i][0], ifIcmpneDataArr[i][1]), _ifIcmpne(ifIcmpneDataArr[i][0], ifIcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIcmpneConst1_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ificmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIcmpneDataArr[i][0]), 2, &(ifIcmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifIcmpneDataArr[i][0], ifIcmpneDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareNE(ifIcmpneDataArr[i][0], ifIcmpneDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifIcmpneConst2_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ificmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIcmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(ifIcmpneDataArr[i][0], ifIcmpneDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, ifIcmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareNE(ifIcmpneDataArr[i][0], ifIcmpneDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, ifIcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIcmpneConst3_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ificmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIcmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifIcmpneDataArr[i][0], ifIcmpneDataArr[i][1]), iCompareConst(ifIcmpneDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareNE(ifIcmpneDataArr[i][0], ifIcmpneDataArr[i][1]), iCompareConst(ifIcmpneDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifIcmpgtDataArr) / sizeof(ifIcmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(ifIcmpgtDataArr[i][0], ifIcmpgtDataArr[i][1]), _ifIcmpgt(ifIcmpgtDataArr[i][0], ifIcmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifIcmpgt, compareGT(ifIcmpgtDataArr[i][0], ifIcmpgtDataArr[i][1]), _ifIcmpgt(ifIcmpgtDataArr[i][0], ifIcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIcmpgtConst1_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ificmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIcmpgtDataArr[i][0]), 2, &(ifIcmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifIcmpgtDataArr[i][0], ifIcmpgtDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareGT(ifIcmpgtDataArr[i][0], ifIcmpgtDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifIcmpgtConst2_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ificmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIcmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(ifIcmpgtDataArr[i][0], ifIcmpgtDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, ifIcmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareGT(ifIcmpgtDataArr[i][0], ifIcmpgtDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, ifIcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIcmpgtConst3_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ificmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIcmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifIcmpgtDataArr[i][0], ifIcmpgtDataArr[i][1]), iCompareConst(ifIcmpgtDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareGT(ifIcmpgtDataArr[i][0], ifIcmpgtDataArr[i][1]), iCompareConst(ifIcmpgtDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifIcmpltDataArr) / sizeof(ifIcmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(ifIcmpltDataArr[i][0], ifIcmpltDataArr[i][1]), _ifIcmplt(ifIcmpltDataArr[i][0], ifIcmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifIcmplt, compareLT(ifIcmpltDataArr[i][0], ifIcmpltDataArr[i][1]), _ifIcmplt(ifIcmpltDataArr[i][0], ifIcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIcmpltConst1_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ificmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIcmpltDataArr[i][0]), 2, &(ifIcmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifIcmpltDataArr[i][0], ifIcmpltDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareLT(ifIcmpltDataArr[i][0], ifIcmpltDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifIcmpltConst2_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ificmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIcmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(ifIcmpltDataArr[i][0], ifIcmpltDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, ifIcmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareLT(ifIcmpltDataArr[i][0], ifIcmpltDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, ifIcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIcmpltConst3_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ificmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIcmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifIcmpltDataArr[i][0], ifIcmpltDataArr[i][1]), iCompareConst(ifIcmpltDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareLT(ifIcmpltDataArr[i][0], ifIcmpltDataArr[i][1]), iCompareConst(ifIcmpltDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifIcmpgeDataArr) / sizeof(ifIcmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(ifIcmpgeDataArr[i][0], ifIcmpgeDataArr[i][1]), _ifIcmpge(ifIcmpgeDataArr[i][0], ifIcmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifIcmpge, compareGE(ifIcmpgeDataArr[i][0], ifIcmpgeDataArr[i][1]), _ifIcmpge(ifIcmpgeDataArr[i][0], ifIcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIcmpgeConst1_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ificmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIcmpgeDataArr[i][0]), 2, &(ifIcmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifIcmpgeDataArr[i][0], ifIcmpgeDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareGE(ifIcmpgeDataArr[i][0], ifIcmpgeDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifIcmpgeConst2_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ificmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIcmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(ifIcmpgeDataArr[i][0], ifIcmpgeDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, ifIcmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareGE(ifIcmpgeDataArr[i][0], ifIcmpgeDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, ifIcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIcmpgeConst3_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ificmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIcmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifIcmpgeDataArr[i][0], ifIcmpgeDataArr[i][1]), iCompareConst(ifIcmpgeDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareGE(ifIcmpgeDataArr[i][0], ifIcmpgeDataArr[i][1]), iCompareConst(ifIcmpgeDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifIcmpleDataArr) / sizeof(ifIcmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(ifIcmpleDataArr[i][0], ifIcmpleDataArr[i][1]), _ifIcmple(ifIcmpleDataArr[i][0], ifIcmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifIcmple, compareLE(ifIcmpleDataArr[i][0], ifIcmpleDataArr[i][1]), _ifIcmple(ifIcmpleDataArr[i][0], ifIcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIcmpleConst1_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ificmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIcmpleDataArr[i][0]), 2, &(ifIcmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifIcmpleDataArr[i][0], ifIcmpleDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareLE(ifIcmpleDataArr[i][0], ifIcmpleDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifIcmpleConst2_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ificmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIcmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(ifIcmpleDataArr[i][0], ifIcmpleDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, ifIcmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareLE(ifIcmpleDataArr[i][0], ifIcmpleDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, ifIcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIcmpleConst3_TestCase%d", i + 1);
       iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ificmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIcmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifIcmpleDataArr[i][0], ifIcmpleDataArr[i][1]), iCompareConst(ifIcmpleDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iCompareConst, compareLE(ifIcmpleDataArr[i][0], ifIcmpleDataArr[i][1]), iCompareConst(ifIcmpleDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    //iflCompare
    testCaseNum = sizeof(ifLcmpneDataArr) / sizeof(ifLcmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(ifLcmpneDataArr[i][0], ifLcmpneDataArr[i][1]), _ifLcmpne(ifLcmpneDataArr[i][0], ifLcmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifLcmpne, compareNE(ifLcmpneDataArr[i][0], ifLcmpneDataArr[i][1]), _ifLcmpne(ifLcmpneDataArr[i][0], ifLcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpneConst1_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpneDataArr[i][0]), 2, &(ifLcmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifLcmpneDataArr[i][0], ifLcmpneDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareNE(ifLcmpneDataArr[i][0], ifLcmpneDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
 #ifndef TR_TARGET_POWER
       sprintf(resolvedMethodName, "ifLcmpneConst2_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(ifLcmpneDataArr[i][0], ifLcmpneDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareNE(ifLcmpneDataArr[i][0], ifLcmpneDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpneConst3_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifLcmpneDataArr[i][0], ifLcmpneDataArr[i][1]), lCompareConst(ifLcmpneDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareNE(ifLcmpneDataArr[i][0], ifLcmpneDataArr[i][1]), lCompareConst(ifLcmpneDataArr[i][0], LONG_PLACEHOLDER_2));
 #endif
       }
 
    testCaseNum = sizeof(ifLcmpgeDataArr) / sizeof(ifLcmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(ifLcmpgeDataArr[i][0], ifLcmpgeDataArr[i][1]), _ifLcmpge(ifLcmpgeDataArr[i][0], ifLcmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifLcmpge, compareGE(ifLcmpgeDataArr[i][0], ifLcmpgeDataArr[i][1]), _ifLcmpge(ifLcmpgeDataArr[i][0], ifLcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpgeConst1_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpgeDataArr[i][0]), 2, &(ifLcmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifLcmpgeDataArr[i][0], ifLcmpgeDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareGE(ifLcmpgeDataArr[i][0], ifLcmpgeDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLcmpgeConst2_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(ifLcmpgeDataArr[i][0], ifLcmpgeDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareGE(ifLcmpgeDataArr[i][0], ifLcmpgeDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpgeConst3_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifLcmpgeDataArr[i][0], ifLcmpgeDataArr[i][1]), lCompareConst(ifLcmpgeDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareGE(ifLcmpgeDataArr[i][0], ifLcmpgeDataArr[i][1]), lCompareConst(ifLcmpgeDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifLcmpleDataArr) / sizeof(ifLcmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(ifLcmpleDataArr[i][0], ifLcmpleDataArr[i][1]), _ifLcmple(ifLcmpleDataArr[i][0], ifLcmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifLcmple, compareLE(ifLcmpleDataArr[i][0], ifLcmpleDataArr[i][1]), _ifLcmple(ifLcmpleDataArr[i][0], ifLcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpleConst1_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpleDataArr[i][0]), 2, &(ifLcmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifLcmpleDataArr[i][0], ifLcmpleDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareLE(ifLcmpleDataArr[i][0], ifLcmpleDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLcmpleConst2_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(ifLcmpleDataArr[i][0], ifLcmpleDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareLE(ifLcmpleDataArr[i][0], ifLcmpleDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpleConst3_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifLcmpleDataArr[i][0], ifLcmpleDataArr[i][1]), lCompareConst(ifLcmpleDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareLE(ifLcmpleDataArr[i][0], ifLcmpleDataArr[i][1]), lCompareConst(ifLcmpleDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //ifiuCompare
    testCaseNum = sizeof(ifIuCmpeqDataArr) / sizeof(ifIuCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(ifIuCmpeqDataArr[i][0], ifIuCmpeqDataArr[i][1]), _ifIuCmpeq(ifIuCmpeqDataArr[i][0], ifIuCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifIuCmpeq, compareEQ(ifIuCmpeqDataArr[i][0], ifIuCmpeqDataArr[i][1]), _ifIuCmpeq(ifIuCmpeqDataArr[i][0], ifIuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIuCmpeqConst1_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifiucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIuCmpeqDataArr[i][0]), 2, &(ifIuCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifIuCmpeqDataArr[i][0], ifIuCmpeqDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareEQ(ifIuCmpeqDataArr[i][0], ifIuCmpeqDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifIuCmpeqConst2_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifiucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIuCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifIuCmpeqDataArr[i][0], ifIuCmpeqDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, ifIuCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareEQ(ifIuCmpeqDataArr[i][0], ifIuCmpeqDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, ifIuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIuCmpeqConst3_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifiucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIuCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifIuCmpeqDataArr[i][0], ifIuCmpeqDataArr[i][1]), iuCompareConst(ifIuCmpeqDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareEQ(ifIuCmpeqDataArr[i][0], ifIuCmpeqDataArr[i][1]), iuCompareConst(ifIuCmpeqDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifIuCmpneDataArr) / sizeof(ifIuCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(ifIuCmpneDataArr[i][0], ifIuCmpneDataArr[i][1]), _ifIuCmpne(ifIuCmpneDataArr[i][0], ifIuCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifIuCmpne, compareNE(ifIuCmpneDataArr[i][0], ifIuCmpneDataArr[i][1]), _ifIuCmpne(ifIuCmpneDataArr[i][0], ifIuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIuCmpneConst1_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifiucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIuCmpneDataArr[i][0]), 2, &(ifIuCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifIuCmpneDataArr[i][0], ifIuCmpneDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareNE(ifIuCmpneDataArr[i][0], ifIuCmpneDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifIuCmpneConst2_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifiucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIuCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(ifIuCmpneDataArr[i][0], ifIuCmpneDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, ifIuCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareNE(ifIuCmpneDataArr[i][0], ifIuCmpneDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, ifIuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIuCmpneConst3_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifiucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIuCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifIuCmpneDataArr[i][0], ifIuCmpneDataArr[i][1]), iuCompareConst(ifIuCmpneDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareNE(ifIuCmpneDataArr[i][0], ifIuCmpneDataArr[i][1]), iuCompareConst(ifIuCmpneDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifIuCmpgtDataArr) / sizeof(ifIuCmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(ifIuCmpgtDataArr[i][0], ifIuCmpgtDataArr[i][1]), _ifIuCmpgt(ifIuCmpgtDataArr[i][0], ifIuCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifIuCmpgt, compareGT(ifIuCmpgtDataArr[i][0], ifIuCmpgtDataArr[i][1]), _ifIuCmpgt(ifIuCmpgtDataArr[i][0], ifIuCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIuCmpgtConst1_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifiucmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIuCmpgtDataArr[i][0]), 2, &(ifIuCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifIuCmpgtDataArr[i][0], ifIuCmpgtDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareGT(ifIuCmpgtDataArr[i][0], ifIuCmpgtDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifIuCmpgtConst2_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifiucmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIuCmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(ifIuCmpgtDataArr[i][0], ifIuCmpgtDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, ifIuCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareGT(ifIuCmpgtDataArr[i][0], ifIuCmpgtDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, ifIuCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIuCmpgtConst3_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifiucmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIuCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifIuCmpgtDataArr[i][0], ifIuCmpgtDataArr[i][1]), iuCompareConst(ifIuCmpgtDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareGT(ifIuCmpgtDataArr[i][0], ifIuCmpgtDataArr[i][1]), iuCompareConst(ifIuCmpgtDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifIuCmpltDataArr) / sizeof(ifIuCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(ifIuCmpltDataArr[i][0], ifIuCmpltDataArr[i][1]), _ifIuCmplt(ifIuCmpltDataArr[i][0], ifIuCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifIuCmplt, compareLT(ifIuCmpltDataArr[i][0], ifIuCmpltDataArr[i][1]), _ifIuCmplt(ifIuCmpltDataArr[i][0], ifIuCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIuCmpltConst1_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifiucmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIuCmpltDataArr[i][0]), 2, &(ifIuCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifIuCmpltDataArr[i][0], ifIuCmpltDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareLT(ifIuCmpltDataArr[i][0], ifIuCmpltDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifIuCmpltConst2_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifiucmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIuCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(ifIuCmpltDataArr[i][0], ifIuCmpltDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, ifIuCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareLT(ifIuCmpltDataArr[i][0], ifIuCmpltDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, ifIuCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIuCmpltConst3_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifiucmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIuCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifIuCmpltDataArr[i][0], ifIuCmpltDataArr[i][1]), iuCompareConst(ifIuCmpltDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareLT(ifIuCmpltDataArr[i][0], ifIuCmpltDataArr[i][1]), iuCompareConst(ifIuCmpltDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifIuCmpgeDataArr) / sizeof(ifIuCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(ifIuCmpgeDataArr[i][0], ifIuCmpgeDataArr[i][1]), _ifIuCmpge(ifIuCmpgeDataArr[i][0], ifIuCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifIuCmpge, compareGE(ifIuCmpgeDataArr[i][0], ifIuCmpgeDataArr[i][1]), _ifIuCmpge(ifIuCmpgeDataArr[i][0], ifIuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIuCmpgeConst1_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifiucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIuCmpgeDataArr[i][0]), 2, &(ifIuCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifIuCmpgeDataArr[i][0], ifIuCmpgeDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareGE(ifIuCmpgeDataArr[i][0], ifIuCmpgeDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifIuCmpgeConst2_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifiucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIuCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(ifIuCmpgeDataArr[i][0], ifIuCmpgeDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, ifIuCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareGE(ifIuCmpgeDataArr[i][0], ifIuCmpgeDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, ifIuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIuCmpgeConst3_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifiucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIuCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifIuCmpgeDataArr[i][0], ifIuCmpgeDataArr[i][1]), iuCompareConst(ifIuCmpgeDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareGE(ifIuCmpgeDataArr[i][0], ifIuCmpgeDataArr[i][1]), iuCompareConst(ifIuCmpgeDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifIuCmpleDataArr) / sizeof(ifIuCmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(ifIuCmpleDataArr[i][0], ifIuCmpleDataArr[i][1]), _ifIuCmple(ifIuCmpleDataArr[i][0], ifIuCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifIuCmple, compareLE(ifIuCmpleDataArr[i][0], ifIuCmpleDataArr[i][1]), _ifIuCmple(ifIuCmpleDataArr[i][0], ifIuCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIuCmpleConst1_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifiucmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIuCmpleDataArr[i][0]), 2, &(ifIuCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifIuCmpleDataArr[i][0], ifIuCmpleDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareLE(ifIuCmpleDataArr[i][0], ifIuCmpleDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifIuCmpleConst2_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifiucmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIuCmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(ifIuCmpleDataArr[i][0], ifIuCmpleDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, ifIuCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareLE(ifIuCmpleDataArr[i][0], ifIuCmpleDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, ifIuCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIuCmpleConst3_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifiucmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIuCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifIuCmpleDataArr[i][0], ifIuCmpleDataArr[i][1]), iuCompareConst(ifIuCmpleDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareLE(ifIuCmpleDataArr[i][0], ifIuCmpleDataArr[i][1]), iuCompareConst(ifIuCmpleDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    //ifluCompare
@@ -2614,127 +2623,127 @@ OpCodesTest::invokeCompareTests()
    testCaseNum = sizeof(ifLuCmpeqDataArr) / sizeof(ifLuCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(ifLuCmpeqDataArr[i][0], ifLuCmpeqDataArr[i][1]), _ifLuCmpeq(ifLuCmpeqDataArr[i][0], ifLuCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifLuCmpeq, compareEQ(ifLuCmpeqDataArr[i][0], ifLuCmpeqDataArr[i][1]), _ifLuCmpeq(ifLuCmpeqDataArr[i][0], ifLuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLuCmpeqConst1_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflucmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLuCmpeqDataArr[i][0]), 2, &(ifLuCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifLuCmpeqDataArr[i][0], ifLuCmpeqDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareEQ(ifLuCmpeqDataArr[i][0], ifLuCmpeqDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLuCmpeqConst2_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflucmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLuCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifLuCmpeqDataArr[i][0], ifLuCmpeqDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, ifLuCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareEQ(ifLuCmpeqDataArr[i][0], ifLuCmpeqDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, ifLuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLuCmpeqConst3_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflucmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLuCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifLuCmpeqDataArr[i][0], ifLuCmpeqDataArr[i][1]), luCompareConst(ifLuCmpeqDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareEQ(ifLuCmpeqDataArr[i][0], ifLuCmpeqDataArr[i][1]), luCompareConst(ifLuCmpeqDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifLuCmpneDataArr) / sizeof(ifLuCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(ifLuCmpneDataArr[i][0], ifLuCmpneDataArr[i][1]), _ifLuCmpne(ifLuCmpneDataArr[i][0], ifLuCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifLuCmpne, compareNE(ifLuCmpneDataArr[i][0], ifLuCmpneDataArr[i][1]), _ifLuCmpne(ifLuCmpneDataArr[i][0], ifLuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLuCmpneConst1_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflucmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLuCmpneDataArr[i][0]), 2, &(ifLuCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifLuCmpneDataArr[i][0], ifLuCmpneDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareNE(ifLuCmpneDataArr[i][0], ifLuCmpneDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLuCmpneConst2_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflucmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLuCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(ifLuCmpneDataArr[i][0], ifLuCmpneDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, ifLuCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareNE(ifLuCmpneDataArr[i][0], ifLuCmpneDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, ifLuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLuCmpneConst3_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflucmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLuCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifLuCmpneDataArr[i][0], ifLuCmpneDataArr[i][1]), luCompareConst(ifLuCmpneDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareNE(ifLuCmpneDataArr[i][0], ifLuCmpneDataArr[i][1]), luCompareConst(ifLuCmpneDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifLuCmpgtDataArr) / sizeof(ifLuCmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(ifLuCmpgtDataArr[i][0], ifLuCmpgtDataArr[i][1]), _ifLuCmpgt(ifLuCmpgtDataArr[i][0], ifLuCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifLuCmpgt, compareGT(ifLuCmpgtDataArr[i][0], ifLuCmpgtDataArr[i][1]), _ifLuCmpgt(ifLuCmpgtDataArr[i][0], ifLuCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLuCmpgtConst1_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflucmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLuCmpgtDataArr[i][0]), 2, &(ifLuCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifLuCmpgtDataArr[i][0], ifLuCmpgtDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareGT(ifLuCmpgtDataArr[i][0], ifLuCmpgtDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLuCmpgtConst2_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflucmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLuCmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(ifLuCmpgtDataArr[i][0], ifLuCmpgtDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, ifLuCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareGT(ifLuCmpgtDataArr[i][0], ifLuCmpgtDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, ifLuCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLuCmpgtConst3_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflucmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLuCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifLuCmpgtDataArr[i][0], ifLuCmpgtDataArr[i][1]), luCompareConst(ifLuCmpgtDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareGT(ifLuCmpgtDataArr[i][0], ifLuCmpgtDataArr[i][1]), luCompareConst(ifLuCmpgtDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifLuCmpltDataArr) / sizeof(ifLuCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(ifLuCmpltDataArr[i][0], ifLuCmpltDataArr[i][1]), _ifLuCmplt(ifLuCmpltDataArr[i][0], ifLuCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifLuCmplt, compareLT(ifLuCmpltDataArr[i][0], ifLuCmpltDataArr[i][1]), _ifLuCmplt(ifLuCmpltDataArr[i][0], ifLuCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLuCmpltConst1_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflucmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLuCmpltDataArr[i][0]), 2, &(ifLuCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifLuCmpltDataArr[i][0], ifLuCmpltDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareLT(ifLuCmpltDataArr[i][0], ifLuCmpltDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLuCmpltConst2_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflucmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLuCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(ifLuCmpltDataArr[i][0], ifLuCmpltDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, ifLuCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareLT(ifLuCmpltDataArr[i][0], ifLuCmpltDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, ifLuCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLuCmpltConst3_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflucmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLuCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifLuCmpltDataArr[i][0], ifLuCmpltDataArr[i][1]), luCompareConst(ifLuCmpltDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareLT(ifLuCmpltDataArr[i][0], ifLuCmpltDataArr[i][1]), luCompareConst(ifLuCmpltDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifLuCmpgeDataArr) / sizeof(ifLuCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(ifLuCmpgeDataArr[i][0], ifLuCmpgeDataArr[i][1]), _ifLuCmpge(ifLuCmpgeDataArr[i][0], ifLuCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifLuCmpge, compareGE(ifLuCmpgeDataArr[i][0], ifLuCmpgeDataArr[i][1]), _ifLuCmpge(ifLuCmpgeDataArr[i][0], ifLuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLuCmpgeConst1_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflucmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLuCmpgeDataArr[i][0]), 2, &(ifLuCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifLuCmpgeDataArr[i][0], ifLuCmpgeDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareGE(ifLuCmpgeDataArr[i][0], ifLuCmpgeDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLuCmpgeConst2_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflucmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLuCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(ifLuCmpgeDataArr[i][0], ifLuCmpgeDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, ifLuCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareGE(ifLuCmpgeDataArr[i][0], ifLuCmpgeDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, ifLuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLuCmpgeConst3_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflucmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLuCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifLuCmpgeDataArr[i][0], ifLuCmpgeDataArr[i][1]), luCompareConst(ifLuCmpgeDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareGE(ifLuCmpgeDataArr[i][0], ifLuCmpgeDataArr[i][1]), luCompareConst(ifLuCmpgeDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifLuCmpleDataArr) / sizeof(ifLuCmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(ifLuCmpleDataArr[i][0], ifLuCmpleDataArr[i][1]), _ifLuCmple(ifLuCmpleDataArr[i][0], ifLuCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifLuCmple, compareLE(ifLuCmpleDataArr[i][0], ifLuCmpleDataArr[i][1]), _ifLuCmple(ifLuCmpleDataArr[i][0], ifLuCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLuCmpleConst1_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflucmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLuCmpleDataArr[i][0]), 2, &(ifLuCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifLuCmpleDataArr[i][0], ifLuCmpleDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareLE(ifLuCmpleDataArr[i][0], ifLuCmpleDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLuCmpleConst2_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflucmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLuCmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(ifLuCmpleDataArr[i][0], ifLuCmpleDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, ifLuCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareLE(ifLuCmpleDataArr[i][0], ifLuCmpleDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, ifLuCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLuCmpleConst3_TestCase%d", i + 1);
       luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflucmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLuCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifLuCmpleDataArr[i][0], ifLuCmpleDataArr[i][1]), luCompareConst(ifLuCmpleDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luCompareConst, compareLE(ifLuCmpleDataArr[i][0], ifLuCmpleDataArr[i][1]), luCompareConst(ifLuCmpleDataArr[i][0], LONG_PLACEHOLDER_2));
       }
    }
 
@@ -2781,35 +2790,35 @@ OpCodesTest::invokeTernaryTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "iTernaryConst%d", i + 1);
-      EXPECT_EQ(ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), _iternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iternary, ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), _iternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]));
 
       iTernaryConst = (signatureCharIII_I_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::iternary,
             resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 6, 1, &iternaryChild1Arr[i], 2, &intArr[i][0], 3, &intArr[i][1]));
-      EXPECT_EQ(ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2, INT_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(iTernaryConst, ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2, INT_PLACEHOLDER_3));
 
       iTernaryConst = (signatureCharIII_I_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::iternary,
             resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 4, 1, &iternaryChild1Arr[i], 2, &intArr[i][0]));
-      EXPECT_EQ(ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2, intArr[i][1]));
+      OMR_CT_EXPECT_EQ(iTernaryConst, ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2, intArr[i][1]));
 
       iTernaryConst = (signatureCharIII_I_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::iternary,
             resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 4, 1, &iternaryChild1Arr[i], 3, &intArr[i][1]));
-      EXPECT_EQ(ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(INT_PLACEHOLDER_1, intArr[i][0], INT_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(iTernaryConst, ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(INT_PLACEHOLDER_1, intArr[i][0], INT_PLACEHOLDER_3));
 
       iTernaryConst = (signatureCharIII_I_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::iternary,
             resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 4, 2, &intArr[i][0], 3, &intArr[i][1]));
-      EXPECT_EQ(ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(iternaryChild1Arr[i], INT_PLACEHOLDER_2, INT_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(iTernaryConst, ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(iternaryChild1Arr[i], INT_PLACEHOLDER_2, INT_PLACEHOLDER_3));
 
       iTernaryConst = (signatureCharIII_I_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::iternary,
             resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 2, 1, &iternaryChild1Arr[i]));
-      EXPECT_EQ(ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(INT_PLACEHOLDER_1, intArr[i][0], intArr[i][1]));
+      OMR_CT_EXPECT_EQ(iTernaryConst, ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(INT_PLACEHOLDER_1, intArr[i][0], intArr[i][1]));
 
       iTernaryConst = (signatureCharIII_I_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::iternary,
             resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 2, 2, &intArr[i][0]));
-      EXPECT_EQ(ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(iternaryChild1Arr[i], INT_PLACEHOLDER_1, intArr[i][1]));
+      OMR_CT_EXPECT_EQ(iTernaryConst, ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(iternaryChild1Arr[i], INT_PLACEHOLDER_1, intArr[i][1]));
 
       iTernaryConst = (signatureCharIII_I_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::iternary,
             resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 2, 3, &intArr[i][1]));
-      EXPECT_EQ(ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(iternaryChild1Arr[i], intArr[i][0], INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(iTernaryConst, ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(iternaryChild1Arr[i], intArr[i][0], INT_PLACEHOLDER_1));
       }
    }
 
@@ -2836,7 +2845,7 @@ OpCodesTest::invokeAddressTests()
    testCaseNum = sizeof(aUnaryDataArr) / sizeof(aUnaryDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(aUnaryDataArr[i], _aload(aUnaryDataArr[i]));
+      OMR_CT_EXPECT_EQ(_aload, aUnaryDataArr[i], _aload(aUnaryDataArr[i]));
       }
 
    testCaseNum = sizeof(aUnaryDataArr) / sizeof(aUnaryDataArr[0]);
@@ -2844,37 +2853,37 @@ OpCodesTest::invokeAddressTests()
       {
       sprintf(resolvedMethodName, "aConst%d", i + 1);
       aUnaryCons = (signatureCharL_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::aconst, resolvedMethodName, _argTypesUnaryAddress, TR::Address, rc, 2, 1, &(aUnaryDataArr[i])));
-      EXPECT_EQ(aUnaryDataArr[i], aUnaryCons(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(aUnaryCons, aUnaryDataArr[i], aUnaryCons(ADDRESS_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(aUnaryDataArr) / sizeof(aUnaryDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(aUnaryDataArr[i], _areturn(aUnaryDataArr[i]));
+      OMR_CT_EXPECT_EQ(_areturn, aUnaryDataArr[i], _areturn(aUnaryDataArr[i]));
 
       sprintf(resolvedMethodName, "aReturnConst%d", i + 1);
       aUnaryCons = (signatureCharL_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::areturn, resolvedMethodName, _argTypesUnaryAddress, TR::Address, rc, 2, 1, &(aUnaryDataArr[i])));
-      EXPECT_EQ(aUnaryDataArr[i], aUnaryCons(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(aUnaryCons, aUnaryDataArr[i], aUnaryCons(ADDRESS_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(aUnaryDataArr) / sizeof(aUnaryDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(aUnaryDataArr[i], _astore(aUnaryDataArr[i]));
+      OMR_CT_EXPECT_EQ(_astore, aUnaryDataArr[i], _astore(aUnaryDataArr[i]));
 
       sprintf(resolvedMethodName, "aStoreConst%d", i + 1);
       aUnaryCons = (signatureCharL_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::astore, resolvedMethodName, _argTypesUnaryAddress, TR::Address, rc, 2, 1, &(aUnaryDataArr[i])));
-      EXPECT_EQ(aUnaryDataArr[i], aUnaryCons(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(aUnaryCons, aUnaryDataArr[i], aUnaryCons(ADDRESS_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(aUnaryDataArr) / sizeof(aUnaryDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(aUnaryDataArr[i], INT_POS), _a2i(aUnaryDataArr[i]));
+      OMR_CT_EXPECT_EQ(_a2i, convert(aUnaryDataArr[i], INT_POS), _a2i(aUnaryDataArr[i]));
 
       sprintf(resolvedMethodName, "a2iConst%d", i + 1);
       a2iConst = (signatureCharL_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::a2i, resolvedMethodName, _argTypesUnaryAddress, TR::Int32, rc, 2, 1, &aUnaryDataArr[i]));
-      EXPECT_EQ(convert(aUnaryDataArr[i], INT_POS), a2iConst(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(a2iConst, convert(aUnaryDataArr[i], INT_POS), a2iConst(ADDRESS_PLACEHOLDER_1));
       }
    }
 

--- a/fvtest/compilertest/tests/OpCodesTest.hpp
+++ b/fvtest/compilertest/tests/OpCodesTest.hpp
@@ -27,6 +27,10 @@
 
 namespace TR { class ResolvedMethod; }
 
+#define OMR_CT_EXPECT_EQ(compilee, a, b) if (compilee != NULL) EXPECT_EQ(a, b)
+#define OMR_CT_EXPECT_DOUBLE_EQ(compilee, a, b) if (compilee != NULL) EXPECT_DOUBLE_EQ(a, b)
+#define OMR_CT_EXPECT_FLOAT_EQ(compilee, a, b) if (compilee != NULL) EXPECT_FLOAT_EQ(a, b)
+
 namespace TestCompiler
 {
 //unsigned signatureChars
@@ -742,3 +746,4 @@ class OpCodesTest : public TestDriver
    };
 
 } // namespace TestCompiler
+

--- a/fvtest/compilertest/tests/PPCOpCodesTest.cpp
+++ b/fvtest/compilertest/tests/PPCOpCodesTest.cpp
@@ -237,127 +237,127 @@ PPCOpCodesTest::invokeUnaryTests()
    testCaseNum = sizeof(doubleDataArray) / sizeof(doubleDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(doubleDataArray[i], BYTE_POS), _d2b(doubleDataArray[i]));
-      EXPECT_EQ(convert(doubleDataArray[i], SHORT_POS), _d2s(doubleDataArray[i]));
+      OMR_CT_EXPECT_EQ(_d2b, convert(doubleDataArray[i], BYTE_POS), _d2b(doubleDataArray[i]));
+      OMR_CT_EXPECT_EQ(_d2s, convert(doubleDataArray[i], SHORT_POS), _d2s(doubleDataArray[i]));
 
       sprintf(resolvedMethodName, "d2bConst%d", i + 1);
       d2bConst = (signatureCharD_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2b,
             resolvedMethodName, _argTypesUnaryDouble, TR::Int8, rc, 2, 1, &doubleDataArray[i]));
-      EXPECT_EQ(convert(doubleDataArray[i], BYTE_POS), d2bConst(DOUBLE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(d2bConst, convert(doubleDataArray[i], BYTE_POS), d2bConst(DOUBLE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "d2sConst%d", i + 1);
       d2sConst = (signatureCharD_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2s,
             resolvedMethodName, _argTypesUnaryDouble, TR::Int16, rc, 2, 1, &doubleDataArray[i]));
-      EXPECT_EQ(convert(doubleDataArray[i], SHORT_POS), d2sConst(DOUBLE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(d2sConst, convert(doubleDataArray[i], SHORT_POS), d2sConst(DOUBLE_PLACEHOLDER_1));
       }
 
    //f2b f2s
    testCaseNum = sizeof(floatDataArray) / sizeof(floatDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(floatDataArray[i], BYTE_POS), _f2b(floatDataArray[i]));
-      EXPECT_EQ(convert(floatDataArray[i], SHORT_POS), _f2s(floatDataArray[i]));
+      OMR_CT_EXPECT_EQ(_f2b, convert(floatDataArray[i], BYTE_POS), _f2b(floatDataArray[i]));
+      OMR_CT_EXPECT_EQ(_f2s, convert(floatDataArray[i], SHORT_POS), _f2s(floatDataArray[i]));
 
       sprintf(resolvedMethodName, "f2bConst%d", i + 1);
       f2bConst = (signatureCharF_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2b,
             resolvedMethodName, _argTypesUnaryFloat, TR::Int8, rc, 2, 1, &floatDataArray[i]));
-      EXPECT_EQ(convert(floatDataArray[i], BYTE_POS), f2bConst(FLOAT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(f2bConst, convert(floatDataArray[i], BYTE_POS), f2bConst(FLOAT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "f2sConst%d", i + 1);
       f2sConst = (signatureCharF_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2s,
             resolvedMethodName, _argTypesUnaryFloat, TR::Int16, rc, 2, 1, &floatDataArray[i]));
-      EXPECT_EQ(convert(floatDataArray[i], SHORT_POS), f2sConst(FLOAT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(f2sConst, convert(floatDataArray[i], SHORT_POS), f2sConst(FLOAT_PLACEHOLDER_1));
       }
 
    //b 2 i,l,s
    testCaseNum = sizeof(byteDataArray) / sizeof(byteDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(byteDataArray[i], SHORT_POS), _b2s(byteDataArray[i]));
-      EXPECT_EQ(convert(byteDataArray[i], INT_POS), _b2i(byteDataArray[i]));
-      EXPECT_EQ(convert(byteDataArray[i], LONG_POS), _b2l(byteDataArray[i]));
+      OMR_CT_EXPECT_EQ(_b2s, convert(byteDataArray[i], SHORT_POS), _b2s(byteDataArray[i]));
+      OMR_CT_EXPECT_EQ(_b2i, convert(byteDataArray[i], INT_POS), _b2i(byteDataArray[i]));
+      OMR_CT_EXPECT_EQ(_b2l, convert(byteDataArray[i], LONG_POS), _b2l(byteDataArray[i]));
 
       sprintf(resolvedMethodName, "b2sConst%d", i + 1);
       b2sConst = (signatureCharB_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2s,
             resolvedMethodName, _argTypesUnaryByte, TR::Int16, rc, 2, 1, &byteDataArray[i]));
-      EXPECT_EQ(convert(byteDataArray[i], SHORT_POS), b2sConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(b2sConst, convert(byteDataArray[i], SHORT_POS), b2sConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "b2iConst%d", i + 1);
       b2iConst = (signatureCharB_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2i,
             resolvedMethodName, _argTypesUnaryByte, TR::Int32, rc, 2, 1, &byteDataArray[i]));
-      EXPECT_EQ(convert(byteDataArray[i], INT_POS), b2iConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(b2iConst, convert(byteDataArray[i], INT_POS), b2iConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "b2lConst%d", i + 1);
       b2lConst = (signatureCharB_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2l,
             resolvedMethodName, _argTypesUnaryByte, TR::Int64, rc, 2, 1, &byteDataArray[i]));
-      EXPECT_EQ(convert(byteDataArray[i], LONG_POS), b2lConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(b2lConst, convert(byteDataArray[i], LONG_POS), b2lConst(BYTE_PLACEHOLDER_1));
       }
 
    //bu 2 i,l,s
    testCaseNum = sizeof(ubyteDataArray) / sizeof(ubyteDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(ubyteDataArray[i], SHORT_POS), _bu2s(ubyteDataArray[i]));
-      EXPECT_EQ(convert(ubyteDataArray[i], INT_POS), _bu2i(ubyteDataArray[i]));
-      EXPECT_EQ(convert(ubyteDataArray[i], LONG_POS), _bu2l(ubyteDataArray[i]));
+      OMR_CT_EXPECT_EQ(_bu2s, convert(ubyteDataArray[i], SHORT_POS), _bu2s(ubyteDataArray[i]));
+      OMR_CT_EXPECT_EQ(_bu2i, convert(ubyteDataArray[i], INT_POS), _bu2i(ubyteDataArray[i]));
+      OMR_CT_EXPECT_EQ(_bu2l, convert(ubyteDataArray[i], LONG_POS), _bu2l(ubyteDataArray[i]));
 
       sprintf(resolvedMethodName, "bu2sConst%d", i + 1);
       bu2sConst = (unsignedSignatureCharB_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2s,
             resolvedMethodName, _argTypesUnaryByte, TR::Int16, rc, 2, 1, &ubyteDataArray[i]));
-      EXPECT_EQ(convert(ubyteDataArray[i], SHORT_POS), bu2sConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(bu2sConst, convert(ubyteDataArray[i], SHORT_POS), bu2sConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "bu2iConst%d", i + 1);
       bu2iConst = (unsignedSignatureCharB_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2i,
             resolvedMethodName, _argTypesUnaryByte, TR::Int32, rc, 2, 1, &ubyteDataArray[i]));
-      EXPECT_EQ(convert(ubyteDataArray[i], INT_POS), bu2iConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(bu2iConst, convert(ubyteDataArray[i], INT_POS), bu2iConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "bu2lConst%d", i + 1);
       bu2lConst = (unsignedSignatureCharB_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2l,
             resolvedMethodName, _argTypesUnaryByte, TR::Int64, rc, 2, 1, &ubyteDataArray[i]));
-      EXPECT_EQ(convert(ubyteDataArray[i], LONG_POS), bu2lConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(bu2lConst, convert(ubyteDataArray[i], LONG_POS), bu2lConst(BYTE_PLACEHOLDER_1));
       }
 
    //s 2 i,l,b
    testCaseNum = sizeof(shortDataArray) / sizeof(shortDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(shortDataArray[i], BYTE_POS), _s2b(shortDataArray[i]));
-      EXPECT_EQ(convert(shortDataArray[i], INT_POS), _s2i(shortDataArray[i]));
-      EXPECT_EQ(convert(shortDataArray[i], LONG_POS), _s2l(shortDataArray[i]));
+      OMR_CT_EXPECT_EQ(_s2b, convert(shortDataArray[i], BYTE_POS), _s2b(shortDataArray[i]));
+      OMR_CT_EXPECT_EQ(_s2i, convert(shortDataArray[i], INT_POS), _s2i(shortDataArray[i]));
+      OMR_CT_EXPECT_EQ(_s2l, convert(shortDataArray[i], LONG_POS), _s2l(shortDataArray[i]));
 
       sprintf(resolvedMethodName, "s2bConst%d", i + 1);
       s2bConst = (signatureCharS_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2b,
             resolvedMethodName, _argTypesUnaryShort, TR::Int8, rc, 2, 1, &shortDataArray[i]));
-      EXPECT_EQ(convert(shortDataArray[i], BYTE_POS), s2bConst(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(s2bConst, convert(shortDataArray[i], BYTE_POS), s2bConst(SHORT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "s2iConst%d", i + 1);
       s2iConst = (signatureCharS_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2i,
             resolvedMethodName, _argTypesUnaryShort, TR::Int32, rc, 2, 1, &shortDataArray[i]));
-      EXPECT_EQ(convert(shortDataArray[i], INT_POS), s2iConst(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(s2iConst, convert(shortDataArray[i], INT_POS), s2iConst(SHORT_PLACEHOLDER_1));
 
 
       sprintf(resolvedMethodName, "s2lConst%d", i + 1);
       s2lConst = (signatureCharS_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2l,
             resolvedMethodName, _argTypesUnaryShort, TR::Int64, rc, 2, 1, &shortDataArray[i]));
-      EXPECT_EQ(convert(shortDataArray[i], LONG_POS), s2lConst(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(s2lConst, convert(shortDataArray[i], LONG_POS), s2lConst(SHORT_PLACEHOLDER_1));
       }
    //su 2 i,l
    testCaseNum = sizeof(ushortDataArray) / sizeof(ushortDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(ushortDataArray[i], INT_POS), _su2i(ushortDataArray[i]));
-      EXPECT_EQ(convert(ushortDataArray[i], LONG_POS), _su2l(ushortDataArray[i]));
+      OMR_CT_EXPECT_EQ(_su2i, convert(ushortDataArray[i], INT_POS), _su2i(ushortDataArray[i]));
+      OMR_CT_EXPECT_EQ(_su2l, convert(ushortDataArray[i], LONG_POS), _su2l(ushortDataArray[i]));
 
       sprintf(resolvedMethodName, "s2iConst%d", i + 1);
       su2iConst = (unsignedSignatureCharS_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2i,
             resolvedMethodName, _argTypesUnaryShort, TR::Int32, rc, 2, 1, &ushortDataArray[i]));
-      EXPECT_EQ(convert(ushortDataArray[i], INT_POS), su2iConst(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(su2iConst, convert(ushortDataArray[i], INT_POS), su2iConst(SHORT_PLACEHOLDER_1));
 
 
       sprintf(resolvedMethodName, "s2lConst%d", i + 1);
       su2lConst = (unsignedSignatureCharS_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2l,
             resolvedMethodName, _argTypesUnaryShort, TR::Int64, rc, 2, 1, &ushortDataArray[i]));
-      EXPECT_EQ(convert(ushortDataArray[i], LONG_POS), su2lConst(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(su2lConst, convert(ushortDataArray[i], LONG_POS), su2lConst(SHORT_PLACEHOLDER_1));
       }
    }
 
@@ -374,35 +374,35 @@ PPCOpCodesTest::invokeMemoryOperationTests()
    int16_t shortDataArray[] = {SHORT_NEG, SHORT_POS, SHORT_MAXIMUM, SHORT_MINIMUM, SHORT_ZERO};
    int8_t byteDataArray[] = {BYTE_NEG, BYTE_POS, BYTE_MAXIMUM, BYTE_MINIMUM, BYTE_ZERO};
 
-   EXPECT_EQ(BYTE_ZERO, _bLoad(BYTE_ZERO));
-   EXPECT_EQ(BYTE_NEG, _bLoad(BYTE_NEG));
-   EXPECT_EQ(BYTE_POS, _bLoad(BYTE_POS));
-   EXPECT_EQ(BYTE_MAXIMUM, _bLoad(BYTE_MAXIMUM));
-   EXPECT_EQ(BYTE_MINIMUM, _bLoad(BYTE_MINIMUM));
+   OMR_CT_EXPECT_EQ(_bLoad, BYTE_ZERO, _bLoad(BYTE_ZERO));
+   OMR_CT_EXPECT_EQ(_bLoad, BYTE_NEG, _bLoad(BYTE_NEG));
+   OMR_CT_EXPECT_EQ(_bLoad, BYTE_POS, _bLoad(BYTE_POS));
+   OMR_CT_EXPECT_EQ(_bLoad, BYTE_MAXIMUM, _bLoad(BYTE_MAXIMUM));
+   OMR_CT_EXPECT_EQ(_bLoad, BYTE_MINIMUM, _bLoad(BYTE_MINIMUM));
 
-   EXPECT_EQ(SHORT_ZERO, _sLoad(SHORT_ZERO));
-   EXPECT_EQ(SHORT_NEG, _sLoad(SHORT_NEG));
-   EXPECT_EQ(SHORT_POS, _sLoad(SHORT_POS));
-   EXPECT_EQ(SHORT_MAXIMUM, _sLoad(SHORT_MAXIMUM));
-   EXPECT_EQ(SHORT_MINIMUM, _sLoad(SHORT_MINIMUM));
+   OMR_CT_EXPECT_EQ(_sLoad, SHORT_ZERO, _sLoad(SHORT_ZERO));
+   OMR_CT_EXPECT_EQ(_sLoad, SHORT_NEG, _sLoad(SHORT_NEG));
+   OMR_CT_EXPECT_EQ(_sLoad, SHORT_POS, _sLoad(SHORT_POS));
+   OMR_CT_EXPECT_EQ(_sLoad, SHORT_MAXIMUM, _sLoad(SHORT_MAXIMUM));
+   OMR_CT_EXPECT_EQ(_sLoad, SHORT_MINIMUM, _sLoad(SHORT_MINIMUM));
 
    //store
    testCaseNum = sizeof(byteDataArray) / sizeof(byteDataArray[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "bStoreConst%d", i + 1);
-      EXPECT_EQ(byteDataArray[i], _bStore(byteDataArray[i]));
+      OMR_CT_EXPECT_EQ(_bStore, byteDataArray[i], _bStore(byteDataArray[i]));
       bMemCons = (signatureCharB_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bstore, resolvedMethodName, _argTypesUnaryByte, TR::Int8, rc, 2, 1, &(byteDataArray[i])));
-      EXPECT_EQ(byteDataArray[i], bMemCons(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(bMemCons, byteDataArray[i], bMemCons(BYTE_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(shortDataArray) / sizeof(shortDataArray[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "sStoreConst%d", i + 1);
-      EXPECT_EQ(shortDataArray[i], _sStore(shortDataArray[i]));
+      OMR_CT_EXPECT_EQ(_sStore, shortDataArray[i], _sStore(shortDataArray[i]));
       sMemCons = (signatureCharS_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::sstore, resolvedMethodName, _argTypesUnaryShort, TR::Int16, rc, 2, 1, &(shortDataArray[i])));
-      EXPECT_EQ(shortDataArray[i], sMemCons(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(sMemCons, shortDataArray[i], sMemCons(SHORT_PLACEHOLDER_1));
       }
 
    int64_t longDataArray[] = {LONG_NEG, LONG_POS, LONG_MAXIMUM, LONG_MINIMUM, LONG_ZERO};
@@ -421,18 +421,41 @@ PPCOpCodesTest::invokeMemoryOperationTests()
    testCaseNum = sizeof(intDataArray) / sizeof(intDataArray[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      _iStorei((uintptrj_t)(&intStoreDataArray[i]) , intDataArray[i]);
-      EXPECT_EQ(intDataArray[i], intStoreDataArray[i]);
-      _lStorei((uintptrj_t)(&longStoreDataArray[i]) , longDataArray[i]);
-      EXPECT_EQ(longDataArray[i], longStoreDataArray[i]);
-      _sStorei((uintptrj_t)(&shortStoreDataArray[i]) , shortDataArray[i]);
-      EXPECT_EQ(shortDataArray[i], shortStoreDataArray[i]);
-      _fStorei((uintptrj_t)(&floatStoreDataArray[i]) , floatDataArray[i]);
-      EXPECT_EQ(floatDataArray[i], floatStoreDataArray[i]);
-      _dStorei((uintptrj_t)(&doubleStoreDataArray[i]) , doubleDataArray[i]);
-      EXPECT_EQ(doubleDataArray[i], doubleStoreDataArray[i]);
-      _aStorei((uintptrj_t)(&addressStoreDataArray[i]) , addressDataArray[i]);
-      EXPECT_EQ(addressDataArray[i], addressStoreDataArray[i]);
+      if (_iStorei != NULL)
+         {
+         _iStorei((uintptrj_t)(&intStoreDataArray[i]) , intDataArray[i]);
+         EXPECT_EQ(intDataArray[i], intStoreDataArray[i]);
+         }
+
+      if (_lStorei != NULL)
+         {
+         _lStorei((uintptrj_t)(&longStoreDataArray[i]) , longDataArray[i]);
+         EXPECT_EQ(longDataArray[i], longStoreDataArray[i]);
+         }
+
+      if (_sStorei != NULL)
+         {
+         _sStorei((uintptrj_t)(&shortStoreDataArray[i]) , shortDataArray[i]);
+         EXPECT_EQ(shortDataArray[i], shortStoreDataArray[i]);
+         }
+
+      if (_fStorei != NULL)
+         {
+         _fStorei((uintptrj_t)(&floatStoreDataArray[i]) , floatDataArray[i]);
+         EXPECT_EQ(floatDataArray[i], floatStoreDataArray[i]);
+         }
+
+      if (_dStorei != NULL)
+         {
+         _dStorei((uintptrj_t)(&doubleStoreDataArray[i]) , doubleDataArray[i]);
+         EXPECT_EQ(doubleDataArray[i], doubleStoreDataArray[i]);
+         }
+
+      if (_aStorei != NULL)
+         {
+         _aStorei((uintptrj_t)(&addressStoreDataArray[i]) , addressDataArray[i]);
+         EXPECT_EQ(addressDataArray[i], addressStoreDataArray[i]);
+         }
       }
    }
 
@@ -685,574 +708,574 @@ PPCOpCodesTest::invokeCompareTests()
    testCaseNum = sizeof(sCmpeqDataArr) / sizeof(sCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), _sCmpeq(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sCmpeq, compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), _sCmpeq(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpeqConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpeqDataArr[i][0]), 2, &(sCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpeqConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpeqConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), sCompareConst(sCmpeqDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), sCompareConst(sCmpeqDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(sCmpneDataArr) / sizeof(sCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), _sCmpne(sCmpneDataArr[i][0], sCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sCmpne, compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), _sCmpne(sCmpneDataArr[i][0], sCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpneConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpneDataArr[i][0]), 2, &(sCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpneConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpneConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), sCompareConst(sCmpneDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), sCompareConst(sCmpneDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(sCmpgtDataArr) / sizeof(sCmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), _sCmpgt(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sCmpgt, compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), _sCmpgt(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpgtConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpgtDataArr[i][0]), 2, &(sCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpgtConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpgtConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), sCompareConst(sCmpgtDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), sCompareConst(sCmpgtDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(sCmpltDataArr) / sizeof(sCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), _sCmplt(sCmpltDataArr[i][0], sCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sCmplt, compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), _sCmplt(sCmpltDataArr[i][0], sCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpltConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpltDataArr[i][0]), 2, &(sCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpltConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpltConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), sCompareConst(sCmpltDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), sCompareConst(sCmpltDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(sCmpgeDataArr) / sizeof(sCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), _sCmpge(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sCmpge, compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), _sCmpge(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpgeConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpgeDataArr[i][0]), 2, &(sCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpgeConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpgeConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), sCompareConst(sCmpgeDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), sCompareConst(sCmpgeDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(sCmpleDataArr) / sizeof(sCmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), _sCmple(sCmpleDataArr[i][0], sCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sCmple, compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), _sCmple(sCmpleDataArr[i][0], sCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpleConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpleDataArr[i][0]), 2, &(sCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpleConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpleConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), sCompareConst(sCmpleDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), sCompareConst(sCmpleDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    //bCompare
    testCaseNum = sizeof(bCmpeqDataArr) / sizeof(bCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), _bCmpeq(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bCmpeq, compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), _bCmpeq(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpeqConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpeqDataArr[i][0]), 2, &(bCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpeqConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpeqConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), bCompareConst(bCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), bCompareConst(bCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(bCmpgtDataArr) / sizeof(bCmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), _bCmpgt(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bCmpgt, compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), _bCmpgt(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpgtConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpgtDataArr[i][0]), 2, &(bCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpgtConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpgtConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), bCompareConst(bCmpgtDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), bCompareConst(bCmpgtDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //ifsCompare
    testCaseNum = sizeof(ifScmpeqDataArr) / sizeof(ifScmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), _ifScmpeq(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifScmpeq, compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), _ifScmpeq(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpeqConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpeqDataArr[i][0]), 2, &(ifScmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpeqConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpeqConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), sCompareConst(ifScmpeqDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), sCompareConst(ifScmpeqDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifScmpneDataArr) / sizeof(ifScmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), _ifScmpne(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifScmpne, compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), _ifScmpne(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpneConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpneDataArr[i][0]), 2, &(ifScmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpneConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpneConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), sCompareConst(ifScmpneDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), sCompareConst(ifScmpneDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifScmpgtDataArr) / sizeof(ifScmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), _ifScmpgt(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifScmpgt, compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), _ifScmpgt(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpgtConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpgtDataArr[i][0]), 2, &(ifScmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpgtConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpgtConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), sCompareConst(ifScmpgtDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), sCompareConst(ifScmpgtDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifScmpltDataArr) / sizeof(ifScmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), _ifScmplt(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifScmplt, compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), _ifScmplt(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpltConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpltDataArr[i][0]), 2, &(ifScmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpltConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpltConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), sCompareConst(ifScmpltDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), sCompareConst(ifScmpltDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifScmpgeDataArr) / sizeof(ifScmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), _ifScmpge(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifScmpge, compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), _ifScmpge(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpgeConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpgeDataArr[i][0]), 2, &(ifScmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpgeConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpgeConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), sCompareConst(ifScmpgeDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), sCompareConst(ifScmpgeDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifScmpleDataArr) / sizeof(ifScmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), _ifScmple(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifScmple, compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), _ifScmple(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpleConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpleDataArr[i][0]), 2, &(ifScmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpleConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpleConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), sCompareConst(ifScmpleDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), sCompareConst(ifScmpleDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    //ifbCompare
    testCaseNum = sizeof(ifBcmpeqDataArr) / sizeof(ifBcmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), _ifBcmpeq(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBcmpeq, compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), _ifBcmpeq(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpeqConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpeqDataArr[i][0]), 2, &(ifBcmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpeqConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpeqConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), bCompareConst(ifBcmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), bCompareConst(ifBcmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBcmpgtDataArr) / sizeof(ifBcmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), _ifBcmpgt(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBcmpgt, compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), _ifBcmpgt(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpgtConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpgtDataArr[i][0]), 2, &(ifBcmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpgtConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpgtConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), bCompareConst(ifBcmpgtDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), bCompareConst(ifBcmpgtDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //iuCompare
    testCaseNum = sizeof(iuCmpeqDataArr) / sizeof(iuCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), _iuCmpeq(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iuCmpeq, compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), _iuCmpeq(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpeqConst1_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpeqDataArr[i][0]), 2, &(iuCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iuCmpeqConst2_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpeqConst3_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), iuCompareConst(iuCmpeqDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), iuCompareConst(iuCmpeqDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(iuCmpneDataArr) / sizeof(iuCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), _iuCmpne(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iuCmpne, compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), _iuCmpne(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpneConst1_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpneDataArr[i][0]), 2, &(iuCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iuCmpneConst2_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpneConst3_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), iuCompareConst(iuCmpneDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), iuCompareConst(iuCmpneDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(iuCmpgeDataArr) / sizeof(iuCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), _iuCmpge(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iuCmpge, compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), _iuCmpge(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpgeConst1_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpgeDataArr[i][0]), 2, &(iuCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iuCmpgeConst2_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpgeConst3_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(iuCmpgeDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(iuCmpgeDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    //suCompare
    testCaseNum = sizeof(suCmpeqDataArr) / sizeof(suCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), _suCmpeq(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1])) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_suCmpeq, compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), _suCmpeq(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1])) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpeqConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpeqDataArr[i][0]), 2, &(suCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpeqConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpeqDataArr[i][1])) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpeqDataArr[i][1])) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpeqConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), suCompareConst(suCmpeqDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), suCompareConst(suCmpeqDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
       }
 
    testCaseNum = sizeof(suCmpneDataArr) / sizeof(suCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), _suCmpne(suCmpneDataArr[i][0], suCmpneDataArr[i][1])) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_suCmpne, compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), _suCmpne(suCmpneDataArr[i][0], suCmpneDataArr[i][1])) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpneConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpneDataArr[i][0]), 2, &(suCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpneConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpneDataArr[i][1])) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpneDataArr[i][1])) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpneConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), suCompareConst(suCmpneDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), suCompareConst(suCmpneDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
       }
 
    testCaseNum = sizeof(suCmpgtDataArr) / sizeof(suCmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), _suCmpgt(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1])) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_suCmpgt, compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), _suCmpgt(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1])) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgtConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpgtDataArr[i][0]), 2, &(suCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgtConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpgtDataArr[i][1])) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpgtDataArr[i][1])) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgtConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), suCompareConst(suCmpgtDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), suCompareConst(suCmpgtDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
       }
 
    testCaseNum = sizeof(suCmpltDataArr) / sizeof(suCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), _suCmplt(suCmpltDataArr[i][0], suCmpltDataArr[i][1])) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_suCmplt, compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), _suCmplt(suCmpltDataArr[i][0], suCmpltDataArr[i][1])) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpltConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpltDataArr[i][0]), 2, &(suCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpltConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpltDataArr[i][1])) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpltDataArr[i][1])) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpltConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), suCompareConst(suCmpltDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), suCompareConst(suCmpltDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
       }
 
    testCaseNum = sizeof(suCmpgeDataArr) / sizeof(suCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), _suCmpge(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1])) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_suCmpge, compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), _suCmpge(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1])) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgeConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpgeDataArr[i][0]), 2, &(suCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgeConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpgeDataArr[i][1])) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpgeDataArr[i][1])) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgeConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), suCompareConst(suCmpgeDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), suCompareConst(suCmpgeDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
       }
 
    testCaseNum = sizeof(suCmpleDataArr) / sizeof(suCmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), _suCmple(suCmpleDataArr[i][0], suCmpleDataArr[i][1])) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_suCmple, compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), _suCmple(suCmpleDataArr[i][0], suCmpleDataArr[i][1])) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpleConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpleDataArr[i][0]), 2, &(suCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpleConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpleDataArr[i][1])) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpleDataArr[i][1])) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpleConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(suCmpleDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(suCmpleDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
       }
 
    //ifBuCompare equal and not equal
    testCaseNum = sizeof(ifBuCmpeqDataArr) / sizeof(ifBuCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), _ifBuCmpeq(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBuCmpeq, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), _ifBuCmpeq(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpeqConst1_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpeqDataArr[i][0]), 2, &(ifBuCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpeqConst2_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpeqConst3_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(ifBuCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(ifBuCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBuCmpneDataArr) / sizeof(ifBuCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), _ifBuCmpne(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBuCmpne, compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), _ifBuCmpne(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpneConst1_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpneDataArr[i][0]), 2, &(ifBuCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpneConst2_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpneConst3_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), buCompareConst(ifBuCmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), buCompareConst(ifBuCmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
 
@@ -1260,212 +1283,212 @@ PPCOpCodesTest::invokeCompareTests()
    testCaseNum = sizeof(ifBuCmpgtDataArr) / sizeof(ifBuCmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), _ifBuCmpgt(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBuCmpgt, compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), _ifBuCmpgt(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpgtConst1_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpgtDataArr[i][0]), 2, &(ifBuCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpgtConst2_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpgtConst3_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), buCompareConst(ifBuCmpgtDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), buCompareConst(ifBuCmpgtDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBuCmpltDataArr) / sizeof(ifBuCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), _ifBuCmplt(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBuCmplt, compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), _ifBuCmplt(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpltConst1_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpltDataArr[i][0]), 2, &(ifBuCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpltConst2_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpltConst3_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), buCompareConst(ifBuCmpltDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), buCompareConst(ifBuCmpltDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBuCmpgeDataArr) / sizeof(ifBuCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), _ifBuCmpge(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBuCmpge, compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), _ifBuCmpge(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpgeConst1_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpgeDataArr[i][0]), 2, &(ifBuCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpgeConst2_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpgeConst3_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), buCompareConst(ifBuCmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), buCompareConst(ifBuCmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBuCmpleDataArr) / sizeof(ifBuCmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), _ifBuCmple(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBuCmple, compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), _ifBuCmple(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpleConst1_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpleDataArr[i][0]), 2, &(ifBuCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpleConst2_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpleConst3_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), buCompareConst(ifBuCmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), buCompareConst(ifBuCmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //ifSuCompare
    testCaseNum = sizeof(ifSuCmpeqDataArr) / sizeof(ifSuCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), _ifSuCmpeq(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1])) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_ifSuCmpeq, compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), _ifSuCmpeq(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1])) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpeqConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpeqDataArr[i][0]), 2, &(ifSuCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpeqConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpeqDataArr[i][1])) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpeqDataArr[i][1])) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpeqConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), suCompareConst(ifSuCmpeqDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), suCompareConst(ifSuCmpeqDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
       }
 
    testCaseNum = sizeof(ifSuCmpneDataArr) / sizeof(ifSuCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), _ifSuCmpne(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1])) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_ifSuCmpne, compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), _ifSuCmpne(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1])) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpneConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpneDataArr[i][0]), 2, &(ifSuCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpneConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpneDataArr[i][1])) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpneDataArr[i][1])) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpneConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), suCompareConst(ifSuCmpneDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), suCompareConst(ifSuCmpneDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
       }
 
    testCaseNum = sizeof(ifSuCmpgtDataArr) / sizeof(ifSuCmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), _ifSuCmpgt(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1])) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_ifSuCmpgt, compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), _ifSuCmpgt(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1])) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgtConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpgtDataArr[i][0]), 2, &(ifSuCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgtConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpgtDataArr[i][1])) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpgtDataArr[i][1])) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgtConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), suCompareConst(ifSuCmpgtDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), suCompareConst(ifSuCmpgtDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
       }
 
    testCaseNum = sizeof(ifSuCmpltDataArr) / sizeof(ifSuCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), _ifSuCmplt(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1])) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_ifSuCmplt, compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), _ifSuCmplt(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1])) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpltConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpltDataArr[i][0]), 2, &(ifSuCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpltConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpltDataArr[i][1])) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpltDataArr[i][1])) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpltConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), suCompareConst(ifSuCmpltDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), suCompareConst(ifSuCmpltDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
       }
 
    testCaseNum = sizeof(ifSuCmpgeDataArr) / sizeof(ifSuCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), _ifSuCmpge(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1])) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_ifSuCmpge, compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), _ifSuCmpge(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1])) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgeConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpgeDataArr[i][0]), 2, &(ifSuCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgeConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpgeDataArr[i][1])) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpgeDataArr[i][1])) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgeConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), suCompareConst(ifSuCmpgeDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), suCompareConst(ifSuCmpgeDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
       }
 
    testCaseNum = sizeof(ifSuCmpleDataArr) / sizeof(ifSuCmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), _ifSuCmple(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1])) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_ifSuCmple, compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), _ifSuCmple(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1])) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpleConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpleDataArr[i][0]), 2, &(ifSuCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpleConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpleDataArr[i][1])) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpleDataArr[i][1])) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpleConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), suCompareConst(ifSuCmpleDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), suCompareConst(ifSuCmpleDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
       }
    }
 
@@ -1625,342 +1648,342 @@ PPCOpCodesTest::invokeAddressTests()
    testCaseNum = sizeof(byteDataArr) / sizeof(byteDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(byteDataArr[i], ADDRESS_PLACEHOLDER_1), _b2a(byteDataArr[i]));
+      OMR_CT_EXPECT_EQ(_b2a, convert(byteDataArr[i], ADDRESS_PLACEHOLDER_1), _b2a(byteDataArr[i]));
 
       sprintf(resolvedMethodName, "b2aConst%d", i + 1);
       b2aConst = (signatureCharB_L_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::b2a, resolvedMethodName, _argTypesUnaryByte, TR::Address, rc, 2, 1, &byteDataArr[i]));
-      EXPECT_EQ(convert(byteDataArr[i], ADDRESS_PLACEHOLDER_1), b2aConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(b2aConst, convert(byteDataArr[i], ADDRESS_PLACEHOLDER_1), b2aConst(BYTE_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(shortDataArr) / sizeof(shortDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(shortDataArr[i], ADDRESS_PLACEHOLDER_1), _s2a(shortDataArr[i]));
+      OMR_CT_EXPECT_EQ(_s2a, convert(shortDataArr[i], ADDRESS_PLACEHOLDER_1), _s2a(shortDataArr[i]));
 
       sprintf(resolvedMethodName, "s2aConst%d", i + 1);
       s2aConst = (signatureCharS_L_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::s2a, resolvedMethodName, _argTypesUnaryShort, TR::Address, rc, 2, 1, &shortDataArr[i]));
-      EXPECT_EQ(convert(shortDataArr[i], ADDRESS_PLACEHOLDER_1), s2aConst(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(s2aConst, convert(shortDataArr[i], ADDRESS_PLACEHOLDER_1), s2aConst(SHORT_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(intDataArr) / sizeof(intDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(intDataArr[i], ADDRESS_PLACEHOLDER_1), _i2a(intDataArr[i]));
+      OMR_CT_EXPECT_EQ(_i2a, convert(intDataArr[i], ADDRESS_PLACEHOLDER_1), _i2a(intDataArr[i]));
 
       sprintf(resolvedMethodName, "i2aConst%d", i + 1);
       i2aConst = (signatureCharI_L_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::i2a, resolvedMethodName, _argTypesUnaryInt, TR::Address, rc, 2, 1, &intDataArr[i]));
-      EXPECT_EQ(convert(intDataArr[i], ADDRESS_PLACEHOLDER_1), i2aConst(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(i2aConst, convert(intDataArr[i], ADDRESS_PLACEHOLDER_1), i2aConst(INT_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(ubyteDataArr) / sizeof(ubyteDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(ubyteDataArr[i], ADDRESS_PLACEHOLDER_1), _bu2a(ubyteDataArr[i]));
+      OMR_CT_EXPECT_EQ(_bu2a, convert(ubyteDataArr[i], ADDRESS_PLACEHOLDER_1), _bu2a(ubyteDataArr[i]));
 
       sprintf(resolvedMethodName, "bu2aConst%d", i + 1);
       bu2aConst = (unsignedSignatureCharB_L_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::bu2a, resolvedMethodName, _argTypesUnaryByte, TR::Address, rc, 2, 1, &ubyteDataArr[i]));
-      EXPECT_EQ(convert(ubyteDataArr[i], ADDRESS_PLACEHOLDER_1), bu2aConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(bu2aConst, convert(ubyteDataArr[i], ADDRESS_PLACEHOLDER_1), bu2aConst(BYTE_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(ulongDataArr) / sizeof(ulongDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(ulongDataArr[i], ADDRESS_PLACEHOLDER_1), _lu2a(ulongDataArr[i]));
+      OMR_CT_EXPECT_EQ(_lu2a, convert(ulongDataArr[i], ADDRESS_PLACEHOLDER_1), _lu2a(ulongDataArr[i]));
 
       sprintf(resolvedMethodName, "lu2aConst%d", i + 1);
       lu2aConst = (unsignedSignatureCharJ_L_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::lu2a, resolvedMethodName, _argTypesUnaryLong, TR::Address, rc, 2, 1, &ulongDataArr[i]));
-      EXPECT_EQ(convert(ulongDataArr[i], ADDRESS_PLACEHOLDER_1), lu2aConst(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lu2aConst, convert(ulongDataArr[i], ADDRESS_PLACEHOLDER_1), lu2aConst(LONG_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(aUnaryDataArr) / sizeof(aUnaryDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(aUnaryDataArr[i], LONG_POS), _a2l(aUnaryDataArr[i]));
+      OMR_CT_EXPECT_EQ(_a2l, convert(aUnaryDataArr[i], LONG_POS), _a2l(aUnaryDataArr[i]));
 
       sprintf(resolvedMethodName, "a2lConst%d", i + 1);
       a2lConst = (signatureCharL_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::a2l, resolvedMethodName, _argTypesUnaryAddress, TR::Int64, rc, 2, 1, &aUnaryDataArr[i]));
-      EXPECT_EQ(convert(aUnaryDataArr[i], LONG_POS), a2lConst(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(a2lConst, convert(aUnaryDataArr[i], LONG_POS), a2lConst(ADDRESS_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(aUnaryDataArr) / sizeof(aUnaryDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(aUnaryDataArr[i], SHORT_POS), _a2s(aUnaryDataArr[i]));
+      OMR_CT_EXPECT_EQ(_a2s, convert(aUnaryDataArr[i], SHORT_POS), _a2s(aUnaryDataArr[i]));
 
       sprintf(resolvedMethodName, "a2sConst%d", i + 1);
       a2sConst = (signatureCharL_S_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::a2s, resolvedMethodName, _argTypesUnaryAddress, TR::Int16, rc, 2, 1, &aUnaryDataArr[i]));
-      EXPECT_EQ(convert(aUnaryDataArr[i], SHORT_POS), a2sConst(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(a2sConst, convert(aUnaryDataArr[i], SHORT_POS), a2sConst(ADDRESS_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(aUnaryDataArr) / sizeof(aUnaryDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(aUnaryDataArr[i], BYTE_POS), _a2b(aUnaryDataArr[i]));
+      OMR_CT_EXPECT_EQ(_a2b, convert(aUnaryDataArr[i], BYTE_POS), _a2b(aUnaryDataArr[i]));
 
       sprintf(resolvedMethodName, "a2bConst%d", i + 1);
       a2bConst = (signatureCharL_B_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::a2b, resolvedMethodName, _argTypesUnaryAddress, TR::Int8, rc, 2, 1, &aUnaryDataArr[i]));
-      EXPECT_EQ(convert(aUnaryDataArr[i], BYTE_POS), a2bConst(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(a2bConst, convert(aUnaryDataArr[i], BYTE_POS), a2bConst(ADDRESS_PLACEHOLDER_1));
       }
 
    //address compare
    testCaseNum = sizeof(acmpeqDataArr) / sizeof(acmpeqDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), _acmpeq(acmpeqDataArr[i][0], acmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_acmpeq, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), _acmpeq(acmpeqDataArr[i][0], acmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpeqConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpeqDataArr[i][0]), 2, &(acmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "aCmpeqConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpeqConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(acmpeqDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(acmpeqDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(acmpneDataArr) / sizeof(acmpneDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), _acmpne(acmpneDataArr[i][0], acmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_acmpne, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), _acmpne(acmpneDataArr[i][0], acmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpneConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpneDataArr[i][0]), 2, &(acmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "aCmpneConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpneConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(acmpneDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(acmpneDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(acmpgtDataArr) / sizeof(acmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), _acmpgt(acmpgtDataArr[i][0], acmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_acmpgt, compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), _acmpgt(acmpgtDataArr[i][0], acmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpgtConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpgtDataArr[i][0]), 2, &(acmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "acmpgtConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpgtConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), aCompareConst(acmpgtDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), aCompareConst(acmpgtDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(acmpltDataArr) / sizeof(acmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), _acmplt(acmpltDataArr[i][0], acmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_acmplt, compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), _acmplt(acmpltDataArr[i][0], acmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpltConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpltDataArr[i][0]), 2, &(acmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "acmpltConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpltConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), aCompareConst(acmpltDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), aCompareConst(acmpltDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(acmpgeDataArr) / sizeof(acmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), _acmpge(acmpgeDataArr[i][0], acmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_acmpge, compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), _acmpge(acmpgeDataArr[i][0], acmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpgeConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpgeDataArr[i][0]), 2, &(acmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "acmpgeConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpgeConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), aCompareConst(acmpgeDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), aCompareConst(acmpgeDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(acmpleDataArr) / sizeof(acmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), _acmple(acmpleDataArr[i][0], acmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_acmple, compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), _acmple(acmpleDataArr[i][0], acmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpleConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpleDataArr[i][0]), 2, &(acmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "acmpleConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpleConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), aCompareConst(acmpleDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), aCompareConst(acmpleDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    //address ifcompare
    testCaseNum = sizeof(ifacmpeqDataArr) / sizeof(ifacmpeqDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), _ifacmpeq(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifacmpeq, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), _ifacmpeq(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpeqConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpeqDataArr[i][0]), 2, &(ifacmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpeqConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpeqConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ifacmpeqDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ifacmpeqDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifacmpneDataArr) / sizeof(ifacmpneDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), _ifacmpne(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifacmpne, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), _ifacmpne(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpneConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpneDataArr[i][0]), 2, &(ifacmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpneConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpneConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ifacmpneDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ifacmpneDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifacmpgtDataArr) / sizeof(ifacmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), _ifacmpgt(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifacmpgt, compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), _ifacmpgt(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpgtConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpgtDataArr[i][0]), 2, &(ifacmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpgtConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpgtConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), aCompareConst(ifacmpgtDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), aCompareConst(ifacmpgtDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifacmpltDataArr) / sizeof(ifacmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), _ifacmplt(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifacmplt, compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), _ifacmplt(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpltConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpltDataArr[i][0]), 2, &(ifacmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpltConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpltConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), aCompareConst(ifacmpltDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), aCompareConst(ifacmpltDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifacmpgeDataArr) / sizeof(ifacmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), _ifacmpge(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifacmpge, compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), _ifacmpge(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpgeConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpgeDataArr[i][0]), 2, &(ifacmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpgeConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpgeConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), aCompareConst(ifacmpgeDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), aCompareConst(ifacmpgeDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifacmpleDataArr) / sizeof(ifacmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), _ifacmple(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifacmple, compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), _ifacmple(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpleConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpleDataArr[i][0]), 2, &(ifacmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpleConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpleConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ifacmpleDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ifacmpleDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    TR_ASSERT((sizeof(aternaryChild1Arr) / sizeof(aternaryChild1Arr[0])) == sizeof(aternaryArr) / sizeof(aternaryArr[0]),
@@ -1968,42 +1991,42 @@ PPCOpCodesTest::invokeAddressTests()
    testCaseNum = sizeof(aternaryChild1Arr) / sizeof(aternaryChild1Arr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), _aternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]));
+      OMR_CT_EXPECT_EQ(_aternary, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), _aternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]));
 
       sprintf(resolvedMethodName, "aTernaryConst1_TestCase%d", i + 1);
       aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
             _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 6, 1, &aternaryChild1Arr[i], 2, &aternaryArr[i][0], 3, &aternaryArr[i][1]));
-      EXPECT_EQ(ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "aTernaryConst2_TestCase%d", i + 1);
       aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
             _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 1, &aternaryChild1Arr[i], 2, &aternaryArr[i][0]));
-      EXPECT_EQ(ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, aternaryArr[i][1]));
+      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, aternaryArr[i][1]));
 
       sprintf(resolvedMethodName, "aTernaryConst3_TestCase%d", i + 1);
       aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
             _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 1, &aternaryChild1Arr[i], 3, &aternaryArr[i][1]));
-      EXPECT_EQ(ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, aternaryArr[i][0], ADDRESS_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, aternaryArr[i][0], ADDRESS_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "aTernaryConst4_TestCase%d", i + 1);
       aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
             _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 2, &aternaryArr[i][0], 3, &aternaryArr[i][1]));
-      EXPECT_EQ(ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "aTernaryConst5_TestCase%d", i + 1);
       aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
             _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 1, &aternaryChild1Arr[i]));
-      EXPECT_EQ(ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, aternaryArr[i][0], aternaryArr[i][1]));
+      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, aternaryArr[i][0], aternaryArr[i][1]));
 
       sprintf(resolvedMethodName, "aTernaryConst6_TestCase%d", i + 1);
       aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
             _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 2, &aternaryArr[i][0]));
-      EXPECT_EQ(ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], ADDRESS_PLACEHOLDER_1, aternaryArr[i][1]));
+      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], ADDRESS_PLACEHOLDER_1, aternaryArr[i][1]));
 
       sprintf(resolvedMethodName, "aTernaryConst7_TestCase%d", i + 1);
       aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
             _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 3, &aternaryArr[i][1]));
-      EXPECT_EQ(ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], aternaryArr[i][0], ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], aternaryArr[i][0], ADDRESS_PLACEHOLDER_1));
       }
 
    }
@@ -2079,42 +2102,42 @@ PPCOpCodesTest::invokeTernaryTests()
    TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in bternary input array");
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), _bternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bternary, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), _bternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bTernaryConst1_Testcase%d", i + 1);
       bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
             resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 6, 1, &bternaryChild1Arr[i], 2, &byteDataArr[i][0], 3, &byteDataArr[i][1]));
-      EXPECT_EQ(ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2, BYTE_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2, BYTE_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "bTernaryConst2_Testcase%d", i + 1);
       bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
             resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 4, 1, &bternaryChild1Arr[i], 2, &byteDataArr[i][0]));
-      EXPECT_EQ(ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2, byteDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2, byteDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bTernaryConst3_Testcase%d", i + 1);
       bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
             resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 4, 1, &bternaryChild1Arr[i], 3, &byteDataArr[i][1]));
-      EXPECT_EQ(ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, byteDataArr[i][0], BYTE_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, byteDataArr[i][0], BYTE_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "bTernaryConst4_Testcase%d", i + 1);
       bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
             resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 4, 2, &byteDataArr[i][0], 3, &byteDataArr[i][1]));
-      EXPECT_EQ(ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(bternaryChild1Arr[i], BYTE_PLACEHOLDER_2, BYTE_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(bternaryChild1Arr[i], BYTE_PLACEHOLDER_2, BYTE_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "bTernaryConst5_Testcase%d", i + 1);
       bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
             resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 2, 1, &bternaryChild1Arr[i]));
-      EXPECT_EQ(ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, byteDataArr[i][0], byteDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, byteDataArr[i][0], byteDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bTernaryConst6_Testcase%d", i + 1);
       bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
             resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 2, 2, &byteDataArr[i][0]));
-      EXPECT_EQ(ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(bternaryChild1Arr[i], BYTE_PLACEHOLDER_1, byteDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(bternaryChild1Arr[i], BYTE_PLACEHOLDER_1, byteDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bTernaryConst7_Testcase%d", i + 1);
       bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
             resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 2, 3, &byteDataArr[i][1]));
-      EXPECT_EQ(ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(bternaryChild1Arr[i], byteDataArr[i][0], BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(bternaryChild1Arr[i], byteDataArr[i][0], BYTE_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(sternaryChild1Arr) / sizeof(sternaryChild1Arr[0]);
@@ -2122,42 +2145,42 @@ PPCOpCodesTest::invokeTernaryTests()
    TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in sternary input array");
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), _sternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sternary, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), _sternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sTernaryConst1_Testcase%d", i + 1);
       sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
             resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 6, 1, &sternaryChild1Arr[i], 2, &shortDataArr[i][0], 3, &shortDataArr[i][1]));
-      EXPECT_EQ(ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2, SHORT_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2, SHORT_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "sTernaryConst2_Testcase%d", i + 1);
       sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
             resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 4, 1, &sternaryChild1Arr[i], 2, &shortDataArr[i][0]));
-      EXPECT_EQ(ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2, shortDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2, shortDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sTernaryConst3_Testcase%d", i + 1);
       sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
             resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 4, 1, &sternaryChild1Arr[i], 3, &shortDataArr[i][1]));
-      EXPECT_EQ(ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, shortDataArr[i][0], SHORT_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, shortDataArr[i][0], SHORT_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "sTernaryConst4_Testcase%d", i + 1);
       sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
             resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 4, 2, &shortDataArr[i][0], 3, &shortDataArr[i][1]));
-      EXPECT_EQ(ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(sternaryChild1Arr[i], SHORT_PLACEHOLDER_2, SHORT_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(sternaryChild1Arr[i], SHORT_PLACEHOLDER_2, SHORT_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "sTernaryConst5_Testcase%d", i + 1);
       sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
             resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 2, 1, &sternaryChild1Arr[i]));
-      EXPECT_EQ(ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, shortDataArr[i][0], shortDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, shortDataArr[i][0], shortDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sTernaryConst6_Testcase%d", i + 1);
       sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
             resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 2, 2, &shortDataArr[i][0]));
-      EXPECT_EQ(ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(sternaryChild1Arr[i], SHORT_PLACEHOLDER_1, shortDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(sternaryChild1Arr[i], SHORT_PLACEHOLDER_1, shortDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sTernaryConst7_Testcase%d", i + 1);
       sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
             resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 2, 3, &shortDataArr[i][1]));
-      EXPECT_EQ(ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(sternaryChild1Arr[i], shortDataArr[i][0], SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(sternaryChild1Arr[i], shortDataArr[i][0], SHORT_PLACEHOLDER_1));
       }
    }
 
@@ -2228,88 +2251,88 @@ PPCOpCodesTest::invokeShiftOrRolTests()
    testCaseNum = sizeof(irolDataArr) / sizeof(irolDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(rol(irolDataArr[i][0], irolDataArr[i][1]), _iRol(irolDataArr[i][0], irolDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iRol, rol(irolDataArr[i][0], irolDataArr[i][1]), _iRol(irolDataArr[i][0], irolDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iRolConst1_TestCase%d", i + 1);
       iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::irol, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &irolDataArr[i][0], 2, &irolDataArr[i][1]));
-      EXPECT_EQ(rol(irolDataArr[i][0], irolDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iShiftOrRolConst, rol(irolDataArr[i][0], irolDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iRolConst2_TestCase%d", i + 1);
       iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::irol, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &irolDataArr[i][0]));
-      EXPECT_EQ(rol(irolDataArr[i][0], irolDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, irolDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iShiftOrRolConst, rol(irolDataArr[i][0], irolDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, irolDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iRolConst3_TestCase%d", i + 1);
       iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::irol, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &irolDataArr[i][1]));
-      EXPECT_EQ(rol(irolDataArr[i][0], irolDataArr[i][1]), iShiftOrRolConst(irolDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iShiftOrRolConst, rol(irolDataArr[i][0], irolDataArr[i][1]), iShiftOrRolConst(irolDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    //bshl
    testCaseNum = sizeof(bshlDataArr) / sizeof(bshlDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shl(bshlDataArr[i][0], bshlDataArr[i][1]), _bShl(bshlDataArr[i][0],bshlDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bShl, shl(bshlDataArr[i][0], bshlDataArr[i][1]), _bShl(bshlDataArr[i][0],bshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bShlConst1_TestCase%d", i + 1);
       bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bshl, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &bshlDataArr[i][0], 2, &bshlDataArr[i][1]));
-      EXPECT_EQ(shl(bshlDataArr[i][0], bshlDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bShiftOrRolConst, shl(bshlDataArr[i][0], bshlDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bShlConst2_TestCase%d", i + 1);
       bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bshl, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &bshlDataArr[i][0]));
-      EXPECT_EQ(shl(bshlDataArr[i][0], bshlDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, bshlDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bShiftOrRolConst, shl(bshlDataArr[i][0], bshlDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, bshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bShlConst3_TestCase%d", i + 1);
       bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bshl, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &bshlDataArr[i][1]));
-      EXPECT_EQ(shl(bshlDataArr[i][0], bshlDataArr[i][1]), bShiftOrRolConst(bshlDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bShiftOrRolConst, shl(bshlDataArr[i][0], bshlDataArr[i][1]), bShiftOrRolConst(bshlDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //bushr
    testCaseNum = sizeof(bushrDataArr) / sizeof(bushrDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shr(bushrDataArr[i][0], bushrDataArr[i][1]), _buShr(bushrDataArr[i][0], bushrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_buShr, shr(bushrDataArr[i][0], bushrDataArr[i][1]), _buShr(bushrDataArr[i][0], bushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buShrConst1_TestCase%d", i + 1);
       buShiftOrRolConst = (unsignedSignatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bushr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &bushrDataArr[i][0], 2, &bushrDataArr[i][1]));
-      EXPECT_EQ(shr(bushrDataArr[i][0], bushrDataArr[i][1]), buShiftOrRolConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buShiftOrRolConst, shr(bushrDataArr[i][0], bushrDataArr[i][1]), buShiftOrRolConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "buShrConst2_TestCase%d", i + 1);
       buShiftOrRolConst = (unsignedSignatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bushr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &bushrDataArr[i][0]));
-      EXPECT_EQ(shr(bushrDataArr[i][0], bushrDataArr[i][1]), buShiftOrRolConst(BYTE_PLACEHOLDER_1, bushrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(buShiftOrRolConst, shr(bushrDataArr[i][0], bushrDataArr[i][1]), buShiftOrRolConst(BYTE_PLACEHOLDER_1, bushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buShrConst3_TestCase%d", i + 1);
       buShiftOrRolConst = (unsignedSignatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bushr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &bushrDataArr[i][1]));
-      EXPECT_EQ(shr(bushrDataArr[i][0], bushrDataArr[i][1]), buShiftOrRolConst(bushrDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buShiftOrRolConst, shr(bushrDataArr[i][0], bushrDataArr[i][1]), buShiftOrRolConst(bushrDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //sshr
    testCaseNum = sizeof(sshrDataArr) / sizeof(sshrDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shr(sshrDataArr[i][0], sshrDataArr[i][1]), _sShr(sshrDataArr[i][0], sshrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sShr, shr(sshrDataArr[i][0], sshrDataArr[i][1]), _sShr(sshrDataArr[i][0], sshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sShrConst1_TestCase%d", i + 1);
       sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sshr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &sshrDataArr[i][0], 2, &sshrDataArr[i][1]));
-      EXPECT_EQ(shr(sshrDataArr[i][0], sshrDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sShiftOrRolConst, shr(sshrDataArr[i][0], sshrDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sShrConst2_TestCase%d", i + 1);
       sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sshr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &sshrDataArr[i][0]));
-      EXPECT_EQ(shr(sshrDataArr[i][0], sshrDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, sshrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sShiftOrRolConst, shr(sshrDataArr[i][0], sshrDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, sshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sShrConst3_TestCase%d", i + 1);
       sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sshr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &sshrDataArr[i][1]));
-      EXPECT_EQ(shr(sshrDataArr[i][0], sshrDataArr[i][1]), sShiftOrRolConst(sshrDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sShiftOrRolConst, shr(sshrDataArr[i][0], sshrDataArr[i][1]), sShiftOrRolConst(sshrDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
    }
 
@@ -2371,132 +2394,132 @@ PPCOpCodesTest::invokeBitwiseTests()
    testCaseNum = sizeof(byteAndArr) / sizeof(byteAndArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(tand(byteAndArr[i][0], byteAndArr[i][1]), _bAnd(byteAndArr[i][0], byteAndArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bAnd, tand(byteAndArr[i][0], byteAndArr[i][1]), _bAnd(byteAndArr[i][0], byteAndArr[i][1]));
 
       sprintf(resolvedMethodName, "bAndConst1_TestCase%d", i + 1);
       bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::band, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &(byteAndArr[i][0]), 2, &(byteAndArr[i][1])));
-      EXPECT_EQ(tand(byteAndArr[i][0], byteAndArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bBitwiseConst, tand(byteAndArr[i][0], byteAndArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bAndConst2_TestCase%d", i + 1);
       bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::band, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &(byteAndArr[i][0])));
-      EXPECT_EQ(tand(byteAndArr[i][0], byteAndArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, byteAndArr[i][1]));
+      OMR_CT_EXPECT_EQ(bBitwiseConst, tand(byteAndArr[i][0], byteAndArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, byteAndArr[i][1]));
 
       sprintf(resolvedMethodName, "bAndConst3_TestCase%d", i + 1);
       bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::band, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &(byteAndArr[i][1])));
-      EXPECT_EQ(tand(byteAndArr[i][0], byteAndArr[i][1]), bBitwiseConst(byteAndArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bBitwiseConst, tand(byteAndArr[i][0], byteAndArr[i][1]), bBitwiseConst(byteAndArr[i][0], BYTE_PLACEHOLDER_2));
      }
 
    //bor
    testCaseNum = sizeof(byteOrArr) / sizeof(byteOrArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(tor(byteOrArr[i][0], byteOrArr[i][1]), _bOr(byteOrArr[i][0], byteOrArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bOr, tor(byteOrArr[i][0], byteOrArr[i][1]), _bOr(byteOrArr[i][0], byteOrArr[i][1]));
 
       sprintf(resolvedMethodName, "bOrConst1_TestCase%d", i + 1);
       bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &(byteOrArr[i][0]), 2, &(byteOrArr[i][1])));
-      EXPECT_EQ(tor(byteOrArr[i][0], byteOrArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bBitwiseConst, tor(byteOrArr[i][0], byteOrArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bOrConst2_TestCase%d", i + 1);
       bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &(byteOrArr[i][0])));
-      EXPECT_EQ(tor(byteOrArr[i][0], byteOrArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, byteOrArr[i][1]));
+      OMR_CT_EXPECT_EQ(bBitwiseConst, tor(byteOrArr[i][0], byteOrArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, byteOrArr[i][1]));
 
       sprintf(resolvedMethodName, "bOrConst3_TestCase%d", i + 1);
       bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &(byteOrArr[i][1])));
-      EXPECT_EQ(tor(byteOrArr[i][0], byteOrArr[i][1]), bBitwiseConst(byteOrArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bBitwiseConst, tor(byteOrArr[i][0], byteOrArr[i][1]), bBitwiseConst(byteOrArr[i][0], BYTE_PLACEHOLDER_2));
      }
 
    //bxor
    testCaseNum = sizeof(byteXorArr) / sizeof(byteXorArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(txor(byteXorArr[i][0], byteXorArr[i][1]), _bXor(byteXorArr[i][0], byteXorArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bXor, txor(byteXorArr[i][0], byteXorArr[i][1]), _bXor(byteXorArr[i][0], byteXorArr[i][1]));
 
       sprintf(resolvedMethodName, "bXorConst1_TestCase%d", i + 1);
       bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bxor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &(byteXorArr[i][0]), 2, &(byteXorArr[i][1])));
-      EXPECT_EQ(txor(byteXorArr[i][0], byteXorArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bBitwiseConst, txor(byteXorArr[i][0], byteXorArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bXorConst2_TestCase%d", i + 1);
       bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bxor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &(byteXorArr[i][0])));
-      EXPECT_EQ(txor(byteXorArr[i][0], byteXorArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, byteXorArr[i][1]));
+      OMR_CT_EXPECT_EQ(bBitwiseConst, txor(byteXorArr[i][0], byteXorArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, byteXorArr[i][1]));
 
       sprintf(resolvedMethodName, "bXorConst3_TestCase%d", i + 1);
       bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bxor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &(byteXorArr[i][1])));
-      EXPECT_EQ(txor(byteXorArr[i][0], byteXorArr[i][1]), bBitwiseConst(byteXorArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bBitwiseConst, txor(byteXorArr[i][0], byteXorArr[i][1]), bBitwiseConst(byteXorArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //sand
    testCaseNum = sizeof(shortAndArr) / sizeof(shortAndArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(tand(shortAndArr[i][0], shortAndArr[i][1]), _sAnd(shortAndArr[i][0], shortAndArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sAnd, tand(shortAndArr[i][0], shortAndArr[i][1]), _sAnd(shortAndArr[i][0], shortAndArr[i][1]));
 
       sprintf(resolvedMethodName, "sAndConst1_TestCase%d", i + 1);
       sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sand, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &(shortAndArr[i][0]), 2, &(shortAndArr[i][1])));
-      EXPECT_EQ(tand(shortAndArr[i][0], shortAndArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sBitwiseConst, tand(shortAndArr[i][0], shortAndArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sAndConst2_TestCase%d", i + 1);
       sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sand, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &(shortAndArr[i][0])));
-      EXPECT_EQ(tand(shortAndArr[i][0], shortAndArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, shortAndArr[i][1]));
+      OMR_CT_EXPECT_EQ(sBitwiseConst, tand(shortAndArr[i][0], shortAndArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, shortAndArr[i][1]));
 
       sprintf(resolvedMethodName, "sAndConst3_TestCase%d", i + 1);
       sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sand, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &(shortAndArr[i][1])));
-      EXPECT_EQ(tand(shortAndArr[i][0], shortAndArr[i][1]), sBitwiseConst(shortAndArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sBitwiseConst, tand(shortAndArr[i][0], shortAndArr[i][1]), sBitwiseConst(shortAndArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    //sor
    testCaseNum = sizeof(shortOrArr) / sizeof(shortOrArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(tor(shortOrArr[i][0], shortOrArr[i][1]), _sOr(shortOrArr[i][0], shortOrArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sOr, tor(shortOrArr[i][0], shortOrArr[i][1]), _sOr(shortOrArr[i][0], shortOrArr[i][1]));
 
       sprintf(resolvedMethodName, "sOrConst1_TestCase%d", i + 1);
       sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &(shortOrArr[i][0]), 2, &(shortOrArr[i][1])));
-      EXPECT_EQ(tor(shortOrArr[i][0], shortOrArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sBitwiseConst, tor(shortOrArr[i][0], shortOrArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sOrConst2_TestCase%d", i + 1);
       sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &(shortOrArr[i][0])));
-      EXPECT_EQ(tor(shortOrArr[i][0], shortOrArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, shortOrArr[i][1]));
+      OMR_CT_EXPECT_EQ(sBitwiseConst, tor(shortOrArr[i][0], shortOrArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, shortOrArr[i][1]));
 
       sprintf(resolvedMethodName, "sOrConst3_TestCase%d", i + 1);
       sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &(shortOrArr[i][1])));
-      EXPECT_EQ(tor(shortOrArr[i][0], shortOrArr[i][1]), sBitwiseConst(shortOrArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sBitwiseConst, tor(shortOrArr[i][0], shortOrArr[i][1]), sBitwiseConst(shortOrArr[i][0], SHORT_PLACEHOLDER_2));
      }
 
    //sxor
    testCaseNum = sizeof(shortXorArr) / sizeof(shortXorArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(txor(shortXorArr[i][0], shortXorArr[i][1]), _sXor(shortXorArr[i][0], shortXorArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sXor, txor(shortXorArr[i][0], shortXorArr[i][1]), _sXor(shortXorArr[i][0], shortXorArr[i][1]));
 
       sprintf(resolvedMethodName, "sXorConst1_TestCase%d", i + 1);
       sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sxor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &(shortXorArr[i][0]), 2, &(shortXorArr[i][1])));
-      EXPECT_EQ(txor(shortXorArr[i][0], shortXorArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sBitwiseConst, txor(shortXorArr[i][0], shortXorArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sXorConst2_TestCase%d", i + 1);
       sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sxor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &(shortXorArr[i][0])));
-      EXPECT_EQ(txor(shortXorArr[i][0], shortXorArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, shortXorArr[i][1]));
+      OMR_CT_EXPECT_EQ(sBitwiseConst, txor(shortXorArr[i][0], shortXorArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, shortXorArr[i][1]));
 
       sprintf(resolvedMethodName, "sXorConst3_TestCase%d", i + 1);
       sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sxor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &(shortXorArr[i][1])));
-      EXPECT_EQ(txor(shortXorArr[i][0], shortXorArr[i][1]), sBitwiseConst(shortXorArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sBitwiseConst, txor(shortXorArr[i][0], shortXorArr[i][1]), sBitwiseConst(shortXorArr[i][0], SHORT_PLACEHOLDER_2));
      }
    }
 
@@ -2552,105 +2575,105 @@ PPCOpCodesTest::invokeDisabledConvertTests()
    testCaseNum = sizeof(uintDataArray) / sizeof(uintDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(uintDataArray[i], FLOAT_POS), _iu2f(uintDataArray[i]));
-      EXPECT_EQ(convert(uintDataArray[i], DOUBLE_POS), _iu2d(uintDataArray[i]));
+      OMR_CT_EXPECT_EQ(_iu2f, convert(uintDataArray[i], FLOAT_POS), _iu2f(uintDataArray[i]));
+      OMR_CT_EXPECT_EQ(_iu2d, convert(uintDataArray[i], DOUBLE_POS), _iu2d(uintDataArray[i]));
 
       sprintf(resolvedMethodName, "iu2fConst%d", i + 1);
       iu2fConst = (unsignedSignatureCharI_F_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::iu2f, resolvedMethodName, _argTypesUnaryInt, TR::Float, rc, 2, 1, &uintDataArray[i]));
-      EXPECT_EQ(convert(uintDataArray[i], FLOAT_POS), iu2fConst(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(iu2fConst, convert(uintDataArray[i], FLOAT_POS), iu2fConst(INT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "iu2dConst%d", i + 1);
       iu2dConst = (unsignedSignatureCharI_D_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::iu2d, resolvedMethodName, _argTypesUnaryInt, TR::Double, rc, 2, 1, &uintDataArray[i]));
-      EXPECT_EQ(convert(uintDataArray[i], DOUBLE_POS), iu2dConst(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(iu2dConst, convert(uintDataArray[i], DOUBLE_POS), iu2dConst(INT_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(ubyteDataArray) / sizeof(ubyteDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(ubyteDataArray[i], FLOAT_POS), _bu2f(ubyteDataArray[i]));
-      EXPECT_EQ(convert(ubyteDataArray[i], DOUBLE_POS), _bu2d(ubyteDataArray[i]));
+      OMR_CT_EXPECT_EQ(_bu2f, convert(ubyteDataArray[i], FLOAT_POS), _bu2f(ubyteDataArray[i]));
+      OMR_CT_EXPECT_EQ(_bu2d, convert(ubyteDataArray[i], DOUBLE_POS), _bu2d(ubyteDataArray[i]));
 
       sprintf(resolvedMethodName, "bu2fConst%d", i + 1);
       bu2fConst = (unsignedSignatureCharB_F_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::bu2f, resolvedMethodName, _argTypesUnaryByte, TR::Float, rc, 2, 1, &ubyteDataArray[i]));
-      EXPECT_EQ(convert(ubyteDataArray[i], FLOAT_POS), bu2fConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(bu2fConst, convert(ubyteDataArray[i], FLOAT_POS), bu2fConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "bu2dConst%d", i + 1);
       bu2dConst = (unsignedSignatureCharB_D_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::bu2d, resolvedMethodName, _argTypesUnaryByte, TR::Double, rc, 2, 1, &ubyteDataArray[i]));
-      EXPECT_EQ(convert(ubyteDataArray[i], DOUBLE_POS), bu2dConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(bu2dConst, convert(ubyteDataArray[i], DOUBLE_POS), bu2dConst(BYTE_PLACEHOLDER_1));
       }
 
    //iu2l
    testCaseNum = sizeof(uintDataArray) / sizeof(uintDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(uintDataArray[i], LONG_POS), _iu2l(uintDataArray[i]));
+      OMR_CT_EXPECT_EQ(_iu2l, convert(uintDataArray[i], LONG_POS), _iu2l(uintDataArray[i]));
 
       sprintf(resolvedMethodName, "iu2lConst%d", i + 1);
       iu2lConst = (unsignedSignatureCharI_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iu2l,
             resolvedMethodName, _argTypesUnaryInt, TR::Int64, rc, 2, 1, &uintDataArray[i]));
-      EXPECT_EQ(convert(uintDataArray[i], LONG_POS), iu2lConst(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(iu2lConst, convert(uintDataArray[i], LONG_POS), iu2lConst(INT_PLACEHOLDER_1));
       }
 
    //f2d
    testCaseNum = sizeof(floatDataArray) / sizeof(floatDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_DOUBLE_EQ(convert(floatDataArray[i], DOUBLE_POS), _f2d(floatDataArray[i]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_f2d, convert(floatDataArray[i], DOUBLE_POS), _f2d(floatDataArray[i]));
 
       sprintf(resolvedMethodName, "f2dConst%d", i + 1);
       f2dConst = (signatureCharF_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2d,
             resolvedMethodName, _argTypesUnaryFloat, TR::Double, rc, 2, 1, &floatDataArray[i]));
-      EXPECT_EQ(convert(floatDataArray[i], DOUBLE_POS), f2dConst(FLOAT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(f2dConst, convert(floatDataArray[i], DOUBLE_POS), f2dConst(FLOAT_PLACEHOLDER_1));
       }
 
    //d2f
    testCaseNum = sizeof(doubleDataArray) / sizeof(doubleDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_FLOAT_EQ(convert(doubleDataArray[i], FLOAT_POS), _d2f(doubleDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_d2f, convert(doubleDataArray[i], FLOAT_POS), _d2f(doubleDataArray[i]));
 
       sprintf(resolvedMethodName, "d2fConst%d", i + 1);
       d2fConst = (signatureCharD_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2f,
             resolvedMethodName, _argTypesUnaryDouble, TR::Float, rc, 2, 1, &doubleDataArray[i]));
-      EXPECT_FLOAT_EQ(convert(doubleDataArray[i], FLOAT_POS), d2fConst(DOUBLE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_FLOAT_EQ(d2fConst, convert(doubleDataArray[i], FLOAT_POS), d2fConst(DOUBLE_PLACEHOLDER_1));
       }
 
    //Jazz103 109605:
    testCaseNum = sizeof(longDataArray) / sizeof(longDataArray[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(longDataArray[i], ADDRESS_PLACEHOLDER_1), _l2a(longDataArray[i]));
+      OMR_CT_EXPECT_EQ(_l2a, convert(longDataArray[i], ADDRESS_PLACEHOLDER_1), _l2a(longDataArray[i]));
 
       sprintf(resolvedMethodName, "l2aConst%d", i + 1);
       l2aConst = (signatureCharJ_L_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::l2a, resolvedMethodName, _argTypesUnaryLong, TR::Address, rc, 2, 1, &longDataArray[i]));
-      EXPECT_EQ(convert(longDataArray[i], ADDRESS_PLACEHOLDER_1), l2aConst(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(l2aConst, convert(longDataArray[i], ADDRESS_PLACEHOLDER_1), l2aConst(LONG_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(ushortDataArray) / sizeof(ushortDataArray[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(ushortDataArray[i], ADDRESS_PLACEHOLDER_1), _su2a(ushortDataArray[i]));
+      OMR_CT_EXPECT_EQ(_su2a, convert(ushortDataArray[i], ADDRESS_PLACEHOLDER_1), _su2a(ushortDataArray[i]));
 
       sprintf(resolvedMethodName, "su2aConst%d", i + 1);
       su2aConst = (unsignedSignatureCharS_L_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::su2a, resolvedMethodName, _argTypesUnaryShort, TR::Address, rc, 2, 1, &ushortDataArray[i]));
-      EXPECT_EQ(convert(ushortDataArray[i], ADDRESS_PLACEHOLDER_1), su2aConst(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(su2aConst, convert(ushortDataArray[i], ADDRESS_PLACEHOLDER_1), su2aConst(SHORT_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(uintDataArray) / sizeof(uintDataArray[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(uintDataArray[i], ADDRESS_PLACEHOLDER_1), _iu2a(uintDataArray[i]));
+      OMR_CT_EXPECT_EQ(_iu2a, convert(uintDataArray[i], ADDRESS_PLACEHOLDER_1), _iu2a(uintDataArray[i]));
 
       sprintf(resolvedMethodName, "iu2aConst%d", i + 1);
       iu2aConst = (unsignedSignatureCharI_L_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::iu2a, resolvedMethodName, _argTypesUnaryInt, TR::Address, rc, 2, 1, &uintDataArray[i]));
-      EXPECT_EQ(convert(uintDataArray[i], ADDRESS_PLACEHOLDER_1), iu2aConst(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(iu2aConst, convert(uintDataArray[i], ADDRESS_PLACEHOLDER_1), iu2aConst(INT_PLACEHOLDER_1));
       }
    }
 
@@ -3007,430 +3030,430 @@ PPCOpCodesTest::invokeDisabledCompareTests()
    testCaseNum = sizeof(lCmpeqDataArr) / sizeof(lCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), _lCmpeq(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lCmpeq, compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), _lCmpeq(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpeqConst1_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpeqDataArr[i][0]), 2, &(lCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lCmpeqConst2_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpeqConst3_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), lCompareConst(lCmpeqDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), lCompareConst(lCmpeqDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //lcmplt
    testCaseNum = sizeof(lCmpltDataArr) / sizeof(lCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), _lCmplt(lCmpltDataArr[i][0], lCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lCmplt, compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), _lCmplt(lCmpltDataArr[i][0], lCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpltConst1_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpltDataArr[i][0]), 2, &(lCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lCmpltConst2_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpltConst3_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), lCompareConst(lCmpltDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), lCompareConst(lCmpltDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //dCompare
    testCaseNum = sizeof(dCmpeqDataArr) / sizeof(dCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), _dCmpeq(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_dCmpeq, compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), _dCmpeq(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpeqConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpeqDataArr[i][0]), 2, &(dCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpeqConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpeqConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), dCompareConst(dCmpeqDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), dCompareConst(dCmpeqDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(dCmpneDataArr) / sizeof(dCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), _dCmpne(dCmpneDataArr[i][0], dCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_dCmpne, compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), _dCmpne(dCmpneDataArr[i][0], dCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpneConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpneDataArr[i][0]), 2, &(dCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpneConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpneConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), dCompareConst(dCmpneDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), dCompareConst(dCmpneDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(dCmpgtDataArr) / sizeof(dCmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), _dCmpgt(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_dCmpgt, compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), _dCmpgt(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpgtConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpgtDataArr[i][0]), 2, &(dCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpgtConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpgtConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), dCompareConst(dCmpgtDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), dCompareConst(dCmpgtDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(dCmpltDataArr) / sizeof(dCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), _dCmplt(dCmpltDataArr[i][0], dCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_dCmplt, compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), _dCmplt(dCmpltDataArr[i][0], dCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpltConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpltDataArr[i][0]), 2, &(dCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpltConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpltConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), dCompareConst(dCmpltDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), dCompareConst(dCmpltDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(dCmpgeDataArr) / sizeof(dCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), _dCmpge(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_dCmpge, compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), _dCmpge(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpgeConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpgeDataArr[i][0]), 2, &(dCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpgeConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpgeConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), dCompareConst(dCmpgeDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), dCompareConst(dCmpgeDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(dCmpleDataArr) / sizeof(dCmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), _dCmple(dCmpleDataArr[i][0], dCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_dCmple, compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), _dCmple(dCmpleDataArr[i][0], dCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpleConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpleDataArr[i][0]), 2, &(dCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpleConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpleConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), dCompareConst(dCmpleDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), dCompareConst(dCmpleDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    //fCompare
    testCaseNum = sizeof(fCmpeqDataArr) / sizeof(fCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), _fCmpeq(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_fCmpeq, compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), _fCmpeq(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpeqConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpeqDataArr[i][0]), 2, &(fCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpeqConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpeqConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), fCompareConst(fCmpeqDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), fCompareConst(fCmpeqDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(fCmpneDataArr) / sizeof(fCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), _fCmpne(fCmpneDataArr[i][0], fCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_fCmpne, compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), _fCmpne(fCmpneDataArr[i][0], fCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpneConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpneDataArr[i][0]), 2, &(fCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpneConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpneConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), fCompareConst(fCmpneDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), fCompareConst(fCmpneDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(fCmpgtDataArr) / sizeof(fCmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), _fCmpgt(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_fCmpgt, compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), _fCmpgt(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpgtConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpgtDataArr[i][0]), 2, &(fCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpgtConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpgtConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), fCompareConst(fCmpgtDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), fCompareConst(fCmpgtDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(fCmpltDataArr) / sizeof(fCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), _fCmplt(fCmpltDataArr[i][0], fCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_fCmplt, compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), _fCmplt(fCmpltDataArr[i][0], fCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpltConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpltDataArr[i][0]), 2, &(fCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpltConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpltConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), fCompareConst(fCmpltDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), fCompareConst(fCmpltDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(fCmpgeDataArr) / sizeof(fCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), _fCmpge(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_fCmpge, compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), _fCmpge(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpgeConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpgeDataArr[i][0]), 2, &(fCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpgeConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpgeConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), fCompareConst(fCmpgeDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), fCompareConst(fCmpgeDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(fCmpleDataArr) / sizeof(fCmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), _fCmple(fCmpleDataArr[i][0], fCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_fCmple, compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), _fCmple(fCmpleDataArr[i][0], fCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpleConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpleDataArr[i][0]), 2, &(fCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpleConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpleConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), fCompareConst(fCmpleDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), fCompareConst(fCmpleDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    //bCompare
    testCaseNum = sizeof(bCmpneDataArr) / sizeof(bCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), _bCmpne(bCmpneDataArr[i][0], bCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bCmpne, compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), _bCmpne(bCmpneDataArr[i][0], bCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpneConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpneDataArr[i][0]), 2, &(bCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpneConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpneConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), bCompareConst(bCmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), bCompareConst(bCmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(bCmpleDataArr) / sizeof(bCmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), _bCmple(bCmpleDataArr[i][0], bCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bCmple, compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), _bCmple(bCmpleDataArr[i][0], bCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpleConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpleDataArr[i][0]), 2, &(bCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpleConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpleConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), bCompareConst(bCmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), bCompareConst(bCmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(bCmpltDataArr) / sizeof(bCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), _bCmplt(bCmpltDataArr[i][0], bCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bCmplt, compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), _bCmplt(bCmpltDataArr[i][0], bCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpltConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpltDataArr[i][0]), 2, &(bCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpltConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpltConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), bCompareConst(bCmpltDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), bCompareConst(bCmpltDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(bCmpgeDataArr) / sizeof(bCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), _bCmpge(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bCmpge, compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), _bCmpge(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpgeConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpgeDataArr[i][0]), 2, &(bCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpgeConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpgeConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), bCompareConst(bCmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), bCompareConst(bCmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //lcmp
    testCaseNum = sizeof(lCmpDataArr) / sizeof(lCmpDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), _lCmp(lCmpDataArr[i][0], lCmpDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lCmp, comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), _lCmp(lCmpDataArr[i][0], lCmpDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpConst1_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmp, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpDataArr[i][0]), 2, &(lCmpDataArr[i][1])));
-      EXPECT_EQ(comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lCmpConst2_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmp, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpDataArr[i][0])));
-      EXPECT_EQ(comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lCompareConst, comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpConst3_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmp, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpDataArr[i][1])));
-      EXPECT_EQ(comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), lCompareConst(lCmpDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), lCompareConst(lCmpDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //dcmpl
    testCaseNum = sizeof(dCmplDataArr) / sizeof(dCmplDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), _dCmpl(dCmplDataArr[i][0], dCmplDataArr[i][1])) <<
+      OMR_CT_EXPECT_EQ(_dCmpl, comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), _dCmpl(dCmplDataArr[i][0], dCmplDataArr[i][1])) <<
             dCmplDataArr[i][0] << " : " << dCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmplConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpl, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmplDataArr[i][0]), 2, &(dCmplDataArr[i][1])));
-      EXPECT_EQ(comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2)) <<
+      OMR_CT_EXPECT_EQ(dCompareConst, comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2)) <<
             dCmplDataArr[i][0] << " : " << dCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmplConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpl, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmplDataArr[i][0])));
-      EXPECT_EQ(comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmplDataArr[i][1])) <<
+      OMR_CT_EXPECT_EQ(dCompareConst, comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmplDataArr[i][1])) <<
             dCmplDataArr[i][0] << " : " << dCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmplConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpl, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmplDataArr[i][1])));
-      EXPECT_EQ(comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), dCompareConst(dCmplDataArr[i][0], DOUBLE_PLACEHOLDER_2)) <<
+      OMR_CT_EXPECT_EQ(dCompareConst, comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), dCompareConst(dCmplDataArr[i][0], DOUBLE_PLACEHOLDER_2)) <<
             dCmplDataArr[i][0] << " : " << dCmplDataArr[i][1];
       }
 
@@ -3438,25 +3461,25 @@ PPCOpCodesTest::invokeDisabledCompareTests()
    testCaseNum = sizeof(dCmpgDataArr) / sizeof(dCmpgDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), _dCmpg(dCmpgDataArr[i][0], dCmpgDataArr[i][1])) <<
+      OMR_CT_EXPECT_EQ(_dCmpg, compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), _dCmpg(dCmpgDataArr[i][0], dCmpgDataArr[i][1])) <<
             dCmpgDataArr[i][0] << " : " << dCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmpgConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpg, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpgDataArr[i][0]), 2, &(dCmpgDataArr[i][1])));
-      EXPECT_EQ(compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2)) <<
+      OMR_CT_EXPECT_EQ(dCompareConst, compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2)) <<
             dCmpgDataArr[i][0] << " : " << dCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmpgConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpg, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpgDataArr[i][0])));
-      EXPECT_EQ(compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpgDataArr[i][1])) <<
+      OMR_CT_EXPECT_EQ(dCompareConst, compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpgDataArr[i][1])) <<
             dCmpgDataArr[i][0] << " : " << dCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmpgConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpg, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpgDataArr[i][1])));
-      EXPECT_EQ(compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), dCompareConst(dCmpgDataArr[i][0], DOUBLE_PLACEHOLDER_2)) <<
+      OMR_CT_EXPECT_EQ(dCompareConst, compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), dCompareConst(dCmpgDataArr[i][0], DOUBLE_PLACEHOLDER_2)) <<
             dCmpgDataArr[i][0] << " : " << dCmpgDataArr[i][1];
       }
 
@@ -3464,25 +3487,25 @@ PPCOpCodesTest::invokeDisabledCompareTests()
    testCaseNum = sizeof(fCmplDataArr) / sizeof(fCmplDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), _fCmpl(fCmplDataArr[i][0], fCmplDataArr[i][1])) <<
+      OMR_CT_EXPECT_EQ(_fCmpl, comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), _fCmpl(fCmplDataArr[i][0], fCmplDataArr[i][1])) <<
             fCmplDataArr[i][0] << " : " << fCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmplConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpl, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmplDataArr[i][0]), 2, &(fCmplDataArr[i][1])));
-      EXPECT_EQ(comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2)) <<
+      OMR_CT_EXPECT_EQ(fCompareConst, comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2)) <<
             fCmplDataArr[i][0] << " : " << fCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmplConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpl, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmplDataArr[i][0])));
-      EXPECT_EQ(comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmplDataArr[i][1])) <<
+      OMR_CT_EXPECT_EQ(fCompareConst, comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmplDataArr[i][1])) <<
             fCmplDataArr[i][0] << " : " << fCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmplConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpl, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmplDataArr[i][1])));
-      EXPECT_EQ(comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), fCompareConst(fCmplDataArr[i][0], FLOAT_PLACEHOLDER_2)) <<
+      OMR_CT_EXPECT_EQ(fCompareConst, comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), fCompareConst(fCmplDataArr[i][0], FLOAT_PLACEHOLDER_2)) <<
             fCmplDataArr[i][0] << " : " << fCmplDataArr[i][1];
       }
 
@@ -3490,25 +3513,25 @@ PPCOpCodesTest::invokeDisabledCompareTests()
    testCaseNum = sizeof(fCmpgDataArr) / sizeof(fCmpgDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), _fCmpg(fCmpgDataArr[i][0], fCmpgDataArr[i][1])) <<
+      OMR_CT_EXPECT_EQ(_fCmpg, compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), _fCmpg(fCmpgDataArr[i][0], fCmpgDataArr[i][1])) <<
             fCmpgDataArr[i][0] << " : " << fCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmpgConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpg, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpgDataArr[i][0]), 2, &(fCmpgDataArr[i][1])));
-      EXPECT_EQ(compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2)) <<
+      OMR_CT_EXPECT_EQ(fCompareConst, compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2)) <<
             fCmpgDataArr[i][0] << " : " << fCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmpgConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpg, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpgDataArr[i][0])));
-      EXPECT_EQ(compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpgDataArr[i][1])) <<
+      OMR_CT_EXPECT_EQ(fCompareConst, compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpgDataArr[i][1])) <<
             fCmpgDataArr[i][0] << " : " << fCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmpgConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpg, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpgDataArr[i][1])));
-      EXPECT_EQ(compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), fCompareConst(fCmpgDataArr[i][0], FLOAT_PLACEHOLDER_2)) <<
+      OMR_CT_EXPECT_EQ(fCompareConst, compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), fCompareConst(fCmpgDataArr[i][0], FLOAT_PLACEHOLDER_2)) <<
             fCmpgDataArr[i][0] << " : " << fCmpgDataArr[i][1];
       }
 
@@ -3516,446 +3539,446 @@ PPCOpCodesTest::invokeDisabledCompareTests()
    testCaseNum = sizeof(ifLcmpeqDataArr) / sizeof(ifLcmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), _ifLcmpeq(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifLcmpeq, compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), _ifLcmpeq(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpeqConst1_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpeqDataArr[i][0]), 2, &(ifLcmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLcmpeqConst2_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpeqConst3_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), lCompareConst(ifLcmpeqDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), lCompareConst(ifLcmpeqDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifLcmpgtDataArr) / sizeof(ifLcmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), _ifLcmpgt(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifLcmpgt, compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), _ifLcmpgt(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpgtConst1_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpgtDataArr[i][0]), 2, &(ifLcmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLcmpgtConst2_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpgtConst3_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), lCompareConst(ifLcmpgtDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), lCompareConst(ifLcmpgtDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifLcmpltDataArr) / sizeof(ifLcmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), _ifLcmplt(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifLcmplt, compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), _ifLcmplt(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpltConst1_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpltDataArr[i][0]), 2, &(ifLcmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLcmpltConst2_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpltConst3_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), lCompareConst(ifLcmpltDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), lCompareConst(ifLcmpltDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //ifdCompare
    testCaseNum = sizeof(dCmpeqDataArr) / sizeof(ifDcmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), _ifDcmpeq(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifDcmpeq, compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), _ifDcmpeq(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpeqConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpeqDataArr[i][0]), 2, &(ifDcmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpeqConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpeqConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), dCompareConst(ifDcmpeqDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), dCompareConst(ifDcmpeqDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifDcmpneDataArr) / sizeof(ifDcmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), _ifDcmpne(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifDcmpne, compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), _ifDcmpne(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpneConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpneDataArr[i][0]), 2, &(ifDcmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpneConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpneConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), dCompareConst(ifDcmpneDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), dCompareConst(ifDcmpneDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifDcmpgtDataArr) / sizeof(ifDcmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), _ifDcmpgt(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifDcmpgt, compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), _ifDcmpgt(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpgtConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpgtDataArr[i][0]), 2, &(ifDcmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpgtConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpgtConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), dCompareConst(ifDcmpgtDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), dCompareConst(ifDcmpgtDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifDcmpltDataArr) / sizeof(ifDcmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), _ifDcmplt(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifDcmplt, compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), _ifDcmplt(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpltConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpltDataArr[i][0]), 2, &(ifDcmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpltConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpltConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), dCompareConst(ifDcmpltDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), dCompareConst(ifDcmpltDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifDcmpgeDataArr) / sizeof(ifDcmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), _ifDcmpge(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifDcmpge, compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), _ifDcmpge(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpgeConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpgeDataArr[i][0]), 2, &(ifDcmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpgeConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpgeConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), dCompareConst(ifDcmpgeDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), dCompareConst(ifDcmpgeDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifDcmpleDataArr) / sizeof(ifDcmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), _ifDcmple(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifDcmple, compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), _ifDcmple(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpleConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpleDataArr[i][0]), 2, &(ifDcmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpleConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpleConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), dCompareConst(ifDcmpleDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), dCompareConst(ifDcmpleDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    //iffCompare
    testCaseNum = sizeof(ifFcmpeqDataArr) / sizeof(ifFcmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), _ifFcmpeq(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifFcmpeq, compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), _ifFcmpeq(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpeqConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpeqDataArr[i][0]), 2, &(ifFcmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpeqConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpeqConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), fCompareConst(ifFcmpeqDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), fCompareConst(ifFcmpeqDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifFcmpneDataArr) / sizeof(ifFcmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), _ifFcmpne(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifFcmpne, compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), _ifFcmpne(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpneConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpneDataArr[i][0]), 2, &(ifFcmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpneConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpneConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), fCompareConst(ifFcmpneDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), fCompareConst(ifFcmpneDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifFcmpgtDataArr) / sizeof(ifFcmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), _ifFcmpgt(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifFcmpgt, compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), _ifFcmpgt(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpgtConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpgtDataArr[i][0]), 2, &(ifFcmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpgtConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpgtConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), fCompareConst(ifFcmpgtDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), fCompareConst(ifFcmpgtDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifFcmpltDataArr) / sizeof(ifFcmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), _ifFcmplt(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifFcmplt, compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), _ifFcmplt(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpltConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpltDataArr[i][0]), 2, &(ifFcmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpltConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpltConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), fCompareConst(ifFcmpltDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), fCompareConst(ifFcmpltDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifFcmpgeDataArr) / sizeof(ifFcmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), _ifFcmpge(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifFcmpge, compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), _ifFcmpge(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpgeConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpgeDataArr[i][0]), 2, &(ifFcmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpgeConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpgeConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), fCompareConst(ifFcmpgeDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), fCompareConst(ifFcmpgeDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifFcmpleDataArr) / sizeof(ifFcmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), _ifFcmple(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifFcmple, compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), _ifFcmple(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpleConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpleDataArr[i][0]), 2, &(ifFcmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpleConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpleConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), fCompareConst(ifFcmpleDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), fCompareConst(ifFcmpleDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    //ifbCompare
    testCaseNum = sizeof(ifBcmpneDataArr) / sizeof(ifBcmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), _ifBcmpne(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBcmpne, compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), _ifBcmpne(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpneConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpneDataArr[i][0]), 2, &(ifBcmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpneConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpneConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), bCompareConst(ifBcmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), bCompareConst(ifBcmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBcmpleDataArr) / sizeof(ifBcmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), _ifBcmple(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBcmple, compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), _ifBcmple(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpleConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpleDataArr[i][0]), 2, &(ifBcmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpleConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpleConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(ifBcmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(ifBcmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBcmpltDataArr) / sizeof(ifBcmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), _ifBcmplt(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBcmplt, compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), _ifBcmplt(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpltConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpltDataArr[i][0]), 2, &(ifBcmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpltConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpltConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), bCompareConst(ifBcmpltDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), bCompareConst(ifBcmpltDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBcmpgeDataArr) / sizeof(ifBcmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), _ifBcmpge(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBcmpge, compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), _ifBcmpge(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpgeConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpgeDataArr[i][0]), 2, &(ifBcmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpgeConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpgeConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(ifBcmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(ifBcmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //buCompare equal and not-equal
    testCaseNum = sizeof(buCmpeqDataArr) / sizeof(buCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), _buCmpeq(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_buCmpeq, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), _buCmpeq(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buCmpeqConst1_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(buCmpeqDataArr[i][0]), 2, &(buCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "buCmpeqConst2_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(buCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, buCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, buCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buCmpeqConst3_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(buCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(buCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(buCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(buCmpneDataArr) / sizeof(buCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), _buCmpne(buCmpneDataArr[i][0], buCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_buCmpne, compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), _buCmpne(buCmpneDataArr[i][0], buCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buCmpneConst1_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(buCmpneDataArr[i][0]), 2, &(buCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "buCmpneConst2_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(buCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, buCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, buCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buCmpneConst3_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(buCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), buCompareConst(buCmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), buCompareConst(buCmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
    }
 
@@ -3984,21 +4007,21 @@ PPCOpCodesTest::invokeDisabledIntegerArithmeticTests()
    {
    //unsigned integer constant test will be enabled in another work item.
    //iumul : overflow just cut
-   EXPECT_EQ(mul(UINT_MAXIMUM, UINT_MINIMUM), _iuMul(UINT_MAXIMUM, UINT_MINIMUM));
-   EXPECT_EQ(mul(UINT_MINIMUM, UINT_POS), _iuMul(UINT_MINIMUM, UINT_POS));
-   EXPECT_EQ(mul(UINT_POS, UINT_MAXIMUM), _iuMul(UINT_POS, UINT_MAXIMUM));
+   OMR_CT_EXPECT_EQ(_iuMul, mul(UINT_MAXIMUM, UINT_MINIMUM), _iuMul(UINT_MAXIMUM, UINT_MINIMUM));
+   OMR_CT_EXPECT_EQ(_iuMul, mul(UINT_MINIMUM, UINT_POS), _iuMul(UINT_MINIMUM, UINT_POS));
+   OMR_CT_EXPECT_EQ(_iuMul, mul(UINT_POS, UINT_MAXIMUM), _iuMul(UINT_POS, UINT_MAXIMUM));
 
    //iudiv
    // TODO: Use ASSERT_DEATH() to catch Remainder by zero which will get "Floating point exception (core dumped)"
    // Test secnario : _iuDiv(UINT_MAXIMUM, 0)
-   EXPECT_EQ(div(UINT_MAXIMUM, UINT_POS), _iuDiv(UINT_MAXIMUM, UINT_POS));
-   EXPECT_EQ(div(UINT_MINIMUM, UINT_POS), _iuDiv(UINT_MINIMUM, UINT_POS));
+   OMR_CT_EXPECT_EQ(_iuDiv, div(UINT_MAXIMUM, UINT_POS), _iuDiv(UINT_MAXIMUM, UINT_POS));
+   OMR_CT_EXPECT_EQ(_iuDiv, div(UINT_MINIMUM, UINT_POS), _iuDiv(UINT_MINIMUM, UINT_POS));
 
    //iurem
    // TODO: Use ASSERT_DEATH() to catch Remainder by zero which will get "Floating point exception (core dumped)"
    // Test secnario : _iuRem(UINT_MAXIMUM, 0)
-   EXPECT_EQ(rem(UINT_POS, UINT_MAXIMUM),       _iuRem(UINT_POS, UINT_MAXIMUM));
-   EXPECT_EQ(rem(UINT_MAXIMUM, UINT_MAXIMUM),      _iuRem(UINT_MAXIMUM, UINT_MAXIMUM));
+   OMR_CT_EXPECT_EQ(_iuRem, rem(UINT_POS, UINT_MAXIMUM),       _iuRem(UINT_POS, UINT_MAXIMUM));
+   OMR_CT_EXPECT_EQ(_iuRem, rem(UINT_MAXIMUM, UINT_MAXIMUM),      _iuRem(UINT_MAXIMUM, UINT_MAXIMUM));
 
    int32_t rc = 0;
 
@@ -4050,66 +4073,66 @@ PPCOpCodesTest::invokeDisabledIntegerArithmeticTests()
    testCaseArrLength = sizeof(longAddArr) / sizeof(longAddArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(add(longAddArr[i][0], longAddArr[i][1]), _lAdd(longAddArr[i][0], longAddArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lAdd, add(longAddArr[i][0], longAddArr[i][1]), _lAdd(longAddArr[i][0], longAddArr[i][1]));
 
       sprintf(resolvedMethodName, "lAddConst1_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ladd,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longAddArr[i][0], 2, &longAddArr[i][1]));
-      EXPECT_EQ(add(longAddArr[i][0], longAddArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, add(longAddArr[i][0], longAddArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lAddConst2_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ladd,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longAddArr[i][0]));
-      EXPECT_EQ(add(longAddArr[i][0], longAddArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longAddArr[i][1]));
+      OMR_CT_EXPECT_EQ(lBinaryCons, add(longAddArr[i][0], longAddArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longAddArr[i][1]));
 
       sprintf(resolvedMethodName, "lAddConst3_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ladd,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longAddArr[i][1]));
-      EXPECT_EQ(add(longAddArr[i][0], longAddArr[i][1]), lBinaryCons(longAddArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, add(longAddArr[i][0], longAddArr[i][1]), lBinaryCons(longAddArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //lsub
    testCaseArrLength = sizeof(longSubArr) / sizeof(longSubArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(sub(longSubArr[i][0], longSubArr[i][1]), _lSub(longSubArr[i][0], longSubArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lSub, sub(longSubArr[i][0], longSubArr[i][1]), _lSub(longSubArr[i][0], longSubArr[i][1]));
 
       sprintf(resolvedMethodName, "lSubConst1_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lsub,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longSubArr[i][0], 2, &longSubArr[i][1]));
-      EXPECT_EQ(sub(longSubArr[i][0], longSubArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, sub(longSubArr[i][0], longSubArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lSubConst2_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lsub,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longSubArr[i][0]));
-      EXPECT_EQ(sub(longSubArr[i][0], longSubArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longSubArr[i][1]));
+      OMR_CT_EXPECT_EQ(lBinaryCons, sub(longSubArr[i][0], longSubArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longSubArr[i][1]));
 
       sprintf(resolvedMethodName, "lSubConst3_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lsub,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longSubArr[i][1]));
-      EXPECT_EQ(sub(longSubArr[i][0], longSubArr[i][1]), lBinaryCons(longSubArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, sub(longSubArr[i][0], longSubArr[i][1]), lBinaryCons(longSubArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //lmul
    testCaseArrLength = sizeof(longMulArr) / sizeof(longMulArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(mul(longMulArr[i][0], longMulArr[i][1]), _lMul(longMulArr[i][0], longMulArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lMul, mul(longMulArr[i][0], longMulArr[i][1]), _lMul(longMulArr[i][0], longMulArr[i][1]));
 
       sprintf(resolvedMethodName, "lMulConst1_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lmul,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longMulArr[i][0], 2, &longMulArr[i][1]));
-      EXPECT_EQ(mul(longMulArr[i][0], longMulArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, mul(longMulArr[i][0], longMulArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lMulConst2_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lmul,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longMulArr[i][0]));
-      EXPECT_EQ(mul(longMulArr[i][0], longMulArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longMulArr[i][1]));
+      OMR_CT_EXPECT_EQ(lBinaryCons, mul(longMulArr[i][0], longMulArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longMulArr[i][1]));
 
       sprintf(resolvedMethodName, "lMulConst3_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lmul,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longMulArr[i][1]));
-      EXPECT_EQ(mul(longMulArr[i][0], longMulArr[i][1]), lBinaryCons(longMulArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, mul(longMulArr[i][0], longMulArr[i][1]), lBinaryCons(longMulArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //ldiv
@@ -4117,44 +4140,44 @@ PPCOpCodesTest::invokeDisabledIntegerArithmeticTests()
    testCaseArrLength = sizeof(longDivArr) / sizeof(longDivArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(div(longDivArr[i][0], longDivArr[i][1]), _lDiv(longDivArr[i][0], longDivArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lDiv, div(longDivArr[i][0], longDivArr[i][1]), _lDiv(longDivArr[i][0], longDivArr[i][1]));
 
       sprintf(resolvedMethodName, "lDivConst1_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ldiv, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longDivArr[i][0], 2, &longDivArr[i][1]));
-      EXPECT_EQ(div(longDivArr[i][0], longDivArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, div(longDivArr[i][0], longDivArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lDivConst2_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ldiv, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longDivArr[i][0]));
-      EXPECT_EQ(div(longDivArr[i][0], longDivArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longDivArr[i][1]));
+      OMR_CT_EXPECT_EQ(lBinaryCons, div(longDivArr[i][0], longDivArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longDivArr[i][1]));
 
       sprintf(resolvedMethodName, "lDivConst3_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ldiv, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longDivArr[i][1]));
-      EXPECT_EQ(div(longDivArr[i][0], longDivArr[i][1]), lBinaryCons(longDivArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, div(longDivArr[i][0], longDivArr[i][1]), lBinaryCons(longDivArr[i][0], LONG_PLACEHOLDER_2));
       }
    //lrem
    //TODO: _lrem(LONG_INT, 0), _lrem(LONG_NEG, 0),
    testCaseArrLength = sizeof(longRemArr) / sizeof(longRemArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(rem(longRemArr[i][0], longRemArr[i][1]), _lRem(longRemArr[i][0], longRemArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lRem, rem(longRemArr[i][0], longRemArr[i][1]), _lRem(longRemArr[i][0], longRemArr[i][1]));
 
       sprintf(resolvedMethodName, "lRemConst1_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lrem, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longRemArr[i][0], 2, &longRemArr[i][1]));
-      EXPECT_EQ(rem(longRemArr[i][0], longRemArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, rem(longRemArr[i][0], longRemArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lRemConst2_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lrem, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longRemArr[i][0]));
-      EXPECT_EQ(rem(longRemArr[i][0], longRemArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longRemArr[i][1]));
+      OMR_CT_EXPECT_EQ(lBinaryCons, rem(longRemArr[i][0], longRemArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longRemArr[i][1]));
 
       sprintf(resolvedMethodName, "lRemConst3_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lrem, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longRemArr[i][1]));
-      EXPECT_EQ(rem(longRemArr[i][0], longRemArr[i][1]), lBinaryCons(longRemArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, rem(longRemArr[i][0], longRemArr[i][1]), lBinaryCons(longRemArr[i][0], LONG_PLACEHOLDER_2));
       }
    }
 
@@ -4253,172 +4276,172 @@ PPCOpCodesTest::invokeDisabledFloatArithmeticTests()
    testCaseNum = sizeof(floatAddArr) / sizeof(floatAddArr[0]);
    for (uint32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_FLOAT_EQ(add(floatAddArr[i][0], floatAddArr[i][1]), _fAdd(floatAddArr[i][0], floatAddArr[i][1]));
+      OMR_CT_EXPECT_FLOAT_EQ(_fAdd, add(floatAddArr[i][0], floatAddArr[i][1]), _fAdd(floatAddArr[i][0], floatAddArr[i][1]));
 
       sprintf(resolvedMethodName, "fAddConst1_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fadd,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatAddArr[i][0], 2, &floatAddArr[i][1]));
-      EXPECT_FLOAT_EQ(add(floatAddArr[i][0], floatAddArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, add(floatAddArr[i][0], floatAddArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fAddConst2_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fadd,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatAddArr[i][0]));
-      EXPECT_FLOAT_EQ(add(floatAddArr[i][0], floatAddArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatAddArr[i][1]));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, add(floatAddArr[i][0], floatAddArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatAddArr[i][1]));
 
       sprintf(resolvedMethodName, "fAddConst3_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fadd,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatAddArr[i][1]));
-      EXPECT_FLOAT_EQ(add(floatAddArr[i][0], floatAddArr[i][1]), fBinaryConst(floatAddArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, add(floatAddArr[i][0], floatAddArr[i][1]), fBinaryConst(floatAddArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    //fsub
    testCaseNum = sizeof(floatSubArr) / sizeof(floatSubArr[0]);
    for (uint32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_FLOAT_EQ(sub(floatSubArr[i][0], floatSubArr[i][1]), _fSub(floatSubArr[i][0], floatSubArr[i][1]));
+      OMR_CT_EXPECT_FLOAT_EQ(_fSub, sub(floatSubArr[i][0], floatSubArr[i][1]), _fSub(floatSubArr[i][0], floatSubArr[i][1]));
 
       sprintf(resolvedMethodName, "fSubConst1_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fsub,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatSubArr[i][0], 2, &floatSubArr[i][1]));
-      EXPECT_FLOAT_EQ(sub(floatSubArr[i][0], floatSubArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, sub(floatSubArr[i][0], floatSubArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fSubConst2_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fsub,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatSubArr[i][0]));
-      EXPECT_FLOAT_EQ(sub(floatSubArr[i][0], floatSubArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatSubArr[i][1]));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, sub(floatSubArr[i][0], floatSubArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatSubArr[i][1]));
 
       sprintf(resolvedMethodName, "fSubConst3_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fsub,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatSubArr[i][1]));
-      EXPECT_FLOAT_EQ(sub(floatSubArr[i][0], floatSubArr[i][1]), fBinaryConst(floatSubArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, sub(floatSubArr[i][0], floatSubArr[i][1]), fBinaryConst(floatSubArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    //fmul
    testCaseNum = sizeof(floatMulArr) / sizeof(floatMulArr[0]);
    for (uint32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_FLOAT_EQ(mul(floatMulArr[i][0], floatMulArr[i][1]), _fMul(floatMulArr[i][0], floatMulArr[i][1]));
+      OMR_CT_EXPECT_FLOAT_EQ(_fMul, mul(floatMulArr[i][0], floatMulArr[i][1]), _fMul(floatMulArr[i][0], floatMulArr[i][1]));
 
       sprintf(resolvedMethodName, "fMulConst1_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fmul,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatMulArr[i][0], 2, &floatMulArr[i][1]));
-      EXPECT_FLOAT_EQ(mul(floatMulArr[i][0], floatMulArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, mul(floatMulArr[i][0], floatMulArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fMulConst2_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fmul,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatMulArr[i][0]));
-      EXPECT_FLOAT_EQ(mul(floatMulArr[i][0], floatMulArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatMulArr[i][1]));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, mul(floatMulArr[i][0], floatMulArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatMulArr[i][1]));
 
       sprintf(resolvedMethodName, "fMulConst3_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fmul,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatMulArr[i][1]));
-      EXPECT_FLOAT_EQ(mul(floatMulArr[i][0], floatMulArr[i][1]), fBinaryConst(floatMulArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, mul(floatMulArr[i][0], floatMulArr[i][1]), fBinaryConst(floatMulArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    //fdiv
    testCaseNum = sizeof(floatDivArr) / sizeof(floatDivArr[0]);
    for (uint32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_FLOAT_EQ(div(floatDivArr[i][0], floatDivArr[i][1]), _fDiv(floatDivArr[i][0], floatDivArr[i][1]));
+      OMR_CT_EXPECT_FLOAT_EQ(_fDiv, div(floatDivArr[i][0], floatDivArr[i][1]), _fDiv(floatDivArr[i][0], floatDivArr[i][1]));
 
       sprintf(resolvedMethodName, "fDivConst1_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fdiv,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatDivArr[i][0], 2, &floatDivArr[i][1]));
-      EXPECT_FLOAT_EQ(div(floatDivArr[i][0], floatDivArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, div(floatDivArr[i][0], floatDivArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fDivConst2_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fdiv,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatDivArr[i][0]));
-      EXPECT_FLOAT_EQ(div(floatDivArr[i][0], floatDivArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatDivArr[i][1]));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, div(floatDivArr[i][0], floatDivArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatDivArr[i][1]));
 
       sprintf(resolvedMethodName, "fDivConst3_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fdiv,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatDivArr[i][1]));
-      EXPECT_FLOAT_EQ(div(floatDivArr[i][0], floatDivArr[i][1]), fBinaryConst(floatDivArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, div(floatDivArr[i][0], floatDivArr[i][1]), fBinaryConst(floatDivArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(doubleAddArr) / sizeof(doubleAddArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_DOUBLE_EQ(add(doubleAddArr[i][0], doubleAddArr[i][1]), _dAdd(doubleAddArr[i][0], doubleAddArr[i][1]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_dAdd, add(doubleAddArr[i][0], doubleAddArr[i][1]), _dAdd(doubleAddArr[i][0], doubleAddArr[i][1]));
 
       sprintf(resolvedMethodName, "dAddConst1_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dadd,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleAddArr[i][0], 2, &doubleAddArr[i][1]));
-      EXPECT_DOUBLE_EQ(add(doubleAddArr[i][0], doubleAddArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, add(doubleAddArr[i][0], doubleAddArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dAddConst2_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dadd,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleAddArr[i][0]));
-      EXPECT_DOUBLE_EQ(add(doubleAddArr[i][0], doubleAddArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleAddArr[i][1]));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, add(doubleAddArr[i][0], doubleAddArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleAddArr[i][1]));
 
       sprintf(resolvedMethodName, "dAddConst3_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dadd,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleAddArr[i][1]));
-      EXPECT_DOUBLE_EQ(add(doubleAddArr[i][0], doubleAddArr[i][1]), dBinaryConst(doubleAddArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, add(doubleAddArr[i][0], doubleAddArr[i][1]), dBinaryConst(doubleAddArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(doubleSubArr) / sizeof(doubleSubArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_DOUBLE_EQ(sub(doubleSubArr[i][0], doubleSubArr[i][1]), _dSub(doubleSubArr[i][0], doubleSubArr[i][1]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_dSub, sub(doubleSubArr[i][0], doubleSubArr[i][1]), _dSub(doubleSubArr[i][0], doubleSubArr[i][1]));
 
       sprintf(resolvedMethodName, "dSubConst1_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dsub,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleSubArr[i][0], 2, &doubleSubArr[i][1]));
-      EXPECT_DOUBLE_EQ(sub(doubleSubArr[i][0], doubleSubArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, sub(doubleSubArr[i][0], doubleSubArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dSubConst2_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dsub,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleSubArr[i][0]));
-      EXPECT_DOUBLE_EQ(sub(doubleSubArr[i][0], doubleSubArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleSubArr[i][1]));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, sub(doubleSubArr[i][0], doubleSubArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleSubArr[i][1]));
 
       sprintf(resolvedMethodName, "dSubConst3_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dsub,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleSubArr[i][1]));
-      EXPECT_DOUBLE_EQ(sub(doubleSubArr[i][0], doubleSubArr[i][1]), dBinaryConst(doubleSubArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, sub(doubleSubArr[i][0], doubleSubArr[i][1]), dBinaryConst(doubleSubArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(doubleMulArr) / sizeof(doubleMulArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_DOUBLE_EQ(mul(doubleMulArr[i][0], doubleMulArr[i][1]), _dMul(doubleMulArr[i][0], doubleMulArr[i][1]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_dMul, mul(doubleMulArr[i][0], doubleMulArr[i][1]), _dMul(doubleMulArr[i][0], doubleMulArr[i][1]));
 
       sprintf(resolvedMethodName, "dMulConst1_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dmul,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleMulArr[i][0], 2, &doubleMulArr[i][1]));
-      EXPECT_DOUBLE_EQ(mul(doubleMulArr[i][0], doubleMulArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, mul(doubleMulArr[i][0], doubleMulArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dMulConst2_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dmul,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleMulArr[i][0]));
-      EXPECT_DOUBLE_EQ(mul(doubleMulArr[i][0], doubleMulArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleMulArr[i][1]));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, mul(doubleMulArr[i][0], doubleMulArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleMulArr[i][1]));
 
       sprintf(resolvedMethodName, "dMulConst3_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dmul,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleMulArr[i][1]));
-      EXPECT_DOUBLE_EQ(mul(doubleMulArr[i][0], doubleMulArr[i][1]), dBinaryConst(doubleMulArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, mul(doubleMulArr[i][0], doubleMulArr[i][1]), dBinaryConst(doubleMulArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(doubleDivArr) / sizeof(doubleDivArr[0]);
    for (int32_t i = 0; i < testCaseNum; i++)
       {
-      EXPECT_DOUBLE_EQ(div(doubleDivArr[i][0], doubleDivArr[i][1]), _dDiv(doubleDivArr[i][0], doubleDivArr[i][1]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_dDiv, div(doubleDivArr[i][0], doubleDivArr[i][1]), _dDiv(doubleDivArr[i][0], doubleDivArr[i][1]));
 
       sprintf(resolvedMethodName, "dDivConst1_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ddiv,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleDivArr[i][0], 2, &doubleDivArr[i][1]));
-      EXPECT_DOUBLE_EQ(div(doubleDivArr[i][0], doubleDivArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, div(doubleDivArr[i][0], doubleDivArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dDivConst2_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ddiv,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleDivArr[i][0]));
-      EXPECT_DOUBLE_EQ(div(doubleDivArr[i][0], doubleDivArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleDivArr[i][1]));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, div(doubleDivArr[i][0], doubleDivArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleDivArr[i][1]));
 
       sprintf(resolvedMethodName, "dDivConst3_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ddiv,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleDivArr[i][1]));
-      EXPECT_DOUBLE_EQ(div(doubleDivArr[i][0], doubleDivArr[i][1]), dBinaryConst(doubleDivArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, div(doubleDivArr[i][0], doubleDivArr[i][1]), dBinaryConst(doubleDivArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
    }
 
@@ -4460,27 +4483,27 @@ PPCOpCodesTest::invokeDisabledMemoryOperationTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "lStoreConst%d", i + 1);
-      EXPECT_EQ(longDataArray[i], _lStore(longDataArray[i]));
+      OMR_CT_EXPECT_EQ(_lStore, longDataArray[i], _lStore(longDataArray[i]));
       lMemCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lstore, resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &(longDataArray[i])));
-      EXPECT_EQ(longDataArray[i], lMemCons(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lMemCons, longDataArray[i], lMemCons(LONG_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(doubleDataArray) / sizeof(doubleDataArray[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "dStoreConst%d", i + 1);
-      EXPECT_DOUBLE_EQ(doubleDataArray[i], _dStore(doubleDataArray[i]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_dStore, doubleDataArray[i], _dStore(doubleDataArray[i]));
       dMemCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dstore, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &(doubleDataArray[i])));
-      EXPECT_DOUBLE_EQ(doubleDataArray[i], dMemCons(DOUBLE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_DOUBLE_EQ(dMemCons, doubleDataArray[i], dMemCons(DOUBLE_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(floatDataArray) / sizeof(floatDataArray[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "fStoreConst%d", i + 1);
-      EXPECT_FLOAT_EQ(floatDataArray[i], _fStore(floatDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_fStore, floatDataArray[i], _fStore(floatDataArray[i]));
       fMemCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::fstore, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &(floatDataArray[i])));
-      EXPECT_FLOAT_EQ(floatDataArray[i], fMemCons(FLOAT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_FLOAT_EQ(fMemCons, floatDataArray[i], fMemCons(FLOAT_PLACEHOLDER_1));
       }
 
    //Jazz103 114122 : indirect load unexpected results
@@ -4492,7 +4515,7 @@ PPCOpCodesTest::invokeDisabledMemoryOperationTests()
       sprintf(resolvedMethodName, "iLoadiConst%d", i + 1);
       uintptrj_t intDataAddress = (uintptrj_t)(&intDataArray[i]);
       iLoadiCons = (signatureCharL_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int32, rc, 2, 1, &intDataAddress));
-      EXPECT_EQ(intDataArray[i], iLoadiCons(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(iLoadiCons, intDataArray[i], iLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(shortDataArray) / sizeof(shortDataArray[0]);
@@ -4502,7 +4525,7 @@ PPCOpCodesTest::invokeDisabledMemoryOperationTests()
       sprintf(resolvedMethodName, "sLoadiConst%d", i + 1);
       uintptrj_t shortDataAddress = (uintptrj_t)(&shortDataArray[i]);
       sLoadiCons = (signatureCharL_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::sloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int16, rc, 2, 1, &shortDataAddress));
-      EXPECT_EQ(shortDataArray[i], sLoadiCons(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(sLoadiCons, shortDataArray[i], sLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(byteDataArray) / sizeof(byteDataArray[0]);
@@ -4512,7 +4535,7 @@ PPCOpCodesTest::invokeDisabledMemoryOperationTests()
       sprintf(resolvedMethodName, "bLoadiConst%d", i + 1);
       uintptrj_t byteDataAddress = (uintptrj_t)(&byteDataArray[i]);
       bLoadiCons = (signatureCharL_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int8, rc, 2, 1, &byteDataAddress));
-      EXPECT_EQ(byteDataArray[i], bLoadiCons(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(bLoadiCons, byteDataArray[i], bLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(longDataArray) / sizeof(longDataArray[0]);
@@ -4522,7 +4545,7 @@ PPCOpCodesTest::invokeDisabledMemoryOperationTests()
       sprintf(resolvedMethodName, "lLoadiConst%d", i + 1);
       uintptrj_t longDataAddress = (uintptrj_t)(&longDataArray[i]);
       lLoadiCons = (signatureCharL_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int64, rc, 2, 1, &longDataAddress));
-      EXPECT_EQ(longDataArray[i], lLoadiCons(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lLoadiCons, longDataArray[i], lLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(doubleDataArray) / sizeof(doubleDataArray[0]);
@@ -4532,7 +4555,7 @@ PPCOpCodesTest::invokeDisabledMemoryOperationTests()
       sprintf(resolvedMethodName, "dLoadiConst%d", i + 1);
       uintptrj_t doubleDataAddress = (uintptrj_t)(&doubleDataArray[i]);
       dLoadiCons = (signatureCharL_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Double, rc, 2, 1, &doubleDataAddress));
-      EXPECT_EQ(doubleDataArray[i], dLoadiCons(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(dLoadiCons, doubleDataArray[i], dLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(floatDataArray) / sizeof(floatDataArray[0]);
@@ -4542,7 +4565,7 @@ PPCOpCodesTest::invokeDisabledMemoryOperationTests()
       sprintf(resolvedMethodName, "fLoadiConst%d", i + 1);
       uintptrj_t floatDataAddress = (uintptrj_t)(&floatDataArray[i]);
       fLoadiCons = (signatureCharL_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::floadi, resolvedMethodName, _argTypesUnaryAddress, TR::Float, rc, 2, 1, &floatDataAddress));
-      EXPECT_EQ(floatDataArray[i], fLoadiCons(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(fLoadiCons, floatDataArray[i], fLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(addressDataArray) / sizeof(addressDataArray[0]);
@@ -4552,16 +4575,19 @@ PPCOpCodesTest::invokeDisabledMemoryOperationTests()
       sprintf(resolvedMethodName, "aLoadiConst%d", i + 1);
       uintptrj_t addressDataAddress = (uintptrj_t)(&addressDataArray[i]);
       aLoadiCons = (signatureCharL_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::aloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Address, rc, 2, 1, &addressDataAddress));
-      EXPECT_EQ(addressDataArray[i], aLoadiCons(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(aLoadiCons, addressDataArray[i], aLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
    //Jazz103 111411 : bstorei unexpected results
    int8_t byteStoreDataArray[] = {0, 0, 0, 0, 0};
    testCaseNum = sizeof(byteDataArray) / sizeof(byteDataArray[0]);
-   for (int32_t i = 0 ; i < testCaseNum ; i++)
+   if (_bStorei != NULL)
       {
-      _bStorei((uintptrj_t)(&byteStoreDataArray[i]) , byteDataArray[i]);
-      EXPECT_EQ(byteDataArray[i], byteStoreDataArray[i]);
+      for (int32_t i = 0 ; i < testCaseNum ; i++)
+         {
+         _bStorei((uintptrj_t)(&byteStoreDataArray[i]) , byteDataArray[i]);
+         EXPECT_EQ(byteDataArray[i], byteStoreDataArray[i]);
+         }
       }
    }
 
@@ -4605,44 +4631,44 @@ PPCOpCodesTest::invokeDisabledUnaryTests()
    testCaseNum = sizeof(longDataArray) / sizeof(longDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(neg(longDataArray[i]), _lNeg(longDataArray[i]));
+      OMR_CT_EXPECT_EQ(_lNeg, neg(longDataArray[i]), _lNeg(longDataArray[i]));
       sprintf(resolvedMethodName, "lNegConst%d", i + 1);
       lUnaryCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lneg,
             resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &longDataArray[i]));
-      EXPECT_EQ(neg(longDataArray[i]), lUnaryCons(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lUnaryCons, neg(longDataArray[i]), lUnaryCons(LONG_PLACEHOLDER_1));
       }
 
    //fneg
    testCaseNum = sizeof(floatDataArray) / sizeof(floatDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_FLOAT_EQ(neg(floatDataArray[i]), _fNeg(floatDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_fNeg, neg(floatDataArray[i]), _fNeg(floatDataArray[i]));
       sprintf(resolvedMethodName, "fNegConst%d", i + 1);
       fUnaryCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::fneg,
             resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &floatDataArray[i]));
-      EXPECT_FLOAT_EQ(neg(floatDataArray[i]), fUnaryCons(FLOAT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_FLOAT_EQ(fUnaryCons, neg(floatDataArray[i]), fUnaryCons(FLOAT_PLACEHOLDER_1));
       }
 
    //dneg
    testCaseNum = sizeof(doubleDataArray) / sizeof(doubleDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_DOUBLE_EQ(neg(doubleDataArray[i]), _dNeg(doubleDataArray[i]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_dNeg, neg(doubleDataArray[i]), _dNeg(doubleDataArray[i]));
       sprintf(resolvedMethodName, "dNegConst%d", i + 1);
       dUnaryCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dneg,
             resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &doubleDataArray[i]));
-      EXPECT_DOUBLE_EQ(neg(doubleDataArray[i]), dUnaryCons(DOUBLE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_DOUBLE_EQ(dUnaryCons, neg(doubleDataArray[i]), dUnaryCons(DOUBLE_PLACEHOLDER_1));
       }
 
    //labs
    testCaseNum = sizeof(longDataArray) / sizeof(longDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(abs(longDataArray[i]), _lAbs(longDataArray[i]));
+      OMR_CT_EXPECT_EQ(_lAbs, abs(longDataArray[i]), _lAbs(longDataArray[i]));
       sprintf(resolvedMethodName, "lAbsConst%d", i + 1);
       lUnaryCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::labs,
             resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &longDataArray[i]));
-      EXPECT_EQ(abs(longDataArray[i]), lUnaryCons(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lUnaryCons, abs(longDataArray[i]), lUnaryCons(LONG_PLACEHOLDER_1));
       }
 
    //lReturn
@@ -4650,9 +4676,9 @@ PPCOpCodesTest::invokeDisabledUnaryTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "lReturnCons%d", i + 1);
-      EXPECT_EQ(longDataArray[i], _lReturn(longDataArray[i]));
+      OMR_CT_EXPECT_EQ(_lReturn, longDataArray[i], _lReturn(longDataArray[i]));
       lUnaryCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lreturn, resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &(longDataArray[i])));
-      EXPECT_EQ(longDataArray[i], lUnaryCons(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lUnaryCons, longDataArray[i], lUnaryCons(LONG_PLACEHOLDER_1));
       }
 
    //dReturn
@@ -4660,9 +4686,9 @@ PPCOpCodesTest::invokeDisabledUnaryTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "dReturnCons%d", i + 1);
-      EXPECT_DOUBLE_EQ(doubleDataArray[i], _dReturn(doubleDataArray[i]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_dReturn, doubleDataArray[i], _dReturn(doubleDataArray[i]));
       dUnaryCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dreturn, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &(doubleDataArray[i])));
-      EXPECT_DOUBLE_EQ(doubleDataArray[i], dUnaryCons(DOUBLE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_DOUBLE_EQ(dUnaryCons, doubleDataArray[i], dUnaryCons(DOUBLE_PLACEHOLDER_1));
       }
 
    //fReturn
@@ -4670,9 +4696,9 @@ PPCOpCodesTest::invokeDisabledUnaryTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "fReturnCons%d", i + 1);
-      EXPECT_FLOAT_EQ(floatDataArray[i], _fReturn(floatDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_fReturn, floatDataArray[i], _fReturn(floatDataArray[i]));
       fUnaryCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::freturn, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &(floatDataArray[i])));
-      EXPECT_FLOAT_EQ(floatDataArray[i], fUnaryCons(FLOAT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_FLOAT_EQ(fUnaryCons, floatDataArray[i], fUnaryCons(FLOAT_PLACEHOLDER_1));
       }
 
    //lConst
@@ -4681,7 +4707,7 @@ PPCOpCodesTest::invokeDisabledUnaryTests()
       {
       sprintf(resolvedMethodName, "lConst%d", i + 1);
       lUnaryCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lconst, resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &(longDataArray[i])));
-      EXPECT_EQ(longDataArray[i], lUnaryCons(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lUnaryCons, longDataArray[i], lUnaryCons(LONG_PLACEHOLDER_1));
       }
 
    //dConst
@@ -4690,7 +4716,7 @@ PPCOpCodesTest::invokeDisabledUnaryTests()
       {
       sprintf(resolvedMethodName, "dConst%d", i + 1);
       dUnaryCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dconst, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &(doubleDataArray[i])));
-      EXPECT_DOUBLE_EQ(doubleDataArray[i], dUnaryCons(DOUBLE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_DOUBLE_EQ(dUnaryCons, doubleDataArray[i], dUnaryCons(DOUBLE_PLACEHOLDER_1));
       }
 
    //fConst
@@ -4699,29 +4725,29 @@ PPCOpCodesTest::invokeDisabledUnaryTests()
       {
       sprintf(resolvedMethodName, "fConst%d", i + 1);
       fUnaryCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::fconst, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &(floatDataArray[i])));
-      EXPECT_FLOAT_EQ(floatDataArray[i], fUnaryCons(FLOAT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_FLOAT_EQ(fUnaryCons, floatDataArray[i], fUnaryCons(FLOAT_PLACEHOLDER_1));
       }
 
    //fabs
    testCaseNum = sizeof(floatDataArray) / sizeof(floatDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(abs(floatDataArray[i]), _fAbs(floatDataArray[i]));
+      OMR_CT_EXPECT_EQ(_fAbs, abs(floatDataArray[i]), _fAbs(floatDataArray[i]));
       sprintf(resolvedMethodName, "fAbsConst%d", i + 1);
       fUnaryCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::fabs, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &floatDataArray[i]));
-      EXPECT_EQ(abs(floatDataArray[i]), fUnaryCons(FLOAT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(fUnaryCons, abs(floatDataArray[i]), fUnaryCons(FLOAT_PLACEHOLDER_1));
       }
 
    //dabs
    testCaseNum = sizeof(doubleDataArray) / sizeof(doubleDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(abs(doubleDataArray[i]), _dAbs(doubleDataArray[i]));
+      OMR_CT_EXPECT_EQ(_dAbs, abs(doubleDataArray[i]), _dAbs(doubleDataArray[i]));
       sprintf(resolvedMethodName, "dAbsConst%d", i + 1);
       dUnaryCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::dabs, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &doubleDataArray[i]));
-      EXPECT_EQ(abs(doubleDataArray[i]), dUnaryCons(DOUBLE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(dUnaryCons, abs(doubleDataArray[i]), dUnaryCons(DOUBLE_PLACEHOLDER_1));
       }
 
    }
@@ -4773,44 +4799,44 @@ PPCOpCodesTest::invokeDisabledShiftOrRolTests()
    testCaseNum = sizeof(bshrDataArr) / sizeof(bshrDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shr(bshrDataArr[i][0], bshrDataArr[i][1]), _bShr(bshrDataArr[i][0], bshrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bShr, shr(bshrDataArr[i][0], bshrDataArr[i][1]), _bShr(bshrDataArr[i][0], bshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bShrConst1_TestCase%d", i + 1);
       bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bshr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &bshrDataArr[i][0], 2, &bshrDataArr[i][1]));
-      EXPECT_EQ(shr(bshrDataArr[i][0], bshrDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bShiftOrRolConst, shr(bshrDataArr[i][0], bshrDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bShrConst2_TestCase%d", i + 1);
       bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bshr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &bshrDataArr[i][0]));
-      EXPECT_EQ(shr(bshrDataArr[i][0], bshrDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, bshrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bShiftOrRolConst, shr(bshrDataArr[i][0], bshrDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, bshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bShrConst3_TestCase%d", i + 1);
       bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bshr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &bshrDataArr[i][1]));
-      EXPECT_EQ(shr(bshrDataArr[i][0], bshrDataArr[i][1]), bShiftOrRolConst(bshrDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bShiftOrRolConst, shr(bshrDataArr[i][0], bshrDataArr[i][1]), bShiftOrRolConst(bshrDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //sushr
    testCaseNum = sizeof(sushrDataArr) / sizeof(sushrDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shr(sushrDataArr[i][0], sushrDataArr[i][1]), _suShr(sushrDataArr[i][0], sushrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_suShr, shr(sushrDataArr[i][0], sushrDataArr[i][1]), _suShr(sushrDataArr[i][0], sushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "suShrConst1_TestCase%d", i + 1);
       suShiftOrRolConst = (unsignedSignatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sushr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &sushrDataArr[i][0], 2, &sushrDataArr[i][1]));
-      EXPECT_EQ(shr(sushrDataArr[i][0], sushrDataArr[i][1]), suShiftOrRolConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(suShiftOrRolConst, shr(sushrDataArr[i][0], sushrDataArr[i][1]), suShiftOrRolConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "suShrConst2_TestCase%d", i + 1);
       suShiftOrRolConst = (unsignedSignatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sushr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &sushrDataArr[i][0]));
-      EXPECT_EQ(shr(sushrDataArr[i][0], sushrDataArr[i][1]), suShiftOrRolConst(SHORT_PLACEHOLDER_1, sushrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(suShiftOrRolConst, shr(sushrDataArr[i][0], sushrDataArr[i][1]), suShiftOrRolConst(SHORT_PLACEHOLDER_1, sushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "suShrConst3_TestCase%d", i + 1);
       suShiftOrRolConst = (unsignedSignatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sushr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &sushrDataArr[i][1]));
-      EXPECT_EQ(shr(sushrDataArr[i][0], sushrDataArr[i][1]), suShiftOrRolConst(sushrDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(suShiftOrRolConst, shr(sushrDataArr[i][0], sushrDataArr[i][1]), suShiftOrRolConst(sushrDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    }
@@ -4865,66 +4891,66 @@ PPCOpCodesTest::invokeDisabledBitwiseTests()
    testCaseNum = sizeof(longAndArr) / sizeof(longAndArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(tand(longAndArr[i][0], longAndArr[i][1]), _lAnd(longAndArr[i][0], longAndArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lAnd, tand(longAndArr[i][0], longAndArr[i][1]), _lAnd(longAndArr[i][0], longAndArr[i][1]));
 
       sprintf(resolvedMethodName, "lAndConst1_TestCase%d", i + 1);
       lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::land, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &(longAndArr[i][0]), 2, &(longAndArr[i][1])));
-      EXPECT_EQ(tand(longAndArr[i][0], longAndArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBitwiseConst, tand(longAndArr[i][0], longAndArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lAndConst2_TestCase%d", i + 1);
       lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::land, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &(longAndArr[i][0])));
-      EXPECT_EQ(tand(longAndArr[i][0], longAndArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, longAndArr[i][1]));
+      OMR_CT_EXPECT_EQ(lBitwiseConst, tand(longAndArr[i][0], longAndArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, longAndArr[i][1]));
 
       sprintf(resolvedMethodName, "lAndConst3_TestCase%d", i + 1);
       lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::land, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &(longAndArr[i][1])));
-      EXPECT_EQ(tand(longAndArr[i][0], longAndArr[i][1]), lBitwiseConst(longAndArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBitwiseConst, tand(longAndArr[i][0], longAndArr[i][1]), lBitwiseConst(longAndArr[i][0], LONG_PLACEHOLDER_2));
      }
 
    //lor
    testCaseNum = sizeof(longOrArr) / sizeof(longOrArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(tor(longOrArr[i][0], longOrArr[i][1]), _lOr(longOrArr[i][0], longOrArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lOr, tor(longOrArr[i][0], longOrArr[i][1]), _lOr(longOrArr[i][0], longOrArr[i][1]));
 
       sprintf(resolvedMethodName, "lOrConst1_TestCase%d", i + 1);
       lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &(longOrArr[i][0]), 2, &(longOrArr[i][1])));
-      EXPECT_EQ(tor(longOrArr[i][0], longOrArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBitwiseConst, tor(longOrArr[i][0], longOrArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lOrConst2_TestCase%d", i + 1);
       lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &(longOrArr[i][0])));
-      EXPECT_EQ(tor(longOrArr[i][0], longOrArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, longOrArr[i][1]));
+      OMR_CT_EXPECT_EQ(lBitwiseConst, tor(longOrArr[i][0], longOrArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, longOrArr[i][1]));
 
       sprintf(resolvedMethodName, "lOrConst3_TestCase%d", i + 1);
       lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &(longOrArr[i][1])));
-      EXPECT_EQ(tor(longOrArr[i][0], longOrArr[i][1]), lBitwiseConst(longOrArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBitwiseConst, tor(longOrArr[i][0], longOrArr[i][1]), lBitwiseConst(longOrArr[i][0], LONG_PLACEHOLDER_2));
      }
 
    //lxor
    testCaseNum = sizeof(longXorArr) / sizeof(longXorArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(txor(longXorArr[i][0], longXorArr[i][1]), _lXor(longXorArr[i][0], longXorArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lXor, txor(longXorArr[i][0], longXorArr[i][1]), _lXor(longXorArr[i][0], longXorArr[i][1]));
 
       sprintf(resolvedMethodName, "lXorConst1_TestCase%d", i + 1);
       lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lxor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &(longXorArr[i][0]), 2, &(longXorArr[i][1])));
-      EXPECT_EQ(txor(longXorArr[i][0], longXorArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBitwiseConst, txor(longXorArr[i][0], longXorArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lXorConst2_TestCase%d", i + 1);
       lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lxor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &(longXorArr[i][0])));
-      EXPECT_EQ(txor(longXorArr[i][0], longXorArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, longXorArr[i][1]));
+      OMR_CT_EXPECT_EQ(lBitwiseConst, txor(longXorArr[i][0], longXorArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, longXorArr[i][1]));
 
       sprintf(resolvedMethodName, "lXorConst3_TestCase%d", i + 1);
       lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lxor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &(longXorArr[i][1])));
-      EXPECT_EQ(txor(longXorArr[i][0], longXorArr[i][1]), lBitwiseConst(longXorArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBitwiseConst, txor(longXorArr[i][0], longXorArr[i][1]), lBitwiseConst(longXorArr[i][0], LONG_PLACEHOLDER_2));
      }
    }
 
@@ -5033,42 +5059,42 @@ PPCOpCodesTest::invokeDisabledTernaryTest()
    TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in fternary input array");
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), _fternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_fternary, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), _fternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fTernaryConst1_Testcase%d", i + 1);
       fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
             resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 6, 1, &fternaryChild1Arr[i], 2, &floatDataArr[i][0], 3, &floatDataArr[i][1]));
-      EXPECT_EQ(ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2, FLOAT_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2, FLOAT_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "fTernaryConst2_Testcase%d", i + 1);
       fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
             resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 4, 1, &fternaryChild1Arr[i], 2, &floatDataArr[i][0]));
-      EXPECT_EQ(ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2, floatDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2, floatDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fTernaryConst3_Testcase%d", i + 1);
       fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
             resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 4, 1, &fternaryChild1Arr[i], 3, &floatDataArr[i][1]));
-      EXPECT_EQ(ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, floatDataArr[i][0], FLOAT_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, floatDataArr[i][0], FLOAT_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "fTernaryConst4_Testcase%d", i + 1);
       fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
             resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 4, 2, &floatDataArr[i][0], 3, &floatDataArr[i][1]));
-      EXPECT_EQ(ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(fternaryChild1Arr[i], FLOAT_PLACEHOLDER_2, FLOAT_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(fternaryChild1Arr[i], FLOAT_PLACEHOLDER_2, FLOAT_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "fTernaryConst5_Testcase%d", i + 1);
       fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
             resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 2, 1, &fternaryChild1Arr[i]));
-      EXPECT_EQ(ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, floatDataArr[i][0], floatDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, floatDataArr[i][0], floatDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fTernaryConst6_Testcase%d", i + 1);
       fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
             resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 2, 2, &floatDataArr[i][0]));
-      EXPECT_EQ(ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(fternaryChild1Arr[i], FLOAT_PLACEHOLDER_1, floatDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(fternaryChild1Arr[i], FLOAT_PLACEHOLDER_1, floatDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fTernaryConst7_Testcase%d", i + 1);
       fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
             resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 2, 3, &floatDataArr[i][1]));
-      EXPECT_EQ(ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(fternaryChild1Arr[i], floatDataArr[i][0], FLOAT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(fternaryChild1Arr[i], floatDataArr[i][0], FLOAT_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(dternaryChild1Arr) / sizeof(dternaryChild1Arr[0]);
@@ -5076,42 +5102,42 @@ PPCOpCodesTest::invokeDisabledTernaryTest()
    TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in dternary input array");
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), _dternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_dternary, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), _dternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dTernaryConst1_Testcase%d", i + 1);
       dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
             resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 6, 1, &dternaryChild1Arr[i], 2, &doubleDataArr[i][0], 3, &doubleDataArr[i][1]));
-      EXPECT_EQ(ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2, DOUBLE_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2, DOUBLE_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "dTernaryConst2_Testcase%d", i + 1);
       dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
             resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 4, 1, &dternaryChild1Arr[i], 2, &doubleDataArr[i][0]));
-      EXPECT_EQ(ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2, doubleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2, doubleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dTernaryConst3_Testcase%d", i + 1);
       dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
             resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 4, 1, &dternaryChild1Arr[i], 3, &doubleDataArr[i][1]));
-      EXPECT_EQ(ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, doubleDataArr[i][0], DOUBLE_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, doubleDataArr[i][0], DOUBLE_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "dTernaryConst4_Testcase%d", i + 1);
       dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
             resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 4, 2, &doubleDataArr[i][0], 3, &doubleDataArr[i][1]));
-      EXPECT_EQ(ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(dternaryChild1Arr[i], DOUBLE_PLACEHOLDER_2, DOUBLE_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(dternaryChild1Arr[i], DOUBLE_PLACEHOLDER_2, DOUBLE_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "dTernaryConst5_Testcase%d", i + 1);
       dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
             resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 2, 1, &dternaryChild1Arr[i]));
-      EXPECT_EQ(ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, doubleDataArr[i][0], doubleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, doubleDataArr[i][0], doubleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dTernaryConst6_Testcase%d", i + 1);
       dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
             resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 2, 2, &doubleDataArr[i][0]));
-      EXPECT_EQ(ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(dternaryChild1Arr[i], DOUBLE_PLACEHOLDER_1, doubleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(dternaryChild1Arr[i], DOUBLE_PLACEHOLDER_1, doubleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dTernaryConst7_Testcase%d", i + 1);
       dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
             resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 2, 3, &doubleDataArr[i][1]));
-      EXPECT_EQ(ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(dternaryChild1Arr[i], doubleDataArr[i][0], DOUBLE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(dternaryChild1Arr[i], doubleDataArr[i][0], DOUBLE_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(lternaryChild1Arr) / sizeof(lternaryChild1Arr[0]);
@@ -5120,35 +5146,35 @@ PPCOpCodesTest::invokeDisabledTernaryTest()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "lTernaryConst%d", i + 1);
-      EXPECT_EQ(ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), _lternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lternary, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), _lternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]));
 
       lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
             resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 6, 1, &lternaryChild1Arr[i], 2, &longArr[i][0], 3, &longArr[i][1]));
-      EXPECT_EQ(ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
 
       lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
             resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 1, &lternaryChild1Arr[i], 2, &longArr[i][0]));
-      EXPECT_EQ(ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, longArr[i][1]));
+      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, longArr[i][1]));
 
       lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
             resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 1, &lternaryChild1Arr[i], 3, &longArr[i][1]));
-      EXPECT_EQ(ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, longArr[i][0], LONG_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, longArr[i][0], LONG_PLACEHOLDER_3));
 
       lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
             resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 2, &longArr[i][0], 3, &longArr[i][1]));
-      EXPECT_EQ(ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
 
       lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
             resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 1, &lternaryChild1Arr[i]));
-      EXPECT_EQ(ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, longArr[i][0], longArr[i][1]));
+      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, longArr[i][0], longArr[i][1]));
 
       lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
             resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 2, &longArr[i][0]));
-      EXPECT_EQ(ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], LONG_PLACEHOLDER_1, longArr[i][1]));
+      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], LONG_PLACEHOLDER_1, longArr[i][1]));
 
       lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
             resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 3, &longArr[i][1]));
-      EXPECT_EQ(ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], longArr[i][0], LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], longArr[i][0], LONG_PLACEHOLDER_1));
       }
    }
 
@@ -5183,11 +5209,11 @@ PPCOpCodesTest::invokeDisabledDirectCallTest()
 
    for (int32_t i = 0; i < 5; i++)
       {
-      EXPECT_EQ(intDataArray[i], _iCall(intDataArray[i]));
-      EXPECT_DOUBLE_EQ(doubleDataArray[i], _dCall(doubleDataArray[i]));
-      EXPECT_FLOAT_EQ(floatDataArray[i], _fCall(floatDataArray[i]));
-      EXPECT_EQ(longDataArray[i], _lCall(longDataArray[i]));
-      EXPECT_EQ(aUnaryDataArr[i], _acall(aUnaryDataArr[i]));
+      OMR_CT_EXPECT_EQ(_iCall, intDataArray[i], _iCall(intDataArray[i]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_dCall, doubleDataArray[i], _dCall(doubleDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_fCall, floatDataArray[i], _fCall(floatDataArray[i]));
+      OMR_CT_EXPECT_EQ(_lCall, longDataArray[i], _lCall(longDataArray[i]));
+      OMR_CT_EXPECT_EQ(_acall, aUnaryDataArr[i], _acall(aUnaryDataArr[i]));
       }
    }
 } // namespace TestCompiler

--- a/fvtest/compilertest/tests/Qux2Test.cpp
+++ b/fvtest/compilertest/tests/Qux2Test.cpp
@@ -19,6 +19,7 @@
 #include <limits.h>
 #include <stdio.h>
 #include "compile/Method.hpp"
+#include "OpCodesTest.hpp"
 #include "tests/Qux2IlInjector.hpp"
 #include "tests/Qux2Test.hpp"
 #include "gtest/gtest.h"
@@ -67,10 +68,10 @@ Qux2Test::qux2(int32_t num)
 void
 Qux2Test::invokeTests()
    {
-   EXPECT_EQ(qux2(5), _qux2(5));
-   EXPECT_EQ(10, _qux2(5));
-   EXPECT_EQ(qux2(INT_MAX/2), _qux2(INT_MAX/2));
-//   EXPECT_EQ(qux2(INT_MIN), _qux2(INT_MIN));
+   OMR_CT_EXPECT_EQ(_qux2, qux2(5), _qux2(5));
+   OMR_CT_EXPECT_EQ(_qux2, 10, _qux2(5));
+   OMR_CT_EXPECT_EQ(_qux2, qux2(INT_MAX/2), _qux2(INT_MAX/2));
+//   OMR_CT_EXPECT_EQ(_qux2, qux2(INT_MIN), _qux2(INT_MIN));
    }
 
 } // namespace TestCompiler

--- a/fvtest/compilertest/tests/S390OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/S390OpCodesTest.cpp
@@ -296,66 +296,66 @@ S390OpCodesTest::invokeIntegerArithmeticTests()
    testCaseArrLength = sizeof(longAddArr) / sizeof(longAddArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(add(longAddArr[i][0], longAddArr[i][1]), _lAdd(longAddArr[i][0], longAddArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lAdd, add(longAddArr[i][0], longAddArr[i][1]), _lAdd(longAddArr[i][0], longAddArr[i][1]));
 
       sprintf(resolvedMethodName, "lAddConst1_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ladd,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longAddArr[i][0], 2, &longAddArr[i][1]));
-      EXPECT_EQ(add(longAddArr[i][0], longAddArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, add(longAddArr[i][0], longAddArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lAddConst2_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ladd,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longAddArr[i][0]));
-      EXPECT_EQ(add(longAddArr[i][0], longAddArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longAddArr[i][1]));
+      OMR_CT_EXPECT_EQ(lBinaryCons, add(longAddArr[i][0], longAddArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longAddArr[i][1]));
 
       sprintf(resolvedMethodName, "lAddConst3_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ladd,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longAddArr[i][1]));
-      EXPECT_EQ(add(longAddArr[i][0], longAddArr[i][1]), lBinaryCons(longAddArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, add(longAddArr[i][0], longAddArr[i][1]), lBinaryCons(longAddArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //lsub
    testCaseArrLength = sizeof(longSubArr) / sizeof(longSubArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(sub(longSubArr[i][0], longSubArr[i][1]), _lSub(longSubArr[i][0], longSubArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lSub, sub(longSubArr[i][0], longSubArr[i][1]), _lSub(longSubArr[i][0], longSubArr[i][1]));
 
       sprintf(resolvedMethodName, "lSubConst1_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lsub,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longSubArr[i][0], 2, &longSubArr[i][1]));
-      EXPECT_EQ(sub(longSubArr[i][0], longSubArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, sub(longSubArr[i][0], longSubArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lSubConst2_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lsub,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longSubArr[i][0]));
-      EXPECT_EQ(sub(longSubArr[i][0], longSubArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longSubArr[i][1]));
+      OMR_CT_EXPECT_EQ(lBinaryCons, sub(longSubArr[i][0], longSubArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longSubArr[i][1]));
 
       sprintf(resolvedMethodName, "lSubConst3_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lsub,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longSubArr[i][1]));
-      EXPECT_EQ(sub(longSubArr[i][0], longSubArr[i][1]), lBinaryCons(longSubArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, sub(longSubArr[i][0], longSubArr[i][1]), lBinaryCons(longSubArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //lmul
    testCaseArrLength = sizeof(longMulArr) / sizeof(longMulArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(mul(longMulArr[i][0], longMulArr[i][1]), _lMul(longMulArr[i][0], longMulArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lMul, mul(longMulArr[i][0], longMulArr[i][1]), _lMul(longMulArr[i][0], longMulArr[i][1]));
 
       sprintf(resolvedMethodName, "lMulConst1_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lmul,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longMulArr[i][0], 2, &longMulArr[i][1]));
-      EXPECT_EQ(mul(longMulArr[i][0], longMulArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, mul(longMulArr[i][0], longMulArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lMulConst2_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lmul,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longMulArr[i][0]));
-      EXPECT_EQ(mul(longMulArr[i][0], longMulArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longMulArr[i][1]));
+      OMR_CT_EXPECT_EQ(lBinaryCons, mul(longMulArr[i][0], longMulArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longMulArr[i][1]));
 
       sprintf(resolvedMethodName, "lMulConst3_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lmul,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longMulArr[i][1]));
-      EXPECT_EQ(mul(longMulArr[i][0], longMulArr[i][1]), lBinaryCons(longMulArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, mul(longMulArr[i][0], longMulArr[i][1]), lBinaryCons(longMulArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //ldiv
@@ -363,22 +363,22 @@ S390OpCodesTest::invokeIntegerArithmeticTests()
    testCaseArrLength = sizeof(longDivArr) / sizeof(longDivArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(div(longDivArr[i][0], longDivArr[i][1]), _lDiv(longDivArr[i][0], longDivArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lDiv, div(longDivArr[i][0], longDivArr[i][1]), _lDiv(longDivArr[i][0], longDivArr[i][1]));
 
       sprintf(resolvedMethodName, "lDivConst1_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ldiv,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longDivArr[i][0], 2, &longDivArr[i][1]));
-      EXPECT_EQ(div(longDivArr[i][0], longDivArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, div(longDivArr[i][0], longDivArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lDivConst2_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ldiv,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longDivArr[i][0]));
-      EXPECT_EQ(div(longDivArr[i][0], longDivArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longDivArr[i][1]));
+      OMR_CT_EXPECT_EQ(lBinaryCons, div(longDivArr[i][0], longDivArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longDivArr[i][1]));
 
       sprintf(resolvedMethodName, "lDivConst3_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ldiv,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longDivArr[i][1]));
-      EXPECT_EQ(div(longDivArr[i][0], longDivArr[i][1]), lBinaryCons(longDivArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, div(longDivArr[i][0], longDivArr[i][1]), lBinaryCons(longDivArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //lrem
@@ -386,22 +386,22 @@ S390OpCodesTest::invokeIntegerArithmeticTests()
    testCaseArrLength = sizeof(longRemArr) / sizeof(longRemArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(rem(longRemArr[i][0], longRemArr[i][1]), _lRem(longRemArr[i][0], longRemArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lRem, rem(longRemArr[i][0], longRemArr[i][1]), _lRem(longRemArr[i][0], longRemArr[i][1]));
 
       sprintf(resolvedMethodName, "lRemConst1_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lrem,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longRemArr[i][0], 2, &longRemArr[i][1]));
-      EXPECT_EQ(rem(longRemArr[i][0], longRemArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, rem(longRemArr[i][0], longRemArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lRemConst2_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lrem,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longRemArr[i][0]));
-      EXPECT_EQ(rem(longRemArr[i][0], longRemArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longRemArr[i][1]));
+      OMR_CT_EXPECT_EQ(lBinaryCons, rem(longRemArr[i][0], longRemArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longRemArr[i][1]));
 
       sprintf(resolvedMethodName, "lRemConst3_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lrem,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longRemArr[i][1]));
-      EXPECT_EQ(rem(longRemArr[i][0], longRemArr[i][1]), lBinaryCons(longRemArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, rem(longRemArr[i][0], longRemArr[i][1]), lBinaryCons(longRemArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //ludiv
@@ -409,22 +409,22 @@ S390OpCodesTest::invokeIntegerArithmeticTests()
    testCaseArrLength = sizeof(ulongDivArr) / sizeof(ulongDivArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(div(ulongDivArr[i][0], ulongDivArr[i][1]), _luDiv(ulongDivArr[i][0], ulongDivArr[i][1]));
+      OMR_CT_EXPECT_EQ(_luDiv, div(ulongDivArr[i][0], ulongDivArr[i][1]), _luDiv(ulongDivArr[i][0], ulongDivArr[i][1]));
 
       sprintf(resolvedMethodName, "luDivConst1_Testcase%d", i);
       luBinaryCons = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ludiv, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &ulongDivArr[i][0], 2, &ulongDivArr[i][1]));
-      EXPECT_EQ(div(ulongDivArr[i][0], ulongDivArr[i][1]), luBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luBinaryCons, div(ulongDivArr[i][0], ulongDivArr[i][1]), luBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "luDivConst2_Testcase%d", i);
       luBinaryCons = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ludiv, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &ulongDivArr[i][0]));
-      EXPECT_EQ(div(ulongDivArr[i][0], ulongDivArr[i][1]), luBinaryCons(LONG_PLACEHOLDER_1, ulongDivArr[i][1]));
+      OMR_CT_EXPECT_EQ(luBinaryCons, div(ulongDivArr[i][0], ulongDivArr[i][1]), luBinaryCons(LONG_PLACEHOLDER_1, ulongDivArr[i][1]));
 
       sprintf(resolvedMethodName, "luDivConst3_Testcase%d", i);
       luBinaryCons = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ludiv, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &ulongDivArr[i][1]));
-      EXPECT_EQ(div(ulongDivArr[i][0], ulongDivArr[i][1]), luBinaryCons(ulongDivArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luBinaryCons, div(ulongDivArr[i][0], ulongDivArr[i][1]), luBinaryCons(ulongDivArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    }
@@ -509,172 +509,172 @@ S390OpCodesTest::invokeFloatArithmeticTests()
    testCaseNum = sizeof(floatAddArr) / sizeof(floatAddArr[0]);
    for (uint32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_FLOAT_EQ(add(floatAddArr[i][0], floatAddArr[i][1]), _fAdd(floatAddArr[i][0], floatAddArr[i][1]));
+      OMR_CT_EXPECT_FLOAT_EQ(_fAdd, add(floatAddArr[i][0], floatAddArr[i][1]), _fAdd(floatAddArr[i][0], floatAddArr[i][1]));
 
       sprintf(resolvedMethodName, "fAddConst1_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fadd,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatAddArr[i][0], 2, &floatAddArr[i][1]));
-      EXPECT_FLOAT_EQ(add(floatAddArr[i][0], floatAddArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, add(floatAddArr[i][0], floatAddArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fAddConst2_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fadd,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatAddArr[i][0]));
-      EXPECT_FLOAT_EQ(add(floatAddArr[i][0], floatAddArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatAddArr[i][1]));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, add(floatAddArr[i][0], floatAddArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatAddArr[i][1]));
 
       sprintf(resolvedMethodName, "fAddConst3_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fadd,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatAddArr[i][1]));
-      EXPECT_FLOAT_EQ(add(floatAddArr[i][0], floatAddArr[i][1]), fBinaryConst(floatAddArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, add(floatAddArr[i][0], floatAddArr[i][1]), fBinaryConst(floatAddArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    //fsub
    testCaseNum = sizeof(floatSubArr) / sizeof(floatSubArr[0]);
    for (uint32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_FLOAT_EQ(sub(floatSubArr[i][0], floatSubArr[i][1]), _fSub(floatSubArr[i][0], floatSubArr[i][1]));
+      OMR_CT_EXPECT_FLOAT_EQ(_fSub, sub(floatSubArr[i][0], floatSubArr[i][1]), _fSub(floatSubArr[i][0], floatSubArr[i][1]));
 
       sprintf(resolvedMethodName, "fSubConst1_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fsub,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatSubArr[i][0], 2, &floatSubArr[i][1]));
-      EXPECT_FLOAT_EQ(sub(floatSubArr[i][0], floatSubArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, sub(floatSubArr[i][0], floatSubArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fSubConst2_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fsub,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatSubArr[i][0]));
-      EXPECT_FLOAT_EQ(sub(floatSubArr[i][0], floatSubArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatSubArr[i][1]));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, sub(floatSubArr[i][0], floatSubArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatSubArr[i][1]));
 
       sprintf(resolvedMethodName, "fSubConst3_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fsub,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatSubArr[i][1]));
-      EXPECT_FLOAT_EQ(sub(floatSubArr[i][0], floatSubArr[i][1]), fBinaryConst(floatSubArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, sub(floatSubArr[i][0], floatSubArr[i][1]), fBinaryConst(floatSubArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    //fmul
    testCaseNum = sizeof(floatMulArr) / sizeof(floatMulArr[0]);
    for (uint32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_FLOAT_EQ(mul(floatMulArr[i][0], floatMulArr[i][1]), _fMul(floatMulArr[i][0], floatMulArr[i][1]));
+      OMR_CT_EXPECT_FLOAT_EQ(_fMul, mul(floatMulArr[i][0], floatMulArr[i][1]), _fMul(floatMulArr[i][0], floatMulArr[i][1]));
 
       sprintf(resolvedMethodName, "fMulConst1_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fmul,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatMulArr[i][0], 2, &floatMulArr[i][1]));
-      EXPECT_FLOAT_EQ(mul(floatMulArr[i][0], floatMulArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, mul(floatMulArr[i][0], floatMulArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fMulConst2_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fmul,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatMulArr[i][0]));
-      EXPECT_FLOAT_EQ(mul(floatMulArr[i][0], floatMulArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatMulArr[i][1]));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, mul(floatMulArr[i][0], floatMulArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatMulArr[i][1]));
 
       sprintf(resolvedMethodName, "fMulConst3_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fmul,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatMulArr[i][1]));
-      EXPECT_FLOAT_EQ(mul(floatMulArr[i][0], floatMulArr[i][1]), fBinaryConst(floatMulArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, mul(floatMulArr[i][0], floatMulArr[i][1]), fBinaryConst(floatMulArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    //fdiv
    testCaseNum = sizeof(floatDivArr) / sizeof(floatDivArr[0]);
    for (uint32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_FLOAT_EQ(div(floatDivArr[i][0], floatDivArr[i][1]), _fDiv(floatDivArr[i][0], floatDivArr[i][1]));
+      OMR_CT_EXPECT_FLOAT_EQ(_fDiv, div(floatDivArr[i][0], floatDivArr[i][1]), _fDiv(floatDivArr[i][0], floatDivArr[i][1]));
 
       sprintf(resolvedMethodName, "fDivConst1_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fdiv,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatDivArr[i][0], 2, &floatDivArr[i][1]));
-      EXPECT_FLOAT_EQ(div(floatDivArr[i][0], floatDivArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, div(floatDivArr[i][0], floatDivArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fDivConst2_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fdiv,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatDivArr[i][0]));
-      EXPECT_FLOAT_EQ(div(floatDivArr[i][0], floatDivArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatDivArr[i][1]));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, div(floatDivArr[i][0], floatDivArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatDivArr[i][1]));
 
       sprintf(resolvedMethodName, "fDivConst3_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fdiv,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatDivArr[i][1]));
-      EXPECT_FLOAT_EQ(div(floatDivArr[i][0], floatDivArr[i][1]), fBinaryConst(floatDivArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, div(floatDivArr[i][0], floatDivArr[i][1]), fBinaryConst(floatDivArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(doubleAddArr) / sizeof(doubleAddArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_DOUBLE_EQ(add(doubleAddArr[i][0], doubleAddArr[i][1]), _dAdd(doubleAddArr[i][0], doubleAddArr[i][1]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_dAdd, add(doubleAddArr[i][0], doubleAddArr[i][1]), _dAdd(doubleAddArr[i][0], doubleAddArr[i][1]));
 
       sprintf(resolvedMethodName, "dAddConst1_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dadd,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleAddArr[i][0], 2, &doubleAddArr[i][1]));
-      EXPECT_DOUBLE_EQ(add(doubleAddArr[i][0], doubleAddArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, add(doubleAddArr[i][0], doubleAddArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dAddConst2_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dadd,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleAddArr[i][0]));
-      EXPECT_DOUBLE_EQ(add(doubleAddArr[i][0], doubleAddArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleAddArr[i][1]));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, add(doubleAddArr[i][0], doubleAddArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleAddArr[i][1]));
 
       sprintf(resolvedMethodName, "dAddConst3_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dadd,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleAddArr[i][1]));
-      EXPECT_DOUBLE_EQ(add(doubleAddArr[i][0], doubleAddArr[i][1]), dBinaryConst(doubleAddArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, add(doubleAddArr[i][0], doubleAddArr[i][1]), dBinaryConst(doubleAddArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(doubleSubArr) / sizeof(doubleSubArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_DOUBLE_EQ(sub(doubleSubArr[i][0], doubleSubArr[i][1]), _dSub(doubleSubArr[i][0], doubleSubArr[i][1]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_dSub, sub(doubleSubArr[i][0], doubleSubArr[i][1]), _dSub(doubleSubArr[i][0], doubleSubArr[i][1]));
 
       sprintf(resolvedMethodName, "dSubConst1_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dsub,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleSubArr[i][0], 2, &doubleSubArr[i][1]));
-      EXPECT_DOUBLE_EQ(sub(doubleSubArr[i][0], doubleSubArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, sub(doubleSubArr[i][0], doubleSubArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dSubConst2_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dsub,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleSubArr[i][0]));
-      EXPECT_DOUBLE_EQ(sub(doubleSubArr[i][0], doubleSubArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleSubArr[i][1]));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, sub(doubleSubArr[i][0], doubleSubArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleSubArr[i][1]));
 
       sprintf(resolvedMethodName, "dSubConst3_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dsub,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleSubArr[i][1]));
-      EXPECT_DOUBLE_EQ(sub(doubleSubArr[i][0], doubleSubArr[i][1]), dBinaryConst(doubleSubArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, sub(doubleSubArr[i][0], doubleSubArr[i][1]), dBinaryConst(doubleSubArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(doubleMulArr) / sizeof(doubleMulArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_DOUBLE_EQ(mul(doubleMulArr[i][0], doubleMulArr[i][1]), _dMul(doubleMulArr[i][0], doubleMulArr[i][1]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_dMul, mul(doubleMulArr[i][0], doubleMulArr[i][1]), _dMul(doubleMulArr[i][0], doubleMulArr[i][1]));
 
       sprintf(resolvedMethodName, "dMulConst1_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dmul,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleMulArr[i][0], 2, &doubleMulArr[i][1]));
-      EXPECT_DOUBLE_EQ(mul(doubleMulArr[i][0], doubleMulArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, mul(doubleMulArr[i][0], doubleMulArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dMulConst2_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dmul,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleMulArr[i][0]));
-      EXPECT_DOUBLE_EQ(mul(doubleMulArr[i][0], doubleMulArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleMulArr[i][1]));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, mul(doubleMulArr[i][0], doubleMulArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleMulArr[i][1]));
 
       sprintf(resolvedMethodName, "dMulConst3_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dmul,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleMulArr[i][1]));
-      EXPECT_DOUBLE_EQ(mul(doubleMulArr[i][0], doubleMulArr[i][1]), dBinaryConst(doubleMulArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, mul(doubleMulArr[i][0], doubleMulArr[i][1]), dBinaryConst(doubleMulArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(doubleDivArr) / sizeof(doubleDivArr[0]);
    for (int32_t i = 0; i < testCaseNum; i++)
       {
-      EXPECT_DOUBLE_EQ(div(doubleDivArr[i][0], doubleDivArr[i][1]), _dDiv(doubleDivArr[i][0], doubleDivArr[i][1]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_dDiv, div(doubleDivArr[i][0], doubleDivArr[i][1]), _dDiv(doubleDivArr[i][0], doubleDivArr[i][1]));
 
       sprintf(resolvedMethodName, "dDivConst1_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ddiv,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleDivArr[i][0], 2, &doubleDivArr[i][1]));
-      EXPECT_DOUBLE_EQ(div(doubleDivArr[i][0], doubleDivArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, div(doubleDivArr[i][0], doubleDivArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dDivConst2_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ddiv,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleDivArr[i][0]));
-      EXPECT_DOUBLE_EQ(div(doubleDivArr[i][0], doubleDivArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleDivArr[i][1]));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, div(doubleDivArr[i][0], doubleDivArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleDivArr[i][1]));
 
       sprintf(resolvedMethodName, "dDivConst3_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ddiv,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleDivArr[i][1]));
-      EXPECT_DOUBLE_EQ(div(doubleDivArr[i][0], doubleDivArr[i][1]), dBinaryConst(doubleDivArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, div(doubleDivArr[i][0], doubleDivArr[i][1]), dBinaryConst(doubleDivArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
    }
 
@@ -702,27 +702,27 @@ S390OpCodesTest::invokeMemoryOperationTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "lStoreConst%d", i + 1);
-      EXPECT_EQ(longDataArray[i], _lStore(longDataArray[i]));
+      OMR_CT_EXPECT_EQ(_lStore, longDataArray[i], _lStore(longDataArray[i]));
       lMemCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lstore, resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &(longDataArray[i])));
-      EXPECT_EQ(longDataArray[i], lMemCons(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lMemCons, longDataArray[i], lMemCons(LONG_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(doubleDataArray) / sizeof(doubleDataArray[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "dStoreConst%d", i + 1);
-      EXPECT_DOUBLE_EQ(doubleDataArray[i], _dStore(doubleDataArray[i]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_dStore, doubleDataArray[i], _dStore(doubleDataArray[i]));
       dMemCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dstore, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &(doubleDataArray[i])));
-      EXPECT_DOUBLE_EQ(doubleDataArray[i], dMemCons(DOUBLE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_DOUBLE_EQ(dMemCons, doubleDataArray[i], dMemCons(DOUBLE_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(floatDataArray) / sizeof(floatDataArray[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "fStoreConst%d", i + 1);
-      EXPECT_FLOAT_EQ(floatDataArray[i], _fStore(floatDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_fStore, floatDataArray[i], _fStore(floatDataArray[i]));
       fMemCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::fstore, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &(floatDataArray[i])));
-      EXPECT_FLOAT_EQ(floatDataArray[i], fMemCons(FLOAT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_FLOAT_EQ(fMemCons, floatDataArray[i], fMemCons(FLOAT_PLACEHOLDER_1));
       }
 
    //indirect load constant
@@ -733,7 +733,7 @@ S390OpCodesTest::invokeMemoryOperationTests()
       sprintf(resolvedMethodName, "iLoadiConst%d", i + 1);
       uintptrj_t intDataAddress = (uintptrj_t)(&intDataArray[i]);
       iLoadiCons = (signatureCharL_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int32, rc, 2, 1, &intDataAddress));
-      EXPECT_EQ(intDataArray[i], iLoadiCons(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(iLoadiCons, intDataArray[i], iLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(shortDataArray) / sizeof(shortDataArray[0]);
@@ -743,7 +743,7 @@ S390OpCodesTest::invokeMemoryOperationTests()
       sprintf(resolvedMethodName, "sLoadiConst%d", i + 1);
       uintptrj_t shortDataAddress = (uintptrj_t)(&shortDataArray[i]);
       sLoadiCons = (signatureCharL_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::sloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int16, rc, 2, 1, &shortDataAddress));
-      EXPECT_EQ(shortDataArray[i], sLoadiCons(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(sLoadiCons, shortDataArray[i], sLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(byteDataArray) / sizeof(byteDataArray[0]);
@@ -753,7 +753,7 @@ S390OpCodesTest::invokeMemoryOperationTests()
       sprintf(resolvedMethodName, "bLoadiConst%d", i + 1);
       uintptrj_t byteDataAddress = (uintptrj_t)(&byteDataArray[i]);
       bLoadiCons = (signatureCharL_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int8, rc, 2, 1, &byteDataAddress));
-      EXPECT_EQ(byteDataArray[i], bLoadiCons(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(bLoadiCons, byteDataArray[i], bLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(longDataArray) / sizeof(longDataArray[0]);
@@ -763,7 +763,7 @@ S390OpCodesTest::invokeMemoryOperationTests()
       sprintf(resolvedMethodName, "lLoadiConst%d", i + 1);
       uintptrj_t longDataAddress = (uintptrj_t)(&longDataArray[i]);
       lLoadiCons = (signatureCharL_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int64, rc, 2, 1, &longDataAddress));
-      EXPECT_EQ(longDataArray[i], lLoadiCons(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lLoadiCons, longDataArray[i], lLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(doubleDataArray) / sizeof(doubleDataArray[0]);
@@ -773,7 +773,7 @@ S390OpCodesTest::invokeMemoryOperationTests()
       sprintf(resolvedMethodName, "dLoadiConst%d", i + 1);
       uintptrj_t doubleDataAddress = (uintptrj_t)(&doubleDataArray[i]);
       dLoadiCons = (signatureCharL_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Double, rc, 2, 1, &doubleDataAddress));
-      EXPECT_EQ(doubleDataArray[i], dLoadiCons(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(dLoadiCons, doubleDataArray[i], dLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(floatDataArray) / sizeof(floatDataArray[0]);
@@ -783,7 +783,7 @@ S390OpCodesTest::invokeMemoryOperationTests()
       sprintf(resolvedMethodName, "fLoadiConst%d", i + 1);
       uintptrj_t floatDataAddress = (uintptrj_t)(&floatDataArray[i]);
       fLoadiCons = (signatureCharL_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::floadi, resolvedMethodName, _argTypesUnaryAddress, TR::Float, rc, 2, 1, &floatDataAddress));
-      EXPECT_EQ(floatDataArray[i], fLoadiCons(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(fLoadiCons, floatDataArray[i], fLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(addressDataArray) / sizeof(addressDataArray[0]);
@@ -793,7 +793,7 @@ S390OpCodesTest::invokeMemoryOperationTests()
       sprintf(resolvedMethodName, "aLoadiConst%d", i + 1);
       uintptrj_t addressDataAddress = (uintptrj_t)(&addressDataArray[i]);
       aLoadiCons = (signatureCharL_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::aloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Address, rc, 2, 1, &addressDataAddress));
-      EXPECT_EQ(addressDataArray[i], aLoadiCons(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(aLoadiCons, addressDataArray[i], aLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
    int64_t longStoreDataArray[] = {0, 0, 0, 0, 0};
@@ -804,18 +804,32 @@ S390OpCodesTest::invokeMemoryOperationTests()
    testCaseNum = sizeof(intDataArray) / sizeof(intDataArray[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      _iStorei((uintptrj_t)(&intStoreDataArray[i]) , intDataArray[i]);
-      EXPECT_EQ(intDataArray[i], intStoreDataArray[i]);
-      _lStorei((uintptrj_t)(&longStoreDataArray[i]) , longDataArray[i]);
-      EXPECT_EQ(longDataArray[i], longStoreDataArray[i]);
-      _fStorei((uintptrj_t)(&floatStoreDataArray[i]) , floatDataArray[i]);
-      EXPECT_EQ(floatDataArray[i], floatStoreDataArray[i]);
-      _dStorei((uintptrj_t)(&doubleStoreDataArray[i]) , doubleDataArray[i]);
-      EXPECT_EQ(doubleDataArray[i], doubleStoreDataArray[i]);
-      _aStorei((uintptrj_t)(&addressStoreDataArray[i]) , addressDataArray[i]);
-      EXPECT_EQ(addressDataArray[i], addressStoreDataArray[i]);
+      if (_iStorei != NULL)
+         {
+         _iStorei((uintptrj_t)(&intStoreDataArray[i]) , intDataArray[i]);
+         EXPECT_EQ(intDataArray[i], intStoreDataArray[i]);
+         }
+      if (_lStorei != NULL)
+         {
+         _lStorei((uintptrj_t)(&longStoreDataArray[i]) , longDataArray[i]);
+         EXPECT_EQ(longDataArray[i], longStoreDataArray[i]);
+         }
+      if (_fStorei != NULL)
+         {
+         _fStorei((uintptrj_t)(&floatStoreDataArray[i]) , floatDataArray[i]);
+         EXPECT_EQ(floatDataArray[i], floatStoreDataArray[i]);
+         }
+      if (_dStorei != NULL)
+         {
+         _dStorei((uintptrj_t)(&doubleStoreDataArray[i]) , doubleDataArray[i]);
+         EXPECT_EQ(doubleDataArray[i], doubleStoreDataArray[i]);
+         }
+      if (_aStorei != NULL)
+         {
+         _aStorei((uintptrj_t)(&addressStoreDataArray[i]) , addressDataArray[i]);
+         EXPECT_EQ(addressDataArray[i], addressStoreDataArray[i]);
+         }
       }
-
    }
 
 void
@@ -875,88 +889,88 @@ S390OpCodesTest::invokeShiftOrRolTests()
    testCaseNum = sizeof(lshlDataArr) / sizeof(lshlDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shl(lshlDataArr[i][0], lshlDataArr[i][1]), _lShl(lshlDataArr[i][0], lshlDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lShl, shl(lshlDataArr[i][0], lshlDataArr[i][1]), _lShl(lshlDataArr[i][0], lshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lShlConst1_TestCase%d", i + 1);
       lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lshl, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lshlDataArr[i][0], 2, &lshlDataArr[i][1]));
-      EXPECT_EQ(shl(lshlDataArr[i][0], lshlDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lShiftOrRolConst, shl(lshlDataArr[i][0], lshlDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "lShlConst2_TestCase%d", i + 1);
       lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lshl, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lshlDataArr[i][0]));
-      EXPECT_EQ(shl(lshlDataArr[i][0], lshlDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, lshlDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lShiftOrRolConst, shl(lshlDataArr[i][0], lshlDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, lshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lShlConst3_TestCase%d", i + 1);
       lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lshl, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lshlDataArr[i][1]));
-      EXPECT_EQ(shl(lshlDataArr[i][0], lshlDataArr[i][1]), lShiftOrRolConst(lshlDataArr[i][0], LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lShiftOrRolConst, shl(lshlDataArr[i][0], lshlDataArr[i][1]), lShiftOrRolConst(lshlDataArr[i][0], LONG_PLACEHOLDER_1));
       }
 
    //lshr
    testCaseNum = sizeof(lshrDataArr) / sizeof(lshrDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shr(lshrDataArr[i][0], lshrDataArr[i][1]), _lShr(lshrDataArr[i][0], lshrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lShr, shr(lshrDataArr[i][0], lshrDataArr[i][1]), _lShr(lshrDataArr[i][0], lshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lShrConst1_TestCase%d", i + 1);
       lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lshr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lshrDataArr[i][0], 2, &lshrDataArr[i][1]));
-      EXPECT_EQ(shr(lshrDataArr[i][0], lshrDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lShiftOrRolConst, shr(lshrDataArr[i][0], lshrDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lShrConst2_TestCase%d", i + 1);
       lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lshr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lshrDataArr[i][0]));
-      EXPECT_EQ(shr(lshrDataArr[i][0], lshrDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, lshrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lShiftOrRolConst, shr(lshrDataArr[i][0], lshrDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, lshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lShrConst3_TestCase%d", i + 1);
       lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lshr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lshrDataArr[i][1]));
-      EXPECT_EQ(shr(lshrDataArr[i][0], lshrDataArr[i][1]), lShiftOrRolConst(lshrDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lShiftOrRolConst, shr(lshrDataArr[i][0], lshrDataArr[i][1]), lShiftOrRolConst(lshrDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //lushr
    testCaseNum = sizeof(lushrDataArr) / sizeof(lushrDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shr(lushrDataArr[i][0], lushrDataArr[i][1]), _luShr(lushrDataArr[i][0], lushrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_luShr, shr(lushrDataArr[i][0], lushrDataArr[i][1]), _luShr(lushrDataArr[i][0], lushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luShrConst1_TestCase%d", i + 1);
       luShiftOrRolConst = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lushr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lushrDataArr[i][0], 2, &lushrDataArr[i][1]));
-      EXPECT_EQ(shr(lushrDataArr[i][0], lushrDataArr[i][1]), luShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luShiftOrRolConst, shr(lushrDataArr[i][0], lushrDataArr[i][1]), luShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "luShrConst2_TestCase%d", i + 1);
       luShiftOrRolConst = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lushr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lushrDataArr[i][0]));
-      EXPECT_EQ(shr(lushrDataArr[i][0], lushrDataArr[i][1]), luShiftOrRolConst(LONG_PLACEHOLDER_1, lushrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(luShiftOrRolConst, shr(lushrDataArr[i][0], lushrDataArr[i][1]), luShiftOrRolConst(LONG_PLACEHOLDER_1, lushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luShrConst3_TestCase%d", i + 1);
       luShiftOrRolConst = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lushr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lushrDataArr[i][1]));
-      EXPECT_EQ(shr(lushrDataArr[i][0], lushrDataArr[i][1]), luShiftOrRolConst(lushrDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luShiftOrRolConst, shr(lushrDataArr[i][0], lushrDataArr[i][1]), luShiftOrRolConst(lushrDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //lrol
    testCaseNum = sizeof(lrolDataArr) / sizeof(lrolDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(rol(lrolDataArr[i][0], lrolDataArr[i][1]), _lRol(lrolDataArr[i][0], lrolDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lRol, rol(lrolDataArr[i][0], lrolDataArr[i][1]), _lRol(lrolDataArr[i][0], lrolDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lRolConst1_TestCase%d", i + 1);
       lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lrol, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lrolDataArr[i][0], 2, &lrolDataArr[i][1]));
-      EXPECT_EQ(rol(lrolDataArr[i][0], lrolDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lShiftOrRolConst, rol(lrolDataArr[i][0], lrolDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lRolConst2_TestCase%d", i + 1);
       lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lrol, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lrolDataArr[i][0]));
-      EXPECT_EQ(rol(lrolDataArr[i][0], lrolDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, lrolDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lShiftOrRolConst, rol(lrolDataArr[i][0], lrolDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, lrolDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lRolConst3_TestCase%d", i + 1);
       lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lrol, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lrolDataArr[i][1]));
-      EXPECT_EQ(rol(lrolDataArr[i][0], lrolDataArr[i][1]), lShiftOrRolConst(lrolDataArr[i][0], LONG_PLACEHOLDER_2)) << lrolDataArr[i][0] << " : " << lrolDataArr[i][1];
+      OMR_CT_EXPECT_EQ(lShiftOrRolConst, rol(lrolDataArr[i][0], lrolDataArr[i][1]), lShiftOrRolConst(lrolDataArr[i][0], LONG_PLACEHOLDER_2)) << lrolDataArr[i][0] << " : " << lrolDataArr[i][1];
       }
 #endif
    }
@@ -999,66 +1013,66 @@ S390OpCodesTest::invokeBitwiseTests()
    testCaseNum = sizeof(longAndArr) / sizeof(longAndArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(tand(longAndArr[i][0], longAndArr[i][1]), _lAnd(longAndArr[i][0], longAndArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lAnd, tand(longAndArr[i][0], longAndArr[i][1]), _lAnd(longAndArr[i][0], longAndArr[i][1]));
 
       sprintf(resolvedMethodName, "lAndConst1_TestCase%d", i + 1);
       lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::land, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &(longAndArr[i][0]), 2, &(longAndArr[i][1])));
-      EXPECT_EQ(tand(longAndArr[i][0], longAndArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBitwiseConst, tand(longAndArr[i][0], longAndArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lAndConst2_TestCase%d", i + 1);
       lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::land, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &(longAndArr[i][0])));
-      EXPECT_EQ(tand(longAndArr[i][0], longAndArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, longAndArr[i][1]));
+      OMR_CT_EXPECT_EQ(lBitwiseConst, tand(longAndArr[i][0], longAndArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, longAndArr[i][1]));
 
       sprintf(resolvedMethodName, "lAndConst3_TestCase%d", i + 1);
       lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::land, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &(longAndArr[i][1])));
-      EXPECT_EQ(tand(longAndArr[i][0], longAndArr[i][1]), lBitwiseConst(longAndArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBitwiseConst, tand(longAndArr[i][0], longAndArr[i][1]), lBitwiseConst(longAndArr[i][0], LONG_PLACEHOLDER_2));
      }
 
    //lor
    testCaseNum = sizeof(longOrArr) / sizeof(longOrArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(tor(longOrArr[i][0], longOrArr[i][1]), _lOr(longOrArr[i][0], longOrArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lOr, tor(longOrArr[i][0], longOrArr[i][1]), _lOr(longOrArr[i][0], longOrArr[i][1]));
 
       sprintf(resolvedMethodName, "lOrConst1_TestCase%d", i + 1);
       lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &(longOrArr[i][0]), 2, &(longOrArr[i][1])));
-      EXPECT_EQ(tor(longOrArr[i][0], longOrArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBitwiseConst, tor(longOrArr[i][0], longOrArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lOrConst2_TestCase%d", i + 1);
       lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &(longOrArr[i][0])));
-      EXPECT_EQ(tor(longOrArr[i][0], longOrArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, longOrArr[i][1]));
+      OMR_CT_EXPECT_EQ(lBitwiseConst, tor(longOrArr[i][0], longOrArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, longOrArr[i][1]));
 
       sprintf(resolvedMethodName, "lOrConst3_TestCase%d", i + 1);
       lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &(longOrArr[i][1])));
-      EXPECT_EQ(tor(longOrArr[i][0], longOrArr[i][1]), lBitwiseConst(longOrArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBitwiseConst, tor(longOrArr[i][0], longOrArr[i][1]), lBitwiseConst(longOrArr[i][0], LONG_PLACEHOLDER_2));
      }
 
    //lxor
    testCaseNum = sizeof(longXorArr) / sizeof(longXorArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(txor(longXorArr[i][0], longXorArr[i][1]), _lXor(longXorArr[i][0], longXorArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lXor, txor(longXorArr[i][0], longXorArr[i][1]), _lXor(longXorArr[i][0], longXorArr[i][1]));
 
       sprintf(resolvedMethodName, "lXorConst1_TestCase%d", i + 1);
       lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lxor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &(longXorArr[i][0]), 2, &(longXorArr[i][1])));
-      EXPECT_EQ(txor(longXorArr[i][0], longXorArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBitwiseConst, txor(longXorArr[i][0], longXorArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lXorConst2_TestCase%d", i + 1);
       lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lxor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &(longXorArr[i][0])));
-      EXPECT_EQ(txor(longXorArr[i][0], longXorArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, longXorArr[i][1]));
+      OMR_CT_EXPECT_EQ(lBitwiseConst, txor(longXorArr[i][0], longXorArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, longXorArr[i][1]));
 
       sprintf(resolvedMethodName, "lXorConst3_TestCase%d", i + 1);
       lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lxor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &(longXorArr[i][1])));
-      EXPECT_EQ(txor(longXorArr[i][0], longXorArr[i][1]), lBitwiseConst(longXorArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBitwiseConst, txor(longXorArr[i][0], longXorArr[i][1]), lBitwiseConst(longXorArr[i][0], LONG_PLACEHOLDER_2));
      }
    }
 
@@ -1098,35 +1112,35 @@ S390OpCodesTest::invokeTernaryTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "lTernaryConst%d", i + 1);
-      EXPECT_EQ(ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), _lternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lternary, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), _lternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]));
 
       lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
             resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 6, 1, &lternaryChild1Arr[i], 2, &longArr[i][0], 3, &longArr[i][1]));
-      EXPECT_EQ(ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
 
       lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
             resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 1, &lternaryChild1Arr[i], 2, &longArr[i][0]));
-      EXPECT_EQ(ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, longArr[i][1]));
+      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, longArr[i][1]));
 
       lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
             resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 1, &lternaryChild1Arr[i], 3, &longArr[i][1]));
-      EXPECT_EQ(ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, longArr[i][0], LONG_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, longArr[i][0], LONG_PLACEHOLDER_3));
 
       lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
             resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 2, &longArr[i][0], 3, &longArr[i][1]));
-      EXPECT_EQ(ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
 
       lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
             resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 1, &lternaryChild1Arr[i]));
-      EXPECT_EQ(ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, longArr[i][0], longArr[i][1]));
+      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, longArr[i][0], longArr[i][1]));
 
       lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
             resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 2, &longArr[i][0]));
-      EXPECT_EQ(ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], LONG_PLACEHOLDER_1, longArr[i][1]));
+      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], LONG_PLACEHOLDER_1, longArr[i][1]));
 
       lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
             resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 3, &longArr[i][1]));
-      EXPECT_EQ(ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], longArr[i][0], LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], longArr[i][0], LONG_PLACEHOLDER_1));
       }
    }
 
@@ -1360,345 +1374,345 @@ S390OpCodesTest::invokeCompareTests()
    testCaseNum = sizeof(lCmpeqDataArr) / sizeof(lCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), _lCmpeq(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lCmpeq, compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), _lCmpeq(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpeqConst1_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpeqDataArr[i][0]), 2, &(lCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lCmpeqConst2_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpeqConst3_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), lCompareConst(lCmpeqDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), lCompareConst(lCmpeqDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //lcmplt
    testCaseNum = sizeof(lCmpltDataArr) / sizeof(lCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), _lCmplt(lCmpltDataArr[i][0], lCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lCmplt, compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), _lCmplt(lCmpltDataArr[i][0], lCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpltConst1_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpltDataArr[i][0]), 2, &(lCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lCmpltConst2_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpltConst3_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), lCompareConst(lCmpltDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), lCompareConst(lCmpltDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //dCompare
    testCaseNum = sizeof(dCmpeqDataArr) / sizeof(dCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), _dCmpeq(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_dCmpeq, compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), _dCmpeq(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpeqConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpeqDataArr[i][0]), 2, &(dCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpeqConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpeqConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), dCompareConst(dCmpeqDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), dCompareConst(dCmpeqDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(dCmpneDataArr) / sizeof(dCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), _dCmpne(dCmpneDataArr[i][0], dCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_dCmpne, compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), _dCmpne(dCmpneDataArr[i][0], dCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpneConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpneDataArr[i][0]), 2, &(dCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpneConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpneConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), dCompareConst(dCmpneDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), dCompareConst(dCmpneDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(dCmpgtDataArr) / sizeof(dCmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), _dCmpgt(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_dCmpgt, compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), _dCmpgt(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpgtConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpgtDataArr[i][0]), 2, &(dCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpgtConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpgtConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), dCompareConst(dCmpgtDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), dCompareConst(dCmpgtDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(dCmpltDataArr) / sizeof(dCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), _dCmplt(dCmpltDataArr[i][0], dCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_dCmplt, compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), _dCmplt(dCmpltDataArr[i][0], dCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpltConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpltDataArr[i][0]), 2, &(dCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpltConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpltConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), dCompareConst(dCmpltDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), dCompareConst(dCmpltDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(dCmpgeDataArr) / sizeof(dCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), _dCmpge(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_dCmpge, compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), _dCmpge(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpgeConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpgeDataArr[i][0]), 2, &(dCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpgeConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpgeConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), dCompareConst(dCmpgeDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), dCompareConst(dCmpgeDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(dCmpleDataArr) / sizeof(dCmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), _dCmple(dCmpleDataArr[i][0], dCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_dCmple, compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), _dCmple(dCmpleDataArr[i][0], dCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpleConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpleDataArr[i][0]), 2, &(dCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpleConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpleConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), dCompareConst(dCmpleDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), dCompareConst(dCmpleDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    //fCompare
    testCaseNum = sizeof(fCmpeqDataArr) / sizeof(fCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), _fCmpeq(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_fCmpeq, compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), _fCmpeq(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpeqConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpeqDataArr[i][0]), 2, &(fCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpeqConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpeqConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), fCompareConst(fCmpeqDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), fCompareConst(fCmpeqDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(fCmpneDataArr) / sizeof(fCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), _fCmpne(fCmpneDataArr[i][0], fCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_fCmpne, compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), _fCmpne(fCmpneDataArr[i][0], fCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpneConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpneDataArr[i][0]), 2, &(fCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpneConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpneConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), fCompareConst(fCmpneDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), fCompareConst(fCmpneDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(fCmpgtDataArr) / sizeof(fCmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), _fCmpgt(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_fCmpgt, compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), _fCmpgt(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpgtConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpgtDataArr[i][0]), 2, &(fCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpgtConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpgtConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), fCompareConst(fCmpgtDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), fCompareConst(fCmpgtDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(fCmpltDataArr) / sizeof(fCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), _fCmplt(fCmpltDataArr[i][0], fCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_fCmplt, compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), _fCmplt(fCmpltDataArr[i][0], fCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpltConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpltDataArr[i][0]), 2, &(fCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpltConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpltConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), fCompareConst(fCmpltDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), fCompareConst(fCmpltDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(fCmpgeDataArr) / sizeof(fCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), _fCmpge(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_fCmpge, compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), _fCmpge(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpgeConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpgeDataArr[i][0]), 2, &(fCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpgeConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpgeConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), fCompareConst(fCmpgeDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), fCompareConst(fCmpgeDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(fCmpleDataArr) / sizeof(fCmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), _fCmple(fCmpleDataArr[i][0], fCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_fCmple, compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), _fCmple(fCmpleDataArr[i][0], fCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpleConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpleDataArr[i][0]), 2, &(fCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpleConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpleConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), fCompareConst(fCmpleDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), fCompareConst(fCmpleDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    //lcmp
    testCaseNum = sizeof(lCmpDataArr) / sizeof(lCmpDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), _lCmp(lCmpDataArr[i][0], lCmpDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lCmp, comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), _lCmp(lCmpDataArr[i][0], lCmpDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpConst1_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmp, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpDataArr[i][0]), 2, &(lCmpDataArr[i][1])));
-      EXPECT_EQ(comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lCmpConst2_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmp, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpDataArr[i][0])));
-      EXPECT_EQ(comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lCompareConst, comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpConst3_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmp, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpDataArr[i][1])));
-      EXPECT_EQ(comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), lCompareConst(lCmpDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), lCompareConst(lCmpDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //dcmpl
    testCaseNum = sizeof(dCmplDataArr) / sizeof(dCmplDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), _dCmpl(dCmplDataArr[i][0], dCmplDataArr[i][1])) <<
+      OMR_CT_EXPECT_EQ(_dCmpl, comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), _dCmpl(dCmplDataArr[i][0], dCmplDataArr[i][1])) <<
             dCmplDataArr[i][0] << " : " << dCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmplConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpl, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmplDataArr[i][0]), 2, &(dCmplDataArr[i][1])));
-      EXPECT_EQ(comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2)) <<
+      OMR_CT_EXPECT_EQ(dCompareConst, comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2)) <<
             dCmplDataArr[i][0] << " : " << dCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmplConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpl, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmplDataArr[i][0])));
-      EXPECT_EQ(comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmplDataArr[i][1])) <<
+      OMR_CT_EXPECT_EQ(dCompareConst, comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmplDataArr[i][1])) <<
             dCmplDataArr[i][0] << " : " << dCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmplConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpl, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmplDataArr[i][1])));
-      EXPECT_EQ(comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), dCompareConst(dCmplDataArr[i][0], DOUBLE_PLACEHOLDER_2)) <<
+      OMR_CT_EXPECT_EQ(dCompareConst, comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), dCompareConst(dCmplDataArr[i][0], DOUBLE_PLACEHOLDER_2)) <<
             dCmplDataArr[i][0] << " : " << dCmplDataArr[i][1];
       }
 
@@ -1706,25 +1720,25 @@ S390OpCodesTest::invokeCompareTests()
    testCaseNum = sizeof(dCmpgDataArr) / sizeof(dCmpgDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), _dCmpg(dCmpgDataArr[i][0], dCmpgDataArr[i][1])) <<
+      OMR_CT_EXPECT_EQ(_dCmpg, compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), _dCmpg(dCmpgDataArr[i][0], dCmpgDataArr[i][1])) <<
             dCmpgDataArr[i][0] << " : " << dCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmpgConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpg, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpgDataArr[i][0]), 2, &(dCmpgDataArr[i][1])));
-      EXPECT_EQ(compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2)) <<
+      OMR_CT_EXPECT_EQ(dCompareConst, compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2)) <<
             dCmpgDataArr[i][0] << " : " << dCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmpgConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpg, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpgDataArr[i][0])));
-      EXPECT_EQ(compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpgDataArr[i][1])) <<
+      OMR_CT_EXPECT_EQ(dCompareConst, compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpgDataArr[i][1])) <<
             dCmpgDataArr[i][0] << " : " << dCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmpgConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpg, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpgDataArr[i][1])));
-      EXPECT_EQ(compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), dCompareConst(dCmpgDataArr[i][0], DOUBLE_PLACEHOLDER_2)) <<
+      OMR_CT_EXPECT_EQ(dCompareConst, compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), dCompareConst(dCmpgDataArr[i][0], DOUBLE_PLACEHOLDER_2)) <<
             dCmpgDataArr[i][0] << " : " << dCmpgDataArr[i][1];
       }
 
@@ -1732,25 +1746,25 @@ S390OpCodesTest::invokeCompareTests()
    testCaseNum = sizeof(fCmplDataArr) / sizeof(fCmplDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), _fCmpl(fCmplDataArr[i][0], fCmplDataArr[i][1])) <<
+      OMR_CT_EXPECT_EQ(_fCmpl, comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), _fCmpl(fCmplDataArr[i][0], fCmplDataArr[i][1])) <<
             fCmplDataArr[i][0] << " : " << fCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmplConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpl, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmplDataArr[i][0]), 2, &(fCmplDataArr[i][1])));
-      EXPECT_EQ(comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2)) <<
+      OMR_CT_EXPECT_EQ(fCompareConst, comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2)) <<
             fCmplDataArr[i][0] << " : " << fCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmplConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpl, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmplDataArr[i][0])));
-      EXPECT_EQ(comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmplDataArr[i][1])) <<
+      OMR_CT_EXPECT_EQ(fCompareConst, comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmplDataArr[i][1])) <<
             fCmplDataArr[i][0] << " : " << fCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmplConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpl, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmplDataArr[i][1])));
-      EXPECT_EQ(comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), fCompareConst(fCmplDataArr[i][0], FLOAT_PLACEHOLDER_2)) <<
+      OMR_CT_EXPECT_EQ(fCompareConst, comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), fCompareConst(fCmplDataArr[i][0], FLOAT_PLACEHOLDER_2)) <<
             fCmplDataArr[i][0] << " : " << fCmplDataArr[i][1];
       }
 
@@ -1758,25 +1772,25 @@ S390OpCodesTest::invokeCompareTests()
    testCaseNum = sizeof(fCmpgDataArr) / sizeof(fCmpgDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), _fCmpg(fCmpgDataArr[i][0], fCmpgDataArr[i][1])) <<
+      OMR_CT_EXPECT_EQ(_fCmpg, compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), _fCmpg(fCmpgDataArr[i][0], fCmpgDataArr[i][1])) <<
             fCmpgDataArr[i][0] << " : " << fCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmpgConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpg, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpgDataArr[i][0]), 2, &(fCmpgDataArr[i][1])));
-      EXPECT_EQ(compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2)) <<
+      OMR_CT_EXPECT_EQ(fCompareConst, compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2)) <<
             fCmpgDataArr[i][0] << " : " << fCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmpgConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpg, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpgDataArr[i][0])));
-      EXPECT_EQ(compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpgDataArr[i][1])) <<
+      OMR_CT_EXPECT_EQ(fCompareConst, compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpgDataArr[i][1])) <<
             fCmpgDataArr[i][0] << " : " << fCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmpgConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpg, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpgDataArr[i][1])));
-      EXPECT_EQ(compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), fCompareConst(fCmpgDataArr[i][0], FLOAT_PLACEHOLDER_2)) <<
+      OMR_CT_EXPECT_EQ(fCompareConst, compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), fCompareConst(fCmpgDataArr[i][0], FLOAT_PLACEHOLDER_2)) <<
             fCmpgDataArr[i][0] << " : " << fCmpgDataArr[i][1];
       }
 
@@ -1784,318 +1798,318 @@ S390OpCodesTest::invokeCompareTests()
    testCaseNum = sizeof(ifLcmpeqDataArr) / sizeof(ifLcmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), _ifLcmpeq(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifLcmpeq, compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), _ifLcmpeq(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpeqConst1_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpeqDataArr[i][0]), 2, &(ifLcmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLcmpeqConst2_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpeqConst3_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), lCompareConst(ifLcmpeqDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), lCompareConst(ifLcmpeqDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifLcmpgtDataArr) / sizeof(ifLcmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), _ifLcmpgt(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifLcmpgt, compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), _ifLcmpgt(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpgtConst1_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpgtDataArr[i][0]), 2, &(ifLcmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLcmpgtConst2_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpgtConst3_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), lCompareConst(ifLcmpgtDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), lCompareConst(ifLcmpgtDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifLcmpltDataArr) / sizeof(ifLcmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), _ifLcmplt(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifLcmplt, compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), _ifLcmplt(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpltConst1_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpltDataArr[i][0]), 2, &(ifLcmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLcmpltConst2_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpltConst3_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), lCompareConst(ifLcmpltDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), lCompareConst(ifLcmpltDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //ifdCompare
    testCaseNum = sizeof(dCmpeqDataArr) / sizeof(ifDcmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), _ifDcmpeq(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifDcmpeq, compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), _ifDcmpeq(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpeqConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpeqDataArr[i][0]), 2, &(ifDcmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpeqConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpeqConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), dCompareConst(ifDcmpeqDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), dCompareConst(ifDcmpeqDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifDcmpneDataArr) / sizeof(ifDcmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), _ifDcmpne(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifDcmpne, compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), _ifDcmpne(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpneConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpneDataArr[i][0]), 2, &(ifDcmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpneConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpneConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), dCompareConst(ifDcmpneDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), dCompareConst(ifDcmpneDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifDcmpgtDataArr) / sizeof(ifDcmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), _ifDcmpgt(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifDcmpgt, compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), _ifDcmpgt(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpgtConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpgtDataArr[i][0]), 2, &(ifDcmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpgtConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpgtConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), dCompareConst(ifDcmpgtDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), dCompareConst(ifDcmpgtDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifDcmpltDataArr) / sizeof(ifDcmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), _ifDcmplt(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifDcmplt, compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), _ifDcmplt(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpltConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpltDataArr[i][0]), 2, &(ifDcmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpltConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpltConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), dCompareConst(ifDcmpltDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), dCompareConst(ifDcmpltDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifDcmpgeDataArr) / sizeof(ifDcmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), _ifDcmpge(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifDcmpge, compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), _ifDcmpge(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpgeConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpgeDataArr[i][0]), 2, &(ifDcmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpgeConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpgeConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), dCompareConst(ifDcmpgeDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), dCompareConst(ifDcmpgeDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifDcmpleDataArr) / sizeof(ifDcmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), _ifDcmple(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifDcmple, compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), _ifDcmple(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpleConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpleDataArr[i][0]), 2, &(ifDcmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpleConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpleConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), dCompareConst(ifDcmpleDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), dCompareConst(ifDcmpleDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    //iffCompare
    testCaseNum = sizeof(ifFcmpeqDataArr) / sizeof(ifFcmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), _ifFcmpeq(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifFcmpeq, compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), _ifFcmpeq(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpeqConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpeqDataArr[i][0]), 2, &(ifFcmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpeqConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpeqConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), fCompareConst(ifFcmpeqDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), fCompareConst(ifFcmpeqDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifFcmpneDataArr) / sizeof(ifFcmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), _ifFcmpne(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifFcmpne, compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), _ifFcmpne(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpneConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpneDataArr[i][0]), 2, &(ifFcmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpneConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpneConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), fCompareConst(ifFcmpneDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), fCompareConst(ifFcmpneDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifFcmpgtDataArr) / sizeof(ifFcmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), _ifFcmpgt(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifFcmpgt, compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), _ifFcmpgt(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpgtConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpgtDataArr[i][0]), 2, &(ifFcmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpgtConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpgtConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), fCompareConst(ifFcmpgtDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), fCompareConst(ifFcmpgtDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifFcmpltDataArr) / sizeof(ifFcmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), _ifFcmplt(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifFcmplt, compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), _ifFcmplt(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpltConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpltDataArr[i][0]), 2, &(ifFcmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpltConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpltConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), fCompareConst(ifFcmpltDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), fCompareConst(ifFcmpltDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifFcmpgeDataArr) / sizeof(ifFcmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), _ifFcmpge(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifFcmpge, compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), _ifFcmpge(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpgeConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpgeDataArr[i][0]), 2, &(ifFcmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpgeConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpgeConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), fCompareConst(ifFcmpgeDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), fCompareConst(ifFcmpgeDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifFcmpleDataArr) / sizeof(ifFcmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), _ifFcmple(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifFcmple, compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), _ifFcmple(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpleConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpleDataArr[i][0]), 2, &(ifFcmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpleConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpleConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), fCompareConst(ifFcmpleDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), fCompareConst(ifFcmpleDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    }
@@ -2138,66 +2152,66 @@ S390OpCodesTest::invokeUnaryTests()
    testCaseNum = sizeof(longDataArray) / sizeof(longDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(neg(longDataArray[i]), _lNeg(longDataArray[i]));
+      OMR_CT_EXPECT_EQ(_lNeg, neg(longDataArray[i]), _lNeg(longDataArray[i]));
       sprintf(resolvedMethodName, "lNegConst%d", i + 1);
       lUnaryCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lneg,
             resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &longDataArray[i]));
-      EXPECT_EQ(neg(longDataArray[i]), lUnaryCons(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lUnaryCons, neg(longDataArray[i]), lUnaryCons(LONG_PLACEHOLDER_1));
       }
 
    //fneg
    testCaseNum = sizeof(floatDataArray) / sizeof(floatDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_FLOAT_EQ(neg(floatDataArray[i]), _fNeg(floatDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_fNeg, neg(floatDataArray[i]), _fNeg(floatDataArray[i]));
       sprintf(resolvedMethodName, "fNegConst%d", i + 1);
       fUnaryCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::fneg,
             resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &floatDataArray[i]));
-      EXPECT_FLOAT_EQ(neg(floatDataArray[i]), fUnaryCons(FLOAT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_FLOAT_EQ(fUnaryCons, neg(floatDataArray[i]), fUnaryCons(FLOAT_PLACEHOLDER_1));
       }
 
    //dneg
    testCaseNum = sizeof(doubleDataArray) / sizeof(doubleDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_DOUBLE_EQ(neg(doubleDataArray[i]), _dNeg(doubleDataArray[i]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_dNeg, neg(doubleDataArray[i]), _dNeg(doubleDataArray[i]));
       sprintf(resolvedMethodName, "dNegConst%d", i + 1);
       dUnaryCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dneg,
             resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &doubleDataArray[i]));
-      EXPECT_DOUBLE_EQ(neg(doubleDataArray[i]), dUnaryCons(DOUBLE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_DOUBLE_EQ(dUnaryCons, neg(doubleDataArray[i]), dUnaryCons(DOUBLE_PLACEHOLDER_1));
       }
 
    //labs
    testCaseNum = sizeof(longDataArray) / sizeof(longDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(abs(longDataArray[i]), _lAbs(longDataArray[i]));
+      OMR_CT_EXPECT_EQ(_lAbs, abs(longDataArray[i]), _lAbs(longDataArray[i]));
       sprintf(resolvedMethodName, "lAbsConst%d", i + 1);
       lUnaryCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::labs,
             resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &longDataArray[i]));
-      EXPECT_EQ(abs(longDataArray[i]), lUnaryCons(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lUnaryCons, abs(longDataArray[i]), lUnaryCons(LONG_PLACEHOLDER_1));
       }
 
    //fabs
    testCaseNum = sizeof(floatDataArray) / sizeof(floatDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(abs(floatDataArray[i]), _fAbs(floatDataArray[i]));
+      OMR_CT_EXPECT_EQ(_fAbs, abs(floatDataArray[i]), _fAbs(floatDataArray[i]));
       sprintf(resolvedMethodName, "fAbsConst%d", i + 1);
       fUnaryCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::fabs, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &floatDataArray[i]));
-      EXPECT_EQ(abs(floatDataArray[i]), fUnaryCons(FLOAT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(fUnaryCons, abs(floatDataArray[i]), fUnaryCons(FLOAT_PLACEHOLDER_1));
       }
 
    //dabs
    testCaseNum = sizeof(doubleDataArray) / sizeof(doubleDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(abs(doubleDataArray[i]), _dAbs(doubleDataArray[i]));
+      OMR_CT_EXPECT_EQ(_dAbs, abs(doubleDataArray[i]), _dAbs(doubleDataArray[i]));
       sprintf(resolvedMethodName, "dAbsConst%d", i + 1);
       dUnaryCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::dabs, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &doubleDataArray[i]));
-      EXPECT_EQ(abs(doubleDataArray[i]), dUnaryCons(DOUBLE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(dUnaryCons, abs(doubleDataArray[i]), dUnaryCons(DOUBLE_PLACEHOLDER_1));
       }
 
    //lReturn
@@ -2205,9 +2219,9 @@ S390OpCodesTest::invokeUnaryTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "lReturnCons%d", i + 1);
-      EXPECT_EQ(longDataArray[i], _lReturn(longDataArray[i]));
+      OMR_CT_EXPECT_EQ(_lReturn, longDataArray[i], _lReturn(longDataArray[i]));
       lUnaryCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lreturn, resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &(longDataArray[i])));
-      EXPECT_EQ(longDataArray[i], lUnaryCons(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lUnaryCons, longDataArray[i], lUnaryCons(LONG_PLACEHOLDER_1));
       }
 
    //dReturn
@@ -2215,9 +2229,9 @@ S390OpCodesTest::invokeUnaryTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "dReturnCons%d", i + 1);
-      EXPECT_DOUBLE_EQ(doubleDataArray[i], _dReturn(doubleDataArray[i]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_dReturn, doubleDataArray[i], _dReturn(doubleDataArray[i]));
       dUnaryCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dreturn, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &(doubleDataArray[i])));
-      EXPECT_DOUBLE_EQ(doubleDataArray[i], dUnaryCons(DOUBLE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_DOUBLE_EQ(dUnaryCons, doubleDataArray[i], dUnaryCons(DOUBLE_PLACEHOLDER_1));
       }
 
    //fReturn
@@ -2225,9 +2239,9 @@ S390OpCodesTest::invokeUnaryTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "fReturnCons%d", i + 1);
-      EXPECT_FLOAT_EQ(floatDataArray[i], _fReturn(floatDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_fReturn, floatDataArray[i], _fReturn(floatDataArray[i]));
       fUnaryCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::freturn, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &(floatDataArray[i])));
-      EXPECT_FLOAT_EQ(floatDataArray[i], fUnaryCons(FLOAT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_FLOAT_EQ(fUnaryCons, floatDataArray[i], fUnaryCons(FLOAT_PLACEHOLDER_1));
       }
 
    //lConst
@@ -2236,7 +2250,7 @@ S390OpCodesTest::invokeUnaryTests()
       {
       sprintf(resolvedMethodName, "lConst%d", i + 1);
       lUnaryCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lconst, resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &(longDataArray[i])));
-      EXPECT_EQ(longDataArray[i], lUnaryCons(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lUnaryCons, longDataArray[i], lUnaryCons(LONG_PLACEHOLDER_1));
       }
 
    //dConst
@@ -2245,7 +2259,7 @@ S390OpCodesTest::invokeUnaryTests()
       {
       sprintf(resolvedMethodName, "dConst%d", i + 1);
       dUnaryCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dconst, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &(doubleDataArray[i])));
-      EXPECT_DOUBLE_EQ(doubleDataArray[i], dUnaryCons(DOUBLE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_DOUBLE_EQ(dUnaryCons, doubleDataArray[i], dUnaryCons(DOUBLE_PLACEHOLDER_1));
       }
 
    //fConst
@@ -2254,139 +2268,139 @@ S390OpCodesTest::invokeUnaryTests()
       {
       sprintf(resolvedMethodName, "fConst%d", i + 1);
       fUnaryCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::fconst, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &(floatDataArray[i])));
-      EXPECT_FLOAT_EQ(floatDataArray[i], fUnaryCons(FLOAT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_FLOAT_EQ(fUnaryCons, floatDataArray[i], fUnaryCons(FLOAT_PLACEHOLDER_1));
       }
 
    //int 2 d,f
    testCaseNum = sizeof(intDataArray) / sizeof(intDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_FLOAT_EQ(convert(intDataArray[i], FLOAT_POS), _i2f(intDataArray[i]));
-      EXPECT_DOUBLE_EQ(convert(intDataArray[i], DOUBLE_POS), _i2d(intDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_i2f, convert(intDataArray[i], FLOAT_POS), _i2f(intDataArray[i]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_i2d, convert(intDataArray[i], DOUBLE_POS), _i2d(intDataArray[i]));
 
       sprintf(resolvedMethodName, "i2fConst%d", i + 1);
       i2fConst = (signatureCharI_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::i2f,
             resolvedMethodName, _argTypesUnaryInt, TR::Float, rc, 2, 1, &intDataArray[i]));
-      EXPECT_FLOAT_EQ(convert(intDataArray[i], FLOAT_POS), i2fConst(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_FLOAT_EQ(i2fConst, convert(intDataArray[i], FLOAT_POS), i2fConst(INT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "i2dConst%d", i + 1);
       i2dConst = (signatureCharI_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::i2d,
             resolvedMethodName, _argTypesUnaryInt, TR::Double, rc, 2, 1, &intDataArray[i]));
-      EXPECT_DOUBLE_EQ(convert(intDataArray[i], DOUBLE_POS), i2dConst(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_DOUBLE_EQ(i2dConst, convert(intDataArray[i], DOUBLE_POS), i2dConst(INT_PLACEHOLDER_1));
       }
 
    //l 2 d,f
    testCaseNum = sizeof(longDataArray) / sizeof(longDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_FLOAT_EQ(convert(longDataArray[i], FLOAT_POS), _l2f(longDataArray[i]));
-      EXPECT_DOUBLE_EQ(convert(longDataArray[i], DOUBLE_POS), _l2d(longDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_l2f, convert(longDataArray[i], FLOAT_POS), _l2f(longDataArray[i]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_l2d, convert(longDataArray[i], DOUBLE_POS), _l2d(longDataArray[i]));
 
       sprintf(resolvedMethodName, "l2fConst%d", i + 1);
       l2fConst = (signatureCharJ_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::l2f,
             resolvedMethodName, _argTypesUnaryLong, TR::Float, rc, 2, 1, &longDataArray[i]));
-      EXPECT_FLOAT_EQ(convert(longDataArray[i], FLOAT_POS), l2fConst(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_FLOAT_EQ(l2fConst, convert(longDataArray[i], FLOAT_POS), l2fConst(LONG_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "l2dConst%d", i + 1);
       l2dConst = (signatureCharJ_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::l2d,
             resolvedMethodName, _argTypesUnaryLong, TR::Double, rc, 2, 1, &longDataArray[i]));
-      EXPECT_DOUBLE_EQ(convert(longDataArray[i], DOUBLE_POS), l2dConst(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_DOUBLE_EQ(l2dConst, convert(longDataArray[i], DOUBLE_POS), l2dConst(LONG_PLACEHOLDER_1));
       }
 
    //iu2l
    testCaseNum = sizeof(uintDataArray) / sizeof(uintDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(uintDataArray[i], LONG_POS), _iu2l(uintDataArray[i]));
+      OMR_CT_EXPECT_EQ(_iu2l, convert(uintDataArray[i], LONG_POS), _iu2l(uintDataArray[i]));
 
       sprintf(resolvedMethodName, "iu2lConst%d", i + 1);
       iu2lConst = (unsignedSignatureCharI_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iu2l,
             resolvedMethodName, _argTypesUnaryInt, TR::Int64, rc, 2, 1, &uintDataArray[i]));
-      EXPECT_EQ(convert(uintDataArray[i], LONG_POS), iu2lConst(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(iu2lConst, convert(uintDataArray[i], LONG_POS), iu2lConst(INT_PLACEHOLDER_1));
       }
 
    //iu2d
    testCaseNum = sizeof(uintDataArray) / sizeof(uintDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(uintDataArray[i], DOUBLE_POS), _iu2d(uintDataArray[i]));
+      OMR_CT_EXPECT_EQ(_iu2d, convert(uintDataArray[i], DOUBLE_POS), _iu2d(uintDataArray[i]));
 
       sprintf(resolvedMethodName, "iu2dConst%d", i + 1);
       iu2dConst = (unsignedSignatureCharI_D_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::iu2d, resolvedMethodName, _argTypesUnaryInt, TR::Double, rc, 2, 1, &uintDataArray[i]));
-      EXPECT_EQ(convert(uintDataArray[i], DOUBLE_POS), iu2dConst(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(iu2dConst, convert(uintDataArray[i], DOUBLE_POS), iu2dConst(INT_PLACEHOLDER_1));
       }
 
    //f2l
    testCaseNum = sizeof(floatDataArray) / sizeof(floatDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(floatDataArray[i], LONG_POS), _f2l(floatDataArray[i]));
+      OMR_CT_EXPECT_EQ(_f2l, convert(floatDataArray[i], LONG_POS), _f2l(floatDataArray[i]));
 
       sprintf(resolvedMethodName, "f2lConst%d", i + 1);
       f2lConst = (signatureCharF_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2l,
             resolvedMethodName, _argTypesUnaryFloat, TR::Int64, rc, 2, 1, &floatDataArray[i]));
-      EXPECT_EQ(convert(floatDataArray[i], LONG_POS), f2lConst(FLOAT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(f2lConst, convert(floatDataArray[i], LONG_POS), f2lConst(FLOAT_PLACEHOLDER_1));
       }
 
    //d2l
    testCaseNum = sizeof(doubleDataArray) / sizeof(doubleDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(doubleDataArray[i], LONG_POS), _d2l(doubleDataArray[i]));
+      OMR_CT_EXPECT_EQ(_d2l, convert(doubleDataArray[i], LONG_POS), _d2l(doubleDataArray[i]));
 
       sprintf(resolvedMethodName, "d2lConst%d", i + 1);
       d2lConst = (signatureCharD_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2l,
             resolvedMethodName, _argTypesUnaryDouble, TR::Int64, rc, 2, 1, &doubleDataArray[i]));
-      EXPECT_EQ(convert(doubleDataArray[i], LONG_POS), d2lConst(DOUBLE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(d2lConst, convert(doubleDataArray[i], LONG_POS), d2lConst(DOUBLE_PLACEHOLDER_1));
       }
 
    //d2b d2s
    testCaseNum = sizeof(doubleDataArray) / sizeof(doubleDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(doubleDataArray[i], BYTE_POS), _d2b(doubleDataArray[i]));
-      EXPECT_EQ(convert(doubleDataArray[i], SHORT_POS), _d2s(doubleDataArray[i]));
-      EXPECT_FLOAT_EQ(convert(doubleDataArray[i], FLOAT_POS), _d2f(doubleDataArray[i]));
+      OMR_CT_EXPECT_EQ(_d2b, convert(doubleDataArray[i], BYTE_POS), _d2b(doubleDataArray[i]));
+      OMR_CT_EXPECT_EQ(_d2s, convert(doubleDataArray[i], SHORT_POS), _d2s(doubleDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_d2f, convert(doubleDataArray[i], FLOAT_POS), _d2f(doubleDataArray[i]));
 
       sprintf(resolvedMethodName, "d2bConst%d", i + 1);
       d2bConst = (signatureCharD_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2b,
             resolvedMethodName, _argTypesUnaryDouble, TR::Int8, rc, 2, 1, &doubleDataArray[i]));
-      EXPECT_EQ(convert(doubleDataArray[i], BYTE_POS), d2bConst(DOUBLE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(d2bConst, convert(doubleDataArray[i], BYTE_POS), d2bConst(DOUBLE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "d2sConst%d", i + 1);
       d2sConst = (signatureCharD_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2s,
             resolvedMethodName, _argTypesUnaryDouble, TR::Int16, rc, 2, 1, &doubleDataArray[i]));
-      EXPECT_EQ(convert(doubleDataArray[i], SHORT_POS), d2sConst(DOUBLE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(d2sConst, convert(doubleDataArray[i], SHORT_POS), d2sConst(DOUBLE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "d2fConst%d", i + 1);
       d2fConst = (signatureCharD_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2f,
             resolvedMethodName, _argTypesUnaryDouble, TR::Float, rc, 2, 1, &doubleDataArray[i]));
-      EXPECT_FLOAT_EQ(convert(doubleDataArray[i], FLOAT_POS), d2fConst(DOUBLE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_FLOAT_EQ(d2fConst, convert(doubleDataArray[i], FLOAT_POS), d2fConst(DOUBLE_PLACEHOLDER_1));
       }
 
    //f2b f2s
    testCaseNum = sizeof(floatDataArray) / sizeof(floatDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(floatDataArray[i], BYTE_POS), _f2b(floatDataArray[i]));
-      EXPECT_EQ(convert(floatDataArray[i], SHORT_POS), _f2s(floatDataArray[i]));
-      EXPECT_DOUBLE_EQ(convert(floatDataArray[i], DOUBLE_POS), _f2d(floatDataArray[i]));
+      OMR_CT_EXPECT_EQ(_f2b, convert(floatDataArray[i], BYTE_POS), _f2b(floatDataArray[i]));
+      OMR_CT_EXPECT_EQ(_f2s, convert(floatDataArray[i], SHORT_POS), _f2s(floatDataArray[i]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_f2d, convert(floatDataArray[i], DOUBLE_POS), _f2d(floatDataArray[i]));
 
       sprintf(resolvedMethodName, "f2bConst%d", i + 1);
       f2bConst = (signatureCharF_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2b,
             resolvedMethodName, _argTypesUnaryFloat, TR::Int8, rc, 2, 1, &floatDataArray[i]));
-      EXPECT_EQ(convert(floatDataArray[i], BYTE_POS), f2bConst(FLOAT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(f2bConst, convert(floatDataArray[i], BYTE_POS), f2bConst(FLOAT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "f2sConst%d", i + 1);
       f2sConst = (signatureCharF_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2s,
             resolvedMethodName, _argTypesUnaryFloat, TR::Int16, rc, 2, 1, &floatDataArray[i]));
-      EXPECT_EQ(convert(floatDataArray[i], SHORT_POS), f2sConst(FLOAT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(f2sConst, convert(floatDataArray[i], SHORT_POS), f2sConst(FLOAT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "f2dConst%d", i + 1);
       f2dConst = (signatureCharF_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2d,
             resolvedMethodName, _argTypesUnaryFloat, TR::Double, rc, 2, 1, &floatDataArray[i]));
-      EXPECT_EQ(convert(floatDataArray[i], DOUBLE_POS), f2dConst(FLOAT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(f2dConst, convert(floatDataArray[i], DOUBLE_POS), f2dConst(FLOAT_PLACEHOLDER_1));
       }
    }
 
@@ -2401,9 +2415,9 @@ S390OpCodesTest::invokeDirectCallTests()
 
    for (int32_t i = 0; i < 5; i++)
       {
-      EXPECT_EQ(intDataArray[i], _iCall(intDataArray[i]));
-      EXPECT_FLOAT_EQ(floatDataArray[i], _fCall(floatDataArray[i]));
-      EXPECT_EQ(longDataArray[i], _lCall(longDataArray[i]));
+      OMR_CT_EXPECT_EQ(_iCall, intDataArray[i], _iCall(intDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_fCall, floatDataArray[i], _fCall(floatDataArray[i]));
+      OMR_CT_EXPECT_EQ(_lCall, longDataArray[i], _lCall(longDataArray[i]));
       }
 #endif
    }
@@ -2757,996 +2771,996 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
    testCaseNum = sizeof(sCmpeqDataArr) / sizeof(sCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), _sCmpeq(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sCmpeq, compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), _sCmpeq(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpeqConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpeqDataArr[i][0]), 2, &(sCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpeqConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpeqConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), sCompareConst(sCmpeqDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), sCompareConst(sCmpeqDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(sCmpneDataArr) / sizeof(sCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), _sCmpne(sCmpneDataArr[i][0], sCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sCmpne, compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), _sCmpne(sCmpneDataArr[i][0], sCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpneConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpneDataArr[i][0]), 2, &(sCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpneConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpneConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), sCompareConst(sCmpneDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), sCompareConst(sCmpneDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(sCmpgtDataArr) / sizeof(sCmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), _sCmpgt(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sCmpgt, compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), _sCmpgt(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpgtConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpgtDataArr[i][0]), 2, &(sCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpgtConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpgtConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), sCompareConst(sCmpgtDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), sCompareConst(sCmpgtDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(sCmpltDataArr) / sizeof(sCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), _sCmplt(sCmpltDataArr[i][0], sCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sCmplt, compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), _sCmplt(sCmpltDataArr[i][0], sCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpltConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpltDataArr[i][0]), 2, &(sCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpltConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpltConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), sCompareConst(sCmpltDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), sCompareConst(sCmpltDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(sCmpgeDataArr) / sizeof(sCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), _sCmpge(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sCmpge, compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), _sCmpge(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpgeConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpgeDataArr[i][0]), 2, &(sCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpgeConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpgeConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), sCompareConst(sCmpgeDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), sCompareConst(sCmpgeDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(sCmpleDataArr) / sizeof(sCmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), _sCmple(sCmpleDataArr[i][0], sCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sCmple, compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), _sCmple(sCmpleDataArr[i][0], sCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpleConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpleDataArr[i][0]), 2, &(sCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpleConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpleConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), sCompareConst(sCmpleDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), sCompareConst(sCmpleDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    //bCompare
    testCaseNum = sizeof(bCmpeqDataArr) / sizeof(bCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), _bCmpeq(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bCmpeq, compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), _bCmpeq(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpeqConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpeqDataArr[i][0]), 2, &(bCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpeqConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpeqConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), bCompareConst(bCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), bCompareConst(bCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(bCmpgtDataArr) / sizeof(bCmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), _bCmpgt(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bCmpgt, compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), _bCmpgt(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpgtConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpgtDataArr[i][0]), 2, &(bCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpgtConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpgtConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), bCompareConst(bCmpgtDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), bCompareConst(bCmpgtDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(bCmpltDataArr) / sizeof(bCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), _bCmplt(bCmpltDataArr[i][0], bCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bCmplt, compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), _bCmplt(bCmpltDataArr[i][0], bCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpltConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpltDataArr[i][0]), 2, &(bCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpltConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpltConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), bCompareConst(bCmpltDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), bCompareConst(bCmpltDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(bCmpgeDataArr) / sizeof(bCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), _bCmpge(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bCmpge, compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), _bCmpge(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpgeConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpgeDataArr[i][0]), 2, &(bCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpgeConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpgeConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), bCompareConst(bCmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), bCompareConst(bCmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(bCmpneDataArr) / sizeof(bCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), _bCmpne(bCmpneDataArr[i][0], bCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bCmpne, compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), _bCmpne(bCmpneDataArr[i][0], bCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpneConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpneDataArr[i][0]), 2, &(bCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpneConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpneConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), bCompareConst(bCmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), bCompareConst(bCmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(bCmpleDataArr) / sizeof(bCmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), _bCmple(bCmpleDataArr[i][0], bCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bCmple, compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), _bCmple(bCmpleDataArr[i][0], bCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpleConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpleDataArr[i][0]), 2, &(bCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpleConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpleConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), bCompareConst(bCmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), bCompareConst(bCmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //iuCompare
    testCaseNum = sizeof(iuCmpeqDataArr) / sizeof(iuCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), _iuCmpeq(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iuCmpeq, compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), _iuCmpeq(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpeqConst1_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpeqDataArr[i][0]), 2, &(iuCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iuCmpeqConst2_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpeqConst3_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), iuCompareConst(iuCmpeqDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), iuCompareConst(iuCmpeqDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(iuCmpneDataArr) / sizeof(iuCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), _iuCmpne(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iuCmpne, compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), _iuCmpne(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpneConst1_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpneDataArr[i][0]), 2, &(iuCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iuCmpneConst2_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpneConst3_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), iuCompareConst(iuCmpneDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), iuCompareConst(iuCmpneDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(iuCmpgeDataArr) / sizeof(iuCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), _iuCmpge(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iuCmpge, compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), _iuCmpge(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpgeConst1_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpgeDataArr[i][0]), 2, &(iuCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iuCmpgeConst2_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpgeConst3_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(iuCmpgeDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(iuCmpgeDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    //buCompare
    testCaseNum = sizeof(buCmpeqDataArr) / sizeof(buCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), _buCmpeq(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_buCmpeq, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), _buCmpeq(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buCmpeqConst1_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(buCmpeqDataArr[i][0]), 2, &(buCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "buCmpeqConst2_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(buCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, buCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, buCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buCmpeqConst3_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(buCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(buCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(buCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(buCmpneDataArr) / sizeof(buCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), _buCmpne(buCmpneDataArr[i][0], buCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_buCmpne, compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), _buCmpne(buCmpneDataArr[i][0], buCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buCmpneConst1_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(buCmpneDataArr[i][0]), 2, &(buCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "buCmpneConst2_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(buCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, buCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, buCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buCmpneConst3_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(buCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), buCompareConst(buCmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), buCompareConst(buCmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //suCompare
    testCaseNum = sizeof(suCmpeqDataArr) / sizeof(suCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), _suCmpeq(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1])) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_suCmpeq, compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), _suCmpeq(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1])) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpeqConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpeqDataArr[i][0]), 2, &(suCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpeqConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpeqDataArr[i][1])) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpeqDataArr[i][1])) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpeqConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), suCompareConst(suCmpeqDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), suCompareConst(suCmpeqDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
       }
 
    testCaseNum = sizeof(suCmpneDataArr) / sizeof(suCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), _suCmpne(suCmpneDataArr[i][0], suCmpneDataArr[i][1])) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_suCmpne, compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), _suCmpne(suCmpneDataArr[i][0], suCmpneDataArr[i][1])) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpneConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpneDataArr[i][0]), 2, &(suCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpneConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpneDataArr[i][1])) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpneDataArr[i][1])) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpneConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), suCompareConst(suCmpneDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), suCompareConst(suCmpneDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
       }
 
    testCaseNum = sizeof(suCmpgtDataArr) / sizeof(suCmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), _suCmpgt(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1])) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_suCmpgt, compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), _suCmpgt(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1])) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgtConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpgtDataArr[i][0]), 2, &(suCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgtConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpgtDataArr[i][1])) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpgtDataArr[i][1])) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgtConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), suCompareConst(suCmpgtDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), suCompareConst(suCmpgtDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
       }
 
    testCaseNum = sizeof(suCmpltDataArr) / sizeof(suCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), _suCmplt(suCmpltDataArr[i][0], suCmpltDataArr[i][1])) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_suCmplt, compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), _suCmplt(suCmpltDataArr[i][0], suCmpltDataArr[i][1])) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpltConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpltDataArr[i][0]), 2, &(suCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpltConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpltDataArr[i][1])) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpltDataArr[i][1])) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpltConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), suCompareConst(suCmpltDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), suCompareConst(suCmpltDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
       }
 
    testCaseNum = sizeof(suCmpgeDataArr) / sizeof(suCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), _suCmpge(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1])) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_suCmpge, compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), _suCmpge(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1])) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgeConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpgeDataArr[i][0]), 2, &(suCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgeConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpgeDataArr[i][1])) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpgeDataArr[i][1])) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgeConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), suCompareConst(suCmpgeDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), suCompareConst(suCmpgeDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
       }
 
    testCaseNum = sizeof(suCmpleDataArr) / sizeof(suCmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), _suCmple(suCmpleDataArr[i][0], suCmpleDataArr[i][1])) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_suCmple, compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), _suCmple(suCmpleDataArr[i][0], suCmpleDataArr[i][1])) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpleConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpleDataArr[i][0]), 2, &(suCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpleConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpleDataArr[i][1])) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpleDataArr[i][1])) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpleConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(suCmpleDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(suCmpleDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
       }
 
    //ifsCompare
    testCaseNum = sizeof(ifScmpeqDataArr) / sizeof(ifScmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), _ifScmpeq(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifScmpeq, compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), _ifScmpeq(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpeqConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpeqDataArr[i][0]), 2, &(ifScmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpeqConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpeqConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), sCompareConst(ifScmpeqDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), sCompareConst(ifScmpeqDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifScmpneDataArr) / sizeof(ifScmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), _ifScmpne(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifScmpne, compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), _ifScmpne(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpneConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpneDataArr[i][0]), 2, &(ifScmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpneConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpneConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), sCompareConst(ifScmpneDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), sCompareConst(ifScmpneDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifScmpgtDataArr) / sizeof(ifScmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), _ifScmpgt(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifScmpgt, compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), _ifScmpgt(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpgtConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpgtDataArr[i][0]), 2, &(ifScmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpgtConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpgtConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), sCompareConst(ifScmpgtDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), sCompareConst(ifScmpgtDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifScmpltDataArr) / sizeof(ifScmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), _ifScmplt(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifScmplt, compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), _ifScmplt(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpltConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpltDataArr[i][0]), 2, &(ifScmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpltConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpltConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), sCompareConst(ifScmpltDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), sCompareConst(ifScmpltDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifScmpgeDataArr) / sizeof(ifScmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), _ifScmpge(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifScmpge, compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), _ifScmpge(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpgeConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpgeDataArr[i][0]), 2, &(ifScmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpgeConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpgeConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), sCompareConst(ifScmpgeDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), sCompareConst(ifScmpgeDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifScmpleDataArr) / sizeof(ifScmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), _ifScmple(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifScmple, compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), _ifScmple(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpleConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpleDataArr[i][0]), 2, &(ifScmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpleConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpleConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), sCompareConst(ifScmpleDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), sCompareConst(ifScmpleDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    //ifbCompare
    testCaseNum = sizeof(ifBcmpeqDataArr) / sizeof(ifBcmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), _ifBcmpeq(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBcmpeq, compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), _ifBcmpeq(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpeqConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpeqDataArr[i][0]), 2, &(ifBcmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpeqConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpeqConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), bCompareConst(ifBcmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), bCompareConst(ifBcmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBcmpgtDataArr) / sizeof(ifBcmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), _ifBcmpgt(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBcmpgt, compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), _ifBcmpgt(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpgtConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpgtDataArr[i][0]), 2, &(ifBcmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpgtConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpgtConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), bCompareConst(ifBcmpgtDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), bCompareConst(ifBcmpgtDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBcmpltDataArr) / sizeof(ifBcmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), _ifBcmplt(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBcmplt, compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), _ifBcmplt(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpltConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpltDataArr[i][0]), 2, &(ifBcmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpltConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpltConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), bCompareConst(ifBcmpltDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), bCompareConst(ifBcmpltDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBcmpgeDataArr) / sizeof(ifBcmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), _ifBcmpge(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBcmpge, compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), _ifBcmpge(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpgeConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpgeDataArr[i][0]), 2, &(ifBcmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpgeConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpgeConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(ifBcmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(ifBcmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBcmpneDataArr) / sizeof(ifBcmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), _ifBcmpne(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBcmpne, compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), _ifBcmpne(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpneConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpneDataArr[i][0]), 2, &(ifBcmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpneConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpneConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), bCompareConst(ifBcmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), bCompareConst(ifBcmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBcmpleDataArr) / sizeof(ifBcmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), _ifBcmple(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBcmple, compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), _ifBcmple(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpleConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpleDataArr[i][0]), 2, &(ifBcmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpleConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpleConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(ifBcmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(ifBcmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //ifBuCompare
    testCaseNum = sizeof(ifBuCmpeqDataArr) / sizeof(ifBuCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), _ifBuCmpeq(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBuCmpeq, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), _ifBuCmpeq(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpeqConst1_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpeqDataArr[i][0]), 2, &(ifBuCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpeqConst2_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpeqConst3_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(ifBuCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(ifBuCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBuCmpneDataArr) / sizeof(ifBuCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), _ifBuCmpne(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBuCmpne, compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), _ifBuCmpne(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpneConst1_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpneDataArr[i][0]), 2, &(ifBuCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpneConst2_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpneConst3_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), buCompareConst(ifBuCmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), buCompareConst(ifBuCmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBuCmpgtDataArr) / sizeof(ifBuCmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), _ifBuCmpgt(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBuCmpgt, compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), _ifBuCmpgt(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpgtConst1_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpgtDataArr[i][0]), 2, &(ifBuCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpgtConst2_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpgtConst3_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), buCompareConst(ifBuCmpgtDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), buCompareConst(ifBuCmpgtDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBuCmpltDataArr) / sizeof(ifBuCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), _ifBuCmplt(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBuCmplt, compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), _ifBuCmplt(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpltConst1_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpltDataArr[i][0]), 2, &(ifBuCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpltConst2_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpltConst3_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), buCompareConst(ifBuCmpltDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), buCompareConst(ifBuCmpltDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBuCmpgeDataArr) / sizeof(ifBuCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), _ifBuCmpge(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBuCmpge, compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), _ifBuCmpge(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpgeConst1_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpgeDataArr[i][0]), 2, &(ifBuCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpgeConst2_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpgeConst3_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), buCompareConst(ifBuCmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), buCompareConst(ifBuCmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBuCmpleDataArr) / sizeof(ifBuCmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), _ifBuCmple(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBuCmple, compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), _ifBuCmple(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpleConst1_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpleDataArr[i][0]), 2, &(ifBuCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpleConst2_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpleConst3_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), buCompareConst(ifBuCmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), buCompareConst(ifBuCmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //ifSuCompare
    testCaseNum = sizeof(ifSuCmpeqDataArr) / sizeof(ifSuCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), _ifSuCmpeq(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1])) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_ifSuCmpeq, compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), _ifSuCmpeq(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1])) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpeqConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpeqDataArr[i][0]), 2, &(ifSuCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpeqConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpeqDataArr[i][1])) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpeqDataArr[i][1])) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpeqConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), suCompareConst(ifSuCmpeqDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), suCompareConst(ifSuCmpeqDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
       }
 
    testCaseNum = sizeof(ifSuCmpneDataArr) / sizeof(ifSuCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), _ifSuCmpne(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1])) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_ifSuCmpne, compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), _ifSuCmpne(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1])) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpneConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpneDataArr[i][0]), 2, &(ifSuCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpneConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpneDataArr[i][1])) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpneDataArr[i][1])) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpneConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), suCompareConst(ifSuCmpneDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), suCompareConst(ifSuCmpneDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
       }
 
    testCaseNum = sizeof(ifSuCmpgtDataArr) / sizeof(ifSuCmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), _ifSuCmpgt(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1])) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_ifSuCmpgt, compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), _ifSuCmpgt(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1])) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgtConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpgtDataArr[i][0]), 2, &(ifSuCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgtConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpgtDataArr[i][1])) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpgtDataArr[i][1])) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgtConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), suCompareConst(ifSuCmpgtDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), suCompareConst(ifSuCmpgtDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
       }
 
    testCaseNum = sizeof(ifSuCmpltDataArr) / sizeof(ifSuCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), _ifSuCmplt(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1])) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_ifSuCmplt, compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), _ifSuCmplt(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1])) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpltConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpltDataArr[i][0]), 2, &(ifSuCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpltConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpltDataArr[i][1])) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpltDataArr[i][1])) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpltConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), suCompareConst(ifSuCmpltDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), suCompareConst(ifSuCmpltDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
       }
 
    testCaseNum = sizeof(ifSuCmpgeDataArr) / sizeof(ifSuCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), _ifSuCmpge(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1])) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_ifSuCmpge, compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), _ifSuCmpge(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1])) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgeConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpgeDataArr[i][0]), 2, &(ifSuCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgeConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpgeDataArr[i][1])) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpgeDataArr[i][1])) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgeConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), suCompareConst(ifSuCmpgeDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), suCompareConst(ifSuCmpgeDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
       }
 
    testCaseNum = sizeof(ifSuCmpleDataArr) / sizeof(ifSuCmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), _ifSuCmple(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1])) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_ifSuCmple, compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), _ifSuCmple(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1])) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpleConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpleDataArr[i][0]), 2, &(ifSuCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpleConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpleDataArr[i][1])) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpleDataArr[i][1])) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpleConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), suCompareConst(ifSuCmpleDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), suCompareConst(ifSuCmpleDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
       }
    }
 
@@ -3783,17 +3797,17 @@ S390OpCodesTest::invokeDisabledDirectCallTests()
 
    for (int32_t i = 0; i < 5; i++)
       {
-      EXPECT_EQ(intDataArray[i], _iCall(intDataArray[i]));
-      EXPECT_FLOAT_EQ(floatDataArray[i], _fCall(floatDataArray[i]));
-      EXPECT_EQ(longDataArray[i], _lCall(longDataArray[i]));
-      EXPECT_EQ(aUnaryDataArr[i], _acall(aUnaryDataArr[i]));
+      OMR_CT_EXPECT_EQ(_iCall, intDataArray[i], _iCall(intDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_fCall, floatDataArray[i], _fCall(floatDataArray[i]));
+      OMR_CT_EXPECT_EQ(_lCall, longDataArray[i], _lCall(longDataArray[i]));
+      OMR_CT_EXPECT_EQ(_acall, aUnaryDataArr[i], _acall(aUnaryDataArr[i]));
       }
 #endif
 
    double doubleDataArray[] = {DOUBLE_NEG, DOUBLE_POS, DOUBLE_MAXIMUM, DOUBLE_MINIMUM, DOUBLE_ZERO};
    for (int32_t i = 0; i < 5; i++)
       {
-      EXPECT_DOUBLE_EQ(doubleDataArray[i], _dCall(doubleDataArray[i]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_dCall, doubleDataArray[i], _dCall(doubleDataArray[i]));
       }
    }
 void
@@ -3878,215 +3892,215 @@ S390OpCodesTest::invokeDisabledUnaryTests()
    testCaseNum = sizeof(byteDataArray) / sizeof(byteDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(neg(byteDataArray[i]), _bNeg(byteDataArray[i]));
+      OMR_CT_EXPECT_EQ(_bNeg, neg(byteDataArray[i]), _bNeg(byteDataArray[i]));
       sprintf(resolvedMethodName, "bNegConst%d", i + 1);
       bUnaryCons = (signatureCharB_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bneg,
             resolvedMethodName, _argTypesUnaryByte, TR::Int8, rc, 2, 1, &byteDataArray[i]));
-      EXPECT_EQ(neg(byteDataArray[i]), bUnaryCons(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(bUnaryCons, neg(byteDataArray[i]), bUnaryCons(BYTE_PLACEHOLDER_1));
       }
 
    //sneg
    testCaseNum = sizeof(shortDataArray) / sizeof(shortDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(neg(shortDataArray[i]), _sNeg(shortDataArray[i]));
+      OMR_CT_EXPECT_EQ(_sNeg, neg(shortDataArray[i]), _sNeg(shortDataArray[i]));
       sprintf(resolvedMethodName, "sNegConst%d", i + 1);
       sUnaryCons = (signatureCharS_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::sneg,
             resolvedMethodName, _argTypesUnaryShort, TR::Int16, rc, 2, 1, &shortDataArray[i]));
-      EXPECT_EQ(neg(shortDataArray[i]), sUnaryCons(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(sUnaryCons, neg(shortDataArray[i]), sUnaryCons(SHORT_PLACEHOLDER_1));
       }
 
    //b 2 d,f
    testCaseNum = sizeof(byteDataArray) / sizeof(byteDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_FLOAT_EQ(convert(byteDataArray[i], FLOAT_POS), _b2f(byteDataArray[i]));
-      EXPECT_DOUBLE_EQ(convert(byteDataArray[i], DOUBLE_POS), _b2d(byteDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_b2f, convert(byteDataArray[i], FLOAT_POS), _b2f(byteDataArray[i]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_b2d, convert(byteDataArray[i], DOUBLE_POS), _b2d(byteDataArray[i]));
 
       sprintf(resolvedMethodName, "b2fConst%d", i + 1);
       b2fConst = (signatureCharB_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2f,
             resolvedMethodName, _argTypesUnaryByte, TR::Float, rc, 2, 1, &byteDataArray[i]));
-      EXPECT_FLOAT_EQ(convert(byteDataArray[i], FLOAT_POS), b2fConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_FLOAT_EQ(b2fConst, convert(byteDataArray[i], FLOAT_POS), b2fConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "b2dConst%d", i + 1);
       b2dConst = (signatureCharB_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2d,
             resolvedMethodName, _argTypesUnaryByte, TR::Double, rc, 2, 1, &byteDataArray[i]));
-      EXPECT_DOUBLE_EQ(convert(byteDataArray[i], DOUBLE_POS), b2dConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_DOUBLE_EQ(b2dConst, convert(byteDataArray[i], DOUBLE_POS), b2dConst(BYTE_PLACEHOLDER_1));
       }
 
    //b 2 i,l,s
    testCaseNum = sizeof(byteDataArray) / sizeof(byteDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(byteDataArray[i], SHORT_POS), _b2s(byteDataArray[i]));
-      EXPECT_EQ(convert(byteDataArray[i], INT_POS), _b2i(byteDataArray[i]));
-      EXPECT_EQ(convert(byteDataArray[i], LONG_POS), _b2l(byteDataArray[i]));
+      OMR_CT_EXPECT_EQ(_b2s, convert(byteDataArray[i], SHORT_POS), _b2s(byteDataArray[i]));
+      OMR_CT_EXPECT_EQ(_b2i, convert(byteDataArray[i], INT_POS), _b2i(byteDataArray[i]));
+      OMR_CT_EXPECT_EQ(_b2l, convert(byteDataArray[i], LONG_POS), _b2l(byteDataArray[i]));
 
       sprintf(resolvedMethodName, "b2sConst%d", i + 1);
       b2sConst = (signatureCharB_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2s,
             resolvedMethodName, _argTypesUnaryByte, TR::Int16, rc, 2, 1, &byteDataArray[i]));
-      EXPECT_EQ(convert(byteDataArray[i], SHORT_POS), b2sConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(b2sConst, convert(byteDataArray[i], SHORT_POS), b2sConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "b2iConst%d", i + 1);
       b2iConst = (signatureCharB_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2i,
             resolvedMethodName, _argTypesUnaryByte, TR::Int32, rc, 2, 1, &byteDataArray[i]));
-      EXPECT_EQ(convert(byteDataArray[i], INT_POS), b2iConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(b2iConst, convert(byteDataArray[i], INT_POS), b2iConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "b2lConst%d", i + 1);
       b2lConst = (signatureCharB_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2l,
             resolvedMethodName, _argTypesUnaryByte, TR::Int64, rc, 2, 1, &byteDataArray[i]));
-      EXPECT_EQ(convert(byteDataArray[i], LONG_POS), b2lConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(b2lConst, convert(byteDataArray[i], LONG_POS), b2lConst(BYTE_PLACEHOLDER_1));
       }
 
    //bu 2 i,l,s
    testCaseNum = sizeof(ubyteDataArray) / sizeof(ubyteDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(ubyteDataArray[i], SHORT_POS), _bu2s(ubyteDataArray[i]));
-      EXPECT_EQ(convert(ubyteDataArray[i], INT_POS), _bu2i(ubyteDataArray[i]));
-      EXPECT_EQ(convert(ubyteDataArray[i], LONG_POS), _bu2l(ubyteDataArray[i]));
+      OMR_CT_EXPECT_EQ(_bu2s, convert(ubyteDataArray[i], SHORT_POS), _bu2s(ubyteDataArray[i]));
+      OMR_CT_EXPECT_EQ(_bu2i, convert(ubyteDataArray[i], INT_POS), _bu2i(ubyteDataArray[i]));
+      OMR_CT_EXPECT_EQ(_bu2l, convert(ubyteDataArray[i], LONG_POS), _bu2l(ubyteDataArray[i]));
 
       sprintf(resolvedMethodName, "bu2sConst%d", i + 1);
       bu2sConst = (unsignedSignatureCharB_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2s,
             resolvedMethodName, _argTypesUnaryByte, TR::Int16, rc, 2, 1, &ubyteDataArray[i]));
-      EXPECT_EQ(convert(ubyteDataArray[i], SHORT_POS), bu2sConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(bu2sConst, convert(ubyteDataArray[i], SHORT_POS), bu2sConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "bu2iConst%d", i + 1);
       bu2iConst = (unsignedSignatureCharB_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2i,
             resolvedMethodName, _argTypesUnaryByte, TR::Int32, rc, 2, 1, &ubyteDataArray[i]));
-      EXPECT_EQ(convert(ubyteDataArray[i], INT_POS), bu2iConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(bu2iConst, convert(ubyteDataArray[i], INT_POS), bu2iConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "bu2lConst%d", i + 1);
       bu2lConst = (unsignedSignatureCharB_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2l,
             resolvedMethodName, _argTypesUnaryByte, TR::Int64, rc, 2, 1, &ubyteDataArray[i]));
-      EXPECT_EQ(convert(ubyteDataArray[i], LONG_POS), bu2lConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(bu2lConst, convert(ubyteDataArray[i], LONG_POS), bu2lConst(BYTE_PLACEHOLDER_1));
       }
 
    //s 2 i,l,b
    testCaseNum = sizeof(shortDataArray) / sizeof(shortDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(shortDataArray[i], BYTE_POS), _s2b(shortDataArray[i]));
-      EXPECT_EQ(convert(shortDataArray[i], INT_POS), _s2i(shortDataArray[i]));
-      EXPECT_EQ(convert(shortDataArray[i], LONG_POS), _s2l(shortDataArray[i]));
+      OMR_CT_EXPECT_EQ(_s2b, convert(shortDataArray[i], BYTE_POS), _s2b(shortDataArray[i]));
+      OMR_CT_EXPECT_EQ(_s2i, convert(shortDataArray[i], INT_POS), _s2i(shortDataArray[i]));
+      OMR_CT_EXPECT_EQ(_s2l, convert(shortDataArray[i], LONG_POS), _s2l(shortDataArray[i]));
 
       sprintf(resolvedMethodName, "s2bConst%d", i + 1);
       s2bConst = (signatureCharS_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2b,
             resolvedMethodName, _argTypesUnaryShort, TR::Int8, rc, 2, 1, &shortDataArray[i]));
-      EXPECT_EQ(convert(shortDataArray[i], BYTE_POS), s2bConst(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(s2bConst, convert(shortDataArray[i], BYTE_POS), s2bConst(SHORT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "s2iConst%d", i + 1);
       s2iConst = (signatureCharS_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2i,
             resolvedMethodName, _argTypesUnaryShort, TR::Int32, rc, 2, 1, &shortDataArray[i]));
-      EXPECT_EQ(convert(shortDataArray[i], INT_POS), s2iConst(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(s2iConst, convert(shortDataArray[i], INT_POS), s2iConst(SHORT_PLACEHOLDER_1));
 
 
       sprintf(resolvedMethodName, "s2lConst%d", i + 1);
       s2lConst = (signatureCharS_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2l,
             resolvedMethodName, _argTypesUnaryShort, TR::Int64, rc, 2, 1, &shortDataArray[i]));
-      EXPECT_EQ(convert(shortDataArray[i], LONG_POS), s2lConst(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(s2lConst, convert(shortDataArray[i], LONG_POS), s2lConst(SHORT_PLACEHOLDER_1));
       }
    //su 2 i,l
    testCaseNum = sizeof(ushortDataArray) / sizeof(ushortDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(ushortDataArray[i], INT_POS), _su2i(ushortDataArray[i]));
-      EXPECT_EQ(convert(ushortDataArray[i], LONG_POS), _su2l(ushortDataArray[i]));
+      OMR_CT_EXPECT_EQ(_su2i, convert(ushortDataArray[i], INT_POS), _su2i(ushortDataArray[i]));
+      OMR_CT_EXPECT_EQ(_su2l, convert(ushortDataArray[i], LONG_POS), _su2l(ushortDataArray[i]));
 
       sprintf(resolvedMethodName, "s2iConst%d", i + 1);
       su2iConst = (unsignedSignatureCharS_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2i,
             resolvedMethodName, _argTypesUnaryShort, TR::Int32, rc, 2, 1, &ushortDataArray[i]));
-      EXPECT_EQ(convert(ushortDataArray[i], INT_POS), su2iConst(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(su2iConst, convert(ushortDataArray[i], INT_POS), su2iConst(SHORT_PLACEHOLDER_1));
 
 
       sprintf(resolvedMethodName, "s2lConst%d", i + 1);
       su2lConst = (unsignedSignatureCharS_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2l,
             resolvedMethodName, _argTypesUnaryShort, TR::Int64, rc, 2, 1, &ushortDataArray[i]));
-      EXPECT_EQ(convert(ushortDataArray[i], LONG_POS), su2lConst(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(su2lConst, convert(ushortDataArray[i], LONG_POS), su2lConst(SHORT_PLACEHOLDER_1));
       }
 
    //s 2 d,f
    testCaseNum = sizeof(shortDataArray) / sizeof(shortDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_FLOAT_EQ(convert(shortDataArray[i], FLOAT_POS), _s2f(shortDataArray[i]));
-      EXPECT_DOUBLE_EQ(convert(shortDataArray[i], DOUBLE_POS), _s2d(shortDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_s2f, convert(shortDataArray[i], FLOAT_POS), _s2f(shortDataArray[i]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_s2d, convert(shortDataArray[i], DOUBLE_POS), _s2d(shortDataArray[i]));
 
       sprintf(resolvedMethodName, "s2fConst%d", i + 1);
       s2fConst = (signatureCharS_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2f,
             resolvedMethodName, _argTypesUnaryShort, TR::Float, rc, 2, 1, &shortDataArray[i]));
-      EXPECT_FLOAT_EQ(convert(shortDataArray[i], FLOAT_POS), s2fConst(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_FLOAT_EQ(s2fConst, convert(shortDataArray[i], FLOAT_POS), s2fConst(SHORT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "s2dConst%d", i + 1);
       s2dConst = (signatureCharS_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2d,
             resolvedMethodName, _argTypesUnaryShort, TR::Double, rc, 2, 1, &shortDataArray[i]));
-      EXPECT_DOUBLE_EQ(convert(shortDataArray[i], DOUBLE_POS), s2dConst(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_DOUBLE_EQ(s2dConst, convert(shortDataArray[i], DOUBLE_POS), s2dConst(SHORT_PLACEHOLDER_1));
       }
 
    //iu2f
    testCaseNum = sizeof(uintDataArray) / sizeof(uintDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(uintDataArray[i], FLOAT_POS), _iu2f(uintDataArray[i]));
+      OMR_CT_EXPECT_EQ(_iu2f, convert(uintDataArray[i], FLOAT_POS), _iu2f(uintDataArray[i]));
 
       sprintf(resolvedMethodName, "iu2fConst%d", i + 1);
       iu2fConst = (unsignedSignatureCharI_F_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::iu2f, resolvedMethodName, _argTypesUnaryInt, TR::Float, rc, 2, 1, &uintDataArray[i]));
-      EXPECT_EQ(convert(uintDataArray[i], FLOAT_POS), iu2fConst(INT_PLACEHOLDER_1)) << uintDataArray[i];
+      OMR_CT_EXPECT_EQ(iu2fConst, convert(uintDataArray[i], FLOAT_POS), iu2fConst(INT_PLACEHOLDER_1)) << uintDataArray[i];
       }
 
    //su 2 d,f
    testCaseNum = sizeof(ushortDataArray) / sizeof(ushortDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_FLOAT_EQ(convert(ushortDataArray[i], FLOAT_POS), _su2f(ushortDataArray[i]));
-      EXPECT_DOUBLE_EQ(convert(ushortDataArray[i], DOUBLE_POS), _su2d(ushortDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_su2f, convert(ushortDataArray[i], FLOAT_POS), _su2f(ushortDataArray[i]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_su2d, convert(ushortDataArray[i], DOUBLE_POS), _su2d(ushortDataArray[i]));
 
       sprintf(resolvedMethodName, "su2fConst%d", i + 1);
       su2fConst = (unsignedSignatureCharS_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2f,
             resolvedMethodName, _argTypesUnaryShort, TR::Float, rc, 2, 1, &ushortDataArray[i]));
-      EXPECT_FLOAT_EQ(convert(ushortDataArray[i], FLOAT_POS), su2fConst(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_FLOAT_EQ(su2fConst, convert(ushortDataArray[i], FLOAT_POS), su2fConst(SHORT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "su2dConst%d", i + 1);
       su2dConst = (unsignedSignatureCharS_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2d,
             resolvedMethodName, _argTypesUnaryShort, TR::Double, rc, 2, 1, &ushortDataArray[i]));
-      EXPECT_DOUBLE_EQ(convert(ushortDataArray[i], DOUBLE_POS), su2dConst(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_DOUBLE_EQ(su2dConst, convert(ushortDataArray[i], DOUBLE_POS), su2dConst(SHORT_PLACEHOLDER_1));
       }
 
    //bu 2 d,f
    testCaseNum = sizeof(ubyteDataArray) / sizeof(ubyteDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_FLOAT_EQ(convert(ubyteDataArray[i], FLOAT_POS), _bu2f(ubyteDataArray[i]));
-      EXPECT_DOUBLE_EQ(convert(ubyteDataArray[i], DOUBLE_POS), _bu2d(ubyteDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_bu2f, convert(ubyteDataArray[i], FLOAT_POS), _bu2f(ubyteDataArray[i]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_bu2d, convert(ubyteDataArray[i], DOUBLE_POS), _bu2d(ubyteDataArray[i]));
 
       sprintf(resolvedMethodName, "bu2fConst%d", i + 1);
       bu2fConst = (unsignedSignatureCharB_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2f,
             resolvedMethodName, _argTypesUnaryByte, TR::Float, rc, 2, 1, &ubyteDataArray[i]));
-      EXPECT_FLOAT_EQ(convert(ubyteDataArray[i], FLOAT_POS), bu2fConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_FLOAT_EQ(bu2fConst, convert(ubyteDataArray[i], FLOAT_POS), bu2fConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "bu2dConst%d", i + 1);
       bu2dConst = (unsignedSignatureCharB_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2d,
             resolvedMethodName, _argTypesUnaryByte, TR::Double, rc, 2, 1, &ubyteDataArray[i]));
-      EXPECT_DOUBLE_EQ(convert(ubyteDataArray[i], DOUBLE_POS), bu2dConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_DOUBLE_EQ(bu2dConst, convert(ubyteDataArray[i], DOUBLE_POS), bu2dConst(BYTE_PLACEHOLDER_1));
       }
 
    //lu2f, d
    testCaseNum = sizeof(ulongDataArray) / sizeof(ulongDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(ulongDataArray[i], FLOAT_POS), _lu2f(ulongDataArray[i]));
-      EXPECT_EQ(convert(ulongDataArray[i], DOUBLE_POS), _lu2d(ulongDataArray[i]));
+      OMR_CT_EXPECT_EQ(_lu2f, convert(ulongDataArray[i], FLOAT_POS), _lu2f(ulongDataArray[i]));
+      OMR_CT_EXPECT_EQ(_lu2d, convert(ulongDataArray[i], DOUBLE_POS), _lu2d(ulongDataArray[i]));
 
       sprintf(resolvedMethodName, "lu2fConst%d", i + 1);
       lu2fConst = (unsignedSignatureCharJ_F_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::lu2f, resolvedMethodName, _argTypesUnaryLong, TR::Float, rc, 2, 1, &ulongDataArray[i]));
-      EXPECT_EQ(convert(ulongDataArray[i], FLOAT_POS), lu2fConst(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lu2fConst, convert(ulongDataArray[i], FLOAT_POS), lu2fConst(LONG_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "lu2dConst%d", i + 1);
       lu2dConst = (unsignedSignatureCharJ_D_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::lu2d, resolvedMethodName, _argTypesUnaryLong, TR::Double, rc, 2, 1, &ulongDataArray[i]));
-      EXPECT_EQ(convert(ulongDataArray[i], DOUBLE_POS), lu2dConst(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lu2dConst, convert(ulongDataArray[i], DOUBLE_POS), lu2dConst(LONG_PLACEHOLDER_1));
       }
    }
 
@@ -4114,21 +4128,21 @@ S390OpCodesTest::invokeDisabledIntegerArithmeticTests()
    {
    //unsigned integer constant test will be enabled in another work item.
    //iumul : overflow just cut
-   EXPECT_EQ(mul(UINT_MAXIMUM, UINT_MINIMUM), _iuMul(UINT_MAXIMUM, UINT_MINIMUM));
-   EXPECT_EQ(mul(UINT_MINIMUM, UINT_POS), _iuMul(UINT_MINIMUM, UINT_POS));
-   EXPECT_EQ(mul(UINT_POS, UINT_MAXIMUM), _iuMul(UINT_POS, UINT_MAXIMUM));
+   OMR_CT_EXPECT_EQ(_iuMul, mul(UINT_MAXIMUM, UINT_MINIMUM), _iuMul(UINT_MAXIMUM, UINT_MINIMUM));
+   OMR_CT_EXPECT_EQ(_iuMul, mul(UINT_MINIMUM, UINT_POS), _iuMul(UINT_MINIMUM, UINT_POS));
+   OMR_CT_EXPECT_EQ(_iuMul, mul(UINT_POS, UINT_MAXIMUM), _iuMul(UINT_POS, UINT_MAXIMUM));
 
    //iudiv
    // TODO: Use ASSERT_DEATH() to catch Remainder by zero which will get "Floating point exception (core dumped)"
    // Test secnario : _iuDiv(UINT_MAXIMUM, 0)
-   EXPECT_EQ(div(UINT_MAXIMUM, UINT_POS), _iuDiv(UINT_MAXIMUM, UINT_POS));
-   EXPECT_EQ(div(UINT_MINIMUM, UINT_POS), _iuDiv(UINT_MINIMUM, UINT_POS));
+   OMR_CT_EXPECT_EQ(_iuDiv, div(UINT_MAXIMUM, UINT_POS), _iuDiv(UINT_MAXIMUM, UINT_POS));
+   OMR_CT_EXPECT_EQ(_iuDiv, div(UINT_MINIMUM, UINT_POS), _iuDiv(UINT_MINIMUM, UINT_POS));
 
    //iurem
    // TODO: Use ASSERT_DEATH() to catch Remainder by zero which will get "Floating point exception (core dumped)"
    // Test secnario : _iuRem(UINT_MAXIMUM, 0)
-   EXPECT_EQ(rem(UINT_POS, UINT_MAXIMUM),       _iuRem(UINT_POS, UINT_MAXIMUM));
-   EXPECT_EQ(rem(UINT_MAXIMUM, UINT_MAXIMUM),      _iuRem(UINT_MAXIMUM, UINT_MAXIMUM));
+   OMR_CT_EXPECT_EQ(_iuRem, rem(UINT_POS, UINT_MAXIMUM),       _iuRem(UINT_POS, UINT_MAXIMUM));
+   OMR_CT_EXPECT_EQ(_iuRem, rem(UINT_MAXIMUM, UINT_MAXIMUM),      _iuRem(UINT_MAXIMUM, UINT_MAXIMUM));
 
    int32_t rc = 0;
    uint32_t testCaseArrLength = 0;
@@ -4173,88 +4187,88 @@ S390OpCodesTest::invokeDisabledIntegerArithmeticTests()
    testCaseArrLength = sizeof(byteAddArr) / sizeof(byteAddArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(add(byteAddArr[i][0], byteAddArr[i][1]), _bAdd(byteAddArr[i][0], byteAddArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bAdd, add(byteAddArr[i][0], byteAddArr[i][1]), _bAdd(byteAddArr[i][0], byteAddArr[i][1]));
 
       sprintf(resolvedMethodName, "bAddConst1_Testcase%d", i);
       bBinaryCons = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::badd,
             resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &byteAddArr[i][0], 2, &byteAddArr[i][1]));
-      EXPECT_EQ(add(byteAddArr[i][0], byteAddArr[i][1]), bBinaryCons(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bBinaryCons, add(byteAddArr[i][0], byteAddArr[i][1]), bBinaryCons(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bAddConst2_Testcase%d", i);
       bBinaryCons = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::badd,
             resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &byteAddArr[i][0]));
-      EXPECT_EQ(add(byteAddArr[i][0], byteAddArr[i][1]), bBinaryCons(BYTE_PLACEHOLDER_1, byteAddArr[i][1]));
+      OMR_CT_EXPECT_EQ(bBinaryCons, add(byteAddArr[i][0], byteAddArr[i][1]), bBinaryCons(BYTE_PLACEHOLDER_1, byteAddArr[i][1]));
 
       sprintf(resolvedMethodName, "bAddConst3_Testcase%d", i);
       bBinaryCons = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::badd,
             resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &byteAddArr[i][1]));
-      EXPECT_EQ(add(byteAddArr[i][0], byteAddArr[i][1]), bBinaryCons(byteAddArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bBinaryCons, add(byteAddArr[i][0], byteAddArr[i][1]), bBinaryCons(byteAddArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //bsub
    testCaseArrLength = sizeof(byteSubArr) / sizeof(byteSubArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(sub(byteSubArr[i][0], byteSubArr[i][1]), _bSub(byteSubArr[i][0], byteSubArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bSub, sub(byteSubArr[i][0], byteSubArr[i][1]), _bSub(byteSubArr[i][0], byteSubArr[i][1]));
 
       sprintf(resolvedMethodName, "bSubConst1_Testcase%d", i);
       bBinaryCons = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bsub,
             resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &byteSubArr[i][0], 2, &byteSubArr[i][1]));
-      EXPECT_EQ(sub(byteSubArr[i][0], byteSubArr[i][1]), bBinaryCons(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bBinaryCons, sub(byteSubArr[i][0], byteSubArr[i][1]), bBinaryCons(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bSubConst2_Testcase%d", i);
       bBinaryCons = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bsub,
             resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &byteSubArr[i][0]));
-      EXPECT_EQ(sub(byteSubArr[i][0], byteSubArr[i][1]), bBinaryCons(BYTE_PLACEHOLDER_1, byteSubArr[i][1]));
+      OMR_CT_EXPECT_EQ(bBinaryCons, sub(byteSubArr[i][0], byteSubArr[i][1]), bBinaryCons(BYTE_PLACEHOLDER_1, byteSubArr[i][1]));
 
       sprintf(resolvedMethodName, "bSubConst3_Testcase%d", i);
       bBinaryCons = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bsub,
             resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &byteSubArr[i][1]));
-      EXPECT_EQ(sub(byteSubArr[i][0], byteSubArr[i][1]), bBinaryCons(byteSubArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bBinaryCons, sub(byteSubArr[i][0], byteSubArr[i][1]), bBinaryCons(byteSubArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //sadd
    testCaseArrLength = sizeof(shortAddArr) / sizeof(shortAddArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(add(shortAddArr[i][0], shortAddArr[i][1]), _sAdd(shortAddArr[i][0], shortAddArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sAdd, add(shortAddArr[i][0], shortAddArr[i][1]), _sAdd(shortAddArr[i][0], shortAddArr[i][1]));
 
       sprintf(resolvedMethodName, "sAddConst1_Testcase%d", i);
       sBinaryCons = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sadd,
             resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &shortAddArr[i][0], 2, &shortAddArr[i][1]));
-      EXPECT_EQ(add(shortAddArr[i][0], shortAddArr[i][1]), sBinaryCons(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sBinaryCons, add(shortAddArr[i][0], shortAddArr[i][1]), sBinaryCons(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sAddConst2_Testcase%d", i);
       sBinaryCons = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sadd,
             resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &shortAddArr[i][0]));
-      EXPECT_EQ(add(shortAddArr[i][0], shortAddArr[i][1]), sBinaryCons(SHORT_PLACEHOLDER_1, shortAddArr[i][1]));
+      OMR_CT_EXPECT_EQ(sBinaryCons, add(shortAddArr[i][0], shortAddArr[i][1]), sBinaryCons(SHORT_PLACEHOLDER_1, shortAddArr[i][1]));
 
       sprintf(resolvedMethodName, "sAddConst3_Testcase%d", i);
       sBinaryCons = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sadd,
             resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &shortAddArr[i][1]));
-      EXPECT_EQ(add(shortAddArr[i][0], shortAddArr[i][1]), sBinaryCons(shortAddArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sBinaryCons, add(shortAddArr[i][0], shortAddArr[i][1]), sBinaryCons(shortAddArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    //ssub
    testCaseArrLength = sizeof(shortSubArr) / sizeof(shortSubArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(sub(shortSubArr[i][0], shortSubArr[i][1]), _sSub(shortSubArr[i][0], shortSubArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sSub, sub(shortSubArr[i][0], shortSubArr[i][1]), _sSub(shortSubArr[i][0], shortSubArr[i][1]));
 
       sprintf(resolvedMethodName, "sSubConst1_Testcase%d", i);
       sBinaryCons = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ssub,
             resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &shortSubArr[i][0], 2, &shortSubArr[i][1]));
-      EXPECT_EQ(sub(shortSubArr[i][0], shortSubArr[i][1]), sBinaryCons(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sBinaryCons, sub(shortSubArr[i][0], shortSubArr[i][1]), sBinaryCons(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sSubConst2_Testcase%d", i);
       sBinaryCons = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ssub,
             resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &shortSubArr[i][0]));
-      EXPECT_EQ(sub(shortSubArr[i][0], shortSubArr[i][1]), sBinaryCons(SHORT_PLACEHOLDER_1, shortSubArr[i][1]));
+      OMR_CT_EXPECT_EQ(sBinaryCons, sub(shortSubArr[i][0], shortSubArr[i][1]), sBinaryCons(SHORT_PLACEHOLDER_1, shortSubArr[i][1]));
 
       sprintf(resolvedMethodName, "sSubConst3_Testcase%d", i);
       sBinaryCons = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ssub,
             resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &shortSubArr[i][1]));
-      EXPECT_EQ(sub(shortSubArr[i][0], shortSubArr[i][1]), sBinaryCons(shortSubArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sBinaryCons, sub(shortSubArr[i][0], shortSubArr[i][1]), sBinaryCons(shortSubArr[i][0], SHORT_PLACEHOLDER_2));
       }
    }
 
@@ -4407,154 +4421,154 @@ S390OpCodesTest::invokeDisabledShiftOrRolTests()
    testCaseNum = sizeof(irolDataArr) / sizeof(irolDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(rol(irolDataArr[i][0], irolDataArr[i][1]), _iRol(irolDataArr[i][0], irolDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iRol, rol(irolDataArr[i][0], irolDataArr[i][1]), _iRol(irolDataArr[i][0], irolDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iRolConst1_TestCase%d", i + 1);
       iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::irol, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &irolDataArr[i][0], 2, &irolDataArr[i][1]));
-      EXPECT_EQ(rol(irolDataArr[i][0], irolDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iShiftOrRolConst, rol(irolDataArr[i][0], irolDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iRolConst2_TestCase%d", i + 1);
       iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::irol, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &irolDataArr[i][0]));
-      EXPECT_EQ(rol(irolDataArr[i][0], irolDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, irolDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iShiftOrRolConst, rol(irolDataArr[i][0], irolDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, irolDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iRolConst3_TestCase%d", i + 1);
       iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::irol, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &irolDataArr[i][1]));
-      EXPECT_EQ(rol(irolDataArr[i][0], irolDataArr[i][1]), iShiftOrRolConst(irolDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iShiftOrRolConst, rol(irolDataArr[i][0], irolDataArr[i][1]), iShiftOrRolConst(irolDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    //bshl
    testCaseNum = sizeof(bshlDataArr) / sizeof(bshlDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shl(bshlDataArr[i][0], bshlDataArr[i][1]), _bShl(bshlDataArr[i][0],bshlDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bShl, shl(bshlDataArr[i][0], bshlDataArr[i][1]), _bShl(bshlDataArr[i][0],bshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bShlConst1_TestCase%d", i + 1);
       bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bshl, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &bshlDataArr[i][0], 2, &bshlDataArr[i][1]));
-      EXPECT_EQ(shl(bshlDataArr[i][0], bshlDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bShiftOrRolConst, shl(bshlDataArr[i][0], bshlDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bShlConst2_TestCase%d", i + 1);
       bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bshl, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &bshlDataArr[i][0]));
-      EXPECT_EQ(shl(bshlDataArr[i][0], bshlDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, bshlDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bShiftOrRolConst, shl(bshlDataArr[i][0], bshlDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, bshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bShlConst3_TestCase%d", i + 1);
       bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bshl, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &bshlDataArr[i][1]));
-      EXPECT_EQ(shl(bshlDataArr[i][0], bshlDataArr[i][1]), bShiftOrRolConst(bshlDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bShiftOrRolConst, shl(bshlDataArr[i][0], bshlDataArr[i][1]), bShiftOrRolConst(bshlDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //bshr
    testCaseNum = sizeof(bshrDataArr) / sizeof(bshrDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shr(bshrDataArr[i][0], bshrDataArr[i][1]), _bShr(bshrDataArr[i][0], bshrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bShr, shr(bshrDataArr[i][0], bshrDataArr[i][1]), _bShr(bshrDataArr[i][0], bshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bShrConst1_TestCase%d", i + 1);
       bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bshr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &bshrDataArr[i][0], 2, &bshrDataArr[i][1]));
-      EXPECT_EQ(shr(bshrDataArr[i][0], bshrDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bShiftOrRolConst, shr(bshrDataArr[i][0], bshrDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bShrConst2_TestCase%d", i + 1);
       bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bshr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &bshrDataArr[i][0]));
-      EXPECT_EQ(shr(bshrDataArr[i][0], bshrDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, bshrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bShiftOrRolConst, shr(bshrDataArr[i][0], bshrDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, bshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bShrConst3_TestCase%d", i + 1);
       bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bshr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &bshrDataArr[i][1]));
-      EXPECT_EQ(shr(bshrDataArr[i][0], bshrDataArr[i][1]), bShiftOrRolConst(bshrDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bShiftOrRolConst, shr(bshrDataArr[i][0], bshrDataArr[i][1]), bShiftOrRolConst(bshrDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //bushr
    testCaseNum = sizeof(bushrDataArr) / sizeof(bushrDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shr(bushrDataArr[i][0], bushrDataArr[i][1]), _buShr(bushrDataArr[i][0], bushrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_buShr, shr(bushrDataArr[i][0], bushrDataArr[i][1]), _buShr(bushrDataArr[i][0], bushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buShrConst1_TestCase%d", i + 1);
       buShiftOrRolConst = (unsignedSignatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bushr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &bushrDataArr[i][0], 2, &bushrDataArr[i][1]));
-      EXPECT_EQ(shr(bushrDataArr[i][0], bushrDataArr[i][1]), buShiftOrRolConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buShiftOrRolConst, shr(bushrDataArr[i][0], bushrDataArr[i][1]), buShiftOrRolConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "buShrConst2_TestCase%d", i + 1);
       buShiftOrRolConst = (unsignedSignatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bushr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &bushrDataArr[i][0]));
-      EXPECT_EQ(shr(bushrDataArr[i][0], bushrDataArr[i][1]), buShiftOrRolConst(BYTE_PLACEHOLDER_1, bushrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(buShiftOrRolConst, shr(bushrDataArr[i][0], bushrDataArr[i][1]), buShiftOrRolConst(BYTE_PLACEHOLDER_1, bushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buShrConst3_TestCase%d", i + 1);
       buShiftOrRolConst = (unsignedSignatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bushr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &bushrDataArr[i][1]));
-      EXPECT_EQ(shr(bushrDataArr[i][0], bushrDataArr[i][1]), buShiftOrRolConst(bushrDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buShiftOrRolConst, shr(bushrDataArr[i][0], bushrDataArr[i][1]), buShiftOrRolConst(bushrDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //sshr
    testCaseNum = sizeof(sshrDataArr) / sizeof(sshrDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shr(sshrDataArr[i][0], sshrDataArr[i][1]), _sShr(sshrDataArr[i][0], sshrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sShr, shr(sshrDataArr[i][0], sshrDataArr[i][1]), _sShr(sshrDataArr[i][0], sshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sShrConst1_TestCase%d", i + 1);
       sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sshr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &sshrDataArr[i][0], 2, &sshrDataArr[i][1]));
-      EXPECT_EQ(shr(sshrDataArr[i][0], sshrDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sShiftOrRolConst, shr(sshrDataArr[i][0], sshrDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sShrConst2_TestCase%d", i + 1);
       sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sshr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &sshrDataArr[i][0]));
-      EXPECT_EQ(shr(sshrDataArr[i][0], sshrDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, sshrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sShiftOrRolConst, shr(sshrDataArr[i][0], sshrDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, sshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sShrConst3_TestCase%d", i + 1);
       sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sshr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &sshrDataArr[i][1]));
-      EXPECT_EQ(shr(sshrDataArr[i][0], sshrDataArr[i][1]), sShiftOrRolConst(sshrDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sShiftOrRolConst, shr(sshrDataArr[i][0], sshrDataArr[i][1]), sShiftOrRolConst(sshrDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    //sshl
    testCaseNum = sizeof(sshlDataArr) / sizeof(sshlDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shl(sshlDataArr[i][0], sshlDataArr[i][1]), _sShl(sshlDataArr[i][0], sshlDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sShl, shl(sshlDataArr[i][0], sshlDataArr[i][1]), _sShl(sshlDataArr[i][0], sshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sShlConst1_TestCase%d", i + 1);
       sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sshl, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &sshlDataArr[i][0], 2, &sshlDataArr[i][1]));
-      EXPECT_EQ(shl(sshlDataArr[i][0], sshlDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sShiftOrRolConst, shl(sshlDataArr[i][0], sshlDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sShlConst2_TestCase%d", i + 1);
       sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sshl, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &sshlDataArr[i][0]));
-      EXPECT_EQ(shl(sshlDataArr[i][0], sshlDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, sshlDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sShiftOrRolConst, shl(sshlDataArr[i][0], sshlDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, sshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sShlConst3_TestCase%d", i + 1);
       sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sshl, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &sshlDataArr[i][1]));
-      EXPECT_EQ(shl(sshlDataArr[i][0], sshlDataArr[i][1]), sShiftOrRolConst(sshlDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sShiftOrRolConst, shl(sshlDataArr[i][0], sshlDataArr[i][1]), sShiftOrRolConst(sshlDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    //sushr
    testCaseNum = sizeof(sushrDataArr) / sizeof(sushrDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shr(sushrDataArr[i][0], sushrDataArr[i][1]), _suShr(sushrDataArr[i][0], sushrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_suShr, shr(sushrDataArr[i][0], sushrDataArr[i][1]), _suShr(sushrDataArr[i][0], sushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "suShrConst1_TestCase%d", i + 1);
       suShiftOrRolConst = (unsignedSignatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sushr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &sushrDataArr[i][0], 2, &sushrDataArr[i][1]));
-      EXPECT_EQ(shr(sushrDataArr[i][0], sushrDataArr[i][1]), suShiftOrRolConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(suShiftOrRolConst, shr(sushrDataArr[i][0], sushrDataArr[i][1]), suShiftOrRolConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "suShrConst2_TestCase%d", i + 1);
       suShiftOrRolConst = (unsignedSignatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sushr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &sushrDataArr[i][0]));
-      EXPECT_EQ(shr(sushrDataArr[i][0], sushrDataArr[i][1]), suShiftOrRolConst(SHORT_PLACEHOLDER_1, sushrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(suShiftOrRolConst, shr(sushrDataArr[i][0], sushrDataArr[i][1]), suShiftOrRolConst(SHORT_PLACEHOLDER_1, sushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "suShrConst3_TestCase%d", i + 1);
       suShiftOrRolConst = (unsignedSignatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sushr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &sushrDataArr[i][1]));
-      EXPECT_EQ(shr(sushrDataArr[i][0], sushrDataArr[i][1]), suShiftOrRolConst(sushrDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(suShiftOrRolConst, shr(sushrDataArr[i][0], sushrDataArr[i][1]), suShiftOrRolConst(sushrDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
 #if !defined(TR_TARGET_64BIT)
@@ -4562,88 +4576,88 @@ S390OpCodesTest::invokeDisabledShiftOrRolTests()
    testCaseNum = sizeof(lshlDataArr) / sizeof(lshlDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shl(lshlDataArr[i][0], lshlDataArr[i][1]), _lShl(lshlDataArr[i][0], lshlDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lShl, shl(lshlDataArr[i][0], lshlDataArr[i][1]), _lShl(lshlDataArr[i][0], lshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lShlConst1_TestCase%d", i + 1);
       lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lshl, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lshlDataArr[i][0], 2, &lshlDataArr[i][1]));
-      EXPECT_EQ(shl(lshlDataArr[i][0], lshlDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lShiftOrRolConst, shl(lshlDataArr[i][0], lshlDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "lShlConst2_TestCase%d", i + 1);
       lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lshl, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lshlDataArr[i][0]));
-      EXPECT_EQ(shl(lshlDataArr[i][0], lshlDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, lshlDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lShiftOrRolConst, shl(lshlDataArr[i][0], lshlDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, lshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lShlConst3_TestCase%d", i + 1);
       lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lshl, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lshlDataArr[i][1]));
-      EXPECT_EQ(shl(lshlDataArr[i][0], lshlDataArr[i][1]), lShiftOrRolConst(lshlDataArr[i][0], LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lShiftOrRolConst, shl(lshlDataArr[i][0], lshlDataArr[i][1]), lShiftOrRolConst(lshlDataArr[i][0], LONG_PLACEHOLDER_1));
       }
 
    //lshr
    testCaseNum = sizeof(lshrDataArr) / sizeof(lshrDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shr(lshrDataArr[i][0], lshrDataArr[i][1]), _lShr(lshrDataArr[i][0], lshrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lShr, shr(lshrDataArr[i][0], lshrDataArr[i][1]), _lShr(lshrDataArr[i][0], lshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lShrConst1_TestCase%d", i + 1);
       lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lshr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lshrDataArr[i][0], 2, &lshrDataArr[i][1]));
-      EXPECT_EQ(shr(lshrDataArr[i][0], lshrDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lShiftOrRolConst, shr(lshrDataArr[i][0], lshrDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lShrConst2_TestCase%d", i + 1);
       lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lshr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lshrDataArr[i][0]));
-      EXPECT_EQ(shr(lshrDataArr[i][0], lshrDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, lshrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lShiftOrRolConst, shr(lshrDataArr[i][0], lshrDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, lshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lShrConst3_TestCase%d", i + 1);
       lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lshr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lshrDataArr[i][1]));
-      EXPECT_EQ(shr(lshrDataArr[i][0], lshrDataArr[i][1]), lShiftOrRolConst(lshrDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lShiftOrRolConst, shr(lshrDataArr[i][0], lshrDataArr[i][1]), lShiftOrRolConst(lshrDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //lushr
    testCaseNum = sizeof(lushrDataArr) / sizeof(lushrDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shr(lushrDataArr[i][0], lushrDataArr[i][1]), _luShr(lushrDataArr[i][0], lushrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_luShr, shr(lushrDataArr[i][0], lushrDataArr[i][1]), _luShr(lushrDataArr[i][0], lushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luShrConst1_TestCase%d", i + 1);
       luShiftOrRolConst = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lushr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lushrDataArr[i][0], 2, &lushrDataArr[i][1]));
-      EXPECT_EQ(shr(lushrDataArr[i][0], lushrDataArr[i][1]), luShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luShiftOrRolConst, shr(lushrDataArr[i][0], lushrDataArr[i][1]), luShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "luShrConst2_TestCase%d", i + 1);
       luShiftOrRolConst = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lushr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lushrDataArr[i][0]));
-      EXPECT_EQ(shr(lushrDataArr[i][0], lushrDataArr[i][1]), luShiftOrRolConst(LONG_PLACEHOLDER_1, lushrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(luShiftOrRolConst, shr(lushrDataArr[i][0], lushrDataArr[i][1]), luShiftOrRolConst(LONG_PLACEHOLDER_1, lushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luShrConst3_TestCase%d", i + 1);
       luShiftOrRolConst = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lushr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lushrDataArr[i][1]));
-      EXPECT_EQ(shr(lushrDataArr[i][0], lushrDataArr[i][1]), luShiftOrRolConst(lushrDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luShiftOrRolConst, shr(lushrDataArr[i][0], lushrDataArr[i][1]), luShiftOrRolConst(lushrDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //lrol
    testCaseNum = sizeof(lrolDataArr) / sizeof(lrolDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(rol(lrolDataArr[i][0], lrolDataArr[i][1]), _lRol(lrolDataArr[i][0], lrolDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lRol, rol(lrolDataArr[i][0], lrolDataArr[i][1]), _lRol(lrolDataArr[i][0], lrolDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lRolConst1_TestCase%d", i + 1);
       lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lrol, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lrolDataArr[i][0], 2, &lrolDataArr[i][1]));
-      EXPECT_EQ(rol(lrolDataArr[i][0], lrolDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lShiftOrRolConst, rol(lrolDataArr[i][0], lrolDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lRolConst2_TestCase%d", i + 1);
       lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lrol, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lrolDataArr[i][0]));
-      EXPECT_EQ(rol(lrolDataArr[i][0], lrolDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, lrolDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lShiftOrRolConst, rol(lrolDataArr[i][0], lrolDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, lrolDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lRolConst3_TestCase%d", i + 1);
       lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lrol, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lrolDataArr[i][1]));
-      EXPECT_EQ(rol(lrolDataArr[i][0], lrolDataArr[i][1]), lShiftOrRolConst(lrolDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lShiftOrRolConst, rol(lrolDataArr[i][0], lrolDataArr[i][1]), lShiftOrRolConst(lrolDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 #endif
    }
@@ -4790,42 +4804,42 @@ S390OpCodesTest::invokeDisabledTernaryTests()
    TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in bternary input array");
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), _bternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bternary, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), _bternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bTernaryConst1_Testcase%d", i + 1);
       bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
             resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 6, 1, &bternaryChild1Arr[i], 2, &byteDataArr[i][0], 3, &byteDataArr[i][1]));
-      EXPECT_EQ(ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2, BYTE_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2, BYTE_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "bTernaryConst2_Testcase%d", i + 1);
       bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
             resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 4, 1, &bternaryChild1Arr[i], 2, &byteDataArr[i][0]));
-      EXPECT_EQ(ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2, byteDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2, byteDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bTernaryConst3_Testcase%d", i + 1);
       bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
             resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 4, 1, &bternaryChild1Arr[i], 3, &byteDataArr[i][1]));
-      EXPECT_EQ(ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, byteDataArr[i][0], BYTE_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, byteDataArr[i][0], BYTE_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "bTernaryConst4_Testcase%d", i + 1);
       bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
             resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 4, 2, &byteDataArr[i][0], 3, &byteDataArr[i][1]));
-      EXPECT_EQ(ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(bternaryChild1Arr[i], BYTE_PLACEHOLDER_2, BYTE_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(bternaryChild1Arr[i], BYTE_PLACEHOLDER_2, BYTE_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "bTernaryConst5_Testcase%d", i + 1);
       bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
             resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 2, 1, &bternaryChild1Arr[i]));
-      EXPECT_EQ(ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, byteDataArr[i][0], byteDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, byteDataArr[i][0], byteDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bTernaryConst6_Testcase%d", i + 1);
       bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
             resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 2, 2, &byteDataArr[i][0]));
-      EXPECT_EQ(ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(bternaryChild1Arr[i], BYTE_PLACEHOLDER_1, byteDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(bternaryChild1Arr[i], BYTE_PLACEHOLDER_1, byteDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bTernaryConst7_Testcase%d", i + 1);
       bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
             resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 2, 3, &byteDataArr[i][1]));
-      EXPECT_EQ(ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(bternaryChild1Arr[i], byteDataArr[i][0], BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(bternaryChild1Arr[i], byteDataArr[i][0], BYTE_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(sternaryChild1Arr) / sizeof(sternaryChild1Arr[0]);
@@ -4833,42 +4847,42 @@ S390OpCodesTest::invokeDisabledTernaryTests()
    TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in sternary input array");
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), _sternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sternary, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), _sternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sTernaryConst1_Testcase%d", i + 1);
       sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
             resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 6, 1, &sternaryChild1Arr[i], 2, &shortDataArr[i][0], 3, &shortDataArr[i][1]));
-      EXPECT_EQ(ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2, SHORT_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2, SHORT_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "sTernaryConst2_Testcase%d", i + 1);
       sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
             resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 4, 1, &sternaryChild1Arr[i], 2, &shortDataArr[i][0]));
-      EXPECT_EQ(ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2, shortDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2, shortDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sTernaryConst3_Testcase%d", i + 1);
       sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
             resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 4, 1, &sternaryChild1Arr[i], 3, &shortDataArr[i][1]));
-      EXPECT_EQ(ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, shortDataArr[i][0], SHORT_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, shortDataArr[i][0], SHORT_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "sTernaryConst4_Testcase%d", i + 1);
       sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
             resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 4, 2, &shortDataArr[i][0], 3, &shortDataArr[i][1]));
-      EXPECT_EQ(ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(sternaryChild1Arr[i], SHORT_PLACEHOLDER_2, SHORT_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(sternaryChild1Arr[i], SHORT_PLACEHOLDER_2, SHORT_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "sTernaryConst5_Testcase%d", i + 1);
       sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
             resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 2, 1, &sternaryChild1Arr[i]));
-      EXPECT_EQ(ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, shortDataArr[i][0], shortDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, shortDataArr[i][0], shortDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sTernaryConst6_Testcase%d", i + 1);
       sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
             resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 2, 2, &shortDataArr[i][0]));
-      EXPECT_EQ(ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(sternaryChild1Arr[i], SHORT_PLACEHOLDER_1, shortDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(sternaryChild1Arr[i], SHORT_PLACEHOLDER_1, shortDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sTernaryConst7_Testcase%d", i + 1);
       sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
             resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 2, 3, &shortDataArr[i][1]));
-      EXPECT_EQ(ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(sternaryChild1Arr[i], shortDataArr[i][0], SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(sternaryChild1Arr[i], shortDataArr[i][0], SHORT_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(fternaryChild1Arr) / sizeof(fternaryChild1Arr[0]);
@@ -4876,42 +4890,42 @@ S390OpCodesTest::invokeDisabledTernaryTests()
    TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in fternary input array");
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), _fternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_fternary, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), _fternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fTernaryConst1_Testcase%d", i + 1);
       fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
             resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 6, 1, &fternaryChild1Arr[i], 2, &floatDataArr[i][0], 3, &floatDataArr[i][1]));
-      EXPECT_EQ(ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2, FLOAT_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2, FLOAT_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "fTernaryConst2_Testcase%d", i + 1);
       fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
             resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 4, 1, &fternaryChild1Arr[i], 2, &floatDataArr[i][0]));
-      EXPECT_EQ(ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2, floatDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2, floatDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fTernaryConst3_Testcase%d", i + 1);
       fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
             resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 4, 1, &fternaryChild1Arr[i], 3, &floatDataArr[i][1]));
-      EXPECT_EQ(ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, floatDataArr[i][0], FLOAT_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, floatDataArr[i][0], FLOAT_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "fTernaryConst4_Testcase%d", i + 1);
       fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
             resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 4, 2, &floatDataArr[i][0], 3, &floatDataArr[i][1]));
-      EXPECT_EQ(ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(fternaryChild1Arr[i], FLOAT_PLACEHOLDER_2, FLOAT_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(fternaryChild1Arr[i], FLOAT_PLACEHOLDER_2, FLOAT_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "fTernaryConst5_Testcase%d", i + 1);
       fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
             resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 2, 1, &fternaryChild1Arr[i]));
-      EXPECT_EQ(ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, floatDataArr[i][0], floatDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, floatDataArr[i][0], floatDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fTernaryConst6_Testcase%d", i + 1);
       fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
             resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 2, 2, &floatDataArr[i][0]));
-      EXPECT_EQ(ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(fternaryChild1Arr[i], FLOAT_PLACEHOLDER_1, floatDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(fternaryChild1Arr[i], FLOAT_PLACEHOLDER_1, floatDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fTernaryConst7_Testcase%d", i + 1);
       fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
             resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 2, 3, &floatDataArr[i][1]));
-      EXPECT_EQ(ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(fternaryChild1Arr[i], floatDataArr[i][0], FLOAT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(fternaryChild1Arr[i], floatDataArr[i][0], FLOAT_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(dternaryChild1Arr) / sizeof(dternaryChild1Arr[0]);
@@ -4919,42 +4933,42 @@ S390OpCodesTest::invokeDisabledTernaryTests()
    TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in dternary input array");
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), _dternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_dternary, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), _dternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dTernaryConst1_Testcase%d", i + 1);
       dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
             resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 6, 1, &dternaryChild1Arr[i], 2, &doubleDataArr[i][0], 3, &doubleDataArr[i][1]));
-      EXPECT_EQ(ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2, DOUBLE_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2, DOUBLE_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "dTernaryConst2_Testcase%d", i + 1);
       dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
             resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 4, 1, &dternaryChild1Arr[i], 2, &doubleDataArr[i][0]));
-      EXPECT_EQ(ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2, doubleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2, doubleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dTernaryConst3_Testcase%d", i + 1);
       dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
             resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 4, 1, &dternaryChild1Arr[i], 3, &doubleDataArr[i][1]));
-      EXPECT_EQ(ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, doubleDataArr[i][0], DOUBLE_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, doubleDataArr[i][0], DOUBLE_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "dTernaryConst4_Testcase%d", i + 1);
       dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
             resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 4, 2, &doubleDataArr[i][0], 3, &doubleDataArr[i][1]));
-      EXPECT_EQ(ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(dternaryChild1Arr[i], DOUBLE_PLACEHOLDER_2, DOUBLE_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(dternaryChild1Arr[i], DOUBLE_PLACEHOLDER_2, DOUBLE_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "dTernaryConst5_Testcase%d", i + 1);
       dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
             resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 2, 1, &dternaryChild1Arr[i]));
-      EXPECT_EQ(ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, doubleDataArr[i][0], doubleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, doubleDataArr[i][0], doubleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dTernaryConst6_Testcase%d", i + 1);
       dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
             resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 2, 2, &doubleDataArr[i][0]));
-      EXPECT_EQ(ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(dternaryChild1Arr[i], DOUBLE_PLACEHOLDER_1, doubleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(dternaryChild1Arr[i], DOUBLE_PLACEHOLDER_1, doubleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dTernaryConst7_Testcase%d", i + 1);
       dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
             resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 2, 3, &doubleDataArr[i][1]));
-      EXPECT_EQ(ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(dternaryChild1Arr[i], doubleDataArr[i][0], DOUBLE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(dternaryChild1Arr[i], doubleDataArr[i][0], DOUBLE_PLACEHOLDER_1));
       }
    }
 
@@ -4989,35 +5003,35 @@ S390OpCodesTest::invokeDisabledMemoryOperationTests()
    int16_t shortDataArray[] = {SHORT_NEG, SHORT_POS, SHORT_MAXIMUM, SHORT_MINIMUM, SHORT_ZERO};
    int8_t byteDataArray[] = {BYTE_NEG, BYTE_POS, BYTE_MAXIMUM, BYTE_MINIMUM, BYTE_ZERO};
 
-   EXPECT_EQ(BYTE_ZERO, _bLoad(BYTE_ZERO));
-   EXPECT_EQ(BYTE_NEG, _bLoad(BYTE_NEG));
-   EXPECT_EQ(BYTE_POS, _bLoad(BYTE_POS));
-   EXPECT_EQ(BYTE_MAXIMUM, _bLoad(BYTE_MAXIMUM));
-   EXPECT_EQ(BYTE_MINIMUM, _bLoad(BYTE_MINIMUM));
+   OMR_CT_EXPECT_EQ(_bLoad, BYTE_ZERO, _bLoad(BYTE_ZERO));
+   OMR_CT_EXPECT_EQ(_bLoad, BYTE_NEG, _bLoad(BYTE_NEG));
+   OMR_CT_EXPECT_EQ(_bLoad, BYTE_POS, _bLoad(BYTE_POS));
+   OMR_CT_EXPECT_EQ(_bLoad, BYTE_MAXIMUM, _bLoad(BYTE_MAXIMUM));
+   OMR_CT_EXPECT_EQ(_bLoad, BYTE_MINIMUM, _bLoad(BYTE_MINIMUM));
 
-   EXPECT_EQ(SHORT_ZERO, _sLoad(SHORT_ZERO));
-   EXPECT_EQ(SHORT_NEG, _sLoad(SHORT_NEG));
-   EXPECT_EQ(SHORT_POS, _sLoad(SHORT_POS));
-   EXPECT_EQ(SHORT_MAXIMUM, _sLoad(SHORT_MAXIMUM));
-   EXPECT_EQ(SHORT_MINIMUM, _sLoad(SHORT_MINIMUM));
+   OMR_CT_EXPECT_EQ(_sLoad, SHORT_ZERO, _sLoad(SHORT_ZERO));
+   OMR_CT_EXPECT_EQ(_sLoad, SHORT_NEG, _sLoad(SHORT_NEG));
+   OMR_CT_EXPECT_EQ(_sLoad, SHORT_POS, _sLoad(SHORT_POS));
+   OMR_CT_EXPECT_EQ(_sLoad, SHORT_MAXIMUM, _sLoad(SHORT_MAXIMUM));
+   OMR_CT_EXPECT_EQ(_sLoad, SHORT_MINIMUM, _sLoad(SHORT_MINIMUM));
 
    //store
    testCaseNum = sizeof(byteDataArray) / sizeof(byteDataArray[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "bStoreConst%d", i + 1);
-      EXPECT_EQ(byteDataArray[i], _bStore(byteDataArray[i]));
+      OMR_CT_EXPECT_EQ(_bStore, byteDataArray[i], _bStore(byteDataArray[i]));
       bMemCons = (signatureCharB_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bstore, resolvedMethodName, _argTypesUnaryByte, TR::Int8, rc, 2, 1, &(byteDataArray[i])));
-      EXPECT_EQ(byteDataArray[i], bMemCons(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(bMemCons, byteDataArray[i], bMemCons(BYTE_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(shortDataArray) / sizeof(shortDataArray[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "sStoreConst%d", i + 1);
-      EXPECT_EQ(shortDataArray[i], _sStore(shortDataArray[i]));
+      OMR_CT_EXPECT_EQ(_sStore, shortDataArray[i], _sStore(shortDataArray[i]));
       sMemCons = (signatureCharS_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::sstore, resolvedMethodName, _argTypesUnaryShort, TR::Int16, rc, 2, 1, &(shortDataArray[i])));
-      EXPECT_EQ(shortDataArray[i], sMemCons(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(sMemCons, shortDataArray[i], sMemCons(SHORT_PLACEHOLDER_1));
       }
 
    //Jazz103 111410 : bstorei, sstorei unexpected results
@@ -5026,10 +5040,16 @@ S390OpCodesTest::invokeDisabledMemoryOperationTests()
    testCaseNum = sizeof(byteDataArray) / sizeof(byteDataArray[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      _bStorei((uintptrj_t)(&byteStoreDataArray[i]) , byteDataArray[i]);
-      EXPECT_EQ(byteDataArray[i], byteStoreDataArray[i]);
-      _sStorei((uintptrj_t)(&shortStoreDataArray[i]) , shortDataArray[i]);
-      EXPECT_EQ(shortDataArray[i], shortStoreDataArray[i]);
+      if (_bStorei != NULL)
+         {
+         _bStorei((uintptrj_t)(&byteStoreDataArray[i]) , byteDataArray[i]);
+         EXPECT_EQ(byteDataArray[i], byteStoreDataArray[i]);
+         }
+      if (_sStorei != NULL)
+         {
+         _sStorei((uintptrj_t)(&shortStoreDataArray[i]) , shortDataArray[i]);
+         EXPECT_EQ(shortDataArray[i], shortStoreDataArray[i]);
+         }
       }
    }
 
@@ -5107,132 +5127,132 @@ S390OpCodesTest::invokeDisabledBitwiseTests()
    testCaseNum = sizeof(byteAndArr) / sizeof(byteAndArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(tand(byteAndArr[i][0], byteAndArr[i][1]), _bAnd(byteAndArr[i][0], byteAndArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bAnd, tand(byteAndArr[i][0], byteAndArr[i][1]), _bAnd(byteAndArr[i][0], byteAndArr[i][1]));
 
       sprintf(resolvedMethodName, "bAndConst1_TestCase%d", i + 1);
       bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::band, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &(byteAndArr[i][0]), 2, &(byteAndArr[i][1])));
-      EXPECT_EQ(tand(byteAndArr[i][0], byteAndArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bBitwiseConst, tand(byteAndArr[i][0], byteAndArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bAndConst2_TestCase%d", i + 1);
       bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::band, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &(byteAndArr[i][0])));
-      EXPECT_EQ(tand(byteAndArr[i][0], byteAndArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, byteAndArr[i][1]));
+      OMR_CT_EXPECT_EQ(bBitwiseConst, tand(byteAndArr[i][0], byteAndArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, byteAndArr[i][1]));
 
       sprintf(resolvedMethodName, "bAndConst3_TestCase%d", i + 1);
       bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::band, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &(byteAndArr[i][1])));
-      EXPECT_EQ(tand(byteAndArr[i][0], byteAndArr[i][1]), bBitwiseConst(byteAndArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bBitwiseConst, tand(byteAndArr[i][0], byteAndArr[i][1]), bBitwiseConst(byteAndArr[i][0], BYTE_PLACEHOLDER_2));
      }
 
    //bor
    testCaseNum = sizeof(byteOrArr) / sizeof(byteOrArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(tor(byteOrArr[i][0], byteOrArr[i][1]), _bOr(byteOrArr[i][0], byteOrArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bOr, tor(byteOrArr[i][0], byteOrArr[i][1]), _bOr(byteOrArr[i][0], byteOrArr[i][1]));
 
       sprintf(resolvedMethodName, "bOrConst1_TestCase%d", i + 1);
       bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &(byteOrArr[i][0]), 2, &(byteOrArr[i][1])));
-      EXPECT_EQ(tor(byteOrArr[i][0], byteOrArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bBitwiseConst, tor(byteOrArr[i][0], byteOrArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bOrConst2_TestCase%d", i + 1);
       bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &(byteOrArr[i][0])));
-      EXPECT_EQ(tor(byteOrArr[i][0], byteOrArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, byteOrArr[i][1]));
+      OMR_CT_EXPECT_EQ(bBitwiseConst, tor(byteOrArr[i][0], byteOrArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, byteOrArr[i][1]));
 
       sprintf(resolvedMethodName, "bOrConst3_TestCase%d", i + 1);
       bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &(byteOrArr[i][1])));
-      EXPECT_EQ(tor(byteOrArr[i][0], byteOrArr[i][1]), bBitwiseConst(byteOrArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bBitwiseConst, tor(byteOrArr[i][0], byteOrArr[i][1]), bBitwiseConst(byteOrArr[i][0], BYTE_PLACEHOLDER_2));
      }
 
    //bxor
    testCaseNum = sizeof(byteXorArr) / sizeof(byteXorArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(txor(byteXorArr[i][0], byteXorArr[i][1]), _bXor(byteXorArr[i][0], byteXorArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bXor, txor(byteXorArr[i][0], byteXorArr[i][1]), _bXor(byteXorArr[i][0], byteXorArr[i][1]));
 
       sprintf(resolvedMethodName, "bXorConst1_TestCase%d", i + 1);
       bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bxor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &(byteXorArr[i][0]), 2, &(byteXorArr[i][1])));
-      EXPECT_EQ(txor(byteXorArr[i][0], byteXorArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bBitwiseConst, txor(byteXorArr[i][0], byteXorArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bXorConst2_TestCase%d", i + 1);
       bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bxor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &(byteXorArr[i][0])));
-      EXPECT_EQ(txor(byteXorArr[i][0], byteXorArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, byteXorArr[i][1]));
+      OMR_CT_EXPECT_EQ(bBitwiseConst, txor(byteXorArr[i][0], byteXorArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, byteXorArr[i][1]));
 
       sprintf(resolvedMethodName, "bXorConst3_TestCase%d", i + 1);
       bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bxor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &(byteXorArr[i][1])));
-      EXPECT_EQ(txor(byteXorArr[i][0], byteXorArr[i][1]), bBitwiseConst(byteXorArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bBitwiseConst, txor(byteXorArr[i][0], byteXorArr[i][1]), bBitwiseConst(byteXorArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //sand
    testCaseNum = sizeof(shortAndArr) / sizeof(shortAndArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(tand(shortAndArr[i][0], shortAndArr[i][1]), _sAnd(shortAndArr[i][0], shortAndArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sAnd, tand(shortAndArr[i][0], shortAndArr[i][1]), _sAnd(shortAndArr[i][0], shortAndArr[i][1]));
 
       sprintf(resolvedMethodName, "sAndConst1_TestCase%d", i + 1);
       sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sand, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &(shortAndArr[i][0]), 2, &(shortAndArr[i][1])));
-      EXPECT_EQ(tand(shortAndArr[i][0], shortAndArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sBitwiseConst, tand(shortAndArr[i][0], shortAndArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sAndConst2_TestCase%d", i + 1);
       sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sand, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &(shortAndArr[i][0])));
-      EXPECT_EQ(tand(shortAndArr[i][0], shortAndArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, shortAndArr[i][1]));
+      OMR_CT_EXPECT_EQ(sBitwiseConst, tand(shortAndArr[i][0], shortAndArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, shortAndArr[i][1]));
 
       sprintf(resolvedMethodName, "sAndConst3_TestCase%d", i + 1);
       sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sand, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &(shortAndArr[i][1])));
-      EXPECT_EQ(tand(shortAndArr[i][0], shortAndArr[i][1]), sBitwiseConst(shortAndArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sBitwiseConst, tand(shortAndArr[i][0], shortAndArr[i][1]), sBitwiseConst(shortAndArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    //sor
    testCaseNum = sizeof(shortOrArr) / sizeof(shortOrArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(tor(shortOrArr[i][0], shortOrArr[i][1]), _sOr(shortOrArr[i][0], shortOrArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sOr, tor(shortOrArr[i][0], shortOrArr[i][1]), _sOr(shortOrArr[i][0], shortOrArr[i][1]));
 
       sprintf(resolvedMethodName, "sOrConst1_TestCase%d", i + 1);
       sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &(shortOrArr[i][0]), 2, &(shortOrArr[i][1])));
-      EXPECT_EQ(tor(shortOrArr[i][0], shortOrArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sBitwiseConst, tor(shortOrArr[i][0], shortOrArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sOrConst2_TestCase%d", i + 1);
       sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &(shortOrArr[i][0])));
-      EXPECT_EQ(tor(shortOrArr[i][0], shortOrArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, shortOrArr[i][1]));
+      OMR_CT_EXPECT_EQ(sBitwiseConst, tor(shortOrArr[i][0], shortOrArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, shortOrArr[i][1]));
 
       sprintf(resolvedMethodName, "sOrConst3_TestCase%d", i + 1);
       sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &(shortOrArr[i][1])));
-      EXPECT_EQ(tor(shortOrArr[i][0], shortOrArr[i][1]), sBitwiseConst(shortOrArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sBitwiseConst, tor(shortOrArr[i][0], shortOrArr[i][1]), sBitwiseConst(shortOrArr[i][0], SHORT_PLACEHOLDER_2));
      }
 
    //sxor
    testCaseNum = sizeof(shortXorArr) / sizeof(shortXorArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(txor(shortXorArr[i][0], shortXorArr[i][1]), _sXor(shortXorArr[i][0], shortXorArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sXor, txor(shortXorArr[i][0], shortXorArr[i][1]), _sXor(shortXorArr[i][0], shortXorArr[i][1]));
 
       sprintf(resolvedMethodName, "sXorConst1_TestCase%d", i + 1);
       sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sxor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &(shortXorArr[i][0]), 2, &(shortXorArr[i][1])));
-      EXPECT_EQ(txor(shortXorArr[i][0], shortXorArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sBitwiseConst, txor(shortXorArr[i][0], shortXorArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sXorConst2_TestCase%d", i + 1);
       sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sxor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &(shortXorArr[i][0])));
-      EXPECT_EQ(txor(shortXorArr[i][0], shortXorArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, shortXorArr[i][1]));
+      OMR_CT_EXPECT_EQ(sBitwiseConst, txor(shortXorArr[i][0], shortXorArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, shortXorArr[i][1]));
 
       sprintf(resolvedMethodName, "sXorConst3_TestCase%d", i + 1);
       sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sxor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &(shortXorArr[i][1])));
-      EXPECT_EQ(txor(shortXorArr[i][0], shortXorArr[i][1]), sBitwiseConst(shortXorArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sBitwiseConst, txor(shortXorArr[i][0], shortXorArr[i][1]), sBitwiseConst(shortXorArr[i][0], SHORT_PLACEHOLDER_2));
      }
    }
 
@@ -5392,337 +5412,337 @@ S390OpCodesTest::invokeAddressTests()
    testCaseNum = sizeof(aUnaryDataArr) / sizeof(aUnaryDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(aUnaryDataArr[i], _acall(aUnaryDataArr[i]));
+      OMR_CT_EXPECT_EQ(_acall, aUnaryDataArr[i], _acall(aUnaryDataArr[i]));
       }
    testCaseNum = sizeof(intDataArr) / sizeof(intDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(intDataArr[i], ADDRESS_PLACEHOLDER_1), _i2a(intDataArr[i]));
+      OMR_CT_EXPECT_EQ(_i2a, convert(intDataArr[i], ADDRESS_PLACEHOLDER_1), _i2a(intDataArr[i]));
 
       sprintf(resolvedMethodName, "i2aConst%d", i + 1);
       i2aConst = (signatureCharI_L_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::i2a, resolvedMethodName, _argTypesUnaryInt, TR::Address, rc, 2, 1, &intDataArr[i]));
-      EXPECT_EQ(convert(intDataArr[i], ADDRESS_PLACEHOLDER_1), i2aConst(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(i2aConst, convert(intDataArr[i], ADDRESS_PLACEHOLDER_1), i2aConst(INT_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(uintDataArr) / sizeof(uintDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(uintDataArr[i], ADDRESS_PLACEHOLDER_1), _iu2a(uintDataArr[i]));
+      OMR_CT_EXPECT_EQ(_iu2a, convert(uintDataArr[i], ADDRESS_PLACEHOLDER_1), _iu2a(uintDataArr[i]));
 
       sprintf(resolvedMethodName, "iu2aConst%d", i + 1);
       iu2aConst = (unsignedSignatureCharI_L_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::iu2a, resolvedMethodName, _argTypesUnaryInt, TR::Address, rc, 2, 1, &uintDataArr[i]));
-      EXPECT_EQ(convert(uintDataArr[i], ADDRESS_PLACEHOLDER_1), iu2aConst(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(iu2aConst, convert(uintDataArr[i], ADDRESS_PLACEHOLDER_1), iu2aConst(INT_PLACEHOLDER_1));
       }
 #endif
 
    testCaseNum = sizeof(longDataArr) / sizeof(longDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(longDataArr[i], ADDRESS_PLACEHOLDER_1), _l2a(longDataArr[i]));
+      OMR_CT_EXPECT_EQ(_l2a, convert(longDataArr[i], ADDRESS_PLACEHOLDER_1), _l2a(longDataArr[i]));
 
       sprintf(resolvedMethodName, "l2aConst%d", i + 1);
       l2aConst = (signatureCharJ_L_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::l2a, resolvedMethodName, _argTypesUnaryLong, TR::Address, rc, 2, 1, &longDataArr[i]));
-      EXPECT_EQ(convert(longDataArr[i], ADDRESS_PLACEHOLDER_1), l2aConst(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(l2aConst, convert(longDataArr[i], ADDRESS_PLACEHOLDER_1), l2aConst(LONG_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(ulongDataArr) / sizeof(ulongDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(ulongDataArr[i], ADDRESS_PLACEHOLDER_1), _lu2a(ulongDataArr[i]));
+      OMR_CT_EXPECT_EQ(_lu2a, convert(ulongDataArr[i], ADDRESS_PLACEHOLDER_1), _lu2a(ulongDataArr[i]));
 
       sprintf(resolvedMethodName, "lu2aConst%d", i + 1);
       lu2aConst = (unsignedSignatureCharJ_L_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::lu2a, resolvedMethodName, _argTypesUnaryLong, TR::Address, rc, 2, 1, &ulongDataArr[i]));
-      EXPECT_EQ(convert(ulongDataArr[i], ADDRESS_PLACEHOLDER_1), lu2aConst(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lu2aConst, convert(ulongDataArr[i], ADDRESS_PLACEHOLDER_1), lu2aConst(INT_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(aUnaryDataArr) / sizeof(aUnaryDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(aUnaryDataArr[i], LONG_POS), _a2l(aUnaryDataArr[i]));
+      OMR_CT_EXPECT_EQ(_a2l, convert(aUnaryDataArr[i], LONG_POS), _a2l(aUnaryDataArr[i]));
 
       sprintf(resolvedMethodName, "a2lConst%d", i + 1);
       a2lConst = (signatureCharL_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::a2l, resolvedMethodName, _argTypesUnaryAddress, TR::Int64, rc, 2, 1, &aUnaryDataArr[i]));
-      EXPECT_EQ(convert(aUnaryDataArr[i], LONG_POS), a2lConst(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(a2lConst, convert(aUnaryDataArr[i], LONG_POS), a2lConst(ADDRESS_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(aUnaryDataArr) / sizeof(aUnaryDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(aUnaryDataArr[i], SHORT_POS), _a2s(aUnaryDataArr[i]));
+      OMR_CT_EXPECT_EQ(_a2s, convert(aUnaryDataArr[i], SHORT_POS), _a2s(aUnaryDataArr[i]));
 
       sprintf(resolvedMethodName, "a2sConst%d", i + 1);
       a2sConst = (signatureCharL_S_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::a2s, resolvedMethodName, _argTypesUnaryAddress, TR::Int16, rc, 2, 1, &aUnaryDataArr[i]));
-      EXPECT_EQ(convert(aUnaryDataArr[i], SHORT_POS), a2sConst(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(a2sConst, convert(aUnaryDataArr[i], SHORT_POS), a2sConst(ADDRESS_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(aUnaryDataArr) / sizeof(aUnaryDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(aUnaryDataArr[i], BYTE_POS), _a2b(aUnaryDataArr[i]));
+      OMR_CT_EXPECT_EQ(_a2b, convert(aUnaryDataArr[i], BYTE_POS), _a2b(aUnaryDataArr[i]));
 
       sprintf(resolvedMethodName, "a2bConst%d", i + 1);
       a2bConst = (signatureCharL_B_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::a2b, resolvedMethodName, _argTypesUnaryAddress, TR::Int8, rc, 2, 1, &aUnaryDataArr[i]));
-      EXPECT_EQ(convert(aUnaryDataArr[i], BYTE_POS), a2bConst(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(a2bConst, convert(aUnaryDataArr[i], BYTE_POS), a2bConst(ADDRESS_PLACEHOLDER_1));
       }
 
    //address compare
    testCaseNum = sizeof(acmpeqDataArr) / sizeof(acmpeqDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), _acmpeq(acmpeqDataArr[i][0], acmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_acmpeq, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), _acmpeq(acmpeqDataArr[i][0], acmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpeqConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpeqDataArr[i][0]), 2, &(acmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "aCmpeqConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpeqConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(acmpeqDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(acmpeqDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(acmpneDataArr) / sizeof(acmpneDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), _acmpne(acmpneDataArr[i][0], acmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_acmpne, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), _acmpne(acmpneDataArr[i][0], acmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpneConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpneDataArr[i][0]), 2, &(acmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "aCmpneConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpneConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(acmpneDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(acmpneDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(acmpgtDataArr) / sizeof(acmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), _acmpgt(acmpgtDataArr[i][0], acmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_acmpgt, compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), _acmpgt(acmpgtDataArr[i][0], acmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpgtConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpgtDataArr[i][0]), 2, &(acmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "acmpgtConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpgtConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), aCompareConst(acmpgtDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), aCompareConst(acmpgtDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(acmpltDataArr) / sizeof(acmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), _acmplt(acmpltDataArr[i][0], acmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_acmplt, compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), _acmplt(acmpltDataArr[i][0], acmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpltConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpltDataArr[i][0]), 2, &(acmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "acmpltConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpltConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), aCompareConst(acmpltDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), aCompareConst(acmpltDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(acmpgeDataArr) / sizeof(acmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), _acmpge(acmpgeDataArr[i][0], acmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_acmpge, compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), _acmpge(acmpgeDataArr[i][0], acmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpgeConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpgeDataArr[i][0]), 2, &(acmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "acmpgeConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpgeConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), aCompareConst(acmpgeDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), aCompareConst(acmpgeDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(acmpleDataArr) / sizeof(acmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), _acmple(acmpleDataArr[i][0], acmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_acmple, compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), _acmple(acmpleDataArr[i][0], acmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpleConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpleDataArr[i][0]), 2, &(acmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "acmpleConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpleConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), aCompareConst(acmpleDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), aCompareConst(acmpleDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    //address ifcompare
    testCaseNum = sizeof(ifacmpeqDataArr) / sizeof(ifacmpeqDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), _ifacmpeq(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifacmpeq, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), _ifacmpeq(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpeqConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpeqDataArr[i][0]), 2, &(ifacmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpeqConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpeqConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ifacmpeqDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ifacmpeqDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifacmpneDataArr) / sizeof(ifacmpneDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), _ifacmpne(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifacmpne, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), _ifacmpne(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpneConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpneDataArr[i][0]), 2, &(ifacmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpneConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpneConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ifacmpneDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ifacmpneDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifacmpgtDataArr) / sizeof(ifacmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), _ifacmpgt(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifacmpgt, compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), _ifacmpgt(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpgtConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpgtDataArr[i][0]), 2, &(ifacmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpgtConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpgtConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), aCompareConst(ifacmpgtDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), aCompareConst(ifacmpgtDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifacmpltDataArr) / sizeof(ifacmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), _ifacmplt(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifacmplt, compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), _ifacmplt(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpltConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpltDataArr[i][0]), 2, &(ifacmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpltConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpltConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), aCompareConst(ifacmpltDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), aCompareConst(ifacmpltDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifacmpgeDataArr) / sizeof(ifacmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), _ifacmpge(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifacmpge, compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), _ifacmpge(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpgeConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpgeDataArr[i][0]), 2, &(ifacmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpgeConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpgeConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), aCompareConst(ifacmpgeDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), aCompareConst(ifacmpgeDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifacmpleDataArr) / sizeof(ifacmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), _ifacmple(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifacmple, compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), _ifacmple(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpleConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpleDataArr[i][0]), 2, &(ifacmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpleConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpleConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ifacmpleDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ifacmpleDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
 
@@ -5731,42 +5751,42 @@ S390OpCodesTest::invokeAddressTests()
    testCaseNum = sizeof(aternaryChild1Arr) / sizeof(aternaryChild1Arr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), _aternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]));
+      OMR_CT_EXPECT_EQ(_aternary, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), _aternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]));
 
       sprintf(resolvedMethodName, "aTernaryConst1_TestCase%d", i + 1);
       aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
             _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 6, 1, &aternaryChild1Arr[i], 2, &aternaryArr[i][0], 3, &aternaryArr[i][1]));
-      EXPECT_EQ(ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "aTernaryConst2_TestCase%d", i + 1);
       aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
             _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 1, &aternaryChild1Arr[i], 2, &aternaryArr[i][0]));
-      EXPECT_EQ(ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, aternaryArr[i][1]));
+      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, aternaryArr[i][1]));
 
       sprintf(resolvedMethodName, "aTernaryConst3_TestCase%d", i + 1);
       aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
             _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 1, &aternaryChild1Arr[i], 3, &aternaryArr[i][1]));
-      EXPECT_EQ(ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, aternaryArr[i][0], ADDRESS_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, aternaryArr[i][0], ADDRESS_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "aTernaryConst4_TestCase%d", i + 1);
       aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
             _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 2, &aternaryArr[i][0], 3, &aternaryArr[i][1]));
-      EXPECT_EQ(ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "aTernaryConst5_TestCase%d", i + 1);
       aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
             _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 1, &aternaryChild1Arr[i]));
-      EXPECT_EQ(ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, aternaryArr[i][0], aternaryArr[i][1]));
+      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, aternaryArr[i][0], aternaryArr[i][1]));
 
       sprintf(resolvedMethodName, "aTernaryConst6_TestCase%d", i + 1);
       aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
             _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 2, &aternaryArr[i][0]));
-      EXPECT_EQ(ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], ADDRESS_PLACEHOLDER_1, aternaryArr[i][1]));
+      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], ADDRESS_PLACEHOLDER_1, aternaryArr[i][1]));
 
       sprintf(resolvedMethodName, "aTernaryConst7_TestCase%d", i + 1);
       aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
             _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 3, &aternaryArr[i][1]));
-      EXPECT_EQ(ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], aternaryArr[i][0], ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], aternaryArr[i][0], ADDRESS_PLACEHOLDER_1));
       }
    }
 
@@ -5813,68 +5833,68 @@ S390OpCodesTest::invokeDisabledS390ConvertToAddressOpCodesTests()
    testCaseNum = sizeof(byteDataArr) / sizeof(byteDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(byteDataArr[i], ADDRESS_PLACEHOLDER_1), _b2a(byteDataArr[i]));
+      OMR_CT_EXPECT_EQ(_b2a, convert(byteDataArr[i], ADDRESS_PLACEHOLDER_1), _b2a(byteDataArr[i]));
 
       sprintf(resolvedMethodName, "b2aConst%d", i + 1);
       b2aConst = (signatureCharB_L_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::b2a, resolvedMethodName, _argTypesUnaryByte, TR::Address, rc, 2, 1, &byteDataArr[i]));
-      EXPECT_EQ(convert(byteDataArr[i], ADDRESS_PLACEHOLDER_1), b2aConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(b2aConst, convert(byteDataArr[i], ADDRESS_PLACEHOLDER_1), b2aConst(BYTE_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(shortDataArr) / sizeof(shortDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(shortDataArr[i], ADDRESS_PLACEHOLDER_1), _s2a(shortDataArr[i]));
+      OMR_CT_EXPECT_EQ(_s2a, convert(shortDataArr[i], ADDRESS_PLACEHOLDER_1), _s2a(shortDataArr[i]));
 
       sprintf(resolvedMethodName, "s2aConst%d", i + 1);
       s2aConst = (signatureCharS_L_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::s2a, resolvedMethodName, _argTypesUnaryShort, TR::Address, rc, 2, 1, &shortDataArr[i]));
-      EXPECT_EQ(convert(shortDataArr[i], ADDRESS_PLACEHOLDER_1), s2aConst(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(s2aConst, convert(shortDataArr[i], ADDRESS_PLACEHOLDER_1), s2aConst(SHORT_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(ubyteDataArr) / sizeof(ubyteDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(ubyteDataArr[i], ADDRESS_PLACEHOLDER_1), _bu2a(ubyteDataArr[i]));
+      OMR_CT_EXPECT_EQ(_bu2a, convert(ubyteDataArr[i], ADDRESS_PLACEHOLDER_1), _bu2a(ubyteDataArr[i]));
 
       sprintf(resolvedMethodName, "bu2aConst%d", i + 1);
       bu2aConst = (unsignedSignatureCharB_L_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::bu2a, resolvedMethodName, _argTypesUnaryByte, TR::Address, rc, 2, 1, &ubyteDataArr[i]));
-      EXPECT_EQ(convert(ubyteDataArr[i], ADDRESS_PLACEHOLDER_1), bu2aConst(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(bu2aConst, convert(ubyteDataArr[i], ADDRESS_PLACEHOLDER_1), bu2aConst(INT_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(ushortDataArr) / sizeof(ushortDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(ushortDataArr[i], ADDRESS_PLACEHOLDER_1), _su2a(ushortDataArr[i]));
+      OMR_CT_EXPECT_EQ(_su2a, convert(ushortDataArr[i], ADDRESS_PLACEHOLDER_1), _su2a(ushortDataArr[i]));
 
       sprintf(resolvedMethodName, "su2aConst%d", i + 1);
       su2aConst = (unsignedSignatureCharS_L_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::su2a, resolvedMethodName, _argTypesUnaryShort, TR::Address, rc, 2, 1, &ushortDataArr[i]));
-      EXPECT_EQ(convert(ushortDataArr[i], ADDRESS_PLACEHOLDER_1), su2aConst(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(su2aConst, convert(ushortDataArr[i], ADDRESS_PLACEHOLDER_1), su2aConst(INT_PLACEHOLDER_1));
       }
 
 #if defined(TR_TARGET_64BIT)
    testCaseNum = sizeof(intDataArr) / sizeof(intDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(intDataArr[i], ADDRESS_PLACEHOLDER_1), _i2a(intDataArr[i]));
+      OMR_CT_EXPECT_EQ(_i2a, convert(intDataArr[i], ADDRESS_PLACEHOLDER_1), _i2a(intDataArr[i]));
 
       sprintf(resolvedMethodName, "i2aConst%d", i + 1);
       i2aConst = (signatureCharI_L_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::i2a, resolvedMethodName, _argTypesUnaryInt, TR::Address, rc, 2, 1, &intDataArr[i]));
-      EXPECT_EQ(convert(intDataArr[i], ADDRESS_PLACEHOLDER_1), i2aConst(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(i2aConst, convert(intDataArr[i], ADDRESS_PLACEHOLDER_1), i2aConst(INT_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(uintDataArr) / sizeof(uintDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(uintDataArr[i], ADDRESS_PLACEHOLDER_1), _iu2a(uintDataArr[i]));
+      OMR_CT_EXPECT_EQ(_iu2a, convert(uintDataArr[i], ADDRESS_PLACEHOLDER_1), _iu2a(uintDataArr[i]));
 
       sprintf(resolvedMethodName, "iu2aConst%d", i + 1);
       iu2aConst = (unsignedSignatureCharI_L_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::iu2a, resolvedMethodName, _argTypesUnaryInt, TR::Address, rc, 2, 1, &uintDataArr[i]));
-      EXPECT_EQ(convert(uintDataArr[i], ADDRESS_PLACEHOLDER_1), iu2aConst(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(iu2aConst, convert(uintDataArr[i], ADDRESS_PLACEHOLDER_1), iu2aConst(INT_PLACEHOLDER_1));
       }
 #endif
    }

--- a/fvtest/compilertest/tests/X86OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/X86OpCodesTest.cpp
@@ -424,154 +424,154 @@ X86OpCodesTest::invokeIntegerArithmeticTests()
    testCaseArrLength = sizeof(byteAddArr) / sizeof(byteAddArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(add(byteAddArr[i][0], byteAddArr[i][1]), _bAdd(byteAddArr[i][0], byteAddArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bAdd, add(byteAddArr[i][0], byteAddArr[i][1]), _bAdd(byteAddArr[i][0], byteAddArr[i][1]));
 
       sprintf(resolvedMethodName, "bAddConst1_Testcase%d", i);
       bBinaryCons = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::badd,
             resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &byteAddArr[i][0], 2, &byteAddArr[i][1]));
-      EXPECT_EQ(add(byteAddArr[i][0], byteAddArr[i][1]), bBinaryCons(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bBinaryCons, add(byteAddArr[i][0], byteAddArr[i][1]), bBinaryCons(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bAddConst2_Testcase%d", i);
       bBinaryCons = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::badd,
             resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &byteAddArr[i][0]));
-      EXPECT_EQ(add(byteAddArr[i][0], byteAddArr[i][1]), bBinaryCons(BYTE_PLACEHOLDER_1, byteAddArr[i][1]));
+      OMR_CT_EXPECT_EQ(bBinaryCons, add(byteAddArr[i][0], byteAddArr[i][1]), bBinaryCons(BYTE_PLACEHOLDER_1, byteAddArr[i][1]));
 
       sprintf(resolvedMethodName, "bAddConst3_Testcase%d", i);
       bBinaryCons = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::badd,
             resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &byteAddArr[i][1]));
-      EXPECT_EQ(add(byteAddArr[i][0], byteAddArr[i][1]), bBinaryCons(byteAddArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bBinaryCons, add(byteAddArr[i][0], byteAddArr[i][1]), bBinaryCons(byteAddArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //bsub
    testCaseArrLength = sizeof(byteSubArr) / sizeof(byteSubArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(sub(byteSubArr[i][0], byteSubArr[i][1]), _bSub(byteSubArr[i][0], byteSubArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bSub, sub(byteSubArr[i][0], byteSubArr[i][1]), _bSub(byteSubArr[i][0], byteSubArr[i][1]));
 
       sprintf(resolvedMethodName, "bSubConst1_Testcase%d", i);
       bBinaryCons = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bsub,
             resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &byteSubArr[i][0], 2, &byteSubArr[i][1]));
-      EXPECT_EQ(sub(byteSubArr[i][0], byteSubArr[i][1]), bBinaryCons(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bBinaryCons, sub(byteSubArr[i][0], byteSubArr[i][1]), bBinaryCons(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bSubConst2_Testcase%d", i);
       bBinaryCons = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bsub,
             resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &byteSubArr[i][0]));
-      EXPECT_EQ(sub(byteSubArr[i][0], byteSubArr[i][1]), bBinaryCons(BYTE_PLACEHOLDER_1, byteSubArr[i][1]));
+      OMR_CT_EXPECT_EQ(bBinaryCons, sub(byteSubArr[i][0], byteSubArr[i][1]), bBinaryCons(BYTE_PLACEHOLDER_1, byteSubArr[i][1]));
 
       sprintf(resolvedMethodName, "bSubConst3_Testcase%d", i);
       bBinaryCons = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bsub,
             resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &byteSubArr[i][1]));
-      EXPECT_EQ(sub(byteSubArr[i][0], byteSubArr[i][1]), bBinaryCons(byteSubArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bBinaryCons, sub(byteSubArr[i][0], byteSubArr[i][1]), bBinaryCons(byteSubArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //sadd
    testCaseArrLength = sizeof(shortAddArr) / sizeof(shortAddArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(add(shortAddArr[i][0], shortAddArr[i][1]), _sAdd(shortAddArr[i][0], shortAddArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sAdd, add(shortAddArr[i][0], shortAddArr[i][1]), _sAdd(shortAddArr[i][0], shortAddArr[i][1]));
 
       sprintf(resolvedMethodName, "sAddConst1_Testcase%d", i);
       sBinaryCons = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sadd,
             resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &shortAddArr[i][0], 2, &shortAddArr[i][1]));
-      EXPECT_EQ(add(shortAddArr[i][0], shortAddArr[i][1]), sBinaryCons(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sBinaryCons, add(shortAddArr[i][0], shortAddArr[i][1]), sBinaryCons(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sAddConst2_Testcase%d", i);
       sBinaryCons = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sadd,
             resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &shortAddArr[i][0]));
-      EXPECT_EQ(add(shortAddArr[i][0], shortAddArr[i][1]), sBinaryCons(SHORT_PLACEHOLDER_1, shortAddArr[i][1]));
+      OMR_CT_EXPECT_EQ(sBinaryCons, add(shortAddArr[i][0], shortAddArr[i][1]), sBinaryCons(SHORT_PLACEHOLDER_1, shortAddArr[i][1]));
 
       sprintf(resolvedMethodName, "sAddConst3_Testcase%d", i);
       sBinaryCons = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sadd,
             resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &shortAddArr[i][1]));
-      EXPECT_EQ(add(shortAddArr[i][0], shortAddArr[i][1]), sBinaryCons(shortAddArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sBinaryCons, add(shortAddArr[i][0], shortAddArr[i][1]), sBinaryCons(shortAddArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    //ssub
    testCaseArrLength = sizeof(shortSubArr) / sizeof(shortSubArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(sub(shortSubArr[i][0], shortSubArr[i][1]), _sSub(shortSubArr[i][0], shortSubArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sSub, sub(shortSubArr[i][0], shortSubArr[i][1]), _sSub(shortSubArr[i][0], shortSubArr[i][1]));
 
       sprintf(resolvedMethodName, "sSubConst1_Testcase%d", i);
       sBinaryCons = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ssub,
             resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &shortSubArr[i][0], 2, &shortSubArr[i][1]));
-      EXPECT_EQ(sub(shortSubArr[i][0], shortSubArr[i][1]), sBinaryCons(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sBinaryCons, sub(shortSubArr[i][0], shortSubArr[i][1]), sBinaryCons(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sSubConst2_Testcase%d", i);
       sBinaryCons = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ssub,
             resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &shortSubArr[i][0]));
-      EXPECT_EQ(sub(shortSubArr[i][0], shortSubArr[i][1]), sBinaryCons(SHORT_PLACEHOLDER_1, shortSubArr[i][1]));
+      OMR_CT_EXPECT_EQ(sBinaryCons, sub(shortSubArr[i][0], shortSubArr[i][1]), sBinaryCons(SHORT_PLACEHOLDER_1, shortSubArr[i][1]));
 
       sprintf(resolvedMethodName, "sSubConst3_Testcase%d", i);
       sBinaryCons = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ssub,
             resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &shortSubArr[i][1]));
-      EXPECT_EQ(sub(shortSubArr[i][0], shortSubArr[i][1]), sBinaryCons(shortSubArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sBinaryCons, sub(shortSubArr[i][0], shortSubArr[i][1]), sBinaryCons(shortSubArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    //ladd
    testCaseArrLength = sizeof(longAddArr) / sizeof(longAddArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(add(longAddArr[i][0], longAddArr[i][1]), _lAdd(longAddArr[i][0], longAddArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lAdd, add(longAddArr[i][0], longAddArr[i][1]), _lAdd(longAddArr[i][0], longAddArr[i][1]));
 
       sprintf(resolvedMethodName, "lAddConst1_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ladd,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longAddArr[i][0], 2, &longAddArr[i][1]));
-      EXPECT_EQ(add(longAddArr[i][0], longAddArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, add(longAddArr[i][0], longAddArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lAddConst2_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ladd,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longAddArr[i][0]));
-      EXPECT_EQ(add(longAddArr[i][0], longAddArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longAddArr[i][1]));
+      OMR_CT_EXPECT_EQ(lBinaryCons, add(longAddArr[i][0], longAddArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longAddArr[i][1]));
 
       sprintf(resolvedMethodName, "lAddConst3_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ladd,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longAddArr[i][1]));
-      EXPECT_EQ(add(longAddArr[i][0], longAddArr[i][1]), lBinaryCons(longAddArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, add(longAddArr[i][0], longAddArr[i][1]), lBinaryCons(longAddArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //lsub
    testCaseArrLength = sizeof(longSubArr) / sizeof(longSubArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(sub(longSubArr[i][0], longSubArr[i][1]), _lSub(longSubArr[i][0], longSubArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lSub, sub(longSubArr[i][0], longSubArr[i][1]), _lSub(longSubArr[i][0], longSubArr[i][1]));
 
       sprintf(resolvedMethodName, "lSubConst1_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lsub,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longSubArr[i][0], 2, &longSubArr[i][1]));
-      EXPECT_EQ(sub(longSubArr[i][0], longSubArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, sub(longSubArr[i][0], longSubArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lSubConst2_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lsub,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longSubArr[i][0]));
-      EXPECT_EQ(sub(longSubArr[i][0], longSubArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longSubArr[i][1]));
+      OMR_CT_EXPECT_EQ(lBinaryCons, sub(longSubArr[i][0], longSubArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longSubArr[i][1]));
 
       sprintf(resolvedMethodName, "lSubConst3_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lsub,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longSubArr[i][1]));
-      EXPECT_EQ(sub(longSubArr[i][0], longSubArr[i][1]), lBinaryCons(longSubArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, sub(longSubArr[i][0], longSubArr[i][1]), lBinaryCons(longSubArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //lmul
    testCaseArrLength = sizeof(longMulArr) / sizeof(longMulArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(mul(longMulArr[i][0], longMulArr[i][1]), _lMul(longMulArr[i][0], longMulArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lMul, mul(longMulArr[i][0], longMulArr[i][1]), _lMul(longMulArr[i][0], longMulArr[i][1]));
 
       sprintf(resolvedMethodName, "lMulConst1_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lmul,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longMulArr[i][0], 2, &longMulArr[i][1]));
-      EXPECT_EQ(mul(longMulArr[i][0], longMulArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, mul(longMulArr[i][0], longMulArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lMulConst2_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lmul,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longMulArr[i][0]));
-      EXPECT_EQ(mul(longMulArr[i][0], longMulArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longMulArr[i][1]));
+      OMR_CT_EXPECT_EQ(lBinaryCons, mul(longMulArr[i][0], longMulArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longMulArr[i][1]));
 
       sprintf(resolvedMethodName, "lMulConst3_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lmul,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longMulArr[i][1]));
-      EXPECT_EQ(mul(longMulArr[i][0], longMulArr[i][1]), lBinaryCons(longMulArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, mul(longMulArr[i][0], longMulArr[i][1]), lBinaryCons(longMulArr[i][0], LONG_PLACEHOLDER_2));
       }
 
 #if defined(TR_TARGET_64BIT)
@@ -580,22 +580,22 @@ X86OpCodesTest::invokeIntegerArithmeticTests()
    testCaseArrLength = sizeof(longDivArr) / sizeof(longDivArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(div(longDivArr[i][0], longDivArr[i][1]), _lDiv(longDivArr[i][0], longDivArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lDiv, div(longDivArr[i][0], longDivArr[i][1]), _lDiv(longDivArr[i][0], longDivArr[i][1]));
 
       sprintf(resolvedMethodName, "lDivConst1_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ldiv,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longDivArr[i][0], 2, &longDivArr[i][1]));
-      EXPECT_EQ(div(longDivArr[i][0], longDivArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, div(longDivArr[i][0], longDivArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lDivConst2_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ldiv,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longDivArr[i][0]));
-      EXPECT_EQ(div(longDivArr[i][0], longDivArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longDivArr[i][1]));
+      OMR_CT_EXPECT_EQ(lBinaryCons, div(longDivArr[i][0], longDivArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longDivArr[i][1]));
 
       sprintf(resolvedMethodName, "lDivConst3_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ldiv,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longDivArr[i][1]));
-      EXPECT_EQ(div(longDivArr[i][0], longDivArr[i][1]), lBinaryCons(longDivArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, div(longDivArr[i][0], longDivArr[i][1]), lBinaryCons(longDivArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //lrem
@@ -603,22 +603,22 @@ X86OpCodesTest::invokeIntegerArithmeticTests()
    testCaseArrLength = sizeof(longRemArr) / sizeof(longRemArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(rem(longRemArr[i][0], longRemArr[i][1]), _lRem(longRemArr[i][0], longRemArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lRem, rem(longRemArr[i][0], longRemArr[i][1]), _lRem(longRemArr[i][0], longRemArr[i][1]));
 
       sprintf(resolvedMethodName, "lRemConst1_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lrem,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longRemArr[i][0], 2, &longRemArr[i][1]));
-      EXPECT_EQ(rem(longRemArr[i][0], longRemArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, rem(longRemArr[i][0], longRemArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lRemConst2_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lrem,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longRemArr[i][0]));
-      EXPECT_EQ(rem(longRemArr[i][0], longRemArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longRemArr[i][1]));
+      OMR_CT_EXPECT_EQ(lBinaryCons, rem(longRemArr[i][0], longRemArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longRemArr[i][1]));
 
       sprintf(resolvedMethodName, "lRemConst3_Testcase%d", i);
       lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lrem,
             resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longRemArr[i][1]));
-      EXPECT_EQ(rem(longRemArr[i][0], longRemArr[i][1]), lBinaryCons(longRemArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBinaryCons, rem(longRemArr[i][0], longRemArr[i][1]), lBinaryCons(longRemArr[i][0], LONG_PLACEHOLDER_2));
       }
 #endif
    }
@@ -703,176 +703,176 @@ X86OpCodesTest::invokeFloatArithmeticTests()
    testCaseNum = sizeof(floatAddArr) / sizeof(floatAddArr[0]);
    for (uint32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_FLOAT_EQ(add(floatAddArr[i][0], floatAddArr[i][1]), _fAdd(floatAddArr[i][0], floatAddArr[i][1]));
+      OMR_CT_EXPECT_FLOAT_EQ(_fAdd, add(floatAddArr[i][0], floatAddArr[i][1]), _fAdd(floatAddArr[i][0], floatAddArr[i][1]));
 
       sprintf(resolvedMethodName, "fAddConst1_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fadd,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatAddArr[i][0], 2, &floatAddArr[i][1]));
-      EXPECT_FLOAT_EQ(add(floatAddArr[i][0], floatAddArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, add(floatAddArr[i][0], floatAddArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fAddConst2_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fadd,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatAddArr[i][0]));
-      EXPECT_FLOAT_EQ(add(floatAddArr[i][0], floatAddArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatAddArr[i][1]));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, add(floatAddArr[i][0], floatAddArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatAddArr[i][1]));
 
       sprintf(resolvedMethodName, "fAddConst3_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fadd,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatAddArr[i][1]));
-      EXPECT_FLOAT_EQ(add(floatAddArr[i][0], floatAddArr[i][1]), fBinaryConst(floatAddArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, add(floatAddArr[i][0], floatAddArr[i][1]), fBinaryConst(floatAddArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    //fsub
    testCaseNum = sizeof(floatSubArr) / sizeof(floatSubArr[0]);
    for (uint32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_FLOAT_EQ(sub(floatSubArr[i][0], floatSubArr[i][1]), _fSub(floatSubArr[i][0], floatSubArr[i][1]));
+      OMR_CT_EXPECT_FLOAT_EQ(_fSub, sub(floatSubArr[i][0], floatSubArr[i][1]), _fSub(floatSubArr[i][0], floatSubArr[i][1]));
 
       sprintf(resolvedMethodName, "fSubConst1_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fsub,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatSubArr[i][0], 2, &floatSubArr[i][1]));
-      EXPECT_FLOAT_EQ(sub(floatSubArr[i][0], floatSubArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, sub(floatSubArr[i][0], floatSubArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fSubConst2_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fsub,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatSubArr[i][0]));
-      EXPECT_FLOAT_EQ(sub(floatSubArr[i][0], floatSubArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatSubArr[i][1]));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, sub(floatSubArr[i][0], floatSubArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatSubArr[i][1]));
 
       sprintf(resolvedMethodName, "fSubConst3_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fsub,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatSubArr[i][1]));
-      EXPECT_FLOAT_EQ(sub(floatSubArr[i][0], floatSubArr[i][1]), fBinaryConst(floatSubArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, sub(floatSubArr[i][0], floatSubArr[i][1]), fBinaryConst(floatSubArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    //fmul
    testCaseNum = sizeof(floatMulArr) / sizeof(floatMulArr[0]);
    for (uint32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_FLOAT_EQ(mul(floatMulArr[i][0], floatMulArr[i][1]), _fMul(floatMulArr[i][0], floatMulArr[i][1]));
+      OMR_CT_EXPECT_FLOAT_EQ(_fMul, mul(floatMulArr[i][0], floatMulArr[i][1]), _fMul(floatMulArr[i][0], floatMulArr[i][1]));
 
       sprintf(resolvedMethodName, "fMulConst1_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fmul,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatMulArr[i][0], 2, &floatMulArr[i][1]));
-      EXPECT_FLOAT_EQ(mul(floatMulArr[i][0], floatMulArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, mul(floatMulArr[i][0], floatMulArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fMulConst2_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fmul,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatMulArr[i][0]));
-      EXPECT_FLOAT_EQ(mul(floatMulArr[i][0], floatMulArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatMulArr[i][1]));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, mul(floatMulArr[i][0], floatMulArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatMulArr[i][1]));
 
       sprintf(resolvedMethodName, "fMulConst3_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fmul,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatMulArr[i][1]));
-      EXPECT_FLOAT_EQ(mul(floatMulArr[i][0], floatMulArr[i][1]), fBinaryConst(floatMulArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, mul(floatMulArr[i][0], floatMulArr[i][1]), fBinaryConst(floatMulArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    //fdiv
    testCaseNum = sizeof(floatDivArr) / sizeof(floatDivArr[0]);
    for (uint32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_FLOAT_EQ(div(floatDivArr[i][0], floatDivArr[i][1]), _fDiv(floatDivArr[i][0], floatDivArr[i][1]));
+      OMR_CT_EXPECT_FLOAT_EQ(_fDiv, div(floatDivArr[i][0], floatDivArr[i][1]), _fDiv(floatDivArr[i][0], floatDivArr[i][1]));
 
       sprintf(resolvedMethodName, "fDivConst1_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fdiv,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatDivArr[i][0], 2, &floatDivArr[i][1]));
-      EXPECT_FLOAT_EQ(div(floatDivArr[i][0], floatDivArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, div(floatDivArr[i][0], floatDivArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fDivConst2_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fdiv,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatDivArr[i][0]));
-      EXPECT_FLOAT_EQ(div(floatDivArr[i][0], floatDivArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatDivArr[i][1]));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, div(floatDivArr[i][0], floatDivArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatDivArr[i][1]));
 
       sprintf(resolvedMethodName, "fDivConst3_Testcase%d", i);
       fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fdiv,
             resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatDivArr[i][1]));
-      EXPECT_FLOAT_EQ(div(floatDivArr[i][0], floatDivArr[i][1]), fBinaryConst(floatDivArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, div(floatDivArr[i][0], floatDivArr[i][1]), fBinaryConst(floatDivArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    //dadd
    testCaseNum = sizeof(doubleAddArr) / sizeof(doubleAddArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_DOUBLE_EQ(add(doubleAddArr[i][0], doubleAddArr[i][1]), _dAdd(doubleAddArr[i][0], doubleAddArr[i][1]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_dAdd, add(doubleAddArr[i][0], doubleAddArr[i][1]), _dAdd(doubleAddArr[i][0], doubleAddArr[i][1]));
 
       sprintf(resolvedMethodName, "dAddConst1_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dadd,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleAddArr[i][0], 2, &doubleAddArr[i][1]));
-      EXPECT_DOUBLE_EQ(add(doubleAddArr[i][0], doubleAddArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, add(doubleAddArr[i][0], doubleAddArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dAddConst2_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dadd,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleAddArr[i][0]));
-      EXPECT_DOUBLE_EQ(add(doubleAddArr[i][0], doubleAddArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleAddArr[i][1]));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, add(doubleAddArr[i][0], doubleAddArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleAddArr[i][1]));
 
       sprintf(resolvedMethodName, "dAddConst3_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dadd,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleAddArr[i][1]));
-      EXPECT_DOUBLE_EQ(add(doubleAddArr[i][0], doubleAddArr[i][1]), dBinaryConst(doubleAddArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, add(doubleAddArr[i][0], doubleAddArr[i][1]), dBinaryConst(doubleAddArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    //dsub
    testCaseNum = sizeof(doubleSubArr) / sizeof(doubleSubArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_DOUBLE_EQ(sub(doubleSubArr[i][0], doubleSubArr[i][1]), _dSub(doubleSubArr[i][0], doubleSubArr[i][1]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_dSub, sub(doubleSubArr[i][0], doubleSubArr[i][1]), _dSub(doubleSubArr[i][0], doubleSubArr[i][1]));
 
       sprintf(resolvedMethodName, "dSubConst1_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dsub,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleSubArr[i][0], 2, &doubleSubArr[i][1]));
-      EXPECT_DOUBLE_EQ(sub(doubleSubArr[i][0], doubleSubArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, sub(doubleSubArr[i][0], doubleSubArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dSubConst2_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dsub,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleSubArr[i][0]));
-      EXPECT_DOUBLE_EQ(sub(doubleSubArr[i][0], doubleSubArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleSubArr[i][1]));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, sub(doubleSubArr[i][0], doubleSubArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleSubArr[i][1]));
 
       sprintf(resolvedMethodName, "dSubConst3_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dsub,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleSubArr[i][1]));
-      EXPECT_DOUBLE_EQ(sub(doubleSubArr[i][0], doubleSubArr[i][1]), dBinaryConst(doubleSubArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, sub(doubleSubArr[i][0], doubleSubArr[i][1]), dBinaryConst(doubleSubArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    //dmul
    testCaseNum = sizeof(doubleMulArr) / sizeof(doubleMulArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_DOUBLE_EQ(mul(doubleMulArr[i][0], doubleMulArr[i][1]), _dMul(doubleMulArr[i][0], doubleMulArr[i][1]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_dMul, mul(doubleMulArr[i][0], doubleMulArr[i][1]), _dMul(doubleMulArr[i][0], doubleMulArr[i][1]));
 
       sprintf(resolvedMethodName, "dMulConst1_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dmul,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleMulArr[i][0], 2, &doubleMulArr[i][1]));
-      EXPECT_DOUBLE_EQ(mul(doubleMulArr[i][0], doubleMulArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, mul(doubleMulArr[i][0], doubleMulArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dMulConst2_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dmul,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleMulArr[i][0]));
-      EXPECT_DOUBLE_EQ(mul(doubleMulArr[i][0], doubleMulArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleMulArr[i][1]));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, mul(doubleMulArr[i][0], doubleMulArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleMulArr[i][1]));
 
       sprintf(resolvedMethodName, "dMulConst3_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dmul,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleMulArr[i][1]));
-      EXPECT_DOUBLE_EQ(mul(doubleMulArr[i][0], doubleMulArr[i][1]), dBinaryConst(doubleMulArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, mul(doubleMulArr[i][0], doubleMulArr[i][1]), dBinaryConst(doubleMulArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    //ddiv
    testCaseNum = sizeof(doubleDivArr) / sizeof(doubleDivArr[0]);
    for (int32_t i = 0; i < testCaseNum; i++)
       {
-      EXPECT_DOUBLE_EQ(div(doubleDivArr[i][0], doubleDivArr[i][1]), _dDiv(doubleDivArr[i][0], doubleDivArr[i][1]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_dDiv, div(doubleDivArr[i][0], doubleDivArr[i][1]), _dDiv(doubleDivArr[i][0], doubleDivArr[i][1]));
 
       sprintf(resolvedMethodName, "dDivConst1_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ddiv,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleDivArr[i][0], 2, &doubleDivArr[i][1]));
-      EXPECT_DOUBLE_EQ(div(doubleDivArr[i][0], doubleDivArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, div(doubleDivArr[i][0], doubleDivArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dDivConst2_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ddiv,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleDivArr[i][0]));
-      EXPECT_DOUBLE_EQ(div(doubleDivArr[i][0], doubleDivArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleDivArr[i][1]));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, div(doubleDivArr[i][0], doubleDivArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleDivArr[i][1]));
 
       sprintf(resolvedMethodName, "dDivConst3_Testcase%d", i);
       dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ddiv,
             resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleDivArr[i][1]));
-      EXPECT_DOUBLE_EQ(div(doubleDivArr[i][0], doubleDivArr[i][1]), dBinaryConst(doubleDivArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, div(doubleDivArr[i][0], doubleDivArr[i][1]), dBinaryConst(doubleDivArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
    }
 
@@ -897,62 +897,62 @@ X86OpCodesTest::invokeMemoryOperationTests()
    double doubleDataArray[] = {DOUBLE_NEG, DOUBLE_POS, DOUBLE_MAXIMUM, DOUBLE_MINIMUM, DOUBLE_ZERO};
    uintptrj_t addressDataArray[] = {(uintptrj_t)&INT_NEG, (uintptrj_t)&LONG_POS, (uintptrj_t)&BYTE_MAXIMUM, (uintptrj_t)&SHORT_MINIMUM, (uintptrj_t)&FLOAT_ZERO};
 
-   EXPECT_EQ(BYTE_ZERO, _bLoad(BYTE_ZERO));
-   EXPECT_EQ(BYTE_NEG, _bLoad(BYTE_NEG));
-   EXPECT_EQ(BYTE_POS, _bLoad(BYTE_POS));
-   EXPECT_EQ(BYTE_MAXIMUM, _bLoad(BYTE_MAXIMUM));
-   EXPECT_EQ(BYTE_MINIMUM, _bLoad(BYTE_MINIMUM));
+   OMR_CT_EXPECT_EQ(_bLoad, BYTE_ZERO, _bLoad(BYTE_ZERO));
+   OMR_CT_EXPECT_EQ(_bLoad, BYTE_NEG, _bLoad(BYTE_NEG));
+   OMR_CT_EXPECT_EQ(_bLoad, BYTE_POS, _bLoad(BYTE_POS));
+   OMR_CT_EXPECT_EQ(_bLoad, BYTE_MAXIMUM, _bLoad(BYTE_MAXIMUM));
+   OMR_CT_EXPECT_EQ(_bLoad, BYTE_MINIMUM, _bLoad(BYTE_MINIMUM));
 
-   EXPECT_EQ(SHORT_ZERO, _sLoad(SHORT_ZERO));
-   EXPECT_EQ(SHORT_NEG, _sLoad(SHORT_NEG));
-   EXPECT_EQ(SHORT_POS, _sLoad(SHORT_POS));
-   EXPECT_EQ(SHORT_MAXIMUM, _sLoad(SHORT_MAXIMUM));
-   EXPECT_EQ(SHORT_MINIMUM, _sLoad(SHORT_MINIMUM));
+   OMR_CT_EXPECT_EQ(_sLoad, SHORT_ZERO, _sLoad(SHORT_ZERO));
+   OMR_CT_EXPECT_EQ(_sLoad, SHORT_NEG, _sLoad(SHORT_NEG));
+   OMR_CT_EXPECT_EQ(_sLoad, SHORT_POS, _sLoad(SHORT_POS));
+   OMR_CT_EXPECT_EQ(_sLoad, SHORT_MAXIMUM, _sLoad(SHORT_MAXIMUM));
+   OMR_CT_EXPECT_EQ(_sLoad, SHORT_MINIMUM, _sLoad(SHORT_MINIMUM));
 
    //store
    testCaseNum = sizeof(byteDataArray) / sizeof(byteDataArray[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "bStoreConst%d", i + 1);
-      EXPECT_EQ(byteDataArray[i], _bStore(byteDataArray[i]));
+      OMR_CT_EXPECT_EQ(_bStore, byteDataArray[i], _bStore(byteDataArray[i]));
       bMemCons = (signatureCharB_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bstore, resolvedMethodName, _argTypesUnaryByte, TR::Int8, rc, 2, 1, &(byteDataArray[i])));
-      EXPECT_EQ(byteDataArray[i], bMemCons(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(bMemCons, byteDataArray[i], bMemCons(BYTE_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(shortDataArray) / sizeof(shortDataArray[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "sStoreConst%d", i + 1);
-      EXPECT_EQ(shortDataArray[i], _sStore(shortDataArray[i]));
+      OMR_CT_EXPECT_EQ(_sStore, shortDataArray[i], _sStore(shortDataArray[i]));
       sMemCons = (signatureCharS_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::sstore, resolvedMethodName, _argTypesUnaryShort, TR::Int16, rc, 2, 1, &(shortDataArray[i])));
-      EXPECT_EQ(shortDataArray[i], sMemCons(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(sMemCons, shortDataArray[i], sMemCons(SHORT_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(longDataArray) / sizeof(longDataArray[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "lStoreConst%d", i + 1);
-      EXPECT_EQ(longDataArray[i], _lStore(longDataArray[i]));
+      OMR_CT_EXPECT_EQ(_lStore, longDataArray[i], _lStore(longDataArray[i]));
       lMemCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lstore, resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &(longDataArray[i])));
-      EXPECT_EQ(longDataArray[i], lMemCons(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lMemCons, longDataArray[i], lMemCons(LONG_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(doubleDataArray) / sizeof(doubleDataArray[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "dStoreConst%d", i + 1);
-      EXPECT_DOUBLE_EQ(doubleDataArray[i], _dStore(doubleDataArray[i]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_dStore, doubleDataArray[i], _dStore(doubleDataArray[i]));
       dMemCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dstore, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &(doubleDataArray[i])));
-      EXPECT_DOUBLE_EQ(doubleDataArray[i], dMemCons(DOUBLE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_DOUBLE_EQ(dMemCons, doubleDataArray[i], dMemCons(DOUBLE_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(floatDataArray) / sizeof(floatDataArray[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "fStoreConst%d", i + 1);
-      EXPECT_FLOAT_EQ(floatDataArray[i], _fStore(floatDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_fStore, floatDataArray[i], _fStore(floatDataArray[i]));
       fMemCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::fstore, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &(floatDataArray[i])));
-      EXPECT_FLOAT_EQ(floatDataArray[i], fMemCons(FLOAT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_FLOAT_EQ(fMemCons, floatDataArray[i], fMemCons(FLOAT_PLACEHOLDER_1));
       }
 
    //indirect load constant
@@ -963,7 +963,7 @@ X86OpCodesTest::invokeMemoryOperationTests()
       sprintf(resolvedMethodName, "iLoadiConst%d", i + 1);
       uintptrj_t intDataAddress = (uintptrj_t)(&intDataArray[i]);
       iLoadiCons = (signatureCharL_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int32, rc, 2, 1, &intDataAddress));
-      EXPECT_EQ(intDataArray[i], iLoadiCons(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(iLoadiCons, intDataArray[i], iLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(shortDataArray) / sizeof(shortDataArray[0]);
@@ -973,7 +973,7 @@ X86OpCodesTest::invokeMemoryOperationTests()
       sprintf(resolvedMethodName, "sLoadiConst%d", i + 1);
       uintptrj_t shortDataAddress = (uintptrj_t)(&shortDataArray[i]);
       sLoadiCons = (signatureCharL_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::sloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int16, rc, 2, 1, &shortDataAddress));
-      EXPECT_EQ(shortDataArray[i], sLoadiCons(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(sLoadiCons, shortDataArray[i], sLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(byteDataArray) / sizeof(byteDataArray[0]);
@@ -983,7 +983,7 @@ X86OpCodesTest::invokeMemoryOperationTests()
       sprintf(resolvedMethodName, "bLoadiConst%d", i + 1);
       uintptrj_t byteDataAddress = (uintptrj_t)(&byteDataArray[i]);
       bLoadiCons = (signatureCharL_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int8, rc, 2, 1, &byteDataAddress));
-      EXPECT_EQ(byteDataArray[i], bLoadiCons(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(bLoadiCons, byteDataArray[i], bLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(longDataArray) / sizeof(longDataArray[0]);
@@ -993,7 +993,7 @@ X86OpCodesTest::invokeMemoryOperationTests()
       sprintf(resolvedMethodName, "lLoadiConst%d", i + 1);
       uintptrj_t longDataAddress = (uintptrj_t)(&longDataArray[i]);
       lLoadiCons = (signatureCharL_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int64, rc, 2, 1, &longDataAddress));
-      EXPECT_EQ(longDataArray[i], lLoadiCons(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lLoadiCons, longDataArray[i], lLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(doubleDataArray) / sizeof(doubleDataArray[0]);
@@ -1003,7 +1003,7 @@ X86OpCodesTest::invokeMemoryOperationTests()
       sprintf(resolvedMethodName, "dLoadiConst%d", i + 1);
       uintptrj_t doubleDataAddress = (uintptrj_t)(&doubleDataArray[i]);
       dLoadiCons = (signatureCharL_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Double, rc, 2, 1, &doubleDataAddress));
-      EXPECT_EQ(doubleDataArray[i], dLoadiCons(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(dLoadiCons, doubleDataArray[i], dLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(floatDataArray) / sizeof(floatDataArray[0]);
@@ -1013,7 +1013,7 @@ X86OpCodesTest::invokeMemoryOperationTests()
       sprintf(resolvedMethodName, "fLoadiConst%d", i + 1);
       uintptrj_t floatDataAddress = (uintptrj_t)(&floatDataArray[i]);
       fLoadiCons = (signatureCharL_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::floadi, resolvedMethodName, _argTypesUnaryAddress, TR::Float, rc, 2, 1, &floatDataAddress));
-      EXPECT_EQ(floatDataArray[i], fLoadiCons(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(fLoadiCons, floatDataArray[i], fLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(addressDataArray) / sizeof(addressDataArray[0]);
@@ -1023,7 +1023,7 @@ X86OpCodesTest::invokeMemoryOperationTests()
       sprintf(resolvedMethodName, "aLoadiConst%d", i + 1);
       uintptrj_t addressDataAddress = (uintptrj_t)(&addressDataArray[i]);
       aLoadiCons = (signatureCharL_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::aloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Address, rc, 2, 1, &addressDataAddress));
-      EXPECT_EQ(addressDataArray[i], aLoadiCons(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(aLoadiCons, addressDataArray[i], aLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
 #if defined(TR_TARGET_64BIT)
@@ -1038,18 +1038,36 @@ X86OpCodesTest::invokeMemoryOperationTests()
    testCaseNum = sizeof(intDataArray) / sizeof(intDataArray[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      _iStorei((uintptrj_t)(&intStoreDataArray[i]) , intDataArray[i]);
-      EXPECT_EQ(intDataArray[i], intStoreDataArray[i]);
-      _lStorei((uintptrj_t)(&longStoreDataArray[i]) , longDataArray[i]);
-      EXPECT_EQ(longDataArray[i], longStoreDataArray[i]);
-      _sStorei((uintptrj_t)(&shortStoreDataArray[i]) , shortDataArray[i]);
-      EXPECT_EQ(shortDataArray[i], shortStoreDataArray[i]);
-      _fStorei((uintptrj_t)(&floatStoreDataArray[i]) , floatDataArray[i]);
-      EXPECT_EQ(floatDataArray[i], floatStoreDataArray[i]);
-      _dStorei((uintptrj_t)(&doubleStoreDataArray[i]) , doubleDataArray[i]);
-      EXPECT_EQ(doubleDataArray[i], doubleStoreDataArray[i]);
-      _aStorei((uintptrj_t)(&addressStoreDataArray[i]) , addressDataArray[i]);
-      EXPECT_EQ(addressDataArray[i], addressStoreDataArray[i]);
+      if (_iStorei != NULL)
+         {
+         _iStorei((uintptrj_t)(&intStoreDataArray[i]) , intDataArray[i]);
+         EXPECT_EQ(intDataArray[i], intStoreDataArray[i]);
+         }
+       if (_lStorei != NULL)
+         {
+         _lStorei((uintptrj_t)(&longStoreDataArray[i]) , longDataArray[i]);
+         EXPECT_EQ(longDataArray[i], longStoreDataArray[i]);
+         }
+      if (_sStorei != NULL)
+         {
+         _sStorei((uintptrj_t)(&shortStoreDataArray[i]) , shortDataArray[i]);
+         EXPECT_EQ(shortDataArray[i], shortStoreDataArray[i]);
+         }
+      if (_fStorei != NULL)
+         {
+         _fStorei((uintptrj_t)(&floatStoreDataArray[i]) , floatDataArray[i]);
+         EXPECT_EQ(floatDataArray[i], floatStoreDataArray[i]);
+         }
+      if (_dStorei != NULL)
+         {
+         _dStorei((uintptrj_t)(&doubleStoreDataArray[i]) , doubleDataArray[i]);
+         EXPECT_EQ(doubleDataArray[i], doubleStoreDataArray[i]);
+         }
+      if (_aStorei != NULL)
+         {
+         _aStorei((uintptrj_t)(&addressStoreDataArray[i]) , addressDataArray[i]);
+         EXPECT_EQ(addressDataArray[i], addressStoreDataArray[i]);
+         }
       }
 #endif
    }
@@ -1142,132 +1160,132 @@ X86OpCodesTest::invokeShiftOrRolTests()
    testCaseNum = sizeof(irolDataArr) / sizeof(irolDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(rol(irolDataArr[i][0], irolDataArr[i][1]), _iRol(irolDataArr[i][0], irolDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iRol, rol(irolDataArr[i][0], irolDataArr[i][1]), _iRol(irolDataArr[i][0], irolDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iRolConst1_TestCase%d", i + 1);
       iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::irol, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &irolDataArr[i][0], 2, &irolDataArr[i][1]));
-      EXPECT_EQ(rol(irolDataArr[i][0], irolDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iShiftOrRolConst, rol(irolDataArr[i][0], irolDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iRolConst2_TestCase%d", i + 1);
       iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::irol, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &irolDataArr[i][0]));
-      EXPECT_EQ(rol(irolDataArr[i][0], irolDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, irolDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iShiftOrRolConst, rol(irolDataArr[i][0], irolDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, irolDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iRolConst3_TestCase%d", i + 1);
       iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::irol, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &irolDataArr[i][1]));
-      EXPECT_EQ(rol(irolDataArr[i][0], irolDataArr[i][1]), iShiftOrRolConst(irolDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iShiftOrRolConst, rol(irolDataArr[i][0], irolDataArr[i][1]), iShiftOrRolConst(irolDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    //bshl
    testCaseNum = sizeof(bshlDataArr) / sizeof(bshlDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shl(bshlDataArr[i][0], bshlDataArr[i][1]), _bShl(bshlDataArr[i][0],bshlDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bShl, shl(bshlDataArr[i][0], bshlDataArr[i][1]), _bShl(bshlDataArr[i][0],bshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bShlConst1_TestCase%d", i + 1);
       bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bshl, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &bshlDataArr[i][0], 2, &bshlDataArr[i][1]));
-      EXPECT_EQ(shl(bshlDataArr[i][0], bshlDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bShiftOrRolConst, shl(bshlDataArr[i][0], bshlDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bShlConst2_TestCase%d", i + 1);
       bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bshl, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &bshlDataArr[i][0]));
-      EXPECT_EQ(shl(bshlDataArr[i][0], bshlDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, bshlDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bShiftOrRolConst, shl(bshlDataArr[i][0], bshlDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, bshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bShlConst3_TestCase%d", i + 1);
       bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bshl, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &bshlDataArr[i][1]));
-      EXPECT_EQ(shl(bshlDataArr[i][0], bshlDataArr[i][1]), bShiftOrRolConst(bshlDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bShiftOrRolConst, shl(bshlDataArr[i][0], bshlDataArr[i][1]), bShiftOrRolConst(bshlDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //bshr
    testCaseNum = sizeof(bshrDataArr) / sizeof(bshrDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shr(bshrDataArr[i][0], bshrDataArr[i][1]), _bShr(bshrDataArr[i][0], bshrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bShr, shr(bshrDataArr[i][0], bshrDataArr[i][1]), _bShr(bshrDataArr[i][0], bshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bShrConst1_TestCase%d", i + 1);
       bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bshr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &bshrDataArr[i][0], 2, &bshrDataArr[i][1]));
-      EXPECT_EQ(shr(bshrDataArr[i][0], bshrDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bShiftOrRolConst, shr(bshrDataArr[i][0], bshrDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bShrConst2_TestCase%d", i + 1);
       bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bshr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &bshrDataArr[i][0]));
-      EXPECT_EQ(shr(bshrDataArr[i][0], bshrDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, bshrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bShiftOrRolConst, shr(bshrDataArr[i][0], bshrDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, bshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bShrConst3_TestCase%d", i + 1);
       bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bshr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &bshrDataArr[i][1]));
-      EXPECT_EQ(shr(bshrDataArr[i][0], bshrDataArr[i][1]), bShiftOrRolConst(bshrDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bShiftOrRolConst, shr(bshrDataArr[i][0], bshrDataArr[i][1]), bShiftOrRolConst(bshrDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //bushr
    testCaseNum = sizeof(bushrDataArr) / sizeof(bushrDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shr(bushrDataArr[i][0], bushrDataArr[i][1]), _buShr(bushrDataArr[i][0], bushrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_buShr, shr(bushrDataArr[i][0], bushrDataArr[i][1]), _buShr(bushrDataArr[i][0], bushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buShrConst1_TestCase%d", i + 1);
       buShiftOrRolConst = (unsignedSignatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bushr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &bushrDataArr[i][0], 2, &bushrDataArr[i][1]));
-      EXPECT_EQ(shr(bushrDataArr[i][0], bushrDataArr[i][1]), buShiftOrRolConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buShiftOrRolConst, shr(bushrDataArr[i][0], bushrDataArr[i][1]), buShiftOrRolConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "buShrConst2_TestCase%d", i + 1);
       buShiftOrRolConst = (unsignedSignatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bushr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &bushrDataArr[i][0]));
-      EXPECT_EQ(shr(bushrDataArr[i][0], bushrDataArr[i][1]), buShiftOrRolConst(BYTE_PLACEHOLDER_1, bushrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(buShiftOrRolConst, shr(bushrDataArr[i][0], bushrDataArr[i][1]), buShiftOrRolConst(BYTE_PLACEHOLDER_1, bushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buShrConst3_TestCase%d", i + 1);
       buShiftOrRolConst = (unsignedSignatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bushr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &bushrDataArr[i][1]));
-      EXPECT_EQ(shr(bushrDataArr[i][0], bushrDataArr[i][1]), buShiftOrRolConst(bushrDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buShiftOrRolConst, shr(bushrDataArr[i][0], bushrDataArr[i][1]), buShiftOrRolConst(bushrDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //sshr
    testCaseNum = sizeof(sshrDataArr) / sizeof(sshrDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shr(sshrDataArr[i][0], sshrDataArr[i][1]), _sShr(sshrDataArr[i][0], sshrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sShr, shr(sshrDataArr[i][0], sshrDataArr[i][1]), _sShr(sshrDataArr[i][0], sshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sShrConst1_TestCase%d", i + 1);
       sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sshr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &sshrDataArr[i][0], 2, &sshrDataArr[i][1]));
-      EXPECT_EQ(shr(sshrDataArr[i][0], sshrDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sShiftOrRolConst, shr(sshrDataArr[i][0], sshrDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sShrConst2_TestCase%d", i + 1);
       sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sshr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &sshrDataArr[i][0]));
-      EXPECT_EQ(shr(sshrDataArr[i][0], sshrDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, sshrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sShiftOrRolConst, shr(sshrDataArr[i][0], sshrDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, sshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sShrConst3_TestCase%d", i + 1);
       sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sshr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &sshrDataArr[i][1]));
-      EXPECT_EQ(shr(sshrDataArr[i][0], sshrDataArr[i][1]), sShiftOrRolConst(sshrDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sShiftOrRolConst, shr(sshrDataArr[i][0], sshrDataArr[i][1]), sShiftOrRolConst(sshrDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    //sushr
    testCaseNum = sizeof(sushrDataArr) / sizeof(sushrDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shr(sushrDataArr[i][0], sushrDataArr[i][1]), _suShr(sushrDataArr[i][0], sushrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_suShr, shr(sushrDataArr[i][0], sushrDataArr[i][1]), _suShr(sushrDataArr[i][0], sushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "suShrConst1_TestCase%d", i + 1);
       suShiftOrRolConst = (unsignedSignatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sushr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &sushrDataArr[i][0], 2, &sushrDataArr[i][1]));
-      EXPECT_EQ(shr(sushrDataArr[i][0], sushrDataArr[i][1]), suShiftOrRolConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(suShiftOrRolConst, shr(sushrDataArr[i][0], sushrDataArr[i][1]), suShiftOrRolConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "suShrConst2_TestCase%d", i + 1);
       suShiftOrRolConst = (unsignedSignatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sushr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &sushrDataArr[i][0]));
-      EXPECT_EQ(shr(sushrDataArr[i][0], sushrDataArr[i][1]), suShiftOrRolConst(SHORT_PLACEHOLDER_1, sushrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(suShiftOrRolConst, shr(sushrDataArr[i][0], sushrDataArr[i][1]), suShiftOrRolConst(SHORT_PLACEHOLDER_1, sushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "suShrConst3_TestCase%d", i + 1);
       suShiftOrRolConst = (unsignedSignatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sushr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &sushrDataArr[i][1]));
-      EXPECT_EQ(shr(sushrDataArr[i][0], sushrDataArr[i][1]), suShiftOrRolConst(sushrDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(suShiftOrRolConst, shr(sushrDataArr[i][0], sushrDataArr[i][1]), suShiftOrRolConst(sushrDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
 
@@ -1275,22 +1293,22 @@ X86OpCodesTest::invokeShiftOrRolTests()
    testCaseNum = sizeof(sshlDataArr) / sizeof(sshlDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shl(sshlDataArr[i][0], sshlDataArr[i][1]), _sShl(sshlDataArr[i][0], sshlDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sShl, shl(sshlDataArr[i][0], sshlDataArr[i][1]), _sShl(sshlDataArr[i][0], sshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sShlConst1_TestCase%d", i + 1);
       sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sshl, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &sshlDataArr[i][0], 2, &sshlDataArr[i][1]));
-      EXPECT_EQ(shl(sshlDataArr[i][0], sshlDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sShiftOrRolConst, shl(sshlDataArr[i][0], sshlDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sShlConst2_TestCase%d", i + 1);
       sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sshl, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &sshlDataArr[i][0]));
-      EXPECT_EQ(shl(sshlDataArr[i][0], sshlDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, sshlDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sShiftOrRolConst, shl(sshlDataArr[i][0], sshlDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, sshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sShlConst3_TestCase%d", i + 1);
       sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sshl, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &sshlDataArr[i][1]));
-      EXPECT_EQ(shl(sshlDataArr[i][0], sshlDataArr[i][1]), sShiftOrRolConst(sshlDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sShiftOrRolConst, shl(sshlDataArr[i][0], sshlDataArr[i][1]), sShiftOrRolConst(sshlDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
 #if defined(TR_TARGET_64BIT)
@@ -1335,88 +1353,88 @@ X86OpCodesTest::invokeShiftOrRolTests()
    testCaseNum = sizeof(lshlDataArr) / sizeof(lshlDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shl(lshlDataArr[i][0], lshlDataArr[i][1]), _lShl(lshlDataArr[i][0], lshlDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lShl, shl(lshlDataArr[i][0], lshlDataArr[i][1]), _lShl(lshlDataArr[i][0], lshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lShlConst1_TestCase%d", i + 1);
       lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lshl, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lshlDataArr[i][0], 2, &lshlDataArr[i][1]));
-      EXPECT_EQ(shl(lshlDataArr[i][0], lshlDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lShiftOrRolConst, shl(lshlDataArr[i][0], lshlDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "lShlConst2_TestCase%d", i + 1);
       lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lshl, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lshlDataArr[i][0]));
-      EXPECT_EQ(shl(lshlDataArr[i][0], lshlDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, lshlDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lShiftOrRolConst, shl(lshlDataArr[i][0], lshlDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, lshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lShlConst3_TestCase%d", i + 1);
       lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lshl, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lshlDataArr[i][1]));
-      EXPECT_EQ(shl(lshlDataArr[i][0], lshlDataArr[i][1]), lShiftOrRolConst(lshlDataArr[i][0], LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lShiftOrRolConst, shl(lshlDataArr[i][0], lshlDataArr[i][1]), lShiftOrRolConst(lshlDataArr[i][0], LONG_PLACEHOLDER_1));
       }
 
    //lshr
    testCaseNum = sizeof(lshrDataArr) / sizeof(lshrDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shr(lshrDataArr[i][0], lshrDataArr[i][1]), _lShr(lshrDataArr[i][0], lshrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lShr, shr(lshrDataArr[i][0], lshrDataArr[i][1]), _lShr(lshrDataArr[i][0], lshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lShrConst1_TestCase%d", i + 1);
       lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lshr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lshrDataArr[i][0], 2, &lshrDataArr[i][1]));
-      EXPECT_EQ(shr(lshrDataArr[i][0], lshrDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lShiftOrRolConst, shr(lshrDataArr[i][0], lshrDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lShrConst2_TestCase%d", i + 1);
       lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lshr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lshrDataArr[i][0]));
-      EXPECT_EQ(shr(lshrDataArr[i][0], lshrDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, lshrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lShiftOrRolConst, shr(lshrDataArr[i][0], lshrDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, lshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lShrConst3_TestCase%d", i + 1);
       lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lshr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lshrDataArr[i][1]));
-      EXPECT_EQ(shr(lshrDataArr[i][0], lshrDataArr[i][1]), lShiftOrRolConst(lshrDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lShiftOrRolConst, shr(lshrDataArr[i][0], lshrDataArr[i][1]), lShiftOrRolConst(lshrDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //lushr
    testCaseNum = sizeof(lushrDataArr) / sizeof(lushrDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(shr(lushrDataArr[i][0], lushrDataArr[i][1]), _luShr(lushrDataArr[i][0], lushrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_luShr, shr(lushrDataArr[i][0], lushrDataArr[i][1]), _luShr(lushrDataArr[i][0], lushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luShrConst1_TestCase%d", i + 1);
       luShiftOrRolConst = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lushr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lushrDataArr[i][0], 2, &lushrDataArr[i][1]));
-      EXPECT_EQ(shr(lushrDataArr[i][0], lushrDataArr[i][1]), luShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luShiftOrRolConst, shr(lushrDataArr[i][0], lushrDataArr[i][1]), luShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "luShrConst2_TestCase%d", i + 1);
       luShiftOrRolConst = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lushr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lushrDataArr[i][0]));
-      EXPECT_EQ(shr(lushrDataArr[i][0], lushrDataArr[i][1]), luShiftOrRolConst(LONG_PLACEHOLDER_1, lushrDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(luShiftOrRolConst, shr(lushrDataArr[i][0], lushrDataArr[i][1]), luShiftOrRolConst(LONG_PLACEHOLDER_1, lushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luShrConst3_TestCase%d", i + 1);
       luShiftOrRolConst = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lushr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lushrDataArr[i][1]));
-      EXPECT_EQ(shr(lushrDataArr[i][0], lushrDataArr[i][1]), luShiftOrRolConst(lushrDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luShiftOrRolConst, shr(lushrDataArr[i][0], lushrDataArr[i][1]), luShiftOrRolConst(lushrDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //lrol
    testCaseNum = sizeof(lrolDataArr) / sizeof(lrolDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(rol(lrolDataArr[i][0], lrolDataArr[i][1]), _lRol(lrolDataArr[i][0], lrolDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lRol, rol(lrolDataArr[i][0], lrolDataArr[i][1]), _lRol(lrolDataArr[i][0], lrolDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lRolConst1_TestCase%d", i + 1);
       lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lrol, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lrolDataArr[i][0], 2, &lrolDataArr[i][1]));
-      EXPECT_EQ(rol(lrolDataArr[i][0], lrolDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lShiftOrRolConst, rol(lrolDataArr[i][0], lrolDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lRolConst2_TestCase%d", i + 1);
       lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lrol, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lrolDataArr[i][0]));
-      EXPECT_EQ(rol(lrolDataArr[i][0], lrolDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, lrolDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lShiftOrRolConst, rol(lrolDataArr[i][0], lrolDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, lrolDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lRolConst3_TestCase%d", i + 1);
       lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lrol, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lrolDataArr[i][1]));
-      EXPECT_EQ(rol(lrolDataArr[i][0], lrolDataArr[i][1]), lShiftOrRolConst(lrolDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lShiftOrRolConst, rol(lrolDataArr[i][0], lrolDataArr[i][1]), lShiftOrRolConst(lrolDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 #endif
    }
@@ -1504,198 +1522,198 @@ X86OpCodesTest::invokeBitwiseTests()
    testCaseNum = sizeof(longAndArr) / sizeof(longAndArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(tand(longAndArr[i][0], longAndArr[i][1]), _lAnd(longAndArr[i][0], longAndArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lAnd, tand(longAndArr[i][0], longAndArr[i][1]), _lAnd(longAndArr[i][0], longAndArr[i][1]));
 
       sprintf(resolvedMethodName, "lAndConst1_TestCase%d", i + 1);
       lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::land, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &(longAndArr[i][0]), 2, &(longAndArr[i][1])));
-      EXPECT_EQ(tand(longAndArr[i][0], longAndArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBitwiseConst, tand(longAndArr[i][0], longAndArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lAndConst2_TestCase%d", i + 1);
       lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::land, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &(longAndArr[i][0])));
-      EXPECT_EQ(tand(longAndArr[i][0], longAndArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, longAndArr[i][1]));
+      OMR_CT_EXPECT_EQ(lBitwiseConst, tand(longAndArr[i][0], longAndArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, longAndArr[i][1]));
 
       sprintf(resolvedMethodName, "lAndConst3_TestCase%d", i + 1);
       lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::land, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &(longAndArr[i][1])));
-      EXPECT_EQ(tand(longAndArr[i][0], longAndArr[i][1]), lBitwiseConst(longAndArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBitwiseConst, tand(longAndArr[i][0], longAndArr[i][1]), lBitwiseConst(longAndArr[i][0], LONG_PLACEHOLDER_2));
      }
 
    //lor
    testCaseNum = sizeof(longOrArr) / sizeof(longOrArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(tor(longOrArr[i][0], longOrArr[i][1]), _lOr(longOrArr[i][0], longOrArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lOr, tor(longOrArr[i][0], longOrArr[i][1]), _lOr(longOrArr[i][0], longOrArr[i][1]));
 
       sprintf(resolvedMethodName, "lOrConst1_TestCase%d", i + 1);
       lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &(longOrArr[i][0]), 2, &(longOrArr[i][1])));
-      EXPECT_EQ(tor(longOrArr[i][0], longOrArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBitwiseConst, tor(longOrArr[i][0], longOrArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lOrConst2_TestCase%d", i + 1);
       lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &(longOrArr[i][0])));
-      EXPECT_EQ(tor(longOrArr[i][0], longOrArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, longOrArr[i][1]));
+      OMR_CT_EXPECT_EQ(lBitwiseConst, tor(longOrArr[i][0], longOrArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, longOrArr[i][1]));
 
       sprintf(resolvedMethodName, "lOrConst3_TestCase%d", i + 1);
       lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &(longOrArr[i][1])));
-      EXPECT_EQ(tor(longOrArr[i][0], longOrArr[i][1]), lBitwiseConst(longOrArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBitwiseConst, tor(longOrArr[i][0], longOrArr[i][1]), lBitwiseConst(longOrArr[i][0], LONG_PLACEHOLDER_2));
      }
 
    //lxor
    testCaseNum = sizeof(longXorArr) / sizeof(longXorArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(txor(longXorArr[i][0], longXorArr[i][1]), _lXor(longXorArr[i][0], longXorArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lXor, txor(longXorArr[i][0], longXorArr[i][1]), _lXor(longXorArr[i][0], longXorArr[i][1]));
 
       sprintf(resolvedMethodName, "lXorConst1_TestCase%d", i + 1);
       lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lxor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &(longXorArr[i][0]), 2, &(longXorArr[i][1])));
-      EXPECT_EQ(txor(longXorArr[i][0], longXorArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBitwiseConst, txor(longXorArr[i][0], longXorArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lXorConst2_TestCase%d", i + 1);
       lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lxor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &(longXorArr[i][0])));
-      EXPECT_EQ(txor(longXorArr[i][0], longXorArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, longXorArr[i][1]));
+      OMR_CT_EXPECT_EQ(lBitwiseConst, txor(longXorArr[i][0], longXorArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, longXorArr[i][1]));
 
       sprintf(resolvedMethodName, "lXorConst3_TestCase%d", i + 1);
       lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lxor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &(longXorArr[i][1])));
-      EXPECT_EQ(txor(longXorArr[i][0], longXorArr[i][1]), lBitwiseConst(longXorArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lBitwiseConst, txor(longXorArr[i][0], longXorArr[i][1]), lBitwiseConst(longXorArr[i][0], LONG_PLACEHOLDER_2));
      }
 
    //band
    testCaseNum = sizeof(byteAndArr) / sizeof(byteAndArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(tand(byteAndArr[i][0], byteAndArr[i][1]), _bAnd(byteAndArr[i][0], byteAndArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bAnd, tand(byteAndArr[i][0], byteAndArr[i][1]), _bAnd(byteAndArr[i][0], byteAndArr[i][1]));
 
       sprintf(resolvedMethodName, "bAndConst1_TestCase%d", i + 1);
       bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::band, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &(byteAndArr[i][0]), 2, &(byteAndArr[i][1])));
-      EXPECT_EQ(tand(byteAndArr[i][0], byteAndArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bBitwiseConst, tand(byteAndArr[i][0], byteAndArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bAndConst2_TestCase%d", i + 1);
       bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::band, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &(byteAndArr[i][0])));
-      EXPECT_EQ(tand(byteAndArr[i][0], byteAndArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, byteAndArr[i][1]));
+      OMR_CT_EXPECT_EQ(bBitwiseConst, tand(byteAndArr[i][0], byteAndArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, byteAndArr[i][1]));
 
       sprintf(resolvedMethodName, "bAndConst3_TestCase%d", i + 1);
       bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::band, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &(byteAndArr[i][1])));
-      EXPECT_EQ(tand(byteAndArr[i][0], byteAndArr[i][1]), bBitwiseConst(byteAndArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bBitwiseConst, tand(byteAndArr[i][0], byteAndArr[i][1]), bBitwiseConst(byteAndArr[i][0], BYTE_PLACEHOLDER_2));
      }
 
    //bor
    testCaseNum = sizeof(byteOrArr) / sizeof(byteOrArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(tor(byteOrArr[i][0], byteOrArr[i][1]), _bOr(byteOrArr[i][0], byteOrArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bOr, tor(byteOrArr[i][0], byteOrArr[i][1]), _bOr(byteOrArr[i][0], byteOrArr[i][1]));
 
       sprintf(resolvedMethodName, "bOrConst1_TestCase%d", i + 1);
       bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &(byteOrArr[i][0]), 2, &(byteOrArr[i][1])));
-      EXPECT_EQ(tor(byteOrArr[i][0], byteOrArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bBitwiseConst, tor(byteOrArr[i][0], byteOrArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bOrConst2_TestCase%d", i + 1);
       bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &(byteOrArr[i][0])));
-      EXPECT_EQ(tor(byteOrArr[i][0], byteOrArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, byteOrArr[i][1]));
+      OMR_CT_EXPECT_EQ(bBitwiseConst, tor(byteOrArr[i][0], byteOrArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, byteOrArr[i][1]));
 
       sprintf(resolvedMethodName, "bOrConst3_TestCase%d", i + 1);
       bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &(byteOrArr[i][1])));
-      EXPECT_EQ(tor(byteOrArr[i][0], byteOrArr[i][1]), bBitwiseConst(byteOrArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bBitwiseConst, tor(byteOrArr[i][0], byteOrArr[i][1]), bBitwiseConst(byteOrArr[i][0], BYTE_PLACEHOLDER_2));
      }
 
    //bxor
    testCaseNum = sizeof(byteXorArr) / sizeof(byteXorArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(txor(byteXorArr[i][0], byteXorArr[i][1]), _bXor(byteXorArr[i][0], byteXorArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bXor, txor(byteXorArr[i][0], byteXorArr[i][1]), _bXor(byteXorArr[i][0], byteXorArr[i][1]));
 
       sprintf(resolvedMethodName, "bXorConst1_TestCase%d", i + 1);
       bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bxor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &(byteXorArr[i][0]), 2, &(byteXorArr[i][1])));
-      EXPECT_EQ(txor(byteXorArr[i][0], byteXorArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bBitwiseConst, txor(byteXorArr[i][0], byteXorArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bXorConst2_TestCase%d", i + 1);
       bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bxor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &(byteXorArr[i][0])));
-      EXPECT_EQ(txor(byteXorArr[i][0], byteXorArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, byteXorArr[i][1]));
+      OMR_CT_EXPECT_EQ(bBitwiseConst, txor(byteXorArr[i][0], byteXorArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, byteXorArr[i][1]));
 
       sprintf(resolvedMethodName, "bXorConst3_TestCase%d", i + 1);
       bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bxor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &(byteXorArr[i][1])));
-      EXPECT_EQ(txor(byteXorArr[i][0], byteXorArr[i][1]), bBitwiseConst(byteXorArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bBitwiseConst, txor(byteXorArr[i][0], byteXorArr[i][1]), bBitwiseConst(byteXorArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //sand
    testCaseNum = sizeof(shortAndArr) / sizeof(shortAndArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(tand(shortAndArr[i][0], shortAndArr[i][1]), _sAnd(shortAndArr[i][0], shortAndArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sAnd, tand(shortAndArr[i][0], shortAndArr[i][1]), _sAnd(shortAndArr[i][0], shortAndArr[i][1]));
 
       sprintf(resolvedMethodName, "sAndConst1_TestCase%d", i + 1);
       sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sand, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &(shortAndArr[i][0]), 2, &(shortAndArr[i][1])));
-      EXPECT_EQ(tand(shortAndArr[i][0], shortAndArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sBitwiseConst, tand(shortAndArr[i][0], shortAndArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sAndConst2_TestCase%d", i + 1);
       sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sand, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &(shortAndArr[i][0])));
-      EXPECT_EQ(tand(shortAndArr[i][0], shortAndArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, shortAndArr[i][1]));
+      OMR_CT_EXPECT_EQ(sBitwiseConst, tand(shortAndArr[i][0], shortAndArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, shortAndArr[i][1]));
 
       sprintf(resolvedMethodName, "sAndConst3_TestCase%d", i + 1);
       sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sand, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &(shortAndArr[i][1])));
-      EXPECT_EQ(tand(shortAndArr[i][0], shortAndArr[i][1]), sBitwiseConst(shortAndArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sBitwiseConst, tand(shortAndArr[i][0], shortAndArr[i][1]), sBitwiseConst(shortAndArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    //sor
    testCaseNum = sizeof(shortOrArr) / sizeof(shortOrArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(tor(shortOrArr[i][0], shortOrArr[i][1]), _sOr(shortOrArr[i][0], shortOrArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sOr, tor(shortOrArr[i][0], shortOrArr[i][1]), _sOr(shortOrArr[i][0], shortOrArr[i][1]));
 
       sprintf(resolvedMethodName, "sOrConst1_TestCase%d", i + 1);
       sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &(shortOrArr[i][0]), 2, &(shortOrArr[i][1])));
-      EXPECT_EQ(tor(shortOrArr[i][0], shortOrArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sBitwiseConst, tor(shortOrArr[i][0], shortOrArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sOrConst2_TestCase%d", i + 1);
       sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &(shortOrArr[i][0])));
-      EXPECT_EQ(tor(shortOrArr[i][0], shortOrArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, shortOrArr[i][1]));
+      OMR_CT_EXPECT_EQ(sBitwiseConst, tor(shortOrArr[i][0], shortOrArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, shortOrArr[i][1]));
 
       sprintf(resolvedMethodName, "sOrConst3_TestCase%d", i + 1);
       sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &(shortOrArr[i][1])));
-      EXPECT_EQ(tor(shortOrArr[i][0], shortOrArr[i][1]), sBitwiseConst(shortOrArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sBitwiseConst, tor(shortOrArr[i][0], shortOrArr[i][1]), sBitwiseConst(shortOrArr[i][0], SHORT_PLACEHOLDER_2));
      }
 
    //sxor
    testCaseNum = sizeof(shortXorArr) / sizeof(shortXorArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(txor(shortXorArr[i][0], shortXorArr[i][1]), _sXor(shortXorArr[i][0], shortXorArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sXor, txor(shortXorArr[i][0], shortXorArr[i][1]), _sXor(shortXorArr[i][0], shortXorArr[i][1]));
 
       sprintf(resolvedMethodName, "sXorConst1_TestCase%d", i + 1);
       sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sxor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &(shortXorArr[i][0]), 2, &(shortXorArr[i][1])));
-      EXPECT_EQ(txor(shortXorArr[i][0], shortXorArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sBitwiseConst, txor(shortXorArr[i][0], shortXorArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sXorConst2_TestCase%d", i + 1);
       sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sxor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &(shortXorArr[i][0])));
-      EXPECT_EQ(txor(shortXorArr[i][0], shortXorArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, shortXorArr[i][1]));
+      OMR_CT_EXPECT_EQ(sBitwiseConst, txor(shortXorArr[i][0], shortXorArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, shortXorArr[i][1]));
 
       sprintf(resolvedMethodName, "sXorConst3_TestCase%d", i + 1);
       sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sxor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &(shortXorArr[i][1])));
-      EXPECT_EQ(txor(shortXorArr[i][0], shortXorArr[i][1]), sBitwiseConst(shortXorArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sBitwiseConst, txor(shortXorArr[i][0], shortXorArr[i][1]), sBitwiseConst(shortXorArr[i][0], SHORT_PLACEHOLDER_2));
      }
    }
 
@@ -1754,66 +1772,66 @@ X86OpCodesTest::invokeUnaryTests()
    testCaseNum = sizeof(byteDataArray) / sizeof(byteDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(neg(byteDataArray[i]), _bNeg(byteDataArray[i]));
+      OMR_CT_EXPECT_EQ(_bNeg, neg(byteDataArray[i]), _bNeg(byteDataArray[i]));
       sprintf(resolvedMethodName, "bNegConst%d", i + 1);
       bUnaryCons = (signatureCharB_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bneg,
             resolvedMethodName, _argTypesUnaryByte, TR::Int8, rc, 2, 1, &byteDataArray[i]));
-      EXPECT_EQ(neg(byteDataArray[i]), bUnaryCons(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(bUnaryCons, neg(byteDataArray[i]), bUnaryCons(BYTE_PLACEHOLDER_1));
       }
 
    //sneg
    testCaseNum = sizeof(shortDataArray) / sizeof(shortDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(neg(shortDataArray[i]), _sNeg(shortDataArray[i]));
+      OMR_CT_EXPECT_EQ(_sNeg, neg(shortDataArray[i]), _sNeg(shortDataArray[i]));
       sprintf(resolvedMethodName, "sNegConst%d", i + 1);
       sUnaryCons = (signatureCharS_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::sneg,
             resolvedMethodName, _argTypesUnaryShort, TR::Int16, rc, 2, 1, &shortDataArray[i]));
-      EXPECT_EQ(neg(shortDataArray[i]), sUnaryCons(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(sUnaryCons, neg(shortDataArray[i]), sUnaryCons(SHORT_PLACEHOLDER_1));
       }
 
    //lneg
    testCaseNum = sizeof(longDataArray) / sizeof(longDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(neg(longDataArray[i]), _lNeg(longDataArray[i]));
+      OMR_CT_EXPECT_EQ(_lNeg, neg(longDataArray[i]), _lNeg(longDataArray[i]));
       sprintf(resolvedMethodName, "lNegConst%d", i + 1);
       lUnaryCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lneg,
             resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &longDataArray[i]));
-      EXPECT_EQ(neg(longDataArray[i]), lUnaryCons(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lUnaryCons, neg(longDataArray[i]), lUnaryCons(LONG_PLACEHOLDER_1));
       }
 
    //fneg
    testCaseNum = sizeof(floatDataArray) / sizeof(floatDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_FLOAT_EQ(neg(floatDataArray[i]), _fNeg(floatDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_fNeg, neg(floatDataArray[i]), _fNeg(floatDataArray[i]));
       sprintf(resolvedMethodName, "fNegConst%d", i + 1);
       fUnaryCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::fneg,
             resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &floatDataArray[i]));
-      EXPECT_FLOAT_EQ(neg(floatDataArray[i]), fUnaryCons(FLOAT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_FLOAT_EQ(fUnaryCons, neg(floatDataArray[i]), fUnaryCons(FLOAT_PLACEHOLDER_1));
       }
 
    //dneg
    testCaseNum = sizeof(doubleDataArray) / sizeof(doubleDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_DOUBLE_EQ(neg(doubleDataArray[i]), _dNeg(doubleDataArray[i]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_dNeg, neg(doubleDataArray[i]), _dNeg(doubleDataArray[i]));
       sprintf(resolvedMethodName, "dNegConst%d", i + 1);
       dUnaryCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dneg,
             resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &doubleDataArray[i]));
-      EXPECT_DOUBLE_EQ(neg(doubleDataArray[i]), dUnaryCons(DOUBLE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_DOUBLE_EQ(dUnaryCons, neg(doubleDataArray[i]), dUnaryCons(DOUBLE_PLACEHOLDER_1));
       }
 
    //labs
    testCaseNum = sizeof(longDataArray) / sizeof(longDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(abs(longDataArray[i]), _lAbs(longDataArray[i]));
+      OMR_CT_EXPECT_EQ(_lAbs, abs(longDataArray[i]), _lAbs(longDataArray[i]));
       sprintf(resolvedMethodName, "lAbsConst%d", i + 1);
       lUnaryCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::labs,
             resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &longDataArray[i]));
-      EXPECT_EQ(abs(longDataArray[i]), lUnaryCons(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lUnaryCons, abs(longDataArray[i]), lUnaryCons(LONG_PLACEHOLDER_1));
       }
 
    //lReturn
@@ -1821,9 +1839,9 @@ X86OpCodesTest::invokeUnaryTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "lReturnCons%d", i + 1);
-      EXPECT_EQ(longDataArray[i], _lReturn(longDataArray[i]));
+      OMR_CT_EXPECT_EQ(_lReturn, longDataArray[i], _lReturn(longDataArray[i]));
       lUnaryCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lreturn, resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &(longDataArray[i])));
-      EXPECT_EQ(longDataArray[i], lUnaryCons(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lUnaryCons, longDataArray[i], lUnaryCons(LONG_PLACEHOLDER_1));
       }
 
    //dReturn
@@ -1831,9 +1849,9 @@ X86OpCodesTest::invokeUnaryTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "dReturnCons%d", i + 1);
-      EXPECT_DOUBLE_EQ(doubleDataArray[i], _dReturn(doubleDataArray[i]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_dReturn, doubleDataArray[i], _dReturn(doubleDataArray[i]));
       dUnaryCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dreturn, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &(doubleDataArray[i])));
-      EXPECT_DOUBLE_EQ(doubleDataArray[i], dUnaryCons(DOUBLE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_DOUBLE_EQ(dUnaryCons, doubleDataArray[i], dUnaryCons(DOUBLE_PLACEHOLDER_1));
       }
 
    //fReturn
@@ -1841,9 +1859,9 @@ X86OpCodesTest::invokeUnaryTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "fReturnCons%d", i + 1);
-      EXPECT_FLOAT_EQ(floatDataArray[i], _fReturn(floatDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_fReturn, floatDataArray[i], _fReturn(floatDataArray[i]));
       fUnaryCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::freturn, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &(floatDataArray[i])));
-      EXPECT_FLOAT_EQ(floatDataArray[i], fUnaryCons(FLOAT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_FLOAT_EQ(fUnaryCons, floatDataArray[i], fUnaryCons(FLOAT_PLACEHOLDER_1));
       }
 
    //lConst
@@ -1852,7 +1870,7 @@ X86OpCodesTest::invokeUnaryTests()
       {
       sprintf(resolvedMethodName, "lConst%d", i + 1);
       lUnaryCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lconst, resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &(longDataArray[i])));
-      EXPECT_EQ(longDataArray[i], lUnaryCons(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lUnaryCons, longDataArray[i], lUnaryCons(LONG_PLACEHOLDER_1));
       }
 
    //dConst
@@ -1861,7 +1879,7 @@ X86OpCodesTest::invokeUnaryTests()
       {
       sprintf(resolvedMethodName, "dConst%d", i + 1);
       dUnaryCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dconst, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &(doubleDataArray[i])));
-      EXPECT_DOUBLE_EQ(doubleDataArray[i], dUnaryCons(DOUBLE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_DOUBLE_EQ(dUnaryCons, doubleDataArray[i], dUnaryCons(DOUBLE_PLACEHOLDER_1));
       }
 
    //fConst
@@ -1870,43 +1888,43 @@ X86OpCodesTest::invokeUnaryTests()
       {
       sprintf(resolvedMethodName, "fConst%d", i + 1);
       fUnaryCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::fconst, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &(floatDataArray[i])));
-      EXPECT_FLOAT_EQ(floatDataArray[i], fUnaryCons(FLOAT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_FLOAT_EQ(fUnaryCons, floatDataArray[i], fUnaryCons(FLOAT_PLACEHOLDER_1));
       }
 
    //int 2 d,f
    testCaseNum = sizeof(intDataArray) / sizeof(intDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_FLOAT_EQ(convert(intDataArray[i], FLOAT_POS), _i2f(intDataArray[i]));
-      EXPECT_DOUBLE_EQ(convert(intDataArray[i], DOUBLE_POS), _i2d(intDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_i2f, convert(intDataArray[i], FLOAT_POS), _i2f(intDataArray[i]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_i2d, convert(intDataArray[i], DOUBLE_POS), _i2d(intDataArray[i]));
 
       sprintf(resolvedMethodName, "i2fConst%d", i + 1);
       i2fConst = (signatureCharI_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::i2f,
             resolvedMethodName, _argTypesUnaryInt, TR::Float, rc, 2, 1, &intDataArray[i]));
-      EXPECT_FLOAT_EQ(convert(intDataArray[i], FLOAT_POS), i2fConst(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_FLOAT_EQ(i2fConst, convert(intDataArray[i], FLOAT_POS), i2fConst(INT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "i2dConst%d", i + 1);
       i2dConst = (signatureCharI_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::i2d,
             resolvedMethodName, _argTypesUnaryInt, TR::Double, rc, 2, 1, &intDataArray[i]));
-      EXPECT_DOUBLE_EQ(convert(intDataArray[i], DOUBLE_POS), i2dConst(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_DOUBLE_EQ(i2dConst, convert(intDataArray[i], DOUBLE_POS), i2dConst(INT_PLACEHOLDER_1));
       }
 
    //l 2 d,f
    testCaseNum = sizeof(longDataArray) / sizeof(longDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_FLOAT_EQ(convert(longDataArray[i], FLOAT_POS), _l2f(longDataArray[i]));
-      EXPECT_DOUBLE_EQ(convert(longDataArray[i], DOUBLE_POS), _l2d(longDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_l2f, convert(longDataArray[i], FLOAT_POS), _l2f(longDataArray[i]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_l2d, convert(longDataArray[i], DOUBLE_POS), _l2d(longDataArray[i]));
 
       sprintf(resolvedMethodName, "l2fConst%d", i + 1);
       l2fConst = (signatureCharJ_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::l2f,
             resolvedMethodName, _argTypesUnaryLong, TR::Float, rc, 2, 1, &longDataArray[i]));
-      EXPECT_FLOAT_EQ(convert(longDataArray[i], FLOAT_POS), l2fConst(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_FLOAT_EQ(l2fConst, convert(longDataArray[i], FLOAT_POS), l2fConst(LONG_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "l2dConst%d", i + 1);
       l2dConst = (signatureCharJ_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::l2d,
             resolvedMethodName, _argTypesUnaryLong, TR::Double, rc, 2, 1, &longDataArray[i]));
-      EXPECT_DOUBLE_EQ(convert(longDataArray[i], DOUBLE_POS), l2dConst(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_DOUBLE_EQ(l2dConst, convert(longDataArray[i], DOUBLE_POS), l2dConst(LONG_PLACEHOLDER_1));
       }
 
    //f2l
@@ -1917,12 +1935,12 @@ X86OpCodesTest::invokeUnaryTests()
    testCaseNum = sizeof(floatDataArray) / sizeof(floatDataArray[0]);
    for (uint32_t i = 0; i < 3; ++i)
       {
-      EXPECT_EQ(convert(floatDataArray[i], LONG_POS), _f2l(floatDataArray[i]));
+      OMR_CT_EXPECT_EQ(_f2l, convert(floatDataArray[i], LONG_POS), _f2l(floatDataArray[i]));
 
       sprintf(resolvedMethodName, "f2lConst%d", i + 1);
       f2lConst = (signatureCharF_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2l,
             resolvedMethodName, _argTypesUnaryFloat, TR::Int64, rc, 2, 1, &floatDataArray[i]));
-      EXPECT_EQ(convert(floatDataArray[i], LONG_POS), f2lConst(FLOAT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(f2lConst, convert(floatDataArray[i], LONG_POS), f2lConst(FLOAT_PLACEHOLDER_1));
       }
 
    //d2l
@@ -1933,188 +1951,188 @@ X86OpCodesTest::invokeUnaryTests()
    testCaseNum = sizeof(doubleDataArray) / sizeof(doubleDataArray[0]);
    for (uint32_t i = 0; i < 3; ++i)
       {
-      EXPECT_EQ(convert(doubleDataArray[i], LONG_POS), _d2l(doubleDataArray[i]));
+      OMR_CT_EXPECT_EQ(_d2l, convert(doubleDataArray[i], LONG_POS), _d2l(doubleDataArray[i]));
 
       sprintf(resolvedMethodName, "d2lConst%d", i + 1);
       d2lConst = (signatureCharD_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2l,
             resolvedMethodName, _argTypesUnaryDouble, TR::Int64, rc, 2, 1, &doubleDataArray[i]));
-      EXPECT_EQ(convert(doubleDataArray[i], LONG_POS), d2lConst(DOUBLE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(d2lConst, convert(doubleDataArray[i], LONG_POS), d2lConst(DOUBLE_PLACEHOLDER_1));
       }
 
    //f2d
    testCaseNum = sizeof(floatDataArray) / sizeof(floatDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_DOUBLE_EQ(convert(floatDataArray[i], DOUBLE_POS), _f2d(floatDataArray[i]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_f2d, convert(floatDataArray[i], DOUBLE_POS), _f2d(floatDataArray[i]));
 
       sprintf(resolvedMethodName, "f2dConst%d", i + 1);
       f2dConst = (signatureCharF_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2d,
             resolvedMethodName, _argTypesUnaryFloat, TR::Double, rc, 2, 1, &floatDataArray[i]));
-      EXPECT_EQ(convert(floatDataArray[i], DOUBLE_POS), f2dConst(FLOAT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(f2dConst, convert(floatDataArray[i], DOUBLE_POS), f2dConst(FLOAT_PLACEHOLDER_1));
       }
 
    //d2f
    testCaseNum = sizeof(doubleDataArray) / sizeof(doubleDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_FLOAT_EQ(convert(doubleDataArray[i], FLOAT_POS), _d2f(doubleDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_d2f, convert(doubleDataArray[i], FLOAT_POS), _d2f(doubleDataArray[i]));
 
       sprintf(resolvedMethodName, "d2fConst%d", i + 1);
       d2fConst = (signatureCharD_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2f,
             resolvedMethodName, _argTypesUnaryDouble, TR::Float, rc, 2, 1, &doubleDataArray[i]));
-      EXPECT_FLOAT_EQ(convert(doubleDataArray[i], FLOAT_POS), d2fConst(DOUBLE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_FLOAT_EQ(d2fConst, convert(doubleDataArray[i], FLOAT_POS), d2fConst(DOUBLE_PLACEHOLDER_1));
       }
 
    //b 2 i,l,s,d,f
    testCaseNum = sizeof(byteDataArray) / sizeof(byteDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(byteDataArray[i], SHORT_POS), _b2s(byteDataArray[i]));
-      EXPECT_EQ(convert(byteDataArray[i], INT_POS), _b2i(byteDataArray[i]));
-      EXPECT_EQ(convert(byteDataArray[i], LONG_POS), _b2l(byteDataArray[i]));
-      EXPECT_FLOAT_EQ(convert(byteDataArray[i], FLOAT_POS), _b2f(byteDataArray[i]));
-      EXPECT_DOUBLE_EQ(convert(byteDataArray[i], DOUBLE_POS), _b2d(byteDataArray[i]));
+      OMR_CT_EXPECT_EQ(_b2s, convert(byteDataArray[i], SHORT_POS), _b2s(byteDataArray[i]));
+      OMR_CT_EXPECT_EQ(_b2i, convert(byteDataArray[i], INT_POS), _b2i(byteDataArray[i]));
+      OMR_CT_EXPECT_EQ(_b2l, convert(byteDataArray[i], LONG_POS), _b2l(byteDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_b2f, convert(byteDataArray[i], FLOAT_POS), _b2f(byteDataArray[i]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_b2d, convert(byteDataArray[i], DOUBLE_POS), _b2d(byteDataArray[i]));
 
       sprintf(resolvedMethodName, "b2sConst%d", i + 1);
       b2sConst = (signatureCharB_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2s,
             resolvedMethodName, _argTypesUnaryByte, TR::Int16, rc, 2, 1, &byteDataArray[i]));
-      EXPECT_EQ(convert(byteDataArray[i], SHORT_POS), b2sConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(b2sConst, convert(byteDataArray[i], SHORT_POS), b2sConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "b2iConst%d", i + 1);
       b2iConst = (signatureCharB_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2i,
             resolvedMethodName, _argTypesUnaryByte, TR::Int32, rc, 2, 1, &byteDataArray[i]));
-      EXPECT_EQ(convert(byteDataArray[i], INT_POS), b2iConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(b2iConst, convert(byteDataArray[i], INT_POS), b2iConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "b2lConst%d", i + 1);
       b2lConst = (signatureCharB_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2l,
             resolvedMethodName, _argTypesUnaryByte, TR::Int64, rc, 2, 1, &byteDataArray[i]));
-      EXPECT_EQ(convert(byteDataArray[i], LONG_POS), b2lConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(b2lConst, convert(byteDataArray[i], LONG_POS), b2lConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "b2fConst%d", i + 1);
       b2fConst = (signatureCharB_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2f,
             resolvedMethodName, _argTypesUnaryByte, TR::Float, rc, 2, 1, &byteDataArray[i]));
-      EXPECT_FLOAT_EQ(convert(byteDataArray[i], FLOAT_POS), b2fConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_FLOAT_EQ(b2fConst, convert(byteDataArray[i], FLOAT_POS), b2fConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "b2dConst%d", i + 1);
       b2dConst = (signatureCharB_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2d,
             resolvedMethodName, _argTypesUnaryByte, TR::Double, rc, 2, 1, &byteDataArray[i]));
-      EXPECT_DOUBLE_EQ(convert(byteDataArray[i], DOUBLE_POS), b2dConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_DOUBLE_EQ(b2dConst, convert(byteDataArray[i], DOUBLE_POS), b2dConst(BYTE_PLACEHOLDER_1));
       }
 
    //bu 2 i,l,s,d,f
    testCaseNum = sizeof(ubyteDataArray) / sizeof(ubyteDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(ubyteDataArray[i], SHORT_POS), _bu2s(ubyteDataArray[i]));
-      EXPECT_EQ(convert(ubyteDataArray[i], INT_POS), _bu2i(ubyteDataArray[i]));
-      EXPECT_EQ(convert(ubyteDataArray[i], LONG_POS), _bu2l(ubyteDataArray[i]));
-      EXPECT_FLOAT_EQ(convert(ubyteDataArray[i], FLOAT_POS), _bu2f(ubyteDataArray[i]));
-      EXPECT_DOUBLE_EQ(convert(ubyteDataArray[i], DOUBLE_POS), _bu2d(ubyteDataArray[i]));
+      OMR_CT_EXPECT_EQ(_bu2s, convert(ubyteDataArray[i], SHORT_POS), _bu2s(ubyteDataArray[i]));
+      OMR_CT_EXPECT_EQ(_bu2i, convert(ubyteDataArray[i], INT_POS), _bu2i(ubyteDataArray[i]));
+      OMR_CT_EXPECT_EQ(_bu2l, convert(ubyteDataArray[i], LONG_POS), _bu2l(ubyteDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_bu2f, convert(ubyteDataArray[i], FLOAT_POS), _bu2f(ubyteDataArray[i]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_bu2d, convert(ubyteDataArray[i], DOUBLE_POS), _bu2d(ubyteDataArray[i]));
 
       sprintf(resolvedMethodName, "bu2sConst%d", i + 1);
       bu2sConst = (unsignedSignatureCharB_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2s,
             resolvedMethodName, _argTypesUnaryByte, TR::Int16, rc, 2, 1, &ubyteDataArray[i]));
-      EXPECT_EQ(convert(ubyteDataArray[i], SHORT_POS), bu2sConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(bu2sConst, convert(ubyteDataArray[i], SHORT_POS), bu2sConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "bu2iConst%d", i + 1);
       bu2iConst = (unsignedSignatureCharB_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2i,
             resolvedMethodName, _argTypesUnaryByte, TR::Int32, rc, 2, 1, &ubyteDataArray[i]));
-      EXPECT_EQ(convert(ubyteDataArray[i], INT_POS), bu2iConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(bu2iConst, convert(ubyteDataArray[i], INT_POS), bu2iConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "bu2lConst%d", i + 1);
       bu2lConst = (unsignedSignatureCharB_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2l,
             resolvedMethodName, _argTypesUnaryByte, TR::Int64, rc, 2, 1, &ubyteDataArray[i]));
-      EXPECT_EQ(convert(ubyteDataArray[i], LONG_POS), bu2lConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(bu2lConst, convert(ubyteDataArray[i], LONG_POS), bu2lConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "bu2fConst%d", i + 1);
       bu2fConst = (unsignedSignatureCharB_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2f,
             resolvedMethodName, _argTypesUnaryByte, TR::Float, rc, 2, 1, &ubyteDataArray[i]));
-      EXPECT_FLOAT_EQ(convert(ubyteDataArray[i], FLOAT_POS), bu2fConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_FLOAT_EQ(bu2fConst, convert(ubyteDataArray[i], FLOAT_POS), bu2fConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "bu2dConst%d", i + 1);
       bu2dConst = (unsignedSignatureCharB_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2d,
             resolvedMethodName, _argTypesUnaryByte, TR::Double, rc, 2, 1, &ubyteDataArray[i]));
-      EXPECT_DOUBLE_EQ(convert(ubyteDataArray[i], DOUBLE_POS), bu2dConst(BYTE_PLACEHOLDER_1));
+      OMR_CT_EXPECT_DOUBLE_EQ(bu2dConst, convert(ubyteDataArray[i], DOUBLE_POS), bu2dConst(BYTE_PLACEHOLDER_1));
       }
 
    //s 2 i,l,b
    testCaseNum = sizeof(shortDataArray) / sizeof(shortDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(shortDataArray[i], BYTE_POS), _s2b(shortDataArray[i]));
-      EXPECT_EQ(convert(shortDataArray[i], INT_POS), _s2i(shortDataArray[i]));
-      EXPECT_EQ(convert(shortDataArray[i], LONG_POS), _s2l(shortDataArray[i]));
-      EXPECT_FLOAT_EQ(convert(shortDataArray[i], FLOAT_POS), _s2f(shortDataArray[i]));
-      EXPECT_DOUBLE_EQ(convert(shortDataArray[i], DOUBLE_POS), _s2d(shortDataArray[i]));
+      OMR_CT_EXPECT_EQ(_s2b, convert(shortDataArray[i], BYTE_POS), _s2b(shortDataArray[i]));
+      OMR_CT_EXPECT_EQ(_s2i, convert(shortDataArray[i], INT_POS), _s2i(shortDataArray[i]));
+      OMR_CT_EXPECT_EQ(_s2l, convert(shortDataArray[i], LONG_POS), _s2l(shortDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_s2f, convert(shortDataArray[i], FLOAT_POS), _s2f(shortDataArray[i]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_s2d, convert(shortDataArray[i], DOUBLE_POS), _s2d(shortDataArray[i]));
 
       sprintf(resolvedMethodName, "s2bConst%d", i + 1);
       s2bConst = (signatureCharS_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2b,
             resolvedMethodName, _argTypesUnaryShort, TR::Int8, rc, 2, 1, &shortDataArray[i]));
-      EXPECT_EQ(convert(shortDataArray[i], BYTE_POS), s2bConst(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(s2bConst, convert(shortDataArray[i], BYTE_POS), s2bConst(SHORT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "s2iConst%d", i + 1);
       s2iConst = (signatureCharS_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2i,
             resolvedMethodName, _argTypesUnaryShort, TR::Int32, rc, 2, 1, &shortDataArray[i]));
-      EXPECT_EQ(convert(shortDataArray[i], INT_POS), s2iConst(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(s2iConst, convert(shortDataArray[i], INT_POS), s2iConst(SHORT_PLACEHOLDER_1));
 
 
       sprintf(resolvedMethodName, "s2lConst%d", i + 1);
       s2lConst = (signatureCharS_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2l,
             resolvedMethodName, _argTypesUnaryShort, TR::Int64, rc, 2, 1, &shortDataArray[i]));
-      EXPECT_EQ(convert(shortDataArray[i], LONG_POS), s2lConst(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(s2lConst, convert(shortDataArray[i], LONG_POS), s2lConst(SHORT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "s2fConst%d", i + 1);
       s2fConst = (signatureCharS_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2f,
             resolvedMethodName, _argTypesUnaryShort, TR::Float, rc, 2, 1, &shortDataArray[i]));
-      EXPECT_FLOAT_EQ(convert(shortDataArray[i], FLOAT_POS), s2fConst(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_FLOAT_EQ(s2fConst, convert(shortDataArray[i], FLOAT_POS), s2fConst(SHORT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "s2dConst%d", i + 1);
       s2dConst = (signatureCharS_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2d,
             resolvedMethodName, _argTypesUnaryShort, TR::Double, rc, 2, 1, &shortDataArray[i]));
-      EXPECT_DOUBLE_EQ(convert(shortDataArray[i], DOUBLE_POS), s2dConst(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_DOUBLE_EQ(s2dConst, convert(shortDataArray[i], DOUBLE_POS), s2dConst(SHORT_PLACEHOLDER_1));
       }
 
    //su 2 i,l,f,d
    testCaseNum = sizeof(ushortDataArray) / sizeof(ushortDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(ushortDataArray[i], INT_POS), _su2i(ushortDataArray[i]));
-      EXPECT_EQ(convert(ushortDataArray[i], LONG_POS), _su2l(ushortDataArray[i]));
-      EXPECT_FLOAT_EQ(convert(ushortDataArray[i], FLOAT_POS), _su2f(ushortDataArray[i]));
-      EXPECT_DOUBLE_EQ(convert(ushortDataArray[i], DOUBLE_POS), _su2d(ushortDataArray[i]));
+      OMR_CT_EXPECT_EQ(_su2i, convert(ushortDataArray[i], INT_POS), _su2i(ushortDataArray[i]));
+      OMR_CT_EXPECT_EQ(_su2l, convert(ushortDataArray[i], LONG_POS), _su2l(ushortDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_su2f, convert(ushortDataArray[i], FLOAT_POS), _su2f(ushortDataArray[i]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_su2d, convert(ushortDataArray[i], DOUBLE_POS), _su2d(ushortDataArray[i]));
 
       sprintf(resolvedMethodName, "s2iConst%d", i + 1);
       su2iConst = (unsignedSignatureCharS_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2i,
             resolvedMethodName, _argTypesUnaryShort, TR::Int32, rc, 2, 1, &ushortDataArray[i]));
-      EXPECT_EQ(convert(ushortDataArray[i], INT_POS), su2iConst(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(su2iConst, convert(ushortDataArray[i], INT_POS), su2iConst(SHORT_PLACEHOLDER_1));
 
 
       sprintf(resolvedMethodName, "s2lConst%d", i + 1);
       su2lConst = (unsignedSignatureCharS_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2l,
             resolvedMethodName, _argTypesUnaryShort, TR::Int64, rc, 2, 1, &ushortDataArray[i]));
-      EXPECT_EQ(convert(ushortDataArray[i], LONG_POS), su2lConst(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(su2lConst, convert(ushortDataArray[i], LONG_POS), su2lConst(SHORT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "su2fConst%d", i + 1);
       su2fConst = (unsignedSignatureCharS_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2f,
             resolvedMethodName, _argTypesUnaryShort, TR::Float, rc, 2, 1, &ushortDataArray[i]));
-      EXPECT_FLOAT_EQ(convert(ushortDataArray[i], FLOAT_POS), su2fConst(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_FLOAT_EQ(su2fConst, convert(ushortDataArray[i], FLOAT_POS), su2fConst(SHORT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "su2dConst%d", i + 1);
       su2dConst = (unsignedSignatureCharS_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2d,
             resolvedMethodName, _argTypesUnaryShort, TR::Double, rc, 2, 1, &ushortDataArray[i]));
-      EXPECT_DOUBLE_EQ(convert(ushortDataArray[i], DOUBLE_POS), su2dConst(SHORT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_DOUBLE_EQ(su2dConst, convert(ushortDataArray[i], DOUBLE_POS), su2dConst(SHORT_PLACEHOLDER_1));
       }
 
    //iu2l
    testCaseNum = sizeof(uintDataArray) / sizeof(uintDataArray[0]);
    for (uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(convert(uintDataArray[i], LONG_POS), _iu2l(uintDataArray[i]));
+      OMR_CT_EXPECT_EQ(_iu2l, convert(uintDataArray[i], LONG_POS), _iu2l(uintDataArray[i]));
 
       sprintf(resolvedMethodName, "iu2lConst%d", i + 1);
       iu2lConst = (unsignedSignatureCharI_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iu2l,
             resolvedMethodName, _argTypesUnaryInt, TR::Int64, rc, 2, 1, &uintDataArray[i]));
-      EXPECT_EQ(convert(uintDataArray[i], LONG_POS), iu2lConst(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(iu2lConst, convert(uintDataArray[i], LONG_POS), iu2lConst(INT_PLACEHOLDER_1));
       }
    }
 
@@ -2626,298 +2644,298 @@ X86OpCodesTest::invokeCompareTests()
    testCaseNum = sizeof(lCmpeqDataArr) / sizeof(lCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), _lCmpeq(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lCmpeq, compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), _lCmpeq(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpeqConst1_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpeqDataArr[i][0]), 2, &(lCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lCmpeqConst2_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpeqConst3_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), lCompareConst(lCmpeqDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), lCompareConst(lCmpeqDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //lcmplt
    testCaseNum = sizeof(lCmpltDataArr) / sizeof(lCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), _lCmplt(lCmpltDataArr[i][0], lCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lCmplt, compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), _lCmplt(lCmpltDataArr[i][0], lCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpltConst1_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpltDataArr[i][0]), 2, &(lCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lCmpltConst2_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpltConst3_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), lCompareConst(lCmpltDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), lCompareConst(lCmpltDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //dCompare
    testCaseNum = sizeof(dCmpeqDataArr) / sizeof(dCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), _dCmpeq(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_dCmpeq, compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), _dCmpeq(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpeqConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpeqDataArr[i][0]), 2, &(dCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpeqConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpeqConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), dCompareConst(dCmpeqDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), dCompareConst(dCmpeqDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(dCmpneDataArr) / sizeof(dCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), _dCmpne(dCmpneDataArr[i][0], dCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_dCmpne, compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), _dCmpne(dCmpneDataArr[i][0], dCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpneConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpneDataArr[i][0]), 2, &(dCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpneConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpneConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), dCompareConst(dCmpneDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), dCompareConst(dCmpneDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(dCmpgtDataArr) / sizeof(dCmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), _dCmpgt(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_dCmpgt, compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), _dCmpgt(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpgtConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpgtDataArr[i][0]), 2, &(dCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpgtConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpgtConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), dCompareConst(dCmpgtDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), dCompareConst(dCmpgtDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(dCmpltDataArr) / sizeof(dCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), _dCmplt(dCmpltDataArr[i][0], dCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_dCmplt, compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), _dCmplt(dCmpltDataArr[i][0], dCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpltConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpltDataArr[i][0]), 2, &(dCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpltConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpltConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), dCompareConst(dCmpltDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), dCompareConst(dCmpltDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(dCmpgeDataArr) / sizeof(dCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), _dCmpge(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_dCmpge, compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), _dCmpge(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpgeConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpgeDataArr[i][0]), 2, &(dCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpgeConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpgeConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), dCompareConst(dCmpgeDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), dCompareConst(dCmpgeDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(dCmpleDataArr) / sizeof(dCmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), _dCmple(dCmpleDataArr[i][0], dCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_dCmple, compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), _dCmple(dCmpleDataArr[i][0], dCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpleConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpleDataArr[i][0]), 2, &(dCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpleConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpleConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), dCompareConst(dCmpleDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), dCompareConst(dCmpleDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    //fCompare
    testCaseNum = sizeof(fCmpeqDataArr) / sizeof(fCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), _fCmpeq(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_fCmpeq, compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), _fCmpeq(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpeqConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpeqDataArr[i][0]), 2, &(fCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpeqConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpeqConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), fCompareConst(fCmpeqDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), fCompareConst(fCmpeqDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(fCmpneDataArr) / sizeof(fCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), _fCmpne(fCmpneDataArr[i][0], fCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_fCmpne, compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), _fCmpne(fCmpneDataArr[i][0], fCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpneConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpneDataArr[i][0]), 2, &(fCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpneConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpneConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), fCompareConst(fCmpneDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), fCompareConst(fCmpneDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(fCmpgtDataArr) / sizeof(fCmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), _fCmpgt(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_fCmpgt, compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), _fCmpgt(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpgtConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpgtDataArr[i][0]), 2, &(fCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpgtConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpgtConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), fCompareConst(fCmpgtDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), fCompareConst(fCmpgtDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(fCmpltDataArr) / sizeof(fCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), _fCmplt(fCmpltDataArr[i][0], fCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_fCmplt, compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), _fCmplt(fCmpltDataArr[i][0], fCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpltConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpltDataArr[i][0]), 2, &(fCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpltConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpltConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), fCompareConst(fCmpltDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), fCompareConst(fCmpltDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(fCmpgeDataArr) / sizeof(fCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), _fCmpge(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_fCmpge, compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), _fCmpge(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpgeConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpgeDataArr[i][0]), 2, &(fCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpgeConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpgeConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), fCompareConst(fCmpgeDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), fCompareConst(fCmpgeDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(fCmpleDataArr) / sizeof(fCmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), _fCmple(fCmpleDataArr[i][0], fCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_fCmple, compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), _fCmple(fCmpleDataArr[i][0], fCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpleConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpleDataArr[i][0]), 2, &(fCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpleConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpleConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), fCompareConst(fCmpleDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), fCompareConst(fCmpleDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
 
@@ -2925,302 +2943,302 @@ X86OpCodesTest::invokeCompareTests()
    testCaseNum = sizeof(sCmpeqDataArr) / sizeof(sCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), _sCmpeq(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sCmpeq, compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), _sCmpeq(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpeqConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpeqDataArr[i][0]), 2, &(sCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpeqConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpeqConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), sCompareConst(sCmpeqDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), sCompareConst(sCmpeqDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(sCmpneDataArr) / sizeof(sCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), _sCmpne(sCmpneDataArr[i][0], sCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sCmpne, compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), _sCmpne(sCmpneDataArr[i][0], sCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpneConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpneDataArr[i][0]), 2, &(sCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpneConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpneConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), sCompareConst(sCmpneDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), sCompareConst(sCmpneDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(sCmpgtDataArr) / sizeof(sCmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), _sCmpgt(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sCmpgt, compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), _sCmpgt(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpgtConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpgtDataArr[i][0]), 2, &(sCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpgtConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpgtConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), sCompareConst(sCmpgtDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), sCompareConst(sCmpgtDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(sCmpltDataArr) / sizeof(sCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), _sCmplt(sCmpltDataArr[i][0], sCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sCmplt, compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), _sCmplt(sCmpltDataArr[i][0], sCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpltConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpltDataArr[i][0]), 2, &(sCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpltConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpltConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), sCompareConst(sCmpltDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), sCompareConst(sCmpltDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(sCmpgeDataArr) / sizeof(sCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), _sCmpge(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sCmpge, compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), _sCmpge(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpgeConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpgeDataArr[i][0]), 2, &(sCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpgeConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpgeConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), sCompareConst(sCmpgeDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), sCompareConst(sCmpgeDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(sCmpleDataArr) / sizeof(sCmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), _sCmple(sCmpleDataArr[i][0], sCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sCmple, compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), _sCmple(sCmpleDataArr[i][0], sCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpleConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpleDataArr[i][0]), 2, &(sCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpleConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpleConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::scmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), sCompareConst(sCmpleDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), sCompareConst(sCmpleDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    //bCompare
    testCaseNum = sizeof(bCmpeqDataArr) / sizeof(bCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), _bCmpeq(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bCmpeq, compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), _bCmpeq(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpeqConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpeqDataArr[i][0]), 2, &(bCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpeqConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpeqConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), bCompareConst(bCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), bCompareConst(bCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(bCmpgtDataArr) / sizeof(bCmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), _bCmpgt(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bCmpgt, compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), _bCmpgt(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpgtConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpgtDataArr[i][0]), 2, &(bCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpgtConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpgtConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), bCompareConst(bCmpgtDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), bCompareConst(bCmpgtDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(bCmpltDataArr) / sizeof(bCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), _bCmplt(bCmpltDataArr[i][0], bCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bCmplt, compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), _bCmplt(bCmpltDataArr[i][0], bCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpltConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpltDataArr[i][0]), 2, &(bCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpltConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpltConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), bCompareConst(bCmpltDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), bCompareConst(bCmpltDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(bCmpgeDataArr) / sizeof(bCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), _bCmpge(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bCmpge, compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), _bCmpge(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpgeConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpgeDataArr[i][0]), 2, &(bCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpgeConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpgeConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), bCompareConst(bCmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), bCompareConst(bCmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //bCompare
    testCaseNum = sizeof(bCmpneDataArr) / sizeof(bCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), _bCmpne(bCmpneDataArr[i][0], bCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bCmpne, compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), _bCmpne(bCmpneDataArr[i][0], bCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpneConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpneDataArr[i][0]), 2, &(bCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpneConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpneConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), bCompareConst(bCmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), bCompareConst(bCmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(bCmpleDataArr) / sizeof(bCmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), _bCmple(bCmpleDataArr[i][0], bCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bCmple, compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), _bCmple(bCmpleDataArr[i][0], bCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpleConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpleDataArr[i][0]), 2, &(bCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpleConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpleConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), bCompareConst(bCmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), bCompareConst(bCmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //lcmp
    testCaseNum = sizeof(lCmpDataArr) / sizeof(lCmpDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), _lCmp(lCmpDataArr[i][0], lCmpDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lCmp, comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), _lCmp(lCmpDataArr[i][0], lCmpDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpConst1_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmp, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpDataArr[i][0]), 2, &(lCmpDataArr[i][1])));
-      EXPECT_EQ(comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lCmpConst2_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmp, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpDataArr[i][0])));
-      EXPECT_EQ(comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lCompareConst, comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpConst3_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::lcmp, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpDataArr[i][1])));
-      EXPECT_EQ(comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), lCompareConst(lCmpDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), lCompareConst(lCmpDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //dcmpl
    testCaseNum = sizeof(dCmplDataArr) / sizeof(dCmplDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), _dCmpl(dCmplDataArr[i][0], dCmplDataArr[i][1])) <<
+      OMR_CT_EXPECT_EQ(_dCmpl, comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), _dCmpl(dCmplDataArr[i][0], dCmplDataArr[i][1])) <<
             dCmplDataArr[i][0] << " : " << dCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmplConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpl, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmplDataArr[i][0]), 2, &(dCmplDataArr[i][1])));
-      EXPECT_EQ(comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2)) <<
+      OMR_CT_EXPECT_EQ(dCompareConst, comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2)) <<
             dCmplDataArr[i][0] << " : " << dCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmplConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpl, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmplDataArr[i][0])));
-      EXPECT_EQ(comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmplDataArr[i][1])) <<
+      OMR_CT_EXPECT_EQ(dCompareConst, comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmplDataArr[i][1])) <<
             dCmplDataArr[i][0] << " : " << dCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmplConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpl, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmplDataArr[i][1])));
-      EXPECT_EQ(comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), dCompareConst(dCmplDataArr[i][0], DOUBLE_PLACEHOLDER_2)) <<
+      OMR_CT_EXPECT_EQ(dCompareConst, comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), dCompareConst(dCmplDataArr[i][0], DOUBLE_PLACEHOLDER_2)) <<
             dCmplDataArr[i][0] << " : " << dCmplDataArr[i][1];
       }
 
@@ -3228,25 +3246,25 @@ X86OpCodesTest::invokeCompareTests()
    testCaseNum = sizeof(dCmpgDataArr) / sizeof(dCmpgDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), _dCmpg(dCmpgDataArr[i][0], dCmpgDataArr[i][1])) <<
+      OMR_CT_EXPECT_EQ(_dCmpg, compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), _dCmpg(dCmpgDataArr[i][0], dCmpgDataArr[i][1])) <<
             dCmpgDataArr[i][0] << " : " << dCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmpgConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpg, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpgDataArr[i][0]), 2, &(dCmpgDataArr[i][1])));
-      EXPECT_EQ(compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2)) <<
+      OMR_CT_EXPECT_EQ(dCompareConst, compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2)) <<
             dCmpgDataArr[i][0] << " : " << dCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmpgConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpg, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpgDataArr[i][0])));
-      EXPECT_EQ(compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpgDataArr[i][1])) <<
+      OMR_CT_EXPECT_EQ(dCompareConst, compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpgDataArr[i][1])) <<
             dCmpgDataArr[i][0] << " : " << dCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmpgConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::dcmpg, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpgDataArr[i][1])));
-      EXPECT_EQ(compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), dCompareConst(dCmpgDataArr[i][0], DOUBLE_PLACEHOLDER_2)) <<
+      OMR_CT_EXPECT_EQ(dCompareConst, compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), dCompareConst(dCmpgDataArr[i][0], DOUBLE_PLACEHOLDER_2)) <<
             dCmpgDataArr[i][0] << " : " << dCmpgDataArr[i][1];
       }
 
@@ -3254,25 +3272,25 @@ X86OpCodesTest::invokeCompareTests()
    testCaseNum = sizeof(fCmplDataArr) / sizeof(fCmplDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), _fCmpl(fCmplDataArr[i][0], fCmplDataArr[i][1])) <<
+      OMR_CT_EXPECT_EQ(_fCmpl, comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), _fCmpl(fCmplDataArr[i][0], fCmplDataArr[i][1])) <<
             fCmplDataArr[i][0] << " : " << fCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmplConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpl, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmplDataArr[i][0]), 2, &(fCmplDataArr[i][1])));
-      EXPECT_EQ(comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2)) <<
+      OMR_CT_EXPECT_EQ(fCompareConst, comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2)) <<
             fCmplDataArr[i][0] << " : " << fCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmplConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpl, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmplDataArr[i][0])));
-      EXPECT_EQ(comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmplDataArr[i][1])) <<
+      OMR_CT_EXPECT_EQ(fCompareConst, comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmplDataArr[i][1])) <<
             fCmplDataArr[i][0] << " : " << fCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmplConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpl, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmplDataArr[i][1])));
-      EXPECT_EQ(comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), fCompareConst(fCmplDataArr[i][0], FLOAT_PLACEHOLDER_2)) <<
+      OMR_CT_EXPECT_EQ(fCompareConst, comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), fCompareConst(fCmplDataArr[i][0], FLOAT_PLACEHOLDER_2)) <<
             fCmplDataArr[i][0] << " : " << fCmplDataArr[i][1];
       }
 
@@ -3280,25 +3298,25 @@ X86OpCodesTest::invokeCompareTests()
    testCaseNum = sizeof(fCmpgDataArr) / sizeof(fCmpgDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), _fCmpg(fCmpgDataArr[i][0], fCmpgDataArr[i][1])) <<
+      OMR_CT_EXPECT_EQ(_fCmpg, compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), _fCmpg(fCmpgDataArr[i][0], fCmpgDataArr[i][1])) <<
             fCmpgDataArr[i][0] << " : " << fCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmpgConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpg, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpgDataArr[i][0]), 2, &(fCmpgDataArr[i][1])));
-      EXPECT_EQ(compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2)) <<
+      OMR_CT_EXPECT_EQ(fCompareConst, compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2)) <<
             fCmpgDataArr[i][0] << " : " << fCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmpgConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpg, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpgDataArr[i][0])));
-      EXPECT_EQ(compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpgDataArr[i][1])) <<
+      OMR_CT_EXPECT_EQ(fCompareConst, compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpgDataArr[i][1])) <<
             fCmpgDataArr[i][0] << " : " << fCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmpgConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::fcmpg, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpgDataArr[i][1])));
-      EXPECT_EQ(compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), fCompareConst(fCmpgDataArr[i][0], FLOAT_PLACEHOLDER_2)) <<
+      OMR_CT_EXPECT_EQ(fCompareConst, compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), fCompareConst(fCmpgDataArr[i][0], FLOAT_PLACEHOLDER_2)) <<
             fCmpgDataArr[i][0] << " : " << fCmpgDataArr[i][1];
       }
 
@@ -3306,1060 +3324,1060 @@ X86OpCodesTest::invokeCompareTests()
    testCaseNum = sizeof(ifLcmpeqDataArr) / sizeof(ifLcmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), _ifLcmpeq(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifLcmpeq, compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), _ifLcmpeq(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpeqConst1_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpeqDataArr[i][0]), 2, &(ifLcmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLcmpeqConst2_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpeqConst3_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), lCompareConst(ifLcmpeqDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), lCompareConst(ifLcmpeqDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifLcmpgtDataArr) / sizeof(ifLcmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), _ifLcmpgt(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifLcmpgt, compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), _ifLcmpgt(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpgtConst1_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpgtDataArr[i][0]), 2, &(ifLcmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLcmpgtConst2_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpgtConst3_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), lCompareConst(ifLcmpgtDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), lCompareConst(ifLcmpgtDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifLcmpltDataArr) / sizeof(ifLcmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), _ifLcmplt(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifLcmplt, compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), _ifLcmplt(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpltConst1_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpltDataArr[i][0]), 2, &(ifLcmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLcmpltConst2_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpltConst3_TestCase%d", i + 1);
       lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iflcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), lCompareConst(ifLcmpltDataArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(lCompareConst, compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), lCompareConst(ifLcmpltDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
    //ifdCompare
    testCaseNum = sizeof(dCmpeqDataArr) / sizeof(ifDcmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), _ifDcmpeq(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifDcmpeq, compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), _ifDcmpeq(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpeqConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpeqDataArr[i][0]), 2, &(ifDcmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpeqConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpeqConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), dCompareConst(ifDcmpeqDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), dCompareConst(ifDcmpeqDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifDcmpneDataArr) / sizeof(ifDcmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), _ifDcmpne(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifDcmpne, compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), _ifDcmpne(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpneConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpneDataArr[i][0]), 2, &(ifDcmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpneConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpneConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), dCompareConst(ifDcmpneDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), dCompareConst(ifDcmpneDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifDcmpgtDataArr) / sizeof(ifDcmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), _ifDcmpgt(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifDcmpgt, compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), _ifDcmpgt(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpgtConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpgtDataArr[i][0]), 2, &(ifDcmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpgtConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpgtConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), dCompareConst(ifDcmpgtDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), dCompareConst(ifDcmpgtDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifDcmpltDataArr) / sizeof(ifDcmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), _ifDcmplt(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifDcmplt, compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), _ifDcmplt(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpltConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpltDataArr[i][0]), 2, &(ifDcmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpltConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpltConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), dCompareConst(ifDcmpltDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), dCompareConst(ifDcmpltDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifDcmpgeDataArr) / sizeof(ifDcmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), _ifDcmpge(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifDcmpge, compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), _ifDcmpge(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpgeConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpgeDataArr[i][0]), 2, &(ifDcmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpgeConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpgeConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), dCompareConst(ifDcmpgeDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), dCompareConst(ifDcmpgeDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifDcmpleDataArr) / sizeof(ifDcmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), _ifDcmple(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifDcmple, compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), _ifDcmple(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpleConst1_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpleDataArr[i][0]), 2, &(ifDcmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpleConst2_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpleConst3_TestCase%d", i + 1);
       dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifdcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), dCompareConst(ifDcmpleDataArr[i][0], DOUBLE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(dCompareConst, compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), dCompareConst(ifDcmpleDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
    //iffCompare
    testCaseNum = sizeof(ifFcmpeqDataArr) / sizeof(ifFcmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), _ifFcmpeq(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifFcmpeq, compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), _ifFcmpeq(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpeqConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpeqDataArr[i][0]), 2, &(ifFcmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpeqConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpeqConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), fCompareConst(ifFcmpeqDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), fCompareConst(ifFcmpeqDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifFcmpneDataArr) / sizeof(ifFcmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), _ifFcmpne(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifFcmpne, compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), _ifFcmpne(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpneConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpneDataArr[i][0]), 2, &(ifFcmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpneConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpneConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), fCompareConst(ifFcmpneDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), fCompareConst(ifFcmpneDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifFcmpgtDataArr) / sizeof(ifFcmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), _ifFcmpgt(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifFcmpgt, compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), _ifFcmpgt(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpgtConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpgtDataArr[i][0]), 2, &(ifFcmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpgtConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpgtConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), fCompareConst(ifFcmpgtDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), fCompareConst(ifFcmpgtDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifFcmpltDataArr) / sizeof(ifFcmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), _ifFcmplt(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifFcmplt, compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), _ifFcmplt(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpltConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpltDataArr[i][0]), 2, &(ifFcmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpltConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpltConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), fCompareConst(ifFcmpltDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), fCompareConst(ifFcmpltDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifFcmpgeDataArr) / sizeof(ifFcmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), _ifFcmpge(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifFcmpge, compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), _ifFcmpge(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpgeConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpgeDataArr[i][0]), 2, &(ifFcmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpgeConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpgeConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), fCompareConst(ifFcmpgeDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), fCompareConst(ifFcmpgeDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifFcmpleDataArr) / sizeof(ifFcmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), _ifFcmple(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifFcmple, compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), _ifFcmple(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpleConst1_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpleDataArr[i][0]), 2, &(ifFcmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpleConst2_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpleConst3_TestCase%d", i + 1);
       fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iffcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), fCompareConst(ifFcmpleDataArr[i][0], FLOAT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(fCompareConst, compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), fCompareConst(ifFcmpleDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
    //ifsCompare
    testCaseNum = sizeof(ifScmpeqDataArr) / sizeof(ifScmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), _ifScmpeq(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifScmpeq, compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), _ifScmpeq(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpeqConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpeqDataArr[i][0]), 2, &(ifScmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpeqConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpeqConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), sCompareConst(ifScmpeqDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), sCompareConst(ifScmpeqDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifScmpneDataArr) / sizeof(ifScmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), _ifScmpne(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifScmpne, compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), _ifScmpne(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpneConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpneDataArr[i][0]), 2, &(ifScmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpneConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpneConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), sCompareConst(ifScmpneDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), sCompareConst(ifScmpneDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifScmpgtDataArr) / sizeof(ifScmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), _ifScmpgt(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifScmpgt, compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), _ifScmpgt(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpgtConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpgtDataArr[i][0]), 2, &(ifScmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpgtConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpgtConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), sCompareConst(ifScmpgtDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), sCompareConst(ifScmpgtDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifScmpltDataArr) / sizeof(ifScmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), _ifScmplt(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifScmplt, compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), _ifScmplt(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpltConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpltDataArr[i][0]), 2, &(ifScmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpltConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpltConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), sCompareConst(ifScmpltDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), sCompareConst(ifScmpltDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifScmpgeDataArr) / sizeof(ifScmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), _ifScmpge(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifScmpge, compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), _ifScmpge(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpgeConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpgeDataArr[i][0]), 2, &(ifScmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpgeConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpgeConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), sCompareConst(ifScmpgeDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), sCompareConst(ifScmpgeDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifScmpleDataArr) / sizeof(ifScmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), _ifScmple(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifScmple, compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), _ifScmple(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpleConst1_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpleDataArr[i][0]), 2, &(ifScmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpleConst2_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpleConst3_TestCase%d", i + 1);
       sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifscmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), sCompareConst(ifScmpleDataArr[i][0], SHORT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(sCompareConst, compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), sCompareConst(ifScmpleDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
    //ifbCompare
    testCaseNum = sizeof(ifBcmpeqDataArr) / sizeof(ifBcmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), _ifBcmpeq(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBcmpeq, compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), _ifBcmpeq(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpeqConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpeqDataArr[i][0]), 2, &(ifBcmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpeqConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpeqConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), bCompareConst(ifBcmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), bCompareConst(ifBcmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBcmpgtDataArr) / sizeof(ifBcmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), _ifBcmpgt(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBcmpgt, compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), _ifBcmpgt(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpgtConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpgtDataArr[i][0]), 2, &(ifBcmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpgtConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpgtConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), bCompareConst(ifBcmpgtDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), bCompareConst(ifBcmpgtDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBcmpltDataArr) / sizeof(ifBcmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), _ifBcmplt(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBcmplt, compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), _ifBcmplt(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpltConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpltDataArr[i][0]), 2, &(ifBcmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpltConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpltConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), bCompareConst(ifBcmpltDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), bCompareConst(ifBcmpltDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBcmpgeDataArr) / sizeof(ifBcmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), _ifBcmpge(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBcmpge, compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), _ifBcmpge(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpgeConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpgeDataArr[i][0]), 2, &(ifBcmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpgeConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpgeConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(ifBcmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(ifBcmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBcmpneDataArr) / sizeof(ifBcmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), _ifBcmpne(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBcmpne, compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), _ifBcmpne(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpneConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpneDataArr[i][0]), 2, &(ifBcmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpneConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpneConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), bCompareConst(ifBcmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), bCompareConst(ifBcmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBcmpleDataArr) / sizeof(ifBcmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), _ifBcmple(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBcmple, compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), _ifBcmple(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpleConst1_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpleDataArr[i][0]), 2, &(ifBcmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpleConst2_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpleConst3_TestCase%d", i + 1);
       bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(ifBcmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(bCompareConst, compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(ifBcmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //iuCompare
    testCaseNum = sizeof(iuCmpeqDataArr) / sizeof(iuCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), _iuCmpeq(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iuCmpeq, compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), _iuCmpeq(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpeqConst1_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpeqDataArr[i][0]), 2, &(iuCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iuCmpeqConst2_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpeqConst3_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), iuCompareConst(iuCmpeqDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), iuCompareConst(iuCmpeqDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(iuCmpneDataArr) / sizeof(iuCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), _iuCmpne(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iuCmpne, compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), _iuCmpne(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpneConst1_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpneDataArr[i][0]), 2, &(iuCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iuCmpneConst2_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpneConst3_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), iuCompareConst(iuCmpneDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), iuCompareConst(iuCmpneDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(iuCmpgeDataArr) / sizeof(iuCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), _iuCmpge(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_iuCmpge, compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), _iuCmpge(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpgeConst1_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpgeDataArr[i][0]), 2, &(iuCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iuCmpgeConst2_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpgeConst3_TestCase%d", i + 1);
       iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::iucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(iuCmpgeDataArr[i][0], INT_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(iuCompareConst, compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(iuCmpgeDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
    //buCompare equal and not-equal
    testCaseNum = sizeof(buCmpeqDataArr) / sizeof(buCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), _buCmpeq(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_buCmpeq, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), _buCmpeq(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buCmpeqConst1_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(buCmpeqDataArr[i][0]), 2, &(buCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "buCmpeqConst2_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(buCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, buCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, buCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buCmpeqConst3_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(buCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(buCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(buCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(buCmpneDataArr) / sizeof(buCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), _buCmpne(buCmpneDataArr[i][0], buCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_buCmpne, compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), _buCmpne(buCmpneDataArr[i][0], buCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buCmpneConst1_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(buCmpneDataArr[i][0]), 2, &(buCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "buCmpneConst2_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(buCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, buCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, buCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buCmpneConst3_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::bucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(buCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), buCompareConst(buCmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), buCompareConst(buCmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //suCompare
    testCaseNum = sizeof(suCmpeqDataArr) / sizeof(suCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), _suCmpeq(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1])) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_suCmpeq, compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), _suCmpeq(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1])) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpeqConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpeqDataArr[i][0]), 2, &(suCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpeqConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpeqDataArr[i][1])) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpeqDataArr[i][1])) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpeqConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), suCompareConst(suCmpeqDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), suCompareConst(suCmpeqDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
       }
 
    testCaseNum = sizeof(suCmpneDataArr) / sizeof(suCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), _suCmpne(suCmpneDataArr[i][0], suCmpneDataArr[i][1])) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_suCmpne, compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), _suCmpne(suCmpneDataArr[i][0], suCmpneDataArr[i][1])) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpneConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpneDataArr[i][0]), 2, &(suCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpneConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpneDataArr[i][1])) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpneDataArr[i][1])) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpneConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), suCompareConst(suCmpneDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), suCompareConst(suCmpneDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
       }
 
    testCaseNum = sizeof(suCmpgtDataArr) / sizeof(suCmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), _suCmpgt(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1])) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_suCmpgt, compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), _suCmpgt(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1])) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgtConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpgtDataArr[i][0]), 2, &(suCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgtConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpgtDataArr[i][1])) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpgtDataArr[i][1])) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgtConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), suCompareConst(suCmpgtDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), suCompareConst(suCmpgtDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
       }
 
    testCaseNum = sizeof(suCmpltDataArr) / sizeof(suCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), _suCmplt(suCmpltDataArr[i][0], suCmpltDataArr[i][1])) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_suCmplt, compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), _suCmplt(suCmpltDataArr[i][0], suCmpltDataArr[i][1])) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpltConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpltDataArr[i][0]), 2, &(suCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpltConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpltDataArr[i][1])) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpltDataArr[i][1])) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpltConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), suCompareConst(suCmpltDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), suCompareConst(suCmpltDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
       }
 
    testCaseNum = sizeof(suCmpgeDataArr) / sizeof(suCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), _suCmpge(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1])) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_suCmpge, compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), _suCmpge(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1])) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgeConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpgeDataArr[i][0]), 2, &(suCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgeConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpgeDataArr[i][1])) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpgeDataArr[i][1])) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgeConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), suCompareConst(suCmpgeDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), suCompareConst(suCmpgeDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
       }
 
    testCaseNum = sizeof(suCmpleDataArr) / sizeof(suCmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), _suCmple(suCmpleDataArr[i][0], suCmpleDataArr[i][1])) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_suCmple, compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), _suCmple(suCmpleDataArr[i][0], suCmpleDataArr[i][1])) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpleConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpleDataArr[i][0]), 2, &(suCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpleConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpleDataArr[i][1])) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpleDataArr[i][1])) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpleConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(suCmpleDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(suCmpleDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
       }
 
    //ifBuCompare
    testCaseNum = sizeof(ifBuCmpeqDataArr) / sizeof(ifBuCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), _ifBuCmpeq(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBuCmpeq, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), _ifBuCmpeq(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpeqConst1_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpeqDataArr[i][0]), 2, &(ifBuCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpeqConst2_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpeqConst3_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(ifBuCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(ifBuCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBuCmpneDataArr) / sizeof(ifBuCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), _ifBuCmpne(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBuCmpne, compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), _ifBuCmpne(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpneConst1_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpneDataArr[i][0]), 2, &(ifBuCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpneConst2_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpneConst3_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), buCompareConst(ifBuCmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), buCompareConst(ifBuCmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBuCmpgtDataArr) / sizeof(ifBuCmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), _ifBuCmpgt(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBuCmpgt, compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), _ifBuCmpgt(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpgtConst1_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpgtDataArr[i][0]), 2, &(ifBuCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpgtConst2_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpgtConst3_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), buCompareConst(ifBuCmpgtDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), buCompareConst(ifBuCmpgtDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBuCmpltDataArr) / sizeof(ifBuCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), _ifBuCmplt(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBuCmplt, compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), _ifBuCmplt(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpltConst1_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpltDataArr[i][0]), 2, &(ifBuCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpltConst2_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpltConst3_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), buCompareConst(ifBuCmpltDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), buCompareConst(ifBuCmpltDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBuCmpgeDataArr) / sizeof(ifBuCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), _ifBuCmpge(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBuCmpge, compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), _ifBuCmpge(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpgeConst1_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpgeDataArr[i][0]), 2, &(ifBuCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpgeConst2_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpgeConst3_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), buCompareConst(ifBuCmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), buCompareConst(ifBuCmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBuCmpleDataArr) / sizeof(ifBuCmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), _ifBuCmple(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifBuCmple, compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), _ifBuCmple(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpleConst1_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpleDataArr[i][0]), 2, &(ifBuCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpleConst2_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpleConst3_TestCase%d", i + 1);
       buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifbucmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), buCompareConst(ifBuCmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(buCompareConst, compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), buCompareConst(ifBuCmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    //ifSuCompare
    testCaseNum = sizeof(ifSuCmpeqDataArr) / sizeof(ifSuCmpeqDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), _ifSuCmpeq(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1])) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_ifSuCmpeq, compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), _ifSuCmpeq(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1])) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpeqConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpeqDataArr[i][0]), 2, &(ifSuCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpeqConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpeqDataArr[i][1])) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpeqDataArr[i][1])) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpeqConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), suCompareConst(ifSuCmpeqDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), suCompareConst(ifSuCmpeqDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
       }
 
    testCaseNum = sizeof(ifSuCmpneDataArr) / sizeof(ifSuCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), _ifSuCmpne(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1])) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_ifSuCmpne, compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), _ifSuCmpne(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1])) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpneConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpneDataArr[i][0]), 2, &(ifSuCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpneConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpneDataArr[i][1])) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpneDataArr[i][1])) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpneConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), suCompareConst(ifSuCmpneDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), suCompareConst(ifSuCmpneDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
       }
 
    testCaseNum = sizeof(ifSuCmpgtDataArr) / sizeof(ifSuCmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), _ifSuCmpgt(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1])) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_ifSuCmpgt, compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), _ifSuCmpgt(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1])) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgtConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpgtDataArr[i][0]), 2, &(ifSuCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgtConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpgtDataArr[i][1])) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpgtDataArr[i][1])) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgtConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), suCompareConst(ifSuCmpgtDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), suCompareConst(ifSuCmpgtDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
       }
 
    testCaseNum = sizeof(ifSuCmpltDataArr) / sizeof(ifSuCmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), _ifSuCmplt(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1])) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_ifSuCmplt, compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), _ifSuCmplt(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1])) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpltConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpltDataArr[i][0]), 2, &(ifSuCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpltConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpltDataArr[i][1])) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpltDataArr[i][1])) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpltConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), suCompareConst(ifSuCmpltDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), suCompareConst(ifSuCmpltDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
       }
 
    testCaseNum = sizeof(ifSuCmpgeDataArr) / sizeof(ifSuCmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), _ifSuCmpge(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1])) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_ifSuCmpge, compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), _ifSuCmpge(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1])) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgeConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpgeDataArr[i][0]), 2, &(ifSuCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgeConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpgeDataArr[i][1])) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpgeDataArr[i][1])) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgeConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), suCompareConst(ifSuCmpgeDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), suCompareConst(ifSuCmpgeDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
       }
 
    testCaseNum = sizeof(ifSuCmpleDataArr) / sizeof(ifSuCmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), _ifSuCmple(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1])) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
+      OMR_CT_EXPECT_EQ(_ifSuCmple, compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), _ifSuCmple(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1])) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpleConst1_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpleDataArr[i][0]), 2, &(ifSuCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpleConst2_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpleDataArr[i][1])) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpleDataArr[i][1])) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpleConst3_TestCase%d", i + 1);
       suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifsucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), suCompareConst(ifSuCmpleDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
+      OMR_CT_EXPECT_EQ(suCompareConst, compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), suCompareConst(ifSuCmpleDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
       }
    }
 
@@ -4465,7 +4483,7 @@ X86OpCodesTest::invokeAddressTests()
    testCaseNum = sizeof(aUnaryDataArr) / sizeof(aUnaryDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(aUnaryDataArr[i], _acall(aUnaryDataArr[i]));
+      OMR_CT_EXPECT_EQ(_acall, aUnaryDataArr[i], _acall(aUnaryDataArr[i]));
       }
 
 #if defined(TR_TARGET_32BIT)
@@ -4474,45 +4492,45 @@ X86OpCodesTest::invokeAddressTests()
    testCaseNum = sizeof(intDataArr) / sizeof(intDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(intDataArr[i], ADDRESS_PLACEHOLDER_1), _i2a(intDataArr[i]));
+      OMR_CT_EXPECT_EQ(_i2a, convert(intDataArr[i], ADDRESS_PLACEHOLDER_1), _i2a(intDataArr[i]));
 
       sprintf(resolvedMethodName, "i2aConst%d", i + 1);
       i2aConst = (signatureCharI_L_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::i2a, resolvedMethodName, _argTypesUnaryInt, TR::Address, rc, 2, 1, &intDataArr[i]));
-      EXPECT_EQ(convert(intDataArr[i], ADDRESS_PLACEHOLDER_1), i2aConst(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(i2aConst, convert(intDataArr[i], ADDRESS_PLACEHOLDER_1), i2aConst(INT_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(uintDataArr) / sizeof(uintDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(uintDataArr[i], ADDRESS_PLACEHOLDER_1), _iu2a(uintDataArr[i]));
+      OMR_CT_EXPECT_EQ(_iu2a, convert(uintDataArr[i], ADDRESS_PLACEHOLDER_1), _iu2a(uintDataArr[i]));
 
       sprintf(resolvedMethodName, "iu2aConst%d", i + 1);
       iu2aConst = (unsignedSignatureCharI_L_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::iu2a, resolvedMethodName, _argTypesUnaryInt, TR::Address, rc, 2, 1, &uintDataArr[i]));
-      EXPECT_EQ(convert(uintDataArr[i], ADDRESS_PLACEHOLDER_1), iu2aConst(INT_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(iu2aConst, convert(uintDataArr[i], ADDRESS_PLACEHOLDER_1), iu2aConst(INT_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(aUnaryDataArr) / sizeof(aUnaryDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(aUnaryDataArr[i], SHORT_POS), _a2s(aUnaryDataArr[i]));
+      OMR_CT_EXPECT_EQ(_a2s, convert(aUnaryDataArr[i], SHORT_POS), _a2s(aUnaryDataArr[i]));
 
       sprintf(resolvedMethodName, "a2sConst%d", i + 1);
       a2sConst = (signatureCharL_S_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::a2s, resolvedMethodName, _argTypesUnaryAddress, TR::Int16, rc, 2, 1, &aUnaryDataArr[i]));
-      EXPECT_EQ(convert(aUnaryDataArr[i], SHORT_POS), a2sConst(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(a2sConst, convert(aUnaryDataArr[i], SHORT_POS), a2sConst(ADDRESS_PLACEHOLDER_1));
       }
 
    testCaseNum = sizeof(aUnaryDataArr) / sizeof(aUnaryDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(aUnaryDataArr[i], BYTE_POS), _a2b(aUnaryDataArr[i]));
+      OMR_CT_EXPECT_EQ(_a2b, convert(aUnaryDataArr[i], BYTE_POS), _a2b(aUnaryDataArr[i]));
 
       sprintf(resolvedMethodName, "a2bConst%d", i + 1);
       a2bConst = (signatureCharL_B_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::a2b, resolvedMethodName, _argTypesUnaryAddress, TR::Int8, rc, 2, 1, &aUnaryDataArr[i]));
-      EXPECT_EQ(convert(aUnaryDataArr[i], BYTE_POS), a2bConst(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(a2bConst, convert(aUnaryDataArr[i], BYTE_POS), a2bConst(ADDRESS_PLACEHOLDER_1));
       }
 #endif //defined(TR_TARGET_32BIT)
 
@@ -4521,112 +4539,112 @@ X86OpCodesTest::invokeAddressTests()
    testCaseNum = sizeof(longDataArr) / sizeof(longDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(longDataArr[i], ADDRESS_PLACEHOLDER_1), _l2a(longDataArr[i]));
+      OMR_CT_EXPECT_EQ(_l2a, convert(longDataArr[i], ADDRESS_PLACEHOLDER_1), _l2a(longDataArr[i]));
 
       sprintf(resolvedMethodName, "l2aConst%d", i + 1);
       l2aConst = (signatureCharJ_L_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::l2a, resolvedMethodName, _argTypesUnaryLong, TR::Address, rc, 2, 1, &longDataArr[i]));
-      EXPECT_EQ(convert(longDataArr[i], ADDRESS_PLACEHOLDER_1), l2aConst(LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(l2aConst, convert(longDataArr[i], ADDRESS_PLACEHOLDER_1), l2aConst(LONG_PLACEHOLDER_1));
       }
 
    //a2l
    testCaseNum = sizeof(aUnaryDataArr) / sizeof(aUnaryDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(aUnaryDataArr[i], LONG_POS), _a2l(aUnaryDataArr[i]));
+      OMR_CT_EXPECT_EQ(_a2l, convert(aUnaryDataArr[i], LONG_POS), _a2l(aUnaryDataArr[i]));
 
       sprintf(resolvedMethodName, "a2lConst%d", i + 1);
       a2lConst = (signatureCharL_J_testMethodType *) (compileOpCodeMethod(
             _numberOfUnaryArgs, TR::a2l, resolvedMethodName, _argTypesUnaryAddress, TR::Int64, rc, 2, 1, &aUnaryDataArr[i]));
-      EXPECT_EQ(convert(aUnaryDataArr[i], LONG_POS), a2lConst(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(a2lConst, convert(aUnaryDataArr[i], LONG_POS), a2lConst(ADDRESS_PLACEHOLDER_1));
       }
 
    //acmpeq
    testCaseNum = sizeof(acmpeqDataArr) / sizeof(acmpeqDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), _acmpeq(acmpeqDataArr[i][0], acmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_acmpeq, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), _acmpeq(acmpeqDataArr[i][0], acmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpeqConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpeqDataArr[i][0]), 2, &(acmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "aCmpeqConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpeqConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(acmpeqDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(acmpeqDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    //acmpne
    testCaseNum = sizeof(acmpneDataArr) / sizeof(acmpneDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), _acmpne(acmpneDataArr[i][0], acmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_acmpne, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), _acmpne(acmpneDataArr[i][0], acmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpneConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpneDataArr[i][0]), 2, &(acmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "aCmpneConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpneConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(acmpneDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(acmpneDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    //ifacmpeq
    testCaseNum = sizeof(ifacmpeqDataArr) / sizeof(ifacmpeqDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), _ifacmpeq(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifacmpeq, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), _ifacmpeq(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpeqConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpeqDataArr[i][0]), 2, &(ifacmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpeqConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpeqConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ifacmpeqDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ifacmpeqDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    //ifacmpne
    testCaseNum = sizeof(ifacmpneDataArr) / sizeof(ifacmpneDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), _ifacmpne(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifacmpne, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), _ifacmpne(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpneConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpneDataArr[i][0]), 2, &(ifacmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpneConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpneConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ifacmpneDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ifacmpneDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    //aternary
@@ -4635,42 +4653,42 @@ X86OpCodesTest::invokeAddressTests()
    testCaseNum = sizeof(aternaryChild1Arr) / sizeof(aternaryChild1Arr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), _aternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]));
+      OMR_CT_EXPECT_EQ(_aternary, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), _aternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]));
 
       sprintf(resolvedMethodName, "aTernaryConst1_TestCase%d", i + 1);
       aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
             _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 6, 1, &aternaryChild1Arr[i], 2, &aternaryArr[i][0], 3, &aternaryArr[i][1]));
-      EXPECT_EQ(ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "aTernaryConst2_TestCase%d", i + 1);
       aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
             _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 1, &aternaryChild1Arr[i], 2, &aternaryArr[i][0]));
-      EXPECT_EQ(ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, aternaryArr[i][1]));
+      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, aternaryArr[i][1]));
 
       sprintf(resolvedMethodName, "aTernaryConst3_TestCase%d", i + 1);
       aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
             _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 1, &aternaryChild1Arr[i], 3, &aternaryArr[i][1]));
-      EXPECT_EQ(ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(ADDRESS_PLACEHOLDER_1, aternaryArr[i][0], ADDRESS_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(ADDRESS_PLACEHOLDER_1, aternaryArr[i][0], ADDRESS_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "aTernaryConst4_TestCase%d", i + 1);
       aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
             _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 2, &aternaryArr[i][0], 3, &aternaryArr[i][1]));
-      EXPECT_EQ(ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "aTernaryConst5_TestCase%d", i + 1);
       aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
             _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 1, &aternaryChild1Arr[i]));
-      EXPECT_EQ(ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(ADDRESS_PLACEHOLDER_1, aternaryArr[i][0], aternaryArr[i][1]));
+      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(ADDRESS_PLACEHOLDER_1, aternaryArr[i][0], aternaryArr[i][1]));
 
       sprintf(resolvedMethodName, "aTernaryConst6_TestCase%d", i + 1);
       aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
             _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 2, &aternaryArr[i][0]));
-      EXPECT_EQ(ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], ADDRESS_PLACEHOLDER_1, aternaryArr[i][1]));
+      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], ADDRESS_PLACEHOLDER_1, aternaryArr[i][1]));
 
       sprintf(resolvedMethodName, "aTernaryConst7_TestCase%d", i + 1);
       aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
             _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 3, &aternaryArr[i][1]));
-      EXPECT_EQ(ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], aternaryArr[i][0], ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], aternaryArr[i][0], ADDRESS_PLACEHOLDER_1));
       }
 #endif //defined(TR_TARGET_64BIT)
    }
@@ -4711,35 +4729,35 @@ X86OpCodesTest::invokeTernaryTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "lTernaryConst%d", i + 1);
-      EXPECT_EQ(ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), _lternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]));
+      OMR_CT_EXPECT_EQ(_lternary, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), _lternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]));
 
       lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
             resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 6, 1, &lternaryChild1Arr[i], 2, &longArr[i][0], 3, &longArr[i][1]));
-      EXPECT_EQ(ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
 
       lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
             resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 1, &lternaryChild1Arr[i], 2, &longArr[i][0]));
-      EXPECT_EQ(ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, longArr[i][1]));
+      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, longArr[i][1]));
 
       lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
             resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 1, &lternaryChild1Arr[i], 3, &longArr[i][1]));
-      EXPECT_EQ(ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, longArr[i][0], LONG_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, longArr[i][0], LONG_PLACEHOLDER_3));
 
       lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
             resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 2, &longArr[i][0], 3, &longArr[i][1]));
-      EXPECT_EQ(ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
+      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
 
       lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
             resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 1, &lternaryChild1Arr[i]));
-      EXPECT_EQ(ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, longArr[i][0], longArr[i][1]));
+      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, longArr[i][0], longArr[i][1]));
 
       lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
             resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 2, &longArr[i][0]));
-      EXPECT_EQ(ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], LONG_PLACEHOLDER_1, longArr[i][1]));
+      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], LONG_PLACEHOLDER_1, longArr[i][1]));
 
       lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
             resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 3, &longArr[i][1]));
-      EXPECT_EQ(ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], longArr[i][0], LONG_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], longArr[i][0], LONG_PLACEHOLDER_1));
       }
    }
 
@@ -4817,11 +4835,11 @@ X86OpCodesTest::invokeDirectCallTests()
 
    for (int32_t i = 0; i < 5; i++)
       {
-      EXPECT_EQ(intDataArray[i], _iCall(intDataArray[i]));
-      EXPECT_DOUBLE_EQ(doubleDataArray[i], _dCall(doubleDataArray[i]));
-      EXPECT_FLOAT_EQ(floatDataArray[i], _fCall(floatDataArray[i]));
+      OMR_CT_EXPECT_EQ(_iCall, intDataArray[i], _iCall(intDataArray[i]));
+      OMR_CT_EXPECT_DOUBLE_EQ(_dCall, doubleDataArray[i], _dCall(doubleDataArray[i]));
+      OMR_CT_EXPECT_FLOAT_EQ(_fCall, floatDataArray[i], _fCall(floatDataArray[i]));
 #if defined(TR_TARGET_64BIT)
-      EXPECT_EQ(longDataArray[i], _lCall(longDataArray[i]));
+      OMR_CT_EXPECT_EQ(_lCall, longDataArray[i], _lCall(longDataArray[i]));
 #endif
       }
    }
@@ -4845,21 +4863,21 @@ X86OpCodesTest::invokeDisabledIntegerArithmeticTests()
    {
    //unsigned integer constant test will be enabled in another work item.
    //iumul : overflow just cut
-   EXPECT_EQ(mul(UINT_MAXIMUM, UINT_MINIMUM), _iuMul(UINT_MAXIMUM, UINT_MINIMUM));
-   EXPECT_EQ(mul(UINT_MINIMUM, UINT_POS), _iuMul(UINT_MINIMUM, UINT_POS));
-   EXPECT_EQ(mul(UINT_POS, UINT_MAXIMUM), _iuMul(UINT_POS, UINT_MAXIMUM));
+   OMR_CT_EXPECT_EQ(_iuMul, mul(UINT_MAXIMUM, UINT_MINIMUM), _iuMul(UINT_MAXIMUM, UINT_MINIMUM));
+   OMR_CT_EXPECT_EQ(_iuMul, mul(UINT_MINIMUM, UINT_POS), _iuMul(UINT_MINIMUM, UINT_POS));
+   OMR_CT_EXPECT_EQ(_iuMul, mul(UINT_POS, UINT_MAXIMUM), _iuMul(UINT_POS, UINT_MAXIMUM));
 
    //iudiv
    // TODO: Use ASSERT_DEATH() to catch Remainder by zero which will get "Floating point exception (core dumped)"
    // Test secnario : _iuDiv(UINT_MAXIMUM, 0)
-   EXPECT_EQ(div(UINT_MAXIMUM, UINT_POS), _iuDiv(UINT_MAXIMUM, UINT_POS));
-   EXPECT_EQ(div(UINT_MINIMUM, UINT_POS), _iuDiv(UINT_MINIMUM, UINT_POS));
+   OMR_CT_EXPECT_EQ(_iuDiv, div(UINT_MAXIMUM, UINT_POS), _iuDiv(UINT_MAXIMUM, UINT_POS));
+   OMR_CT_EXPECT_EQ(_iuDiv, div(UINT_MINIMUM, UINT_POS), _iuDiv(UINT_MINIMUM, UINT_POS));
 
    //iurem
    // TODO: Use ASSERT_DEATH() to catch Remainder by zero which will get "Floating point exception (core dumped)"
    // Test secnario : _iuRem(UINT_MAXIMUM, 0)
-   EXPECT_EQ(rem(UINT_POS, UINT_MAXIMUM),       _iuRem(UINT_POS, UINT_MAXIMUM));
-   EXPECT_EQ(rem(UINT_MAXIMUM, UINT_MAXIMUM),      _iuRem(UINT_MAXIMUM, UINT_MAXIMUM));
+   OMR_CT_EXPECT_EQ(_iuRem, rem(UINT_POS, UINT_MAXIMUM), _iuRem(UINT_POS, UINT_MAXIMUM));
+   OMR_CT_EXPECT_EQ(_iuRem, rem(UINT_MAXIMUM, UINT_MAXIMUM), _iuRem(UINT_MAXIMUM, UINT_MAXIMUM));
 
    int32_t rc = 0;
    uint32_t testCaseArrLength = 0;
@@ -4888,22 +4906,22 @@ X86OpCodesTest::invokeDisabledIntegerArithmeticTests()
    testCaseArrLength = sizeof(ulongDivArr) / sizeof(ulongDivArr[0]);
    for(uint32_t i = 0; i < testCaseArrLength; ++i)
       {
-      EXPECT_EQ(div(ulongDivArr[i][0], ulongDivArr[i][1]), _luDiv(ulongDivArr[i][0], ulongDivArr[i][1]));
+      OMR_CT_EXPECT_EQ(_luDiv, div(ulongDivArr[i][0], ulongDivArr[i][1]), _luDiv(ulongDivArr[i][0], ulongDivArr[i][1]));
 
       sprintf(resolvedMethodName, "luDivConst1_Testcase%d", i);
       luBinaryCons = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ludiv, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &ulongDivArr[i][0], 2, &ulongDivArr[i][1]));
-      EXPECT_EQ(div(ulongDivArr[i][0], ulongDivArr[i][1]), luBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luBinaryCons, div(ulongDivArr[i][0], ulongDivArr[i][1]), luBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "luDivConst2_Testcase%d", i);
       luBinaryCons = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ludiv, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &ulongDivArr[i][0]));
-      EXPECT_EQ(div(ulongDivArr[i][0], ulongDivArr[i][1]), luBinaryCons(LONG_PLACEHOLDER_1, ulongDivArr[i][1]));
+      OMR_CT_EXPECT_EQ(luBinaryCons, div(ulongDivArr[i][0], ulongDivArr[i][1]), luBinaryCons(LONG_PLACEHOLDER_1, ulongDivArr[i][1]));
 
       sprintf(resolvedMethodName, "luDivConst3_Testcase%d", i);
       luBinaryCons = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ludiv, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &ulongDivArr[i][1]));
-      EXPECT_EQ(div(ulongDivArr[i][0], ulongDivArr[i][1]), luBinaryCons(ulongDivArr[i][0], LONG_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(luBinaryCons, div(ulongDivArr[i][0], ulongDivArr[i][1]), luBinaryCons(ulongDivArr[i][0], LONG_PLACEHOLDER_2));
       }
 
 #endif
@@ -5024,254 +5042,254 @@ X86OpCodesTest::invokeDisabledCompareOpCodesTest()
    testCaseNum = sizeof(acmpeqDataArr) / sizeof(acmpeqDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), _acmpeq(acmpeqDataArr[i][0], acmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_acmpeq, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), _acmpeq(acmpeqDataArr[i][0], acmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpeqConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpeqDataArr[i][0]), 2, &(acmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "aCmpeqConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpeqConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(acmpeqDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(acmpeqDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(acmpneDataArr) / sizeof(acmpneDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), _acmpne(acmpneDataArr[i][0], acmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_acmpne, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), _acmpne(acmpneDataArr[i][0], acmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpneConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpneDataArr[i][0]), 2, &(acmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "aCmpneConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpneConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(acmpneDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(acmpneDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(acmpgtDataArr) / sizeof(acmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), _acmpgt(acmpgtDataArr[i][0], acmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_acmpgt, compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), _acmpgt(acmpgtDataArr[i][0], acmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpgtConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpgtDataArr[i][0]), 2, &(acmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "acmpgtConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpgtConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), aCompareConst(acmpgtDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), aCompareConst(acmpgtDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(acmpltDataArr) / sizeof(acmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), _acmplt(acmpltDataArr[i][0], acmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_acmplt, compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), _acmplt(acmpltDataArr[i][0], acmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpltConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpltDataArr[i][0]), 2, &(acmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "acmpltConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpltConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), aCompareConst(acmpltDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), aCompareConst(acmpltDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(acmpgeDataArr) / sizeof(acmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), _acmpge(acmpgeDataArr[i][0], acmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_acmpge, compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), _acmpge(acmpgeDataArr[i][0], acmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpgeConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpgeDataArr[i][0]), 2, &(acmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "acmpgeConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpgeConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), aCompareConst(acmpgeDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), aCompareConst(acmpgeDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(acmpleDataArr) / sizeof(acmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), _acmple(acmpleDataArr[i][0], acmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_acmple, compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), _acmple(acmpleDataArr[i][0], acmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpleConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpleDataArr[i][0]), 2, &(acmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "acmpleConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpleConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::acmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), aCompareConst(acmpleDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), aCompareConst(acmpleDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    //address ifcompare
    testCaseNum = sizeof(ifacmpeqDataArr) / sizeof(ifacmpeqDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), _ifacmpeq(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifacmpeq, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), _ifacmpeq(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpeqConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpeqDataArr[i][0]), 2, &(ifacmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpeqConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpeqDataArr[i][0])));
-      EXPECT_EQ(compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpeqDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpeqConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpeqDataArr[i][1])));
-      EXPECT_EQ(compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ifacmpeqDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ifacmpeqDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifacmpneDataArr) / sizeof(ifacmpneDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), _ifacmpne(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifacmpne, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), _ifacmpne(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpneConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpneDataArr[i][0]), 2, &(ifacmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpneConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpneDataArr[i][0])));
-      EXPECT_EQ(compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpneDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpneConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpneDataArr[i][1])));
-      EXPECT_EQ(compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ifacmpneDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ifacmpneDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifacmpgtDataArr) / sizeof(ifacmpgtDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), _ifacmpgt(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifacmpgt, compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), _ifacmpgt(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpgtConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpgtDataArr[i][0]), 2, &(ifacmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpgtConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpgtDataArr[i][0])));
-      EXPECT_EQ(compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpgtDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpgtConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpgtDataArr[i][1])));
-      EXPECT_EQ(compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), aCompareConst(ifacmpgtDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), aCompareConst(ifacmpgtDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifacmpltDataArr) / sizeof(ifacmpltDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), _ifacmplt(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifacmplt, compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), _ifacmplt(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpltConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpltDataArr[i][0]), 2, &(ifacmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpltConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpltDataArr[i][0])));
-      EXPECT_EQ(compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpltDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpltConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpltDataArr[i][1])));
-      EXPECT_EQ(compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), aCompareConst(ifacmpltDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), aCompareConst(ifacmpltDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifacmpgeDataArr) / sizeof(ifacmpgeDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), _ifacmpge(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifacmpge, compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), _ifacmpge(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpgeConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpgeDataArr[i][0]), 2, &(ifacmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpgeConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpgeDataArr[i][0])));
-      EXPECT_EQ(compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpgeDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpgeConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpgeDataArr[i][1])));
-      EXPECT_EQ(compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), aCompareConst(ifacmpgeDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), aCompareConst(ifacmpgeDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifacmpleDataArr) / sizeof(ifacmpleDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
-      EXPECT_EQ(compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), _ifacmple(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_ifacmple, compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), _ifacmple(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpleConst1_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpleDataArr[i][0]), 2, &(ifacmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpleConst2_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpleDataArr[i][0])));
-      EXPECT_EQ(compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpleConst3_TestCase%d", i + 1);
       aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
             _numberOfBinaryArgs, TR::ifacmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpleDataArr[i][1])));
-      EXPECT_EQ(compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ifacmpleDataArr[i][0], ADDRESS_PLACEHOLDER_2));
+      OMR_CT_EXPECT_EQ(aCompareConst, compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ifacmpleDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 #endif
    }
@@ -5309,11 +5327,11 @@ X86OpCodesTest::invokeDisabledConvertOpCodesTest()
    testCaseNum = sizeof(aUnaryDataArr) / sizeof(aUnaryDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      EXPECT_EQ(convert(aUnaryDataArr[i], LONG_POS), _a2l(aUnaryDataArr[i]));
+      OMR_CT_EXPECT_EQ(_a2l, convert(aUnaryDataArr[i], LONG_POS), _a2l(aUnaryDataArr[i]));
 
       sprintf(resolvedMethodName, "a2lConst%d", i + 1);
       a2lConst = (signatureCharL_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::a2l, resolvedMethodName, _argTypesUnaryAddress, TR::Int64, rc, 2, 1, &aUnaryDataArr[i]));
-      EXPECT_EQ(convert(aUnaryDataArr[i], LONG_POS), a2lConst(ADDRESS_PLACEHOLDER_1));
+      OMR_CT_EXPECT_EQ(a2lConst, convert(aUnaryDataArr[i], LONG_POS), a2lConst(ADDRESS_PLACEHOLDER_1));
       }
 #endif
    }
@@ -5334,7 +5352,7 @@ X86OpCodesTest::invokeDisabledMemoryOpCodesTest()
    int8_t byteDataArray[] = {BYTE_NEG, BYTE_POS, BYTE_MAXIMUM, BYTE_MINIMUM, BYTE_ZERO};
    int8_t byteStoreDataArray[] = {0, 0, 0, 0, 0};
    uint32_t testCaseNum = sizeof(byteDataArray) / sizeof(byteDataArray[0]);
-   for (int32_t i = 0 ; i < testCaseNum ; i++)
+   for (int32_t i = 0 ; _bStorei != NULL && i < testCaseNum ; i++)
       {
       _bStorei((uintptrj_t)(&byteStoreDataArray[i]) , byteDataArray[i]);
       EXPECT_EQ(byteDataArray[i], byteStoreDataArray[i]);


### PR DESCRIPTION
1. Check for any compilation failing after each method compile.
2. Make sure the starting PC of a compiled method is non-NULL before
invoking it by using a new macro OMR_CT_EXPECT_EQ.
3. Add a new compilation status, namely COMPILATION_REQUESTED. It is
used to track when a method compilation doesn't succeed but doesn't
fail either, i.e. compilation exiting earlier due to user limiting
methods, not being able to create an optimization plan, etc.

Signed-off-by: Xiaoli Liang <xsliang@ca.ibm.com>