### PR TITLE
Rename floating-point Condition Code

### DIFF
--- a/compiler/p/codegen/FPTreeEvaluator.cpp
+++ b/compiler/p/codegen/FPTreeEvaluator.cpp
@@ -1981,7 +1981,7 @@ TR::Register *OMR::Power::TreeEvaluator::dcmpltEvaluator(TR::Node *node, TR::Cod
    int64_t imm = 0;
    if (TR::Compiler->target.cpu.id() >= TR_PPCp9)
       {
-      imm = (TR::RealRegister::FPCC_FL << 21 | TR::RealRegister::FPCC_FL << 16 | TR::RealRegister::FPCC_FU << 11);
+      imm = (TR::RealRegister::CRCC_LT <<  TR::RealRegister::pos_RT | TR::RealRegister::CRCC_LT <<  TR::RealRegister::pos_RA | TR::RealRegister::CRCC_SO << TR::RealRegister::pos_RB);
       }
    return compareFloatAndSetOrderedBoolean(TR::InstOpCode::blt, TR::InstOpCode::bad, imm, node, cg);
    }
@@ -1998,7 +1998,7 @@ TR::Register *OMR::Power::TreeEvaluator::dcmpgtEvaluator(TR::Node *node, TR::Cod
    int64_t imm = 0;
    if (TR::Compiler->target.cpu.id() >= TR_PPCp9)
       {
-      imm = (TR::RealRegister::FPCC_FG << 21 | TR::RealRegister::FPCC_FG << 16 | TR::RealRegister::FPCC_FU << 11);
+      imm = (TR::RealRegister::CRCC_GT <<  TR::RealRegister::pos_RT | TR::RealRegister::CRCC_GT <<  TR::RealRegister::pos_RA | TR::RealRegister::CRCC_SO << TR::RealRegister::pos_RB);
       }
    return compareFloatAndSetOrderedBoolean(TR::InstOpCode::bgt, TR::InstOpCode::bad, imm, node, cg);
    }

--- a/compiler/p/codegen/OMRRealRegister.hpp
+++ b/compiler/p/codegen/OMRRealRegister.hpp
@@ -78,12 +78,13 @@ class OMR_EXTENSIBLE RealRegister : public OMR::RealRegister
       pos_CX     = 3
    } PPCOperandPosition;
 
-   typedef enum {
-      FPCC_FL = 0x0, // less than
-      FPCC_FG = 0x1, // greater than
-      FPCC_FE = 0x2, // equal
-      FPCC_FU = 0x3  // unordered
-   } PPCFloatingPointConditionCode;
+   enum CRCC {
+      //Condition Register Condition Code (CRCC)
+      CRCC_LT = 0x0, // less than
+      CRCC_GT = 0x1, // greater than
+      CRCC_EQ = 0x2, // equal
+      CRCC_SO = 0x3  // summary overflow
+   };
 
    bool getUseVSR() { return _useVSR; }
    void setUseVSR(bool value) { _useVSR = value; }

--- a/compiler/p/codegen/OMRRealRegister.hpp
+++ b/compiler/p/codegen/OMRRealRegister.hpp
@@ -80,10 +80,11 @@ class OMR_EXTENSIBLE RealRegister : public OMR::RealRegister
 
    enum CRCC {
       //Condition Register Condition Code (CRCC)
-      CRCC_LT = 0x0, // less than
-      CRCC_GT = 0x1, // greater than
-      CRCC_EQ = 0x2, // equal
-      CRCC_SO = 0x3  // summary overflow
+      CRCC_LT = 0x0,    // less than
+      CRCC_GT = 0x1,    // greater than
+      CRCC_EQ = 0x2,    // equal
+      CRCC_SO = 0x3,    // summary overflow
+      CRCC_FU = CRCC_SO // floating-point unordered
    };
 
    bool getUseVSR() { return _useVSR; }


### PR DESCRIPTION
Floating-point and fixed-point have the same condition code. So we
can use a more general name for the condition code.

Issue: #401
Signed-off-by: Zhouyang Gao <zhouyang@ca.ibm.com>