### PR TITLE
Add new service AtomicAdd() in IlBuilder and a new testcase in JitBuilder

### DIFF
--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -1479,6 +1479,72 @@ IlBuilder::genCall(TR::SymbolReference *methodSymRef, int32_t numArgs, TR::IlVal
    return NULL;
    }
 
+/** \brief
+ *     The service is used to atomically increase memory location [\p baseAddress + \p offset] by amount of \p value. 
+ *
+ *  \param value
+ *     The amount to increase for the memory location.
+ * 
+ *  \note
+ *	   This service currently only supports Int32/Int64.
+ *
+ *  \return
+ *     The old value at the location [\p baseAddress + \p offset].
+ */
+TR::IlValue *
+IlBuilder::AtomicAddWithOffset(TR::IlValue * baseAddress, TR::IlValue * offset, TR::IlValue * value)
+   {
+   TR_ASSERT(baseAddress->getSymbol()->getDataType() == TR::Address, "baseAddress must be TR::Address");
+   TR_ASSERT(offset == NULL || offset->getSymbol()->getDataType() == TR::Int32 || offset->getSymbol()->getDataType() == TR::Int64, "offset must be TR::Int32/64 or NULL");
+
+   //Determine the implementation type and returnType by detecting "value"'s type
+   TR::DataType returnType = value->getSymbol()->getDataType();
+   TR_ASSERT(returnType == TR::Int32 || (returnType == TR::Int64 && TR::Compiler->target.is64Bit()), "AtomicAdd currently only supports Int32/64 values");
+   TraceIL("IlBuilder[ %p ]::AtomicAddWithOffset (%d, %d, %d)\n", this, baseAddress->getCPIndex(), offset == NULL ? 0 : offset->getCPIndex(), value->getCPIndex());
+
+   appendBlock();
+
+   OMR::SymbolReferenceTable::CommonNonhelperSymbol atomicBitSymbol = returnType == TR::Int32 ? TR::SymbolReferenceTable::atomicAdd32BitSymbol : TR::SymbolReferenceTable::atomicAdd64BitSymbol;//lock add
+   TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateCodeGenInlinedHelper(atomicBitSymbol); 
+   TR::Node *callNode;
+   //Evaluator will handle if it's (baseAddress+offset) or baseAddress based on the number of children the call node have 
+   callNode = TR::Node::createWithSymRef(TR::ILOpCode::getDirectCall(returnType), offset == NULL ? 2 : 3, methodSymRef);
+   callNode->setAndIncChild(0, loadValue(baseAddress));
+   if (offset == NULL)
+      {
+      callNode->setAndIncChild(1, loadValue(value));
+      }
+   else
+      {
+      callNode->setAndIncChild(1, loadValue(offset));
+      callNode->setAndIncChild(2, loadValue(value));
+      }
+
+   genTreeTop(callNode); 
+   TR::IlValue *returnValue = newValue(callNode->getDataType());
+   genTreeTop(TR::Node::createStore(returnValue, callNode)); 
+   
+   return returnValue; 
+   }
+
+/** \brief
+ *     The service is used to atomically increase memory location \p baseAddress by amount of \p value. 
+ *
+ *  \param value
+ *     The amount to increase for the memory location.
+ *
+ *  \note
+ *     This service currently only supports Int32/Int64. 
+ *
+ *  \return
+ *     The old value at the location \p baseAddress.
+ */
+TR::IlValue *
+IlBuilder::AtomicAdd(TR::IlValue * baseAddress, TR::IlValue * value)
+   {
+   return AtomicAddWithOffset(baseAddress, NULL, value);    
+   }
+
 void
 IlBuilder::IfCmpNotEqualZero(TR::IlBuilder **target, TR::IlValue *condition)
    {

--- a/compiler/ilgen/IlBuilder.hpp
+++ b/compiler/ilgen/IlBuilder.hpp
@@ -183,6 +183,8 @@ public:
    TR::IlValue *LoadIndirect(const char *type, const char *field, TR::IlValue *object);
    TR::IlValue *StoreField(const char *name, TR::IlValue *object, TR::IlValue *value);
    TR::IlValue *IndexAt(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index);
+   TR::IlValue *AtomicAddWithOffset(TR::IlValue *baseAddress, TR::IlValue *offset, TR::IlValue *value);
+   TR::IlValue *AtomicAdd(TR::IlValue *baseAddress, TR::IlValue * value);
    
    // vector memory
    TR::IlValue *VectorLoad(const char *name);

--- a/jitbuilder/release/Makefile
+++ b/jitbuilder/release/Makefile
@@ -22,7 +22,7 @@ CXXFLAGS=-g -std=c++0x -O2 -c -fno-rtti -fPIC -I./include/compiler -I./include
 
 .SUFFIXES: .cpp .o
 
-goal: call conststring dotproduct iterfib linkedlist localarray mandelbrot nestedloop pointer recfib simple switch pow2 structarray controlflowtests issupportedtype toiltype
+goal: call conststring dotproduct iterfib linkedlist localarray mandelbrot nestedloop pointer recfib simple switch pow2 structarray controlflowtests issupportedtype toiltype atomicoperations
 
 all: goal
 
@@ -43,6 +43,7 @@ test: goal
 	./controlflowtests
 	./issupportedtype
 	./toiltype
+	./atomicoperations
 
 call : libjitbuilder.a Call.o
 	g++ -g -fno-rtti -o $@ Call.o -L. -ljitbuilder -ldl
@@ -137,6 +138,11 @@ simple : libjitbuilder.a Simple.o
 Simple.o: src/Simple.cpp src/Simple.hpp
 	g++ -o $@ $(CXXFLAGS) $<
 
+atomicoperations : libjitbuilder.a AtomicOperations.o
+	g++ -g -fno-rtti -o $@ AtomicOperations.o -L. -ljitbuilder -ldl
+
+AtomicOperations.o: src/AtomicOperations.cpp src/AtomicOperations.hpp
+	g++ -o $@ $(CXXFLAGS) $<
 
 switch : libjitbuilder.a Switch.o
 	g++ -g -fno-rtti -o $@ Switch.o -L. -ljitbuilder -ldl
@@ -189,4 +195,4 @@ BadToIlType.o: src/ToIlType.cpp
 
 
 clean:
-	@rm -f call conststring dotproduct iterfib linkedlist localarray mandelbrot matmult nestedloop pointer recfib simple switch pow2 structarray controlflowtests issupportedtype toiltype badtoiltype *.o
+	@rm -f call conststring dotproduct iterfib linkedlist localarray mandelbrot matmult nestedloop pointer recfib simple switch pow2 structarray controlflowtests issupportedtype toiltype badtoiltype atomicoperations *.o

--- a/jitbuilder/release/src/AtomicOperations.cpp
+++ b/jitbuilder/release/src/AtomicOperations.cpp
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+
+#include <iostream>
+#include <stdlib.h>
+#include <stdint.h>
+#include <dlfcn.h>
+#include <errno.h>
+
+#include "Jit.hpp"
+#include "ilgen/TypeDictionary.hpp"
+#include "ilgen/MethodBuilder.hpp"
+#include "AtomicOperations.hpp"
+
+using std::cout;
+using std::cerr;
+
+
+int
+main(int argc, char *argv[])
+   {
+   cout << "Step 1: initialize JIT\n";
+   bool initialized = initializeJit();
+   if (!initialized)
+      {
+      cerr << "FAIL: could not initialize JIT\n";
+      exit(-1);
+      }
+
+   cout << "Step 2: define type dictionary\n";
+   TR::TypeDictionary types;
+
+   cout << "Step 3: compile 32-bit method builders\n";
+   AtomicInt32Add method(&types);
+   uint8_t *entry32 = 0;
+   int32_t rc = compileMethodBuilder(&method, &entry32);
+   if (rc != 0)
+      {
+      cerr << "First method FAIL: compilation error " << rc << "\n";
+      exit(-2);
+      }
+
+   cout << "Step 4: start testing 32-bit atomic increment\n";
+   typedef int32_t (Atomic32MethodFunction)(int32_t*);
+   Atomic32MethodFunction *increment32 = (Atomic32MethodFunction *) entry32;
+
+   int32_t v;
+   v=0;   cout << "atomic increment32(" << v; cout << ") == " << increment32(&v) << "\n";
+   v=1;   cout << "atomic increment32(" << v; cout << ") == " << increment32(&v) << "\n";
+   v=10;  cout << "atomic increment32(" << v; cout << ") == " << increment32(&v) << "\n";
+   v=-15; cout << "atomic increment32(" << v; cout << ") == " << increment32(&v) << "\n";
+
+   cout << "Step 5: compile 64-bit method builders\n";
+   AtomicInt64Add method2(&types);
+   uint8_t *entry64 = 0;
+   int32_t rsc = compileMethodBuilder(&method2, &entry64);
+   if (rsc != 0)
+      {   
+      cerr << "Second method FAIL: compilation error " << rsc << "\n";
+      exit(-2); 
+      } 
+
+   cout << "Step 6: start testing 64-bit atomic increment\n";
+   typedef int64_t (Atomic64MethodFunction)(int64_t*);
+   Atomic64MethodFunction *increment64 = (Atomic64MethodFunction *) entry64;
+
+   int64_t val;
+   val=0;   cout << "atomic increment64(" << val; cout << ") == " << increment64(&val) << "\n";
+   val=1;   cout << "atomic increment64(" << val; cout << ") == " << increment64(&val) << "\n";
+   val=10;  cout << "atomic increment64(" << val; cout << ") == " << increment64(&val) << "\n";
+   val=-15; cout << "atomic increment64(" << val; cout << ") == " << increment64(&val) << "\n";
+
+   cout << "Step 7: shutdown JIT\n";
+   shutdownJit();
+   }
+
+AtomicInt32Add::AtomicInt32Add(TR::TypeDictionary *d)
+   : MethodBuilder(d)
+   {
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   DefineName("increment");
+   pInt32=d->PointerTo(Int32);
+   DefineParameter("addressOfValue", pInt32);
+   DefineReturnType(Int32);
+   }
+
+bool
+AtomicInt32Add::buildIL()
+   {
+   cout << "AtomicInt32Add::buildIL() running!\n";
+   AtomicAdd(
+           IndexAt(pInt32, Load("addressOfValue"), ConstInt32(0)),
+           ConstInt32(1));
+   Return(LoadAt(pInt32, Load("addressOfValue")));
+   
+   return true;
+   }
+
+AtomicInt64Add::AtomicInt64Add(TR::TypeDictionary *d) 
+   : MethodBuilder(d)
+   {   
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   DefineName("increment64");
+   pInt64=d->PointerTo(Int64);
+   DefineParameter("addressOfValue", pInt64);
+   DefineReturnType(Int64);
+   }   
+
+bool
+AtomicInt64Add::buildIL()
+   {   
+   cout << "AtomicInt64Add::buildIL() running!\n";
+   AtomicAdd(
+           IndexAt(pInt64, Load("addressOfValue"), ConstInt64(0)),
+           ConstInt64(1));
+   Return(LoadAt(pInt64, Load("addressOfValue")));
+   
+   return true;
+   }  

--- a/jitbuilder/release/src/AtomicOperations.hpp
+++ b/jitbuilder/release/src/AtomicOperations.hpp
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+
+#ifndef ATOMICOPS_INCL
+#define ATOMICOPS_IMPL
+
+#include "ilgen/MethodBuilder.hpp"
+
+/**
+ * I created two methodBuilders for testing
+ * Int32 / Int64 atomicadd() respectively
+ */
+
+class AtomicInt32Add : public TR::MethodBuilder
+   {
+   private:
+   TR::IlType *pInt32;
+
+   public:
+   AtomicInt32Add(TR::TypeDictionary *);
+   virtual bool buildIL();
+   };
+
+class AtomicInt64Add : public TR::MethodBuilder
+   {   
+   private:
+   TR::IlType *pInt64;
+
+   public:
+   AtomicInt64Add(TR::TypeDictionary *); 
+   virtual bool buildIL();
+   };
+
+#endif // !defined(ATOMICOPS_INCL)


### PR DESCRIPTION
Add AtomicAdd() service in JitBuilder and a new testcase

1. Based on the common helpers for atomic primitives, add AtomicrAdd() and AtomicAddWithOffset() service in JitBuilder. Since evaluator handles if (address+offset) or address by counting the number of children call node has, I passed NULL instead of 0 as offset in AtomicAdd() then call AtomicAddWithoffset(). This service only supports Int32/Int64 for now.
2. Add a new testcase in jitbuilder named AtomicOperations.cpp/hpp, in which we passed the address of each variable and increment by 1.

Signed-off-by: fredqiu <fredqiu@ca.ibm.com>