### PR TITLE
Simplify widened and operations

### DIFF
--- a/compiler/ilgen/IlInjector.cpp
+++ b/compiler/ilgen/IlInjector.cpp
@@ -273,6 +273,11 @@ OMR::IlInjector::i2l(TR::Node *n)
    return TR::Node::create(TR::i2l, 1, n);
    }
 
+TR::Node *
+OMR::IlInjector::iu2l(TR::Node *n)
+   {
+   return TR::Node::create(TR::iu2l, 1, n);
+   }
 
 void
 OMR::IlInjector::ifjump(TR::ILOpCodes op,

--- a/compiler/ilgen/IlInjector.hpp
+++ b/compiler/ilgen/IlInjector.hpp
@@ -108,6 +108,7 @@ public:
    void                           storeToTemp(TR::SymbolReference *tempSymRef, TR::Node *value);
    TR::Node                     * loadTemp(TR::SymbolReference *tempSymRef);
    TR::Node                     * i2l(TR::Node *n);
+   TR::Node                     * iu2l(TR::Node *n);
 
    void                           ifjump(TR::ILOpCodes op, TR::Node *first, TR::Node *second, TR::Block *targetBlock);
    void                           ifjump(TR::ILOpCodes op, TR::Node *first, TR::Node *second, int32_t targetBlockNumber);

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -10967,6 +10967,11 @@ TR::Node *iandSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    orderChildren(node, firstChild, secondChild, s);
    BINARY_IDENTITY_OR_ZERO_OP(int32_t, Int, -1, 0)
 
+   if (TR::Node* foldedNode = tryFoldAndWidened(s, node))
+      {
+      return foldedNode;
+      }
+
    TR::ILOpCodes firstChildOp  = firstChild->getOpCodeValue();
    TR::ILOpCodes secondChildOp = secondChild->getOpCodeValue();
 
@@ -11109,6 +11114,11 @@ TR::Node *landSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    orderChildren(node, firstChild, secondChild, s);
    orderChildrenByHighWordZero(node, firstChild, secondChild, s);
    BINARY_IDENTITY_OR_ZERO_OP(int64_t, LongInt, -1L, 0L)
+
+   if (TR::Node* foldedNode = tryFoldAndWidened(s, node))
+      {
+      return foldedNode;
+      }
 
    TR::ILOpCodes firstChildOp  = firstChild->getOpCodeValue();
    TR::ILOpCodes secondChildOp = secondChild->getOpCodeValue();
@@ -11317,6 +11327,12 @@ TR::Node *sandSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       }
    orderChildren(node, firstChild, secondChild, s);
    BINARY_IDENTITY_OR_ZERO_OP(int16_t, ShortInt, -1, 0)
+
+   if (TR::Node* foldedNode = tryFoldAndWidened(s, node))
+      {
+      return foldedNode;
+      }
+
    return node;
    }
 

--- a/compiler/optimizer/OMRSimplifierHelpers.hpp
+++ b/compiler/optimizer/OMRSimplifierHelpers.hpp
@@ -85,6 +85,7 @@ bool swapChildren(TR::Node * node, TR::Node * & firstChild, TR::Node * & secondC
 bool isExprInvariant(TR_RegionStructure *region, TR::Node *node);
 void orderChildren(TR::Node * node, TR::Node * & firstChild, TR::Node * & secondChild, TR::Simplifier * s);
 TR::Node *foldRedundantAND(TR::Node * node, TR::ILOpCodes andOpCode, TR::ILOpCodes constOpCode, int64_t andVal, TR::Simplifier * s);
+TR::Node* tryFoldAndWidened(TR::Simplifier* simplifier, TR::Node* node);
 bool branchToFollowingBlock(TR::Node * node, TR::Block * block, TR::Compilation *comp);
 void makeConstantTheRightChild(TR::Node * node, TR::Node * & firstChild, TR::Node * & secondChild, TR::Simplifier * s);
 void makeConstantTheRightChildAndSetOpcode(TR::Node * node, TR::Node * & firstChild, TR::Node * & secondChild, TR::Simplifier * s);

--- a/fvtest/compilertest/README.md
+++ b/fvtest/compilertest/README.md
@@ -6,10 +6,13 @@ language independent compiler tests for the Testarossa compiler technology.
 
 Building
 --------
+Before building the Test compiler you must make sure to configure the project
+by following the 'Basic configuration and compile' step as outlined in the 
+top-level `omr/README.md` document.
 
 To build the Test compiler, typing `make` in this directory
 (`omr/fvtest/compilertest`) should suffice. A binary called 
-`testjit` will be produced in `../../objs/compilertest_$(BUILD_CONFIG)/`
+`testjit` will be produced in the top-level `omr` directory.
 
 BUILD_CONFIG defaults to prod. 
 

--- a/fvtest/compilertest/build/files/common.mk
+++ b/fvtest/compilertest/build/files/common.mk
@@ -201,6 +201,8 @@ JIT_PRODUCT_SOURCE_FILES+=\
     $(JIT_PRODUCT_DIR)/tests/PPCOpCodesTest.cpp \
     $(JIT_PRODUCT_DIR)/tests/Qux2Test.cpp \
     $(JIT_PRODUCT_DIR)/tests/Qux2IlInjector.cpp \
+    $(JIT_PRODUCT_DIR)/tests/SimplifierFoldAndTest.cpp \
+    $(JIT_PRODUCT_DIR)/tests/SimplifierFoldAndIlInjector.cpp \
     $(JIT_PRODUCT_DIR)/tests/S390OpCodesTest.cpp \
     $(JIT_PRODUCT_DIR)/tests/TestDriver.cpp \
     $(JIT_PRODUCT_DIR)/tests/X86OpCodesTest.cpp \

--- a/fvtest/compilertest/tests/SimplifierFoldAndIlInjector.cpp
+++ b/fvtest/compilertest/tests/SimplifierFoldAndIlInjector.cpp
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2000, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+
+#include "compile/Compilation.hpp"
+#include "env/FrontEnd.hpp"
+#include "compile/Method.hpp"
+#include "tests/SimplifierFoldAndIlInjector.hpp"
+#include "ilgen/TypeDictionary.hpp"
+
+namespace TestCompiler
+{
+bool
+SimplifierFoldAndIlInjector::injectIL()
+   {
+   createBlocks(1);
+
+   TR::SymbolReference* i = newTemp(Int64);
+
+   // int64_t i = ((int64_t) parameter) & 0xFFFFFFFF00000000ll;
+   storeToTemp(i,
+         createWithoutSymRef(TR::land, 2,
+               iu2l
+                    (parameter(0, Int32)),
+               lconst(0xFFFFFFFF00000000ll)));
+
+   // return i;
+   returnValue(loadTemp(i));
+
+   return true;
+   }
+}

--- a/fvtest/compilertest/tests/SimplifierFoldAndIlInjector.hpp
+++ b/fvtest/compilertest/tests/SimplifierFoldAndIlInjector.hpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2000, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+
+#include "ilgen/IlInjector.hpp"
+
+namespace TR { class TypeDictionary; }
+
+namespace TestCompiler
+{
+class SimplifierFoldAndIlInjector : public TR::IlInjector
+   {
+   public:
+
+   TR_ALLOC(TR_Memory::IlGenerator)
+
+   SimplifierFoldAndIlInjector(TR::TypeDictionary* types, TestDriver* test)
+   :
+      TR::IlInjector(types, test)
+      {
+      // Void
+      }
+
+   bool injectIL();
+   };
+}

--- a/fvtest/compilertest/tests/SimplifierFoldAndTest.cpp
+++ b/fvtest/compilertest/tests/SimplifierFoldAndTest.cpp
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2000, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+
+#include <limits.h>
+#include <stdio.h>
+#include "compile/Method.hpp"
+#include "tests/SimplifierFoldAndTest.hpp"
+#include "tests/SimplifierFoldAndIlInjector.hpp"
+#include "gtest/gtest.h"
+#include "ilgen/TypeDictionary.hpp"
+#include "ilgen/IlGeneratorMethodDetails_inlines.hpp"
+
+namespace TestCompiler
+{
+SimplifierFoldAndTest::TestCompiledMethodType SimplifierFoldAndTest::testCompiledMethod = 0;
+
+void
+SimplifierFoldAndTest::allocateTestData()
+   {
+   }
+
+void
+SimplifierFoldAndTest::deallocateTestData()
+   {
+   }
+
+void
+SimplifierFoldAndTest::compileTestMethods()
+   {
+   int32_t rc = 0;
+
+   TR::TypeDictionary types;
+
+   TR::IlType* Int32 = types.PrimitiveType(TR::Int32);
+   TR::IlType* Int64 = types.PrimitiveType(TR::Int64);
+
+   int32_t numberOfArguments = 1;
+
+   TR::IlType** argTypes = new TR::IlType*[numberOfArguments]
+   {
+      Int32
+   };
+
+   SimplifierFoldAndIlInjector ilInjector(&types, this);
+
+   TR::ResolvedMethod compilee(__FILE__, LINETOSTR(__LINE__), "simplifierFoldAnd", numberOfArguments, argTypes, Int64, 0, &ilInjector);
+
+   TR::IlGeneratorMethodDetails details(&compilee);
+
+   testCompiledMethod = reinterpret_cast<SimplifierFoldAndTest::TestCompiledMethodType>(compileMethod(details, warm, rc));
+   }
+
+void
+SimplifierFoldAndTest::invokeTests()
+   {
+   ASSERT_EQ(0ll, testCompiledMethod(0));
+   ASSERT_EQ(0ll, testCompiledMethod(1));
+   ASSERT_EQ(0ll, testCompiledMethod(-1));
+   ASSERT_EQ(0ll, testCompiledMethod(-9));
+   ASSERT_EQ(0ll, testCompiledMethod(2147483647));
+   }
+}
+
+TEST(JITSimplifierTest, SimplifierFoldAndTest)
+   {
+   ::TestCompiler::SimplifierFoldAndTest().RunTest();
+   }

--- a/fvtest/compilertest/tests/SimplifierFoldAndTest.hpp
+++ b/fvtest/compilertest/tests/SimplifierFoldAndTest.hpp
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2000, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+
+#include "TestDriver.hpp"
+
+namespace TestCompiler
+{
+class SimplifierFoldAndTest : public TestDriver
+   {
+   public:
+
+   // int64_t testCompiledMethod(int32_t x);
+   typedef int64_t (*TestCompiledMethodType)(int32_t);
+
+   protected:
+
+   virtual void allocateTestData();
+   virtual void compileTestMethods();
+   virtual void invokeTests();
+   virtual void deallocateTestData();
+
+   private:
+
+   static TestCompiledMethodType testCompiledMethod;
+   };
+}


### PR DESCRIPTION
When a widening (extension) operation is found under an and with a constant value such that the constant being anded will never overlap with the unwidened value then such a tree can be folded to zero.