### PR TITLE
Add Vector support to Register Assigner on x

### DIFF
--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -407,6 +407,15 @@ OMR::CodeGenerator::prepareRegistersForAssignment()
       if (registerCursor->getKind() != TR_SSR)
          registerCursor->setFutureUseCount(registerCursor->getTotalUseCount());
       km = registerCursor->getKindAsMask();
+
+      /*
+       * Sometimes real registers marked as being a TR_FPR register can be used as a TR_VRF register
+       * isFPRUsedAsVFR is used to check for this
+       * if true, RA is told is may need to assign TR_VRF as well as TR_FPR registers if a TR_FPR real register is seen
+       */
+      if (registerCursor->getKind() == TR_FPR && isFPRUsedAsVFR())
+         km |= TO_KIND_MASK(TR_VRF);
+
       if (!(foundKindsMask & km))
          foundKindsMask |= km;
       }

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1175,6 +1175,7 @@ class OMR_EXTENSIBLE CodeGenerator
    TR_RegisterKinds prepareRegistersForAssignment(); // no virt
    void addToUnlatchedRegisterList(TR::RealRegister *reg);
    void freeUnlatchedRegisters();
+   bool isFPRUsedAsVFR() { return false; }
 
    // --------------------------------------------------------------------------
    // Listing

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -251,6 +251,7 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
       {
       self()->setUseSSEForSinglePrecision();
       self()->setUseSSEForDoublePrecision();
+      self()->setSupportsAutoSIMD();
       }
 
    // Choose the best XMM double precision load instruction for the target architecture.
@@ -966,6 +967,39 @@ bool OMR::X86::CodeGenerator::enableAESInHardwareTransformations()
 #undef ALLOWED_TO_REMATERIALIZE
 #undef CAN_REMATERIALIZE
 
+bool
+OMR::X86::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR::DataType dt)
+   {
+   /*
+    * This is a place holder function. It currently always returns false because none of the SIMD evaluators for OpCodes used
+    * in AutoSIMD have been implemented.
+    * This should be filled in (and this comment updated) as support for SIMD evaluators is implemented.
+    */
+   // implemented vector opcodes
+   switch (opcode.getOpCodeValue())
+      {
+      case TR::vadd:
+      case TR::vsub:
+      case TR::vmul:
+      case TR::vdiv:
+      case TR::vrem:
+      case TR::vneg:
+      case TR::vload:
+      case TR::vloadi:
+      case TR::vstore:
+      case TR::vstorei:
+      case TR::vxor:
+      case TR::vor:
+      case TR::vand:
+      case TR::vsplats:
+      case TR::getvelem:
+      default:
+         return false;
+      }
+
+   return false;
+   }
+
 
 bool
 OMR::X86::CodeGenerator::getSupportsEncodeUtf16LittleWithSurrogateTest()
@@ -1545,7 +1579,7 @@ void OMR::X86::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssig
    LexicalTimer pt2("GP register assignment", self()->comp()->phaseTimer());
    // Assign GPRs and XMMRs in a backward pass
    //
-   kindsToAssign = TR_RegisterKinds(kindsToAssign & (TR_GPR_Mask | TR_FPR_Mask));
+   kindsToAssign = TR_RegisterKinds(kindsToAssign & (TR_GPR_Mask | TR_FPR_Mask | TR_VRF_Mask));
    if (kindsToAssign)
       {
       self()->getVMThreadRegister()->setFutureUseCount(self()->getVMThreadRegister()->getTotalUseCount());

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -351,6 +351,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    bool hasComplexAddressingMode() { return true; }
    bool getSupportsBitOpCodes() { return true; }
 
+   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataType);
    bool getSupportsEncodeUtf16LittleWithSurrogateTest();
    bool getSupportsEncodeUtf16BigWithSurrogateTest();
 
@@ -616,6 +617,8 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    virtual TR_BitVector *getGlobalRegisters(TR_SpillKinds kind, TR_LinkageConventions lc){ return &_globalRegisterBitVectors[kind]; }
 
    virtual void simulateNodeEvaluation (TR::Node *node, TR_RegisterPressureState *state, TR_RegisterPressureSummary *summary);
+
+   bool isFPRUsedAsVFR() { return _targetProcessorInfo.supportsSSE2(); }
 
    protected:
 

--- a/compiler/x/codegen/OMRRealRegister.cpp
+++ b/compiler/x/codegen/OMRRealRegister.cpp
@@ -31,7 +31,7 @@ OMR::X86::RealRegister::regMaskToRealRegister(TR_RegisterMask mask, TR_RegisterK
       rr = TR::RealRegister::FirstGPR;
    else if (rk == TR_X87)
       rr = TR::RealRegister::FirstFPR;
-   else if (rk == TR_FPR)
+   else if (rk == TR_FPR || rk == TR_VRF)
       rr = TR::RealRegister::FirstXMMR;
    else
       TR_ASSERT(false, "Invalid TR_RegisterKinds value passed to OMR::X86::RealRegister::regMaskToRealRegister()");
@@ -46,7 +46,7 @@ OMR::X86::RealRegister::getAvailableRegistersMask(TR_RegisterKinds rk)
       return TR::RealRegister::AvailableGPRMask;
    else if (rk == TR_X87)
       return TR::RealRegister::AvailableFPRMask;
-   else if (rk == TR_FPR)
+   else if (rk == TR_FPR || rk == TR_VRF)
       return TR::RealRegister::AvailableXMMRMask;
    else // MMX: not used
       return 0;
@@ -59,7 +59,7 @@ OMR::X86::RealRegister::getRealRegisterMask(TR_RegisterKinds rk, TR::RealRegiste
       return TR::RealRegister::gprMask(idx);
    else if (rk == TR_X87)
       return TR::RealRegister::fprMask(idx);
-   else if (rk == TR_FPR)
+   else if (rk == TR_FPR || rk == TR_VRF)
       return TR::RealRegister::xmmrMask(idx);
    else // MMX: not used
       return TR::RealRegister::mmrMask(idx);


### PR DESCRIPTION
Register Assigner on x now recognizes "TR_VRF" virtual register as
being a vector register and will attempt to assign a XMM register to
them.

Created method isFPRUsedAsVFR. It checks if the processor supports SSE2
and if so attempts to assign vector registers if the system has TR_FPR
real registers.

Created method getSupportsOpCodeForAutoSIMD. It is used to check which
vector opcode are currently supported for autoSIMD. Currently there are
none so it always returns false.

Added code to handle spilling and filling of registers for 128 bit
vector sized data.

Issue: #431
Signed-off-by: jimmyk <jimmyk@ca.ibm.com>