### PR TITLE
Added vector evaluators to TreeEvaluatorTable

### DIFF
--- a/compiler/p/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/TreeEvaluatorTable.hpp
@@ -464,9 +464,9 @@
    TR::TreeEvaluator::vmulEvaluator,                    // TR::vmul
    TR::TreeEvaluator::vdivEvaluator,                    // TR::vdiv
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::vrem
-   TR::TreeEvaluator::unImpOpEvaluator,                    // TR::vand
-   TR::TreeEvaluator::unImpOpEvaluator,                    // TR::vor
-   TR::TreeEvaluator::unImpOpEvaluator,                    // TR::vxor
+   TR::TreeEvaluator::vandEvaluator,                    // TR::vand
+   TR::TreeEvaluator::vorEvaluator,                    // TR::vor
+   TR::TreeEvaluator::vxorEvaluator,                    // TR::vxor
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::vshl
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::vushr
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::vshr


### PR DESCRIPTION
The evaluators for "vor", "vxor" and "vand" although implemented were
not added to the TreeEvaluatorTable. This causes an issue where they are
used, as they are seen as unimplemented

Signed-off-by: Ryan Santhirarajan <rsanth@ca.ibm.com>