### PR TITLE
Remove _isGenAsm* flags

### DIFF
--- a/compiler/il/OMRBlock.hpp
+++ b/compiler/il/OMRBlock.hpp
@@ -413,12 +413,6 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
    void setIsAdded()                                  { _flags.set(_isAdded); }
    bool isAdded()                                     { return _flags.testAny(_isAdded); }
 
-   void setIsGenAsmBlock(bool b)                      { _flags.set(_isGenAsmBlock, b); }
-   bool isGenAsmBlock()                               { return _flags.testAny(_isGenAsmBlock); }
-
-   void setIsGenAsmFlowBlock(bool b)                  { _flags.set(_isGenAsmFlowBlock, b); }
-   bool isGenAsmFlowBlock()                           { return _flags.testAny(_isGenAsmFlowBlock); }
-
    void setIsOSRCodeBlock()                           { _flags.set(_isOSRCodeBlock); }
    bool isOSRCodeBlock()                              { return _flags.testAny(_isOSRCodeBlock); }
 
@@ -507,8 +501,6 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
       _hasBeenVisited                       = 0x00000400,
       _isPRECandidate                       = 0x00000800,
       _isAdded                              = 0x00001000,
-      _isGenAsmBlock                        = 0x00010000,
-      _isGenAsmFlowBlock                    = 0x00100000,
       _isOSRCodeBlock                       = 0x00004000,
       _isOSRCatchBlock                      = 0x00008000,
       _createdAtCodeGen                     = 0x00080000,

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -15723,10 +15723,6 @@ TR::Node *endBlockSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
       block->setHasCalls(true);
    if (nextBlock->hasCallToSuperCold())
      block->setHasCallToSuperCold(true);
-   if (nextBlock->isGenAsmBlock())
-      block->setIsGenAsmBlock(true);
-   if (nextBlock->isGenAsmFlowBlock())
-      block->setIsGenAsmFlowBlock(true);
 
    block->setIsCold(nextBlock->isCold());
    block->setIsSuperCold(nextBlock->isSuperCold());

--- a/compiler/optimizer/OrderBlocks.hpp
+++ b/compiler/optimizer/OrderBlocks.hpp
@@ -99,9 +99,6 @@ class TR_OrderBlocks : public TR_BlockOrderingOptimization
    bool            needBetterChoice( TR::CFG *cfg, TR::CFGNode  *block, TR::CFGNode  *prevBlock);
    bool            cannotFollowBlock(TR::Block *block, TR::Block *prevBlock);
    bool            mustFollowBlock(TR::Block *block, TR::Block *prevBlock);
-   bool            hasOtherHotAsmFlowPredeccessors(TR::Block *block, TR::Block *prevBlock);
-   bool            asmFlowHasNonFallThroughHotSuccessors(TR::Block *block);
-   bool            safeToMoveAway(TR::Block *block, TR::Block *prevBlock);
 
    TR::CFGNode *    findSuitablePathInList(List<TR::CFGNode> & list, TR::CFGNode *prevBlock);
    TR::CFGNode *    findBestPath(TR::CFGNode *prevBlock);


### PR DESCRIPTION
Remove _isGenAsmBlock and _isGenAsmFlowBlock flags.
Remove TR_OrderBlocks::asmFlowHasNonFallThroughHotSuccessors and
fold away as always false.

These flags were used in a project that existed prior to this code
being contributed and are not relevant to the open source code base.

Signed-off-by: Aman Kumar <amank@ca.ibm.com>