### PR TITLE
Fix Z codegen generating invalid snippets in directMemoryStoreHelper

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -1573,17 +1573,6 @@ void TR_InlinerBase::rematerializeCallArguments(TR_TransformInlinedFunction & ti
          }
       }
 
-   // TODO: remove this disable once z codegen snippets issue has been fixed
-   //       see github issue #427
-   if (TR::Compiler->target.cpu.isZ())
-      {
-      static char *enableZPrivArgRemat = feGetEnv("TR_enablePrivArgRematForZ");
-      if (!enableZPrivArgRemat)
-         {
-         suitableForRemat = false;
-         }
-      }
-
    // TODO: remove this diable once we have finished vetting all changes
    //       and bug fixes for priv arg remat have been contributed
    //       see github issue #437

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -6309,7 +6309,7 @@ bool directMemoryStoreHelper(TR::CodeGenerator* cg, TR::Node* storeNode)
          {
          TR::Node* valueNode = storeNode->getOpCode().isIndirect() ? storeNode->getChild(1) : storeNode->getChild(0);
 
-         if (valueNode->getOpCode().isLoadVar() && !valueNode->getOpCode().isReverseLoadOrStore () && valueNode->isSingleRefUnevaluated())
+         if (valueNode->getOpCode().isLoadVar() && !valueNode->getOpCode().isReverseLoadOrStore () && valueNode->isSingleRefUnevaluated() && !valueNode->hasUnresolvedSymbolReference())
             {
             if (valueNode->getOpCode().isIndirect() || !valueNode->getSymbolReference()->getSymbol()->isRegisterSymbol())
                {
@@ -6339,7 +6339,7 @@ bool directMemoryStoreHelper(TR::CodeGenerator* cg, TR::Node* storeNode)
                return true;
                }
             }
-         else if (valueNode->getOpCode().isConversion() && valueNode->isSingleRefUnevaluated())
+         else if (valueNode->getOpCode().isConversion() && valueNode->isSingleRefUnevaluated() && !valueNode->hasUnresolvedSymbolReference())
             {
             TR::Node* conversionNode = valueNode;
 


### PR DESCRIPTION
These changes fix issue #427, which was uncovered when when privatized inliner argument re-materialization is enabled on the z code generator by PR #428. See the discussion on #427.

Build 127307

Issue: #427
Signed-off-by: John Xu <xujohn@ca.ibm.com>