### PR TITLE
Add interface for specifying the offset of struct members in JitBuilder

### DIFF
--- a/compiler/ilgen/TypeDictionary.hpp
+++ b/compiler/ilgen/TypeDictionary.hpp
@@ -85,7 +85,9 @@ public:
 
    TR::IlType * LookupStruct(const char *structName);
    TR::IlType * DefineStruct(const char *structName);
+   void DefineField(const char *structName, const char *fieldName, TR::IlType *type, size_t offset);
    void DefineField(const char *structName, const char *fieldName, TR::IlType *type);
+   void CloseStruct(const char *structName, size_t finalSize);
    void CloseStruct(const char *structName);
    TR::IlType * GetFieldType(const char *structName, const char *fieldName);
 

--- a/compiler/ilgen/TypeDictionary.hpp
+++ b/compiler/ilgen/TypeDictionary.hpp
@@ -84,11 +84,78 @@ public:
    ~TypeDictionary() throw();
 
    TR::IlType * LookupStruct(const char *structName);
+
+   /**
+    * @brief Begin definition of a new structure type
+    * @param structName the name of the new type
+    * @return pointer to IlType instance of the new type being defined
+    * 
+    * The name of the new type will have to be used when specifying
+    * fields of the type. This method must be invoked once before any
+    * calls to `DefineField()` and `CloseStruct()`.
+    */
    TR::IlType * DefineStruct(const char *structName);
+
+   /**
+    * @brief Define a member of a new structure type
+    * @param structName the name of the struct type on which to define the field
+    * @param fieldName the name of the field
+    * @param type the IlType instance representing the type of the field
+    * @param offset the offset of the field within the structure (in bytes)
+    * 
+    * Fields defined using this method must be defined in offset order.
+    * Specifically, the `offset` on any call to this method must be greater
+    * than or equal to the size of the new struct at the time of the call
+    * (`getSize() <= offset`). Failure to meet this condition will result
+    * in a runtime failure. This was done as an initial attempt to prevent
+    * struct fields from overlapping in memory.
+    * 
+    * This method can only be called after a call to `DefineStruct` and
+    * before a call to `CloseStruct` with the same `structName`.
+    */
    void DefineField(const char *structName, const char *fieldName, TR::IlType *type, size_t offset);
+
+   /**
+    * @brief Define a member of a new structure type
+    * @param structName the name of the struct type on which to define the field
+    * @param fieldName the name of the field
+    * @param type the IlType instance representing the type of the field
+    * 
+    * This is an overloaded method. Since no offset for the new struct field is
+    * specified, it will be added to the end of the struct using alignment rules
+    * internally defined by JitBuilder. These are not guaranteed match the rules
+    * used by a C/C++ compiler as alignment rules are compiler specific. However,
+    * the alignment should be the same in most cases.
+    * 
+    * This method can only be called after a call to `DefineStruct` and
+    * before a call to `CloseStruct` with the same `structName`.
+    */
    void DefineField(const char *structName, const char *fieldName, TR::IlType *type);
+
+   /**
+    * @brief End definition of a new structure type
+    * @param structName the name of the new type of which the definition is ended
+    * @param finalSize the final size (in bytes) of the type
+    * 
+    * The `finalSize` of the struct must be greater than or equal to the size of
+    * the new struct at the time of the call (`getSize() <= finalSize`). If
+    * `finalSize` is greater, the size of the struct will be adjusted. Failure to
+    * meet this condition will result in a runtime failure. This was done as
+    * done as an initial attempt to help ensure that adequate padding is added to
+    * the end of the new struct for use in arrays and nested structs.
+    */
    void CloseStruct(const char *structName, size_t finalSize);
+
+   /**
+    * @brief End definition of a new structure type
+    * @param structName the name of the new type of which the definition is ended
+    * 
+    * This is an overloaded method. Since the final size of the struct is not
+    * specified, the size of the new struct at the time of call to this method
+    * will be the final size of the new struct type.
+    */
    void CloseStruct(const char *structName);
+
    TR::IlType * GetFieldType(const char *structName, const char *fieldName);
 
    TR::IlType *PrimitiveType(TR::DataType primitiveType)

--- a/jitbuilder/release/src/StructArray.cpp
+++ b/jitbuilder/release/src/StructArray.cpp
@@ -28,7 +28,7 @@
 #include "StructArray.hpp"
 
 
-void printStructElems(int8_t type, int32_t value)
+void printStructElems(uint8_t type, int32_t value)
    {
    #define PRINTSTRUCTELEMS_LINE LINETOSTR(__LINE__)
    printf("StructType { type = %#x, value = %d }\n", type, value);
@@ -41,12 +41,12 @@ CreateStructArrayMethod::CreateStructArrayMethod(TR::TypeDictionary *d)
    DefineLine(LINETOSTR(__LINE__));
    DefineFile(__FILE__);
 
-   DefineName("testCreateStructArray");
-   DefineParameter("size", Int32);
-   DefineReturnType(Address);
-
    StructType = d->LookupStruct("Struct");
    pStructType = d->PointerTo(StructType);
+
+   DefineName("testCreateStructArray");
+   DefineParameter("size", Int32);
+   DefineReturnType(pStructType);
 
    DefineFunction("malloc",
                   "",
@@ -98,13 +98,13 @@ ReadStructArrayMethod::ReadStructArrayMethod(TR::TypeDictionary *d)
    DefineLine(LINETOSTR(__LINE__));
    DefineFile(__FILE__);
 
-   DefineName("testReadStructArray");
-   DefineParameter("myArray", Address);
-   DefineParameter("size", Int32);
-   DefineReturnType(NoType);
-
    StructType = d->LookupStruct("Struct");
    pStructType = d->PointerTo(StructType);
+
+   DefineName("testReadStructArray");
+   DefineParameter("myArray", pStructType);
+   DefineParameter("size", Int32);
+   DefineReturnType(NoType);
 
    DefineFunction("printStructElems",
                   __FILE__,
@@ -149,9 +149,9 @@ class StructArrayTypeDictionary : public TR::TypeDictionary
       TR::TypeDictionary()
       {
       DefineStruct("Struct");
-      DefineField("Struct", "type", Int8);
-      DefineField("Struct", "value", Int32);
-      CloseStruct("Struct");
+      DefineField("Struct", "type", Int8, offsetof(Struct, type));
+      DefineField("Struct", "value", Int32, offsetof(Struct, value));
+      CloseStruct("Struct", sizeof(Struct));
       }
    };
 
@@ -194,7 +194,7 @@ main(int argc, char *argv[])
    printf("Step 5: invoke compiled code for createMethod\n");
    auto arraySize = 16;
    CreateStructArrayFunctionType *create = (CreateStructArrayFunctionType *) createEntry;
-   void* array = create(arraySize);
+   Struct* array = create(arraySize);
 
    printf("Step 6: invoke compiled code for readMethod and verify results\n");
    ReadStructArrayFunctionType *read = (ReadStructArrayFunctionType *) readEntry;

--- a/jitbuilder/release/src/StructArray.hpp
+++ b/jitbuilder/release/src/StructArray.hpp
@@ -24,9 +24,14 @@
 
 namespace TR { class TypeDictionary; }
 
-typedef void* (CreateStructArrayFunctionType)(int);
+struct Struct {
+   uint8_t type;
+   int32_t value;
+};
 
-typedef void (ReadStructArrayFunctionType)(void*, int);
+typedef Struct* (CreateStructArrayFunctionType)(int);
+
+typedef void (ReadStructArrayFunctionType)(Struct*, int);
 
 class CreateStructArrayMethod : public TR::MethodBuilder
    {


### PR DESCRIPTION
This interface provides a way of resolving issue #376 by allowing the user to specify offsets in such a way that they match those of the C/C++ compiler.

It also provides a workaround for issue #390, since the offset of the an inner struct can be simply specified. However, it does not address the issue of accessing the member. This will have to be resolved by another PR.