### PR TITLE
Adding a few macros and assembly defines

### DIFF
--- a/compiler/p/runtime/ppcasmdefines.inc
+++ b/compiler/p/runtime/ppcasmdefines.inc
@@ -287,7 +287,7 @@
         .macro lvx      vrt, ra, rb
         .int 0x7c0000ce | \vrt << 21 | \ra << 16 | \rb << 11
         .endm
-		.macro lxvw4x   xt, ra, rb
+	.macro lxvw4x   xt, ra, rb
         .int 0x7c000618 | (\xt & 31) << 21 | \ra << 16 | \rb << 11 | (\xt & 32) >> 5
         .endm
         .macro lxvw4ux  xt, ra, rb
@@ -408,6 +408,20 @@
         .macro vsbox   vrt, vra
         .int 0x100005c8 | \vrt << 21 | \vra << 16
         .endm
+
+	.macro vpmsumw	vrt, vra, vrb
+        .int 0x10000488 | (\vrt & 31) << 21 | (\vra & 31) << 16 | (\vrb & 31) << 11 | (\vra & 32) >> 3 | (\vrb & 32) >> 4 | (\vrt & 32) >> 5
+        .endm
+	.macro vpmsumd	vrt, vra, vrb
+	.int 0x100004c8 | (\vrt & 31) << 21 | (\vra & 31) << 16 | (\vrb & 31) << 11 | (\vra & 32) >> 3 | (\vrb & 32) >> 4 | (\vrt & 32) >> 5
+	.endm
+
+        .macro mfvsrd	ra, vrs
+	.int 0x7c000066 | \ra << 16 | (\vrs & 31) << 21 | (\vrs & 32) >> 5
+        .endm
+        .macro mtvsrd	vrt, ra
+	.int 0x7c000166 | \ra << 16 | (\vrt & 31) << 21 | (\vrt & 32) >> 5
+        .endm
 #endif
 
 !The record form instructions break the Linux Assembler, this is the workaround for it
@@ -422,12 +436,20 @@
 #define VNCIPHER(vrt,vra,vrb)           .long 0x10000548 | vrt < 21 | vra < 16 | vrb < 11
 #define VNCIPHERLAST(vrt,vra,vrb)       .long 0x10000549 | vrt < 21 | vra < 16 | vrb < 11
 #define VSBOX(vrt,vra)                  .long 0x100005c8 | vrt < 21 | vra < 16
+#define VPMSUMW(vrt,vra,vrb)		.long 0x10000488 |(vrt & 31) < 21 |(vra & 31) < 16 |(vrb & 31) < 11 |(vra & 32) > 3 |(vrb & 32) > 4 |(vrt & 32) > 5
+#define VPMSUMD(vrt,vra,vrb)		.long 0x100004c8 |(vrt & 31) < 21 |(vra & 31) < 16 |(vrb & 31) < 11 |(vra & 32) > 3 |(vrb & 32) > 4 |(vrt & 32) > 5
+#define MFVSRD(ra, vrs)			.long 0x7c000066 | ra < 16 | (vrs & 31) < 21 | (vrs & 32) > 5
+#define MTVSRD(vrt, ra)			.long 0x7c000166 | ra < 16 | (vrt & 31) < 21 | (vrt & 32) > 5
 #else
 #define VCIPHER(vrt,vra,vrb)            vcipher         vrt, vra, vrb
 #define VCIPHERLAST(vrt,vra,vrb)        vcipherlast     vrt, vra, vrb
 #define VNCIPHER(vrt,vra,vrb)           vncipher        vrt, vra, vrb
 #define VNCIPHERLAST(vrt,vra,vrb)       vncipherlast    vrt, vra, vrb
 #define VSBOX(vrt,vra)                  vsbox           vrt, vra, vrb
+#define VPMSUMW(vrt,vra,vrb)		vpmsumw		vrt, vra, vrb
+#define VPMSUMD(vrt,vra,vrb)		vpmsumd		vrt, vra, vrb
+#define MFVSRD(ra, vrs)			mfvsrd		ra, vrs
+#define MTVSRD(vrt, ra)			mtvsrd		vrt, ra
 #endif
 
 #if defined(LINUXPPC64)


### PR DESCRIPTION
for new POWER8 polynomial multiply and move to/from VSX registers
instructions which most of assemblers don't recognize yet.

Signed-off-by: Julian Wang <zlwang@ca.ibm.com>