### PR TITLE
Implement ConstString and wrote test for it

### DIFF
--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -893,6 +893,17 @@ IlBuilder::ConstDouble(double value)
    }
 
 TR::IlValue *
+IlBuilder::ConstString(const char* value)
+   {
+   appendBlock();
+   TR::IlValue *returnValue = newValue(Address);
+   storeNode(returnValue, TR::Node::aconst((uintptrj_t)value));
+   TraceIL("IlBuilder[ %p ]::%d is ConstString %p\n", this, returnValue->getCPIndex(), value);
+   ILB_REPLAY("%s = %s->ConstString(%p);", REPLAY_VALUE(returnValue), REPLAY_BUILDER(this), value);
+   return returnValue;
+   }
+
+TR::IlValue *
 IlBuilder::ConstAddress(void* value)
    {
    appendBlock();

--- a/jitbuilder/release/Makefile
+++ b/jitbuilder/release/Makefile
@@ -22,12 +22,13 @@ CXXFLAGS=-g -std=c++0x -O2 -c -fno-rtti -fPIC -I./include/compiler -I./include
 
 .SUFFIXES: .cpp .o
 
-goal: call dotproduct iterfib linkedlist localarray mandelbrot nestedloop pointer recfib simple switch pow2
+goal: call conststring dotproduct iterfib linkedlist localarray mandelbrot nestedloop pointer recfib simple switch pow2
 
 all: goal
 
 test: goal
 	./call
+	./conststring
 	./dotproduct
 	./iterfib
 	./linkedlist
@@ -45,6 +46,11 @@ call : libjitbuilder.a Call.o
 Call.o: src/Call.cpp src/Call.hpp
 	g++ -o $@ $(CXXFLAGS) $<
 
+conststring : libjitbuilder.a ConstString.o	
+	g++ -g -fno-rtti -o $@ ConstString.o -L. -ljitbuilder -ldl
+
+ConstString.o: src/ConstString.cpp src/ConstString.hpp
+	g++ -o $@ $(CXXFLAGS) $<
 
 dotproduct : libjitbuilder.a DotProduct.o
 	g++ -g -fno-rtti -o $@ DotProduct.o -L. -ljitbuilder -ldl
@@ -144,4 +150,4 @@ Pow2.o: src/Pow2.cpp src/Pow2.hpp
 
 
 clean:
-	@rm -f call dotproduct iterfib linkedlist localarray mandelbrot matmult nestedloop pointer recfib simple switch pow2 *.o
+	@rm -f call conststring dotproduct iterfib linkedlist localarray mandelbrot matmult nestedloop pointer recfib simple switch pow2 *.o

--- a/jitbuilder/release/src/ConstString.cpp
+++ b/jitbuilder/release/src/ConstString.cpp
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <dlfcn.h>
+#include <errno.h>
+
+#include "Jit.hpp"
+#include "ilgen/TypeDictionary.hpp"
+#include "ilgen/MethodBuilder.hpp"
+#include "ConstString.hpp"
+
+static void printString(const char* val)
+   {
+   #define PRINTSTRING_LINE LINETOSTR(__LINE__)
+   printf("%s", val);
+   }
+
+ConstStringMethod::ConstStringMethod(TR::TypeDictionary *d)
+   : MethodBuilder(d)
+   {
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   DefineName("testConstString");
+
+   DefineReturnType(NoType);
+
+   DefineFunction((const char* const)"printString", 
+                  (const char* const)__FILE__,
+                  (const char* const)PRINTSTRING_LINE,
+                  (void *)&printString,
+                  NoType,
+                  1,
+                  Address);
+   }
+
+bool
+ConstStringMethod::buildIL()
+   {
+   TR::IlValue* value = ConstString("The test string is: Hello World!\n");
+   Call("printString", 1,
+      value);
+
+   Return();
+
+   return true;
+   }
+
+
+int
+main(int argc, char *argv[])
+   {
+   printf("Step 1: initialize JIT\n");
+   bool initialized = initializeJit();
+   if (!initialized)
+      {
+      fprintf(stderr, "FAIL: could not initialize JIT\n");
+      exit(-1);
+      }
+
+   printf("Step 2: define type dictionary\n");
+   TR::TypeDictionary types;
+
+   printf("Step 3: compile method builder\n");
+   ConstStringMethod method(&types);
+   uint8_t *entry;
+   int32_t rc = compileMethodBuilder(&method, &entry);
+   if (rc != 0)
+      {
+      fprintf(stderr,"FAIL: compilation error %d\n", rc);
+      exit(-2);
+      }
+
+   printf("Step 4: invoke compiled code and verify results\n");
+   ConstStringFunctionType *test = (ConstStringFunctionType *)entry; 
+   test();
+
+   printf ("Step 5: shutdown JIT\n");
+   shutdownJit();
+
+   printf("PASS\n");
+   }

--- a/jitbuilder/release/src/ConstString.hpp
+++ b/jitbuilder/release/src/ConstString.hpp
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+
+#ifndef CONSTSTRING_INCL
+#define CONSTSTRING_INCL
+
+#include "ilgen/MethodBuilder.hpp"
+
+namespace TR { class TypeDictionary; }
+
+typedef void (ConstStringFunctionType)();
+
+class ConstStringMethod : public TR::MethodBuilder
+   {
+   public:
+   ConstStringMethod(TR::TypeDictionary *);
+   virtual bool buildIL();
+   };
+
+#endif // !defined(CONSTSTRING_INCL)


### PR DESCRIPTION
The original `ConstString` just has a declaration in the head file. In
order to call `ConstString` successfully, implement `ConstString` in
`IlBuilder` and wrote test in jitbuilder/src to test its functionality.

Signed-off-by: Shuyu Li <shuyuli@ca.ibm.com>