### PR TITLE
Re-enable Inliner PrivArgRemat

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -1573,15 +1573,6 @@ void TR_InlinerBase::rematerializeCallArguments(TR_TransformInlinedFunction & ti
          }
       }
 
-   // TODO: remove this diable once we have finished vetting all changes
-   //       and bug fixes for priv arg remat have been contributed
-   //       see github issue #437
-   static char *enablePrivArgRemat = feGetEnv("TR_enablePrivArgRemat");
-   if (!enablePrivArgRemat)
-      {
-      suitableForRemat = false;
-      }
-
    if (suitableForRemat)
       {
       static char *dumpRematTrees = feGetEnv("TR_DumpPrivArgRematTrees");


### PR DESCRIPTION
Issue 437 caused priv arg remat to be disabled because it was thought bug fixes were missing from teh priv arg remat code contributed to OMR. The failing test that triggered this suspicion has now been proven to be invalid so issue 437 has been closed and this commit re-enables the optimization in the inliner.