### PR TITLE
Provide alternatives for some of the CS2::ArrayOf containers used by AuxiliaryData

### DIFF
--- a/compiler/optimizer/UseDefInfo.cpp
+++ b/compiler/optimizer/UseDefInfo.cpp
@@ -157,7 +157,6 @@ void TR_UseDefInfo::prepareUseDefInfo(bool requiresGlobals, bool prefersGlobals,
 
    aux._neverReferencedSymbols.GrowTo(numSymRefs);
    aux._neverWrittenSymbols.GrowTo(numSymRefs);
-   aux._onceWrittenSymbols.GrowTo(numSymRefs);
    aux._onceWrittenSymbolsIndices.GrowTo(numSymRefs);
 
    aux._volatileOrAliasedToVolatileSymbols.GrowTo(numSymRefs);

--- a/compiler/optimizer/UseDefInfo.cpp
+++ b/compiler/optimizer/UseDefInfo.cpp
@@ -134,8 +134,6 @@ void TR_UseDefInfo::prepareUseDefInfo(bool requiresGlobals, bool prefersGlobals,
    TR::SymbolReferenceTable *symRefTab = comp()->getSymRefTab();
    int32_t numSymRefs = comp()->getSymRefCount();
 
-   aux._numAliases.GrowTo(numSymRefs);
-
    _sideTableToSymRefNumMap.GrowTo(numSymRefs);
 
    aux._neverReadSymbols.GrowTo(numSymRefs);

--- a/compiler/optimizer/UseDefInfo.cpp
+++ b/compiler/optimizer/UseDefInfo.cpp
@@ -169,7 +169,6 @@ void TR_UseDefInfo::prepareUseDefInfo(bool requiresGlobals, bool prefersGlobals,
          }
       }
 
-   aux._nodesByGlobalIndex.GrowTo(comp()->getNodeCount());
    aux._loadsBySymRefNum.GrowTo(numSymRefs);
 
    aux._neverWrittenSymbols.SetAll(numSymRefs);

--- a/compiler/optimizer/UseDefInfo.cpp
+++ b/compiler/optimizer/UseDefInfo.cpp
@@ -169,8 +169,6 @@ void TR_UseDefInfo::prepareUseDefInfo(bool requiresGlobals, bool prefersGlobals,
          }
       }
 
-   aux._loadsBySymRefNum.GrowTo(numSymRefs);
-
    aux._neverWrittenSymbols.SetAll(numSymRefs);
    aux._neverReadSymbols.SetAll(numSymRefs);
 

--- a/compiler/optimizer/UseDefInfo.cpp
+++ b/compiler/optimizer/UseDefInfo.cpp
@@ -107,7 +107,11 @@ void TR_UseDefInfo::prepareUseDefInfo(bool requiresGlobals, bool prefersGlobals,
    comp()->printMemStatsBefore("prepareUseDefInfo");
    LexicalTimer tlex("useDefInfo", comp()->phaseTimer());
 
-   TR_UseDefInfo::AuxiliaryData aux(comp());
+   TR_UseDefInfo::AuxiliaryData aux(
+      comp()->getSymRefCount(),
+      comp()->getNodeCount(),
+      comp()->allocator("UseDefAux")
+      );
 
    int32_t i;
    dumpOptDetails(comp(), "   (Building use/def info)\n");
@@ -136,7 +140,6 @@ void TR_UseDefInfo::prepareUseDefInfo(bool requiresGlobals, bool prefersGlobals,
    aux._nodeSideTableToSymRefNumMap.GrowTo(comp()->getNodeCount());
 
    aux._neverReadSymbols.GrowTo(numSymRefs);
-   aux._onceReadSymbols.GrowTo(numSymRefs);
    aux._onceReadSymbolsIndices.GrowTo(numSymRefs);
    if (_hasLoadsAsDefs &&
        !cannotOmitTrivialDefs &&

--- a/compiler/optimizer/UseDefInfo.cpp
+++ b/compiler/optimizer/UseDefInfo.cpp
@@ -140,7 +140,6 @@ void TR_UseDefInfo::prepareUseDefInfo(bool requiresGlobals, bool prefersGlobals,
    aux._nodeSideTableToSymRefNumMap.GrowTo(comp()->getNodeCount());
 
    aux._neverReadSymbols.GrowTo(numSymRefs);
-   aux._onceReadSymbolsIndices.GrowTo(numSymRefs);
    if (_hasLoadsAsDefs &&
        !cannotOmitTrivialDefs &&
        (comp()->getMethodHotness() < hot))

--- a/compiler/optimizer/UseDefInfo.cpp
+++ b/compiler/optimizer/UseDefInfo.cpp
@@ -157,7 +157,6 @@ void TR_UseDefInfo::prepareUseDefInfo(bool requiresGlobals, bool prefersGlobals,
 
    aux._neverReferencedSymbols.GrowTo(numSymRefs);
    aux._neverWrittenSymbols.GrowTo(numSymRefs);
-   aux._onceWrittenSymbolsIndices.GrowTo(numSymRefs);
 
    aux._volatileOrAliasedToVolatileSymbols.GrowTo(numSymRefs);
 

--- a/compiler/optimizer/UseDefInfo.cpp
+++ b/compiler/optimizer/UseDefInfo.cpp
@@ -137,7 +137,6 @@ void TR_UseDefInfo::prepareUseDefInfo(bool requiresGlobals, bool prefersGlobals,
    aux._numAliases.GrowTo(numSymRefs);
 
    _sideTableToSymRefNumMap.GrowTo(numSymRefs);
-   aux._nodeSideTableToSymRefNumMap.GrowTo(comp()->getNodeCount());
 
    aux._neverReadSymbols.GrowTo(numSymRefs);
    if (_hasLoadsAsDefs &&
@@ -1777,8 +1776,6 @@ void TR_UseDefInfo::insertData(TR::Block *block, TR::Node *node,TR::Node *parent
             if (aux._expandedAtoms[k].getKey() == NULL)
                aux._expandedAtoms[k] = CS2::Pair<TR::Node *, TR::TreeTop *>(node, treeTop);
             }
-
-         aux._nodeSideTableToSymRefNumMap[k] = aliasedSymRef->getReferenceNumber();
 
          if (trace())
             traceMsg(comp(), "    symbol (u/d index=%d) is defined by node with localIndex %d \n",j, k);

--- a/compiler/optimizer/UseDefInfo.hpp
+++ b/compiler/optimizer/UseDefInfo.hpp
@@ -91,7 +91,7 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
              _expandedAtoms(allocator, CS2::Pair<TR::Node *, TR::TreeTop *>(NULL, NULL)),
              _sideTableToUseDefMap(allocator),
              _numAliases(numSymRefs, allocator),
-             _nodesByGlobalIndex(allocator),
+             _nodesByGlobalIndex(nodeCount, allocator),
              _loadsBySymRefNum(allocator),
              _defsForOSR(allocator, TR_UseDefInfo::BitVector(allocator))
             {}
@@ -114,7 +114,7 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
       CS2::ArrayOf<uint32_t, TR::Allocator> _sideTableToUseDefMap;
       private:
       TR::deque<uint32_t> _numAliases;
-      CS2::ArrayOf<TR::Node *, TR::Allocator> _nodesByGlobalIndex;
+      TR::deque<TR::Node *> _nodesByGlobalIndex;
       CS2::ArrayOf<TR::Node *, TR::Allocator> _loadsBySymRefNum;
 
       protected:

--- a/compiler/optimizer/UseDefInfo.hpp
+++ b/compiler/optimizer/UseDefInfo.hpp
@@ -87,7 +87,7 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
              _neverWrittenSymbols(allocator),
              _volatileOrAliasedToVolatileSymbols(allocator),
              _onceWrittenSymbolsIndices(numSymRefs, TR::SparseBitVector(allocator), allocator),
-             _onceReadSymbolsIndices(allocator, TR::SparseBitVector(allocator)),
+             _onceReadSymbolsIndices(numSymRefs, TR::SparseBitVector(allocator), allocator),
              _nodeSideTableToSymRefNumMap(allocator),
              _symRefToLocalIndexMap(allocator),
              _expandedAtoms(allocator, CS2::Pair<TR::Node *, TR::TreeTop *>(NULL, NULL)),
@@ -107,7 +107,7 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
       TR::BitVector _neverWrittenSymbols;
       TR::BitVector _volatileOrAliasedToVolatileSymbols;
       TR::deque<TR::SparseBitVector> _onceWrittenSymbolsIndices;
-      CS2::ArrayOf<TR::SparseBitVector, TR::Allocator> _onceReadSymbolsIndices;
+      TR::deque<TR::SparseBitVector> _onceReadSymbolsIndices;
 
       CS2::ArrayOf<int32_t, TR::Allocator>             _nodeSideTableToSymRefNumMap;
       CS2::ArrayOf<uint32_t, TR::Allocator>            _symRefToLocalIndexMap;

--- a/compiler/optimizer/UseDefInfo.hpp
+++ b/compiler/optimizer/UseDefInfo.hpp
@@ -88,7 +88,6 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
              _volatileOrAliasedToVolatileSymbols(allocator),
              _onceWrittenSymbolsIndices(numSymRefs, TR::SparseBitVector(allocator), allocator),
              _onceReadSymbolsIndices(numSymRefs, TR::SparseBitVector(allocator), allocator),
-             _nodeSideTableToSymRefNumMap(allocator),
              _symRefToLocalIndexMap(allocator),
              _expandedAtoms(allocator, CS2::Pair<TR::Node *, TR::TreeTop *>(NULL, NULL)),
              _sideTableToUseDefMap(allocator),
@@ -109,7 +108,6 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
       TR::deque<TR::SparseBitVector> _onceWrittenSymbolsIndices;
       TR::deque<TR::SparseBitVector> _onceReadSymbolsIndices;
 
-      CS2::ArrayOf<int32_t, TR::Allocator>             _nodeSideTableToSymRefNumMap;
       CS2::ArrayOf<uint32_t, TR::Allocator>            _symRefToLocalIndexMap;
       CS2::ArrayOf<CS2::Pair<TR::Node *, TR::TreeTop *>, TR::Allocator> _expandedAtoms;    //TR::Node            **_expandedNodes;
 

--- a/compiler/optimizer/UseDefInfo.hpp
+++ b/compiler/optimizer/UseDefInfo.hpp
@@ -88,7 +88,6 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
              _volatileOrAliasedToVolatileSymbols(allocator),
              _onceWrittenSymbolsIndices(numSymRefs, TR::SparseBitVector(allocator), allocator),
              _onceReadSymbolsIndices(numSymRefs, TR::SparseBitVector(allocator), allocator),
-             _symRefToLocalIndexMap(allocator),
              _expandedAtoms(allocator, CS2::Pair<TR::Node *, TR::TreeTop *>(NULL, NULL)),
              _sideTableToUseDefMap(allocator),
              _numAliases(allocator),
@@ -108,7 +107,6 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
       TR::deque<TR::SparseBitVector> _onceWrittenSymbolsIndices;
       TR::deque<TR::SparseBitVector> _onceReadSymbolsIndices;
 
-      CS2::ArrayOf<uint32_t, TR::Allocator>            _symRefToLocalIndexMap;
       CS2::ArrayOf<CS2::Pair<TR::Node *, TR::TreeTop *>, TR::Allocator> _expandedAtoms;    //TR::Node            **_expandedNodes;
 
 
@@ -288,7 +286,15 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
    void fillInDataStructures(AuxiliaryData &aux);
 
    bool indexSymbolsAndNodes(AuxiliaryData &aux);
-   bool findUseDefNodes(TR::Block *block, TR::Node *node, TR::Node *parent, TR::TreeTop *treeTop, AuxiliaryData &aux, bool considerImplicitStores = false);
+   bool findUseDefNodes(
+      TR::Block *block,
+      TR::Node *node,
+      TR::Node *parent,
+      TR::TreeTop *treeTop,
+      AuxiliaryData &aux,
+      TR::deque<uint32_t> &symRefToLocalIndexMap,
+      bool considerImplicitStores = false
+      );
    bool assignAdjustedNodeIndex(TR::Block *, TR::Node *node, TR::Node *parent, TR::TreeTop *treeTop, AuxiliaryData &aux, bool considerImplicitStores = false);
    bool childIndexIndicatesImplicitStore(TR::Node * node, int32_t childIndex);
    void insertData(TR::Block *, TR::Node *node, TR::Node *parent, TR::TreeTop *treeTop, AuxiliaryData &aux, TR::SparseBitVector &, bool considerImplicitStores = false);

--- a/compiler/optimizer/UseDefInfo.hpp
+++ b/compiler/optimizer/UseDefInfo.hpp
@@ -92,7 +92,7 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
              _sideTableToUseDefMap(allocator),
              _numAliases(numSymRefs, allocator),
              _nodesByGlobalIndex(nodeCount, allocator),
-             _loadsBySymRefNum(allocator),
+             _loadsBySymRefNum(numSymRefs, allocator),
              _defsForOSR(allocator, TR_UseDefInfo::BitVector(allocator))
             {}
 
@@ -115,7 +115,7 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
       private:
       TR::deque<uint32_t> _numAliases;
       TR::deque<TR::Node *> _nodesByGlobalIndex;
-      CS2::ArrayOf<TR::Node *, TR::Allocator> _loadsBySymRefNum;
+      TR::deque<TR::Node *> _loadsBySymRefNum;
 
       protected:
       // used only in TR_OSRDefInfo - should extend AuxiliaryData really:

--- a/compiler/optimizer/UseDefInfo.hpp
+++ b/compiler/optimizer/UseDefInfo.hpp
@@ -90,7 +90,7 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
              _onceReadSymbolsIndices(numSymRefs, TR::SparseBitVector(allocator), allocator),
              _expandedAtoms(allocator, CS2::Pair<TR::Node *, TR::TreeTop *>(NULL, NULL)),
              _sideTableToUseDefMap(allocator),
-             _numAliases(allocator),
+             _numAliases(numSymRefs, allocator),
              _nodesByGlobalIndex(allocator),
              _loadsBySymRefNum(allocator),
              _defsForOSR(allocator, TR_UseDefInfo::BitVector(allocator))
@@ -113,7 +113,7 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
       protected:
       CS2::ArrayOf<uint32_t, TR::Allocator> _sideTableToUseDefMap;
       private:
-      CS2::ArrayOf<uint32_t, TR::Allocator> _numAliases;
+      TR::deque<uint32_t> _numAliases;
       CS2::ArrayOf<TR::Node *, TR::Allocator> _nodesByGlobalIndex;
       CS2::ArrayOf<TR::Node *, TR::Allocator> _loadsBySymRefNum;
 

--- a/compiler/optimizer/UseDefInfo.hpp
+++ b/compiler/optimizer/UseDefInfo.hpp
@@ -86,7 +86,7 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
              _neverReferencedSymbols(allocator),
              _neverWrittenSymbols(allocator),
              _volatileOrAliasedToVolatileSymbols(allocator),
-             _onceWrittenSymbolsIndices(allocator, TR::SparseBitVector(allocator)),
+             _onceWrittenSymbolsIndices(numSymRefs, TR::SparseBitVector(allocator), allocator),
              _onceReadSymbolsIndices(allocator, TR::SparseBitVector(allocator)),
              _nodeSideTableToSymRefNumMap(allocator),
              _symRefToLocalIndexMap(allocator),
@@ -106,7 +106,7 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
       TR::BitVector _neverReferencedSymbols;
       TR::BitVector _neverWrittenSymbols;
       TR::BitVector _volatileOrAliasedToVolatileSymbols;
-      CS2::ArrayOf<TR::SparseBitVector, TR::Allocator> _onceWrittenSymbolsIndices;
+      TR::deque<TR::SparseBitVector> _onceWrittenSymbolsIndices;
       CS2::ArrayOf<TR::SparseBitVector, TR::Allocator> _onceReadSymbolsIndices;
 
       CS2::ArrayOf<int32_t, TR::Allocator>             _nodeSideTableToSymRefNumMap;

--- a/compiler/optimizer/UseDefInfo.hpp
+++ b/compiler/optimizer/UseDefInfo.hpp
@@ -82,7 +82,6 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
              _onceReadSymbols(numSymRefs, BitVector(allocator), allocator),
              _onceWrittenSymbols(numSymRefs, BitVector(allocator), allocator),
              _defsForSymbol(allocator, BitVector(allocator)),
-             _symsKilledByMustKills(allocator, TR::SparseBitVector(allocator)),
              _neverReadSymbols(allocator),
              _neverReferencedSymbols(allocator),
              _neverWrittenSymbols(allocator),
@@ -103,7 +102,6 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
       TR::deque<BitVector> _onceWrittenSymbols;
       // defsForSymbol are known definitions of the symbol
       CS2::ArrayOf<BitVector, TR::Allocator> _defsForSymbol;
-      CS2::ArrayOf<TR::SparseBitVector, TR::Allocator> _symsKilledByMustKills;    // symbol localIndex killed by function call due to mustDef
       TR::BitVector _neverReadSymbols;
       TR::BitVector _neverReferencedSymbols;
       TR::BitVector _neverWrittenSymbols;

--- a/compiler/optimizer/UseDefInfo.hpp
+++ b/compiler/optimizer/UseDefInfo.hpp
@@ -32,6 +32,7 @@
 #include "il/Symbol.hpp"            // for Symbol
 #include "il/SymbolReference.hpp"   // for SymbolReference
 #include "infra/Assert.hpp"         // for TR_ASSERT
+#include "infra/deque.hpp"          // for TR::deque
 #include "infra/TRlist.hpp"         // for TR::list
 
 class TR_ReachingDefinitions;
@@ -77,28 +78,28 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
    class AuxiliaryData
       {
       private:
-         AuxiliaryData(TR::Compilation *c) :
-             _onceReadSymbols(c->allocator("UseDefAux"), BitVector(c->allocator("UseDefAux"))),
-             _onceWrittenSymbols(c->allocator("UseDefAux"), BitVector(c->allocator("UseDefAux"))),
-             _defsForSymbol(c->allocator("UseDefAux"), BitVector(c->allocator("UseDefAux"))),
-             _symsKilledByMustKills(c->allocator("UseDefAux"), TR::SparseBitVector(c->allocator("UseDefAux"))),
-             _neverReadSymbols(c->allocator("UseDefAux")),
-             _neverReferencedSymbols(c->allocator("UseDefAux")),
-             _neverWrittenSymbols(c->allocator("UseDefAux")),
-             _volatileOrAliasedToVolatileSymbols(c->allocator("UseDefAux")),
-             _onceWrittenSymbolsIndices(c->allocator("UseDefAux"), TR::SparseBitVector(c->allocator("UseDefAux"))),
-             _onceReadSymbolsIndices(c->allocator("UseDefAux"), TR::SparseBitVector(c->allocator("UseDefAux"))),
-             _nodeSideTableToSymRefNumMap(c->allocator("UseDefAux")),
-             _symRefToLocalIndexMap(c->allocator("UseDefAux")),
-             _expandedAtoms(c->allocator("UseDefAux"), CS2::Pair<TR::Node *, TR::TreeTop *>(NULL, NULL)),
-             _sideTableToUseDefMap(c->allocator("UseDefAux")),
-             _numAliases(c->allocator("UseDefAux")),
-             _nodesByGlobalIndex(c->allocator("UseDefAux")),
-             _loadsBySymRefNum(c->allocator("UseDefAux")),
-             _defsForOSR(c->allocator("UseDefAux"), TR_UseDefInfo::BitVector(c->allocator("UseDefAux")))
+         AuxiliaryData(int32_t numSymRefs, ncount_t nodeCount, TR::Allocator allocator) :
+             _onceReadSymbols(numSymRefs, BitVector(allocator), allocator),
+             _onceWrittenSymbols(allocator, BitVector(allocator)),
+             _defsForSymbol(allocator, BitVector(allocator)),
+             _symsKilledByMustKills(allocator, TR::SparseBitVector(allocator)),
+             _neverReadSymbols(allocator),
+             _neverReferencedSymbols(allocator),
+             _neverWrittenSymbols(allocator),
+             _volatileOrAliasedToVolatileSymbols(allocator),
+             _onceWrittenSymbolsIndices(allocator, TR::SparseBitVector(allocator)),
+             _onceReadSymbolsIndices(allocator, TR::SparseBitVector(allocator)),
+             _nodeSideTableToSymRefNumMap(allocator),
+             _symRefToLocalIndexMap(allocator),
+             _expandedAtoms(allocator, CS2::Pair<TR::Node *, TR::TreeTop *>(NULL, NULL)),
+             _sideTableToUseDefMap(allocator),
+             _numAliases(allocator),
+             _nodesByGlobalIndex(allocator),
+             _loadsBySymRefNum(allocator),
+             _defsForOSR(allocator, TR_UseDefInfo::BitVector(allocator))
             {}
 
-      CS2::ArrayOf<BitVector,TR::Allocator> _onceReadSymbols;
+      TR::deque<BitVector> _onceReadSymbols;
       CS2::ArrayOf<BitVector,TR::Allocator> _onceWrittenSymbols;
       // defsForSymbol are known definitions of the symbol
       CS2::ArrayOf<BitVector, TR::Allocator> _defsForSymbol;

--- a/compiler/optimizer/UseDefInfo.hpp
+++ b/compiler/optimizer/UseDefInfo.hpp
@@ -80,7 +80,7 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
       private:
          AuxiliaryData(int32_t numSymRefs, ncount_t nodeCount, TR::Allocator allocator) :
              _onceReadSymbols(numSymRefs, BitVector(allocator), allocator),
-             _onceWrittenSymbols(allocator, BitVector(allocator)),
+             _onceWrittenSymbols(numSymRefs, BitVector(allocator), allocator),
              _defsForSymbol(allocator, BitVector(allocator)),
              _symsKilledByMustKills(allocator, TR::SparseBitVector(allocator)),
              _neverReadSymbols(allocator),
@@ -100,7 +100,7 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
             {}
 
       TR::deque<BitVector> _onceReadSymbols;
-      CS2::ArrayOf<BitVector,TR::Allocator> _onceWrittenSymbols;
+      TR::deque<BitVector> _onceWrittenSymbols;
       // defsForSymbol are known definitions of the symbol
       CS2::ArrayOf<BitVector, TR::Allocator> _defsForSymbol;
       CS2::ArrayOf<TR::SparseBitVector, TR::Allocator> _symsKilledByMustKills;    // symbol localIndex killed by function call due to mustDef


### PR DESCRIPTION
TR_UseDefInfo::AuxiliaryData uses many containers of type CS2::ArrayOf.  These changes provide alternatives for the most obvious of these.  The remaining ArrayOf uses will require some thought as the selection of and transformation to C++ standard library containers is significantly less obvious.