### PR TITLE
Load Power Table Of Constants in method prologue

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -380,6 +380,13 @@ OMR::Power::CodeGenerator::CodeGenerator() :
    self()->comp()->setReturnInfo(returnInfo);
    }
 
+uintptrj_t *
+OMR::Power::CodeGenerator::getTOCBase()
+    {
+        TR_PPCTableOfConstants *pTOC = toPPCTableOfConstants(self()->comp()->getPersistentInfo()->getPersistentTOC());
+        return pTOC->getTOCBase();
+    }
+
 TR_PPCScratchRegisterManager*
 OMR::Power::CodeGenerator::generateScratchRegisterManager(int32_t capacity)
    {

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -95,7 +95,8 @@ extern TR::Instruction *loadConstant(TR::CodeGenerator *cg,
                                     int64_t         value,
                                     TR::Register    *targetRegister,
                                     TR::Instruction *cursor=NULL,
-                                    bool            isPicSite=false);
+                                    bool            isPicSite=false,
+                                    bool            useTOC=true);
 
 extern TR::Instruction *fixedSeqMemAccess(TR::CodeGenerator *cg,
                                          TR::Node          *node,
@@ -237,6 +238,8 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    TR::RealRegister *getTOCBaseRegister()                       {return _tocBaseRegister;}
    TR::RealRegister *setTOCBaseRegister(TR::RealRegister *r)  {return (_tocBaseRegister = r);}
+
+   uintptrj_t *getTOCBase();
 
    TR_PPCScratchRegisterManager* generateScratchRegisterManager(int32_t capacity = 32);
 

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -185,7 +185,7 @@ TR::Instruction *loadConstant(TR::CodeGenerator *cg, TR::Node * node, int32_t va
    return(cursor);
    }
 
-TR::Instruction *loadConstant(TR::CodeGenerator *cg, TR::Node * node, int64_t value, TR::Register *trgReg, TR::Instruction *cursor, bool isPicSite)
+TR::Instruction *loadConstant(TR::CodeGenerator *cg, TR::Node * node, int64_t value, TR::Register *trgReg, TR::Instruction *cursor, bool isPicSite, bool useTOC)
    {
    if ((TR::getMinSigned<TR::Int32>() <= value) && (value <= TR::getMaxSigned<TR::Int32>()))
       {
@@ -202,7 +202,7 @@ TR::Instruction *loadConstant(TR::CodeGenerator *cg, TR::Node * node, int64_t va
 
    bool canUseTOC = (!TR::isJ9() || !isPicSite) &&
                     !comp->getOption(TR_DisableTOCForConsts);
-   if (canUseTOC)
+   if (canUseTOC && useTOC)
       offset = TR_PPCTableOfConstants::lookUp((int8_t *)&value, sizeof(int64_t), true, 0, cg);
 
    if (offset != PTOC_FULL_INDEX)

--- a/compiler/p/codegen/PPCSystemLinkage.cpp
+++ b/compiler/p/codegen/PPCSystemLinkage.cpp
@@ -641,6 +641,7 @@ TR_PPCSystemLinkage::createPrologue(
    cg()->setStackPointerRegister(machine->getPPCRealRegister(properties.getNormalStackPointerRegister()));
    TR::RealRegister        *sp = cg()->getStackPointerRegister();
    TR::RealRegister        *metaBase = cg()->getMethodMetaDataRegister();
+   TR::RealRegister        *gr2 = machine->getPPCRealRegister(TR::RealRegister::gr2);
    TR::RealRegister        *gr0 = machine->getPPCRealRegister(TR::RealRegister::gr0);
    TR::RealRegister        *gr11 = machine->getPPCRealRegister(TR::RealRegister::gr11);
    TR::RealRegister        *cr0 = machine->getPPCRealRegister(TR::RealRegister::cr0);
@@ -648,6 +649,12 @@ TR_PPCSystemLinkage::createPrologue(
    TR::RealRegister::RegNum regIndex;
    int32_t                    size = bodySymbol->getLocalMappingCursor();
    int32_t                    argSize;
+    
+   
+#ifdef __LITTLE_ENDIAN__
+   //Move TOCBase into r2
+   cursor = loadConstant(cg(), firstNode, (int64_t)(cg()->getTOCBase()), gr2, cursor, false, false);
+#endif
 
    if (machine->getLinkRegisterKilled())
       {


### PR DESCRIPTION
The Power Table Of Contents(TOC) was not being loaded into r2 as specified by the Power System
Linkage. When the caller does not do this, the callee will try and use
the TOC base register, r2, resulting in an error. To fix this the TOC
will be loaded when the prologue is created.

Signed-off-by: Ryan Santhirarajan <rsanth@ca.ibm.com>