### PR TITLE
Remove use of error codes in OMR compiler

### DIFF
--- a/compiler/arm/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/arm/codegen/ControlFlowEvaluator.cpp
@@ -1295,8 +1295,9 @@ static void lookupScheme3(TR::CodeGenerator *cg, TR::Node *node, bool unbalanced
 // Called by switchDispatch().
 static void lookupScheme4(TR::Node *node, TR::CodeGenerator *cg)
    {
-   cg->fe()->outOfMemory(TR::comp(), "Automatically failing on lookup scheme 4");
-   TR_ASSERT(0, "implement lookupScheme4");
+   traceMsg(TR::comp(), "Automatically failing on lookup scheme 4");
+   throw TR::CompilationException();
+
 /*  TODO implement lookups
    int32_t  total = node->getNumChildren();
    int32_t  numberOfEntries = total - 2;

--- a/compiler/arm/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.cpp
@@ -1156,8 +1156,8 @@ TR::Register *OMR::ARM::TreeEvaluator::loadaddrEvaluator(TR::Node *node, TR::Cod
       resultReg = sym->isLocalObject() ?  cg->allocateCollectedReferenceRegister() : cg->allocateRegister();
       if (mref->useIndexedForm())
          {
-         cg->fe()->outOfMemory(TR::comp(), "implement unresolved loadAddr indexed");
-         TR_ASSERT(0, "implement unresolved loadAddr indexed\n");
+         traceMsg(TR::comp(), "implement unresolved loadAddr indexed");
+         throw TR::CompilationException();
          generateTrg1MemInstruction(cg, ARMOp_add, node, resultReg, mref);
          }
       else

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -375,7 +375,6 @@ OMR::CodeGenPhase::performRegisterAssigningPhase(TR::CodeGenerator * cg, TR::Cod
 
       if (comp->compilationShouldBeInterrupted(AFTER_REGISTER_ASSIGNMENT_CONTEXT))
          {
-         comp->setErrorCode(COMPILATION_INTERRUPTED);
          traceMsg(comp, "interrupted after RA");
          throw TR::CompilationInterrupted();
          }
@@ -427,7 +426,6 @@ OMR::CodeGenPhase::performInstructionSelectionPhase(TR::CodeGenerator * cg, TR::
    // check interrupt
    if (comp->compilationShouldBeInterrupted(AFTER_INSTRUCTION_SELECTION_CONTEXT))
       {
-      comp->setErrorCode(COMPILATION_INTERRUPTED);
       traceMsg(comp, "interrupted after instruction selection");
       throw TR::CompilationInterrupted();
       }

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -2426,7 +2426,7 @@ OMR::CodeGenerator::allocateCodeMemory(uint32_t warmSize, uint32_t coldSize, uin
       {
       self()->commitToCodeCache();
       }
-   TR_ASSERT( !((warmSize && !warmCode) || (coldSize && !coldCode)), "Allocation failed but didn't call outOfMemory()");
+   TR_ASSERT( !((warmSize && !warmCode) || (coldSize && !coldCode)), "Allocation failed but didn't throw an exception");
    return warmCode;
    }
 

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -2409,7 +2409,6 @@ OMR::CodeGenerator::reserveCodeCache()
 
       if (self()->comp()->compileRelocatableCode())
          {
-         self()->comp()->setErrorCode(COMPILATION_OUT_OF_MEMORY_RELOCATION_DATA);
          throw TR::RecoverableCodeCacheError();
          }
 

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -1867,11 +1867,9 @@ void OMR::Compilation::switchCodeCache(TR::CodeCache *newCodeCache)
 
       if (newCodeCache)
          {
-         self()->setErrorCode(COMPILATION_ILLEGAL_CODE_CACHE_SWITCH);
          throw TR::RecoverableCodeCacheError();
          }
 
-      self()->setErrorCode(COMPILATION_NULL_SUBSTITUTE_CODE_CACHE);
       throw TR::CodeCacheError();
       }
    }

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -856,7 +856,10 @@ int32_t OMR::Compilation::compile()
       //if so, fail the compile
       //
       if (_methodSymbol->catchBlocksHaveRealPredecessors(_methodSymbol->getFlowGraph(), self()))
-         self()->fe()->outOfMemory(self(), "Catch blocks have real predecessors");
+         {
+         traceMsg(self(), "Catch blocks have real predecessors");
+         throw TR::CompilationException();
+         }
 
       if ((debug("dumpInitialTrees") || self()->getOption(TR_TraceTrees)) && self()->getOutFile() != NULL)
          {
@@ -903,7 +906,10 @@ int32_t OMR::Compilation::compile()
          {
          static char *abortafterilgen = feGetEnv("TR_TOSS_IL");
          if(abortafterilgen)
-            self()->fe()->outOfMemory(self(), "Aborting after IL Gen due to TR_TOSS_IL");
+            {
+            traceMsg(self(), "Aborting after IL Gen due to TR_TOSS_IL");
+            throw TR::CompilationException();
+            }
 
 
          if (_recompilationInfo)
@@ -1187,7 +1193,8 @@ bool OMR::Compilation::incInlineDepth(TR_OpaqueMethodBlock *methodInfo, TR::Reso
    if (inlinedCallStackSize >= TR_ByteCodeInfo::maxCallerIndex)
       {
       TR_ASSERT(0, "max number of inlined calls exceeded");
-      self()->fe()->outOfMemory(self(), "max number of inlined calls exceeded");
+      traceMsg(self(), "max number of inlined calls exceeded");
+      throw TR::ExcessiveComplexity();
       }
 
    if (inlinedCallStackSize > _maxInlineDepth)
@@ -2107,7 +2114,8 @@ OMR::Compilation::incVisitCount()
    if (_visitCount == MAX_VCOUNT-1)
       {
       TR_ASSERT(0, "_visitCount equals MAX_VCOUNT-1");
-      self()->fe()->outOfMemory(self(), "_visitCount equals MAX_VCOUNT-1");
+      traceMsg(self(), "_visitCount equals MAX_VCOUNT-1");
+      throw TR::CompilationException();
       }
    return ++_visitCount;
    }

--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -1591,7 +1591,6 @@ OMR::SymbolReferenceTable::findOrCreateAutoSymbol(TR::ResolvedMethodSymbol * own
          _numInternalPointers++;
          if (_numInternalPointers > comp()->maxInternalPointers())
             {
-            comp()->setErrorCode(COMPILATION_MAX_NODE_COUNT_EXCEEDED);
             traceMsg(comp(), "Excessive number of internal pointers");
             throw TR::ExcessiveComplexity();
             }

--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -1513,7 +1513,8 @@ OMR::SymbolReferenceTable::findOrCreateAutoSymbol(TR::ResolvedMethodSymbol * own
          {
          if (symRef->getSymbol()->getParmSymbol() || comp()->getOption(TR_DontJitIfSlotsSharedByRefAndNonRef))
             {
-            comp()->fe()->outOfMemory(comp(), "stack mapping can't handle a parameter slot that is shared between refs and nonrefs 0");
+            traceMsg(comp(), "stack mapping can't handle a parameter slot that is shared between refs and nonrefs 0");
+            throw TR::CompilationException();
             }
 
          slotSharedbyRefAndNonRef = true;
@@ -1535,8 +1536,8 @@ OMR::SymbolReferenceTable::findOrCreateAutoSymbol(TR::ResolvedMethodSymbol * own
                {
                if (symRef2->getSymbol()->getParmSymbol() || comp()->getOption(TR_DontJitIfSlotsSharedByRefAndNonRef))
                   {
-                  comp()->fe()->outOfMemory(comp(), "stack mapping can't handle a parameter slot that is shared between refs and nonrefs 1");
-
+                  traceMsg(comp(), "stack mapping can't handle a parameter slot that is shared between refs and nonrefs 1");
+                  throw TR::CompilationException();
                   }
                slotSharedbyRefAndNonRef = true;
                symRef2->getSymbol()->setSlotSharedByRefAndNonRef(true); // An address slot is being shared with an int slot.
@@ -1559,7 +1560,8 @@ OMR::SymbolReferenceTable::findOrCreateAutoSymbol(TR::ResolvedMethodSymbol * own
                {
                if (symRef2->getSymbol()->getParmSymbol() || comp()->getOption(TR_DontJitIfSlotsSharedByRefAndNonRef))
                   {
-                  comp()->fe()->outOfMemory(comp(), "stack mapping can't handle a parameter slot that is shared between refs and nonrefs 3");
+                  traceMsg(comp(), "stack mapping can't handle a parameter slot that is shared between refs and nonrefs 3");
+                  throw TR::CompilationException();
                   }
                slotSharedbyRefAndNonRef = true;
                symRef2->getSymbol()->setSlotSharedByRefAndNonRef(true); // An address slot is being shared with an int slot.

--- a/compiler/compile/OSRData.cpp
+++ b/compiler/compile/OSRData.cpp
@@ -472,7 +472,8 @@ void TR_OSRCompilationData::checkOSRLimits()
       if (comp->getOptions()->isAnyVerboseOptionSet(TR_VerboseOSR, TR_VerboseOSRDetails))
          TR_VerboseLog::writeLineLocked(TR_Vlog_OSR, "OSR COMPILE ABORT in %s: frame size %d, scratch size %d, stack size %d were not accommodated by the VM\n",
                   comp->signature(), maxFrameSize, getMaxScratchBufferSize(), maxStackFrameSize);
-      comp->fe()->outOfMemory(comp, "OSR buffers could not be enlarged to accomodate compiled method");
+      traceMsg(comp, "OSR buffers could not be enlarged to accomodate compiled method");
+      throw TR::CompilationException();
       }
    }
 

--- a/compiler/env/FEBase_t.hpp
+++ b/compiler/env/FEBase_t.hpp
@@ -20,6 +20,7 @@
 #include "compile/Compilation.hpp"
 #include "env/FEBase.hpp"
 #include "env/jittypes.h"
+#include "runtime/CodeCacheExceptions.hpp"
 
 namespace TR
 {
@@ -52,12 +53,7 @@ FEBase<Derived>::allocateCodeMemory(TR::Compilation *comp, uint32_t warmCodeSize
 
    uint8_t *warmCode = codeCacheManager().allocateCodeMemory(warmCodeSize, coldCodeSize, &codeCache,
                                                              coldCode, false, isMethodHeaderNeeded);
-   if (warmCode == NULL)
-      {
-      comp->setErrorCode(jitConfig()->isCodeCacheFull() ?
-                         COMPILATION_CODE_MEMORY_EXHAUSTED :
-                         COMPILATION_ALL_CODE_CACHES_RESERVED);
-      }
+
    if (codeCache != comp->getCurrentCodeCache())
       {
       // Either we didn't get a code cache, or the one we get should be reserved
@@ -65,12 +61,22 @@ FEBase<Derived>::allocateCodeMemory(TR::Compilation *comp, uint32_t warmCodeSize
       comp->setAotMethodCodeStart(warmCode);
       switchCodeCache(codeCache);
       }
-   if ( comp->getErrorCode() != COMPILATION_SUCCEEDED )
+
+   if (warmCode == NULL)
       {
-      outOfMemory(comp, "code");
+      if (jitConfig()->isCodeCacheFull())
+         {
+         comp->setErrorCode(COMPILATION_CODE_MEMORY_EXHAUSTED);
+         throw TR::CodeCacheError();
+         }
+      else
+         {
+         comp->setErrorCode(COMPILATION_ALL_CODE_CACHES_RESERVED);
+         throw TR::RecoverableCodeCacheError();
+         }
       }
 
-   TR_ASSERT( !((warmCodeSize && !warmCode) || (coldCodeSize && !coldCode)), "Allocation failed but didn't call outOfMemory()");
+   TR_ASSERT( !((warmCodeSize && !warmCode) || (coldCodeSize && !coldCode)), "Allocation failed but didn't throw an exception");
 
    codeCacheManager().registerCompiledMethod(TR::comp()->signature(), warmCode, warmCodeSize);
    return warmCode;

--- a/compiler/env/FEBase_t.hpp
+++ b/compiler/env/FEBase_t.hpp
@@ -66,12 +66,10 @@ FEBase<Derived>::allocateCodeMemory(TR::Compilation *comp, uint32_t warmCodeSize
       {
       if (jitConfig()->isCodeCacheFull())
          {
-         comp->setErrorCode(COMPILATION_CODE_MEMORY_EXHAUSTED);
          throw TR::CodeCacheError();
          }
       else
          {
-         comp->setErrorCode(COMPILATION_ALL_CODE_CACHES_RESERVED);
          throw TR::RecoverableCodeCacheError();
          }
       }

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -156,7 +156,6 @@ OMR::Node::Node(TR::Node *originatingByteCodeNode, TR::ILOpCodes op, uint16_t nu
       if (self()->getGlobalIndex() == MAX_NODE_COUNT)
          {
          TR_ASSERT(0, "getGlobalIndex() == MAX_NODE_COUNT");
-         comp->setErrorCode(COMPILATION_MAX_NODE_COUNT_EXCEEDED);
          traceMsg(comp, "Global index equal to max node count");
          throw TR::ExcessiveComplexity();
          }
@@ -248,7 +247,6 @@ OMR::Node::Node(TR::Node * from, uint16_t numChildren)
    if (self()->getGlobalIndex() == MAX_NODE_COUNT)
       {
       TR_ASSERT(0, "getGlobalIndex() == MAX_NODE_COUNT");
-      comp->setErrorCode(COMPILATION_MAX_NODE_COUNT_EXCEEDED);
       traceMsg(comp, "Global index equal to max node count");
       throw TR::ExcessiveComplexity();
       }

--- a/compiler/il/symbol/OMRRegisterMappedSymbol.cpp
+++ b/compiler/il/symbol/OMRRegisterMappedSymbol.cpp
@@ -84,7 +84,7 @@ OMR::RegisterMappedSymbol::setLiveLocalIndex(uint16_t i, TR_FrontEnd * fe)
    if (self()->isLiveLocalIndexUninitialized())
       {
       TR_ASSERT(0, "OMR::RegisterMappedSymbol::_liveLocalIndex == USHRT_MAX");
-      fe->outOfMemory(0, "OMR::RegisterMappedSymbol::_liveLocalIndex == USHRT_MAX");
+      throw TR::CompilationException();
       }
    }
 

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -147,7 +147,6 @@ OMR::ResolvedMethodSymbol::ResolvedMethodSymbol(TR_ResolvedMethod * method, TR::
 
    if (_methodIndex >= MAX_CALLER_INDEX)
       {
-      comp->setErrorCode(COMPILATION_MAX_CALLER_INDEX_EXCEEDED);
       traceMsg(comp, "Exceeded MAX_CALLER_INDEX");
       throw TR::MaxCallerIndexExceeded();
       }
@@ -1030,7 +1029,6 @@ OMR::ResolvedMethodSymbol::genOSRHelperCall(int32_t currentInlinedSiteIndex, TR:
                traceMsg(self()->comp(), "#%d shares pending push slot\n", symRef->getReferenceNumber());
             if (self()->comp()->getOption(TR_DisableOSRSharedSlots))
               {
-               self()->comp()->setErrorCode(COMPILATION_IL_GEN_FAILURE);
                traceMsg(self()->comp(), "Pending push slot sharing detected");
                throw TR::ILGenFailure();
                }
@@ -1063,7 +1061,6 @@ OMR::ResolvedMethodSymbol::genOSRHelperCall(int32_t currentInlinedSiteIndex, TR:
                traceMsg(self()->comp(), "#%d shares auto slot\n", symRef->getReferenceNumber());
             if (self()->comp()->getOption(TR_DisableOSRSharedSlots))
                {
-               self()->comp()->setErrorCode(COMPILATION_IL_GEN_FAILURE);
                traceMsg(self()->comp(), "Auto/parm slot sharing detected");
                throw TR::ILGenFailure();
                }

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -1221,7 +1221,10 @@ OMR::ResolvedMethodSymbol::genIL(TR_FrontEnd * fe, TR::Compilation * comp, TR::S
          if (!comp->isPeekingMethod())
             {
             if (self()->catchBlocksHaveRealPredecessors(comp->getFlowGraph(), comp))
-               comp->fe()->outOfMemory(comp, "Catch blocks have real predecessors");
+               {
+               traceMsg(comp, "Catch blocks have real predecessors");
+               throw TR::CompilationException();
+               }
             }
 
          // If OSR is enabled, need to create an OSR helper call to keep the pending pushes,
@@ -1749,6 +1752,17 @@ OMR::ResolvedMethodSymbol::addTrivialDeadTreeBlock(TR::Block *b)
       _trivialDeadTreeBlocksList.add(b);
    }
 
+// get/setTempIndex is called from TR_ResolvedMethod::makeParameterList
+int32_t
+OMR::ResolvedMethodSymbol::setTempIndex(int32_t index, TR_FrontEnd * fe)
+   {
+   if ((_tempIndex = index) < 0)
+      {
+      traceMsg(self()->comp(), "TR::ResolvedMethodSymbol::_tempIndex overflow");
+      throw TR::CompilationException();
+      }
+   return index;
+   }
 
 ncount_t
 OMR::ResolvedMethodSymbol::generateAccurateNodeCount()

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
@@ -282,15 +282,7 @@ public:
    void setIsSideEffectFree(bool b)       { _properties.set(IsSideEffectFree,b); }
    int32_t uncheckedSetTempIndex(int32_t index) { return _tempIndex = index; }
 
-// get/setTempIndex is called from TR_ResolvedMethod::makeParameterList
-   int32_t setTempIndex(int32_t index, TR_FrontEnd * fe)
-      {
-      if ((_tempIndex = index) < 0)
-         {
-         fe->outOfMemory(0, "TR::ResolvedMethodSymbol::_tempIndex overflow");
-         }
-      return index;
-      }
+   int32_t setTempIndex(int32_t index, TR_FrontEnd * fe);
 
    int32_t getTempIndex() { return _tempIndex; }
    int32_t getArrayCopyTempSlot(TR_FrontEnd * fe);

--- a/compiler/infra/ILWalk.cpp
+++ b/compiler/infra/ILWalk.cpp
@@ -660,7 +660,10 @@ void TR::ILValidator::soundnessRule(TR::TreeTop *location, bool condition, const
       fprintf(stderr, "\n");
       static char *continueAfterValidationError = feGetEnv("TR_continueAfterValidationError");
       if (!continueAfterValidationError)
-         comp()->fe()->outOfMemory(comp(), "Validation error");
+         {
+         traceMsg(comp(), "Validation error");
+         throw TR::CompilationException();
+         }
       }
    }
 
@@ -679,7 +682,10 @@ void TR::ILValidator::validityRule(Location &location, bool condition, const cha
       fprintf(stderr, "\n");
       static char *continueAfterValidationError = feGetEnv("TR_continueAfterValidationError");
       if (!continueAfterValidationError)
-         comp()->fe()->outOfMemory(comp(), "Validation error");
+         {
+         traceMsg(comp(), "Validation error");
+         throw TR::CompilationException();
+         }
       }
    }
 

--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -959,7 +959,6 @@ bool OMR::CFG::removeEdge(TR::CFGEdge *edge, bool recursiveImpl)
        (comp()->getOption(TR_ProcessHugeMethods) ?
         (MAX_REMOVE_EDGE_NESTING_DEPTH * 2) : MAX_REMOVE_EDGE_NESTING_DEPTH))
       {
-      comp()->setErrorCode(COMPILATION_REMOVE_EDGE_NESTING_DEPTH_EXCEEDED);
       traceMsg(comp(), "Exceeded removeEdge nesting depth");
       throw TR::ExcessiveComplexity();
       }

--- a/compiler/optimizer/BackwardBitVectorAnalysis.cpp
+++ b/compiler/optimizer/BackwardBitVectorAnalysis.cpp
@@ -223,7 +223,6 @@ template<class Container>void TR_BackwardDFSetAnalysis<Container *>::initializeG
 
       if (this->_analysisInterrupted)
          {
-         this->comp()->setErrorCode(COMPILATION_INTERRUPTED);
          traceMsg(this->comp(), "interrupted in backward bit vector analysis");
          throw TR::CompilationInterrupted();
          }
@@ -1046,7 +1045,6 @@ template<class Container>bool TR_BackwardDFSetAnalysis<Container *>::analyzeNode
 
       if (this->_analysisInterrupted)
          {
-         this->comp()->setErrorCode(COMPILATION_INTERRUPTED);
          traceMsg(this->comp(), "interrupted in backward bit vector analysis");
          throw TR::CompilationInterrupted();
          }

--- a/compiler/optimizer/BitVectorAnalysis.cpp
+++ b/compiler/optimizer/BitVectorAnalysis.cpp
@@ -612,7 +612,6 @@ template<class Container>void TR_ForwardDFSetAnalysis<Container *>::initializeGe
 
       if (this->_analysisInterrupted)
          {
-         this->comp()->setErrorCode(COMPILATION_INTERRUPTED);
          traceMsg(this->comp(), "interrupted in forward bit vector analysis");
          throw TR::CompilationInterrupted();
          }
@@ -1187,7 +1186,6 @@ template<class Container>bool TR_ForwardDFSetAnalysis<Container *>::analyzeNodeI
 
       if (this->_analysisInterrupted)
          {
-         this->comp()->setErrorCode(COMPILATION_INTERRUPTED);
          traceMsg(this->comp(), "interrupted in forward bit vector analysis");
          throw TR::CompilationInterrupted();
          }

--- a/compiler/optimizer/GlobalRegisterAllocator.cpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.cpp
@@ -513,7 +513,6 @@ TR_GlobalRegisterAllocator::perform()
       if (comp()->getOptions()->realTimeGC() &&
           comp()->compilationShouldBeInterrupted(GRA_AFTER_FIND_LOOP_AUTO_CONTEXT))
          {
-         comp()->setErrorCode(COMPILATION_INTERRUPTED);
          traceMsg(comp(), "interrupted during GRA");
          throw TR::CompilationInterrupted();
          }
@@ -3927,7 +3926,6 @@ TR_GlobalRegisterAllocator::findLoopsAndCorrespondingAutos(TR_StructureSubGraphN
                static uint32_t numIter = 0;
                if (((++numIter) & 0x3f)==0 && comp()->compilationShouldBeInterrupted(GRA_FIND_LOOPS_AND_CORRESPONDING_AUTOS_BLOCK_CONTEXT))
                   {
-                  comp()->setErrorCode(COMPILATION_INTERRUPTED);
                   traceMsg(comp(), "interrupted in GRA-findLoopsAndCorrspondingAuto-block");
                   throw TR::CompilationInterrupted();
                   }

--- a/compiler/optimizer/OMRLocalCSE.cpp
+++ b/compiler/optimizer/OMRLocalCSE.cpp
@@ -416,7 +416,6 @@ void OMR::LocalCSE::examineNode(TR::Node *node, SharedSparseBitVector &seenAvail
    {
    if (depth > MAX_DEPTH)
       {
-      comp()->setErrorCode(COMPILATION_MAX_DEPTH_EXCEEDED);
       traceMsg(comp(), "scratch space in local CSE");
       throw TR::ExcessiveComplexity();
       }

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -1119,7 +1119,6 @@ int32_t OMR::Optimizer::optimize()
       if (nextHotness > comp()->getMethodHotness())
          {
          comp()->setNextOptLevel(nextHotness);
-         comp()->setErrorCode(COMPILATION_NEEDED_AT_HIGHER_LEVEL);
          traceMsg(comp(), "Method needs to be compiled at higher level");
          throw TR::InsufficientlyAggressiveCompilation();
          }
@@ -1971,7 +1970,6 @@ int32_t OMR::Optimizer::performOptimization(const OptimizationStrategy *optimiza
                }
             else
                {
-               comp()->setErrorCode(COMPILATION_LOOPS_OR_BASICBLOCKS_EXCEEDED);
                if (comp()->getOption(TR_MimicInterpreterFrameShape))
                   {
                   traceMsg(comp(), "complex method under MimicInterpreterFrameShape");
@@ -2042,7 +2040,6 @@ int32_t OMR::Optimizer::performOptimization(const OptimizationStrategy *optimiza
 
       if (comp()->compilationShouldBeInterrupted((TR_CallingContext)optNum))
          {
-         comp()->setErrorCode(COMPILATION_INTERRUPTED);
          traceMsg(comp(), "interrupted between optimizations");
          throw TR::CompilationInterrupted();
          }

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -1102,14 +1102,14 @@ int32_t OMR::Optimizer::optimize()
    const OptimizationStrategy *opt = _strategy;
    while (opt->_num != endOpts)
       {
-        if (performOptimization(opt, firstOptIndex, lastOptIndex, doTiming) == COMPILATION_INTERRUPTED)
-          return COMPILATION_INTERRUPTED;
-        opt++;
-        if (!isIlGenOpt() && comp()->getNodePool().removeDeadNodes())
-           {
-             setValueNumberInfo(NULL);
-           }
+      int32_t actualCost = performOptimization(opt, firstOptIndex, lastOptIndex, doTiming);
+      opt++;
+      if (!isIlGenOpt() && comp()->getNodePool().removeDeadNodes())
+         {
+         setValueNumberInfo(NULL);
+         }
       }
+
    if (TR::Options::getCmdLineOptions()->getOption(TR_EnableDeterministicOrientedCompilation) &&
        comp()->isOutermostMethod() &&
        (comp()->getMethodHotness() > cold) &&

--- a/compiler/optimizer/OSRDefAnalysis.cpp
+++ b/compiler/optimizer/OSRDefAnalysis.cpp
@@ -98,8 +98,6 @@ void TR_OSRDefInfo::performFurtherAnalysis(AuxiliaryData &aux)
       //TR_ASSERT(0, "osr def analysis failed. need to undo whatever we did for OSR and disable OSR but we don't. Implementation is not completed.\n");
       traceMsg(comp(), "compilation failed for %s because osr def analysis failed\n",
             optimizer()->getMethodSymbol()->signature(comp()->trMemory()));
-      comp()->setErrorCode(COMPILATION_IL_GEN_FAILURE);
-      traceMsg(comp(), "osr def analysis failed");
       throw TR::ILGenFailure();
       }
    comp()->printMemStatsAfter("computeOSRDefInfo");

--- a/compiler/optimizer/PartialRedundancy.cpp
+++ b/compiler/optimizer/PartialRedundancy.cpp
@@ -4260,7 +4260,6 @@ bool TR_ExceptionCheckMotion::analyzeNodeIfSuccessorsAnalyzed(TR::CFGNode *cfgNo
 
       if (_analysisInterrupted)
          {
-         comp()->setErrorCode(COMPILATION_INTERRUPTED);
          traceMsg(comp(), "interrupted in forward bit vector analysis");
          throw TR::CompilationInterrupted();
          }

--- a/compiler/optimizer/RegisterCandidate.cpp
+++ b/compiler/optimizer/RegisterCandidate.cpp
@@ -2673,7 +2673,6 @@ TR_RegisterCandidates::assign(TR::Block ** cfgBlocks, int32_t numberOfBlocks, in
          {
          if (comp()->compilationShouldBeInterrupted(GRA_ASSIGN_CONTEXT))
             {
-            comp()->setErrorCode(COMPILATION_INTERRUPTED);
             traceMsg(comp(), "interrupted in GRA");
             throw TR::CompilationInterrupted();
             }

--- a/compiler/optimizer/Structure.hpp
+++ b/compiler/optimizer/Structure.hpp
@@ -178,7 +178,8 @@ class TR_Structure
       if (f > SHRT_MAX-1)
          {
          TR_ASSERT(0, "nesting depth must be less than or equal to SHRT_MAX-1");
-         comp()->fe()->outOfMemory(comp(), "nesting depth must be less than or equal to SHRT_MAX-1");
+         traceMsg(comp(), "nesting depth must be less than or equal to SHRT_MAX-1");
+         throw TR::CompilationException();
          }
       _nestingDepth = f;
       }
@@ -190,7 +191,8 @@ class TR_Structure
       if (f > SHRT_MAX-1)
          {
          TR_ASSERT(0, "nesting depth must be less than or equal to SHRT_MAX-1");
-         comp()->fe()->outOfMemory(comp(), "nesting depth must be less than or equal to SHRT_MAX-1");
+         traceMsg(comp(), "nesting depth must be less than or equal to SHRT_MAX-1");
+         throw TR::CompilationException();
          }
       _anyCyclicRegionNestingDepth = f;
       }
@@ -205,7 +207,8 @@ class TR_Structure
       if (f > SHRT_MAX-1)
          {
          TR_ASSERT(0, "max nesting depth must be less than or equal to SHRT_MAX-1");
-         comp()->fe()->outOfMemory(comp(), "max nesting depth must be less than or equal to SHRT_MAX-1");
+         traceMsg(comp(), "max nesting depth must be less than or equal to SHRT_MAX-1");
+         throw TR::CompilationException();
          }
       _maxNestingDepth = f;
       }

--- a/compiler/optimizer/ValuePropagation.cpp
+++ b/compiler/optimizer/ValuePropagation.cpp
@@ -4256,7 +4256,6 @@ void TR::GlobalValuePropagation::processStructure(TR_StructureSubGraphNode *node
        ((++numIter) & 0xf) == 0 &&
        comp()->compilationShouldBeInterrupted(BEFORE_PROCESS_STRUCTURE_CONTEXT))
       {
-      comp()->setErrorCode(COMPILATION_INTERRUPTED);
       traceMsg(comp(), "interrupted when starting processStructure()");
       throw TR::CompilationInterrupted();
       }

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -2010,7 +2010,6 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
       if (!addrToPatch)
          {
          TR_ASSERT(false, "Must have updated gcrPatchPointSymbol with the correct address by now\n");
-         self()->comp()->setErrorCode(COMPILATION_GCRPATCH_FAILURE);
          traceMsg(self()->comp(), "Must have updated gcrPatchPointSymbol with the correct address by now");
          throw TR::GCRPatchFailure();
          }

--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -495,7 +495,8 @@ uint8_t *TR::X86LabelInstruction::generateBinaryEncoding()
                // distances are guaranteed.
                //
                TR_ASSERT(0, "short form branch displacement too large: instr=%p, distance=%d\n", this, distance);
-               comp->fe()->outOfMemory(comp, "short form branch displacement too large");
+               traceMsg(comp, "short form branch displacement too large");
+               throw TR::CompilationException();
                }
 
             cursor = getOpCode().copyBinaryToBuffer(instructionStart);

--- a/compiler/z/codegen/OMRRegisterDependency.cpp
+++ b/compiler/z/codegen/OMRRegisterDependency.cpp
@@ -779,7 +779,8 @@ TR_S390RegisterDependencyGroup::checkDependencyGroup(TR::Instruction * currentIn
          cg->getDebug()->printRegisterDependencies(comp->getOutFile(), this, numberOfRegisters);
          }
       TR_ASSERT( 0, "checkDependencyGroup::Insufficient available pairs to satisfy all reg deps.\n");
-      cg->fe()->outOfMemory(comp, "checkDependencyGroup::Insufficient available pairs to satisfy all reg deps, abort compilation\n");
+      traceMsg(comp, "checkDependencyGroup::Insufficient available pairs to satisfy all reg deps, abort compilation\n");
+      throw TR::CompilationException();
       }
 
    // Check for dups, cause an assertion

--- a/compiler/z/codegen/OMRRegisterDependency.hpp
+++ b/compiler/z/codegen/OMRRegisterDependency.hpp
@@ -389,8 +389,8 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
          // If this failure is triggered in a prod build, you might
          // not get a SEGV nor any meaningful error msg.
          TR_ASSERT(0,"ERROR: addPreCondition list overflow\n");
-         _cg->fe()->outOfMemory(_cg->comp(), "addPreCondition list overflow, abort compilation\n");
-
+         traceMsg(_cg->comp(), "addPreCondition list overflow, abort compilation\n");
+         throw TR::CompilationException();
          }
       _preConditions->setDependencyInfo(_addCursorForPre++, vr, rr, flag);
       }
@@ -426,8 +426,8 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
          // If this failure is triggered in a prod build, you might
          // not get a SEGV nor any meaningful error msg.
          TR_ASSERT(0,"ERROR: addPostCondition list overflow\n");
-         _cg->fe()->outOfMemory(_cg->comp(), "addPostCondition list overflow, abort compilation\n");
-
+         traceMsg(_cg->comp(), "addPostCondition list overflow, abort compilation\n");
+         throw TR::CompilationException();
          }
       _postConditions->setDependencyInfo(_addCursorForPost++, vr, rr, flag);
       if((flag & DefinesDependentRegister) != 0)

--- a/fvtest/compilertest/env/FrontEnd.cpp
+++ b/fvtest/compilertest/env/FrontEnd.cpp
@@ -186,7 +186,10 @@ FrontEnd::createStackAtlas(
        stackAtlas->getNumberOfParmSlotsMapped() > USHRT_MAX ||
        stackAtlas->getParmBaseOffset()  < SHRT_MIN || stackAtlas->getParmBaseOffset()  > SHRT_MAX ||
        stackAtlas->getLocalBaseOffset() < SHRT_MIN || stackAtlas->getLocalBaseOffset() > SHRT_MAX)
-      cg->fe()->outOfMemory(comp, "GC data");
+      {
+      traceMsg(comp, "Overflowed the fields in pyAtlas");
+      throw TR::CompilationException();
+      }
 
    // Maps are in reverse order in list from what we want in the atlas
    // so advance to the address where the last map should go and start

--- a/jitbuilder/env/FrontEnd.cpp
+++ b/jitbuilder/env/FrontEnd.cpp
@@ -186,7 +186,10 @@ FrontEnd::createStackAtlas(
        stackAtlas->getNumberOfParmSlotsMapped() > USHRT_MAX ||
        stackAtlas->getParmBaseOffset()  < SHRT_MIN || stackAtlas->getParmBaseOffset()  > SHRT_MAX ||
        stackAtlas->getLocalBaseOffset() < SHRT_MIN || stackAtlas->getLocalBaseOffset() > SHRT_MAX)
-      cg->fe()->outOfMemory(comp, "GC data");
+      {
+      traceMsg(comp, "Overflowed the fields in pyAtlas");
+      throw TR::CompilationException();
+      }
 
    // Maps are in reverse order in list from what we want in the atlas
    // so advance to the address where the last map should go and start


### PR DESCRIPTION
This PR contains commits that remove the use of error codes in OMR. It sets the stage for Step 3 in #380 (once all other projects that depend on OMR are cleaned up).