### PR TITLE
Store callNode ByteCodeInfo in a TR_VirtualGuard

### DIFF
--- a/compiler/compile/VirtualGuard.cpp
+++ b/compiler/compile/VirtualGuard.cpp
@@ -61,6 +61,17 @@ TR_VirtualGuard::TR_VirtualGuard(TR_VirtualGuardTestType test, TR_VirtualGuardKi
      _evalChildren(true), _mergedWithHCRGuard(false),
      _guardNode(guardNode), _currentInlinedSiteIndex(currentSiteIndex)
    {
+   if (callNode)
+      {
+      _bcInfo = callNode->getByteCodeInfo();
+      }
+   else
+      {
+      _bcInfo.setInvalidCallerIndex();
+      _bcInfo.setInvalidByteCodeIndex();
+      _bcInfo.setDoNotProfile(true);
+      }
+      
    comp->addVirtualGuard(this);
    if(kind != TR_ArrayStoreCheckGuard)
       {
@@ -88,6 +99,17 @@ TR_VirtualGuard::TR_VirtualGuard(TR_VirtualGuardTestType test, TR_VirtualGuardKi
    {
    if (kind==TR_SideEffectGuard)
       _callNode = 0;
+   if (_callNode)
+      {
+      _bcInfo = _callNode->getByteCodeInfo();
+      }
+   else
+      {
+      _bcInfo.setInvalidCallerIndex();
+      _bcInfo.setInvalidByteCodeIndex();
+      _bcInfo.setDoNotProfile(true);
+      }
+      
    comp->addVirtualGuard(this);
    if (comp->getOption(TR_TraceRelocatableDataDetailsCG))
       traceMsg(comp, "addVirtualGuard %p, guardkind = %d, virtualGuardTestType %d, bc index %d, callee index %d, callNode %p, guardNode %p, currentInlinedSiteIdx %d\n", this, _kind, test, this->getByteCodeIndex(), this->getCalleeIndex(), callNode, guardNode, _currentInlinedSiteIndex);

--- a/compiler/compile/VirtualGuard.hpp
+++ b/compiler/compile/VirtualGuard.hpp
@@ -231,6 +231,7 @@ class TR_VirtualGuard
 
    bool                    isInlineGuard()  { return _callNode == NULL; }
    TR::Node                *getCallNode()    { TR_ASSERT(!isInlineGuard(), "assertion failure"); return _callNode; }
+   TR_ByteCodeInfo         &getByteCodeInfo() { return _bcInfo; }
    void                    setCannotBeRemoved() { _cannotBeRemoved = true; }
    bool                    canBeRemoved()   { return !_cannotBeRemoved; }
 
@@ -289,6 +290,7 @@ class TR_VirtualGuard
    // These reference locations are non-null only for MutableCallSiteGuards
    uintptrj_t                *_mutableCallSiteObject;
    TR::KnownObjectTable::Index _mutableCallSiteEpoch;
+   TR_ByteCodeInfo           _bcInfo;
    };
 
 #endif


### PR DESCRIPTION
For a given virtual guard you may want to retrieve the original ByteCodeInfo for the guard. While the caller index and bytecode index are stored in the inlining table, the table does not store the true original ByteCodeInfo including the doNotProfile bit. The VirtualGuard constructor is always given the callNode (when it exists) so this change stashes the call's ByteCodeInfo when possible otherwise it sets the ByteCodeInfo to be invalid with the doNotProfile bit set.