### PR TITLE
Move J9 specific code from OMR compilation to J9 compilation

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1922,6 +1922,7 @@ void TR_SetMonitorStateOnBlockEntry::set(bool& lmmdFailed, bool traceIt)
          }
       }
 
+#ifdef J9_PROJECT_SPECIFIC
    static bool disableCountingMonitors = feGetEnv("TR_disableCountingMonitors")? true: false;
    if (initializeMonitorAutos && !disableCountingMonitors)
       {
@@ -1940,6 +1941,7 @@ void TR_SetMonitorStateOnBlockEntry::set(bool& lmmdFailed, bool traceIt)
             }
          }
       }
+#endif
    }
 
 

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -684,26 +684,6 @@ public:
    void setNodeOpCodeLength( int32_t opCodeLen ) { _nodeOpCodeLength = opCodeLen; }
    void incrNodeOpCodeLength( int32_t incr ) { _nodeOpCodeLength += incr; }
 
-
-   // ==========================================================================
-   // J9
-   //
-
-   // cache some VM pointers
-   TR_OpaqueClassBlock *getObjectClassPointer() { return _ObjectClassPointer; }
-   TR_OpaqueClassBlock *getRunnableClassPointer() { return _RunnableClassPointer; }
-   TR_OpaqueClassBlock *getStringClassPointer() { return _StringClassPointer; }
-   TR_OpaqueClassBlock *getSystemClassPointer() { return _SystemClassPointer; }
-   TR_OpaqueClassBlock *getReferenceClassPointer() { return _ReferenceClassPointer; }
-   TR_OpaqueClassBlock *getJITHelpersClassPointer() { return _JITHelpersClassPointer; }
-   TR_OpaqueClassBlock *getClassClassPointer();
-
-   TR_Array<List<TR::RegisterMappedSymbol> * > & getMonitorAutos() { return _monitorAutos; }
-
-   void addMonitorAuto(TR::RegisterMappedSymbol *, int32_t callerIndex);
-   void addAsMonitorAuto(TR::SymbolReference* symRef, bool dontAddIfDLT);
-   TR::list<TR::SymbolReference*> * getMonitorAutoSymRefsInCompiledMethod() { return &_monitorAutoSymRefsInCompiledMethod; }
-
    // ==========================================================================
    // CHTable
    //
@@ -1050,12 +1030,6 @@ private:
    TR_RegisterCandidates             *_globalRegisterCandidates;
    TR::SymbolReferenceTable          *_currentSymRefTab;
    TR::Recompilation                  *_recompilationInfo;
-   TR_OpaqueClassBlock               *_ObjectClassPointer;
-   TR_OpaqueClassBlock               *_RunnableClassPointer;
-   TR_OpaqueClassBlock               *_StringClassPointer;
-   TR_OpaqueClassBlock               *_SystemClassPointer;
-   TR_OpaqueClassBlock               *_ReferenceClassPointer;
-   TR_OpaqueClassBlock               *_JITHelpersClassPointer;
    TR_OptimizationPlan               *_optimizationPlan;
 
    TR_RandomGenerator*                 _primaryRandom; // Used to spawn other RandomGenerators to keep nondeterminism contained
@@ -1064,8 +1038,6 @@ private:
    TR_Array<TR::ResolvedMethodSymbol*> _methodSymbols;
    TR_Array<TR::SymbolReference*>      _resolvedMethodSymbolReferences;
    TR_Array<TR_InlinedCallSiteInfo>   _inlinedCallSites;
-   TR_Array<List<TR::RegisterMappedSymbol> *> _monitorAutos;
-   TR::list<TR::SymbolReference*>           _monitorAutoSymRefsInCompiledMethod;
    TR_Stack<int32_t>                  _inlinedCallStack;
    TR_Stack<TR_PrexArgInfo *>         _inlinedCallArgInfoStack;
    TR::list<TR_DevirtualizedCallInfo*>     _devirtualizedCalls;

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -2900,6 +2900,7 @@ OMR::Node::isClassUnloadingConst()
 TR_OpaqueClassBlock *
 OMR::Node::getMonitorClass(TR_ResolvedMethod * vmMethod)
    {
+#ifdef J9_PROJECT_SPECIFIC
    TR::Compilation * c = TR::comp();
    TR::Node * object = self()->getOpCodeValue() != TR::tstart ? self()->getFirstChild() : self()->getThirdChild();
    if (self()->isStaticMonitor())
@@ -2925,6 +2926,7 @@ OMR::Node::getMonitorClass(TR_ResolvedMethod * vmMethod)
           return (TR_OpaqueClassBlock *)symRef->getSymbol()->castToLocalObjectSymbol()->getClassSymbolReference()->getSymbol()->castToStaticSymbol()->getStaticAddress();
          }
       }
+#endif
    return 0;
    }
 

--- a/compiler/optimizer/VPConstraint.cpp
+++ b/compiler/optimizer/VPConstraint.cpp
@@ -680,9 +680,11 @@ bool TR::VPResolvedClass::isPrimitiveArray(TR::Compilation *comp)
 
 bool TR::VPResolvedClass::isJavaLangObject(TR::ValuePropagation *vp)
    {
+#ifdef J9_PROJECT_SPECIFIC
    void *javaLangObject = vp->comp()->getObjectClassPointer();
    if (javaLangObject)
       return javaLangObject == _class;
+#endif
 
    return (_len == 18 && !strncmp(_sig, "Ljava/lang/Object;", 18));
    }
@@ -3553,6 +3555,7 @@ TR::VPConstraint *TR::VPKnownObject::intersect1(TR::VPConstraint *other, TR::Val
 
 TR::VPConstraint *TR::VPConstString::intersect1(TR::VPConstraint *other, TR::ValuePropagation *vp)
    {
+#ifdef J9_PROJECT_SPECIFIC
    TRACER(vp, this, other);
 
    if (other->asConstString())
@@ -3595,6 +3598,8 @@ TR::VPConstraint *TR::VPConstString::intersect1(TR::VPConstraint *other, TR::Val
       if (!location) return NULL;
       return TR::VPClass::create(vp, this, NULL, NULL, NULL, location);
       }
+#endif
+
    return NULL;
    }
 

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -1577,7 +1577,6 @@ TR::Node *constrainAload(TR::ValuePropagation *vp, TR::Node *node)
                if (classInfo && classInfo->isInitialized())
                   isClassInitialized = true;
 
-#ifdef J9_PROJECT_SPECIFIC
                if (classOfStatic != vp->comp()->getSystemClassPointer() &&
                    isClassInitialized &&
                    !vp->comp()->getOption(TR_AOT) &&
@@ -1612,7 +1611,6 @@ TR::Node *constrainAload(TR::ValuePropagation *vp, TR::Node *node)
                         }
                      }
                   }
-#endif
                }
 
             if (!foundInfo)
@@ -4822,6 +4820,7 @@ static void devirtualizeCall(TR::ValuePropagation *vp, TR::Node *node)
    // java/lang/Object for the purposes of devirtualization.
    if ( constraint->getArrayInfo())
       {
+#ifdef J9_PROJECT_SPECIFIC
       thisType = vp->comp()->getObjectClassPointer();
       if (!thisType)
          {
@@ -4830,6 +4829,7 @@ static void devirtualizeCall(TR::ValuePropagation *vp, TR::Node *node)
          return;
          }
       constraint = TR::VPFixedClass::create(vp, thisType);
+#endif
       }
 
 
@@ -4838,6 +4838,7 @@ static void devirtualizeCall(TR::ValuePropagation *vp, TR::Node *node)
         (constraint->asObjectLocation() &&
          (constraint->asObjectLocation()->isClassObject() == TR_yes)))
       {
+#ifdef J9_PROJECT_SPECIFIC
       thisType = vp->comp()->getClassClassPointer();
       if (!thisType)
          {
@@ -4846,6 +4847,7 @@ static void devirtualizeCall(TR::ValuePropagation *vp, TR::Node *node)
          return;
          }
       constraint = TR::VPFixedClass::create(vp, thisType);
+#endif
       }
 
    // The fixed type may be different than the type of the this pointer.
@@ -9501,6 +9503,7 @@ static TR::Node *constrainIfcmpeqne(TR::ValuePropagation *vp, TR::Node *node, bo
             {
             case TR_VftTest:
                   {
+#ifdef J9_PROJECT_SPECIFIC
                   instanceofObjectRef = node->getFirstChild();
                   TR::Node *classChild = node->getSecondChild();
                   bool foldedGuard = false;
@@ -9544,6 +9547,7 @@ static TR::Node *constrainIfcmpeqne(TR::ValuePropagation *vp, TR::Node *node, bo
                      else
                         instanceofOnBranch = true;
                      }
+#endif
                   }
                break;
             case TR_MethodTest:

--- a/compiler/optimizer/ValuePropagation.cpp
+++ b/compiler/optimizer/ValuePropagation.cpp
@@ -1675,7 +1675,11 @@ void TR::ValuePropagation::checkTypeRelationship(TR::VPConstraint *lhs, TR::VPCo
       traceMsg(comp(), "   checking for relationship between types...\n");
 
    int32_t result = value;
-   TR_OpaqueClassBlock *jlKlass = comp()->getClassClassPointer();
+   TR_OpaqueClassBlock *jlKlass = NULL;
+
+#ifdef J9_PROJECT_SPECIFIC
+   jlKlass = comp()->getClassClassPointer();
+#endif   
 
    if (lhs->asClass() && rhs->asClass())
       {
@@ -7065,7 +7069,6 @@ TR::SymbolReference * TR::ValuePropagation::getStringCacheRef()
   TR_OpaqueClassBlock *stringClass = comp()->getStringClassPointer();
   TR::SymbolReference      *stringSymRef;
   methodSymbol = comp()->getOwningMethodSymbol(feMethod);
-  stringClass = comp()->getStringClassPointer();
   stringSymRef = comp()->getSymRefTab()->findOrCreateClassSymbol(methodSymbol, -1, stringClass);
   TR_ScratchList<TR_ResolvedMethod> stringMethods(comp()->trMemory());
   comp()->fej9()->getResolvedMethods(comp()->trMemory(), stringClass, &stringMethods);


### PR DESCRIPTION
Remove data members and methods related to cached J9 VM pointers
and monitors from OMR compilation. Add #ifdef guards for uses of
these methods in OMR.

Signed-off-by: Xiaoli Liang <xsliang@ca.ibm.com>