### PR TITLE
Remove unused external helpers

### DIFF
--- a/compiler/x/amd64/runtime/AMD64ArrayCopy.inc
+++ b/compiler/x/amd64/runtime/AMD64ArrayCopy.inc
@@ -102,10 +102,6 @@ ifdef DEBUGSTATS
                 ExternHelper _numSSECopiesAlignFailed:dword
                 ExternHelper _numStringMoves:dword
 endif
-                ExternHelper jitWriteBarrierStore
-                ExternHelper jitWriteBarrierBatchStore
-                ExternHelper jitInstanceOf
-                ExternHelper jitThrowArrayStoreExceptionWithIP
 
                 public _arrayCopy
                 public _halfWordArrayCopy


### PR DESCRIPTION
These helpers are not in-use and also J9 specific.
Should be removed from OMR.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>