### PR TITLE
Remove type parameter from IlBuilder::StoreAt*

### DIFF
--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -622,9 +622,9 @@ IlBuilder::VectorStore(const char *varName, TR::IlValue *value)
    }
 
 void
-IlBuilder::StoreAt(TR::IlType *dt, TR::IlValue *address, TR::IlValue *value)
+IlBuilder::StoreAt(TR::IlValue *address, TR::IlValue *value)
    {
-   ILB_REPLAY("%s->StoreAt(%s, %s, %s);", REPLAY_BUILDER(this), REPLAY_TYPE(dt), REPLAY_VALUE(address), REPLAY_VALUE(value));
+   ILB_REPLAY("%s->StoreAt(%s, %s);", REPLAY_BUILDER(this), REPLAY_VALUE(address), REPLAY_VALUE(value));
 
    TR_ASSERT(address->getSymbol()->getDataType() == TR::Address, "StoreAt needs an address operand");
 
@@ -633,9 +633,9 @@ IlBuilder::StoreAt(TR::IlType *dt, TR::IlValue *address, TR::IlValue *value)
    }
 
 void
-IlBuilder::VectorStoreAt(TR::IlType *dt, TR::IlValue *address, TR::IlValue *value)
+IlBuilder::VectorStoreAt(TR::IlValue *address, TR::IlValue *value)
    {
-   ILB_REPLAY("%s->VectorStoreAt(%s, %s, %s);", REPLAY_BUILDER(this), REPLAY_TYPE(dt), REPLAY_VALUE(address), REPLAY_VALUE(value));
+   ILB_REPLAY("%s->VectorStoreAt(%s, %s);", REPLAY_BUILDER(this), REPLAY_VALUE(address), REPLAY_VALUE(value));
 
    TR_ASSERT(address->getSymbol()->getDataType() == TR::Address, "StoreAt needs an address operand");
 

--- a/compiler/ilgen/IlBuilder.hpp
+++ b/compiler/ilgen/IlBuilder.hpp
@@ -175,7 +175,7 @@ public:
    TR::IlValue *CreateLocalStruct(TR::IlType *structType);
    TR::IlValue *Load(const char *name);
    void Store(const char *name, TR::IlValue *value);
-   void StoreAt(TR::IlType *dt, TR::IlValue *address, TR::IlValue *value);
+   void StoreAt(TR::IlValue *address, TR::IlValue *value);
    TR::IlValue *LoadAt(TR::IlType *dt, TR::IlValue *address);
    TR::IlValue *LoadIndirect(const char *type, const char *field, TR::IlValue *object);
    TR::IlValue *StoreField(const char *name, TR::IlValue *object, TR::IlValue *value);
@@ -185,7 +185,7 @@ public:
    TR::IlValue *VectorLoad(const char *name);
    TR::IlValue *VectorLoadAt(TR::IlType *dt, TR::IlValue *address);
    void VectorStore(const char *name, TR::IlValue *value);
-   void VectorStoreAt(TR::IlType *dt, TR::IlValue *address, TR::IlValue *value);
+   void VectorStoreAt(TR::IlValue *address, TR::IlValue *value);
 
    // control
    void StoreIndirect(const char *type, const char *field, TR::IlValue *object, TR::IlValue *value);

--- a/jitbuilder/release/src/DotProduct.cpp
+++ b/jitbuilder/release/src/DotProduct.cpp
@@ -134,7 +134,7 @@ DotProduct::buildIL()
       Load("length"),
       ConstInt32(1));
 
-   loop->StoreAt(pDouble,
+   loop->StoreAt(
    loop->   IndexAt(pDouble,
    loop->      Load("result"),
    loop->      Load("i")),

--- a/jitbuilder/release/src/LocalArray.cpp
+++ b/jitbuilder/release/src/LocalArray.cpp
@@ -78,52 +78,52 @@ LocalArrayMethod::buildIL()
    Store("myArray",
       CreateLocalArray(10, Int64));
 
-   StoreAt(pInt64,
+   StoreAt(
       IndexAt(pInt64,
          Load("myArray"),
          ConstInt32(0)),
       ConstInt64(100));
-   StoreAt(pInt64,
+   StoreAt(
       IndexAt(pInt64,
          Load("myArray"),
          ConstInt32(1)),
       ConstInt64(101));
-   StoreAt(pInt64,
+   StoreAt(
       IndexAt(pInt64,
          Load("myArray"),
          ConstInt32(2)),
       ConstInt64(102));
-   StoreAt(pInt64,
+   StoreAt(
       IndexAt(pInt64,
          Load("myArray"),
          ConstInt32(3)),
       ConstInt64(103));
-   StoreAt(pInt64,
+   StoreAt(
       IndexAt(pInt64,
          Load("myArray"),
          ConstInt32(4)),
       ConstInt64(104));
-   StoreAt(pInt64,
+   StoreAt(
       IndexAt(pInt64,
          Load("myArray"),
          ConstInt32(5)),
       ConstInt64(105));
-   StoreAt(pInt64,
+   StoreAt(
       IndexAt(pInt64,
          Load("myArray"),
          ConstInt32(6)),
       ConstInt64(106));
-   StoreAt(pInt64,
+   StoreAt(
       IndexAt(pInt64,
          Load("myArray"),
          ConstInt32(7)),
       ConstInt64(107));
-   StoreAt(pInt64,
+   StoreAt(
       IndexAt(pInt64,
          Load("myArray"),
          ConstInt32(8)),
       ConstInt64(108));
-   StoreAt(pInt64,
+   StoreAt(
       IndexAt(pInt64,
          Load("myArray"),
          ConstInt32(9)),

--- a/jitbuilder/release/src/Mandelbrot.cpp
+++ b/jitbuilder/release/src/Mandelbrot.cpp
@@ -117,7 +117,7 @@ MandelbrotMethod::buildIL()
    k1Loop->         Load("x")),
    k1Loop->      Load("k")));
 
-   k1Loop->StoreAt(pDouble,
+   k1Loop->StoreAt(
    k1Loop->   IndexAt(pDouble,
    k1Loop->      Load("cr0"),
    k1Loop->      Load("xk")),
@@ -174,7 +174,7 @@ MandelbrotMethod::buildIL()
    x2Loop->   ConstInt32(8),
    x2Loop->   ConstInt32(1));
 
-   k2Loop->StoreAt(pDouble,
+   k2Loop->StoreAt(
    k2Loop->   IndexAt(pDouble,
    k2Loop->      Load("cr"),
    k2Loop->      Load("k")),
@@ -183,7 +183,7 @@ MandelbrotMethod::buildIL()
    k2Loop->         Load("cr0_x"),
    k2Loop->         Load("k"))));
 
-   k2Loop->StoreAt(pDouble,
+   k2Loop->StoreAt(
    k2Loop->   IndexAt(pDouble,
    k2Loop->      Load("ci"),
    k2Loop->      Load("k")),
@@ -238,7 +238,7 @@ MandelbrotMethod::buildIL()
    bit_k_set->      Load("ci_k"),
    bit_k_set->      Load("ci_k")));
 
-   bit_k_set->StoreAt(pDouble,
+   bit_k_set->StoreAt(
    bit_k_set->   IndexAt(pDouble,
    bit_k_set->      Load("cr"),
    bit_k_set->      Load("k")),
@@ -251,7 +251,7 @@ MandelbrotMethod::buildIL()
    bit_k_set->            Load("cr0_x"),
    bit_k_set->            Load("k")))));
 
-   bit_k_set->StoreAt(pDouble,
+   bit_k_set->StoreAt(
    bit_k_set->   IndexAt(pDouble,
    bit_k_set->      Load("ci"),
    bit_k_set->      Load("k")),
@@ -281,7 +281,7 @@ MandelbrotMethod::buildIL()
    k3Loop->      Load("bit_k"),
    k3Loop->      ConstInt32(1)));
 
-   x2Loop->StoreAt(pInt8,
+   x2Loop->StoreAt(
    x2Loop->   IndexAt(pInt8,
    x2Loop->      Load("line"),
    x2Loop->      Load("x")),

--- a/jitbuilder/release/src/MatMult.cpp
+++ b/jitbuilder/release/src/MatMult.cpp
@@ -59,7 +59,7 @@ MatMult::Store2D(TR::IlBuilder *bldr,
                  TR::IlValue *N,
                  TR::IlValue *value)
    {
-   bldr->StoreAt(pDouble,
+   bldr->StoreAt(
    bldr->   IndexAt(pDouble,
                base,
    bldr->      Add(
@@ -169,7 +169,7 @@ VectorMatMult::VectorStore2D(TR::IlBuilder *bldr,
                              TR::IlValue *N,
                              TR::IlValue *value)
    {
-   bldr->VectorStoreAt(pDouble,
+   bldr->VectorStoreAt(
    bldr->   IndexAt(pDouble,
                base,
    bldr->      Add(


### PR DESCRIPTION
The data type parameter passed into `StoreAt` and `VectorStoreAt` is
being ignored since the store is the same dataype as what is accessed
(the load).

Issue: #414
Signed-off-by: Aman Kumar <amank@ca.ibm.com>