### PR TITLE
Mark TreeEvaluator as extensible

### DIFF
--- a/compiler/arm/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.hpp
@@ -51,7 +51,7 @@ namespace OMR
 namespace ARM
 {
 
-class TreeEvaluator: public OMR::TreeEvaluator
+class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    {
 public:
    static TR::Register *badILOpEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/codegen/OMRTreeEvaluator.cpp
@@ -60,7 +60,7 @@ bool OMR::TreeEvaluator::instanceOfOrCheckCastNeedEqualityTest(TR::Node * node, 
    TR::Node            *castClassNode    = node->getSecondChild();
    TR::SymbolReference *castClassSymRef  = castClassNode->getSymbolReference();
 
-   if (!isStaticClassSymRef(castClassSymRef))
+   if (!TR::TreeEvaluator::isStaticClassSymRef(castClassSymRef))
       {
       return true;
       }
@@ -107,7 +107,7 @@ bool OMR::TreeEvaluator::instanceOfOrCheckCastNeedSuperTest(TR::Node * node, TR:
    TR::MethodSymbol    *helperSym        = node->getSymbol()->castToMethodSymbol();
    TR::SymbolReference *castClassSymRef  = castClassNode->getSymbolReference();
 
-   if (!isStaticClassSymRef(castClassSymRef))
+   if (!TR::TreeEvaluator::isStaticClassSymRef(castClassSymRef))
       {
       // We could theoretically do a super test on something with no sym, but it would require significant
       // changes to platform code. The benefit is little at this point (shows up from reference arraycopy reductions)
@@ -328,7 +328,7 @@ TR::Register *OMR::TreeEvaluator::badILOpEvaluator(TR::Node *node, TR::CodeGener
 
 bool OMR::TreeEvaluator::nodeIsIArithmeticOverflowCheck(TR::Node *node, TR_ArithmeticOverflowCheckNodes *u)
    {
-   return nodeIsIAddOverflowCheck(node, u) || nodeIsISubOverflowCheck(node, u);
+   return TR::TreeEvaluator::nodeIsIAddOverflowCheck(node, u) || TR::TreeEvaluator::nodeIsISubOverflowCheck(node, u);
    }
 
 bool OMR::TreeEvaluator::nodeIsIAddOverflowCheck(TR::Node *node, TR_ArithmeticOverflowCheckNodes *u)
@@ -385,7 +385,7 @@ bool OMR::TreeEvaluator::nodeIsISubOverflowCheck(TR::Node *node, TR_ArithmeticOv
 
 bool OMR::TreeEvaluator::nodeIsLArithmeticOverflowCheck(TR::Node *node, TR_ArithmeticOverflowCheckNodes *u)
    {
-   return nodeIsLAddOverflowCheck(node, u) || nodeIsLSubOverflowCheck(node, u);
+   return TR::TreeEvaluator::nodeIsLAddOverflowCheck(node, u) || TR::TreeEvaluator::nodeIsLSubOverflowCheck(node, u);
    }
 
 bool OMR::TreeEvaluator::nodeIsLAddOverflowCheck(TR::Node *node, TR_ArithmeticOverflowCheckNodes *u)
@@ -507,7 +507,7 @@ void OMR::TreeEvaluator::evaluateNodesWithFutureUses(TR::Node *node, TR::CodeGen
       }
 
    for (int32_t i = 0; i<node->getNumChildren(); i++)
-      evaluateNodesWithFutureUses(node->getChild(i), cg);
+      TR::TreeEvaluator::evaluateNodesWithFutureUses(node->getChild(i), cg);
    }
 
 // This routine detects every subtree S of a node N that meets the following criteria:
@@ -536,7 +536,7 @@ void OMR::TreeEvaluator::initializeStrictlyFutureUseCounts(TR::Node *node, vcoun
       node->setVisitCount(visitCount);
 
       for (int32_t i = 0; i<node->getNumChildren(); i++)
-         initializeStrictlyFutureUseCounts(node->getChild(i), visitCount, cg);
+         TR::TreeEvaluator::initializeStrictlyFutureUseCounts(node->getChild(i), visitCount, cg);
       }
 
    if (node->getReferenceCount() > 0)

--- a/compiler/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/codegen/OMRTreeEvaluator.hpp
@@ -28,9 +28,10 @@ namespace OMR { class TreeEvaluator; }
 namespace OMR { typedef OMR::TreeEvaluator TreeEvaluatorConnector; }
 #endif
 
-#include <stddef.h>     // for NULL
-#include <stdint.h>     // for int32_t, etc
-#include "il/Node.hpp"  // for vcount_t
+#include <stddef.h>               // for NULL
+#include <stdint.h>               // for int32_t, etc
+#include "infra/Annotations.hpp"  // for OMR_EXTENSIBLE
+#include "il/Node.hpp"            // for vcount_t
 
 class TR_OpaqueClassBlock;
 namespace TR { class SymbolReference; }
@@ -42,7 +43,7 @@ typedef TR::Register *(* TR_TreeEvaluatorFunctionPointer)(TR::Node *node, TR::Co
 namespace OMR
 {
 
-class TreeEvaluator
+class OMR_EXTENSIBLE TreeEvaluator
    {
    public:
    static bool instanceOfOrCheckCastNeedEqualityTest(TR::Node * castClassNode, TR::CodeGenerator *cg);

--- a/compiler/codegen/TreeEvaluator.hpp
+++ b/compiler/codegen/TreeEvaluator.hpp
@@ -24,7 +24,7 @@
 namespace TR
 {
 
-class TreeEvaluator: public OMR::TreeEvaluatorConnector
+class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluatorConnector
    {
 
    };

--- a/compiler/p/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.hpp
@@ -50,7 +50,7 @@ namespace OMR
 namespace Power
 {
 
-class TreeEvaluator: public OMR::TreeEvaluator
+class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    {
 
    public:

--- a/compiler/x/amd64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluator.cpp
@@ -52,7 +52,7 @@
 
 TR::Register *OMR::X86::AMD64::TreeEvaluator::aconstEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::Register *targetRegister = loadConstant(node, node->getLongInt(), TR_RematerializableAddress, cg);
+   TR::Register *targetRegister = TR::TreeEvaluator::loadConstant(node, node->getLongInt(), TR_RematerializableAddress, cg);
 
    node->setRegister(targetRegister);
    return targetRegister;
@@ -60,7 +60,7 @@ TR::Register *OMR::X86::AMD64::TreeEvaluator::aconstEvaluator(TR::Node *node, TR
 
 TR::Register *OMR::X86::AMD64::TreeEvaluator::lconstEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::Register *targetRegister = loadConstant(node, node->getLongInt(), TR_RematerializableLong, cg);
+   TR::Register *targetRegister = TR::TreeEvaluator::loadConstant(node, node->getLongInt(), TR_RematerializableLong, cg);
 
    node->setRegister(targetRegister);
    return targetRegister;
@@ -91,7 +91,7 @@ TR::Register *OMR::X86::AMD64::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR
             {
             node->setChild(1, valueChild->getFirstChild());
             TR::Node::recreate(node, TR::dstorei);
-            floatingPointStoreEvaluator(node, cg);
+            TR::TreeEvaluator::floatingPointStoreEvaluator(node, cg);
             node->setChild(1, valueChild);
             TR::Node::recreate(node, TR::lstorei);
             }
@@ -99,7 +99,7 @@ TR::Register *OMR::X86::AMD64::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR
             {
             node->setChild(0, valueChild->getFirstChild());
             TR::Node::recreate(node, TR::dstore);
-            floatingPointStoreEvaluator(node, cg);
+            TR::TreeEvaluator::floatingPointStoreEvaluator(node, cg);
             node->setChild(0, valueChild);
             TR::Node::recreate(node, TR::lstore);
             }
@@ -108,14 +108,14 @@ TR::Register *OMR::X86::AMD64::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR
          }
       }
 
-   return integerStoreEvaluator(node, cg);
+   return TR::TreeEvaluator::integerStoreEvaluator(node, cg);
    }
 
 // also handles ilload
 TR::Register *OMR::X86::AMD64::TreeEvaluator::lloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::MemoryReference  *sourceMR = generateX86MemoryReference(node, cg);
-   TR::Register *reg = loadMemory(node, sourceMR, TR_RematerializableLong, node->getOpCode().isIndirect(), cg);
+   TR::Register *reg = TR::TreeEvaluator::loadMemory(node, sourceMR, TR_RematerializableLong, node->getOpCode().isIndirect(), cg);
 
    reg->setMemRef(sourceMR);
    node->setRegister(reg);
@@ -125,17 +125,17 @@ TR::Register *OMR::X86::AMD64::TreeEvaluator::lloadEvaluator(TR::Node *node, TR:
 
 TR::Register *OMR::X86::AMD64::TreeEvaluator::landEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return logicalEvaluator(node, _logicalOpPackage[landOpPackage], cg);
+   return TR::TreeEvaluator::logicalEvaluator(node, _logicalOpPackage[landOpPackage], cg);
    }
 
 TR::Register *OMR::X86::AMD64::TreeEvaluator::lorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return logicalEvaluator(node, _logicalOpPackage[lorOpPackage], cg);
+   return TR::TreeEvaluator::logicalEvaluator(node, _logicalOpPackage[lorOpPackage], cg);
    }
 
 TR::Register *OMR::X86::AMD64::TreeEvaluator::lxorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return logicalEvaluator(node, _logicalOpPackage[lxorOpPackage], cg);
+   return TR::TreeEvaluator::logicalEvaluator(node, _logicalOpPackage[lxorOpPackage], cg);
    }
 
 TR::Register *OMR::X86::AMD64::TreeEvaluator::i2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -181,7 +181,7 @@ TR::Register *OMR::X86::AMD64::TreeEvaluator::i2lEvaluator(TR::Node *node, TR::C
          regMemOpCode = MOVSXReg8Mem4;
          regRegOpCode = MOVSXReg8Reg4;
          }
-      return conversionAnalyser(node, regMemOpCode, regRegOpCode, cg);
+      return TR::TreeEvaluator::conversionAnalyser(node, regMemOpCode, regRegOpCode, cg);
       }
    }
 
@@ -239,32 +239,32 @@ TR::Register *OMR::X86::AMD64::TreeEvaluator::iu2lEvaluator(TR::Node *node, TR::
       return targetRegister;
       }
    else
-      return conversionAnalyser(node, L4RegMem, MOVZXReg8Reg4, cg); // This zero-extends on AMD64
+      return TR::TreeEvaluator::conversionAnalyser(node, L4RegMem, MOVZXReg8Reg4, cg); // This zero-extends on AMD64
    }
 
 TR::Register *OMR::X86::AMD64::TreeEvaluator::b2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return conversionAnalyser(node, MOVSXReg8Mem1, MOVSXReg8Reg1, cg);
+   return TR::TreeEvaluator::conversionAnalyser(node, MOVSXReg8Mem1, MOVSXReg8Reg1, cg);
    }
 
 TR::Register *OMR::X86::AMD64::TreeEvaluator::bu2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return conversionAnalyser(node, MOVZXReg8Mem1, MOVZXReg8Reg1, cg);
+   return TR::TreeEvaluator::conversionAnalyser(node, MOVZXReg8Mem1, MOVZXReg8Reg1, cg);
    }
 
 TR::Register *OMR::X86::AMD64::TreeEvaluator::s2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return conversionAnalyser(node, MOVSXReg8Mem2, MOVSXReg8Reg2, cg);
+   return TR::TreeEvaluator::conversionAnalyser(node, MOVSXReg8Mem2, MOVSXReg8Reg2, cg);
    }
 
 TR::Register *OMR::X86::AMD64::TreeEvaluator::su2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return conversionAnalyser(node, MOVZXReg8Mem2, MOVZXReg8Reg2, cg);
+   return TR::TreeEvaluator::conversionAnalyser(node, MOVZXReg8Mem2, MOVZXReg8Reg2, cg);
    }
 
 TR::Register *OMR::X86::AMD64::TreeEvaluator::c2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return conversionAnalyser(node, MOVZXReg8Mem2, MOVZXReg8Reg2, cg);
+   return TR::TreeEvaluator::conversionAnalyser(node, MOVZXReg8Mem2, MOVZXReg8Reg2, cg);
    }
 
 TR::Register *OMR::X86::AMD64::TreeEvaluator::lcmpEvaluator(TR::Node *node, TR::CodeGenerator *cg)

--- a/compiler/x/amd64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluator.cpp
@@ -441,18 +441,3 @@ TR::Register *OMR::X86::AMD64::TreeEvaluator::dbits2lEvaluator(TR::Node *node, T
    cg->decReferenceCount(child);
    return treg;
    }
-
-
-// Comparing instanceof to a constant
-//
-TR::Register *OMR::X86::AMD64::TreeEvaluator::ifInstanceOfHelper(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   TR_ASSERT(0, "TR::TreeEvaluator::ifInstanceOfHelper not implemented");
-   return NULL;
-   // TODO:AMD64: The ifInstanceOfHelper mechanism could use some cleaning up.
-   // Rather than changing the opcode, and then having VMisInstanceOfEvaluator
-   // check that opcode, it seems cleaner just to pass in any necessary
-   // information to VMisInstanceOfEvaluator via arguments.  It's not a real
-   // evaluator anyway, so we can add arguments to it (and we should also
-   // probably rename it.)
-   }

--- a/compiler/x/amd64/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluator.hpp
@@ -44,7 +44,7 @@ namespace X86
 namespace AMD64
 {
 
-class TreeEvaluator: public OMR::X86::TreeEvaluator
+class OMR_EXTENSIBLE TreeEvaluator: public OMR::X86::TreeEvaluator
    {
 
    public:

--- a/compiler/x/amd64/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluator.hpp
@@ -81,7 +81,6 @@ class TreeEvaluator: public OMR::X86::TreeEvaluator
    static TR::Register *iflcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *conditionalHelperEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *longStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *ifInstanceOfHelper(TR::Node *node, TR::CodeGenerator *cg);
 
    // TODO:AMD64: Delete these?
    static TR::Register *aconstEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/x/codegen/BinaryEvaluator.cpp
+++ b/compiler/x/codegen/BinaryEvaluator.cpp
@@ -107,7 +107,7 @@ inline TR::Register *evaluateAndForceSize(TR::Node *node, bool is64Bit, TR::Code
 
 bool OMR::X86::TreeEvaluator::analyseSubForLEA(TR::Node *node, TR::CodeGenerator *cg)
    {
-   bool                    nodeIs64Bit    = getNodeIs64Bit(node, cg);
+   bool                    nodeIs64Bit    = TR::TreeEvaluator::getNodeIs64Bit(node, cg);
    TR::Node                *firstChild     = node->getFirstChild();
    TR::Node                *secondChild    = node->getSecondChild();
    TR::ILOpCode            &firstOp        = firstChild->getOpCode();
@@ -121,7 +121,7 @@ bool OMR::X86::TreeEvaluator::analyseSubForLEA(TR::Node *node, TR::CodeGenerator
    //    const       (secondChild)
    //
    TR_ASSERT(secondChild->getOpCode().isLoadConst(), "assertion failure");
-   intptrj_t displacement = -integerConstNodeValue(secondChild, cg);
+   intptrj_t displacement = -TR::TreeEvaluator::integerConstNodeValue(secondChild, cg);
    intptrj_t dummyConstValue = 0;
 
    if (firstChild->getRegister() == NULL && firstChild->getReferenceCount() == 1)
@@ -151,7 +151,7 @@ bool OMR::X86::TreeEvaluator::analyseSubForLEA(TR::Node *node, TR::CodeGenerator
          }
 
       if (firstOp.isAdd() &&
-          constNodeValueIs32BitSigned(secondChild, &dummyConstValue, cg))
+          TR::TreeEvaluator::constNodeValueIs32BitSigned(secondChild, &dummyConstValue, cg))
          {
          // sub
          //    add         (firstChild)
@@ -226,7 +226,7 @@ bool OMR::X86::TreeEvaluator::analyseAddForLEA(TR::Node *node, TR::CodeGenerator
    if (!performTransformation(cg->comp(), "O^O analyseAddForLEA\n"))
         return false;
 
-   bool                 nodeIs64Bit    = getNodeIs64Bit(node, cg);
+   bool                 nodeIs64Bit    = TR::TreeEvaluator::getNodeIs64Bit(node, cg);
    TR::Node            *firstChild     = node->getFirstChild();
    TR::Node            *secondChild    = node->getSecondChild();
    TR::ILOpCode         &firstOp        = firstChild->getOpCode();
@@ -266,7 +266,7 @@ bool OMR::X86::TreeEvaluator::analyseAddForLEA(TR::Node *node, TR::CodeGenerator
          //       const       (addSecondChild)
          //
 
-         intptrj_t offset = integerConstNodeValue(addSecondChild, cg);
+         intptrj_t offset = TR::TreeEvaluator::integerConstNodeValue(addSecondChild, cg);
          if (secondOp.isSub())
             offset = -offset;
 
@@ -362,7 +362,7 @@ bool OMR::X86::TreeEvaluator::analyseAddForLEA(TR::Node *node, TR::CodeGenerator
                baseNode->getReferenceCount() == 1       &&
                baseNode->getOpCode().isAdd()            &&
                baseNode->getSecondChild()->getOpCode().isLoadConst() &&
-               constNodeValueIs32BitSigned(baseNode->getSecondChild(), &dummyConstValue, cg))
+               TR::TreeEvaluator::constNodeValueIs32BitSigned(baseNode->getSecondChild(), &dummyConstValue, cg))
          {
          // add            (** children may be reversed **)
          //    add            (baseNode)
@@ -377,7 +377,7 @@ bool OMR::X86::TreeEvaluator::analyseAddForLEA(TR::Node *node, TR::CodeGenerator
          leaMR = generateX86MemoryReference(cg->evaluate(baseNode->getFirstChild()),
                                          indexRegister,
                                          stride,
-                                         integerConstNodeValue(constNode, cg), cg);
+                                         TR::TreeEvaluator::integerConstNodeValue(constNode, cg), cg);
          tempNode = baseNode->getFirstChild();
          }
       else
@@ -405,7 +405,7 @@ bool OMR::X86::TreeEvaluator::analyseAddForLEA(TR::Node *node, TR::CodeGenerator
       return true;
       }
    else if (constNode  &&
-         constNodeValueIs32BitSigned(constNode, &dummyConstValue, cg))
+         TR::TreeEvaluator::constNodeValueIs32BitSigned(constNode, &dummyConstValue, cg))
       {
       // add
       //    firstChild
@@ -454,7 +454,7 @@ bool OMR::X86::TreeEvaluator::analyseAddForLEA(TR::Node *node, TR::CodeGenerator
                leaMR = generateX86MemoryReference(cg->evaluate(baseNode),
                                                cg->evaluate(indexNode),
                                                stride1,
-                                               integerConstNodeValue(constNode, cg),
+                                               TR::TreeEvaluator::integerConstNodeValue(constNode, cg),
                                                cg);
                cg->decReferenceCount(firstChild->getFirstChild()->getSecondChild());
                cg->decReferenceCount(firstChild->getFirstChild());
@@ -475,7 +475,7 @@ bool OMR::X86::TreeEvaluator::analyseAddForLEA(TR::Node *node, TR::CodeGenerator
                leaMR = generateX86MemoryReference(cg->evaluate(baseNode),
                                                cg->evaluate(indexNode),
                                                stride2,
-                                               integerConstNodeValue(constNode, cg),
+                                               TR::TreeEvaluator::integerConstNodeValue(constNode, cg),
                                                cg);
                cg->decReferenceCount(firstChild->getSecondChild()->getSecondChild());
                cg->decReferenceCount(firstChild->getSecondChild());
@@ -496,15 +496,15 @@ bool OMR::X86::TreeEvaluator::analyseAddForLEA(TR::Node *node, TR::CodeGenerator
                //
 
                leaMR = generateX86MemoryReference(cg->evaluate(baseNode),
-                                               integerConstNodeValue(constNode,cg) +
-                                               integerConstNodeValue(indexNode, cg), cg);
+                                               TR::TreeEvaluator::integerConstNodeValue(constNode,cg) +
+                                               TR::TreeEvaluator::integerConstNodeValue(indexNode, cg), cg);
                }
             else
                {
                leaMR = generateX86MemoryReference(cg->evaluate(baseNode),
                                                cg->evaluate(indexNode),
                                                0,
-                                               integerConstNodeValue(constNode, cg), cg);
+                                               TR::TreeEvaluator::integerConstNodeValue(constNode, cg), cg);
                }
             }
          targetRegister = cg->allocateRegister();
@@ -533,7 +533,7 @@ bool OMR::X86::TreeEvaluator::analyseAddForLEA(TR::Node *node, TR::CodeGenerator
       //
       // leaMR is not first chid's memory reference, it also plus second second child,
       // so can't allocate register directly according to first kid's symbol
-      targetRegister = generateLEAForLoadAddr(firstChild, leaMR, firstChild->getSymbolReference(), cg, isInternal);
+      targetRegister = TR::TreeEvaluator::generateLEAForLoadAddr(firstChild, leaMR, firstChild->getSymbolReference(), cg, isInternal);
       cg->decReferenceCount(firstChild);
       node->setRegister(targetRegister);
       return true;
@@ -542,7 +542,7 @@ bool OMR::X86::TreeEvaluator::analyseAddForLEA(TR::Node *node, TR::CodeGenerator
            (firstChild->getOpCode().getSize() == node->getOpCode().getSize()) &&
            (firstChild->getRegister() == NULL) &&
            (firstChild->getSecondChild()->getOpCode().isLoadConst()) &&
-           constNodeValueIs32BitSigned(firstChild->getSecondChild(), &dummyConstValue, cg) &&
+           TR::TreeEvaluator::constNodeValueIs32BitSigned(firstChild->getSecondChild(), &dummyConstValue, cg) &&
            (firstChild->getReferenceCount() == 1)
            )
       {
@@ -551,7 +551,7 @@ bool OMR::X86::TreeEvaluator::analyseAddForLEA(TR::Node *node, TR::CodeGenerator
       //        child 0
       //        loadconstant
       //    ?        (second)
-      intptrj_t val = integerConstNodeValue(firstChild->getSecondChild(), cg);
+      intptrj_t val = TR::TreeEvaluator::integerConstNodeValue(firstChild->getSecondChild(), cg);
       if (firstChild->getOpCode().isSub())
          val = -val;
       leaMR = generateX86MemoryReference(cg->evaluate(firstChild->getFirstChild()),
@@ -684,7 +684,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerDualAddOrSubEvaluator(TR::Node *no
 TR::Register *OMR::X86::TreeEvaluator::integerAddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    const TR::ILOpCodes  opCode              = node->getOpCodeValue();
-   bool                 nodeIs64Bit         = getNodeIs64Bit(node, cg);
+   bool                 nodeIs64Bit         = TR::TreeEvaluator::getNodeIs64Bit(node, cg);
    TR::Register        *targetRegister      = NULL;
    TR::Node            *firstChild          = node->getFirstChild();
    TR::Node            *secondChild         = node->getSecondChild();
@@ -699,7 +699,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerAddEvaluator(TR::Node *node, TR::C
    if (node->isDualCyclic() && !computesCarry)
       {
       // first visit for this node, recurse once
-      return integerDualAddOrSubEvaluator(node, cg);
+      return TR::TreeEvaluator::integerDualAddOrSubEvaluator(node, cg);
       }
    computesCarry = computesCarry || isWithCarry || node->nodeRequiresConditionCodes();
 
@@ -724,7 +724,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerAddEvaluator(TR::Node *node, TR::C
    // a store) to indicate that the store has already been done.
    //
    bool isMemOp = node->isDirectMemoryUpdate();
-   if (!computesCarry && analyseAddForLEA(node, cg))
+   if (!computesCarry && TR::TreeEvaluator::analyseAddForLEA(node, cg))
       {
       targetRegister = node->getRegister();
       }
@@ -751,7 +751,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerAddEvaluator(TR::Node *node, TR::C
       if (!targetRegister                                                 &&
           secondChild->getOpCode().isLoadConst()                          &&
           (secondChild->getRegister() == NULL)                            &&
-          ((constNodeValueIs32BitSigned(secondChild, &constValue, cg)) ||
+          ((TR::TreeEvaluator::constNodeValueIs32BitSigned(secondChild, &constValue, cg)) ||
            (comp->useCompressedPointers() &&
            (constValue == TR::Compiler->vm.heapBaseAddress()) &&
             firstChild->getReferenceCount() > 1 && !isMemOp))             &&
@@ -810,7 +810,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerAddEvaluator(TR::Node *node, TR::C
             // the firstChild is commoned, so the add & iu2l will get different registers
             //
             TR::Register *tempReg = firstOperandReg;
-            if (genNullTestSequence(node, firstOperandReg, targetRegister, cg))
+            if (TR::TreeEvaluator::genNullTestSequence(node, firstOperandReg, targetRegister, cg))
                tempReg = targetRegister;
 
             if (computesCarry)
@@ -871,7 +871,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerAddEvaluator(TR::Node *node, TR::C
                //    iu2l
                // the firstChild is not commoned
                //
-               genNullTestSequence(node, targetRegister, targetRegister, cg);
+               TR::TreeEvaluator::genNullTestSequence(node, targetRegister, targetRegister, cg);
 
                if (isMemOp)
                   instr = generateMemImmInstruction(AddMemImm4(nodeIs64Bit, isWithCarry), node, tempMR, constValue, cg);
@@ -1323,7 +1323,7 @@ TR::Register *OMR::X86::TreeEvaluator::caddEvaluator(TR::Node *node, TR::CodeGen
 TR::Register *OMR::X86::TreeEvaluator::integerSubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    const TR::ILOpCodes  opCode              = node->getOpCodeValue();
-   bool                 nodeIs64Bit         = getNodeIs64Bit(node, cg);
+   bool                 nodeIs64Bit         = TR::TreeEvaluator::getNodeIs64Bit(node, cg);
    TR::Node            *firstChild          = node->getFirstChild();
    TR::Node            *secondChild         = node->getSecondChild();
    TR::Register        *targetRegister      = NULL;
@@ -1338,7 +1338,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerSubEvaluator(TR::Node *node, TR::C
    if (node->isDualCyclic() && !computesCarry)
       {
       // first visit for this node, recurse once
-      return integerDualAddOrSubEvaluator(node, cg);
+      return TR::TreeEvaluator::integerDualAddOrSubEvaluator(node, cg);
       }
    computesCarry = computesCarry || isWithBorrow || node->nodeRequiresConditionCodes();
 
@@ -1389,10 +1389,10 @@ TR::Register *OMR::X86::TreeEvaluator::integerSubEvaluator(TR::Node *node, TR::C
    TR::Register * testRegister = secondChild->getRegister();
    if (secondChild->getOpCode().isLoadConst() &&
        testRegister == NULL     &&
-       constNodeValueIs32BitSigned(secondChild, &constValue, cg) &&
+       TR::TreeEvaluator::constNodeValueIs32BitSigned(secondChild, &constValue, cg) &&
        performTransformation(comp, "O^O IntegerSubEvaluator: register is not NULL, or second operand is not a 32 bit constant. Register value: %x\n", testRegister))
       {
-      if (!computesCarry && analyseSubForLEA(node, cg))
+      if (!computesCarry && TR::TreeEvaluator::analyseSubForLEA(node, cg))
          {
          return node->getRegister();
          }
@@ -1920,16 +1920,16 @@ TR::Register *OMR::X86::TreeEvaluator::integerMulEvaluator(TR::Node *node, TR::C
    TR::Register *targetRegister = 0;
    TR::Node     *firstChild     = node->getFirstChild();
    TR::Node     *secondChild    = node->getSecondChild();
-   bool          nodeIs64Bit    = getNodeIs64Bit(node, cg);
+   bool          nodeIs64Bit    = TR::TreeEvaluator::getNodeIs64Bit(node, cg);
    intptrj_t    value;
 
    if (node->isDualCyclic())
       {
-      return integerDualMulEvaluator(node, cg);
+      return TR::TreeEvaluator::integerDualMulEvaluator(node, cg);
       }
 
    if (secondChild->getOpCode().isLoadConst() &&
-      (value = integerConstNodeValue(secondChild, cg)))
+      (value = TR::TreeEvaluator::integerConstNodeValue(secondChild, cg)))
       {
       intptrj_t absValue = (value < 0) ? -value : value;
       bool firstChildRefCountIsZero = false;
@@ -2056,16 +2056,16 @@ TR::Register *OMR::X86::TreeEvaluator::integerMulhEvaluator(TR::Node *node, TR::
    {
    TR::Node *firstChild  = node->getFirstChild();
    TR::Node *secondChild = node->getSecondChild();
-   const bool nodeIs64Bit = getNodeIs64Bit(node, cg);
+   const bool nodeIs64Bit = TR::TreeEvaluator::getNodeIs64Bit(node, cg);
 
    bool needsUnsignedHighMulOnly = (node->getOpCodeValue() == TR::lumulh) && !node->isDualCyclic();
    if (node->isDualCyclic() || needsUnsignedHighMulOnly)
       {
-      return integerDualMulEvaluator(node, cg);
+      return TR::TreeEvaluator::integerDualMulEvaluator(node, cg);
       }
 
    if (  secondChild->getOpCode().isLoadConst()
-      && integerConstNodeValue(secondChild, cg) == 0)
+      && TR::TreeEvaluator::integerConstNodeValue(secondChild, cg) == 0)
       {
       // TODO: Why special-case this?  Simplifier should catch this.
 
@@ -2084,8 +2084,8 @@ TR::Register *OMR::X86::TreeEvaluator::integerMulhEvaluator(TR::Node *node, TR::
    // EDX:EAX <-- EAX * r/m doubleword
    // result <-- EDX
    //
-   TR::Register *targetRegister = intOrLongClobberEvaluate(secondChild, nodeIs64Bit, cg);
-   TR::Register *eaxRegister    = intOrLongClobberEvaluate(firstChild,  nodeIs64Bit, cg);
+   TR::Register *targetRegister = TR::TreeEvaluator::intOrLongClobberEvaluate(secondChild, nodeIs64Bit, cg);
+   TR::Register *eaxRegister    = TR::TreeEvaluator::intOrLongClobberEvaluate(firstChild,  nodeIs64Bit, cg);
 
    TR::RegisterDependencyConditions  *multDependencies = generateRegisterDependencyConditions((uint8_t)2, 2, cg);
    multDependencies->addPreCondition (eaxRegister, TR::RealRegister::eax, cg);
@@ -2107,16 +2107,16 @@ TR::Register *OMR::X86::TreeEvaluator::integerMulhEvaluator(TR::Node *node, TR::
 
 TR::Register *OMR::X86::TreeEvaluator::signedIntegerDivOrRemAnalyser(TR::Node *node, TR::CodeGenerator *cg)
    {
-   bool           nodeIs64Bit  = getNodeIs64Bit(node, cg);
+   bool           nodeIs64Bit  = TR::TreeEvaluator::getNodeIs64Bit(node, cg);
    TR::Node       *dividend     = node->getFirstChild();
    TR::ILOpCode   &rootOpCode   = node->getOpCode();
-   intptrj_t      dvalue       = integerConstNodeValue(node->getSecondChild(), cg);
+   intptrj_t      dvalue       = TR::TreeEvaluator::integerConstNodeValue(node->getSecondChild(), cg);
    TR_ASSERT(dvalue != 0, "assertion failure");
 
    bool isMinInt = ((!nodeIs64Bit && dvalue == TR::getMinSigned<TR::Int32>()) ||
                     (nodeIs64Bit && dvalue == TR::getMinSigned<TR::Int64>()));
 
-   TR::Register *dividendRegister = intOrLongClobberEvaluate(dividend, nodeIs64Bit, cg);
+   TR::Register *dividendRegister = TR::TreeEvaluator::intOrLongClobberEvaluate(dividend, nodeIs64Bit, cg);
    TR::Register *edxRegister      = NULL;
 
    if (rootOpCode.isRem())
@@ -2461,16 +2461,16 @@ TR::Register *OMR::X86::TreeEvaluator::signedIntegerDivOrRemAnalyser(TR::Node *n
 
 TR::Register *OMR::X86::TreeEvaluator::integerDivOrRemEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   bool     nodeIs64Bit = getNodeIs64Bit(node, cg);
+   bool      nodeIs64Bit = TR::TreeEvaluator::getNodeIs64Bit(node, cg);
    TR::ILOpCode &opCode  = node->getOpCode();
    TR::Node *firstChild  = node->getFirstChild();
    TR::Node *secondChild = node->getSecondChild();
 
    // Signed division by a constant can be done cheaper than using IDIV.
    if (secondChild->getOpCode().isLoadConst() &&
-       integerConstNodeValue(secondChild, cg) != 0)
+       TR::TreeEvaluator::integerConstNodeValue(secondChild, cg) != 0)
       {
-      TR::Register *reg = signedIntegerDivOrRemAnalyser(node, cg);
+      TR::Register *reg = TR::TreeEvaluator::signedIntegerDivOrRemAnalyser(node, cg);
       node->setRegister(reg);
       cg->decReferenceCount(firstChild);
       cg->decReferenceCount(secondChild);
@@ -2484,7 +2484,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerDivOrRemEvaluator(TR::Node *node, 
 
       TR::Instruction *divideInstr = NULL;
 
-      TR::Register *eaxRegister     = intOrLongClobberEvaluate(firstChild, nodeIs64Bit, cg);
+      TR::Register *eaxRegister     = TR::TreeEvaluator::intOrLongClobberEvaluate(firstChild, nodeIs64Bit, cg);
       TR::Register *edxRegister     = cg->allocateRegister();
       TR::Register *divisorRegister = NULL;
 
@@ -2632,7 +2632,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerDivOrRemEvaluator(TR::Node *node, 
 
 TR::X86RegInstruction  *OMR::X86::TreeEvaluator::generateRegisterShift(TR::Node *node, TR_X86OpCodes immShiftOpCode, TR_X86OpCodes regShiftOpCode,TR::CodeGenerator *cg)
    {
-   bool                  nodeIs64Bit    = getNodeIs64Bit(node, cg);
+   bool                  nodeIs64Bit    = TR::TreeEvaluator::getNodeIs64Bit(node, cg);
    TR::Register         *targetRegister = NULL;
    TR::Node             *firstChild     = node->getFirstChild();
    TR::Node             *secondChild    = node->getSecondChild();
@@ -2641,7 +2641,7 @@ TR::X86RegInstruction  *OMR::X86::TreeEvaluator::generateRegisterShift(TR::Node 
 
    if (secondChild->getOpCode().isLoadConst())
       {
-      intptrj_t shiftAmount = integerConstNodeValue(secondChild, cg) & shiftMask(nodeIs64Bit);
+      intptrj_t shiftAmount = TR::TreeEvaluator::integerConstNodeValue(secondChild, cg) & TR::TreeEvaluator::shiftMask(nodeIs64Bit);
       if (shiftAmount == 0)
          {
          targetRegister = cg->evaluate(firstChild);
@@ -2661,7 +2661,7 @@ TR::X86RegInstruction  *OMR::X86::TreeEvaluator::generateRegisterShift(TR::Node 
             }
          else
             {
-            targetRegister = intOrLongClobberEvaluate(firstChild, (SHIFT_MAY_HAVE_ADDRESS_CHILD) ? getNodeIs64Bit(firstChild, cg) : nodeIs64Bit, cg);
+            targetRegister = TR::TreeEvaluator::intOrLongClobberEvaluate(firstChild, (SHIFT_MAY_HAVE_ADDRESS_CHILD) ? TR::TreeEvaluator::getNodeIs64Bit(firstChild, cg) : nodeIs64Bit, cg);
             }
 
          instr = generateRegImmInstruction(immShiftOpCode, node, targetRegister, shiftAmount, cg);
@@ -2721,7 +2721,7 @@ TR::X86RegInstruction  *OMR::X86::TreeEvaluator::generateRegisterShift(TR::Node 
       TR::RegisterDependencyConditions  *shiftDependencies = generateRegisterDependencyConditions((uint8_t)1, 1, cg);
       shiftDependencies->addPreCondition(shiftAmountReg, TR::RealRegister::ecx, cg);
       shiftDependencies->addPostCondition(shiftAmountReg, TR::RealRegister::ecx, cg);
-      targetRegister = intOrLongClobberEvaluate(firstChild, nodeIs64Bit, cg);
+      targetRegister = TR::TreeEvaluator::intOrLongClobberEvaluate(firstChild, nodeIs64Bit, cg);
 
       if (SHIFT_MAY_HAVE_ADDRESS_CHILD     &&
           node->getOpCode().isLeftShift()  &&
@@ -2745,7 +2745,7 @@ TR::X86MemInstruction  *OMR::X86::TreeEvaluator::generateMemoryShift(TR::Node *n
    {
    TR_ASSERT(node->isDirectMemoryUpdate(), "assertion failure");
 
-   bool                  nodeIs64Bit         = getNodeIs64Bit(node, cg);
+   bool                  nodeIs64Bit         = TR::TreeEvaluator::getNodeIs64Bit(node, cg);
    TR::Register         *targetRegister      = NULL;
    TR::Node             *firstChild          = node->getFirstChild();
    TR::Node             *secondChild         = node->getSecondChild();
@@ -2771,7 +2771,7 @@ TR::X86MemInstruction  *OMR::X86::TreeEvaluator::generateMemoryShift(TR::Node *n
    bool loadConstant = secondChild->getOpCode().isLoadConst();
    if (loadConstant && performTransformation(comp, "O^O GenerateMemoryShift: load is not constant %d\n", loadConstant))
       {
-      intptrj_t shiftAmount = integerConstNodeValue(secondChild, cg) & shiftMask(nodeIs64Bit);
+      intptrj_t shiftAmount = TR::TreeEvaluator::integerConstNodeValue(secondChild, cg) & TR::TreeEvaluator::shiftMask(nodeIs64Bit);
       if (shiftAmount != 0)
          {
          if (debug("traceMemOp"))
@@ -2851,17 +2851,17 @@ TR::X86MemInstruction  *OMR::X86::TreeEvaluator::generateMemoryShift(TR::Node *n
 
 TR::Register *OMR::X86::TreeEvaluator::integerShlEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   bool      nodeIs64Bit     = getNodeIs64Bit(node, cg);
+   bool       nodeIs64Bit     = TR::TreeEvaluator::getNodeIs64Bit(node, cg);
    TR::Node  *shiftAmountNode = node->getSecondChild();
    intptrj_t shiftAmount;
    TR::Compilation *comp = cg->comp();
 
    if (node->isDirectMemoryUpdate())
       {
-      generateMemoryShift(node, SHLMemImm1(nodeIs64Bit), SHLMemCL(nodeIs64Bit), cg);
+      TR::TreeEvaluator::generateMemoryShift(node, SHLMemImm1(nodeIs64Bit), SHLMemCL(nodeIs64Bit), cg);
       }
    else if (shiftAmountNode->getOpCode().isLoadConst()  &&
-            (shiftAmount = integerConstNodeValue(shiftAmountNode, cg) & shiftMask(nodeIs64Bit),
+            (shiftAmount = TR::TreeEvaluator::integerConstNodeValue(shiftAmountNode, cg) & TR::TreeEvaluator::shiftMask(nodeIs64Bit),
              shiftAmount > 0 && shiftAmount <= 3)       &&
              performTransformation(comp, "O^O IntegerShlEvaluator: replace shift with lea\n"))
       {
@@ -2880,7 +2880,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerShlEvaluator(TR::Node *node, TR::C
       }
    else
       {
-      generateRegisterShift(node, SHLRegImm1(nodeIs64Bit), SHLRegCL(nodeIs64Bit), cg);
+      TR::TreeEvaluator::generateRegisterShift(node, SHLRegImm1(nodeIs64Bit), SHLRegCL(nodeIs64Bit), cg);
       }
    return node->getRegister();
    }
@@ -2890,24 +2890,24 @@ TR::Register *OMR::X86::TreeEvaluator::integerRolEvaluator(TR::Node *node, TR::C
    TR::Register *targetRegister = NULL;
    TR::Node     *secondChild = node->getSecondChild();
    TR::Node     *firstChild  = node->getFirstChild();
-   bool nodeIs64Bit = getNodeIs64Bit(node, cg);
+   bool          nodeIs64Bit = TR::TreeEvaluator::getNodeIs64Bit(node, cg);
 
    if (secondChild->getOpCode().isLoadConst())
       {
-      intptrj_t rotateAmount = integerConstNodeValue(secondChild, cg) & rotateMask(nodeIs64Bit);
+      intptrj_t rotateAmount = TR::TreeEvaluator::integerConstNodeValue(secondChild, cg) & TR::TreeEvaluator::rotateMask(nodeIs64Bit);
       if (rotateAmount == 0)
          {
          targetRegister = cg->evaluate(firstChild);
          }
       else
          {
-         targetRegister = intOrLongClobberEvaluate(firstChild, nodeIs64Bit, cg);
+         targetRegister = TR::TreeEvaluator::intOrLongClobberEvaluate(firstChild, nodeIs64Bit, cg);
          generateRegImmInstruction(ROLRegImm1(nodeIs64Bit), node, targetRegister, rotateAmount , cg);
          }
       }
    else
       {
-      targetRegister = intOrLongClobberEvaluate(firstChild, nodeIs64Bit, cg);
+      targetRegister = TR::TreeEvaluator::intOrLongClobberEvaluate(firstChild, nodeIs64Bit, cg);
       TR::Register *rotateAmountReg = cg->evaluate(secondChild);
       TR::RegisterDependencyConditions  *rotateDependencies = generateRegisterDependencyConditions((uint8_t)1, 1, cg);
 
@@ -2925,21 +2925,21 @@ TR::Register *OMR::X86::TreeEvaluator::integerRolEvaluator(TR::Node *node, TR::C
 
 TR::Register *OMR::X86::TreeEvaluator::integerShrEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   bool nodeIs64Bit = getNodeIs64Bit(node, cg);
+   bool nodeIs64Bit = TR::TreeEvaluator::getNodeIs64Bit(node, cg);
    if (node->isDirectMemoryUpdate())
       {
-      generateMemoryShift(node, SARMemImm1(nodeIs64Bit), SARMemCL(nodeIs64Bit), cg);
+      TR::TreeEvaluator::generateMemoryShift(node, SARMemImm1(nodeIs64Bit), SARMemCL(nodeIs64Bit), cg);
       }
    else
       {
-      generateRegisterShift(node, SARRegImm1(nodeIs64Bit), SARRegCL(nodeIs64Bit), cg);
+      TR::TreeEvaluator::generateRegisterShift(node, SARRegImm1(nodeIs64Bit), SARRegCL(nodeIs64Bit), cg);
       }
    return node->getRegister();
    }
 
 TR::Register *OMR::X86::TreeEvaluator::integerUshrEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   bool nodeIs64Bit = getNodeIs64Bit(node, cg);
+   bool nodeIs64Bit = TR::TreeEvaluator::getNodeIs64Bit(node, cg);
    TR::Compilation *comp = cg->comp();
 
    // Just in case this is a lowered "arraylength" opcode below a null check,
@@ -2950,13 +2950,13 @@ TR::Register *OMR::X86::TreeEvaluator::integerUshrEvaluator(TR::Node *node, TR::
 
    if (node->isDirectMemoryUpdate())
       {
-      TR::Instruction *shiftInstruction = generateMemoryShift(node, SHRMemImm1(nodeIs64Bit), SHRMemCL(nodeIs64Bit), cg);
+      TR::Instruction *shiftInstruction = TR::TreeEvaluator::generateMemoryShift(node, SHRMemImm1(nodeIs64Bit), SHRMemCL(nodeIs64Bit), cg);
       if (shiftInstruction)
          faultingInstruction = shiftInstruction;
       }
    else
       {
-      generateRegisterShift(node, SHRRegImm1(nodeIs64Bit), SHRRegCL(nodeIs64Bit), cg);
+      TR::TreeEvaluator::generateRegisterShift(node, SHRRegImm1(nodeIs64Bit), SHRRegCL(nodeIs64Bit), cg);
       }
 
    if (comp->useCompressedPointers() && nodeIs64Bit &&
@@ -3591,7 +3591,7 @@ TR::Register *OMR::X86::TreeEvaluator::logicalEvaluator(TR::Node          *node,
                                                    TR_X86OpCodes    package[],
                                                    TR::CodeGenerator *cg)
    {
-   bool                 nodeIs64Bit              = getNodeIs64Bit(node, cg);
+   bool                 nodeIs64Bit              = TR::TreeEvaluator::getNodeIs64Bit(node, cg);
    TR::Register        *targetRegister           = NULL;
    TR::Node            *firstChild               = node->getFirstChild();
    TR::Node            *secondChild              = node->getSecondChild();
@@ -3677,7 +3677,7 @@ TR::Register *OMR::X86::TreeEvaluator::logicalEvaluator(TR::Node          *node,
          firstGrandchildEvaluated = true;
          }
       if (!firstGrandchildEvaluated && !isMemOp)
-         targetRegister = intOrLongClobberEvaluate(firstChild, nodeIs64Bit, cg);
+         targetRegister = TR::TreeEvaluator::intOrLongClobberEvaluate(firstChild, nodeIs64Bit, cg);
 
       if (node->getOpCode().isXor() && constValue == -1)
          {
@@ -3749,7 +3749,7 @@ TR::Register *OMR::X86::TreeEvaluator::logicalEvaluator(TR::Node          *node,
 
 TR::Register *OMR::X86::TreeEvaluator::bandEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::Register *targetRegister = logicalEvaluator(node, _logicalOpPackage[bandOpPackage], cg);
+   TR::Register *targetRegister = TR::TreeEvaluator::logicalEvaluator(node, _logicalOpPackage[bandOpPackage], cg);
 
    if (cg->enableRegisterInterferences() && targetRegister)
       cg->getLiveRegisters(TR_GPR)->setByteRegisterAssociation(targetRegister);
@@ -3759,22 +3759,22 @@ TR::Register *OMR::X86::TreeEvaluator::bandEvaluator(TR::Node *node, TR::CodeGen
 
 TR::Register *OMR::X86::TreeEvaluator::sandEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return logicalEvaluator(node, _logicalOpPackage[sandOpPackage], cg);
+   return TR::TreeEvaluator::logicalEvaluator(node, _logicalOpPackage[sandOpPackage], cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::candEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return logicalEvaluator(node, _logicalOpPackage[candOpPackage], cg);
+   return TR::TreeEvaluator::logicalEvaluator(node, _logicalOpPackage[candOpPackage], cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::iandEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return logicalEvaluator(node, _logicalOpPackage[iandOpPackage], cg);
+   return TR::TreeEvaluator::logicalEvaluator(node, _logicalOpPackage[iandOpPackage], cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::borEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::Register *targetRegister = logicalEvaluator(node, _logicalOpPackage[borOpPackage], cg);
+   TR::Register *targetRegister = TR::TreeEvaluator::logicalEvaluator(node, _logicalOpPackage[borOpPackage], cg);
 
    if (cg->enableRegisterInterferences() && targetRegister)
       cg->getLiveRegisters(TR_GPR)->setByteRegisterAssociation(targetRegister);
@@ -3784,22 +3784,22 @@ TR::Register *OMR::X86::TreeEvaluator::borEvaluator(TR::Node *node, TR::CodeGene
 
 TR::Register *OMR::X86::TreeEvaluator::sorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return logicalEvaluator(node, _logicalOpPackage[sorOpPackage], cg);
+   return TR::TreeEvaluator::logicalEvaluator(node, _logicalOpPackage[sorOpPackage], cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::corEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return logicalEvaluator(node, _logicalOpPackage[corOpPackage], cg);
+   return TR::TreeEvaluator::logicalEvaluator(node, _logicalOpPackage[corOpPackage], cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::iorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return logicalEvaluator(node, _logicalOpPackage[iorOpPackage], cg);
+   return TR::TreeEvaluator::logicalEvaluator(node, _logicalOpPackage[iorOpPackage], cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::bxorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::Register *targetRegister = logicalEvaluator(node, _logicalOpPackage[bxorOpPackage], cg);
+   TR::Register *targetRegister = TR::TreeEvaluator::logicalEvaluator(node, _logicalOpPackage[bxorOpPackage], cg);
 
    if (cg->enableRegisterInterferences() && targetRegister)
       cg->getLiveRegisters(TR_GPR)->setByteRegisterAssociation(targetRegister);
@@ -3809,15 +3809,15 @@ TR::Register *OMR::X86::TreeEvaluator::bxorEvaluator(TR::Node *node, TR::CodeGen
 
 TR::Register *OMR::X86::TreeEvaluator::sxorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return logicalEvaluator(node, _logicalOpPackage[sxorOpPackage], cg);
+   return TR::TreeEvaluator::logicalEvaluator(node, _logicalOpPackage[sxorOpPackage], cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::cxorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return logicalEvaluator(node, _logicalOpPackage[cxorOpPackage], cg);
+   return TR::TreeEvaluator::logicalEvaluator(node, _logicalOpPackage[cxorOpPackage], cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::ixorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return logicalEvaluator(node, _logicalOpPackage[ixorOpPackage], cg);
+   return TR::TreeEvaluator::logicalEvaluator(node, _logicalOpPackage[ixorOpPackage], cg);
    }

--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -650,13 +650,13 @@ void OMR::X86::TreeEvaluator::compareIntegersForEquality(TR::Node *node, TR::Cod
    TR::Node  *secondChild = node->getSecondChild();
    // The opcode size of the compare node doesn't tell us whether we need a
    // 64-bit compare.  We need to check a child.
-   bool is64Bit = getNodeIs64Bit(secondChild, cg);
+   bool is64Bit = TR::TreeEvaluator::getNodeIs64Bit(secondChild, cg);
 
    intptrj_t constValue;
    if (secondChild->getOpCode().isLoadConst() &&
        secondChild->getRegister() == NULL     &&
        ((secondChild->getSize() <= 2) && (!secondChild->isUnsigned()) ||
-       constNodeValueIs32BitSigned(secondChild, &constValue, cg) && !cg->constantAddressesCanChangeSize(secondChild)))
+       TR::TreeEvaluator::constNodeValueIs32BitSigned(secondChild, &constValue, cg) && !cg->constantAddressesCanChangeSize(secondChild)))
       {
       if(secondChild->getSize() <= 2)
          constValue = (intptrj_t)secondChild->get64bitIntegralValue();
@@ -737,7 +737,7 @@ void OMR::X86::TreeEvaluator::compareIntegersForEquality(TR::Node *node, TR::Cod
                      else if(andSecondChild->getSize() == 2)
                         {
                         TR::Register *tempReg = cg->allocateRegister();
-                        loadConstant(node, mask, TR_RematerializableShort, cg, tempReg);
+                        TR::TreeEvaluator::loadConstant(node, mask, TR_RematerializableShort, cg, tempReg);
                         generateMemRegInstruction(TEST2MemReg, node, tempMR, tempReg, cg);
                         cg->stopUsingRegister(tempReg);
                         }
@@ -856,12 +856,12 @@ void OMR::X86::TreeEvaluator::compareIntegersForEquality(TR::Node *node, TR::Cod
                         {
                         //shouldn't use Imm2 instructions
                         TR::Register *tempReg = cg->allocateRegister();
-                        loadConstant(node, 0, TR_RematerializableShort, cg, tempReg);
+                        TR::TreeEvaluator::loadConstant(node, 0, TR_RematerializableShort, cg, tempReg);
                         generateMemRegInstruction(CMP2MemReg, node, tempMR, tempReg, cg);
                         cg->stopUsingRegister(tempReg);
                         }
                      else
-                        compareGPMemoryToImmediate(node, tempMR, 0, cg);
+                        TR::TreeEvaluator::compareGPMemoryToImmediate(node, tempMR, 0, cg);
                      tempMR->decNodeReferenceCounts(cg);
                      }
                   else
@@ -879,7 +879,7 @@ void OMR::X86::TreeEvaluator::compareIntegersForEquality(TR::Node *node, TR::Cod
                         else if (compareSize == 2)
                            generateRegRegInstruction(TEST2RegReg, node, firstChildReg, firstChildReg, cg);
                         else
-                           compareGPRegisterToImmediateForEquality(node, firstChildReg, 0, cg);
+                           TR::TreeEvaluator::compareGPRegisterToImmediateForEquality(node, firstChildReg, 0, cg);
                         }
                      }
                   }
@@ -918,12 +918,12 @@ void OMR::X86::TreeEvaluator::compareIntegersForEquality(TR::Node *node, TR::Cod
                   {
                   //shouldn't use Imm2 instructions
                   TR::Register *tempReg = cg->allocateRegister();
-                  loadConstant(node, constValue, TR_RematerializableShort, cg, tempReg);
+                  TR::TreeEvaluator::loadConstant(node, constValue, TR_RematerializableShort, cg, tempReg);
                   generateMemRegInstruction(CMP2MemReg, node, tempMR, tempReg, cg);
                   cg->stopUsingRegister(tempReg);
                   }
                else
-                  compareGPMemoryToImmediate(node, tempMR, constValue, cg);
+                  TR::TreeEvaluator::compareGPMemoryToImmediate(node, tempMR, constValue, cg);
                tempMR->decNodeReferenceCounts(cg);
                }
             else
@@ -937,7 +937,7 @@ void OMR::X86::TreeEvaluator::compareIntegersForEquality(TR::Node *node, TR::Cod
                   generateWiderCompare(node, firstChildReg, constValue, cg);
                   }
                else
-                  compareGPRegisterToImmediateForEquality(node, firstChildReg, constValue, cg);
+                  TR::TreeEvaluator::compareGPRegisterToImmediateForEquality(node, firstChildReg, constValue, cg);
                }
 
             if (secondChild->getOpCodeValue() == TR::aconst)
@@ -976,7 +976,7 @@ void OMR::X86::TreeEvaluator::compareIntegersForEquality(TR::Node *node, TR::Cod
             if (secondChild->isClassPointerConstant())
                {
                if (cg->profiledPointersRequireRelocation())
-                  setupProfiledGuardRelocation((TR::X86RegImmInstruction *)cmpInstruction, node, TR_ClassPointer);
+                  TR::TreeEvaluator::setupProfiledGuardRelocation((TR::X86RegImmInstruction *)cmpInstruction, node, TR_ClassPointer);
 
                if (cg->fe()->isUnloadAssumptionRequired((TR_OpaqueClassBlock *) secondChild->getAddress(), comp->getCurrentMethod()) || cg->profiledPointersRequireRelocation())
                   comp->getStaticPICSites()->push_front(cmpInstruction);
@@ -985,7 +985,7 @@ void OMR::X86::TreeEvaluator::compareIntegersForEquality(TR::Node *node, TR::Cod
             if (secondChild->isMethodPointerConstant())
                {
                if (cg->profiledPointersRequireRelocation())
-                  setupProfiledGuardRelocation((TR::X86RegImmInstruction *)cmpInstruction, node, TR_MethodPointer);
+                  TR::TreeEvaluator::setupProfiledGuardRelocation((TR::X86RegImmInstruction *)cmpInstruction, node, TR_MethodPointer);
 
                if (cg->fe()->isUnloadAssumptionRequired(cg->fe()->createResolvedMethod(cg->trMemory(), (TR_OpaqueMethodBlock *) secondChild->getAddress(), comp->getCurrentMethod())->classOfMethod(), comp->getCurrentMethod()) || cg->profiledPointersRequireRelocation())
                   comp->getStaticMethodPICSites()->push_front(cmpInstruction);
@@ -1043,9 +1043,9 @@ void OMR::X86::TreeEvaluator::compareIntegersForEquality(TR::Node *node, TR::Cod
          if (secondChild->getOpCodeValue() == TR::aconst)
             {
             if (secondChild->isClassPointerConstant())
-               setupProfiledGuardRelocation(NULL, node, TR_ClassPointer);
+               TR::TreeEvaluator::setupProfiledGuardRelocation(NULL, node, TR_ClassPointer);
             else if (secondChild->isMethodPointerConstant())
-               setupProfiledGuardRelocation(NULL, node, TR_MethodPointer);
+               TR::TreeEvaluator::setupProfiledGuardRelocation(NULL, node, TR_MethodPointer);
             }
          }
       }
@@ -1062,7 +1062,7 @@ void OMR::X86::TreeEvaluator::compareIntegersForOrder(
 
    if (secondChild->getOpCode().isLoadConst() &&
        secondChild->getRegister() == NULL     &&
-       constNodeValueIs32BitSigned(secondChild, &constValue, cg))
+       TR::TreeEvaluator::constNodeValueIs32BitSigned(secondChild, &constValue, cg))
       {
       // If the constant is 0 and there is a previous instruction that has set the
       // condition codes for the first child's register, then we can omit the compare
@@ -1082,12 +1082,12 @@ void OMR::X86::TreeEvaluator::compareIntegersForOrder(
              firstChild->getReferenceCount() == 1)
             {
             TR::MemoryReference  *tempMR = generateX86MemoryReference(firstChild, cg);
-            compareGPMemoryToImmediate(node, tempMR, constValue, cg);
+            TR::TreeEvaluator::compareGPMemoryToImmediate(node, tempMR, constValue, cg);
             tempMR->decNodeReferenceCounts(cg);
             }
          else
             {
-            compareGPRegisterToImmediate(node, cg->evaluate(firstChild), constValue, cg);
+            TR::TreeEvaluator::compareGPRegisterToImmediate(node, cg->evaluate(firstChild), constValue, cg);
             }
          }
 
@@ -1099,7 +1099,7 @@ void OMR::X86::TreeEvaluator::compareIntegersForOrder(
       // The opcode size of the compare node doesn't tell us whether we need a
       // 64-bit compare -- we need to check a child.
       //
-      bool is64Bit = getNodeIs64Bit(secondChild, cg);
+      bool is64Bit = TR::TreeEvaluator::getNodeIs64Bit(secondChild, cg);
       TR_X86CompareAnalyser temp(cg);
       temp.integerCompareAnalyser(
          node,
@@ -1112,7 +1112,7 @@ void OMR::X86::TreeEvaluator::compareIntegersForOrder(
 
 void OMR::X86::TreeEvaluator::compareIntegersForOrder(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareIntegersForOrder(node, node->getFirstChild(), node->getSecondChild(), cg);
+   TR::TreeEvaluator::compareIntegersForOrder(node, node->getFirstChild(), node->getSecondChild(), cg);
    }
 
 
@@ -1137,7 +1137,7 @@ void OMR::X86::TreeEvaluator::compare2BytesForOrder(TR::Node *node, TR::CodeGene
          else
             {
             TR::Register *tempReg = cg->allocateRegister();
-            loadConstant(node, value, TR_RematerializableShort, cg, tempReg);
+            TR::TreeEvaluator::loadConstant(node, value, TR_RematerializableShort, cg, tempReg);
             generateMemRegInstruction(CMP2MemReg, node, tempMR, tempReg, cg);
             cg->stopUsingRegister(tempReg);
             }
@@ -1359,15 +1359,15 @@ TR::Register *OMR::X86::TreeEvaluator::iternaryEvaluator(TR::Node *node, TR::Cod
    TR::Node *falseVal  = node->getChild(2);
 
    TR::Register *falseReg = cg->evaluate(falseVal);
-   bool trueValIs64Bit = getNodeIs64Bit(trueVal, cg);
-   TR::Register *trueReg  = intOrLongClobberEvaluate(trueVal, trueValIs64Bit, cg);
+   bool trueValIs64Bit = TR::TreeEvaluator::getNodeIs64Bit(trueVal, cg);
+   TR::Register *trueReg  = TR::TreeEvaluator::intOrLongClobberEvaluate(trueVal, trueValIs64Bit, cg);
 
    // don't need to test if we're already using a compare eq or compare ne
    auto conditionOp = condition->getOpCode();
    //if ((conditionOp == TR::icmpeq) || (conditionOp == TR::icmpne) || (conditionOp == TR::lcmpeq) || (conditionOp == TR::lcmpne))
    if (conditionOp.isCompareForEquality())
       {
-      compareIntegersForEquality(condition, cg);
+      TR::TreeEvaluator::compareIntegersForEquality(condition, cg);
       //if ((conditionOp == TR::icmpeq) || (conditionOp == TR::lcmpeq))
       if (conditionOp.isCompareTrueIfEqual())
          generateRegRegInstruction(CMOVNERegReg(trueValIs64Bit), node, trueReg, falseReg, cg);
@@ -1486,7 +1486,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerIfCmpeqEvaluator(TR::Node *node, T
          cg->evaluate(firstChild);
          }
 
-      compareIntegersForEquality(node, cg);
+      TR::TreeEvaluator::compareIntegersForEquality(node, cg);
 
       cg->setVMThreadRequired(true);
       generateConditionalJumpInstruction(JE4, node, cg, true);
@@ -1625,7 +1625,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerIfCmpneEvaluator(TR::Node *node, T
          return NULL;
          }
 
-      compareIntegersForEquality(node, cg);
+      TR::TreeEvaluator::compareIntegersForEquality(node, cg);
       cg->setVMThreadRequired(true);
 
       // If this is a guard that has not been NOPed, then
@@ -1658,7 +1658,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerIfCmpneEvaluator(TR::Node *node, T
 bool OMR::X86::TreeEvaluator::generateIAddOrSubForOverflowCheck(TR::Node *compareNode, TR::CodeGenerator *cg)
    {
    TR_ArithmeticOverflowCheckNodes u = {0};
-   bool matches = nodeIsIArithmeticOverflowCheck(compareNode, &u);
+   bool matches = TR::TreeEvaluator::nodeIsIArithmeticOverflowCheck(compareNode, &u);
    if (matches
       && (u.operationNode->getOpCode().isAdd() || u.operationNode->getOpCode().isSub())
       && (u.leftChild->getReferenceCount() >= 1)
@@ -1695,7 +1695,7 @@ bool OMR::X86::TreeEvaluator::generateIAddOrSubForOverflowCheck(TR::Node *compar
 bool OMR::X86::TreeEvaluator::generateLAddOrSubForOverflowCheck(TR::Node *compareNode, TR::CodeGenerator *cg)
    {
    TR_ArithmeticOverflowCheckNodes u = {0};
-   bool matches = nodeIsLArithmeticOverflowCheck(compareNode, &u);
+   bool matches = TR::TreeEvaluator::nodeIsLArithmeticOverflowCheck(compareNode, &u);
    if (matches
       && (u.operationNode->getOpCode().isAdd() || u.operationNode->getOpCode().isSub())
       && (u.leftChild->getReferenceCount() >= 1)
@@ -1740,9 +1740,9 @@ bool OMR::X86::TreeEvaluator::generateLAddOrSubForOverflowCheck(TR::Node *compar
 
 TR::Register *OMR::X86::TreeEvaluator::integerIfCmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (getNodeIs64Bit(node, cg)?
-         generateLAddOrSubForOverflowCheck(node, cg)
-       : generateIAddOrSubForOverflowCheck(node, cg))
+   if (TR::TreeEvaluator::getNodeIs64Bit(node, cg)?
+         TR::TreeEvaluator::generateLAddOrSubForOverflowCheck(node, cg)
+       : TR::TreeEvaluator::generateIAddOrSubForOverflowCheck(node, cg))
       {
       cg->setVMThreadRequired(true);
       generateConditionalJumpInstruction(JO4, node, cg, true);
@@ -1750,7 +1750,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerIfCmpltEvaluator(TR::Node *node, T
       }
    else
       {
-      compareIntegersForOrder(node, cg);
+      TR::TreeEvaluator::compareIntegersForOrder(node, cg);
       cg->setVMThreadRequired(true);
       generateConditionalJumpInstruction(JL4, node, cg, true);
       cg->setVMThreadRequired(false);
@@ -1760,9 +1760,9 @@ TR::Register *OMR::X86::TreeEvaluator::integerIfCmpltEvaluator(TR::Node *node, T
 
 TR::Register *OMR::X86::TreeEvaluator::integerIfCmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (getNodeIs64Bit(node, cg)?
-         generateLAddOrSubForOverflowCheck(node, cg)
-       : generateIAddOrSubForOverflowCheck(node, cg))
+   if (TR::TreeEvaluator::getNodeIs64Bit(node, cg)?
+         TR::TreeEvaluator::generateLAddOrSubForOverflowCheck(node, cg)
+       : TR::TreeEvaluator::generateIAddOrSubForOverflowCheck(node, cg))
       {
       cg->setVMThreadRequired(true);
       generateConditionalJumpInstruction(JNO4, node, cg, true);
@@ -1770,7 +1770,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerIfCmpgeEvaluator(TR::Node *node, T
       }
    else
       {
-      compareIntegersForOrder(node, cg);
+      TR::TreeEvaluator::compareIntegersForOrder(node, cg);
       cg->setVMThreadRequired(true);
       generateConditionalJumpInstruction(JGE4, node, cg, true);
       cg->setVMThreadRequired(false);
@@ -1780,7 +1780,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerIfCmpgeEvaluator(TR::Node *node, T
 
 TR::Register *OMR::X86::TreeEvaluator::integerIfCmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareIntegersForOrder(node, cg);
+   TR::TreeEvaluator::compareIntegersForOrder(node, cg);
    cg->setVMThreadRequired(true);
    generateConditionalJumpInstruction(JG4, node, cg, true);
    cg->setVMThreadRequired(false);
@@ -1789,7 +1789,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerIfCmpgtEvaluator(TR::Node *node, T
 
 TR::Register *OMR::X86::TreeEvaluator::integerIfCmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareIntegersForOrder(node, cg);
+   TR::TreeEvaluator::compareIntegersForOrder(node, cg);
    cg->setVMThreadRequired(true);
    generateConditionalJumpInstruction(JLE4, node, cg, true);
    cg->setVMThreadRequired(false);
@@ -1798,7 +1798,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerIfCmpleEvaluator(TR::Node *node, T
 
 TR::Register *OMR::X86::TreeEvaluator::unsignedIntegerIfCmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareIntegersForOrder(node, cg);
+   TR::TreeEvaluator::compareIntegersForOrder(node, cg);
    cg->setVMThreadRequired(true);
    generateConditionalJumpInstruction(JB4, node, cg, true);
    cg->setVMThreadRequired(false);
@@ -1807,7 +1807,7 @@ TR::Register *OMR::X86::TreeEvaluator::unsignedIntegerIfCmpltEvaluator(TR::Node 
 
 TR::Register *OMR::X86::TreeEvaluator::unsignedIntegerIfCmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareIntegersForOrder(node, cg);
+   TR::TreeEvaluator::compareIntegersForOrder(node, cg);
    cg->setVMThreadRequired(true);
    generateConditionalJumpInstruction(JAE4, node, cg, true);
    cg->setVMThreadRequired(false);
@@ -1816,7 +1816,7 @@ TR::Register *OMR::X86::TreeEvaluator::unsignedIntegerIfCmpgeEvaluator(TR::Node 
 
 TR::Register *OMR::X86::TreeEvaluator::unsignedIntegerIfCmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareIntegersForOrder(node, cg);
+   TR::TreeEvaluator::compareIntegersForOrder(node, cg);
    cg->setVMThreadRequired(true);
    generateConditionalJumpInstruction(JA4, node, cg, true);
    cg->setVMThreadRequired(false);
@@ -1825,7 +1825,7 @@ TR::Register *OMR::X86::TreeEvaluator::unsignedIntegerIfCmpgtEvaluator(TR::Node 
 
 TR::Register *OMR::X86::TreeEvaluator::unsignedIntegerIfCmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareIntegersForOrder(node, cg);
+   TR::TreeEvaluator::compareIntegersForOrder(node, cg);
    cg->setVMThreadRequired(true);
    generateConditionalJumpInstruction(JBE4, node, cg, true);
    cg->setVMThreadRequired(false);
@@ -1932,56 +1932,56 @@ TR::Register *OMR::X86::TreeEvaluator::ifbcmpeqEvaluator(TR::Node *node, TR::Cod
 
 TR::Register *OMR::X86::TreeEvaluator::ifbcmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareBytesForOrder(node, cg);
+   TR::TreeEvaluator::compareBytesForOrder(node, cg);
    generateConditionalJumpInstruction(JL4, node, cg, true);
    return NULL;
    }
 
 TR::Register *OMR::X86::TreeEvaluator::ifbucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareBytesForOrder(node, cg);
+   TR::TreeEvaluator::compareBytesForOrder(node, cg);
    generateConditionalJumpInstruction(JB4, node, cg, true);
    return NULL;
    }
 
 TR::Register *OMR::X86::TreeEvaluator::ifbcmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareBytesForOrder(node, cg);
+   TR::TreeEvaluator::compareBytesForOrder(node, cg);
    generateConditionalJumpInstruction(JGE4, node, cg, true);
    return NULL;
    }
 
 TR::Register *OMR::X86::TreeEvaluator::ifbucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareBytesForOrder(node, cg);
+   TR::TreeEvaluator::compareBytesForOrder(node, cg);
    generateConditionalJumpInstruction(JAE4, node, cg, true);
    return NULL;
    }
 
 TR::Register *OMR::X86::TreeEvaluator::ifbcmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareBytesForOrder(node, cg);
+   TR::TreeEvaluator::compareBytesForOrder(node, cg);
    generateConditionalJumpInstruction(JG4, node, cg, true);
    return NULL;
    }
 
 TR::Register *OMR::X86::TreeEvaluator::ifbucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareBytesForOrder(node, cg);
+   TR::TreeEvaluator::compareBytesForOrder(node, cg);
    generateConditionalJumpInstruction(JA4, node, cg, true);
    return NULL;
    }
 
 TR::Register *OMR::X86::TreeEvaluator::ifbcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareBytesForOrder(node, cg);
+   TR::TreeEvaluator::compareBytesForOrder(node, cg);
    generateConditionalJumpInstruction(JLE4, node, cg, true);
    return NULL;
    }
 
 TR::Register *OMR::X86::TreeEvaluator::ifbucmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareBytesForOrder(node, cg);
+   TR::TreeEvaluator::compareBytesForOrder(node, cg);
    generateConditionalJumpInstruction(JBE4, node, cg, true);
    return NULL;
    }
@@ -2010,7 +2010,7 @@ TR::Register *OMR::X86::TreeEvaluator::ifscmpeqEvaluator(TR::Node *node, TR::Cod
             {
             //try to avoid Imm2 instructions
             TR::Register *tempReg = cg->allocateRegister();
-            loadConstant(node, value, TR_RematerializableShort, cg, tempReg);
+            TR::TreeEvaluator::loadConstant(node, value, TR_RematerializableShort, cg, tempReg);
             generateMemRegInstruction(CMP2MemReg, node, tempMR, tempReg, cg);
             cg->stopUsingRegister(tempReg);
             }
@@ -2053,28 +2053,28 @@ TR::Register *OMR::X86::TreeEvaluator::ifscmpeqEvaluator(TR::Node *node, TR::Cod
 
 TR::Register *OMR::X86::TreeEvaluator::ifscmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compare2BytesForOrder(node, cg);
+   TR::TreeEvaluator::compare2BytesForOrder(node, cg);
    generateConditionalJumpInstruction(JL4, node, cg, true);
    return NULL;
    }
 
 TR::Register *OMR::X86::TreeEvaluator::ifscmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compare2BytesForOrder(node, cg);
+   TR::TreeEvaluator::compare2BytesForOrder(node, cg);
    generateConditionalJumpInstruction(JGE4, node, cg, true);
    return NULL;
    }
 
 TR::Register *OMR::X86::TreeEvaluator::ifscmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compare2BytesForOrder(node, cg);
+   TR::TreeEvaluator::compare2BytesForOrder(node, cg);
    generateConditionalJumpInstruction(JG4, node, cg, true);
    return NULL;
    }
 
 TR::Register *OMR::X86::TreeEvaluator::ifscmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compare2BytesForOrder(node, cg);
+   TR::TreeEvaluator::compare2BytesForOrder(node, cg);
    generateConditionalJumpInstruction(JLE4, node, cg, true);
    return NULL;
    }
@@ -2082,7 +2082,7 @@ TR::Register *OMR::X86::TreeEvaluator::ifscmpleEvaluator(TR::Node *node, TR::Cod
 // also handles ifsucmpne
 TR::Register *OMR::X86::TreeEvaluator::ifsucmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareIntegersForEquality(node, cg);
+   TR::TreeEvaluator::compareIntegersForEquality(node, cg);
    generateConditionalJumpInstruction(node->getOpCodeValue() == TR::ifsucmpeq ? JE4 : JNE4,
                                       node, cg, true);
    return NULL;
@@ -2092,35 +2092,35 @@ TR::Register *OMR::X86::TreeEvaluator::ifsucmpeqEvaluator(TR::Node *node, TR::Co
 
 TR::Register *OMR::X86::TreeEvaluator::ifsucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compare2BytesForOrder(node, cg);
+   TR::TreeEvaluator::compare2BytesForOrder(node, cg);
    generateConditionalJumpInstruction(JB4, node, cg, true);
    return NULL;
    }
 
 TR::Register *OMR::X86::TreeEvaluator::ifsucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compare2BytesForOrder(node, cg);
+   TR::TreeEvaluator::compare2BytesForOrder(node, cg);
    generateConditionalJumpInstruction(JAE4, node, cg, true);
    return NULL;
    }
 
 TR::Register *OMR::X86::TreeEvaluator::ifsucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compare2BytesForOrder(node, cg);
+   TR::TreeEvaluator::compare2BytesForOrder(node, cg);
    generateConditionalJumpInstruction(JA4, node, cg, true);
    return NULL;
    }
 
 TR::Register *OMR::X86::TreeEvaluator::ifsucmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compare2BytesForOrder(node, cg);
+   TR::TreeEvaluator::compare2BytesForOrder(node, cg);
    generateConditionalJumpInstruction(JBE4, node, cg, true);
    return NULL;
    }
 
 TR::Register *OMR::X86::TreeEvaluator::integerEqualityHelper(TR::Node *node, TR_X86OpCodes setOp, TR::CodeGenerator *cg)
    {
-   compareIntegersForEquality(node, cg);
+   TR::TreeEvaluator::compareIntegersForEquality(node, cg);
    TR::Register *targetRegister = cg->allocateRegister();
    generateRegInstruction(setOp, node, targetRegister, cg);
 
@@ -2135,12 +2135,12 @@ TR::Register *OMR::X86::TreeEvaluator::integerEqualityHelper(TR::Node *node, TR_
 
 TR::Register *OMR::X86::TreeEvaluator::integerCmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return integerEqualityHelper(node, SETE1Reg, cg);
+   return TR::TreeEvaluator::integerEqualityHelper(node, SETE1Reg, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::integerCmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return integerEqualityHelper(node, SETNE1Reg, cg);
+   return TR::TreeEvaluator::integerEqualityHelper(node, SETNE1Reg, cg);
    }
 
 
@@ -2150,7 +2150,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerOrderHelper(TR::Node          *nod
    {
    TR::Register  *targetRegister = cg->allocateRegister();
    node->setRegister(targetRegister);
-   compareIntegersForOrder(node, cg);
+   TR::TreeEvaluator::compareIntegersForOrder(node, cg);
    generateRegInstruction(setOp, node, targetRegister, cg);
 
    generateRegRegInstruction(MOVZXReg4Reg1, node, targetRegister, targetRegister, cg);
@@ -2163,43 +2163,43 @@ TR::Register *OMR::X86::TreeEvaluator::integerOrderHelper(TR::Node          *nod
 
 TR::Register *OMR::X86::TreeEvaluator::integerCmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return integerOrderHelper(node, SETL1Reg, cg);
+   return TR::TreeEvaluator::integerOrderHelper(node, SETL1Reg, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::integerCmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return integerOrderHelper(node, SETGE1Reg, cg);
+   return TR::TreeEvaluator::integerOrderHelper(node, SETGE1Reg, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::integerCmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return integerOrderHelper(node, SETG1Reg, cg);
+   return TR::TreeEvaluator::integerOrderHelper(node, SETG1Reg, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::integerCmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return integerOrderHelper(node, SETLE1Reg, cg);
+   return TR::TreeEvaluator::integerOrderHelper(node, SETLE1Reg, cg);
    }
 
 
 TR::Register *OMR::X86::TreeEvaluator::unsignedIntegerCmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return integerOrderHelper(node, SETB1Reg, cg);
+   return TR::TreeEvaluator::integerOrderHelper(node, SETB1Reg, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::unsignedIntegerCmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return integerOrderHelper(node, SETAE1Reg, cg);
+   return TR::TreeEvaluator::integerOrderHelper(node, SETAE1Reg, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::unsignedIntegerCmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return integerOrderHelper(node, SETA1Reg, cg);
+   return TR::TreeEvaluator::integerOrderHelper(node, SETA1Reg, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::unsignedIntegerCmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return integerOrderHelper(node, SETBE1Reg, cg);
+   return TR::TreeEvaluator::integerOrderHelper(node, SETBE1Reg, cg);
    }
 
 
@@ -2250,7 +2250,7 @@ TR::Register *OMR::X86::TreeEvaluator::bcmpEvaluator(TR::Node        *node,
                                                  TR::CodeGenerator *cg)
    {
    TR::Register  *targetRegister = cg->allocateRegister();
-   compareBytesForOrder(node, cg);
+   TR::TreeEvaluator::compareBytesForOrder(node, cg);
    node->setRegister(targetRegister);
    generateRegInstruction(setOp, node, targetRegister, cg);
    generateRegRegInstruction(MOVZXReg4Reg1, node, targetRegister, targetRegister, cg);
@@ -2263,22 +2263,22 @@ TR::Register *OMR::X86::TreeEvaluator::bcmpEvaluator(TR::Node        *node,
 
 TR::Register *OMR::X86::TreeEvaluator::bcmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return bcmpEvaluator(node, SETL1Reg, cg);
+   return TR::TreeEvaluator::bcmpEvaluator(node, SETL1Reg, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::bcmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return bcmpEvaluator(node, SETGE1Reg, cg);
+   return TR::TreeEvaluator::bcmpEvaluator(node, SETGE1Reg, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::bcmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return bcmpEvaluator(node, SETG1Reg, cg);
+   return TR::TreeEvaluator::bcmpEvaluator(node, SETG1Reg, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::bcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return bcmpEvaluator(node, SETLE1Reg, cg);
+   return TR::TreeEvaluator::bcmpEvaluator(node, SETLE1Reg, cg);
    }
 
 // also handles scmpne
@@ -2335,7 +2335,7 @@ TR::Register *OMR::X86::TreeEvaluator::cmp2BytesEvaluator(TR::Node        *node,
                                                       TR::CodeGenerator *cg)
    {
    TR::Register *targetRegister = cg->allocateRegister();
-   compare2BytesForOrder(node, cg);
+   TR::TreeEvaluator::compare2BytesForOrder(node, cg);
    generateRegInstruction(setOp, node, targetRegister, cg);
    generateRegRegInstruction(MOVZXReg4Reg1, node, targetRegister, targetRegister, cg);
 
@@ -2347,22 +2347,22 @@ TR::Register *OMR::X86::TreeEvaluator::cmp2BytesEvaluator(TR::Node        *node,
 
 TR::Register *OMR::X86::TreeEvaluator::scmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return cmp2BytesEvaluator(node, SETL1Reg, cg);
+   return TR::TreeEvaluator::cmp2BytesEvaluator(node, SETL1Reg, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::scmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return cmp2BytesEvaluator(node, SETGE1Reg, cg);
+   return TR::TreeEvaluator::cmp2BytesEvaluator(node, SETGE1Reg, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::scmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return cmp2BytesEvaluator(node, SETG1Reg, cg);
+   return TR::TreeEvaluator::cmp2BytesEvaluator(node, SETG1Reg, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::scmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return cmp2BytesEvaluator(node, SETLE1Reg, cg);
+   return TR::TreeEvaluator::cmp2BytesEvaluator(node, SETLE1Reg, cg);
    }
 
 // also handles sucmpne
@@ -2417,22 +2417,22 @@ TR::Register *OMR::X86::TreeEvaluator::sucmpeqEvaluator(TR::Node *node, TR::Code
 
 TR::Register *OMR::X86::TreeEvaluator::sucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return cmp2BytesEvaluator(node, SETB1Reg, cg);
+   return TR::TreeEvaluator::cmp2BytesEvaluator(node, SETB1Reg, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::sucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return cmp2BytesEvaluator(node, SETAE1Reg, cg);
+   return TR::TreeEvaluator::cmp2BytesEvaluator(node, SETAE1Reg, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::sucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return cmp2BytesEvaluator(node, SETA1Reg, cg);
+   return TR::TreeEvaluator::cmp2BytesEvaluator(node, SETA1Reg, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::sucmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return cmp2BytesEvaluator(node, SETBE1Reg, cg);
+   return TR::TreeEvaluator::cmp2BytesEvaluator(node, SETBE1Reg, cg);
    }
 
 static bool virtualGuardHelper(TR::Node *node, TR::CodeGenerator *cg)

--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -74,7 +74,6 @@
 class TR_OpaqueClassBlock;
 class TR_OpaqueMethodBlock;
 
-static TR::Register *ifInstanceOfHelper(TR::Node *node, TR::CodeGenerator *cg);
 static bool virtualGuardHelper(TR::Node *node, TR::CodeGenerator *cg);
 
 // The following functions are simple enough to inline, and are called often
@@ -1441,7 +1440,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerIfCmpeqEvaluator(TR::Node *node, T
    {
    if (canBeHandledByIfInstanceOfHelper(node, cg))
       {
-      return ifInstanceOfHelper(node, cg);
+      return TR::TreeEvaluator::VMifInstanceOfEvaluator(node, cg);
       }
    else if (canBeHandledByIfArrayCmpHelper(node, cg))
       {
@@ -1543,7 +1542,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerIfCmpneEvaluator(TR::Node *node, T
       }
    else if (canBeHandledByIfInstanceOfHelper(node, cg))
       {
-      return ifInstanceOfHelper(node, cg);
+      return TR::TreeEvaluator::VMifInstanceOfEvaluator(node, cg);
       }
    else if (canBeHandledByIfArrayCmpHelper(node, cg))
       {

--- a/compiler/x/codegen/FPTreeEvaluator.cpp
+++ b/compiler/x/codegen/FPTreeEvaluator.cpp
@@ -112,7 +112,7 @@ void OMR::X86::TreeEvaluator::coerceFPOperandsToXMMRs(TR::Node *node, TR::CodeGe
 
       if (reg && reg->getKind() == TR_X87 /* && child->getReferenceCount() > 1 */)
          {
-         coerceFPRToXMMR(child, reg, cg);
+         TR::TreeEvaluator::coerceFPRToXMMR(child, reg, cg);
          }
       }
    }
@@ -324,7 +324,7 @@ TR::Register *OMR::X86::TreeEvaluator::performFload(TR::Node *node, TR::MemoryRe
 TR::Register *OMR::X86::TreeEvaluator::floadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::MemoryReference  *tempMR = generateX86MemoryReference(node, cg);
-   TR::Register *targetRegister = performFload(node, tempMR, cg);
+   TR::Register *targetRegister = TR::TreeEvaluator::performFload(node, tempMR, cg);
    tempMR->decNodeReferenceCounts(cg);
    return targetRegister;
    }
@@ -367,14 +367,14 @@ TR::Register *OMR::X86::TreeEvaluator::performDload(TR::Node *node, TR::MemoryRe
 TR::Register *OMR::X86::TreeEvaluator::dloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::MemoryReference  *tempMR = generateX86MemoryReference(node, cg);
-   TR::Register *targetRegister = performDload(node, tempMR, cg);
+   TR::Register *targetRegister = TR::TreeEvaluator::performDload(node, tempMR, cg);
    tempMR->decNodeReferenceCounts(cg);
    return targetRegister;
    }
 
 TR::Register *OMR::X86::TreeEvaluator::floatingPointStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   bool     nodeIs64Bit    = getNodeIs64Bit(node, cg);
+   bool     nodeIs64Bit    = TR::TreeEvaluator::getNodeIs64Bit(node, cg);
    bool     nodeIsIndirect = node->getOpCode().isIndirect()? 1 : 0;
    TR::Node *valueChild     = node->getChild(nodeIsIndirect);
 
@@ -397,7 +397,7 @@ TR::Register *OMR::X86::TreeEvaluator::floatingPointStoreEvaluator(TR::Node *nod
 
       // Generate an integer store
       //
-      integerStoreEvaluator(node, cg);
+      TR::TreeEvaluator::integerStoreEvaluator(node, cg);
       return NULL;
       }
 
@@ -512,11 +512,11 @@ TR::Register *OMR::X86::TreeEvaluator::fpReturnEvaluator(TR::Node *node, TR::Cod
        returnRegister->getKind() == TR_FPR)
       {
       // TODO: Modify linkage to allow the returned value to remain in an XMMR.
-      returnRegister = coerceXMMRToFPR(node->getFirstChild(), returnRegister, cg);
+      returnRegister = TR::TreeEvaluator::coerceXMMRToFPR(node->getFirstChild(), returnRegister, cg);
       }
    else if (returnRegister->mayNeedPrecisionAdjustment())
       {
-      insertPrecisionAdjustment(returnRegister, node, cg);
+      TR::TreeEvaluator::insertPrecisionAdjustment(returnRegister, node, cg);
       }
 
    // Restore the default FPCW if it has been forced to single precision mode.
@@ -601,42 +601,42 @@ TR::Register *OMR::X86::TreeEvaluator::fpBinaryArithmeticEvaluator(TR::Node     
 
 TR::Register *OMR::X86::TreeEvaluator::faddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return fpBinaryArithmeticEvaluator(node, true, cg);
+   return TR::TreeEvaluator::fpBinaryArithmeticEvaluator(node, true, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::daddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return fpBinaryArithmeticEvaluator(node, false, cg);
+   return TR::TreeEvaluator::fpBinaryArithmeticEvaluator(node, false, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::fsubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return fpBinaryArithmeticEvaluator(node, true, cg);
+   return TR::TreeEvaluator::fpBinaryArithmeticEvaluator(node, true, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::dsubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return fpBinaryArithmeticEvaluator(node, false, cg);
+   return TR::TreeEvaluator::fpBinaryArithmeticEvaluator(node, false, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::fmulEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return fpBinaryArithmeticEvaluator(node, true, cg);
+   return TR::TreeEvaluator::fpBinaryArithmeticEvaluator(node, true, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::dmulEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return fpBinaryArithmeticEvaluator(node, false, cg);
+   return TR::TreeEvaluator::fpBinaryArithmeticEvaluator(node, false, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::fdivEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return fpBinaryArithmeticEvaluator(node, true, cg);
+   return TR::TreeEvaluator::fpBinaryArithmeticEvaluator(node, true, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::ddivEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return fpBinaryArithmeticEvaluator(node, false, cg);
+   return TR::TreeEvaluator::fpBinaryArithmeticEvaluator(node, false, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::fpRemEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -655,17 +655,17 @@ TR::Register *OMR::X86::TreeEvaluator::fpRemEvaluator(TR::Node *node, TR::CodeGe
          {
          // TODO: We should do this for IA32 eventually
          TR::SymbolReference *helperSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(nodeIsDouble ? TR_AMD64doubleRemainder : TR_AMD64floatRemainder, false, false, false);
-         targetRegister = performHelperCall(node, helperSymRef, nodeIsDouble ? TR::dcall : TR::fcall, false, cg);
+         targetRegister = TR::TreeEvaluator::performHelperCall(node, helperSymRef, nodeIsDouble ? TR::dcall : TR::fcall, false, cg);
          }
       else
          {
          TR::SymbolReference *helperSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(nodeIsDouble ? TR_IA32doubleRemainderSSE : TR_IA32floatRemainderSSE, false, false, false);
-         targetRegister = performHelperCall(node, helperSymRef, nodeIsDouble ? TR::dcall : TR::fcall, false, cg);
+         targetRegister = TR::TreeEvaluator::performHelperCall(node, helperSymRef, nodeIsDouble ? TR::dcall : TR::fcall, false, cg);
          }
       }
    else
       {
-      targetRegister = commonFPRemEvaluator(node, cg, nodeIsDouble);
+      targetRegister = TR::TreeEvaluator::commonFPRemEvaluator(node, cg, nodeIsDouble);
       }
 
 
@@ -706,13 +706,13 @@ TR::Register *OMR::X86::TreeEvaluator::commonFPRemEvaluator(TR::Node          *n
    TR_ASSERT(divisorReg->getKind() == TR_X87, "X87 Instructions only.");
 
    if (divisorReg->needsPrecisionAdjustment())
-      insertPrecisionAdjustment(divisorReg, divisor, cg);
+      TR::TreeEvaluator::insertPrecisionAdjustment(divisorReg, divisor, cg);
 
    TR::Register *dividendReg = cg->evaluate( dividend);
    TR_ASSERT(dividendReg->getKind() == TR_X87, "X87 Instructions only.");
 
    if (dividendReg->needsPrecisionAdjustment())
-      insertPrecisionAdjustment(dividendReg, dividend, cg);
+      TR::TreeEvaluator::insertPrecisionAdjustment(dividendReg, dividend, cg);
 
    if (isDouble)
       dividendReg = cg->doubleClobberEvaluate(dividend);
@@ -960,7 +960,7 @@ TR::Register *OMR::X86::TreeEvaluator::fpConvertToInt(TR::Node *node, TR::Symbol
       floatReg  = cg->evaluate(child);
       if (floatReg  && floatReg->needsPrecisionAdjustment())
          {
-         insertPrecisionAdjustment(floatReg, node, cg);
+         TR::TreeEvaluator::insertPrecisionAdjustment(floatReg, node, cg);
          }
       }
 
@@ -1174,7 +1174,7 @@ TR::Register *OMR::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::Symbo
       TR::Register *highReg   = cg->allocateRegister(TR_GPR);
       TR::Register *doubleReg = cg->evaluate(child);
       if (doubleReg->getKind() == TR_FPR)
-         doubleReg = coerceXMMRToFPR(child, doubleReg, cg);
+         doubleReg = TR::TreeEvaluator::coerceXMMRToFPR(child, doubleReg, cg);
 
       TR::RegisterDependencyConditions  *deps;
 
@@ -1196,7 +1196,7 @@ TR::Register *OMR::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::Symbo
 
       if (doubleReg && doubleReg->needsPrecisionAdjustment())
          {
-         insertPrecisionAdjustment(doubleReg, node, cg);
+         TR::TreeEvaluator::insertPrecisionAdjustment(doubleReg, node, cg);
          }
 
       generateLabelInstruction(LABEL, node, startLabel, cg);
@@ -1414,7 +1414,7 @@ TR::Register *OMR::X86::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGene
          cvttOpCode   = CVTTSS2SIReg4Reg;
          }
 
-      coerceFPOperandsToXMMRs(node, cg);
+      TR::TreeEvaluator::coerceFPOperandsToXMMRs(node, cg);
 
       TR::Node        *child          = node->getFirstChild();
       TR::Register    *sourceRegister = NULL;
@@ -1501,7 +1501,7 @@ TR::Register *OMR::X86::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGene
    else
       {
       TR_ASSERT(TR::Compiler->target.is32Bit(), "assertion failure");
-      return fpConvertToInt(node, cg->symRefTab()->findOrCreateRuntimeHelper(TR_IA32floatToInt, false, false, false), cg);
+      return TR::TreeEvaluator::fpConvertToInt(node, cg->symRefTab()->findOrCreateRuntimeHelper(TR_IA32floatToInt, false, false, false), cg);
       }
    }
 
@@ -1509,7 +1509,7 @@ TR::Register *OMR::X86::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGene
 TR::Register *OMR::X86::TreeEvaluator::f2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR_ASSERT(TR::Compiler->target.is32Bit(), "AMD64 uses f2iEvaluator for this");
-   return fpConvertToLong(node, cg->symRefTab()->findOrCreateRuntimeHelper(TR_IA32floatToLong, false, false, false), cg);
+   return TR::TreeEvaluator::fpConvertToLong(node, cg->symRefTab()->findOrCreateRuntimeHelper(TR_IA32floatToLong, false, false, false), cg);
    }
 
 
@@ -1541,7 +1541,7 @@ TR::Register *OMR::X86::TreeEvaluator::f2dEvaluator(TR::Node *node, TR::CodeGene
          targetRegister->setIsSinglePrecision(false);
          if (targetRegister->needsPrecisionAdjustment())
             {
-            insertPrecisionAdjustment(targetRegister, node, cg);
+            TR::TreeEvaluator::insertPrecisionAdjustment(targetRegister, node, cg);
             }
          }
       }
@@ -1581,7 +1581,7 @@ TR::Register *OMR::X86::TreeEvaluator::d2iEvaluator(TR::Node *node, TR::CodeGene
 
    if (cg->useSSEForDoublePrecision())
       {
-      coerceFPOperandsToXMMRs(node, cg);
+      TR::TreeEvaluator::coerceFPOperandsToXMMRs(node, cg);
 
       TR::Node        *child          = node->getFirstChild();
       TR::Register    *sourceRegister = cg->evaluate(child);
@@ -1624,7 +1624,7 @@ TR::Register *OMR::X86::TreeEvaluator::d2iEvaluator(TR::Node *node, TR::CodeGene
       }
    else
       {
-      return fpConvertToInt(node, cg->symRefTab()->findOrCreateRuntimeHelper(TR_IA32doubleToInt, false, false, false), cg);
+      return TR::TreeEvaluator::fpConvertToInt(node, cg->symRefTab()->findOrCreateRuntimeHelper(TR_IA32doubleToInt, false, false, false), cg);
       }
    }
 
@@ -1633,7 +1633,7 @@ TR::Register *OMR::X86::TreeEvaluator::d2lEvaluator(TR::Node *node, TR::CodeGene
    {
    TR_ASSERT(TR::Compiler->target.is32Bit(), "AMD64 uses f2iEvaluator for this");
 
-   return fpConvertToLong(node, cg->symRefTab()->findOrCreateRuntimeHelper(TR_IA32doubleToLong, false, false, false), cg);
+   return TR::TreeEvaluator::fpConvertToLong(node, cg->symRefTab()->findOrCreateRuntimeHelper(TR_IA32doubleToLong, false, false, false), cg);
    }
 
 
@@ -1644,7 +1644,7 @@ TR::Register *OMR::X86::TreeEvaluator::d2fEvaluator(TR::Node *node, TR::CodeGene
 
    if (cg->useSSEForDoublePrecision())
       {
-      coerceFPOperandsToXMMRs(node, cg);
+      TR::TreeEvaluator::coerceFPOperandsToXMMRs(node, cg);
       targetRegister = cg->doubleClobberEvaluate(child);
       targetRegister->setIsSinglePrecision(true);
       generateRegRegInstruction(CVTSD2SSRegReg, node, targetRegister, targetRegister, cg);
@@ -1732,7 +1732,7 @@ TR::Register *OMR::X86::TreeEvaluator::ibits2fEvaluator(TR::Node *node, TR::Code
             }
 
          if (child->getReferenceCount() > 1)
-            performIload(child, generateX86MemoryReference(*tempMR, 0, cg), cg);
+            TR::TreeEvaluator::performIload(child, generateX86MemoryReference(*tempMR, 0, cg), cg);
          }
       tempMR->decNodeReferenceCounts(cg);
       }
@@ -1960,7 +1960,7 @@ TR::Register *OMR::X86::TreeEvaluator::fRegStoreEvaluator(TR::Node *node, TR::Co
    if (cg->useSSEForSinglePrecision())
       {
       if (globalReg->getKind() != TR_FPR)
-         globalReg = coerceFPRToXMMR(child, globalReg, cg);
+         globalReg = TR::TreeEvaluator::coerceFPRToXMMR(child, globalReg, cg);
 
       machine->setXMMGlobalRegister(globalRegNum - machine->getNumGlobalGPRs(), globalReg);
       cg->decReferenceCount(child);
@@ -2019,7 +2019,7 @@ TR::Register *OMR::X86::TreeEvaluator::dRegStoreEvaluator(TR::Node *node, TR::Co
    if (cg->useSSEForDoublePrecision())
       {
       if (globalReg->getKind() != TR_FPR)
-         globalReg = coerceFPRToXMMR(child, globalReg, cg);
+         globalReg = TR::TreeEvaluator::coerceFPRToXMMR(child, globalReg, cg);
 
       machine->setXMMGlobalRegister(globalRegNum - machine->getNumGlobalGPRs(), globalReg);
       cg->decReferenceCount(child);
@@ -2317,60 +2317,60 @@ bool OMR::X86::TreeEvaluator::canUseFCOMIInstructions(TR::Node *node, TR::CodeGe
 
 TR::Register *OMR::X86::TreeEvaluator::compareFloatAndBranchEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   bool useFCOMIInstructions = canUseFCOMIInstructions(node, cg);
-   TR::Register *accRegister = compareFloatOrDoubleForOrder(node,
+   bool useFCOMIInstructions = TR::TreeEvaluator::canUseFCOMIInstructions(node, cg);
+   TR::Register *accRegister = TR::TreeEvaluator::compareFloatOrDoubleForOrder(node,
                                                            FCOMRegReg, FCOMRegMem, FCOMIRegReg,
                                                            UCOMISSRegReg, UCOMISSRegMem,
                                                            useFCOMIInstructions, cg);
-   return generateBranchOrSetOnFPCompare(node, accRegister, true, cg);
+   return TR::TreeEvaluator::generateBranchOrSetOnFPCompare(node, accRegister, true, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::compareDoubleAndBranchEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   bool useFCOMIInstructions = canUseFCOMIInstructions(node, cg);
-   TR::Register *accRegister = compareFloatOrDoubleForOrder(node,
+   bool useFCOMIInstructions = TR::TreeEvaluator::canUseFCOMIInstructions(node, cg);
+   TR::Register *accRegister = TR::TreeEvaluator::compareFloatOrDoubleForOrder(node,
                                                            DCOMRegReg, DCOMRegMem, DCOMIRegReg,
                                                            UCOMISDRegReg, UCOMISDRegMem,
                                                            useFCOMIInstructions, cg);
-   return generateBranchOrSetOnFPCompare(node, accRegister, true, cg);
+   return TR::TreeEvaluator::generateBranchOrSetOnFPCompare(node, accRegister, true, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::compareFloatAndSetEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   bool useFCOMIInstructions = canUseFCOMIInstructions(node, cg);
-   TR::Register *accRegister = compareFloatOrDoubleForOrder(node,
+   bool useFCOMIInstructions = TR::TreeEvaluator::canUseFCOMIInstructions(node, cg);
+   TR::Register *accRegister = TR::TreeEvaluator::compareFloatOrDoubleForOrder(node,
                                                            FCOMRegReg, FCOMRegMem, FCOMIRegReg,
                                                            UCOMISSRegReg, UCOMISSRegMem,
                                                            useFCOMIInstructions, cg);
-   return generateBranchOrSetOnFPCompare(node, accRegister, false, cg);
+   return TR::TreeEvaluator::generateBranchOrSetOnFPCompare(node, accRegister, false, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::compareDoubleAndSetEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   bool useFCOMIInstructions = canUseFCOMIInstructions(node, cg);
-   TR::Register *accRegister = compareFloatOrDoubleForOrder(node,
+   bool useFCOMIInstructions = TR::TreeEvaluator::canUseFCOMIInstructions(node, cg);
+   TR::Register *accRegister = TR::TreeEvaluator::compareFloatOrDoubleForOrder(node,
                                                            DCOMRegReg, DCOMRegMem, DCOMIRegReg,
                                                            UCOMISDRegReg, UCOMISDRegMem,
                                                            useFCOMIInstructions, cg);
-   return generateBranchOrSetOnFPCompare(node, accRegister, false, cg);
+   return TR::TreeEvaluator::generateBranchOrSetOnFPCompare(node, accRegister, false, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::compareFloatEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   bool useFCOMIInstructions = canUseFCOMIInstructions(node, cg);
-   TR::Register *accRegister = compareFloatOrDoubleForOrder(node,
+   bool useFCOMIInstructions = TR::TreeEvaluator::canUseFCOMIInstructions(node, cg);
+   TR::Register *accRegister = TR::TreeEvaluator::compareFloatOrDoubleForOrder(node,
                                                            FCOMRegReg, FCOMRegMem, FCOMIRegReg,
                                                            UCOMISSRegReg, UCOMISSRegMem,
                                                            useFCOMIInstructions, cg);
-   return generateFPCompareResult(node, accRegister, cg);
+   return TR::TreeEvaluator::generateFPCompareResult(node, accRegister, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::compareDoubleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   bool useFCOMIInstructions = canUseFCOMIInstructions(node, cg);
-   TR::Register *accRegister = compareFloatOrDoubleForOrder(node,
+   bool useFCOMIInstructions = TR::TreeEvaluator::canUseFCOMIInstructions(node, cg);
+   TR::Register *accRegister = TR::TreeEvaluator::compareFloatOrDoubleForOrder(node,
                                                            DCOMRegReg, DCOMRegMem, DCOMIRegReg,
                                                            UCOMISDRegReg, UCOMISDRegMem,
                                                            useFCOMIInstructions, cg);
-   return generateFPCompareResult(node, accRegister, cg);
+   return TR::TreeEvaluator::generateFPCompareResult(node, accRegister, cg);
    }

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -3925,14 +3925,6 @@ TR::Register *OMR::X86::TreeEvaluator::treetopEvaluator(TR::Node *node, TR::Code
    }
 
 
-
-TR::Register *OMR::X86::TreeEvaluator::ifInstanceOfHelper(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   // Comparing instanceof to a constant
-   return TR::TreeEvaluator::VMifInstanceOfEvaluator(node, cg);
-   }
-
-
 void OMR::X86::TreeEvaluator::compareGPRegisterToConstantForEquality(TR::Node          *node,
                                                                  int32_t           value,
                                                                  TR::Register      *cmpRegister,

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -103,7 +103,7 @@ TR::Register *OMR::X86::TreeEvaluator::ifxcmpoEvaluator(TR::Node *node, TR::Code
              (opCode == TR::ificmpo) || (opCode == TR::ificmpno) ||
              (opCode == TR::iflcmpo) || (opCode == TR::iflcmpno), "invalid opcode");
 
-   bool nodeIs64Bit = getNodeIs64Bit(node->getFirstChild(), cg);
+   bool nodeIs64Bit = TR::TreeEvaluator::getNodeIs64Bit(node->getFirstChild(), cg);
    bool reverseBranch = (opCode == TR::ificmnno) || (opCode == TR::iflcmnno) || (opCode == TR::ificmpno) || (opCode == TR::iflcmpno);
 
    TR::Register* rs1 = cg->evaluate(node->getFirstChild());
@@ -152,7 +152,7 @@ TR::Instruction *OMR::X86::TreeEvaluator::compareGPMemoryToImmediate(TR::Node   
    {
    // On IA32, this is called to do half of an 8-byte compare, so even though
    // the node is 64 bit, we should do a 32-bit compare
-   bool is64Bit = TR::Compiler->target.is64Bit()? getNodeIs64Bit(node->getFirstChild(), cg) : false;
+   bool is64Bit = TR::Compiler->target.is64Bit()? TR::TreeEvaluator::getNodeIs64Bit(node->getFirstChild(), cg) : false;
    TR_X86OpCodes cmpOp = (value >= -128 && value <= 127) ? CMPMemImms(is64Bit) : CMPMemImm4(is64Bit);
    TR::Instruction *instr = generateMemImmInstruction(cmpOp, node, mr, value, cg);
    cg->setImplicitExceptionPoint(instr);
@@ -166,7 +166,7 @@ void OMR::X86::TreeEvaluator::compareGPRegisterToImmediate(TR::Node          *no
    {
    // On IA32, this is called to do half of an 8-byte compare, so even though
    // the node is 64 bit, we should do a 32-bit compare
-   bool is64Bit = TR::Compiler->target.is64Bit()? getNodeIs64Bit(node->getFirstChild(), cg) : false;
+   bool is64Bit = TR::Compiler->target.is64Bit()? TR::TreeEvaluator::getNodeIs64Bit(node->getFirstChild(), cg) : false;
    TR_X86OpCodes cmpOp = (value >= -128 && value <= 127) ? CMPRegImms(is64Bit) : CMPRegImm4(is64Bit);
    generateRegImmInstruction(cmpOp, node, cmpRegister, value, cg);
    }
@@ -178,7 +178,7 @@ void OMR::X86::TreeEvaluator::compareGPRegisterToImmediateForEquality(TR::Node  
    {
    // On IA32, this is called to do half of an 8-byte compare, so even though
    // the node is 64 bit, we should do a 32-bit compare
-   bool is64Bit = TR::Compiler->target.is64Bit()? getNodeIs64Bit(node->getFirstChild(), cg) : false;
+   bool is64Bit = TR::Compiler->target.is64Bit()? TR::TreeEvaluator::getNodeIs64Bit(node->getFirstChild(), cg) : false;
    TR_X86OpCodes cmpOp = (value >= -128 && value <= 127) ? CMPRegImms(is64Bit) : CMPRegImm4(is64Bit);
    if (value==0)
       generateRegRegInstruction(TESTRegReg(is64Bit), node, cmpRegister, cmpRegister, cg);
@@ -401,7 +401,7 @@ TR::Register *OMR::X86::TreeEvaluator::loadConstant(TR::Node * node, intptrj_t v
       targetRegister = cg->allocateRegister();
       }
 
-   TR::Instruction *instr = insertLoadConstant(node, targetRegister, value, type, cg);
+   TR::Instruction *instr = TR::TreeEvaluator::insertLoadConstant(node, targetRegister, value, type, cg);
 
    if (cg->enableRematerialisation())
       {
@@ -536,12 +536,12 @@ OMR::X86::TreeEvaluator::loadMemory(
    {
    TR::Register *targetRegister = cg->allocateRegister();
    TR::Instruction *instr;
-   instr = insertLoadMemory(node, targetRegister, sourceMR, type, cg);
+   instr = TR::TreeEvaluator::insertLoadMemory(node, targetRegister, sourceMR, type, cg);
 
    TR::SymbolReference& symRef = sourceMR->getSymbolReference();
    if (symRef.isUnresolved())
       {
-      padUnresolvedDataReferences(node, symRef, cg);
+      TR::TreeEvaluator::padUnresolvedDataReferences(node, symRef, cg);
       }
 
    if (cg->enableRematerialisation())
@@ -589,7 +589,7 @@ void OMR::X86::TreeEvaluator::removeLiveDiscardableStatics(TR::CodeGenerator *cg
 
 TR::Register *OMR::X86::TreeEvaluator::performIload(TR::Node *node, TR::MemoryReference  *sourceMR, TR::CodeGenerator *cg)
    {
-   TR::Register *reg = loadMemory(node, sourceMR, TR_RematerializableInt, node->getOpCode().isIndirect(), cg);
+   TR::Register *reg = TR::TreeEvaluator::loadMemory(node, sourceMR, TR_RematerializableInt, node->getOpCode().isIndirect(), cg);
 
    node->setRegister(reg);
    return reg;
@@ -599,7 +599,7 @@ TR::Register *OMR::X86::TreeEvaluator::performIload(TR::Node *node, TR::MemoryRe
 TR::Register *OMR::X86::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::MemoryReference  *sourceMR = generateX86MemoryReference(node, cg);
-   TR::Register            *reg      = loadMemory(node, sourceMR, TR_RematerializableAddress, node->getOpCode().isIndirect(), cg);
+   TR::Register         *reg      = TR::TreeEvaluator::loadMemory(node, sourceMR, TR_RematerializableAddress, node->getOpCode().isIndirect(), cg);
    reg->setMemRef(sourceMR);
    TR::Compilation *comp = cg->comp();
 
@@ -709,7 +709,7 @@ bool OMR::X86::TreeEvaluator::genNullTestSequence(TR::Node *node,
 TR::Register *OMR::X86::TreeEvaluator::iloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::MemoryReference  *sourceMR = generateX86MemoryReference(node, cg);
-   TR::Register            *reg      = performIload(node, sourceMR, cg);
+   TR::Register         *reg      = TR::TreeEvaluator::performIload(node, sourceMR, cg);
    reg->setMemRef(sourceMR);
    sourceMR->decNodeReferenceCounts(cg);
    TR::Compilation *comp = cg->comp();
@@ -739,7 +739,7 @@ TR::Register *OMR::X86::TreeEvaluator::iloadEvaluator(TR::Node *node, TR::CodeGe
 TR::Register *OMR::X86::TreeEvaluator::bloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::MemoryReference  *sourceMR = generateX86MemoryReference(node, cg);
-   TR::Register            *reg      = loadMemory(node, sourceMR, TR_RematerializableByte, node->getOpCode().isIndirect(), cg);
+   TR::Register         *reg      = TR::TreeEvaluator::loadMemory(node, sourceMR, TR_RematerializableByte, node->getOpCode().isIndirect(), cg);
 
    reg->setMemRef(sourceMR);
    node->setRegister(reg);
@@ -755,7 +755,7 @@ TR::Register *OMR::X86::TreeEvaluator::bloadEvaluator(TR::Node *node, TR::CodeGe
 TR::Register *OMR::X86::TreeEvaluator::sloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::MemoryReference  *sourceMR = generateX86MemoryReference(node, cg);
-   TR::Register            *reg      = loadMemory(node, sourceMR, TR_RematerializableShort, node->getOpCode().isIndirect(), cg);
+   TR::Register         *reg      = TR::TreeEvaluator::loadMemory(node, sourceMR, TR_RematerializableShort, node->getOpCode().isIndirect(), cg);
 
    reg->setMemRef(sourceMR);
    node->setRegister(reg);
@@ -986,7 +986,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerStoreEvaluator(TR::Node *node, TR:
          TR::SymbolReference& symRef = tempMR->getSymbolReference();
          if (symRef.isUnresolved())
             {
-            padUnresolvedDataReferences(node, symRef, cg);
+            TR::TreeEvaluator::padUnresolvedDataReferences(node, symRef, cg);
             }
 
          // Make the register being stored rematerializable from the destination of
@@ -1111,7 +1111,7 @@ TR::Register *OMR::X86::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::CodeG
             {
             node->setChild(1, valueChild->getFirstChild());
             TR::Node::recreate(node, TR::fstorei);
-            floatingPointStoreEvaluator(node, cg);
+            TR::TreeEvaluator::floatingPointStoreEvaluator(node, cg);
             node->setChild(1, valueChild);
             TR::Node::recreate(node, TR::istorei);
             }
@@ -1119,7 +1119,7 @@ TR::Register *OMR::X86::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::CodeG
             {
             node->setChild(0, valueChild->getFirstChild());
             TR::Node::recreate(node, TR::fstore);
-            floatingPointStoreEvaluator(node, cg);
+            TR::TreeEvaluator::floatingPointStoreEvaluator(node, cg);
             node->setChild(0, valueChild);
             TR::Node::recreate(node, TR::istore);
             }
@@ -1128,7 +1128,7 @@ TR::Register *OMR::X86::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::CodeG
          }
       }
 
-   return integerStoreEvaluator(node, cg);
+   return TR::TreeEvaluator::integerStoreEvaluator(node, cg);
    }
 
 // astoreEvaluator handled by istoreEvaluator
@@ -1136,19 +1136,19 @@ TR::Register *OMR::X86::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::CodeG
 // also handles ibstore
 TR::Register *OMR::X86::TreeEvaluator::bstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return integerStoreEvaluator(node, cg);
+   return TR::TreeEvaluator::integerStoreEvaluator(node, cg);
    }
 
 // also handles isstore
 TR::Register *OMR::X86::TreeEvaluator::sstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return integerStoreEvaluator(node, cg);
+   return TR::TreeEvaluator::integerStoreEvaluator(node, cg);
    }
 
 // also handles icstore
 TR::Register *OMR::X86::TreeEvaluator::cstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return integerStoreEvaluator(node, cg);
+   return TR::TreeEvaluator::integerStoreEvaluator(node, cg);
    }
 
 // iistore handled by istoreEvaluator
@@ -1177,7 +1177,7 @@ OMR::X86::TreeEvaluator::arraycmpEvaluator(
    //
    if (cg->getX86ProcessorInfo().supportsSSE2())
       {
-      return node->isArrayCmpLen() ? SSE2ArraycmpLenEvaluator(node, cg) : SSE2ArraycmpEvaluator(node, cg);
+      return node->isArrayCmpLen() ? TR::TreeEvaluator::SSE2ArraycmpLenEvaluator(node, cg) : TR::TreeEvaluator::SSE2ArraycmpEvaluator(node, cg);
       }
 
    TR::Node *src1AddrNode = node->getChild(0);
@@ -1202,9 +1202,9 @@ OMR::X86::TreeEvaluator::arraycmpEvaluator(
    if (TR::Compiler->target.is64Bit())
       byteLen = 8;
 
-   TR::Register *src1AddrReg = intOrLongClobberEvaluate(src1AddrNode, getNodeIs64Bit(src1AddrNode, cg), cg);
-   TR::Register *src2AddrReg = intOrLongClobberEvaluate(src2AddrNode, getNodeIs64Bit(src2AddrNode, cg), cg);
-   byteLenRegister  = intOrLongClobberEvaluate(byteLenNode,  getNodeIs64Bit(byteLenNode, cg), cg);
+   TR::Register *src1AddrReg = TR::TreeEvaluator::intOrLongClobberEvaluate(src1AddrNode, TR::TreeEvaluator::getNodeIs64Bit(src1AddrNode, cg), cg);
+   TR::Register *src2AddrReg = TR::TreeEvaluator::intOrLongClobberEvaluate(src2AddrNode, TR::TreeEvaluator::getNodeIs64Bit(src2AddrNode, cg), cg);
+   byteLenRegister  = TR::TreeEvaluator::intOrLongClobberEvaluate(byteLenNode,  TR::TreeEvaluator::getNodeIs64Bit(byteLenNode, cg), cg);
 
    byteLenRemainingRegister = cg->allocateRegister(TR_GPR);
 
@@ -2203,7 +2203,7 @@ OMR::X86::TreeEvaluator::constLengthArrayCopyEvaluator(
 
    TR_ASSERT(node->isForwardArrayCopy(), "expecting forward arraycopy");
    TR_ASSERT(byteLenNode->getOpCode().isLoadConst(), "expecting constant length arraycopy");
-   uintptrj_t byteLength = integerConstNodeValue(byteLenNode, cg);
+   uintptrj_t byteLength = TR::TreeEvaluator::integerConstNodeValue(byteLenNode, cg);
 
    TR::Register *byteSrcReg = cg->evaluate(byteSrcNode);
    TR::Register *byteDstReg = cg->evaluate(byteDstNode);
@@ -2278,10 +2278,10 @@ OMR::X86::TreeEvaluator::compressStringEvaluator(
    startNode = node->getChild(2);
    lengthNode = node->getChild(3);
 
-   stopUsingCopyReg1 = stopUsingCopyRegAddr(srcObjNode, srcObjReg, cg);
-   stopUsingCopyReg2 = stopUsingCopyRegAddr(dstObjNode, dstObjReg, cg);
-   stopUsingCopyReg3 = stopUsingCopyRegInteger(startNode, startReg, cg);
-   stopUsingCopyReg4 = stopUsingCopyRegInteger(lengthNode, lengthReg, cg);
+   stopUsingCopyReg1 = TR::TreeEvaluator::stopUsingCopyRegAddr(srcObjNode, srcObjReg, cg);
+   stopUsingCopyReg2 = TR::TreeEvaluator::stopUsingCopyRegAddr(dstObjNode, dstObjReg, cg);
+   stopUsingCopyReg3 = TR::TreeEvaluator::stopUsingCopyRegInteger(startNode, startReg, cg);
+   stopUsingCopyReg4 = TR::TreeEvaluator::stopUsingCopyRegInteger(lengthNode, lengthReg, cg);
 
    uintptrj_t hdrSize = TR::Compiler->om.contiguousArrayHeaderSizeInBytes();
    generateRegImmInstruction(ADDRegImms(), node, srcObjReg, hdrSize, cg);
@@ -2340,10 +2340,10 @@ OMR::X86::TreeEvaluator::compressStringNoCheckEvaluator(
    startNode = node->getChild(2);
    lengthNode = node->getChild(3);
 
-   stopUsingCopyReg1 = stopUsingCopyRegAddr(srcObjNode, srcObjReg, cg);
-   stopUsingCopyReg2 = stopUsingCopyRegAddr(dstObjNode, dstObjReg, cg);
-   stopUsingCopyReg3 = stopUsingCopyRegInteger(startNode, startReg, cg);
-   stopUsingCopyReg4 = stopUsingCopyRegInteger(lengthNode, lengthReg, cg);
+   stopUsingCopyReg1 = TR::TreeEvaluator::stopUsingCopyRegAddr(srcObjNode, srcObjReg, cg);
+   stopUsingCopyReg2 = TR::TreeEvaluator::stopUsingCopyRegAddr(dstObjNode, dstObjReg, cg);
+   stopUsingCopyReg3 = TR::TreeEvaluator::stopUsingCopyRegInteger(startNode, startReg, cg);
+   stopUsingCopyReg4 = TR::TreeEvaluator::stopUsingCopyRegInteger(lengthNode, lengthReg, cg);
 
    uintptrj_t hdrSize = TR::Compiler->om.contiguousArrayHeaderSizeInBytes();
    generateRegImmInstruction(ADDRegImms(), node, srcObjReg, hdrSize, cg);
@@ -2394,9 +2394,9 @@ TR::Register *OMR::X86::TreeEvaluator::andORStringEvaluator(TR::Node *node, TR::
    startNode = node->getChild(1);
    lengthNode = node->getChild(2);
 
-   stopUsingCopyReg1 = stopUsingCopyRegAddr(srcObjNode, srcObjReg, cg);
-   stopUsingCopyReg2 = stopUsingCopyRegInteger(startNode, startReg, cg);
-   stopUsingCopyReg3 = stopUsingCopyRegInteger(lengthNode, lengthReg, cg);
+   stopUsingCopyReg1 = TR::TreeEvaluator::stopUsingCopyRegAddr(srcObjNode, srcObjReg, cg);
+   stopUsingCopyReg2 = TR::TreeEvaluator::stopUsingCopyRegInteger(startNode, startReg, cg);
+   stopUsingCopyReg3 = TR::TreeEvaluator::stopUsingCopyRegInteger(lengthNode, lengthReg, cg);
 
    uintptrj_t hdrSize = TR::Compiler->om.contiguousArrayHeaderSizeInBytes();
    generateRegImmInstruction(ADDRegImms(), node, srcObjReg, hdrSize, cg);
@@ -2446,7 +2446,7 @@ TR::Register *OMR::X86::TreeEvaluator::OverflowCHKEvaluator(TR::Node *node, TR::
    TR::Node *operand2 = node->getThirdChild();
    //it is fine that nodeIs64Bit is false for long operand on 32bits platform because
    //the analyzers below don't use *op* in this case anyways
-   bool nodeIs64Bit = TR::Compiler->target.is32Bit()? false: getNodeIs64Bit(operand1, cg);
+   bool nodeIs64Bit = TR::Compiler->target.is32Bit()? false: TR::TreeEvaluator::getNodeIs64Bit(operand1, cg);
    switch (node->getOverflowCHKOperation())
       {
       //add group
@@ -2634,7 +2634,7 @@ TR::Register *OMR::X86::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Co
 
    static char *disableConstantLengthArrayCopy = feGetEnv("TR_disableConstantLengthArrayCopy");
 
-   uintptrj_t constantByteLength = integerConstNodeValue(byteLenNode, cg);
+   uintptrj_t constantByteLength = TR::TreeEvaluator::integerConstNodeValue(byteLenNode, cg);
    TR::Compilation *comp = cg->comp();
 
    if (isArrayStoreCheckUnnecessary &&
@@ -2646,7 +2646,7 @@ TR::Register *OMR::X86::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Co
       static char * p = feGetEnv("TR_OldConstArrayCopy");
       if (constantByteLength > 28 || !p)
          {
-         constLengthArrayCopyEvaluator(node, cg);
+         TR::TreeEvaluator::constLengthArrayCopyEvaluator(node, cg);
          if (!isPrimitiveCopy)
             {
 #ifdef J9_PROJECT_SPECIFIC
@@ -2742,7 +2742,7 @@ TR::Register *OMR::X86::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Co
           byteLenNode->getSecondChild()->getOpCode().isLoadConst())
          {
          TR::Node *constNode = byteLenNode->getSecondChild();
-         size = integerConstNodeValue(constNode, cg);
+         size = TR::TreeEvaluator::integerConstNodeValue(constNode, cg);
          }
 
       if (size == 8 || size == 4 || size == 2)
@@ -3236,10 +3236,10 @@ TR::Register *OMR::X86::TreeEvaluator::arraytranslateEvaluator(TR::Node *node, T
    bool sourceByte = node->isSourceByteArrayTranslate();
 
    TR::Register *srcPtrReg, *dstPtrReg, *transTableReg, *termCharReg, *lengthReg;
-   bool stopUsingCopyReg1 = stopUsingCopyRegAddr(node->getChild(0), srcPtrReg, cg);
-   bool stopUsingCopyReg2 = stopUsingCopyRegAddr(node->getChild(1), dstPtrReg, cg);
-   bool stopUsingCopyReg4 = stopUsingCopyRegInteger(node->getChild(3), termCharReg, cg);
-   bool stopUsingCopyReg5 = stopUsingCopyRegInteger(node->getChild(4), lengthReg, cg);
+   bool stopUsingCopyReg1 = TR::TreeEvaluator::stopUsingCopyRegAddr(node->getChild(0), srcPtrReg, cg);
+   bool stopUsingCopyReg2 = TR::TreeEvaluator::stopUsingCopyRegAddr(node->getChild(1), dstPtrReg, cg);
+   bool stopUsingCopyReg4 = TR::TreeEvaluator::stopUsingCopyRegInteger(node->getChild(3), termCharReg, cg);
+   bool stopUsingCopyReg5 = TR::TreeEvaluator::stopUsingCopyRegInteger(node->getChild(4), lengthReg, cg);
    TR::Register *resultReg = cg->allocateRegister();
    TR::Register *dummy1 = cg->allocateRegister();
    TR::Register *dummy2 = cg->allocateRegister(TR_FPR);
@@ -3324,9 +3324,9 @@ TR::Register *OMR::X86::TreeEvaluator::encodeUTF16Evaluator(TR::Node *node, TR::
    const int fprClobberCount = bigEndian ? 5 : 4; // xmm4 only needed for big-endian
    TR::Register *srcPtrReg, *dstPtrReg, *lengthReg, *resultReg;
    TR::Register *gprClobbers[gprClobberCount], *fprClobbers[maxFprClobberCount];
-   bool killSrc = stopUsingCopyRegAddr(node->getChild(0), srcPtrReg, cg);
-   bool killDst = stopUsingCopyRegAddr(node->getChild(1), dstPtrReg, cg);
-   bool killLen = stopUsingCopyRegInteger(node->getChild(2), lengthReg, cg);
+   bool killSrc = TR::TreeEvaluator::stopUsingCopyRegAddr(node->getChild(0), srcPtrReg, cg);
+   bool killDst = TR::TreeEvaluator::stopUsingCopyRegAddr(node->getChild(1), dstPtrReg, cg);
+   bool killLen = TR::TreeEvaluator::stopUsingCopyRegInteger(node->getChild(2), lengthReg, cg);
    resultReg = cg->allocateRegister();
    for (int i = 0; i < gprClobberCount; i++)
       gprClobbers[i] = cg->allocateRegister();
@@ -3396,12 +3396,12 @@ TR::Register *OMR::X86::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::Cod
    TR::Node* valueNode = node->getChild(1);    // Value
    TR::Node* sizeNode  = node->getChild(2);    // Size
 
-   TR::Register* addressReg = intOrLongClobberEvaluate(addressNode, TR::Compiler->target.is64Bit(), cg);
+   TR::Register* addressReg = TR::TreeEvaluator::intOrLongClobberEvaluate(addressNode, TR::Compiler->target.is64Bit(), cg);
    TR::Register* valueReg = cg->evaluate(valueNode);
-   TR::Register* sizeReg = intOrLongClobberEvaluate(sizeNode, getNodeIs64Bit(sizeNode, cg), cg);
+   TR::Register* sizeReg = TR::TreeEvaluator::intOrLongClobberEvaluate(sizeNode, TR::TreeEvaluator::getNodeIs64Bit(sizeNode, cg), cg);
 
    // Zero-extend array size if passed in as 32-bit on 64-bit architecture
-   if (TR::Compiler->target.is64Bit() && !getNodeIs64Bit(sizeNode, cg))
+   if (TR::Compiler->target.is64Bit() && !TR::TreeEvaluator::getNodeIs64Bit(sizeNode, cg))
    {
        generateRegRegInstruction(MOVZXReg8Reg4, node, sizeReg, sizeReg, cg);
    }
@@ -3531,7 +3531,7 @@ TR::Register *OMR::X86::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::Cod
 
 bool OMR::X86::TreeEvaluator::constNodeValueIs32BitSigned(TR::Node *node, intptrj_t *value, TR::CodeGenerator *cg)
    {
-   *value = integerConstNodeValue(node, cg);
+   *value = TR::TreeEvaluator::integerConstNodeValue(node, cg);
    if (TR::Compiler->target.is64Bit())
       {
       return IS_32BIT_SIGNED(*value);
@@ -3561,7 +3561,7 @@ bool OMR::X86::TreeEvaluator::getNodeIs64Bit(TR::Node *node, TR::CodeGenerator *
 
 intptrj_t OMR::X86::TreeEvaluator::integerConstNodeValue(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (getNodeIs64Bit(node, cg))
+   if (TR::TreeEvaluator::getNodeIs64Bit(node, cg))
       {
       return (intptrj_t)node->getLongInt(); // Cast to satisfy 32-bit compilers, even though they never take this path
       }
@@ -3592,7 +3592,7 @@ OMR::X86::TreeEvaluator::performCall(
 
    if (cg->enableRematerialisation() &&
        cg->supportsStaticMemoryRematerialization())
-      removeLiveDiscardableStatics(cg);
+      TR::TreeEvaluator::removeLiveDiscardableStatics(cg);
 
    node->setRegister(returnRegister);
    return returnRegister;
@@ -3610,7 +3610,7 @@ OMR::X86::TreeEvaluator::performHelperCall(
    TR::Node::recreate(node, helperCallOpCode);
    if(helperSymRef)
       node->setSymbolReference(helperSymRef);
-   TR::Register *targetReg = performCall(node, false, spillFPRegs, cg);
+   TR::Register *targetReg = TR::TreeEvaluator::performCall(node, false, spillFPRegs, cg);
    TR::Node::recreate(node, opCode);
    return targetReg;
    }
@@ -3714,27 +3714,27 @@ TR::Register *OMR::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::C
       {
       if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicAdd32BitSymbol))
          {
-         return performSimpleAtomicMemoryUpdate(node, 4, LADD4MemReg, cg);
+         return TR::TreeEvaluator::performSimpleAtomicMemoryUpdate(node, 4, LADD4MemReg, cg);
          }
       if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicAdd64BitSymbol))
          {
-         return performSimpleAtomicMemoryUpdate(node, 8, LADD8MemReg, cg);
+         return TR::TreeEvaluator::performSimpleAtomicMemoryUpdate(node, 8, LADD8MemReg, cg);
          }
       if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicFetchAndAdd32BitSymbol))
          {
-         return performSimpleAtomicMemoryUpdate(node, 4, LXADD4MemReg, cg);
+         return TR::TreeEvaluator::performSimpleAtomicMemoryUpdate(node, 4, LXADD4MemReg, cg);
          }
       if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicFetchAndAdd64BitSymbol))
          {
-         return performSimpleAtomicMemoryUpdate(node, 8, LXADD8MemReg, cg);
+         return TR::TreeEvaluator::performSimpleAtomicMemoryUpdate(node, 8, LXADD8MemReg, cg);
          }
       if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicSwap32BitSymbol))
          {
-         return performSimpleAtomicMemoryUpdate(node, 4, XCHG4MemReg, cg);
+         return TR::TreeEvaluator::performSimpleAtomicMemoryUpdate(node, 4, XCHG4MemReg, cg);
          }
       if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicSwap64BitSymbol))
          {
-         return performSimpleAtomicMemoryUpdate(node, 8, XCHG8MemReg, cg);
+         return TR::TreeEvaluator::performSimpleAtomicMemoryUpdate(node, 8, XCHG8MemReg, cg);
          }
       }
 
@@ -3788,7 +3788,7 @@ TR::Register *OMR::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::C
    if (symbol->getMandatoryRecognizedMethod() == TR::com_ibm_jit_JITHelpers_transformedEncodeUTF16Big ||
        symbol->getMandatoryRecognizedMethod() == TR::com_ibm_jit_JITHelpers_transformedEncodeUTF16Little)
       {
-      return encodeUTF16Evaluator(node, cg);
+      return TR::TreeEvaluator::encodeUTF16Evaluator(node, cg);
       }
 
    if (cg->getSupportsBDLLHardwareOverflowCheck() &&
@@ -3851,24 +3851,24 @@ TR::Register *OMR::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::C
       if (TR::TreeEvaluator::VMinlineCallEvaluator(node, false, cg))
          returnRegister = node->getRegister();
       else
-         returnRegister = performCall(node, false, true, cg);
+         returnRegister = TR::TreeEvaluator::performCall(node, false, true, cg);
       }
    else if (symbol->getRecognizedMethod() == TR::java_lang_String_compress)
       {
-      return compressStringEvaluator(node, cg, useJapaneseCompression);
+      return TR::TreeEvaluator::compressStringEvaluator(node, cg, useJapaneseCompression);
       }
    else if (symbol->getRecognizedMethod() == TR::java_lang_String_compressNoCheck)
       {
-      return compressStringNoCheckEvaluator(node, cg, useJapaneseCompression);
+      return TR::TreeEvaluator::compressStringNoCheckEvaluator(node, cg, useJapaneseCompression);
       }
    else if (symbol->getRecognizedMethod() == TR::java_lang_String_andOR)
       {
-      return andORStringEvaluator(node, cg);
+      return TR::TreeEvaluator::andORStringEvaluator(node, cg);
       }
    else
 #endif
       {
-      returnRegister = performCall(node, false, true, cg);
+      returnRegister = TR::TreeEvaluator::performCall(node, false, true, cg);
       }
 
    // A strictfp caller needs to adjust double return values;
@@ -3878,7 +3878,7 @@ TR::Register *OMR::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::C
        returnRegister->needsPrecisionAdjustment() &&
        comp->getCurrentMethod()->isStrictFP())
       {
-      insertPrecisionAdjustment(returnRegister, node, cg);
+      TR::TreeEvaluator::insertPrecisionAdjustment(returnRegister, node, cg);
       }
 
    return returnRegister;
@@ -3898,10 +3898,10 @@ TR::Register *OMR::X86::TreeEvaluator::indirectCallEvaluator(TR::Node *node, TR:
       if (TR::TreeEvaluator::VMinlineCallEvaluator(node, true, cg))
          returnRegister = node->getRegister();
       else
-         returnRegister = performCall(node, true, true, cg);
+         returnRegister = TR::TreeEvaluator::performCall(node, true, true, cg);
       }
    else
-      returnRegister = performCall(node, true, true, cg);
+      returnRegister = TR::TreeEvaluator::performCall(node, true, true, cg);
 
    // A strictfp caller needs to adjust double return values;
    // a float callee always returns values that have correct precision.
@@ -3910,7 +3910,7 @@ TR::Register *OMR::X86::TreeEvaluator::indirectCallEvaluator(TR::Node *node, TR:
        returnRegister->needsPrecisionAdjustment() &&
        comp->getCurrentMethod()->isStrictFP())
       {
-      insertPrecisionAdjustment(returnRegister, node, cg);
+      TR::TreeEvaluator::insertPrecisionAdjustment(returnRegister, node, cg);
       }
 
    return returnRegister;
@@ -3936,7 +3936,7 @@ void OMR::X86::TreeEvaluator::compareGPRegisterToConstantForEquality(TR::Node   
       }
    else
       {
-      compareGPRegisterToImmediate(node, cmpRegister, value, cg);
+      TR::TreeEvaluator::compareGPRegisterToImmediate(node, cmpRegister, value, cg);
       }
    }
 
@@ -4014,11 +4014,11 @@ TR::Register *OMR::X86::TreeEvaluator::loadaddrEvaluator(TR::Node *node, TR::Cod
    TR::MemoryReference  *memRef = generateX86MemoryReference(symRef, cg);
 
    // for loadaddr, directly allocated register according to its symRef, since memRef only represents symRef
-   TR::Register *targetRegister = generateLEAForLoadAddr(node, memRef, symRef, cg, false);
+   TR::Register *targetRegister = TR::TreeEvaluator::generateLEAForLoadAddr(node, memRef, symRef, cg, false);
 
    if (symRef->isUnresolved() && TR::Compiler->target.is32Bit())
       {
-      padUnresolvedDataReferences(node, memRef->getSymbolReference(), cg);
+      TR::TreeEvaluator::padUnresolvedDataReferences(node, memRef->getSymbolReference(), cg);
       }
 
    node->setRegister(targetRegister);
@@ -4433,7 +4433,7 @@ TR::Register *OMR::X86::TreeEvaluator::conversionAnalyser(TR::Node          *nod
                child->getOpCode().isLoadIndirect() &&
                child->getSymbolReference()->getSymbol()->getDataType() == TR::Address)
             {
-            targetRegister = iloadEvaluator(child, cg);
+            targetRegister = TR::TreeEvaluator::iloadEvaluator(child, cg);
             }
          else
             {
@@ -4493,11 +4493,11 @@ OMR::X86::TreeEvaluator::icmpsetEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    // - the pointer node cannot be used because on x64 the pointer is 64 bit for both icmpset and lcmpset but
    //   icmpset should only cmpxchg 4 bytes in memory
 
-   bool nodeIs64Bit = getNodeIs64Bit(compareValue, cg);
+   bool nodeIs64Bit = TR::TreeEvaluator::getNodeIs64Bit(compareValue, cg);
 
    TR::Register *pointerReg = cg->evaluate(pointer);
    TR::MemoryReference *memRef = generateX86MemoryReference(pointerReg, 0, cg);
-   TR::Register *compareReg = intOrLongClobberEvaluate(compareValue, nodeIs64Bit, cg);
+   TR::Register *compareReg = TR::TreeEvaluator::intOrLongClobberEvaluate(compareValue, nodeIs64Bit, cg);
    TR::Register *replaceReg = cg->evaluate(replaceValue);
 
    // zero the result register to avoid zero extension after the setne
@@ -4654,37 +4654,37 @@ TR_X86ComputeCC::setCarryBorrow(TR::Node *flagNode, bool invertValue, TR::CodeGe
 
 TR::Register *OMR::X86::TreeEvaluator::bcmpEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareBytesForOrder(node, cg);
+   TR::TreeEvaluator::compareBytesForOrder(node, cg);
    return node->setRegister(NULL);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::bucmpEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareBytesForOrder(node, cg);
+   TR::TreeEvaluator::compareBytesForOrder(node, cg);
    return node->setRegister(NULL);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::scmpEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compare2BytesForOrder(node, cg);
+   TR::TreeEvaluator::compare2BytesForOrder(node, cg);
    return node->setRegister(NULL);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::sucmpEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compare2BytesForOrder(node, cg);
+   TR::TreeEvaluator::compare2BytesForOrder(node, cg);
    return node->setRegister(NULL);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::icmpEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareIntegersForOrder(node, cg);
+   TR::TreeEvaluator::compareIntegersForOrder(node, cg);
    return node->setRegister(NULL);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::iucmpEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareIntegersForOrder(node, cg);
+   TR::TreeEvaluator::compareIntegersForOrder(node, cg);
    return node->setRegister(NULL);
    }
 

--- a/compiler/x/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.hpp
@@ -156,7 +156,6 @@ class TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *c2iEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ibits2fEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *fbits2iEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *ifInstanceOfHelper(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *compareFloatAndBranchEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *compareDoubleAndBranchEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *compareFloatAndSetEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/x/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.hpp
@@ -56,7 +56,7 @@ namespace OMR
 namespace X86
 {
 
-class TreeEvaluator: public OMR::TreeEvaluator
+class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    {
 
    public:

--- a/compiler/x/codegen/UnaryEvaluator.cpp
+++ b/compiler/x/codegen/UnaryEvaluator.cpp
@@ -35,7 +35,7 @@ extern TR::Register *intOrLongClobberEvaluate(TR::Node *node, bool nodeIs64Bit, 
 
 TR::Register *OMR::X86::TreeEvaluator::bconstEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::Register *reg = loadConstant(node, node->getInt(), TR_RematerializableByte, cg);
+   TR::Register *reg = TR::TreeEvaluator::loadConstant(node, node->getInt(), TR_RematerializableByte, cg);
    node->setRegister(reg);
 
    if (cg->enableRegisterInterferences())
@@ -46,21 +46,21 @@ TR::Register *OMR::X86::TreeEvaluator::bconstEvaluator(TR::Node *node, TR::CodeG
 
 TR::Register *OMR::X86::TreeEvaluator::sconstEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::Register *reg = loadConstant(node, node->getInt(), TR_RematerializableShort, cg);
+   TR::Register *reg = TR::TreeEvaluator::loadConstant(node, node->getInt(), TR_RematerializableShort, cg);
    node->setRegister(reg);
    return reg;
    }
 
 TR::Register *OMR::X86::TreeEvaluator::cconstEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::Register *reg = loadConstant(node, node->getInt(), TR_RematerializableChar, cg);
+   TR::Register *reg = TR::TreeEvaluator::loadConstant(node, node->getInt(), TR_RematerializableChar, cg);
    node->setRegister(reg);
    return reg;
    }
 
 TR::Register *OMR::X86::TreeEvaluator::iconstEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::Register *reg = loadConstant(node, node->getInt(), TR_RematerializableInt, cg);
+   TR::Register *reg = TR::TreeEvaluator::loadConstant(node, node->getInt(), TR_RematerializableInt, cg);
    node->setRegister(reg);
    return reg;
    }
@@ -70,7 +70,7 @@ TR::Register *OMR::X86::TreeEvaluator::negEvaluatorHelper(TR::Node        *node,
                                                TR::CodeGenerator *cg)
    {
    TR::Node *firstChild = node->getFirstChild();
-   TR::Register *targetRegister = intOrLongClobberEvaluate(firstChild, getNodeIs64Bit(node, cg), cg);
+   TR::Register *targetRegister = TR::TreeEvaluator::intOrLongClobberEvaluate(firstChild, TR::TreeEvaluator::getNodeIs64Bit(node, cg), cg);
    node->setRegister(targetRegister);
    cg->decReferenceCount(firstChild);
    generateRegInstruction(negInstr, node, targetRegister, cg);
@@ -79,14 +79,14 @@ TR::Register *OMR::X86::TreeEvaluator::negEvaluatorHelper(TR::Node        *node,
 
 TR::Register *OMR::X86::TreeEvaluator::integerNegEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return negEvaluatorHelper(node, NEGReg(getNodeIs64Bit(node, cg)), cg);
+   return TR::TreeEvaluator::negEvaluatorHelper(node, NEGReg(TR::TreeEvaluator::getNodeIs64Bit(node, cg)), cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::integerAbsEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node *child = node->getFirstChild();
-   bool is64Bit = getNodeIs64Bit(node, cg);
-   TR::Register *targetRegister = intOrLongClobberEvaluate(child, is64Bit, cg);
+   bool is64Bit = TR::TreeEvaluator::getNodeIs64Bit(node, cg);
+   TR::Register *targetRegister = TR::TreeEvaluator::intOrLongClobberEvaluate(child, is64Bit, cg);
    node->setRegister(targetRegister);
    TR::Register *signRegister = cg->allocateRegister(TR_GPR);
    generateRegRegInstruction(MOVRegReg(is64Bit), node, signRegister, targetRegister, cg);
@@ -100,7 +100,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerAbsEvaluator(TR::Node *node, TR::C
 
 TR::Register *OMR::X86::TreeEvaluator::bnegEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::Register *targetRegister = negEvaluatorHelper(node, NEG1Reg, cg);
+   TR::Register *targetRegister = TR::TreeEvaluator::negEvaluatorHelper(node, NEG1Reg, cg);
 
    if (cg->enableRegisterInterferences())
       cg->getLiveRegisters(TR_GPR)->setByteRegisterAssociation(targetRegister);
@@ -110,7 +110,7 @@ TR::Register *OMR::X86::TreeEvaluator::bnegEvaluator(TR::Node *node, TR::CodeGen
 
 TR::Register *OMR::X86::TreeEvaluator::snegEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return negEvaluatorHelper(node, NEG2Reg, cg);
+   return TR::TreeEvaluator::negEvaluatorHelper(node, NEG2Reg, cg);
    }
 
 // also handles i2s, i2c, s2b, a2s, a2c, a2b, a2bu
@@ -238,37 +238,37 @@ TR::Register *OMR::X86::TreeEvaluator::b2iEvaluator(TR::Node *node, TR::CodeGene
      reg4mem1Op = MOVSXReg4Mem1;
      reg4reg1Op = MOVSXReg4Reg1;
      }
-   return conversionAnalyser(node, reg4mem1Op, reg4reg1Op, cg);
+   return TR::TreeEvaluator::conversionAnalyser(node, reg4mem1Op, reg4reg1Op, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::bu2iEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return conversionAnalyser(node, MOVZXReg4Mem1, MOVZXReg4Reg1, cg);
+   return TR::TreeEvaluator::conversionAnalyser(node, MOVZXReg4Mem1, MOVZXReg4Reg1, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::b2sEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return conversionAnalyser(node, MOVSXReg2Mem1, MOVSXReg2Reg1, cg);
+   return TR::TreeEvaluator::conversionAnalyser(node, MOVSXReg2Mem1, MOVSXReg2Reg1, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::bu2sEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return conversionAnalyser(node, MOVZXReg2Mem1, MOVZXReg2Reg1, cg);
+   return TR::TreeEvaluator::conversionAnalyser(node, MOVZXReg2Mem1, MOVZXReg2Reg1, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::s2iEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return conversionAnalyser(node, MOVSXReg4Mem2, MOVSXReg4Reg2, cg);
+   return TR::TreeEvaluator::conversionAnalyser(node, MOVSXReg4Mem2, MOVSXReg4Reg2, cg);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::su2iEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return conversionAnalyser(node, MOVZXReg4Mem2, MOVZXReg4Reg2, cg);
+   return TR::TreeEvaluator::conversionAnalyser(node, MOVZXReg4Mem2, MOVZXReg4Reg2, cg);
    }
 
 // s2b handled by i2b
 
 TR::Register *OMR::X86::TreeEvaluator::c2iEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return conversionAnalyser(node, MOVZXReg4Mem2, MOVZXReg4Reg2, cg);
+   return TR::TreeEvaluator::conversionAnalyser(node, MOVZXReg4Mem2, MOVZXReg4Reg2, cg);
    }

--- a/compiler/x/i386/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluator.hpp
@@ -47,7 +47,7 @@ namespace X86
 namespace i386
 {
 
-class TreeEvaluator: public OMR::X86::TreeEvaluator
+class OMR_EXTENSIBLE TreeEvaluator: public OMR::X86::TreeEvaluator
    {
 
    public:

--- a/compiler/z/codegen/BinaryEvaluator.cpp
+++ b/compiler/z/codegen/BinaryEvaluator.cpp
@@ -1988,7 +1988,7 @@ OMR::Z::TreeEvaluator::addrAddHelper(TR::Node *node, TR::CodeGenerator *cg)
    else if (node->getOpCodeValue() == TR::aladd)
       {
       if (cg->getCurrentRegisterPressure() < CODEGEN_REGPRESSURE_THRESHOLD)
-         return laddEvaluator(node, cg);
+         return TR::TreeEvaluator::laddEvaluator(node, cg);
       else
          {
          TR_S390BinaryCommutativeAnalyser temp(cg);
@@ -3416,11 +3416,11 @@ OMR::Z::TreeEvaluator::dualMulEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
       if (TR::Compiler->target.is64Bit() || cg->use64BitRegsOn32Bit())
          {
-         return dualMulHelper64(node, lmulNode, lumulhNode, cg);
+         return TR::TreeEvaluator::dualMulHelper64(node, lmulNode, lumulhNode, cg);
          }
       else
          {
-         return dualMulHelper32(node, lmulNode, lumulhNode, cg);
+         return TR::TreeEvaluator::dualMulHelper32(node, lmulNode, lumulhNode, cg);
          }
       }
    }
@@ -3621,7 +3621,7 @@ OMR::Z::TreeEvaluator::lmulhEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    bool needsUnsignedHighMulOnly = (node->getOpCodeValue() == TR::lumulh) && !node->isDualCyclic();
    if (node->isDualCyclic() || needsUnsignedHighMulOnly)
       {
-      return dualMulEvaluator(node, cg);
+      return TR::TreeEvaluator::dualMulEvaluator(node, cg);
       }
 
    TR::Node * firstChild = node->getFirstChild();
@@ -3903,7 +3903,7 @@ OMR::Z::TreeEvaluator::lmulEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    bool needsUnsignedHighMulOnly = (node->getOpCodeValue() == TR::lumulh) && !node->isDualCyclic();
    if (node->isDualCyclic() || needsUnsignedHighMulOnly)
       {
-      return dualMulEvaluator(node, cg);
+      return TR::TreeEvaluator::dualMulEvaluator(node, cg);
       }
 
    if (TR::Compiler->target.is64Bit() || cg->use64BitRegsOn32Bit())
@@ -4756,7 +4756,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::bandEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("band", node, cg);
-   return iandEvaluator(node, cg);
+   return TR::TreeEvaluator::iandEvaluator(node, cg);
    }
 
 /**
@@ -4766,7 +4766,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::sandEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("sand", node, cg);
-   return iandEvaluator(node, cg);
+   return TR::TreeEvaluator::iandEvaluator(node, cg);
    }
 
 /**
@@ -4776,7 +4776,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::candEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("cand", node, cg);
-   return iandEvaluator(node, cg);
+   return TR::TreeEvaluator::iandEvaluator(node, cg);
    }
 
 
@@ -4881,7 +4881,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::borEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("bor", node, cg);
-   return iorEvaluator(node, cg);
+   return TR::TreeEvaluator::iorEvaluator(node, cg);
    }
 
 /**
@@ -4891,7 +4891,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::sorEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("sor", node, cg);
-   return iorEvaluator(node, cg);
+   return TR::TreeEvaluator::iorEvaluator(node, cg);
    }
 
 /**
@@ -4901,7 +4901,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::corEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("cor", node, cg);
-   return iorEvaluator(node, cg);
+   return TR::TreeEvaluator::iorEvaluator(node, cg);
    }
 
 /**
@@ -5005,7 +5005,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::bxorEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("bxor", node, cg);
-   return ixorEvaluator(node, cg);
+   return TR::TreeEvaluator::ixorEvaluator(node, cg);
    }
 
 /**
@@ -5015,7 +5015,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::sxorEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("sxor", node, cg);
-   return ixorEvaluator(node, cg);
+   return TR::TreeEvaluator::ixorEvaluator(node, cg);
    }
 
 /**
@@ -5025,7 +5025,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::cxorEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("cxor", node, cg);
-   return ixorEvaluator(node, cg);
+   return TR::TreeEvaluator::ixorEvaluator(node, cg);
    }
 
 TR::Register *
@@ -5034,7 +5034,7 @@ OMR::Z::TreeEvaluator::dexpEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR_ASSERT(0, "This evaluator is not functionally correct. Do Not use.");
 
 
-   return libmFuncEvaluator(node, cg);
+   return TR::TreeEvaluator::libmFuncEvaluator(node, cg);
    }
 
 TR::Register *
@@ -5043,5 +5043,5 @@ OMR::Z::TreeEvaluator::fexpEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR_ASSERT(0, "This evaluator is not functionally correct. Do Not use.");
 
 
-   return libmFuncEvaluator(node, cg);
+   return TR::TreeEvaluator::libmFuncEvaluator(node, cg);
    }

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -1240,7 +1240,7 @@ bool OMR::Z::TreeEvaluator::isCandidateForButestEvaluation(TR::Node * node)
 bool OMR::Z::TreeEvaluator::isCandidateForCompareEvaluation(TR::Node * node)
    {
    return node->getOpCode().isIf() &&
-          isSingleRefUnevalAndCompareOrBu2iOverCompare(node->getFirstChild()) &&
+          TR::TreeEvaluator::isSingleRefUnevalAndCompareOrBu2iOverCompare(node->getFirstChild()) &&
           node->getSecondChild()->getOpCode().isLoadConst() &&
           node->getSecondChild()->getType().isInt32();
    }
@@ -1251,7 +1251,7 @@ bool OMR::Z::TreeEvaluator::isSingleRefUnevalAndCompareOrBu2iOverCompare(TR::Nod
       return false;
 
    if (node->getOpCodeValue() == TR::bu2i)
-      return isSingleRefUnevalAndCompareOrBu2iOverCompare(node->getFirstChild());
+      return TR::TreeEvaluator::isSingleRefUnevalAndCompareOrBu2iOverCompare(node->getFirstChild());
 
    return false;
    }
@@ -1329,16 +1329,16 @@ OMR::Z::TreeEvaluator::ificmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg
       return NULL;
       }
 
-   if (isCandidateForButestEvaluation(node))
+   if (TR::TreeEvaluator::isCandidateForButestEvaluation(node))
       {
       TR::Node * cmpNode = node;
       TR::Node * butestNode = node->getFirstChild();
       TR::Node * valueNode = node->getSecondChild();
 
-      return inlineIfButestEvaluator(butestNode, cg, cmpNode, valueNode);
+      return TR::TreeEvaluator::inlineIfButestEvaluator(butestNode, cg, cmpNode, valueNode);
       }
 
-   if (isCandidateForCompareEvaluation(node))
+   if (TR::TreeEvaluator::isCandidateForCompareEvaluation(node))
       {
       TR::Node *ifNode = node;
       TR::Node *cmpNode = node->getFirstChild();
@@ -1346,7 +1346,7 @@ OMR::Z::TreeEvaluator::ificmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg
          cmpNode = cmpNode->getFirstChild();
       TR::Node *valueNode = node->getSecondChild();
 
-      return inlineIfBifEvaluator(ifNode, cg, cmpNode, valueNode);
+      return TR::TreeEvaluator::inlineIfBifEvaluator(ifNode, cg, cmpNode, valueNode);
       }
 
    TR::Node * firstChild = node-> getFirstChild(), * secondChild = node->getSecondChild();
@@ -1371,14 +1371,14 @@ OMR::Z::TreeEvaluator::ificmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg
    bool inlined = false;
    TR::Register *reg;
 
-   reg = inlineIfArraycmpEvaluator(node, cg, inlined);
+   reg = TR::TreeEvaluator::inlineIfArraycmpEvaluator(node, cg, inlined);
    if (inlined)
       {
       generateMergedHCRGuardCodeIfNeeded(node, cg);
       return reg;
       }
 
-   reg = inlineIfTestDataClassHelper(node, cg, inlined);
+   reg = TR::TreeEvaluator::inlineIfTestDataClassHelper(node, cg, inlined);
    if(inlined)
       {
       generateMergedHCRGuardCodeIfNeeded(node, cg);
@@ -1426,7 +1426,7 @@ TR::Register* OMR::Z::TreeEvaluator::ifFoldingHelper(TR::Node *node, TR::CodeGen
 
 
    bool inlined = false;
-   TR::Register *reg = inlineIfTestDataClassHelper(node, cg, inlined);
+   TR::Register *reg = TR::TreeEvaluator::inlineIfTestDataClassHelper(node, cg, inlined);
    if(inlined)
       return reg;
 
@@ -1447,11 +1447,11 @@ OMR::Z::TreeEvaluator::ificmpltEvaluator(TR::Node * node, TR::CodeGenerator * cg
    TR::Register *reg;
 
 
-   reg = inlineIfArraycmpEvaluator(node, cg, inlined);
+   reg = TR::TreeEvaluator::inlineIfArraycmpEvaluator(node, cg, inlined);
    if (inlined) return reg;
 
    bool handledBIF = false;
-   TR::Register *result = ifFoldingHelper(node, cg, handledBIF);
+   TR::Register *result = TR::TreeEvaluator::ifFoldingHelper(node, cg, handledBIF);
    if (handledBIF)
       return result;
 
@@ -1470,11 +1470,11 @@ OMR::Z::TreeEvaluator::ificmpgeEvaluator(TR::Node * node, TR::CodeGenerator * cg
    TR::Register *reg;
 
 
-   reg = inlineIfArraycmpEvaluator(node, cg, inlined);
+   reg = TR::TreeEvaluator::inlineIfArraycmpEvaluator(node, cg, inlined);
    if (inlined) return reg;
 
    bool handledBIF = false;
-   TR::Register *result = ifFoldingHelper(node, cg, handledBIF);
+   TR::Register *result = TR::TreeEvaluator::ifFoldingHelper(node, cg, handledBIF);
    if (handledBIF)
       return result;
 
@@ -1493,11 +1493,11 @@ OMR::Z::TreeEvaluator::ificmpgtEvaluator(TR::Node * node, TR::CodeGenerator * cg
    TR::Register *reg;
 
 
-   reg = inlineIfArraycmpEvaluator(node, cg, inlined);
+   reg = TR::TreeEvaluator::inlineIfArraycmpEvaluator(node, cg, inlined);
    if (inlined) return reg;
 
    bool handledBIF = false;
-   TR::Register *result = ifFoldingHelper(node, cg, handledBIF);
+   TR::Register *result = TR::TreeEvaluator::ifFoldingHelper(node, cg, handledBIF);
    if (handledBIF)
       return result;
 
@@ -1515,11 +1515,11 @@ OMR::Z::TreeEvaluator::ificmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg
 
    TR::Register *reg;
 
-   reg = inlineIfArraycmpEvaluator(node, cg, inlined);
+   reg = TR::TreeEvaluator::inlineIfArraycmpEvaluator(node, cg, inlined);
    if (inlined) return reg;
 
    bool handledBIF = false;
-   TR::Register *result = ifFoldingHelper(node, cg, handledBIF);
+   TR::Register *result = TR::TreeEvaluator::ifFoldingHelper(node, cg, handledBIF);
    if (handledBIF)
       return result;
 
@@ -1652,7 +1652,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::ifacmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("ifacmpeq", node, cg);
-   return ificmpeqEvaluator(node, cg);
+   return TR::TreeEvaluator::ificmpeqEvaluator(node, cg);
    }
 
 /**
@@ -1662,7 +1662,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::ifacmpneEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("ifacmpne", node, cg);
-   return ificmpeqEvaluator(node, cg);
+   return TR::TreeEvaluator::ificmpeqEvaluator(node, cg);
    }
 
 /**
@@ -1694,7 +1694,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::ifbcmpltEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("ifbcmplt", node, cg);
-   return ificmpltEvaluator(node, cg);
+   return TR::TreeEvaluator::ificmpltEvaluator(node, cg);
    }
 
 /**
@@ -1704,7 +1704,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::ifbcmpgeEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("ifbcmpge", node, cg);
-   return ificmpgeEvaluator(node, cg);
+   return TR::TreeEvaluator::ificmpgeEvaluator(node, cg);
    }
 
 /**
@@ -1714,7 +1714,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::ifbcmpgtEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("ifbcmpgt", node, cg);
-   return ificmpgtEvaluator(node, cg);
+   return TR::TreeEvaluator::ificmpgtEvaluator(node, cg);
    }
 
 /**
@@ -1724,7 +1724,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::ifbcmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("ifbcmple", node, cg);
-   return ificmpleEvaluator(node, cg);
+   return TR::TreeEvaluator::ificmpleEvaluator(node, cg);
    }
 
 /**
@@ -1752,7 +1752,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::ifscmpltEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("ifscmplt", node, cg);
-   return ificmpltEvaluator(node, cg);
+   return TR::TreeEvaluator::ificmpltEvaluator(node, cg);
    }
 
 /**
@@ -1762,7 +1762,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::ifscmpgeEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("ifscmpge", node, cg);
-   return ificmpgeEvaluator(node, cg);
+   return TR::TreeEvaluator::ificmpgeEvaluator(node, cg);
    }
 
 /**
@@ -1772,7 +1772,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::ifscmpgtEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("ifscmpgt", node, cg);
-   return ificmpgtEvaluator(node, cg);
+   return TR::TreeEvaluator::ificmpgtEvaluator(node, cg);
    }
 
 /**
@@ -1782,7 +1782,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::ifscmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("ifscmple", node, cg);
-   return ificmpleEvaluator(node, cg);
+   return TR::TreeEvaluator::ificmpleEvaluator(node, cg);
    }
 
 /**
@@ -1810,7 +1810,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::ifsucmpltEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("ifsucmplt", node, cg);
-   return ificmpltEvaluator(node, cg);
+   return TR::TreeEvaluator::ificmpltEvaluator(node, cg);
    }
 
 /**
@@ -1820,7 +1820,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::ifsucmpgeEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("ifsucmpge", node, cg);
-   return ificmpgeEvaluator(node, cg);
+   return TR::TreeEvaluator::ificmpgeEvaluator(node, cg);
    }
 
 /**
@@ -1830,7 +1830,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::ifsucmpgtEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("ifsucmpgt", node, cg);
-   return ificmpgtEvaluator(node, cg);
+   return TR::TreeEvaluator::ificmpgtEvaluator(node, cg);
    }
 
 /**
@@ -1840,7 +1840,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::ifsucmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("ifsucmple", node, cg);
-   return ificmpleEvaluator(node, cg);
+   return TR::TreeEvaluator::ificmpleEvaluator(node, cg);
    }
 
 
@@ -2093,7 +2093,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::acmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("acmpeq", node, cg);
-   return icmpeqEvaluator(node, cg);
+   return TR::TreeEvaluator::icmpeqEvaluator(node, cg);
    }
 
 /**
@@ -2125,7 +2125,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::bcmpltEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("bcmplt", node, cg);
-   return icmpltEvaluator(node, cg);
+   return TR::TreeEvaluator::icmpltEvaluator(node, cg);
    }
 
 /**
@@ -2135,7 +2135,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::bcmpgeEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("bcmpge", node, cg);
-   return icmpgeEvaluator(node, cg);
+   return TR::TreeEvaluator::icmpgeEvaluator(node, cg);
    }
 
 /**
@@ -2145,7 +2145,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::bcmpgtEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("bcmpgt", node, cg);
-   return icmpgtEvaluator(node, cg);
+   return TR::TreeEvaluator::icmpgtEvaluator(node, cg);
    }
 
 /**
@@ -2155,7 +2155,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::bcmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("bcmple", node, cg);
-   return icmpleEvaluator(node, cg);
+   return TR::TreeEvaluator::icmpleEvaluator(node, cg);
    }
 
 /**
@@ -2183,7 +2183,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::scmpltEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("scmplt", node, cg);
-   return icmpltEvaluator(node, cg);
+   return TR::TreeEvaluator::icmpltEvaluator(node, cg);
    }
 
 /**
@@ -2193,7 +2193,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::scmpgeEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("scmpge", node, cg);
-   return icmpgeEvaluator(node, cg);
+   return TR::TreeEvaluator::icmpgeEvaluator(node, cg);
    }
 
 /**
@@ -2203,7 +2203,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::scmpgtEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("scmpgt", node, cg);
-   return icmpgtEvaluator(node, cg);
+   return TR::TreeEvaluator::icmpgtEvaluator(node, cg);
    }
 
 /**
@@ -2213,7 +2213,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::scmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("scmple", node, cg);
-   return icmpleEvaluator(node, cg);
+   return TR::TreeEvaluator::icmpleEvaluator(node, cg);
    }
 
 /**
@@ -2241,7 +2241,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::sucmpltEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("sucmplt", node, cg);
-   return icmpltEvaluator(node, cg);
+   return TR::TreeEvaluator::icmpltEvaluator(node, cg);
    }
 
 /**
@@ -2251,7 +2251,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::sucmpgeEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("sucmpge", node, cg);
-   return icmpgeEvaluator(node, cg);
+   return TR::TreeEvaluator::icmpgeEvaluator(node, cg);
    }
 
 /**
@@ -2261,7 +2261,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::sucmpgtEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("sucmpgt", node, cg);
-   return icmpgtEvaluator(node, cg);
+   return TR::TreeEvaluator::icmpgtEvaluator(node, cg);
    }
 
 /**
@@ -2271,7 +2271,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::sucmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("sucmple", node, cg);
-   return icmpleEvaluator(node, cg);
+   return TR::TreeEvaluator::icmpleEvaluator(node, cg);
    }
 
 /**
@@ -2296,21 +2296,21 @@ TR::Register *
 OMR::Z::TreeEvaluator::lucmpEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("lucmp", node, cg);
-   return badILOpEvaluator(node, cg);
+   return TR::TreeEvaluator::badILOpEvaluator(node, cg);
    }
 
 TR::Register *
 OMR::Z::TreeEvaluator::icmpEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("icmp", node, cg);
-   return badILOpEvaluator(node, cg);
+   return TR::TreeEvaluator::badILOpEvaluator(node, cg);
    }
 
 TR::Register *
 OMR::Z::TreeEvaluator::iucmpEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("iucmp", node, cg);
-   return badILOpEvaluator(node, cg);
+   return TR::TreeEvaluator::badILOpEvaluator(node, cg);
    }
 
 void OMR::Z::TreeEvaluator::tableEvaluatorCaseLabelHelper(TR::Node * node, TR::CodeGenerator * cg, tableKind tableKindToBeEvaluated, int32_t numBranchTableEntries, TR::Register * selectorReg, TR::Register * branchTableReg, TR::Register *reg1)
@@ -2479,7 +2479,7 @@ OMR::Z::TreeEvaluator::tableEvaluator(TR::Node * node, TR::CodeGenerator * cg)
          break;
       }
 
-   tableEvaluatorCaseLabelHelper(node,cg, tableKindToBeEvaluated, numBranchTableEntries, selectorReg, branchTableReg, reg1);
+   TR::TreeEvaluator::tableEvaluatorCaseLabelHelper(node,cg, tableKindToBeEvaluated, numBranchTableEntries, selectorReg, branchTableReg, reg1);
 
    TR::Instruction *cursor = generateS390RegInstruction(cg, TR::InstOpCode::BCR, node, selectorReg, deps);
    ((TR::S390RegInstruction *)cursor)->setBranchCondition(TR::InstOpCode::COND_BCR);
@@ -3085,7 +3085,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::NULLCHKEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("NULLCHK", node, cg);
-   return evaluateNULLCHKWithPossibleResolve(node, false, cg);
+   return TR::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(node, false, cg);
    }
 
 /**
@@ -3156,7 +3156,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::resolveAndNULLCHKEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("resolveAndNULLCHK", node, cg);
-   return evaluateNULLCHKWithPossibleResolve(node, true, cg);
+   return TR::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(node, true, cg);
    }
 
 
@@ -3217,11 +3217,11 @@ void OMR::Z::TreeEvaluator::createDAACondDeps(TR::Node * node, TR::RegisterDepen
          TR::S390RXInstruction * instr = (TR::S390RXInstruction *)daaInstr;
          TR::MemoryReference * mr = instr->getMemoryReference();
 
-         addToRegDep(daaDeps, instr->getRegisterOperand(1), false);
+         TR::TreeEvaluator::addToRegDep(daaDeps, instr->getRegisterOperand(1), false);
          if (mr)
          {
-               addToRegDep(daaDeps, (TR::Register *)mr->getBaseRegister(), false);
-               addToRegDep(daaDeps, (TR::Register *)mr->getIndexRegister(), false);
+               TR::TreeEvaluator::addToRegDep(daaDeps, (TR::Register *)mr->getBaseRegister(), false);
+               TR::TreeEvaluator::addToRegDep(daaDeps, (TR::Register *)mr->getIndexRegister(), false);
          }
 
          break;
@@ -3231,11 +3231,11 @@ void OMR::Z::TreeEvaluator::createDAACondDeps(TR::Node * node, TR::RegisterDepen
          TR::S390RXYInstruction * instr = (TR::S390RXYInstruction *)daaInstr;
          TR::MemoryReference * mr = instr->getMemoryReference();
 
-         addToRegDep(daaDeps, instr->getRegisterOperand(1), true);
+         TR::TreeEvaluator::addToRegDep(daaDeps, instr->getRegisterOperand(1), true);
          if (mr)
             {
-               addToRegDep(daaDeps, (TR::Register *)mr->getBaseRegister(), true);
-               addToRegDep(daaDeps, (TR::Register *)mr->getIndexRegister(), true);
+               TR::TreeEvaluator::addToRegDep(daaDeps, (TR::Register *)mr->getBaseRegister(), true);
+               TR::TreeEvaluator::addToRegDep(daaDeps, (TR::Register *)mr->getIndexRegister(), true);
             }
             break;
          }
@@ -3247,14 +3247,14 @@ void OMR::Z::TreeEvaluator::createDAACondDeps(TR::Node * node, TR::RegisterDepen
 
          if (mr1)
             {
-               addToRegDep(daaDeps, (TR::Register *)mr1->getBaseRegister(), false);
-               addToRegDep(daaDeps, (TR::Register *)mr1->getIndexRegister(), false);
+               TR::TreeEvaluator::addToRegDep(daaDeps, (TR::Register *)mr1->getBaseRegister(), false);
+               TR::TreeEvaluator::addToRegDep(daaDeps, (TR::Register *)mr1->getIndexRegister(), false);
             }
 
          if (mr2)
             {
-               addToRegDep(daaDeps, (TR::Register *)mr2->getBaseRegister(), false);
-               addToRegDep(daaDeps, (TR::Register *)mr2->getIndexRegister(), false);
+               TR::TreeEvaluator::addToRegDep(daaDeps, (TR::Register *)mr2->getBaseRegister(), false);
+               TR::TreeEvaluator::addToRegDep(daaDeps, (TR::Register *)mr2->getIndexRegister(), false);
             }
          break;
          }
@@ -3321,7 +3321,7 @@ OMR::Z::TreeEvaluator::butestEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("butest", node, cg);
 
-   commonButestEvaluator(node, cg);
+   TR::TreeEvaluator::commonButestEvaluator(node, cg);
    TR::Register *ccReg = getConditionCode(node, cg);
 
    node->setRegister(ccReg);
@@ -3360,7 +3360,7 @@ OMR::Z::TreeEvaluator::inlineIfButestEvaluator(TR::Node * node, TR::CodeGenerato
 
    TR::RegisterDependencyConditions *deps = getGLRegDepsDependenciesFromIfNode(cg, cmpOpNode);
 
-   commonButestEvaluator(node, cg);
+   TR::TreeEvaluator::commonButestEvaluator(node, cg);
 
    TR::InstOpCode::S390BranchCondition cond = getButestBranchCondition(cmpOpNode->getOpCodeValue(), cmpValNode->getInt());
    TR::Instruction * instr = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, cond, cmpOpNode, cmpOpNode->getBranchDestination()->getNode()->getLabel(), deps);
@@ -3555,7 +3555,7 @@ int32_t OMR::Z::TreeEvaluator::countReferencesInTree(TR::Node *treeNode, TR::Nod
    int32_t sum=0;
    for(int32_t i = 0 ; i < treeNode->getNumChildren() ; i++)
       {
-      sum += countReferencesInTree(treeNode->getChild(i), node);
+      sum += TR::TreeEvaluator::countReferencesInTree(treeNode->getChild(i), node);
       }
    return sum;
    }
@@ -3575,7 +3575,7 @@ OMR::Z::TreeEvaluator::treeContainsAllOtherUsesForNode(TR::Node *treeNode, TR::N
    if (numberOfInstancesToFind == 0)
       return true;
 
-   int32_t instancesFound = countReferencesInTree(treeNode, node);
+   int32_t instancesFound = TR::TreeEvaluator::countReferencesInTree(treeNode, node);
 
    //traceMsg(cg->comp(), "numberOfInstancesToFind = %d instancesFound = %d\n",numberOfInstancesToFind,instancesFound);
 
@@ -3599,8 +3599,8 @@ OMR::Z::TreeEvaluator::ternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       traceMsg(comp, "Starting evaluation of ternary node %p condition %p (in reg %p) trueVal %p (in reg %p) falseVal %p (in reg %p)\n",node,condition,condition->getRegister(), trueVal, trueVal->getRegister(), falseVal, falseVal->getRegister());
 
   TR::Register *trueReg = 0;
-  if(treeContainsAllOtherUsesForNode(condition,trueVal) &&
-     (!trueVal->isUnneededConversion() || treeContainsAllOtherUsesForNode(condition, trueVal->getFirstChild())))
+  if(TR::TreeEvaluator::treeContainsAllOtherUsesForNode(condition,trueVal) &&
+     (!trueVal->isUnneededConversion() || TR::TreeEvaluator::treeContainsAllOtherUsesForNode(condition, trueVal->getFirstChild())))
      {
      if (comp->getOption(TR_TraceCG))
         traceMsg(comp, "Calling evaluate (instead of clobber evaluate for node %p because all other uses are in the compare tree)\n",trueVal);
@@ -3624,7 +3624,7 @@ OMR::Z::TreeEvaluator::ternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       if (comp->getOption(TR_TraceCG))
          traceMsg(comp, "First Child %p is a compare\n",condition);
 
-      TR::InstOpCode::Mnemonic compareOp = getCompareOpFromNode(cg, condition);
+      TR::InstOpCode::Mnemonic compareOp = TR::TreeEvaluator::getCompareOpFromNode(cg, condition);
 
       TR::Node *firstChild = condition->getFirstChild();
       TR::Node *secondChild = condition->getSecondChild();
@@ -3635,7 +3635,7 @@ OMR::Z::TreeEvaluator::ternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       cg->decReferenceCount(firstChild);
       cg->decReferenceCount(secondChild);
 
-      TR::InstOpCode::S390BranchCondition bc = getBranchConditionFromCompareOpCode(condition->getOpCodeValue());
+      TR::InstOpCode::S390BranchCondition bc = TR::TreeEvaluator::getBranchConditionFromCompareOpCode(condition->getOpCodeValue());
 
       if (comp->getOption(TR_TraceCG))
          traceMsg(comp, "Emitting a compare between reg %p and %p instruction\n", firstReg, secondReg);
@@ -3652,7 +3652,7 @@ OMR::Z::TreeEvaluator::ternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg)
          generateRRFInstruction(cg, is64BitRegister ? TR::InstOpCode::LOCGR: TR::InstOpCode::LOCR, node, trueReg->getLowOrder(), falseReg->getLowOrder(), getMaskForBranchCondition(TR::InstOpCode::COND_BERC)>>4, true);
       }
       else
-         generateRRFInstruction(cg, trueVal->getOpCode().is8Byte() ? TR::InstOpCode::LOCGR: TR::InstOpCode::LOCR, node, trueReg, falseReg, getMaskForBranchCondition(mapBranchConditionToLOCRCondition(bc))>>4, true);
+         generateRRFInstruction(cg, trueVal->getOpCode().is8Byte() ? TR::InstOpCode::LOCGR: TR::InstOpCode::LOCR, node, trueReg, falseReg, getMaskForBranchCondition(TR::TreeEvaluator::mapBranchConditionToLOCRCondition(bc))>>4, true);
       }
    else
       {

--- a/compiler/z/codegen/FPTreeEvaluator.cpp
+++ b/compiler/z/codegen/FPTreeEvaluator.cpp
@@ -837,7 +837,7 @@ OMR::Z::TreeEvaluator::floadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    //traceMsg(comp,"In fload evaluator for Node %p. isRegisterSymbol = %d\n",node,node->getSymbolReference()->getSymbol()->isRegisterSymbol());
 
    if (node->getSymbolReference()->getSymbol()->isRegisterSymbol())
-     return fRegLoadEvaluator(node, cg);
+     return TR::TreeEvaluator::fRegLoadEvaluator(node, cg);
    else
      return floadHelper(node, cg, NULL);
    }
@@ -846,7 +846,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::dloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    if (node->getSymbolReference()->getSymbol()->isRegisterSymbol())
-     return dRegLoadEvaluator(node, cg);
+     return TR::TreeEvaluator::dRegLoadEvaluator(node, cg);
    else
      return dloadHelper(node, cg, NULL);
    }
@@ -855,7 +855,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::fstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    if (node->getSymbolReference()->getSymbol()->isRegisterSymbol())
-     fRegStoreEvaluator(node, cg);
+     TR::TreeEvaluator::fRegStoreEvaluator(node, cg);
    else
      fstoreHelper(node, cg);
    return NULL;
@@ -865,7 +865,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::dstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    if (node->getSymbolReference()->getSymbol()->isRegisterSymbol())
-     dRegStoreEvaluator(node, cg);
+     TR::TreeEvaluator::dRegStoreEvaluator(node, cg);
    else
      dstoreHelper(node, cg);
    return NULL;
@@ -1116,13 +1116,13 @@ OMR::Z::TreeEvaluator::floatRemHelper(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::dremEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   return floatRemHelper(node, cg);
+   return TR::TreeEvaluator::floatRemHelper(node, cg);
    }
 
 TR::Register *
 OMR::Z::TreeEvaluator::fremEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   return floatRemHelper(node, cg);
+   return TR::TreeEvaluator::floatRemHelper(node, cg);
    }
 
 TR::Register *
@@ -2352,25 +2352,25 @@ OMR::Z::TreeEvaluator::dRegStoreEvaluator(TR::Node * node, TR::CodeGenerator * c
 TR::Register *
 OMR::Z::TreeEvaluator::dceilEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   return floorCeilEvaluator(node, cg, TR::InstOpCode::FIDBR, (int8_t)0x6);
+   return TR::TreeEvaluator::floorCeilEvaluator(node, cg, TR::InstOpCode::FIDBR, (int8_t)0x6);
    }
 
 TR::Register *
 OMR::Z::TreeEvaluator::dfloorEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   return floorCeilEvaluator(node, cg, TR::InstOpCode::FIDBR, (int8_t)0x7);
+   return TR::TreeEvaluator::floorCeilEvaluator(node, cg, TR::InstOpCode::FIDBR, (int8_t)0x7);
    }
 
 TR::Register *
 OMR::Z::TreeEvaluator::fceilEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   return floorCeilEvaluator(node, cg, TR::InstOpCode::FIEBR, (int8_t)0x6);
+   return TR::TreeEvaluator::floorCeilEvaluator(node, cg, TR::InstOpCode::FIEBR, (int8_t)0x6);
    }
 
 TR::Register *
 OMR::Z::TreeEvaluator::ffloorEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   return floorCeilEvaluator(node, cg, TR::InstOpCode::FIEBR, (int8_t)0x7);
+   return TR::TreeEvaluator::floorCeilEvaluator(node, cg, TR::InstOpCode::FIEBR, (int8_t)0x7);
    }
 
 TR::Register *

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -5231,7 +5231,7 @@ OMR::Z::TreeEvaluator::narrowCastEvaluator(TR::Node * node, TR::CodeGenerator * 
       targetRegister = targetRegister->getLowOrder();
    else
      {
-      targetRegister = passThroughEvaluator(node, cg);
+      targetRegister = TR::TreeEvaluator::passThroughEvaluator(node, cg);
       if(targetRegister->getStartOfRangeNode() == firstChild)
         targetRegister->setStartOfRangeNode(node);
       return targetRegister;
@@ -5335,20 +5335,20 @@ OMR::Z::TreeEvaluator::addressCastEvaluator(TR::Node * node, TR::CodeGenerator *
    if (otherSize == addrSize)
       {
       //CASE(1);
-      return passThroughEvaluator(node, cg);
+      return TR::TreeEvaluator::passThroughEvaluator(node, cg);
       }
    else if (dirToAddr && otherSize > addrSize) //i.e. (otherSize)2a
       {
       //CASE(2);
       switch (addrSize)
          {
-      case 56:         return extendCastEvaluator<false, 56, 64>(node, cg);   break;
-      case 48:         return extendCastEvaluator<false, 48, 64>(node, cg);   break;
-      case 40:         return extendCastEvaluator<false, 40, 64>(node, cg);   break;
-      case 32:         return narrowCastEvaluator<false, 32>(node, cg);         break;
-      case 24:         return narrowCastEvaluator<false, 24>(node, cg);         break;
-      case 16:         return narrowCastEvaluator<false, 16>(node, cg);         break;
-      case 8:          return narrowCastEvaluator<false,  8>(node, cg);         break;
+      case 56:         return TR::TreeEvaluator::extendCastEvaluator<false, 56, 64>(node, cg);   break;
+      case 48:         return TR::TreeEvaluator::extendCastEvaluator<false, 48, 64>(node, cg);   break;
+      case 40:         return TR::TreeEvaluator::extendCastEvaluator<false, 40, 64>(node, cg);   break;
+      case 32:         return TR::TreeEvaluator::narrowCastEvaluator<false, 32>(node, cg);         break;
+      case 24:         return TR::TreeEvaluator::narrowCastEvaluator<false, 24>(node, cg);         break;
+      case 16:         return TR::TreeEvaluator::narrowCastEvaluator<false, 16>(node, cg);         break;
+      case 8:          return TR::TreeEvaluator::narrowCastEvaluator<false,  8>(node, cg);         break;
       default:
          TR_ASSERT(0, "Invalid Address Precision (%d)\n", addrSize);
          break;
@@ -5387,14 +5387,14 @@ OMR::Z::TreeEvaluator::addressCastEvaluator(TR::Node * node, TR::CodeGenerator *
       //CASE(6);
       switch (addrSize)
          {
-      case 56:         return extendCastEvaluator<false, 56, 64>(node, cg);   break;
-      case 48:         return extendCastEvaluator<false, 48, 64>(node, cg);   break;
-      case 40:         return extendCastEvaluator<false, 40, 64>(node, cg);   break;
+      case 56:         return TR::TreeEvaluator::extendCastEvaluator<false, 56, 64>(node, cg);   break;
+      case 48:         return TR::TreeEvaluator::extendCastEvaluator<false, 48, 64>(node, cg);   break;
+      case 40:         return TR::TreeEvaluator::extendCastEvaluator<false, 40, 64>(node, cg);   break;
                        // NOTE 31, on purpose!
-      case 32:         return extendCastEvaluator<false, 31, 64>(node, cg); break;
-      case 24:         return extendCastEvaluator<false, 24, (otherSize>32) ? 64:32>(node, cg);       break;
-      case 16:         return extendCastEvaluator<false, 16, (otherSize>32) ? 64:32>(node, cg);       break;
-      case 8:          return extendCastEvaluator<false,  8, (otherSize>32) ? 64:32>(node, cg);       break;
+      case 32:         return TR::TreeEvaluator::extendCastEvaluator<false, 31, 64>(node, cg); break;
+      case 24:         return TR::TreeEvaluator::extendCastEvaluator<false, 24, (otherSize>32) ? 64:32>(node, cg);       break;
+      case 16:         return TR::TreeEvaluator::extendCastEvaluator<false, 16, (otherSize>32) ? 64:32>(node, cg);       break;
+      case 8:          return TR::TreeEvaluator::extendCastEvaluator<false,  8, (otherSize>32) ? 64:32>(node, cg);       break;
       default:
          TR_ASSERT(0, "Invalid Address Precision (%d)\n", addrSize);
          break;
@@ -7072,7 +7072,7 @@ OMR::Z::TreeEvaluator::aloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    PRINT_ME("aload", node, cg);
 
    if (node->getSymbolReference()->getSymbol()->isRegisterSymbol())
-     return aRegLoadEvaluator(node, cg);
+     return TR::TreeEvaluator::aRegLoadEvaluator(node, cg);
 
    return aloadHelper(node, cg, NULL);
    }
@@ -7262,7 +7262,7 @@ OMR::Z::TreeEvaluator::iloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("iload", node, cg);
    if (node->getSymbolReference()->getSymbol()->isRegisterSymbol())
-     return iRegLoadEvaluator(node, cg);
+     return TR::TreeEvaluator::iRegLoadEvaluator(node, cg);
    else
      return iloadHelper(node, cg, NULL);
    }
@@ -7277,7 +7277,7 @@ OMR::Z::TreeEvaluator::lloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("lload", node, cg);
    if (node->getSymbolReference()->getSymbol()->isRegisterSymbol())
-     return lRegLoadEvaluator(node, cg);
+     return TR::TreeEvaluator::lRegLoadEvaluator(node, cg);
    else if (!cg->evaluateNodeInRegPair(node) &&
       (TR::Compiler->target.is64Bit() || cg->use64BitRegsOn32Bit()))
       {
@@ -7298,7 +7298,7 @@ OMR::Z::TreeEvaluator::sloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("sload", node, cg);
    if (node->getSymbolReference()->getSymbol()->isRegisterSymbol())
-     return iRegLoadEvaluator(node, cg);
+     return TR::TreeEvaluator::iRegLoadEvaluator(node, cg);
    else
      return sloadHelper(node, cg, NULL);
    }
@@ -7314,7 +7314,7 @@ OMR::Z::TreeEvaluator::bloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::Compilation *comp = cg->comp();
 
    if (node->getSymbolReference()->getSymbol()->isRegisterSymbol())
-     return iRegLoadEvaluator(node, cg);
+     return TR::TreeEvaluator::iRegLoadEvaluator(node, cg);
 
 
    TR::Register * tempReg;
@@ -7392,7 +7392,7 @@ OMR::Z::TreeEvaluator::istoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    bool adjustRefCnt = false;
 
    if (node->getSymbolReference()->getSymbol()->isRegisterSymbol())
-      iRegStoreEvaluator(node, cg);
+      TR::TreeEvaluator::iRegStoreEvaluator(node, cg);
    else
       istoreHelper(node, cg);
    if (adjustRefCnt)
@@ -7411,7 +7411,7 @@ OMR::Z::TreeEvaluator::lstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("lstore", node, cg);
    if (node->getSymbolReference()->getSymbol()->isRegisterSymbol())
-     lRegStoreEvaluator(node, cg);
+     TR::TreeEvaluator::lRegStoreEvaluator(node, cg);
    else if (TR::Compiler->target.is64Bit() || cg->use64BitRegsOn32Bit())
       {
       lstoreHelper64(node, cg);
@@ -7433,7 +7433,7 @@ OMR::Z::TreeEvaluator::sstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("sstore", node, cg);
    if (node->getSymbolReference()->getSymbol()->isRegisterSymbol())
-     iRegStoreEvaluator(node, cg);
+     TR::TreeEvaluator::iRegStoreEvaluator(node, cg);
    else
      sstoreHelper(node, cg);
    return NULL;
@@ -7448,7 +7448,7 @@ OMR::Z::TreeEvaluator::cstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("cstore", node, cg);
    if (node->getSymbolReference()->getSymbol()->isRegisterSymbol())
-     iRegStoreEvaluator(node, cg);
+     TR::TreeEvaluator::iRegStoreEvaluator(node, cg);
    else
      sstoreHelper(node, cg);
    return NULL;
@@ -7463,7 +7463,7 @@ OMR::Z::TreeEvaluator::astoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("astore", node, cg);
    if (node->getSymbolReference()->getSymbol()->isRegisterSymbol())
-     iRegStoreEvaluator(node, cg);
+     TR::TreeEvaluator::iRegStoreEvaluator(node, cg);
    else
      astoreHelper(node, cg);
    return NULL;
@@ -7502,7 +7502,7 @@ OMR::Z::TreeEvaluator::bstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
    if (node->getSymbolReference()->getSymbol()->isRegisterSymbol())
      {
-     iRegStoreEvaluator(node, cg);
+     TR::TreeEvaluator::iRegStoreEvaluator(node, cg);
      return NULL;
      }
    // Use MVI when we can
@@ -10413,7 +10413,7 @@ OMR::Z::TreeEvaluator::arraycmpHelper(TR::Node *node,
          {
          source1Reg = cg->evaluate(source1Node);
          source2Reg = cg->evaluate(source2Node);
-         lengthReg = evaluateLengthMinusOneForMemoryCmp(lengthNode, cg, true, lenMinusOne);
+         lengthReg = TR::TreeEvaluator::evaluateLengthMinusOneForMemoryCmp(lengthNode, cg, true, lenMinusOne);
 
          if (isWideChar)
             {
@@ -10751,7 +10751,7 @@ OMR::Z::TreeEvaluator::arraycmpHelper(TR::Node *node,
 TR::Register *
 OMR::Z::TreeEvaluator::memcmpEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return arraycmpHelper(node, cg, false);
+   return TR::TreeEvaluator::arraycmpHelper(node, cg, false);
    }
 
 
@@ -10785,15 +10785,15 @@ OMR::Z::TreeEvaluator::inlineIfArraycmpEvaluator(TR::Node *node, TR::CodeGenerat
    TR::Register *ret;
    if (opNode->getOpCodeValue() == TR::arraycmp)
       {
-      ret = arraycmpHelper(opNode,
-                           cg,
-                           isWide,        //isWideChar
-                           isEqualCmp,    //isEqualCmp
-                           compareVal,    //cmpValue
-                           compareTarget, //compareTarget
-                           node,          //ificmpNode
-                           false,         //needResultReg
-                           true);         //return102
+      ret = TR::TreeEvaluator::arraycmpHelper(opNode,
+                                              cg,
+                                              isWide,        //isWideChar
+                                              isEqualCmp,    //isEqualCmp
+                                              compareVal,    //cmpValue
+                                              compareTarget, //compareTarget
+                                              node,          //ificmpNode
+                                              false,         //needResultReg
+                                              true);         //return102
       }
    else
       {
@@ -11301,7 +11301,7 @@ OMR::Z::TreeEvaluator::directCallEvaluator(TR::Node * node, TR::CodeGenerator * 
 
    if (!cg->inlineDirectCall(node, resultReg))
       {
-      resultReg = performCall(node, false, cg);
+      resultReg = TR::TreeEvaluator::performCall(node, false, cg);
        // on 64bit, lcall returns 64bit registers
       if (cg->supportsHighWordFacility() && !cg->comp()->getOption(TR_DisableHighWordRA) && TR::Compiler->target.is64Bit())
          {
@@ -11337,7 +11337,7 @@ OMR::Z::TreeEvaluator::indirectCallEvaluator(TR::Node * node, TR::CodeGenerator 
 #endif
       }
 
-   TR::Register * returnRegister = performCall(node, true, cg);
+   TR::Register * returnRegister = TR::TreeEvaluator::performCall(node, true, cg);
 
    // on 64bit, lcall returns 64bit registers
    if (cg->supportsHighWordFacility() && !cg->comp()->getOption(TR_DisableHighWordRA) && TR::Compiler->target.is64Bit())
@@ -11934,15 +11934,16 @@ OMR::Z::TreeEvaluator::arraycmpEvaluator(TR::Node * node, TR::CodeGenerator * cg
          bool    clobber = (comp->getOption(TR_DisableSSOpts) || elems>256 || elems==0 || node->isArrayCmpSign());
          if (!node->isArrayCmpSign())
             {
-            resultReg = arraycmpHelper(node,
-                                       cg,
-                                       false, //isWideChar
-                                       true,  //isEqualCmp
-                                       0,     //cmpValue. It means it is equivalent to do "arraycmp(A,B) == 0"
-                                       NULL,  //compareTarget
-                                       NULL,  //ificmpNode
-                                       true,  //needResultReg
-                                       true); //return102
+            resultReg = TR::TreeEvaluator::arraycmpHelper(
+                            node,
+                            cg,
+                            false, //isWideChar
+                            true,  //isEqualCmp
+                            0,     //cmpValue. It means it is equivalent to do "arraycmp(A,B) == 0"
+                            NULL,  //compareTarget
+                            NULL,  //ificmpNode
+                            true,  //needResultReg
+                            true); //return102
             // node->setRegister(resultReg);
             return resultReg;
             }
@@ -11961,15 +11962,16 @@ OMR::Z::TreeEvaluator::arraycmpEvaluator(TR::Node * node, TR::CodeGenerator * cg
 
          if (!node->isArrayCmpSign())
             {
-            resultReg = arraycmpHelper(node,
-                                       cg,
-                                       false, //isWideChar
-                                       true,  //isEqualCmp
-                                       0,     //cmpValue. It means it is equivalent to do "arraycmp(A,B) == 0"
-                                       NULL,  //compareTarget
-                                       NULL,  //ificmpNode
-                                       true,  //needResultReg
-                                       true); //return102
+            resultReg = TR::TreeEvaluator::arraycmpHelper(
+                          node,
+                          cg,
+                          false, //isWideChar
+                          true,  //isEqualCmp
+                          0,     //cmpValue. It means it is equivalent to do "arraycmp(A,B) == 0"
+                          NULL,  //compareTarget
+                          NULL,  //ificmpNode
+                          true,  //needResultReg
+                          true); //return102
 
             // node->setRegister(resultReg);
             return resultReg;
@@ -14489,7 +14491,7 @@ TR::Register *OMR::Z::TreeEvaluator::bitOpMemEvaluator(TR::Node * node, TR::Code
    if (byteDstReg!=NULL) cg->decReferenceCount(byteDstNode);
    if (byteLenNode) cg->decReferenceCount(byteLenNode);
 
-   return getConditionCodeOrFold(node, cg, foldType, parent);
+   return TR::TreeEvaluator::getConditionCodeOrFold(node, cg, foldType, parent);
    }
 
 
@@ -14526,7 +14528,7 @@ TR::Register *OMR::Z::TreeEvaluator::libmFuncEvaluator(TR::Node *node, TR::CodeG
    else
       TR_ASSERT(false, "Invalid type for libmFuncEvaluator.\n");
 
-   TR::Register *trgReg = directCallEvaluator(node, cg);
+   TR::Register *trgReg = TR::TreeEvaluator::directCallEvaluator(node, cg);
    return trgReg;
    }
 
@@ -14564,7 +14566,7 @@ TR::Register *OMR::Z::TreeEvaluator::libxloptFuncEvaluator(TR::Node *node, TR::C
    node->setSymbolReference(callSymRef);
 
    // And finally evaluate the tree
-   TR::Register *trgReg = directCallEvaluator(node,cg);
+   TR::Register *trgReg = TR::TreeEvaluator::directCallEvaluator(node,cg);
 
    return trgReg;
    }
@@ -16158,9 +16160,9 @@ TR::Register *OMR::Z::TreeEvaluator::inlineIfTestDataClassHelper(TR::Node *node,
  */
 TR::Register *OMR::Z::TreeEvaluator::getConditionCodeOrFold(TR::Node *node, TR::CodeGenerator *cg, TR_FoldType foldType, TR::Node *parent){
    switch(foldType){
-      case TR_FoldNone: return getConditionCodeOrFoldIf(node, cg, false, NULL);
-      case TR_FoldIf: return getConditionCodeOrFoldIf(node, cg, true, parent);
-      case TR_FoldLookup: return foldLookup(cg, parent);
+      case TR_FoldNone: return TR::TreeEvaluator::getConditionCodeOrFoldIf(node, cg, false, NULL);
+      case TR_FoldIf: return TR::TreeEvaluator::getConditionCodeOrFoldIf(node, cg, true, parent);
+      case TR_FoldLookup: return TR::TreeEvaluator::foldLookup(cg, parent);
       case TR_FoldNoIPM: return NULL;
       default: TR_ASSERT(false, "unexpected folding type\n");
    }
@@ -16332,7 +16334,7 @@ OMR::Z::TreeEvaluator::inlineVectorUnaryOp(TR::Node * node,
    TR_ASSERT(node->getNumChildren() <= 1, "Unary node must only contain 1 or less children");
 
    TR::Node   *firstChild = node->getFirstChild();
-   TR::Register *returnReg = tryToReuseInputVectorRegs(node, cg);
+   TR::Register *returnReg = TR::TreeEvaluator::tryToReuseInputVectorRegs(node, cg);
    TR::Register *sourceReg1 = cg->evaluate(firstChild);
 
    switch (op)
@@ -16361,7 +16363,7 @@ OMR::Z::TreeEvaluator::inlineVectorBinaryOp(TR::Node * node, TR::CodeGenerator *
    TR::Node *firstChild  = node->getFirstChild();
    TR::Node *secondChild = node->getSecondChild();
 
-   TR::Register *targetReg  = tryToReuseInputVectorRegs(node, cg);
+   TR::Register *targetReg  = TR::TreeEvaluator::tryToReuseInputVectorRegs(node, cg);
    TR::Register *sourceReg1 = cg->evaluate(firstChild);
    TR::Register *sourceReg2 = cg->evaluate(secondChild);
 
@@ -16421,7 +16423,7 @@ OMR::Z::TreeEvaluator::inlineVectorTernaryOp(TR::Node * node, TR::CodeGenerator 
    TR::Node *secondChild = node->getSecondChild();
    TR::Node *thirdChild  = node->getThirdChild();
 
-   TR::Register *targetReg  = tryToReuseInputVectorRegs(node, cg);
+   TR::Register *targetReg  = TR::TreeEvaluator::tryToReuseInputVectorRegs(node, cg);
 
    TR::Register *sourceReg1 = cg->evaluate(firstChild);
    TR::Register *sourceReg2 = cg->evaluate(secondChild);
@@ -16465,7 +16467,7 @@ OMR::Z::TreeEvaluator::vloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    TR::InstOpCode::Mnemonic opcode = TR::InstOpCode::BAD;
 
    if (node->getSymbolReference()->getSymbol()->isRegisterSymbol())
-     return vRegLoadEvaluator(node, cg);
+     return TR::TreeEvaluator::vRegLoadEvaluator(node, cg);
 
    if (node->getOpCodeValue() == TR::vload ||
        node->getOpCodeValue() == TR::vloadi)
@@ -16527,7 +16529,7 @@ OMR::Z::TreeEvaluator::vstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    TR::InstOpCode::Mnemonic opcode = TR::InstOpCode::BAD;
 
    if (node->getSymbolReference()->getSymbol()->isRegisterSymbol())
-     return vRegStoreEvaluator(node, cg);
+     return TR::TreeEvaluator::vRegStoreEvaluator(node, cg);
 
    if (node->getOpCodeValue() == TR::vstore ||
        node->getOpCodeValue() == TR::vstorei)
@@ -16556,13 +16558,13 @@ OMR::Z::TreeEvaluator::vstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 TR::Register *
 OMR::Z::TreeEvaluator::vdremEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorBinaryOp(node, cg, TR::InstOpCode::BAD);
+   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::BAD);
    }
 
 TR::Register *
 OMR::Z::TreeEvaluator::vdmaddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorTernaryOp(node, cg, TR::InstOpCode::VFMA);
+   return TR::TreeEvaluator::inlineVectorTernaryOp(node, cg, TR::InstOpCode::VFMA);
    }
 
 TR::Register *
@@ -18279,8 +18281,8 @@ OMR::Z::TreeEvaluator::vnegEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       case TR::VectorInt8:
       case TR::VectorInt16:
       case TR::VectorInt32:
-      case TR::VectorInt64: return inlineVectorUnaryOp(node, cg, TR::InstOpCode::VLC);
-      case TR::VectorDouble: return inlineVectorUnaryOp(node, cg, TR::InstOpCode::VFPSO);
+      case TR::VectorInt64: return TR::TreeEvaluator::inlineVectorUnaryOp(node, cg, TR::InstOpCode::VLC);
+      case TR::VectorDouble: return TR::TreeEvaluator::inlineVectorUnaryOp(node, cg, TR::InstOpCode::VFPSO);
       default: TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
       }
    }
@@ -18401,8 +18403,8 @@ OMR::Z::TreeEvaluator::vaddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
          case TR::VectorInt8:
          case TR::VectorInt16:
          case TR::VectorInt32:
-         case TR::VectorInt64: return inlineVectorBinaryOp(node, cg, TR::InstOpCode::VA);
-         case TR::VectorDouble: return inlineVectorBinaryOp(node, cg, TR::InstOpCode::VFA);
+         case TR::VectorInt64: return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::VA);
+         case TR::VectorDouble: return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::VFA);
          default: TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
          }
       }
@@ -18427,8 +18429,8 @@ OMR::Z::TreeEvaluator::vsubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
          case TR::VectorInt8:
          case TR::VectorInt16:
          case TR::VectorInt32:
-         case TR::VectorInt64: return inlineVectorBinaryOp(node, cg, TR::InstOpCode::VS);
-         case TR::VectorDouble: return inlineVectorBinaryOp(node, cg, TR::InstOpCode::VFS);
+         case TR::VectorInt64: return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::VS);
+         case TR::VectorDouble: return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::VFS);
          default: TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
          }
       }
@@ -18441,7 +18443,7 @@ OMR::Z::TreeEvaluator::vmulEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       {
       case TR::VectorInt8:
       case TR::VectorInt16:
-      case TR::VectorInt32: return inlineVectorBinaryOp(node, cg, TR::InstOpCode::VML);
+      case TR::VectorInt32: return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::VML);
       case TR::VectorInt64:
          {
          // emulated, no Z instruction available
@@ -18488,7 +18490,7 @@ OMR::Z::TreeEvaluator::vmulEvaluator(TR::Node *node, TR::CodeGenerator *cg)
          cg->decReferenceCount(node->getChild(1));
          return returnReg;
          }
-      case TR::VectorDouble: return inlineVectorBinaryOp(node, cg, TR::InstOpCode::VFM);
+      case TR::VectorDouble: return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::VFM);
       default: TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
       }
    }
@@ -18586,8 +18588,8 @@ OMR::Z::TreeEvaluator::vdivEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       case TR::VectorInt8:
       case TR::VectorInt16:
       case TR::VectorInt32:
-      case TR::VectorInt64: return vDivOrRemHelper(node, cg, true);
-      case TR::VectorDouble: return inlineVectorBinaryOp(node, cg, TR::InstOpCode::VFD);
+      case TR::VectorInt64: return TR::TreeEvaluator::vDivOrRemHelper(node, cg, true);
+      case TR::VectorDouble: return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::VFD);
       default: TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
       }
    }
@@ -18595,25 +18597,25 @@ OMR::Z::TreeEvaluator::vdivEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 TR::Register *
 OMR::Z::TreeEvaluator::vremEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return vDivOrRemHelper(node, cg, false);
+   return TR::TreeEvaluator::vDivOrRemHelper(node, cg, false);
    }
 
 TR::Register *
 OMR::Z::TreeEvaluator::vandEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorBinaryOp(node, cg, TR::InstOpCode::VN);
+   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::VN);
    }
 
 TR::Register *
 OMR::Z::TreeEvaluator::vorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorBinaryOp(node, cg, TR::InstOpCode::VO);
+   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::VO);
    }
 
 TR::Register *
 OMR::Z::TreeEvaluator::vxorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorBinaryOp(node, cg, TR::InstOpCode::VX);
+   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::VX);
    }
 
 /**
@@ -18700,8 +18702,8 @@ OMR::Z::TreeEvaluator::vcmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       case TR::VectorInt8:
       case TR::VectorInt16:
       case TR::VectorInt32:
-      case TR::VectorInt64: return inlineVectorBinaryOp(node, cg, TR::InstOpCode::VCEQ);
-      case TR::VectorDouble: return inlineVectorBinaryOp(node, cg, TR::InstOpCode::VFCE);
+      case TR::VectorInt64: return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::VCEQ);
+      case TR::VectorDouble: return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::VFCE);
       default: TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
       }
    }
@@ -18715,8 +18717,8 @@ OMR::Z::TreeEvaluator::vcmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       case TR::VectorInt8:
       case TR::VectorInt16:
       case TR::VectorInt32:
-      case TR::VectorInt64: targetReg = inlineVectorBinaryOp(node, cg, TR::InstOpCode::VCEQ); break;
-      case TR::VectorDouble: targetReg = inlineVectorBinaryOp(node, cg, TR::InstOpCode::VFCE); break;
+      case TR::VectorInt64: targetReg = TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::VCEQ); break;
+      case TR::VectorDouble: targetReg = TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::VFCE); break;
       default: TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); break;
       }
 
@@ -18733,7 +18735,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::vcmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    node->swapChildren();
-   return vcmpgtEvaluator(node, cg);
+   return TR::TreeEvaluator::vcmpgtEvaluator(node, cg);
    }
 
 TR::Register *
@@ -18745,8 +18747,8 @@ OMR::Z::TreeEvaluator::vcmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       case TR::VectorInt8:
       case TR::VectorInt16:
       case TR::VectorInt32:
-      case TR::VectorInt64: return inlineVectorBinaryOp(node, cg, op);
-      case TR::VectorDouble: return inlineVectorBinaryOp(node, cg, TR::InstOpCode::VFCH);
+      case TR::VectorInt64: return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, op);
+      case TR::VectorDouble: return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::VFCH);
       default: TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
       }
    }
@@ -18755,7 +18757,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::vcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    node->swapChildren();
-   return vcmpgeEvaluator(node, cg);
+   return TR::TreeEvaluator::vcmpgeEvaluator(node, cg);
    }
 
 TR::Register *
@@ -18764,7 +18766,7 @@ OMR::Z::TreeEvaluator::vcmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    TR::InstOpCode::Mnemonic op = node->getOpCode().isUnsignedCompare() ? TR::InstOpCode::VCHL : TR::InstOpCode::VCH;
 
    if (node->getFirstChild()->getDataType() == TR::VectorDouble)
-      return inlineVectorBinaryOp(node, cg, TR::InstOpCode::VFCHE);
+      return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::VFCHE);
    else
       {
       TR::Node *firstChild = node->getFirstChild();

--- a/compiler/z/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.hpp
@@ -78,7 +78,7 @@ namespace OMR
 namespace Z
 {
 
-class TreeEvaluator: public OMR::TreeEvaluator
+class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    {
    public:
 

--- a/compiler/z/codegen/UnaryEvaluator.cpp
+++ b/compiler/z/codegen/UnaryEvaluator.cpp
@@ -448,7 +448,7 @@ OMR::Z::TreeEvaluator::l2aEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::Compilation *comp = cg->comp();
    if (!comp->useCompressedPointers())
       {
-      return addressCastEvaluator<64, true>(node, cg);
+      return TR::TreeEvaluator::addressCastEvaluator<64, true>(node, cg);
       }
 
    // if comp->useCompressedPointers


### PR DESCRIPTION
Since the TreeEvaluator hierarchy is extensible, it should be marked as such using OMR_EXTENSIBLE. The resulting linting errors are also resolved.