### PR TITLE
 Add late block ordering optimization to JitBuilder warm strategy 

### DIFF
--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -1799,7 +1799,8 @@ IlBuilder::ForLoop(bool countsUp,
                    TR::IlValue *increment)
    {
    //ILB_REPLAY_BEGIN();
-
+   
+   methodSymbol()->setMayHaveLoops(true);
    TR_ASSERT(loopCode != NULL, "ForLoop needs to have loopCode builder");
    *loopCode = createBuilderIfNeeded(*loopCode);
 
@@ -1868,6 +1869,7 @@ IlBuilder::DoWhileLoop(const char *whileCondition, TR::IlBuilder **body, TR::IlB
    {
    //ILB_REPLAY_BEGIN();
 
+   methodSymbol()->setMayHaveLoops(true);
    TR_ASSERT(body != NULL, "doWhileLoop needs to have a body");
 
    if (!_methodBuilder->symbolDefined(whileCondition))
@@ -1912,6 +1914,7 @@ IlBuilder::WhileDoLoop(const char *whileCondition, TR::IlBuilder **body, TR::IlB
    {
    //ILB_REPLAY_BEGIN();
 
+   methodSymbol()->setMayHaveLoops(true);
    TR_ASSERT(body != NULL, "WhileDo needs to have a body");
    TraceIL("IlBuilder[ %p ]::WhileDoLoop while %s do body %p\n", this, whileCondition, *body);
 

--- a/compiler/optimizer/SinkStores.cpp
+++ b/compiler/optimizer/SinkStores.cpp
@@ -622,6 +622,7 @@ void TR_SinkStores::recordPlacementForDefAlongEdge(TR_EdgeStorePlacement *edgePl
          (*edgeInfo->_symbolsUsedOrKilled) |= (*_usedSymbolsToMove);
          (*edgeInfo->_symbolsUsedOrKilled) |= (*_killedSymbolsToMove);
          _allEdgePlacements.add(edgePlacement);
+	 optimizer()->setRequestOptimization(OMR::basicBlockOrdering, true);
 
          if (_placementsForEdgesToBlock[toBlockNumber] == NULL)
             _placementsForEdgesToBlock[toBlockNumber] = new (trStackMemory()) TR_EdgeStorePlacementList(trMemory());

--- a/jitbuilder/optimizer/JBOptimizer.cpp
+++ b/jitbuilder/optimizer/JBOptimizer.cpp
@@ -116,6 +116,7 @@ static const OptimizationStrategy JBwarmStrategyOpts[] =
    { OMR::andSimplification,                         OMR::IfEnabled                },  //clean up after versioner
    { OMR::deadTreesElimination,                      OMR::IfEnabled                }, // cleanup at the end
    { OMR::generalStoreSinking                                                      },
+   { OMR::basicBlockOrdering,                        OMR::IfEnabled                },
    { OMR::treesCleansing,                            OMR::IfEnabled                },
    { OMR::deadTreesElimination,                      OMR::IfEnabled                }, // cleanup at the end
    { OMR::localCSE,                                  OMR::IfEnabled                }, // common up expressions for sunk stores


### PR DESCRIPTION
Add an optimization strategy called `basicBlockOrdering` in order to
clean up block orders. Set the methodSymbol() in `IlBuilder` in order to
use `basicBlockOrdering`.

Signed-off-by: Shuyu Li <shuyuli@ca.ibm.com>