### PR TITLE
WIP: Add canBeInternalPtrOfObject query

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -2382,7 +2382,9 @@ OMR::Node::canBeInternalPtrOfObject()
       // Come across a node that has already been checked
       TR::ILOpCode op = curNode->getOpCode();
       if (printOp)
+         {
          fprintf(stderr,"->%s", op.getName());
+         }
 
       if (visited.contains(curNode))
          break;
@@ -2434,12 +2436,12 @@ OMR::Node::canBeInternalPtrOfObject()
                    ops == TR::variableNewArray ||
                    ops == TR::multianewarray ||
                    ops == TR::aconst ||
-                   ops == TR::i2a ||
-                   ops == TR::l2a ||
+                   //ops == TR::i2a ||
+                   //ops == TR::l2a ||
                    ops == TR::aiadd ||
                    ops == TR::aladd))
             {
-            fprintf(stderr, "Found unsupported opcode: %s",childOp.getName());
+            fprintf(stderr, "Found unsupported opcode: ");
             printOp = true;
             }
          }
@@ -2449,8 +2451,13 @@ OMR::Node::canBeInternalPtrOfObject()
 
    newResult = newResult && !printOp;
    if (printOp)
+      {
       fprintf(stderr, "Node %p %s internal pointer and we return true\n", self(), newResult ? "is" : "is not");
-   TR_ASSERT(newResult, "Return true when we should really return false, node is "POINTER_PRINTF_FORMAT, self());
+      fflush(stderr);
+      //comp->setOutFile(TR::FilePointer::Stdout());
+      //comp->dumpMethodTrees("About to assert, tree is");
+      }
+   TR_ASSERT(!printOp, "Return true when we should really return false, node is %p", self());
    return true;
    }
 

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -452,6 +452,7 @@ public:
    bool                   dontEliminateStores(bool isForLocalDeadStore = false);
 
    bool                   isNotCollected();
+   bool                   canBeInternalPtrOfObject();
 
    bool                   addressPointsAtObject();
 

--- a/compiler/optimizer/GeneralLoopUnroller.cpp
+++ b/compiler/optimizer/GeneralLoopUnroller.cpp
@@ -714,10 +714,11 @@ void TR_LoopUnroller::modifyBranchTree(TR_RegionStructure *loop,
 
       if (getIndexType().isAddress())
          {
-         firstChild = TR::Node::create(geta2xOpCode(getTestChildType()), 1, firstChild);
+         firstChild = TR::Node::create(geta2xOpCode(getTestChildType()), 1, firstChild); // Liqun: getTestChildType is always int64 or int32, where to fix it?
          }
       else if (firstChild->getType().isAggregate() && !getTestChildType().isAggregate())
          {
+         // Aggregate to any type is TR::BadILOp
          TR::ILOpCodes o2xOp = TR::ILOpCode::getProperConversion(firstChild->getDataType(), getTestChildType().getDataType(), true);
          TR_ASSERT(o2xOp != TR::BadILOp,"could not find conv op for %s -> %s conversion\n",TR::DataType::getName(firstChild->getDataType()),TR::DataType::getName(getTestChildType().getDataType()));
          firstChild = TR::Node::create(o2xOp, 1, firstChild);
@@ -937,6 +938,7 @@ void TR_LoopUnroller::modifyOriginalLoop(TR_RegionStructure *loop, TR_StructureS
          modifyBranchTree(loop, loopNode, branchNode);
          }
 
+      // Liqun: We might want to add support for acmp
       //convert the != condition to a '<' or '>' condition.
       if (branch->getOpCodeValue() == TR::ificmpne)
          {

--- a/compiler/optimizer/InductionVariable.cpp
+++ b/compiler/optimizer/InductionVariable.cpp
@@ -6800,7 +6800,8 @@ TR_InductionVariableAnalysis::getEntryValue(TR::Block *block,
          }
       else
          {
-         TR_ASSERT(symRef->getSymbol()->isParm(), "uninitialized local discovered.");
+         int32_t blockNum = block->getNumber();
+         TR_ASSERT(symRef->getSymbol()->isParm(), "uninitialized local discovered. symRef is " POINTER_PRINTF_FORMAT, symRef);
          }
       return 0;
       }

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -3167,12 +3167,13 @@ TR::TreeTop * OMR_InlinerUtil::storeValueInATemp(
 
       // disable internal pointer symbols for C/C++
       if (
-         (value->getOpCode().isArrayRef() ||
+         ((value->getOpCode().isArrayRef() && value->canBeInternalPtrOfObject()) ||
             (value->getOpCode().isLoadVarDirect() &&
              value->getSymbolReference()->getSymbol()->isAuto() &&
              value->getSymbolReference()->getSymbol()->castToAutoSymbol()->isInternalPointer())))
          isInternalPointer = true;
 
+      // value->isNotCollected() == false does not mean value is collected
       if ((value->isNotCollected() && dataType != TR::Aggregate) || isIndirect)
          {
          TR::SymbolReference *valueRef;

--- a/compiler/optimizer/OMRLocalCSE.cpp
+++ b/compiler/optimizer/OMRLocalCSE.cpp
@@ -1357,6 +1357,7 @@ TR::Node* OMR::LocalCSE::getAvailableExpression(TR::Node *parent, TR::Node *node
       }
 
    if ((node->getOpCode().isArrayRef()) &&
+       node->canBeInternalPtrOfObject() &&
        cg()->supportsInternalPointers() &&
        (node->getFirstChild()->getOpCodeValue() == TR::aload) &&
        (node->getFirstChild()->getSymbolReference()->getSymbol()->isAuto()) &&


### PR DESCRIPTION
The query isArrayRef by its name is supposed to return true for nodes
who are addresses pointing to the middle of objects. However, it is a
query on an opcode and returns true for aiadd and aladd, which is
insufficient to serve its original purpose. In some places in the code,
the isInternalPtr flag on a node will be incorrectly set if isArrayRef
returns true, resulting crashes in the gc when it tries to scan the
object the node points to. Unfortunately, isArrayRef is used everywhere
to check if the opcode is aiadd or aladd or to serve other purposes,
thus we can not simply change the implementation of this query or
replace it everywhere with a different query. This commit adds a new
query canBeInternalPtrOfObject on the node and ask the new query
whereever isInternalPtr flag might be set when isArrayRef returns true.

issue: #563
Signed-off-by: liqunl <liqunl@ca.ibm.com>