### PR TITLE
Clean up OSR APIs

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -696,12 +696,12 @@ bool OMR::Compilation::isPotentialOSRPoint(TR::TreeTop *tt, TR::Node *ttNode)
    else if (node->canGCandReturn())
       potentialOSRPoint = true;
 
-   if (potentialOSRPoint && tt && !self()->getOption(TR_FullSpeedDebug))
+   if (potentialOSRPoint && !self()->getOption(TR_FullSpeedDebug))
       {
       TR_ByteCodeInfo &bci = node->getByteCodeInfo();
       TR::ResolvedMethodSymbol *method = bci.getCallerIndex() == -1 ?
          self()->getMethodSymbol() : self()->getInlinedResolvedMethodSymbol(bci.getCallerIndex());
-      potentialOSRPoint = method->supportsInduceOSR(bci, tt->getEnclosingBlock(), NULL, self());
+      potentialOSRPoint = method->supportsInduceOSR(bci, tt ? tt->getEnclosingBlock() : NULL, NULL, self(), false);
       }
 
    return potentialOSRPoint;

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
@@ -137,7 +137,8 @@ public:
    const char * signature(TR_Memory * m) { return _resolvedMethod->signature(m); }
 
    bool genIL(TR_FrontEnd *fe, TR::Compilation *comp, TR::SymbolReferenceTable *symRefTab, TR::IlGenRequest & customRequest);
-   bool cleanupUnreachableOSRBlocks(int32_t inlinedSiteIndex, TR::Compilation *comp);
+   bool allCallerOSRBlocksArePresent(int32_t inlinedSiteIndex, TR::Compilation *comp);
+   void cleanupUnreachableOSRBlocks(int32_t inlinedSiteIndex, TR::Compilation *comp);
    void insertStoresForDeadStackSlotsBeforeInducingOSR(TR::Compilation *comp, int32_t inlinedSiteIndex, TR::TreeTop *induceOSRTree, TR::ResolvedMethodSymbol *callSymbolForDeadSlots);
    bool sharesStackSlots(TR::Compilation *comp);
    void resetLiveLocalIndices();
@@ -266,8 +267,8 @@ public:
    bool catchBlocksHaveRealPredecessors(TR::CFG *cfg, TR::Compilation *comp);
 
    void setCannotAttemptOSR(int32_t);
-   bool cannotAttemptOSR(TR_ByteCodeInfo bci, TR::Block *blockToOSRAt, TR::ResolvedMethodSymbol *calleeSymbolIfCallNode, TR::Compilation *comp);
-   bool supportsInduceOSR(TR_ByteCodeInfo bci, TR::Block *blockToOSRAt, TR::ResolvedMethodSymbol *calleeSymbolIfCallNode, TR::Compilation *comp);
+   bool cannotAttemptOSR(TR_ByteCodeInfo bci, TR::Block *blockToOSRAt, TR::ResolvedMethodSymbol *calleeSymbolIfCallNode, TR::Compilation *comp, bool runCleanup = true);
+   bool supportsInduceOSR(TR_ByteCodeInfo bci, TR::Block *blockToOSRAt, TR::ResolvedMethodSymbol *calleeSymbolIfCallNode, TR::Compilation *comp, bool runCleanup = true);
 
    void setShouldNotAttemptOSR(int32_t n);
 


### PR DESCRIPTION
Currently the OSR APIs conflate testing for OSR support with the notion of when it is ok to clean-up unused OSR exception edges. You many need to query for OSR support without running the clean-up if asking
mid-transformation. This change makes it explicit in the API whether you want clean-up to run or not.