### PR TITLE
Remove unused field lockingWord

### DIFF
--- a/gc/base/AtomicOperations.hpp
+++ b/gc/base/AtomicOperations.hpp
@@ -125,7 +125,6 @@ public:
 	 * else retain the <b>oldValue</b>.
 	 * 
 	 * @param address The memory location to be updated
-	 * @param lockingWord The location used to lock the slot for exchange
 	 * @param oldValue The expected value at memory address
 	 * @param newValue The new value to be stored at memory address
 	 * 
@@ -144,7 +143,6 @@ public:
 	 * else retain the <b>oldValue</b>.
 	 * 
 	 * @param address The memory location to be updated
-	 * @param lockingWord The location used to lock the slot for exchange
 	 * @param oldValue The expected value at memory address
 	 * @param newValue The new value to be stored at memory address
 	 * 
@@ -163,7 +161,6 @@ public:
 	 * else retain the <b>oldValue</b>.
 	 * 
 	 * @param address The memory location to be updated
-	 * @param lockingWord The location used to lock the slot for exchange
 	 * @param oldValue The expected value at memory address
 	 * @param newValue The new value to be stored at memory address
 	 * 
@@ -181,7 +178,6 @@ public:
 	 * to by <b>address</b>.
 	 *
 	 * @param address The memory location to be updated
-	 * @param lockingWord The location used to lock the slot for exchange
 	 * @param addend The value to be added
 	 *
 	 * @return The value at memory location <b>address</b> AFTER the add is completed
@@ -198,7 +194,6 @@ public:
 	 * to by <b>address</b>.
 	 *
 	 * @param address The memory location to be updated
-	 * @param lockingWord The location used to lock the slot for exchange
 	 * @param addend The value to be added
 	 *
 	 * @return The value at memory location <b>address</b>
@@ -215,7 +210,6 @@ public:
 	 * to by <b>address</b>.
 	 *
 	 * @param address The memory location to be updated
-	 * @param lockingWord The location used to lock the slot for exchange
 	 * @param addend The value to be added
 	 *
 	 * @return The value at memory location <b>address</b>
@@ -232,7 +226,6 @@ public:
 	 * to by <b>address</b>.
 	 *
 	 * @param address The memory location to be updated
-	 * @param lockingWord The location used to lock the slot for exchange
 	 * @param addend The value to be added
 	 *
 	 * @return The value at memory location <b>address</b>
@@ -249,7 +242,6 @@ public:
 	 * to by <b>address</b>.
 	 * 
 	 * @param address The memory location to be updated
-	 * @param lockingWord The location used to lock the slot for exchange
 	 * @param value The value to be subtracted
 	 * 
 	 * @return The value at memory location <b>address</b>
@@ -266,7 +258,6 @@ public:
 	 * to by <b>address</b>.
 	 * 
 	 * @param address The memory location to be updated
-	 * @param lockingWord The location used to lock the slot for exchange
 	 * @param value The value to be subtracted
 	 * 
 	 * @return The value at memory location <b>address</b>
@@ -283,7 +274,6 @@ public:
 	 * to by <b>address</b>.
 	 *
 	 * @param address The memory location to be updated
-	 * @param lockingWord The location used to lock the slot for exchange
 	 * @param value The value to be subtracted
 	 *
 	 * @return The value at memory location <b>address</b>
@@ -299,7 +289,6 @@ public:
 	 * Stores <b>value</b> at memory location pointed to be <b>address</b>.
 	 * 
 	 * @param address The memory location to be updated
-	 * @param lockingWord The location used to lock the slot for exchange
 	 * @param value The value to be stored
 	 * 
 	 * @note This method can spin indefinitely while attempting to write the new value.
@@ -315,7 +304,6 @@ public:
 	 * Stores <b>value</b> at memory location pointed to be <b>address</b>.
 	 *
 	 * @param address The memory location to be updated
-	 * @param lockingWord The location used to lock the slot for exchange
 	 * @param value The value to be stored
 	 *
 	 * @note This method can spin indefinitely while attempting to write the new value.
@@ -345,7 +333,6 @@ public:
 	 * Subtracts <b>subtrahend</b> from the value stored at memory location pointed to by <b>address</b>, saturing to zero.
 	 * 
 	 * @param address The memory location to be updated
-	 * @param lockingWord The location used to lock the slot for exchange
 	 * @param subtrahend The value to be subtracted
 	 * 
 	 * @return The value at memory location <b>address</b> AFTER the subtraction operation has been completed

--- a/gc/base/gcspinlock.cpp
+++ b/gc/base/gcspinlock.cpp
@@ -148,7 +148,6 @@ omrgc_spinlock_init(J9GCSpinlock *spinlock)
 	intptr_t result;
 
 	spinlock->target = -1;
-	spinlock->lockingWord = 0;
 
 	result = j9sem_init(&spinlock->osSemaphore, 0);
 

--- a/gc/base/gcspinlock.h
+++ b/gc/base/gcspinlock.h
@@ -26,7 +26,6 @@
 typedef struct J9GCSpinlock {
     intptr_t target;
     j9sem_t osSemaphore;
-    uintptr_t lockingWord;
     uintptr_t spinCount1;
     uintptr_t spinCount2;
     uintptr_t spinCount3;

--- a/include_core/omrthread_generated.h
+++ b/include_core/omrthread_generated.h
@@ -158,7 +158,6 @@ typedef struct J9ThreadMonitorTracing {
 #if defined(OMR_THR_THREE_TIER_LOCKING)
 #define J9_ABSTRACT_MONITOR_FIELDS_4 \
     uintptr_t spinlockState; \
-    uintptr_t lockingWord; \
     uintptr_t spinCount1; \
     uintptr_t spinCount2; \
     uintptr_t spinCount3; \

--- a/thread/common/omrthread.c
+++ b/thread/common/omrthread.c
@@ -3562,7 +3562,6 @@ monitor_init(omrthread_monitor_t monitor, uintptr_t flags, omrthread_library_t l
 #ifdef OMR_THR_THREE_TIER_LOCKING
 	monitor->blocking = NULL;
 	monitor->spinlockState = J9THREAD_MONITOR_SPINLOCK_UNOWNED;
-	monitor->lockingWord = 0;
 
 	/* check if we should spin on system monitors that are backing a Object monitor
 	 * the default is now that we do not spin.

--- a/thread/common/threadhelpers.cpp
+++ b/thread/common/threadhelpers.cpp
@@ -38,7 +38,7 @@ omrthread_monitor_unpin(omrthread_monitor_t monitor, omrthread_t self)
 #if defined(OMR_THR_THREE_TIER_LOCKING)
 
 /**
- * Spin on a monitor's lockingWord field until we can atomically swap out a value of SPINLOCK_UNOWNED
+ * Spin on a monitor's spinlockState field until we can atomically swap out a value of SPINLOCK_UNOWNED
  * for the value SPINLOCK_OWNED.
  *
  * @param[in] self the current omrthread_t
@@ -112,7 +112,7 @@ done:
 
 /**
   * Try to atomically swap out a value of SPINLOCK_UNOWNED from
-  * a monitor's lockingWord field for the value SPINLOCK_OWNED.
+  * a monitor's spinlockState field for the value SPINLOCK_OWNED.
   *
   * @param[in] self the current omrthread_t
   * @param[in] monitor the monitor whose spinlock will be acquired


### PR DESCRIPTION
Unused field lockingWord has been removed from:
i) struct J9ThreadMonitor: omrthread_generated.h and omrthread.c
ii) struct J9GCSpinlock: gcspinlock.h and gcspinlock.cpp

Amended or removed lockingWord references in comments within AtomicOperations.hpp and
threadhelpers.cpp

Issue: #463

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>