### PR TITLE
Prevent RS pruning for object remembered during CS cycle.

### DIFF
--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -207,7 +207,7 @@ private:
 	 * @param objectPtr The pointer to the  Object in Tenured Space.
 	 * @return True If Object should be remembered
 	 */
-	bool walkObjectSlotsForRSO(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr);
+	bool shouldRememberObject(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr);
 
 	/**
 	 * BackOutFixSlot implementation


### PR DESCRIPTION
If a Tenure object had no Nursery references in initial pass of RS in
Concurrent Scavenger, it would be tagged for removal for the second
pass, but remembered bit would stay set during CS cycle till the second
RS pass. If a Nursery reference was added by mutator to this object, the
generation barrier will do nothing, since the object appears to be
already remembered. However, the second pass will (incorrectly) remove
this object since it is unaware of Nursery reference.

As a temporary solution, during second pass, if object is tagged for
removal, we will re-check if there are indeed no new Nursery references
before removing it from RS.

Also:
- return from object re-scan as soon as the first Nursery ref is found
- a minor enhancement of a couple of debug messages in Scavenger code


Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>