### PR TITLE
Workaround for TypeDictionary symref cleanup issue

### DIFF
--- a/jitbuilder/release/src/MatMult.cpp
+++ b/jitbuilder/release/src/MatMult.cpp
@@ -314,8 +314,9 @@ main(int argc, char *argv[])
    printMatrix(A, N, "A");
    printMatrix(B, N, "B");
 
-   printf("Step 3: define type dictionary\n");
+   printf("Step 3: define type dictionaries\n");
    TR::TypeDictionary types;
+   TR::TypeDictionary vectypes;
 
    printf("Step 4: compile MatMult method builder\n");
    MatMult method(&types);
@@ -333,7 +334,7 @@ main(int argc, char *argv[])
    printMatrix(C, N, "C");
 
    printf("Step 6: compile VectorMatMult method builder\n");
-   VectorMatMult vecmethod(&types);
+   VectorMatMult vecmethod(&vectypes);
    uint8_t *vecentry=0;
    rc = compileMethodBuilder(&vecmethod, &vecentry);
    if (rc != 0)

--- a/jitbuilder/release/src/StructArray.cpp
+++ b/jitbuilder/release/src/StructArray.cpp
@@ -167,11 +167,12 @@ main(int argc, char *argv[])
       exit(-1);
       }
 
-   printf("Step 2: define type dictionary\n");
-   StructArrayTypeDictionary types;
+   printf("Step 2: define type dictionaries\n");
+   StructArrayTypeDictionary createMethodTypes;
+   StructArrayTypeDictionary readMethodTypes;
 
    printf("Step 3: compile createMethod builder\n");
-   CreateStructArrayMethod createMethod(&types);
+   CreateStructArrayMethod createMethod(&createMethodTypes);
    uint8_t *createEntry;
    int32_t rc = compileMethodBuilder(&createMethod, &createEntry);
    if (rc != 0)
@@ -181,7 +182,7 @@ main(int argc, char *argv[])
       }
 
    printf("Step 4: compile readMethod builder\n");
-   ReadStructArrayMethod readMethod(&types);
+   ReadStructArrayMethod readMethod(&readMethodTypes);
    uint8_t *readEntry;
    rc = compileMethodBuilder(&readMethod, &readEntry);
    if (rc != 0)


### PR DESCRIPTION
Fix StructArray and MatMult example to work around the issue of symrefs in
TypeDictionary that persist through more than one compilation (see issues #468
and #406). The workaround is to  use a new TypeDictionary instance for each
method compilation.

Issue: #468

Signed-off-by: Leonardo Banderali <leob@linux.vnet.ibm.com>