### PR TITLE
Implement OffsetOf and a convenience API for overlaying structs

### DIFF
--- a/compiler/ilgen/TypeDictionary.cpp
+++ b/compiler/ilgen/TypeDictionary.cpp
@@ -164,6 +164,7 @@ public:
    void AddField(const char *name, TR::IlType *fieldType, size_t offset);
    void AddField(const char *name, TR::IlType *fieldType);
    TR::IlType * getFieldType(const char *fieldName);
+   size_t getFieldOffset(const char *fieldName);
 
    TR::SymbolReference *getFieldSymRef(const char *name);
    bool isStruct() { return true; }
@@ -234,6 +235,15 @@ StructType::getFieldType(const char *fieldName)
    if (NULL == info)
       return NULL;
    return info->_type;
+   }
+
+size_t
+StructType::getFieldOffset(const char *fieldName)
+   {
+   FieldInfo *info = findField(fieldName);
+   if (NULL == info)
+      return -1;
+   return info->getOffset();
    }
 
 TR::IlReference *
@@ -419,6 +429,16 @@ TypeDictionary::GetFieldType(const char *structName, const char *fieldName)
    _structsByName->locate(structName, structID);
    StructType *theStruct = (StructType *) _structsByName->getData(structID);
    return theStruct->getFieldType(fieldName);
+   }
+
+size_t
+TypeDictionary::OffsetOf(const char *structName, const char *fieldName)
+   {
+   TR_HashId structID = 0;
+   bool structNameFound = _structsByName->locate(structName, structID);
+   TR_ASSERT(structNameFound, "No struct with name %s found when getting offset of field %s\n", structName, fieldName);
+   StructType *theStruct = (StructType *) _structsByName->getData(structID);
+   return theStruct->getFieldOffset(fieldName);
    }
 
 void

--- a/compiler/ilgen/TypeDictionary.hpp
+++ b/compiler/ilgen/TypeDictionary.hpp
@@ -204,6 +204,13 @@ public:
    void CloseStruct(const char *structName);
 
    TR::IlType * GetFieldType(const char *structName, const char *fieldName);
+
+   /**
+    * @brief Returns the offset of a field in a struct
+    * @param structName the name of the struct containing the field
+    * @param fieldName the name of the field in the struct
+    * @return the memory offset of the field in bytes
+    */
    size_t OffsetOf(const char *structName, const char *fieldName);
 
    TR::IlType *PrimitiveType(TR::DataType primitiveType)

--- a/compiler/ilgen/TypeDictionary.hpp
+++ b/compiler/ilgen/TypeDictionary.hpp
@@ -204,6 +204,7 @@ public:
    void CloseStruct(const char *structName);
 
    TR::IlType * GetFieldType(const char *structName, const char *fieldName);
+   size_t OffsetOf(const char *structName, const char *fieldName);
 
    TR::IlType *PrimitiveType(TR::DataType primitiveType)
       {

--- a/compiler/ilgen/TypeDictionary.hpp
+++ b/compiler/ilgen/TypeDictionary.hpp
@@ -75,6 +75,53 @@ protected:
    };
 
 
+/**
+ * @brief Convenience API for defining JitBuilder structs from C/C++ structs (PODs)
+ * 
+ * These macros simply allow the name of C/C++ structs and fields to be used to
+ * define JitBuilder structs. This can help ensure a consistent API between a
+ * VM struct and JitBuilder's representation of the same struct. Their definitions
+ * expand to calls to `TR::TypeDictionary` methods that create a representation
+ * corresponding to that specified type.
+ * 
+ * ## Usage
+ * 
+ * Given the following struct:
+ * 
+ * ```c++
+ * struct MyStruct {
+ *    int32_t id;
+ *    int32_t* val;
+ * };
+ * 
+ * a JitBuilder representation of this struct can be defined as follows:
+ * 
+ * ```c++
+ * TR::TypeDictionary d;
+ * d.DEFINE_STRUCT(MyStruct);
+ * d.DEFINE_FIELD(MyStruct, id, Int32);
+ * d.DEFINE_FIELD(MyStruct, val, pInt32);
+ * d.CLOSE_STRUCT(MyStruct);
+ * ```
+ * 
+ * This definition will expand to the following:
+ * 
+ * ```c++
+ * TR::TypeDictionary d;
+ * d.DefineStruct("MyStruct");
+ * d.DefineField("MyStruct", "id", Int32, offsetof(MyStruct, id));
+ * d.DefineField("MyStruct", "val", pInt32, offsetof(MyStruct, val));
+ * d.CloseStruct("MyStruct", sizeof(MyStruct));
+ * ```
+ */
+#define DEFINE_STRUCT(structName) \
+   DefineStruct(#structName)
+#define DEFINE_FIELD(structName, fieldName, filedIlType) \
+   DefineField(#structName, #fieldName, filedIlType, offsetof(structName, fieldName))
+#define CLOSE_STRUCT(structName) \
+   CloseStruct(#structName, sizeof(structName))
+
+
 class TypeDictionary
    {
 public:

--- a/jitbuilder/release/src/LinkedList.cpp
+++ b/jitbuilder/release/src/LinkedList.cpp
@@ -165,12 +165,12 @@ class LinkedListTypeDictionary : public TR::TypeDictionary
    LinkedListTypeDictionary() :
       TR::TypeDictionary()
       {
-      TR::IlType *ElementType = DefineStruct("Element");
+      TR::IlType *ElementType = DEFINE_STRUCT(Element);
       TR::IlType *pElementType = PointerTo("Element");
-      DefineField("Element", "next", pElementType);
-      DefineField("Element", "key", Int16);
-      DefineField("Element", "val", Int32);
-      CloseStruct("Element");
+      DEFINE_FIELD(Element, next, pElementType);
+      DEFINE_FIELD(Element, key, Int16);
+      DEFINE_FIELD(Element, val, Int32);
+      CLOSE_STRUCT(Element);
       }
    };
 

--- a/jitbuilder/release/src/StructArray.cpp
+++ b/jitbuilder/release/src/StructArray.cpp
@@ -34,6 +34,12 @@ void printStructElems(uint8_t type, int32_t value)
    printf("StructType { type = %#x, value = %d }\n", type, value);
    }
 
+void printElemOffsets(int32_t typeOffset, int32_t valueOffset)
+   {
+   #define PRINTELEMOFFSETS_LINE LINETOSTR(__LINE__)
+   printf("StructType: OffsetOf(type) = %d, OffsetOf(value) = %d\n", typeOffset, valueOffset);
+   }
+
 
 CreateStructArrayMethod::CreateStructArrayMethod(TR::TypeDictionary *d)
    : MethodBuilder(d)
@@ -114,11 +120,24 @@ ReadStructArrayMethod::ReadStructArrayMethod(TR::TypeDictionary *d)
                   2,
                   Int8,
                   Int32);
+
+   DefineFunction("printElemOffsets",
+                  __FILE__,
+                  PRINTELEMOFFSETS_LINE,
+                  (void *)&printElemOffsets,
+                  NoType,
+                  2,
+                  Int32,
+                  Int32);
    }
 
 bool
 ReadStructArrayMethod::buildIL()
    {
+   Call("printElemOffsets", 2,
+      ConstInt32(typeDictionary()->OffsetOf("Struct", "type")),
+      ConstInt32(typeDictionary()->OffsetOf("Struct", "value")));
+
    TR::IlBuilder* readArray = NULL;
    ForLoopUp("i", &readArray,
       ConstInt32(0),

--- a/jitbuilder/release/src/StructArray.cpp
+++ b/jitbuilder/release/src/StructArray.cpp
@@ -149,9 +149,9 @@ class StructArrayTypeDictionary : public TR::TypeDictionary
       TR::TypeDictionary()
       {
       DefineStruct("Struct");
-      DefineField("Struct", "type", Int8, offsetof(Struct, type));
-      DefineField("Struct", "value", Int32, offsetof(Struct, value));
-      CloseStruct("Struct", sizeof(Struct));
+      DefineField("Struct", "type", Int8);
+      DefineField("Struct", "value", Int32);
+      CloseStruct("Struct");
       }
    };
 


### PR DESCRIPTION
Implement the OffsetOf function in JitBuilder. Also implement an API for more conveniently overlaying sturcts in JitBuilder.