### PR TITLE
Add and improve JitBuilder examples

### DIFF
--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -652,7 +652,7 @@ IlBuilder::VectorStoreAt(TR::IlType *dt, TR::IlValue *address, TR::IlValue *valu
 TR::IlValue *
 IlBuilder::CreateLocalArray(int32_t numElements, TR::IlType *elementType)
    {
-   uint32_t size = numElements * TR::DataType::getSize(elementType->getPrimitiveType());
+   uint32_t size = numElements * elementType->getSize();
    TR::SymbolReference *localArraySymRef = symRefTab()->createLocalPrimArray(size,
                                                                              methodSymbol(),
                                                                              8 /*FIXME: JVM-specific - byte*/);

--- a/compiler/ilgen/TypeDictionary.cpp
+++ b/compiler/ilgen/TypeDictionary.cpp
@@ -165,7 +165,7 @@ public:
 
    TR::SymbolReference *getFieldSymRef(const char *name);
    bool isStruct() { return true; }
-   virtual size_t getSize();
+   virtual size_t getSize() { return _size; }
 
 protected:
    FieldInfo * findField(const char *fieldName);
@@ -192,7 +192,7 @@ StructType::AddField(const char *name, TR::IlType *typeInfo)
    else
       _firstField = fieldInfo;
    _lastField = fieldInfo;
-   _size += TR::DataType::getSize(primitiveType);
+   _size += typeInfo->getSize();
    }
 
 FieldInfo *
@@ -256,19 +256,6 @@ StructType::getFieldSymRef(const char *fieldName)
    return (TR::IlReference *)symRef;
    }
 
-size_t
-StructType::getSize()
-   {
-   size_t size = 0;
-   FieldInfo *currentField = _firstField;
-   while (currentField != NULL)
-      {
-      size += TR::DataType::getSize(currentField->getPrimitiveType());
-      currentField = currentField->getNext();
-      }
-   return size;
-   }
-
 class PointerType : public TR::IlType
    {
 public:
@@ -290,6 +277,8 @@ public:
    virtual const char *getName() { return _name; }
 
    virtual TR::DataType getPrimitiveType() { return TR::Address; }
+
+   virtual size_t getSize() { return TR::DataType::getSize(TR::Address); }
 
    TR::SymbolReference *getSymRef();
 

--- a/jitbuilder/release/.gitignore
+++ b/jitbuilder/release/.gitignore
@@ -24,6 +24,7 @@ iterfib
 jitbuilder.tgz
 linkedlist
 localarray
+structarray
 mandelbrot
 nestedloop
 pointer

--- a/jitbuilder/release/Makefile
+++ b/jitbuilder/release/Makefile
@@ -22,7 +22,7 @@ CXXFLAGS=-g -std=c++0x -O2 -c -fno-rtti -fPIC -I./include/compiler -I./include
 
 .SUFFIXES: .cpp .o
 
-goal: call conststring dotproduct iterfib linkedlist localarray mandelbrot nestedloop pointer recfib simple switch pow2
+goal: call conststring dotproduct iterfib linkedlist localarray structarray mandelbrot nestedloop pointer recfib simple switch pow2
 
 all: goal
 
@@ -33,6 +33,7 @@ test: goal
 	./iterfib
 	./linkedlist
 	./localarray
+	./structarray
 	./nestedloop
 	./pointer
 	./recfib
@@ -148,6 +149,13 @@ Pow2.o: src/Pow2.cpp src/Pow2.hpp
 	g++ -o $@ $(CXXFLAGS) $<
 
 
+structarray : libjitbuilder.a StructArray.o
+	g++ -g -fno-rtti -o $@ StructArray.o -L. -ljitbuilder -ldl
+
+StructArray.o: src/StructArray.cpp src/StructArray.hpp
+	g++ -o $@ $(CXXFLAGS) $<
+
+
 
 clean:
-	@rm -f call conststring dotproduct iterfib linkedlist localarray mandelbrot matmult nestedloop pointer recfib simple switch pow2 *.o
+	@rm -f call conststring dotproduct iterfib linkedlist localarray structarray mandelbrot matmult nestedloop pointer recfib simple switch pow2 *.o

--- a/jitbuilder/release/src/LinkedList.cpp
+++ b/jitbuilder/release/src/LinkedList.cpp
@@ -35,16 +35,22 @@ static void printString(int64_t ptr)
    printf("%s", string);
    }
 
+static void printInt16(int16_t val)
+   {
+   #define PRINTINT16_LINE LINETOSTR(__LINE__)
+   printf("%d", val);
+   }
+
 static void printInt32(int32_t val)
    {
    #define PRINTINT32_LINE LINETOSTR(__LINE__)
    printf("%d", val);
    }
 
-static void printAddress(int64_t addr)
+static void printAddress(void* addr)
    {
    #define PRINTADDRESS_LINE LINETOSTR(__LINE__)
-   printf("%lx", addr);
+   printf("%p", addr);
    }
 
 LinkedListMethod::LinkedListMethod(TR::TypeDictionary *d)
@@ -56,7 +62,7 @@ LinkedListMethod::LinkedListMethod(TR::TypeDictionary *d)
    DefineName("search");
    TR::IlType *pElementType = d->PointerTo((char *)"Element");
    DefineParameter("list", pElementType);
-   DefineParameter("key", Int32);
+   DefineParameter("key", Int16);
    DefineReturnType(Int32);
 
    DefineFunction((char *)"printString", 
@@ -66,6 +72,13 @@ LinkedListMethod::LinkedListMethod(TR::TypeDictionary *d)
                   NoType,
                   1,
                   Int64);
+   DefineFunction((char *)"printInt16", 
+                  (char *)__FILE__,
+                  (char *)PRINTINT16_LINE,
+                  (void *)&printInt16,
+                  NoType,
+                  1,
+                  Int16);
    DefineFunction((char *)"printInt32", 
                   (char *)__FILE__,
                   (char *)PRINTINT32_LINE,
@@ -79,7 +92,7 @@ LinkedListMethod::LinkedListMethod(TR::TypeDictionary *d)
                   (void *)&printAddress,
                   NoType,
                   1,
-                  Int64);
+                  Address);
    }
 
 bool
@@ -109,7 +122,7 @@ LinkedListMethod::buildIL()
    loop->                     Load("ptr"));
    loop->Call("printString",  1,
    loop->                     ConstInt64((int64_t) "] = { k"));
-   loop->Call("printInt32",   1,
+   loop->Call("printInt16",   1,
    loop->                     LoadIndirect("Element", "key",
    loop->                        Load("ptr")));
    loop->Call("printString",  1,
@@ -155,7 +168,7 @@ class LinkedListTypeDictionary : public TR::TypeDictionary
       TR::IlType *ElementType = DefineStruct("Element");
       TR::IlType *pElementType = PointerTo("Element");
       DefineField("Element", "next", pElementType);
-      DefineField("Element", "key", Int32);
+      DefineField("Element", "key", Int16);
       DefineField("Element", "val", Int32);
       CloseStruct("Element");
       }
@@ -198,7 +211,7 @@ main(int argc, char *argv[])
 
    printf("Step 4: allocate and populate list\n");
    Element *cdr = NULL;
-   for (int32_t c=0;c < 100;c++)
+   for (int16_t c=0;c < 100;c++)
       {
       Element *car = new Element();
       car->key = c;
@@ -217,7 +230,7 @@ main(int argc, char *argv[])
       printf("FAIL!\n");
    else
       {
-      for (int32_t n=0;n < 100;n++)
+      for (int16_t n=0;n < 100;n++)
          {
          val = search(list, n);
          printf("search(list,%2d) = %d\n", n, val);

--- a/jitbuilder/release/src/LinkedList.hpp
+++ b/jitbuilder/release/src/LinkedList.hpp
@@ -27,11 +27,11 @@ namespace TR { class TypeDictionary; }
 typedef struct Element
    {
    struct Element *next;
-   int key;
-   int val;
+   int16_t key;
+   int32_t val;
    } Element;
 
-typedef int32_t (LinkedListFunctionType)(Element *, int32_t);
+typedef int32_t (LinkedListFunctionType)(Element *, int16_t);
 
 class LinkedListMethod : public TR::MethodBuilder
    {

--- a/jitbuilder/release/src/Pointer.cpp
+++ b/jitbuilder/release/src/Pointer.cpp
@@ -52,11 +52,13 @@ static void printDouble(double val)
    printf("%lf", val);
    }
 
-static void printPointer(int64_t val)
+static void printPointer(void* val)
    {
    #define PRINTPOINTER_LINE LINETOSTR(__LINE__)
-   printf("%lx", val);
+   printf("%p", val);
    }
+
+int32_t PointerMethod::staticInt32 = 3;
 
 PointerMethod::PointerMethod(TR::TypeDictionary *d)
    : MethodBuilder(d)
@@ -150,6 +152,16 @@ PointerMethod::buildIL()
       LoadAt(pDouble,
          LoadAt(ppDouble,
             Load("ppDouble"))));
+
+   PrintString(this, "\nOther pointers:\n");
+
+   PrintString(this, "   staticInt32[");
+   Call("printPointer", 1,
+      ConstAddress(&staticInt32));
+   PrintString(this, "] = ");
+   Call("printInt32", 1,
+      LoadAt(pInt32,
+         ConstAddress(&staticInt32)));
 
    PrintString(this, "\n");
 

--- a/jitbuilder/release/src/Pointer.hpp
+++ b/jitbuilder/release/src/Pointer.hpp
@@ -35,6 +35,7 @@ class PointerMethod : public TR::MethodBuilder
    TR::IlType *pFloat;
    TR::IlType *pDouble;
    TR::IlType *ppDouble;
+   static int32_t staticInt32;
 
    public:
    PointerMethod(TR::TypeDictionary *);

--- a/jitbuilder/release/src/StructArray.cpp
+++ b/jitbuilder/release/src/StructArray.cpp
@@ -1,0 +1,207 @@
+/******************************************************************************
+ Copyright IBM Corp. 2016, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <dlfcn.h>
+#include <errno.h>
+
+#include "Jit.hpp"
+#include "ilgen/TypeDictionary.hpp"
+#include "ilgen/MethodBuilder.hpp"
+#include "StructArray.hpp"
+
+
+void printStructElems(int8_t type, int32_t value)
+   {
+   #define PRINTSTRUCTELEMS_LINE LINETOSTR(__LINE__)
+   printf("StructType { type = %#x, value = %d }\n", type, value);
+   }
+
+
+CreateStructArrayMethod::CreateStructArrayMethod(TR::TypeDictionary *d)
+   : MethodBuilder(d)
+   {
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   DefineName("testCreateStructArray");
+   DefineParameter("size", Int32);
+   DefineReturnType(Address);
+
+   StructType = d->LookupStruct("Struct");
+   pStructType = d->PointerTo(StructType);
+
+   DefineFunction("malloc",
+                  "",
+                  "",
+                  (void*)&malloc,
+                  Address,
+                  1,
+                  Int32);
+   }
+
+bool
+CreateStructArrayMethod::buildIL()
+   {
+   Store("myArray",
+      Call("malloc",1,
+         Mul(
+            Load("size"),
+            ConstInt32(StructType->getSize()))));
+
+   TR::IlBuilder* fillArray = nullptr;
+   ForLoopUp("i", &fillArray,
+      ConstInt32(0),
+      Load("size"),
+      ConstInt32(1));
+
+   fillArray->Store("element",
+   fillArray->   IndexAt(pStructType,
+   fillArray->      Load("myArray"),
+   fillArray->      Load("i")));
+
+   fillArray->StoreIndirect("Struct", "type",
+   fillArray->   Load("element"),
+   fillArray->   ConvertTo(Int8,
+   fillArray->      Load("i")));
+
+   fillArray->StoreIndirect("Struct", "value",
+   fillArray->   Load("element"),
+   fillArray->   Load("i"));
+
+   Return(
+      Load("myArray"));
+
+   return true;
+   }
+
+ReadStructArrayMethod::ReadStructArrayMethod(TR::TypeDictionary *d)
+   : MethodBuilder(d)
+   {
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   DefineName("testReadStructArray");
+   DefineParameter("myArray", Address);
+   DefineParameter("size", Int32);
+   DefineReturnType(NoType);
+
+   StructType = d->LookupStruct("Struct");
+   pStructType = d->PointerTo(StructType);
+
+   DefineFunction("printStructElems",
+                  __FILE__,
+                  PRINTSTRUCTELEMS_LINE,
+                  (void *)&printStructElems,
+                  NoType,
+                  2,
+                  Int8,
+                  Int32);
+   }
+
+bool
+ReadStructArrayMethod::buildIL()
+   {
+   TR::IlBuilder* readArray = nullptr;
+   ForLoopUp("i", &readArray,
+      ConstInt32(0),
+      Load("size"),
+      ConstInt32(1));
+
+   readArray->Store("element",
+   readArray->   IndexAt(pStructType,
+   readArray->      Load("myArray"),
+   readArray->      Load("i")));
+
+   readArray->Call("printStructElems", 2,
+   readArray->   LoadIndirect("Struct", "type",
+   readArray->      Load("element")),
+   readArray->   LoadIndirect("Struct", "value",
+   readArray->      Load("element")));
+
+   Return();
+
+   return true;
+   }
+
+
+class StructArrayTypeDictionary : public TR::TypeDictionary
+   {
+   public:
+   StructArrayTypeDictionary() :
+      TR::TypeDictionary()
+      {
+      DefineStruct("Struct");
+      DefineField("Struct", "type", Int8);
+      DefineField("Struct", "value", Int32);
+      CloseStruct("Struct");
+      }
+   };
+
+
+int
+main(int argc, char *argv[])
+   {
+   printf("Step 1: initialize JIT\n");
+   bool initialized = initializeJit();
+   if (!initialized)
+      {
+      fprintf(stderr, "FAIL: could not initialize JIT\n");
+      exit(-1);
+      }
+
+   printf("Step 2: define type dictionary\n");
+   StructArrayTypeDictionary types;
+
+   printf("Step 3: compile createMethod builder\n");
+   CreateStructArrayMethod createMethod(&types);
+   uint8_t *createEntry;
+   int32_t rc = compileMethodBuilder(&createMethod, &createEntry);
+   if (rc != 0)
+      {
+      fprintf(stderr,"FAIL: compilation error %d\n", rc);
+      exit(-2);
+      }
+
+   printf("Step 4: compile readMethod builder\n");
+   ReadStructArrayMethod readMethod(&types);
+   uint8_t *readEntry;
+   rc = compileMethodBuilder(&readMethod, &readEntry);
+   if (rc != 0)
+      {
+      fprintf(stderr,"FAIL: compilation error %d\n", rc);
+      exit(-2);
+      }
+
+   printf("Step 5: invoke compiled code for createMethod\n");
+   auto arraySize = 16;
+   CreateStructArrayFunctionType *create = (CreateStructArrayFunctionType *) createEntry;
+   void* array = create(arraySize);
+
+   printf("Step 6: invoke compiled code for readMethod and verify results\n");
+   ReadStructArrayFunctionType *read = (ReadStructArrayFunctionType *) readEntry;
+   read(array, arraySize);
+
+   printf ("Step 7: shutdown JIT\n");
+   shutdownJit();
+
+   printf("PASS\n");
+   }
+

--- a/jitbuilder/release/src/StructArray.hpp
+++ b/jitbuilder/release/src/StructArray.hpp
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+
+#ifndef STRUCTARRAY_INCL
+#define STRUCTARRAY_INCL
+
+#include "ilgen/MethodBuilder.hpp"
+
+namespace TR { class TypeDictionary; }
+
+typedef void* (CreateStructArrayFunctionType)(int);
+
+typedef void (ReadStructArrayFunctionType)(void*, int);
+
+class CreateStructArrayMethod : public TR::MethodBuilder
+   {
+   private:
+
+   TR::IlType *StructType;
+   TR::IlType *pStructType;
+
+   public:
+   CreateStructArrayMethod(TR::TypeDictionary *);
+   virtual bool buildIL();
+   };
+
+class ReadStructArrayMethod : public TR::MethodBuilder
+   {
+   private:
+
+   TR::IlType *StructType;
+   TR::IlType *pStructType;
+
+   public:
+   ReadStructArrayMethod(TR::TypeDictionary *);
+   virtual bool buildIL();
+   };
+
+#endif // !defined(LOCALARRAY_INCL)


### PR DESCRIPTION
Add and improve JitBuilder examples of to cover issue #377. Also fix the issues in JitBuilder uncovered by new examples/tests.

Examples created:
- `StructArray`: shows how to create an array of structs. This uncovers an bug in the implementation of `StructType::getSize()` that is also fixed by this PR.

Improved examples:
- `Pointer`: add example of calling `ConstAddress()` to declare an address value
- `LinkedList`: already showed how to overlay external structs so change the size of a struct field to ensure alignment is exercised 
