### PR TITLE
Remove node from supportsInduceOSR API

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -701,7 +701,7 @@ bool OMR::Compilation::isPotentialOSRPoint(TR::TreeTop *tt, TR::Node *ttNode)
       TR_ByteCodeInfo &bci = node->getByteCodeInfo();
       TR::ResolvedMethodSymbol *method = bci.getCallerIndex() == -1 ?
          self()->getMethodSymbol() : self()->getInlinedResolvedMethodSymbol(bci.getCallerIndex());
-      potentialOSRPoint = method->supportsInduceOSR(bci, node, tt->getEnclosingBlock(), NULL, self());
+      potentialOSRPoint = method->supportsInduceOSR(bci, tt->getEnclosingBlock(), NULL, self());
       }
 
    return potentialOSRPoint;

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
@@ -266,8 +266,8 @@ public:
    bool catchBlocksHaveRealPredecessors(TR::CFG *cfg, TR::Compilation *comp);
 
    void setCannotAttemptOSR(int32_t);
-   bool cannotAttemptOSR(TR_ByteCodeInfo bci, TR::Node *nodeToOSRAt, TR::Block *blockToOSRAt, TR::ResolvedMethodSymbol *calleeSymbolIfCallNode, TR::Compilation *comp);
-   bool supportsInduceOSR(TR_ByteCodeInfo bci, TR::Node *nodeToOSRAt, TR::Block *blockToOSRAt, TR::ResolvedMethodSymbol *calleeSymbolIfCallNode, TR::Compilation *comp);
+   bool cannotAttemptOSR(TR_ByteCodeInfo bci, TR::Block *blockToOSRAt, TR::ResolvedMethodSymbol *calleeSymbolIfCallNode, TR::Compilation *comp);
+   bool supportsInduceOSR(TR_ByteCodeInfo bci, TR::Block *blockToOSRAt, TR::ResolvedMethodSymbol *calleeSymbolIfCallNode, TR::Compilation *comp);
 
    void setShouldNotAttemptOSR(int32_t n);
 

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -2141,7 +2141,7 @@ TR_InlinerBase::addGuardForVirtual(
        (guard->_kind == TR_HierarchyGuard))
       shouldAttemptOSR = false;
 
-   if (callerSymbol->supportsInduceOSR(callNode->getByteCodeInfo(), callNode, block1, calleeSymbol, comp()))
+   if (callerSymbol->supportsInduceOSR(callNode->getByteCodeInfo(), block1, calleeSymbol, comp()))
       {
       bool shouldUseOSR = heuristicForUsingOSR(callNode, calleeSymbol, callerSymbol, createdHCRAndVirtualGuard);
 


### PR DESCRIPTION
Currently supportsInduceOSR and cannotAttemptOSR accept a node parameter in their API. This node parameter is used only for logging. The question of whether OSR is prohibited or supported is a question asked based on the bytecode index -- nodes do not consider in the equation. Soon we will want to use these APIs in various IL generators so this commit removes the node since the IL generator may want to ask the question before having a node in hand.