### PR TITLE
Use failCompilation to fail compilations

### DIFF
--- a/compiler/arm/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/arm/codegen/ControlFlowEvaluator.cpp
@@ -1295,8 +1295,7 @@ static void lookupScheme3(TR::CodeGenerator *cg, TR::Node *node, bool unbalanced
 // Called by switchDispatch().
 static void lookupScheme4(TR::Node *node, TR::CodeGenerator *cg)
    {
-   traceMsg(TR::comp(), "Automatically failing on lookup scheme 4");
-   throw TR::CompilationException();
+   TR::comp()->failCompilation<TR::CompilationException>("Automatically failing on lookup scheme 4");
 
 /*  TODO implement lookups
    int32_t  total = node->getNumChildren();

--- a/compiler/arm/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.cpp
@@ -1156,8 +1156,7 @@ TR::Register *OMR::ARM::TreeEvaluator::loadaddrEvaluator(TR::Node *node, TR::Cod
       resultReg = sym->isLocalObject() ?  cg->allocateCollectedReferenceRegister() : cg->allocateRegister();
       if (mref->useIndexedForm())
          {
-         traceMsg(TR::comp(), "implement unresolved loadAddr indexed");
-         throw TR::CompilationException();
+         TR::comp()->failCompilation<TR::CompilationException>("implement unresolved loadAddr indexed");
          generateTrg1MemInstruction(cg, ARMOp_add, node, resultReg, mref);
          }
       else

--- a/compiler/codegen/FrontEnd.cpp
+++ b/compiler/codegen/FrontEnd.cpp
@@ -100,12 +100,6 @@ TR_FrontEnd::resizeCodeMemory(TR::Compilation *, uint8_t *, uint32_t numBytes)
    notImplemented("resizeCodeMemory");
    }
 
-void
-TR_FrontEnd::outOfMemory(TR::Compilation *, const char *)
-   {
-   notImplemented("outOfMemory");
-   }
-
 /*
  * Return conservative approximation of code-cache base.
  */

--- a/compiler/codegen/FrontEnd.hpp
+++ b/compiler/codegen/FrontEnd.hpp
@@ -243,7 +243,6 @@ public:
    // --------------------------------------------------------------------------
 
    virtual TR_Debug * createDebug(TR::Compilation * comp = NULL);
-   virtual void outOfMemory(TR::Compilation *, const char *);
 
    // --------------------------------------------------------------------------
 

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -375,8 +375,7 @@ OMR::CodeGenPhase::performRegisterAssigningPhase(TR::CodeGenerator * cg, TR::Cod
 
       if (comp->compilationShouldBeInterrupted(AFTER_REGISTER_ASSIGNMENT_CONTEXT))
          {
-         traceMsg(comp, "interrupted after RA");
-         throw TR::CompilationInterrupted();
+         comp->failCompilation<TR::CompilationInterrupted>("interrupted after RA");
          }
       }
 
@@ -426,8 +425,7 @@ OMR::CodeGenPhase::performInstructionSelectionPhase(TR::CodeGenerator * cg, TR::
    // check interrupt
    if (comp->compilationShouldBeInterrupted(AFTER_INSTRUCTION_SELECTION_CONTEXT))
       {
-      traceMsg(comp, "interrupted after instruction selection");
-      throw TR::CompilationInterrupted();
+      comp->failCompilation<TR::CompilationInterrupted>("interrupted after instruction selection");
       }
    }
 

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -2407,14 +2407,13 @@ OMR::CodeGenerator::reserveCodeCache()
       // We may reach this point if all code caches have been used up
       // If some code caches have some space but cannot be used because they are reserved
       // we will throw an exception in the call to getDesignatedCodeCache
-      traceMsg(self()->comp(), "Cannot reserve code cache");
 
       if (self()->comp()->compileRelocatableCode())
          {
-         throw TR::RecoverableCodeCacheError();
+         self()->comp()->failCompilation<TR::RecoverableCodeCacheError>("Cannot reserve code cache");
          }
 
-      throw TR::CodeCacheError();
+      self()->comp()->failCompilation<TR::CodeCacheError>("Cannot reserve code cache");
       }
    }
 

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -1661,6 +1661,13 @@ void OMR::Compilation::resetVisitCounts(vcount_t count, TR::TreeTop *start)
       tt->getNode()->resetVisitCounts(count);
    }
 
+void OMR::Compilation::reportFailure(const char *reason)
+   {
+   traceMsg(self(), "Compilation Failed Because: %s\n", reason);
+   if (TR::Options::getCmdLineOptions()->getOption(TR_PrintErrorInfoOnCompFailure))
+      fprintf(stderr, "Compilation Failed Because: %s\n", reason);
+   }
+
 void OMR::Compilation::AddCopyPropagationRematerializationCandidate(TR::SymbolReference * sr)
    {
    _copyPropagationRematerializationCandidates[sr->getReferenceNumber()] = 1;

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -850,8 +850,7 @@ int32_t OMR::Compilation::compile()
       //
       if (_methodSymbol->catchBlocksHaveRealPredecessors(_methodSymbol->getFlowGraph(), self()))
          {
-         traceMsg(self(), "Catch blocks have real predecessors");
-         throw TR::CompilationException();
+         self()->failCompilation<TR::CompilationException>("Catch blocks have real predecessors");
          }
 
       if ((debug("dumpInitialTrees") || self()->getOption(TR_TraceTrees)) && self()->getOutFile() != NULL)
@@ -900,8 +899,7 @@ int32_t OMR::Compilation::compile()
          static char *abortafterilgen = feGetEnv("TR_TOSS_IL");
          if(abortafterilgen)
             {
-            traceMsg(self(), "Aborting after IL Gen due to TR_TOSS_IL");
-            throw TR::CompilationException();
+            self()->failCompilation<TR::CompilationException>("Aborting after IL Gen due to TR_TOSS_IL");
             }
 
 
@@ -1186,8 +1184,7 @@ bool OMR::Compilation::incInlineDepth(TR_OpaqueMethodBlock *methodInfo, TR::Reso
    if (inlinedCallStackSize >= TR_ByteCodeInfo::maxCallerIndex)
       {
       TR_ASSERT(0, "max number of inlined calls exceeded");
-      traceMsg(self(), "max number of inlined calls exceeded");
-      throw TR::ExcessiveComplexity();
+      self()->failCompilation<TR::ExcessiveComplexity>("max number of inlined calls exceeded");
       }
 
    if (inlinedCallStackSize > _maxInlineDepth)
@@ -1824,14 +1821,12 @@ void OMR::Compilation::switchCodeCache(TR::CodeCache *newCodeCache)
    _numReservedIPICTrampolines = 0;
    if ( self()->cg()->committedToCodeCache() || !newCodeCache )
       {
-      traceMsg(self(), "Already committed to current code cache");
-
       if (newCodeCache)
          {
-         throw TR::RecoverableCodeCacheError();
+         self()->failCompilation<TR::RecoverableCodeCacheError>("Already committed to current code cache");
          }
 
-      throw TR::CodeCacheError();
+      self()->failCompilation<TR::CodeCacheError>("Already committed to current code cache");
       }
    }
 
@@ -2073,8 +2068,7 @@ OMR::Compilation::incVisitCount()
    if (_visitCount == MAX_VCOUNT-1)
       {
       TR_ASSERT(0, "_visitCount equals MAX_VCOUNT-1");
-      traceMsg(self(), "_visitCount equals MAX_VCOUNT-1");
-      throw TR::CompilationException();
+      self()->failCompilation<TR::CompilationException>("_visitCount equals MAX_VCOUNT-1");
       }
    return ++_visitCount;
    }

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -740,6 +740,13 @@ public:
    static const char *getHotnessName(TR_Hotness t);
    const char *getHotnessName();
 
+   template<typename Exception>
+   void failCompilation(const char *reason)
+      {
+      OMR::Compilation::reportFailure(reason);
+      throw Exception();
+      }
+
    void setOptimizationPlan(TR_OptimizationPlan *optimizationPlan ) {_optimizationPlan = optimizationPlan;}
    TR_OptimizationPlan * getOptimizationPlan() {return _optimizationPlan;}
 
@@ -951,6 +958,7 @@ public:
 private:
    void resetVisitCounts(vcount_t, TR::ResolvedMethodSymbol *);
    int16_t restoreInlineDepthUntil(int32_t stopIndex, TR_ByteCodeInfo &currentInfo);
+   void reportFailure(const char *reason);
 
 protected:
    TR::Options *_options;

--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -1513,8 +1513,7 @@ OMR::SymbolReferenceTable::findOrCreateAutoSymbol(TR::ResolvedMethodSymbol * own
          {
          if (symRef->getSymbol()->getParmSymbol() || comp()->getOption(TR_DontJitIfSlotsSharedByRefAndNonRef))
             {
-            traceMsg(comp(), "stack mapping can't handle a parameter slot that is shared between refs and nonrefs 0");
-            throw TR::CompilationException();
+            comp()->failCompilation<TR::CompilationException>("stack mapping can't handle a parameter slot that is shared between refs and nonrefs 0");
             }
 
          slotSharedbyRefAndNonRef = true;
@@ -1536,8 +1535,7 @@ OMR::SymbolReferenceTable::findOrCreateAutoSymbol(TR::ResolvedMethodSymbol * own
                {
                if (symRef2->getSymbol()->getParmSymbol() || comp()->getOption(TR_DontJitIfSlotsSharedByRefAndNonRef))
                   {
-                  traceMsg(comp(), "stack mapping can't handle a parameter slot that is shared between refs and nonrefs 1");
-                  throw TR::CompilationException();
+                  comp()->failCompilation<TR::CompilationException>("stack mapping can't handle a parameter slot that is shared between refs and nonrefs 1");
                   }
                slotSharedbyRefAndNonRef = true;
                symRef2->getSymbol()->setSlotSharedByRefAndNonRef(true); // An address slot is being shared with an int slot.
@@ -1560,8 +1558,7 @@ OMR::SymbolReferenceTable::findOrCreateAutoSymbol(TR::ResolvedMethodSymbol * own
                {
                if (symRef2->getSymbol()->getParmSymbol() || comp()->getOption(TR_DontJitIfSlotsSharedByRefAndNonRef))
                   {
-                  traceMsg(comp(), "stack mapping can't handle a parameter slot that is shared between refs and nonrefs 3");
-                  throw TR::CompilationException();
+                  comp()->failCompilation<TR::CompilationException>("stack mapping can't handle a parameter slot that is shared between refs and nonrefs 3");
                   }
                slotSharedbyRefAndNonRef = true;
                symRef2->getSymbol()->setSlotSharedByRefAndNonRef(true); // An address slot is being shared with an int slot.
@@ -1591,8 +1588,7 @@ OMR::SymbolReferenceTable::findOrCreateAutoSymbol(TR::ResolvedMethodSymbol * own
          _numInternalPointers++;
          if (_numInternalPointers > comp()->maxInternalPointers())
             {
-            traceMsg(comp(), "Excessive number of internal pointers");
-            throw TR::ExcessiveComplexity();
+            comp()->failCompilation<TR::ExcessiveComplexity>("Excessive number of internal pointers");
             }
          }
       else

--- a/compiler/compile/OSRData.cpp
+++ b/compiler/compile/OSRData.cpp
@@ -472,8 +472,7 @@ void TR_OSRCompilationData::checkOSRLimits()
       if (comp->getOptions()->isAnyVerboseOptionSet(TR_VerboseOSR, TR_VerboseOSRDetails))
          TR_VerboseLog::writeLineLocked(TR_Vlog_OSR, "OSR COMPILE ABORT in %s: frame size %d, scratch size %d, stack size %d were not accommodated by the VM\n",
                   comp->signature(), maxFrameSize, getMaxScratchBufferSize(), maxStackFrameSize);
-      traceMsg(comp, "OSR buffers could not be enlarged to accomodate compiled method");
-      throw TR::CompilationException();
+      comp->failCompilation<TR::CompilationException>("OSR buffers could not be enlarged to accomodate compiled method");
       }
    }
 

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -980,6 +980,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"poisonDeadSlots",    "O\tpaints all dead slots with deadf00d", SET_OPTION_BIT(TR_PoisonDeadSlots), "F"},
    {"prepareForOSREvenIfThatDoesNothing",   "O\temit the call to prepareForOSR even if there is no slot sharing", SET_OPTION_BIT(TR_EnablePrepareForOSREvenIfThatDoesNothing), "F"},
    {"printAbsoluteTimestampInVerboseLog", "O\tPrint Absolute Timestamp in vlog", SET_OPTION_BIT(TR_PrintAbsoluteTimestampInVerboseLog), "F", NOT_IN_SUBSET},
+   {"printErrorInfoOnCompFailure",        "O\tPrint compilation error info to stderr", SET_OPTION_BIT(TR_PrintErrorInfoOnCompFailure), "F", NOT_IN_SUBSET},
    {"privatizeOverlaps",  "O\tif BCD storageRefs are going to overlap then do the move through a temp", SET_OPTION_BIT(TR_PrivatizeOverlaps), "F"},
    {"profile",            "O\tcompile a profiling method body", SET_OPTION_BIT(TR_Profile), "F"},
    {"profilingCompNodecountThreshold=", "M<nnn>\tthreshold for doubling the method to do a profiling compile is considered expensive",

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -175,7 +175,7 @@ enum TR_CompilationOptions
    TR_TraceValueNumbers                   = 0x00008000 + 2,
    TR_TraceLiveness                       = 0x00010000 + 2,
    TR_BreakAfterCompile                   = 0x00020000 + 2,
-   //Available                            = 0x00040000 + 2,
+   TR_PrintErrorInfoOnCompFailure         = 0x00040000 + 2,
    TR_DisableArrayCopyOpts                = 0x00080000 + 2,
    TR_NoResumableTrapHandler              = 0x00100000 + 2,
    TR_disableInterfaceCallCaching         = 0x00200000 + 2,

--- a/compiler/env/FEBase.cpp
+++ b/compiler/env/FEBase.cpp
@@ -50,20 +50,6 @@ TR::FECommon::createDebug( TR::Compilation *comp)
    return createDebugObject(comp);
    }
 
-void feOutOfMemory(void *, TR::Compilation *comp, const char *reason)
-   {
-   throw TR::CompilationException();
-   }
-
-void
-TR::FECommon::outOfMemory(TR::Compilation *comp, const char *reason)
-   {
-   // FIXME: This will break when we have more than a single thread
-   // FIXME: This is going to crash if outOfMemory is ever called from
-   // outside of setjmp block
-   feOutOfMemory(0, comp, reason);
-   }
-
 
 //                 .o.                          oooo
 //                .888.                         `888

--- a/compiler/env/FEBase.hpp
+++ b/compiler/env/FEBase.hpp
@@ -56,8 +56,6 @@ class FECommon : public ::TR_FrontEnd
 
    // need this so z codegen can create a sym ref to compare to another sym ref it cannot possibly be equal to
    virtual uintptrj_t getOffsetOfIndexableSizeField() { return -1; }
-
-   virtual void outOfMemory(TR::Compilation *comp, const char *reason);
    };
 
 template <class T> struct FETraits {};

--- a/compiler/env/FEBase_t.hpp
+++ b/compiler/env/FEBase_t.hpp
@@ -66,11 +66,11 @@ FEBase<Derived>::allocateCodeMemory(TR::Compilation *comp, uint32_t warmCodeSize
       {
       if (jitConfig()->isCodeCacheFull())
          {
-         throw TR::CodeCacheError();
+         comp->failCompilation<TR::CodeCacheError>("Code Cache Full");
          }
       else
          {
-         throw TR::RecoverableCodeCacheError();
+         comp->failCompilation<TR::RecoverableCodeCacheError>("Failed to allocate code memory");
          }
       }
 

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -156,8 +156,7 @@ OMR::Node::Node(TR::Node *originatingByteCodeNode, TR::ILOpCodes op, uint16_t nu
       if (self()->getGlobalIndex() == MAX_NODE_COUNT)
          {
          TR_ASSERT(0, "getGlobalIndex() == MAX_NODE_COUNT");
-         traceMsg(comp, "Global index equal to max node count");
-         throw TR::ExcessiveComplexity();
+         comp->failCompilation<TR::ExcessiveComplexity>("Global index equal to max node count");
          }
       }
 
@@ -247,8 +246,7 @@ OMR::Node::Node(TR::Node * from, uint16_t numChildren)
    if (self()->getGlobalIndex() == MAX_NODE_COUNT)
       {
       TR_ASSERT(0, "getGlobalIndex() == MAX_NODE_COUNT");
-      traceMsg(comp, "Global index equal to max node count");
-      throw TR::ExcessiveComplexity();
+      comp->failCompilation<TR::ExcessiveComplexity>("Global index equal to max node count");
       }
 
    if(comp->getDebug())

--- a/compiler/il/symbol/OMRRegisterMappedSymbol.cpp
+++ b/compiler/il/symbol/OMRRegisterMappedSymbol.cpp
@@ -84,7 +84,7 @@ OMR::RegisterMappedSymbol::setLiveLocalIndex(uint16_t i, TR_FrontEnd * fe)
    if (self()->isLiveLocalIndexUninitialized())
       {
       TR_ASSERT(0, "OMR::RegisterMappedSymbol::_liveLocalIndex == USHRT_MAX");
-      throw TR::CompilationException();
+      TR::comp()->failCompilation<TR::CompilationException>("OMR::RegisterMappedSymbol::_liveLocalIndex == USHRT_MAX");
       }
    }
 

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -147,8 +147,7 @@ OMR::ResolvedMethodSymbol::ResolvedMethodSymbol(TR_ResolvedMethod * method, TR::
 
    if (_methodIndex >= MAX_CALLER_INDEX)
       {
-      traceMsg(comp, "Exceeded MAX_CALLER_INDEX");
-      throw TR::MaxCallerIndexExceeded();
+      comp->failCompilation<TR::MaxCallerIndexExceeded>("Exceeded MAX_CALLER_INDEX");
       }
 
    if (_resolvedMethod->isSynchronized())
@@ -1032,9 +1031,8 @@ OMR::ResolvedMethodSymbol::genOSRHelperCall(int32_t currentInlinedSiteIndex, TR:
             if (trace)
                traceMsg(self()->comp(), "#%d shares pending push slot\n", symRef->getReferenceNumber());
             if (self()->comp()->getOption(TR_DisableOSRSharedSlots))
-              {
-               traceMsg(self()->comp(), "Pending push slot sharing detected");
-               throw TR::ILGenFailure();
+               {
+               self()->comp()->failCompilation<TR::ILGenFailure>("Pending push slot sharing detected");
                }
             }
 
@@ -1065,8 +1063,7 @@ OMR::ResolvedMethodSymbol::genOSRHelperCall(int32_t currentInlinedSiteIndex, TR:
                traceMsg(self()->comp(), "#%d shares auto slot\n", symRef->getReferenceNumber());
             if (self()->comp()->getOption(TR_DisableOSRSharedSlots))
                {
-               traceMsg(self()->comp(), "Auto/parm slot sharing detected");
-               throw TR::ILGenFailure();
+               self()->comp()->failCompilation<TR::ILGenFailure>("Auto/parm slot sharing detected");
                }
             }
          // Certain special temps go into the OSR buffer, but most don't
@@ -1223,8 +1220,7 @@ OMR::ResolvedMethodSymbol::genIL(TR_FrontEnd * fe, TR::Compilation * comp, TR::S
             {
             if (self()->catchBlocksHaveRealPredecessors(comp->getFlowGraph(), comp))
                {
-               traceMsg(comp, "Catch blocks have real predecessors");
-               throw TR::CompilationException();
+               comp->failCompilation<TR::CompilationException>("Catch blocks have real predecessors");
                }
             }
 
@@ -1774,8 +1770,7 @@ OMR::ResolvedMethodSymbol::setTempIndex(int32_t index, TR_FrontEnd * fe)
    {
    if ((_tempIndex = index) < 0)
       {
-      traceMsg(self()->comp(), "TR::ResolvedMethodSymbol::_tempIndex overflow");
-      throw TR::CompilationException();
+      self()->comp()->failCompilation<TR::CompilationException>("TR::ResolvedMethodSymbol::_tempIndex overflow");
       }
    return index;
    }

--- a/compiler/infra/ILWalk.cpp
+++ b/compiler/infra/ILWalk.cpp
@@ -661,8 +661,7 @@ void TR::ILValidator::soundnessRule(TR::TreeTop *location, bool condition, const
       static char *continueAfterValidationError = feGetEnv("TR_continueAfterValidationError");
       if (!continueAfterValidationError)
          {
-         traceMsg(comp(), "Validation error");
-         throw TR::CompilationException();
+         comp()->failCompilation<TR::CompilationException>("Validation error");
          }
       }
    }
@@ -683,8 +682,7 @@ void TR::ILValidator::validityRule(Location &location, bool condition, const cha
       static char *continueAfterValidationError = feGetEnv("TR_continueAfterValidationError");
       if (!continueAfterValidationError)
          {
-         traceMsg(comp(), "Validation error");
-         throw TR::CompilationException();
+         comp()->failCompilation<TR::CompilationException>("Validation error");
          }
       }
    }

--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -959,8 +959,7 @@ bool OMR::CFG::removeEdge(TR::CFGEdge *edge, bool recursiveImpl)
        (comp()->getOption(TR_ProcessHugeMethods) ?
         (MAX_REMOVE_EDGE_NESTING_DEPTH * 2) : MAX_REMOVE_EDGE_NESTING_DEPTH))
       {
-      traceMsg(comp(), "Exceeded removeEdge nesting depth");
-      throw TR::ExcessiveComplexity();
+      comp()->failCompilation<TR::ExcessiveComplexity>("Exceeded removeEdge nesting depth");
       }
 
 

--- a/compiler/optimizer/BackwardBitVectorAnalysis.cpp
+++ b/compiler/optimizer/BackwardBitVectorAnalysis.cpp
@@ -223,8 +223,8 @@ template<class Container>void TR_BackwardDFSetAnalysis<Container *>::initializeG
 
       if (this->_analysisInterrupted)
          {
-         traceMsg(this->comp(), "interrupted in backward bit vector analysis");
-         throw TR::CompilationInterrupted();
+         TR::Compilation *comp = this->comp();
+         comp->failCompilation<TR::CompilationInterrupted>("interrupted in backward bit vector analysis");
          }
 
       TR::CFGNode *node = this->_analysisQueue.getListHead()->getData();
@@ -1045,8 +1045,8 @@ template<class Container>bool TR_BackwardDFSetAnalysis<Container *>::analyzeNode
 
       if (this->_analysisInterrupted)
          {
-         traceMsg(this->comp(), "interrupted in backward bit vector analysis");
-         throw TR::CompilationInterrupted();
+         TR::Compilation *comp = this->comp();
+         comp->failCompilation<TR::CompilationInterrupted>("interrupted in backward bit vector analysis");
          }
 
       TR::CFGNode *node = this->_analysisQueue.getListHead()->getData();

--- a/compiler/optimizer/BitVectorAnalysis.cpp
+++ b/compiler/optimizer/BitVectorAnalysis.cpp
@@ -612,8 +612,8 @@ template<class Container>void TR_ForwardDFSetAnalysis<Container *>::initializeGe
 
       if (this->_analysisInterrupted)
          {
-         traceMsg(this->comp(), "interrupted in forward bit vector analysis");
-         throw TR::CompilationInterrupted();
+         TR::Compilation *comp = this->comp();
+         comp->failCompilation<TR::CompilationInterrupted>("interrupted in forward bit vector analysis");
          }
 
       TR::CFGNode *node = this->_analysisQueue.getListHead()->getData();
@@ -1186,8 +1186,8 @@ template<class Container>bool TR_ForwardDFSetAnalysis<Container *>::analyzeNodeI
 
       if (this->_analysisInterrupted)
          {
-         traceMsg(this->comp(), "interrupted in forward bit vector analysis");
-         throw TR::CompilationInterrupted();
+         TR::Compilation *comp = this->comp();
+         comp->failCompilation<TR::CompilationInterrupted>("interrupted in forward bit vector analysis");
          }
 
       TR::CFGNode *node = this->_analysisQueue.getListHead()->getData();

--- a/compiler/optimizer/GlobalRegisterAllocator.cpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.cpp
@@ -513,8 +513,7 @@ TR_GlobalRegisterAllocator::perform()
       if (comp()->getOptions()->realTimeGC() &&
           comp()->compilationShouldBeInterrupted(GRA_AFTER_FIND_LOOP_AUTO_CONTEXT))
          {
-         traceMsg(comp(), "interrupted during GRA");
-         throw TR::CompilationInterrupted();
+         comp()->failCompilation<TR::CompilationInterrupted>("interrupted during GRA");
          }
 
       bool canAffordAssignment = true;
@@ -3924,8 +3923,7 @@ TR_GlobalRegisterAllocator::findLoopsAndCorrespondingAutos(TR_StructureSubGraphN
                static uint32_t numIter = 0;
                if (((++numIter) & 0x3f)==0 && comp()->compilationShouldBeInterrupted(GRA_FIND_LOOPS_AND_CORRESPONDING_AUTOS_BLOCK_CONTEXT))
                   {
-                  traceMsg(comp(), "interrupted in GRA-findLoopsAndCorrspondingAuto-block");
-                  throw TR::CompilationInterrupted();
+                  comp()->failCompilation<TR::CompilationInterrupted>("interrupted in GRA-findLoopsAndCorrspondingAuto-block");
                   }
                nextBlock->setVisitCount(visitCount);
                int32_t executionFrequency = 1;

--- a/compiler/optimizer/OMRLocalCSE.cpp
+++ b/compiler/optimizer/OMRLocalCSE.cpp
@@ -416,8 +416,7 @@ void OMR::LocalCSE::examineNode(TR::Node *node, SharedSparseBitVector &seenAvail
    {
    if (depth > MAX_DEPTH)
       {
-      traceMsg(comp(), "scratch space in local CSE");
-      throw TR::ExcessiveComplexity();
+      comp()->failCompilation<TR::ExcessiveComplexity>("scratch space in local CSE");
       }
 
    // If register pressure is high at this point, then nothing should be commoned or copy propagated across this point

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -1120,8 +1120,7 @@ int32_t OMR::Optimizer::optimize()
       if (nextHotness > comp()->getMethodHotness())
          {
          comp()->setNextOptLevel(nextHotness);
-         traceMsg(comp(), "Method needs to be compiled at higher level");
-         throw TR::InsufficientlyAggressiveCompilation();
+         comp()->failCompilation<TR::InsufficientlyAggressiveCompilation>("Method needs to be compiled at higher level");
          }
       }
 
@@ -1973,13 +1972,12 @@ int32_t OMR::Optimizer::performOptimization(const OptimizationStrategy *optimiza
                {
                if (comp()->getOption(TR_MimicInterpreterFrameShape))
                   {
-                  traceMsg(comp(), "complex method under MimicInterpreterFrameShape");
+                  comp()->failCompilation<TR::ExcessiveComplexity>("complex method under MimicInterpreterFrameShape");
                   }
                else
                   {
-                  traceMsg(comp(), "Method is too large");
+                  comp()->failCompilation<TR::ExcessiveComplexity>("Method is too large");
                   }
-               throw TR::ExcessiveComplexity();
                }
             }
          }
@@ -2041,8 +2039,7 @@ int32_t OMR::Optimizer::performOptimization(const OptimizationStrategy *optimiza
 
       if (comp()->compilationShouldBeInterrupted((TR_CallingContext)optNum))
          {
-         traceMsg(comp(), "interrupted between optimizations");
-         throw TR::CompilationInterrupted();
+         comp()->failCompilation<TR::CompilationInterrupted>("interrupted between optimizations");
          }
 
       manager->setTrace(origTraceSetting);

--- a/compiler/optimizer/OSRDefAnalysis.cpp
+++ b/compiler/optimizer/OSRDefAnalysis.cpp
@@ -98,7 +98,7 @@ void TR_OSRDefInfo::performFurtherAnalysis(AuxiliaryData &aux)
       //TR_ASSERT(0, "osr def analysis failed. need to undo whatever we did for OSR and disable OSR but we don't. Implementation is not completed.\n");
       traceMsg(comp(), "compilation failed for %s because osr def analysis failed\n",
             optimizer()->getMethodSymbol()->signature(comp()->trMemory()));
-      throw TR::ILGenFailure();
+      comp()->failCompilation<TR::ILGenFailure>("compilation failed because osr def analysis failed");
       }
    comp()->printMemStatsAfter("computeOSRDefInfo");
 

--- a/compiler/optimizer/PartialRedundancy.cpp
+++ b/compiler/optimizer/PartialRedundancy.cpp
@@ -4260,8 +4260,7 @@ bool TR_ExceptionCheckMotion::analyzeNodeIfSuccessorsAnalyzed(TR::CFGNode *cfgNo
 
       if (_analysisInterrupted)
          {
-         traceMsg(comp(), "interrupted in forward bit vector analysis");
-         throw TR::CompilationInterrupted();
+         comp()->failCompilation<TR::CompilationInterrupted>("interrupted in forward bit vector analysis");
          }
 
       TR::CFGNode *node = _analysisQueue.getListHead()->getData();

--- a/compiler/optimizer/RegisterCandidate.cpp
+++ b/compiler/optimizer/RegisterCandidate.cpp
@@ -2673,8 +2673,7 @@ TR_RegisterCandidates::assign(TR::Block ** cfgBlocks, int32_t numberOfBlocks, in
          {
          if (comp()->compilationShouldBeInterrupted(GRA_ASSIGN_CONTEXT))
             {
-            traceMsg(comp(), "interrupted in GRA");
-            throw TR::CompilationInterrupted();
+            comp()->failCompilation<TR::CompilationInterrupted>("interrupted in GRA");
             }
          }
 

--- a/compiler/optimizer/Structure.hpp
+++ b/compiler/optimizer/Structure.hpp
@@ -178,8 +178,7 @@ class TR_Structure
       if (f > SHRT_MAX-1)
          {
          TR_ASSERT(0, "nesting depth must be less than or equal to SHRT_MAX-1");
-         traceMsg(comp(), "nesting depth must be less than or equal to SHRT_MAX-1");
-         throw TR::CompilationException();
+         comp()->failCompilation<TR::CompilationException>("nesting depth must be less than or equal to SHRT_MAX-1");
          }
       _nestingDepth = f;
       }
@@ -191,8 +190,7 @@ class TR_Structure
       if (f > SHRT_MAX-1)
          {
          TR_ASSERT(0, "nesting depth must be less than or equal to SHRT_MAX-1");
-         traceMsg(comp(), "nesting depth must be less than or equal to SHRT_MAX-1");
-         throw TR::CompilationException();
+         comp()->failCompilation<TR::CompilationException>("nesting depth must be less than or equal to SHRT_MAX-1");
          }
       _anyCyclicRegionNestingDepth = f;
       }
@@ -207,8 +205,7 @@ class TR_Structure
       if (f > SHRT_MAX-1)
          {
          TR_ASSERT(0, "max nesting depth must be less than or equal to SHRT_MAX-1");
-         traceMsg(comp(), "max nesting depth must be less than or equal to SHRT_MAX-1");
-         throw TR::CompilationException();
+         comp()->failCompilation<TR::CompilationException>("max nesting depth must be less than or equal to SHRT_MAX-1");
          }
       _maxNestingDepth = f;
       }

--- a/compiler/optimizer/ValuePropagation.cpp
+++ b/compiler/optimizer/ValuePropagation.cpp
@@ -4260,8 +4260,7 @@ void TR::GlobalValuePropagation::processStructure(TR_StructureSubGraphNode *node
        ((++numIter) & 0xf) == 0 &&
        comp()->compilationShouldBeInterrupted(BEFORE_PROCESS_STRUCTURE_CONTEXT))
       {
-      traceMsg(comp(), "interrupted when starting processStructure()");
-      throw TR::CompilationInterrupted();
+      comp()->failCompilation<TR::CompilationInterrupted>("interrupted when starting processStructure()");
       }
    TR_RegionStructure *region = node->getStructure()->asRegion();
    if (region)

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -2010,8 +2010,7 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
       if (!addrToPatch)
          {
          TR_ASSERT(false, "Must have updated gcrPatchPointSymbol with the correct address by now\n");
-         traceMsg(self()->comp(), "Must have updated gcrPatchPointSymbol with the correct address by now");
-         throw TR::GCRPatchFailure();
+         self()->comp()->failCompilation<TR::GCRPatchFailure>("Must have updated gcrPatchPointSymbol with the correct address by now");
          }
       }
 #endif

--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -495,8 +495,7 @@ uint8_t *TR::X86LabelInstruction::generateBinaryEncoding()
                // distances are guaranteed.
                //
                TR_ASSERT(0, "short form branch displacement too large: instr=%p, distance=%d\n", this, distance);
-               traceMsg(comp, "short form branch displacement too large");
-               throw TR::CompilationException();
+               comp->failCompilation<TR::CompilationException>("short form branch displacement too large");
                }
 
             cursor = getOpCode().copyBinaryToBuffer(instructionStart);

--- a/compiler/z/codegen/OMRRegisterDependency.cpp
+++ b/compiler/z/codegen/OMRRegisterDependency.cpp
@@ -779,8 +779,7 @@ TR_S390RegisterDependencyGroup::checkDependencyGroup(TR::Instruction * currentIn
          cg->getDebug()->printRegisterDependencies(comp->getOutFile(), this, numberOfRegisters);
          }
       TR_ASSERT( 0, "checkDependencyGroup::Insufficient available pairs to satisfy all reg deps.\n");
-      traceMsg(comp, "checkDependencyGroup::Insufficient available pairs to satisfy all reg deps, abort compilation\n");
-      throw TR::CompilationException();
+      comp->failCompilation<TR::CompilationException>("checkDependencyGroup::Insufficient available pairs to satisfy all reg deps, abort compilation\n");
       }
 
    // Check for dups, cause an assertion

--- a/compiler/z/codegen/OMRRegisterDependency.hpp
+++ b/compiler/z/codegen/OMRRegisterDependency.hpp
@@ -389,8 +389,7 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
          // If this failure is triggered in a prod build, you might
          // not get a SEGV nor any meaningful error msg.
          TR_ASSERT(0,"ERROR: addPreCondition list overflow\n");
-         traceMsg(_cg->comp(), "addPreCondition list overflow, abort compilation\n");
-         throw TR::CompilationException();
+         _cg->comp()->failCompilation<TR::CompilationException>("addPreCondition list overflow, abort compilation\n");
          }
       _preConditions->setDependencyInfo(_addCursorForPre++, vr, rr, flag);
       }
@@ -426,8 +425,7 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
          // If this failure is triggered in a prod build, you might
          // not get a SEGV nor any meaningful error msg.
          TR_ASSERT(0,"ERROR: addPostCondition list overflow\n");
-         traceMsg(_cg->comp(), "addPostCondition list overflow, abort compilation\n");
-         throw TR::CompilationException();
+         _cg->comp()->failCompilation<TR::CompilationException>("addPostCondition list overflow, abort compilation\n");
          }
       _postConditions->setDependencyInfo(_addCursorForPost++, vr, rr, flag);
       if((flag & DefinesDependentRegister) != 0)

--- a/fvtest/compilertest/env/FrontEnd.cpp
+++ b/fvtest/compilertest/env/FrontEnd.cpp
@@ -187,8 +187,7 @@ FrontEnd::createStackAtlas(
        stackAtlas->getParmBaseOffset()  < SHRT_MIN || stackAtlas->getParmBaseOffset()  > SHRT_MAX ||
        stackAtlas->getLocalBaseOffset() < SHRT_MIN || stackAtlas->getLocalBaseOffset() > SHRT_MAX)
       {
-      traceMsg(comp, "Overflowed the fields in pyAtlas");
-      throw TR::CompilationException();
+      comp->failCompilation<TR::CompilationException>("Overflowed the fields in pyAtlas");
       }
 
    // Maps are in reverse order in list from what we want in the atlas

--- a/jitbuilder/env/FrontEnd.cpp
+++ b/jitbuilder/env/FrontEnd.cpp
@@ -187,8 +187,7 @@ FrontEnd::createStackAtlas(
        stackAtlas->getParmBaseOffset()  < SHRT_MIN || stackAtlas->getParmBaseOffset()  > SHRT_MAX ||
        stackAtlas->getLocalBaseOffset() < SHRT_MIN || stackAtlas->getLocalBaseOffset() > SHRT_MAX)
       {
-      traceMsg(comp, "Overflowed the fields in pyAtlas");
-      throw TR::CompilationException();
+      comp->failCompilation<TR::CompilationException>("Overflowed the fields in pyAtlas");
       }
 
    // Maps are in reverse order in list from what we want in the atlas


### PR DESCRIPTION
Before the error handling story of the OMR Compiler was changed to throw specific C++ exceptions, the outOfMemory call was used to do so. This call would first write a specified error message to the traceLog but would also write to stderr under an option before throwing a generic exception. This PR introduces a template method called failCompilation that will handle writing a specified message to the tracelog/stderr and throw an exception specified by the template parameter.