### PR TITLE
Default processor machine type on z to undefined

### DIFF
--- a/compiler/env/FEBase.cpp
+++ b/compiler/env/FEBase.cpp
@@ -95,7 +95,7 @@ portLib_get390zLinuxMachineType()
    const char procHeader[] = "processor ";
    const int PROC_LINE_SIZE = 69;
    const int PROC_HEADER_SIZE = sizeof(procHeader) - 1;
-   TR_S390MachineType ret_machine = TR_DEFAULT_S390_MACHINE;  /* return value */
+   TR_S390MachineType ret_machine = TR_UNDEFINED_S390_MACHINE;  /* return value */
 
    ::FILE * fp = fopen("/proc/cpuinfo", "r");
    if (fp)

--- a/compiler/env/ProcessorInfo.hpp
+++ b/compiler/env/ProcessorInfo.hpp
@@ -29,7 +29,6 @@ enum TR_S390MachineType
    TR_MULTIPRISE7000          =  7060,
    TR_FREEWAY                 =  2064,  // z900
    TR_Z800                    =  2066,  // z800 - entry-level, less powerful variant of the z900
-   TR_DEFAULT_S390_MACHINE    =  TR_FREEWAY,
    TR_MIRAGE                  =  1090,
    TR_MIRAGE2                 =  1091,
    TR_TREX                    =  2084,  // z990


### PR DESCRIPTION
The default value for the processor machine type should be undefined,
not some arbitrary real machine type when attempting to parse the
processor ID.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>