### PR TITLE
Create interface for generating JitBuilder types from C/C++ types

### DIFF
--- a/compiler/ilgen/TypeDictionary.hpp
+++ b/compiler/ilgen/TypeDictionary.hpp
@@ -229,6 +229,185 @@ public:
 
    //TR::IlReference *ArrayReference(TR::IlType *arrayType);
 
+   /**
+    * @brief A template class for checking whether a particular type is supported by `toIlType<>()`
+    * @tparam C/C++ type
+    * @return whether `toIlType<>()` can generate a corresponding TR::IlType instance or will fail to compile
+    *
+    * A type is considered supported iff JitBuilder directly provides, or can derive,
+    * a type that corresponds, or that is equivalent, to the specified type.
+    * 
+    * ## Usage
+    * 
+    * `is_supported` can be used the same way as any type property check from
+    * the C++11 type traits standard library. Eg:
+    * 
+    * ```c++
+    * static_assert(is_supported<int>::value, "int is not a supported type!");
+    * ```
+    * 
+    * ## Examples
+    *
+    * - `is_supported<int8_t>::value == true` because JitBuilder directly provides the corresponding type `Int8`
+    * - `is_supported<int32_t*>::value == true` because JitBuilder directly provides the corresponding type `pInt32` or `PointerTo(Int32)`
+    * - `is_supported<double**>::value == true` because JitBuilder can derive the corresponding type `PointerTo(pFloat)` or `PointerTo(PointerTo(Float))`
+    * - `is_supported<uint16_t>::value == true` because JitBuilder provides the equivalent type `Int16`
+    * - `is_supported<SomeStruct>::value == false` because JitBuilder cannot derive the type of a struct
+    * - `is_supported<SomeEnum>::value == true` because JitBuilder can derive a type that is equivalent to the underlying type of the enum
+    * - `is_supported<void>::value == true` because JitBuilder directly provides the corresponding `NoType`
+    */
+   template <typename T>
+   struct is_supported {
+      static const bool value =  std::is_arithmetic<T>::value // note: is_arithmetic = is_integral || is_floating_point
+                              || std::is_void<T>::value
+                              || std::is_enum<T>::value;
+   };
+   template <typename T>
+   struct is_supported<T*> {
+      // a pointer type is supported iff the type being pointed to is supported
+      static const bool value =  is_supported<T>::value;
+   };
+
+   /** @fn template <typename T> TR::IlType* toIlType()
+    * @brief Given a C/C++ type, returns a corresponding TR::IlType, if available
+    * @tparam C/C++ type
+    * @return TR::IlType instance corresponding to the specified C/C++ type
+    * 
+    * Given a C/C++ type, `toIlType<>` will attempt to match the type with a
+    * corresponding TR::IlType instance that is usable with JitBuilder. If no
+    * type is **known** to match the specified type (meaning the type is
+    * unsupported), then the function call fails to compile.
+    * 
+    * Currently, only the following types are supported:
+    * 
+    * - all integral types (int, long, etc.)
+    * - all floating point types (float, double)
+    * - void
+    * - all enum types
+    * - pointers to all the above types
+    * 
+    * Note that many user defined types (e.g. structs and arrays) are not
+    * currently supported.
+    * 
+    * For convenience, the template class `is_supported` can be used to determine
+    * at compile time whether a particular type is supported.
+    * 
+    * ## Usage
+    * 
+    * Using this template function is as simple as:
+    * 
+    * ```c++
+    * auto d = TR::TypeDictionary{};
+    * auto t = d.toIlType<int>();
+    * ```
+    * 
+    * If the type specified has no known corresponding TR::IlType, then the function
+    * call simply fails to compile, reporting that there is "no matching function
+    * call" (or some variation thereof).
+    * 
+    * ## Design
+    * 
+    * `toIlType<>()` is an overloaded template function. It uses SFINAE and the C++11
+    * type traits library to enable a specific overload (function implementation)
+    * that will return an instance of TR::IlType. Type traits are used to define
+    * rules that a type must follow to match a given function implementation.
+    * 
+    * For integer and floating point types, the type traits library is used to
+    * identify the "family" of the specified type. For example, `std::is_integral<>`
+    * is used to identify all the integer types. The `sizeof` operator is then used
+    * to determine the size of the specified type. The combination of the type's
+    * family and size is used to select the function that gets selected.
+    * 
+    * For types that do not belong to a family (e.g. `void`), the size is not needed.
+    * 
+    * For enum types, `toIlType<>` is recursively called on the underlying type
+    * of the enum, which can be determined using `std::underlying_type<>`.
+    * 
+    * For pointer types, `std::remove_pointer<>` is used to get the type being
+    * pointed to. Iff `is_supported<>::value` evaluates to true for this type,
+    * then `toIlType<>()` is recursively called on it.
+    * 
+    * If `toIlType<>()` is called on a type that does not match any rule,
+    * no implementation is instantiated and the call fails to compile.
+    * 
+    * ### Rule definition
+    * 
+    * The rules for enable a template overload (described above) are defined
+    * using `std::enable_if<>`, where conditional enabling is achieved using
+    * SFINAE. The field `std::enable_if<>::type` is used as the type of the
+    * anonymous argument in `toIlType<>()`.
+    * 
+    * All definitions take the following form:
+    * 
+    * ```c++
+    * template <typename T>
+    * void toIlType(typename std::enable_if<THE CONDITION>::type* = 0) {...}
+    * ```
+    * 
+    * and have the same signature: `void(void*)`. Calls to `toIlType<>()`
+    * **must** therefore specify a type parameter to avoid ambiguity.
+    * 
+    * ### Design considerations
+    * 
+    * Conceptually, `toIlType<>()` defines a mapping from C/C++ types to
+    * `TR::IlType` instances.
+    * 
+    * A more idiomatic implementation of `toIlType<>()` would have used a template
+    * class (metafunction) instead of a template function. However, because instances
+    * of `TR::IlType` are stored and returned as pointers, the "return" value of the
+    * metafunction cannot be known at compile time. Therefore, a function returning
+    * the correct instance must be used instead.
+    * 
+    * For rule definitions, especially for integer types, although it may seem
+    * feasible to simply specialize `toIlType<>()` for `int8_t`, `int16_t`, etc.
+    * this approach does not take into consideration that multiple integer types
+    * may have the same size (e.g. `int` and `long`). Using this approach would
+    * cause `toIlType<>()` to only be implemented for one of those types.
+    * 
+    * Another approach might be to attempt to specialize for all primitive types
+    * (i.e. `int`, `float`, etc). However, in this approach, a specialization
+    * would not only have to be provided for each type but also for all
+    * `unsigned`, `const`, and `volatile` variations of those types. Furthermore,
+    * because the C and C++ standards do not specify the exact size of some types,
+    * a size check would have to also be performed. This leads to the combinatorial
+    * explosion of the number of template specializations that must be defined,
+    * which is rather unmanageable.
+    * 
+    * As a note, it's important that enabling rules be mutually exclusive so
+    * that a type either enables a single template overload, or none at all.
+    * Otherwise, calls to `toIlType<>()` can become ambiguous for some types.
+    */
+
+   // integral
+   template <typename T>
+   TR::IlType* toIlType(typename std::enable_if<std::is_integral<T>::value && (sizeof(T) == 1)>::type* = 0) { return Int8; }
+   template <typename T>
+   TR::IlType* toIlType(typename std::enable_if<std::is_integral<T>::value && (sizeof(T) == 2)>::type* = 0) { return Int16; }
+   template <typename T>
+   TR::IlType* toIlType(typename std::enable_if<std::is_integral<T>::value && (sizeof(T) == 4)>::type* = 0) { return Int32; }
+   template <typename T>
+   TR::IlType* toIlType(typename std::enable_if<std::is_integral<T>::value && (sizeof(T) == 8)>::type* = 0) { return Int64; }
+
+   // floating point
+   template <typename T>
+   TR::IlType* toIlType(typename std::enable_if<std::is_floating_point<T>::value && (sizeof(T) == 4)>::type* = 0) { return Float; }
+   template <typename T>
+   TR::IlType* toIlType(typename std::enable_if<std::is_floating_point<T>::value && (sizeof(T) == 8)>::type* = 0) { return Double; }
+
+   // void
+   template <typename T>
+   TR::IlType* toIlType(typename std::enable_if<std::is_void<T>::value>::type* = 0) { return NoType; }
+
+   // enum
+   template <typename T>
+   TR::IlType* toIlType(typename std::enable_if<std::is_enum<T>::value>::type* = 0) { return toIlType<typename std::underlying_type<T>::type>(); }
+
+   // pointer
+   template <typename T>
+   TR::IlType* toIlType(typename std::enable_if<std::is_pointer<T>::value && is_supported<typename std::remove_pointer<T>::type>::value>::type* = 0) {
+      return PointerTo(toIlType<typename std::remove_pointer<T>::type>());
+   }
+
 protected:
    TR::SegmentProvider *_segmentProvider;
    TR::Region *_memoryRegion;

--- a/compiler/ilgen/TypeDictionary.hpp
+++ b/compiler/ilgen/TypeDictionary.hpp
@@ -253,14 +253,13 @@ public:
     * - `is_supported<double**>::value == true` because JitBuilder can derive the corresponding type `PointerTo(pFloat)` or `PointerTo(PointerTo(Float))`
     * - `is_supported<uint16_t>::value == true` because JitBuilder provides the equivalent type `Int16`
     * - `is_supported<SomeStruct>::value == false` because JitBuilder cannot derive the type of a struct
-    * - `is_supported<SomeEnum>::value == true` because JitBuilder can derive a type that is equivalent to the underlying type of the enum
+    * - `is_supported<SomeEnum>::value == false` because JitBuilder cannot derive a type that is equivalent to the underlying type of the enum
     * - `is_supported<void>::value == true` because JitBuilder directly provides the corresponding `NoType`
     */
    template <typename T>
    struct is_supported {
       static const bool value =  std::is_arithmetic<T>::value // note: is_arithmetic = is_integral || is_floating_point
-                              || std::is_void<T>::value
-                              || std::is_enum<T>::value;
+                              || std::is_void<T>::value;
    };
    template <typename T>
    struct is_supported<T*> {
@@ -283,7 +282,6 @@ public:
     * - all integral types (int, long, etc.)
     * - all floating point types (float, double)
     * - void
-    * - all enum types
     * - pointers to all the above types
     * 
     * Note that many user defined types (e.g. structs and arrays) are not
@@ -319,9 +317,6 @@ public:
     * family and size is used to select the function that gets selected.
     * 
     * For types that do not belong to a family (e.g. `void`), the size is not needed.
-    * 
-    * For enum types, `toIlType<>` is recursively called on the underlying type
-    * of the enum, which can be determined using `std::underlying_type<>`.
     * 
     * For pointer types, `std::remove_pointer<>` is used to get the type being
     * pointed to. Iff `is_supported<>::value` evaluates to true for this type,
@@ -397,10 +392,6 @@ public:
    // void
    template <typename T>
    TR::IlType* toIlType(typename std::enable_if<std::is_void<T>::value>::type* = 0) { return NoType; }
-
-   // enum
-   template <typename T>
-   TR::IlType* toIlType(typename std::enable_if<std::is_enum<T>::value>::type* = 0) { return toIlType<typename std::underlying_type<T>::type>(); }
 
    // pointer
    template <typename T>

--- a/jitbuilder/release/.gitignore
+++ b/jitbuilder/release/.gitignore
@@ -34,3 +34,6 @@ recfib
 simple
 switch
 controlflowtests
+issupportedtype
+toiltype
+badtoiltype

--- a/jitbuilder/release/Makefile
+++ b/jitbuilder/release/Makefile
@@ -22,7 +22,7 @@ CXXFLAGS=-g -std=c++0x -O2 -c -fno-rtti -fPIC -I./include/compiler -I./include
 
 .SUFFIXES: .cpp .o
 
-goal: call conststring dotproduct iterfib linkedlist localarray structarray mandelbrot nestedloop pointer recfib simple switch pow2 controlflowtests issupportedtype toiltype
+goal: call conststring dotproduct iterfib linkedlist localarray mandelbrot nestedloop pointer recfib simple switch pow2 structarray controlflowtests issupportedtype toiltype
 
 all: goal
 
@@ -33,13 +33,13 @@ test: goal
 	./iterfib
 	./linkedlist
 	./localarray
-	./structarray
 	./nestedloop
 	./pointer
 	./recfib
 	./simple
 	./switch
 	./pow2
+	./structarray
 	./controlflowtests
 	./issupportedtype
 	./toiltype
@@ -189,4 +189,4 @@ BadToIlType.o: src/ToIlType.cpp
 
 
 clean:
-	@rm -f call conststring dotproduct iterfib linkedlist localarray structarray mandelbrot matmult nestedloop pointer recfib simple switch pow2 issupportedtype toiltype badtoiltype *.o
+	@rm -f call conststring dotproduct iterfib linkedlist localarray mandelbrot matmult nestedloop pointer recfib simple switch pow2 structarray controlflowtests issupportedtype toiltype badtoiltype *.o

--- a/jitbuilder/release/Makefile
+++ b/jitbuilder/release/Makefile
@@ -22,7 +22,7 @@ CXXFLAGS=-g -std=c++0x -O2 -c -fno-rtti -fPIC -I./include/compiler -I./include
 
 .SUFFIXES: .cpp .o
 
-goal: call conststring dotproduct iterfib linkedlist localarray structarray mandelbrot nestedloop pointer recfib simple switch pow2 controlflowtests
+goal: call conststring dotproduct iterfib linkedlist localarray structarray mandelbrot nestedloop pointer recfib simple switch pow2 controlflowtests issupportedtype toiltype
 
 all: goal
 
@@ -41,6 +41,8 @@ test: goal
 	./switch
 	./pow2
 	./controlflowtests
+	./issupportedtype
+	./toiltype
 
 call : libjitbuilder.a Call.o
 	g++ -g -fno-rtti -o $@ Call.o -L. -ljitbuilder -ldl
@@ -164,6 +166,27 @@ ControlFlowTests.o: src/ControlFlowTests.cpp src/ControlFlowTests.hpp
 	g++ -o $@ $(CXXFLAGS) $<
 
 
+issupportedtype : libjitbuilder.a IsSupportedType.o
+	g++ -g -fno-rtti -o $@ IsSupportedType.o -L. -ljitbuilder -ldl
+
+IsSupportedType.o: src/IsSupportedType.cpp
+	g++ -o $@ $(CXXFLAGS) $<
+
+
+toiltype : libjitbuilder.a ToIlType.o
+	g++ -g -fno-rtti -o $@ ToIlType.o -L. -ljitbuilder -ldl
+
+ToIlType.o: src/ToIlType.cpp
+	g++ -o $@ $(CXXFLAGS) $<
+
+
+badtoiltype : libjitbuilder.a BadToIlType.o
+	g++ -g -fno-rtti -o $@ BadToIlType.o -L. -ljitbuilder -ldl
+
+BadToIlType.o: src/ToIlType.cpp
+	g++ -o $@ -DEXPECTED_FAIL $(CXXFLAGS) $<
+
+
 
 clean:
-	@rm -f call conststring dotproduct iterfib linkedlist localarray structarray mandelbrot matmult nestedloop pointer recfib simple switch pow2 *.o
+	@rm -f call conststring dotproduct iterfib linkedlist localarray structarray mandelbrot matmult nestedloop pointer recfib simple switch pow2 issupportedtype toiltype badtoiltype *.o

--- a/jitbuilder/release/src/IsSupportedType.cpp
+++ b/jitbuilder/release/src/IsSupportedType.cpp
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+ 
+#include <iostream>
+#include <cstdint>
+#include <cassert>
+
+#include "Jit.hpp"
+#include "ilgen/TypeDictionary.hpp"
+
+// types for use in test cases
+enum Int8Enum : int8_t { Field_8 };
+struct StructType { int field; };
+union UnionType { StructType s; char field; };
+
+int main()
+   {
+   /* Note: In an actual project, `static_assert` should be used in
+    * favour of `assert`. This is not done here for testability
+    * purposes.
+    */
+
+   std::cout << "Step 1: test signed integral types\n";
+   assert(true == TR::TypeDictionary::is_supported<int8_t>::value);
+   assert(true == TR::TypeDictionary::is_supported<int16_t>::value);
+   assert(true == TR::TypeDictionary::is_supported<int32_t>::value);
+   assert(true == TR::TypeDictionary::is_supported<int64_t>::value);
+
+   std::cout << "Step 2: test unsigned integral types\n";
+   assert(true == TR::TypeDictionary::is_supported<uint8_t>::value);
+   assert(true == TR::TypeDictionary::is_supported<uint16_t>::value);
+   assert(true == TR::TypeDictionary::is_supported<uint32_t>::value);
+   assert(true == TR::TypeDictionary::is_supported<uint64_t>::value);
+
+   std::cout << "Step 3: test language primitive signed integral types\n";
+   assert(true == TR::TypeDictionary::is_supported<char>::value);
+   assert(true == TR::TypeDictionary::is_supported<short>::value);
+   assert(true == TR::TypeDictionary::is_supported<int>::value);
+   assert(true == TR::TypeDictionary::is_supported<long>::value);
+   assert(true == TR::TypeDictionary::is_supported<long long>::value);
+
+   std::cout << "Step 4: test language primitive unsigned integral types\n";
+   assert(true == TR::TypeDictionary::is_supported<unsigned char>::value);
+   assert(true == TR::TypeDictionary::is_supported<unsigned short>::value);
+   assert(true == TR::TypeDictionary::is_supported<unsigned int>::value);
+   assert(true == TR::TypeDictionary::is_supported<unsigned long>::value);
+   assert(true == TR::TypeDictionary::is_supported<unsigned long long>::value);
+
+   std::cout << "Step 5: test floating point types\n";
+   assert(true == TR::TypeDictionary::is_supported<float>::value);
+   assert(true == TR::TypeDictionary::is_supported<double>::value);
+
+   std::cout << "Step 6: test cv qualified types\n";
+   assert(true == TR::TypeDictionary::is_supported<const int8_t>::value);
+   assert(true == TR::TypeDictionary::is_supported<volatile uint16_t>::value);
+   assert(true == TR::TypeDictionary::is_supported<const volatile int32_t>::value);
+
+   std::cout << "Step 7: test void type\n";
+   assert(true == TR::TypeDictionary::is_supported<void>::value);
+
+   std::cout << "Step 8: test pointer to primitive types\n";
+   assert(true == TR::TypeDictionary::is_supported<int32_t*>::value);
+   assert(true == TR::TypeDictionary::is_supported<double*>::value);
+   assert(true == TR::TypeDictionary::is_supported<void*>::value);
+
+   std::cout << "Step 9: test pointer to pointer to primitive types\n";
+   assert(true == TR::TypeDictionary::is_supported<int32_t**>::value);
+   assert(true == TR::TypeDictionary::is_supported<double**>::value);
+   assert(true == TR::TypeDictionary::is_supported<void**>::value);
+
+   std::cout << "Step 10: test enum types\n";
+   assert(true == TR::TypeDictionary::is_supported<Int8Enum>::value);
+
+   std::cout << "Step 11: test unsupported types\n";
+   assert(false == TR::TypeDictionary::is_supported<int[10]>::value);
+   assert(false == TR::TypeDictionary::is_supported<StructType>::value);
+   assert(false == TR::TypeDictionary::is_supported<UnionType>::value);
+   assert(false == TR::TypeDictionary::is_supported<StructType*>::value);
+   assert(false == TR::TypeDictionary::is_supported<UnionType*>::value);
+   assert(false == TR::TypeDictionary::is_supported<StructType**>::value);
+   assert(false == TR::TypeDictionary::is_supported<UnionType**>::value);
+
+   std::cout << "PASS\n";
+   }

--- a/jitbuilder/release/src/IsSupportedType.cpp
+++ b/jitbuilder/release/src/IsSupportedType.cpp
@@ -83,11 +83,9 @@ int main()
    assert(true == TR::TypeDictionary::is_supported<double**>::value);
    assert(true == TR::TypeDictionary::is_supported<void**>::value);
 
-   std::cout << "Step 10: test enum types\n";
-   assert(true == TR::TypeDictionary::is_supported<Int8Enum>::value);
-
-   std::cout << "Step 11: test unsupported types\n";
+   std::cout << "Step 10: test unsupported types\n";
    assert(false == TR::TypeDictionary::is_supported<int[10]>::value);
+   assert(false == TR::TypeDictionary::is_supported<Int8Enum>::value);
    assert(false == TR::TypeDictionary::is_supported<StructType>::value);
    assert(false == TR::TypeDictionary::is_supported<UnionType>::value);
    assert(false == TR::TypeDictionary::is_supported<StructType*>::value);

--- a/jitbuilder/release/src/ToIlType.cpp
+++ b/jitbuilder/release/src/ToIlType.cpp
@@ -1,0 +1,142 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+ 
+#include <iostream>
+#include <cstdint>
+#include <cassert>
+
+#include "Jit.hpp"
+#include "ilgen/TypeDictionary.hpp"
+
+// types for use in test cases
+enum Int8Enum : int8_t { Field_8 };
+enum Int64Enum : int64_t { Field_64 };
+struct StructType { int field; };
+union UnionType { StructType s; char field; };
+
+int main()
+   {
+   std::cout << "Step 1: initialize JIT\n";
+   bool jit_initialized = initializeJit();
+   assert(jit_initialized);
+
+   std::cout << "Step 2: create TR::TypeDictionary instance\n";
+   auto d = TR::TypeDictionary{};
+
+   std::cout << "Step 3: test signed integral types\n";
+   assert(TR::Int8 == d.toIlType<int8_t>()->getPrimitiveType());
+   assert(TR::Int16 == d.toIlType<int16_t>()->getPrimitiveType());
+   assert(TR::Int32 == d.toIlType<int32_t>()->getPrimitiveType());
+   assert(TR::Int64 == d.toIlType<int64_t>()->getPrimitiveType());
+
+   std::cout << "Step 4: test unsigned integral types\n";
+   assert(TR::Int8 == d.toIlType<uint8_t>()->getPrimitiveType());
+   assert(TR::Int16 == d.toIlType<uint16_t>()->getPrimitiveType());
+   assert(TR::Int32 == d.toIlType<uint32_t>()->getPrimitiveType());
+   assert(TR::Int64 == d.toIlType<uint64_t>()->getPrimitiveType());
+
+   std::cout << "Step 5: test language primitive signed integral types\n";
+   assert(sizeof(char) == d.toIlType<char>()->getSize());
+   assert(sizeof(short) == d.toIlType<short>()->getSize());
+   assert(sizeof(int) == d.toIlType<int>()->getSize());
+   assert(sizeof(long) == d.toIlType<long>()->getSize());
+   assert(sizeof(long long) == d.toIlType<long long>()->getSize());
+
+   std::cout << "Step 6: test language primitive unsigned integral types\n";
+   assert(sizeof(unsigned char) == d.toIlType<unsigned char>()->getSize());
+   assert(sizeof(unsigned short) == d.toIlType<unsigned short>()->getSize());
+   assert(sizeof(unsigned int) == d.toIlType<unsigned int>()->getSize());
+   assert(sizeof(unsigned long) == d.toIlType<unsigned long>()->getSize());
+   assert(sizeof(unsigned long long) == d.toIlType<unsigned long long>()->getSize());
+
+   std::cout << "Step 7: test floating point types\n";
+   assert(TR::Float == d.toIlType<float>()->getPrimitiveType());
+   assert(TR::Double == d.toIlType<double>()->getPrimitiveType());
+
+   std::cout << "Step 8: test cv qualified types\n";
+   assert(TR::Int8 == d.toIlType<const int8_t>()->getPrimitiveType());
+   assert(TR::Int16 == d.toIlType<volatile uint16_t>()->getPrimitiveType());
+   assert(TR::Int32 == d.toIlType<const volatile int32_t>()->getPrimitiveType());
+
+   std::cout << "Step 9: test void type\n";
+   assert(TR::NoType == d.toIlType<void>()->getPrimitiveType());
+
+   std::cout << "Step 10: test pointer to primitive types\n";
+   auto pInt32_type = d.toIlType<int32_t*>();
+   assert(true == pInt32_type->isPointer());
+   assert(TR::Int32 == pInt32_type->baseType()->getPrimitiveType());
+
+   auto pDouble_type = d.toIlType<double*>();
+   assert(true == pDouble_type->isPointer());
+   assert(TR::Double == pDouble_type->baseType()->getPrimitiveType());
+
+   auto pVoid_type = d.toIlType<void*>();
+   assert(true == pVoid_type->isPointer());
+   assert(TR::NoType == pVoid_type->baseType()->getPrimitiveType());
+
+   std::cout << "Step 11: test pointer to pointer to primitive types\n";
+   auto ppInt32_type = d.toIlType<int32_t**>();
+   assert(true == ppInt32_type->isPointer());
+   assert(true == ppInt32_type->baseType()->isPointer());
+   assert(TR::Int32 == ppInt32_type->baseType()->baseType()->getPrimitiveType());
+
+   auto ppDouble_type = d.toIlType<double**>();
+   assert(true == ppDouble_type->isPointer());
+   assert(true == ppDouble_type->baseType()->isPointer());
+   assert(TR::Double == ppDouble_type->baseType()->baseType()->getPrimitiveType());
+
+   auto ppVoid_type = d.toIlType<void**>();
+   assert(true == ppVoid_type->isPointer());
+   assert(true == ppVoid_type->baseType()->isPointer());
+   assert(TR::NoType == ppVoid_type->baseType()->baseType()->getPrimitiveType());
+
+   std::cout << "Step 12: test enum types\n";
+   assert(TR::Int8 == d.toIlType<Int8Enum>()->getPrimitiveType());
+   assert(TR::Int64 == d.toIlType<Int64Enum>()->getPrimitiveType());
+
+#ifdef EXPECTED_FAIL
+   /* Note: If enabled, the following tests should result in compilation errors. */
+
+   // test array type
+   d.toIlType<int[10]>();
+
+   // test struct type
+   d.toIlType<StructType>();
+
+   // test pointer to struct type
+   d.toIlType<StructType*>();
+
+   // test pointer to pointer to struct type
+   d.toIlType<StructType**>();
+
+   // test union type
+   d.toIlType<UnionType>();
+
+   // test pointer to union type
+   d.toIlType<UnionType*>();
+
+   // test pointer to pointer to union type
+   d.toIlType<UnionType**>();
+
+#endif // defined(EXPECTED_FAIL)
+
+   std::cout << "Step 13: shutdown JIT\n";
+   shutdownJit();
+   
+   std::cout << "PASS\n";
+   }

--- a/jitbuilder/release/src/ToIlType.cpp
+++ b/jitbuilder/release/src/ToIlType.cpp
@@ -105,12 +105,12 @@ int main()
    assert(true == ppVoid_type->baseType()->isPointer());
    assert(TR::NoType == ppVoid_type->baseType()->baseType()->getPrimitiveType());
 
-   std::cout << "Step 12: test enum types\n";
-   assert(TR::Int8 == d.toIlType<Int8Enum>()->getPrimitiveType());
-   assert(TR::Int64 == d.toIlType<Int64Enum>()->getPrimitiveType());
-
 #ifdef EXPECTED_FAIL
    /* Note: If enabled, the following tests should result in compilation errors. */
+
+   // test enum types
+   assert(TR::Int8 == d.toIlType<Int8Enum>()->getPrimitiveType());
+   assert(TR::Int64 == d.toIlType<Int64Enum>()->getPrimitiveType());
 
    // test array type
    d.toIlType<int[10]>();
@@ -135,7 +135,7 @@ int main()
 
 #endif // defined(EXPECTED_FAIL)
 
-   std::cout << "Step 13: shutdown JIT\n";
+   std::cout << "Step 12: shutdown JIT\n";
    shutdownJit();
    
    std::cout << "PASS\n";


### PR DESCRIPTION
This adds an interface to JitBuilder that allows instances of `TR::IlType` to be generated from C/C++ types.

Issue: #445 