### PR TITLE
Use the correct child to optimize primitiveClone

### DIFF
--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -5694,7 +5694,11 @@ TR::Node *constrainAcall(TR::ValuePropagation *vp, TR::Node *node)
              || method->getRecognizedMethod() == TR::java_lang_J9VMInternals_primitiveClone)
             {
             bool isGlobal;
-            constraint = vp->getConstraint(node->getFirstChild(), isGlobal);
+            if (method->getRecognizedMethod() == TR::java_lang_Object_clone)
+              constraint = vp->getConstraint(node->getFirstChild(), isGlobal);
+            else
+              constraint = vp->getConstraint(node->getLastChild(), isGlobal);
+
             TR::VPResolvedClass *newTypeConstraint = NULL;
             if (constraint)
                {


### PR DESCRIPTION
An optimization that transforms calls to Object.clone or calls to
J9VMInternals.primitiveClone to cheaper operations mistakenly assumed
the structure of the trees for them is the same, which leads to a wrong
node being used as the object node during the transformation of
J9VMInternals.primitiveClone. This change will fix the problem and also
remove Object.clone from the surppress-inline list in codegen so that
inliner can inline it when it can.

Signed-off-by: liqunl <liqunl@ca.ibm.com>