### PR TITLE
preparation for reporting Macro fragmentation for local gc in verbose gc

### DIFF
--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -275,8 +275,13 @@ MM_ParallelGlobalGC::masterThreadGarbageCollect(MM_EnvironmentBase *env, MM_Allo
 #if defined(OMR_GC_MODRON_COMPACTION)
 	/* If a compaction was required, then do one */
 	if (_compactThisCycle) {
-		_collectionStatistics._tenureFragmentation = true;
+		_collectionStatistics._tenureFragmentation = MICRO_FRAGMENTATION;
+		if (GLOBALGC_ESTIMATE_FRAGMENTATION == (_extensions->estimateFragmentation & GLOBALGC_ESTIMATE_FRAGMENTATION)) {
+			_collectionStatistics._tenureFragmentation |= MACRO_FRAGMENTATION;
+		}
+
 		masterThreadCompact(env, allocDescription, rebuildMarkBits);
+		_collectionStatistics._tenureFragmentation = NO_FRAGMENTATION;
 	} else {
 		/* If a compaction was prevented, report the reason */
 		CompactPreventedReason compactPreventedReason = (CompactPreventedReason)(_extensions->globalGCStats.compactStats._compactPreventedReason);
@@ -288,7 +293,10 @@ MM_ParallelGlobalGC::masterThreadGarbageCollect(MM_EnvironmentBase *env, MM_Allo
 			compactStats->_endTime = 0;
 			reportCompactEnd(env);
 		}
-		_collectionStatistics._tenureFragmentation = true;
+		_collectionStatistics._tenureFragmentation = MICRO_FRAGMENTATION;
+		if (GLOBALGC_ESTIMATE_FRAGMENTATION == (_extensions->estimateFragmentation & GLOBALGC_ESTIMATE_FRAGMENTATION)) {
+			_collectionStatistics._tenureFragmentation |= MACRO_FRAGMENTATION;
+		}
 	}
 #endif /* defined(OMR_GC_MODRON_COMPACTION) */	
 

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -3530,6 +3530,7 @@ MM_Scavenger::processLargeAllocateStatsAfterGC(MM_EnvironmentBase *env)
 	/* estimate Fragmentation */
 	if (LOCALGC_ESTIMATE_FRAGMENTATION == (_extensions->estimateFragmentation & LOCALGC_ESTIMATE_FRAGMENTATION)) {
 		stats->estimateFragmentation(env);
+		((MM_CollectionStatisticsStandard *) env->_cycleState->_collectionStatistics)->_tenureFragmentation = MACRO_FRAGMENTATION;
 	} else {
 		stats->resetRemainingFreeMemoryAfterEstimate();
 	}

--- a/gc/verbose/handler_standard/VerboseHandlerOutputStandard.hpp
+++ b/gc/verbose/handler_standard/VerboseHandlerOutputStandard.hpp
@@ -23,6 +23,7 @@
 #include "omrcomp.h"
 
 #include "VerboseHandlerOutput.hpp"
+#include "CollectionStatisticsStandard.hpp"
 
 class MM_CollectionStatistics;
 class MM_EnvironmentBase;
@@ -36,8 +37,7 @@ public:
 private:
 
 protected:
-	void outputMemType(MM_EnvironmentBase* env, uintptr_t indent, const char* type, uintptr_t free, uintptr_t total);
-	void outputMemType(MM_EnvironmentBase* env, uintptr_t indent, const char* type, uintptr_t free, uintptr_t total, uintptr_t microFragment, uintptr_t macroFragment);
+	void outputMemType(MM_EnvironmentBase* env, uintptr_t indent, const char* type, uintptr_t free, uintptr_t total, uint32_t tenureFragmentation=NO_FRAGMENTATION, uintptr_t microFragment=0, uintptr_t macroFragment=0);
 	virtual bool initialize(MM_EnvironmentBase *env, MM_VerboseManager *manager);
 	virtual void tearDown(MM_EnvironmentBase *env);
 


### PR DESCRIPTION
report Macro fragmentation info for local and global gc 
if any of them is enabled for estimate fragmentation.
- flag _tenureFragmentation has 2 bits(bit0:MicroFragmentation,
  bit1:MacroFragmentation), 
  in order to output either or both (Macro,
  Micro) fragmentations when they are available.
- consolidate similar output methods into one  

Signed-off-by: Lin Hu linhu@ca.ibm.com
