### PR TITLE
Fix OSR Liveness Analysis

### DIFF
--- a/compiler/optimizer/OSRDefAnalysis.cpp
+++ b/compiler/optimizer/OSRDefAnalysis.cpp
@@ -791,7 +791,7 @@ int32_t TR_OSRLiveRangeAnalysis::perform()
    int32_t blockNum = -1;
    TR_BitVector *liveVars = NULL;
    TR::TreeTop *tt;
-   TR_OSRPoint *osrPoint;
+   TR_OSRPoint *osrPoint = NULL;
 
    vcount_t visitCount = comp()->incVisitCount();
    block = comp()->getStartBlock();
@@ -830,6 +830,10 @@ int32_t TR_OSRLiveRangeAnalysis::perform()
                }
             }
 
+         maintainLiveness(tt->getNode(), NULL, -1, visitCount, &liveLocals, _liveVars, block);
+
+         if (osrPoint && osrPoint->induceAfter())
+             buildOSRLiveRangeInfo(tt->getPrevTreeTop()->getNode(), _liveVars, osrPoint, liveLocalIndexToSymRefNumberMap, maxSymRefNumber, numBits, osrMethodData);
 
          if (comp()->isPotentialOSRPointWithSupport(tt))
             {
@@ -840,11 +844,6 @@ int32_t TR_OSRLiveRangeAnalysis::perform()
             osrPoint = NULL;
 
          if (osrPoint && !osrPoint->induceAfter())
-             buildOSRLiveRangeInfo(tt->getNode(), _liveVars, osrPoint, liveLocalIndexToSymRefNumberMap, maxSymRefNumber, numBits, osrMethodData);
-
-         maintainLiveness(tt->getNode(), NULL, -1, visitCount, &liveLocals, _liveVars, block);
-
-         if (osrPoint && osrPoint->induceAfter())
              buildOSRLiveRangeInfo(tt->getNode(), _liveVars, osrPoint, liveLocalIndexToSymRefNumberMap, maxSymRefNumber, numBits, osrMethodData);
          }
 


### PR DESCRIPTION
In recent refactoring OSR liveness analysis was changed to allow for OSR induction to take place after a given treetop rather than before it. The refactoring done in liveness analysis was incorrect - the liveness for
normal induction points is calculated too late to produce the correct values. This change restores the original code order and handles late induction correctly.