### PR TITLE
Remove isAlwaysKeepBlock

### DIFF
--- a/compiler/il/OMRBlock.hpp
+++ b/compiler/il/OMRBlock.hpp
@@ -430,9 +430,6 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
    void setIsOSRCatchBlock()                          { _flags.set(_isOSRCatchBlock); }
    bool isOSRCatchBlock()                             { return _flags.testAny(_isOSRCatchBlock); }
 
-   void setIsAlwaysKeepBlock(bool b)                  { _flags.set(_isAlwaysKeepBlock, b); }
-   bool isAlwaysKeepBlock()                           { return _flags.testAny(_isAlwaysKeepBlock); }
-
    void setIsCreatedAtCodeGen(bool b = true)          { _flags.set(_createdAtCodeGen, b); }
    bool isCreatedAtCodeGen()                          { return _flags.testAny(_createdAtCodeGen); }
 
@@ -520,7 +517,6 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
       _isGenAsmFlowBlock                    = 0x00100000,
       _isOSRCodeBlock                       = 0x00004000,
       _isOSRCatchBlock                      = 0x00008000,
-      _isAlwaysKeepBlock                    = 0x00020000,  // Block referenced by addr(label) or gen refs(label) or gen control block
       _createdAtCodeGen                     = 0x00080000,
       _hasCalls                             = 0x00200000,
       _hasCallToSuperCold                   = 0x00400000,

--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -841,9 +841,6 @@ bool OMR::CFG::removeEdge(TR::CFGEdge *edge)
          if(from->nodeIsRemoved())
              continue;
 
-         if (from->asBlock()->isAlwaysKeepBlock())
-            continue;
-
          if (comp()->getOption(TR_TraceAddAndRemoveEdge))
             traceMsg(comp(), "Processing unreachable node %d\n", from->getNumber());
 
@@ -1132,7 +1129,6 @@ OMR::CFG::removeUnreachableBlocks()
       {
       if (!reachableBlocks.get(node->getNumber()) && node->asBlock() && node != getEnd())
          unreachableNodes.push(node);
-      //TODO:  need to issue message if isGenControlBlock() is not on but isAlwaysKeepBlock() is on
       }
 
    while (!unreachableNodes.isEmpty())
@@ -3211,10 +3207,6 @@ OMR::CFG::findReachableBlocks(TR_BitVector *result)
             for (TR::CFGEdge * edge = edges.getFirst(); edge; edge = edges.getNext())
                {
                stack.push(edge->getTo());
-               // remove the start block predecessor of AlwaysKeepBlocks if they can be reached from somewhere else (excluding multiple entry points, and external_defined labels)
-               if (edge->getTo()->asBlock()->isAlwaysKeepBlock() && edge->getFrom() != getStart() && edge->getTo()->hasPredecessor(getStart()))
-                  {
-                  }
                }
             }
          }

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -5099,17 +5099,11 @@ bool TR_InlinerBase::inlineCallTarget2(TR_CallStack * callStack, TR_CallTarget *
       tif->firstBBEnd()->getNode()->setBlock(blockContainingTheCall);
       blockContainingTheCall->setExit(tif->firstBBEnd());
 
-      //Reset isGenControlBlock or isAlwasyKeepBlock flag so it can be deleted later
+      //Reset isGenControlBlock flag so it can be deleted later
       if (firstCalleeBlock->isGenControlBlock())
          {
          blockContainingTheCall->setIsGenControlBlock(true);
          firstCalleeBlock->setIsGenControlBlock(false);
-         }
-
-      if (firstCalleeBlock->isAlwaysKeepBlock())
-         {
-         blockContainingTheCall->setIsAlwaysKeepBlock(true);
-         firstCalleeBlock->setIsAlwaysKeepBlock(false);
          }
 
       firstCalleeBlock->setEntry(0);

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -301,8 +301,6 @@ int32_t TR_ExtendBasicBlocks::orderBlocksWithoutFrequencyInfo()
 
          if (!prevBlock->isCold() && newBlock->isCold()) continue;
 
-         if (newBlock->isAlwaysKeepBlock()) continue;
-
 
          // See if we can easily move the current block without adding a new goto.
          //
@@ -3755,13 +3753,6 @@ int32_t TR_CleanseTrees::process(TR::TreeTop *startTree, TR::TreeTop *endTreeTop
           (node->getBranchDestination() &&
            node->getBranchDestination()->getNode()->getBlock()->isGenControlBlock()))
          continue;
-
-      if ((block->getNextBlock() &&
-           block->getNextBlock()->isAlwaysKeepBlock()) ||
-          (node->getBranchDestination() &&
-           node->getBranchDestination()->getNode()->getBlock()->isAlwaysKeepBlock()))
-         continue;
-
 
       TR::Block *block1;
       TR::Block *block2;

--- a/compiler/optimizer/OrderBlocks.cpp
+++ b/compiler/optimizer/OrderBlocks.cpp
@@ -1014,9 +1014,6 @@ void TR_OrderBlocks::addRemainingSuccessorsToList(TR::CFGNode *block, TR::CFGNod
       {
       TR::CFGNode *succBlock = (*succEdge)->getTo();
       // If the edge is created by BE, don't add block 1 to list for now
-      if (block->getNumber() != 0 && succBlock->getNumber() == 1 &&
-          block->asBlock()->isAlwaysKeepBlock() && block->asBlock()->getExit()->getNextTreeTop() != NULL)
-         continue;
       if (succBlock != excludeBlock && succBlock->getVisitCount() != _visitCount &&
            isCandidateTheHottestSuccessor(*succEdge, comp()))
          {
@@ -1065,9 +1062,6 @@ void TR_OrderBlocks::addRemainingSuccessorsToListHWProfile(TR::CFGNode *block, T
       {
       TR::CFGNode *succBlock = (*succEdge)->getTo();
       // If the edge is created by BE, don't add block 1 to list for now
-      if (block->getNumber() != 0 && succBlock->getNumber() == 1 &&
-            block->asBlock()->isAlwaysKeepBlock() && block->asBlock()->getExit()->getNextTreeTop() != NULL)
-         continue;
       if (succBlock != excludeBlock && succBlock->getVisitCount() != _visitCount &&
             succBlock->getFrequency() > 0)
          {
@@ -1650,7 +1644,7 @@ bool TR_OrderBlocks::doPeepHoleBlockCorrections(TR::Block *block, char *title)
       }
 
    // pattern: dead block because it has no predecessors
-   if (block->getPredecessors().empty() && (block->hasExceptionPredecessors() == false) && block->getEntry() != NULL && !block->isAlwaysKeepBlock())
+   if (block->getPredecessors().empty() && (block->hasExceptionPredecessors() == false) && block->getEntry() != NULL)
       {
       if (performTransformation(comp(), "%s block_%d has no predecessors so removing it and its out edges from the flow graph\n", title, block->getNumber()))
          {

--- a/compiler/optimizer/Structure.cpp
+++ b/compiler/optimizer/Structure.cpp
@@ -148,7 +148,6 @@ void TR_RegionStructure::addSubNode(TR_StructureSubGraphNode *subNode)
 void TR_RegionStructure::cleanupAfterEdgeRemoval(TR::CFGNode *node)
    {
    TR_BlockStructure *blockSt = toStructureSubGraphNode(node)->getStructure()->asBlock();
-   if ( blockSt != NULL  && blockSt->getBlock()->isAlwaysKeepBlock()) return;
    if (node != getEntry() &&
        node->getPredecessors().empty() &&
        node->getExceptionPredecessors().empty())
@@ -1043,7 +1042,7 @@ void TR_RegionStructure::addEdge(TR::CFGEdge *edge, bool isExceptionEdge)
 
       if (!toNode)
          {
-         if ((to == comp()->getFlowGraph()->getEnd() || to->isAlwaysKeepBlock()) /* &&
+         if (to == comp()->getFlowGraph()->getEnd() /* &&
              to->getPredecessors().empty() */)
             {
             toStruct = to->getStructureOf();

--- a/compiler/ras/CFGChecker.cpp
+++ b/compiler/ras/CFGChecker.cpp
@@ -187,7 +187,6 @@ bool TR_CFGChecker::arrangeBlocksInProgramOrder()
    // at the "next" block to a real block.
    //
    _blocksInProgramOrder = (TR::Block **) _cfg->comp()->trMemory()->allocateStackMemory((_numRealBlocks+1)*sizeof(TR::Block *));
-   bool ignore_block_count=false;
 
    memset(_blocksInProgramOrder, 0, (_numRealBlocks+1)*sizeof(TR::Block *));
 
@@ -217,11 +216,6 @@ bool TR_CFGChecker::arrangeBlocksInProgramOrder()
       TR_ASSERT( node->getOpCodeValue() == TR::BBStart, "Missing TR::BBStart");
       TR::Block *b = node->getBlock();
 
-      // WCODE: We sometimes keep around empty blocks that contain
-      // user labels for debug purposes. In such a case, the block
-      // count check is not valid
-      if (b->isAlwaysKeepBlock())   ignore_block_count=true;
-
       if (!_blockChecklist.isSet(b->getNumber()))
          {
          if (_outFile) trfprintf(_outFile, "Block %d [%p]  at tree node [%p] is in the trees but not in the CFG\n", b->getNumber(),
@@ -243,7 +237,7 @@ bool TR_CFGChecker::arrangeBlocksInProgramOrder()
 
    // Check for the right number of blocks in the trees
    //
-   if (!ignore_block_count && (i != _numRealBlocks))
+   if (i != _numRealBlocks)
       {
       if (_outFile) trfprintf(_outFile, "Number of blocks in trees [%d] does not match number in CFG [%d]\n", i, _numRealBlocks);
       return false;
@@ -269,7 +263,6 @@ bool TR_CFGChecker::areSuccessorsCorrect(int32_t i)
    if (block == NULL)
       return true;
 
-   if (block->isAlwaysKeepBlock()) return true;
    /*
    if ((_cfg->getMaxFrequency() >= 0) &&
        (block->getFrequency() < 0))


### PR DESCRIPTION
The flag `_isAlwaysKeepBlock` was used in a project that existed
prior to this code being contributed and is not relevant to the
open source code base.

Signed-off-by: Aman Kumar <amank@ca.ibm.com>