### PR TITLE
Cleanup the compareAndSwap functions

### DIFF
--- a/fvtest/porttest/omrmemTest.cpp
+++ b/fvtest/porttest/omrmemTest.cpp
@@ -647,11 +647,11 @@ TEST(PortMemTest, mem_test7_allocate32)
 
 static uint32_t childrenOfDummyCategoryOne[] = {DUMMY_CATEGORY_TWO, DUMMY_CATEGORY_THREE, OMRMEM_CATEGORY_PORT_LIBRARY, OMRMEM_CATEGORY_UNKNOWN};
 
-static OMRMemCategory dummyCategoryOne = {"Dummy One", DUMMY_CATEGORY_ONE, 0, 0, 0, 0, 4, childrenOfDummyCategoryOne};
+static OMRMemCategory dummyCategoryOne = {"Dummy One", DUMMY_CATEGORY_ONE, 0, 0, 4, childrenOfDummyCategoryOne};
 
-static OMRMemCategory dummyCategoryTwo = {"Dummy Two", DUMMY_CATEGORY_TWO, 0, 0, 0, 0, 0, NULL};
+static OMRMemCategory dummyCategoryTwo = {"Dummy Two", DUMMY_CATEGORY_TWO, 0, 0, 0, NULL};
 
-static OMRMemCategory dummyCategoryThree = {"Dummy Three", DUMMY_CATEGORY_THREE, 0, 0, 0, 0, 0, NULL};
+static OMRMemCategory dummyCategoryThree = {"Dummy Three", DUMMY_CATEGORY_THREE, 0, 0, 0, NULL};
 
 static OMRMemCategory *categoryList[3] = {&dummyCategoryOne, &dummyCategoryTwo, &dummyCategoryThree};
 

--- a/include_core/omrmemcategories.h
+++ b/include_core/omrmemcategories.h
@@ -31,9 +31,7 @@ typedef struct OMRMemCategory {
 	const char *const name;
 	const uint32_t categoryCode;
 	uintptr_t liveBytes;
-	uintptr_t liveBytesLockWord;
 	uintptr_t liveAllocations;
-	uintptr_t liveAllocationsLockWord;
 	const uint32_t numberOfChildren;
 	const uint32_t *const children;
 } OMRMemCategory;
@@ -88,31 +86,31 @@ typedef struct OMRMemCategorySet {
 #define OMRMEM_OMR_CATEGORY_INDEX_FROM_CODE(code) (((uint32_t)0x7FFFFFFF) & (code))
 
 #define OMRMEM_CATEGORY_NO_CHILDREN(description, code) \
-	static OMRMemCategory _omrmem_category_##code = {description, code, 0, 0, 0, 0, 0, NULL}
+	static OMRMemCategory _omrmem_category_##code = {description, code, 0, 0, 0, NULL}
 #define OMRMEM_CATEGORY_1_CHILD(description, code, c1) \
 	static uint32_t _omrmem_##code##_child_categories[] = {c1}; \
-	static OMRMemCategory _omrmem_category_##code = {description, code, 0, 0, 0, 0, 1, _omrmem_##code##_child_categories}
+	static OMRMemCategory _omrmem_category_##code = {description, code, 0, 0, 1, _omrmem_##code##_child_categories}
 #define OMRMEM_CATEGORY_2_CHILDREN(description, code, c1, c2) \
 	static uint32_t _omrmem_##code##_child_categories[] = {c1, c2}; \
-	static OMRMemCategory _omrmem_category_##code = {description, code, 0, 0, 0, 0, 2, _omrmem_##code##_child_categories}
+	static OMRMemCategory _omrmem_category_##code = {description, code, 0, 0, 2, _omrmem_##code##_child_categories}
 #define OMRMEM_CATEGORY_3_CHILDREN(description, code, c1, c2, c3) \
 	static uint32_t _omrmem_##code##_child_categories[] = {c1, c2, c3}; \
-	static OMRMemCategory _omrmem_category_##code = {description, code, 0, 0, 0, 0, 3, _omrmem_##code##_child_categories}
+	static OMRMemCategory _omrmem_category_##code = {description, code, 0, 0, 3, _omrmem_##code##_child_categories}
 #define OMRMEM_CATEGORY_4_CHILDREN(description, code, c1, c2, c3, c4) \
 	static uint32_t _omrmem_##code##_child_categories[] = {c1, c2, c3, c4}; \
-	static OMRMemCategory _omrmem_category_##code = {description, code, 0, 0, 0, 0, 4, _omrmem_##code##_child_categories}
+	static OMRMemCategory _omrmem_category_##code = {description, code, 0, 0, 4, _omrmem_##code##_child_categories}
 #define OMRMEM_CATEGORY_5_CHILDREN(description, code, c1, c2, c3, c4, c5) \
 	static uint32_t _omrmem_##code##_child_categories[] = {c1, c2, c3, c4, c5}; \
-	static OMRMemCategory _omrmem_category_##code = {description, code, 0, 0, 0, 0, 5, _omrmem_##code##_child_categories}
+	static OMRMemCategory _omrmem_category_##code = {description, code, 0, 0, 5, _omrmem_##code##_child_categories}
 #define OMRMEM_CATEGORY_6_CHILDREN(description, code, c1, c2, c3, c4, c5, c6) \
 	static uint32_t _omrmem_##code##_child_categories[] = {c1, c2, c3, c4, c5, c6}; \
-	static OMRMemCategory _omrmem_category_##code = {description, code, 0, 0, 0, 0, 6, _omrmem_##code##_child_categories}
+	static OMRMemCategory _omrmem_category_##code = {description, code, 0, 0, 6, _omrmem_##code##_child_categories}
 #define OMRMEM_CATEGORY_7_CHILDREN(description, code, c1, c2, c3, c4, c5, c6, c7) \
 	static uint32_t _omrmem_##code##_child_categories[] = {c1, c2, c3, c4, c5, c6, c7}; \
-	static OMRMemCategory _omrmem_category_##code = {description, code, 0, 0, 0, 0, 7, _omrmem_##code##_child_categories}
+	static OMRMemCategory _omrmem_category_##code = {description, code, 0, 0, 7, _omrmem_##code##_child_categories}
 #define OMRMEM_CATEGORY_8_CHILDREN(description, code, c1, c2, c3, c4, c5, c6, c7, c8) \
 	static uint32_t _omrmem_##code##_child_categories[] = {c1, c2, c3, c4, c5, c6, c7, c8}; \
-	static OMRMemCategory _omrmem_category_##code = {description, code, 0, 0, 0, 0, 8, _omrmem_##code##_child_categories}
+	static OMRMemCategory _omrmem_category_##code = {description, code, 0, 0, 8, _omrmem_##code##_child_categories}
 
 #define CATEGORY_TABLE_ENTRY(name) &_omrmem_category_##name
 

--- a/include_core/omrutilbase.h
+++ b/include_core/omrutilbase.h
@@ -26,10 +26,8 @@ extern "C" {
 #endif /* defined(__cplusplus) */
 
 /* ---------------- AtomicFunctions.cpp ---------------- */
-uintptr_t compareAndSwapUDATA(uintptr_t *location, uintptr_t oldValue, uintptr_t newValue, uintptr_t *spinlock);
-uintptr_t compareAndSwapUDATANoSpinlock(uintptr_t *location, uintptr_t oldValue, uintptr_t newValue);
-uint32_t compareAndSwapU32(uint32_t *location, uint32_t oldValue, uint32_t newValue, uintptr_t *spinlock);
-uint32_t compareAndSwapU32NoSpinlock(uint32_t *location, uint32_t oldValue, uint32_t newValue);
+uintptr_t compareAndSwapUDATA(uintptr_t *location, uintptr_t oldValue, uintptr_t newValue);
+uint32_t compareAndSwapU32(uint32_t *location, uint32_t oldValue, uint32_t newValue);
 void issueReadBarrier(void);
 void issueReadWriteBarrier(void);
 void issueWriteBarrier(void);

--- a/port/common/omrmemcategories.c
+++ b/port/common/omrmemcategories.c
@@ -40,8 +40,7 @@
 /* J9VMAtomicFunctions*/
 #ifndef _J9VMATOMICFUNCTIONS_
 #define _J9VMATOMICFUNCTIONS_
-extern uintptr_t compareAndSwapUDATA(uintptr_t *location, uintptr_t oldValue, uintptr_t newValue, uintptr_t *spinlock);
-extern uint32_t compareAndSwapU32(uint32_t *location, uint32_t oldValue, uint32_t newValue, uintptr_t *spinlock);
+extern uintptr_t compareAndSwapUDATA(uintptr_t *location, uintptr_t oldValue, uintptr_t newValue);
 #endif /* _J9VMATOMICFUNCTIONS_ */
 
 
@@ -71,7 +70,7 @@ omrmem_categories_increment_counters(OMRMemCategory *category, uintptr_t size)
 	/* Increment block count */
 	do {
 		oldValue = category->liveAllocations;
-	} while (compareAndSwapUDATA(&category->liveAllocations, oldValue, oldValue + 1, & category->liveAllocationsLockWord) != oldValue);
+	} while (compareAndSwapUDATA(&category->liveAllocations, oldValue, oldValue + 1) != oldValue);
 
 	omrmem_categories_increment_bytes(category, size);
 }
@@ -91,7 +90,7 @@ omrmem_categories_increment_bytes(OMRMemCategory *category, uintptr_t size)
 	/* Increment bytes */
 	do {
 		oldValue = category->liveBytes;
-	} while (compareAndSwapUDATA(&category->liveBytes, oldValue, oldValue + size, &category->liveBytesLockWord) != oldValue);
+	} while (compareAndSwapUDATA(&category->liveBytes, oldValue, oldValue + size) != oldValue);
 }
 
 /**
@@ -109,7 +108,7 @@ omrmem_categories_decrement_counters(OMRMemCategory *category, uintptr_t size)
 	/* Decrement block count */
 	do {
 		oldValue = category->liveAllocations;
-	} while (compareAndSwapUDATA(&category->liveAllocations, oldValue, oldValue - 1, & category->liveAllocationsLockWord) != oldValue);
+	} while (compareAndSwapUDATA(&category->liveAllocations, oldValue, oldValue - 1) != oldValue);
 
 	omrmem_categories_decrement_bytes(category, size);
 }
@@ -129,7 +128,7 @@ omrmem_categories_decrement_bytes(OMRMemCategory *category, uintptr_t size)
 	/* Decrement size */
 	do {
 		oldValue = category->liveBytes;
-	} while (compareAndSwapUDATA(&category->liveBytes, oldValue, oldValue - size, &category->liveBytesLockWord) != oldValue);
+	} while (compareAndSwapUDATA(&category->liveBytes, oldValue, oldValue - size) != oldValue);
 }
 
 /**

--- a/thread/common/omrthreadmem.cpp
+++ b/thread/common/omrthreadmem.cpp
@@ -28,14 +28,14 @@ extern "C" {
 /* Template category data to be copied into the thread library structure in omrthread_mem_init */
 #if defined(OMR_THR_FORK_SUPPORT)
 const uint32_t threadCategoryChildren[] = {OMRMEM_CATEGORY_THREADS_RUNTIME_STACK, OMRMEM_CATEGORY_THREADS_NATIVE_STACK, OMRMEM_CATEGORY_OSMUTEXES, OMRMEM_CATEGORY_OSCONDVARS};
-const OMRMemCategory threadCategoryTemplate = { "Threads", OMRMEM_CATEGORY_THREADS, 0, 0, 0, 0, 4, threadCategoryChildren };
-const OMRMemCategory mutexCategoryTemplate = { "OS Mutexes", OMRMEM_CATEGORY_OSMUTEXES, 0, 0, 0, 0, 0, NULL };
-const OMRMemCategory condvarCategoryTemplate = { "OS Condvars", OMRMEM_CATEGORY_OSCONDVARS, 0, 0, 0, 0, 0, NULL };
+const OMRMemCategory threadCategoryTemplate = { "Threads", OMRMEM_CATEGORY_THREADS, 0, 0, 4, threadCategoryChildren };
+const OMRMemCategory mutexCategoryTemplate = { "OS Mutexes", OMRMEM_CATEGORY_OSMUTEXES, 0, 0, 0, NULL };
+const OMRMemCategory condvarCategoryTemplate = { "OS Condvars", OMRMEM_CATEGORY_OSCONDVARS, 0, 0, 0, NULL };
 #else /* defined(OMR_THR_FORK_SUPPORT) */
 const uint32_t threadCategoryChildren[] = {OMRMEM_CATEGORY_THREADS_RUNTIME_STACK, OMRMEM_CATEGORY_THREADS_NATIVE_STACK};
-const OMRMemCategory threadCategoryTemplate = { "Threads", OMRMEM_CATEGORY_THREADS, 0, 0, 0, 0, 2, threadCategoryChildren };
+const OMRMemCategory threadCategoryTemplate = { "Threads", OMRMEM_CATEGORY_THREADS, 0, 0, 2, threadCategoryChildren };
 #endif /* defined(OMR_THR_FORK_SUPPORT) */
-const OMRMemCategory nativeStackCategoryTemplate = { "Native Stack", OMRMEM_CATEGORY_THREADS_NATIVE_STACK, 0, 0, 0, 0, 0, NULL };
+const OMRMemCategory nativeStackCategoryTemplate = { "Native Stack", OMRMEM_CATEGORY_THREADS_NATIVE_STACK, 0, 0, 0, NULL };
 
 
 typedef struct J9ThreadMemoryHeader {

--- a/util/omrutil/AtomicFunctions.cpp
+++ b/util/omrutil/AtomicFunctions.cpp
@@ -20,25 +20,13 @@
 #include "AtomicSupport.hpp"
 
 uintptr_t
-compareAndSwapUDATA(uintptr_t *location, uintptr_t oldValue, uintptr_t newValue, uintptr_t *spinlock)
-{
-	return VM_AtomicSupport::lockCompareExchange(location, oldValue, newValue);
-}
-
-uintptr_t
-compareAndSwapUDATANoSpinlock(uintptr_t *location, uintptr_t oldValue, uintptr_t newValue)
+compareAndSwapUDATA(uintptr_t *location, uintptr_t oldValue, uintptr_t newValue)
 {
 	return VM_AtomicSupport::lockCompareExchange(location, oldValue, newValue);
 }
 
 uint32_t
-compareAndSwapU32(uint32_t *location, uint32_t oldValue, uint32_t newValue, uintptr_t *spinlock)
-{
-	return VM_AtomicSupport::lockCompareExchangeU32(location, oldValue, newValue);
-}
-
-uint32_t
-compareAndSwapU32NoSpinlock(uint32_t *location, uint32_t oldValue, uint32_t newValue)
+compareAndSwapU32(uint32_t *location, uint32_t oldValue, uint32_t newValue)
 {
 	return VM_AtomicSupport::lockCompareExchangeU32(location, oldValue, newValue);
 }


### PR DESCRIPTION
Delete the spinlock parameter from the compareAndSwapUDATA and 
compareAndSwapU32 functions as it is unused. Now that the functions
are exactly the same as the NoSpinLock versions delete them

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>