### PR TITLE
Cleanup Test compiler environment

### DIFF
--- a/fvtest/compilertest/tests/OMRTestEnv.cpp
+++ b/fvtest/compilertest/tests/OMRTestEnv.cpp
@@ -30,14 +30,25 @@ extern "C" bool initializeTestJit(TR_RuntimeHelper *helperIDs, void **helperAddr
 extern "C" void shutdownJit();
 
 void
-OMRTestEnv::SetUp()
+TestCompiler::OMRTestEnv::SetUp()
    {
-   initializeTestJit(0, 0, 0, "-Xjit");
+   initialize("-Xjit");
    }
 
 void
-OMRTestEnv::TearDown()
+TestCompiler::OMRTestEnv::TearDown()
+   {
+   shutdown();
+   }
+
+void
+TestCompiler::OMRTestEnv::initialize(char *options)
+   {
+   initializeTestJit(0, 0, 0, options);
+   }
+
+void
+TestCompiler::OMRTestEnv::shutdown()
    {
    shutdownJit();
    }
-

--- a/fvtest/compilertest/tests/OMRTestEnv.cpp
+++ b/fvtest/compilertest/tests/OMRTestEnv.cpp
@@ -26,15 +26,13 @@
 #include <errno.h>
 #include "OMRTestEnv.hpp"
 
-extern "C" bool initializeTestJit(TR_RuntimeHelper *helperIDs, void **helperAddresses, int32_t numHelpers, char *options, TR_Memory **m);
+extern "C" bool initializeTestJit(TR_RuntimeHelper *helperIDs, void **helperAddresses, int32_t numHelpers, char *options);
 extern "C" void shutdownJit();
-
-TR_Memory * OMRTestEnv::_trMemory = 0;
 
 void
 OMRTestEnv::SetUp()
    {
-   initializeTestJit(0, 0, 0, "-Xjit", &_trMemory);
+   initializeTestJit(0, 0, 0, "-Xjit");
    }
 
 void

--- a/fvtest/compilertest/tests/OMRTestEnv.hpp
+++ b/fvtest/compilertest/tests/OMRTestEnv.hpp
@@ -28,12 +28,17 @@
 
 class TR_Memory;
 
+namespace TestCompiler {
+
 class OMRTestEnv : public testing::Environment
    {
    public:
    virtual void SetUp();
    virtual void TearDown();
+   static void initialize(char *options);
+   static void shutdown();
 };
 
+}
 
 #endif /* TEST_TESTS_OMRTESTENV_HPP_ */

--- a/fvtest/compilertest/tests/OMRTestEnv.hpp
+++ b/fvtest/compilertest/tests/OMRTestEnv.hpp
@@ -33,10 +33,6 @@ class OMRTestEnv : public testing::Environment
    public:
    virtual void SetUp();
    virtual void TearDown();
-   static TR_Memory *trMemory() { return _trMemory; }
-
-   private:
-   static TR_Memory *_trMemory;
 };
 
 

--- a/fvtest/compilertest/tests/main.cpp
+++ b/fvtest/compilertest/tests/main.cpp
@@ -35,6 +35,6 @@
 int main(int argc, char **argv)
    {
    ::testing::InitGoogleTest(&argc, argv);
-   ::testing::AddGlobalTestEnvironment(new OMRTestEnv);
+   ::testing::AddGlobalTestEnvironment(new TestCompiler::OMRTestEnv);
    return RUN_ALL_TESTS();
    }

--- a/fvtest/porttest/omrfilestreamTest.cpp
+++ b/fvtest/porttest/omrfilestreamTest.cpp
@@ -901,6 +901,7 @@ writeOnlyTest:
 	/*umask vary so we can't test 'isGroupWritable', 'isGroupReadable', 'isOtherWritable', or 'isOtherReadable'*/
 #endif /* defined(WIN32) */
 
+	rc = omrfile_unlink(filename);
 	if (0 != rc) {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_unlink failed: %s\n", filename);
 			goto exit;


### PR DESCRIPTION
This includes various fixes for the Test compiler. Namely, it deletes a left over test file, fixes an incorrect function declaration, and splits up `OMRTestEnv`'s JIT initialization and shutdown into their own methods.

These are preliminary to testing limitfiles, which is tracked in my [test-limit-files](https://github.com/noryb009/omr/tree/test-limit-files) branch.