### PR TITLE
Refactor isPotentialOSRPoint query in two

### DIFF
--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -842,7 +842,8 @@ public:
     * and is primarily intended for ILGen before blocks are created - you risk
     * incorrect answers if you fail to supply the TreeTop
     */
-   bool isPotentialOSRPoint(TR::TreeTop *tt, TR::Node *ttNode = NULL);
+   bool isPotentialOSRPoint(TR::Node *node);
+   bool isPotentialOSRPointWithSupport(TR::TreeTop *tt);
    int32_t getOSRInductionOffset(TR::Node *node);
 
    // for OSR

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -884,7 +884,7 @@ OMR::ResolvedMethodSymbol::genAndAttachOSRCodeBlocks(int32_t currentInlinedSiteI
          skipNextTT = false;
       // check potential OSR point using a node to avoid a check for the exception successor
       // which we are responsible for creating if we decide to continue with this OSR point
-      if (self()->comp()->isPotentialOSRPoint(NULL, tt->getNode()))
+      if (self()->comp()->isPotentialOSRPoint(tt->getNode()))
          {
          TR::Block * block = tt->getEnclosingBlock();
          // Add the OSR point to the list

--- a/compiler/optimizer/DataFlowAnalysis.hpp
+++ b/compiler/optimizer/DataFlowAnalysis.hpp
@@ -187,7 +187,7 @@ class TR_DataFlowAnalysis : public TR::Allocatable<TR_DataFlowAnalysis, TR::Allo
       if (node != NULL && tt->getNode() != node)
          return node->exceptionsRaised() != 0;
       return (tt->getNode()->exceptionsRaised() != 0 ||
-              (comp()->isPotentialOSRPoint(tt)));
+              (comp()->isPotentialOSRPointWithSupport(tt)));
       }
    bool areSyntacticallyEquivalent(TR::Node *, TR::Node *);
    template<class Container>static void copyFromInto(Container *from, Container *to)

--- a/compiler/optimizer/OSRDefAnalysis.cpp
+++ b/compiler/optimizer/OSRDefAnalysis.cpp
@@ -383,7 +383,7 @@ void TR_OSRDefInfo::buildOSRDefs(void *vblockInfo, AuxiliaryData &aux)
          }
 
       TR_OSRPoint *point = NULL;
-      if (comp()->isPotentialOSRPoint(treeTop))
+      if (comp()->isPotentialOSRPointWithSupport(treeTop))
          {
          point = _methodSymbol->findOSRPoint(node);
          TR_ASSERT(point != NULL, "Cannot find an OSR point for node %p", node);
@@ -831,7 +831,7 @@ int32_t TR_OSRLiveRangeAnalysis::perform()
             }
 
 
-         if (comp()->isPotentialOSRPoint(tt))
+         if (comp()->isPotentialOSRPointWithSupport(tt))
             {
             osrPoint = comp()->getMethodSymbol()->findOSRPoint(tt->getNode());
             TR_ASSERT(osrPoint != NULL, "Cannot find an OSR point for node %p", tt->getNode());
@@ -1087,7 +1087,7 @@ void TR_OSRExceptionEdgeRemoval::newperform()
       TR::TreeTop *treeTop;
       for (treeTop = block->getEntry(); treeTop != block->getExit(); treeTop = treeTop->getNextTreeTop())
          {
-         if (comp()->isPotentialOSRPoint(treeTop))
+         if (comp()->isPotentialOSRPointWithSupport(treeTop))
             {
             blockCanOSR = true;
             break;

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -553,7 +553,7 @@ void TR::ValuePropagation::removeChildren(TR::Node *node, bool anchorIt)
 
 static bool canCauseOSR(TR::TreeTop *tt, TR::Compilation *comp)
    {
-   if (comp->isPotentialOSRPoint(tt))
+   if (comp->isPotentialOSRPointWithSupport(tt))
       return true;
 
    return false;


### PR DESCRIPTION
The isPotentialOSRPoint query is used in two way. The first mode of operation is the ILGen or other related infrastructure asking if a given node could be an OSR point. This is a property of the node itself and
does not rely on the OSR infrastructure determining if OSR is actually supported at that point - it is a conservative yes we may need to support OSR at this point rather than a definite we can OSR at this
point. The second mode of operation is with a TreeTop where the optimizer needs to know if OSR can be performed at a particular point. This question requires that the first mode of operation says yes we may
OSR as well as the OSR infrastructure saying yes OSR is supported.

This change breaks apart the these two uses - isPotentialOSRPoint answers the first query while isPotentialOSRPointWithSupport answers the second query.