### PR TITLE
Disable HCR guard merging when using OSR HCR

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -1495,7 +1495,8 @@ OMR::Compilation::removeVirtualGuard(TR_VirtualGuard *guard)
    for (auto current = _virtualGuards.begin(); current != _virtualGuards.end(); ++current)
       {
       if (((*current)->getCalleeIndex() == guard->getCalleeIndex()) &&
-          ((*current)->getByteCodeIndex() == guard->getByteCodeIndex()))
+          ((*current)->getByteCodeIndex() == guard->getByteCodeIndex()) &&
+          ((*current)->getKind() == guard->getKind()))
          {
          if (self()->getOption(TR_TraceRelocatableDataDetailsCG))
             traceMsg(self(), "removeVirtualGuard %p, kind %d bcindex %d calleeindex %d\n", *current, (*current)->getKind(), (*current)->getByteCodeIndex(), (*current)->getCalleeIndex());

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -1790,7 +1790,11 @@ TR_InlinerBase::addGuardForVirtual(
       {
       createdHCRAndVirtualGuard = true;
 
+      // we merge virtual guards and OSR guards for simplicity in most modes
+      // when using OSR to implement HCR we keep the HCR guards distinct since they
+      // will undergo special processing later in the compilation
       if (virtualGuard &&
+          comp()->getHCRMode() != TR::osr &&
           comp()->cg()->supportsMergingOfHCRGuards())
          {
          TR::Node *guardNode = virtualGuard->getNode();


### PR DESCRIPTION
In most circumstances the Inliner will merge HCR guards and true virtual gurds to simplify the trees generated. When using OSR to implement HCR we want to skip this merging so that the HCR guards are distinct fromthe true virtual guards. The HCR guards undergo special processing later in the compile and merging the guards only complicates this processing for now real benefit.

As part of this change I am fixing a bug in the removeVirtualGuard code where it does not check the guard type for equality like findVirtualGuard does - this is only an issue when there are multiple guards for a given bytecode which this change makes much more common.