### PR TITLE
Upgrade concurrentScavengerInProgress flag to a toggle counter

### DIFF
--- a/gc/base/EnvironmentBase.hpp
+++ b/gc/base/EnvironmentBase.hpp
@@ -161,9 +161,9 @@ public:
 	MM_ScavengerStats _scavengerStats;
 	MM_ScavengerHotFieldStats _hotFieldStats; /**< hot field statistics for this GC thread */
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC) */
-#if defined(OMR_GC_MODRON_SCAVENGER)
-	bool _concurrentScavengerInProgress; /**< thread local flag/state, if concurrent scavenger is in progress */
-#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	uint64_t _concurrentScavengerSwitchCount; /**< local counter of cycle start and cycle end transitions */
+#endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 
 private:
 
@@ -609,9 +609,9 @@ public:
 #if defined(OMR_GC_SEGREGATED_HEAP)
 		,_allocationTracker(NULL)
 #endif /* OMR_GC_SEGREGATED_HEAP */
-#if defined(OMR_GC_MODRON_SCAVENGER)
-		,_concurrentScavengerInProgress(false)
-#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+		,_concurrentScavengerSwitchCount(0)
+#endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 
 	{
 		_typeId = __FUNCTION__;
@@ -651,9 +651,9 @@ public:
 #if defined(OMR_GC_SEGREGATED_HEAP)
 		,_allocationTracker(NULL)
 #endif /* OMR_GC_SEGREGATED_HEAP */
-#if defined(OMR_GC_MODRON_SCAVENGER)
-		,_concurrentScavengerInProgress(false)
-#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+		,_concurrentScavengerSwitchCount(0)
+#endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 	{
 		_typeId = __FUNCTION__;
 	}

--- a/gc/base/j9mm.tdf
+++ b/gc/base/j9mm.tdf
@@ -853,4 +853,5 @@ TraceAssert=Assert_MM_inflateInvalidRange noEnv Overhead=1 Level=1 Assert="(0 /*
 
 TraceEvent=Trc_MM_ParallelDispatcher_adjustThreadCount_ReducedCPU noEnv Overhead=1 Level=2 Template="MM_ParallelDispatcher::adjustThreadCount limiting threads to %zu due to reduced CPU availability"
 
-TraceEvent=Trc_MM_Scavenger_switchConcurrent Overhead=1 Level=1 Group=scavenger Template="Concurrent switch %zu"
+TraceEvent=Trc_MM_Scavenger_switchConcurrentOld Obsolete Overhead=1 Level=1 Group=scavenger Template="Concurrent switch %zu"
+TraceEvent=Trc_MM_Scavenger_switchConcurrent Overhead=1 Level=1 Group=scavenger Template="Concurrent switch state %zu global/local count %zu/%zu"

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -121,6 +121,8 @@ private:
 		concurrent_state_complete
 	} _concurrentState;
 	
+	uint64_t _concurrentScavengerSwitchCount; /**< global counter of cycle start and cycle end transitions */
+	
 	/* TODO: put it parent Collector class and share with Balanced? */ 
 	volatile bool _forceConcurrentTermination;
 #endif
@@ -686,6 +688,7 @@ public:
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 		, _masterGCThread(env)
 		, _concurrentState(concurrent_state_idle)
+		, _concurrentScavengerSwitchCount(0)
 		, _forceConcurrentTermination(false)		
 #endif		
 		, _omrVM(env->getOmrVM())


### PR DESCRIPTION
There is a global and a thread local counter. Whenever a local counter
is behind the global one, a concurrent switch  should occur, and update
local counter. Global counter is incremented on every start and end STW
phase. 
The counter is needed to help with scenarios when a thread goes asleep
during one GC cycle and gets awaken during another GC cycle. We still
need to trigger the switch, since relevant parameters (like Evacuate
boundaries) change from a cycle to a cycle. 

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>