### PR TITLE
Improve methodHandleInvokeInliningGroup

### DIFF
--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -2094,7 +2094,7 @@ OMR::ResolvedMethodSymbol::hasEscapeAnalysisOpportunities()
 bool
 OMR::ResolvedMethodSymbol::doJSR292PerfTweaks()
    {
-   return self()->hasMethodHandleInvokes();
+   return false;
    }
 
 int32_t

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -8212,6 +8212,7 @@ TR_ColdBlockMarker::isBlockCold(TR::Block *block)
       if (  _notYetRunMeansCold
          && node->getOpCode().isCall()
          && node->getSymbol()->isResolvedMethod()
+         && !node->getSymbol()->getResolvedMethodSymbol()->getResolvedMethod()->convertToMethod()->isArchetypeSpecimen()
          && !comp()->getJittedMethodSymbol()->castToResolvedMethodSymbol()->doJSR292PerfTweaks())
          {
          TR::ResolvedMethodSymbol *calleeSymbol = node->getSymbol()->getResolvedMethodSymbol();

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -319,19 +319,20 @@ const OptimizationStrategy methodHandleInvokeInliningOpts[] =
    { localCSE,                                     }, // Especially copy propagation to replace temps with more descriptive trees
    { localValuePropagation                         }, // Propagate known-object info and derive more specific archetype specimen symbols for inlining
 #ifdef J9_PROJECT_SPECIFIC
-   { inlining,                                     },
+   { targetedInlining,                             },
 #endif
+   { deadTreesElimination                          },
    { methodHandleInvokeInliningGroup,    IfEnabled }, // Repeat as required to inline all the MethodHandle.invoke calls we can afford
    { endGroup                                      },
    };
 
 const OptimizationStrategy earlyGlobalOpts[] =
    {
+   { methodHandleInvokeInliningGroup,  IfMethodHandleInvokes },
 #ifdef J9_PROJECT_SPECIFIC
    { inlining                             },
 #endif
    { osrExceptionEdgeRemoval                       }, // most inlining is done by now
-   { methodHandleInvokeInliningGroup,  IfMethodHandleInvokes },
    //{ basicBlockOrdering,          IfLoops }, // early ordering with no extension
    { treeSimplification,        IfEnabled },
    { compactNullChecks                    }, // cleans up after inlining; MUST be done before PRE

--- a/compiler/optimizer/Optimizations.enum
+++ b/compiler/optimizer/Optimizations.enum
@@ -24,6 +24,7 @@
    OPTIMIZATION_ENUM_ONLY(endOpts = 0x00) // Marks the end of a list of optimizations
 
    OPTIMIZATION(inlining)
+   OPTIMIZATION(targetedInlining)
    OPTIMIZATION(trivialInlining)
    OPTIMIZATION(CFGSimplification)
    OPTIMIZATION(basicBlockHoisting)


### PR DESCRIPTION
These changes are part of work to clean up the handling of the methodHandleInvokeInliningGroup and generalize it as a type of targeted inlining. It turns off doJSR292PerfTweaks for now since this is an API
we want to eliminate in the long run but are not quite ready to delete it completely - we just turn it off as deprecated pending final removal at a later date. It adds a targetedInlining optimization enum which is used to distinguish targetedInlining from regular inlining in the opt strategies.