### PR TITLE
Fix DCB properties and reg dependencies on z

### DIFF
--- a/compiler/z/codegen/ArchInstOpCodeProperties.hpp
+++ b/compiler/z/codegen/ArchInstOpCodeProperties.hpp
@@ -6473,5 +6473,8 @@
    S390OpProp_IsCall,
 
 	   // DCB
-	0,
+   S390OpProp_SetsSignFlag |
+   S390OpProp_SetsOverflowFlag |
+   S390OpProp_IsLoad |
+   S390OpProp_IsStore,
 

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -2668,6 +2668,7 @@ OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
             if ( realReg->getState() == TR::RealRegister::Free && realReg->getHighWordRegister()->getState() == TR::RealRegister::Free)
                {
                dcbInstr->setAssignableReg(realReg);
+               realReg->setHasBeenAssignedInMethod(true);
                break;
                }
             }
@@ -2899,7 +2900,7 @@ TR_S390Peephole::isBarrierToPeepHoleLookback(TR::Instruction *current)
    if (s390current->isCall())  return true;
    if (s390current->isAsmGen()) return true;
    if (s390current->isBranchOp()) return true;
-
+   if (s390current->getOpCodeValue() == TR::InstOpCode::DCB) return true;
 
    return false;
    }
@@ -10571,6 +10572,8 @@ void handleLoadWithRegRanges(TR::Instruction *inst, TR::CodeGenerator *cg)
 
 /**
  * Create a snippet of the debug counter address and generate a DCB (DebugCounterBump) pseudo-instruction that will be ignored during register assignment
+ * Be aware that the constituent add immediate instruction (ASI/AGSI) sets condition codes for sign and overflow
+ * In most cases the condition code is 2; for result greater than zero and no overflow
  *
  * @param cursor     Current binary encoding cursor
  * @param counter    The debug counter to increment

--- a/compiler/z/codegen/S390Debug.cpp
+++ b/compiler/z/codegen/S390Debug.cpp
@@ -957,7 +957,17 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390PseudoInstruction * instr)
 
    if (instr->getOpCodeValue() == TR::InstOpCode::DCB)
       {
-      trfprintf(pOutFile, "Debug Counter Bump");
+      
+      if (static_cast<TR::S390DebugCounterBumpInstruction*>(instr)->getAssignableReg())
+         {
+         print(pOutFile, static_cast<TR::S390DebugCounterBumpInstruction*>(instr)->getAssignableReg());
+         }
+      else
+         {
+         trfprintf(pOutFile, "Spill Reg");
+         }
+         
+      trfprintf(pOutFile, ", Debug Counter Bump");
       }
 
    if (instr->getOpCodeValue() == TR::InstOpCode::FENCE)


### PR DESCRIPTION
### OpCode properties

Since the DCB pseudo-instruction [combines several instructions at binary encoding](https://github.com/eclipse/omr/blob/0d62aac087bf747b9db51a83830fc4a8e5c10ca8/compiler/z/codegen/S390Instruction.cpp#L1283-L1286), we need to ensure its OpCode properties are set according to z architecture. For example, the constituent `AGSI` instruction sets a condition code based on the sign and overflow of the add result. This could unintentionally alter the behavior of the subsequent instruction. A notice of the possible side effects of the sign and overflow flags (which is the main concern) is also added to the documentation.

### Register dependencies

Further testing with all debug counters enabled uncovered two register dependency issues with the new implementation:

1. 
When DCB finds a free register during register assignment, there is presently no logic to consider the register requirements of caller/callee. A case may happen where for example a method callee saves GPR6 to GPR9 to be loaded back upon returning to method caller, but DCB dirties GPR10 in the middle: 

```
STMG    GPR6,GPR9,
...
DCB (changes GPR10)
...
LMG     GPR6,GPR9
```
`setHasBeenAssignedInMethod(true);` is the API to implement this logic. 

2. 
Since DCB sets its free register during register allocation, the implicit assumption is made that it will continue to be free at the instruction cursor. However this may change due to peephole optimizations.

This is a real example of [`TR_S390Peephole::LRReduction`](https://github.com/doubletea/omr/blob/8c0392b356fb2a83ae85ae37bbd4640a3c7e0950/compiler/z/codegen/OMRCodeGenerator.cpp#L3534).
Notice GPR1 is free for DCB pre Peephole Optimization:

```
 [...]	LGR     GPR6,GPR1	 ; LR=Reg_move
 [...]	LLZRGF  GPR8, Shadow[<vft-symbol>] 0(GPR6)
 [...]	DCB     GPR1, Debug Counter Bump	
 [...]	LGR     GPR1,GPR6	 ; LR=Reg_param
 [...]	ASSOCREGS
 [...]	LGR     GPR7,GPR1	 ; LR=Reg_move

```

Notice that is no longer the case post Peephole Optimization:

```
 [...]	LGR     GPR6,GPR1	 ; LR=Reg_move
 [...]	LLZRGF  GPR8, Shadow[<vft-symbol>] 0(GPR1)
 [...]	DCB     GPR1, Debug Counter Bump	
 [...]	ASSOCREGS
 [...]	LGR     GPR7,GPR1	 ; LR=Reg_move
```

Therefore the peephole look back must be guarded against  DCB similar to branch ops etc.

### Added better logging for DCB by printing the assigned free reg if present 