### PR TITLE
Move TR_*Relocation into TR namespace

### DIFF
--- a/compiler/arm/codegen/ARMBinaryEncoding.cpp
+++ b/compiler/arm/codegen/ARMBinaryEncoding.cpp
@@ -80,7 +80,7 @@ uint32_t encodeHelperBranch(bool isBranchAndLink, TR::SymbolReference *symRef, u
       }
 
    cg->addAOTRelocation(
-      new (cg->trHeapMemory()) TR_ExternalRelocation(cursor,
+      new (cg->trHeapMemory()) TR::ExternalRelocation(cursor,
                                      (uint8_t *)symRef,
                                      TR_HelperAddress, cg),
       __FILE__, __LINE__, node);
@@ -108,7 +108,7 @@ uint8_t *TR::ARMLabelInstruction::generateBinaryEncoding()
          if (destination != 0)
             *(int32_t *)cursor |= encodeBranchDistance((uintptr_t)cursor, destination);
          else
-            cg()->addRelocation(new (cg()->trHeapMemory()) TR_24BitLabelRelativeRelocation(cursor, label));
+            cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative24BitRelocation(cursor, label));
          }
       else
          {
@@ -117,7 +117,7 @@ uint8_t *TR::ARMLabelInstruction::generateBinaryEncoding()
          insertTargetRegister(toARMCursor(cursor));
          insertSource1Register(toARMCursor(cursor));
          *((uint32_t *)cursor) |= 1 << 25;    // set the I bit
-         cg()->addRelocation(new (cg()->trHeapMemory()) TR_8BitLabelRelativeRelocation(cursor, label));
+         cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative8BitRelocation(cursor, label));
          }
       cursor += ARM_INSTRUCTION_LENGTH;
       }
@@ -216,13 +216,13 @@ uint8_t *TR::ARMImmInstruction::generateBinaryEncoding()
       switch(getReloKind())
          {
          case TR_AbsoluteHelperAddress:
-            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, (uint8_t *)getSymbolReference(), TR_AbsoluteHelperAddress, cg()), __FILE__, __LINE__, getNode());
+            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)getSymbolReference(), TR_AbsoluteHelperAddress, cg()), __FILE__, __LINE__, getNode());
             break;
          case TR_RamMethod:
-            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, NULL, TR_RamMethod, cg()), __FILE__, __LINE__, getNode());
+            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_RamMethod, cg()), __FILE__, __LINE__, getNode());
             break;
          case TR_BodyInfoAddress:
-            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, 0, TR_BodyInfoAddress, cg()), __FILE__, __LINE__, getNode());
+            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, 0, TR_BodyInfoAddress, cg()), __FILE__, __LINE__, getNode());
             break;
          default:
             TR_ASSERT(false, "Unsupported AOT relocation type specified.");
@@ -234,7 +234,7 @@ uint8_t *TR::ARMImmInstruction::generateBinaryEncoding()
       //
       void **locationToPatch = (void**)cursor;
       cg()->jitAddPicToPatchOnClassRedefinition(*locationToPatch, locationToPatch);
-      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation((uint8_t *)locationToPatch, (uint8_t *)*locationToPatch, TR_HCR, cg()), __FILE__,__LINE__, getNode());
+      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation((uint8_t *)locationToPatch, (uint8_t *)*locationToPatch, TR_HCR, cg()), __FILE__,__LINE__, getNode());
       }
 
    cursor += ARM_INSTRUCTION_LENGTH;
@@ -293,7 +293,7 @@ uint8_t *TR::ARMImmSymInstruction::generateBinaryEncoding()
          }
       else if (label != NULL)
          {
-         cg()->addRelocation(new (cg()->trHeapMemory()) TR_24BitLabelRelativeRelocation(cursor, label));
+         cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative24BitRelocation(cursor, label));
          ((TR::ARMCallSnippet *)getCallSnippet())->setCallRA(cursor+4);
          }
       else
@@ -335,7 +335,7 @@ uint8_t *TR::ARMImmSymInstruction::generateBinaryEncoding()
 
                // no need to add 4 to cursor, it is done below in the
                // common path
-               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(
+               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
                   cursor,
                   NULL,
                   TR_AbsoluteMethodAddress,
@@ -612,7 +612,7 @@ uint8_t *TR::ARMVirtualGuardNOPInstruction::generateBinaryEncoding()
    if (label->getCodeLocation() == NULL)
       {
       _site->setDestination(cursor);
-      cg()->addRelocation(new (cg()->trHeapMemory()) TR_LabelAbsoluteRelocation((uint8_t *) (&_site->getDestination()), label));
+      cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelAbsoluteRelocation((uint8_t *) (&_site->getDestination()), label));
 
 #ifdef DEBUG
    if (debug("traceVGNOP"))

--- a/compiler/arm/codegen/ConstantDataSnippet.cpp
+++ b/compiler/arm/codegen/ConstantDataSnippet.cpp
@@ -336,7 +336,7 @@ uint8_t *TR::ARMConstantDataSnippet::emitSnippetBody()
                   }
                else
                   {
-                  cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_BeforeBinaryEncodingExternalRelocation(requestors[i],
+                  cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(requestors[i],
                                                                                                (uint8_t *)(addr),
                                                                                                (uint8_t *)fixedSequence4,
                                                                                                TR_FixedSequenceAddress2, cg()),
@@ -351,7 +351,7 @@ uint8_t *TR::ARMConstantDataSnippet::emitSnippetBody()
                *(int32_t *)iloc2 |= LO_VALUE(addr) & 0x0000ffff;
                TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
                recordInfo->data3 = orderedPairSequence1;
-               cg()->addAOTRelocation(new (_cg->trHeapMemory()) TR_32BitExternalOrderedPairRelocation(iloc1,
+               cg()->addAOTRelocation(new (_cg->trHeapMemory()) TR::ExternalOrderedPair32BitRelocation(iloc1,
                                                                                                       iloc2,
                                                                                                       (uint8_t *)recordInfo,
                                                                                                       TR_AbsoluteMethodAddressOrderedPair,
@@ -398,7 +398,7 @@ uint8_t *TR::ARMConstantDataSnippet::emitSnippetBody()
                   }
                else
                   {
-                  cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_BeforeBinaryEncodingExternalRelocation(requestors[i],
+                  cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(requestors[i],
                                                                                                (uint8_t *)(addr),
                                                                                                (uint8_t *)fixedSequence4,
                                                                                                TR_FixedSequenceAddress2,
@@ -415,7 +415,7 @@ uint8_t *TR::ARMConstantDataSnippet::emitSnippetBody()
 
                TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
                recordInfo->data3 = orderedPairSequence1;
-               cg()->addAOTRelocation(new (_cg->trHeapMemory()) TR_32BitExternalOrderedPairRelocation(iloc1, iloc2, (uint8_t *)recordInfo, TR_AbsoluteMethodAddressOrderedPair, cg()),
+               cg()->addAOTRelocation(new (_cg->trHeapMemory()) TR::ExternalOrderedPair32BitRelocation(iloc1, iloc2, (uint8_t *)recordInfo, TR_AbsoluteMethodAddressOrderedPair, cg()),
                                       __FILE__, __LINE__, requestors[i]->getNode());
                }
             }
@@ -453,8 +453,8 @@ uint8_t *TR::ARMConstantDataSnippet::emitSnippetBody()
 
                if (kind != TR_NoRelocation)
                   {
-                  TR_Relocation *relo;
-                  relo = new (cg()->trHeapMemory()) TR_ExternalRelocation(codeCursor, (uint8_t *)node, kind, cg());
+                  TR::Relocation *relo;
+                  relo = new (cg()->trHeapMemory()) TR::ExternalRelocation(codeCursor, (uint8_t *)node, kind, cg());
                   cg()->addAOTRelocation(relo, __FILE__, __LINE__, node);
                   }
                }
@@ -490,7 +490,7 @@ uint8_t *TR::ARMConstantDataSnippet::emitSnippetBody()
                }
             else
                {
-               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_BeforeBinaryEncodingExternalRelocation(requestors[i],
+               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(requestors[i],
                                                                                                (uint8_t *)(addr),
                                                                                                (uint8_t *)fixedSequence4,
                                                                                                TR_FixedSequenceAddress2,

--- a/compiler/arm/codegen/OMRMemoryReference.cpp
+++ b/compiler/arm/codegen/OMRMemoryReference.cpp
@@ -847,7 +847,7 @@ uint8_t *OMR::ARM::MemoryReference::generateBinaryEncoding(TR::Instruction *curr
       TR::RealRegister *mBase = toRealRegister(self()->getModBase());
       self()->getUnresolvedSnippet()->setAddressOfDataReference(cursor);
       self()->getUnresolvedSnippet()->setMemoryReference(self());
-      cg->addRelocation(new (cg->trHeapMemory()) TR_24BitLabelRelativeRelocation(cursor, self()->getUnresolvedSnippet()->getSnippetLabel()));
+      cg->addRelocation(new (cg->trHeapMemory()) TR::LabelRelative24BitRelocation(cursor, self()->getUnresolvedSnippet()->getSnippetLabel()));
       *wcursor = 0xEA000000; // insert a branch to the snippet
       wcursor++;
       cursor += ARM_INSTRUCTION_LENGTH;

--- a/compiler/arm/codegen/OMRMemoryReference.hpp
+++ b/compiler/arm/codegen/OMRMemoryReference.hpp
@@ -43,7 +43,7 @@ namespace OMR { typedef OMR::ARM::MemoryReference MemoryReferenceConnector; }
 #include "il/symbol/ResolvedMethodSymbol.hpp"
 #include "il/symbol/StaticSymbol.hpp"
 
-class TR_ARMPairedRelocation;
+namespace TR { class ARMPairedRelocation; }
 namespace TR { class CodeGenerator; }
 namespace TR { class Register; }
 namespace TR { class RegisterDependencyConditions; }
@@ -65,7 +65,7 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
    TR::Register *_modBase;
 
    TR::UnresolvedDataSnippet *_unresolvedSnippet;
-   TR_ARMPairedRelocation *_staticRelocation;
+   TR::ARMPairedRelocation *_staticRelocation;
    TR::SymbolReference _symbolReference;
 
    uint8_t                       _flag;
@@ -172,8 +172,8 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
       return (_unresolvedSnippet = s);
       }
 
-   TR_ARMPairedRelocation *getStaticRelocation() {return _staticRelocation;}
-   TR_ARMPairedRelocation *setStaticRelocation(TR_ARMPairedRelocation *r)
+   TR::ARMPairedRelocation *getStaticRelocation() {return _staticRelocation;}
+   TR::ARMPairedRelocation *setStaticRelocation(TR::ARMPairedRelocation *r)
       {
       return (_staticRelocation = r);
       }

--- a/compiler/arm/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.cpp
@@ -212,7 +212,7 @@ TR::Instruction *loadAddressConstantFixed(TR::CodeGenerator *cg, TR::Node * node
       if (typeAddress == -1)
          {
          if (doAOTRelocation)
-            cg->addAOTRelocation(new (cg->trHeapMemory()) TR_BeforeBinaryEncodingExternalRelocation(
+            cg->addAOTRelocation(new (cg->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
                               cursor,
                               (uint8_t *)value,
                               (uint8_t *)seqKind,
@@ -232,7 +232,7 @@ TR::Instruction *loadAddressConstantFixed(TR::CodeGenerator *cg, TR::Node * node
                recordInfo->data2 = (uintptr_t)node->getInlinedSiteIndex();
                recordInfo->data3 = (uintptr_t)seqKind;
 
-               cg->addAOTRelocation(new (cg->trHeapMemory()) TR_BeforeBinaryEncodingExternalRelocation(
+               cg->addAOTRelocation(new (cg->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
                                  cursor,
                                  (uint8_t *)recordInfo,
                                  (TR_ExternalRelocationTargetKind)typeAddress, cg),
@@ -250,7 +250,7 @@ TR::Instruction *loadAddressConstantFixed(TR::CodeGenerator *cg, TR::Node * node
                 recordInfo->data2 = (uintptr_t)targetAddress2;
                 recordInfo->data3 = (uintptr_t)seqKind;
 
-                cg->addAOTRelocation(new (cg->trHeapMemory()) TR_BeforeBinaryEncodingExternalRelocation(
+                cg->addAOTRelocation(new (cg->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
                                   cursor,
                                   (uint8_t *)recordInfo,
                                   (TR_ExternalRelocationTargetKind)typeAddress, cg),
@@ -263,7 +263,7 @@ TR::Instruction *loadAddressConstantFixed(TR::CodeGenerator *cg, TR::Node * node
             {
             if (doAOTRelocation)
                {
-               cg->addAOTRelocation(new (cg->trHeapMemory()) TR_BeforeBinaryEncodingExternalRelocation(
+               cg->addAOTRelocation(new (cg->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
                                  cursor,
                                  targetAddress,
                                  targetAddress2,
@@ -276,7 +276,7 @@ TR::Instruction *loadAddressConstantFixed(TR::CodeGenerator *cg, TR::Node * node
          else
             {
             if (doAOTRelocation)
-               cg->addAOTRelocation(new (cg->trHeapMemory()) TR_BeforeBinaryEncodingExternalRelocation(
+               cg->addAOTRelocation(new (cg->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
                                  cursor,
                                  (uint8_t *)value,
                                  (uint8_t *)seqKind,

--- a/compiler/codegen/OMRAheadOfTimeCompile.cpp
+++ b/compiler/codegen/OMRAheadOfTimeCompile.cpp
@@ -19,7 +19,7 @@
 #include "codegen/AheadOfTimeCompile.hpp"
 
 #include "codegen/CodeGenerator.hpp"         // for CodeGenerator
-#include "codegen/Relocation.hpp"            // for TR_Relocation
+#include "codegen/Relocation.hpp"            // for TR::Relocation
 #include "compile/Method.hpp"                // for TR_AOTMethodInfo
 #include "compile/ResolvedMethod.hpp"        // for TR_ResolvedMethod
 #include "compile/SymbolReferenceTable.hpp"  // for SymbolReferenceTable

--- a/compiler/codegen/OMRAheadOfTimeCompile.hpp
+++ b/compiler/codegen/OMRAheadOfTimeCompile.hpp
@@ -34,7 +34,7 @@ namespace OMR { typedef OMR::AheadOfTimeCompile AheadOfTimeCompileConnector; }
 #include "runtime/Runtime.hpp"      // for TR_ExternalRelocationTargetKind
 
 class TR_Debug;
-class TR_IteratedExternalRelocation;
+namespace TR { class IteratedExternalRelocation; }
 namespace TR { class AheadOfTimeCompile; }
 
 namespace OMR
@@ -58,7 +58,7 @@ class OMR_EXTENSIBLE AheadOfTimeCompile
    TR_Debug *   getDebug();
    TR_Memory *      trMemory();
 
-   TR_LinkHead<TR_IteratedExternalRelocation>& getAOTRelocationTargets() {return _aotRelocationTargets;}
+   TR_LinkHead<TR::IteratedExternalRelocation>& getAOTRelocationTargets() {return _aotRelocationTargets;}
 
    uint32_t getSizeOfAOTRelocations()             {return _sizeOfAOTRelocations;}
    uint32_t setSizeOfAOTRelocations(uint32_t s)   {return (_sizeOfAOTRelocations = s);}
@@ -78,7 +78,7 @@ class OMR_EXTENSIBLE AheadOfTimeCompile
       }
 
    virtual void     processRelocations() = 0;
-   virtual uint8_t *initialiseAOTRelocationHeader(TR_IteratedExternalRelocation *relocation) = 0;
+   virtual uint8_t *initialiseAOTRelocationHeader(TR::IteratedExternalRelocation *relocation) = 0;
 
    // virtual void dumpRelocationData() = 0;
    void dumpRelocationData() {}
@@ -88,7 +88,7 @@ class OMR_EXTENSIBLE AheadOfTimeCompile
 
    private:
    TR::Compilation *                           _comp;
-   TR_LinkHead<TR_IteratedExternalRelocation> _aotRelocationTargets;
+   TR_LinkHead<TR::IteratedExternalRelocation> _aotRelocationTargets;
    uint32_t                                   _sizeOfAOTRelocations;
    uint8_t                                   *_relocationData;
    uint32_t                                  *_aotRelocationKindToHeaderSizeMap;

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -44,7 +44,7 @@
 #include "codegen/RegisterConstants.hpp"
 #include "codegen/RegisterPair.hpp"                 // for RegisterPair
 #include "codegen/RegisterUsage.hpp"                // for RegisterUsage
-#include "codegen/Relocation.hpp"                   // for TR_Relocation, etc
+#include "codegen/Relocation.hpp"                   // for TR::Relocation, etc
 #include "codegen/Snippet.hpp"                      // for Snippet
 #include "codegen/StorageInfo.hpp"                  // for TR_StorageInfo, etc
 #include "codegen/TreeEvaluator.hpp"                // for TreeEvaluator
@@ -265,8 +265,8 @@ OMR::CodeGenerator::generateNop(TR::Node * node, TR::Instruction *instruction, T
      _nodesSpineCheckedList(getTypedAllocator<TR::Node*>(TR::comp()->allocator())),
      _collectedSpillList(getTypedAllocator<TR_BackingStore*>(TR::comp()->allocator())),
      _allSpillList(getTypedAllocator<TR_BackingStore*>(TR::comp()->allocator())),
-     _relocationList(getTypedAllocator<TR_Relocation*>(TR::comp()->allocator())),
-     _aotRelocationList(getTypedAllocator<TR_Relocation*>(TR::comp()->allocator())),
+     _relocationList(getTypedAllocator<TR::Relocation*>(TR::comp()->allocator())),
+     _aotRelocationList(getTypedAllocator<TR::Relocation*>(TR::comp()->allocator())),
      _breakPointList(getTypedAllocator<uint8_t*>(TR::comp()->allocator())),
      _jniCallSites(getTypedAllocator<TR_Pair<TR_ResolvedMethod,TR::Instruction> *>(TR::comp()->allocator())),
      _lowestSavedReg(0),
@@ -3746,7 +3746,7 @@ TR::list<OMR::RegisterUsage*> *OMR::CodeGenerator::stopRecordingRegisterUsage()
    }
 
 
-void OMR::CodeGenerator::addRelocation(TR_Relocation *r)
+void OMR::CodeGenerator::addRelocation(TR::Relocation *r)
    {
    if (r->isAOTRelocation())
       {
@@ -3758,12 +3758,12 @@ void OMR::CodeGenerator::addRelocation(TR_Relocation *r)
       }
    }
 
-void OMR::CodeGenerator::addAOTRelocation(TR_Relocation *r, char *generatingFileName, uintptr_t generatingLineNumber, TR::Node *node)
+void OMR::CodeGenerator::addAOTRelocation(TR::Relocation *r, char *generatingFileName, uintptr_t generatingLineNumber, TR::Node *node)
    {
    TR_ASSERT(generatingFileName, "AOT relocation location has improper NULL filename specified");
    if (self()->comp()->compileRelocatableCode())
       {
-      TR_RelocationDebugInfo *genData = new(self()->trHeapMemory()) TR_RelocationDebugInfo;
+      TR::RelocationDebugInfo *genData = new(self()->trHeapMemory()) TR::RelocationDebugInfo;
       genData->file = generatingFileName;
       genData->line = generatingLineNumber;
       genData->node = node;
@@ -3772,7 +3772,7 @@ void OMR::CodeGenerator::addAOTRelocation(TR_Relocation *r, char *generatingFile
       }
    }
 
-void OMR::CodeGenerator::addAOTRelocation(TR_Relocation *r, TR_RelocationDebugInfo* info)
+void OMR::CodeGenerator::addAOTRelocation(TR::Relocation *r, TR::RelocationDebugInfo* info)
    {
    if (self()->comp()->compileRelocatableCode())
       {

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -77,8 +77,8 @@ class TR_OSRMethodData;
 class TR_PseudoRegister;
 class TR_RegisterCandidate;
 class TR_RegisterCandidates;
-class TR_Relocation;
-class TR_RelocationDebugInfo;
+namespace TR { class Relocation; }
+namespace TR { class RelocationDebugInfo; }
 class TR_ResolvedMethod;
 class TR_ScratchRegisterManager;
 namespace TR { class GCStackAtlas; }
@@ -1059,12 +1059,12 @@ class OMR_EXTENSIBLE CodeGenerator
    // --------------------------------------------------------------------------
    // Relocations
    //
-   TR::list<TR_Relocation*>& getRelocationList() {return _relocationList;}
-   TR::list<TR_Relocation*>& getAOTRelocationList() {return _aotRelocationList;}
+   TR::list<TR::Relocation*>& getRelocationList() {return _relocationList;}
+   TR::list<TR::Relocation*>& getAOTRelocationList() {return _aotRelocationList;}
 
-   void addRelocation(TR_Relocation *r);
-   void addAOTRelocation(TR_Relocation *r, char *generatingFileName, uintptr_t generatingLineNumber, TR::Node *node);
-   void addAOTRelocation(TR_Relocation *r, TR_RelocationDebugInfo *info);
+   void addRelocation(TR::Relocation *r);
+   void addAOTRelocation(TR::Relocation *r, char *generatingFileName, uintptr_t generatingLineNumber, TR::Node *node);
+   void addAOTRelocation(TR::Relocation *r, TR::RelocationDebugInfo *info);
 
    void addProjectSpecializedRelocation(uint8_t *location,
                                           uint8_t *target,
@@ -1888,8 +1888,8 @@ class OMR_EXTENSIBLE CodeGenerator
    TR::list<TR_BackingStore*> _internalPointerSpillFreeList;
    TR::list<TR_BackingStore*> _collectedSpillList;
    TR::list<TR_BackingStore*> _allSpillList;
-   TR::list<TR_Relocation *> _relocationList;
-   TR::list<TR_Relocation *> _aotRelocationList;
+   TR::list<TR::Relocation *> _relocationList;
+   TR::list<TR::Relocation *> _aotRelocationList;
    TR::list<uint8_t*> _breakPointList;
 
    TR::list<TR::SymbolReference*> _variableSizeSymRefPendingFreeList;

--- a/compiler/codegen/Relocation.cpp
+++ b/compiler/codegen/Relocation.cpp
@@ -36,101 +36,101 @@
 #include "infra/Link.hpp"                   // for TR_LinkHead, TR_Link
 #include "runtime/Runtime.hpp"
 
-void TR_Relocation::apply(TR::CodeGenerator *codeGen)
+void TR::Relocation::apply(TR::CodeGenerator *codeGen)
    {
    TR_ASSERT(0, "Should never get here");
    }
 
-void TR_Relocation::trace(TR::Compilation* comp)
+void TR::Relocation::trace(TR::Compilation* comp)
    {
    TR_ASSERT(0, "Should never get here");
    }
 
-void TR_Relocation::setDebugInfo(TR_RelocationDebugInfo* info)
+void TR::Relocation::setDebugInfo(TR::RelocationDebugInfo* info)
    {
    this->_genData= info;
    }
 
-TR_RelocationDebugInfo* TR_Relocation::getDebugInfo()
+TR::RelocationDebugInfo* TR::Relocation::getDebugInfo()
    {
    return this->_genData;
    }
-void TR_8BitLabelRelativeRelocation::apply(TR::CodeGenerator *codeGen)
+void TR::LabelRelative8BitRelocation::apply(TR::CodeGenerator *codeGen)
    {
    // *this    swipeable for debugging purposes
-   AOTcgDiag2(codeGen->comp(), "TR_8BitLabelRelativeRelocation::apply cursor=%x label=%x\n", getUpdateLocation(), getLabel());
+   AOTcgDiag2(codeGen->comp(), "TR::LabelRelative8BitRelocation::apply cursor=%x label=%x\n", getUpdateLocation(), getLabel());
    codeGen->apply8BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel());
    }
 
-void TR_12BitLabelRelativeRelocation::apply(TR::CodeGenerator *codeGen)
+void TR::LabelRelative12BitRelocation::apply(TR::CodeGenerator *codeGen)
    {
    // *this    swipeable for debugging purposes
-   AOTcgDiag2(codeGen->comp(), "TR_12BitLabelRelativeRelocation::apply cursor=%x label=%x\n", getUpdateLocation(), getLabel());
+   AOTcgDiag2(codeGen->comp(), "TR::LabelRelative12BitRelocation::apply cursor=%x label=%x\n", getUpdateLocation(), getLabel());
    codeGen->apply12BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel(), isCheckDisp());
    }
 
-void TR_16BitLabelRelativeRelocation::apply(TR::CodeGenerator *codeGen)
+void TR::LabelRelative16BitRelocation::apply(TR::CodeGenerator *codeGen)
    {
    // *this    swipeable for debugging purposes
-   AOTcgDiag2(codeGen->comp(), "TR_16BitLabelRelativeRelocation::apply cursor=%x label=%x\n", getUpdateLocation(), getLabel());
+   AOTcgDiag2(codeGen->comp(), "TR::LabelRelative16BitRelocation::apply cursor=%x label=%x\n", getUpdateLocation(), getLabel());
    if(getAddressDifferenceDivisor() == 1)
    codeGen->apply16BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel());
    else
      codeGen->apply16BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel(), getAddressDifferenceDivisor(), isInstructionOffset());
    }
 
-void TR_24BitLabelRelativeRelocation::apply(TR::CodeGenerator *codeGen)
+void TR::LabelRelative24BitRelocation::apply(TR::CodeGenerator *codeGen)
    {
    // *this    swipeable for debugging purposes
-   AOTcgDiag2(codeGen->comp(), "TR_24BitLabelRelativeRelocation::apply cursor=%x label=%x\n", getUpdateLocation(), getLabel());
+   AOTcgDiag2(codeGen->comp(), "TR::LabelRelative24BitRelocation::apply cursor=%x label=%x\n", getUpdateLocation(), getLabel());
    codeGen->apply24BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel());
    }
 
-void TR_32BitLabelRelativeRelocation::apply(TR::CodeGenerator *codeGen)
+void TR::LabelRelative32BitRelocation::apply(TR::CodeGenerator *codeGen)
    {
    // *this    swipeable for debugging purposes
-   AOTcgDiag2(codeGen->comp(), "TR_32BitLabelRelativeRelocation::apply cursor=%x label=%x\n", getUpdateLocation(), getLabel());
+   AOTcgDiag2(codeGen->comp(), "TR::LabelRelative32BitRelocation::apply cursor=%x label=%x\n", getUpdateLocation(), getLabel());
    codeGen->apply32BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel());
    }
 
-void TR_LabelAbsoluteRelocation::apply(TR::CodeGenerator *codeGen)
+void TR::LabelAbsoluteRelocation::apply(TR::CodeGenerator *codeGen)
    {
    // *this    swipeable for debugging purposes
    intptrj_t *cursor = (intptrj_t *)getUpdateLocation();
-   AOTcgDiag2(codeGen->comp(), "TR_LabelAbsoluteRelocation::apply cursor=%x label=%x\n", cursor, getLabel());
+   AOTcgDiag2(codeGen->comp(), "TR::LabelAbsoluteRelocation::apply cursor=%x label=%x\n", cursor, getLabel());
    *cursor = (intptrj_t)getLabel()->getCodeLocation();
    }
 
-void TR_InstructionAbsoluteRelocation::apply(TR::CodeGenerator *codeGen)
+void TR::InstructionAbsoluteRelocation::apply(TR::CodeGenerator *codeGen)
    {
    intptrj_t *cursor = (intptrj_t*)getUpdateLocation();
    intptrj_t address = (intptrj_t)getInstruction()->getBinaryEncoding();
    if (useEndAddress())
       address += getInstruction()->getBinaryLength();
-   AOTcgDiag2(codeGen->comp(), "TR_InstructionAbsoluteRelocation::apply cursor=%x instruction=%x\n", cursor, address);
+   AOTcgDiag2(codeGen->comp(), "TR::InstructionAbsoluteRelocation::apply cursor=%x instruction=%x\n", cursor, address);
    *cursor = address;
    }
 
 
-void TR_16BitLoadLabelRelativeRelocation::apply(TR::CodeGenerator *codeGen)
+void TR::LoadLabelRelative16BitRelocation::apply(TR::CodeGenerator *codeGen)
    {
-   AOTcgDiag3(codeGen->comp(), "TR_16BitLoadLabelRelativeRelocation::apply lastInstruction=%x startLabel=%x endLabel=%x\n", getLastInstruction(), getStartLabel(), getEndLabel());
+   AOTcgDiag3(codeGen->comp(), "TR::LoadLabelRelative16BitRelocation::apply lastInstruction=%x startLabel=%x endLabel=%x\n", getLastInstruction(), getStartLabel(), getEndLabel());
    codeGen->apply16BitLoadLabelRelativeRelocation(getLastInstruction(), getStartLabel(), getEndLabel(), getDeltaToStartLabel());
    }
 
-void TR_32BitLoadLabelRelativeRelocation::apply(TR::CodeGenerator *codeGen)
+void TR::LoadLabelRelative32BitRelocation::apply(TR::CodeGenerator *codeGen)
    {
-   AOTcgDiag3(codeGen->comp(), "TR_32BitLoadLabelRelativeRelocation::apply lastInstruction=%x startLabel=%x endLabel=%x\n", getLastInstruction(), getStartLabel(), getEndLabel());
+   AOTcgDiag3(codeGen->comp(), "TR::LoadLabelRelative32BitRelocation::apply lastInstruction=%x startLabel=%x endLabel=%x\n", getLastInstruction(), getStartLabel(), getEndLabel());
    codeGen->apply32BitLoadLabelRelativeRelocation(getLastInstruction(), getStartLabel(), getEndLabel(), getDeltaToStartLabel());
    }
 
-void TR_64BitLoadLabelRelativeRelocation::apply(TR::CodeGenerator *codeGen)
+void TR::LoadLabelRelative64BitRelocation::apply(TR::CodeGenerator *codeGen)
    {
-   AOTcgDiag2(codeGen->comp(), "TR_64BitLoadLabelRelativeRelocation::apply lastInstruction=%x label=%x\n", getLastInstruction(), getLabel());
+   AOTcgDiag2(codeGen->comp(), "TR::LoadLabelRelative64BitRelocation::apply lastInstruction=%x label=%x\n", getLastInstruction(), getLabel());
    codeGen->apply64BitLoadLabelRelativeRelocation(getLastInstruction(), getLabel());
    }
 
-uint8_t TR_ExternalRelocation::collectModifier()
+uint8_t TR::ExternalRelocation::collectModifier()
    {
    // *this    swipeable for debugging purposes
    TR::Compilation *comp = TR::comp();
@@ -150,7 +150,7 @@ uint8_t TR_ExternalRelocation::collectModifier()
       }
 
    int32_t distance = updateLocation - aotMethodCodeStart;
-   AOTcgDiag1(comp, "TR_ExternalRelocation::collectModifier distance=%x\n", distance);
+   AOTcgDiag1(comp, "TR::ExternalRelocation::collectModifier distance=%x\n", distance);
 
    if (distance < MIN_SHORT_OFFSET || distance > MAX_SHORT_OFFSET)
       return RELOCATION_TYPE_WIDE_OFFSET;
@@ -158,18 +158,18 @@ uint8_t TR_ExternalRelocation::collectModifier()
    return 0;
    }
 
-void TR_ExternalRelocation::addAOTRelocation(TR::CodeGenerator *codeGen)
+void TR::ExternalRelocation::addAOTRelocation(TR::CodeGenerator *codeGen)
    {
    // *this    swipeable for debugging purposes
    TR::Compilation *comp = codeGen->comp();
-   AOTcgDiag0(comp, "TR_ExternalRelocation::addAOTRelocation\n");
+   AOTcgDiag0(comp, "TR::ExternalRelocation::addAOTRelocation\n");
    if (comp->getOption(TR_AOT))
       {
-      TR_LinkHead<TR_IteratedExternalRelocation>& aot = codeGen->getAheadOfTimeCompile()->getAOTRelocationTargets();
+      TR_LinkHead<TR::IteratedExternalRelocation>& aot = codeGen->getAheadOfTimeCompile()->getAOTRelocationTargets();
       uint32_t narrowSize = getNarrowSize();
       uint32_t wideSize = getWideSize();
       flags8_t modifier(collectModifier());
-      TR_IteratedExternalRelocation *r;
+      TR::IteratedExternalRelocation *r;
 
       AOTcgDiag1(comp, "target=%x\n", _targetAddress);
       if (_targetAddress2)
@@ -224,9 +224,9 @@ void TR_ExternalRelocation::addAOTRelocation(TR::CodeGenerator *codeGen)
             return;
             }
          }
-      TR_IteratedExternalRelocation *temp =   _targetAddress2 ?
-         new (codeGen->trHeapMemory()) TR_IteratedExternalRelocation(_targetAddress, _targetAddress2, _kind, modifier, codeGen) :
-         new (codeGen->trHeapMemory()) TR_IteratedExternalRelocation(_targetAddress, _kind, modifier, codeGen);
+      TR::IteratedExternalRelocation *temp =   _targetAddress2 ?
+         new (codeGen->trHeapMemory()) TR::IteratedExternalRelocation(_targetAddress, _targetAddress2, _kind, modifier, codeGen) :
+         new (codeGen->trHeapMemory()) TR::IteratedExternalRelocation(_targetAddress, _kind, modifier, codeGen);
 
       aot.add(temp);
       if (_targetAddress2)
@@ -250,11 +250,11 @@ void TR_ExternalRelocation::addAOTRelocation(TR::CodeGenerator *codeGen)
       }
    }
 
-void TR_ExternalRelocation::apply(TR::CodeGenerator *codeGen)
+void TR::ExternalRelocation::apply(TR::CodeGenerator *codeGen)
    {
    // *this    swipeable for debugging purposes
    TR::Compilation *comp = codeGen->comp();
-   AOTcgDiag1(comp, "TR_ExternalRelocation::apply updateLocation=%x \n", getUpdateLocation());
+   AOTcgDiag1(comp, "TR::ExternalRelocation::apply updateLocation=%x \n", getUpdateLocation());
    if (comp->getOption(TR_AOT))
       {
       uint8_t * aotMethodCodeStart = (uint8_t *)comp->getAotMethodCodeStart();
@@ -264,9 +264,9 @@ void TR_ExternalRelocation::apply(TR::CodeGenerator *codeGen)
       }
    }
 
-void TR_ExternalRelocation::trace(TR::Compilation* comp)
+void TR::ExternalRelocation::trace(TR::Compilation* comp)
    {
-   TR_RelocationDebugInfo* data = this->getDebugInfo();
+   TR::RelocationDebugInfo* data = this->getDebugInfo();
    uint8_t* updateLocation;
    TR_ExternalRelocationTargetKind kind = getRelocationRecord()->getTargetKind();
 
@@ -289,29 +289,29 @@ void TR_ExternalRelocation::trace(TR::Compilation* comp)
       }
    }
 
-uint8_t* TR_BeforeBinaryEncodingExternalRelocation::getUpdateLocation()
+uint8_t* TR::BeforeBinaryEncodingExternalRelocation::getUpdateLocation()
    {
-   if (NULL == TR_ExternalRelocation::getUpdateLocation())
+   if (NULL == TR::ExternalRelocation::getUpdateLocation())
       setUpdateLocation(getUpdateInstruction()->getBinaryEncoding());
-   return TR_ExternalRelocation::getUpdateLocation();
+   return TR::ExternalRelocation::getUpdateLocation();
    }
 
-TR_32BitExternalOrderedPairRelocation::TR_32BitExternalOrderedPairRelocation(
+TR::ExternalOrderedPair32BitRelocation::ExternalOrderedPair32BitRelocation(
                  uint8_t                         *location1,
                  uint8_t                         *location2,
                  uint8_t                         *target,
                  TR_ExternalRelocationTargetKind  k,
                  TR::CodeGenerator                *codeGen) :
-   TR_ExternalRelocation(), _update2Location(location2)
+   TR::ExternalRelocation(), _update2Location(location2)
    {
-   AOTcgDiag0(codeGen->comp(), "TR_32BitExternalOrderedPairRelocation::TR_32BitExternalOrderedPairRelocation\n");
+   AOTcgDiag0(codeGen->comp(), "TR::ExternalOrderedPair32BitRelocation::ExternalOrderedPair32BitRelocation\n");
    setUpdateLocation(location1);
    setTargetAddress(target);
    setTargetKind(k);
    }
 
 
-uint8_t TR_32BitExternalOrderedPairRelocation::collectModifier()
+uint8_t TR::ExternalOrderedPair32BitRelocation::collectModifier()
    {
    TR::Compilation *comp = TR::comp();
    uint8_t * aotMethodCodeStart = (uint8_t *)comp->getAotMethodCodeStart();
@@ -335,7 +335,7 @@ uint8_t TR_32BitExternalOrderedPairRelocation::collectModifier()
 
    int32_t iLoc = updateLocation - aotMethodCodeStart;
    int32_t iLoc2 = updateLocation2 - aotMethodCodeStart;
-   AOTcgDiag0(comp, "TR_32BitExternalOrderedPairRelocation::collectModifier\n");
+   AOTcgDiag0(comp, "TR::ExternalOrderedPair32BitRelocation::collectModifier\n");
    if ( (iLoc < MIN_SHORT_OFFSET  || iLoc > MAX_SHORT_OFFSET ) || (iLoc2 < MIN_SHORT_OFFSET || iLoc2 > MAX_SHORT_OFFSET ) )
       return RELOCATION_TYPE_WIDE_OFFSET | RELOCATION_TYPE_ORDERED_PAIR;
 
@@ -343,13 +343,13 @@ uint8_t TR_32BitExternalOrderedPairRelocation::collectModifier()
    }
 
 
-void TR_32BitExternalOrderedPairRelocation::apply(TR::CodeGenerator *codeGen)
+void TR::ExternalOrderedPair32BitRelocation::apply(TR::CodeGenerator *codeGen)
    {
    TR::Compilation *comp = codeGen->comp();
-   AOTcgDiag0(comp, "TR_32BitExternalOrderedPairRelocation::apply\n");
+   AOTcgDiag0(comp, "TR::ExternalOrderedPair32BitRelocation::apply\n");
    if (comp->getOption(TR_AOT))
       {
-      TR_IteratedExternalRelocation *rec = getRelocationRecord();
+      TR::IteratedExternalRelocation *rec = getRelocationRecord();
       uint8_t *codeStart = (uint8_t *)comp->getAotMethodCodeStart();
       TR_ExternalRelocationTargetKind kind = getRelocationRecord()->getTargetKind();
       if (TR::Compiler->target.cpu.isPower() &&
@@ -369,7 +369,7 @@ void TR_32BitExternalOrderedPairRelocation::apply(TR::CodeGenerator *codeGen)
    }
 
 // remember to update the debug extensions when add or changing relocations.
-char *TR_ExternalRelocation::_externalRelocationTargetKindNames[TR_NumExternalRelocationKinds] =
+char *TR::ExternalRelocation::_externalRelocationTargetKindNames[TR_NumExternalRelocationKinds] =
    {
    "TR_ConstantPool (0)",
    "TR_HelperAddress (1)",
@@ -429,7 +429,7 @@ char *TR_ExternalRelocation::_externalRelocationTargetKindNames[TR_NumExternalRe
    "TR_InlinedVirtualMethod (55)",
    };
 
-uintptr_t TR_ExternalRelocation::_globalValueList[TR_NumGlobalValueItems] =
+uintptr_t TR::ExternalRelocation::_globalValueList[TR_NumGlobalValueItems] =
    {
    0,          // not used
    0,          // TR_CountForRecompile
@@ -440,7 +440,7 @@ uintptr_t TR_ExternalRelocation::_globalValueList[TR_NumGlobalValueItems] =
    0           // TR_HeapSizeForBarrierRange0
    };
 
-char *TR_ExternalRelocation::_globalValueNames[TR_NumGlobalValueItems] =
+char *TR::ExternalRelocation::_globalValueNames[TR_NumGlobalValueItems] =
    {
    "not used (0)",
    "TR_CountForRecompile (1)",
@@ -452,8 +452,8 @@ char *TR_ExternalRelocation::_globalValueNames[TR_NumGlobalValueItems] =
    };
 
 
-TR_IteratedExternalRelocation::TR_IteratedExternalRelocation(uint8_t *target, TR_ExternalRelocationTargetKind k, flags8_t modifier, TR::CodeGenerator *codeGen)
-      : TR_Link<TR_IteratedExternalRelocation>(),
+TR::IteratedExternalRelocation::IteratedExternalRelocation(uint8_t *target, TR_ExternalRelocationTargetKind k, flags8_t modifier, TR::CodeGenerator *codeGen)
+      : TR_Link<TR::IteratedExternalRelocation>(),
         _numberOfRelocationSites(0),
         _targetAddress(target),
         _targetAddress2(NULL),
@@ -465,11 +465,11 @@ TR_IteratedExternalRelocation::TR_IteratedExternalRelocation(uint8_t *target, TR
         _full(false),
         _kind(k)
       {
-      AOTcgDiag0(TR::comp(), "TR_IteratedExternalRelocation::TR_IteratedExternalRelocation\n");
+      AOTcgDiag0(TR::comp(), "TR::IteratedExternalRelocation::IteratedExternalRelocation\n");
       }
 
-TR_IteratedExternalRelocation::TR_IteratedExternalRelocation(uint8_t *target, uint8_t *target2, TR_ExternalRelocationTargetKind k, flags8_t modifier, TR::CodeGenerator *codeGen)
-      : TR_Link<TR_IteratedExternalRelocation>(),
+TR::IteratedExternalRelocation::IteratedExternalRelocation(uint8_t *target, uint8_t *target2, TR_ExternalRelocationTargetKind k, flags8_t modifier, TR::CodeGenerator *codeGen)
+      : TR_Link<TR::IteratedExternalRelocation>(),
         _numberOfRelocationSites(0),
         _targetAddress(target),
         _targetAddress2(target2),
@@ -481,21 +481,21 @@ TR_IteratedExternalRelocation::TR_IteratedExternalRelocation(uint8_t *target, ui
         _full(false),
         _kind(k)
       {
-      AOTcgDiag0(TR::comp(), "TR_IteratedExternalRelocation::TR_IteratedExternalRelocation\n");
+      AOTcgDiag0(TR::comp(), "TR::IteratedExternalRelocation::IteratedExternalRelocation\n");
       }
 
-void TR_IteratedExternalRelocation::initialiseRelocation(TR::CodeGenerator *codeGen)
+void TR::IteratedExternalRelocation::initialiseRelocation(TR::CodeGenerator *codeGen)
    {
    // *this    swipeable for debugging purposes
-   AOTcgDiag0(TR::comp(), "TR_IteratedExternalRelocation::initialiseRelocation\n");
+   AOTcgDiag0(TR::comp(), "TR::IteratedExternalRelocation::initialiseRelocation\n");
    _relocationDataCursor = codeGen->getAheadOfTimeCompile()->initialiseAOTRelocationHeader(this);
    }
 
-void TR_IteratedExternalRelocation::addRelocationEntry(uint32_t locationOffset)
+void TR::IteratedExternalRelocation::addRelocationEntry(uint32_t locationOffset)
    {
    // *this    swipeable for debugging purposes
    TR::Compilation *comp = TR::comp();
-   AOTcgDiag1(comp, "TR_IteratedExternalRelocation::addRelocationEntry _relocationDataCursor=%x\n", _relocationDataCursor);
+   AOTcgDiag1(comp, "TR::IteratedExternalRelocation::addRelocationEntry _relocationDataCursor=%x\n", _relocationDataCursor);
    if (!needsWideOffsets())
       {
       *(uint16_t *)_relocationDataCursor = (uint16_t)locationOffset;
@@ -508,7 +508,7 @@ void TR_IteratedExternalRelocation::addRelocationEntry(uint32_t locationOffset)
       }
    }
 
-void TR_32BitLabelTableRelocation::apply(TR::CodeGenerator *codeGen)
+void TR::LabelTable32BitRelocation::apply(TR::CodeGenerator *codeGen)
    {
    codeGen->apply32BitLabelTableRelocation((int32_t *)getUpdateLocation(), getLabel());
    }

--- a/compiler/codegen/Relocation.hpp
+++ b/compiler/codegen/Relocation.hpp
@@ -69,8 +69,10 @@ typedef enum
    TR_NumGlobalValueItems           = 9
    } TR_GlobalValueItem;
 
+namespace TR {
+
 /** encapsulates debug information about a relocation record */
-struct TR_RelocationDebugInfo
+struct RelocationDebugInfo
    {
    /** the file name of the code that generated the associated RR*/
    char* file;
@@ -82,25 +84,25 @@ struct TR_RelocationDebugInfo
    TR_ALLOC(TR_Memory::RelocationDebugInfo);
    };
 
-class TR_Relocation
+class Relocation
    {
    uint8_t *_updateLocation;
-   TR_RelocationDebugInfo* _genData;
+   TR::RelocationDebugInfo* _genData;
 
    public:
    TR_ALLOC(TR_Memory::Relocation)
 
-   TR_Relocation() : _updateLocation(NULL) {}
-   TR_Relocation(uint8_t *p) : _updateLocation(p) {}
+   Relocation() : _updateLocation(NULL) {}
+   Relocation(uint8_t *p) : _updateLocation(p) {}
 
    virtual uint8_t *getUpdateLocation()           {return _updateLocation;}
    uint8_t *setUpdateLocation(uint8_t *p) {return (_updateLocation = p);}
 
    virtual bool isAOTRelocation() { return true; }
 
-   TR_RelocationDebugInfo* getDebugInfo();
+   TR::RelocationDebugInfo* getDebugInfo();
 
-   void setDebugInfo(TR_RelocationDebugInfo* info);
+   void setDebugInfo(TR::RelocationDebugInfo* info);
 
    /**dumps a trace of the internals - override as required */
    virtual void trace(TR::Compilation* comp);
@@ -110,13 +112,13 @@ class TR_Relocation
    virtual void apply(TR::CodeGenerator *codeGen);
    };
 
-class TR_LabelRelocation : public TR_Relocation
+class LabelRelocation : public TR::Relocation
    {
    TR::LabelSymbol *_label;
    public:
-   TR_LabelRelocation() : TR_Relocation(), _label(NULL) {}
-   TR_LabelRelocation(uint8_t *p, TR::LabelSymbol *l) : TR_Relocation(p),
-                                                       _label(l) {}
+   LabelRelocation() : TR::Relocation(), _label(NULL) {}
+   LabelRelocation(uint8_t *p, TR::LabelSymbol *l) : TR::Relocation(p),
+                                                     _label(l) {}
 
    TR::LabelSymbol *getLabel()                  {return _label;}
    TR::LabelSymbol *setLabel(TR::LabelSymbol *l) {return (_label = l);}
@@ -124,43 +126,43 @@ class TR_LabelRelocation : public TR_Relocation
    bool isAOTRelocation() { return false; }
    };
 
-class TR_8BitLabelRelativeRelocation : public TR_LabelRelocation
+class LabelRelative8BitRelocation : public TR::LabelRelocation
    {
    public:
-   TR_8BitLabelRelativeRelocation() : TR_LabelRelocation() {}
-   TR_8BitLabelRelativeRelocation(uint8_t *p, TR::LabelSymbol *l)
-      : TR_LabelRelocation(p, l) {}
+   LabelRelative8BitRelocation() : TR::LabelRelocation() {}
+   LabelRelative8BitRelocation(uint8_t *p, TR::LabelSymbol *l)
+      : TR::LabelRelocation(p, l) {}
    virtual void apply(TR::CodeGenerator *codeGen);
    };
 
-class TR_12BitLabelRelativeRelocation : public TR_LabelRelocation
+class LabelRelative12BitRelocation : public TR::LabelRelocation
    {
    bool _isCheckDisp;
    public:
-   TR_12BitLabelRelativeRelocation() : TR_LabelRelocation() {}
-   TR_12BitLabelRelativeRelocation(uint8_t *p, TR::LabelSymbol *l, bool isCheckDisp = true)
-      : TR_LabelRelocation(p, l), _isCheckDisp(isCheckDisp) {}
+   LabelRelative12BitRelocation() : TR::LabelRelocation() {}
+   LabelRelative12BitRelocation(uint8_t *p, TR::LabelSymbol *l, bool isCheckDisp = true)
+      : TR::LabelRelocation(p, l), _isCheckDisp(isCheckDisp) {}
    bool isCheckDisp() {return _isCheckDisp;}
    virtual void apply(TR::CodeGenerator *codeGen);
    };
 
 
-class TR_16BitLabelRelativeRelocation : public TR_LabelRelocation
+class LabelRelative16BitRelocation : public TR::LabelRelocation
    {
    // field _instructionOffser is used for 16-bit relocation when we need to specify where relocation starts relative to the first byte of the instruction.
-   //Eg.: BranchPreload instruction BPP (48-bit instruction), where 16-bit relocation is at 32-47 bits, TR_16BitLabelRelativeRelocation(*p,*l, 4, true)
+   //Eg.: BranchPreload instruction BPP (48-bit instruction), where 16-bit relocation is at 32-47 bits, TR::LabelRelative16BitRelocation(*p,*l, 4, true)
    //
-   // The regular TR_16BitLabelRelativeRelocation(uint8_t *p, TR::LabelSymbol *l) only supports instructions with 16-bit relocations,
+   // The regular TR::LabelRelative16BitRelocation(uint8_t *p, TR::LabelSymbol *l) only supports instructions with 16-bit relocations,
    // where the relocation is 2 bytes (hardcoded value) form the start of the instruction
    bool _instructionOffset;
    int8_t _addressDifferenceDivisor;
    public:
-   TR_16BitLabelRelativeRelocation()
-      : TR_LabelRelocation(), _addressDifferenceDivisor(1) {}
-   TR_16BitLabelRelativeRelocation(uint8_t *p, TR::LabelSymbol *l)
-      : TR_LabelRelocation(p, l), _addressDifferenceDivisor(1) {}
-   TR_16BitLabelRelativeRelocation(uint8_t *p, TR::LabelSymbol *l, int8_t divisor, bool isInstOffset = false)
-      : TR_LabelRelocation(p, l), _addressDifferenceDivisor(divisor), _instructionOffset(isInstOffset) {}
+   LabelRelative16BitRelocation()
+      : TR::LabelRelocation(), _addressDifferenceDivisor(1) {}
+   LabelRelative16BitRelocation(uint8_t *p, TR::LabelSymbol *l)
+      : TR::LabelRelocation(p, l), _addressDifferenceDivisor(1) {}
+   LabelRelative16BitRelocation(uint8_t *p, TR::LabelSymbol *l, int8_t divisor, bool isInstOffset = false)
+      : TR::LabelRelocation(p, l), _addressDifferenceDivisor(divisor), _instructionOffset(isInstOffset) {}
 
    bool isInstructionOffset()  {return _instructionOffset;}
    bool setInstructionOffset(bool b) {return (_instructionOffset = b);}
@@ -170,33 +172,33 @@ class TR_16BitLabelRelativeRelocation : public TR_LabelRelocation
    virtual void apply(TR::CodeGenerator *codeGen);
    };
 
-class TR_24BitLabelRelativeRelocation : public TR_LabelRelocation
+class LabelRelative24BitRelocation : public TR::LabelRelocation
    {
    public:
-   TR_24BitLabelRelativeRelocation() : TR_LabelRelocation() {}
-   TR_24BitLabelRelativeRelocation(uint8_t *p, TR::LabelSymbol *l)
-      : TR_LabelRelocation(p, l) {}
+   LabelRelative24BitRelocation() : TR::LabelRelocation() {}
+   LabelRelative24BitRelocation(uint8_t *p, TR::LabelSymbol *l)
+      : TR::LabelRelocation(p, l) {}
    virtual void apply(TR::CodeGenerator *codeGen);
    };
 
-class TR_32BitLabelRelativeRelocation : public TR_LabelRelocation
+class LabelRelative32BitRelocation : public TR::LabelRelocation
    {
    public:
-   TR_32BitLabelRelativeRelocation() : TR_LabelRelocation() {}
-   TR_32BitLabelRelativeRelocation(uint8_t *p, TR::LabelSymbol *l)
-      : TR_LabelRelocation(p, l) {}
+   LabelRelative32BitRelocation() : TR::LabelRelocation() {}
+   LabelRelative32BitRelocation(uint8_t *p, TR::LabelSymbol *l)
+      : TR::LabelRelocation(p, l) {}
    virtual void apply(TR::CodeGenerator *codeGen);
    };
 
-class TR_InstructionAbsoluteRelocation : public TR_Relocation
+class InstructionAbsoluteRelocation : public TR::Relocation
    {
    public:
-   TR_InstructionAbsoluteRelocation(uint8_t *updateLocation,
+   InstructionAbsoluteRelocation(uint8_t *updateLocation,
                                     TR::Instruction *i,
                                     bool useEndAddr) /* specified if the start or
                                                         the end address of the instruction
                                                         is required */
-      : TR_Relocation(updateLocation), _instruction(i), _useEndAddr(useEndAddr) {}
+      : TR::Relocation(updateLocation), _instruction(i), _useEndAddr(useEndAddr) {}
    virtual void apply(TR::CodeGenerator *cg);
 
    bool isAOTRelocation() { return false; }
@@ -212,17 +214,17 @@ class TR_InstructionAbsoluteRelocation : public TR_Relocation
 
 //FIXME: these label absolute relocations should really be a subclass of instruction
 // absolute.
-class TR_LabelAbsoluteRelocation : public TR_LabelRelocation
+class LabelAbsoluteRelocation : public TR::LabelRelocation
    {
    public:
-   TR_LabelAbsoluteRelocation() : TR_LabelRelocation() {}
-   TR_LabelAbsoluteRelocation(uint8_t *p, TR::LabelSymbol *l)
-      : TR_LabelRelocation(p, l) {}
+   LabelAbsoluteRelocation() : TR::LabelRelocation() {}
+   LabelAbsoluteRelocation(uint8_t *p, TR::LabelSymbol *l)
+      : TR::LabelRelocation(p, l) {}
    virtual void apply(TR::CodeGenerator *codeGen);
    };
 
 
-class TR_16BitLoadLabelRelativeRelocation : public TR_Relocation
+class LoadLabelRelative16BitRelocation : public TR::Relocation
    {
    TR::Instruction *_lastInstruction;
    TR::LabelSymbol *_startLabel;
@@ -230,9 +232,9 @@ class TR_16BitLoadLabelRelativeRelocation : public TR_Relocation
    int32_t _deltaToStartLabel;   // used to catch potentially nasty register dep related bugs
 
    public:
-   TR_16BitLoadLabelRelativeRelocation() : TR_Relocation() {}
-   TR_16BitLoadLabelRelativeRelocation(TR::Instruction *i, TR::LabelSymbol *start, TR::LabelSymbol *end, int32_t delta)
-      : TR_Relocation(NULL), _lastInstruction(i), _startLabel(start), _endLabel(end), _deltaToStartLabel(delta) {}
+   LoadLabelRelative16BitRelocation() : TR::Relocation() {}
+   LoadLabelRelative16BitRelocation(TR::Instruction *i, TR::LabelSymbol *start, TR::LabelSymbol *end, int32_t delta)
+      : TR::Relocation(NULL), _lastInstruction(i), _startLabel(start), _endLabel(end), _deltaToStartLabel(delta) {}
    TR::Instruction *getLastInstruction() {return _lastInstruction;}
    TR::Instruction *setLastInstruction(TR::Instruction *i) {return (_lastInstruction = i);}
 
@@ -250,7 +252,7 @@ class TR_16BitLoadLabelRelativeRelocation : public TR_Relocation
    virtual void apply(TR::CodeGenerator *codeGen);
    };
 
-class TR_32BitLoadLabelRelativeRelocation : public TR_Relocation
+class LoadLabelRelative32BitRelocation : public TR::Relocation
    {
    TR::Instruction *_lastInstruction;
    TR::LabelSymbol *_startLabel;
@@ -258,9 +260,9 @@ class TR_32BitLoadLabelRelativeRelocation : public TR_Relocation
    int32_t _deltaToStartLabel;   // used to catch potentially nasty register dep related bugs
 
    public:
-   TR_32BitLoadLabelRelativeRelocation() : TR_Relocation() {}
-   TR_32BitLoadLabelRelativeRelocation(TR::Instruction *i, TR::LabelSymbol *start, TR::LabelSymbol *end, int32_t delta)
-      : TR_Relocation(NULL), _lastInstruction(i), _startLabel(start), _endLabel(end), _deltaToStartLabel(delta) {}
+   LoadLabelRelative32BitRelocation() : TR::Relocation() {}
+   LoadLabelRelative32BitRelocation(TR::Instruction *i, TR::LabelSymbol *start, TR::LabelSymbol *end, int32_t delta)
+      : TR::Relocation(NULL), _lastInstruction(i), _startLabel(start), _endLabel(end), _deltaToStartLabel(delta) {}
    TR::Instruction *getLastInstruction() {return _lastInstruction;}
    TR::Instruction *setLastInstruction(TR::Instruction *i) {return (_lastInstruction = i);}
 
@@ -278,13 +280,13 @@ class TR_32BitLoadLabelRelativeRelocation : public TR_Relocation
    virtual void apply(TR::CodeGenerator *codeGen);
    };
 
-class TR_64BitLoadLabelRelativeRelocation : public TR_LabelRelocation
+class LoadLabelRelative64BitRelocation : public TR::LabelRelocation
    {
    TR::Instruction *_lastInstruction;
    public:
-   TR_64BitLoadLabelRelativeRelocation() : TR_LabelRelocation() {}
-   TR_64BitLoadLabelRelativeRelocation(TR::Instruction *i, TR::LabelSymbol *l)
-      : TR_LabelRelocation(NULL, l), _lastInstruction(i) {}
+   LoadLabelRelative64BitRelocation() : TR::LabelRelocation() {}
+   LoadLabelRelative64BitRelocation(TR::Instruction *i, TR::LabelSymbol *l)
+      : TR::LabelRelocation(NULL, l), _lastInstruction(i) {}
    TR::Instruction *getLastInstruction() {return _lastInstruction;}
    TR::Instruction *setLastInstruction(TR::Instruction *i) {return (_lastInstruction = i);}
 
@@ -295,22 +297,22 @@ class TR_64BitLoadLabelRelativeRelocation : public TR_LabelRelocation
 #define MIN_SHORT_OFFSET         -32768
 #define MAX_SHORT_OFFSET         32767
 
-class TR_IteratedExternalRelocation : public TR_Link<TR_IteratedExternalRelocation>
+class IteratedExternalRelocation : public TR_Link<TR::IteratedExternalRelocation>
    {
    public:
-   TR_IteratedExternalRelocation() : TR_Link<TR_IteratedExternalRelocation>(),
-                                     _numberOfRelocationSites(0),
-                                     _targetAddress(NULL),
-                                     _targetAddress2(NULL),
-                                     _relocationData(NULL),
-                                     _relocationDataCursor(NULL),
-                                     _sizeOfRelocationData(0),
-                                     _recordModifier(0),
-                                     _full(false),
-                                     _kind(TR_ConstantPool) {}
+   IteratedExternalRelocation() : TR_Link<TR::IteratedExternalRelocation>(),
+                                  _numberOfRelocationSites(0),
+                                  _targetAddress(NULL),
+                                  _targetAddress2(NULL),
+                                  _relocationData(NULL),
+                                  _relocationDataCursor(NULL),
+                                  _sizeOfRelocationData(0),
+                                  _recordModifier(0),
+                                  _full(false),
+                                  _kind(TR_ConstantPool) {}
 
-   TR_IteratedExternalRelocation(uint8_t *target, TR_ExternalRelocationTargetKind k, flags8_t modifier, TR::CodeGenerator *codeGen);
-   TR_IteratedExternalRelocation(uint8_t *target, uint8_t *target2, TR_ExternalRelocationTargetKind k, flags8_t modifier, TR::CodeGenerator *codeGen);
+   IteratedExternalRelocation(uint8_t *target, TR_ExternalRelocationTargetKind k, flags8_t modifier, TR::CodeGenerator *codeGen);
+   IteratedExternalRelocation(uint8_t *target, uint8_t *target2, TR_ExternalRelocationTargetKind k, flags8_t modifier, TR::CodeGenerator *codeGen);
 
    uint32_t getNumberOfRelocationSites() {return _numberOfRelocationSites;}
    uint32_t setNumberOfRelocationSites(uint32_t s)
@@ -362,34 +364,34 @@ class TR_IteratedExternalRelocation : public TR_Link<TR_IteratedExternalRelocati
    TR_ExternalRelocationTargetKind _kind;
    };
 
-class TR_ExternalRelocation : public TR_Relocation
+class ExternalRelocation : public TR::Relocation
    {
    public:
-   TR_ExternalRelocation()
-      : TR_Relocation(),
+   ExternalRelocation()
+      : TR::Relocation(),
         _targetAddress(NULL),
         _targetAddress2(NULL),
         _kind(TR_ConstantPool),
         _relocationRecord(NULL)
         {}
 
-   TR_ExternalRelocation(uint8_t                        *p,
-                              uint8_t                        *target,
-                              TR_ExternalRelocationTargetKind kind,
-                              TR::CodeGenerator *codeGen)
-      : TR_Relocation(p),
+   ExternalRelocation(uint8_t                        *p,
+                      uint8_t                        *target,
+                      TR_ExternalRelocationTargetKind kind,
+                      TR::CodeGenerator *codeGen)
+      : TR::Relocation(p),
         _targetAddress(target),
         _targetAddress2(NULL),
         _kind(kind),
         _relocationRecord(NULL)
         {}
 
-   TR_ExternalRelocation(uint8_t                        *p,
-                              uint8_t                        *target,
-                              uint8_t                        *target2,
-                              TR_ExternalRelocationTargetKind  kind,
-                              TR::CodeGenerator *codeGen)
-      : TR_Relocation(p),
+   ExternalRelocation(uint8_t                        *p,
+                      uint8_t                        *target,
+                      uint8_t                        *target2,
+                      TR_ExternalRelocationTargetKind  kind,
+                      TR::CodeGenerator *codeGen)
+      : TR::Relocation(p),
         _targetAddress(target),
         _targetAddress2(target2),
         _kind(kind),
@@ -404,7 +406,7 @@ class TR_ExternalRelocation : public TR_Relocation
    TR_ExternalRelocationTargetKind getTargetKind()                                  {return _kind;}
    TR_ExternalRelocationTargetKind setTargetKind(TR_ExternalRelocationTargetKind k) {return (_kind = k);}
 
-   TR_IteratedExternalRelocation *getRelocationRecord()
+   TR::IteratedExternalRelocation *getRelocationRecord()
       {return _relocationRecord;}
 
    void trace(TR::Compilation* comp);
@@ -436,7 +438,7 @@ class TR_ExternalRelocation : public TR_Relocation
    private:
    uint8_t                         *_targetAddress;
    uint8_t                         *_targetAddress2;
-   TR_IteratedExternalRelocation   *_relocationRecord;
+   TR::IteratedExternalRelocation   *_relocationRecord;
    TR_ExternalRelocationTargetKind  _kind;
    static char                     *_externalRelocationTargetKindNames[TR_NumExternalRelocationKinds];
    static uintptr_t                 _globalValueList[TR_NumGlobalValueItems];
@@ -444,14 +446,14 @@ class TR_ExternalRelocation : public TR_Relocation
    static char                     *_globalValueNames[TR_NumGlobalValueItems];
    };
 
-class TR_32BitExternalOrderedPairRelocation: public TR_ExternalRelocation
+class ExternalOrderedPair32BitRelocation: public TR::ExternalRelocation
    {
    public:
-   TR_32BitExternalOrderedPairRelocation(uint8_t *location1,
-                                         uint8_t *location2,
-                                         uint8_t *target,
-                                         TR_ExternalRelocationTargetKind  k,
-                                         TR::CodeGenerator *codeGen);
+   ExternalOrderedPair32BitRelocation(uint8_t *location1,
+                                      uint8_t *location2,
+                                      uint8_t *target,
+                                      TR_ExternalRelocationTargetKind  k,
+                                      TR::CodeGenerator *codeGen);
 
    uint8_t *getLocation2() {return _update2Location;}
    void setLocation2(uint8_t *l) {_update2Location = l;}
@@ -465,30 +467,30 @@ class TR_32BitExternalOrderedPairRelocation: public TR_ExternalRelocation
    uint8_t                         *_update2Location;
    };
 
-class TR_BeforeBinaryEncodingExternalRelocation : public TR_ExternalRelocation
+class BeforeBinaryEncodingExternalRelocation : public TR::ExternalRelocation
    {
    private:
    TR::Instruction  *_instruction;
 
    public:
-   TR_BeforeBinaryEncodingExternalRelocation()
-      : TR_ExternalRelocation()
+   BeforeBinaryEncodingExternalRelocation()
+      : TR::ExternalRelocation()
         {}
 
-   TR_BeforeBinaryEncodingExternalRelocation(TR::Instruction *instr,
-                                             uint8_t *target,
-                                             TR_ExternalRelocationTargetKind kind,
-                                             TR::CodeGenerator *codeGen)
-      : TR_ExternalRelocation(NULL, target, kind, codeGen),
+   BeforeBinaryEncodingExternalRelocation(TR::Instruction *instr,
+                                          uint8_t *target,
+                                          TR_ExternalRelocationTargetKind kind,
+                                          TR::CodeGenerator *codeGen)
+      : TR::ExternalRelocation(NULL, target, kind, codeGen),
         _instruction(instr)
          {}
 
-   TR_BeforeBinaryEncodingExternalRelocation(TR::Instruction *instr,
-                                             uint8_t *target,
-                                             uint8_t *target2,
-                                             TR_ExternalRelocationTargetKind kind,
-                                             TR::CodeGenerator *codeGen)
-      : TR_ExternalRelocation(NULL, target, target2, kind, codeGen),
+   BeforeBinaryEncodingExternalRelocation(TR::Instruction *instr,
+                                          uint8_t *target,
+                                          uint8_t *target2,
+                                          TR_ExternalRelocationTargetKind kind,
+                                          TR::CodeGenerator *codeGen)
+      : TR::ExternalRelocation(NULL, target, target2, kind, codeGen),
         _instruction(instr)
          {}
 
@@ -498,12 +500,34 @@ class TR_BeforeBinaryEncodingExternalRelocation : public TR_ExternalRelocation
 
    };
 
-class TR_32BitLabelTableRelocation : public TR_LabelRelocation
+class LabelTable32BitRelocation : public TR::LabelRelocation
    {
    public:
-   TR_32BitLabelTableRelocation() : TR_LabelRelocation() {}
-   TR_32BitLabelTableRelocation(uint8_t *p, TR::LabelSymbol *l)
-      : TR_LabelRelocation(p, l) {}
+   LabelTable32BitRelocation() : TR::LabelRelocation() {}
+   LabelTable32BitRelocation(uint8_t *p, TR::LabelSymbol *l)
+      : TR::LabelRelocation(p, l) {}
    virtual void apply(TR::CodeGenerator *codeGen);
    };
+
+}
+
+typedef TR::RelocationDebugInfo TR_RelocationDebugInfo;
+typedef TR::Relocation TR_Relocation;
+typedef TR::LabelRelocation TR_LabelRelocation;
+typedef TR::LabelRelative8BitRelocation TR_8BitLabelRelativeRelocation;
+typedef TR::LabelRelative12BitRelocation TR_12BitLabelRelativeRelocation;
+typedef TR::LabelRelative16BitRelocation TR_16BitLabelRelativeRelocation;
+typedef TR::LabelRelative24BitRelocation TR_24BitLabelRelativeRelocation;
+typedef TR::LabelRelative32BitRelocation TR_32BitLabelRelativeRelocation;
+typedef TR::InstructionAbsoluteRelocation TR_InstructionAbsoluteRelocation;
+typedef TR::LabelAbsoluteRelocation TR_LabelAbsoluteRelocation;
+typedef TR::LoadLabelRelative16BitRelocation TR_16BitLoadLabelRelativeRelocation;
+typedef TR::LoadLabelRelative32BitRelocation TR_32BitLoadLabelRelativeRelocation;
+typedef TR::LoadLabelRelative64BitRelocation TR_64BitLoadLabelRelativeRelocation;
+typedef TR::IteratedExternalRelocation TR_IteratedExternalRelocation;
+typedef TR::ExternalRelocation TR_ExternalRelocation;
+typedef TR::ExternalOrderedPair32BitRelocation TR_32BitExternalOrderedPairRelocation;
+typedef TR::BeforeBinaryEncodingExternalRelocation TR_BeforeBinaryEncodingExternalRelocation;
+typedef TR::LabelTable32BitRelocation TR_32BitLabelTableRelocation;
+
 #endif

--- a/compiler/env/TRMemory.cpp
+++ b/compiler/env/TRMemory.cpp
@@ -273,7 +273,7 @@ const char * objectName[] =
    "DecimalReduction",
 
    "TR_PreviousNodeConversion",
-   "TR_RelocationDebugInfo",
+   "TR::RelocationDebugInfo",
    "TR::AOTClassInfo",
    "TR_SharedCache",
 

--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -3281,7 +3281,7 @@ static void lookupScheme3(TR::Node *node, bool unbalanced, TR::CodeGenerator *cg
 
       TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
       recordInfo->data3 = orderedPairSequence1;
-      cg->getAheadOfTimeCompile()->getRelocationList().push_front(new (cg->trHeapMemory()) TR_PPCPairedRelocation(
+      cg->getAheadOfTimeCompile()->getRelocationList().push_front(new (cg->trHeapMemory()) TR::PPCPairedRelocation(
                                      rel1,
                                      rel2,
                                      (uint8_t *)recordInfo,
@@ -3509,7 +3509,7 @@ static void lookupScheme4(TR::Node *node, TR::CodeGenerator *cg)
 
       TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
       recordInfo->data3 = orderedPairSequence1;
-      cg->getAheadOfTimeCompile()->getRelocationList().push_front(new (cg->trHeapMemory()) TR_PPCPairedRelocation(
+      cg->getAheadOfTimeCompile()->getRelocationList().push_front(new (cg->trHeapMemory()) TR::PPCPairedRelocation(
                                      rel1,
                                      rel2,
                                      (uint8_t *)recordInfo,

--- a/compiler/p/codegen/OMRAheadOfTimeCompile.hpp
+++ b/compiler/p/codegen/OMRAheadOfTimeCompile.hpp
@@ -39,14 +39,14 @@ class OMR_EXTENSIBLE AheadOfTimeCompile : public OMR::AheadOfTimeCompile
    public:
    AheadOfTimeCompile(uint32_t *headerSizeMap, TR::Compilation * c)
        : OMR::AheadOfTimeCompile(headerSizeMap, c),
-        _relocationList(getTypedAllocator<TR_PPCRelocation*>(c->allocator()))
+        _relocationList(getTypedAllocator<TR::PPCRelocation*>(c->allocator()))
      {
      }
 
-   TR::list<TR_PPCRelocation*>& getRelocationList() {return _relocationList;}
+   TR::list<TR::PPCRelocation*>& getRelocationList() {return _relocationList;}
 
    private:
-   TR::list<TR_PPCRelocation*> _relocationList;
+   TR::list<TR::PPCRelocation*> _relocationList;
    };
 
 } // namespace Power

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -3596,7 +3596,7 @@ OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed(
          if (typeAddress == -1)
             {
             if (doAOTRelocation)
-               self()->addAOTRelocation(new (self()->trHeapMemory()) TR_BeforeBinaryEncodingExternalRelocation(
+               self()->addAOTRelocation(new (self()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
                                  firstInstruction,
                                  (uint8_t *)value,
                                  (uint8_t *)seqKind,
@@ -3616,7 +3616,7 @@ OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed(
                   recordInfo->data2 = (uintptr_t)node->getInlinedSiteIndex();
                   recordInfo->data3 = (uintptr_t)seqKind;
                   //printf("TreeEvaluator.cpp:137, inlinedSiteIndex: %d, tempSR->getCPIndex(): %x, tempSR->getOffset(): %x\n", node->getInlinedSiteIndex(), node->getSymbolReference()->getCPIndex(), node->getSymbolReference()->getOffset());fflush(stdout);
-                  self()->addAOTRelocation(new (self()->trHeapMemory()) TR_BeforeBinaryEncodingExternalRelocation(
+                  self()->addAOTRelocation(new (self()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
                                     firstInstruction,
                                     (uint8_t *)recordInfo,
                                     TR_DataAddress, self()),
@@ -3628,7 +3628,7 @@ OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed(
             else
                {
                if (doAOTRelocation)
-                  self()->addAOTRelocation(new (self()->trHeapMemory()) TR_BeforeBinaryEncodingExternalRelocation(
+                  self()->addAOTRelocation(new (self()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
                                     firstInstruction,
                                     (uint8_t *)value,
                                     (uint8_t *)seqKind,
@@ -3648,7 +3648,7 @@ OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed(
          if (typeAddress == -1)
             {
             if (doAOTRelocation)
-               self()->addAOTRelocation(new (self()->trHeapMemory()) TR_BeforeBinaryEncodingExternalRelocation(
+               self()->addAOTRelocation(new (self()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
                                  firstInstruction,
                                  (uint8_t *)value,
                                  (uint8_t *)seqKind,
@@ -3662,7 +3662,7 @@ OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed(
             if (typeAddress == TR_RamMethodSequence) // NOTE: 32 bit changed to use TR_RamMethodSequence for ordered pair, hence, we should check this instead
                {
                if (doAOTRelocation)
-                  self()->addAOTRelocation(new (self()->trHeapMemory()) TR_BeforeBinaryEncodingExternalRelocation(
+                  self()->addAOTRelocation(new (self()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
                                     firstInstruction,
                                     (uint8_t *)value,
                                     (uint8_t *)seqKind,
@@ -3679,7 +3679,7 @@ OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed(
                   recordInfo->data1 = (uintptr_t)node->getSymbolReference();
                   recordInfo->data2 = (uintptr_t)node->getInlinedSiteIndex();
                   recordInfo->data3 = (uintptr_t)seqKind;
-                  self()->addAOTRelocation(new (self()->trHeapMemory()) TR_BeforeBinaryEncodingExternalRelocation(
+                  self()->addAOTRelocation(new (self()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
                                     firstInstruction,
                                     (uint8_t *)recordInfo,
                                     TR_DataAddress, self()),
@@ -3691,7 +3691,7 @@ OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed(
             else
                {
                if (doAOTRelocation)
-                  self()->addAOTRelocation(new (self()->trHeapMemory()) TR_BeforeBinaryEncodingExternalRelocation(
+                  self()->addAOTRelocation(new (self()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
                                     firstInstruction,
                                     (uint8_t *)value,
                                     (uint8_t *)seqKind,
@@ -3790,7 +3790,7 @@ OMR::Power::CodeGenerator::addMetaDataForLoadIntConstantFixed(
       recordInfo->data1 = (uintptr_t)node->getSymbolReference();
       recordInfo->data2 = node ? (uintptr_t)node->getInlinedSiteIndex() : (uintptr_t)-1;
       recordInfo->data3 = orderedPairSequence2;
-      self()->addAOTRelocation(new (self()->trHeapMemory()) TR_32BitExternalOrderedPairRelocation((uint8_t *)firstInstruction,
+      self()->addAOTRelocation(new (self()->trHeapMemory()) TR::ExternalOrderedPair32BitRelocation((uint8_t *)firstInstruction,
                                                                                           (uint8_t *)secondInstruction,
                                                                                           (uint8_t *)recordInfo,
                                                                                           (TR_ExternalRelocationTargetKind)TR_DataAddress, self()),
@@ -3801,7 +3801,7 @@ OMR::Power::CodeGenerator::addMetaDataForLoadIntConstantFixed(
       TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
       recordInfo->data1 = (uintptr_t)value;
       recordInfo->data3 = orderedPairSequence2;
-      self()->addAOTRelocation(new (self()->trHeapMemory()) TR_32BitExternalOrderedPairRelocation((uint8_t *)firstInstruction,
+      self()->addAOTRelocation(new (self()->trHeapMemory()) TR::ExternalOrderedPair32BitRelocation((uint8_t *)firstInstruction,
                                                                                           (uint8_t *)secondInstruction,
                                                                                           (uint8_t *)recordInfo,
                                                                                           (TR_ExternalRelocationTargetKind)typeAddress, self()),
@@ -3858,11 +3858,11 @@ OMR::Power::CodeGenerator::addMetaDataFor32BitFixedLoadLabelAddressIntoReg(
    TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
    recordInfo->data3 = orderedPairSequence1;
 
-   self()->getAheadOfTimeCompile()->getRelocationList().push_front(new (self()->trHeapMemory()) TR_PPCPairedRelocation
+   self()->getAheadOfTimeCompile()->getRelocationList().push_front(new (self()->trHeapMemory()) TR::PPCPairedRelocation
                         (firstInstruction, secondInstruction, (uint8_t *)recordInfo,
                          TR_AbsoluteMethodAddressOrderedPair, node));
 
-   self()->addRelocation(new (self()->trHeapMemory()) TR_PPCPairedLabelAbsoluteRelocation
+   self()->addRelocation(new (self()->trHeapMemory()) TR::PPCPairedLabelAbsoluteRelocation
                      (firstInstruction, secondInstruction, NULL, NULL, label));
 
    }
@@ -3878,10 +3878,10 @@ OMR::Power::CodeGenerator::addMetaDataFor64BitFixedLoadLabelAddressIntoReg(
 
    if (!self()->comp()->compileRelocatableCode())
       {
-      self()->addRelocation(new (self()->trHeapMemory()) TR_PPCPairedLabelAbsoluteRelocation(q[0], q[1], q[2], q[3], label));
+      self()->addRelocation(new (self()->trHeapMemory()) TR::PPCPairedLabelAbsoluteRelocation(q[0], q[1], q[2], q[3], label));
       }
 
-   self()->addAOTRelocation(new (self()->trHeapMemory()) TR_BeforeBinaryEncodingExternalRelocation(q[0],
+   self()->addAOTRelocation(new (self()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(q[0],
                                                                             (uint8_t *)(label),
                                                                             (uint8_t *) (tempReg ? fixedSequence4 : fixedSequence2),
                                                                             TR_FixedSequenceAddress, self()),

--- a/compiler/p/codegen/OMRConstantDataSnippet.cpp
+++ b/compiler/p/codegen/OMRConstantDataSnippet.cpp
@@ -329,7 +329,7 @@ OMR::ConstantDataSnippet::emitFloatingPointConstant(
             }
          else
             {
-            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_BeforeBinaryEncodingExternalRelocation(requestors[i],
+            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(requestors[i],
                                                                                          (uint8_t *)(addr),
                                                                                          (uint8_t *)fixedSequence4,
                                                                                          TR_FixedSequenceAddress2,
@@ -346,7 +346,7 @@ OMR::ConstantDataSnippet::emitFloatingPointConstant(
 
          TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
          recordInfo->data3 = orderedPairSequence1;
-         cg()->addAOTRelocation(new (_cg->trHeapMemory()) TR_32BitExternalOrderedPairRelocation(iloc1,
+         cg()->addAOTRelocation(new (_cg->trHeapMemory()) TR::ExternalOrderedPair32BitRelocation(iloc1,
                                                                                                 iloc2,
                                                                                                 (uint8_t *)recordInfo,
                                                                                                 TR_AbsoluteMethodAddressOrderedPair,
@@ -391,8 +391,8 @@ OMR::ConstantDataSnippet::emitAddressConstant(
 
          if (kind != TR_NoRelocation)
             {
-            TR_Relocation *relo;
-            relo = new (cg()->trHeapMemory()) TR_ExternalRelocation(codeCursor, (uint8_t *)node, kind, cg());
+            TR::Relocation *relo;
+            relo = new (cg()->trHeapMemory()) TR::ExternalRelocation(codeCursor, (uint8_t *)node, kind, cg());
             cg()->addAOTRelocation(relo, __FILE__, __LINE__, node);
             }
          }
@@ -435,7 +435,7 @@ OMR::ConstantDataSnippet::emitAddressConstant(
             }
          else
             {
-            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_BeforeBinaryEncodingExternalRelocation(requestors[i],
+            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(requestors[i],
                                                                                          (uint8_t *)(addr),
                                                                                          (uint8_t *)fixedSequence4,
                                                                                          TR_FixedSequenceAddress2,
@@ -452,7 +452,7 @@ OMR::ConstantDataSnippet::emitAddressConstant(
 
          TR_RelocationRecordInformation *recordInfo = (TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
          recordInfo->data3 = orderedPairSequence1;
-         cg()->addAOTRelocation(new (_cg->trHeapMemory()) TR_32BitExternalOrderedPairRelocation(iloc1, iloc2, (uint8_t *)recordInfo, TR_AbsoluteMethodAddressOrderedPair, cg()),
+         cg()->addAOTRelocation(new (_cg->trHeapMemory()) TR::ExternalOrderedPair32BitRelocation(iloc1, iloc2, (uint8_t *)recordInfo, TR_AbsoluteMethodAddressOrderedPair, cg()),
                                 __FILE__, __LINE__, requestors[i]->getNode());
          }
       }

--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -1109,7 +1109,7 @@ uint8_t *OMR::Power::MemoryReference::generateBinaryEncoding(TR::Instruction *cu
          getUnresolvedSnippet()->setAddressOfDataReference(cursor);
          getUnresolvedSnippet()->setMemoryReference(self());
          getUnresolvedSnippet()->setDataRegister(target);
-         cg->addRelocation(new (cg->trHeapMemory()) TR_24BitLabelRelativeRelocation(cursor, getUnresolvedSnippet()->getSnippetLabel()));
+         cg->addRelocation(new (cg->trHeapMemory()) TR::LabelRelative24BitRelocation(cursor, getUnresolvedSnippet()->getSnippetLabel()));
          *wcursor = 0x48000000;                        // b SnippetLabel;
          wcursor++;
          cursor += PPC_INSTRUCTION_LENGTH;
@@ -1226,7 +1226,7 @@ uint8_t *OMR::Power::MemoryReference::generateBinaryEncoding(TR::Instruction *cu
 
       getUnresolvedSnippet()->setAddressOfDataReference(cursor);
       getUnresolvedSnippet()->setMemoryReference(self());
-      cg->addRelocation(new (cg->trHeapMemory()) TR_24BitLabelRelativeRelocation(cursor, getUnresolvedSnippet()->getSnippetLabel()));
+      cg->addRelocation(new (cg->trHeapMemory()) TR::LabelRelative24BitRelocation(cursor, getUnresolvedSnippet()->getSnippetLabel()));
       *wcursor = 0x48000000;                        // b SnippetLabel;
       wcursor++;
       cursor += PPC_INSTRUCTION_LENGTH;
@@ -1655,7 +1655,7 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
          {
          TR::Instruction                 *rel1, *rel2;
          uint8_t                        *relocationTarget;
-         TR_PPCPairedRelocation         *staticRelocation;
+         TR::PPCPairedRelocation         *staticRelocation;
          TR::Register                    *reg = _baseRegister = cg->allocateRegister();
          TR_ExternalRelocationTargetKind relocationKind;
          intptrj_t                        addr;
@@ -1717,7 +1717,7 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
             recordInfo->data1 = (uintptr_t)relocationTarget;
             recordInfo->data2 = node ? (uintptr_t)node->getInlinedSiteIndex() : (uintptr_t)-1;
             recordInfo->data3 = orderedPairSequence1;
-            staticRelocation = new (cg->trHeapMemory()) TR_PPCPairedRelocation(rel1, rel2, (uint8_t *)recordInfo, relocationKind, node);
+            staticRelocation = new (cg->trHeapMemory()) TR::PPCPairedRelocation(rel1, rel2, (uint8_t *)recordInfo, relocationKind, node);
             cg->getAheadOfTimeCompile()->getRelocationList().push_front(staticRelocation);
 
             if (!specialCase)

--- a/compiler/p/codegen/OMRMemoryReference.hpp
+++ b/compiler/p/codegen/OMRMemoryReference.hpp
@@ -41,7 +41,7 @@ namespace OMR { typedef OMR::Power::MemoryReference MemoryReferenceConnector; }
 #include "il/SymbolReference.hpp"           // for SymbolReference
 #include "il/symbol/StaticSymbol.hpp"       // for StaticSymbol
 
-class TR_PPCPairedRelocation;
+namespace TR { class PPCPairedRelocation; }
 namespace TR { class CodeGenerator; }
 namespace TR { class Compilation; }
 namespace TR { class Instruction; }
@@ -66,7 +66,7 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
    intptrj_t _offset;
 
    TR::UnresolvedDataSnippet *_unresolvedSnippet;
-   TR_PPCPairedRelocation *_staticRelocation;
+   TR::PPCPairedRelocation *_staticRelocation;
    TR::SymbolReference *_symbolReference;
    TR::RegisterDependencyConditions *_conditions;
 
@@ -213,8 +213,8 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
       return (_unresolvedSnippet = s);
       }
 
-   TR_PPCPairedRelocation *getStaticRelocation() {return _staticRelocation;}
-   TR_PPCPairedRelocation *setStaticRelocation(TR_PPCPairedRelocation *r)
+   TR::PPCPairedRelocation *getStaticRelocation() {return _staticRelocation;}
+   TR::PPCPairedRelocation *setStaticRelocation(TR::PPCPairedRelocation *r)
       {
       return (_staticRelocation = r);
       }

--- a/compiler/p/codegen/PPCAOTRelocation.cpp
+++ b/compiler/p/codegen/PPCAOTRelocation.cpp
@@ -32,12 +32,12 @@
 #include "il/symbol/LabelSymbol.hpp"        // for LabelSymbol
 #include "runtime/Runtime.hpp"              // for LO_VALUE
 
-void TR_PPCPairedRelocation::mapRelocation(TR::CodeGenerator *cg)
+void TR::PPCPairedRelocation::mapRelocation(TR::CodeGenerator *cg)
    {
    if (cg->comp()->getOption(TR_AOT))
       {
       cg->addAOTRelocation(
-         new (cg->trHeapMemory()) TR_32BitExternalOrderedPairRelocation(
+         new (cg->trHeapMemory()) TR::ExternalOrderedPair32BitRelocation(
             getSourceInstruction()->getBinaryEncoding(),
             getSource2Instruction()->getBinaryEncoding(),
             getRelocationTarget(),
@@ -49,7 +49,7 @@ void TR_PPCPairedRelocation::mapRelocation(TR::CodeGenerator *cg)
    }
 
 
-void TR_PPCPairedLabelAbsoluteRelocation::apply(TR::CodeGenerator *cg)
+void TR::PPCPairedLabelAbsoluteRelocation::apply(TR::CodeGenerator *cg)
    {
    intptrj_t p = (intptrj_t)getLabel()->getCodeLocation();
 

--- a/compiler/p/codegen/PPCAOTRelocation.hpp
+++ b/compiler/p/codegen/PPCAOTRelocation.hpp
@@ -20,7 +20,7 @@
 #define PPCAOTRELOCATION_INCL
 
 #include <stdint.h>                         // for uint8_t
-#include "codegen/Relocation.hpp"           // for TR_LabelRelocation
+#include "codegen/Relocation.hpp"           // for TR::LabelRelocation
 #include "env/TRMemory.hpp"                 // for TR_Memory, etc
 #include "runtime/Runtime.hpp"
 
@@ -29,13 +29,15 @@ namespace TR { class Instruction; }
 namespace TR { class LabelSymbol; }
 namespace TR { class Node; }
 
-class TR_PPCRelocation
+namespace TR {
+
+class PPCRelocation
    {
    public:
    TR_ALLOC(TR_Memory::PPCRelocation)
 
-   TR_PPCRelocation(TR::Instruction *src,
-                    uint8_t           *trg,
+   PPCRelocation(TR::Instruction *src,
+                 uint8_t           *trg,
        TR_ExternalRelocationTargetKind k):
       _srcInstruction(src), _relTarget(trg), _kind(k)
       {}
@@ -57,15 +59,15 @@ class TR_PPCRelocation
    TR_ExternalRelocationTargetKind  _kind;
    };
 
-class TR_PPCPairedRelocation: public TR_PPCRelocation
+class PPCPairedRelocation: public TR::PPCRelocation
    {
    public:
-   TR_PPCPairedRelocation(TR::Instruction *src1,
-                          TR::Instruction *src2,
-                          uint8_t           *trg,
-                          TR_ExternalRelocationTargetKind k,
-                          TR::Node *node) :
-      TR_PPCRelocation(src1, trg, k), _src2Instruction(src2), _node(node)
+   PPCPairedRelocation(TR::Instruction *src1,
+                       TR::Instruction *src2,
+                       uint8_t           *trg,
+                       TR_ExternalRelocationTargetKind k,
+                       TR::Node *node) :
+      TR::PPCRelocation(src1, trg, k), _src2Instruction(src2), _node(node)
       {}
 
    TR::Instruction *getSource2Instruction() {return _src2Instruction;}
@@ -86,15 +88,15 @@ class TR_PPCPairedRelocation: public TR_PPCRelocation
 //   lis  gr3, addr_hi
 //   addi gr3, gr3, addr_lo
 //
-class TR_PPCPairedLabelAbsoluteRelocation : public TR_LabelRelocation
+class PPCPairedLabelAbsoluteRelocation : public TR::LabelRelocation
    {
    public:
-   TR_PPCPairedLabelAbsoluteRelocation(TR::Instruction *src1,
-				       TR::Instruction *src2,
-                                       TR::Instruction *src3,
-                                       TR::Instruction *src4,
-				       TR::LabelSymbol *label)
-      : TR_LabelRelocation(0, label), _instr1(src1), _instr2(src2), _instr3(src3), _instr4(src4) {}
+   PPCPairedLabelAbsoluteRelocation(TR::Instruction *src1,
+                                    TR::Instruction *src2,
+                                    TR::Instruction *src3,
+                                    TR::Instruction *src4,
+                                    TR::LabelSymbol *label)
+      : TR::LabelRelocation(0, label), _instr1(src1), _instr2(src2), _instr3(src3), _instr4(src4) {}
    virtual void apply(TR::CodeGenerator *cg);
 
    private:
@@ -103,5 +105,11 @@ class TR_PPCPairedLabelAbsoluteRelocation : public TR_LabelRelocation
    TR::Instruction *_instr3;
    TR::Instruction *_instr4;
    };
+
+}
+
+typedef TR::PPCRelocation TR_PPCRelocation;
+typedef TR::PPCPairedRelocation TR_PPCPairedRelocation;
+typedef TR::PPCPairedLabelAbsoluteRelocation TR_PPCPairedLabelAbsoluteRelocation;
 
 #endif

--- a/compiler/p/codegen/PPCBinaryEncoding.cpp
+++ b/compiler/p/codegen/PPCBinaryEncoding.cpp
@@ -26,7 +26,7 @@
 #include "codegen/Machine.hpp"                 // for Machine
 #include "codegen/MemoryReference.hpp"         // for MemoryReference
 #include "codegen/RealRegister.hpp"            // for RealRegister, etc
-#include "codegen/Relocation.hpp"              // for TR_ExternalRelocation, etc
+#include "codegen/Relocation.hpp"              // for TR::ExternalRelocation, etc
 #include "compile/Compilation.hpp"             // for Compilation
 #include "compile/ResolvedMethod.hpp"          // for TR_ResolvedMethod
 #include "env/CompilerEnv.hpp"
@@ -109,7 +109,7 @@ uint8_t *TR::PPCLabelInstruction::generateBinaryEncoding()
              }
           else
              {
-             cg()->addRelocation(new (cg()->trHeapMemory()) TR_24BitLabelRelativeRelocation(cursor, label));
+             cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative24BitRelocation(cursor, label));
              }
           cursor += 4;
       }
@@ -279,7 +279,7 @@ uint8_t *TR::PPCConditionalBranchInstruction::generateBinaryEncoding()
          if (!getFarRelocation())
             {
             insertConditionRegister((uint32_t *)cursor);
-            cg()->addRelocation(new (cg()->trHeapMemory()) TR_16BitLabelRelativeRelocation(cursor, label));
+            cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative16BitRelocation(cursor, label));
             }
          else // too far - need fix up
             {
@@ -294,7 +294,7 @@ uint8_t *TR::PPCConditionalBranchInstruction::generateBinaryEncoding()
             cursor += 4;
 
             cursor = extraOpCode.copyBinaryToBuffer(cursor);
-            cg()->addRelocation(new (cg()->trHeapMemory()) TR_24BitLabelRelativeRelocation(cursor, label));
+            cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative24BitRelocation(cursor, label));
             }
          }
       }
@@ -379,13 +379,13 @@ TR::PPCImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
          switch(getReloKind())
             {
             case TR_AbsoluteHelperAddress:
-               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, (uint8_t *)getSymbolReference(), TR_AbsoluteHelperAddress, cg()), __FILE__, __LINE__, getNode());
+               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)getSymbolReference(), TR_AbsoluteHelperAddress, cg()), __FILE__, __LINE__, getNode());
                break;
             case TR_RamMethod:
-               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, NULL, TR_RamMethod, cg()), __FILE__, __LINE__, getNode());
+               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_RamMethod, cg()), __FILE__, __LINE__, getNode());
                break;
             case TR_BodyInfoAddress:
-               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, 0, TR_BodyInfoAddress, cg()), __FILE__, __LINE__, getNode());
+               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, 0, TR_BodyInfoAddress, cg()), __FILE__, __LINE__, getNode());
                break;
             default:
                TR_ASSERT(false, "Unsupported AOT relocation type specified.");
@@ -409,7 +409,7 @@ TR::PPCImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
       //
       void **locationToPatch = (void**)(cursor - (TR::Compiler->target.is64Bit()?4:0));
       cg()->jitAddPicToPatchOnClassRedefinition(*locationToPatch, locationToPatch);
-      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation((uint8_t *)locationToPatch, (uint8_t *)*locationToPatch, TR_HCR, cg()), __FILE__,__LINE__, getNode());
+      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation((uint8_t *)locationToPatch, (uint8_t *)*locationToPatch, TR_HCR, cg()), __FILE__,__LINE__, getNode());
       }
 
    }
@@ -954,7 +954,7 @@ uint8_t *TR::PPCVirtualGuardNOPInstruction::generateBinaryEncoding()
    if (label->getCodeLocation() == NULL)
       {
       _site->setDestination(cursor);
-      cg()->addRelocation(new (cg()->trHeapMemory()) TR_LabelAbsoluteRelocation((uint8_t *) (&_site->getDestination()), label));
+      cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelAbsoluteRelocation((uint8_t *) (&_site->getDestination()), label));
 
 #ifdef DEBUG
    if (debug("traceVGNOP"))

--- a/compiler/x/amd64/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.cpp
@@ -388,7 +388,7 @@ OMR::X86::AMD64::MemoryReference::addMetaDataForCodeAddressWithLoad(
          if (sr.getSymbol()->isStatic())
             {
             if (cg->needClassAndMethodPointerRelocations())
-               cg->addAOTRelocation(new (cg->trHeapMemory()) TR_ExternalRelocation(displacementLocation, (uint8_t *)&_symbolReference,
+               cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(displacementLocation, (uint8_t *)&_symbolReference,
                                                                                         (uint8_t *)containingInstruction->getNode()->getInlinedSiteIndex(),
                                                                                         TR_ClassAddress, cg),__FILE__, __LINE__,
                                                                                         containingInstruction->getNode());
@@ -401,7 +401,7 @@ OMR::X86::AMD64::MemoryReference::addMetaDataForCodeAddressWithLoad(
       else if (sr.getSymbol()->isCountForRecompile())
          {
          if (cg->needRelocationsForStatics())
-            cg->addAOTRelocation(new (cg->trHeapMemory()) TR_ExternalRelocation(
+            cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(
                                    displacementLocation, (uint8_t *) TR_CountForRecompile, TR_GlobalValue, cg),
                                  __FILE__,
                                  __LINE__,
@@ -410,15 +410,15 @@ OMR::X86::AMD64::MemoryReference::addMetaDataForCodeAddressWithLoad(
       else if (sr.getSymbol()->isRecompilationCounter())
          {
          if (cg->needRelocationsForStatics())
-            cg->addAOTRelocation(new (cg->trHeapMemory()) TR_ExternalRelocation(displacementLocation, 0, TR_BodyInfoAddress, cg),
+            cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(displacementLocation, 0, TR_BodyInfoAddress, cg),
                                  __FILE__,__LINE__,containingInstruction->getNode());
          }
       else if (sr.getSymbol()->isGCRPatchPoint())
          {
          if (cg->needRelocationsForStatics())
             {
-            TR_ExternalRelocation* r= new (cg->trHeapMemory())
-                           TR_ExternalRelocation(displacementLocation,
+            TR::ExternalRelocation* r= new (cg->trHeapMemory())
+                           TR::ExternalRelocation(displacementLocation,
                                                       0,
                                                       TR_AbsoluteMethodAddress, cg);
             cg->addAOTRelocation(r, __FILE__, __LINE__, containingInstruction->getNode());
@@ -427,13 +427,13 @@ OMR::X86::AMD64::MemoryReference::addMetaDataForCodeAddressWithLoad(
       else if (sr.getSymbol()->isCompiledMethod())
          {
          if (cg->needRelocationsForStatics())
-            cg->addAOTRelocation(new (cg->trHeapMemory()) TR_ExternalRelocation(displacementLocation, 0, TR_RamMethod, cg),
+            cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(displacementLocation, 0, TR_RamMethod, cg),
                                  __FILE__,__LINE__,containingInstruction->getNode());
          }
       else if (sr.getSymbol()->isStartPC())
          {
          if (cg->needRelocationsForStatics())
-            cg->addAOTRelocation(new (cg->trHeapMemory()) TR_ExternalRelocation(displacementLocation, 0, TR_AbsoluteMethodAddress, cg),
+            cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(displacementLocation, 0, TR_AbsoluteMethodAddress, cg),
                                  __FILE__,__LINE__,containingInstruction->getNode());
          }
       }
@@ -441,7 +441,7 @@ OMR::X86::AMD64::MemoryReference::addMetaDataForCodeAddressWithLoad(
       {
       if (self()->needsCodeAbsoluteExternalRelocation())
          {
-         cg->addAOTRelocation(new (cg->trHeapMemory()) TR_ExternalRelocation(displacementLocation,
+         cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(displacementLocation,
                                                                                  (uint8_t *)0,
                                                                                  TR_AbsoluteMethodAddress, cg),
                               __FILE__,

--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -2575,11 +2575,11 @@ OMR::X86::CodeGenerator::addMetaDataForBranchTableAddress(
       TR::X86MemTableInstruction *jmpTableInstruction)
    {
 
-   self()->addAOTRelocation(new (self()->trHeapMemory()) TR_ExternalRelocation(target, 0, TR_AbsoluteMethodAddress, self()),
+   self()->addAOTRelocation(new (self()->trHeapMemory()) TR::ExternalRelocation(target, 0, TR_AbsoluteMethodAddress, self()),
                            __FILE__, __LINE__, caseNode->getBranchDestination()->getNode());
 
    TR::LabelSymbol *label = caseNode->getBranchDestination()->getNode()->getLabel();
-   TR_LabelRelocation *relocation = new (self()->trHeapMemory()) TR_LabelAbsoluteRelocation(target, label);
+   TR::LabelRelocation *relocation = new (self()->trHeapMemory()) TR::LabelAbsoluteRelocation(target, label);
    self()->addRelocation(relocation);
 
    if (jmpTableInstruction)

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -1199,14 +1199,14 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
          {
          if (self()->needsCodeAbsoluteExternalRelocation())
             {
-            cg->addAOTRelocation(new (cg->trHeapMemory()) TR_ExternalRelocation(cursor,
+            cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                   0,
                                                                   TR_AbsoluteMethodAddress, cg),
                                  __FILE__,__LINE__, node);
             }
          else if (self()->getReloKind() == TR_ACTIVE_CARD_TABLE_BASE)
             {
-            cg->addAOTRelocation(new (cg->trHeapMemory()) TR_ExternalRelocation(cursor,
+            cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                   (uint8_t*)TR_ActiveCardTableBase,
                                                                   TR_GlobalValue, cg),
                                  __FILE__,__LINE__, node);
@@ -1236,7 +1236,7 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
                   if (symbol->isConst())
                      {
                      TR::Compilation *comp = cg->comp();
-                     cg->addAOTRelocation(new (cg->trHeapMemory()) TR_ExternalRelocation(cursor,
+                     cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                             (uint8_t *)self()->getSymbolReference().getOwningMethod(comp)->constantPool(),
                                                                             node ? (uint8_t *)(intptrj_t)node->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                            TR_ConstantPool, cg),
@@ -1247,7 +1247,7 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
                      if (cg->needClassAndMethodPointerRelocations())
                         {
                         *(int32_t *)cursor = (int32_t)(TR::Compiler->cls.persistentClassPointerFromClassPointer(cg->comp(), (TR_OpaqueClassBlock*)(self()->getSymbolReference().getOffset() + (intptrj_t)staticSym->getStaticAddress())));
-                        cg->addAOTRelocation(new (cg->trHeapMemory()) TR_ExternalRelocation(cursor, (uint8_t *)&self()->getSymbolReference(),
+                        cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)&self()->getSymbolReference(),
                                                                                                  node ? (uint8_t *)(intptrj_t)node->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                                                  TR_ClassAddress, cg), __FILE__, __LINE__, node);
                         }
@@ -1261,29 +1261,29 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
                      {
                      if (staticSym->isCountForRecompile())
                         {
-                        cg->addAOTRelocation(new (cg->trHeapMemory()) TR_ExternalRelocation(cursor, (uint8_t *) TR_CountForRecompile, TR_GlobalValue, cg),
+                        cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) TR_CountForRecompile, TR_GlobalValue, cg),
                                              __FILE__,
                                              __LINE__,
                                              node);
                         }
                      else if (staticSym->isRecompilationCounter())
                         {
-                        cg->addAOTRelocation(new (cg->trHeapMemory()) TR_ExternalRelocation(cursor, 0, TR_BodyInfoAddress, cg),
+                        cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, 0, TR_BodyInfoAddress, cg),
                                              __FILE__,
                                              __LINE__,
                                              node);
                         }
                      else if (staticSym->isGCRPatchPoint())
                         {
-                        TR_ExternalRelocation* r= new (cg->trHeapMemory())
-                           TR_ExternalRelocation(cursor,
+                        TR::ExternalRelocation* r= new (cg->trHeapMemory())
+                           TR::ExternalRelocation(cursor,
                                                       0,
                                                       TR_AbsoluteMethodAddress, cg);
                         cg->addAOTRelocation(r, __FILE__, __LINE__, node);
                         }
                      else
                         {
-                        cg->addAOTRelocation(new (cg->trHeapMemory()) TR_ExternalRelocation(cursor,
+                        cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                            (uint8_t *)&self()->getSymbolReference(),
                                                                            node ? (uint8_t *)node->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                            TR_DataAddress, cg),
@@ -1318,12 +1318,12 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
                   {
                   // Assume the snippet is in RIP range
                   // TODO:AMD64: Would it be cleaner to have some kind of "isRelative" flag rather than "is64BitTarget"?
-                  cg->addRelocation(new (cg->trHeapMemory()) TR_32BitLabelRelativeRelocation(cursor, label));
+                  cg->addRelocation(new (cg->trHeapMemory()) TR::LabelRelative32BitRelocation(cursor, label));
                   }
                else
                   {
-                  cg->addRelocation(new (cg->trHeapMemory()) TR_LabelAbsoluteRelocation(cursor, label));
-                  cg->addAOTRelocation(new (cg->trHeapMemory()) TR_ExternalRelocation(cursor,
+                  cg->addRelocation(new (cg->trHeapMemory()) TR::LabelAbsoluteRelocation(cursor, label));
+                  cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                         0,
                                                                         TR_AbsoluteMethodAddress, cg),
                                        __FILE__, __LINE__, node);

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -1967,7 +1967,7 @@ void TR::X86MemTableInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssig
          //
          for (ncount_t i = 0; i < getNumRelocations(); i++)
             {
-            TR_LabelRelocation *relocation = getRelocation(i);
+            TR::LabelRelocation *relocation = getRelocation(i);
             TR::LabelSymbol *targetLabel = relocation->getLabel();
             if (targetLabel->getInstruction())
                {

--- a/compiler/x/codegen/OMRX86Instruction.hpp
+++ b/compiler/x/codegen/OMRX86Instruction.hpp
@@ -44,7 +44,7 @@
 #include "x/codegen/X86Ops.hpp"                       // for TR_X86OpCodes, etc
 #include "env/CompilerEnv.hpp"
 
-class TR_LabelRelocation;
+namespace TR { class LabelRelocation; }
 class TR_VirtualGuardSite;
 namespace TR { class X86RegMemInstruction; }
 namespace TR { class X86RegRegInstruction; }
@@ -1540,7 +1540,7 @@ class X86MemInstruction : public TR::Instruction
 
 class X86MemTableInstruction : public TR::X86MemInstruction
    {
-   TR_LabelRelocation **_relocations;
+   TR::LabelRelocation **_relocations;
    ncount_t _numRelocations, _capacity;
 
    public:
@@ -1548,13 +1548,13 @@ class X86MemTableInstruction : public TR::X86MemInstruction
    X86MemTableInstruction(TR_X86OpCodes op, TR::Node *node, TR::MemoryReference *mr, ncount_t numEntries, TR::CodeGenerator *cg):
       TR::X86MemInstruction(op, node, mr, cg),_numRelocations(0),_capacity(numEntries)
       {
-      _relocations = (TR_LabelRelocation**)cg->trMemory()->allocateHeapMemory(numEntries * sizeof(_relocations[0]));
+      _relocations = (TR::LabelRelocation**)cg->trMemory()->allocateHeapMemory(numEntries * sizeof(_relocations[0]));
       }
 
    X86MemTableInstruction(TR_X86OpCodes op, TR::Node *node, TR::MemoryReference *mr, ncount_t numEntries, TR::RegisterDependencyConditions *deps, TR::CodeGenerator *cg):
       TR::X86MemInstruction(op, node, mr, deps, cg),_numRelocations(0),_capacity(numEntries)
       {
-      _relocations = (TR_LabelRelocation**)cg->trMemory()->allocateHeapMemory(numEntries * sizeof(_relocations[0]));
+      _relocations = (TR::LabelRelocation**)cg->trMemory()->allocateHeapMemory(numEntries * sizeof(_relocations[0]));
       }
 
    virtual char *description() { return "X86MemTable"; }
@@ -1564,13 +1564,13 @@ class X86MemTableInstruction : public TR::X86MemInstruction
    ncount_t getNumRelocations()    { return _numRelocations; }
    ncount_t getRelocationCapacity(){ return _capacity; }
 
-   void addRelocation(TR_LabelRelocation *r)
+   void addRelocation(TR::LabelRelocation *r)
       {
       TR_ASSERT(_numRelocations < _capacity, "Can't add another relocation to a X86MemTableInstruction that is already full");
       _relocations[_numRelocations++] = r;
       }
 
-   TR_LabelRelocation *getRelocation(ncount_t index)
+   TR::LabelRelocation *getRelocation(ncount_t index)
       {
       TR_ASSERT(0 <= index && index < _numRelocations, "X86MemTableInstruction::getRelocation - index %d is out of range (0-%d)", index, _numRelocations);
       return _relocations[index];

--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -478,7 +478,7 @@ uint8_t *TR::X86LabelInstruction::generateBinaryEncoding()
                }
             else
                {
-               cg()->addRelocation(new (cg()->trHeapMemory()) TR_8BitLabelRelativeRelocation(cursor, label));
+               cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative8BitRelocation(cursor, label));
                *cursor = (uint8_t)(-(intptrj_t)(cursor+1));
                }
 
@@ -507,7 +507,7 @@ uint8_t *TR::X86LabelInstruction::generateBinaryEncoding()
                }
             else
                {
-               cg()->addRelocation(new (cg()->trHeapMemory()) TR_32BitLabelRelativeRelocation(cursor, label));
+               cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative32BitRelocation(cursor, label));
                *(uint32_t *)cursor = (uint32_t)(-(intptrj_t)(cursor+4));
                }
 
@@ -524,7 +524,7 @@ uint8_t *TR::X86LabelInstruction::generateBinaryEncoding()
       {
       cursor = getOpCode().copyBinaryToBuffer(instructionStart);
       immediateCursor = cursor;
-      cg()->addRelocation(new (cg()->trHeapMemory()) TR_LabelAbsoluteRelocation(cursor, label));
+      cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelAbsoluteRelocation(cursor, label));
       *(uint32_t *)cursor = 0;
       cursor += 4;
       }
@@ -803,7 +803,7 @@ uint8_t *TR::X86VirtualGuardNOPInstruction::generateBinaryEncoding()
       setBinaryEncoding(cursor);
       if (label->getCodeLocation() == NULL)
          {
-         cg()->addRelocation(new (cg()->trHeapMemory()) TR_LabelAbsoluteRelocation
+         cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelAbsoluteRelocation
                                    ((uint8_t *) (&_site->getDestination()), label));
          }
       else
@@ -827,7 +827,7 @@ uint8_t *TR::X86VirtualGuardNOPInstruction::generateBinaryEncoding()
       // Can't call _site->setDestination because we don't know the destination
       // yet, so use a relocation instead.
       //
-      cg()->addRelocation(new (cg()->trHeapMemory()) TR_LabelAbsoluteRelocation
+      cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelAbsoluteRelocation
                                 ((uint8_t *) (&_site->getDestination()), label));
       }
    else
@@ -924,7 +924,7 @@ TR::X86ImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
       {
       if (needsAOTRelocation())
          {
-         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, 0, TR_BodyInfoAddress, cg()),
+         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, 0, TR_BodyInfoAddress, cg()),
                                 __FILE__,
                                 __LINE__,
                                 getNode());
@@ -937,12 +937,12 @@ TR::X86ImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
             case TR_StaticRamMethodConst:
             case TR_VirtualRamMethodConst:
             case TR_SpecialRamMethodConst:
-               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, (uint8_t *)getNode()->getSymbolReference(),
+               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)getNode()->getSymbolReference(),
                   (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() , (TR_ExternalRelocationTargetKind) getReloKind(), cg()),
                   __FILE__, __LINE__, getNode());
                break;
             default:
-               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, 0, (TR_ExternalRelocationTargetKind)getReloKind(), cg()),
+               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, 0, (TR_ExternalRelocationTargetKind)getReloKind(), cg()),
                   __FILE__,
                   __LINE__,
                   getNode());
@@ -1147,7 +1147,7 @@ TR::X86ImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
             {
             if (labelSym)
                {
-               cg()->addRelocation(new (cg()->trHeapMemory()) TR_32BitLabelRelativeRelocation(cursor, labelSym));
+               cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative32BitRelocation(cursor, labelSym));
                }
             else
                {
@@ -1163,7 +1163,7 @@ TR::X86ImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
                   int rType = methodSym->getMethodKind()-1;  //method kinds are 1-based
                   TR_ASSERT(reloTypes[rType], "There shouldn't be direct JNI interface calls!");
 
-                  cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, (uint8_t *)getNode()->getSymbolReference(),
+                  cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)getNode()->getSymbolReference(),
                         getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
                         (TR_ExternalRelocationTargetKind) reloTypes [rType], cg()),
                         __FILE__, __LINE__, getNode());
@@ -1178,7 +1178,7 @@ TR::X86ImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
          }
       else if (getOpCodeValue() == DDImm4)
          {
-         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor,
+         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                 (uint8_t *)(uintptrj_t)getSourceImmediate(),
                                                                 getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                TR_ConstantPool,
@@ -1190,7 +1190,7 @@ TR::X86ImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
          TR::Symbol *symbol = getSymbolReference()->getSymbol();
          if (symbol->isConst())
             {
-            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor,
+            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                   (uint8_t *)getSymbolReference()->getOwningMethod(comp)->constantPool(),
                                                                   getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                   TR_ConstantPool,
@@ -1201,7 +1201,7 @@ TR::X86ImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
             {
             if (cg()->needClassAndMethodPointerRelocations())
                {
-               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor,
+               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                 (uint8_t *)getSymbolReference(),
                                                                 getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                 TR_ClassAddress,
@@ -1210,7 +1210,7 @@ TR::X86ImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
             }
          else if (symbol->isMethod())
             {
-            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor,
+            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                   (uint8_t *)getSymbolReference(),
                                                                   getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                   TR_MethodObject,
@@ -1221,14 +1221,14 @@ TR::X86ImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
             {
             TR::StaticSymbol *staticSym = sym->getStaticSymbol();
             if (staticSym && staticSym->isCompiledMethod())
-               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, 0, TR_RamMethod, cg()),
+               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, 0, TR_RamMethod, cg()),
                                       __FILE__, __LINE__, getNode());
             else if (staticSym && staticSym->isStartPC())
-               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor,
+               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                    (uint8_t *) (staticSym->getStaticAddress()), TR_AbsoluteMethodAddress, cg()),
                                       __FILE__, __LINE__, getNode());
             else
-               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor,
+               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                    (uint8_t *)getSymbolReference(), getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_DataAddress, cg()),
                                        __FILE__, __LINE__, getNode());
             }
@@ -1627,7 +1627,7 @@ TR::X86RegImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
 
       if (staticHCRPIC)
          {
-         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation((uint8_t *)cursor, (uint8_t *)getSourceImmediate(), TR_HCR, cg()), __FILE__,__LINE__, getNode());
+         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation((uint8_t *)cursor, (uint8_t *)getSourceImmediate(), TR_HCR, cg()), __FILE__,__LINE__, getNode());
          cg()->jitAdd32BitPicToPatchOnClassRedefinition(((void *) getSourceImmediateAsAddress()), (void *) cursor);
          }
 
@@ -1640,7 +1640,7 @@ TR::X86RegImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
       switch (_reloKind)
          {
          case TR_HEAP_BASE:
-            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor,
+            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                     (uint8_t*)TR_HeapBase,
                                                       TR_GlobalValue,
                                                       cg()),
@@ -1648,28 +1648,28 @@ TR::X86RegImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
             break;
 
          case TR_HEAP_TOP:
-            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor,
+            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                       (uint8_t*)TR_HeapTop,
                                                       TR_GlobalValue,
                                                       cg()),
                           __FILE__, __LINE__, getNode());
             break;
          case TR_HEAP_BASE_FOR_BARRIER_RANGE:
-            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor,
+            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                       (uint8_t*)TR_HeapBaseForBarrierRange0,
                                                       TR_GlobalValue,
                                                       cg()),
                           __FILE__, __LINE__, getNode());
             break;
          case TR_HEAP_SIZE_FOR_BARRIER_RANGE:
-            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor,
+            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                       (uint8_t*)TR_HeapSizeForBarrierRange0,
                                                       TR_GlobalValue,
                                                       cg()),
                           __FILE__, __LINE__, getNode());
             break;
          case TR_ACTIVE_CARD_TABLE_BASE:
-            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor,
+            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                       (uint8_t*)TR_ActiveCardTableBase,
                                                       TR_GlobalValue,
                                                       cg()),
@@ -1683,7 +1683,7 @@ TR::X86RegImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
          case TR_RamMethod:
             // intentional fall-through
          case TR_ClassPointer:
-            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor,
+            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                               (uint8_t*)getNode(),
                                                               (TR_ExternalRelocationTargetKind) _reloKind,
                                                               cg()),
@@ -1812,7 +1812,7 @@ TR::X86RegImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
       {
       case TR_ConstantPool:
          TR_ASSERT(symbol->isConst(), "assertion failure");
-         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor,
+         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                                    (uint8_t *)getSymbolReference()->getOwningMethod(comp)->constantPool(),
                                                                                    getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                                    (TR_ExternalRelocationTargetKind)getReloKind(),
@@ -1830,7 +1830,7 @@ TR::X86RegImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
             TR_ASSERT(!(getSymbolReference()->isUnresolved() && !symbol->isClassObject()), "expecting a resolved symbol for this instruction class!\n");
 
             *(int32_t *)cursor = (int32_t)TR::Compiler->cls.persistentClassPointerFromClassPointer(cg()->comp(), (TR_OpaqueClassBlock*)getSourceImmediate());
-             cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor,
+             cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                                    (uint8_t *)getSymbolReference(),
                                                                                    getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                                    (TR_ExternalRelocationTargetKind)getReloKind(),
@@ -1845,7 +1845,7 @@ TR::X86RegImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
       case TR_DataAddress:
          TR_ASSERT(!(getSymbolReference()->isUnresolved() && !symbol->isClassObject()), "expecting a resolved symbol for this instruction class!\n");
 
-         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor,
+         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                                    (uint8_t *)getSymbolReference(),
                                                                                    getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                                    (TR_ExternalRelocationTargetKind)getReloKind(),
@@ -1859,7 +1859,7 @@ TR::X86RegImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
             setReloKind(TR_RamMethod);
          // intentional fall-through
       case TR_ClassPointer:
-         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor,
+         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                            (uint8_t*)getNode(),
                                                            (TR_ExternalRelocationTargetKind)getReloKind(),
                                                            cg()),
@@ -2172,7 +2172,7 @@ TR::X86MemImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
       if (_reloKind == TR_ClassAddress && cg()->needClassAndMethodPointerRelocations())
          {
          TR_ASSERT(getNode(), "node expected to be non-NULL here");
-         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor,
+         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                        (uint8_t *)getNode()->getSymbolReference(),
                                                        (uint8_t *)getNode()->getInlinedSiteIndex(),
                                                        TR_ClassAddress,
@@ -2348,7 +2348,7 @@ TR::X86MemImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
    if (symbol->isConst())
       {
       cg()->addAOTRelocation(
-            new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor,
+            new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                   (uint8_t *)getSymbolReference()->getOwningMethod(comp)->constantPool(),
                                                                    getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                    TR_ConstantPool,
@@ -2363,19 +2363,19 @@ TR::X86MemImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
       if (cg()->needClassAndMethodPointerRelocations())
          {
          *(int32_t *)cursor = (int32_t)TR::Compiler->cls.persistentClassPointerFromClassPointer(cg()->comp(), (TR_OpaqueClassBlock*)getSourceImmediate());
-         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, (uint8_t *)getSymbolReference(), getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_ClassAddress, cg()),
+         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)getSymbolReference(), getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_ClassAddress, cg()),
                                                                                       __FILE__, __LINE__, getNode());
 
          }
       }
    else if (symbol->isMethod())
       {
-      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, (uint8_t *)getSymbolReference(), getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_MethodObject, cg()),
+      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)getSymbolReference(), getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_MethodObject, cg()),
                               __FILE__, __LINE__, getNode());
       }
    else
       {
-      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, (uint8_t *)getSymbolReference(), getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_DataAddress, cg()),
+      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)getSymbolReference(), getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_DataAddress, cg()),
                               __FILE__, __LINE__, getNode());
       }
    }
@@ -3077,7 +3077,7 @@ TR::AMD64RegImm64Instruction::addMetaDataForCodeAddress(uint8_t *cursor)
             )
          )
          {// the reference number is set in j9x86evaluator.cpp/VMarrayStoreCheckArrayCopyEvaluator
-         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor,
+         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                          (uint8_t *)methodSymRef,
                                                          TR_AbsoluteHelperAddress,
                                                          cg()),
@@ -3085,7 +3085,7 @@ TR::AMD64RegImm64Instruction::addMetaDataForCodeAddress(uint8_t *cursor)
          }
       else if (((getNode()->getOpCodeValue() == TR::aconst) && getNode()->isMethodPointerConstant() && needsAOTRelocation()) || staticHCRPIC)
          {
-         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor,
+         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                          NULL,
                                                          TR_RamMethod,
                                                          cg()),
@@ -3096,7 +3096,7 @@ TR::AMD64RegImm64Instruction::addMetaDataForCodeAddress(uint8_t *cursor)
          switch (_reloKind)
             {
             case TR_HEAP_BASE_FOR_BARRIER_RANGE:
-               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor,
+               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                  (uint8_t*)TR_HeapBaseForBarrierRange0,
                                                                  TR_GlobalValue,
                                                                  cg()),
@@ -3104,14 +3104,14 @@ TR::AMD64RegImm64Instruction::addMetaDataForCodeAddress(uint8_t *cursor)
                break;
 
             case TR_HEAP_SIZE_FOR_BARRIER_RANGE:
-               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor,
+               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                (uint8_t*)TR_HeapSizeForBarrierRange0,
                                                                TR_GlobalValue,
                                                                cg()),
                                    __FILE__, __LINE__, getNode());
                break;
             case TR_ACTIVE_CARD_TABLE_BASE:
-               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor,
+               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                (uint8_t*)TR_ActiveCardTableBase,
                                                                TR_GlobalValue,
                                                                cg()),
@@ -3119,7 +3119,7 @@ TR::AMD64RegImm64Instruction::addMetaDataForCodeAddress(uint8_t *cursor)
                break;
             case TR_ClassAddress:
                TR_ASSERT(getNode(), "node assumed to be non-NULL here");
-               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor,
+               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                 (uint8_t *)methodSymRef,
                                                                 (uint8_t *)getNode()->getInlinedSiteIndex(),
                                                                 TR_ClassAddress,
@@ -3134,7 +3134,7 @@ TR::AMD64RegImm64Instruction::addMetaDataForCodeAddress(uint8_t *cursor)
             case TR_RamMethod:
                // intentional fall-through
             case TR_ClassPointer:
-               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor,
+               cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                  (uint8_t*)getNode(),
                                                                  (TR_ExternalRelocationTargetKind) _reloKind,
                                                                  cg()),
@@ -3147,7 +3147,7 @@ TR::AMD64RegImm64Instruction::addMetaDataForCodeAddress(uint8_t *cursor)
             case TR_VirtualRamMethodConst:
             case TR_SpecialRamMethodConst:
 
-                cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, (uint8_t *) getNode()->getSymbolReference(), getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,  (TR_ExternalRelocationTargetKind) _reloKind, cg()),  __FILE__,__LINE__, getNode());
+                cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) getNode()->getSymbolReference(), getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,  (TR_ExternalRelocationTargetKind) _reloKind, cg()),  __FILE__,__LINE__, getNode());
                break;
 
             }
@@ -3162,7 +3162,7 @@ TR::AMD64RegImm64Instruction::addMetaDataForCodeAddress(uint8_t *cursor)
 
    if (staticHCRPIC)
       {
-      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation((uint8_t *)cursor, (uint8_t *)getSourceImmediate(), TR_HCR, cg()), __FILE__,__LINE__, getNode());
+      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation((uint8_t *)cursor, (uint8_t *)getSourceImmediate(), TR_HCR, cg()), __FILE__,__LINE__, getNode());
       cg()->jitAddPicToPatchOnClassRedefinition(((void *) getSourceImmediate()), (void *) cursor);
       }
 
@@ -3230,12 +3230,12 @@ TR::AMD64RegImm64SymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
       {
       // Assumes a 64-bit absolute relocation (i.e., not relative).
       //
-      cg()->addRelocation(new (cg()->trHeapMemory()) TR_LabelAbsoluteRelocation(cursor, getSymbolReference()->getSymbol()->castToLabelSymbol()));
+      cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelAbsoluteRelocation(cursor, getSymbolReference()->getSymbol()->castToLabelSymbol()));
 
       switch (getReloKind())
          {
          case TR_AbsoluteMethodAddress:
-            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, NULL, TR_AbsoluteMethodAddress, cg()), __FILE__, __LINE__, getNode());
+            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_AbsoluteMethodAddress, cg()), __FILE__, __LINE__, getNode());
             break;
          default:
             break;
@@ -3248,7 +3248,7 @@ TR::AMD64RegImm64SymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
       switch (getReloKind())
          {
          case TR_ConstantPool:
-            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor,
+            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                                       (uint8_t *)getSymbolReference()->getOwningMethod(comp)->constantPool(),
                                                                                        getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                                        (TR_ExternalRelocationTargetKind) getReloKind(),
@@ -3260,7 +3260,7 @@ TR::AMD64RegImm64SymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
 
          case TR_DataAddress:
             {
-            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor,
+            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                                       (uint8_t *) getSymbolReference(),
                                                                                       (uint8_t *)getNode() ? (uint8_t *) getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                                       (TR_ExternalRelocationTargetKind) getReloKind(),

--- a/compiler/z/codegen/ConstantDataSnippet.cpp
+++ b/compiler/z/codegen/ConstantDataSnippet.cpp
@@ -108,7 +108,7 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
          {
          AOTcgDiag3(comp, "add relocation (%d) cursor=%x symbolReference=%x\n", reloType, cursor, getSymbolReference());
          TR::SymbolReference *reloSymRef= (reloType==TR_ClassAddress)?getNode()->getSymbolReference():getSymbolReference();
-         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, (uint8_t *) reloSymRef,
+         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) reloSymRef,
                                                                                 getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                                 (TR_ExternalRelocationTargetKind) reloType, cg()),
                                    __FILE__, __LINE__, getNode());
@@ -120,7 +120,7 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
       case TR_JNIVirtualTargetAddress:
          {
          AOTcgDiag3(comp, "add relocation (%d) cursor=%x symbolReference=%x\n", reloType, cursor, getSymbolReference());
-         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, (uint8_t *)getNode()->getSymbolReference(),
+         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)getNode()->getSymbolReference(),
                   getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
                         (TR_ExternalRelocationTargetKind) reloType, cg()),
                         __FILE__, __LINE__, getNode());
@@ -129,7 +129,7 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
 
       case TR_DataAddress:
          AOTcgDiag3(comp, "add relocation (%d) cursor=%x symbolReference=%x\n", reloType, cursor, getSymbolReference());
-         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, (uint8_t *) getNode()->getSymbolReference(),
+         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) getNode()->getSymbolReference(),
                                   getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                                 (TR_ExternalRelocationTargetKind) reloType, cg()),
                                   __FILE__,__LINE__, getNode());
@@ -137,7 +137,7 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
 
       case TR_ArrayCopyHelper:
          AOTcgDiag3(comp, "add relocation (%d) cursor=%x symbolReference=%x\n", reloType, cursor, getSymbolReference());
-         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, (uint8_t *) getSymbolReference(),
+         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) getSymbolReference(),
                                                                                 (TR_ExternalRelocationTargetKind) reloType, cg()),
                                 __FILE__, __LINE__, getNode());
          break;
@@ -146,12 +146,12 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
          AOTcgDiag1(comp, "add TR_AbsoluteHelperAddress cursor=%x\n", cursor);
          if (TR::Compiler->target.is64Bit())
             {
-            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, (uint8_t *) *((uint64_t*) cursor), TR_AbsoluteHelperAddress, cg()),
+            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) *((uint64_t*) cursor), TR_AbsoluteHelperAddress, cg()),
                                 __FILE__, __LINE__, getNode());
             }
          else
             {
-            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, (uint8_t *)(intptr_t) *((uint32_t*) cursor), TR_AbsoluteHelperAddress, cg()),
+            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)(intptr_t) *((uint32_t*) cursor), TR_AbsoluteHelperAddress, cg()),
                                 __FILE__, __LINE__, getNode());
             }
          break;
@@ -161,13 +161,13 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
          AOTcgDiag2(comp, "add relocation (%d) cursor=%x\n", reloType, cursor);
          if (TR::Compiler->target.is64Bit())
             {
-            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, (uint8_t *) *((uint64_t*) cursor),
+            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) *((uint64_t*) cursor),
                   (TR_ExternalRelocationTargetKind) reloType, cg()),
                   __FILE__, __LINE__, getNode());
             }
          else
             {
-            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, (uint8_t *)(intptr_t) *((uint32_t*) cursor),
+            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)(intptr_t) *((uint32_t*) cursor),
                   (TR_ExternalRelocationTargetKind) reloType, cg()),
                   __FILE__, __LINE__, getNode());
             }
@@ -175,7 +175,7 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
 
       case TR_GlobalValue:
          AOTcgDiag2(comp, "add TR_GlobalValue (countForRecompile) cursor=%x\n", reloType, cursor);
-         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, (uint8_t *) TR_CountForRecompile,
+         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) TR_CountForRecompile,
                                                                                 TR_GlobalValue, cg()),
                                   __FILE__, __LINE__, getNode());
          break;
@@ -185,7 +185,7 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
       case TR_ClassPointer:
          {
          AOTcgDiag2(comp, "add relocation (%d) cursor=%x\n", reloType, cursor);
-         TR_Relocation *relo;
+         TR::Relocation *relo;
          //for optimizations where we are trying to relocate either profiled j9class or getfrom signature we can't use node to get the target address
          //so we need to pass it to relocation in targetaddress2 for now
          //two instances where use this relotype in such way are: profile checkcast and arraystore check object check optimiztaions
@@ -197,7 +197,7 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
             else
                targetAdress2 = (uint8_t *) *((uintptrj_t*) cursor);
             }
-         relo = new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, (uint8_t *) getNode(), targetAdress2, (TR_ExternalRelocationTargetKind) reloType, cg());
+         relo = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) getNode(), targetAdress2, (TR_ExternalRelocationTargetKind) reloType, cg());
          cg()->addAOTRelocation(relo, __FILE__, __LINE__, getNode());
          }
          break;
@@ -400,7 +400,7 @@ TR::S390WarmEyeCatcherDataSnippet::emitSnippetBody()
 
    // Pointer to Full EyeCatcher Snippet Label
    TR_ASSERT(_fullEyeCatcherSnippet != NULL, "Warm EyeCatcher does not have a corresponding full EyeCatcher.");
-   cg()->addRelocation(new (cg()->trHeapMemory()) TR_LabelAbsoluteRelocation(cursor, _fullEyeCatcherSnippet));
+   cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelAbsoluteRelocation(cursor, _fullEyeCatcherSnippet));
    cursor += sizeof(intptrj_t);
    return cursor;
    }
@@ -451,7 +451,7 @@ TR::S390TargetAddressSnippet::emitSnippetBody()
       {
       *(intptrj_t *) cursor = 0;
       AOTcgDiag1(comp, "add TR_AbsoluteMethodAddress cursor=%x\n", cursor);
-      cg()->addRelocation(new (cg()->trHeapMemory()) TR_LabelAbsoluteRelocation(cursor, _targetsnippet->getSnippetLabel()));
+      cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelAbsoluteRelocation(cursor, _targetsnippet->getSnippetLabel()));
       cg()->addProjectSpecializedRelocation(cursor, NULL, NULL, TR_AbsoluteMethodAddress,
                                 __FILE__, __LINE__, getNode());
       }
@@ -465,7 +465,7 @@ TR::S390TargetAddressSnippet::emitSnippetBody()
       else
          {
          AOTcgDiag1(comp, "add TR_AbsoluteMethodAddress cursor=%x\n", cursor);
-         cg()->addRelocation(new (cg()->trHeapMemory()) TR_LabelAbsoluteRelocation(cursor, _targetlabel));
+         cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelAbsoluteRelocation(cursor, _targetlabel));
          cg()->addProjectSpecializedRelocation(cursor, NULL, NULL, TR_AbsoluteMethodAddress,
                                    __FILE__, __LINE__, getNode());
          }
@@ -988,7 +988,7 @@ TR::S390JNICallDataSnippet::emitSnippetBody()
          }
 
       AOTcgDiag2(comp, "add relocation (%d) cursor=%x\n", reloType, cursor);
-      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, (uint8_t *) callNode->getSymbolReference(),
+      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) callNode->getSymbolReference(),
                callNode  ? (uint8_t *)(intptr_t)callNode->getInlinedSiteIndex() : (uint8_t *)-1,
                      (TR_ExternalRelocationTargetKind) reloType, cg()),
                      __FILE__, __LINE__, callNode);
@@ -1002,8 +1002,8 @@ TR::S390JNICallDataSnippet::emitSnippetBody()
        *(intptrj_t *) cursor = (intptrj_t) (_returnFromJNICallLabel->getCodeLocation());
 
        AOTcgDiag1(comp, "add TR_AbsoluteMethodAddress cursor=%x\n", cursor);
-       cg()->addRelocation(new (cg()->trHeapMemory()) TR_LabelAbsoluteRelocation(cursor, _returnFromJNICallLabel));
-       cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, NULL, TR_AbsoluteMethodAddress, cg()),
+       cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelAbsoluteRelocation(cursor, _returnFromJNICallLabel));
+       cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_AbsoluteMethodAddress, cg()),
              __FILE__, __LINE__, getNode());
 
        cursor += TR::Compiler->om.sizeofReferenceAddress();
@@ -1049,7 +1049,7 @@ TR::S390JNICallDataSnippet::emitSnippetBody()
          TR_ASSERT(0,"JNI relocation not supported.");
          }
 
-      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation(cursor, (uint8_t *) callNode->getSymbolReference(),
+      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) callNode->getSymbolReference(),
                callNode  ? (uint8_t *)(intptr_t)callNode->getInlinedSiteIndex() : (uint8_t *)-1,
                      (TR_ExternalRelocationTargetKind) reloType, cg()),
                      __FILE__, __LINE__, callNode);
@@ -1427,7 +1427,7 @@ TR::S390LabelTableSnippet::emitSnippetBody()
       {
       if (_labelTable[i])
          {
-         cg()->addRelocation(new (cg()->trHeapMemory()) TR_32BitLabelTableRelocation(cursor, _labelTable[i]));
+         cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelTable32BitRelocation(cursor, _labelTable[i]));
          *(uint32_t *) cursor = cursor - snip;
          }
       else
@@ -1465,7 +1465,7 @@ TR::S390DeclTrampSnippet::emitSnippetBody()
    *(uint32_t *) cursor = 0x50d0a000;
    cursor += 4;
    *(uint16_t *) cursor = 0xc0f4;
-   cg()->addRelocation(new (cg()->trHeapMemory()) TR_32BitLabelRelativeRelocation(cursor, _label));
+   cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative32BitRelocation(cursor, _label));
    cursor += 6;
    *(uint32_t *) cursor = 0xdead;
    cursor += 2;
@@ -1494,7 +1494,7 @@ TR::S390SortJumpTrampSnippet::emitSnippetBody()
    *(uint32_t *) cursor = 0x50d0a000;
    cursor += 4;
    *(uint16_t *) cursor = 0xc0f4;
-   cg()->addRelocation(new (cg()->trHeapMemory()) TR_32BitLabelRelativeRelocation(cursor, _label));
+   cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative32BitRelocation(cursor, _label));
    cursor += 6;
    *(uint32_t *) cursor = 0xdead;
    cursor += 2;

--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -2882,7 +2882,7 @@ OMR::Z::MemoryReference::calcDisplacement(uint8_t * cursor, TR::Instruction * in
          //
          if(cursor != NULL)
             {
-            cg->addRelocation(new (cg->trHeapMemory()) TR_12BitLabelRelativeRelocation(cursor, snippet->getSnippetLabel()));
+            cg->addRelocation(new (cg->trHeapMemory()) TR::LabelRelative12BitRelocation(cursor, snippet->getSnippetLabel()));
             }
          }
       }

--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -312,7 +312,7 @@ TR::S390LabelInstruction::generateBinaryEncoding()
    if (getOpCode().getOpCodeValue() == TR::InstOpCode::DC)
       {
       AOTcgDiag1(comp, "add TR_AbsoluteMethodAddress cursor=%x\n", cursor);
-      cg()->addRelocation(new (cg()->trHeapMemory()) TR_LabelAbsoluteRelocation(cursor, label));
+      cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelAbsoluteRelocation(cursor, label));
       cg()->addProjectSpecializedRelocation(cursor, NULL, NULL, TR_AbsoluteMethodAddress,
                              __FILE__, __LINE__, getNode());
 
@@ -807,16 +807,16 @@ TR::S390BranchInstruction::generateBinaryEncoding()
       {
       if (shortRelocation)
          {
-         cg()->addRelocation(new (cg()->trHeapMemory()) TR_16BitLabelRelativeRelocation(relocationPoint, label));
+         cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative16BitRelocation(relocationPoint, label));
          }
       else if (longRelocation)
          {
-         cg()->addRelocation(new (cg()->trHeapMemory()) TR_32BitLabelRelativeRelocation(relocationPoint, label));
+         cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative32BitRelocation(relocationPoint, label));
          }
       else
          {
          AOTcgDiag1(comp, "add TR_AbsoluteMethodAddress cursor=%x\n", cursor);
-         cg()->addRelocation(new (cg()->trHeapMemory()) TR_LabelAbsoluteRelocation(relocationPoint, label));
+         cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelAbsoluteRelocation(relocationPoint, label));
          cg()->addProjectSpecializedRelocation(relocationPoint, NULL, NULL, TR_AbsoluteMethodAddress,
                                 __FILE__, __LINE__, getNode());
 
@@ -914,7 +914,7 @@ TR::S390BranchOnCountInstruction::generateBinaryEncoding()
       toRealRegister(getRegisterOperand(1))->setRegisterField((uint32_t *) instructionStart);
       if (doRelocation)
          {
-         cg()->addRelocation(new (cg()->trHeapMemory()) TR_32BitLabelRelativeRelocation(relocationPoint, label));
+         cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative32BitRelocation(relocationPoint, label));
          }
       }
    else
@@ -954,12 +954,12 @@ TR::S390BranchOnCountInstruction::generateBinaryEncoding()
          {
          if (shortRelocation)
             {
-            cg()->addRelocation(new (cg()->trHeapMemory()) TR_16BitLabelRelativeRelocation(relocationPoint, label));
+            cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative16BitRelocation(relocationPoint, label));
             }
          else
             {
             AOTcgDiag1(comp, "add TR_AbsoluteMethodAddress cursor=%x\n", relocationPoint);
-            cg()->addRelocation(new (cg()->trHeapMemory()) TR_LabelAbsoluteRelocation(relocationPoint, label));
+            cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelAbsoluteRelocation(relocationPoint, label));
             cg()->addProjectSpecializedRelocation(relocationPoint, NULL, NULL, TR_AbsoluteMethodAddress,
                                    __FILE__, __LINE__, getNode());
             }
@@ -1123,13 +1123,13 @@ TR::S390BranchOnIndexInstruction::generateBinaryEncoding()
       {
       if (shortRelocation)
          {
-         cg()->addRelocation(new (cg()->trHeapMemory()) TR_16BitLabelRelativeRelocation(relocationPoint, label));
+         cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative16BitRelocation(relocationPoint, label));
          }
       else
          {
          AOTcgDiag1(cg()->comp(), "add TR_AbsoluteMethodAddress cursor=%x\n", relocationPoint);
 
-         cg()->addRelocation(new (cg()->trHeapMemory()) TR_LabelAbsoluteRelocation(relocationPoint, label));
+         cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelAbsoluteRelocation(relocationPoint, label));
          cg()->addProjectSpecializedRelocation(relocationPoint, NULL, NULL, TR_AbsoluteMethodAddress,
                                 __FILE__, __LINE__, getNode());
          }
@@ -1326,7 +1326,7 @@ TR::S390DebugCounterBumpInstruction::generateBinaryEncoding()
    *(int16_t *) cursor  = bos(0xC408);                                                    // LGRL Rscrtch, counterRelocation
    scratchReg->setRegisterField((uint32_t *)cursor);                                      //
    cg()->addRelocation(new (cg()->trHeapMemory())                                         //
-      TR_32BitLabelRelativeRelocation(cursor, getCounterSnippet()->getSnippetLabel()));   //
+      TR::LabelRelative32BitRelocation(cursor, getCounterSnippet()->getSnippetLabel()));   //
    cursor += 6;                                                                           //
 
    *(int32_t *) cursor  = boi(0xEB000000 | (((int8_t) getDelta()) << 16));                // On 64-bit platforms
@@ -1398,7 +1398,7 @@ TR::S390ImmInstruction::generateBinaryEncoding()
       //
       void **locationToPatch = (void**)(cursor - (TR::Compiler->target.is64Bit()?4:0));
       cg()->jitAddPicToPatchOnClassRedefinition(*locationToPatch, locationToPatch);
-      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR_ExternalRelocation((uint8_t *)locationToPatch, (uint8_t *)*locationToPatch, TR_HCR, cg()), __FILE__,__LINE__, getNode());
+      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation((uint8_t *)locationToPatch, (uint8_t *)*locationToPatch, TR_HCR, cg()), __FILE__,__LINE__, getNode());
       }
 
    cursor += getOpCode().getInstructionLength();
@@ -2086,7 +2086,7 @@ TR::S390RILInstruction::generateBinaryEncoding()
       //
       getOpCode().copyBinaryToBuffer(instructionStart);
       toRealRegister(getRegisterOperand(1))->setRegister1Field((uint32_t *) cursor);
-      cg()->addRelocation(new (cg()->trHeapMemory()) TR_32BitLabelRelativeRelocation(cursor, getTargetSnippet()->getSnippetLabel()));
+      cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative32BitRelocation(cursor, getTargetSnippet()->getSnippetLabel()));
       cursor += getOpCode().getInstructionLength();
       }
    else if (getTargetSnippet() &&
@@ -2096,7 +2096,7 @@ TR::S390RILInstruction::generateBinaryEncoding()
       //
       getOpCode().copyBinaryToBuffer(instructionStart);
       toRealRegister(getRegisterOperand(1))->setRegister1Field((uint32_t *) cursor);
-      cg()->addRelocation(new (cg()->trHeapMemory()) TR_32BitLabelRelativeRelocation(cursor, getTargetSnippet()->getSnippetLabel()));
+      cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative32BitRelocation(cursor, getTargetSnippet()->getSnippetLabel()));
       cursor += getOpCode().getInstructionLength();
       }
    else if (getOpCode().getOpCodeValue() == TR::InstOpCode::LRL   ||
@@ -2290,11 +2290,11 @@ TR::S390RILInstruction::generateBinaryEncoding()
 
       if (getTargetSnippet() != NULL)
          {
-         cg()->addRelocation(new (cg()->trHeapMemory()) TR_32BitLabelRelativeRelocation(cursor, getTargetSnippet()->getSnippetLabel()));
+         cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative32BitRelocation(cursor, getTargetSnippet()->getSnippetLabel()));
          }
       else if (getTargetLabel() != NULL)
          {
-         cg()->addRelocation(new (cg()->trHeapMemory()) TR_32BitLabelRelativeRelocation(cursor, getTargetLabel()));
+         cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative32BitRelocation(cursor, getTargetLabel()));
          }
 
       cursor += getOpCode().getInstructionLength();
@@ -2342,13 +2342,13 @@ TR::S390RILInstruction::generateBinaryEncoding()
       toRealRegister(getRegisterOperand(1))->setRegister1Field((uint32_t *) cursor);
       if (getTargetLabel() != NULL)
          {
-         cg()->addRelocation(new (cg()->trHeapMemory()) TR_32BitLabelRelativeRelocation(cursor, getTargetLabel()));
+         cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative32BitRelocation(cursor, getTargetLabel()));
          }
       else
          {
          if (getTargetSnippet() != NULL)
             {
-            cg()->addRelocation(new (cg()->trHeapMemory()) TR_32BitLabelRelativeRelocation(cursor, getTargetSnippet()->getSnippetLabel()));
+            cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative32BitRelocation(cursor, getTargetSnippet()->getSnippetLabel()));
             }
          else
             {
@@ -2429,7 +2429,7 @@ TR::S390RILInstruction::generateBinaryEncoding()
       if (getTargetSnippet() != NULL)
          {
          // delegate to targetSnippet Label to patch the imm. operand
-         cg()->addRelocation(new (cg()->trHeapMemory()) TR_32BitLabelRelativeRelocation(cursor, getTargetSnippet()->getSnippetLabel()));
+         cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative32BitRelocation(cursor, getTargetSnippet()->getSnippetLabel()));
          }
       else
          {
@@ -2496,7 +2496,7 @@ TR::S390RILInstruction::generateBinaryEncoding()
       // delegate to targetSnippet Label to patch the imm. operand
       if (getTargetSnippet() != NULL)
          {
-         cg()->addRelocation(new (cg()->trHeapMemory()) TR_32BitLabelRelativeRelocation(cursor, getTargetSnippet()->getSnippetLabel()));
+         cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative32BitRelocation(cursor, getTargetSnippet()->getSnippetLabel()));
          }
       else
          {
@@ -2866,7 +2866,7 @@ TR::S390RIEInstruction::generateBinaryEncoding()
          {
          if (doRelocation)
             {
-            cg()->addRelocation(new (cg()->trHeapMemory()) TR_16BitLabelRelativeRelocation(cursor, label));
+            cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative16BitRelocation(cursor, label));
             }
          else
             {
@@ -2875,7 +2875,7 @@ TR::S390RIEInstruction::generateBinaryEncoding()
          }
       else if (getWarmToColdTrampolineSnippet() &&  trampolineDistance >= MIN_IMMEDIATE_VAL && trampolineDistance <= MAX_IMMEDIATE_VAL)
          {
-         cg()->addRelocation(new (cg()->trHeapMemory()) TR_16BitLabelRelativeRelocation(cursor, getWarmToColdTrampolineSnippet()->getSnippetLabel()));
+         cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative16BitRelocation(cursor, getWarmToColdTrampolineSnippet()->getSnippetLabel()));
          ((TR::S390WarmToColdTrampolineSnippet*)getWarmToColdTrampolineSnippet())->setIsUsed(true);
          }
       else
@@ -2987,7 +2987,7 @@ TR::S390RIEInstruction::generateBinaryEncoding()
 
          if (doRelocation)
             {
-            cg()->addRelocation(new (cg()->trHeapMemory()) TR_32BitLabelRelativeRelocation(cursor, label));
+            cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative32BitRelocation(cursor, label));
             }
          else
             {
@@ -5089,14 +5089,14 @@ TR::S390NOPInstruction::generateBinaryEncoding()
          // If within range, we don't have to emit our psuedo branch around instruction.
          if (distance < 0x3FFF8 && distance > 0)
             {
-            cg()->addRelocation(new (cg()->trHeapMemory()) TR_16BitLabelRelativeRelocation(cursor+2, getTargetSnippet()->getSnippetLabel(),8));
+            cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative16BitRelocation(cursor+2, getTargetSnippet()->getSnippetLabel(),8));
             }
          else
             {
             // Snippet is beyond 16 bit relative relocation distance.
             // In this case, we have to activate our pseudo branch around call descriptor
             getCallDescInstr()->setCallDescValue(((TR::S390ConstantDataSnippet *)getTargetSnippet())->getDataAs8Bytes(), cg()->trMemory());
-            cg()->addRelocation(new (cg()->trHeapMemory()) TR_16BitLabelRelativeRelocation(cursor+2, getCallDescInstr()->getCallDescLabel(),8));
+            cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative16BitRelocation(cursor+2, getCallDescInstr()->getCallDescLabel(),8));
 
             }
          }
@@ -5173,8 +5173,8 @@ TR::S390MIIInstruction::generateBinaryEncoding()
       cursor += 1;
 
       //add relocation 12-24 bits
-      //TODO: later add TR_12BitInstructionRelativeRelocation
-      cg()->addRelocation(new (cg()->trHeapMemory()) TR_12BitLabelRelativeRelocation(cursor, getLabelSymbol(),false));
+      //TODO: later add TR::12BitInstructionRelativeRelocation
+      cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative12BitRelocation(cursor, getLabelSymbol(),false));
 
       // add the comparison mask for the instruction to the buffer.
       *(int16_t *) cursor |= ((uint16_t)getMask() << 12);
@@ -5272,8 +5272,8 @@ TR::S390SMIInstruction::generateBinaryEncoding()
       //TODO: fix for when displacement is too big and need an extra instruction cursor += padding;
       cursor += 2;
       // add relocation
-      //TODO: later add TR_16BitInstructionRelativeRelocation
-      cg()->addRelocation(new (cg()->trHeapMemory()) TR_16BitLabelRelativeRelocation(cursor, getLabelSymbol(), 4, true));
+      //TODO: later add TR::16BitInstructionRelativeRelocation
+      cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative16BitRelocation(cursor, getLabelSymbol(), 4, true));
 
       // advance the cursor past the immediate.
       cursor += 2;
@@ -5327,7 +5327,7 @@ TR::S390VirtualGuardNOPInstruction::generateBinaryEncoding()
       setBinaryEncoding(cursor);
       if (label->getCodeLocation() == NULL)
          {
-         cg()->addRelocation(new (cg()->trHeapMemory()) TR_LabelAbsoluteRelocation((uint8_t *) (&_site->getDestination()), label));
+         cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelAbsoluteRelocation((uint8_t *) (&_site->getDestination()), label));
          }
       else
          {
@@ -5364,7 +5364,7 @@ TR::S390VirtualGuardNOPInstruction::generateBinaryEncoding()
       //bool brcRangeExceeded = (distance<MIN_IMMEDIATE_VAL || distance>MAX_IMMEDIATE_VAL);
 
       AOTcgDiag1(comp, "add TR_AbsoluteMethodAddress cursor=%x\n", (uint8_t *) (&_site->getDestination()));
-      cg()->addRelocation(new (cg()->trHeapMemory()) TR_LabelAbsoluteRelocation((uint8_t *) (&_site->getDestination()), label));
+      cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelAbsoluteRelocation((uint8_t *) (&_site->getDestination()), label));
 
       doRelocation = true;
 #ifdef DEBUG
@@ -5525,12 +5525,12 @@ TR::S390VirtualGuardNOPInstruction::generateBinaryEncoding()
       {
       if (shortRelocation)
          {
-         cg()->addRelocation(new (cg()->trHeapMemory()) TR_16BitLabelRelativeRelocation(relocationPoint, label));
+         cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative16BitRelocation(relocationPoint, label));
          }
       else
          {
          TR_ASSERT( longRelocation, "how did I get here??\n");
-         cg()->addRelocation(new (cg()->trHeapMemory()) TR_32BitLabelRelativeRelocation(relocationPoint, label));
+         cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative32BitRelocation(relocationPoint, label));
          }
       }
 

--- a/compiler/z/codegen/S390Snippets.cpp
+++ b/compiler/z/codegen/S390Snippets.cpp
@@ -37,7 +37,7 @@ TR::S390WarmToColdTrampolineSnippet::emitSnippetBody()
 
    if (getIsUsed())
       {
-      cg()->addRelocation(new (cg()->trHeapMemory()) TR_32BitLabelRelativeRelocation(cursor, getTargetLabel()));
+      cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative32BitRelocation(cursor, getTargetLabel()));
 
       // BRCL 0xf, <target>
       *(int16_t *) cursor = 0xC0F4;


### PR DESCRIPTION
This is part of moving all classes from using the TR_ prefix to the TR namespace.

There are [a few](https://github.com/eclipse/omr/pull/503/files#diff-dc1053b2d3d1f717cf5e5d85690cdfceR514) classes in this which started with `TR_#Bit`, eg. `TR_8BitLabelRelativeRelocation`. Since C++ classes can't start with digits, I've moved the `#Bit` to the end, eg. `TR_LabelRelativeRelocation8Bit`. I'm open to changing this if someone suggests a better format.