### PR TITLE
Add support for offset OSR induction

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -707,6 +707,13 @@ bool OMR::Compilation::isPotentialOSRPoint(TR::TreeTop *tt, TR::Node *ttNode)
    return potentialOSRPoint;
    }
 
+int32_t
+OMR::Compilation::getOSRInductionOffset(TR::Node *node)
+   {
+   if (self()->getHCRMode() == TR::osr && node->getOpCodeValue() != TR::asynccheck)
+      return 3;
+   return 0;
+   }
 
 bool
 OMR::Compilation::isProfilingCompilation()

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -843,6 +843,7 @@ public:
     * incorrect answers if you fail to supply the TreeTop
     */
    bool isPotentialOSRPoint(TR::TreeTop *tt, TR::Node *ttNode = NULL);
+   int32_t getOSRInductionOffset(TR::Node *node);
 
    // for OSR
    TR_OSRCompilationData* getOSRCompilationData() {return _osrCompilationData;}

--- a/compiler/compile/OSRData.cpp
+++ b/compiler/compile/OSRData.cpp
@@ -882,10 +882,12 @@ TR::Compilation& operator<< (TR::Compilation& out, const TR_OSRMethodData& osrMe
    return out;
    }
 
-TR_OSRPoint::TR_OSRPoint(TR::Node *node, TR_OSRMethodData *methodData, TR_Memory *m)
+TR_OSRPoint::TR_OSRPoint(TR::Node *node, int32_t induceOffset, TR_OSRMethodData *methodData, TR_Memory *m)
    : _methodData(methodData)
    {
-   _bcinfo = node->getByteCodeInfo();
+   _nodeBCInfo = node->getByteCodeInfo();
+   _induceBCInfo = node->getByteCodeInfo();
+   _induceBCInfo.setByteCodeIndex(_induceBCInfo.getByteCodeIndex() + induceOffset);
    }
 
 TR_OSRSlotSharingInfo::TR_OSRSlotSharingInfo(TR::Compilation* _comp) :

--- a/compiler/compile/OSRData.hpp
+++ b/compiler/compile/OSRData.hpp
@@ -305,17 +305,20 @@ class TR_OSRPoint
    public:
    TR_ALLOC(TR_Memory::OSR);
 
-   TR_OSRPoint(TR::Node *node, TR_OSRMethodData *methodData, TR_Memory *m);
+   TR_OSRPoint(TR::Node *node, int32_t induceOffset, TR_OSRMethodData *methodData, TR_Memory *m);
    TR_OSRMethodData *getOSRMethodData() { return _methodData; }
 
    void setOSRIndex(uint32_t index) { _index = index; }
    uint32_t getOSRIndex() { return _index; }
-   TR_ByteCodeInfo& getByteCodeInfo() {return _bcinfo;}
+   TR_ByteCodeInfo& getNodeByteCodeInfo() {return _nodeBCInfo;}
+   TR_ByteCodeInfo& getInduceByteCodeInfo() {return _induceBCInfo;}
+   bool induceAfter() { return _induceBCInfo.getByteCodeIndex() > _nodeBCInfo.getByteCodeIndex(); }
 
    private:
    TR_OSRMethodData                   *_methodData;
    uint32_t                            _index;
-   TR_ByteCodeInfo                     _bcinfo;
+   TR_ByteCodeInfo                     _nodeBCInfo;
+   TR_ByteCodeInfo                     _induceBCInfo;
    };
 
 

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
@@ -139,7 +139,7 @@ public:
    bool genIL(TR_FrontEnd *fe, TR::Compilation *comp, TR::SymbolReferenceTable *symRefTab, TR::IlGenRequest & customRequest);
    bool allCallerOSRBlocksArePresent(int32_t inlinedSiteIndex, TR::Compilation *comp);
    void cleanupUnreachableOSRBlocks(int32_t inlinedSiteIndex, TR::Compilation *comp);
-   void insertStoresForDeadStackSlotsBeforeInducingOSR(TR::Compilation *comp, int32_t inlinedSiteIndex, TR::TreeTop *induceOSRTree, TR::ResolvedMethodSymbol *callSymbolForDeadSlots);
+   void insertStoresForDeadStackSlotsBeforeInducingOSR(TR::Compilation *comp, int32_t inlinedSiteIndex, TR_ByteCodeInfo &byteCodeInfo, TR::TreeTop *induceOSRTree, TR::ResolvedMethodSymbol *callSymbolForDeadSlots);
    bool sharesStackSlots(TR::Compilation *comp);
    void resetLiveLocalIndices();
 

--- a/compiler/optimizer/OSRDefAnalysis.hpp
+++ b/compiler/optimizer/OSRDefAnalysis.hpp
@@ -43,7 +43,7 @@ class TR_OSRDefInfo : public TR_UseDefInfo
    void performFurtherAnalysis(AuxiliaryData &aux);
    virtual void processReachingDefinition(void* vblockInfo, AuxiliaryData &aux);
    void buildOSRDefs(void *blockInfo, AuxiliaryData &aux);
-   void buildOSRDefs(TR::Node *node, void *analysisInfo, TR_OSRPoint *osrPoint, TR::Node *parent, AuxiliaryData &aux);
+   void buildOSRDefs(TR::Node *node, void *analysisInfo, TR_OSRPoint *osrPoint, TR_OSRPoint *osrPoint2, TR::Node *parent, AuxiliaryData &aux);
    void addSharingInfo(AuxiliaryData &aux);
 
    TR::ResolvedMethodSymbol *_methodSymbol;


### PR DESCRIPTION
The current OSR infrastructure believes that the target bytecode for an OSR induce must be the bytecode of the node. This is true if induction is meant to land before the effect of executing the bytecode has occurred. We also want to support landing after the bytecode affect has occurred which means we need to support an induction offset. This changeset adds the notion of an OSR induction offset and updates the
various OSR analyses to be performed at the correct point.