### PR TITLE
Initialize the vm access mutex.

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -59,6 +59,9 @@ testMain(int argc, char ** argv, char **envp)
 	int j9rc = (int) omrthread_attach_ex(&self, J9THREAD_ATTR_DEFAULT);
 	Assert_MM_true(0 == j9rc);
 
+	/* Set up the vm access mutex */
+	omrthread_rwmutex_init(&exampleVM._vmAccessMutex, 0, "VM exclusive access");
+
 	/* Initialize root table */
 	exampleVM.rootTable = hashTableNew(
 			exampleVM._omrVM->_runtime->_portLibrary, OMR_GET_CALLSITE(), 0, sizeof(RootEntry), 0, 0, OMRMEM_CATEGORY_MM,


### PR DESCRIPTION
This mutex need to be initialized before used. Or else , there would be a crash with following stack:

#0  0xf7675b46 in pthread_mutex_lock () from /lib/libpthread.so.0
#1  0x081118ff in j9OSMutex_enter (mutex=0x0) at ./unix/thrdsup.c:357
#2  0x08109127 in monitor_enter_three_tier (self=0x94a83a0, monitor=0x94b31e8, isAbortable=0) at ./common/omrthread.c:3827
#3  0x08108e04 in omrthread_monitor_enter (monitor=0x94b31e8) at ./common/omrthread.c:3663
#4  0x08111cce in omrthread_rwmutex_enter_write (mutex=0xff976d38) at ./common/rwmutex.c:223
#5  0x0804f1a8 in MM_EnvironmentLanguageInterfaceImpl::acquireExclusiveVMAccess (this=0x94c5590)
    at .././example/glue/EnvironmentLanguageInterfaceImpl.hpp:83
#6  0x0805b522 in MM_EnvironmentBase::acquireExclusiveVMAccess (this=0x94b31e8) at EnvironmentBase.cpp:357
#7  0x0805bc9d in MM_EnvironmentBase::tryAcquireExclusiveVMAccessForGC (this=0x94b31e8, collector=0x94b5278)
    at EnvironmentBase.cpp:491
#8  0x08131863 in MM_MemorySubSpaceFlat::allocationRequestFailed (this=0x94c4c08, env=0x94b31e8, allocateDescription=0xff976c98, 
    allocationType=MM_MemorySubSpace::ALLOCATION_TYPE_TLH, objectAllocationInterface=0x94c55e8, baseSubSpace=0x94c4978, 
    previousSubSpace=0x94c4978) at MemorySubSpaceFlat.cpp:90
.....

Signed-off-by: zheddie@163.com