### PR TITLE
Fix incorrect ref count in transformObjectCloneCall

### DIFF
--- a/compiler/optimizer/ValuePropagation.cpp
+++ b/compiler/optimizer/ValuePropagation.cpp
@@ -7268,7 +7268,6 @@ void TR::ValuePropagation::doDelayedTransformations()
       transformConverterCall(converterCallTree);
       }
    _converterCalls.deleteAll();
-#endif
 
    ListIterator<TR::TreeTop> objCloneIt(&_objectCloneCalls);
    ListIterator<ObjCloneInfo> objCloneTypeIt(&_objectCloneTypes);
@@ -7299,6 +7298,7 @@ void TR::ValuePropagation::doDelayedTransformations()
       }
    _arrayCloneCalls.deleteAll();
    _arrayCloneTypes.deleteAll();
+#endif
 
    ListIterator<TR_TreeTopWrtBarFlag> treesIt(&_unknownTypeArrayCopyTrees);
    TR_TreeTopWrtBarFlag *unknownTypeArrayCopyTree;

--- a/compiler/optimizer/ValuePropagation.hpp
+++ b/compiler/optimizer/ValuePropagation.hpp
@@ -689,9 +689,6 @@ class ValuePropagation : public TR::Optimization
    void transformUnknownTypeArrayCopy(TR_TreeTopWrtBarFlag *);
    void transformReferenceArrayCopy(TR_TreeTopWrtBarFlag *);
    void transformReferenceArrayCopyWithoutCreatingStoreTrees(TR_TreeTopWrtBarFlag *arrayTree, TR::SymbolReference *srcObjRef, TR::SymbolReference *dstObjRef, TR::SymbolReference *srcRef, TR::SymbolReference *dstRef, TR::SymbolReference *lenRef);
-#ifdef J9_PROJECT_SPECIFIC
-   void transformConverterCall(TR::TreeTop *);
-#endif
 
    struct ObjCloneInfo {
       TR_ALLOC(TR_Memory::ValuePropagation)
@@ -702,8 +699,12 @@ class ValuePropagation : public TR::Optimization
          : _clazz(clazz), _isFixed(isFixed)  { }
    };
 
+#ifdef J9_PROJECT_SPECIFIC
+   void transformConverterCall(TR::TreeTop *);
    void transformObjectCloneCall(TR::TreeTop *, ObjCloneInfo *cloneInfo);
    void transformArrayCloneCall(TR::TreeTop *, TR_OpaqueClassBlock *j9class);
+#endif
+
 
 
    TR::TreeTop *createPrimitiveArrayNodeWithoutFlags(TR::TreeTop* tree, TR::TreeTop* newTree, TR::SymbolReference* srcRef, TR::SymbolReference* dstRef, TR::SymbolReference * lenRef, bool useFlagsOnOriginalArraycopy, bool isOptimizedReferenceArraycopy);


### PR DESCRIPTION
Ref count of the first child of the call to primitiveClone is anchored
but not decremented. This fix will anchor all the children and call
prepareToReplace on the call node before the transformation, avoiding
the need to fix up any single node's ref count. This change also moves
the whole optimization for Object.clone into J9_PROJECT_SPECIFIC,
reducing the number of J9_PROJECT_SPECIFIC.

issue: #506
Signed-off-by: liqunl <liqunl@ca.ibm.com>