### PR TITLE
Avoid duplicated reporting fragmentation info in gc-start tag of verbosegclog

### DIFF
--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -1283,6 +1283,9 @@ MM_ParallelGlobalGC::reportGCIncrementEnd(MM_EnvironmentBase *env)
 		stats->_endTime,
 		J9HOOK_MM_PRIVATE_GC_INCREMENT_END,
 		stats);
+
+	/* reset fragmentation indicator after reporting fragmentation */
+	stats->_tenureFragmentation = NO_FRAGMENTATION;
 }
 
 void

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -4066,6 +4066,9 @@ MM_Scavenger::reportGCIncrementEnd(MM_EnvironmentStandard *env)
 		stats->_endTime,
 		J9HOOK_MM_PRIVATE_GC_INCREMENT_END,
 		stats);
+
+	/* reset fragmentation indicator after reporting fragmentation */
+	stats->_tenureFragmentation = NO_FRAGMENTATION;
 }
 
 uintptr_t


### PR DESCRIPTION
reset fragmentation flag after end of gc reporting to avoid duplicated
fragmentation information inside tag gc-start in some cases.

Signed-off-by: Lin Hu <linhu@ca.ibm.com>