### PR TITLE
Purge unused CS2 allocators

### DIFF
--- a/compiler/cs2/arrayof.h
+++ b/compiler/cs2/arrayof.h
@@ -63,7 +63,7 @@ namespace CS2 {
 /// \ingroup CompilerServices
 ///
 // ------------------------------------------------------------------------
-template <class AElementType, class Allocator = CS2::allocator, size_t segmentBits = 8>
+template <class AElementType, class Allocator, size_t segmentBits = 8>
 class BaseArrayOf : private Allocator {
 public:
 
@@ -396,7 +396,7 @@ CS2_ARTEMP inline unsigned long CS2_BASEARDECL::MemoryUsage() const {
 }
 
 
-template <class AElementType, class Allocator = CS2::allocator, size_t segmentBits = 8, class Initializer = AElementType>
+template <class AElementType, class Allocator, size_t segmentBits = 8, class Initializer = AElementType>
   class ArrayOf : public CS2_BASEARDECL {
 
   using CS2_BASEARDECL::fNumberOfSegments;
@@ -742,7 +742,7 @@ private:
   uint32_t     fNumInitialized;
 };
 
-template <class AElementType, class Allocator = CS2::allocator, size_t segmentBits = 8, class Initializer = AElementType>
+template <class AElementType, class Allocator, size_t segmentBits = 8, class Initializer = AElementType>
   class StaticArrayOf : public ArrayOf<AElementType, Allocator, segmentBits, Initializer> {
   public:
     StaticArrayOf (size_t size,

--- a/compiler/cs2/bitvectr.h
+++ b/compiler/cs2/bitvectr.h
@@ -63,7 +63,7 @@ const uint32_t kZeroBits      = 0x00000000ul;
 const uint32_t kBitWordSize   = 8 * sizeof(BitWord);
 const uint32_t kShortWordSize = 8 * sizeof(ShortWord);
 
-template <class Allocator = CS2::allocator>
+template <class Allocator>
 class ABitVector : private Allocator {
 private:
   class BitRef;
@@ -1675,7 +1675,6 @@ bool ABitVector<Allocator>::Xor (const ABitVector<Allocator> &inputVector,
   return changed;
 }
 
-typedef ABitVector<>  BitVector;
 }
 
 #ifdef CS2_ALLOCINFO

--- a/compiler/cs2/hashtab.h
+++ b/compiler/cs2/hashtab.h
@@ -47,7 +47,6 @@ namespace CS2 {
 // to customize the hash table for specific key-types.
 // ------------------------------------------------------------------------
 
-class allocator;
 typedef uint32_t HashIndex;
 typedef uint32_t HashValue; // If this is changed, then the Hash_FNV constants *must* be updated
 
@@ -149,7 +148,7 @@ struct HashInfo<CompoundHashKey<First, Second> > {
 };
 
 template <typename AKeyType, typename ADataType,
-          class Allocator = CS2::allocator,
+          class Allocator,
           class AHashInfo = CS2::HashInfo<AKeyType> >
 class HashTable : private Allocator {
  private:

--- a/compiler/cs2/listof.h
+++ b/compiler/cs2/listof.h
@@ -40,7 +40,7 @@ namespace CS2 {
 
 typedef uint32_t ListIndex;
 
-template <class AElementType, class Allocator = CS2::allocator, uint32_t segmentBits = 8>
+template <class AElementType, class Allocator, uint32_t segmentBits = 8>
  class ListOf : public BaseArrayOf<AElementType, Allocator, segmentBits>  {
   public:
 

--- a/compiler/cs2/llistof.h
+++ b/compiler/cs2/llistof.h
@@ -40,7 +40,7 @@ namespace CS2 {
 #define CS2_LL_TEMP template <class ADataType, class Allocator>
 #define CS2_LL_DECL LinkedListOf <ADataType, Allocator>
 
-template <class ADataType, class Allocator = CS2::allocator>
+template <class ADataType, class Allocator>
 class LinkedListOf : private Allocator {
   public:
   LinkedListOf (const Allocator &a = Allocator()) : Allocator(a), fFirst(NULL) {}
@@ -528,7 +528,7 @@ unsigned long CS2_LL_DECL::MemoryUsage() const {
   return mem;
 }
 
-template <class ADataType, class Allocator = CS2::allocator>
+template <class ADataType, class Allocator>
 class QueueOf : public LinkedListOf<ADataType, Allocator>
    {
    public:
@@ -539,7 +539,7 @@ class QueueOf : public LinkedListOf<ADataType, Allocator>
    void Push(const ADataType &data) { Add(data, true); }
    ADataType Pop() { ADataType head = *(Head()); Remove(); return head; }
    };
-template <class ADataType, class Allocator = CS2::allocator>
+template <class ADataType, class Allocator>
 class StackOf : public QueueOf<ADataType, Allocator>
    {
    public:

--- a/compiler/cs2/sparsrbit.h
+++ b/compiler/cs2/sparsrbit.h
@@ -22,6 +22,7 @@
 #include "cs2/cs2.h"
 #include "cs2/allocator.h"
 #include "cs2/bitmanip.h"
+#include "cs2/bitvectr.h"
 
 #ifdef CS2_ALLOCINFO
 #define allocate(x) allocate(x, __FILE__, __LINE__)
@@ -49,7 +50,7 @@ typedef uint64_t SparseBitIndex;
 typedef uint32_t SparseBitIndex;
 #endif
 
-template <class Allocator = CS2::allocator>
+template <class Allocator>
 class ASparseBitVector : private Allocator {
   class SparseBitRef;
   public:
@@ -1788,7 +1789,7 @@ bool ASparseBitVector<Allocator>::Andc(const B2 &inputVector) {
     SparseBitIndex pc = s->PopulationCount();
 
 
-    if (BitVector::hasFastRandomLookup()) {
+    if (inputVector.hasFastRandomLookup()) {
       if (sHighBits>lastOne) break;
 
       while (j<pc) {
@@ -2431,8 +2432,6 @@ ASparseBitVector<Allocator>::operator&=(const B2 &v) {
   return *this;
 }
 
-
-typedef ASparseBitVector<> SparseBitVector;
 }
 
 #ifdef CS2_ALLOCINFO

--- a/compiler/cs2/tableof.h
+++ b/compiler/cs2/tableof.h
@@ -40,7 +40,7 @@ namespace CS2{
 
 typedef size_t TableIndex;
 
-template <class AElementType, class Allocator = CS2::allocator, uint32_t segmentBits = 8, template<class = Allocator>class SupportingBitVector = ASparseBitVector>
+template <class AElementType, class Allocator, uint32_t segmentBits = 8, template<class = Allocator>class SupportingBitVector = ASparseBitVector>
 class TableOf : public CS2_TAR_DECL {
   public:
 

--- a/compiler/cs2/timer.h
+++ b/compiler/cs2/timer.h
@@ -335,7 +335,7 @@ private:
   bool fIsRunning;
 };
 
-template <class Meter, class Allocator = CS2::allocator>
+template <class Meter, class Allocator>
   class PhaseMeasuringNode : private Allocator
 {
  public:
@@ -444,7 +444,7 @@ template <class Meter, class Allocator = CS2::allocator>
  * thread-safe; it maintains the current meter hierarchy for each
  * threads using the meter.
  */
-template <class Meter, class Allocator = CS2::allocator>
+template <class Meter, class Allocator>
 class PhaseMeasuringSummary
 {
 
@@ -669,7 +669,7 @@ inline void PhaseMeasuringSummary<Meter, Allocator>::DumpSummary(ostream & out, 
  * Metering starts when Start() is called. When Stop() is called, the meter is
  * stopped and the metric us submitted to gPhaseMeasuringSummary.
  */
-template <class Meter, class Allocator = CS2::allocator, class PhaseMeasuringSummary = CS2::PhaseMeasuringSummary<Meter, Allocator> >
+template <class Meter, class Allocator, class PhaseMeasuringSummary = CS2::PhaseMeasuringSummary<Meter, Allocator> >
 class PhaseProfiler {
  private:
   ListIndex fIndex;
@@ -711,7 +711,7 @@ class PhaseProfiler {
  * starts at construction and ends at destruction. The metric is automatically reported
  * to gPhaseMeasuringSummary.
  */
-template <class Meter, class Allocator = CS2::allocator, class PhaseMeasuringSummary = CS2::PhaseMeasuringSummary<Meter, Allocator> >
+template <class Meter, class Allocator, class PhaseMeasuringSummary = CS2::PhaseMeasuringSummary<Meter, Allocator> >
 class LexicalBlockProfiler : private PhaseProfiler<Meter, Allocator> {
 private:
   // Should not be copy constructed or copied.
@@ -782,7 +782,7 @@ typedef RunnableMeter<Timer> RunnableTimer;
 // so can use
 //   typedef PhaseTimingSummary<Allocator> PhaseTimingSummary;
 //
-template <class Allocator = CS2::allocator>
+template <class Allocator>
 class PhaseTimingSummary : public PhaseMeasuringSummary<RunnableTimer, Allocator>
 {
 private:
@@ -803,7 +803,7 @@ public:
 // so can use
 //   typedef LexicalBlockTimer<Allocator> LexicalTimer;
 //
-template <class Allocator = CS2::allocator, class PhaseTimingSummary = CS2::PhaseMeasuringSummary<RunnableTimer, Allocator> >
+template <class Allocator, class PhaseTimingSummary = CS2::PhaseMeasuringSummary<RunnableTimer, Allocator> >
 class LexicalBlockTimer : public LexicalBlockProfiler<RunnableTimer, Allocator, PhaseTimingSummary> {
 private:
   // Should not be copy constructed or copied.

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -1688,7 +1688,7 @@ OMR::Node::getAndDecChild(int32_t c)
 
 
 TR::Node *
-OMR::Node::duplicateTreeWithCommoningImpl(CS2::HashTable<TR::Node*, TR::Node*, CS2::allocator> &nodeMapping)
+OMR::Node::duplicateTreeWithCommoningImpl(CS2::HashTable<TR::Node*, TR::Node*, TR::Allocator> &nodeMapping)
    {
    CS2::HashIndex hashIndex = 0;
 
@@ -1737,9 +1737,9 @@ OMR::Node::duplicateTree(bool duplicateChildren)
  * Method to duplicate an entire subtree. Tries to do so 'safely' by maintaining a mapping of visited (and duplicated) nodes
  */
 TR::Node *
-OMR::Node::duplicateTreeWithCommoning()
+OMR::Node::duplicateTreeWithCommoning(TR::Allocator allocator)
    {
-   CS2::HashTable<TR::Node*, TR::Node*, CS2::allocator> nodeMapping;
+   CS2::HashTable<TR::Node*, TR::Node*, TR::Allocator> nodeMapping(allocator);
    return self()->duplicateTreeWithCommoningImpl(nodeMapping);
    }
 

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -51,7 +51,6 @@ class TR_NodeUseAliasSetInterface;
 class TR_OpaqueClassBlock;
 class TR_OpaqueMethodBlock;
 class TR_ResolvedMethod;
-namespace CS2 { class allocator; }
 namespace TR { class AutomaticSymbol; }
 namespace TR { class Block; }
 namespace TR { class CodeGenerator; }
@@ -358,7 +357,7 @@ public:
    TR::Node *             getAndDecChild(int32_t c);
 
    TR::Node *             duplicateTree(bool duplicateChildren = true);
-   TR::Node *             duplicateTreeWithCommoning();
+   TR::Node *             duplicateTreeWithCommoning(TR::Allocator allocator);
    TR::Node *             duplicateTree_DEPRECATED(bool duplicateChildren = true);
    bool                   isUnsafeToDuplicateAndExecuteAgain(int32_t *nodeVisitBudget);
 
@@ -1544,7 +1543,7 @@ protected:
    TR::ILOpCodes setOpCodeValue(TR::ILOpCodes op);
 
    // Misc helpers
-   TR::Node * duplicateTreeWithCommoningImpl(CS2::HashTable<TR::Node*, TR::Node*, CS2::allocator> &nodeMapping);
+   TR::Node * duplicateTreeWithCommoningImpl(CS2::HashTable<TR::Node *, TR::Node *, TR::Allocator> &nodeMapping);
 
    bool collectSymbolReferencesInNode(TR_BitVector &symbolReferencesInNode, vcount_t visitCount);
 

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -5485,7 +5485,7 @@ static void cleanseIntegralNodeFlagsInSubtree(TR::Compilation *comp, TR::Node *n
          OPT_DETAILS_LOOP_VERSIONER, node->getGlobalIndex());
 
    using namespace CS2;
-   QueueOf<ncount_t> queue;
+   QueueOf<ncount_t, TR::Allocator> queue(comp->allocator());
    queue.Push(node->getNodePoolIndex());
    TR::Node *tmp = NULL;
    TR::SparseBitVector seen(comp->allocator());

--- a/compiler/optimizer/PartialRedundancy.cpp
+++ b/compiler/optimizer/PartialRedundancy.cpp
@@ -484,7 +484,7 @@ int32_t TR_PartialRedundancy::perform()
 
       if (nextRedundantComputation != 0)
          {
-         supportedNodesAsArray[nextRedundantComputation] =  supportedNodesAsArray[nextRedundantComputation]->duplicateTreeWithCommoning();
+         supportedNodesAsArray[nextRedundantComputation] =  supportedNodesAsArray[nextRedundantComputation]->duplicateTreeWithCommoning(comp()->allocator());
          supportedNodesAsArray[nextRedundantComputation]->resetFlagsForCodeMotion();
          }
       }

--- a/compiler/optimizer/ShrinkWrapping.cpp
+++ b/compiler/optimizer/ShrinkWrapping.cpp
@@ -262,18 +262,18 @@ TR::Instruction *TR_ShrinkWrap::findJumpInstructionsInBlock (int32_t blockNum, T
 
    TR_ASSERT(current != _swBlockInfo[blockNum]._startInstr, "Current should not have been able to make it all the way back to the start instruction without encountering a jump\n");
 
-   CS2::HashTable<TR::Instruction *, bool> setOfJumps;
+   CS2::HashTable<TR::Instruction *, bool, TR::Allocator> setOfJumps(comp()->allocator());
    findJumpInstructionsInCodeRegion(_swBlockInfo[blockNum]._startInstr, _swBlockInfo[blockNum]._endInstr, setOfJumps);
 
    //Populate jmpInstrs from setOfJumps
-   CS2::HashTable<TR::Instruction *, bool>::Cursor h(setOfJumps);
+   CS2::HashTable<TR::Instruction *, bool, TR::Allocator>::Cursor h(setOfJumps);
    for (h.SetToFirst(); h.Valid(); h.SetToNext())
       jmpInstrs->push_front(setOfJumps.KeyAt(h));
 
    return current;
    }
 
-void TR_ShrinkWrap::findJumpInstructionsInCodeRegion (TR::Instruction *firstInstr, TR::Instruction *lastInstr, CS2::HashTable<TR::Instruction *, bool> & setOfJumps)
+void TR_ShrinkWrap::findJumpInstructionsInCodeRegion (TR::Instruction *firstInstr, TR::Instruction *lastInstr, CS2::HashTable<TR::Instruction *, bool, TR::Allocator> & setOfJumps)
    {
    TR::Instruction *loc = lastInstr;
    while (loc != firstInstr)

--- a/compiler/optimizer/ShrinkWrapping.hpp
+++ b/compiler/optimizer/ShrinkWrapping.hpp
@@ -76,7 +76,7 @@ class TR_ShrinkWrap : public TR::Optimization
    void prePerformOnBlocks();
    void analyzeInstructions();
    TR::Instruction *findJumpInstructionsInBlock (int32_t blockNum, TR::list<TR::Instruction*> *jmpInstrs);
-   void findJumpInstructionsInCodeRegion (TR::Instruction *firstInstr, TR::Instruction *endInstr, CS2::HashTable<TR::Instruction *, bool> & setOfJumps);
+   void findJumpInstructionsInCodeRegion (TR::Instruction *firstInstr, TR::Instruction *endInstr, CS2::HashTable<TR::Instruction *, bool, TR::Allocator> &setOfJumps);
    void computeSaveRestoreSets(TR_RegisterAnticipatability &registerAnticipatability, TR_RegisterAvailability &registerAvailability);
    void doPlacement(TR_RegisterAnticipatability &registerAnticipatability, TR_RegisterAvailability &registerAvailability);
    PreservedRegisterInfo *findPreservedRegisterInfo(int32_t regIndex);

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -5175,7 +5175,7 @@ genericLoadHelper(TR::Node * node, TR::CodeGenerator * cg, TR::MemoryReference *
 void OMR::Z::TreeEvaluator::evaluateRegLoads(TR::Node *node, TR::CodeGenerator *cg)
    {
    using namespace CS2;
-   QueueOf<TR::Node*> queue;
+   QueueOf<TR::Node*, TR::Allocator> queue(cg->comp()->allocator());
    queue.Push(node);
    TR::BitVector visited(cg->comp()->allocator());
    while (!queue.IsEmpty())


### PR DESCRIPTION
Remove CS2 allocator forms that are not under deliberate active use.
This includes trace_allocator, account_allocator, check_allocator,
named_allocator, as well the alias / typedef of malloc_allocator as
CS2::allocator.

Remove template defaults that used CS2::allocator from all places where
it was the first default in the template declaration. Replace locations
where a default is still required such that they use malloc_allocator
as their default template parameter.

Fix multiple locations in the code base where we were incorrectly
referring to CS2::allocator either directly or inadvertantly through a
container default template. Those locations are:

* OMR::Node::duplicateTreeWithCommoning
* OMR::Node::duplicateTreeWithCommoningImpl
* cleanseIntegralNodeFlagsInSubtree (in LoopVersioner.cpp)
* TR_ShrinkWrap::findJumpInstructionsInBlock
* TR_ShrinkWrap::findJumpInstructionsInCodeRegion
* OMR::Z::TreeEvaluator::evaluateRegLoads

At each location, replace CS2::allocator template parameters with
TR::Allocator, and fix container construction as appropriate.

Signed-off-by: Luc des Trois Maisons <lmaisons@ca.ibm.com>