### PR TITLE
Fix unreachable BytecodeBuilder processing problem

### DIFF
--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -1879,7 +1879,7 @@ OMR::ResolvedMethodSymbol::removeTree(TR::TreeTop *tt)
       prev->setNextTreeTop(next);
    else
       {
-      TR_ASSERT(_firstTreeTop == tt, "treetops are not forming a single doubly linked list");
+      TR_ASSERT(_firstTreeTop == tt, "treetops are not forming a single doubly linked list: node address = %p, global index = %d", node, (node ? node->getGlobalIndex() : -1));
       _firstTreeTop = next;
       }
    if (next != NULL)

--- a/compiler/ilgen/MethodBuilder.cpp
+++ b/compiler/ilgen/MethodBuilder.cpp
@@ -259,7 +259,7 @@ MethodBuilder::connectTrees()
 
    TR::TreeTop *lastTree = blocks[currentBlock-1]->getExit();
 
-   while (!_connectTreesWorklist->isEmpty())
+   do
       {
 
       // iterate on the worklist pulling trees and blocks into this builder
@@ -304,7 +304,7 @@ MethodBuilder::connectTrees()
             _connectTreesWorklist->add(builder);
             }
          }
-      }
+      } while (!_connectTreesWorklist->isEmpty());
 
    return true;
    }

--- a/jitbuilder/release/.gitignore
+++ b/jitbuilder/release/.gitignore
@@ -33,3 +33,4 @@ pow2
 recfib
 simple
 switch
+controlflowtests

--- a/jitbuilder/release/Makefile
+++ b/jitbuilder/release/Makefile
@@ -22,7 +22,7 @@ CXXFLAGS=-g -std=c++0x -O2 -c -fno-rtti -fPIC -I./include/compiler -I./include
 
 .SUFFIXES: .cpp .o
 
-goal: call conststring dotproduct iterfib linkedlist localarray structarray mandelbrot nestedloop pointer recfib simple switch pow2
+goal: call conststring dotproduct iterfib linkedlist localarray structarray mandelbrot nestedloop pointer recfib simple switch pow2 controlflowtests
 
 all: goal
 
@@ -40,6 +40,7 @@ test: goal
 	./simple
 	./switch
 	./pow2
+	./controlflowtests
 
 call : libjitbuilder.a Call.o
 	g++ -g -fno-rtti -o $@ Call.o -L. -ljitbuilder -ldl
@@ -153,6 +154,13 @@ structarray : libjitbuilder.a StructArray.o
 	g++ -g -fno-rtti -o $@ StructArray.o -L. -ljitbuilder -ldl
 
 StructArray.o: src/StructArray.cpp src/StructArray.hpp
+	g++ -o $@ $(CXXFLAGS) $<
+
+
+controlflowtests : libjitbuilder.a ControlFlowTests.o
+	g++ -g -fno-rtti -o $@ ControlFlowTests.o -L. -ljitbuilder -ldl
+
+ControlFlowTests.o: src/ControlFlowTests.cpp src/ControlFlowTests.hpp
 	g++ -o $@ $(CXXFLAGS) $<
 
 

--- a/jitbuilder/release/src/ControlFlowTests.cpp
+++ b/jitbuilder/release/src/ControlFlowTests.cpp
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+
+/**
+ * This file containse JitBuilder methods that are only useful as tests and
+ * not as examples of how to use JitBuilder
+ */
+
+#include <iostream>
+#include <stdlib.h>
+#include <stdint.h>
+#include <dlfcn.h>
+#include <errno.h>
+
+#include "Jit.hpp"
+#include "ilgen/TypeDictionary.hpp"
+#include "ilgen/MethodBuilder.hpp"
+#include "ilgen/BytecodeBuilder.hpp"
+#include "ControlFlowTests.hpp"
+
+using std::cout;
+using std::cerr;
+
+
+DoubleReturnBytecodeMethod::DoubleReturnBytecodeMethod(TR::TypeDictionary* d)
+   : MethodBuilder(d)
+   {
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   DefineName("doubleReturn");
+   DefineReturnType(NoType);
+   }
+
+bool
+DoubleReturnBytecodeMethod::buildIL()
+   {
+   auto firstBuilder = OrphanBytecodeBuilder(0, (char *)"return");
+   AppendBuilder(firstBuilder);
+   firstBuilder->Return();
+
+   auto secondBuilder = OrphanBytecodeBuilder(1, (char *)"return"); // should be ignored and cleanedup
+   secondBuilder->Return();
+
+   return true;
+   }
+
+
+int
+main(int argc, char *argv[])
+   {
+   cout << "Step 1: initialize JIT\n";
+   bool initialized = initializeJit();
+   if (!initialized)
+      {
+      cerr << "FAIL: could not initialize JIT\n";
+      exit(-1);
+      }
+
+   cout << "Step 2: define type dictionary\n";
+   TR::TypeDictionary types;
+
+   cout << "Step 3: compile method builder\n";
+   DoubleReturnBytecodeMethod method(&types);
+   uint8_t *entry = 0;
+   int32_t rc = compileMethodBuilder(&method, &entry);
+   if (rc != 0)
+      {
+      cerr << "FAIL: compilation error " << rc << "\n";
+      exit(-2);
+      }
+
+   cout << "Step 4: invoke compiled code\n";
+   DoubleReturnBytecodeMethodFunction *doubleReturn = (DoubleReturnBytecodeMethodFunction *) entry;
+   doubleReturn();
+
+   cout << "Step 5: shutdown JIT\n";
+   shutdownJit();
+   }

--- a/jitbuilder/release/src/ControlFlowTests.hpp
+++ b/jitbuilder/release/src/ControlFlowTests.hpp
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+ 
+#ifndef USELESS_INCL
+#define USELESS_INCL
+
+/**
+ * This file containse JitBuilder methods that are only useful as tests and
+ * not as examples of how to use JitBuilder
+ */
+
+#include "ilgen/MethodBuilder.hpp"
+
+typedef void (DoubleReturnBytecodeMethodFunction)(void);
+
+class DoubleReturnBytecodeMethod : public TR::MethodBuilder
+   {
+   public:
+   DoubleReturnBytecodeMethod(TR::TypeDictionary *);
+   virtual bool buildIL();
+   };
+
+#endif // !defined(USELESS_INCL)


### PR DESCRIPTION
Fix the problem with the unreachable BytecodeBuilder processing where having only one reachable builder inside a MethodBuilder prevents other unreachable builders from being processed.

Issue: #488