### PR TITLE
Optimize Object.clone only for cloneable objects

### DIFF
--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -5704,6 +5704,16 @@ TR::Node *constrainAcall(TR::ValuePropagation *vp, TR::Node *node)
             TR::VPResolvedClass *newTypeConstraint = NULL;
             if (constraint)
                {
+               // Do nothing if the class of the object doesn't implement Cloneable
+               if (constraint->getClass() && !vp->comp()->fej9()->isCloneable(constraint->getClass()))
+                  {
+                  if (vp->trace())
+                     traceMsg(vp->comp(), "Object Clone: Class of node %p is not cloneable, quit\n", node);
+
+                  TR::DebugCounter::incStaticDebugCounter(vp->comp(), TR::DebugCounter::debugCounterName(vp->comp(), "inlineClone/unsuitable/(%s)/%s/block_%d", vp->comp()->signature(), vp->comp()->getHotnessName(vp->comp()->getMethodHotness()), vp->_curTree->getEnclosingBlock()->getNumber()));
+
+                  return node;
+                  }
                if ( constraint->isFixedClass() )
                   {
                   newTypeConstraint = TR::VPFixedClass::create(vp, constraint->getClass());

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -3446,8 +3446,8 @@ const char* transformedTargetName (TR::RecognizedMethod rm)
 void TR::ValuePropagation::transformObjectCloneCall(TR::TreeTop *callTree, TR::ValuePropagation::ObjCloneInfo *cloneInfo)
    {
    TR_OpaqueClassBlock *j9class = cloneInfo->_clazz;
-   static char *enableObjectCloneOpt = feGetEnv("TR_enableFastObjectClone");
-   if (!enableObjectCloneOpt)
+   static char *disableObjectCloneOpt = feGetEnv("TR_disableFastObjectClone");
+   if (disableObjectCloneOpt)
       return;
 
    TR::Node *callNode = callTree->getNode()->getFirstChild();


### PR DESCRIPTION
In java, only instances of classes that implement Cloneable can be
cloned, otherwise a CloneNotSupportedException will be thrown. This fix
checks whether the object is cloneable before adding the object to the
candidate list and re-enable the optimization.

Signed-off-by: liqunl <liqunl@ca.ibm.com>