### PR TITLE
Issue #253: Disable estimate fragmentation process during vm startup

### DIFF
--- a/gc/base/CollectorLanguageInterface.hpp
+++ b/gc/base/CollectorLanguageInterface.hpp
@@ -558,6 +558,15 @@ public:
 #endif /* OMR_GC_MODRON_CONCURRENT_MARK */
 
 	/**
+	 * This method is called to check if vm is in Startup stage, return true if vm is in Startup stage(Default: false).
+	 *
+	 * @param[in] env The environment for the calling thread.
+	 * @return true if vm is in Startup stage.
+	 */
+	virtual bool isVMInStartupPhase(MM_EnvironmentBase *env) { return false; }
+
+
+	/**
 	 * In the absence of other (equivalent) write barrier, this method must be called
 	 * to effect the assignment of a child reference to a parent slot.
 	 *

--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -855,7 +855,8 @@ MM_ParallelGlobalGC::processLargeAllocateStatsAfterSweep(MM_EnvironmentBase *env
 
 	stats->verifyFreeEntryCount(memoryPool->getActualFreeEntryCount());
 	/* estimate Fragmentation */
-	if (GLOBALGC_ESTIMATE_FRAGMENTATION == (_extensions->estimateFragmentation & GLOBALGC_ESTIMATE_FRAGMENTATION)) {
+	if ((GLOBALGC_ESTIMATE_FRAGMENTATION == (_extensions->estimateFragmentation & GLOBALGC_ESTIMATE_FRAGMENTATION)) &&
+		!_cli->isVMInStartupPhase(env)) {
 		stats->estimateFragmentation(env);
 	} else {
 		stats->resetRemainingFreeMemoryAfterEstimate();

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -3530,7 +3530,8 @@ MM_Scavenger::processLargeAllocateStatsAfterGC(MM_EnvironmentBase *env)
 
 	stats->verifyFreeEntryCount(memoryPool->getActualFreeEntryCount());
 	/* estimate Fragmentation */
-	if (LOCALGC_ESTIMATE_FRAGMENTATION == (_extensions->estimateFragmentation & LOCALGC_ESTIMATE_FRAGMENTATION)) {
+	if ((LOCALGC_ESTIMATE_FRAGMENTATION == (_extensions->estimateFragmentation & LOCALGC_ESTIMATE_FRAGMENTATION)) &&
+		!_cli->isVMInStartupPhase(env)) {
 		stats->estimateFragmentation(env);
 		((MM_CollectionStatisticsStandard *) env->_cycleState->_collectionStatistics)->_tenureFragmentation = MACRO_FRAGMENTATION;
 	} else {


### PR DESCRIPTION
- new method in isVMInStartupPhase() in CollectorLanguageInterface
- the vm code need to override the default isVMInStartupPhase() 
  to detect startup mode(the default always returns false) 
- add new condition check if vm is not in startup stage before calling
estimate fragmentation. 

Signed-off-by: Lin Hu <linhu@ca.ibm.com>