### PR TITLE
Clean up OMR Compilation class

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -299,8 +299,6 @@ OMR::Compilation::Compilation(
    _optimizationPlan(optimizationPlan),
    _verboseOptTransformationCount(0),
    _currentBlock(NULL),
-   _unreferencedAutoOrParmOrExternals(self()->allocator("unreferenced external or auto or Parm")),
-   _externalSparseBitVector(self()->allocator("external")),
    _monitorAutoSymRefsInCompiledMethod(getTypedAllocator<TR::SymbolReference*>(self()->allocator())),
    _aotMethodCodeStart(NULL),
    _failCHtableCommitFlag(false),
@@ -1810,11 +1808,6 @@ void OMR::Compilation::setUsesPreexistence(bool v)
    if (v)
       TR_ASSERT(self()->ilGenRequest().details().supportsInvalidation(), "Can't use preexistence on ilgen request that does not support invalidation");
    _usesPreexistence = v;
-   }
-
-int32_t OMR::Compilation::getOptMessageIndex()
-   {
-   return (self()->getOptimizer()? self()->getOptimizer()->getOptMessageIndex():0);
    }
 
 // Dump the trees for the method and return the number of nodes in the trees.

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -654,8 +654,6 @@ public:
    void setPeekingSymRefTab(TR::SymbolReferenceTable *symRefTab) { _peekingSymRefTab = symRefTab; }
    int32_t getMaxPeekedBytecodeSize() const { return TR::Options::getMaxPeekedBytecodeSize() >> (_optimizationPlan->getReduceMaxPeekedBytecode());}
 
-   int32_t getOptMessageIndex();
-
    void AddCopyPropagationRematerializationCandidate(TR::SymbolReference * sr);
    void RemoveCopyPropagationRematerializationCandidate(TR::SymbolReference * sr);
    bool IsCopyPropagationRematerializationCandidate(TR::SymbolReference * sr);
@@ -872,9 +870,6 @@ public:
 
    bool supressEarlyInlining() { return _noEarlyInline; }
    void setSupressEarlyInlining(bool b) { _noEarlyInline = b; }
-
-   TR::SparseBitVector &getUnreferencedAutoOrParmOrExternals() { return _unreferencedAutoOrParmOrExternals; }
-   TR::SparseBitVector &getExternalSparseBitVector() { return _externalSparseBitVector; }
 
    void setHasColdBlocks()
       {
@@ -1140,11 +1135,6 @@ private:
    TR_OSRCompilationData                *_osrCompilationData;
 
    TR::Block *                         _currentBlock;
-
-   TR::SparseBitVector _unreferencedAutoOrParmOrExternals;
-
-   // Move to Optimizer (UseDefInfo)
-   TR::SparseBitVector _externalSparseBitVector;
 
    // for TR_Debug usage
    ToNumberMap    _toNumberMap; // maps TR::LabelSymbol, etc. objects to numbers

--- a/compiler/optimizer/GlobalRegisterAllocator.cpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.cpp
@@ -3607,7 +3607,6 @@ void TR_GlobalRegisterAllocator::offerAllAutosAndRegisterParmAsCandidates(TR::Bl
    //
    //comp()->printMemStatsBefore("GRA_offer_autos");
    int32_t symRefNumber;
-   TR::SparseBitVector &unreferencedSym = comp()->getUnreferencedAutoOrParmOrExternals();
    for (symRefNumber = symRefTab->getIndexOfFirstSymRef(); symRefNumber < symRefCount; symRefNumber++)
       {
       symRef = symRefTab->getSymRef(symRefNumber);
@@ -3771,7 +3770,6 @@ void TR_GlobalRegisterAllocator::offerAllFPAutosAndParmsAsCandidates(TR::Block *
    // Offer all FP autos now
    //
    int32_t symRefNumber;
-   TR::SparseBitVector &unreferencedSym = comp()->getUnreferencedAutoOrParmOrExternals();
    for (symRefNumber = symRefTab->getIndexOfFirstSymRef(); symRefNumber < symRefCount; symRefNumber++)
       {
       symRef = symRefTab->getSymRef(symRefNumber);

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -1941,7 +1941,7 @@ int32_t OMR::Optimizer::performOptimization(const OptimizationStrategy *optimiza
       int32_t origSymRefCount = comp()->getSymRefCount();
       int32_t origNodeCount = comp()->getNodeCount();
       int32_t origCfgNodeCount = comp()->getFlowGraph()->getNextNodeNumber();
-      int32_t origOptMsgIndex = comp()->getOptMessageIndex();
+      int32_t origOptMsgIndex = self()->getOptMessageIndex();
 
       if (comp()->isOutermostMethod() && (comp()->getFlowGraph()->getMaxFrequency() < 0))
          {
@@ -2047,7 +2047,7 @@ int32_t OMR::Optimizer::performOptimization(const OptimizationStrategy *optimiza
 
       manager->setTrace(origTraceSetting);
 
-      int32_t finalOptMsgIndex = comp()->getOptMessageIndex();
+      int32_t finalOptMsgIndex = self()->getOptMessageIndex();
       if ((finalOptMsgIndex != origOptMsgIndex ) &&  !manager->getDoesNotRequireTreeDumps())
            comp()->reportOptimizationPhaseForSnap(optNum);
 

--- a/compiler/optimizer/UseDefInfo.cpp
+++ b/compiler/optimizer/UseDefInfo.cpp
@@ -1021,7 +1021,6 @@ bool TR_UseDefInfo::indexSymbolsAndNodes(AuxiliaryData &aux)
 
    _numStaticsAndFields = _numSymbols;
 
-   TR::SparseBitVector &isExternal = comp()->getExternalSparseBitVector();
    for (refIter.SetToFirstOne(); refIter.Valid(); refIter.SetToNextOne())
       {
       symRefNumber = refIter;
@@ -1913,7 +1912,6 @@ void TR_UseDefInfo::buildUseDefs(void *vblockInfo, AuxiliaryData &aux)
 
       int32_t i, ii;
       TR_Method *method = comp()->getMethodSymbol()->getMethod();
-      TR::SparseBitVector &externalSym = comp()->getExternalSparseBitVector();
       TR_BitVectorIterator bvi(*analysisInfo);
       while (bvi.hasMoreElements())
          {


### PR DESCRIPTION
Removed data members and methods that were extraneous or not used in
OMR Compilation class.

Signed-off-by: Xiaoli Liang <xsliang@ca.ibm.com>