### PR TITLE
Resolve warning during compilation

### DIFF
--- a/compiler/ilgen/IlBuilder.hpp
+++ b/compiler/ilgen/IlBuilder.hpp
@@ -100,8 +100,8 @@ public:
       _connectedTrees(false),
       _comesBack(true),
       _haveReplayName(false),
-      _rpILCpp(0),
-      _isHandler(false)
+      _isHandler(false),
+      _rpILCpp(0)
       {
       }
    IlBuilder(TR::IlBuilder *source);


### PR DESCRIPTION
During jitbuilder compilation there are a lot of warnings related to
the initialization order of OMR::IlBuilder::_rpILCpp and
OMR::IlBuilder::_isHandler. Fields should be initialized in declaration
order so I moved the initialization of _rpILcpp after _isHandler.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>