### PR TITLE
Fix Mandelbrot buffer size issue

### DIFF
--- a/jitbuilder/release/src/Mandelbrot.cpp
+++ b/jitbuilder/release/src/Mandelbrot.cpp
@@ -285,7 +285,8 @@ MandelbrotMethod::buildIL()
    x2Loop->   IndexAt(pInt8,
    x2Loop->      Load("line"),
    x2Loop->      Load("x")),
-   x2Loop->   Load("bits"));
+   x2Loop->   ConvertTo(Int8,
+   x2Loop->      Load("bits")));
 
    Return();
 
@@ -330,7 +331,7 @@ main(int argc, char *argv[])
    MandelbrotFunctionType *mandelbrot = (MandelbrotFunctionType *)entry;
    const int height = N;
    const int max_x = (N + 7) / 8;
-   const int size = height * max_x * sizeof(uint8_t) + 3;
+   const int size = height * max_x * sizeof(uint8_t);
    uint8_t *buffer = (uint8_t *) malloc(size);
    double *cr0 = (double *) malloc(8 * max_x * sizeof(double));
 


### PR DESCRIPTION
Valgrind errors were caused in Mandelbrot due to out of scope
memory writes caused by wiritng a 32-bit value `bits` in an
8-bit index at `buffer`.

The errors were caused on writes to the last three indices in
`buffer`. This commit fixes the errors by explicitly converting
`bits` to 8-bit.

The underlying problem with StoreAt needs to be fixed.

Issue: #414
Signed-off-by: Aman Kumar <amank@ca.ibm.com>