### PR TITLE
Implement Or in IlBuilder

### DIFF
--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -1263,6 +1263,15 @@ IlBuilder::And(TR::IlValue *left, TR::IlValue *right)
    }
 
 TR::IlValue *
+IlBuilder::Or(TR::IlValue *left, TR::IlValue *right)
+   {
+   TR::IlValue *returnValue=binaryOpFromOpMap(TR::ILOpCode::orOpCode, left, right);
+   TraceIL("IlBuilder[ %p ]::%d is Or %d | %d\n", this, returnValue->getCPIndex(), left->getCPIndex(), right->getCPIndex());
+   ILB_REPLAY("%s = %s->Or(%s, %s);", REPLAY_VALUE(returnValue), REPLAY_BUILDER(this), REPLAY_VALUE(left), REPLAY_VALUE(right));
+   return returnValue;
+   }
+
+TR::IlValue *
 IlBuilder::Xor(TR::IlValue *left, TR::IlValue *right)
    {
    TR::IlValue *returnValue=binaryOpFromOpMap(TR::ILOpCode::xorOpCode, left, right);

--- a/compiler/ilgen/IlBuilder.hpp
+++ b/compiler/ilgen/IlBuilder.hpp
@@ -157,6 +157,7 @@ public:
    TR::IlValue *MulWithOverflow(TR::IlBuilder **handler, TR::IlValue *left, TR::IlValue *right);
    TR::IlValue *Div(TR::IlValue *left, TR::IlValue *right);
    TR::IlValue *And(TR::IlValue *left, TR::IlValue *right);
+   TR::IlValue *Or(TR::IlValue *left, TR::IlValue *right);
    TR::IlValue *Xor(TR::IlValue *left, TR::IlValue *right);
    TR::IlValue *ShiftL(TR::IlValue *v, TR::IlValue *amount);
    TR::IlValue *ShiftL(TR::IlValue *v, int8_t amount)                { return ShiftL(v, ConstInt8(amount)); }


### PR DESCRIPTION
In order to use `Or`, implement `Or` in `IlBuilder`.

Signed-off-by: Shuyu Li <shuyuli@ca.ibm.com>