### PR TITLE
Test option sets

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -3277,7 +3277,7 @@ OMR::Options::processOptionSet(
             endOpt = options + strlen(EXCLUDED_METHOD_OPTIONS_PREFIX);
             }
          //filter starts with a limitfile subset index
-         else if (*options >= '0' && *options < '9')
+         else if (*options >= '0' && *options <= '9')
             {
             filterHeader = options;
             // Option subset represented by an index (used in limitfiles)

--- a/fvtest/compilertest/build/files/common.mk
+++ b/fvtest/compilertest/build/files/common.mk
@@ -198,6 +198,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     $(JIT_PRODUCT_DIR)/tests/FooIlInjector.cpp \
     $(JIT_PRODUCT_DIR)/tests/LimitFileTest.cpp \
     $(JIT_PRODUCT_DIR)/tests/OMRTestEnv.cpp \
+    $(JIT_PRODUCT_DIR)/tests/OptionSetTest.cpp \
     $(JIT_PRODUCT_DIR)/tests/OpCodesTest.cpp \
     $(JIT_PRODUCT_DIR)/tests/PPCOpCodesTest.cpp \
     $(JIT_PRODUCT_DIR)/tests/Qux2Test.cpp \

--- a/fvtest/compilertest/tests/LimitFileTest.hpp
+++ b/fvtest/compilertest/tests/LimitFileTest.hpp
@@ -33,7 +33,10 @@ class LimitFileTest : public ::testing::Test
    void createVLog(const char *vlog, const char *limitFile = NULL);
    void createAndCheckVLog(const char *vlog, const char *limitFile = NULL, int *iNegLine = NULL);
 
-   void checkVLogForMethod(const char *vlog, const char *method, bool compiled, int *foundOnLine = NULL);
+   void checkVLogForMethod(const char *vlog, const char *method, const char *level = "warm", int *foundOnLine = NULL);
+
+   protected:
+   void delayUnlink(const char *file);
 
    private:
    std::vector<const char *> _vlog;

--- a/fvtest/compilertest/tests/OptionSetTest.cpp
+++ b/fvtest/compilertest/tests/OptionSetTest.cpp
@@ -1,0 +1,160 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+
+#include "tests/OptionSetTest.hpp"
+
+#include <fstream>
+#include <string>
+
+/**
+ * Get the method that was compiled on a given line. The line
+ * must be a compilation success line (starting with '+')
+ * from a verbose log, without a trailing newline,
+ * 
+ * @param line The line to extract the method name from.
+ * @return The name of the method, or an empty string if
+ *         the method name could not be extracted.
+ */
+std::string
+TestCompiler::OptionSetTest::getMethodFromLine(const std::string &line)
+   {
+   size_t sep = line.find_last_of(':');
+   if(sep == std::string::npos)
+      return "";
+   return line.substr(sep + 1);
+   }
+
+/**
+ * Take a limit file \p limitFile, modify it by placing some methods
+ * into option sets according to \p methods, then place the result
+ * into a new file \p optSetFile.
+ *
+ * @param limitFile The name of the limit file to modify.
+ * @param optSetFile The name of the file to create. The
+ *        contents will be the same as \p limitFile, with
+ *        some methods in option sets.
+ * @param methods A mapping from method name to the set
+ *        which it should be in. If a method is not specified
+ *        in this map, it is not placed in any set.
+ */
+void
+TestCompiler::OptionSetTest::applyOptionSets(const char *limitFile, const char *optSetFile, const TestCompiler::MethodSets &methods)
+   {
+   std::ifstream in(limitFile);
+   ASSERT_TRUE(in.is_open());
+
+   std::ofstream out(optSetFile);
+   ASSERT_TRUE(out.is_open());
+   delayUnlink(optSetFile);
+
+   std::string line;
+   while(std::getline(in, line))
+      {
+      // Limitfiles have a leading newline, but no newline on the end
+      out << '\n';
+
+      if(line.empty())
+         continue;
+
+      // Method successfully compiled
+      if(line[0] == '+')
+         {
+         std::string compMethod = getMethodFromLine(line);
+         auto search = methods.find(compMethod);
+         if(search != methods.end())
+            {
+            int set = search->second;
+            ASSERT_GE(set, 0);
+            ASSERT_LE(set, 9);
+            out << '+' << set << line.substr(1);
+            continue;
+            }
+         }
+
+      // Normal line, output and continue
+      out << line;
+      }
+   }
+
+namespace TestCompiler {
+
+TEST_F(OptionSetTest, UseOptionSets)
+   {
+   const char *vlog = "useOptionSets.log";
+   const char *limitFile = "useOptionSets.limit";
+   const char *optSet = "useOptionSets.options";
+
+   // Create limit file.
+   TestCompiler::MethodSets methodSets;
+   methodSets["iNeg"] = 2;
+   methodSets["iReturn"] = 3;
+
+   createAndCheckVLog(limitFile);
+
+   // Run with option sets.
+   applyOptionSets(limitFile, optSet, methodSets);
+
+   std::string limitArg = std::string(optSet)
+      + ",2(optlevel=hot)"
+      + ",3(optlevel=cold)";
+
+   createVLog(vlog, limitArg.c_str());
+
+   // Ensure option sets were follwed.
+   checkVLogForMethod(vlog, "iNeg", "hot");
+   checkVLogForMethod(vlog, "iReturn", "cold");
+   checkVLogForMethod(vlog, "iAbs", "warm");
+   }
+
+TEST_F(OptionSetTest, WithDefault)
+   {
+   const char *vlog = "optionSetsWithDefault.log";
+   const char *limitFile = "optionSetsWithDefault.limit";
+   const char *optSet = "optionSetsWithDefault.options";
+
+   // Create limit file.
+   TestCompiler::MethodSets methodSets;
+   methodSets["iNeg"] = 1;
+   methodSets["i2l"] = 2;
+   methodSets["iReturn"] = 3;
+   methodSets["i2b"] = 3;
+   methodSets["i2s"] = 9;
+
+   createAndCheckVLog(limitFile);
+
+   // Run with option sets.
+   applyOptionSets(limitFile, optSet, methodSets);
+
+   std::string limitArg = std::string(optSet)
+      + ",1(optlevel=hot)"
+      + ",3(optlevel=warm)"
+      + ",9(optlevel=warm)"
+      + ",optlevel=cold";
+
+   createVLog(vlog, limitArg.c_str());
+
+   // Ensure option sets were follwed.
+   checkVLogForMethod(vlog, "iNeg", "hot");
+   checkVLogForMethod(vlog, "i2l", "cold");
+   checkVLogForMethod(vlog, "iReturn", "warm");
+   checkVLogForMethod(vlog, "i2b", "warm");
+   checkVLogForMethod(vlog, "i2s", "warm");
+   checkVLogForMethod(vlog, "iAbs", "cold");
+   }
+
+}

--- a/fvtest/compilertest/tests/OptionSetTest.hpp
+++ b/fvtest/compilertest/tests/OptionSetTest.hpp
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+
+#ifndef TEST_OPTIONSET_INCL
+#define TEST_OPTIONSET_INCL
+
+#include "LimitFileTest.hpp"
+
+#include <map>
+#include <string>
+
+namespace TestCompiler {
+
+typedef std::map<const std::string, int> MethodSets;
+
+class OptionSetTest : public LimitFileTest
+   {
+   public:
+   void applyOptionSets(const char *limitFile, const char *newFile, const TestCompiler::MethodSets &methods);
+
+   private:
+   std::string getMethodFromLine(const std::string &line);
+   };
+
+}
+
+#endif // !defined(TEST_OPTIONSET_INCL)


### PR DESCRIPTION
This adds some basic option set tests. It ensures methods can be
added to option sets using limit files, command line arguments
can be given to option sets, and those options are correctly applied.

Option sets are a way to apply certain command line arguments to
groups of specific methods being compiled. Each method can optionally
be placed into one of these sets by annotating a limit file.

Methods can be added by modifying their successful compilation message
(starting with '+') in a limit file.

    + (warm @ ...) File.cpp:123:myMethod

is not in any option set. It can be added to set 1 by adding a '1'
directly after the '+':

    +1 (warm @ ...) File.cpp:123:myMethod

There are 10 option sets methods can be placed into, numbered 0 to 9.
By default, methods are in option set 0.

Command line arguments can be targeted towards a certain option set by
placing the argument in brackets after the set number. For example,

    -Xjit:optlevel=cold,2(optlevel=warm),7(optlevel=hot)

will compile all methods in option set 2 as warm, all methods in set 7
as hot, and all other methods as cold.