### PR TITLE
Remove GenControlBlock code

### DIFF
--- a/compiler/il/OMRBlock.cpp
+++ b/compiler/il/OMRBlock.cpp
@@ -1438,18 +1438,6 @@ OMR::Block::inheritBlockInfo(TR::Block * org, bool inheritFreq)
    self()->setIsSpecialized(org->isSpecialized());
    }
 
-bool
-OMR::Block::isSimpleGenControlBlock()
-   {
-   if (self()->isGenControlBlock())
-      {
-      // Block only contain single gen control
-      if (self()->getEntry()->getNextRealTreeTop() == self()->getExit()->getPrevRealTreeTop())
-         return true;
-      }
-   return false;
-   }
-
 TR::Block *
 OMR::Block::startOfExtendedBlock()
    {

--- a/compiler/il/OMRBlock.hpp
+++ b/compiler/il/OMRBlock.hpp
@@ -191,8 +191,6 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
 
    bool isTargetOfJumpWhoseTargetCanBeChanged(TR::Compilation * comp);
 
-   bool isSimpleGenControlBlock();
-
    static int32_t getMaxColdFrequency(TR::Block *b1, TR::Block *b2);
    static int32_t getMinColdFrequency(TR::Block *b1, TR::Block *b2);
    static int32_t getScaledSpecializedFrequency(int32_t fastFrequency);
@@ -415,9 +413,6 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
    void setIsAdded()                                  { _flags.set(_isAdded); }
    bool isAdded()                                     { return _flags.testAny(_isAdded); }
 
-   void setIsGenControlBlock(bool b)                  { _flags.set(_isGenControlBlock, b); }
-   bool isGenControlBlock()                           { return _flags.testAny(_isGenControlBlock); }
-
    void setIsGenAsmBlock(bool b)                      { _flags.set(_isGenAsmBlock, b); }
    bool isGenAsmBlock()                               { return _flags.testAny(_isGenAsmBlock); }
 
@@ -512,7 +507,6 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
       _hasBeenVisited                       = 0x00000400,
       _isPRECandidate                       = 0x00000800,
       _isAdded                              = 0x00001000,
-      _isGenControlBlock                    = 0x00002000,
       _isGenAsmBlock                        = 0x00010000,
       _isGenAsmFlowBlock                    = 0x00100000,
       _isOSRCodeBlock                       = 0x00004000,

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -5099,13 +5099,6 @@ bool TR_InlinerBase::inlineCallTarget2(TR_CallStack * callStack, TR_CallTarget *
       tif->firstBBEnd()->getNode()->setBlock(blockContainingTheCall);
       blockContainingTheCall->setExit(tif->firstBBEnd());
 
-      //Reset isGenControlBlock flag so it can be deleted later
-      if (firstCalleeBlock->isGenControlBlock())
-         {
-         blockContainingTheCall->setIsGenControlBlock(true);
-         firstCalleeBlock->setIsGenControlBlock(false);
-         }
-
       firstCalleeBlock->setEntry(0);
 
       // hook up the last BBStart in the callee with the next BBEnd

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -3747,13 +3747,6 @@ int32_t TR_CleanseTrees::process(TR::TreeTop *startTree, TR::TreeTop *endTreeTop
       if (node->getBranchDestination() == treeTop)
          continue;
 
-      // Don't move if either of the bloks are gen control block
-      if ((block->getNextBlock() &&
-           block->getNextBlock()->isGenControlBlock()) ||
-          (node->getBranchDestination() &&
-           node->getBranchDestination()->getNode()->getBlock()->isGenControlBlock()))
-         continue;
-
       TR::Block *block1;
       TR::Block *block2;
       TR::TreeTop *tt1 = exitTreeTop->getNextTreeTop();

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -3578,15 +3578,6 @@ static bool isLegalToMerge(TR::Node * node, TR::Block * block, TR::Block * nextB
    if (blockIsEmpty && (inEdge.size() > 1) && (block == s->comp()->getStartBlock() || block->hasExceptionPredecessors()))
      return false;
 
-   // only merge gen control block with another gen control block
-   if ((block->isGenControlBlock() && !nextBlock->isGenControlBlock()) ||
-       (block->isGenControlBlock() && !nextBlock->isSimpleGenControlBlock()) ||
-       (!block->isGenControlBlock() && nextBlock->isGenControlBlock()) ||
-       (block->isGenControlBlock() &&
-        block->getPredecessors().empty() &&
-        block->getExceptionPredecessors().empty()))
-      return false;
-
    // See if the two blocks have compatible exception edges
    //
    if (nextBlock->hasExceptionPredecessors())
@@ -15734,8 +15725,6 @@ TR::Node *endBlockSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
      block->setHasCallToSuperCold(true);
    if (nextBlock->isGenAsmBlock())
       block->setIsGenAsmBlock(true);
-   if (nextBlock->isGenControlBlock())
-      block->setIsGenControlBlock(true);
    if (nextBlock->isGenAsmFlowBlock())
       block->setIsGenAsmFlowBlock(true);
 

--- a/compiler/optimizer/OrderBlocks.cpp
+++ b/compiler/optimizer/OrderBlocks.cpp
@@ -1101,61 +1101,6 @@ bool TR_OrderBlocks::peepHoleGotoToFollowing(TR::CFG *cfg, TR::Block *block, TR:
          return true;
          }
       }
-#if 1
-   else if (peepHoleBranchAroundSimpleGenControlBlocks(cfg, block, followingBlock, title))
-      return true;
-
-#endif
-   return false;
-   }
-
-bool TR_OrderBlocks::peepHoleBranchAroundSimpleGenControlBlocks(TR::CFG *cfg, TR::Block *block, TR::Block *followingBlock, char *title)
-   {
-   //If goto go around blocks with single gen cotnrol, it is safe to remove the goto
-   TR::Block *nextBlock = block->getNextBlock();
-   TR::Block *prevBlock = block;
-   TR::Block *oldNext   = nextBlock;
-   TR::Node  *branchNode = block->getLastRealTreeTop()->getNode();
-   TR::Block *branchTarget =  branchNode->getBranchDestination()->getNode()->getBlock();
-
-   //return false;
-
-   //traceMsg(comp(), " block %d nextblock %d isSingleGenCtrlBlock=%d\n", block->getNumber(),nextBlock->getNumber(), nextBlock->isSimpleGenControlBlock());
-   //Skip gen control blocks with only gen control
-   while (nextBlock->isSimpleGenControlBlock())
-      {
-      prevBlock = nextBlock;
-      nextBlock = nextBlock->getNextBlock();
-      }
-
-   //At least one gen control block between block and branchTarget
-   if (prevBlock != block && branchTarget == nextBlock)
-      {
-      if (performTransformation(comp(), "%s branch/goto in block_%d branch/goto around simple gen control bloks to block_%d, removing the branch/goto node\n", title, block->getNumber(), branchTarget->getNumber()))
-         {
-         TR::TreeTop *        nextTreeTop = block->getLastRealTreeTop()->getNextTreeTop();
-         bool                hasPred0    = (oldNext->getPredecessors().size() == 1) && oldNext->hasPredecessor(cfg->getStart());
-         //TR_RegionStructure *parent      = block->getCommonParentStructureIfExists(branchTarget, cfg);
-
-         if (block->endsInGoto())
-            cfg->addEdge(block, oldNext);
-
-         // for PLX, there may be something like unrestricted after goto
-         block->getLastRealTreeTop()->getPrevTreeTop()->join(nextTreeTop);
-         branchNode->recursivelyDecReferenceCount();
-
-         //If oldNext only has block 0 as predecessor before, remove edge from block 0
-         if (hasPred0)
-            cfg->removeEdge(cfg->getStart(), oldNext);
-
-         //traceMsg(comp(), " block %d oldNext %d prevBlock %d nextBlock %d branchTarget %d\n", block->getNumber(), oldNext->getNumber(), prevBlock->getNumber(), nextBlock->getNumber(),branchTarget->getNumber());
-
-         cfg->removeEdge(block, branchTarget);
-         //Invalidate structure
-         //_donePeepholeGotoToLoopHeader = true;
-         return true;
-         }
-      }
    return false;
    }
 
@@ -1555,8 +1500,6 @@ bool TR_OrderBlocks::peepHoleBranchToFollowing(TR::CFG *cfg, TR::Block *block, T
       removeRedundantBranch(cfg, block, branchNode, takenBlock);
       return true;
       }
-   else if (peepHoleBranchAroundSimpleGenControlBlocks(cfg, block, followingBlock, title))
-      return true;
 
    return false;
    }

--- a/compiler/optimizer/OrderBlocks.hpp
+++ b/compiler/optimizer/OrderBlocks.hpp
@@ -121,7 +121,6 @@ class TR_OrderBlocks : public TR_BlockOrderingOptimization
    void            peepHoleBranchBlock(TR::CFG *cfg, TR::Block *block, char *title);
    void            peepHoleBranchAroundSingleGoto(TR::CFG *cfg, TR::Block *block, char *title);
    bool            peepHoleBranchToFollowing(TR::CFG *cfg, TR::Block *block, TR::Block *followingBlock, char *title);
-   bool            peepHoleBranchAroundSimpleGenControlBlocks(TR::CFG *cfg, TR::Block *block, TR::Block *followingBlock, char *title);
    bool            peepHoleBranchToLoopHeader(TR::CFG *cfg, TR::Block *block, TR::Block *fallThrough, TR::Block *dest, char *title);
    void            removeEmptyBlock(TR::CFG *cfg, TR::Block *block, char *title);
    bool            doPeepHoleBlockCorrections(TR::Block *block, char *title);


### PR DESCRIPTION
The flag _isGenControlBlock was used in a project that existed
prior to this code being contributed and is not relevant to the
open source code base.

Signed-off-by: Aman Kumar <amank@ca.ibm.com>