### PR TITLE
Add linkage information for each runtime helper

### DIFF
--- a/compiler/codegen/LinkageConventions.enum
+++ b/compiler/codegen/LinkageConventions.enum
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2000, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+
+/*
+ * This file will be included within an enum.  Only comments, preprocessor macros,
+ * and enumerator definitions are permitted.
+ */
+
+   TR_None = 0,
+   TR_Private,
+   TR_System,
+   TR_AllRegister,
+   TR_InterpretedStatic,
+   TR_Helper,
+   TR_J9JNILinkage,

--- a/compiler/codegen/LinkageConventionsEnum.hpp
+++ b/compiler/codegen/LinkageConventionsEnum.hpp
@@ -21,15 +21,21 @@
 
 // Linkage conventions
 //
+// A "Linkage Convention" is the abstraction of one group of similar calling conventions;
+// actual interpretation is up to the Front End / Code Generator combination.
+// For example, by default, TR_System is interpreted as:
+//     X86-32 Windows and Linux: cdecl calling convention
+//     X86-64 Windows:           Microsoft x64 calling convention
+//     X86-64 Linux:             System V AMD64 ABI
+//
+
 enum TR_LinkageConventions
    {
-   TR_Private           = 0,
-   TR_System            = 1,
-   TR_AllRegister       = 2,
-   TR_InterpretedStatic = 3,
-   TR_Helper            = 4,
-   TR_J9JNILinkage      = 5,
-   TR_NumLinkages       = 6
+   #include "codegen/LinkageConventions.enum"
+   TR_NumLinkages,
+
+   // Force size to be at least 32-bit, as it may be cast to/from integers
+   TR_LinkageForceSize = 0x7fffffff
    };
 
 #endif

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1053,7 +1053,10 @@ bool OMR::CodeGenerator::isMethodInAtomicLongGroup (TR::RecognizedMethod rm)
 TR::Linkage *
 OMR::CodeGenerator::getLinkage(TR_LinkageConventions lc)
    {
-   return _linkages[lc] ? _linkages[lc] : self()->createLinkage(lc);
+   if (lc == TR_None)
+      return NULL;
+   else
+      return _linkages[lc] ? _linkages[lc] : self()->createLinkage(lc);
    }
 
 void OMR::CodeGenerator::initializeLinkage()

--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -25,7 +25,7 @@
 #include <string.h>                            // for strlen, strncmp, etc
 #include "codegen/CodeGenerator.hpp"           // for CodeGenerator
 #include "codegen/FrontEnd.hpp"                // for TR_FrontEnd, feGetEnv
-#include "env/KnownObjectTable.hpp"        // for KnownObjectTable, etc
+#include "env/KnownObjectTable.hpp"            // for KnownObjectTable, etc
 #include "codegen/LinkageConventionsEnum.hpp"
 #include "codegen/Machine.hpp"                 // for Machine
 #include "codegen/RealRegister.hpp"            // for RealRegister
@@ -677,11 +677,12 @@ OMR::SymbolReferenceTable::createIsOverriddenSymbolRef(TR::ResolvedMethodSymbol 
 
 
 TR::SymbolReference *
-OMR::SymbolReferenceTable::createRuntimeHelper(
-   TR_RuntimeHelper index, bool canGCandReturn, bool canGCandExcept, bool preservesAllRegisters)
+OMR::SymbolReferenceTable::createRuntimeHelper(TR_RuntimeHelper index,
+                                               bool             canGCandReturn,
+                                               bool             canGCandExcept,
+                                               bool             preservesAllRegisters)
    {
-
-   TR::MethodSymbol * methodSymbol = TR::MethodSymbol::create(trHeapMemory(),TR_Helper);
+   TR::MethodSymbol * methodSymbol = TR::MethodSymbol::create(trHeapMemory(),runtimeHelperLinkage(index));
    methodSymbol->setHelper();
    methodSymbol->setMethodAddress(runtimeHelperValue(index));
 
@@ -699,7 +700,10 @@ OMR::SymbolReferenceTable::createRuntimeHelper(
    }
 
 TR::SymbolReference *
-OMR::SymbolReferenceTable::findOrCreateRuntimeHelper(TR_RuntimeHelper index, bool canGCandReturn, bool canGCandExcept, bool preservesAllRegisters)
+OMR::SymbolReferenceTable::findOrCreateRuntimeHelper(TR_RuntimeHelper index,
+                                                     bool             canGCandReturn,
+                                                     bool             canGCandExcept,
+                                                     bool             preservesAllRegisters)
    {
 
    TR::SymbolReference * symRef = baseArray.element(index);
@@ -713,7 +717,7 @@ OMR::SymbolReferenceTable::findOrCreateCodeGenInlinedHelper(CommonNonhelperSymbo
    {
    if (!element(index))
       {
-      TR::MethodSymbol * sym = TR::MethodSymbol::create(trHeapMemory(),TR_Helper);
+      TR::MethodSymbol * sym = TR::MethodSymbol::create(trHeapMemory(),TR_None);
       sym->setHelper();
       sym->setIsInlinedByCG();
       element(index) = new (trHeapMemory()) TR::SymbolReference(self(), index, sym);

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -240,8 +240,8 @@ class SymbolReferenceTable
    TR::SymbolReference * getSymRef(CommonNonhelperSymbol i);
    TR::SymbolReference * getSymRef(int32_t i) { return baseArray.element(i); }
 
-   TR::SymbolReference * createRuntimeHelper(TR_RuntimeHelper, bool = false, bool = false, bool preservesAllRegisters = false);
-   TR::SymbolReference * findOrCreateRuntimeHelper(TR_RuntimeHelper, bool, bool, bool preservesAllRegisters);
+   TR::SymbolReference * createRuntimeHelper(TR_RuntimeHelper index, bool canGCandReturn, bool canGCandExcept, bool preservesAllRegisters);
+   TR::SymbolReference * findOrCreateRuntimeHelper(TR_RuntimeHelper index, bool canGCandReturn, bool canGCandExcept, bool preservesAllRegisters);
 
    TR::SymbolReference * findOrCreateCodeGenInlinedHelper(CommonNonhelperSymbol index);
 

--- a/compiler/runtime/Runtime.cpp
+++ b/compiler/runtime/Runtime.cpp
@@ -38,10 +38,10 @@ TR_RuntimeHelperTable runtimeHelpers;
 
 extern "C" void *PyTuple_GetItem(void*,int);
 
-void
-TR_RuntimeHelperTable::setAddress(TR_RuntimeHelper h, void *a)
+void*
+TR_RuntimeHelperTable::translateAddress(void * a)
    {
-   _helpers[h] = a;
+   return a;
    }
 
 void


### PR DESCRIPTION
As there are many different ABI, each runtime helper potentially
requires a specific ABI. Existing code does not take this important
information, and hence this PR proposes adding linkage convention
to each runtime helper.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>