### PR TITLE
Add new service AtomicIntegerAdd() in IlBuilder and a new testcase in JitBuilder

### DIFF
--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -1419,6 +1419,49 @@ IlBuilder::Call(const char *functionName, int32_t numArgs, TR::IlValue ** argVal
    return NULL;
    }
 
+TR::IlValue *
+IlBuilder::AtomicIntegerAdd(TR::IlValue * object, TR::IlValue * offset, TR::IlValue * value)
+   {
+   TraceIL("IlBuilder[ %p ]::AtomicIntegerAdd (%d, %d, %d)\n", this, object->getCPIndex(), offset->getCPIndex(), value->getCPIndex());
+   appendBlock();
+
+   TR::DataType returnType = TR::Int32;
+   
+   TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateCodeGenInlinedHelper(TR::SymbolReferenceTable::atomicAdd32BitSymbol); //lock add
+   TR::Node *callNode = TR::Node::createWithSymRef(TR::ILOpCode::getDirectCall(returnType), 3, methodSymRef);
+
+   callNode->setAndIncChild(0, loadValue(object));
+   callNode->setAndIncChild(1, loadValue(offset));
+   callNode->setAndIncChild(2, loadValue(value));
+
+   genTreeTop(callNode); 
+   TR::IlValue *returnValue = newValue(callNode->getDataType());
+   genTreeTop(TR::Node::createStore(returnValue, callNode)); 
+   
+   return returnValue; 
+   }
+
+TR::IlValue *
+IlBuilder::AtomicIntegerAdd(TR::IlValue * object, TR::IlValue * value)
+   {
+   TraceIL("IlBuilder[ %p ]::AtomicIntegerAdd (%d, %d)\n", this, object->getCPIndex(), value->getCPIndex());
+   appendBlock();
+
+   TR::DataType returnType = TR::Int32;
+   
+   TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateCodeGenInlinedHelper(TR::SymbolReferenceTable::atomicAdd32BitSymbol); //lock add
+   TR::Node *callNode = TR::Node::createWithSymRef(TR::ILOpCode::getDirectCall(returnType), 2, methodSymRef);
+
+   callNode->setAndIncChild(0, loadValue(object));
+   callNode->setAndIncChild(1, loadValue(value));
+
+   genTreeTop(callNode); 
+   TR::IlValue *returnValue = newValue(callNode->getDataType());
+   genTreeTop(TR::Node::createStore(returnValue, callNode)); 
+   
+   return returnValue;    
+   }
+
 void
 IlBuilder::IfCmpNotEqualZero(TR::IlBuilder **target, TR::IlValue *condition)
    {

--- a/compiler/ilgen/IlBuilder.hpp
+++ b/compiler/ilgen/IlBuilder.hpp
@@ -182,6 +182,8 @@ public:
    TR::IlValue *LoadIndirect(const char *type, const char *field, TR::IlValue *object);
    TR::IlValue *StoreField(const char *name, TR::IlValue *object, TR::IlValue *value);
    TR::IlValue *IndexAt(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index);
+   TR::IlValue *AtomicIntegerAdd(TR::IlValue * object, TR::IlValue * offset, TR::IlValue * value);
+   TR::IlValue *AtomicIntegerAdd(TR::IlValue * object, TR::IlValue * value);
    
    // vector memory
    TR::IlValue *VectorLoad(const char *name);

--- a/jitbuilder/release/Makefile
+++ b/jitbuilder/release/Makefile
@@ -22,7 +22,7 @@ CXXFLAGS=-g -std=c++0x -O2 -c -fno-rtti -fPIC -I./include/compiler -I./include
 
 .SUFFIXES: .cpp .o
 
-goal: call conststring dotproduct iterfib linkedlist localarray structarray mandelbrot nestedloop pointer recfib simple switch pow2 controlflowtests
+goal: call conststring dotproduct iterfib linkedlist localarray structarray mandelbrot nestedloop pointer recfib simple switch pow2 controlflowtests atom
 
 all: goal
 
@@ -41,6 +41,7 @@ test: goal
 	./switch
 	./pow2
 	./controlflowtests
+	./atom
 
 call : libjitbuilder.a Call.o
 	g++ -g -fno-rtti -o $@ Call.o -L. -ljitbuilder -ldl
@@ -135,6 +136,11 @@ simple : libjitbuilder.a Simple.o
 Simple.o: src/Simple.cpp src/Simple.hpp
 	g++ -o $@ $(CXXFLAGS) $<
 
+atom : libjitbuilder.a Atomic.o
+	g++ -g -fno-rtti -o $@ Atomic.o -L. -ljitbuilder -ldl
+
+Atomic.o: src/Atomic.cpp src/Atomic.hpp
+	g++ -o $@ $(CXXFLAGS) $<
 
 switch : libjitbuilder.a Switch.o
 	g++ -g -fno-rtti -o $@ Switch.o -L. -ljitbuilder -ldl
@@ -166,4 +172,4 @@ ControlFlowTests.o: src/ControlFlowTests.cpp src/ControlFlowTests.hpp
 
 
 clean:
-	@rm -f call conststring dotproduct iterfib linkedlist localarray structarray mandelbrot matmult nestedloop pointer recfib simple switch pow2 *.o
+	@rm -f call conststring dotproduct iterfib linkedlist localarray structarray mandelbrot matmult nestedloop pointer recfib simple atom switch pow2 *.o

--- a/jitbuilder/release/src/Atomic.cpp
+++ b/jitbuilder/release/src/Atomic.cpp
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+
+#include <iostream>
+#include <stdlib.h>
+#include <stdint.h>
+#include <dlfcn.h>
+#include <errno.h>
+
+#include "Jit.hpp"
+#include "ilgen/TypeDictionary.hpp"
+#include "ilgen/MethodBuilder.hpp"
+#include "Atomic.hpp"
+
+using std::cout;
+using std::cerr;
+
+
+int
+main(int argc, char *argv[])
+   {
+   cout << "Step 1: initialize JIT\n";
+   bool initialized = initializeJit();
+   if (!initialized)
+      {
+      cerr << "FAIL: could not initialize JIT\n";
+      exit(-1);
+      }
+
+   cout << "Step 2: define type dictionary\n";
+   TR::TypeDictionary types;
+
+   cout << "Step 3: compile method builder\n";
+   AtomicMethod method(&types);
+   uint8_t *entry = 0;
+   int32_t rc = compileMethodBuilder(&method, &entry);
+   if (rc != 0)
+      {
+      cerr << "FAIL: compilation error " << rc << "\n";
+      exit(-2);
+      }
+
+   cout << "Step 4: invoke compiled code and print results\n";
+   typedef int32_t (AtomicMethodFunction)(int32_t*);
+   AtomicMethodFunction *increment = (AtomicMethodFunction *) entry;
+
+   int32_t v;
+   v=0;   cout << "atomic increment(" << v; cout << ") == " << increment(&v) << "\n";
+   v=1;   cout << "atomic increment(" << v; cout << ") == " << increment(&v) << "\n";
+   v=10;  cout << "atomic increment(" << v; cout << ") == " << increment(&v) << "\n";
+   v=-15; cout << "atomic increment(" << v; cout << ") == " << increment(&v) << "\n";
+
+   cout << "Step 5: shutdown JIT\n";
+   shutdownJit();
+   }
+
+AtomicMethod::AtomicMethod(TR::TypeDictionary *d)
+   : MethodBuilder(d)
+   {
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   DefineName("increment");
+   pInt32=d->PointerTo(Int32);
+   DefineParameter("addressOfValue", pInt32);
+   DefineReturnType(Int32);
+   }
+
+bool
+AtomicMethod::buildIL()
+   {
+   cout << "AtomicMethod::buildIL() running!\n";
+   AtomicIntegerAdd(
+           IndexAt(pInt32, Load("addressOfValue"), ConstInt32(0)),
+           ConstInt32(1));
+   Return(LoadAt(pInt32, Load("addressOfValue")));
+   
+   return true;
+   }
+

--- a/jitbuilder/release/src/Atomic.hpp
+++ b/jitbuilder/release/src/Atomic.hpp
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+
+#ifndef SIMPLE_INCL
+#define SIMPLE_IMPL
+
+#include "ilgen/MethodBuilder.hpp"
+
+class AtomicMethod : public TR::MethodBuilder
+   {
+   private:
+   TR::IlType *pInt32;
+
+   public:
+   AtomicMethod(TR::TypeDictionary *);
+   virtual bool buildIL();
+   };
+
+#endif // !defined(POINTER_INCL)


### PR DESCRIPTION
1) Based on the common helpers for atomic primitives, add AtomicIntegerAdd() service in JitBuilder, one with offset and one without.
2) Add a new testcase in jitbuilder named Atomic.cpp/hpp, in which we passed the address of each variable and increment by 1.