### PR TITLE
Fix LoopVersioner to treat receivers outside of the loop as variant

### DIFF
--- a/compiler/optimizer/LoopVersioner.hpp
+++ b/compiler/optimizer/LoopVersioner.hpp
@@ -205,7 +205,7 @@ class TR_LoopVersioner : public TR_LoopTransformer
    bool detectInvariantSpineChecks(List<TR::TreeTop> *);
    bool detectInvariantDivChecks(List<TR::TreeTop> *);
    bool detectInvariantIwrtbars(List<TR::TreeTop> *);
-   bool detectInvariantTrees(List<TR::TreeTop> *, bool, bool *, SharedSparseBitVector &reverseBranchInLoops);
+   bool detectInvariantTrees(TR_RegionStructure *whileLoop, List<TR::TreeTop> *, bool, bool *, SharedSparseBitVector &reverseBranchInLoops);
    bool detectInvariantNodes(List<TR_NodeParentSymRef> *invariantNodes, List<TR_NodeParentSymRefWeightTuple> *invariantTranslationNodes);
    bool detectInvariantSpecializedExprs(List<TR::Node> *);
    bool detectInvariantArrayStoreChecks(List<TR::TreeTop> *);


### PR DESCRIPTION
When LoopVersioner decides whether a guard is loop invariant, it looks
at the receiver on the taken side as the last resort. In some cases,
the taken side is out of the loop and hard to reason about. The
LoopVersioner is fixed to conservatively treat those receivers as
variant.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>