### PR TITLE
Rename recreateWithSymRef*

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -496,7 +496,7 @@ OMR::Node::recreate(TR::Node *originalNode, TR::ILOpCodes op)
    }
 
 TR::Node *
-OMR::Node::recreateWithSymRefAndCopyValidProperties(TR::Node *originalNode, TR::ILOpCodes op, TR::SymbolReference *newSymRef)
+OMR::Node::recreateWithSymRef(TR::Node *originalNode, TR::ILOpCodes op, TR::SymbolReference *newSymRef)
    {
    return TR::Node::recreateAndCopyValidPropertiesImpl(originalNode, op, newSymRef);
    }
@@ -779,7 +779,7 @@ OMR::Node::recreateWithoutSymRef(TR::Node *originalNode, TR::ILOpCodes op,
    }
 
 TR::Node *
-OMR::Node::recreateWithSymRef(TR::Node *originalNode, TR::ILOpCodes op,
+OMR::Node::recreateWithSymRefWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op,
                                    uint16_t numChildren, uint16_t numChildArgs,
                                    ...)
    {
@@ -950,56 +950,56 @@ TR::Node *
 OMR::Node::recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::SymbolReference * symRef)
    {
    TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
-   return TR::Node::recreateWithSymRef(originalNode, op, numChildren, 1, first, symRef);
+   return TR::Node::recreateWithSymRefWithoutProperties(originalNode, op, numChildren, 1, first, symRef);
    }
 
 TR::Node *
 OMR::Node::recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::SymbolReference * symRef)
    {
    TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
-   return TR::Node::recreateWithSymRef(originalNode, op, numChildren, 2, first, second, symRef);
+   return TR::Node::recreateWithSymRefWithoutProperties(originalNode, op, numChildren, 2, first, second, symRef);
    }
 
 TR::Node *
 OMR::Node::recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::SymbolReference * symRef)
    {
    TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
-   return TR::Node::recreateWithSymRef(originalNode, op, numChildren, 3, first, second, third, symRef);
+   return TR::Node::recreateWithSymRefWithoutProperties(originalNode, op, numChildren, 3, first, second, third, symRef);
    }
 
 TR::Node *
 OMR::Node::recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::SymbolReference * symRef)
    {
    TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
-   return TR::Node::recreateWithSymRef(originalNode, op, numChildren, 4, first, second, third, fourth, symRef);
+   return TR::Node::recreateWithSymRefWithoutProperties(originalNode, op, numChildren, 4, first, second, third, fourth, symRef);
    }
 
 TR::Node *
 OMR::Node::recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::SymbolReference * symRef)
    {
    TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
-   return TR::Node::recreateWithSymRef(originalNode, op, numChildren, 5, first, second, third, fourth, fifth, symRef);
+   return TR::Node::recreateWithSymRefWithoutProperties(originalNode, op, numChildren, 5, first, second, third, fourth, fifth, symRef);
    }
 
 TR::Node *
 OMR::Node::recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::SymbolReference * symRef)
    {
    TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
-   return TR::Node::recreateWithSymRef(originalNode, op, numChildren, 6, first, second, third, fourth, fifth, sixth, symRef);
+   return TR::Node::recreateWithSymRefWithoutProperties(originalNode, op, numChildren, 6, first, second, third, fourth, fifth, sixth, symRef);
    }
 
 TR::Node *
 OMR::Node::recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh, TR::SymbolReference * symRef)
    {
    TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
-   return TR::Node::recreateWithSymRef(originalNode, op, numChildren, 7, first, second, third, fourth, fifth, sixth, seventh, symRef);
+   return TR::Node::recreateWithSymRefWithoutProperties(originalNode, op, numChildren, 7, first, second, third, fourth, fifth, sixth, seventh, symRef);
    }
 
 TR::Node *
 OMR::Node::recreateWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *first, TR::Node *second, TR::Node *third, TR::Node *fourth, TR::Node *fifth, TR::Node *sixth, TR::Node *seventh, TR::Node *eighth, TR::SymbolReference * symRef)
    {
    TR_ASSERT(TR::Node::isLegalCallToCreate(op), "assertion failure");
-   return TR::Node::recreateWithSymRef(originalNode, op, numChildren, 8, first, second, third, fourth, fifth, sixth, seventh, eighth, symRef);
+   return TR::Node::recreateWithSymRefWithoutProperties(originalNode, op, numChildren, 8, first, second, third, fourth, fifth, sixth, seventh, eighth, symRef);
    }
 
 

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -164,7 +164,7 @@ public:
    static TR::Node *copy(TR::Node *, int32_t numChildren);
 
    static TR::Node *recreate(TR::Node *originalNode, TR::ILOpCodes op);
-   static TR::Node *recreateWithSymRefAndCopyValidProperties(TR::Node *originalNode, TR::ILOpCodes op, TR::SymbolReference *newSymRef);
+   static TR::Node *recreateWithSymRef(TR::Node *originalNode, TR::ILOpCodes op, TR::SymbolReference *newSymRef);
 
    // create methods from everywhere other than the ilGenerator need
    // to pass in a TR::Node pointer from which the byte code information will be copied
@@ -192,7 +192,7 @@ private:
    static TR::Node *recreateWithoutSymRef_va_args(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, uint16_t numChildArgs, va_list &args);
    static TR::Node *createWithoutSymRef(TR::ILOpCodes op, uint16_t numChildren, uint16_t numChildArgs, ...);
    static TR::Node *recreateWithoutSymRef(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, uint16_t numChildArgs, ...);
-   static TR::Node *recreateWithSymRef(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, uint16_t numChildArgs, ...);
+   static TR::Node *recreateWithSymRefWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, uint16_t numChildArgs, ...);
 
 public:
    // only this variadic method is part of the external interface
@@ -207,7 +207,7 @@ private:
    uint16_t addChildrenAndSymRef(uint16_t childIndex, TR::Node *child, ChildrenAndSymRefType... childrenAndSymRef);
 
    template <class...ChildrenAndSymRefType>
-   static TR::Node *recreateWithSymRef(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, uint16_t numChildArgs, TR::Node *first, ChildrenAndSymRefType... childrenAndSymRef);
+   static TR::Node *recreateWithSymRefWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, uint16_t numChildArgs, TR::Node *first, ChildrenAndSymRefType... childrenAndSymRef);
 
    template <class...Children>
    static TR::Node *recreateWithoutSymRef(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, uint16_t numChildArgs, TR::Node *first, Children... children);

--- a/compiler/il/OMRNode_inlines.hpp
+++ b/compiler/il/OMRNode_inlines.hpp
@@ -70,7 +70,7 @@ OMR::Node::addChildrenAndSymRef(uint16_t childIndex, TR::Node *child,
 
 template <class...ChildrenAndSymRefType>
 TR::Node *
-OMR::Node::recreateWithSymRef(TR::Node *originalNode, TR::ILOpCodes op,
+OMR::Node::recreateWithSymRefWithoutProperties(TR::Node *originalNode, TR::ILOpCodes op,
                               uint16_t numChildren, uint16_t numChildArgs,
                               TR::Node *first,
                               ChildrenAndSymRefType... childrenAndSymRef)
@@ -88,7 +88,7 @@ OMR::Node::recreateWithoutSymRef(TR::Node *originalNode, TR::ILOpCodes op,
                                  uint16_t numChildren, uint16_t numChildArgs,
                                  TR::Node *first, Children... children)
    {
-   return recreateWithSymRef(originalNode, op, numChildren, numChildArgs,
+   return recreateWithSymRefWithoutProperties(originalNode, op, numChildren, numChildArgs,
                              first, children...);
    }
 
@@ -98,7 +98,7 @@ OMR::Node::createWithSymRefInternal(TR::ILOpCodes op, uint16_t numChildren,
                                     uint16_t numChildArgs, TR::Node *first,
                                     ChildrenAndSymRefType... childrenAndSymRef)
    {
-   return recreateWithSymRef(0, op, numChildren, numChildArgs, first,
+   return recreateWithSymRefWithoutProperties(0, op, numChildren, numChildArgs, first,
                              childrenAndSymRef...);
    }
 template <class...Children>

--- a/compiler/optimizer/PartialRedundancy.cpp
+++ b/compiler/optimizer/PartialRedundancy.cpp
@@ -868,7 +868,7 @@ void TR_PartialRedundancy::processReusedNode(TR::Node *node, TR::ILOpCodes newOp
 
    node->setNumChildren(newNumChildren);
    if (newSymRef)
-      node = TR::Node::recreateWithSymRefAndCopyValidProperties(node, newOpCode, newSymRef);
+      node = TR::Node::recreateWithSymRef(node, newOpCode, newSymRef);
    else
       node = TR::Node::recreate(node, newOpCode);
 


### PR DESCRIPTION
Rename `recreateWithSymRef` to `recreateWithSymRefWithoutProperties`, and
rename `recreateWithSymRefAndCopyValidProperties` to
`recreateWithSymRef`.

Most of the time, when a node is recreated, valid properties should
be copied. If the properties are not to be copied, it should be
explicitly stated.

Signed-off-by: Aman Kumar <amank@ca.ibm.com>