### PR TITLE
Remove inconsistent mechanism to enable or disable fast notify

### DIFF
--- a/thread/common/omrthread.c
+++ b/thread/common/omrthread.c
@@ -309,26 +309,6 @@ omrthread_init(omrthread_library_t lib)
 	lib->flags |= J9THREAD_LIB_FLAG_DESTROY_MUTEX_ON_MONITOR_FREE;
 #endif
 
-#ifdef OMR_THR_THREE_TIER_LOCKING
-	/*
-	 * VMDESIGN WIP 1320
-	 * TODO: Remove this code when performance analysis is complete.
-	 */
-	{
-		const char *fastNotifyEnv;
-
-		fastNotifyEnv = getenv("J9VM_THR_FAST_NOTIFY");
-		if (fastNotifyEnv) {
-			if (*fastNotifyEnv == '1') {
-				lib->flags |= J9THREAD_LIB_FLAG_FAST_NOTIFY;
-			}
-		}
-		if (lib->flags & J9THREAD_LIB_FLAG_FAST_NOTIFY) {
-			printf("fast notify enabled\n");
-		}
-	}
-#endif /* OMR_THR_THREE_TIER_LOCKING */
-
 	if (omrthread_attr_init(&lib->systemThreadAttr) != J9THREAD_SUCCESS) {
 		goto init_cleanup10;
 	}


### PR DESCRIPTION
Currently, we rely upon an environment variable to enable or disable the
fast notify feature. Environment variables can be set by anyone, and all
runtime instances will read the environment variable. So, it is not safe
and reliable to use environment variables. A runtime should use command
line options to enable or disable a feature. Using command line options,
a user can be assured that a feature is enabled or disabled for a
specific instance of the runtime. Also, no third party will be able to
influence the runtime's behaviour. Thus, the current mechanism to enable
or disable the fast notify feature has been removed.

Issue: #478

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>