### PR TITLE
Remove unused field spin_time in J9ThreadMonitorTracing

### DIFF
--- a/gc/base/gcspinlock.cpp
+++ b/gc/base/gcspinlock.cpp
@@ -34,7 +34,6 @@
 			tracing->holdtime_avg = 0;\
 			tracing->spin2_count = 0;\
 			tracing->yield_count = 0;\
-			tracing->spin_time = 0;\
 		}\
 	} while (0)
 

--- a/include_core/omrthread_generated.h
+++ b/include_core/omrthread_generated.h
@@ -131,7 +131,6 @@ typedef struct J9ThreadMonitorTracing {
 	uint64_t enter_time;
 	uint64_t holdtime_sum;
 	uint64_t holdtime_avg;
-	uint64_t spin_time;
 	uintptr_t volatile holdtime_count;
 	uintptr_t enter_pause_count;
 #endif /* OMR_THR_JLM_HOLD_TIMES */

--- a/thread/common/threaddef.h
+++ b/thread/common/threaddef.h
@@ -448,7 +448,6 @@ enum {
 				(monitor)->tracing->holdtime_avg = 0; \
 				(monitor)->tracing->spin2_count = 0; \
 				(monitor)->tracing->yield_count = 0; \
-				(monitor)->tracing->spin_time = 0; \
 			} \
 			if (isSlowEnter) { \
 				(monitor)->tracing->slow_count++; \


### PR DESCRIPTION
Field spin_time in J9ThreadMonitorTracing is not being used. It has been
removed to reduce footprint.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>