### PR TITLE
Allow inhibiting of array splitting in GC_IndexableObjectScanner

### DIFF
--- a/gc/base/standard/ObjectScanner.hpp
+++ b/gc/base/standard/ObjectScanner.hpp
@@ -65,8 +65,9 @@ public:
 	{
 		scanRoots = 1			/* scavenge roots phase -- scan & copy/forward root objects */
 		, scanHeap = 2			/* scavenge heap phase -- scan  & copy/forward objects reachable from scanned roots */
-		, indexableObject = 4	/* this is set for array object scanners */
-		, noMoreSlots = 8		/* this is set when object has more no slots to scan past current bitmap */
+		, indexableObject = 4			/* this is set for array object scanners where the array elements can be partitioned for multithreaded scanning */
+		, indexableObjectNoSplit = 8	/* this is set for array object scanners where the array elements cannot be partitioned for multithreaded scanning */
+		, noMoreSlots = 128				/* this is set when object has more no slots to scan past current bitmap */
 	};
 
 	/* Member Functions */
@@ -190,6 +191,10 @@ public:
 	MMINLINE static bool isIndexableObject(uintptr_t flags) { return (0 != (indexableObject & flags)); }
 
 	MMINLINE bool isIndexableObject() { return (0 != (indexableObject & _flags)); }
+
+	MMINLINE static bool isIndexableObjectNoSplit(uintptr_t flags) { return (0 != (indexableObjectNoSplit & flags)); }
+
+	MMINLINE bool isIndexableObjectNoSplit() { return (0 != (indexableObjectNoSplit & _flags)); }
 };
 
 #endif /* OBJECTSCANNER_HPP_ */


### PR DESCRIPTION
Enable inhibition of array splitting in GC_IndexableObjectScanner.

Update MM_Scavenger::walkObjectSlotsForRSO() to not split arrays when 
scanning for RS overflow and to return as soon as an array element is
found in new space (if any).

Optimize MM_Scavenger::pruneRememberedSetOverflow() by inhibiting 
unnecessary checks after a dependent object is found in new space.

Signed-off-by: Kim Briggs briggs@ca.ibm.com
