### PR TITLE
Move TR_*Snippet into TR namespace

### DIFF
--- a/compiler/arm/codegen/ARMBinaryEncoding.cpp
+++ b/compiler/arm/codegen/ARMBinaryEncoding.cpp
@@ -294,7 +294,7 @@ uint8_t *TR::ARMImmSymInstruction::generateBinaryEncoding()
       else if (label != NULL)
          {
          cg()->addRelocation(new (cg()->trHeapMemory()) TR_24BitLabelRelativeRelocation(cursor, label));
-         ((TR_ARMCallSnippet *)getCallSnippet())->setCallRA(cursor+4);
+         ((TR::ARMCallSnippet *)getCallSnippet())->setCallRA(cursor+4);
          }
       else
          {

--- a/compiler/arm/codegen/ARMDebug.cpp
+++ b/compiler/arm/codegen/ARMDebug.cpp
@@ -1062,37 +1062,37 @@ TR_Debug::printa(TR::FILE *pOutFile, TR::Snippet * snippet)
    switch (snippet->getKind())
       {
       case TR::Snippet::IsCall:
-         print(pOutFile, (TR_ARMCallSnippet *)snippet);
+         print(pOutFile, (TR::ARMCallSnippet *)snippet);
          break;
       case TR::Snippet::IsUnresolvedCall:
-         print(pOutFile, (TR_ARMUnresolvedCallSnippet *)snippet);
+         print(pOutFile, (TR::ARMUnresolvedCallSnippet *)snippet);
          break;
       case TR::Snippet::IsVirtualUnresolved:
-         print(pOutFile, (TR_ARMVirtualUnresolvedSnippet *)snippet);
+         print(pOutFile, (TR::ARMVirtualUnresolvedSnippet *)snippet);
          break;
       case TR::Snippet::IsInterfaceCall:
-         print(pOutFile, (TR_ARMInterfaceCallSnippet *)snippet);
+         print(pOutFile, (TR::ARMInterfaceCallSnippet *)snippet);
          break;
       case TR::Snippet::IsStackCheckFailure:
-         print(pOutFile, (TR_ARMStackCheckFailureSnippet *)snippet);
+         print(pOutFile, (TR::ARMStackCheckFailureSnippet *)snippet);
          break;
       case TR::Snippet::IsUnresolvedData:
          print(pOutFile, (TR::UnresolvedDataSnippet *)snippet);
          break;
       case TR::Snippet::IsRecompilation:
-         print(pOutFile, (TR_ARMRecompilationSnippet *)snippet);
+         print(pOutFile, (TR::ARMRecompilationSnippet *)snippet);
          break;
 #ifdef J9_PROJECT_SPECIFIC
       case TR::Snippet::IsHelperCall:
-         print(pOutFile, (TR_ARMHelperCallSnippet *)snippet);
+         print(pOutFile, (TR::ARMHelperCallSnippet *)snippet);
          break;
 #endif
       case TR::Snippet::IsMonitorEnter:
-         //print(pOutFile, (TR_ARMMonitorEnterSnippet *)snippet);
+         //print(pOutFile, (TR::ARMMonitorEnterSnippet *)snippet);
          trfprintf(pOutFile, "** MonitorEnterSnippet **\n");
          break;
       case TR::Snippet::IsMonitorExit:
-         //print(pOutFile, (TR_ARMMonitorExitSnippet *)snippet);
+         //print(pOutFile, (TR::ARMMonitorExitSnippet *)snippet);
          trfprintf(pOutFile, "** MonitorExitSnippet **\n");
          break;
       default:
@@ -1101,7 +1101,7 @@ TR_Debug::printa(TR::FILE *pOutFile, TR::Snippet * snippet)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_ARMCallSnippet * snippet)
+TR_Debug::print(TR::FILE *pOutFile, TR::ARMCallSnippet * snippet)
    {
    TR::Node            *callNode     = snippet->getNode();
    TR::SymbolReference *glueRef      = _cg->getSymRef(snippet->getHelper());;
@@ -1218,7 +1218,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_ARMCallSnippet * snippet)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_ARMUnresolvedCallSnippet * snippet)
+TR_Debug::print(TR::FILE *pOutFile, TR::ARMUnresolvedCallSnippet * snippet)
    {
    TR::SymbolReference *methodSymRef = snippet->getNode()->getSymbolReference();
    TR::MethodSymbol    *methodSymbol = methodSymRef->getSymbol()->castToMethodSymbol();
@@ -1246,7 +1246,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_ARMUnresolvedCallSnippet * snippet)
          break;
       }
 
-   print(pOutFile, (TR_ARMCallSnippet *)snippet);
+   print(pOutFile, (TR::ARMCallSnippet *)snippet);
    bufferPos += (snippet->getLength(0) - 12);
 
    printPrefix(pOutFile, NULL, bufferPos, 4);
@@ -1258,7 +1258,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_ARMUnresolvedCallSnippet * snippet)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_ARMVirtualUnresolvedSnippet * snippet)
+TR_Debug::print(TR::FILE *pOutFile, TR::ARMVirtualUnresolvedSnippet * snippet)
    {
    TR::SymbolReference *callSymRef = snippet->getNode()->getSymbolReference();
 
@@ -1282,7 +1282,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_ARMVirtualUnresolvedSnippet * snippet)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_ARMInterfaceCallSnippet * snippet)
+TR_Debug::print(TR::FILE *pOutFile, TR::ARMInterfaceCallSnippet * snippet)
    {
    TR::SymbolReference *callSymRef = snippet->getNode()->getSymbolReference();
    TR::SymbolReference *glueRef    = _cg->getSymRef(TR_ARMinterfaceCallHelper);
@@ -1354,7 +1354,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_ARMInterfaceCallSnippet * snippet)
 
 #ifdef J9_PROJECT_SPECIFIC
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_ARMHelperCallSnippet * snippet)
+TR_Debug::print(TR::FILE *pOutFile, TR::ARMHelperCallSnippet * snippet)
    {
    uint8_t *bufferPos = snippet->getSnippetLabel()->getCodeLocation();
    printSnippetLabel(pOutFile, snippet->getSnippetLabel(), bufferPos, getName(snippet));
@@ -1376,7 +1376,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_ARMHelperCallSnippet * snippet)
 #endif
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_ARMStackCheckFailureSnippet * snippet)
+TR_Debug::print(TR::FILE *pOutFile, TR::ARMStackCheckFailureSnippet * snippet)
    {
    uint8_t *bufferPos  = snippet->getSnippetLabel()->getCodeLocation();
    printSnippetLabel(pOutFile, snippet->getSnippetLabel(), bufferPos, getName(snippet));
@@ -1485,7 +1485,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::UnresolvedDataSnippet * snippet)
 #endif
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_ARMRecompilationSnippet * snippet)
+TR_Debug::print(TR::FILE *pOutFile, TR::ARMRecompilationSnippet * snippet)
    {
    // *this    swipeable for debugging purposes
    uint8_t             *cursor        = snippet->getSnippetLabel()->getCodeLocation();

--- a/compiler/arm/codegen/ConstantDataSnippet.cpp
+++ b/compiler/arm/codegen/ConstantDataSnippet.cpp
@@ -34,7 +34,7 @@
 #include "infra/Bit.hpp"                      // for intParts
 #include "runtime/Runtime.hpp"
 
-int32_t TR_ARMConstantDataSnippet::addConstantRequest(void              *v,
+int32_t TR::ARMConstantDataSnippet::addConstantRequest(void              *v,
                                                   TR::DataType       type,
                                                   TR::Instruction *nibble0,
                                                   TR::Instruction *nibble1,
@@ -55,8 +55,8 @@ int32_t TR_ARMConstantDataSnippet::addConstantRequest(void              *v,
 #if 0
       case TR::Float:
 	 {
-	 ListIterator< TR_ARMConstant<float> >  fiterator(&_floatConstants);
-         TR_ARMConstant<float>                 *fcursor=fiterator.getFirst();
+	 ListIterator< TR::ARMConstant<float> >  fiterator(&_floatConstants);
+         TR::ARMConstant<float>                 *fcursor=fiterator.getFirst();
 
          fin.fvalue = *(float *)v;
          while (fcursor != NULL)
@@ -68,7 +68,7 @@ int32_t TR_ARMConstantDataSnippet::addConstantRequest(void              *v,
 	    }
          if (fcursor == NULL)
 	    {
-            fcursor = new (_cg->trHeapMemory()) TR_ARMConstant<float>(_cg, fin.fvalue);
+            fcursor = new (_cg->trHeapMemory()) TR::ARMConstant<float>(_cg, fin.fvalue);
             _floatConstants.add(fcursor);
             if (TR::Compiler->target.is64Bit() && !comp->getOption(TR_DisableTOCForConsts))
 	       {
@@ -84,8 +84,8 @@ int32_t TR_ARMConstantDataSnippet::addConstantRequest(void              *v,
 
       case TR::Double:
 	 {
-	 ListIterator< TR_ARMConstant<double> > diterator(&_doubleConstants);
-         TR_ARMConstant<double>                *dcursor=diterator.getFirst();
+	 ListIterator< TR::ARMConstant<double> > diterator(&_doubleConstants);
+         TR::ARMConstant<double>                *dcursor=diterator.getFirst();
 
          din.dvalue = *(double *)v;
          while (dcursor != NULL)
@@ -97,7 +97,7 @@ int32_t TR_ARMConstantDataSnippet::addConstantRequest(void              *v,
 	    }
          if (dcursor == NULL)
 	    {
-            dcursor = new (_cg->trHeapMemory()) TR_ARMConstant<double>(_cg, din.dvalue);
+            dcursor = new (_cg->trHeapMemory()) TR::ARMConstant<double>(_cg, din.dvalue);
             _doubleConstants.add(dcursor);
             if (TR::Compiler->target.is64Bit() && !comp->getOption(TR_DisableTOCForConsts))
 	       {
@@ -113,8 +113,8 @@ int32_t TR_ARMConstantDataSnippet::addConstantRequest(void              *v,
 #endif
       case TR::Address:
 	 {
-	 ListIterator< TR_ARMConstant<intptrj_t> >  aiterator(&_addressConstants);
-         TR_ARMConstant<intptrj_t>                 *acursor=aiterator.getFirst();
+	 ListIterator< TR::ARMConstant<intptrj_t> >  aiterator(&_addressConstants);
+         TR::ARMConstant<intptrj_t>                 *acursor=aiterator.getFirst();
 
          ain = *(intptrj_t *)v;
          while (acursor != NULL)
@@ -134,7 +134,7 @@ int32_t TR_ARMConstantDataSnippet::addConstantRequest(void              *v,
             }
          if (acursor == NULL)
 	    {
-            acursor = new (_cg->trHeapMemory()) TR_ARMConstant<intptrj_t>(_cg, ain, node, isUnloadablePicSite);
+            acursor = new (_cg->trHeapMemory()) TR::ARMConstant<intptrj_t>(_cg, ain, node, isUnloadablePicSite);
             _addressConstants.add(acursor);
 	    }
          acursor->addValueRequest(nibble0, nibble1, nibble2, nibble3);
@@ -148,12 +148,12 @@ int32_t TR_ARMConstantDataSnippet::addConstantRequest(void              *v,
    return(ret);
    }
 
-bool TR_ARMConstantDataSnippet::getRequestorsFromNibble(TR::Instruction* nibble, TR::Instruction **q, bool remove)
+bool TR::ARMConstantDataSnippet::getRequestorsFromNibble(TR::Instruction* nibble, TR::Instruction **q, bool remove)
    {
    int32_t count = TR::Compiler->target.is64Bit()?4:2;
 #if 0
-   ListIterator< TR_ARMConstant<double> >  diterator(&_doubleConstants);
-   TR_ARMConstant<double>                 *dcursor=diterator.getFirst();
+   ListIterator< TR::ARMConstant<double> >  diterator(&_doubleConstants);
+   TR::ARMConstant<double>                 *dcursor=diterator.getFirst();
 
    while (dcursor != NULL)
       {
@@ -197,8 +197,8 @@ bool TR_ARMConstantDataSnippet::getRequestorsFromNibble(TR::Instruction* nibble,
          }
       dcursor = diterator.getNext();
       }
-   ListIterator< TR_ARMConstant<float> >  fiterator(&_floatConstants);
-   TR_ARMConstant<float>               *fcursor=fiterator.getFirst();
+   ListIterator< TR::ARMConstant<float> >  fiterator(&_floatConstants);
+   TR::ARMConstant<float>               *fcursor=fiterator.getFirst();
    while (fcursor != NULL)
       {
       TR_Array<TR::Instruction *> &requestors = fcursor->getRequestors();
@@ -242,8 +242,8 @@ bool TR_ARMConstantDataSnippet::getRequestorsFromNibble(TR::Instruction* nibble,
       fcursor = fiterator.getNext();
       }
 #endif
-   ListIterator< TR_ARMConstant<intptrj_t> >  aiterator(&_addressConstants);
-   TR_ARMConstant<intptrj_t>               *acursor=aiterator.getFirst();
+   ListIterator< TR::ARMConstant<intptrj_t> >  aiterator(&_addressConstants);
+   TR::ARMConstant<intptrj_t>               *acursor=aiterator.getFirst();
    while (acursor != NULL)
       {
       TR_Array<TR::Instruction *> &requestors = acursor->getRequestors();
@@ -289,7 +289,7 @@ bool TR_ARMConstantDataSnippet::getRequestorsFromNibble(TR::Instruction* nibble,
    return false;
    }
 
-uint8_t *TR_ARMConstantDataSnippet::emitSnippetBody()
+uint8_t *TR::ARMConstantDataSnippet::emitSnippetBody()
    {
    uint8_t   *codeCursor = cg()->getBinaryBufferCursor();
    uint8_t   *iloc1, *iloc2, *iloc3, *iloc4;
@@ -305,8 +305,8 @@ uint8_t *TR_ARMConstantDataSnippet::emitSnippetBody()
    count = 4;
 
 #if 0
-   ListIterator< TR_ARMConstant<double> >  diterator(&_doubleConstants);
-   TR_ARMConstant<double>                 *dcursor=diterator.getFirst();
+   ListIterator< TR::ARMConstant<double> >  diterator(&_doubleConstants);
+   TR::ARMConstant<double>                 *dcursor=diterator.getFirst();
    while (dcursor != NULL)
       {
       TR_Array<TR::Instruction *> &requestors = dcursor->getRequestors();
@@ -368,8 +368,8 @@ uint8_t *TR_ARMConstantDataSnippet::emitSnippetBody()
       dcursor = diterator.getNext();
       }
 
-   ListIterator< TR_ARMConstant<float> >  fiterator(&_floatConstants);
-   TR_ARMConstant<float>               *fcursor=fiterator.getFirst();
+   ListIterator< TR::ARMConstant<float> >  fiterator(&_floatConstants);
+   TR::ARMConstant<float>               *fcursor=fiterator.getFirst();
    while (fcursor != NULL)
       {
       TR_Array<TR::Instruction *> &requestors = fcursor->getRequestors();
@@ -426,8 +426,8 @@ uint8_t *TR_ARMConstantDataSnippet::emitSnippetBody()
       }
 #endif
 
-   ListIterator< TR_ARMConstant<intptrj_t> >  aiterator(&_addressConstants);
-   TR_ARMConstant<intptrj_t>               *acursor=aiterator.getFirst();
+   ListIterator< TR::ARMConstant<intptrj_t> >  aiterator(&_addressConstants);
+   TR::ARMConstant<intptrj_t>               *acursor=aiterator.getFirst();
    while (acursor != NULL)
       {
       TR_Array<TR::Instruction *> &requestors = acursor->getRequestors();
@@ -509,17 +509,17 @@ uint8_t *TR_ARMConstantDataSnippet::emitSnippetBody()
 
 
 
-uint32_t TR_ARMConstantDataSnippet::getLength()
+uint32_t TR::ARMConstantDataSnippet::getLength()
    {
 #if 0
    if (TR::Compiler->target.is64Bit())
       {
-      ListIterator< TR_ARMConstant<double> >  diterator(&_doubleConstants);
-      TR_ARMConstant<double>                 *dcursor=diterator.getFirst();
-      ListIterator< TR_ARMConstant<float> >   fiterator(&_floatConstants);
-      TR_ARMConstant<float>                  *fcursor=fiterator.getFirst();
-      ListIterator< TR_ARMConstant<intptrj_t> >   aiterator(&_addressConstants);
-      TR_ARMConstant<intptrj_t>              *acursor=aiterator.getFirst();
+      ListIterator< TR::ARMConstant<double> >  diterator(&_doubleConstants);
+      TR::ARMConstant<double>                 *dcursor=diterator.getFirst();
+      ListIterator< TR::ARMConstant<float> >   fiterator(&_floatConstants);
+      TR::ARMConstant<float>                  *fcursor=fiterator.getFirst();
+      ListIterator< TR::ARMConstant<intptrj_t> >   aiterator(&_addressConstants);
+      TR::ARMConstant<intptrj_t>              *acursor=aiterator.getFirst();
       uint32_t length=0;
 
       while (dcursor!=NULL)
@@ -552,7 +552,7 @@ uint32_t TR_ARMConstantDataSnippet::getLength()
 
 
 #if DEBUG
-void TR_ARMConstantDataSnippet::print(TR::FILE *outFile)
+void TR::ARMConstantDataSnippet::print(TR::FILE *outFile)
    {
    if (outFile == NULL)
       return;
@@ -565,8 +565,8 @@ void TR_ARMConstantDataSnippet::print(TR::FILE *outFile)
    trfprintf(outFile, "\n%08x\t\t\t\t\t; Constant Data", codeCursor-codeStart);
 
 #if 0
-   ListIterator< TR_ARMConstant<double> >  diterator(&_doubleConstants);
-   TR_ARMConstant<double>                 *dcursor=diterator.getFirst();
+   ListIterator< TR::ARMConstant<double> >  diterator(&_doubleConstants);
+   TR::ARMConstant<double>                 *dcursor=diterator.getFirst();
    while (dcursor != NULL)
       {
       if (TR::Compiler->target.is32Bit() || dcursor->getRequestors().size()>0)
@@ -578,8 +578,8 @@ void TR_ARMConstantDataSnippet::print(TR::FILE *outFile)
       dcursor = diterator.getNext();
       }
 
-   ListIterator< TR_ARMConstant<float> >  fiterator(&_floatConstants);
-   TR_ARMConstant<float>                 *fcursor=fiterator.getFirst();
+   ListIterator< TR::ARMConstant<float> >  fiterator(&_floatConstants);
+   TR::ARMConstant<float>                 *fcursor=fiterator.getFirst();
    while (fcursor != NULL)
       {
       if (TR::Compiler->target.is32Bit() || fcursor->getRequestors().size()>0)
@@ -591,8 +591,8 @@ void TR_ARMConstantDataSnippet::print(TR::FILE *outFile)
       fcursor = fiterator.getNext();
       }
 #endif
-   ListIterator< TR_ARMConstant<intptrj_t> >  aiterator(&_addressConstants);
-   TR_ARMConstant<intptrj_t>                 *acursor=aiterator.getFirst();
+   ListIterator< TR::ARMConstant<intptrj_t> >  aiterator(&_addressConstants);
+   TR::ARMConstant<intptrj_t>                 *acursor=aiterator.getFirst();
    while (acursor != NULL)
       {
       if (acursor->getRequestors().size()>0)

--- a/compiler/arm/codegen/ConstantDataSnippet.hpp
+++ b/compiler/arm/codegen/ConstantDataSnippet.hpp
@@ -31,7 +31,9 @@
 
 namespace TR { class Node; }
 
-template <class T> class TR_ARMConstant
+namespace TR {
+
+template <class T> class ARMConstant
    {
    TR_Array<TR::Instruction *>     _instructionPairs;
    int32_t                         _tocOffset;
@@ -43,7 +45,7 @@ template <class T> class TR_ARMConstant
 
    TR_ALLOC(TR_Memory::ARMConstant)
 
-   TR_ARMConstant(TR::CodeGenerator * cg, T v, TR::Node *n=NULL, bool ps=false) : _instructionPairs(cg->trMemory()), _value(v), _node(n), _isUnloadablePicSite(ps) {};
+   ARMConstant(TR::CodeGenerator * cg, T v, TR::Node *n=NULL, bool ps=false) : _instructionPairs(cg->trMemory()), _value(v), _node(n), _isUnloadablePicSite(ps) {};
 
    T getConstantValue() {return _value;}
    bool isUnloadablePicSite() {return _isUnloadablePicSite;}
@@ -70,13 +72,13 @@ template <class T> class TR_ARMConstant
    TR::Node *getNode() { return _node; }
    };
 
-class TR_ARMConstantDataSnippet
+class ARMConstantDataSnippet
    {
 #if 0
-   List< TR_ARMConstant<double> >     _doubleConstants;
-   List< TR_ARMConstant<float> >      _floatConstants;
+   List< TR::ARMConstant<double> >     _doubleConstants;
+   List< TR::ARMConstant<float> >      _floatConstants;
 #endif
-   List< TR_ARMConstant<intptrj_t> > _addressConstants;
+   List< TR::ARMConstant<intptrj_t> > _addressConstants;
    uint8_t                                *_snippetBinaryStart;
    TR::CodeGenerator                       *_cg;
 
@@ -84,7 +86,7 @@ class TR_ARMConstantDataSnippet
 
    TR_ALLOC(TR_Memory::ARMConstantDataSnippet)
 
-   TR_ARMConstantDataSnippet(TR::CodeGenerator *cg) : _cg(cg), _addressConstants(cg->trMemory())
+   ARMConstantDataSnippet(TR::CodeGenerator *cg) : _cg(cg), _addressConstants(cg->trMemory())
       /* , _doubleConstants(cg->trMemory()), _floatConstants(cg->trMemory()) */
       {
       };
@@ -113,5 +115,8 @@ class TR_ARMConstantDataSnippet
    virtual void print(TR::FILE *outFile);
 #endif
 
-};
+   };
+
+}
+
 #endif

--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -688,7 +688,7 @@ int32_t OMR::ARM::CodeGenerator::findOrCreateAddressConstant(void *v, TR::DataTy
                              TR::Node *node, bool isUnloadablePicSite)
    {
    if (_constantData == NULL)
-      _constantData = new (self()->trHeapMemory()) TR_ARMConstantDataSnippet(self());
+      _constantData = new (self()->trHeapMemory()) TR::ARMConstantDataSnippet(self());
    return(_constantData->addConstantRequest(v, t, n0, n1, n2, n3, n4, node, isUnloadablePicSite));
    }
 

--- a/compiler/arm/codegen/OMRCodeGenerator.hpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.hpp
@@ -86,7 +86,7 @@ namespace TR { class CodeGenerator; }
 struct TR_ARMLinkageProperties;
 namespace TR { class ARMImmInstruction; }
 class TR_ARMOpCode;
-class TR_ARMConstantDataSnippet;
+namespace TR { class ARMConstantDataSnippet; }
 class TR_ARMLoadLabelItem;
 class TR_BitVector;
 class TR_ARMScratchRegisterManager;
@@ -228,7 +228,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    TR::RealRegister            *_frameRegister;
    TR::RealRegister            *_methodMetaDataRegister;
    TR::ARMImmInstruction          *_returnTypeInfoInstruction;
-   TR_ARMConstantDataSnippet       *_constantData;
+   TR::ARMConstantDataSnippet       *_constantData;
    TR_ARMLinkageProperties   *_linkageProperties;
    List<TR_ARMOutOfLineCodeSection> _outOfLineCodeSectionList;
    // Internal Control Flow Depth Counters

--- a/compiler/arm/codegen/OMRLinkage.cpp
+++ b/compiler/arm/codegen/OMRLinkage.cpp
@@ -1053,11 +1053,11 @@ TR::Register *OMR::ARM::Linkage::buildARMLinkageDirectDispatch(TR::Node *callNod
 
       if (callSymRef->isUnresolved() || codeGen->comp()->compileRelocatableCode())
          {
-         snippet = new (self()->trHeapMemory()) TR_ARMUnresolvedCallSnippet(codeGen, callNode, label, argSize);
+         snippet = new (self()->trHeapMemory()) TR::ARMUnresolvedCallSnippet(codeGen, callNode, label, argSize);
          }
       else
          {
-         snippet = new (self()->trHeapMemory()) TR_ARMCallSnippet(codeGen, callNode, label, argSize);
+         snippet = new (self()->trHeapMemory()) TR::ARMCallSnippet(codeGen, callNode, label, argSize);
          }
 
       codeGen->addSnippet(snippet);

--- a/compiler/arm/codegen/StackCheckFailureSnippet.cpp
+++ b/compiler/arm/codegen/StackCheckFailureSnippet.cpp
@@ -53,7 +53,7 @@ uint8_t *loadArgumentItem(TR_ARMOpCodes op, uint8_t *buffer, TR::RealRegister *r
    return(buffer+4);
    }
 
-uint8_t *TR_ARMStackCheckFailureSnippet::emitSnippetBody()
+uint8_t *TR::ARMStackCheckFailureSnippet::emitSnippetBody()
    {
    uint8_t *buffer = cg()->getBinaryBufferCursor();
 
@@ -151,7 +151,7 @@ uint8_t *TR_ARMStackCheckFailureSnippet::emitSnippetBody()
    return buffer + 4;
    }
 
-uint32_t TR_ARMStackCheckFailureSnippet::getLength(int32_t estimatedSnippetStart)
+uint32_t TR::ARMStackCheckFailureSnippet::getLength(int32_t estimatedSnippetStart)
    {
    TR::ResolvedMethodSymbol *bodySymbol=cg()->comp()->getJittedMethodSymbol();
    int32_t length = 20; // mov/sub, add, bl, sub, b

--- a/compiler/arm/codegen/StackCheckFailureSnippet.hpp
+++ b/compiler/arm/codegen/StackCheckFailureSnippet.hpp
@@ -25,16 +25,18 @@
 #include "codegen/Register.hpp"
 #include "codegen/ARMInstruction.hpp"
 
-class TR_ARMStackCheckFailureSnippet : public TR::Snippet
+namespace TR {
+
+class ARMStackCheckFailureSnippet : public TR::Snippet
    {
    TR::LabelSymbol *reStartLabel;
 
    public:
 
-   TR_ARMStackCheckFailureSnippet(TR::CodeGenerator *cg,
-                                  TR::Node        *node,
-                                  TR::LabelSymbol *restartlab,
-                                  TR::LabelSymbol *snippetlab)
+   ARMStackCheckFailureSnippet(TR::CodeGenerator *cg,
+                               TR::Node        *node,
+                               TR::LabelSymbol *restartlab,
+                               TR::LabelSymbol *snippetlab)
       : TR::Snippet(cg, node, snippetlab, true), reStartLabel(restartlab)
       {
       }
@@ -48,6 +50,8 @@ class TR_ARMStackCheckFailureSnippet : public TR::Snippet
 
    virtual uint32_t getLength(int32_t estimatedSnippetStart);
    };
+
+}
 
 #endif
 

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -154,7 +154,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"breakOnPrint=",     "D{regex}\traise trap when print an item whose name matches regex", TR::Options::setRegex, offsetof(OMR::Options,_breakOnPrint), 0, "P"},
    {"breakOnThrow=",       "D{regex}\traise trap when throwing an exception whose class name matches regex", TR::Options::setRegex, offsetof(OMR::Options,             _breakOnThrow), 0, "P"},
    {"breakOnWriteBarrier", "D\tinsert breakpoint instruction ahead of inline write barrier", SET_OPTION_BIT(TR_BreakOnWriteBarrier), "F" },
-   {"breakOnWriteBarrierSnippet", "D\tinsert breakpoint instruction at beginning of write barrier snippet", SET_OPTION_BIT(TR_BreakOnWriteBarrierSnippet), "F" },
+   {"breakOnWriteBarrierSnippet", "D\tinsert breakpoint instruction at beginning of write barrier snippet", SET_OPTION_BIT(BreakOnWriteBarrierSnippet), "F" },
    {"checkGRA",                "D\tPreserve stores that would otherwise be removed by GRA, and then verify that the stored value matches the global register", SET_OPTION_BIT(TR_CheckGRA), "F"},
    {"classesWithFoldableFinalFields=",   "O{regex}\tAllow hard-coding of values of final fields in the specified classes.  Default is to fold anything considered safe.", TR::Options::setRegex, offsetof(OMR::Options, _classesWithFolableFinalFields), 0, "F"},
    {"classExtendRatSize=",   "M<nnn>\tsize of runtime assumption table for class extend",

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -391,7 +391,7 @@ enum TR_CompilationOptions
    TR_DisableWriteBarriersRangeCheck      = 0x00100000 + 9,
    TR_Randomize                           = 0x00200000 + 9,
    TR_BreakOnWriteBarrier                 = 0x00400000 + 9,
-   TR_BreakOnWriteBarrierSnippet          = 0x00800000 + 9,
+   BreakOnWriteBarrierSnippet             = 0x00800000 + 9,
    TR_Enable64BitRegsOn32Bit              = 0x01000000 + 9,
    TR_CountWriteBarriersRT                = 0x02000000 + 9,
    TR_DisableNoServerDuringStartup        = 0x04000000 + 9,  // set TR_NoOptServer during startup and insert GCR trees

--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -32,7 +32,7 @@
 #include "codegen/RegisterDependency.hpp"
 #include "codegen/RegisterDependencyStruct.hpp"
 #include "codegen/RegisterPair.hpp"                  // for RegisterPair
-#include "codegen/Snippet.hpp"                       // for TR_PPCSnippet, etc
+#include "codegen/Snippet.hpp"                       // for TR::PPCSnippet, etc
 #include "codegen/TreeEvaluator.hpp"
 #include "compile/Compilation.hpp"                   // for Compilation, etc
 #include "compile/SymbolReferenceTable.hpp"
@@ -3757,7 +3757,7 @@ OMR::Power::TreeEvaluator::generateNullTestInstructions(
       if (snippetLabel == NULL)
          {
          snippetLabel = generateLabelSymbol(cg);
-         cg->addSnippet(new (cg->trHeapMemory()) TR_PPCHelperCallSnippet(cg, node, snippetLabel, symRef));
+         cg->addSnippet(new (cg->trHeapMemory()) TR::PPCHelperCallSnippet(cg, node, snippetLabel, symRef));
          }
 
       // trampoline kills gr11

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -2437,7 +2437,7 @@ bool OMR::Power::CodeGenerator::isSnippetMatched(TR::Snippet *snippet, int32_t s
       {
       case TR::Snippet::IsHelperCall:
          {
-         TR_PPCHelperCallSnippet *helperSnippet = (TR_PPCHelperCallSnippet *)snippet;
+         TR::PPCHelperCallSnippet *helperSnippet = (TR::PPCHelperCallSnippet *)snippet;
          if (helperSnippet->getRestartLabel()==NULL && helperSnippet->getDestination()==symRef)
             return true;
          return false;

--- a/compiler/p/codegen/PPCDebug.cpp
+++ b/compiler/p/codegen/PPCDebug.cpp
@@ -55,18 +55,18 @@ int jitDebugPPC;
 #include "p/codegen/PPCInstruction.hpp"
 #include "p/codegen/PPCOpsDefines.hpp"
 #include "p/codegen/PPCOutOfLineCodeSection.hpp"
-#include "codegen/Snippet.hpp"                     // for TR_PPCSnippet, etc
+#include "codegen/Snippet.hpp"                     // for TR::PPCSnippet, etc
 #include "ras/Debug.hpp"                           // for TR_Debug
 #include "runtime/Runtime.hpp"
 
 #ifdef J9_PROJECT_SPECIFIC
-#include "p/codegen/CallSnippet.hpp"               // for TR_PPCCallSnippet, etc
+#include "p/codegen/CallSnippet.hpp"               // for TR::PPCCallSnippet, etc
 #include "p/codegen/InterfaceCastSnippet.hpp"
 #include "p/codegen/StackCheckFailureSnippet.hpp"
 #endif
 
-class TR_PPCForceRecompilationSnippet;
-class TR_PPCRecompilationSnippet;
+namespace TR { class PPCForceRecompilationSnippet; }
+namespace TR { class PPCRecompilationSnippet; }
 
 extern const char * ppcOpCodeToNameMap[][2];
 
@@ -263,12 +263,12 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCLabelInstruction * instr)
 #ifdef J9_PROJECT_SPECIFIC
             case TR::Snippet::IsCall:
             case TR::Snippet::IsUnresolvedCall:
-               callSym = ((TR_PPCCallSnippet *)snippet)->getNode()->getSymbolReference();
+               callSym = ((TR::PPCCallSnippet *)snippet)->getNode()->getSymbolReference();
                break;
             case TR::Snippet::IsVirtual:
             case TR::Snippet::IsVirtualUnresolved:
             case TR::Snippet::IsInterfaceCall:
-               callSym = ((TR_PPCCallSnippet *)snippet)->getNode()->getSymbolReference();
+               callSym = ((TR::PPCCallSnippet *)snippet)->getNode()->getSymbolReference();
                break;
 #endif
             case TR::Snippet::IsHelperCall:
@@ -278,7 +278,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCLabelInstruction * instr)
             case TR::Snippet::IsLockReservationEnter:
             case TR::Snippet::IsLockReservationExit:
             case TR::Snippet::IsArrayCopyCall:
-               callSym = ((TR_PPCHelperCallSnippet *)snippet)->getDestination();
+               callSym = ((TR::PPCHelperCallSnippet *)snippet)->getDestination();
                break;
             }
          if (callSym)
@@ -999,36 +999,36 @@ TR_Debug::printp(TR::FILE *pOutFile, TR::Snippet * snippet)
       {
 #ifdef J9_PROJECT_SPECIFIC
       case TR::Snippet::IsCall:
-         print(pOutFile, (TR_PPCCallSnippet *)snippet);
+         print(pOutFile, (TR::PPCCallSnippet *)snippet);
          break;
       case TR::Snippet::IsUnresolvedCall:
-         print(pOutFile, (TR_PPCUnresolvedCallSnippet *)snippet);
+         print(pOutFile, (TR::PPCUnresolvedCallSnippet *)snippet);
          break;
       case TR::Snippet::IsVirtual:
-         print(pOutFile, (TR_PPCVirtualSnippet *)snippet);
+         print(pOutFile, (TR::PPCVirtualSnippet *)snippet);
          break;
       case TR::Snippet::IsVirtualUnresolved:
-         print(pOutFile, (TR_PPCVirtualUnresolvedSnippet *)snippet);
+         print(pOutFile, (TR::PPCVirtualUnresolvedSnippet *)snippet);
          break;
       case TR::Snippet::IsInterfaceCall:
-         print(pOutFile, (TR_PPCInterfaceCallSnippet *)snippet);
+         print(pOutFile, (TR::PPCInterfaceCallSnippet *)snippet);
          break;
       case TR::Snippet::IsInterfaceCastSnippet:
-         print(pOutFile, (TR_PPCInterfaceCastSnippet *)snippet);
+         print(pOutFile, (TR::PPCInterfaceCastSnippet *)snippet);
          break;
       case TR::Snippet::IsStackCheckFailure:
-         print(pOutFile, (TR_PPCStackCheckFailureSnippet *)snippet);
+         print(pOutFile, (TR::PPCStackCheckFailureSnippet *)snippet);
          break;
       case TR::Snippet::IsForceRecompilation:
-         print(pOutFile, (TR_PPCForceRecompilationSnippet *)snippet);
+         print(pOutFile, (TR::PPCForceRecompilationSnippet *)snippet);
          break;
       case TR::Snippet::IsRecompilation:
-         print(pOutFile, (TR_PPCRecompilationSnippet *)snippet);
+         print(pOutFile, (TR::PPCRecompilationSnippet *)snippet);
          break;
 #endif
       case TR::Snippet::IsArrayCopyCall:
       case TR::Snippet::IsHelperCall:
-         print(pOutFile, (TR_PPCHelperCallSnippet *)snippet);
+         print(pOutFile, (TR::PPCHelperCallSnippet *)snippet);
          break;
       case TR::Snippet::IsUnresolvedData:
          print(pOutFile, (TR::UnresolvedDataSnippet *)snippet);

--- a/compiler/p/codegen/PPCHelperCallSnippet.cpp
+++ b/compiler/p/codegen/PPCHelperCallSnippet.cpp
@@ -42,7 +42,7 @@
 #include "ras/Debug.hpp"                       // for TR_Debug
 #include "runtime/Runtime.hpp"                 // for BRANCH_BACKWARD_LIMIT, etc
 
-uint8_t *TR_PPCHelperCallSnippet::emitSnippetBody()
+uint8_t *TR::PPCHelperCallSnippet::emitSnippetBody()
    {
    // *this    swipeable for debugging purposes
    uint8_t             *buffer = cg()->getBinaryBufferCursor();
@@ -55,7 +55,7 @@ uint8_t *TR_PPCHelperCallSnippet::emitSnippetBody()
 
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_PPCHelperCallSnippet * snippet)
+TR_Debug::print(TR::FILE *pOutFile, TR::PPCHelperCallSnippet * snippet)
    {
    // *this    swipeable for debugging purposes
    uint8_t *cursor = snippet->getSnippetLabel()->getCodeLocation();
@@ -63,7 +63,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_PPCHelperCallSnippet * snippet)
 
    if (snippet->getKind() == TR::Snippet::IsArrayCopyCall)
       {
-      cursor = print(pOutFile, (TR_PPCArrayCopyCallSnippet *)snippet, cursor);
+      cursor = print(pOutFile, (TR::PPCArrayCopyCallSnippet *)snippet, cursor);
       }
    else
       {
@@ -91,13 +91,13 @@ TR_Debug::print(TR::FILE *pOutFile, TR_PPCHelperCallSnippet * snippet)
       }
    }
 
-uint32_t TR_PPCHelperCallSnippet::getLength(int32_t estimatedSnippetStart)
+uint32_t TR::PPCHelperCallSnippet::getLength(int32_t estimatedSnippetStart)
    {
    // *this    swipeable for debugging purposes
    return getHelperCallLength();
    }
 
-uint8_t *TR_PPCHelperCallSnippet::genHelperCall(uint8_t *buffer)
+uint8_t *TR::PPCHelperCallSnippet::genHelperCall(uint8_t *buffer)
    {
    intptrj_t distance = (intptrj_t)getDestination()->getSymbol()->castToMethodSymbol()->getMethodAddress() - (intptrj_t)buffer;
 
@@ -131,12 +131,12 @@ uint8_t *TR_PPCHelperCallSnippet::genHelperCall(uint8_t *buffer)
    return buffer;
    }
 
-uint32_t TR_PPCHelperCallSnippet::getHelperCallLength()
+uint32_t TR::PPCHelperCallSnippet::getHelperCallLength()
    {
    return ((_restartLabel==NULL)?4:8);
    }
 
-uint8_t *TR_PPCArrayCopyCallSnippet::emitSnippetBody()
+uint8_t *TR::PPCArrayCopyCallSnippet::emitSnippetBody()
    {
    TR::Node *node = getNode();
    TR_ASSERT(node->getOpCodeValue() == TR::arraycopy &&
@@ -158,11 +158,11 @@ uint8_t *TR_PPCArrayCopyCallSnippet::emitSnippetBody()
    *(int32_t *)buffer |= byteLen;
    buffer += 4;
 
-   return TR_PPCHelperCallSnippet::genHelperCall(buffer);
+   return TR::PPCHelperCallSnippet::genHelperCall(buffer);
    }
 
 uint8_t*
-TR_Debug::print(TR::FILE *pOutFile, TR_PPCArrayCopyCallSnippet *snippet, uint8_t *cursor)
+TR_Debug::print(TR::FILE *pOutFile, TR::PPCArrayCopyCallSnippet *snippet, uint8_t *cursor)
    {
    printSnippetLabel(pOutFile, snippet->getSnippetLabel(), cursor, "ArrayCopy Helper Call Snippet");
 
@@ -175,7 +175,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_PPCArrayCopyCallSnippet *snippet, uint8_t
    return cursor;
    }
 
-uint32_t TR_PPCArrayCopyCallSnippet::getLength(int32_t estimatedSnippetStart)
+uint32_t TR::PPCArrayCopyCallSnippet::getLength(int32_t estimatedSnippetStart)
    {
-   return TR_PPCHelperCallSnippet::getHelperCallLength() + 4;
+   return TR::PPCHelperCallSnippet::getHelperCallLength() + 4;
    }

--- a/compiler/p/codegen/PPCHelperCallSnippet.hpp
+++ b/compiler/p/codegen/PPCHelperCallSnippet.hpp
@@ -32,18 +32,20 @@ namespace TR { class CodeGenerator; }
 namespace TR { class LabelSymbol; }
 namespace TR { class Node; }
 
-class TR_PPCHelperCallSnippet : public TR::Snippet
+namespace TR {
+
+class PPCHelperCallSnippet : public TR::Snippet
    {
    TR::SymbolReference      *_destination;
    TR::LabelSymbol          *_restartLabel;
 
    public:
 
-   TR_PPCHelperCallSnippet(TR::CodeGenerator    *cg,
-                           TR::Node             *node,
-                           TR::LabelSymbol      *snippetlab,
-                           TR::SymbolReference  *helper,
-                           TR::LabelSymbol      *restartLabel=NULL)
+   PPCHelperCallSnippet(TR::CodeGenerator    *cg,
+                        TR::Node             *node,
+                        TR::LabelSymbol      *snippetlab,
+                        TR::SymbolReference  *helper,
+                        TR::LabelSymbol      *restartLabel=NULL)
       : TR::Snippet(cg, node, snippetlab, (restartLabel!=NULL && helper->canCauseGC())),
         _destination(helper),
         _restartLabel(restartLabel)
@@ -66,19 +68,19 @@ class TR_PPCHelperCallSnippet : public TR::Snippet
    virtual uint32_t getLength(int32_t estimatedSnippetStart);
    };
 
-class TR_PPCArrayCopyCallSnippet : public TR_PPCHelperCallSnippet
+class PPCArrayCopyCallSnippet : public TR::PPCHelperCallSnippet
    {
    TR::RealRegister::RegNum _lengthRegNum;
 
    public:
 
-   TR_PPCArrayCopyCallSnippet(TR::CodeGenerator    *cg,
-                              TR::Node             *node,
-                              TR::LabelSymbol      *snippetlab,
-                              TR::SymbolReference  *helper,
-                              TR::RealRegister::RegNum lengthRegNum,
-                              TR::LabelSymbol      *restartLabel=NULL)
-      : TR_PPCHelperCallSnippet(cg, node, snippetlab, helper, restartLabel),
+   PPCArrayCopyCallSnippet(TR::CodeGenerator    *cg,
+                           TR::Node             *node,
+                           TR::LabelSymbol      *snippetlab,
+                           TR::SymbolReference  *helper,
+                           TR::RealRegister::RegNum lengthRegNum,
+                           TR::LabelSymbol      *restartLabel=NULL)
+      : TR::PPCHelperCallSnippet(cg, node, snippetlab, helper, restartLabel),
         _lengthRegNum(lengthRegNum)
       {
       }
@@ -92,5 +94,7 @@ class TR_PPCArrayCopyCallSnippet : public TR_PPCHelperCallSnippet
 
    virtual uint32_t getLength(int32_t estimatedSnippetStart);
    };
+
+}
 
 #endif

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -137,24 +137,24 @@ namespace TR { class X86FPRegRegInstruction;               }
 namespace TR { class X86FPMemRegInstruction;               }
 namespace TR { class X86FPRegMemInstruction;               }
 class TR_X86RegisterDependencyGroup;
-class TR_X86RestartSnippet;
-class TR_S390LookupSwitchSnippet;
-class TR_X86PicDataSnippet;
-class TR_IA32ConstantDataSnippet;
-class TR_IA32DataSnippet;
-class TR_X86DivideCheckSnippet;
-class TR_X86FPConvertToIntSnippet;
-class TR_X86FPConvertToLongSnippet;
-class TR_X86fbits2iSnippet;
-class TR_X86GuardedDevirtualSnippet;
-class TR_X86HelperCallSnippet;
-class TR_X86ScratchArgHelperCallSnippet;
+namespace TR { class X86RestartSnippet; }
+namespace TR { class S390LookupSwitchSnippet; }
+namespace TR { class X86PicDataSnippet; }
+namespace TR { class IA32ConstantDataSnippet; }
+namespace TR { class IA32DataSnippet; }
+namespace TR { class X86DivideCheckSnippet; }
+namespace TR { class X86FPConvertToIntSnippet; }
+namespace TR { class X86FPConvertToLongSnippet; }
+namespace TR { class X86fbits2iSnippet; }
+namespace TR { class X86GuardedDevirtualSnippet; }
+namespace TR { class X86HelperCallSnippet; }
+namespace TR { class X86ScratchArgHelperCallSnippet; }
 namespace TR { class UnresolvedDataSnippet; }
-class TR_X86UnresolvedVirtualCallSnippet;
+namespace TR { class X86UnresolvedVirtualCallSnippet; }
 namespace TR { class AMD64Imm64Instruction;    }
 namespace TR { class AMD64Imm64SymInstruction; }
 namespace TR { class AMD64RegImm64Instruction; }
-class TR_AMD64FPConversionSnippet;
+namespace TR { class AMD64FPConversionSnippet; }
 
 struct TR_VFPState;
 namespace TR { class X86VFPSaveInstruction;        }
@@ -164,18 +164,18 @@ namespace TR { class X86VFPReleaseInstruction;     }
 namespace TR { class X86VFPCallCleanupInstruction; }
 
 #ifdef J9_PROJECT_SPECIFIC
-class TR_X86CallSnippet;
-class TR_IA32WriteBarrierSnippet;
-class TR_AMD64WriteBarrierSnippet;
-class TR_X86JNIPauseSnippet;
-class TR_X86PassJNINullSnippet;
-class TR_X86HeapAllocationSnippet;
-class TR_X86CheckFailureSnippet;
-class TR_X86CheckFailureSnippetWithResolve;
-class TR_X86BoundCheckWithSpineCheckSnippet;
-class TR_X86SpineCheckSnippet;
-class TR_X86ForceRecompilationSnippet;
-class TR_X86RecompilationSnippet;
+namespace TR { class X86CallSnippet; }
+namespace TR { class IA32WriteBarrierSnippet; }
+namespace TR { class AMD64WriteBarrierSnippet; }
+namespace TR { class X86JNIPauseSnippet; }
+namespace TR { class X86PassJNINullSnippet; }
+namespace TR { class X86HeapAllocationSnippet; }
+namespace TR { class X86CheckFailureSnippet; }
+namespace TR { class X86CheckFailureSnippetWithResolve; }
+namespace TR { class X86BoundCheckWithSpineCheckSnippet; }
+namespace TR { class X86SpineCheckSnippet; }
+namespace TR { class X86ForceRecompilationSnippet; }
+namespace TR { class X86RecompilationSnippet; }
 #endif
 
 namespace TR { class PPCDepInstruction;                  }
@@ -202,28 +202,28 @@ namespace TR { class PPCMemInstruction;                  }
 namespace TR { class PPCTrg1MemInstruction;              }
 namespace TR { class PPCControlFlowInstruction;          }
 namespace TR { class PPCVirtualGuardNOPInstruction;      }
-class TR_PPCUnresolvedCallSnippet;
-class TR_PPCVirtualSnippet;
-class TR_PPCVirtualUnresolvedSnippet;
-class TR_PPCInterfaceCallSnippet;
-class TR_PPCHelperCallSnippet;
-class TR_PPCMonitorEnterSnippet;
-class TR_PPCMonitorExitSnippet;
-class TR_PPCReadMonitorSnippet;
-class TR_PPCHeapAllocSnippet;
+namespace TR { class PPCUnresolvedCallSnippet; }
+namespace TR { class PPCVirtualSnippet; }
+namespace TR { class PPCVirtualUnresolvedSnippet; }
+namespace TR { class PPCInterfaceCallSnippet; }
+namespace TR { class PPCHelperCallSnippet; }
+namespace TR { class PPCMonitorEnterSnippet; }
+namespace TR { class PPCMonitorExitSnippet; }
+namespace TR { class PPCReadMonitorSnippet; }
+namespace TR { class PPCHeapAllocSnippet; }
 
-class TR_PPCAllocPrefetchSnippet;
+namespace TR { class PPCAllocPrefetchSnippet; }
 
-class TR_PPCLockReservationEnterSnippet;
-class TR_PPCLockReservationExitSnippet;
-class TR_PPCArrayCopyCallSnippet;
+namespace TR { class PPCLockReservationEnterSnippet; }
+namespace TR { class PPCLockReservationExitSnippet; }
+namespace TR { class PPCArrayCopyCallSnippet; }
 
 #ifdef J9_PROJECT_SPECIFIC
-class TR_PPCInterfaceCastSnippet;
-class TR_PPCStackCheckFailureSnippet;
-class TR_PPCForceRecompilationSnippet;
-class TR_PPCRecompilationSnippet;
-class TR_PPCCallSnippet;
+namespace TR { class PPCInterfaceCastSnippet; }
+namespace TR { class PPCStackCheckFailureSnippet; }
+namespace TR { class PPCForceRecompilationSnippet; }
+namespace TR { class PPCRecompilationSnippet; }
+namespace TR { class PPCCallSnippet; }
 #endif
 
 
@@ -247,16 +247,16 @@ namespace TR { class ARMMultipleMoveInstruction; }
 class TR_ARMMemoryReference;
 class TR_ARMOperand2;
 class TR_ARMRealRegister;
-class TR_ARMCallSnippet;
-class TR_ARMUnresolvedCallSnippet;
-class TR_ARMVirtualSnippet;
-class TR_ARMVirtualUnresolvedSnippet;
-class TR_ARMInterfaceCallSnippet;
-class TR_ARMHelperCallSnippet;
-class TR_ARMMonitorEnterSnippet;
-class TR_ARMMonitorExitSnippet;
-class TR_ARMStackCheckFailureSnippet;
-class TR_ARMRecompilationSnippet;
+namespace TR { class ARMCallSnippet; }
+namespace TR { class ARMUnresolvedCallSnippet; }
+namespace TR { class ARMVirtualSnippet; }
+namespace TR { class ARMVirtualUnresolvedSnippet; }
+namespace TR { class ARMInterfaceCallSnippet; }
+namespace TR { class ARMHelperCallSnippet; }
+namespace TR { class ARMMonitorEnterSnippet; }
+namespace TR { class ARMMonitorExitSnippet; }
+namespace TR { class ARMStackCheckFailureSnippet; }
+namespace TR { class ARMRecompilationSnippet; }
 class TR_ARMRegisterDependencyGroup;
 
 namespace TR { class S390LabelInstruction; }
@@ -316,18 +316,18 @@ namespace TR { class S390SInstruction; }
 namespace TR { class S390SIInstruction; }
 namespace TR { class S390SILInstruction; }
 namespace TR { class S390NOPInstruction; }
-class TR_S390WarmToColdTrampolineSnippet;
-class TR_S390RestoreGPR7Snippet;
-class TR_S390CallSnippet;
-class TR_S390ConstantDataSnippet;
-class TR_S390WritableDataSnippet;
-class TR_S390TargetAddressSnippet;
-class TR_S390HelperCallSnippet;
-class TR_S390InterfaceCallDataSnippet;
-class TR_S390JNICallDataSnippet;
+namespace TR { class S390WarmToColdTrampolineSnippet; }
+namespace TR { class S390RestoreGPR7Snippet; }
+namespace TR { class S390CallSnippet; }
+namespace TR { class S390ConstantDataSnippet; }
+namespace TR { class S390WritableDataSnippet; }
+namespace TR { class S390TargetAddressSnippet; }
+namespace TR { class S390HelperCallSnippet; }
+namespace TR { class S390InterfaceCallDataSnippet; }
+namespace TR { class S390JNICallDataSnippet; }
 
-class TR_S390StackCheckFailureSnippet;
-class TR_S390HeapAllocSnippet;
+namespace TR { class S390StackCheckFailureSnippet; }
+namespace TR { class S390HeapAllocSnippet; }
 class TR_S390RegisterDependencyGroup;
 namespace TR { class S390RRSInstruction; }
 namespace TR { class S390RIEInstruction; }
@@ -335,12 +335,12 @@ namespace TR { class S390RISInstruction; }
 namespace TR { class S390IEInstruction; }
 
 #ifdef J9_PROJECT_SPECIFIC
-class TR_S390ForceRecompilationSnippet;
-class TR_S390ForceRecompilationDataSnippet;
-class TR_S390UnresolvedCallSnippet;
-class TR_S390VirtualSnippet;
-class TR_S390VirtualUnresolvedSnippet;
-class TR_S390InterfaceCallSnippet;
+namespace TR { class S390ForceRecompilationSnippet; }
+namespace TR { class S390ForceRecompilationDataSnippet; }
+namespace TR { class S390UnresolvedCallSnippet; }
+namespace TR { class S390VirtualSnippet; }
+namespace TR { class S390VirtualUnresolvedSnippet; }
+namespace TR { class S390InterfaceCallSnippet; }
 #endif
 
 TR_Debug *createDebugObject(TR::Compilation *);
@@ -582,7 +582,7 @@ public:
 #if defined(TR_TARGET_POWER)
    virtual const char * getOpCodeName(TR::InstOpCode *);
    const char * getName(TR::RealRegister *, TR_RegisterSizes size = TR_WordReg);
-   void print(TR::FILE *, TR_PPCHelperCallSnippet *);
+   void print(TR::FILE *, TR::PPCHelperCallSnippet *);
 #endif
 #if defined(TR_TARGET_ARM)
    virtual void printARMDelayedOffsetInstructions(TR::FILE *pOutFile, TR::ARMMemInstruction *instr);
@@ -590,7 +590,7 @@ public:
    virtual const char * getOpCodeName(TR_ARMOpCode *);
    const char * getName(TR::RealRegister *, TR_RegisterSizes size = TR_WordReg);
    const char * getName(uint32_t realRegisterIndex, TR_RegisterSizes = (TR_RegisterSizes)-1);
-   void print(TR::FILE *, TR_ARMHelperCallSnippet *);
+   void print(TR::FILE *, TR::ARMHelperCallSnippet *);
 #endif
 #if defined(TR_TARGET_S390)
    virtual const char * getOpCodeName(TR::InstOpCode *);
@@ -661,11 +661,11 @@ public:
 
 
    void printLabelInstruction(TR::FILE *, const char *, TR::LabelSymbol *label);
-   int32_t printRestartJump(TR::FILE *, TR_X86RestartSnippet *, uint8_t *);
-   int32_t printRestartJump(TR::FILE *, TR_X86RestartSnippet *, uint8_t *, int32_t, const char *);
+   int32_t printRestartJump(TR::FILE *, TR::X86RestartSnippet *, uint8_t *);
+   int32_t printRestartJump(TR::FILE *, TR::X86RestartSnippet *, uint8_t *, int32_t, const char *);
 
 #ifdef J9_PROJECT_SPECIFIC
-   int32_t printRestartJump(TR::FILE *, TR_AMD64WriteBarrierSnippet *, uint8_t *);
+   int32_t printRestartJump(TR::FILE *, TR::AMD64WriteBarrierSnippet *, uint8_t *);
 #endif
 
    char * printSymbolName(TR::FILE *, TR::Symbol *, TR::SymbolReference *, TR::MemoryReference *mr=NULL)  ;
@@ -819,42 +819,42 @@ public:
    void printx(TR::FILE *, TR::Snippet *);
 
 #ifdef J9_PROJECT_SPECIFIC
-   void print(TR::FILE *, TR_X86CallSnippet *);
-   void print(TR::FILE *, TR_X86PicDataSnippet *);
-   void print(TR::FILE *, TR_X86UnresolvedVirtualCallSnippet *);
-   void print(TR::FILE *, TR_IA32WriteBarrierSnippet *);
+   void print(TR::FILE *, TR::X86CallSnippet *);
+   void print(TR::FILE *, TR::X86PicDataSnippet *);
+   void print(TR::FILE *, TR::X86UnresolvedVirtualCallSnippet *);
+   void print(TR::FILE *, TR::IA32WriteBarrierSnippet *);
 #ifdef TR_TARGET_64BIT
-   uint8_t *printArgs(TR::FILE *, TR_AMD64WriteBarrierSnippet *, bool, uint8_t *);
-   void print(TR::FILE *, TR_AMD64WriteBarrierSnippet *);
+   uint8_t *printArgs(TR::FILE *, TR::AMD64WriteBarrierSnippet *, bool, uint8_t *);
+   void print(TR::FILE *, TR::AMD64WriteBarrierSnippet *);
 #endif
-   void print(TR::FILE *, TR_X86JNIPauseSnippet *);
-   void print(TR::FILE *, TR_X86PassJNINullSnippet *);
-   void print(TR::FILE *, TR_X86HeapAllocationSnippet *);
-   void print(TR::FILE *, TR_X86CheckFailureSnippet *);
-   void print(TR::FILE *, TR_X86CheckFailureSnippetWithResolve *);
-   void print(TR::FILE *, TR_X86BoundCheckWithSpineCheckSnippet *);
-   void print(TR::FILE *, TR_X86SpineCheckSnippet *);
-   void print(TR::FILE *, TR_X86ForceRecompilationSnippet *);
-   void print(TR::FILE *, TR_X86RecompilationSnippet *);
+   void print(TR::FILE *, TR::X86JNIPauseSnippet *);
+   void print(TR::FILE *, TR::X86PassJNINullSnippet *);
+   void print(TR::FILE *, TR::X86HeapAllocationSnippet *);
+   void print(TR::FILE *, TR::X86CheckFailureSnippet *);
+   void print(TR::FILE *, TR::X86CheckFailureSnippetWithResolve *);
+   void print(TR::FILE *, TR::X86BoundCheckWithSpineCheckSnippet *);
+   void print(TR::FILE *, TR::X86SpineCheckSnippet *);
+   void print(TR::FILE *, TR::X86ForceRecompilationSnippet *);
+   void print(TR::FILE *, TR::X86RecompilationSnippet *);
 #endif
 
-   void print(TR::FILE *, TR_IA32ConstantDataSnippet *);
-   void print(TR::FILE *, TR_IA32DataSnippet *);
-   void print(TR::FILE *, TR_X86DivideCheckSnippet *);
-   void print(TR::FILE *, TR_X86FPConvertToIntSnippet *);
-   void print(TR::FILE *, TR_X86FPConvertToLongSnippet *);
-   void print(TR::FILE *, TR_X86fbits2iSnippet *);
-   void print(TR::FILE *, TR_X86GuardedDevirtualSnippet *);
-   void print(TR::FILE *, TR_X86HelperCallSnippet *);
-   void printBody(TR::FILE *, TR_X86HelperCallSnippet *, uint8_t *bufferPos);
-   void print(TR::FILE *, TR_X86ScratchArgHelperCallSnippet *);
+   void print(TR::FILE *, TR::IA32ConstantDataSnippet *);
+   void print(TR::FILE *, TR::IA32DataSnippet *);
+   void print(TR::FILE *, TR::X86DivideCheckSnippet *);
+   void print(TR::FILE *, TR::X86FPConvertToIntSnippet *);
+   void print(TR::FILE *, TR::X86FPConvertToLongSnippet *);
+   void print(TR::FILE *, TR::X86fbits2iSnippet *);
+   void print(TR::FILE *, TR::X86GuardedDevirtualSnippet *);
+   void print(TR::FILE *, TR::X86HelperCallSnippet *);
+   void printBody(TR::FILE *, TR::X86HelperCallSnippet *, uint8_t *bufferPos);
+   void print(TR::FILE *, TR::X86ScratchArgHelperCallSnippet *);
 
 
    void print(TR::FILE *, TR::UnresolvedDataSnippet *);
 
 #ifdef TR_TARGET_64BIT
    uint8_t *printArgumentFlush(TR::FILE *, TR::Node *, bool, uint8_t *);
-   void print(TR::FILE *, TR_AMD64FPConversionSnippet *);
+   void print(TR::FILE *, TR::AMD64FPConversionSnippet *);
 #endif
 #endif
 #ifdef TR_TARGET_POWER
@@ -905,33 +905,33 @@ public:
    void printInstructionComment(TR::FILE *pOutFile, int32_t tabStops, TR::Instruction *instr);
 
    void printp(TR::FILE *, TR::Snippet *);
-   void print(TR::FILE *, TR_PPCMonitorEnterSnippet *);
-   void print(TR::FILE *, TR_PPCMonitorExitSnippet *);
-   void print(TR::FILE *, TR_PPCReadMonitorSnippet *);
-   void print(TR::FILE *, TR_PPCHeapAllocSnippet *);
-   void print(TR::FILE *, TR_PPCAllocPrefetchSnippet *);
+   void print(TR::FILE *, TR::PPCMonitorEnterSnippet *);
+   void print(TR::FILE *, TR::PPCMonitorExitSnippet *);
+   void print(TR::FILE *, TR::PPCReadMonitorSnippet *);
+   void print(TR::FILE *, TR::PPCHeapAllocSnippet *);
+   void print(TR::FILE *, TR::PPCAllocPrefetchSnippet *);
 
 
    void print(TR::FILE *, TR::UnresolvedDataSnippet *);
 
 #ifdef J9_PROJECT_SPECIFIC
-   void print(TR::FILE *, TR_PPCStackCheckFailureSnippet *);
-   void print(TR::FILE *, TR_PPCInterfaceCastSnippet *);
-   void print(TR::FILE *, TR_PPCUnresolvedCallSnippet *);
-   void print(TR::FILE *, TR_PPCVirtualSnippet *);
-   void print(TR::FILE *, TR_PPCVirtualUnresolvedSnippet *);
-   void print(TR::FILE *, TR_PPCInterfaceCallSnippet *);
-   void print(TR::FILE *, TR_PPCForceRecompilationSnippet *);
-   void print(TR::FILE *, TR_PPCRecompilationSnippet *);
-   void print(TR::FILE *, TR_PPCCallSnippet *);
+   void print(TR::FILE *, TR::PPCStackCheckFailureSnippet *);
+   void print(TR::FILE *, TR::PPCInterfaceCastSnippet *);
+   void print(TR::FILE *, TR::PPCUnresolvedCallSnippet *);
+   void print(TR::FILE *, TR::PPCVirtualSnippet *);
+   void print(TR::FILE *, TR::PPCVirtualUnresolvedSnippet *);
+   void print(TR::FILE *, TR::PPCInterfaceCallSnippet *);
+   void print(TR::FILE *, TR::PPCForceRecompilationSnippet *);
+   void print(TR::FILE *, TR::PPCRecompilationSnippet *);
+   void print(TR::FILE *, TR::PPCCallSnippet *);
 #endif
 
 
 
    void printMemoryReferenceComment(TR::FILE *pOutFile, TR::MemoryReference *mr);
-   void print(TR::FILE *, TR_PPCLockReservationEnterSnippet *);
-   void print(TR::FILE *, TR_PPCLockReservationExitSnippet *);
-   uint8_t* print(TR::FILE *pOutFile, TR_PPCArrayCopyCallSnippet *snippet, uint8_t *cursor);
+   void print(TR::FILE *, TR::PPCLockReservationEnterSnippet *);
+   void print(TR::FILE *, TR::PPCLockReservationExitSnippet *);
+   uint8_t* print(TR::FILE *pOutFile, TR::PPCArrayCopyCallSnippet *snippet, uint8_t *cursor);
 
 #endif
 #ifdef TR_TARGET_ARM
@@ -969,16 +969,16 @@ public:
    void printInstructionComment(TR::FILE *pOutFile, int32_t tabStops, TR::Instruction *instr);
 
    void printa(TR::FILE *, TR::Snippet *);
-   void print(TR::FILE *, TR_ARMCallSnippet *);
-   void print(TR::FILE *, TR_ARMUnresolvedCallSnippet *);
-   void print(TR::FILE *, TR_ARMVirtualSnippet *);
-   void print(TR::FILE *, TR_ARMVirtualUnresolvedSnippet *);
-   void print(TR::FILE *, TR_ARMInterfaceCallSnippet *);
-   void print(TR::FILE *, TR_ARMMonitorEnterSnippet *);
-   void print(TR::FILE *, TR_ARMMonitorExitSnippet *);
-   void print(TR::FILE *, TR_ARMStackCheckFailureSnippet *);
+   void print(TR::FILE *, TR::ARMCallSnippet *);
+   void print(TR::FILE *, TR::ARMUnresolvedCallSnippet *);
+   void print(TR::FILE *, TR::ARMVirtualSnippet *);
+   void print(TR::FILE *, TR::ARMVirtualUnresolvedSnippet *);
+   void print(TR::FILE *, TR::ARMInterfaceCallSnippet *);
+   void print(TR::FILE *, TR::ARMMonitorEnterSnippet *);
+   void print(TR::FILE *, TR::ARMMonitorExitSnippet *);
+   void print(TR::FILE *, TR::ARMStackCheckFailureSnippet *);
    void print(TR::FILE *, TR::UnresolvedDataSnippet *);
-   void print(TR::FILE *, TR_ARMRecompilationSnippet *);
+   void print(TR::FILE *, TR::ARMRecompilationSnippet *);
    void printARM(TR::FILE *, uint8_t *, uint8_t *);
 #endif
 #ifdef TR_TARGET_S390
@@ -1051,28 +1051,28 @@ public:
    uint8_t * printS390ArgumentsFlush(TR::FILE *, TR::Node *, uint8_t *, int32_t);
 
    void printz(TR::FILE *, TR::Snippet *);
-   void print(TR::FILE *, TR_S390CallSnippet *);
+   void print(TR::FILE *, TR::S390CallSnippet *);
 
-   void print(TR::FILE *, TR_S390ConstantDataSnippet *);
-   void print(TR::FILE *, TR_S390TargetAddressSnippet *);
+   void print(TR::FILE *, TR::S390ConstantDataSnippet *);
+   void print(TR::FILE *, TR::S390TargetAddressSnippet *);
 
-   void print(TR::FILE *, TR_S390LookupSwitchSnippet *);
-   void print(TR::FILE *, TR_S390HelperCallSnippet *);
+   void print(TR::FILE *, TR::S390LookupSwitchSnippet *);
+   void print(TR::FILE *, TR::S390HelperCallSnippet *);
 #ifdef J9_PROJECT_SPECIFIC
-   void print(TR::FILE *, TR_S390ForceRecompilationSnippet *);
-   void print(TR::FILE *, TR_S390ForceRecompilationDataSnippet *);
-   void print(TR::FILE *, TR_S390UnresolvedCallSnippet *);
-   void print(TR::FILE *, TR_S390VirtualSnippet *);
-   void print(TR::FILE *, TR_S390VirtualUnresolvedSnippet *);
-   void print(TR::FILE *, TR_S390InterfaceCallSnippet *);
+   void print(TR::FILE *, TR::S390ForceRecompilationSnippet *);
+   void print(TR::FILE *, TR::S390ForceRecompilationDataSnippet *);
+   void print(TR::FILE *, TR::S390UnresolvedCallSnippet *);
+   void print(TR::FILE *, TR::S390VirtualSnippet *);
+   void print(TR::FILE *, TR::S390VirtualUnresolvedSnippet *);
+   void print(TR::FILE *, TR::S390InterfaceCallSnippet *);
 #endif
-   void print(TR::FILE *, TR_S390StackCheckFailureSnippet *);
+   void print(TR::FILE *, TR::S390StackCheckFailureSnippet *);
    void print(TR::FILE *, TR::UnresolvedDataSnippet *);
-   void print(TR::FILE *, TR_S390HeapAllocSnippet *);
-   void print(TR::FILE *, TR_S390InterfaceCallDataSnippet *);
-   void print(TR::FILE *, TR_S390JNICallDataSnippet *);
-   void print(TR::FILE *, TR_S390WarmToColdTrampolineSnippet *);
-   void print(TR::FILE *, TR_S390RestoreGPR7Snippet *);
+   void print(TR::FILE *, TR::S390HeapAllocSnippet *);
+   void print(TR::FILE *, TR::S390InterfaceCallDataSnippet *);
+   void print(TR::FILE *, TR::S390JNICallDataSnippet *);
+   void print(TR::FILE *, TR::S390WarmToColdTrampolineSnippet *);
+   void print(TR::FILE *, TR::S390RestoreGPR7Snippet *);
 
    // Assembly related snippet display
    void printGPRegisterStatus(TR::FILE *pOutFile, TR::Machine *machine);

--- a/compiler/runtime/Trampoline.cpp
+++ b/compiler/runtime/Trampoline.cpp
@@ -36,9 +36,12 @@
 
 namespace TR { class CodeGenerator; }
 
+namespace TR {
+
 void createCCPreLoadedCode(uint8_t *CCPreLoadedCodeBase, uint8_t *CCPreLoadedCodeTop, void ** CCPreLoadedCodeTable, TR::CodeGenerator *cg);
 uint32_t getCCPreLoadedCodeSize();
 
+}
 
 #define PPC_INSTRUCTION_LENGTH 4
 
@@ -178,8 +181,8 @@ void ppcCodeCacheParameters(int32_t *trampolineSize, void **callBacks, int32_t *
    callBacks[1] = (void *)&ppcCreateHelperTrampolines;
    callBacks[2] = (void *)NULL;
    callBacks[3] = (void *)NULL;
-   callBacks[4] = (void *)createCCPreLoadedCode;
-   *CCPreLoadedCodeSize = getCCPreLoadedCodeSize();
+   callBacks[4] = (void *)TR::createCCPreLoadedCode;
+   *CCPreLoadedCodeSize = TR::getCCPreLoadedCodeSize();
    *numHelpers = TR_PPCnumRuntimeHelpers;
    }
 
@@ -244,8 +247,8 @@ void amd64CodeCacheParameters(int32_t *trampolineSize, OMR::CodeCacheCodeGenCall
    callBacks->createHelperTrampolines = &amd64CreateHelperTrampolines;
    callBacks->createMethodTrampoline = NULL;
    callBacks->patchTrampoline = NULL;
-   callBacks->createCCPreLoadedCode = createCCPreLoadedCode;
-   *CCPreLoadedCodeSize = getCCPreLoadedCodeSize();
+   callBacks->createCCPreLoadedCode = TR::createCCPreLoadedCode;
+   *CCPreLoadedCodeSize = TR::getCCPreLoadedCodeSize();
    *numHelpers = TR_AMD64numRuntimeHelpers;
    }
 
@@ -266,8 +269,8 @@ void ia32CodeCacheParameters(int32_t *trampolineSize, OMR::CodeCacheCodeGenCallb
    callBacks->createHelperTrampolines = NULL;
    callBacks->createMethodTrampoline = NULL;
    callBacks->patchTrampoline = NULL;
-   callBacks->createCCPreLoadedCode = createCCPreLoadedCode;
-   *CCPreLoadedCodeSize = getCCPreLoadedCodeSize();
+   callBacks->createCCPreLoadedCode = TR::createCCPreLoadedCode;
+   *CCPreLoadedCodeSize = TR::getCCPreLoadedCodeSize();
    *numHelpers = 0;
    }
 
@@ -552,13 +555,13 @@ void setupCodeCacheParameters(int32_t *trampolineSize, OMR::CodeCacheCodeGenCall
    }
 
 uint32_t
-getCCPreLoadedCodeSize()
+TR::getCCPreLoadedCodeSize()
    {
    return 0;
    }
 
 void
-createCCPreLoadedCode(uint8_t *CCPreLoadedCodeBase,
+TR::createCCPreLoadedCode(uint8_t *CCPreLoadedCodeBase,
                       uint8_t *CCPreLoadedCodeTop,
                       void ** CCPreLoadedCodeTable,
                       TR::CodeGenerator *cg)

--- a/compiler/x/amd64/codegen/AMD64FPConversionSnippet.cpp
+++ b/compiler/x/amd64/codegen/AMD64FPConversionSnippet.cpp
@@ -51,7 +51,7 @@ static const uint8_t popBinary[] =
    0x48, 0x83, 0xc4, 0x08
    };
 
-uint8_t *TR_AMD64FPConversionSnippet::genFPConversion(uint8_t *buffer)
+uint8_t *TR::AMD64FPConversionSnippet::genFPConversion(uint8_t *buffer)
    {
    // *this    swipeable for debugging purposes
 
@@ -135,7 +135,7 @@ uint8_t *TR_AMD64FPConversionSnippet::genFPConversion(uint8_t *buffer)
 #define IS_REX(byte) (((byte)&0xf0) == TR::RealRegister::REX )
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_AMD64FPConversionSnippet * snippet)
+TR_Debug::print(TR::FILE *pOutFile, TR::AMD64FPConversionSnippet * snippet)
    {
 
    if (pOutFile == NULL)
@@ -214,7 +214,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_AMD64FPConversionSnippet * snippet)
    }
 
 
-uint32_t TR_AMD64FPConversionSnippet::getLength(int32_t estimatedSnippetStart)
+uint32_t TR::AMD64FPConversionSnippet::getLength(int32_t estimatedSnippetStart)
    {
    // *this    swipeable for debugging purposes
    uint32_t length = 11;

--- a/compiler/x/amd64/codegen/MemoryReference.hpp
+++ b/compiler/x/amd64/codegen/MemoryReference.hpp
@@ -25,7 +25,7 @@
 #include <stdint.h>        // for uint8_t
 #include "env/jittypes.h"  // for intptrj_t
 
-class TR_IA32DataSnippet;
+namespace TR { class IA32DataSnippet; }
 class TR_ScratchRegisterManager;
 namespace TR { class CodeGenerator; }
 namespace TR { class LabelSymbol; }
@@ -73,7 +73,7 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
       TR::CodeGenerator *cg) :
          OMR::MemoryReferenceConnector(br, ir, s, disp, cg) {}
 
-   MemoryReference(TR_IA32DataSnippet *cds,
+   MemoryReference(TR::IA32DataSnippet *cds,
       TR::CodeGenerator *cg) :
          OMR::MemoryReferenceConnector(cds, cg) {}
 

--- a/compiler/x/amd64/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.cpp
@@ -92,7 +92,7 @@ OMR::X86::AMD64::MemoryReference::MemoryReference(TR::Register *br, TR::Register
    self()->finishInitialization(cg, NULL);
    }
 
-OMR::X86::AMD64::MemoryReference::MemoryReference(TR_IA32DataSnippet *cds, TR::CodeGenerator *cg):
+OMR::X86::AMD64::MemoryReference::MemoryReference(TR::IA32DataSnippet *cds, TR::CodeGenerator *cg):
    OMR::X86::MemoryReference(cds, cg)
    {
    self()->finishInitialization(cg, NULL);

--- a/compiler/x/amd64/codegen/OMRMemoryReference.hpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.hpp
@@ -81,7 +81,7 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::X86::MemoryReference
 
    MemoryReference(TR::Register *br, TR::Register *ir, uint8_t s, intptrj_t disp, TR::CodeGenerator *cg);
 
-   MemoryReference(TR_IA32DataSnippet *cds, TR::CodeGenerator *cg);
+   MemoryReference(TR::IA32DataSnippet *cds, TR::CodeGenerator *cg);
 
    MemoryReference(TR::LabelSymbol    *label, TR::CodeGenerator *cg);
 

--- a/compiler/x/amd64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluator.cpp
@@ -371,8 +371,8 @@ TR::Register *OMR::X86::AMD64::TreeEvaluator::dbits2lEvaluator(TR::Node *node, T
          TR::RegisterDependencyConditions  *deps = generateRegisterDependencyConditions((uint8_t)0, (uint8_t)1, cg);
          deps->addPostCondition(treg, TR::RealRegister::NoReg, cg);
 
-         TR_IA32ConstantDataSnippet *nan1Snippet = cg->findOrCreate8ByteConstant(node, DOUBLE_NAN_1_LOW);
-         TR_IA32ConstantDataSnippet *nan2Snippet = cg->findOrCreate8ByteConstant(node, DOUBLE_NAN_2_LOW);
+         TR::IA32ConstantDataSnippet *nan1Snippet = cg->findOrCreate8ByteConstant(node, DOUBLE_NAN_1_LOW);
+         TR::IA32ConstantDataSnippet *nan2Snippet = cg->findOrCreate8ByteConstant(node, DOUBLE_NAN_2_LOW);
          TR::MemoryReference      *nan1MR      = generateX86MemoryReference(nan1Snippet, cg);
          TR::MemoryReference      *nan2MR      = generateX86MemoryReference(nan2Snippet, cg);
 
@@ -404,7 +404,7 @@ TR::Register *OMR::X86::AMD64::TreeEvaluator::dbits2lEvaluator(TR::Node *node, T
          helperDeps->addPreCondition( treg, TR::RealRegister::eax, cg);
          helperDeps->addPostCondition(treg, TR::RealRegister::eax, cg);
 
-         TR_IA32ConstantDataSnippet *nanDetectorSnippet  = cg->findOrCreate8ByteConstant(node, nanDetector);
+         TR::IA32ConstantDataSnippet *nanDetectorSnippet  = cg->findOrCreate8ByteConstant(node, nanDetector);
          TR::MemoryReference      *nanDetectorMR       = generateX86MemoryReference(nanDetectorSnippet,  cg);
 
          TR::LabelSymbol *startLabel     = TR::LabelSymbol::create(cg->trHeapMemory(),cg);

--- a/compiler/x/codegen/BinaryEvaluator.cpp
+++ b/compiler/x/codegen/BinaryEvaluator.cpp
@@ -2549,7 +2549,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerDivOrRemEvaluator(TR::Node *node, 
          generateLabelInstruction(LABEL, node, restartLabel, allDeps, cg);
 
          TR_ASSERT(divisorRegister != NULL, "Divide check snippet needs divisor in a register");
-         cg->addSnippet(new (cg->trHeapMemory()) TR_X86DivideCheckSnippet(restartLabel,
+         cg->addSnippet(new (cg->trHeapMemory()) TR::X86DivideCheckSnippet(restartLabel,
                                                       overflowSnippetLabel,
                                                       divisionLabel,
                                                       node->getOpCode(),

--- a/compiler/x/codegen/ConstantDataSnippet.cpp
+++ b/compiler/x/codegen/ConstantDataSnippet.cpp
@@ -20,7 +20,7 @@
 
 #include <stddef.h>                           // for NULL
 #include <stdint.h>                           // for uint8_t, int16_t
-#include "DataSnippet.hpp"                    // for TR_IA32DataSnippet
+#include "DataSnippet.hpp"                    // for TR::IA32DataSnippet
 #include "codegen/Snippet.hpp"                // for commentString, etc
 #include "compile/Compilation.hpp"            // for Compilation
 #include "il/symbol/LabelSymbol.hpp"          // for LabelSymbol
@@ -30,13 +30,13 @@
 namespace TR { class CodeGenerator; }
 namespace TR { class Node; }
 
-TR_IA32ConstantDataSnippet::TR_IA32ConstantDataSnippet(TR::CodeGenerator *cg, TR::Node * n, void *c, uint8_t size)
-   : TR_IA32DataSnippet(cg, n, c, size)
+TR::IA32ConstantDataSnippet::IA32ConstantDataSnippet(TR::CodeGenerator *cg, TR::Node * n, void *c, uint8_t size)
+   : TR::IA32DataSnippet(cg, n, c, size)
    {
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_IA32ConstantDataSnippet * snippet)
+TR_Debug::print(TR::FILE *pOutFile, TR::IA32ConstantDataSnippet * snippet)
    {
    // *this   swipeable for debugger
    if (pOutFile == NULL)

--- a/compiler/x/codegen/ConstantDataSnippet.hpp
+++ b/compiler/x/codegen/ConstantDataSnippet.hpp
@@ -22,18 +22,23 @@
 #include "x/codegen/DataSnippet.hpp"
 
 #include <stdint.h>                   // for uint8_t
-#include "codegen/Snippet.hpp"        // for TR_X86Snippet::Kind, etc
+#include "codegen/Snippet.hpp"        // for TR::X86Snippet::Kind, etc
 
 namespace TR { class CodeGenerator; }
 namespace TR { class Node; }
 
-class TR_IA32ConstantDataSnippet : public TR_IA32DataSnippet
+namespace TR {
+
+class IA32ConstantDataSnippet : public TR::IA32DataSnippet
    {
    public:
 
-   TR_IA32ConstantDataSnippet(TR::CodeGenerator *cg, TR::Node *, void *c, uint8_t size);
+   IA32ConstantDataSnippet(TR::CodeGenerator *cg, TR::Node *, void *c, uint8_t size);
 
    virtual Kind getKind() { return IsConstantData; }
    uint8_t getConstantSize()  { return getDataSize(); }
    };
+
+}
+
 #endif

--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -1243,7 +1243,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerReturnEvaluator(TR::Node *node, TR
    if (cg->enableSinglePrecisionMethods() &&
        comp->getJittedMethodSymbol()->usesSinglePrecisionMode())
       {
-      TR_IA32ConstantDataSnippet *cds = cg->findOrCreate2ByteConstant(node, DOUBLE_PRECISION_ROUND_TO_NEAREST);
+      TR::IA32ConstantDataSnippet *cds = cg->findOrCreate2ByteConstant(node, DOUBLE_PRECISION_ROUND_TO_NEAREST);
       generateMemInstruction(LDCWMem, node, generateX86MemoryReference(cds, cg), cg);
       }
 
@@ -1323,7 +1323,7 @@ TR::Register *OMR::X86::TreeEvaluator::returnEvaluator(TR::Node *node, TR::CodeG
    if (cg->enableSinglePrecisionMethods() &&
        comp->getJittedMethodSymbol()->usesSinglePrecisionMode())
       {
-      TR_IA32ConstantDataSnippet *cds = cg->findOrCreate2ByteConstant(node, DOUBLE_PRECISION_ROUND_TO_NEAREST);
+      TR::IA32ConstantDataSnippet *cds = cg->findOrCreate2ByteConstant(node, DOUBLE_PRECISION_ROUND_TO_NEAREST);
       generateMemInstruction(LDCWMem, node, generateX86MemoryReference(cds, cg), cg);
       }
 

--- a/compiler/x/codegen/DataSnippet.cpp
+++ b/compiler/x/codegen/DataSnippet.cpp
@@ -31,7 +31,7 @@
 
 namespace TR { class Node; }
 
-TR_IA32DataSnippet::TR_IA32DataSnippet(TR::CodeGenerator *cg, TR::Node * n, void *c, uint8_t size)
+TR::IA32DataSnippet::IA32DataSnippet(TR::CodeGenerator *cg, TR::Node * n, void *c, uint8_t size)
    : TR::Snippet(cg, n, TR::LabelSymbol::create(cg->trHeapMemory(),cg), false)
    {
 
@@ -42,7 +42,7 @@ TR_IA32DataSnippet::TR_IA32DataSnippet(TR::CodeGenerator *cg, TR::Node * n, void
 
 
 void
-TR_IA32DataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
+TR::IA32DataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
    {
    // add dummy class unload/redefinition assumption.
    if (_isClassAddress)
@@ -67,7 +67,7 @@ TR_IA32DataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
    }
 
 
-uint8_t *TR_IA32DataSnippet::emitSnippetBody()
+uint8_t *TR::IA32DataSnippet::emitSnippetBody()
    {
    // *this   swipeable for debugging purposes
 
@@ -92,7 +92,7 @@ uint8_t *TR_IA32DataSnippet::emitSnippetBody()
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_IA32DataSnippet * snippet)
+TR_Debug::print(TR::FILE *pOutFile, TR::IA32DataSnippet * snippet)
    {
    // *this   swipeable for debugger
    if (pOutFile == NULL)
@@ -140,7 +140,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_IA32DataSnippet * snippet)
       }
    }
 
-uint32_t TR_IA32DataSnippet::getLength(int32_t estimatedSnippetStart)
+uint32_t TR::IA32DataSnippet::getLength(int32_t estimatedSnippetStart)
    {
    // *this   swipeable for debugging purposes
    return _length;

--- a/compiler/x/codegen/DataSnippet.hpp
+++ b/compiler/x/codegen/DataSnippet.hpp
@@ -26,7 +26,9 @@
 namespace TR { class CodeGenerator; }
 namespace TR { class Node; }
 
-class TR_IA32DataSnippet : public TR::Snippet
+namespace TR {
+
+class IA32DataSnippet : public TR::Snippet
    {
    uint8_t _length;
    bool    _isClassAddress;
@@ -34,7 +36,7 @@ class TR_IA32DataSnippet : public TR::Snippet
    uint8_t _value[16];
    public:
 
-   TR_IA32DataSnippet(TR::CodeGenerator *cg, TR::Node *, void *c, uint8_t size);
+   IA32DataSnippet(TR::CodeGenerator *cg, TR::Node *, void *c, uint8_t size);
 
    virtual Kind getKind() { return IsData; }
    uint8_t* getValue()  { return _value; }
@@ -49,4 +51,7 @@ class TR_IA32DataSnippet : public TR::Snippet
    int32_t getDataAs4Bytes() { return *((int32_t *) &_value); }
    int64_t getDataAs8Bytes() { return *((int64_t *) &_value); }
    };
+
+}
+
 #endif

--- a/compiler/x/codegen/DivideCheckSnippet.cpp
+++ b/compiler/x/codegen/DivideCheckSnippet.cpp
@@ -30,7 +30,7 @@
 #include "env/IO.hpp"
 #include "env/CompilerEnv.hpp"
 
-uint8_t *TR_X86DivideCheckSnippet::emitSnippetBody()
+uint8_t *TR::X86DivideCheckSnippet::emitSnippetBody()
    {
    // *this    swipeable for debugging purposes
    uint8_t *buffer = cg()->getBinaryBufferCursor();
@@ -98,7 +98,7 @@ uint8_t *TR_X86DivideCheckSnippet::emitSnippetBody()
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_X86DivideCheckSnippet  * snippet) // TODO:FIX THIS!!!
+TR_Debug::print(TR::FILE *pOutFile, TR::X86DivideCheckSnippet  * snippet) // TODO:FIX THIS!!!
    {
    // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
@@ -166,7 +166,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_X86DivideCheckSnippet  * snippet) // TODO
 
 
 
-uint32_t TR_X86DivideCheckSnippet::getLength(int32_t estimatedSnippetStart)
+uint32_t TR::X86DivideCheckSnippet::getLength(int32_t estimatedSnippetStart)
    {
    TR::RealRegister *realDivisorReg  = toRealRegister(_divideInstruction->getSourceRegister());
    TR::RealRegister *realDividendReg = toRealRegister(_divideInstruction->getTargetRegister());

--- a/compiler/x/codegen/DivideCheckSnippet.hpp
+++ b/compiler/x/codegen/DivideCheckSnippet.hpp
@@ -20,27 +20,29 @@
 #define DIVIDECHECKSNIPPET_INCL
 
 #include <stdint.h>                      // for int32_t, uint32_t, uint8_t
-#include "codegen/Snippet.hpp"           // for TR_X86Snippet::Kind, etc
+#include "codegen/Snippet.hpp"           // for TR::X86Snippet::Kind, etc
 #include "il/DataTypes.hpp"              // for TR::DataType
-#include "x/codegen/RestartSnippet.hpp"  // for TR_X86RestartSnippet
+#include "x/codegen/RestartSnippet.hpp"  // for TR::X86RestartSnippet
 #include "x/codegen/X86Instruction.hpp"  // for TR::X86RegRegInstruction
 
 namespace TR { class CodeGenerator; }
 namespace TR { class ILOpCode; }
 namespace TR { class LabelSymbol; }
 
-class TR_X86DivideCheckSnippet  : public TR_X86RestartSnippet
+namespace TR {
+
+class X86DivideCheckSnippet  : public TR::X86RestartSnippet
    {
    public:
 
-   TR_X86DivideCheckSnippet(TR::LabelSymbol           *restartLabel,
+   X86DivideCheckSnippet(TR::LabelSymbol           *restartLabel,
                             TR::LabelSymbol           *snippetLabel,
                             TR::LabelSymbol           *divideLabel,
                             TR::ILOpCode               &divOp,
                             TR::DataType               type,
                             TR::X86RegRegInstruction  *divideInstruction,
                             TR::CodeGenerator         *cg)
-      : TR_X86RestartSnippet(cg, divideInstruction->getNode(), restartLabel, snippetLabel, true),
+      : TR::X86RestartSnippet(cg, divideInstruction->getNode(), restartLabel, snippetLabel, true),
         _divOp(divOp),
         _type(type),
         _divideLabel(divideLabel),
@@ -67,5 +69,7 @@ class TR_X86DivideCheckSnippet  : public TR_X86RestartSnippet
    TR::ILOpCode              &_divOp;
    TR::DataType              _type;
    };
+
+}
 
 #endif

--- a/compiler/x/codegen/FPBinaryArithmeticAnalyser.cpp
+++ b/compiler/x/codegen/FPBinaryArithmeticAnalyser.cpp
@@ -226,7 +226,7 @@ void TR_X86FPBinaryArithmeticAnalyser::genericFPAnalyser(TR::Node *root)
          {
          scalingRegister = _cg->allocateRegister(TR_X87);
 
-         TR_IA32ConstantDataSnippet *cds = _cg->findOrCreate8ByteConstant(root, DOUBLE_EXPONENT_SCALE);
+         TR::IA32ConstantDataSnippet *cds = _cg->findOrCreate8ByteConstant(root, DOUBLE_EXPONENT_SCALE);
          constMR = generateX86MemoryReference(cds, _cg);
 
          generateFPRegMemInstruction(DLDRegMem, root, scalingRegister, constMR, _cg);

--- a/compiler/x/codegen/FPTreeEvaluator.cpp
+++ b/compiler/x/codegen/FPTreeEvaluator.cpp
@@ -209,7 +209,7 @@ TR::Register *OMR::X86::TreeEvaluator::fconstEvaluator(TR::Node *node, TR::CodeG
          }
       else
          {
-         TR_IA32ConstantDataSnippet *cds = cg->findOrCreate4ByteConstant(node, node->getFloatBits());
+         TR::IA32ConstantDataSnippet *cds = cg->findOrCreate4ByteConstant(node, node->getFloatBits());
          TR::MemoryReference  *tempMR = generateX86MemoryReference(cds, cg);
          TR::Instruction *instr = generateRegMemInstruction(MOVSSRegMem, node, targetRegister, tempMR, cg);
          setDiscardableIfPossible(TR_RematerializableFloat, targetRegister, node, instr, (intptrj_t)node->getFloatBits(), cg);
@@ -229,7 +229,7 @@ TR::Register *OMR::X86::TreeEvaluator::fconstEvaluator(TR::Node *node, TR::CodeG
          }
       else
          {
-         TR_IA32ConstantDataSnippet *cds = cg->findOrCreate4ByteConstant(node, node->getFloatBits());
+         TR::IA32ConstantDataSnippet *cds = cg->findOrCreate4ByteConstant(node, node->getFloatBits());
          TR::MemoryReference  *tempMR = generateX86MemoryReference(cds, cg);
          generateFPRegMemInstruction(FLDRegMem, node, targetRegister, tempMR, cg);
          }
@@ -252,7 +252,7 @@ TR::Register *OMR::X86::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::CodeG
          }
       else
          {
-         TR_IA32ConstantDataSnippet *cds = cg->findOrCreate8ByteConstant(node, node->getLongInt());
+         TR::IA32ConstantDataSnippet *cds = cg->findOrCreate8ByteConstant(node, node->getLongInt());
          TR::MemoryReference  *tempMR = generateX86MemoryReference(cds, cg);
          generateRegMemInstruction(cg->getXMMDoubleLoadOpCode(), node, targetRegister, tempMR, cg);
          }
@@ -271,7 +271,7 @@ TR::Register *OMR::X86::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::CodeG
          }
       else
          {
-         TR_IA32ConstantDataSnippet *cds = cg->findOrCreate8ByteConstant(node, node->getLongInt());
+         TR::IA32ConstantDataSnippet *cds = cg->findOrCreate8ByteConstant(node, node->getLongInt());
          TR::MemoryReference  *tempMR = generateX86MemoryReference(cds, cg);
          generateFPRegMemInstruction(DLDRegMem, node, targetRegister, tempMR, cg);
          }
@@ -523,7 +523,7 @@ TR::Register *OMR::X86::TreeEvaluator::fpReturnEvaluator(TR::Node *node, TR::Cod
    //
    if (comp->getJittedMethodSymbol()->usesSinglePrecisionMode() && !cg->useSSEForDoublePrecision())
       {
-      TR_IA32ConstantDataSnippet *cds = cg->findOrCreate2ByteConstant(node, DOUBLE_PRECISION_ROUND_TO_NEAREST);
+      TR::IA32ConstantDataSnippet *cds = cg->findOrCreate2ByteConstant(node, DOUBLE_PRECISION_ROUND_TO_NEAREST);
       generateMemInstruction(LDCWMem, node, generateX86MemoryReference(cds, cg), cg);
       }
 
@@ -753,7 +753,7 @@ TR::Register *OMR::X86::TreeEvaluator::fnegEvaluator(TR::Node *node, TR::CodeGen
    TR::Register *targetRegister;
    if (sourceRegister->getKind() == TR_FPR)
       {
-      TR_IA32ConstantDataSnippet *cds = cg->findOrCreate4ByteConstant(node, FLOAT_NEG_ZERO);
+      TR::IA32ConstantDataSnippet *cds = cg->findOrCreate4ByteConstant(node, FLOAT_NEG_ZERO);
       targetRegister = cg->allocateSinglePrecisionRegister(TR_FPR);
       generateRegMemInstruction(MOVSSRegMem, node, targetRegister, generateX86MemoryReference(cds, cg), cg);
       generateRegRegInstruction(XORPSRegReg, node, targetRegister, sourceRegister, cg);
@@ -775,7 +775,7 @@ TR::Register *OMR::X86::TreeEvaluator::dnegEvaluator(TR::Node *node, TR::CodeGen
    TR::Register *targetRegister;
    if (sourceRegister->getKind() == TR_FPR)
       {
-      TR_IA32ConstantDataSnippet *cds = cg->findOrCreate8ByteConstant(node, DOUBLE_NEG_ZERO);
+      TR::IA32ConstantDataSnippet *cds = cg->findOrCreate8ByteConstant(node, DOUBLE_NEG_ZERO);
       targetRegister = cg->allocateRegister(TR_FPR);
       generateRegMemInstruction(cg->getXMMDoubleLoadOpCode(), node, targetRegister, generateX86MemoryReference(cds, cg), cg);
       generateRegRegInstruction(XORPDRegReg, node, targetRegister, sourceRegister, cg);
@@ -973,12 +973,12 @@ TR::Register *OMR::X86::TreeEvaluator::fpConvertToInt(TR::Node *node, TR::Symbol
       fpcw = comp->getJittedMethodSymbol()->usesSinglePrecisionMode() ?
                 SINGLE_PRECISION_ROUND_TO_ZERO : DOUBLE_PRECISION_ROUND_TO_ZERO;
 
-      TR_IA32ConstantDataSnippet *cds1 = cg->findOrCreate2ByteConstant(node, fpcw);
+      TR::IA32ConstantDataSnippet *cds1 = cg->findOrCreate2ByteConstant(node, fpcw);
 
       fpcw = comp->getJittedMethodSymbol()->usesSinglePrecisionMode() ?
                 SINGLE_PRECISION_ROUND_TO_NEAREST : DOUBLE_PRECISION_ROUND_TO_NEAREST;
 
-      TR_IA32ConstantDataSnippet *cds2 = cg->findOrCreate2ByteConstant(node, fpcw);
+      TR::IA32ConstantDataSnippet *cds2 = cg->findOrCreate2ByteConstant(node, fpcw);
 
       tempMR = (cg->machine())->getDummyLocalMR(TR::Int32);
 
@@ -1057,7 +1057,7 @@ TR::Register *OMR::X86::TreeEvaluator::fpConvertToInt(TR::Node *node, TR::Symbol
 
    // Create the conversion snippet.
    //
-   cg->addSnippet( new (cg->trHeapMemory()) TR_X86FPConvertToIntSnippet(reStartLabel,
+   cg->addSnippet( new (cg->trHeapMemory()) TR::X86FPConvertToIntSnippet(reStartLabel,
                                                          snippetLabel,
                                                          helperSymRef,
                                                          loadInstr,
@@ -1226,7 +1226,7 @@ TR::Register *OMR::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::Symbo
          int16_t fpcw = comp->getJittedMethodSymbol()->usesSinglePrecisionMode() ?
                            SINGLE_PRECISION_ROUND_TO_ZERO : DOUBLE_PRECISION_ROUND_TO_ZERO;
 
-         TR_IA32ConstantDataSnippet *cds1 = cg->findOrCreate2ByteConstant(node, fpcw);
+         TR::IA32ConstantDataSnippet *cds1 = cg->findOrCreate2ByteConstant(node, fpcw);
          generateMemInstruction(LDCWMem, node, generateX86MemoryReference(cds1, cg), cg);
          }
 
@@ -1239,7 +1239,7 @@ TR::Register *OMR::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::Symbo
          int16_t fpcw = comp->getJittedMethodSymbol()->usesSinglePrecisionMode() ?
                            SINGLE_PRECISION_ROUND_TO_NEAREST : DOUBLE_PRECISION_ROUND_TO_NEAREST;
 
-         TR_IA32ConstantDataSnippet *cds2 = cg->findOrCreate2ByteConstant(node, fpcw);
+         TR::IA32ConstantDataSnippet *cds2 = cg->findOrCreate2ByteConstant(node, fpcw);
          generateMemInstruction(LDCWMem, node, generateX86MemoryReference(cds2, cg), cg);
          }
 
@@ -1336,7 +1336,7 @@ TR::Register *OMR::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::Symbo
 
       // Create the conversion snippet.
       //
-      cg->addSnippet( new (cg->trHeapMemory()) TR_X86FPConvertToLongSnippet(reStartLabel,
+      cg->addSnippet( new (cg->trHeapMemory()) TR::X86FPConvertToLongSnippet(reStartLabel,
                                                         snippetLabel,
                                                         helperSymRef,
                                                         clobInstruction,
@@ -1446,7 +1446,7 @@ TR::Register *OMR::X86::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGene
 
       if( TR::Compiler->target.is64Bit() )
          {
-         cg->addSnippet( new (cg->trHeapMemory()) TR_AMD64FPConversionSnippet(reStartLabel,
+         cg->addSnippet( new (cg->trHeapMemory()) TR::AMD64FPConversionSnippet(reStartLabel,
                                                               snippetLabel,
                                                               helperSymRef,
                                                               instr,
@@ -1454,7 +1454,7 @@ TR::Register *OMR::X86::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGene
          }
       else
          {
-         cg->addSnippet( new (cg->trHeapMemory()) TR_X86FPConvertToIntSnippet(reStartLabel,
+         cg->addSnippet( new (cg->trHeapMemory()) TR::X86FPConvertToIntSnippet(reStartLabel,
                                                                snippetLabel,
                                                                helperSymRef,
                                                                instr,
@@ -1607,7 +1607,7 @@ TR::Register *OMR::X86::TreeEvaluator::d2iEvaluator(TR::Node *node, TR::CodeGene
          instr = generateRegRegInstruction(CVTTSD2SIReg4Reg, node, targetRegister, sourceRegister, cg);
          }
 
-      cg->addSnippet( new (cg->trHeapMemory()) TR_X86FPConvertToIntSnippet(reStartLabel,
+      cg->addSnippet( new (cg->trHeapMemory()) TR::X86FPConvertToIntSnippet(reStartLabel,
                                                             snippetLabel,
                                                             helperSymRef,
                                                             instr,
@@ -1823,7 +1823,7 @@ TR::Register *OMR::X86::TreeEvaluator::fbits2iEvaluator(TR::Node *node, TR::Code
          TR::X86RegImmInstruction  *instr = generateRegImmInstruction(ROL4RegImm1, node, target, 23, cg); // restore bits to proper order
          TR::RegisterDependencyConditions  *deps = generateRegisterDependencyConditions((uint8_t)0, (uint8_t)1, cg);
          deps->addPostCondition(target, TR::RealRegister::NoReg, cg);
-         TR_X86fbits2iSnippet  *snippet = new (cg->trHeapMemory()) TR_X86fbits2iSnippet(restartLabel, snippetLabel, instr, cg);
+         TR::X86fbits2iSnippet  *snippet = new (cg->trHeapMemory()) TR::X86fbits2iSnippet(restartLabel, snippetLabel, instr, cg);
          cg->addSnippet(snippet);
          generateLabelInstruction(LABEL, node, restartLabel, deps, cg);
          restartLabel->setEndInternalControlFlow();

--- a/compiler/x/codegen/HelperCallSnippet.cpp
+++ b/compiler/x/codegen/HelperCallSnippet.cpp
@@ -53,13 +53,13 @@
 #include "env/IO.hpp"
 #include "env/CompilerEnv.hpp"
 
-TR_X86HelperCallSnippet::TR_X86HelperCallSnippet(TR::CodeGenerator   *cg,
+TR::X86HelperCallSnippet::X86HelperCallSnippet(TR::CodeGenerator   *cg,
                                                  TR::Node            *node,
                                                  TR::LabelSymbol      *restartlab,
                                                  TR::LabelSymbol      *snippetlab,
                                                  TR::SymbolReference *helper,
                                                  int32_t             stackPointerAdjustment)
-   : TR_X86RestartSnippet(cg, node, restartlab, snippetlab, helper->canCauseGC()),
+   : TR::X86RestartSnippet(cg, node, restartlab, snippetlab, helper->canCauseGC()),
      _destination(helper),
      _callNode(0),
      _offset(-1),
@@ -81,12 +81,12 @@ TR_X86HelperCallSnippet::TR_X86HelperCallSnippet(TR::CodeGenerator   *cg,
       }
    }
 
-TR_X86HelperCallSnippet::TR_X86HelperCallSnippet(TR::CodeGenerator *cg,
+TR::X86HelperCallSnippet::X86HelperCallSnippet(TR::CodeGenerator *cg,
                                                  TR::LabelSymbol    *restartlab,
                                                  TR::LabelSymbol    *snippetlab,
                                                  TR::Node          *callNode,
                                                  int32_t           stackPointerAdjustment)
-   : TR_X86RestartSnippet(cg, callNode, restartlab, snippetlab, callNode->getSymbolReference()->canCauseGC()),
+   : TR::X86RestartSnippet(cg, callNode, restartlab, snippetlab, callNode->getSymbolReference()->canCauseGC()),
      _destination(callNode->getSymbolReference()),
      _callNode(callNode),
      _offset(-1),
@@ -104,7 +104,7 @@ TR_X86HelperCallSnippet::TR_X86HelperCallSnippet(TR::CodeGenerator *cg,
       }
    }
 
-uint8_t *TR_X86HelperCallSnippet::emitSnippetBody()
+uint8_t *TR::X86HelperCallSnippet::emitSnippetBody()
    {
    uint8_t *buffer = cg()->getBinaryBufferCursor();
    getSnippetLabel()->setCodeLocation(buffer);
@@ -116,7 +116,7 @@ uint8_t *TR_X86HelperCallSnippet::emitSnippetBody()
 
 
 void
-TR_X86HelperCallSnippet::addMetaDataForLoadAddrArg(
+TR::X86HelperCallSnippet::addMetaDataForLoadAddrArg(
       uint8_t *buffer,
       TR::Node *child)
    {
@@ -135,7 +135,7 @@ TR_X86HelperCallSnippet::addMetaDataForLoadAddrArg(
    }
 
 
-uint8_t *TR_X86HelperCallSnippet::genHelperCall(uint8_t *buffer)
+uint8_t *TR::X86HelperCallSnippet::genHelperCall(uint8_t *buffer)
    {
    // add esp, _stackPointerAdjustment
    //
@@ -317,7 +317,7 @@ uint8_t *TR_X86HelperCallSnippet::genHelperCall(uint8_t *buffer)
 
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_X86HelperCallSnippet  * snippet)
+TR_Debug::print(TR::FILE *pOutFile, TR::X86HelperCallSnippet  * snippet)
    {
    // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
@@ -328,7 +328,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_X86HelperCallSnippet  * snippet)
    }
 
 void
-TR_Debug::printBody(TR::FILE *pOutFile, TR_X86HelperCallSnippet  * snippet, uint8_t *bufferPos)
+TR_Debug::printBody(TR::FILE *pOutFile, TR::X86HelperCallSnippet  * snippet, uint8_t *bufferPos)
    {
    // *this    swipeable for debugging purposes
    TR_ASSERT(pOutFile != NULL, "assertion failure");
@@ -422,7 +422,7 @@ TR_Debug::printBody(TR::FILE *pOutFile, TR_X86HelperCallSnippet  * snippet, uint
    }
 
 
-uint32_t TR_X86HelperCallSnippet::getLength(int32_t estimatedSnippetStart)
+uint32_t TR::X86HelperCallSnippet::getLength(int32_t estimatedSnippetStart)
    {
    // *this    swipeable for debugging purposes
    uint32_t length = 35;
@@ -480,7 +480,7 @@ uint32_t TR_X86HelperCallSnippet::getLength(int32_t estimatedSnippetStart)
    }
 
 
-int32_t TR_X86HelperCallSnippet::branchDisplacementToHelper(
+int32_t TR::X86HelperCallSnippet::branchDisplacementToHelper(
    uint8_t            *nextInstructionAddress,
    TR::SymbolReference *helper,
    TR::CodeGenerator   *cg)
@@ -497,12 +497,12 @@ int32_t TR_X86HelperCallSnippet::branchDisplacementToHelper(
    }
 
 
-uint8_t *TR_X86CheckAsyncMessagesSnippet::genHelperCall(uint8_t *buffer)
+uint8_t *TR::X86CheckAsyncMessagesSnippet::genHelperCall(uint8_t *buffer)
    {
    // This code assumes that the superclass' genHelperCall() will only emit
    // the call and nothing more.  This should always be true for the asynccheck
    // helpers.
    //
-   uint8_t *cursor = TR_X86HelperCallSnippet::genHelperCall(buffer);
+   uint8_t *cursor = TR::X86HelperCallSnippet::genHelperCall(buffer);
    return cursor;
    }

--- a/compiler/x/codegen/HelperCallSnippet.hpp
+++ b/compiler/x/codegen/HelperCallSnippet.hpp
@@ -20,15 +20,17 @@
 #define X86HELPERCALLSNIPPET_INCL
 
 #include <stdint.h>                      // for int32_t, uint8_t, uint32_t
-#include "codegen/Snippet.hpp"           // for TR_X86Snippet::Kind, etc
+#include "codegen/Snippet.hpp"           // for TR::X86Snippet::Kind, etc
 #include "il/Node.hpp"                   // for Node
-#include "x/codegen/RestartSnippet.hpp"  // for TR_X86RestartSnippet
+#include "x/codegen/RestartSnippet.hpp"  // for TR::X86RestartSnippet
 
 namespace TR { class CodeGenerator; }
 namespace TR { class LabelSymbol; }
 namespace TR { class SymbolReference; }
 
-class TR_X86HelperCallSnippet : public TR_X86RestartSnippet
+namespace TR {
+
+class X86HelperCallSnippet : public TR::X86RestartSnippet
    {
    TR::Node            *_callNode;
    TR::SymbolReference *_destination;
@@ -41,18 +43,18 @@ class TR_X86HelperCallSnippet : public TR_X86RestartSnippet
 
    public:
 
-   TR_X86HelperCallSnippet(TR::CodeGenerator   *cg,
-                           TR::Node            *node,
-                           TR::LabelSymbol      *restartLabel,
-                           TR::LabelSymbol      *snippetLabel,
-                           TR::SymbolReference *helper,
-                           int32_t             stackPointerAdjustment=0);
+   X86HelperCallSnippet(TR::CodeGenerator   *cg,
+                        TR::Node            *node,
+                        TR::LabelSymbol      *restartLabel,
+                        TR::LabelSymbol      *snippetLabel,
+                        TR::SymbolReference *helper,
+                        int32_t             stackPointerAdjustment=0);
 
-   TR_X86HelperCallSnippet(TR::CodeGenerator   *cg,
-                           TR::LabelSymbol      *restartLabel,
-                           TR::LabelSymbol      *snippetLabel,
-                           TR::Node            *callNode,
-                           int32_t             stackPointerAdjustment=0);
+   X86HelperCallSnippet(TR::CodeGenerator   *cg,
+                        TR::LabelSymbol      *restartLabel,
+                        TR::LabelSymbol      *snippetLabel,
+                        TR::Node            *callNode,
+                        int32_t             stackPointerAdjustment=0);
 
    virtual Kind getKind() { return IsHelperCall; }
 
@@ -82,20 +84,22 @@ class TR_X86HelperCallSnippet : public TR_X86RestartSnippet
    };
 
 
-class TR_X86CheckAsyncMessagesSnippet : public TR_X86HelperCallSnippet
+class X86CheckAsyncMessagesSnippet : public TR::X86HelperCallSnippet
    {
    public:
 
-   TR_X86CheckAsyncMessagesSnippet(
+   X86CheckAsyncMessagesSnippet(
       TR::Node            *node,
       TR::LabelSymbol      *restartLabel,
       TR::LabelSymbol      *snippetLabel,
       TR::CodeGenerator   *cg) :
-         TR_X86HelperCallSnippet(cg, node, restartLabel, snippetLabel, node->getSymbolReference())
+         TR::X86HelperCallSnippet(cg, node, restartLabel, snippetLabel, node->getSymbolReference())
       {
       }
 
    virtual uint8_t *genHelperCall(uint8_t *buffer);
    };
+
+}
 
 #endif

--- a/compiler/x/codegen/MemoryReference.hpp
+++ b/compiler/x/codegen/MemoryReference.hpp
@@ -25,7 +25,7 @@
 #include <stdint.h>        // for uint8_t
 #include "env/jittypes.h"  // for intptrj_t
 
-class TR_IA32DataSnippet;
+namespace TR { class IA32DataSnippet; }
 class TR_ScratchRegisterManager;
 namespace TR { class CodeGenerator; }
 namespace TR { class LabelSymbol; }
@@ -72,7 +72,7 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
       TR::CodeGenerator *cg) :
          OMR::MemoryReferenceConnector(br, ir, s, disp, cg) {}
 
-   MemoryReference(TR_IA32DataSnippet *cds,
+   MemoryReference(TR::IA32DataSnippet *cds,
       TR::CodeGenerator *cg) :
          OMR::MemoryReferenceConnector(cds, cg) {}
 

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -470,7 +470,7 @@ OMR::X86::CodeGenerator::CodeGenerator() :
    _assignmentDirection(Backward),
    _lastCatchAppendInstruction(NULL),
    _betterSpillPlacements(NULL),
-   _dataSnippetList(getTypedAllocator<TR_IA32DataSnippet*>(TR::comp()->allocator())),
+   _dataSnippetList(getTypedAllocator<TR::IA32DataSnippet*>(TR::comp()->allocator())),
    _spilledIntRegisters(getTypedAllocator<TR::Register*>(TR::comp()->allocator())),
    _liveDiscardableRegisters(getTypedAllocator<TR::Register*>(TR::comp()->allocator())),
    _dependentDiscardableRegisters(getTypedAllocator<TR::Register*>(TR::comp()->allocator())),
@@ -580,7 +580,7 @@ OMR::X86::CodeGenerator::beginInstructionSelection()
    //
    if (self()->enableSinglePrecisionMethods() && comp->getJittedMethodSymbol()->usesSinglePrecisionMode())
       {
-      TR_IA32ConstantDataSnippet * cds = self()->findOrCreate2ByteConstant(startNode, SINGLE_PRECISION_ROUND_TO_NEAREST);
+      TR::IA32ConstantDataSnippet * cds = self()->findOrCreate2ByteConstant(startNode, SINGLE_PRECISION_ROUND_TO_NEAREST);
       generateMemInstruction(LDCWMem, startNode, generateX86MemoryReference(cds, self()), self());
       }
    }
@@ -606,7 +606,7 @@ OMR::X86::CodeGenerator::endInstructionSelection()
       TR_ASSERT(self()->getLastCatchAppendInstruction(),
              "endInstructionSelection() ==> Could not find the dummy finally block!\n");
 
-      TR_IA32ConstantDataSnippet * cds = self()->findOrCreate2ByteConstant(self()->getLastCatchAppendInstruction()->getNode(), DOUBLE_PRECISION_ROUND_TO_NEAREST);
+      TR::IA32ConstantDataSnippet * cds = self()->findOrCreate2ByteConstant(self()->getLastCatchAppendInstruction()->getNode(), DOUBLE_PRECISION_ROUND_TO_NEAREST);
       generateMemInstruction(self()->getLastCatchAppendInstruction(), LDCWMem, generateX86MemoryReference(cds, self()), self());
       }
    }
@@ -2182,11 +2182,11 @@ TR_OutlinedInstructions * OMR::X86::CodeGenerator::findOutlinedInstructionsFromM
 
 
 
-TR_IA32ConstantDataSnippet * OMR::X86::CodeGenerator::findOrCreateConstant(TR::Node * n, void * c, uint8_t size, bool isWarm)
+TR::IA32ConstantDataSnippet * OMR::X86::CodeGenerator::findOrCreateConstant(TR::Node * n, void * c, uint8_t size, bool isWarm)
    {
    // *this    swipeable for debugging purposes
 
-    TR_IA32DataSnippet * cursor;
+    TR::IA32DataSnippet * cursor;
 
    // A simple linear search should suffice for now since the number of FP constants
    // produced is typically very small.  Eventually, this should be implemented as an
@@ -2194,7 +2194,7 @@ TR_IA32ConstantDataSnippet * OMR::X86::CodeGenerator::findOrCreateConstant(TR::N
    for (auto iterator = _dataSnippetList.begin(); iterator != _dataSnippetList.end(); ++iterator)
       {
       if ((*iterator)->getKind() == TR::Snippet::IsConstantData &&
-          ((TR_IA32ConstantDataSnippet*)(*iterator))->getConstantSize() == size &&
+          ((TR::IA32ConstantDataSnippet*)(*iterator))->getConstantSize() == size &&
           (*iterator)->isWarmSnippet() == isWarm)
          {
          switch (size)
@@ -2202,28 +2202,28 @@ TR_IA32ConstantDataSnippet * OMR::X86::CodeGenerator::findOrCreateConstant(TR::N
             case 4:
                if ((*iterator)->getDataAs4Bytes() == *((int32_t *)c))
                   {
-                  return (TR_IA32ConstantDataSnippet*)(*iterator);
+                  return (TR::IA32ConstantDataSnippet*)(*iterator);
                   }
                break;
 
             case 8:
                if ((*iterator)->getDataAs8Bytes() == *((int64_t *)c))
                   {
-                  return (TR_IA32ConstantDataSnippet*)(*iterator);
+                  return (TR::IA32ConstantDataSnippet*)(*iterator);
                   }
                break;
 
             case 2:
                if ((*iterator)->getDataAs2Bytes() == *((int16_t *)c))
                   {
-                  return (TR_IA32ConstantDataSnippet*)(*iterator);
+                  return (TR::IA32ConstantDataSnippet*)(*iterator);
                   }
                break;
 
             case 16:
                if (!memcmp((*iterator)->getValue(), c, 16))
                   {
-                  return (TR_IA32ConstantDataSnippet*)(*iterator);
+                  return (TR::IA32ConstantDataSnippet*)(*iterator);
                   }
                break;
 
@@ -2238,10 +2238,10 @@ TR_IA32ConstantDataSnippet * OMR::X86::CodeGenerator::findOrCreateConstant(TR::N
 
    // Constant was not found: create a new snippet for it and add it to the constant list.
    //
-   cursor = new (self()->trHeapMemory()) TR_IA32ConstantDataSnippet(self(), n, c, size);
+   cursor = new (self()->trHeapMemory()) TR::IA32ConstantDataSnippet(self(), n, c, size);
    _dataSnippetList.push_front(cursor);
 
-   return (TR_IA32ConstantDataSnippet*)cursor;
+   return (TR::IA32ConstantDataSnippet*)cursor;
    }
 
 int32_t OMR::X86::CodeGenerator::setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart, bool isWarm)
@@ -2278,7 +2278,7 @@ void OMR::X86::CodeGenerator::emitDataSnippets(bool isWarm)
    {
    // *this    swipeable for debugging purposes
 
-   TR_IA32DataSnippet              * cursor;
+   TR::IA32DataSnippet              * cursor;
    uint8_t                                 * codeOffset;
    bool                                     first;
    int32_t                                  size;
@@ -2307,50 +2307,50 @@ void OMR::X86::CodeGenerator::emitDataSnippets(bool isWarm)
       }
    }
 
-TR_IA32ConstantDataSnippet *OMR::X86::CodeGenerator::findOrCreate2ByteConstant(TR::Node * n, int16_t c, bool isWarm)
+TR::IA32ConstantDataSnippet *OMR::X86::CodeGenerator::findOrCreate2ByteConstant(TR::Node * n, int16_t c, bool isWarm)
    {
    return self()->findOrCreateConstant(n, &c, 2, isWarm);
    }
 
-TR_IA32ConstantDataSnippet *OMR::X86::CodeGenerator::findOrCreate4ByteConstant(TR::Node * n, int32_t c, bool isWarm)
+TR::IA32ConstantDataSnippet *OMR::X86::CodeGenerator::findOrCreate4ByteConstant(TR::Node * n, int32_t c, bool isWarm)
    {
    return self()->findOrCreateConstant(n, &c, 4, isWarm);
    }
 
-TR_IA32ConstantDataSnippet *OMR::X86::CodeGenerator::findOrCreate8ByteConstant(TR::Node * n, int64_t c, bool isWarm)
+TR::IA32ConstantDataSnippet *OMR::X86::CodeGenerator::findOrCreate8ByteConstant(TR::Node * n, int64_t c, bool isWarm)
    {
    return self()->findOrCreateConstant(n, &c, 8, isWarm);
    }
 
-TR_IA32ConstantDataSnippet *OMR::X86::CodeGenerator::findOrCreate16ByteConstant(TR::Node * n, void *c, bool isWarm)
+TR::IA32ConstantDataSnippet *OMR::X86::CodeGenerator::findOrCreate16ByteConstant(TR::Node * n, void *c, bool isWarm)
    {
    return self()->findOrCreateConstant(n, c, 16, isWarm);
    }
 
-TR_IA32DataSnippet *OMR::X86::CodeGenerator::create2ByteData(TR::Node *n, int16_t c, bool isWarm)
+TR::IA32DataSnippet *OMR::X86::CodeGenerator::create2ByteData(TR::Node *n, int16_t c, bool isWarm)
    {
-   TR_IA32DataSnippet *cursor = new (self()->trHeapMemory()) TR_IA32DataSnippet(self(), n, &c, 2);
+   TR::IA32DataSnippet *cursor = new (self()->trHeapMemory()) TR::IA32DataSnippet(self(), n, &c, 2);
    _dataSnippetList.push_front(cursor);
    return cursor;
    }
 
-TR_IA32DataSnippet *OMR::X86::CodeGenerator::create4ByteData(TR::Node *n, int32_t c, bool isWarm)
+TR::IA32DataSnippet *OMR::X86::CodeGenerator::create4ByteData(TR::Node *n, int32_t c, bool isWarm)
    {
-   TR_IA32DataSnippet *cursor = new (self()->trHeapMemory()) TR_IA32DataSnippet(self(), n, &c, 4);
+   TR::IA32DataSnippet *cursor = new (self()->trHeapMemory()) TR::IA32DataSnippet(self(), n, &c, 4);
    _dataSnippetList.push_front(cursor);
    return cursor;
    }
 
-TR_IA32DataSnippet *OMR::X86::CodeGenerator::create8ByteData(TR::Node *n, int64_t c, bool isWarm)
+TR::IA32DataSnippet *OMR::X86::CodeGenerator::create8ByteData(TR::Node *n, int64_t c, bool isWarm)
    {
-   TR_IA32DataSnippet *cursor = new (self()->trHeapMemory()) TR_IA32DataSnippet(self(), n, &c, 8);
+   TR::IA32DataSnippet *cursor = new (self()->trHeapMemory()) TR::IA32DataSnippet(self(), n, &c, 8);
    _dataSnippetList.push_front(cursor);
    return cursor;
    }
 
-TR_IA32DataSnippet *OMR::X86::CodeGenerator::create16ByteData(TR::Node *n, void *c, bool isWarm)
+TR::IA32DataSnippet *OMR::X86::CodeGenerator::create16ByteData(TR::Node *n, void *c, bool isWarm)
    {
-   TR_IA32DataSnippet *cursor = new (self()->trHeapMemory()) TR_IA32DataSnippet(self(), n, c, 16);
+   TR::IA32DataSnippet *cursor = new (self()->trHeapMemory()) TR::IA32DataSnippet(self(), n, c, 16);
    _dataSnippetList.push_front(cursor);
    return cursor;
    }
@@ -3748,7 +3748,7 @@ void OMR::X86::CodeGenerator::dumpDataSnippets(TR::FILE *outFile, bool isWarm)
    if (outFile == NULL)
       return;
 
-   TR_IA32DataSnippet              * cursor;
+   TR::IA32DataSnippet              * cursor;
    int32_t                                  size;
 
    for (int exp=3; exp > 0; exp--)

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -58,8 +58,8 @@ namespace OMR { typedef OMR::X86::CodeGenerator CodeGeneratorConnector; }
 #include "codegen/GCStackAtlas.hpp"
 
 class TR_GCStackMap;
-class TR_IA32ConstantDataSnippet;
-class TR_IA32DataSnippet;
+namespace TR { class IA32ConstantDataSnippet; }
+namespace TR { class IA32DataSnippet; }
 class TR_OutlinedInstructions;
 namespace OMR { namespace X86 { class CodeGenerator; } }
 namespace TR { class CodeGenerator; }
@@ -574,14 +574,14 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    void dumpDataSnippets(TR::FILE *pOutFile, bool isWarm = 0);
 #endif
 
-   TR_IA32ConstantDataSnippet *findOrCreate2ByteConstant(TR::Node *, int16_t c, bool isWarm = 0);
-   TR_IA32ConstantDataSnippet *findOrCreate4ByteConstant(TR::Node *, int32_t c, bool isWarm = 0);
-   TR_IA32ConstantDataSnippet *findOrCreate8ByteConstant(TR::Node *, int64_t c, bool isWarm = 0);
-   TR_IA32ConstantDataSnippet *findOrCreate16ByteConstant(TR::Node *, void *c, bool isWarm = 0);
-   TR_IA32DataSnippet *create2ByteData(TR::Node *, int16_t c, bool isWarm = 0);
-   TR_IA32DataSnippet *create4ByteData(TR::Node *, int32_t c, bool isWarm = 0);
-   TR_IA32DataSnippet *create8ByteData(TR::Node *, int64_t c, bool isWarm = 0);
-   TR_IA32DataSnippet *create16ByteData(TR::Node *, void *c, bool isWarm = 0);
+   TR::IA32ConstantDataSnippet *findOrCreate2ByteConstant(TR::Node *, int16_t c, bool isWarm = 0);
+   TR::IA32ConstantDataSnippet *findOrCreate4ByteConstant(TR::Node *, int32_t c, bool isWarm = 0);
+   TR::IA32ConstantDataSnippet *findOrCreate8ByteConstant(TR::Node *, int64_t c, bool isWarm = 0);
+   TR::IA32ConstantDataSnippet *findOrCreate16ByteConstant(TR::Node *, void *c, bool isWarm = 0);
+   TR::IA32DataSnippet *create2ByteData(TR::Node *, int16_t c, bool isWarm = 0);
+   TR::IA32DataSnippet *create4ByteData(TR::Node *, int32_t c, bool isWarm = 0);
+   TR::IA32DataSnippet *create8ByteData(TR::Node *, int64_t c, bool isWarm = 0);
+   TR::IA32DataSnippet *create16ByteData(TR::Node *, void *c, bool isWarm = 0);
 
    bool supportsCMOV() {return (_targetProcessorInfo.supportsCMOVInstructions());}
 
@@ -646,7 +646,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    bool nodeIsFoldableMemOperand(TR::Node *node, TR::Node *parent, TR_RegisterPressureState *state);
 
-   TR_IA32ConstantDataSnippet     *findOrCreateConstant(TR::Node *, void *c, uint8_t size, bool isWarm=0);
+   TR::IA32ConstantDataSnippet     *findOrCreateConstant(TR::Node *, void *c, uint8_t size, bool isWarm=0);
 
    TR::RealRegister             *_frameRegister;
 
@@ -658,7 +658,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    TR::Instruction                 *_lastCatchAppendInstruction;
    TR_BetterSpillPlacement        *_betterSpillPlacements;
 
-   TR::list<TR_IA32DataSnippet*>          _dataSnippetList;
+   TR::list<TR::IA32DataSnippet*>          _dataSnippetList;
    TR::list<TR::Register*>               _spilledIntRegisters;
    TR::list<TR::Register*>               _liveDiscardableRegisters;
    TR::list<TR::Register*>               _dependentDiscardableRegisters;

--- a/compiler/x/codegen/OMRMachine.cpp
+++ b/compiler/x/codegen/OMRMachine.cpp
@@ -847,7 +847,7 @@ TR::RealRegister *OMR::X86::Machine::freeBestGPRegister(TR::Instruction         
          {
          if (info->getDataType() == TR_RematerializableFloat)
             {
-            TR_IA32ConstantDataSnippet *cds = self()->cg()->findOrCreate4ByteConstant(currentInstruction->getNode(), info->getConstant());
+            TR::IA32ConstantDataSnippet *cds = self()->cg()->findOrCreate4ByteConstant(currentInstruction->getNode(), info->getConstant());
             TR::MemoryReference  *tempMR = generateX86MemoryReference(cds, self()->cg());
             instr = generateRegMemInstruction(currentInstruction, MOVSSRegMem, best, tempMR, self()->cg());
 #ifdef DEBUG

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -84,7 +84,7 @@ OMR::X86::MemoryReference::getDisplacement()
    }
 
 
-OMR::X86::MemoryReference::MemoryReference(TR_IA32DataSnippet *cds, TR::CodeGenerator   *cg):
+OMR::X86::MemoryReference::MemoryReference(TR::IA32DataSnippet *cds, TR::CodeGenerator   *cg):
    _baseRegister(NULL),
    _baseNode(NULL),
    _indexRegister(NULL),
@@ -290,10 +290,10 @@ OMR::X86::MemoryReference::setUnresolvedDataSnippet(TR::UnresolvedDataSnippet *s
    return ( (TR::UnresolvedDataSnippet *) (_dataSnippet = s) );
    }
 
-TR_IA32DataSnippet *
+TR::IA32DataSnippet *
 OMR::X86::MemoryReference::getDataSnippet()
    {
-   return (self()->hasUnresolvedDataSnippet() || self()->hasUnresolvedVirtualCallSnippet()) ? NULL : (TR_IA32DataSnippet *)_dataSnippet;
+   return (self()->hasUnresolvedDataSnippet() || self()->hasUnresolvedVirtualCallSnippet()) ? NULL : (TR::IA32DataSnippet *)_dataSnippet;
    }
 
 
@@ -1304,7 +1304,7 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
             }
          else
             {
-            TR_IA32DataSnippet *cds = self()->getDataSnippet();
+            TR::IA32DataSnippet *cds = self()->getDataSnippet();
             TR::LabelSymbol *label = NULL;
 
             if (cds)
@@ -1556,7 +1556,7 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
             }
          else
             {
-            TR_IA32DataSnippet *cds = self()->getDataSnippet();
+            TR::IA32DataSnippet *cds = self()->getDataSnippet();
             TR_ASSERT(cds == NULL || self()->getLabel() == NULL,
                    "a memRef cannot have both a constant data snippet and a label");
             TR::LabelSymbol *label = NULL;
@@ -1851,7 +1851,7 @@ generateX86MemoryReference(TR::SymbolReference * sr, intptrj_t displacement, TR:
    }
 
 TR::MemoryReference  *
-generateX86MemoryReference(TR_IA32DataSnippet * cds, TR::CodeGenerator *cg)
+generateX86MemoryReference(TR::IA32DataSnippet * cds, TR::CodeGenerator *cg)
    {
    return new (cg->trHeapMemory()) TR::MemoryReference(cds, cg);
    }

--- a/compiler/x/codegen/OMRMemoryReference.hpp
+++ b/compiler/x/codegen/OMRMemoryReference.hpp
@@ -208,7 +208,7 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
       _symbolReference.setOffset(disp);
       }
 
-   MemoryReference(TR_IA32DataSnippet *cds, TR::CodeGenerator   *cg);
+   MemoryReference(TR::IA32DataSnippet *cds, TR::CodeGenerator   *cg);
 
    MemoryReference(TR::LabelSymbol *label, TR::CodeGenerator *cg);
 
@@ -241,11 +241,11 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
 
    TR::UnresolvedDataSnippet *setUnresolvedDataSnippet(TR::UnresolvedDataSnippet *s);
 
-   TR_IA32DataSnippet *getDataSnippet();
+   TR::IA32DataSnippet *getDataSnippet();
 
-   TR_IA32DataSnippet *setConstantDataSnippet(TR_IA32DataSnippet *s)
+   TR::IA32DataSnippet *setConstantDataSnippet(TR::IA32DataSnippet *s)
       {
-      return ( (TR_IA32DataSnippet *) (_dataSnippet = s) );
+      return ( (TR::IA32DataSnippet *) (_dataSnippet = s) );
       }
 
    TR::LabelSymbol *getLabel()                   { return _label; }
@@ -447,7 +447,7 @@ TR::MemoryReference  * generateX86MemoryReference(TR::MemoryReference  &, intptr
 TR::MemoryReference  * generateX86MemoryReference(TR::MemoryReference  &, intptrj_t, TR_ScratchRegisterManager *, TR::CodeGenerator *cg);
 TR::MemoryReference  * generateX86MemoryReference(TR::SymbolReference *, TR::CodeGenerator *cg);
 TR::MemoryReference  * generateX86MemoryReference(TR::SymbolReference *, intptrj_t, TR::CodeGenerator *cg);
-TR::MemoryReference  * generateX86MemoryReference(TR_IA32DataSnippet *, TR::CodeGenerator *cg);
+TR::MemoryReference  * generateX86MemoryReference(TR::IA32DataSnippet *, TR::CodeGenerator *cg);
 TR::MemoryReference  * generateX86MemoryReference(TR::LabelSymbol *, TR::CodeGenerator *cg);
 
 #endif

--- a/compiler/x/codegen/OMRSnippet.cpp
+++ b/compiler/x/codegen/OMRSnippet.cpp
@@ -30,22 +30,22 @@
 #include "x/codegen/X86Ops.hpp"                    // for ::JMP4, etc
 #include "codegen/UnresolvedDataSnippet.hpp"
 
-class TR_AMD64FPConversionSnippet;
-class TR_X86BoundCheckWithSpineCheckSnippet;
-class TR_X86CallSnippet;
-class TR_X86CheckFailureSnippet;
-class TR_X86CheckFailureSnippetWithResolve;
-class TR_X86DivideCheckSnippet;
-class TR_X86FPConvertToIntSnippet;
-class TR_X86FPConvertToLongSnippet;
-class TR_X86ForceRecompilationSnippet;
-class TR_X86GuardedDevirtualSnippet;
-class TR_X86PicDataSnippet;
-class TR_X86RecompilationSnippet;
-class TR_X86ScratchArgHelperCallSnippet;
-class TR_X86SpineCheckSnippet;
-class TR_X86UnresolvedVirtualCallSnippet;
-class TR_X86fbits2iSnippet;
+namespace TR { class AMD64FPConversionSnippet; }
+namespace TR { class X86BoundCheckWithSpineCheckSnippet; }
+namespace TR { class X86CallSnippet; }
+namespace TR { class X86CheckFailureSnippet; }
+namespace TR { class X86CheckFailureSnippetWithResolve; }
+namespace TR { class X86DivideCheckSnippet; }
+namespace TR { class X86FPConvertToIntSnippet; }
+namespace TR { class X86FPConvertToLongSnippet; }
+namespace TR { class X86ForceRecompilationSnippet; }
+namespace TR { class X86GuardedDevirtualSnippet; }
+namespace TR { class X86PicDataSnippet; }
+namespace TR { class X86RecompilationSnippet; }
+namespace TR { class X86ScratchArgHelperCallSnippet; }
+namespace TR { class X86SpineCheckSnippet; }
+namespace TR { class X86UnresolvedVirtualCallSnippet; }
+namespace TR { class X86fbits2iSnippet; }
 namespace TR { class LabelSymbol; }
 namespace TR { class Node; }
 
@@ -187,85 +187,85 @@ TR_Debug::printx(TR::FILE *pOutFile, TR::Snippet *snippet)
       {
 #ifdef J9_PROJECT_SPECIFIC
       case TR::Snippet::IsCall:
-         print(pOutFile, (TR_X86CallSnippet *)snippet);
+         print(pOutFile, (TR::X86CallSnippet *)snippet);
          break;
       case TR::Snippet::IsIPicData:
       case TR::Snippet::IsVPicData:
-         print(pOutFile, (TR_X86PicDataSnippet *)snippet);
+         print(pOutFile, (TR::X86PicDataSnippet *)snippet);
          break;
       case TR::Snippet::IsUnresolvedVirtualCall:
-         print(pOutFile, (TR_X86UnresolvedVirtualCallSnippet *)snippet);
+         print(pOutFile, (TR::X86UnresolvedVirtualCallSnippet *)snippet);
          break;
       case TR::Snippet::IsHeapAllocation:
-         print(pOutFile, (TR_X86HeapAllocationSnippet  *)snippet);
+         print(pOutFile, (TR::X86HeapAllocationSnippet  *)snippet);
          break;
       case TR::Snippet::IsWriteBarrier:
-         print(pOutFile, (TR_IA32WriteBarrierSnippet *)snippet);
+         print(pOutFile, (TR::IA32WriteBarrierSnippet *)snippet);
          break;
 #ifdef TR_TARGET_64BIT
       case TR::Snippet::IsWriteBarrierAMD64:
-         print(pOutFile, (TR_AMD64WriteBarrierSnippet *)snippet);
+         print(pOutFile, (TR::AMD64WriteBarrierSnippet *)snippet);
          break;
 #endif
       case TR::Snippet::IsJNIPause:
-         print(pOutFile, (TR_X86JNIPauseSnippet  *)snippet);
+         print(pOutFile, (TR::X86JNIPauseSnippet  *)snippet);
          break;
       case TR::Snippet::IsPassJNINull:
-         print(pOutFile, (TR_X86PassJNINullSnippet  *)snippet);
+         print(pOutFile, (TR::X86PassJNINullSnippet  *)snippet);
          break;
       case TR::Snippet::IsCheckFailure:
-         print(pOutFile, (TR_X86CheckFailureSnippet *)snippet);
+         print(pOutFile, (TR::X86CheckFailureSnippet *)snippet);
          break;
       case TR::Snippet::IsCheckFailureWithResolve:
-         print(pOutFile, (TR_X86CheckFailureSnippetWithResolve *)snippet);
+         print(pOutFile, (TR::X86CheckFailureSnippetWithResolve *)snippet);
          break;
       case TR::Snippet::IsBoundCheckWithSpineCheck:
-         print(pOutFile, (TR_X86BoundCheckWithSpineCheckSnippet *)snippet);
+         print(pOutFile, (TR::X86BoundCheckWithSpineCheckSnippet *)snippet);
          break;
       case TR::Snippet::IsSpineCheck:
-         print(pOutFile, (TR_X86SpineCheckSnippet *)snippet);
+         print(pOutFile, (TR::X86SpineCheckSnippet *)snippet);
          break;
       case TR::Snippet::IsScratchArgHelperCall:
-         print(pOutFile, (TR_X86ScratchArgHelperCallSnippet *)snippet);
+         print(pOutFile, (TR::X86ScratchArgHelperCallSnippet *)snippet);
          break;
       case TR::Snippet::IsForceRecompilation:
-         print(pOutFile, (TR_X86ForceRecompilationSnippet  *)snippet);
+         print(pOutFile, (TR::X86ForceRecompilationSnippet  *)snippet);
          break;
       case TR::Snippet::IsRecompilation:
-         print(pOutFile, (TR_X86RecompilationSnippet *)snippet);
+         print(pOutFile, (TR::X86RecompilationSnippet *)snippet);
          break;
 #endif
       case TR::Snippet::IsConstantData:
-         print(pOutFile, (TR_IA32ConstantDataSnippet *)snippet);
+         print(pOutFile, (TR::IA32ConstantDataSnippet *)snippet);
          break;
       case TR::Snippet::IsData:
-         print(pOutFile, (TR_IA32DataSnippet *)snippet);
+         print(pOutFile, (TR::IA32DataSnippet *)snippet);
          break;
       case TR::Snippet::IsDivideCheck:
-         print(pOutFile, (TR_X86DivideCheckSnippet  *)snippet);
+         print(pOutFile, (TR::X86DivideCheckSnippet  *)snippet);
          break;
 
 #ifdef J9_PROJECT_SPECIFIC
       case TR::Snippet::IsGuardedDevirtual:
-         print(pOutFile, (TR_X86GuardedDevirtualSnippet  *)snippet);
+         print(pOutFile, (TR::X86GuardedDevirtualSnippet  *)snippet);
          break;
 #endif
       case TR::Snippet::IsHelperCall:
-         print(pOutFile, (TR_X86HelperCallSnippet  *)snippet);
+         print(pOutFile, (TR::X86HelperCallSnippet  *)snippet);
          break;
       case TR::Snippet::IsFPConvertToInt:
-         print(pOutFile, (TR_X86FPConvertToIntSnippet  *)snippet);
+         print(pOutFile, (TR::X86FPConvertToIntSnippet  *)snippet);
          break;
       case TR::Snippet::IsFPConvertToLong:
-         print(pOutFile, (TR_X86FPConvertToLongSnippet  *)snippet);
+         print(pOutFile, (TR::X86FPConvertToLongSnippet  *)snippet);
          break;
 #ifdef TR_TARGET_64BIT
       case TR::Snippet::IsFPConvertAMD64:
-         print(pOutFile, (TR_AMD64FPConversionSnippet *)snippet);
+         print(pOutFile, (TR::AMD64FPConversionSnippet *)snippet);
          break;
 #endif
       case TR::Snippet::Isfbits2i:
-         print(pOutFile, (TR_X86fbits2iSnippet  *)snippet);
+         print(pOutFile, (TR::X86fbits2iSnippet  *)snippet);
          break;
       case TR::Snippet::IsUnresolvedDataIA32:
          print(pOutFile, (TR::UnresolvedDataSnippet *)snippet);
@@ -289,7 +289,7 @@ TR_Debug::printx(TR::FILE *pOutFile, TR::Snippet *snippet)
    }
 
 int32_t
-TR_Debug::printRestartJump(TR::FILE *pOutFile, TR_X86RestartSnippet * snippet, uint8_t *bufferPos)
+TR_Debug::printRestartJump(TR::FILE *pOutFile, TR::X86RestartSnippet * snippet, uint8_t *bufferPos)
    {
    int32_t size = snippet->estimateRestartJumpLength(JMP4, bufferPos - (uint8_t*)snippet->cg()->getBinaryBufferStart());
    printPrefix(pOutFile, NULL, bufferPos, size);
@@ -299,7 +299,7 @@ TR_Debug::printRestartJump(TR::FILE *pOutFile, TR_X86RestartSnippet * snippet, u
 
 #ifdef J9_PROJECT_SPECIFIC
 int32_t
-TR_Debug::printRestartJump(TR::FILE *pOutFile, TR_AMD64WriteBarrierSnippet * snippet, uint8_t *bufferPos)
+TR_Debug::printRestartJump(TR::FILE *pOutFile, TR::AMD64WriteBarrierSnippet * snippet, uint8_t *bufferPos)
    {
    int32_t size = snippet->estimateRestartJumpLength(JMP4, bufferPos - (uint8_t*)snippet->cg()->getBinaryBufferStart());
    printPrefix(pOutFile, NULL, bufferPos, size);
@@ -311,7 +311,7 @@ TR_Debug::printRestartJump(TR::FILE *pOutFile, TR_AMD64WriteBarrierSnippet * sni
 
 
 int32_t
-TR_Debug::printRestartJump(TR::FILE *pOutFile, TR_X86RestartSnippet * snippet, uint8_t *bufferPos, int32_t branchOp, const char *branchOpName)
+TR_Debug::printRestartJump(TR::FILE *pOutFile, TR::X86RestartSnippet * snippet, uint8_t *bufferPos, int32_t branchOp, const char *branchOpName)
    {
    int32_t size = snippet->estimateRestartJumpLength((TR_X86OpCodes) branchOp, bufferPos - (uint8_t*)snippet->cg()->getBinaryBufferStart());
    printPrefix(pOutFile, NULL, bufferPos, size);

--- a/compiler/x/codegen/OMRSnippet.hpp
+++ b/compiler/x/codegen/OMRSnippet.hpp
@@ -34,7 +34,7 @@ namespace OMR { typedef OMR::X86::Snippet SnippetConnector; }
 #include "compiler/codegen/OMRSnippet.hpp"
 #include "env/CompilerEnv.hpp"
 
-class TR_X86GuardedDevirtualSnippet;
+namespace TR { class X86GuardedDevirtualSnippet; }
 namespace TR { class CodeGenerator; }
 namespace TR { class LabelSymbol; }
 namespace TR { class Node; }

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -2883,8 +2883,8 @@ TR::Register *OMR::X86::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Co
 
          TR::SymbolReference *helperSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(helper, false, false, false);
 
-         TR_X86HelperCallSnippet *snippet = new (cg->trHeapMemory())
-            TR_X86HelperCallSnippet(cg, node, restartLabel, snippetLabel, helperSymRef);
+         TR::X86HelperCallSnippet *snippet = new (cg->trHeapMemory())
+            TR::X86HelperCallSnippet(cg, node, restartLabel, snippetLabel, helperSymRef);
 
          cg->addSnippet(snippet);
 

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -354,7 +354,7 @@ void TR::X86LabelInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned
          {
 #ifdef J9_PROJECT_SPECIFIC
          TR::Snippet *snippet = getLabelSymbol()->getSnippet();
-         TR_X86GuardedDevirtualSnippet *devirtSnippet;
+         TR::X86GuardedDevirtualSnippet *devirtSnippet;
 
          // If this is a GuardedDevirtualSnippet, then must find out what real register
          // contains the class object reference.  This must be used by the snippet to generate

--- a/compiler/x/codegen/RestartSnippet.hpp
+++ b/compiler/x/codegen/RestartSnippet.hpp
@@ -30,18 +30,20 @@
 
 namespace TR { class Node; }
 
-class TR_X86RestartSnippet  : public TR::Snippet
+namespace TR {
+
+class X86RestartSnippet  : public TR::Snippet
    {
    TR::LabelSymbol *_restartLabel;
    bool            _forceLongRestartJump;
 
    public:
 
-   TR_X86RestartSnippet(TR::CodeGenerator *cg,
-                         TR::Node * n,
-                         TR::LabelSymbol *restartlab,
-                         TR::LabelSymbol *snippetlab,
-                         bool            isGCSafePoint)
+   X86RestartSnippet(TR::CodeGenerator *cg,
+                     TR::Node * n,
+                     TR::LabelSymbol *restartlab,
+                     TR::LabelSymbol *snippetlab,
+                     bool            isGCSafePoint)
       : TR::Snippet(cg, n, snippetlab, isGCSafePoint),
         _restartLabel(restartlab), _forceLongRestartJump(false) {}
 
@@ -137,5 +139,7 @@ class TR_X86RestartSnippet  : public TR::Snippet
    // } RTSJ Support ends
 
    };
+
+}
 
 #endif

--- a/compiler/x/codegen/X86Debug.cpp
+++ b/compiler/x/codegen/X86Debug.cpp
@@ -47,7 +47,7 @@
 #include "infra/Assert.hpp"                      // for TR_ASSERT
 #include "infra/List.hpp"                        // for ListIterator, List
 #include "ras/Debug.hpp"                         // for TR_Debug, etc
-#include "x/codegen/DataSnippet.hpp"             // for TR_IA32DataSnippet
+#include "x/codegen/DataSnippet.hpp"             // for TR::IA32DataSnippet
 #include "x/codegen/OutlinedInstructions.hpp"
 #include "x/codegen/X86Instruction.hpp"
 #include "x/codegen/X86Ops.hpp"                  // for TR_X86OpCode, etc
@@ -55,7 +55,7 @@
 #include "env/CompilerEnv.hpp"
 
 #ifdef J9_PROJECT_SPECIFIC
-#include "x/codegen/CallSnippet.hpp"             // for TR_X86CallSnippet
+#include "x/codegen/CallSnippet.hpp"             // for TR::X86CallSnippet
 #include "x/codegen/WriteBarrierSnippet.hpp"
 #endif
 
@@ -1652,7 +1652,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::MemoryReference  * mr, TR_RegisterSizes 
       {
       // This must be an absolute memory reference (a constant data snippet or a label)
       //
-      TR_IA32DataSnippet *cds = mr->getDataSnippet();
+      TR::IA32DataSnippet *cds = mr->getDataSnippet();
       TR::LabelSymbol *label = NULL;
       if (cds)
          label = cds->getSnippetLabel();
@@ -2259,7 +2259,7 @@ getInterpretedMethodNameHelper(TR::MethodSymbol *methodSymbol,
 
 #ifdef J9_PROJECT_SPECIFIC
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_X86CallSnippet  * snippet)
+TR_Debug::print(TR::FILE *pOutFile, TR::X86CallSnippet  * snippet)
    {
    // *this   swipeable for debugger
    if (pOutFile == NULL)
@@ -2490,7 +2490,7 @@ TR_Debug::printArgumentFlush(TR::FILE *              pOutFile,
 #ifdef J9_PROJECT_SPECIFIC
 uint8_t*
 TR_Debug::printArgs(TR::FILE *pOutFile,
-                    TR_AMD64WriteBarrierSnippet * snippet,
+                    TR::AMD64WriteBarrierSnippet * snippet,
                     bool restoreRegs,
                     uint8_t *bufferPos)
    {
@@ -2670,7 +2670,7 @@ TR_Debug::printArgs(TR::FILE *pOutFile,
    }
 
 static uint8_t *
-estimateJumpSize(TR_AMD64WriteBarrierSnippet * snippet,
+estimateJumpSize(TR::AMD64WriteBarrierSnippet * snippet,
                  uint8_t * bufferPos)
    {
    TR::LabelSymbol *restartLabel = snippet->getRestartLabel();
@@ -2696,7 +2696,7 @@ estimateJumpSize(TR_AMD64WriteBarrierSnippet * snippet,
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_AMD64WriteBarrierSnippet * snippet)
+TR_Debug::print(TR::FILE *pOutFile, TR::AMD64WriteBarrierSnippet * snippet)
    {
    if (pOutFile == NULL)
       return;

--- a/compiler/x/codegen/X86FPConversionSnippet.cpp
+++ b/compiler/x/codegen/X86FPConversionSnippet.cpp
@@ -41,7 +41,7 @@
 #include "runtime/Runtime.hpp"                   // for ::TR_HelperAddress
 #include "x/codegen/X86Instruction.hpp"
 
-uint8_t *TR_X86FPConversionSnippet::emitSnippetBody()
+uint8_t *TR::X86FPConversionSnippet::emitSnippetBody()
    {
    // *this    swipeable for debugging purposes
    uint8_t *buffer = cg()->getBinaryBufferCursor();
@@ -50,7 +50,7 @@ uint8_t *TR_X86FPConversionSnippet::emitSnippetBody()
    }
 
 
-uint8_t *TR_X86FPConversionSnippet::emitCallToConversionHelper(uint8_t *buffer)
+uint8_t *TR::X86FPConversionSnippet::emitCallToConversionHelper(uint8_t *buffer)
    {
    // *this    swipeable for debugging purposes
 
@@ -71,7 +71,7 @@ uint8_t *TR_X86FPConversionSnippet::emitCallToConversionHelper(uint8_t *buffer)
    }
 
 
-uint8_t *TR_X86FPConvertToIntSnippet::genFPConversion(uint8_t *buffer)
+uint8_t *TR::X86FPConvertToIntSnippet::genFPConversion(uint8_t *buffer)
    {
    // *this    swipeable for debugging purposes
 
@@ -163,7 +163,7 @@ uint8_t *TR_X86FPConvertToIntSnippet::genFPConversion(uint8_t *buffer)
 
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_X86FPConvertToIntSnippet  * snippet)
+TR_Debug::print(TR::FILE *pOutFile, TR::X86FPConvertToIntSnippet  * snippet)
    {
    // *this    swipeable for debugging purposes
 
@@ -231,7 +231,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_X86FPConvertToIntSnippet  * snippet)
    }
 
 
-uint32_t TR_X86FPConvertToIntSnippet::getLength(int32_t estimatedSnippetStart)
+uint32_t TR::X86FPConvertToIntSnippet::getLength(int32_t estimatedSnippetStart)
    {
    // *this    swipeable for debugging purposes
    uint32_t length = 11;
@@ -263,7 +263,7 @@ uint32_t TR_X86FPConvertToIntSnippet::getLength(int32_t estimatedSnippetStart)
 
 // Each _registerAction is a union of actionFlags
 //
-const uint8_t TR_X86FPConvertToLongSnippet::_registerActions[16] =
+const uint8_t TR::X86FPConvertToLongSnippet::_registerActions[16] =
    { 0x1e,   // 0
      0x14,   // 1
      0x0e,   // 2
@@ -282,7 +282,7 @@ const uint8_t TR_X86FPConvertToLongSnippet::_registerActions[16] =
      0x00};  // 15
 
 
-uint8_t *TR_X86FPConvertToLongSnippet::genFPConversion(uint8_t *buffer)
+uint8_t *TR::X86FPConvertToLongSnippet::genFPConversion(uint8_t *buffer)
    {
    // *this    swipeable for debugging purposes
 
@@ -354,7 +354,7 @@ uint8_t *TR_X86FPConvertToLongSnippet::genFPConversion(uint8_t *buffer)
 
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_X86FPConvertToLongSnippet  * snippet)
+TR_Debug::print(TR::FILE *pOutFile, TR::X86FPConvertToLongSnippet  * snippet)
    {
    // *this    swipeable for debugging purposes
 
@@ -363,7 +363,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_X86FPConvertToLongSnippet  * snippet)
 
    uint8_t *bufferPos = snippet->getSnippetLabel()->getCodeLocation();
 
-   uint8_t action = TR_X86FPConvertToLongSnippet::_registerActions[snippet->getAction() & 0x7f ];
+   uint8_t action = TR::X86FPConvertToLongSnippet::_registerActions[snippet->getAction() & 0x7f ];
 
    printSnippetLabel(pOutFile, snippet->getSnippetLabel(), bufferPos, getName(snippet));
 
@@ -453,7 +453,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_X86FPConvertToLongSnippet  * snippet)
 
 
 
-void TR_X86FPConvertToLongSnippet::analyseLongConversion()
+void TR::X86FPConvertToLongSnippet::analyseLongConversion()
    {
    // *this    swipeable for debugging purposes
 
@@ -481,7 +481,7 @@ void TR_X86FPConvertToLongSnippet::analyseLongConversion()
    }
 
 
-uint32_t TR_X86FPConvertToLongSnippet::getLength(int32_t estimatedSnippetStart)
+uint32_t TR::X86FPConvertToLongSnippet::getLength(int32_t estimatedSnippetStart)
    {
    // *this    swipeable for debugging purposes
    uint32_t length = 5;
@@ -533,7 +533,7 @@ uint32_t TR_X86FPConvertToLongSnippet::getLength(int32_t estimatedSnippetStart)
    return length + estimateRestartJumpLength(estimatedSnippetStart + length);
    }
 
-uint8_t *TR_X86fbits2iSnippet::emitSnippetBody()
+uint8_t *TR::X86fbits2iSnippet::emitSnippetBody()
    {
    // *this    swipeable for debugging purposes
    uint8_t *buffer = cg()->getBinaryBufferCursor();
@@ -566,7 +566,7 @@ uint8_t *TR_X86fbits2iSnippet::emitSnippetBody()
 
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_X86fbits2iSnippet  * snippet)
+TR_Debug::print(TR::FILE *pOutFile, TR::X86fbits2iSnippet  * snippet)
    {
    // *this    swipeable for debugging purposes
 
@@ -603,7 +603,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_X86fbits2iSnippet  * snippet)
    }
 
 
-uint32_t TR_X86fbits2iSnippet::getLength(int32_t estimatedSnippetStart)
+uint32_t TR::X86fbits2iSnippet::getLength(int32_t estimatedSnippetStart)
    {
    // *this    swipeable for debugging purposes
    uint32_t length = 6;  // 6 for test instruction

--- a/compiler/x/codegen/X86FPConversionSnippet.hpp
+++ b/compiler/x/codegen/X86FPConversionSnippet.hpp
@@ -21,28 +21,30 @@
 
 #include <stdint.h>                      // for uint8_t, int32_t, uint32_t
 #include "codegen/RealRegister.hpp"      // for toRealRegister
-#include "codegen/Snippet.hpp"           // for TR_X86Snippet::Kind, etc
+#include "codegen/Snippet.hpp"           // for TR::X86Snippet::Kind, etc
 #include "il/SymbolReference.hpp"        // for SymbolReference
 #include "infra/Assert.hpp"              // for TR_ASSERT
-#include "x/codegen/RestartSnippet.hpp"  // for TR_X86RestartSnippet
+#include "x/codegen/RestartSnippet.hpp"  // for TR::X86RestartSnippet
 #include "codegen/X86Instruction.hpp"  // for TR::X86RegInstruction, etc
 
 namespace TR { class CodeGenerator; }
 namespace TR { class LabelSymbol; }
 namespace TR { class Node; }
 
-class TR_X86FPConversionSnippet : public TR_X86RestartSnippet
+namespace TR {
+
+class X86FPConversionSnippet : public TR::X86RestartSnippet
    {
    TR::SymbolReference *_helperSymRef;
 
    public:
 
-   TR_X86FPConversionSnippet(TR::CodeGenerator   *codeGen,
-                              TR::Node            *node,
-                              TR::LabelSymbol      *restartlab,
-                              TR::LabelSymbol      *snippetlab,
-                              TR::SymbolReference *helperSymRef)
-      : TR_X86RestartSnippet(codeGen, node, restartlab, snippetlab, helperSymRef->canCauseGC()),
+   X86FPConversionSnippet(TR::CodeGenerator   *codeGen,
+                          TR::Node            *node,
+                          TR::LabelSymbol      *restartlab,
+                          TR::LabelSymbol      *snippetlab,
+                          TR::SymbolReference *helperSymRef)
+      : TR::X86RestartSnippet(codeGen, node, restartlab, snippetlab, helperSymRef->canCauseGC()),
            _helperSymRef(helperSymRef)
       {
       // The code generation for this snippet does not allow a proper GC map
@@ -61,18 +63,18 @@ class TR_X86FPConversionSnippet : public TR_X86RestartSnippet
    };
 
 
-class TR_X86FPConvertToIntSnippet  : public TR_X86FPConversionSnippet
+class X86FPConvertToIntSnippet  : public TR::X86FPConversionSnippet
    {
    TR::X86RegInstruction  *_convertInstruction;
 
    public:
 
-   TR_X86FPConvertToIntSnippet(TR::LabelSymbol            *restartlab,
-                                TR::LabelSymbol            *snippetlab,
-                                TR::SymbolReference       *helperSymRef,
-                                TR::X86RegInstruction     *convertInstr,
-                                TR::CodeGenerator *codeGen)
-      : TR_X86FPConversionSnippet(codeGen, convertInstr->getNode(), restartlab, snippetlab, helperSymRef),
+   X86FPConvertToIntSnippet(TR::LabelSymbol            *restartlab,
+                            TR::LabelSymbol            *snippetlab,
+                            TR::SymbolReference       *helperSymRef,
+                            TR::X86RegInstruction     *convertInstr,
+                            TR::CodeGenerator *codeGen)
+      : TR::X86FPConversionSnippet(codeGen, convertInstr->getNode(), restartlab, snippetlab, helperSymRef),
            _convertInstruction(convertInstr) {}
 
    TR::X86RegInstruction  * getConvertInstruction() {return _convertInstruction;}
@@ -82,7 +84,7 @@ class TR_X86FPConvertToIntSnippet  : public TR_X86FPConversionSnippet
    };
 
 
-class TR_X86FPConvertToLongSnippet  : public TR_X86FPConversionSnippet
+class X86FPConvertToLongSnippet  : public TR::X86FPConversionSnippet
    {
    TR::X86RegMemInstruction          *_loadHighInstruction,
                                     *_loadLowInstruction;
@@ -108,14 +110,14 @@ class TR_X86FPConvertToLongSnippet  : public TR_X86FPConversionSnippet
       kNeedFXCH    = 0x80
       };
 
-   TR_X86FPConvertToLongSnippet(TR::LabelSymbol                    *restartlab,
-                                 TR::LabelSymbol                    *snippetlab,
-                                 TR::SymbolReference               *helperSymRef,
-                                 TR::X86FPST0STiRegRegInstruction  *clobInstr,
-                                 TR::X86RegMemInstruction          *loadHighInstr,
-                                 TR::X86RegMemInstruction          *loadLowInstr,
-                                 TR::CodeGenerator *codeGen)
-      : TR_X86FPConversionSnippet(codeGen, clobInstr->getNode(), restartlab, snippetlab, helperSymRef),
+   X86FPConvertToLongSnippet(TR::LabelSymbol                    *restartlab,
+                             TR::LabelSymbol                    *snippetlab,
+                             TR::SymbolReference               *helperSymRef,
+                             TR::X86FPST0STiRegRegInstruction  *clobInstr,
+                             TR::X86RegMemInstruction          *loadHighInstr,
+                             TR::X86RegMemInstruction          *loadLowInstr,
+                             TR::CodeGenerator *codeGen)
+      : TR::X86FPConversionSnippet(codeGen, clobInstr->getNode(), restartlab, snippetlab, helperSymRef),
            _loadHighInstruction(loadHighInstr),
            _loadLowInstruction(loadLowInstr),
            _clobberInstruction(clobInstr),
@@ -136,17 +138,17 @@ class TR_X86FPConvertToLongSnippet  : public TR_X86FPConversionSnippet
    };
 
 
-class TR_X86fbits2iSnippet : public TR_X86RestartSnippet
+class X86fbits2iSnippet : public TR::X86RestartSnippet
    {
    TR::X86RegImmInstruction  *_instruction;
 
    public:
 
-   TR_X86fbits2iSnippet(TR::LabelSymbol            *restartlab,
-                         TR::LabelSymbol            *snippetlab,
-                         TR::X86RegImmInstruction  *instr,
-                         TR::CodeGenerator *codeGen)
-      : TR_X86RestartSnippet(codeGen, instr->getNode(), restartlab, snippetlab, false),
+   X86fbits2iSnippet(TR::LabelSymbol            *restartlab,
+                     TR::LabelSymbol            *snippetlab,
+                     TR::X86RegImmInstruction  *instr,
+                     TR::CodeGenerator *codeGen)
+      : TR::X86RestartSnippet(codeGen, instr->getNode(), restartlab, snippetlab, false),
         _instruction(instr) {}
 
    TR::X86RegImmInstruction  *getInstruction() {return _instruction;}
@@ -161,25 +163,25 @@ class TR_X86fbits2iSnippet : public TR_X86RestartSnippet
    virtual Kind getKind() {return Isfbits2i;}
    };
 
-class TR_AMD64FPConversionSnippet : public TR_X86FPConversionSnippet
+class AMD64FPConversionSnippet : public TR::X86FPConversionSnippet
    {
 public:
    virtual Kind getKind() {return IsFPConvertAMD64;}
 
 #if !defined(TR_TARGET_64BIT)
-   TR_AMD64FPConversionSnippet(TR::LabelSymbol *, TR::LabelSymbol *, TR::SymbolReference *, TR::X86RegInstruction  *, TR::CodeGenerator *)
-      : TR_X86FPConversionSnippet(0, 0, 0, 0, 0) { }
+   AMD64FPConversionSnippet(TR::LabelSymbol *, TR::LabelSymbol *, TR::SymbolReference *, TR::X86RegInstruction  *, TR::CodeGenerator *)
+      : TR::X86FPConversionSnippet(0, 0, 0, 0, 0) { }
 
    virtual uint32_t getLength(int32_t estimatedSnippetStart) { return 0; }
    uint8_t *genFPConversion(uint8_t *buffer) { return buffer; }
 #else
 
-   TR_AMD64FPConversionSnippet(TR::LabelSymbol            *restartlab,
-                               TR::LabelSymbol            *snippetlab,
-                               TR::SymbolReference       *helperSymRef,
-                               TR::X86RegInstruction  *convertInstr,
-                               TR::CodeGenerator *codeGen)
-      : TR_X86FPConversionSnippet(codeGen, convertInstr->getNode(), restartlab, snippetlab, helperSymRef),
+   AMD64FPConversionSnippet(TR::LabelSymbol            *restartlab,
+                            TR::LabelSymbol            *snippetlab,
+                            TR::SymbolReference       *helperSymRef,
+                            TR::X86RegInstruction  *convertInstr,
+                            TR::CodeGenerator *codeGen)
+      : TR::X86FPConversionSnippet(codeGen, convertInstr->getNode(), restartlab, snippetlab, helperSymRef),
            _convertInstruction(convertInstr->getIA32RegRegInstruction()) {}
 
    TR::X86RegRegInstruction  * getConvertInstruction() {return _convertInstruction;}
@@ -190,5 +192,7 @@ private:
 
 #endif
    };
+
+}
 
 #endif

--- a/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
@@ -597,7 +597,7 @@ TR::Register *OMR::X86::i386::TreeEvaluator::integerPairReturnEvaluator(TR::Node
    if (cg->enableSinglePrecisionMethods() &&
        comp->getJittedMethodSymbol()->usesSinglePrecisionMode())
       {
-      TR_IA32ConstantDataSnippet *cds = cg->findOrCreate2ByteConstant(node, DOUBLE_PRECISION_ROUND_TO_NEAREST);
+      TR::IA32ConstantDataSnippet *cds = cg->findOrCreate2ByteConstant(node, DOUBLE_PRECISION_ROUND_TO_NEAREST);
       generateMemInstruction(LDCWMem, node, generateX86MemoryReference(cds, cg), cg);
       }
 

--- a/compiler/z/codegen/CallSnippet.cpp
+++ b/compiler/z/codegen/CallSnippet.cpp
@@ -49,7 +49,7 @@
 #define TR_S390_ARG_SLOT_SIZE 4
 
 uint8_t *
-TR_S390CallSnippet::storeArgumentItem(TR::InstOpCode::Mnemonic op, uint8_t * buffer, TR::RealRegister * reg, int32_t offset,
+TR::S390CallSnippet::storeArgumentItem(TR::InstOpCode::Mnemonic op, uint8_t * buffer, TR::RealRegister * reg, int32_t offset,
    TR::CodeGenerator * cg)
    {
    TR::RealRegister * stackPtr = cg->getStackPointerRealRegister();
@@ -63,7 +63,7 @@ TR_S390CallSnippet::storeArgumentItem(TR::InstOpCode::Mnemonic op, uint8_t * buf
    }
 
 uint8_t *
-TR_S390CallSnippet::loadArgumentItem(TR::InstOpCode::Mnemonic op, uint8_t * buffer, TR::RealRegister * reg, int32_t offset)
+TR::S390CallSnippet::loadArgumentItem(TR::InstOpCode::Mnemonic op, uint8_t * buffer, TR::RealRegister * reg, int32_t offset)
    {
    TR::RealRegister * stackPtr = cg()->getStackPointerRealRegister();
    TR::InstOpCode opCode(op);
@@ -77,7 +77,7 @@ TR_S390CallSnippet::loadArgumentItem(TR::InstOpCode::Mnemonic op, uint8_t * buff
 
 
 uint8_t *
-TR_S390CallSnippet::S390flushArgumentsToStack(uint8_t * buffer, TR::Node * callNode, int32_t argSize, TR::CodeGenerator * cg)
+TR::S390CallSnippet::S390flushArgumentsToStack(uint8_t * buffer, TR::Node * callNode, int32_t argSize, TR::CodeGenerator * cg)
    {
    int32_t intArgNum = 0, floatArgNum = 0, offset;
    TR::Machine *machine = cg->machine();
@@ -211,7 +211,7 @@ TR_S390CallSnippet::S390flushArgumentsToStack(uint8_t * buffer, TR::Node * callN
  * @return the total instruction length in bytes for setting up arguments
  */
 int32_t
-TR_S390CallSnippet::instructionCountForArguments(TR::Node * callNode, TR::CodeGenerator * cg)
+TR::S390CallSnippet::instructionCountForArguments(TR::Node * callNode, TR::CodeGenerator * cg)
    {
    int32_t intArgNum = 0, floatArgNum = 0, count = 0;
    TR::Linkage* linkage = cg->getLinkage(callNode->getSymbol()->castToMethodSymbol()->getLinkageConvention());
@@ -269,7 +269,7 @@ TR_S390CallSnippet::instructionCountForArguments(TR::Node * callNode, TR::CodeGe
    }
 
 uint8_t *
-TR_S390CallSnippet::getCallRA()
+TR::S390CallSnippet::getCallRA()
    {
    //Return Address is the address of the instr follows the branch instr
    TR_ASSERT( getBranchInstruction() != NULL, "CallSnippet: branchInstruction is NULL");
@@ -278,7 +278,7 @@ TR_S390CallSnippet::getCallRA()
 
 
 TR_RuntimeHelper
-TR_S390CallSnippet::getHelper(TR::MethodSymbol * methodSymbol, TR::DataType type, TR::CodeGenerator * cg)
+TR::S390CallSnippet::getHelper(TR::MethodSymbol * methodSymbol, TR::DataType type, TR::CodeGenerator * cg)
    {
    bool synchronised = methodSymbol->isSynchronised();
 
@@ -379,7 +379,7 @@ TR_S390CallSnippet::getHelper(TR::MethodSymbol * methodSymbol, TR::DataType type
       }
    }
 
-TR_RuntimeHelper TR_S390CallSnippet::getInterpretedDispatchHelper(
+TR_RuntimeHelper TR::S390CallSnippet::getInterpretedDispatchHelper(
    TR::SymbolReference *methodSymRef,
    TR::DataType        type)
    {
@@ -411,15 +411,15 @@ TR_RuntimeHelper TR_S390CallSnippet::getInterpretedDispatchHelper(
 
 
 uint8_t *
-TR_S390CallSnippet::emitSnippetBody()
+TR::S390CallSnippet::emitSnippetBody()
    {
-   TR_ASSERT(0, "TR_S390CallSnippet::emitSnippetBody not implemented");
+   TR_ASSERT(0, "TR::S390CallSnippet::emitSnippetBody not implemented");
    return NULL;
    }
 
 
 uint32_t
-TR_S390CallSnippet::getLength(int32_t  estimatedSnippetStart)
+TR::S390CallSnippet::getLength(int32_t  estimatedSnippetStart)
    {
    // *this   swipeable for debugger
    // length = instructionCountForArgsInBytes + (BASR + L(or LG) + BASR +3*sizeof(uintptrj_t)) + NOPs
@@ -434,7 +434,7 @@ TR_S390CallSnippet::getLength(int32_t  estimatedSnippetStart)
 
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390CallSnippet * snippet)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390CallSnippet * snippet)
    {
    uint8_t * bufferPos = snippet->getSnippetLabel()->getCodeLocation();
    TR::Node * callNode = snippet->getNode();

--- a/compiler/z/codegen/CallSnippet.hpp
+++ b/compiler/z/codegen/CallSnippet.hpp
@@ -24,7 +24,7 @@
 #include "codegen/InstOpCode.hpp"     // for InstOpCode, etc
 #include "il/DataTypes.hpp"           // for DataTypes
 #include "runtime/Runtime.hpp"        // for TR_RuntimeHelper
-#include "codegen/Snippet.hpp"  // for TR_S390Snippet, etc
+#include "codegen/Snippet.hpp"  // for TR::S390Snippet, etc
 
 #include "z/codegen/S390Instruction.hpp"
 
@@ -36,7 +36,9 @@ namespace TR { class Node; }
 namespace TR { class RealRegister; }
 namespace TR { class SymbolReference; }
 
-class TR_S390CallSnippet : public TR::Snippet
+namespace TR {
+
+class S390CallSnippet : public TR::Snippet
    {
    int32_t  sizeOfArguments;
    TR::Instruction *branchInstruction;
@@ -47,12 +49,12 @@ class TR_S390CallSnippet : public TR::Snippet
                                                  TR::DataType        type);
    public:
 
-   TR_S390CallSnippet(TR::CodeGenerator *cg, TR::Node *c, TR::LabelSymbol *lab, int32_t s)
+   S390CallSnippet(TR::CodeGenerator *cg, TR::Node *c, TR::LabelSymbol *lab, int32_t s)
       : TR::Snippet(cg, c, lab, false), sizeOfArguments(s),branchInstruction(NULL), _realMethodSymbolReference(NULL)
       {
       }
 
-   TR_S390CallSnippet(TR::CodeGenerator *cg, TR::Node *c, TR::LabelSymbol *lab, TR::SymbolReference *symRef, int32_t s)
+   S390CallSnippet(TR::CodeGenerator *cg, TR::Node *c, TR::LabelSymbol *lab, TR::SymbolReference *symRef, int32_t s)
       : TR::Snippet(cg, c, lab, false), sizeOfArguments(s),branchInstruction(NULL), _realMethodSymbolReference(symRef)
       {
       }
@@ -89,5 +91,6 @@ class TR_S390CallSnippet : public TR::Snippet
 
    };
 
+}
 
 #endif

--- a/compiler/z/codegen/ConstantDataSnippet.cpp
+++ b/compiler/z/codegen/ConstantDataSnippet.cpp
@@ -63,7 +63,7 @@
 #include <time.h>                               // for NULL
 #endif
 
-TR_S390ConstantDataSnippet::TR_S390ConstantDataSnippet(TR::CodeGenerator * cg, TR::Node * n, void * c, uint16_t size) :
+TR::S390ConstantDataSnippet::S390ConstantDataSnippet(TR::CodeGenerator * cg, TR::Node * n, void * c, uint16_t size) :
    TR::Snippet(cg, n, TR::LabelSymbol::create(cg->trHeapMemory(),cg), false)
    {
 
@@ -76,7 +76,7 @@ TR_S390ConstantDataSnippet::TR_S390ConstantDataSnippet(TR::CodeGenerator * cg, T
    _isString = false;
    }
 
-TR_S390ConstantDataSnippet::TR_S390ConstantDataSnippet(TR::CodeGenerator * cg, TR::Node * n, char* c) :
+TR::S390ConstantDataSnippet::S390ConstantDataSnippet(TR::CodeGenerator * cg, TR::Node * n, char* c) :
    TR::Snippet(cg, n, TR::LabelSymbol::create(cg->trHeapMemory(),cg), false)
    {
    // *this   swipeable for debugging purposes
@@ -91,7 +91,7 @@ TR_S390ConstantDataSnippet::TR_S390ConstantDataSnippet(TR::CodeGenerator * cg, T
 
 
 void
-TR_S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
+TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
    {
    TR::Compilation *comp = cg()->comp();
 
@@ -267,13 +267,13 @@ TR_S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
 
 
 uint8_t *
-TR_S390ConstantDataSnippet::emitSnippetBody()
+TR::S390ConstantDataSnippet::emitSnippetBody()
    {
    // *this   swipeable for debugging purposes
    uint8_t * cursor = cg()->getBinaryBufferCursor();
    TR::Compilation *comp = cg()->comp();
 
-   AOTcgDiag1(comp, "TR_S390ConstantDataSnippet::emitSnippetBody cursor=%x\n", cursor);
+   AOTcgDiag1(comp, "TR::S390ConstantDataSnippet::emitSnippetBody cursor=%x\n", cursor);
    getSnippetLabel()->setCodeLocation(cursor);
    memcpy(cursor, &_value, _length);
 
@@ -306,14 +306,14 @@ TR_S390ConstantDataSnippet::emitSnippetBody()
    }
 
 uint32_t
-TR_S390ConstantDataSnippet::getLength(int32_t  estimatedSnippetStart)
+TR::S390ConstantDataSnippet::getLength(int32_t  estimatedSnippetStart)
    {
    // *this   swipeable for debugging purposes
    return _length;
    }
 
-TR_S390ConstantInstructionSnippet::TR_S390ConstantInstructionSnippet(TR::CodeGenerator * cg, TR::Node * n, TR::Instruction *instr)
-   : TR_S390ConstantDataSnippet(cg, n, NULL, 0)
+TR::S390ConstantInstructionSnippet::S390ConstantInstructionSnippet(TR::CodeGenerator * cg, TR::Node * n, TR::Instruction *instr)
+   : TR::S390ConstantDataSnippet(cg, n, NULL, 0)
    {
    _instruction = instr;
    setLength(instr->getOpCode().getInstructionLength());
@@ -321,7 +321,7 @@ TR_S390ConstantInstructionSnippet::TR_S390ConstantInstructionSnippet(TR::CodeGen
    }
 
 uint8_t *
-TR_S390ConstantInstructionSnippet::emitSnippetBody()
+TR::S390ConstantInstructionSnippet::emitSnippetBody()
    {
    TR::Instruction * instr = this->getInstruction();
    uint8_t * cursor = cg()->getBinaryBufferCursor();
@@ -335,15 +335,15 @@ TR_S390ConstantInstructionSnippet::emitSnippetBody()
    }
 
 int64_t
-TR_S390ConstantInstructionSnippet::getDataAs8Bytes()
+TR::S390ConstantInstructionSnippet::getDataAs8Bytes()
    {
    emitSnippetBody();
 
    return *((uint64_t *)_value);
    }
 
-TR_S390EyeCatcherDataSnippet::TR_S390EyeCatcherDataSnippet(TR::CodeGenerator *cg, TR::Node *n)
-   : TR_S390ConstantDataSnippet(cg, n, NULL, 0)
+TR::S390EyeCatcherDataSnippet::S390EyeCatcherDataSnippet(TR::CodeGenerator *cg, TR::Node *n)
+   : TR::S390ConstantDataSnippet(cg, n, NULL, 0)
    {
    // Cold Eyecatcher is used for padding of endPC so that Return Address for exception snippets will never equal the endPC.
    /*
@@ -357,7 +357,7 @@ TR_S390EyeCatcherDataSnippet::TR_S390EyeCatcherDataSnippet(TR::CodeGenerator *cg
    }
 
 uint8_t *
-TR_S390EyeCatcherDataSnippet::emitSnippetBody()
+TR::S390EyeCatcherDataSnippet::emitSnippetBody()
    {
    uint8_t * cursor = cg()->getBinaryBufferCursor();
    getSnippetLabel()->setCodeLocation(cursor);
@@ -375,8 +375,8 @@ TR_S390EyeCatcherDataSnippet::emitSnippetBody()
  *      JITMETHD  - 8 byte (ASCII/EBCDIC depending on platform).
  *      Ptr to Full Eye Catcher
  */
-TR_S390WarmEyeCatcherDataSnippet::TR_S390WarmEyeCatcherDataSnippet(TR::CodeGenerator *cg, TR::Node *n, TR::LabelSymbol *fullEyeCatcherSnippetLabel)
-   : TR_S390ConstantDataSnippet(cg, n, NULL, 0)
+TR::S390WarmEyeCatcherDataSnippet::S390WarmEyeCatcherDataSnippet(TR::CodeGenerator *cg, TR::Node *n, TR::LabelSymbol *fullEyeCatcherSnippetLabel)
+   : TR::S390ConstantDataSnippet(cg, n, NULL, 0)
    {
    _fullEyeCatcherSnippet = fullEyeCatcherSnippetLabel;
 
@@ -387,7 +387,7 @@ TR_S390WarmEyeCatcherDataSnippet::TR_S390WarmEyeCatcherDataSnippet(TR::CodeGener
    }
 
 uint8_t *
-TR_S390WarmEyeCatcherDataSnippet::emitSnippetBody()
+TR::S390WarmEyeCatcherDataSnippet::emitSnippetBody()
    {
    uint8_t * cursor = cg()->getBinaryBufferCursor();
    getSnippetLabel()->setCodeLocation(cursor);
@@ -407,43 +407,43 @@ TR_S390WarmEyeCatcherDataSnippet::emitSnippetBody()
 
 
 
-TR_S390WritableDataSnippet::TR_S390WritableDataSnippet(TR::CodeGenerator * cg, TR::Node * n, void * c, uint16_t size)
-   : TR_S390ConstantDataSnippet(cg, n, c, size)
+TR::S390WritableDataSnippet::S390WritableDataSnippet(TR::CodeGenerator * cg, TR::Node * n, void * c, uint16_t size)
+   : TR::S390ConstantDataSnippet(cg, n, c, size)
    {
    // *this   swipeable for debugging purposes
    }
 
 //////////////////////////////////////////////////////////////////////////////////////
-// TR_S390TargetAddressSnippet member functions
+// TR::S390TargetAddressSnippet member functions
 //////////////////////////////////////////////////////////////////////////////////////
-TR_S390TargetAddressSnippet::TR_S390TargetAddressSnippet(TR::CodeGenerator * cg, TR::Node * n, TR::LabelSymbol * targetLabel)
+TR::S390TargetAddressSnippet::S390TargetAddressSnippet(TR::CodeGenerator * cg, TR::Node * n, TR::LabelSymbol * targetLabel)
    : TR::Snippet(cg, n, TR::LabelSymbol::create(cg->trHeapMemory(),cg), false), _targetsnippet(NULL), _targetaddress(0), _targetsym(NULL),
    _targetlabel(targetLabel)
    {
    }
 
-TR_S390TargetAddressSnippet::TR_S390TargetAddressSnippet(TR::CodeGenerator * cg, TR::Node * n, TR::Snippet * s)
+TR::S390TargetAddressSnippet::S390TargetAddressSnippet(TR::CodeGenerator * cg, TR::Node * n, TR::Snippet * s)
    : TR::Snippet(cg, n, TR::LabelSymbol::create(cg->trHeapMemory(),cg), false), _targetsnippet(s), _targetaddress(0), _targetsym(NULL), _targetlabel(NULL)
    {
    }
 
-TR_S390TargetAddressSnippet::TR_S390TargetAddressSnippet(TR::CodeGenerator * cg, TR::Node * n, uintptrj_t addr)
+TR::S390TargetAddressSnippet::S390TargetAddressSnippet(TR::CodeGenerator * cg, TR::Node * n, uintptrj_t addr)
    : TR::Snippet(cg, n, TR::LabelSymbol::create(cg->trHeapMemory(),cg), false), _targetsnippet(NULL), _targetaddress(addr), _targetsym(NULL),
    _targetlabel(NULL)
    {
    }
 
-TR_S390TargetAddressSnippet::TR_S390TargetAddressSnippet(TR::CodeGenerator * cg, TR::Node * n, TR::Symbol * sym)
+TR::S390TargetAddressSnippet::S390TargetAddressSnippet(TR::CodeGenerator * cg, TR::Node * n, TR::Symbol * sym)
    : TR::Snippet(cg, n, TR::LabelSymbol::create(cg->trHeapMemory(),cg), false), _targetsnippet(NULL), _targetaddress(0), _targetsym(sym), _targetlabel(NULL)
    {
    }
 
 uint8_t *
-TR_S390TargetAddressSnippet::emitSnippetBody()
+TR::S390TargetAddressSnippet::emitSnippetBody()
    {
    // *this   swipeable for debugging purposes
    uint8_t * cursor = cg()->getBinaryBufferCursor();
-   AOTcgDiag1(cg()->comp(), "TR_S390TargetAddressSnippet::emitSnippetBody cursor=%x\n", cursor);
+   AOTcgDiag1(cg()->comp(), "TR::S390TargetAddressSnippet::emitSnippetBody cursor=%x\n", cursor);
    getSnippetLabel()->setCodeLocation(cursor);
    TR::Compilation* comp = cg()->comp();
 
@@ -496,7 +496,7 @@ TR_S390TargetAddressSnippet::emitSnippetBody()
    }
 
 uint32_t
-TR_S390TargetAddressSnippet::getLength(int32_t  estimatedSnippetStart)
+TR::S390TargetAddressSnippet::getLength(int32_t  estimatedSnippetStart)
    {
    // *this   swipeable for debugging purposes
    return sizeof(uintptrj_t);
@@ -504,21 +504,21 @@ TR_S390TargetAddressSnippet::getLength(int32_t  estimatedSnippetStart)
 
 //////////////////////////////////////////////////////////////////////////////////////
 
-TR_S390LookupSwitchSnippet::TR_S390LookupSwitchSnippet(TR::CodeGenerator * cg, TR::Node * switchNode)
-   : TR_S390TargetAddressSnippet(cg, switchNode, TR::LabelSymbol::create(cg->trHeapMemory(),cg))
+TR::S390LookupSwitchSnippet::S390LookupSwitchSnippet(TR::CodeGenerator * cg, TR::Node * switchNode)
+   : TR::S390TargetAddressSnippet(cg, switchNode, TR::LabelSymbol::create(cg->trHeapMemory(),cg))
    {
    // *this   swipeable for debugger
    }
 
 
 uint8_t *
-TR_S390LookupSwitchSnippet::emitSnippetBody()
+TR::S390LookupSwitchSnippet::emitSnippetBody()
    {
    int32_t numChildren = getNode()->getCaseIndexUpperBound() - 1;
    uint8_t * cursor = cg()->getBinaryBufferCursor();
    TR::Compilation* comp = cg()->comp();
 
-   AOTcgDiag1(comp, "TR_S390LookupSwitchSnippet::emitSnippetBody cursor=%x\n", cursor);
+   AOTcgDiag1(comp, "TR::S390LookupSwitchSnippet::emitSnippetBody cursor=%x\n", cursor);
    getSnippetLabel()->setCodeLocation(cursor);
 
    for (int32_t i = 1; i <= numChildren; i++)
@@ -541,20 +541,20 @@ TR_S390LookupSwitchSnippet::emitSnippetBody()
    }
 
 uint32_t
-TR_S390LookupSwitchSnippet::getLength(int32_t  estimatedSnippetStart)
+TR::S390LookupSwitchSnippet::getLength(int32_t  estimatedSnippetStart)
    {
    TR::Compilation* comp = cg()->comp();
    return (getNode()->getCaseIndexUpperBound() - 1) * (sizeof(int32_t) + TR::Compiler->om.sizeofReferenceAddress());
    }
 
 ///////////////////////////////////////////////////////////////////////////////
-// TR_S390InterfaceCallDataSnippet member functions
+// TR::S390InterfaceCallDataSnippet member functions
 ///////////////////////////////////////////////////////////////////////////////
-TR_S390InterfaceCallDataSnippet::TR_S390InterfaceCallDataSnippet(TR::CodeGenerator * cg,
+TR::S390InterfaceCallDataSnippet::S390InterfaceCallDataSnippet(TR::CodeGenerator * cg,
                                                                  TR::Node * node,
                                                                  uint8_t n,
                                                                  bool useCLFIandBRCL)
-   : TR_S390ConstantDataSnippet(cg,node,TR::LabelSymbol::create(cg->trHeapMemory(),cg),0),
+   : TR::S390ConstantDataSnippet(cg,node,TR::LabelSymbol::create(cg->trHeapMemory(),cg),0),
      _numInterfaceCallCacheSlots(n),
      _codeRA(NULL),
      thunkAddress(NULL),
@@ -562,12 +562,12 @@ TR_S390InterfaceCallDataSnippet::TR_S390InterfaceCallDataSnippet(TR::CodeGenerat
    {
    }
 
-TR_S390InterfaceCallDataSnippet::TR_S390InterfaceCallDataSnippet(TR::CodeGenerator * cg,
+TR::S390InterfaceCallDataSnippet::S390InterfaceCallDataSnippet(TR::CodeGenerator * cg,
                                                                  TR::Node * node,
                                                                  uint8_t n,
                                                                  uint8_t *thunkPtr,
                                                                  bool useCLFIandBRCL)
-   : TR_S390ConstantDataSnippet(cg,node,TR::LabelSymbol::create(cg->trHeapMemory(),cg),0),
+   : TR::S390ConstantDataSnippet(cg,node,TR::LabelSymbol::create(cg->trHeapMemory(),cg),0),
      _numInterfaceCallCacheSlots(n),
      _codeRA(NULL),
      thunkAddress(thunkPtr),
@@ -576,7 +576,7 @@ TR_S390InterfaceCallDataSnippet::TR_S390InterfaceCallDataSnippet(TR::CodeGenerat
    }
 
 uint8_t *
-TR_S390InterfaceCallDataSnippet::emitSnippetBody()
+TR::S390InterfaceCallDataSnippet::emitSnippetBody()
    {
 
 //  64-Bit Layout.
@@ -631,7 +631,7 @@ TR_S390InterfaceCallDataSnippet::emitSnippetBody()
    TR::Compilation *comp = cg()->comp();
    int32_t i = 0;
    uint8_t * cursor = cg()->getBinaryBufferCursor();
-   AOTcgDiag1(comp, "TR_S390InterfaceCallDataSnippet::emitSnippetBody cursor=%x\n", cursor);
+   AOTcgDiag1(comp, "TR::S390InterfaceCallDataSnippet::emitSnippetBody cursor=%x\n", cursor);
 
    // Class Pointer must be double word aligned.
    int32_t padBytes = ((intptrj_t)cursor + 5 * sizeof(intptrj_t) + 7) / 8 * 8 - ((intptrj_t)cursor + 5 * sizeof(intptrj_t));
@@ -786,43 +786,43 @@ TR_S390InterfaceCallDataSnippet::emitSnippetBody()
 
 
 uint32_t
-TR_S390InterfaceCallDataSnippet::getCallReturnAddressOffset()
+TR::S390InterfaceCallDataSnippet::getCallReturnAddressOffset()
    {
    return 0;
    }
 
 uint32_t
-TR_S390InterfaceCallDataSnippet::getSingleDynamicSlotOffset()
+TR::S390InterfaceCallDataSnippet::getSingleDynamicSlotOffset()
    {
    return getCallReturnAddressOffset() + 5 * TR::Compiler->om.sizeofReferenceAddress();
    }
 
 uint32_t
-TR_S390InterfaceCallDataSnippet::getLastCachedSlotFieldOffset()
+TR::S390InterfaceCallDataSnippet::getLastCachedSlotFieldOffset()
    {
    return getCallReturnAddressOffset() + 6 * TR::Compiler->om.sizeofReferenceAddress();
    }
 
 uint32_t
-TR_S390InterfaceCallDataSnippet::getFirstSlotFieldOffset()
+TR::S390InterfaceCallDataSnippet::getFirstSlotFieldOffset()
    {
    return getLastCachedSlotFieldOffset() + TR::Compiler->om.sizeofReferenceAddress();
    }
 
 uint32_t
-TR_S390InterfaceCallDataSnippet::getLastSlotFieldOffset()
+TR::S390InterfaceCallDataSnippet::getLastSlotFieldOffset()
    {
    return getFirstSlotFieldOffset() + TR::Compiler->om.sizeofReferenceAddress();
    }
 
 uint32_t
-TR_S390InterfaceCallDataSnippet::getFirstSlotOffset()
+TR::S390InterfaceCallDataSnippet::getFirstSlotOffset()
    {
    return getLastSlotFieldOffset() + TR::Compiler->om.sizeofReferenceAddress();
    }
 
 uint32_t
-TR_S390InterfaceCallDataSnippet::getLastSlotOffset()
+TR::S390InterfaceCallDataSnippet::getLastSlotOffset()
    {
    return (getFirstSlotOffset() +
           (getNumInterfaceCallCacheSlots() - 1) *
@@ -830,7 +830,7 @@ TR_S390InterfaceCallDataSnippet::getLastSlotOffset()
    }
 
 uint32_t
-TR_S390InterfaceCallDataSnippet::getLength(int32_t)
+TR::S390InterfaceCallDataSnippet::getLength(int32_t)
    {
    TR::Compilation *comp = cg()->comp();
    // the 1st item is for padding...
@@ -849,79 +849,79 @@ TR_S390InterfaceCallDataSnippet::getLength(int32_t)
 
 
 ///////////////////////////////////////////////////////////////////////////////
-// TR_S390InterfaceCallDataSnippet member functions
+// TR::S390InterfaceCallDataSnippet member functions
 ///////////////////////////////////////////////////////////////////////////////
 
 uint32_t
-TR_S390JNICallDataSnippet::getJNICallOutFrameFlagsOffset()
+TR::S390JNICallDataSnippet::getJNICallOutFrameFlagsOffset()
    {
    return TR::Compiler->om.sizeofReferenceAddress();
    }
 
 uint32_t
-TR_S390JNICallDataSnippet::getReturnFromJNICallOffset()
+TR::S390JNICallDataSnippet::getReturnFromJNICallOffset()
    {
    return 2 * TR::Compiler->om.sizeofReferenceAddress();
    }
 
 uint32_t
-TR_S390JNICallDataSnippet::getSavedPCOffset()
+TR::S390JNICallDataSnippet::getSavedPCOffset()
    {
    return 3 * TR::Compiler->om.sizeofReferenceAddress();
    }
 
 uint32_t
-TR_S390JNICallDataSnippet::getTagBitsOffset()
+TR::S390JNICallDataSnippet::getTagBitsOffset()
    {
    return 4 * TR::Compiler->om.sizeofReferenceAddress();
    }
 
 uint32_t
-TR_S390JNICallDataSnippet::getPCOffset()
+TR::S390JNICallDataSnippet::getPCOffset()
    {
    return 5 * TR::Compiler->om.sizeofReferenceAddress();
    }
 
 uint32_t
-TR_S390JNICallDataSnippet::getLiteralsOffset()
+TR::S390JNICallDataSnippet::getLiteralsOffset()
    {
    return 6 * TR::Compiler->om.sizeofReferenceAddress();
    }
 
 uint32_t
-TR_S390JNICallDataSnippet::getJitStackFrameFlagsOffset()
+TR::S390JNICallDataSnippet::getJitStackFrameFlagsOffset()
    {
    return 7 * TR::Compiler->om.sizeofReferenceAddress();
    }
 
 uint32_t
-TR_S390JNICallDataSnippet::getConstReleaseVMAccessMaskOffset()
+TR::S390JNICallDataSnippet::getConstReleaseVMAccessMaskOffset()
    {
    return 8 * TR::Compiler->om.sizeofReferenceAddress();
    }
 
 uint32_t
-TR_S390JNICallDataSnippet::getConstReleaseVMAccessOutOfLineMaskOffset()
+TR::S390JNICallDataSnippet::getConstReleaseVMAccessOutOfLineMaskOffset()
    {
    return 9 * TR::Compiler->om.sizeofReferenceAddress();
    }
 
 uint32_t
-TR_S390JNICallDataSnippet::getTargetAddressOffset()
+TR::S390JNICallDataSnippet::getTargetAddressOffset()
    {
    return 10 * TR::Compiler->om.sizeofReferenceAddress();
    }
 
 uint32_t
-TR_S390JNICallDataSnippet::getLength(int32_t estimatedSnippetStart)
+TR::S390JNICallDataSnippet::getLength(int32_t estimatedSnippetStart)
    {
    return 12 * TR::Compiler->om.sizeofReferenceAddress(); /*one ptr more for possible padding */
    }
 
 
-TR_S390JNICallDataSnippet::TR_S390JNICallDataSnippet(TR::CodeGenerator * cg,
+TR::S390JNICallDataSnippet::S390JNICallDataSnippet(TR::CodeGenerator * cg,
                                TR::Node * node)
-: TR_S390ConstantDataSnippet(cg, node, TR::LabelSymbol::create(cg->trHeapMemory(),cg),0),
+: TR::S390ConstantDataSnippet(cg, node, TR::LabelSymbol::create(cg->trHeapMemory(),cg),0),
  _baseRegister(0),
  _ramMethod(0),
  _JNICallOutFrameFlags(0),
@@ -939,12 +939,12 @@ TR_S390JNICallDataSnippet::TR_S390JNICallDataSnippet(TR::CodeGenerator * cg,
    }
 
 uint8_t *
-TR_S390JNICallDataSnippet::emitSnippetBody()
+TR::S390JNICallDataSnippet::emitSnippetBody()
    {
    uint8_t * cursor = cg()->getBinaryBufferCursor();
 
 #ifdef J9_PROJECT_SPECIFIC
-   /* TR_S390JNICallDataSnippet Layout: all fields are pointer sized
+   /* TR::S390JNICallDataSnippet Layout: all fields are pointer sized
        ramMethod
        JNICallOutFrameFlags
        returnFromJNICall
@@ -959,7 +959,7 @@ TR_S390JNICallDataSnippet::emitSnippetBody()
    */
       TR::Compilation *comp = cg()->comp();
 
-      AOTcgDiag1(comp, "TR_S390JNICallDataSnippet::emitSnippetBody cursor=%x\n", cursor);
+      AOTcgDiag1(comp, "TR::S390JNICallDataSnippet::emitSnippetBody cursor=%x\n", cursor);
       // Ensure pointer sized alignment
       int32_t alignSize = TR::Compiler->om.sizeofReferenceAddress();
       int32_t padBytes = ((intptrj_t)cursor + alignSize -1) / alignSize * alignSize - (intptrj_t)cursor;
@@ -1061,7 +1061,7 @@ TR_S390JNICallDataSnippet::emitSnippetBody()
    }
 
 void
-TR_S390JNICallDataSnippet::print(TR::FILE *pOutFile, TR_Debug *debug)
+TR::S390JNICallDataSnippet::print(TR::FILE *pOutFile, TR_Debug *debug)
    {
 /*
        ramMethod
@@ -1131,7 +1131,7 @@ TR_S390JNICallDataSnippet::print(TR::FILE *pOutFile, TR_Debug *debug)
 
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390TargetAddressSnippet * snippet)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390TargetAddressSnippet * snippet)
    {
    // *this   swipeable for debugger
    if (pOutFile == NULL)
@@ -1154,7 +1154,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390TargetAddressSnippet * snippet)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390LookupSwitchSnippet * snippet)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390LookupSwitchSnippet * snippet)
    {
    int upperBound = snippet->getNode()->getCaseIndexUpperBound();
    uint8_t * bufferPos = snippet->getSnippetLabel()->getCodeLocation();
@@ -1178,7 +1178,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390LookupSwitchSnippet * snippet)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390ConstantDataSnippet * snippet)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390ConstantDataSnippet * snippet)
    {
    // *this   swipeable for debugger
    if (pOutFile == NULL)
@@ -1232,14 +1232,14 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390ConstantDataSnippet * snippet)
    else if (snippet->getKind() == TR::Snippet::IsConstantInstruction)
       {
       printSnippetLabel(pOutFile, snippet->getSnippetLabel(), bufferPos, "Constant Instruction Snippet");
-      print(pOutFile, ((TR_S390ConstantInstructionSnippet *)snippet)->getInstruction());
+      print(pOutFile, ((TR::S390ConstantInstructionSnippet *)snippet)->getInstruction());
       return;
       }
    else if (snippet->getKind() == TR::Snippet::IsLabelTable)
       {
       printSnippetLabel(pOutFile, snippet->getSnippetLabel(), bufferPos, "Label Table Snippet");
       trfprintf(pOutFile, "\n");
-      TR_S390LabelTableSnippet *labelTable = (TR_S390LabelTableSnippet *) snippet;
+      TR::S390LabelTableSnippet *labelTable = (TR::S390LabelTableSnippet *) snippet;
       for (int32_t i = 0; i < labelTable->getSize(); i++)
          {
          TR::LabelSymbol *label = labelTable->getLabel(i);
@@ -1258,7 +1258,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390ConstantDataSnippet * snippet)
       {
       printSnippetLabel(pOutFile, snippet->getSnippetLabel(), bufferPos, "Declarative Trampoline Snippet");
       trfprintf(pOutFile, "\n");
-      TR_S390DeclTrampSnippet *declTrampSnippet = (TR_S390DeclTrampSnippet *) snippet;
+      TR::S390DeclTrampSnippet *declTrampSnippet = (TR::S390DeclTrampSnippet *) snippet;
       TR::LabelSymbol *label = declTrampSnippet->getLabel();
       trfprintf(pOutFile, "[");
       print(pOutFile, label);
@@ -1269,7 +1269,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390ConstantDataSnippet * snippet)
       {
       printSnippetLabel(pOutFile, snippet->getSnippetLabel(), bufferPos, "Sort Jump Trampoline Snippet");
       trfprintf(pOutFile, "\n");
-      TR_S390SortJumpTrampSnippet *sortJumpTrampSnippet = (TR_S390SortJumpTrampSnippet *) snippet;
+      TR::S390SortJumpTrampSnippet *sortJumpTrampSnippet = (TR::S390SortJumpTrampSnippet *) snippet;
       TR::LabelSymbol *label = sortJumpTrampSnippet->getLabel();
       trfprintf(pOutFile, "[");
       print(pOutFile, label);
@@ -1320,7 +1320,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390ConstantDataSnippet * snippet)
 
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390InterfaceCallDataSnippet * snippet)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390InterfaceCallDataSnippet * snippet)
    {
    uint8_t * bufferPos = snippet->getSnippetLabel()->getCodeLocation();
 
@@ -1409,16 +1409,16 @@ TR_Debug::print(TR::FILE *pOutFile, TR_S390InterfaceCallDataSnippet * snippet)
    }
 
 
-TR_S390LabelTableSnippet::TR_S390LabelTableSnippet(TR::CodeGenerator *cg, TR::Node *node, uint32_t size)
-   : TR_S390ConstantDataSnippet(cg, node, NULL, 0), _size(size)
+TR::S390LabelTableSnippet::S390LabelTableSnippet(TR::CodeGenerator *cg, TR::Node *node, uint32_t size)
+   : TR::S390ConstantDataSnippet(cg, node, NULL, 0), _size(size)
    {
-   TR_ASSERT(TR::Compiler->target.is32Bit(), "only 31bit mode supported for TR_S390LabelTableSnippet\n");
+   TR_ASSERT(TR::Compiler->target.is32Bit(), "only 31bit mode supported for TR::S390LabelTableSnippet\n");
    _labelTable = (TR::LabelSymbol **) cg->trMemory()->allocateMemory(sizeof(TR::LabelSymbol *) * size, heapAlloc);
    setLength(0);
    }
 
 uint8_t *
-TR_S390LabelTableSnippet::emitSnippetBody()
+TR::S390LabelTableSnippet::emitSnippetBody()
    {
    uint8_t * snip = cg()->getBinaryBufferCursor();
    getSnippetLabel()->setCodeLocation(snip);
@@ -1438,20 +1438,20 @@ TR_S390LabelTableSnippet::emitSnippetBody()
    }
 
 uint32_t
-TR_S390LabelTableSnippet::getLength(int32_t estimatedSnippetStart)
+TR::S390LabelTableSnippet::getLength(int32_t estimatedSnippetStart)
    {
    return _size * 4;
    }
 
-TR_S390DeclTrampSnippet::TR_S390DeclTrampSnippet(TR::CodeGenerator *cg, TR::LabelSymbol *label)
-   : TR_S390ConstantDataSnippet(cg, NULL, NULL, 0), _label(label)
+TR::S390DeclTrampSnippet::S390DeclTrampSnippet(TR::CodeGenerator *cg, TR::LabelSymbol *label)
+   : TR::S390ConstantDataSnippet(cg, NULL, NULL, 0), _label(label)
    {
-   TR_ASSERT(TR::Compiler->target.is32Bit(), "only 31bit mode supported for TR_S390DeclTrampSnippet\n");
+   TR_ASSERT(TR::Compiler->target.is32Bit(), "only 31bit mode supported for TR::S390DeclTrampSnippet\n");
    setLength(16);
    }
 
 uint8_t *
-TR_S390DeclTrampSnippet::emitSnippetBody()
+TR::S390DeclTrampSnippet::emitSnippetBody()
    {
    uint8_t * snip = cg()->getBinaryBufferCursor();
    getSnippetLabel()->setCodeLocation(snip);
@@ -1472,15 +1472,15 @@ TR_S390DeclTrampSnippet::emitSnippetBody()
    return cursor;
    }
 
-TR_S390SortJumpTrampSnippet::TR_S390SortJumpTrampSnippet(TR::CodeGenerator *cg, TR::LabelSymbol *label)
-   : TR_S390ConstantDataSnippet(cg, NULL, NULL, 0), _label(label)
+TR::S390SortJumpTrampSnippet::S390SortJumpTrampSnippet(TR::CodeGenerator *cg, TR::LabelSymbol *label)
+   : TR::S390ConstantDataSnippet(cg, NULL, NULL, 0), _label(label)
    {
-   TR_ASSERT(TR::Compiler->target.is32Bit(), "only 31bit mode supported for TR_S390SortJumpTrampSnippet\n");
+   TR_ASSERT(TR::Compiler->target.is32Bit(), "only 31bit mode supported for TR::S390SortJumpTrampSnippet\n");
    setLength(16);
    }
 
 uint8_t *
-TR_S390SortJumpTrampSnippet::emitSnippetBody()
+TR::S390SortJumpTrampSnippet::emitSnippetBody()
    {
    uint8_t * snip = cg()->getBinaryBufferCursor();
    getSnippetLabel()->setCodeLocation(snip);

--- a/compiler/z/codegen/ConstantDataSnippet.hpp
+++ b/compiler/z/codegen/ConstantDataSnippet.hpp
@@ -37,10 +37,12 @@ namespace TR { class Symbol; }
 namespace TR { class SymbolReference; }
 namespace TR { class UnresolvedDataSnippet; }
 
+namespace TR {
+
 /**
  * ConstantDataSnippet is used to hold shared data
  */
-class TR_S390ConstantDataSnippet : public TR::Snippet
+class S390ConstantDataSnippet : public TR::Snippet
    {
    protected:
    union
@@ -60,8 +62,8 @@ class TR_S390ConstantDataSnippet : public TR::Snippet
 
    public:
 
-   TR_S390ConstantDataSnippet(TR::CodeGenerator *cg, TR::Node *, void *c, uint16_t size);
-   TR_S390ConstantDataSnippet(TR::CodeGenerator *cg, TR::Node *, char *c);
+   S390ConstantDataSnippet(TR::CodeGenerator *cg, TR::Node *, void *c, uint16_t size);
+   S390ConstantDataSnippet(TR::CodeGenerator *cg, TR::Node *, char *c);
 
    virtual Kind getKind() { return IsConstantData; }
 
@@ -120,14 +122,14 @@ class TR_S390ConstantDataSnippet : public TR::Snippet
 
    };
 
-class TR_S390ConstantInstructionSnippet : public TR_S390ConstantDataSnippet
+class S390ConstantInstructionSnippet : public TR::S390ConstantDataSnippet
    {
    TR::Instruction * _instruction;
    bool             _isRefed;
 
    public:
 
-   TR_S390ConstantInstructionSnippet(TR::CodeGenerator *cg, TR::Node *, TR::Instruction *);
+   S390ConstantInstructionSnippet(TR::CodeGenerator *cg, TR::Node *, TR::Instruction *);
    TR::Instruction * getInstruction() { return _instruction; }
    Kind getKind() { return IsConstantInstruction; }
    virtual uint32_t getLength(int32_t estimatedSnippetStart) { return 8; }
@@ -141,13 +143,13 @@ class TR_S390ConstantInstructionSnippet : public TR_S390ConstantDataSnippet
 /**
  * Create constant data snippet with method ep and complete method signature
  */
-class TR_S390EyeCatcherDataSnippet : public TR_S390ConstantDataSnippet
+class S390EyeCatcherDataSnippet : public TR::S390ConstantDataSnippet
    {
    uint8_t *  _value;
 
    public:
 
-   TR_S390EyeCatcherDataSnippet(TR::CodeGenerator *cg, TR::Node *);
+   S390EyeCatcherDataSnippet(TR::CodeGenerator *cg, TR::Node *);
 
    uint8_t *emitSnippetBody();
    Kind getKind() { return IsEyeCatcherData; }
@@ -157,14 +159,14 @@ class TR_S390EyeCatcherDataSnippet : public TR_S390ConstantDataSnippet
  * Create constant data snippet with pointer to full eye-catcher.
  * This is used as a small eyecatcher in warm code.
  */
-class TR_S390WarmEyeCatcherDataSnippet : public TR_S390ConstantDataSnippet
+class S390WarmEyeCatcherDataSnippet : public TR::S390ConstantDataSnippet
    {
    uint8_t *  _value;
    TR::LabelSymbol * _fullEyeCatcherSnippet;
 
    public:
 
-   TR_S390WarmEyeCatcherDataSnippet(TR::CodeGenerator *cg, TR::Node *, TR::LabelSymbol *);
+   S390WarmEyeCatcherDataSnippet(TR::CodeGenerator *cg, TR::Node *, TR::LabelSymbol *);
 
    uint8_t *emitSnippetBody();
    Kind getKind() { return IsEyeCatcherData; }
@@ -173,11 +175,11 @@ class TR_S390WarmEyeCatcherDataSnippet : public TR_S390ConstantDataSnippet
 /**
  * WritableDataSnippet is used to hold patchable data
  */
-class TR_S390WritableDataSnippet : public TR_S390ConstantDataSnippet
+class S390WritableDataSnippet : public TR::S390ConstantDataSnippet
    {
    public:
 
-   TR_S390WritableDataSnippet(TR::CodeGenerator *cg, TR::Node *, void *c, uint16_t size);
+   S390WritableDataSnippet(TR::CodeGenerator *cg, TR::Node *, void *c, uint16_t size);
 
    virtual Kind getKind() { return IsWritableData; }
    };
@@ -185,7 +187,7 @@ class TR_S390WritableDataSnippet : public TR_S390ConstantDataSnippet
 /**
  * TargetAddress Snippet is used to hold address of snippet which exceed the branch limit
  */
-class TR_S390TargetAddressSnippet : public TR::Snippet
+class S390TargetAddressSnippet : public TR::Snippet
    {
    uintptrj_t   _targetaddress;
    TR::Snippet *_targetsnippet;
@@ -194,10 +196,10 @@ class TR_S390TargetAddressSnippet : public TR::Snippet
 
    public:
 
-   TR_S390TargetAddressSnippet(TR::CodeGenerator *cg, TR::Node *, TR::LabelSymbol *targetLabel);
-   TR_S390TargetAddressSnippet(TR::CodeGenerator *cg, TR::Node *, TR::Snippet *s);
-   TR_S390TargetAddressSnippet(TR::CodeGenerator *cg, TR::Node *, uintptrj_t addr);
-   TR_S390TargetAddressSnippet(TR::CodeGenerator *cg, TR::Node *, TR::Symbol *sym);
+   S390TargetAddressSnippet(TR::CodeGenerator *cg, TR::Node *, TR::LabelSymbol *targetLabel);
+   S390TargetAddressSnippet(TR::CodeGenerator *cg, TR::Node *, TR::Snippet *s);
+   S390TargetAddressSnippet(TR::CodeGenerator *cg, TR::Node *, uintptrj_t addr);
+   S390TargetAddressSnippet(TR::CodeGenerator *cg, TR::Node *, TR::Symbol *sym);
 
    TR::Snippet *getTargetSnippet()   { return _targetsnippet; }
    uintptrj_t  getTargetAddress()   { return _targetaddress; }
@@ -210,11 +212,11 @@ class TR_S390TargetAddressSnippet : public TR::Snippet
    };
 
 
-class TR_S390LookupSwitchSnippet : public TR_S390TargetAddressSnippet
+class S390LookupSwitchSnippet : public TR::S390TargetAddressSnippet
    {
    public:
 
-   TR_S390LookupSwitchSnippet(TR::CodeGenerator *cg, TR::Node* switchNode);
+   S390LookupSwitchSnippet(TR::CodeGenerator *cg, TR::Node* switchNode);
 
    virtual Kind getKind() { return IsLookupSwitch; }
    virtual uint8_t *emitSnippetBody();
@@ -222,7 +224,7 @@ class TR_S390LookupSwitchSnippet : public TR_S390TargetAddressSnippet
    };
 
 
-class TR_S390InterfaceCallDataSnippet : public TR_S390ConstantDataSnippet
+class S390InterfaceCallDataSnippet : public TR::S390ConstantDataSnippet
    {
    TR::Instruction * _firstCLFI;
    uint8_t _numInterfaceCallCacheSlots;
@@ -232,16 +234,16 @@ class TR_S390InterfaceCallDataSnippet : public TR_S390ConstantDataSnippet
 
    public:
 
-  TR_S390InterfaceCallDataSnippet(TR::CodeGenerator *,
-                                  TR::Node *,
-                                  uint8_t,
-                                  bool useCLFIandBRCL = false);
+  S390InterfaceCallDataSnippet(TR::CodeGenerator *,
+                               TR::Node *,
+                               uint8_t,
+                               bool useCLFIandBRCL = false);
 
-  TR_S390InterfaceCallDataSnippet(TR::CodeGenerator *,
-                                  TR::Node *,
-                                  uint8_t,
-                                  uint8_t *,
-                                  bool useCLFIandBRCL = false);
+  S390InterfaceCallDataSnippet(TR::CodeGenerator *,
+                               TR::Node *,
+                               uint8_t,
+                               uint8_t *,
+                               bool useCLFIandBRCL = false);
 
    virtual Kind getKind() { return IsInterfaceCallData; }
    virtual uint8_t *emitSnippetBody();
@@ -271,7 +273,7 @@ class TR_S390InterfaceCallDataSnippet : public TR_S390ConstantDataSnippet
   };
 
 
-class TR_S390JNICallDataSnippet : public TR_S390ConstantDataSnippet
+class S390JNICallDataSnippet : public TR::S390ConstantDataSnippet
    {
    /** Base register for this snippet */
    TR::Register *  _baseRegister;
@@ -298,7 +300,7 @@ class TR_S390JNICallDataSnippet : public TR_S390ConstantDataSnippet
 
    public:
 
-  TR_S390JNICallDataSnippet(TR::CodeGenerator *,
+  S390JNICallDataSnippet(TR::CodeGenerator *,
                                   TR::Node *);
 
    virtual Kind getKind() { return IsJNICallData; }
@@ -340,10 +342,10 @@ class TR_S390JNICallDataSnippet : public TR_S390ConstantDataSnippet
    uint32_t getLength(int32_t estimatedSnippetStart);
   };
 
-class TR_S390LabelTableSnippet : public TR_S390ConstantDataSnippet
+class S390LabelTableSnippet : public TR::S390ConstantDataSnippet
    {
    public:
-   TR_S390LabelTableSnippet(TR::CodeGenerator *cg, TR::Node *node, uint32_t size);
+   S390LabelTableSnippet(TR::CodeGenerator *cg, TR::Node *node, uint32_t size);
    virtual Kind getKind() { return IsLabelTable; }
    virtual uint8_t *emitSnippetBody();
    virtual uint32_t getLength(int32_t estimatedSnippetStart);
@@ -357,10 +359,10 @@ class TR_S390LabelTableSnippet : public TR_S390ConstantDataSnippet
    TR::LabelSymbol **_labelTable;
    };
 
-class TR_S390DeclTrampSnippet : public TR_S390ConstantDataSnippet
+class S390DeclTrampSnippet : public TR::S390ConstantDataSnippet
    {
    public:
-   TR_S390DeclTrampSnippet(TR::CodeGenerator *cg, TR::LabelSymbol *label);
+   S390DeclTrampSnippet(TR::CodeGenerator *cg, TR::LabelSymbol *label);
    virtual Kind getKind() { return IsDeclTramp; }
    virtual uint8_t *emitSnippetBody();
    TR::LabelSymbol *getLabel() { return _label; }
@@ -370,10 +372,10 @@ class TR_S390DeclTrampSnippet : public TR_S390ConstantDataSnippet
    TR::LabelSymbol *_label;
    };
 
-class TR_S390SortJumpTrampSnippet : public TR_S390ConstantDataSnippet
+class S390SortJumpTrampSnippet : public TR::S390ConstantDataSnippet
    {
    public:
-   TR_S390SortJumpTrampSnippet(TR::CodeGenerator *cg, TR::LabelSymbol *label);
+   S390SortJumpTrampSnippet(TR::CodeGenerator *cg, TR::LabelSymbol *label);
    virtual Kind getKind() { return IsSortJumpTramp; }
    virtual uint8_t *emitSnippetBody();
    TR::LabelSymbol *getLabel() { return _label; }
@@ -382,5 +384,7 @@ class TR_S390SortJumpTrampSnippet : public TR_S390ConstantDataSnippet
    private:
    TR::LabelSymbol *_label;
    };
+
+}
 
 #endif

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -2889,7 +2889,7 @@ TR::Register *OMR::Z::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node
          // NULLCHK snippet label.
          TR::LabelSymbol * snippetLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
          TR::SymbolReference *symRef = node->getSymbolReference();
-         cg->addSnippet(new (cg->trHeapMemory()) TR_S390HelperCallSnippet(cg, node, snippetLabel, symRef));
+         cg->addSnippet(new (cg->trHeapMemory()) TR::S390HelperCallSnippet(cg, node, snippetLabel, symRef));
 
          if (!firstChild->getOpCode().isCall() &&
                reference->getOpCode().isLoadVar() &&

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -49,7 +49,7 @@
 #include "codegen/RegisterDependencyStruct.hpp"
 #include "codegen/RegisterIterator.hpp"             // for RegisterIterator
 #include "codegen/RegisterPair.hpp"                 // for RegisterPair
-#include "codegen/Snippet.hpp"                      // for TR_S390Snippet, etc
+#include "codegen/Snippet.hpp"                      // for TR::S390Snippet, etc
 #include "codegen/StorageInfo.hpp"
 #include "codegen/SystemLinkage.hpp"                // for toSystemLinkage, etc
 #include "codegen/TreeEvaluator.hpp"                // for TreeEvaluator, etc
@@ -485,13 +485,13 @@ OMR::Z::CodeGenerator::CodeGenerator()
      _processorInfo(),
      _extentOfLitPool(-1),
      _recompPatchInsnList(getTypedAllocator<TR::Instruction*>(self()->comp()->allocator())),
-     _targetList(getTypedAllocator<TR_S390TargetAddressSnippet*>(self()->comp()->allocator())),
+     _targetList(getTypedAllocator<TR::S390TargetAddressSnippet*>(self()->comp()->allocator())),
      _constantHash(self()->comp()->allocator()),
      _constantHashCur(_constantHash),
-     _constantList(getTypedAllocator<TR_S390ConstantDataSnippet*>(self()->comp()->allocator())),
-     _writableList(getTypedAllocator<TR_S390WritableDataSnippet*>(self()->comp()->allocator())),
+     _constantList(getTypedAllocator<TR::S390ConstantDataSnippet*>(self()->comp()->allocator())),
+     _writableList(getTypedAllocator<TR::S390WritableDataSnippet*>(self()->comp()->allocator())),
      _transientLongRegisters(self()->trMemory()),
-     _snippetDataList(getTypedAllocator<TR_S390ConstantDataSnippet*>(self()->comp()->allocator())),
+     _snippetDataList(getTypedAllocator<TR::S390ConstantDataSnippet*>(self()->comp()->allocator())),
      _outOfLineCodeSectionList(getTypedAllocator<TR_S390OutOfLineCodeSection*>(self()->comp()->allocator())),
      _returnTypeInfoInstruction(NULL),
      _ARSaveAreaForTM(NULL),
@@ -4410,9 +4410,9 @@ TR_S390Peephole::inlineEXtargetHelper(TR::Instruction *inst, TR::Instruction * i
    if (performTransformation(comp(), "O^O S390 PEEPHOLE: Converting LARL;EX into EXRL instr=[%p]\n", _cursor))
       {
       // fetch the dispatched SS instr
-      TR_S390ConstantDataSnippet * cnstDataSnip = _cursor->getMemoryReference()->getConstantDataSnippet();
+      TR::S390ConstantDataSnippet * cnstDataSnip = _cursor->getMemoryReference()->getConstantDataSnippet();
       TR_ASSERT( (cnstDataSnip->getKind() == TR::Snippet::IsConstantInstruction),"The constant data snippet kind should be ConstantInstruction!\n");
-      TR::Instruction * cnstDataInstr = ((TR_S390ConstantInstructionSnippet *)cnstDataSnip)->getInstruction();
+      TR::Instruction * cnstDataInstr = ((TR::S390ConstantInstructionSnippet *)cnstDataSnip)->getInstruction();
 
       // EX Dispatch would have created a load of the literal pool address, a register which is then killed
       // immediately after its use in the EX instruction. Since we are transforming the EX to an EXRL, this
@@ -4470,7 +4470,7 @@ TR_S390Peephole::inlineEXtargetHelper(TR::Instruction *inst, TR::Instruction * i
       _cg->replaceInst(oldCursor, newEXRLInst);
 
       // remove the instr constant data snippet
-      ((TR_S390ConstantInstructionSnippet *)cnstDataSnip)->setIsRefed(false);
+      ((TR::S390ConstantInstructionSnippet *)cnstDataSnip)->setIsRefed(false);
       (_cg->getConstantInstructionSnippets()).remove(cnstDataSnip);
 
       return true;
@@ -5563,7 +5563,7 @@ OMR::Z::CodeGenerator::supportsMergingOfHCRGuards()
 
 // Helpers for profiled interface slots
 void
-OMR::Z::CodeGenerator::addPICsListForInterfaceSnippet(TR_S390ConstantDataSnippet * ifcSnippet, TR::list<TR_OpaqueClassBlock*> * PICSlist)
+OMR::Z::CodeGenerator::addPICsListForInterfaceSnippet(TR::S390ConstantDataSnippet * ifcSnippet, TR::list<TR_OpaqueClassBlock*> * PICSlist)
    {
    if (_interfaceSnippetToPICsListHashTab == NULL)
       {_interfaceSnippetToPICsListHashTab = new (self()->trHeapMemory()) TR_HashTab(self()->comp()->trMemory(), heapAlloc, 10, true);}
@@ -5573,7 +5573,7 @@ OMR::Z::CodeGenerator::addPICsListForInterfaceSnippet(TR_S390ConstantDataSnippet
    }
 
 TR::list<TR_OpaqueClassBlock*> *
-OMR::Z::CodeGenerator::getPICsListForInterfaceSnippet(TR_S390ConstantDataSnippet * ifcSnippet)
+OMR::Z::CodeGenerator::getPICsListForInterfaceSnippet(TR::S390ConstantDataSnippet * ifcSnippet)
    {
    if (_interfaceSnippetToPICsListHashTab == NULL)
       return NULL;
@@ -5649,7 +5649,7 @@ bool
 OMR::Z::CodeGenerator::anyLitPoolSnippets()
    {
    CS2::HashIndex hi;
-   TR_S390ConstantDataSnippet *cursor1 = NULL;
+   TR::S390ConstantDataSnippet *cursor1 = NULL;
     if (!_targetList.empty())
       {
       return true;
@@ -7447,7 +7447,7 @@ TR_S390OutOfLineCodeSection * OMR::Z::CodeGenerator::findS390OutOfLineCodeSectio
 ////////////////////////////////////////////////////////////////////////////////
 // OMR::Z::CodeGenerator::Constant Data List Functions
 ////////////////////////////////////////////////////////////////////////////////
-TR_S390ConstantDataSnippet *
+TR::S390ConstantDataSnippet *
 OMR::Z::CodeGenerator::findOrCreateConstant(TR::Node * node, void * c, uint16_t size, bool isWarm)
    {
    // *this    swipeable for debugging purposes
@@ -7456,7 +7456,7 @@ OMR::Z::CodeGenerator::findOrCreateConstant(TR::Node * node, void * c, uint16_t 
    key.c      = c;
    key.size   = size;
    key.isWarm = isWarm;
-   TR_S390ConstantDataSnippet * data;
+   TR::S390ConstantDataSnippet * data;
 
    // Can only share data snippets for literal pool address when inlined site indices are the same
    // for now conservatively create a new literal pool data snippet per unique node
@@ -7489,7 +7489,7 @@ OMR::Z::CodeGenerator::findOrCreateConstant(TR::Node * node, void * c, uint16_t 
 
    // Constant was not found: create a new snippet for it and add it to the constant list.
    //
-   data = new (self()->trHeapMemory()) TR_S390ConstantDataSnippet(self(), node, c, size);
+   data = new (self()->trHeapMemory()) TR::S390ConstantDataSnippet(self(), node, c, size);
    if (isWarm)
       data->setWarmSnippet();  // Set as a warm snippet if requested.
    key.c = (void *)data->getRawData();
@@ -7506,31 +7506,31 @@ OMR::Z::CodeGenerator::findOrCreateConstant(TR::Node * node, void * c, uint16_t 
    return data;
    }
 
-TR_S390ConstantInstructionSnippet *
+TR::S390ConstantInstructionSnippet *
 OMR::Z::CodeGenerator::createConstantInstruction(TR::CodeGenerator * cg, TR::Node *node, TR::Instruction * instr)
    {
-   TR_S390ConstantInstructionSnippet * cis = new (cg->trHeapMemory()) TR_S390ConstantInstructionSnippet(cg,node,instr);
+   TR::S390ConstantInstructionSnippet * cis = new (cg->trHeapMemory()) TR::S390ConstantInstructionSnippet(cg,node,instr);
    _constantList.push_front(cis);
    return cis;
    }
 
 
-TR_S390ConstantDataSnippet *
+TR::S390ConstantDataSnippet *
 OMR::Z::CodeGenerator::CreateConstant(TR::Node * node, void * c, uint16_t size, bool writable)
    {
    // *this    swipeable for debugging purposes
 
    if (writable)
       {
-      TR_S390WritableDataSnippet * cursor;
-      cursor = new (self()->trHeapMemory()) TR_S390WritableDataSnippet(self(), node, c, size);
+      TR::S390WritableDataSnippet * cursor;
+      cursor = new (self()->trHeapMemory()) TR::S390WritableDataSnippet(self(), node, c, size);
       _writableList.push_front(cursor);
-      return (TR_S390ConstantDataSnippet *) cursor;
+      return (TR::S390ConstantDataSnippet *) cursor;
       }
    else
       {
-      TR_S390ConstantDataSnippet * cursor;
-      cursor = new (self()->trHeapMemory()) TR_S390ConstantDataSnippet(self(), node, c, size);
+      TR::S390ConstantDataSnippet * cursor;
+      cursor = new (self()->trHeapMemory()) TR::S390ConstantDataSnippet(self(), node, c, size);
       TR_S390ConstantDataSnippetKey key;
       key.c = (void *)cursor->getRawData();
       key.size = size;
@@ -7540,17 +7540,17 @@ OMR::Z::CodeGenerator::CreateConstant(TR::Node * node, void * c, uint16_t size, 
       }
    }
 
-TR_S390LabelTableSnippet *
+TR::S390LabelTableSnippet *
 OMR::Z::CodeGenerator::createLabelTable(TR::Node * node, int32_t size)
    {
-   TR_S390LabelTableSnippet * labelTableSnippet = new (self()->trHeapMemory()) TR_S390LabelTableSnippet(self(), node, size);
+   TR::S390LabelTableSnippet * labelTableSnippet = new (self()->trHeapMemory()) TR::S390LabelTableSnippet(self(), node, size);
    _snippetDataList.push_front(labelTableSnippet);
    return labelTableSnippet;
    }
 
 
 void
-OMR::Z::CodeGenerator::addDataConstantSnippet(TR_S390ConstantDataSnippet * snippet)
+OMR::Z::CodeGenerator::addDataConstantSnippet(TR::S390ConstantDataSnippet * snippet)
    {
    _snippetDataList.push_front(snippet);
    }
@@ -7564,7 +7564,7 @@ int32_t
 OMR::Z::CodeGenerator::setEstimatedOffsetForConstantDataSnippets(int32_t targetAddressSnippetSize, bool isWarm)
    {
    // *this    swipeable for debugging purposes
-   TR_S390ConstantDataSnippet * cursor;
+   TR::S390ConstantDataSnippet * cursor;
    bool first;
    int32_t size;
    int32_t offset = targetAddressSnippetSize;
@@ -7645,7 +7645,7 @@ int32_t
 OMR::Z::CodeGenerator::setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart, bool isWarm)
    {
    // *this    swipeable for debugging purposes
-   TR_S390ConstantDataSnippet * cursor;
+   TR::S390ConstantDataSnippet * cursor;
    bool first;
    int32_t size;
    int32_t exp;
@@ -7734,11 +7734,11 @@ OMR::Z::CodeGenerator::emitDataSnippets(bool isWarm)
    {
    // *this    swipeable for debugging purposes
    // If you change logic here, be sure to do similar change in
-   // the method : TR_S390ConstantDataSnippet *OMR::Z::CodeGenerator::getFirstConstantData()
+   // the method : TR::S390ConstantDataSnippet *OMR::Z::CodeGenerator::getFirstConstantData()
 
    TR_ConstHashCursor constCur(_constantHash);
-   TR_S390ConstantDataSnippet * cursor;
-   TR_S390EyeCatcherDataSnippet * eyeCatcher = NULL;
+   TR::S390ConstantDataSnippet * cursor;
+   TR::S390EyeCatcherDataSnippet * eyeCatcher = NULL;
    uint8_t * codeOffset;
    bool first;
    int32_t size;
@@ -7839,7 +7839,7 @@ OMR::Z::CodeGenerator::emitDataSnippets(bool isWarm)
          {
          if ((*snippetDataIterator)->getKind() == TR::Snippet::IsEyeCatcherData )
             {
-            eyeCatcher = (TR_S390EyeCatcherDataSnippet *)(*snippetDataIterator);
+            eyeCatcher = (TR::S390EyeCatcherDataSnippet *)(*snippetDataIterator);
             }
          else
             {
@@ -7865,7 +7865,7 @@ OMR::Z::CodeGenerator::emitDataSnippets(bool isWarm)
    }
 
 
-TR_S390ConstantDataSnippet *
+TR::S390ConstantDataSnippet *
 OMR::Z::CodeGenerator::create64BitLiteralPoolSnippet(TR::DataType dt, int64_t value)
    {
    TR_ASSERT( dt == TR::Int64, "create64BitLiteralPoolSnippet is only for data constants\n");
@@ -7902,10 +7902,10 @@ OMR::Z::CodeGenerator::createLinkage(TR_LinkageConventions lc)
    return linkage;
    }
 
-TR_S390ConstantDataSnippet *
+TR::S390ConstantDataSnippet *
 OMR::Z::CodeGenerator::createLiteralPoolSnippet(TR::Node * node)
    {
-   TR_S390ConstantDataSnippet * targetSnippet = NULL;
+   TR::S390ConstantDataSnippet * targetSnippet = NULL;
 
    // offset in the symbol reference points to the constant node
    // get this constant node
@@ -7993,51 +7993,51 @@ OMR::Z::CodeGenerator::createLiteralPoolSnippet(TR::Node * node)
 
 
 
-TR_S390ConstantDataSnippet *
+TR::S390ConstantDataSnippet *
 OMR::Z::CodeGenerator::findOrCreate2ByteConstant(TR::Node * node, int16_t c, bool isWarm)
    {
    return self()->findOrCreateConstant(node, &c, 2, isWarm);
    }
 
-TR_S390ConstantDataSnippet *
+TR::S390ConstantDataSnippet *
 OMR::Z::CodeGenerator::findOrCreate4ByteConstant(TR::Node * node, int32_t c, bool isWarm)
    {
    return self()->findOrCreateConstant(node, &c, 4, isWarm);
    }
 
-TR_S390ConstantDataSnippet *
+TR::S390ConstantDataSnippet *
 OMR::Z::CodeGenerator::findOrCreate8ByteConstant(TR::Node * node, int64_t c, bool isWarm)
    {
    return self()->findOrCreateConstant(node, &c, 8, isWarm);
    }
 
-TR_S390ConstantDataSnippet *
+TR::S390ConstantDataSnippet *
 OMR::Z::CodeGenerator::Create4ByteConstant(TR::Node * node, int32_t c, bool writable)
    {
    return self()->CreateConstant(node, &c, 4, writable);
    }
 
-TR_S390ConstantDataSnippet *
+TR::S390ConstantDataSnippet *
 OMR::Z::CodeGenerator::Create8ByteConstant(TR::Node * node, int64_t c, bool writable)
    {
    return self()->CreateConstant(node, &c, 8, writable);
    }
 
-TR_S390WritableDataSnippet *
+TR::S390WritableDataSnippet *
 OMR::Z::CodeGenerator::CreateWritableConstant(TR::Node * node)
    {
    if (TR::Compiler->target.is64Bit())
       {
-      return (TR_S390WritableDataSnippet *) self()->Create8ByteConstant(node, 0, true);
+      return (TR::S390WritableDataSnippet *) self()->Create8ByteConstant(node, 0, true);
       }
    else
       {
-      return (TR_S390WritableDataSnippet *) self()->Create4ByteConstant(node, 0, true);
+      return (TR::S390WritableDataSnippet *) self()->Create4ByteConstant(node, 0, true);
       }
    }
 
 
-TR_S390ConstantDataSnippet *
+TR::S390ConstantDataSnippet *
 OMR::Z::CodeGenerator::getFirstConstantData()
    {
    // Logic in this method should always be kept in sync with
@@ -8046,7 +8046,7 @@ OMR::Z::CodeGenerator::getFirstConstantData()
    // hense the first emited constant may not be iterator.getFirst(),
    // but the first constant with biggest size
    //
-   TR_S390ConstantDataSnippet * cursor;
+   TR::S390ConstantDataSnippet * cursor;
    TR_ConstHashCursor constCur(_constantHash);
    int32_t exp;
 
@@ -8170,44 +8170,44 @@ OMR::Z::CodeGenerator::emitTargetAddressSnippets(bool isWarm)
 
 
 
-TR_S390LookupSwitchSnippet *
+TR::S390LookupSwitchSnippet *
 OMR::Z::CodeGenerator::CreateLookupSwitchSnippet(TR::Node * node, TR::Snippet * s)
    {
-   _targetList.push_front((TR_S390LookupSwitchSnippet *) s);
-   return (TR_S390LookupSwitchSnippet *) s;
+   _targetList.push_front((TR::S390LookupSwitchSnippet *) s);
+   return (TR::S390LookupSwitchSnippet *) s;
    }
 
 
 
-TR_S390TargetAddressSnippet *
+TR::S390TargetAddressSnippet *
 OMR::Z::CodeGenerator::CreateTargetAddressSnippet(TR::Node * node, TR::Snippet * s)
    {
-   TR_S390TargetAddressSnippet * targetsnippet;
-   targetsnippet = new (self()->trHeapMemory()) TR_S390TargetAddressSnippet(self(), node, s);
+   TR::S390TargetAddressSnippet * targetsnippet;
+   targetsnippet = new (self()->trHeapMemory()) TR::S390TargetAddressSnippet(self(), node, s);
    _targetList.push_front(targetsnippet);
    return targetsnippet;
    }
 
-TR_S390TargetAddressSnippet *
+TR::S390TargetAddressSnippet *
 OMR::Z::CodeGenerator::CreateTargetAddressSnippet(TR::Node * node, TR::LabelSymbol * s)
    {
-   TR_S390TargetAddressSnippet * targetsnippet;
-   targetsnippet = new (self()->trHeapMemory()) TR_S390TargetAddressSnippet(self(), node, s);
+   TR::S390TargetAddressSnippet * targetsnippet;
+   targetsnippet = new (self()->trHeapMemory()) TR::S390TargetAddressSnippet(self(), node, s);
    _targetList.push_front(targetsnippet);
    return targetsnippet;
    }
 
-TR_S390TargetAddressSnippet *
+TR::S390TargetAddressSnippet *
 OMR::Z::CodeGenerator::CreateTargetAddressSnippet(TR::Node * node, TR::Symbol * s)
    {
    TR_ASSERT(self()->supportsOnDemandLiteralPool() == false, "May not be here with Literal Pool On Demand enabled\n");
-   TR_S390TargetAddressSnippet * targetsnippet;
-   targetsnippet = new (self()->trHeapMemory()) TR_S390TargetAddressSnippet(self(), node, s);
+   TR::S390TargetAddressSnippet * targetsnippet;
+   targetsnippet = new (self()->trHeapMemory()) TR::S390TargetAddressSnippet(self(), node, s);
    _targetList.push_front(targetsnippet);
    return targetsnippet;
    }
 
-TR_S390TargetAddressSnippet *
+TR::S390TargetAddressSnippet *
 OMR::Z::CodeGenerator::findOrCreateTargetAddressSnippet(TR::Node * node, uintptrj_t addr)
    {
    TR_ASSERT(self()->supportsOnDemandLiteralPool() == false, "May not be here with Literal Pool On Demand enabled\n");
@@ -8223,14 +8223,14 @@ OMR::Z::CodeGenerator::findOrCreateTargetAddressSnippet(TR::Node * node, uintptr
          }
       }
 
-   TR_S390TargetAddressSnippet * targetsnippet;
+   TR::S390TargetAddressSnippet * targetsnippet;
 
-   targetsnippet = new (self()->trHeapMemory()) TR_S390TargetAddressSnippet(self(), node, addr);
+   targetsnippet = new (self()->trHeapMemory()) TR::S390TargetAddressSnippet(self(), node, addr);
    _targetList.push_front(targetsnippet);
    return targetsnippet;
    }
 
-TR_S390TargetAddressSnippet *
+TR::S390TargetAddressSnippet *
 OMR::Z::CodeGenerator::getFirstTargetAddress()
    {
    if(_targetList.empty())
@@ -9221,8 +9221,8 @@ OMR::Z::CodeGenerator::dumpDataSnippets(TR::FILE *outFile, bool isWarm)
       return;
       }
    TR_ConstHashCursor constCur(_constantHash);
-   TR_S390EyeCatcherDataSnippet * eyeCatcher = NULL;
-   TR_S390ConstantDataSnippet *cursor = NULL;
+   TR::S390EyeCatcherDataSnippet * eyeCatcher = NULL;
+   TR::S390ConstantDataSnippet *cursor = NULL;
    int32_t size;
    int32_t exp;
 
@@ -9264,7 +9264,7 @@ OMR::Z::CodeGenerator::dumpDataSnippets(TR::FILE *outFile, bool isWarm)
       if ((*snippetDataIterator)->isWarmSnippet() == isWarm)
          {
          if((*snippetDataIterator)->getKind() == TR::Snippet::IsEyeCatcherData)
-            eyeCatcher = (TR_S390EyeCatcherDataSnippet *)(*snippetDataIterator);
+            eyeCatcher = (TR::S390EyeCatcherDataSnippet *)(*snippetDataIterator);
          else
             self()->getDebug()->print(outFile,*snippetDataIterator);
          }

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -88,19 +88,19 @@ class TR_GCStackMap;
 class TR_OpaquePseudoRegister;
 class TR_PseudoRegister;
 class TR_RegisterCandidate;
-class TR_S390ConstantDataSnippet;
-class TR_S390ConstantInstructionSnippet;
-class TR_S390DeclTrampSnippet;
-class TR_S390EyeCatcherDataSnippet;
+namespace TR { class S390ConstantDataSnippet; }
+namespace TR { class S390ConstantInstructionSnippet; }
+namespace TR { class S390DeclTrampSnippet; }
+namespace TR { class S390EyeCatcherDataSnippet; }
 namespace TR { class S390ImmInstruction; }
-class TR_S390LabelTableSnippet;
-class TR_S390LookupSwitchSnippet;
+namespace TR { class S390LabelTableSnippet; }
+namespace TR { class S390LookupSwitchSnippet; }
 class TR_S390OutOfLineCodeSection;
 class TR_S390PrivateLinkage;
 class TR_S390ScratchRegisterManager;
-class TR_S390SortJumpTrampSnippet;
-class TR_S390TargetAddressSnippet;
-class TR_S390WritableDataSnippet;
+namespace TR { class S390SortJumpTrampSnippet; }
+namespace TR { class S390TargetAddressSnippet; }
+namespace TR { class S390WritableDataSnippet; }
 class TR_StorageReference;
 namespace OMR { class Linkage; }
 namespace TR { class CodeGenerator; }
@@ -385,8 +385,8 @@ public:
    void setLabelHashTable(TR_HashTab *notPrintLabelHashTab) {_notPrintLabelHashTab = notPrintLabelHashTab;}
    TR_HashTab * getLabelHashTable() {return _notPrintLabelHashTab;}
 
-   void addPICsListForInterfaceSnippet(TR_S390ConstantDataSnippet * ifcSnippet, TR::list<TR_OpaqueClassBlock*> * PICSlist);
-   TR::list<TR_OpaqueClassBlock*> * getPICsListForInterfaceSnippet(TR_S390ConstantDataSnippet * ifcSnippet);
+   void addPICsListForInterfaceSnippet(TR::S390ConstantDataSnippet * ifcSnippet, TR::list<TR_OpaqueClassBlock*> * PICSlist);
+   TR::list<TR_OpaqueClassBlock*> * getPICsListForInterfaceSnippet(TR::S390ConstantDataSnippet * ifcSnippet);
 
    void doInstructionSelection();
    void doRegisterAssignment(TR_RegisterKinds kindsToAssign);
@@ -863,7 +863,7 @@ public:
               }
         };
 
-    typedef CS2::HashTable<TR_S390ConstantDataSnippetKey,TR_S390ConstantDataSnippet *, TR::Allocator, constantHashInfo> TR_ConstantSnippetHash;
+    typedef CS2::HashTable<TR_S390ConstantDataSnippetKey,TR::S390ConstantDataSnippet *, TR::Allocator, constantHashInfo> TR_ConstantSnippetHash;
     typedef TR_ConstantSnippetHash::Cursor TR_ConstHashCursor;
 
 
@@ -874,29 +874,29 @@ public:
    int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart, bool isWarm = 0);
    void emitDataSnippets(bool isWarm = 0);
    bool hasDataSnippets() { return (_constantList.empty() && _writableList.empty() && _snippetDataList.empty() && _constantHash.IsEmpty()) ? false : true; }
-   TR::list<TR_S390ConstantDataSnippet*> &getConstantInstructionSnippets() { return _constantList; }
-   TR::list<TR_S390ConstantDataSnippet*> &getConstantDataStringSnippets() { return _constantList; }
+   TR::list<TR::S390ConstantDataSnippet*> &getConstantInstructionSnippets() { return _constantList; }
+   TR::list<TR::S390ConstantDataSnippet*> &getConstantDataStringSnippets() { return _constantList; }
    TR_ConstHashCursor getConstantDataSnippets() { return _constantHashCur;}
-   TR_S390ConstantDataSnippet * getConstantDataSnippet(CS2::HashIndex hi) { return _constantHash.DataAt(hi);}
+   TR::S390ConstantDataSnippet * getConstantDataSnippet(CS2::HashIndex hi) { return _constantHash.DataAt(hi);}
 
 
-   TR_S390ConstantDataSnippet * create64BitLiteralPoolSnippet(TR::DataType dt, int64_t value);
-   TR_S390ConstantDataSnippet * createLiteralPoolSnippet(TR::Node * node);
-   TR_S390ConstantInstructionSnippet *createConstantInstruction(TR::CodeGenerator * cg, TR::Node *node, TR::Instruction * instr);
-   TR_S390ConstantDataSnippet *findOrCreateConstant(TR::Node *, void *c, uint16_t size, bool isWarm = 0);
-   TR_S390ConstantDataSnippet *findOrCreate2ByteConstant(TR::Node *, int16_t c, bool isWarm = 0);
-   TR_S390ConstantDataSnippet *findOrCreate4ByteConstant(TR::Node *, int32_t c, bool isWarm = 0);
-   TR_S390ConstantDataSnippet *findOrCreate8ByteConstant(TR::Node *, int64_t c, bool isWarm = 0);
-   TR_S390ConstantDataSnippet *Create4ByteConstant(TR::Node *, int32_t c, bool writable);
-   TR_S390ConstantDataSnippet *Create8ByteConstant(TR::Node *, int64_t c, bool writable);
-   TR_S390ConstantDataSnippet *CreateConstant(TR::Node *, void *c, uint16_t size, bool writable);
-   TR_S390ConstantDataSnippet *getFirstConstantData();
+   TR::S390ConstantDataSnippet * create64BitLiteralPoolSnippet(TR::DataType dt, int64_t value);
+   TR::S390ConstantDataSnippet * createLiteralPoolSnippet(TR::Node * node);
+   TR::S390ConstantInstructionSnippet *createConstantInstruction(TR::CodeGenerator * cg, TR::Node *node, TR::Instruction * instr);
+   TR::S390ConstantDataSnippet *findOrCreateConstant(TR::Node *, void *c, uint16_t size, bool isWarm = 0);
+   TR::S390ConstantDataSnippet *findOrCreate2ByteConstant(TR::Node *, int16_t c, bool isWarm = 0);
+   TR::S390ConstantDataSnippet *findOrCreate4ByteConstant(TR::Node *, int32_t c, bool isWarm = 0);
+   TR::S390ConstantDataSnippet *findOrCreate8ByteConstant(TR::Node *, int64_t c, bool isWarm = 0);
+   TR::S390ConstantDataSnippet *Create4ByteConstant(TR::Node *, int32_t c, bool writable);
+   TR::S390ConstantDataSnippet *Create8ByteConstant(TR::Node *, int64_t c, bool writable);
+   TR::S390ConstantDataSnippet *CreateConstant(TR::Node *, void *c, uint16_t size, bool writable);
+   TR::S390ConstantDataSnippet *getFirstConstantData();
 
-   TR_S390LabelTableSnippet *createLabelTable(TR::Node *, int32_t);
+   TR::S390LabelTableSnippet *createLabelTable(TR::Node *, int32_t);
 
    // Writable Data List functions
    bool hasWritableDataSnippets() { return _writableList.empty() ? false : true; }
-   TR_S390WritableDataSnippet *CreateWritableConstant(TR::Node *);
+   TR::S390WritableDataSnippet *CreateWritableConstant(TR::Node *);
 
    // OutOfLineCodeSection List functions
    TR::list<TR_S390OutOfLineCodeSection*> &getS390OutOfLineCodeSectionList() {return _outOfLineCodeSectionList;}
@@ -911,7 +911,7 @@ public:
 
 
    // Snippet Data functions
-   void addDataConstantSnippet(TR_S390ConstantDataSnippet * snippet);
+   void addDataConstantSnippet(TR::S390ConstantDataSnippet * snippet);
 
    // Identify the Inst selection phase
    bool getDoingInstructionSelection() { return _cgFlags.testAny(S390CG_doingInstructionSelection); }
@@ -922,12 +922,12 @@ public:
    int32_t setEstimatedLocationsForTargetAddressSnippetLabels(int32_t estimatedSnippetStart, bool isWarm = 0);
    void emitTargetAddressSnippets(bool isWarm = 0);
    bool hasTargetAddressSnippets() { return _targetList.empty() ? false : true; }
-   TR_S390LookupSwitchSnippet  *CreateLookupSwitchSnippet(TR::Node *,  TR::Snippet* s);
-   TR_S390TargetAddressSnippet *CreateTargetAddressSnippet(TR::Node *, TR::Snippet* s);
-   TR_S390TargetAddressSnippet *CreateTargetAddressSnippet(TR::Node *, TR::LabelSymbol * s);
-   TR_S390TargetAddressSnippet *CreateTargetAddressSnippet(TR::Node *, TR::Symbol* s);
-   TR_S390TargetAddressSnippet *findOrCreateTargetAddressSnippet(TR::Node *, uintptrj_t s);
-   TR_S390TargetAddressSnippet *getFirstTargetAddress();
+   TR::S390LookupSwitchSnippet  *CreateLookupSwitchSnippet(TR::Node *,  TR::Snippet* s);
+   TR::S390TargetAddressSnippet *CreateTargetAddressSnippet(TR::Node *, TR::Snippet* s);
+   TR::S390TargetAddressSnippet *CreateTargetAddressSnippet(TR::Node *, TR::LabelSymbol * s);
+   TR::S390TargetAddressSnippet *CreateTargetAddressSnippet(TR::Node *, TR::Symbol* s);
+   TR::S390TargetAddressSnippet *findOrCreateTargetAddressSnippet(TR::Node *, uintptrj_t s);
+   TR::S390TargetAddressSnippet *getFirstTargetAddress();
 
    // Transient Long Registers
 
@@ -1133,15 +1133,15 @@ public:
    int32_t                        _extentOfLitPool;  // excludes snippets
    uint64_t                       _availableHPRSpillMask;
 
-   TR::list<TR_S390TargetAddressSnippet*> _targetList;
+   TR::list<TR::S390TargetAddressSnippet*> _targetList;
 
 protected:
-   TR::list<TR_S390ConstantDataSnippet*>  _constantList;
-   TR::list<TR_S390ConstantDataSnippet*>  _snippetDataList;
+   TR::list<TR::S390ConstantDataSnippet*>  _constantList;
+   TR::list<TR::S390ConstantDataSnippet*>  _snippetDataList;
 
 
 private:
-   TR::list<TR_S390WritableDataSnippet*>  _writableList;
+   TR::list<TR::S390WritableDataSnippet*>  _writableList;
    TR::list<TR_S390OutOfLineCodeSection*> _outOfLineCodeSectionList;
 
    CS2::HashTable<TR::Register *, TR::RealRegister::RegNum, TR::Allocator> _previouslyAssignedTo;

--- a/compiler/z/codegen/OMRInstruction.cpp
+++ b/compiler/z/codegen/OMRInstruction.cpp
@@ -1214,13 +1214,13 @@ OMR::Z::Instruction::getOutOfLineEXInstr()
       case TR::InstOpCode::EX:
       {
          TR::MemoryReference * tempMR = ((TR::S390RXInstruction *)self())->getMemoryReference();
-         TR_S390ConstantInstructionSnippet * cis = (TR_S390ConstantInstructionSnippet *) tempMR->getConstantDataSnippet();
+         TR::S390ConstantInstructionSnippet * cis = (TR::S390ConstantInstructionSnippet *) tempMR->getConstantDataSnippet();
          TR_ASSERT( cis != NULL, "Out of line EX instruction doesn't have a constantInstructionSnippet\n");
          return cis->getInstruction();
       }
       case TR::InstOpCode::EXRL:
       {
-         TR_S390ConstantInstructionSnippet * cis = (TR_S390ConstantInstructionSnippet *)
+         TR::S390ConstantInstructionSnippet * cis = (TR::S390ConstantInstructionSnippet *)
             ((TR::S390RILInstruction *)self())->getTargetSnippet();
          TR_ASSERT( cis != NULL, "Out of line EXRL instruction doesn't have a constantInstructionSnippet\n");
          return cis->getInstruction();
@@ -1700,14 +1700,14 @@ bool OMR::Z::Instruction::containsRegister(TR::Register *reg)
       if (self()->getOpCodeValue() == TR::InstOpCode::EX)
          {
          TR::MemoryReference * tempMR = ((TR::S390RXInstruction *)self())->getMemoryReference();
-         TR_S390ConstantInstructionSnippet * cis = (TR_S390ConstantInstructionSnippet *) tempMR->getConstantDataSnippet();
+         TR::S390ConstantInstructionSnippet * cis = (TR::S390ConstantInstructionSnippet *) tempMR->getConstantDataSnippet();
          TR_ASSERT( cis != NULL, "Out of line EX instruction doesn't have a constantInstructionSnippet\n");
          if (cis->getInstruction()->containsRegister(reg))
             return true;
          }
       else if (self()->getOpCodeValue() == TR::InstOpCode::EXRL)
          {
-         TR_S390ConstantInstructionSnippet * cis = (TR_S390ConstantInstructionSnippet *) ((TR::S390RILInstruction *)self())->getTargetSnippet();
+         TR::S390ConstantInstructionSnippet * cis = (TR::S390ConstantInstructionSnippet *) ((TR::S390RILInstruction *)self())->getTargetSnippet();
          TR_ASSERT( cis != NULL, "Out of line EXRL instruction doesn't have a constantInstructionSnippet\n");
          if (cis->getInstruction()->containsRegister(reg))
             return true;

--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -855,7 +855,7 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
                      {
                      if (genBinary)
                         {
-                        cursor =  (void *) TR_S390CallSnippet::storeArgumentItem(storeOpCode, (uint8_t *) cursor,
+                        cursor =  (void *) TR::S390CallSnippet::storeArgumentItem(storeOpCode, (uint8_t *) cursor,
                                              self()->getS390RealRegister(regNum), offset, self()->cg());
                         }
                      else
@@ -885,7 +885,7 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
                      {
                      if (genBinary)
                         {
-                        cursor =  (void *) TR_S390CallSnippet::storeArgumentItem(TR::InstOpCode::ST, (uint8_t *) cursor, self()->getS390RealRegister(regNum),
+                        cursor =  (void *) TR::S390CallSnippet::storeArgumentItem(TR::InstOpCode::ST, (uint8_t *) cursor, self()->getS390RealRegister(regNum),
                                              offset, self()->cg());
                         }
                      else
@@ -912,7 +912,7 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
 #endif
                   if (genBinary)
                      {
-                     cursor =  (void *) TR_S390CallSnippet::storeArgumentItem(TR::InstOpCode::STE, (uint8_t *) cursor, self()->getS390RealRegister(regNum),
+                     cursor =  (void *) TR::S390CallSnippet::storeArgumentItem(TR::InstOpCode::STE, (uint8_t *) cursor, self()->getS390RealRegister(regNum),
                                           offset, self()->cg());
                      }
                   else
@@ -931,7 +931,7 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
 #endif
                   if (genBinary)
                      {
-                     cursor =  (void *) TR_S390CallSnippet::storeArgumentItem(TR::InstOpCode::STD, (uint8_t *) cursor, self()->getS390RealRegister(regNum),
+                     cursor =  (void *) TR::S390CallSnippet::storeArgumentItem(TR::InstOpCode::STD, (uint8_t *) cursor, self()->getS390RealRegister(regNum),
                                           offset, self()->cg());
                      }
                   else
@@ -948,9 +948,9 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
                case TR::DecimalLongDouble:
                   if (genBinary)
                      {
-                     cursor =  (void *) TR_S390CallSnippet::storeArgumentItem(TR::InstOpCode::STD, (uint8_t *) cursor, self()->getS390RealRegister(regNum),
+                     cursor =  (void *) TR::S390CallSnippet::storeArgumentItem(TR::InstOpCode::STD, (uint8_t *) cursor, self()->getS390RealRegister(regNum),
                                           offset, self()->cg());
-                     cursor =  (void *) TR_S390CallSnippet::storeArgumentItem(TR::InstOpCode::STD, (uint8_t *) cursor, self()->getS390RealRegister(REGNUM(regNum+2)),
+                     cursor =  (void *) TR::S390CallSnippet::storeArgumentItem(TR::InstOpCode::STD, (uint8_t *) cursor, self()->getS390RealRegister(REGNUM(regNum+2)),
                                           offset+8, self()->cg());
                      }
                   else
@@ -978,7 +978,7 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
                case TR::VectorDouble:
                   if (genBinary)
                      {
-                     cursor =  (void *) TR_S390CallSnippet::storeArgumentItem(TR::InstOpCode::VST, (uint8_t *) cursor, self()->getS390RealRegister(regNum),
+                     cursor =  (void *) TR::S390CallSnippet::storeArgumentItem(TR::InstOpCode::VST, (uint8_t *) cursor, self()->getS390RealRegister(regNum),
                                           offset, self()->cg());
                      }
                   else
@@ -3058,7 +3058,7 @@ void
 OMR::Z::Linkage::performCallNativeFunctionForLinkage(TR::Node * callNode, TR_DispatchType dispatchType, TR::Register * &javaReturnRegister, TR::SystemLinkage * systemLinkage,
       TR::RegisterDependencyConditions * &deps, TR::Register * javaLitOffsetReg, TR::Register * methodAddressReg, bool isJNIGCPoint)
    {
-   TR_S390JNICallDataSnippet * jniCallDataSnippet = NULL;
+   TR::S390JNICallDataSnippet * jniCallDataSnippet = NULL;
    TR::LabelSymbol * returnFromJNICallLabel = generateLabelSymbol(self()->cg());
    intptrj_t targetAddress = (intptrj_t) 0;
 

--- a/compiler/z/codegen/OMRLinkage.hpp
+++ b/compiler/z/codegen/OMRLinkage.hpp
@@ -46,7 +46,7 @@ namespace OMR { typedef OMR::Z::Linkage LinkageConnector; }
 #include "codegen/RegisterDependency.hpp"
 
 class TR_FrontEnd;
-class TR_S390JNICallDataSnippet;
+namespace TR { class S390JNICallDataSnippet; }
 class TR_S390PrivateLinkage;
 namespace TR { class AutomaticSymbol; }
 namespace TR { class Compilation; }

--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -43,7 +43,7 @@
 #include "codegen/RegisterConstants.hpp"
 #include "codegen/RegisterPair.hpp"                 // for RegisterPair
 #include "codegen/Relocation.hpp"
-#include "codegen/Snippet.hpp"                      // for TR_S390Snippet, etc
+#include "codegen/Snippet.hpp"                      // for TR::S390Snippet, etc
 #include "codegen/TreeEvaluator.hpp"
 #include "codegen/UnresolvedDataSnippet.hpp"
 #include "compile/Compilation.hpp"                  // for Compilation
@@ -553,7 +553,7 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node * rootLoadOrStore, TR::CodeGen
          else
             {
             uintptrj_t staticAddressValue = (uintptrj_t) symbol->getStaticSymbol()->getStaticAddress();
-            TR_S390ConstantDataSnippet * targetsnippet;
+            TR::S390ConstantDataSnippet * targetsnippet;
             if (TR::Compiler->target.is64Bit())
                {
                targetsnippet = cg->findOrCreate8ByteConstant(0, staticAddressValue);
@@ -680,7 +680,7 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node * rootLoadOrStore, TR::CodeGen
    if (symRef && symRef->isLiteralPoolAddress())
       {
       TR_ASSERT(cg->supportsOnDemandLiteralPool() == true, "May not be here with Literal Pool On Demand disabled\n");
-      TR_S390ConstantDataSnippet * targetsnippet = self()->createLiteralPoolSnippet(rootLoadOrStore, cg);
+      TR::S390ConstantDataSnippet * targetsnippet = self()->createLiteralPoolSnippet(rootLoadOrStore, cg);
 
       self()->initSnippetPointers(targetsnippet, cg);
       }
@@ -748,7 +748,7 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node *addressChild, bool canUseInde
    self()->setupCausesImplicitNullPointerException(cg);
    }
 
-TR_S390ConstantDataSnippet *
+TR::S390ConstantDataSnippet *
 OMR::Z::MemoryReference::createLiteralPoolSnippet(TR::Node * node, TR::CodeGenerator * cg)
    {
    return cg->createLiteralPoolSnippet(node);
@@ -820,17 +820,17 @@ OMR::Z::MemoryReference::initSnippetPointers(TR::Snippet * s, TR::CodeGenerator 
       }
    else if (s->getKind() == TR::Snippet::IsTargetAddress)
       {
-      self()->setTargetAddressSnippet((TR_S390TargetAddressSnippet *) s);
+      self()->setTargetAddressSnippet((TR::S390TargetAddressSnippet *) s);
       }
    else if (s->getKind() == TR::Snippet::IsWritableData ||
             s->getKind() == TR::Snippet::IsConstantInstruction ||
             s->getKind() == TR::Snippet::IsConstantData)
       {
-      self()->setConstantDataSnippet((TR_S390ConstantDataSnippet *) s);
+      self()->setConstantDataSnippet((TR::S390ConstantDataSnippet *) s);
       }
    else if (s->getKind() == TR::Snippet::IsLookupSwitch)
       {
-      self()->setLookupSwitchSnippet((TR_S390LookupSwitchSnippet *) s);
+      self()->setLookupSwitchSnippet((TR::S390LookupSwitchSnippet *) s);
       }
    }
 
@@ -1061,43 +1061,43 @@ OMR::Z::MemoryReference::setUnresolvedSnippet(TR::UnresolvedDataSnippet *s)
    return (TR::UnresolvedDataSnippet *) (_targetSnippet = (TR::Snippet *) s);
    }
 
-TR_S390TargetAddressSnippet *
+TR::S390TargetAddressSnippet *
 OMR::Z::MemoryReference::getTargetAddressSnippet()
    {
-   return self()->isTargetAddressSnippet() ? (TR_S390TargetAddressSnippet *)_targetSnippet : NULL;
+   return self()->isTargetAddressSnippet() ? (TR::S390TargetAddressSnippet *)_targetSnippet : NULL;
    }
 
-TR_S390TargetAddressSnippet *
-OMR::Z::MemoryReference::setTargetAddressSnippet(TR_S390TargetAddressSnippet *s)
+TR::S390TargetAddressSnippet *
+OMR::Z::MemoryReference::setTargetAddressSnippet(TR::S390TargetAddressSnippet *s)
    {
    self()->setTargetAddressSnippet();
-   return (TR_S390TargetAddressSnippet *) (_targetSnippet = s);
+   return (TR::S390TargetAddressSnippet *) (_targetSnippet = s);
    }
 
-TR_S390ConstantDataSnippet *
+TR::S390ConstantDataSnippet *
 OMR::Z::MemoryReference::getConstantDataSnippet()
    {
-   return self()->isConstantDataSnippet() ? (TR_S390ConstantDataSnippet *)_targetSnippet : NULL;
+   return self()->isConstantDataSnippet() ? (TR::S390ConstantDataSnippet *)_targetSnippet : NULL;
    }
 
-TR_S390ConstantDataSnippet *
-OMR::Z::MemoryReference::setConstantDataSnippet(TR_S390ConstantDataSnippet *s)
+TR::S390ConstantDataSnippet *
+OMR::Z::MemoryReference::setConstantDataSnippet(TR::S390ConstantDataSnippet *s)
    {
    self()->setConstantDataSnippet();
-   return (TR_S390ConstantDataSnippet *) (_targetSnippet = s);
+   return (TR::S390ConstantDataSnippet *) (_targetSnippet = s);
    }
 
-TR_S390LookupSwitchSnippet *
+TR::S390LookupSwitchSnippet *
 OMR::Z::MemoryReference::getLookupSwitchSnippet()
    {
-   return self()->isLookupSwitchSnippet() ? (TR_S390LookupSwitchSnippet *)_targetSnippet : NULL;
+   return self()->isLookupSwitchSnippet() ? (TR::S390LookupSwitchSnippet *)_targetSnippet : NULL;
    }
 
-TR_S390LookupSwitchSnippet *
-OMR::Z::MemoryReference::setLookupSwitchSnippet(TR_S390LookupSwitchSnippet *s)
+TR::S390LookupSwitchSnippet *
+OMR::Z::MemoryReference::setLookupSwitchSnippet(TR::S390LookupSwitchSnippet *s)
    {
    self()->setLookupSwitchSnippet();
-   return (TR_S390LookupSwitchSnippet *) (_targetSnippet = s);
+   return (TR::S390LookupSwitchSnippet *) (_targetSnippet = s);
    }
 
 void
@@ -3652,7 +3652,7 @@ generateS390MemoryReference(TR::CodeGenerator * cg)
 TR::MemoryReference *
 generateS390MemoryReference(int32_t iValue, TR::DataType type, TR::CodeGenerator * cg, TR::Register * treg, TR::Node *node)
    {
-   TR_S390ConstantDataSnippet * targetsnippet = cg->findOrCreate4ByteConstant(node, iValue);
+   TR::S390ConstantDataSnippet * targetsnippet = cg->findOrCreate4ByteConstant(node, iValue);
 
    return generateS390MemoryReference(targetsnippet, cg, treg, node);
    }
@@ -3660,7 +3660,7 @@ generateS390MemoryReference(int32_t iValue, TR::DataType type, TR::CodeGenerator
 TR::MemoryReference *
 generateS390MemoryReference(int64_t iValue, TR::DataType type, TR::CodeGenerator * cg, TR::Register * treg, TR::Node *node)
    {
-   TR_S390ConstantDataSnippet * targetsnippet = cg->findOrCreate8ByteConstant(node, iValue);
+   TR::S390ConstantDataSnippet * targetsnippet = cg->findOrCreate8ByteConstant(node, iValue);
    return generateS390MemoryReference(targetsnippet, cg, treg, node);
    }
 

--- a/compiler/z/codegen/OMRMemoryReference.hpp
+++ b/compiler/z/codegen/OMRMemoryReference.hpp
@@ -56,7 +56,7 @@ namespace TR { class Node; }
 namespace TR { class ParameterSymbol; }
 namespace TR { class UnresolvedDataSnippet; }
 
-#define TR_S390MemRef_UnresolvedDataSnippet      0x01
+#define S390MemRef_UnresolvedDataSnippet         0x01
 #define MemRef_TargetAddressSnippet              0x02
 #define MemRef_ConstantDataSnippet               0x04
 #define MemRef_LookupSwitchSnippet               0x08
@@ -210,17 +210,17 @@ TR::Instruction *setTargetSnippetInstruction(TR::Instruction *i)
    return _targetSnippetInstruction = i;
    }
 
-TR_S390TargetAddressSnippet *getTargetAddressSnippet();
+TR::S390TargetAddressSnippet *getTargetAddressSnippet();
 
-TR_S390TargetAddressSnippet *setTargetAddressSnippet(TR_S390TargetAddressSnippet *s);
+TR::S390TargetAddressSnippet *setTargetAddressSnippet(TR::S390TargetAddressSnippet *s);
 
-TR_S390ConstantDataSnippet *getConstantDataSnippet();
+TR::S390ConstantDataSnippet *getConstantDataSnippet();
 
-TR_S390ConstantDataSnippet *setConstantDataSnippet(TR_S390ConstantDataSnippet *s);
+TR::S390ConstantDataSnippet *setConstantDataSnippet(TR::S390ConstantDataSnippet *s);
 
-TR_S390LookupSwitchSnippet *getLookupSwitchSnippet();
+TR::S390LookupSwitchSnippet *getLookupSwitchSnippet();
 
-TR_S390LookupSwitchSnippet *setLookupSwitchSnippet(TR_S390LookupSwitchSnippet *s);
+TR::S390LookupSwitchSnippet *setLookupSwitchSnippet(TR::S390LookupSwitchSnippet *s);
 
 
 TR_StorageReference *getStorageReference()                           { return _storageReference; }
@@ -326,8 +326,8 @@ bool refsRegister(TR::Register *reg)
 int32_t getDisp()          {return _displacement;}
 void setDisp(int32_t f)    {_displacement=f;}
 
-bool isUnresolvedDataSnippet()  {return _flags.testAny(TR_S390MemRef_UnresolvedDataSnippet);}
-void setUnresolvedDataSnippet() {_flags.set(TR_S390MemRef_UnresolvedDataSnippet);}
+bool isUnresolvedDataSnippet()  {return _flags.testAny(S390MemRef_UnresolvedDataSnippet);}
+void setUnresolvedDataSnippet() {_flags.set(S390MemRef_UnresolvedDataSnippet);}
 
 bool isTargetAddressSnippet()  {return _flags.testAny(MemRef_TargetAddressSnippet);}
 void setTargetAddressSnippet() {_flags.set(MemRef_TargetAddressSnippet);}
@@ -362,7 +362,7 @@ void bookKeepingRegisterUses(TR::Instruction *instr, TR::CodeGenerator *cg);
 
 void populateThroughEvaluation(TR::Node * rootLoadOrStore, TR::CodeGenerator *cg);
 void populateMemoryReference(TR::Node *subTree, TR::CodeGenerator *cg);
-TR_S390ConstantDataSnippet* createLiteralPoolSnippet(TR::Node *rootNode, TR::CodeGenerator *cg);
+TR::S390ConstantDataSnippet* createLiteralPoolSnippet(TR::Node *rootNode, TR::CodeGenerator *cg);
 void populateLoadAddrTree(TR::Node* subTree, TR::CodeGenerator* cg);
 void populateAloadTree(TR::Node* subTree, TR::CodeGenerator* cg, bool privateArea = false);
 void populateShiftLeftTree(TR::Node* subTree, TR::CodeGenerator* cg);

--- a/compiler/z/codegen/OMRSnippet.cpp
+++ b/compiler/z/codegen/OMRSnippet.cpp
@@ -31,7 +31,7 @@
 #include "codegen/RealRegister.hpp"             // for RealRegister
 #include "codegen/Register.hpp"                 // for Register
 #include "codegen/Relocation.hpp"
-#include "codegen/Snippet.hpp"                  // for TR_S390Snippet, etc
+#include "codegen/Snippet.hpp"                  // for TR::S390Snippet, etc
 #include "codegen/UnresolvedDataSnippet.hpp"
 #include "compile/Compilation.hpp"              // for Compilation
 #include "control/Options.hpp"
@@ -46,7 +46,7 @@
 #include "infra/Assert.hpp"                     // for TR_ASSERT
 #include "ras/Debug.hpp"                        // for TR_Debug
 #include "runtime/Runtime.hpp"                  // for ::TR_HelperAddress, etc
-#include "z/codegen/CallSnippet.hpp"            // for TR_S390CallSnippet
+#include "z/codegen/CallSnippet.hpp"            // for TR::S390CallSnippet
 #include "z/codegen/S390HelperCallSnippet.hpp"
 
 namespace TR { class Node; }
@@ -257,64 +257,64 @@ TR_Debug::printz(TR::FILE *pOutFile, TR::Snippet * snippet)
    switch (snippet->getKind())
       {
       case TR::Snippet::IsCall:
-         print(pOutFile, (TR_S390CallSnippet *) snippet);
+         print(pOutFile, (TR::S390CallSnippet *) snippet);
          break;
       case TR::Snippet::IsHelperCall:
-         print(pOutFile, (TR_S390HelperCallSnippet *) snippet);
+         print(pOutFile, (TR::S390HelperCallSnippet *) snippet);
          break;
 #if J9_PROJECT_SPECIFIC
       case TR::Snippet::IsForceRecomp:
-         print(pOutFile, (TR_S390ForceRecompilationSnippet *) snippet);
+         print(pOutFile, (TR::S390ForceRecompilationSnippet *) snippet);
          break;
       case TR::Snippet::IsForceRecompData:
-         print(pOutFile, (TR_S390ForceRecompilationDataSnippet *) snippet);
+         print(pOutFile, (TR::S390ForceRecompilationDataSnippet *) snippet);
          break;
       case TR::Snippet::IsUnresolvedCall:
-         print(pOutFile, (TR_S390UnresolvedCallSnippet *) snippet);
+         print(pOutFile, (TR::S390UnresolvedCallSnippet *) snippet);
          break;
       case TR::Snippet::IsVirtual:
-         print(pOutFile, (TR_S390VirtualSnippet *) snippet);
+         print(pOutFile, (TR::S390VirtualSnippet *) snippet);
          break;
       case TR::Snippet::IsVirtualUnresolved:
-         print(pOutFile, (TR_S390VirtualUnresolvedSnippet *) snippet);
+         print(pOutFile, (TR::S390VirtualUnresolvedSnippet *) snippet);
          break;
       case TR::Snippet::IsInterfaceCall:
-         print(pOutFile, (TR_S390InterfaceCallSnippet *) snippet);
+         print(pOutFile, (TR::S390InterfaceCallSnippet *) snippet);
          break;
       case TR::Snippet::IsStackCheckFailure:
-         print(pOutFile, (TR_S390StackCheckFailureSnippet *) snippet);
+         print(pOutFile, (TR::S390StackCheckFailureSnippet *) snippet);
          break;
 #endif
       case TR::Snippet::IsLabelTable:
-         print(pOutFile, (TR_S390LabelTableSnippet *) snippet);
+         print(pOutFile, (TR::S390LabelTableSnippet *) snippet);
          break;
       case TR::Snippet::IsConstantData:
       case TR::Snippet::IsWritableData:
       case TR::Snippet::IsEyeCatcherData:
       case TR::Snippet::IsDeclTramp:
       case TR::Snippet::IsSortJumpTramp:
-         print(pOutFile, (TR_S390ConstantDataSnippet *) snippet);
+         print(pOutFile, (TR::S390ConstantDataSnippet *) snippet);
          break;
       case TR::Snippet::IsTargetAddress:
-         print(pOutFile, (TR_S390TargetAddressSnippet *) snippet);
+         print(pOutFile, (TR::S390TargetAddressSnippet *) snippet);
          break;
       case TR::Snippet::IsLookupSwitch:
-         print(pOutFile, (TR_S390LookupSwitchSnippet *) snippet);
+         print(pOutFile, (TR::S390LookupSwitchSnippet *) snippet);
          break;
       case TR::Snippet::IsUnresolvedData:
          print(pOutFile, (TR::UnresolvedDataSnippet *) snippet);
          break;
       case TR::Snippet::IsInterfaceCallData:
-         print(pOutFile, (TR_S390InterfaceCallDataSnippet *) snippet);
+         print(pOutFile, (TR::S390InterfaceCallDataSnippet *) snippet);
          break;
       case TR::Snippet::IsWarmToColdTrampoline:
-         print(pOutFile, (TR_S390WarmToColdTrampolineSnippet *) snippet);
+         print(pOutFile, (TR::S390WarmToColdTrampolineSnippet *) snippet);
          break;
       case TR::Snippet::IsConstantInstruction:
-         print(pOutFile, (TR_S390ConstantInstructionSnippet *) snippet);
+         print(pOutFile, (TR::S390ConstantInstructionSnippet *) snippet);
          break;
       case TR::Snippet::IsRestoreGPR7:
-         print(pOutFile, (TR_S390RestoreGPR7Snippet *) snippet);
+         print(pOutFile, (TR::S390RestoreGPR7Snippet *) snippet);
          break;
 
       /* These types are frontend specific - we use virtual dispatch

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -11491,7 +11491,7 @@ OMR::Z::TreeEvaluator::loadaddrEvaluator(TR::Node * node, TR::CodeGenerator * cg
       uds->setBranchInstruction(cursor);
 
       // create a patchable data in litpool
-      TR_S390WritableDataSnippet * litpool = cg->CreateWritableConstant(node);
+      TR::S390WritableDataSnippet * litpool = cg->CreateWritableConstant(node);
       litpool->setUnresolvedDataSnippet(uds);
 
       TR::S390RILInstruction * LRLinst;
@@ -12343,7 +12343,7 @@ OMR::Z::TreeEvaluator::arraytranslateAndTestEvaluator(TR::Node * node, TR::CodeG
             instr = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BZRC, node, boundCheckFailureLabel); // not find !!
             instr->setStartInternalControlFlow();
             }
-         cg->addSnippet(new (cg->trHeapMemory()) TR_S390HelperCallSnippet(cg, node, boundCheckFailureLabel,
+         cg->addSnippet(new (cg->trHeapMemory()) TR::S390HelperCallSnippet(cg, node, boundCheckFailureLabel,
                                                      comp->getSymRefTab()->findOrCreateArrayBoundsCheckSymbolRef(comp->getMethodSymbol())));
          cg->stopUsingRegister(alenReg);
 
@@ -12454,7 +12454,7 @@ OMR::Z::TreeEvaluator::arraytranslateAndTestEvaluator(TR::Node * node, TR::CodeG
             {
             instr = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BPRC, node, boundCheckFailureLabel);   // if the searching byte is NOT found
             }
-         cg->addSnippet(new (cg->trHeapMemory()) TR_S390HelperCallSnippet(cg, node, boundCheckFailureLabel,
+         cg->addSnippet(new (cg->trHeapMemory()) TR::S390HelperCallSnippet(cg, node, boundCheckFailureLabel,
                                                      comp->getSymRefTab()->findOrCreateArrayBoundsCheckSymbolRef(comp->getMethodSymbol())));
          cg->stopUsingRegister(alenReg);
 

--- a/compiler/z/codegen/S390Debug.cpp
+++ b/compiler/z/codegen/S390Debug.cpp
@@ -1989,7 +1989,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::MemoryReference * mr, TR::Instruction * 
       if (mr->getConstantDataSnippet() != NULL)
          {
          uint64_t value;
-         TR_S390ConstantDataSnippet * cnstDataSnip = mr->getConstantDataSnippet();
+         TR::S390ConstantDataSnippet * cnstDataSnip = mr->getConstantDataSnippet();
 
          switch (cnstDataSnip->getConstantSize())
             {

--- a/compiler/z/codegen/S390GenerateInstructions.cpp
+++ b/compiler/z/codegen/S390GenerateInstructions.cpp
@@ -63,7 +63,7 @@
 #include "infra/Assert.hpp"                       // for TR_ASSERT
 #include "infra/List.hpp"                         // for List
 #include "ras/Debug.hpp"                          // for TR_DebugBase
-#include "z/codegen/CallSnippet.hpp"              // for TR_S390CallSnippet
+#include "z/codegen/CallSnippet.hpp"              // for TR::S390CallSnippet
 #include "z/codegen/S390Instruction.hpp"          // for etc
 
 
@@ -317,7 +317,7 @@ generateS390CompareAndBranchInstruction(TR::CodeGenerator * cg,
       // Generate a temporary warm trampoline for warm -> cold code cache branches.
       if (cg->getIsInWarmCodeCache() && targetIsFarAndCold)
          {
-         TR_S390WarmToColdTrampolineSnippet * trampolineSnippet = new (INSN_HEAP) TR_S390WarmToColdTrampolineSnippet(cg, node,  TR::LabelSymbol::create(INSN_HEAP,cg), branchDestination);
+         TR::S390WarmToColdTrampolineSnippet * trampolineSnippet = new (INSN_HEAP) TR::S390WarmToColdTrampolineSnippet(cg, node,  TR::LabelSymbol::create(INSN_HEAP,cg), branchDestination);
          ((TR::S390RIEInstruction*)returnInstruction)->setWarmToColdTrampolineSnippet(trampolineSnippet);
          cg->addSnippet(trampolineSnippet);
          }
@@ -418,7 +418,7 @@ generateS390CompareAndBranchInstruction(TR::CodeGenerator * cg,
       // Generate a temporary warm trampoline for warm -> cold code cache branches.
       if (cg->getIsInWarmCodeCache() && targetIsFarAndCold)
          {
-         TR_S390WarmToColdTrampolineSnippet * trampolineSnippet = new (INSN_HEAP) TR_S390WarmToColdTrampolineSnippet(cg, node,  TR::LabelSymbol::create(INSN_HEAP,cg), branchDestination);
+         TR::S390WarmToColdTrampolineSnippet * trampolineSnippet = new (INSN_HEAP) TR::S390WarmToColdTrampolineSnippet(cg, node,  TR::LabelSymbol::create(INSN_HEAP,cg), branchDestination);
          ((TR::S390RIEInstruction*)cursor)->setWarmToColdTrampolineSnippet(trampolineSnippet);
          cg->addSnippet(trampolineSnippet);
          }
@@ -791,8 +791,8 @@ generateRXInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
          //so we will assume that at this moment the second child of BCDCHKNode is the label.
          TR::LabelSymbol * label = (TR::LabelSymbol *)BCDCHKNode->getChild(1);
 
-         TR_S390RestoreGPR7Snippet * restoreSnippet =
-                        new (INSN_HEAP) TR_S390RestoreGPR7Snippet(cg, n,  TR::LabelSymbol::create(INSN_HEAP,cg), label);
+         TR::S390RestoreGPR7Snippet * restoreSnippet =
+                        new (INSN_HEAP) TR::S390RestoreGPR7Snippet(cg, n,  TR::LabelSymbol::create(INSN_HEAP,cg), label);
          cg->addSnippet(restoreSnippet);
          TR::Instruction * nop = new (INSN_HEAP) TR::S390NOPInstruction(TR::InstOpCode::NOP, 2, n, cg);
          TR::Instruction* brcInstr = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_NOP, n, restoreSnippet->getSnippetLabel());
@@ -831,8 +831,8 @@ generateRXInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
          //so we will assume that at this moment the second child of BCDCHKNode is the label.
          TR::LabelSymbol * label = (TR::LabelSymbol *)BCDCHKNode->getChild(1);
 
-         TR_S390RestoreGPR7Snippet * restoreSnippet =
-                        new (INSN_HEAP) TR_S390RestoreGPR7Snippet(cg, n,  TR::LabelSymbol::create(INSN_HEAP,cg), label);
+         TR::S390RestoreGPR7Snippet * restoreSnippet =
+                        new (INSN_HEAP) TR::S390RestoreGPR7Snippet(cg, n,  TR::LabelSymbol::create(INSN_HEAP,cg), label);
          cg->addSnippet(restoreSnippet);
          TR::Instruction * nop = new (INSN_HEAP) TR::S390NOPInstruction(TR::InstOpCode::NOP, 2, n, cg);
          TR::Instruction* brcInstr = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_NOP, n, restoreSnippet->getSnippetLabel());
@@ -883,8 +883,8 @@ generateRXYInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
          //so we will assume that at this moment the second child of BCDCHKNode is the label.
          TR::LabelSymbol * label = (TR::LabelSymbol *)BCDCHKNode->getChild(1);
 
-         TR_S390RestoreGPR7Snippet * restoreSnippet =
-                        new (INSN_HEAP) TR_S390RestoreGPR7Snippet(cg, n,  TR::LabelSymbol::create(INSN_HEAP,cg), label);
+         TR::S390RestoreGPR7Snippet * restoreSnippet =
+                        new (INSN_HEAP) TR::S390RestoreGPR7Snippet(cg, n,  TR::LabelSymbol::create(INSN_HEAP,cg), label);
          cg->addSnippet(restoreSnippet);
          TR::Instruction* brcInstr = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_NOP, n, restoreSnippet->getSnippetLabel());
 
@@ -955,8 +955,8 @@ generateRXYInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
          //so we will assume that at this moment the second child of BCDCHKNode is the label.
          TR::LabelSymbol * label = (TR::LabelSymbol *)BCDCHKNode->getChild(1);
 
-         TR_S390RestoreGPR7Snippet * restoreSnippet =
-                        new (INSN_HEAP) TR_S390RestoreGPR7Snippet(cg, n,  TR::LabelSymbol::create(INSN_HEAP,cg), label);
+         TR::S390RestoreGPR7Snippet * restoreSnippet =
+                        new (INSN_HEAP) TR::S390RestoreGPR7Snippet(cg, n,  TR::LabelSymbol::create(INSN_HEAP,cg), label);
          cg->addSnippet(restoreSnippet);
          TR::Instruction* brcInstr =generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_NOP, n, restoreSnippet->getSnippetLabel());
 
@@ -1005,8 +1005,8 @@ generateRXYInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
          //so we will assume that at this moment the second child of BCDCHKNode is the label.
          TR::LabelSymbol * label = (TR::LabelSymbol *)BCDCHKNode->getChild(1);
 
-         TR_S390RestoreGPR7Snippet * restoreSnippet =
-                        new (INSN_HEAP) TR_S390RestoreGPR7Snippet(cg, n,  TR::LabelSymbol::create(INSN_HEAP,cg), label);
+         TR::S390RestoreGPR7Snippet * restoreSnippet =
+                        new (INSN_HEAP) TR::S390RestoreGPR7Snippet(cg, n,  TR::LabelSymbol::create(INSN_HEAP,cg), label);
          cg->addSnippet(restoreSnippet);
          TR::Instruction* brcInstr = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_NOP, n, restoreSnippet->getSnippetLabel());
 
@@ -1573,8 +1573,8 @@ generateSS2Instruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
          //so we will assume that at this moment the second child of BCDCHKNode is the label.
          TR::LabelSymbol * label = (TR::LabelSymbol *)BCDCHKNode->getChild(1);
 
-         TR_S390RestoreGPR7Snippet * restoreSnippet =
-                        new (INSN_HEAP) TR_S390RestoreGPR7Snippet(cg, n,  TR::LabelSymbol::create(INSN_HEAP,cg), label);
+         TR::S390RestoreGPR7Snippet * restoreSnippet =
+                        new (INSN_HEAP) TR::S390RestoreGPR7Snippet(cg, n,  TR::LabelSymbol::create(INSN_HEAP,cg), label);
          cg->addSnippet(restoreSnippet);
          TR::Instruction* brcInstr = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_NOP, n, restoreSnippet->getSnippetLabel());
 
@@ -1618,8 +1618,8 @@ generateSS3Instruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
          //so we will assume that at this moment the second child of BCDCHKNode is the label.
          TR::LabelSymbol * label = (TR::LabelSymbol *)BCDCHKNode->getChild(1);
 
-         TR_S390RestoreGPR7Snippet * restoreSnippet =
-                        new (INSN_HEAP) TR_S390RestoreGPR7Snippet(cg, n,  TR::LabelSymbol::create(INSN_HEAP,cg), label);
+         TR::S390RestoreGPR7Snippet * restoreSnippet =
+                        new (INSN_HEAP) TR::S390RestoreGPR7Snippet(cg, n,  TR::LabelSymbol::create(INSN_HEAP,cg), label);
          cg->addSnippet(restoreSnippet);
          TR::Instruction* brcInstr = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_NOP, n, restoreSnippet->getSnippetLabel());
 
@@ -1656,8 +1656,8 @@ generateSS3Instruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
          //so we will assume that at this moment the second child of BCDCHKNode is the label.
          TR::LabelSymbol * label = (TR::LabelSymbol *)BCDCHKNode->getChild(1);
 
-         TR_S390RestoreGPR7Snippet * restoreSnippet =
-                        new (INSN_HEAP) TR_S390RestoreGPR7Snippet(cg, n,  TR::LabelSymbol::create(INSN_HEAP,cg), label);
+         TR::S390RestoreGPR7Snippet * restoreSnippet =
+                        new (INSN_HEAP) TR::S390RestoreGPR7Snippet(cg, n,  TR::LabelSymbol::create(INSN_HEAP,cg), label);
          cg->addSnippet(restoreSnippet);
          TR::Instruction* brcInstr = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_NOP, n, restoreSnippet->getSnippetLabel());
 
@@ -2273,7 +2273,7 @@ generateDirectCall(TR::CodeGenerator * cg, TR::Node * callNode, bool myself, TR:
 
    AOTcgDiag2(comp, "\nimm=%x isHelper=%x\n", imm, isHelper);
 
-   TR_S390TargetAddressSnippet * targetsnippet;
+   TR::S390TargetAddressSnippet * targetsnippet;
 
    // Since N3 generate TR::InstOpCode::BRASL -- only need 1 instruction, and no worry
    // about the displacement
@@ -2394,7 +2394,7 @@ generateSnippetCall(TR::CodeGenerator * cg, TR::Node * callNode, TR::Snippet * s
       }
 
    TR_ASSERT( s->isCallSnippet(), "targetSnippet is NOT CallSnippet ");
-   ((TR_S390CallSnippet *) s)->setBranchInstruction(callInstr);
+   ((TR::S390CallSnippet *) s)->setBranchInstruction(callInstr);
    return callInstr;
    }
 
@@ -2437,7 +2437,7 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
    TR::Compilation *comp = cg->comp();
    bool alloc = false;
    TR::Instruction * cursor;
-   TR_S390ConstantDataSnippet * targetsnippet = 0;
+   TR::S390ConstantDataSnippet * targetsnippet = 0;
    TR::MemoryReference * dataref = 0;
    TR::S390RILInstruction *LRLinst = 0;
    if (cg->isLiteralPoolOnDemandOn() && (base == 0))
@@ -2517,7 +2517,7 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
 
    if (op == TR::InstOpCode::LG || op == TR::InstOpCode::L)
       {
-      TR_S390ConstantDataSnippet *targetSnippet;
+      TR::S390ConstantDataSnippet *targetSnippet;
       if(op == TR::InstOpCode::LG)
          targetSnippet = cg->findOrCreate8ByteConstant(node, (int64_t)imm);
       else
@@ -2614,14 +2614,14 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
    {
    bool alloc = false;
    TR::Instruction * cursor;
-   TR_S390ConstantDataSnippet * targetsnippet = 0;
+   TR::S390ConstantDataSnippet * targetsnippet = 0;
    TR::MemoryReference * dataref = 0;
    TR::S390RILInstruction *LGRLinst = 0;
    TR::Compilation *comp = cg->comp();
 
    if (TR::InstOpCode(op).getInstructionFormat() == RIL_FORMAT)
       {
-      TR_S390ConstantDataSnippet * constDataSnip = cg->create64BitLiteralPoolSnippet(TR::Int64, imm);
+      TR::S390ConstantDataSnippet * constDataSnip = cg->create64BitLiteralPoolSnippet(TR::Int64, imm);
 
       // HCR in generateRegLitRefInstruction 64-bit: register const data snippet used by Z6
       if (comp->getOption(TR_EnableHCR) && isPICCandidate )
@@ -2936,7 +2936,7 @@ generateEXDispatch(TR::Node * node, TR::CodeGenerator *cg, TR::Register * maskRe
          }
 
       //create a memory reference to that instruction
-      TR_S390ConstantInstructionSnippet * cis = cg->createConstantInstruction(cg, node, instr);
+      TR::S390ConstantInstructionSnippet * cis = cg->createConstantInstruction(cg, node, instr);
       TR::MemoryReference * tempMR = generateS390MemoryReference(cis, cg, litPool, node);
 
       //the memory reference should create a constant data snippet

--- a/compiler/z/codegen/S390HelperCallSnippet.cpp
+++ b/compiler/z/codegen/S390HelperCallSnippet.cpp
@@ -36,12 +36,12 @@
 #include "infra/Assert.hpp"                     // for TR_ASSERT
 #include "ras/Debug.hpp"                        // for TR_Debug
 #include "runtime/Runtime.hpp"
-#include "z/codegen/CallSnippet.hpp"            // for TR_S390CallSnippet
+#include "z/codegen/CallSnippet.hpp"            // for TR::S390CallSnippet
 
 namespace TR { class Node; }
 
 uint8_t *
-TR_S390HelperCallSnippet::emitSnippetBody()
+TR::S390HelperCallSnippet::emitSnippetBody()
    {
    uint8_t * cursor = cg()->getBinaryBufferCursor();
    getSnippetLabel()->setCodeLocation(cursor);
@@ -52,7 +52,7 @@ TR_S390HelperCallSnippet::emitSnippetBody()
    if (jitInduceOSR)
       {
       // Flush in-register arguments back to the stack for interpreter
-      cursor = TR_S390CallSnippet::S390flushArgumentsToStack(cursor, callNode, getSizeOfArguments(), cg());
+      cursor = TR::S390CallSnippet::S390flushArgumentsToStack(cursor, callNode, getSizeOfArguments(), cg());
       }
 
 
@@ -133,7 +133,7 @@ TR_S390HelperCallSnippet::emitSnippetBody()
    }
 
 uint32_t
-TR_S390HelperCallSnippet::getLength(int32_t)
+TR::S390HelperCallSnippet::getLength(int32_t)
    {
    uint32_t length;
    TR::SymbolReference * helperSymRef = getHelperSymRef();
@@ -143,7 +143,7 @@ TR_S390HelperCallSnippet::getLength(int32_t)
 
    if (helperSymRef == cg()->symRefTab()->element(TR_induceOSRAtCurrentPC))
       {
-      length += TR_S390CallSnippet::instructionCountForArguments(getNode(), cg());
+      length += TR::S390CallSnippet::instructionCountForArguments(getNode(), cg());
       }
 
    length += getLoadVMThreadInstructionLength(cg());
@@ -154,7 +154,7 @@ TR_S390HelperCallSnippet::getLength(int32_t)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390HelperCallSnippet * snippet)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390HelperCallSnippet * snippet)
    {
    // *this    swipeable for debugging purposes
    if (pOutFile == NULL)

--- a/compiler/z/codegen/S390HelperCallSnippet.hpp
+++ b/compiler/z/codegen/S390HelperCallSnippet.hpp
@@ -30,7 +30,9 @@ namespace TR { class CodeGenerator; }
 namespace TR { class LabelSymbol; }
 namespace TR { class Node; }
 
-class TR_S390HelperCallSnippet : public TR::Snippet
+namespace TR {
+
+class S390HelperCallSnippet : public TR::Snippet
    {
    TR::LabelSymbol           *_reStartLabel;         ///< Label of Return Address in Main Line Code.
    TR::SymbolReference      *_helperSymRef;         ///< Helper Symbol Reference.
@@ -38,12 +40,12 @@ class TR_S390HelperCallSnippet : public TR::Snippet
 
    public:
 
-   TR_S390HelperCallSnippet(TR::CodeGenerator        *cg,
-                            TR::Node                 *node,
-                            TR::LabelSymbol           *snippetlab,
-                            TR::SymbolReference      *helper,
-                            TR::LabelSymbol           *restartlab = NULL,
-			                int32_t                  s = 0)
+   S390HelperCallSnippet(TR::CodeGenerator        *cg,
+                         TR::Node                 *node,
+                         TR::LabelSymbol           *snippetlab,
+                         TR::SymbolReference      *helper,
+                         TR::LabelSymbol           *restartlab = NULL,
+                         int32_t                  s = 0)
       : TR::Snippet(cg, node, snippetlab, (restartlab == NULL)),
         _reStartLabel(restartlab),
         _helperSymRef(helper),
@@ -76,5 +78,7 @@ class TR_S390HelperCallSnippet : public TR::Snippet
 
    virtual uint32_t getLength(int32_t);
    };
+
+}
 
 #endif

--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -2876,7 +2876,7 @@ TR::S390RIEInstruction::generateBinaryEncoding()
       else if (getWarmToColdTrampolineSnippet() &&  trampolineDistance >= MIN_IMMEDIATE_VAL && trampolineDistance <= MAX_IMMEDIATE_VAL)
          {
          cg()->addRelocation(new (cg()->trHeapMemory()) TR_16BitLabelRelativeRelocation(cursor, getWarmToColdTrampolineSnippet()->getSnippetLabel()));
-         ((TR_S390WarmToColdTrampolineSnippet*)getWarmToColdTrampolineSnippet())->setIsUsed(true);
+         ((TR::S390WarmToColdTrampolineSnippet*)getWarmToColdTrampolineSnippet())->setIsUsed(true);
          }
       else
          {
@@ -5095,7 +5095,7 @@ TR::S390NOPInstruction::generateBinaryEncoding()
             {
             // Snippet is beyond 16 bit relative relocation distance.
             // In this case, we have to activate our pseudo branch around call descriptor
-            getCallDescInstr()->setCallDescValue(((TR_S390ConstantDataSnippet *)getTargetSnippet())->getDataAs8Bytes(), cg()->trMemory());
+            getCallDescInstr()->setCallDescValue(((TR::S390ConstantDataSnippet *)getTargetSnippet())->getDataAs8Bytes(), cg()->trMemory());
             cg()->addRelocation(new (cg()->trHeapMemory()) TR_16BitLabelRelativeRelocation(cursor+2, getCallDescInstr()->getCallDescLabel(),8));
 
             }

--- a/compiler/z/codegen/S390Snippets.cpp
+++ b/compiler/z/codegen/S390Snippets.cpp
@@ -22,7 +22,7 @@
 #include "env/IO.hpp"
 
 uint32_t
-TR_S390WarmToColdTrampolineSnippet::getLength(int32_t estimatedSnippetStart)
+TR::S390WarmToColdTrampolineSnippet::getLength(int32_t estimatedSnippetStart)
    {
    // BRCL - 6 bytes
    return 6;
@@ -30,7 +30,7 @@ TR_S390WarmToColdTrampolineSnippet::getLength(int32_t estimatedSnippetStart)
 
 
 uint8_t *
-TR_S390WarmToColdTrampolineSnippet::emitSnippetBody()
+TR::S390WarmToColdTrampolineSnippet::emitSnippetBody()
    {
    uint8_t * cursor = cg()->getBinaryBufferCursor();
    getSnippetLabel()->setCodeLocation(cursor);
@@ -52,7 +52,7 @@ TR_S390WarmToColdTrampolineSnippet::emitSnippetBody()
 
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390WarmToColdTrampolineSnippet *snippet)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390WarmToColdTrampolineSnippet *snippet)
    {
    uint8_t * buffer = snippet->getSnippetLabel()->getCodeLocation();
 

--- a/compiler/z/codegen/S390Snippets.hpp
+++ b/compiler/z/codegen/S390Snippets.hpp
@@ -25,23 +25,24 @@ namespace TR { class CodeGenerator; }
 namespace TR { class LabelSymbol; }
 namespace TR { class Node; }
 
+namespace TR {
 
 /**
  * Create trampolines from warm code to cold code, when branch targets is not
  * reachable by compare-and-branch instructions.
  */
-class TR_S390WarmToColdTrampolineSnippet : public TR::Snippet
+class S390WarmToColdTrampolineSnippet : public TR::Snippet
    {
    TR::LabelSymbol * _targetLabel;
 
 public:
-   TR_S390WarmToColdTrampolineSnippet(TR::CodeGenerator* cg, TR::Node *c, TR::LabelSymbol *lab, TR::LabelSymbol *targetLabel)
+   S390WarmToColdTrampolineSnippet(TR::CodeGenerator* cg, TR::Node *c, TR::LabelSymbol *lab, TR::LabelSymbol *targetLabel)
       : TR::Snippet(cg, c, lab, false), _targetLabel(targetLabel)
       {
       setWarmSnippet();
       }
 
-   TR_S390WarmToColdTrampolineSnippet(TR::CodeGenerator* cg, TR::Node *c, TR::LabelSymbol *lab, TR::Snippet *targetSnippet)
+   S390WarmToColdTrampolineSnippet(TR::CodeGenerator* cg, TR::Node *c, TR::LabelSymbol *lab, TR::Snippet *targetSnippet)
       : TR::Snippet(cg, c, lab, false), _targetLabel(targetSnippet->getSnippetLabel())
       {
       setWarmSnippet();
@@ -60,17 +61,17 @@ public:
    };
 
 
-class TR_S390RestoreGPR7Snippet : public TR::Snippet
+class S390RestoreGPR7Snippet : public TR::Snippet
    {
    TR::LabelSymbol * _targetLabel;
 
 public:
-   TR_S390RestoreGPR7Snippet(TR::CodeGenerator* cg, TR::Node *c, TR::LabelSymbol *lab, TR::LabelSymbol *targetLabel)
+   S390RestoreGPR7Snippet(TR::CodeGenerator* cg, TR::Node *c, TR::LabelSymbol *lab, TR::LabelSymbol *targetLabel)
       : TR::Snippet(cg, c, lab, false), _targetLabel(targetLabel)
       {
       }
 
-   TR_S390RestoreGPR7Snippet(TR::CodeGenerator* cg, TR::Node *c, TR::LabelSymbol *lab, TR::Snippet *targetSnippet)
+   S390RestoreGPR7Snippet(TR::CodeGenerator* cg, TR::Node *c, TR::LabelSymbol *lab, TR::Snippet *targetSnippet)
       : TR::Snippet(cg, c, lab, false), _targetLabel(targetSnippet->getSnippetLabel())
       {
       }
@@ -86,5 +87,7 @@ public:
    virtual Kind getKind() { return IsRestoreGPR7; }
 
    };
+
+}
 
 #endif

--- a/compiler/z/codegen/S390SystemLinkage.hpp
+++ b/compiler/z/codegen/S390SystemLinkage.hpp
@@ -44,7 +44,7 @@ namespace OMR { typedef TR_S390SystemLinkage SystemLinkageConnector; }
 #include "infra/Array.hpp"                     // for TR_Array
 #include "infra/Assert.hpp"                    // for TR_ASSERT
 
-class TR_S390JNICallDataSnippet;
+namespace TR { class S390JNICallDataSnippet; }
 namespace TR { class Block; }
 namespace TR { class CodeGenerator; }
 namespace TR { class Instruction; }
@@ -217,10 +217,10 @@ public:
 
    virtual void generateInstructionsForCall(TR::Node * callNode, TR::RegisterDependencyConditions * dependencies,
          intptrj_t targetAddress, TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel,
-         TR_S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint = true);
+         TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint = true);
 
    virtual TR::Register * callNativeFunction(TR::Node * callNode, TR::RegisterDependencyConditions * dependencies,
-      intptrj_t targetAddress, TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel, TR_S390JNICallDataSnippet * jniCallDataSnippet,
+      intptrj_t targetAddress, TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel, TR::S390JNICallDataSnippet * jniCallDataSnippet,
       bool isJNIGCPoint = true);
 
    virtual TR::Register *

--- a/compiler/z/codegen/SystemLinkage.cpp
+++ b/compiler/z/codegen/SystemLinkage.cpp
@@ -953,7 +953,7 @@ TR_S390zLinuxSystemLinkage::TR_S390zLinuxSystemLinkage(TR::CodeGenerator * codeG
 void
 TR_S390SystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR::RegisterDependencyConditions * deps, intptrj_t targetAddress,
       TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel,
-      TR_S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint)
+      TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint)
    {
    TR_ASSERT(0,"Different system types should have their own implementation.");
    }
@@ -965,7 +965,7 @@ TR_S390SystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR::Regis
 TR::Register *
 TR_S390SystemLinkage::callNativeFunction(TR::Node * callNode, TR::RegisterDependencyConditions * deps, intptrj_t targetAddress,
       TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel,
-      TR_S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint)
+      TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint)
    {
    return 0;
    }
@@ -976,7 +976,7 @@ TR_S390SystemLinkage::callNativeFunction(TR::Node * callNode, TR::RegisterDepend
 void
 TR_S390zOSSystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR::RegisterDependencyConditions * deps, intptrj_t targetAddress,
       TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel,
-      TR_S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint)
+      TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint)
    {
  #if defined(PYTHON) || defined(OMR_RUBY) || defined(JITTEST)
    TR_ASSERT(0,"Python/Ruby/Test should have their own front-end customization.");
@@ -991,7 +991,7 @@ TR_S390zOSSystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR::Re
 TR::Register *
 TR_S390zOSSystemLinkage::callNativeFunction(TR::Node * callNode, TR::RegisterDependencyConditions * deps, intptrj_t targetAddress,
       TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel,
-      TR_S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint)
+      TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint)
    {
 
    /*****************************/
@@ -1108,7 +1108,7 @@ TR_S390zOSSystemLinkage::callNativeFunction(TR::Node * callNode, TR::RegisterDep
 void
 TR_S390zLinuxSystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR::RegisterDependencyConditions * deps, intptrj_t targetAddress,
       TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel,
-      TR_S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint)
+      TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint)
    {
    TR::CodeGenerator * codeGen = cg();
 
@@ -1150,7 +1150,7 @@ TR::Register *
 TR_S390zLinuxSystemLinkage::callNativeFunction(TR::Node * callNode,
    TR::RegisterDependencyConditions * deps, intptrj_t targetAddress,
    TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel,
-   TR_S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint)
+   TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint)
    {
    /********************************/
    /***Generate call instructions***/

--- a/compiler/z/codegen/TRSystemLinkage.hpp
+++ b/compiler/z/codegen/TRSystemLinkage.hpp
@@ -34,8 +34,8 @@
 #include "il/SymbolReference.hpp"                 // for SymbolReference
 
 class TR_EntryPoint;
-class TR_S390ConstantDataSnippet;
-class TR_S390JNICallDataSnippet;
+namespace TR { class S390ConstantDataSnippet; }
+namespace TR { class S390JNICallDataSnippet; }
 namespace TR { class AutomaticSymbol; }
 namespace TR { class CodeGenerator; }
 namespace TR { class Instruction; }
@@ -86,10 +86,10 @@ public:
 
    virtual void generateInstructionsForCall(TR::Node * callNode, TR::RegisterDependencyConditions * dependencies,
          intptrj_t targetAddress, TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel,
-         TR_S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint = true);
+         TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint = true);
 
    virtual TR::Register * callNativeFunction(TR::Node * callNode, TR::RegisterDependencyConditions * dependencies,
-      intptrj_t targetAddress, TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel, TR_S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint = true);
+      intptrj_t targetAddress, TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel, TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint = true);
 
    virtual TR::RealRegister::RegNum setEnvironmentPointerRegister (TR::RealRegister::RegNum r) { return _environmentPointerRegister = r; }
    virtual TR::RealRegister::RegNum getEnvironmentPointerRegister() { return _environmentPointerRegister; }
@@ -161,9 +161,9 @@ public:
 
    virtual void generateInstructionsForCall(TR::Node * callNode, TR::RegisterDependencyConditions * deps, intptrj_t targetAddress,
          TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel,
-         TR_S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint);
+         TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint);
    virtual TR::Register * callNativeFunction(TR::Node * callNode, TR::RegisterDependencyConditions * dependencies,
-      intptrj_t targetAddress, TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel, TR_S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint = true);
+      intptrj_t targetAddress, TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel, TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint = true);
 
    virtual void setGOTPointerRegister (TR::RealRegister::RegNum r)         { _GOTPointerRegister = r; }
    virtual TR::RealRegister::RegNum getGOTPointerRegister()         { return _GOTPointerRegister; }

--- a/fvtest/compilertest/z/codegen/Evaluator.cpp
+++ b/fvtest/compilertest/z/codegen/Evaluator.cpp
@@ -30,21 +30,21 @@
 
 
 uint32_t
-TR_S390RestoreGPR7Snippet::getLength(int32_t estimatedSnippetStart)
+TR::S390RestoreGPR7Snippet::getLength(int32_t estimatedSnippetStart)
    {
    NOT_IMPLEMENTED;
    return 0;
    }
 
 uint8_t *
-TR_S390RestoreGPR7Snippet::emitSnippetBody()
+TR::S390RestoreGPR7Snippet::emitSnippetBody()
    {
    NOT_IMPLEMENTED;
    return NULL;
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390RestoreGPR7Snippet *snippet)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390RestoreGPR7Snippet *snippet)
    {
    NOT_IMPLEMENTED;
    }

--- a/jitbuilder/z/codegen/Evaluator.cpp
+++ b/jitbuilder/z/codegen/Evaluator.cpp
@@ -30,21 +30,21 @@
 
 
 uint32_t
-TR_S390RestoreGPR7Snippet::getLength(int32_t estimatedSnippetStart)
+TR::S390RestoreGPR7Snippet::getLength(int32_t estimatedSnippetStart)
    {
    NOT_IMPLEMENTED;
    return 0;
    }
 
 uint8_t *
-TR_S390RestoreGPR7Snippet::emitSnippetBody()
+TR::S390RestoreGPR7Snippet::emitSnippetBody()
    {
    NOT_IMPLEMENTED;
    return NULL;
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR_S390RestoreGPR7Snippet *snippet)
+TR_Debug::print(TR::FILE *pOutFile, TR::S390RestoreGPR7Snippet *snippet)
    {
    NOT_IMPLEMENTED;
    }


### PR DESCRIPTION
This is part of moving all classes from using the TR_ prefix to the TR namespace.

This also moves a few unprefixed functions, such as `createCCPreLoadedCode` and `getCCPreLoadedCodeSize`, to the TR namespace.