### PR TITLE
Test vlog creation and limitfile adherence

### DIFF
--- a/compiler/codegen/FrontEnd.cpp
+++ b/compiler/codegen/FrontEnd.cpp
@@ -193,16 +193,18 @@ TR_FrontEnd::getFormattedName(
    // FIXME: TODO: This is a temporary implementation -- we ignore the suffix format and
    // use the pid only
 
-   pid_t pid = getpid();
-   snprintf(buf, bufLength, "%s-%d", name, pid);
+   if(suffix)
+      {
+      pid_t pid = getpid();
+      snprintf(buf, bufLength, "%s-%d", name, pid);
 
-   // FIXME: proper error handling for snprintf
+      // FIXME: proper error handling for snprintf
+      return buf;
+      }
 
-   return buf;
-
-#else
-   return strncpy(buf, name, bufLength);
 #endif
+
+   return strncpy(buf, name, bufLength);
 
    }
 

--- a/compiler/ras/LimitFile.cpp
+++ b/compiler/ras/LimitFile.cpp
@@ -996,7 +996,7 @@ TR_Debug::scanFilterName(char *string, TR_FilterBST *filter)
    char *signatureChars = string;
    int32_t signatureLen = 0;
    char  filterType = filter->getFilterType();
-   if (*string == '/') // hack that works for linux
+   if (*string == '/' || *string == '.') // hack that works for linux
       omrPattern = true;
 
    while (*string && *string != '\t' && *string != ',' && *string != '\n')
@@ -1133,7 +1133,7 @@ TR_Debug::methodSigCanBeFound(const char *methodSig, TR::CompilationFilters * fi
    methodClass = methodSig;
    if (methodType != TR_Method::J9)
       {
-      if (methodSig[0] == '/') // omr method pattern
+      if (methodSig[0] == '/' || methodSig[0] == '.') // omr method pattern
          {
          methodClass = methodSig;
          methodSignature = strchr(methodSig, ':');

--- a/fvtest/compilertest/build/files/common.mk
+++ b/fvtest/compilertest/build/files/common.mk
@@ -195,6 +195,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     $(JIT_PRODUCT_DIR)/tests/IndirectStoreIlInjector.cpp \
     $(JIT_PRODUCT_DIR)/tests/FooBarTest.cpp \
     $(JIT_PRODUCT_DIR)/tests/FooIlInjector.cpp \
+    $(JIT_PRODUCT_DIR)/tests/LimitFileTest.cpp \
     $(JIT_PRODUCT_DIR)/tests/OMRTestEnv.cpp \
     $(JIT_PRODUCT_DIR)/tests/OpCodesTest.cpp \
     $(JIT_PRODUCT_DIR)/tests/PPCOpCodesTest.cpp \

--- a/fvtest/compilertest/tests/LimitFileTest.cpp
+++ b/fvtest/compilertest/tests/LimitFileTest.cpp
@@ -1,0 +1,269 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+
+#include "tests/LimitFileTest.hpp"
+
+#include <fstream>
+#include <string>
+#include <sstream>
+#include <unistd.h>
+#include <sys/stat.h>
+
+#include "tests/OMRTestEnv.hpp"
+#include "tests/OpCodesTest.hpp"
+
+TestCompiler::LimitFileTest::LimitFileTest()
+   {
+   // Don't use fork(), since that doesn't let us initialize the JIT
+   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+   }
+
+TestCompiler::LimitFileTest::~LimitFileTest()
+   {
+   // Remove all generated vlog files.
+   for(auto it = _vlog.begin(); it != _vlog.end(); ++it)
+      {
+      unlink(*it);
+      }
+   }
+
+void
+TestCompiler::LimitFileTest::compileTests()
+   {
+   ::TestCompiler::OpCodesTest unaryTest;
+   unaryTest.compileUnaryTestMethods();
+   //unaryTest.invokeUnaryTests();
+   }
+
+/**
+ * Determine if a file exists.
+ *
+ * @param name The name of the file.
+ */
+bool
+TestCompiler::LimitFileTest::fileExists(const char *name)
+   {
+   // TODO: use port library for file operations
+   struct stat buf;
+   int result = stat(name, &buf);
+   return result == 0;
+   }
+
+/**
+ * Startup the JIT, run tests, shut down the JIT, then exit with
+ * an exit code of 0.
+ * This must be called in a process that has not initialized the
+ * JIT yet.
+ *
+ * @param vlog The file to log to.
+ * @param limitFile A limit file argument.
+ */
+void
+TestCompiler::LimitFileTest::generateVLog(const char *vlog, const char *limitFile)
+   {
+   std::string args = std::string("-Xjit:verbose,disableSuffixLogs,vlog=");
+   args = args + vlog;
+
+   // Add the limit file, if provided.
+   if(limitFile)
+      args = args + ",limitFile=" + limitFile;
+
+   OMRTestEnv::initialize(const_cast<char *>(args.c_str()));
+   compileTests();
+   OMRTestEnv::shutdown();
+
+   exit(0);
+   }
+
+/**
+ * Assert if a method was or was not compiled in a test, by searching
+ * the vlog file for the method.
+ *
+ * @param[in] vlog The log from the test.
+ * @param[in] method The name of the method to search for.
+ * @param[in] compiled Assert that the method was or was not compiled.
+ * @param[out] The line of the log that the method is on. This can be
+ *             used in a limit file parameter. This parameter is only
+ *             valid when compiled is true.
+ */
+void
+TestCompiler::LimitFileTest::checkVLogForMethod(const char *vlog, const char *method, bool compiled, int *foundOnLine)
+   {
+   std::ifstream vlogFile(vlog);
+   ASSERT_TRUE(vlogFile.is_open());
+
+   bool foundPlus = false;
+   bool foundSpace = false;
+   std::string line;
+   for(int i = 1; std::getline(vlogFile, line); ++i)
+      {
+      // If method hasn't been compiled, it shouldn't be anywhere in the vlog
+      if(!compiled)
+         {
+         ASSERT_EQ(line.find(method), std::string::npos);
+         continue;
+         }
+
+      if(line.empty())
+         continue;
+
+      // Lines in a vlog file are dependent on their first character.
+      switch(line[0])
+         {
+         // Method successfully compiled
+         case '+':
+            if(line.find(method) != std::string::npos)
+               {
+               ASSERT_NE(line.find("(warm"), std::string::npos);
+               foundPlus = true;
+               if(compiled && foundOnLine)
+                  *foundOnLine = i;
+               }
+            break;
+         // Method compilation began
+         case ' ':
+            if(line.find(method) != std::string::npos)
+               {
+               ASSERT_NE(line.find(" compiling"), std::string::npos);
+               foundSpace = true;
+               }
+            break;
+         }
+      }
+
+   if(!compiled)
+      return;
+
+   // If asserting compilation, we should have found both a compilation
+   // beginning message, and a successful compilation message.
+   ASSERT_TRUE(foundPlus);
+   ASSERT_TRUE(foundSpace);
+   }
+
+/**
+ * Create a vlog file by creating a new process and running a set of tests.
+ *
+ * In order to properly test the vlog and limit file arguments, a JIT must
+ * be initialized. Since a JIT is already initialized when these tests are
+ * run, and since shutting down the JIT does not reset everything, we need
+ * to create a new process that initializes a JIT with its own options.
+ *
+ * Note that this is made possible by disabling the global test environment
+ * in main.cpp for any new processes in this file.
+ *
+ * @param vlog The location to place the vlog file.
+ * @param limitFile A limit file argument. This can be of the form
+ *        "limitfile", "(limitfile,n), or (limitfile,n,m).
+ */
+void
+TestCompiler::LimitFileTest::createVLog(const char *vlog, const char *limitFile)
+   {
+   _vlog.push_back(vlog);
+
+   /* This creates the new process, runs generateVLog, and asserts it exits
+    * with a status code of 0.
+    */
+   ASSERT_EXIT(generateVLog(vlog, limitFile), ::testing::ExitedWithCode(0), "");
+
+   ASSERT_TRUE(fileExists(vlog));
+   }
+
+/**
+ * Create a vlog file by creating a new process and running a set of tests,
+ * then asserting that select methods were compiled. The line number of
+ * a compiled method is placed in methodLine.
+ *
+ * @param[in] vlog The location to place the vlog file.
+ * @param[in] limitFile A limit file argument.
+ * @param[out] methodLine A pointer to the line of the vlog where a method
+ *             was compiled. This is currently the method `iNeg`, however
+ *             this is subject to change.
+ */
+void
+TestCompiler::LimitFileTest::createAndCheckVLog(const char *vlog, const char *limitFile, int *methodLine)
+   {
+   createVLog(vlog, limitFile);
+
+   checkVLogForMethod(vlog, "iNeg", true, methodLine);
+   checkVLogForMethod(vlog, "iReturn", true);
+   }
+
+namespace TestCompiler {
+
+// Assert a vlog file was created.
+TEST_F(LimitFileTest, CreateVLogTest)
+   {
+   const char *vlog = "createVLog.log";
+   createVLog(vlog);
+   }
+
+// Assert that methods were compiled and logged.
+TEST_F(LimitFileTest, CheckVLogTest)
+   {
+   const char *vlog = "checkVLog.log";
+   createAndCheckVLog(vlog);
+   }
+
+// Use a limit file.
+TEST_F(LimitFileTest, UseLimitFileTest)
+   {
+   const char *vlog = "checkLimitFileSuccess.log";
+   const char *limitFile = "checkLimitFileSuccess.limit";
+
+   // Create limit file.
+   createAndCheckVLog(limitFile, NULL);
+
+   createAndCheckVLog(vlog, limitFile);
+   }
+
+// Use (limitfile,n,m) notation.
+TEST_F(LimitFileTest, UseLimitFileRangeTest)
+   {
+   const char *vlog = "checkLimitFileSuccess.log";
+   const char *limitFile = "checkLimitFileSuccess.limit";
+
+   // Create limit file.
+   int iNegLine;
+   createAndCheckVLog(limitFile, NULL, &iNegLine);
+
+   // Note VC++ 2010 doesn't support std::to_string(int).
+   std::string iNegLineStr = std::to_string(static_cast<long long>(iNegLine));
+   std::string limitArg = std::string("(") + limitFile + "," + iNegLineStr + "," + iNegLineStr + ")";
+   createVLog(vlog, limitArg.c_str());
+
+   checkVLogForMethod(vlog, "iNeg", true);
+   checkVLogForMethod(vlog, "iReturn", false);
+   }
+
+// Use (limitfile,n) notation.
+TEST_F(LimitFileTest, UseLimitFileBoundTest)
+   {
+   const char *vlog = "checkLimitFileSuccess.log";
+   const char *limitFile = "checkLimitFileSuccess.limit";
+
+   // Create limit file.
+   int iNegLine;
+   createAndCheckVLog(limitFile, NULL, &iNegLine);
+
+   iNegLine++; // Start at line after iNeg.
+   std::string limitArg = std::string("(") + limitFile + "," + std::to_string(static_cast<long long>(iNegLine)) + ")";
+   createVLog(vlog, limitArg.c_str());
+   checkVLogForMethod(vlog, "iNeg", false);
+   }
+
+}

--- a/fvtest/compilertest/tests/LimitFileTest.hpp
+++ b/fvtest/compilertest/tests/LimitFileTest.hpp
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+
+#ifndef TEST_LIMITFILE_INCL
+#define TEST_LIMITFILE_INCL
+
+#include <vector>
+#include "gtest/gtest.h"
+
+namespace TestCompiler {
+
+class LimitFileTest : public ::testing::Test
+   {
+   public:
+   LimitFileTest();
+   ~LimitFileTest();
+
+   void createVLog(const char *vlog, const char *limitFile = NULL);
+   void createAndCheckVLog(const char *vlog, const char *limitFile = NULL, int *iNegLine = NULL);
+
+   void checkVLogForMethod(const char *vlog, const char *method, bool compiled, int *foundOnLine = NULL);
+
+   private:
+   std::vector<const char *> _vlog;
+
+   bool fileExists(const char *name);
+   void generateVLog(const char *vlog, const char *limitFile = NULL);
+
+   void compileTests();
+   };
+
+}
+
+#endif // !defined(TEST_LIMITFILE_INCL)

--- a/fvtest/compilertest/tests/main.cpp
+++ b/fvtest/compilertest/tests/main.cpp
@@ -34,7 +34,26 @@
 
 int main(int argc, char **argv)
    {
+   bool useOMRTestEnv = true;
+
+   /* Disable OMRTestEnv on some tests. This is needed when the test
+    * wants to initialize the JIT with special options which cannot be
+    * easily cleaned up.
+    */
+   const char *exitAssertFlag="--gtest_internal_run_death_test=";
+   for(int i = 0; i < argc; ++i)
+      {
+      if(!strncmp(argv[i], exitAssertFlag, strlen(exitAssertFlag))
+         && strstr(argv[i], "LimitFileTest.cpp"))
+         {
+         useOMRTestEnv = false;
+         }
+      }
+
    ::testing::InitGoogleTest(&argc, argv);
-   ::testing::AddGlobalTestEnvironment(new TestCompiler::OMRTestEnv);
+
+   if(useOMRTestEnv)
+      ::testing::AddGlobalTestEnvironment(new TestCompiler::OMRTestEnv);
+
    return RUN_ALL_TESTS();
    }


### PR DESCRIPTION
Limitfiles are a way to whitelist which methods are compiled by the JIT. This can be useful in determining which function is triggering a compiler bug.

Verbose log (vlog) files are logs that can be generated by the JIT. Among other things, these include information about which functions have been compiled. These files can be used as limitfiles.

This also runs some basic tests to ensure the JIT uses the limitfile as a whitelist, using either a part of the limitfile or the entire limitfile.

Also included in these changes is support for the `disableSuffixLogs` option in OMR. If specifies, log files are created without a PID suffix.
