### PR TITLE
Simplify packed decimal restore snippet generation

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -498,6 +498,7 @@ OMR::Z::CodeGenerator::CodeGenerator()
      _notPrintLabelHashTab(NULL),
      _interfaceSnippetToPICsListHashTab(NULL),
      _currentCheckNode(NULL),
+     _currentBCDCHKHandlerLabel(NULL),
      _internalControlFlowRegisters(getTypedAllocator<TR::Register*>(self()->comp()->allocator())),
      _nodesToBeEvaluatedInRegPairs(self()->comp()->allocator()),
      _killedRestrictedRegisters(NULL),

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -524,9 +524,16 @@ public:
 
    void buildRegisterMapForInstruction(TR_GCStackMap *map);
 
+   // BCDCHK node
    TR::Node * _currentCheckNode;
    void setCurrentCheckNodeBeingEvaluated(TR::Node * n) { _currentCheckNode = n; }
    TR::Node * getCurrentCheckNodeBeingEvaluated(){ return _currentCheckNode; }
+
+   // BCDCHK node exception handler label
+   TR::LabelSymbol* _currentBCDCHKHandlerLabel;
+   void setCurrentBCDCHKHandlerLabel(TR::LabelSymbol * l) { _currentBCDCHKHandlerLabel = l; }
+   TR::LabelSymbol* getCurrentBCDCHKHandlerLabel(){ return _currentBCDCHKHandlerLabel; }
+
    TR::RegisterDependencyConditions * _currentBCDRegDeps;
    void setCurrentCheckNodeRegDeps(TR::RegisterDependencyConditions * daaDeps) {_currentBCDRegDeps = daaDeps;}
    TR::RegisterDependencyConditions * getCurrentCheckNodeRegDeps() {return _currentBCDRegDeps;}

--- a/compiler/z/codegen/S390GenerateInstructions.cpp
+++ b/compiler/z/codegen/S390GenerateInstructions.cpp
@@ -780,26 +780,7 @@ generateRXInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
 #ifdef J9_PROJECT_SPECIFIC
    if (op == TR::InstOpCode::CVB || op == TR::InstOpCode::EX)
       {
-      TR::Node* BCDCHKNode = cg->getCurrentCheckNodeBeingEvaluated();
-
-      if (BCDCHKNode && BCDCHKNode->getOpCodeValue() == TR::BCDCHK)
-         {
-         // Explicitly mark as a DAA intrinsic instruction
-         instr->setThrowsImplicitException();
-
-         //there might be cases that two or more insts generated will throw exception, and we only need one of the label.
-         //so we will assume that at this moment the second child of BCDCHKNode is the label.
-         TR::LabelSymbol * label = (TR::LabelSymbol *)BCDCHKNode->getChild(1);
-
-         TR::S390RestoreGPR7Snippet * restoreSnippet =
-                        new (INSN_HEAP) TR::S390RestoreGPR7Snippet(cg, n,  TR::LabelSymbol::create(INSN_HEAP,cg), label);
-         cg->addSnippet(restoreSnippet);
-         TR::Instruction * nop = new (INSN_HEAP) TR::S390NOPInstruction(TR::InstOpCode::NOP, 2, n, cg);
-         TR::Instruction* brcInstr = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_NOP, n, restoreSnippet->getSnippetLabel());
-
-         //generate register deps for CVB so that we will not see spills between CVB and the following branch
-         TR::TreeEvaluator::createDAACondDeps(n, cg->getCurrentCheckNodeRegDeps(), instr, cg);
-         }
+      generateS390DAAExceptionRestoreSnippet(cg, n, instr, op, true);
       }
 #endif
 
@@ -820,26 +801,7 @@ generateRXInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
 #ifdef J9_PROJECT_SPECIFIC
    if (op == TR::InstOpCode::CVB || op == TR::InstOpCode::EX)
       {
-      TR::Node* BCDCHKNode = cg->getCurrentCheckNodeBeingEvaluated();
-
-      if (BCDCHKNode && BCDCHKNode->getOpCodeValue() == TR::BCDCHK)
-         {
-         // Explicitly mark as a DAA intrinsic instruction
-         instr->setThrowsImplicitException();
-
-         //there might be cases that two or more insts generated will throw exception, and we only need one of the label.
-         //so we will assume that at this moment the second child of BCDCHKNode is the label.
-         TR::LabelSymbol * label = (TR::LabelSymbol *)BCDCHKNode->getChild(1);
-
-         TR::S390RestoreGPR7Snippet * restoreSnippet =
-                        new (INSN_HEAP) TR::S390RestoreGPR7Snippet(cg, n,  TR::LabelSymbol::create(INSN_HEAP,cg), label);
-         cg->addSnippet(restoreSnippet);
-         TR::Instruction * nop = new (INSN_HEAP) TR::S390NOPInstruction(TR::InstOpCode::NOP, 2, n, cg);
-         TR::Instruction* brcInstr = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_NOP, n, restoreSnippet->getSnippetLabel());
-
-         //generate register deps for CVB so that we will not see spills between CVB and the following branch
-         TR::TreeEvaluator::createDAACondDeps(n, cg->getCurrentCheckNodeRegDeps(), instr, cg);
-         }
+      generateS390DAAExceptionRestoreSnippet(cg, n, instr, op, true);
       }
 #endif
 
@@ -872,26 +834,7 @@ generateRXYInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
 #ifdef J9_PROJECT_SPECIFIC
    if (op == TR::InstOpCode::CVBY || op == TR::InstOpCode::CVBG)
       {
-      TR::Node* BCDCHKNode = cg->getCurrentCheckNodeBeingEvaluated();
-
-      if (BCDCHKNode && BCDCHKNode->getOpCodeValue() == TR::BCDCHK)
-         {
-         // Explicitly mark as a DAA intrinsic instruction
-         instr->setThrowsImplicitException();
-
-         //there might be cases that two or more insts generated will throw exception, and we only need one of the label.
-         //so we will assume that at this moment the second child of BCDCHKNode is the label.
-         TR::LabelSymbol * label = (TR::LabelSymbol *)BCDCHKNode->getChild(1);
-
-         TR::S390RestoreGPR7Snippet * restoreSnippet =
-                        new (INSN_HEAP) TR::S390RestoreGPR7Snippet(cg, n,  TR::LabelSymbol::create(INSN_HEAP,cg), label);
-         cg->addSnippet(restoreSnippet);
-         TR::Instruction* brcInstr = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_NOP, n, restoreSnippet->getSnippetLabel());
-
-         //generate register deps for CVBY/CVBG so that we will not see spills between CVB and the following branch
-         TR::TreeEvaluator::createDAACondDeps(n, cg->getCurrentCheckNodeRegDeps(), instr, cg);
-
-         }
+      generateS390DAAExceptionRestoreSnippet(cg, n, instr, op, false);
       }
 #endif
 
@@ -944,24 +887,7 @@ generateRXYInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
 #ifdef J9_PROJECT_SPECIFIC
    if (op == TR::InstOpCode::CVBY || op == TR::InstOpCode::CVBG)
       {
-      TR::Node* BCDCHKNode = cg->getCurrentCheckNodeBeingEvaluated();
-
-      if (BCDCHKNode && BCDCHKNode->getOpCodeValue() == TR::BCDCHK)
-         {
-         // Explicitly mark as a DAA intrinsic instruction
-         instr->setThrowsImplicitException();
-
-         //there might be cases that two or more insts generated will throw exception, and we only need one of the label.
-         //so we will assume that at this moment the second child of BCDCHKNode is the label.
-         TR::LabelSymbol * label = (TR::LabelSymbol *)BCDCHKNode->getChild(1);
-
-         TR::S390RestoreGPR7Snippet * restoreSnippet =
-                        new (INSN_HEAP) TR::S390RestoreGPR7Snippet(cg, n,  TR::LabelSymbol::create(INSN_HEAP,cg), label);
-         cg->addSnippet(restoreSnippet);
-         TR::Instruction* brcInstr =generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_NOP, n, restoreSnippet->getSnippetLabel());
-
-         TR::TreeEvaluator::createDAACondDeps(n, cg->getCurrentCheckNodeRegDeps(), instr, cg);
-         }
+      generateS390DAAExceptionRestoreSnippet(cg, n, instr, op, false);
       }
 #endif
 
@@ -994,24 +920,7 @@ generateRXYInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
 #ifdef J9_PROJECT_SPECIFIC
    if (op == TR::InstOpCode::CVBY || op == TR::InstOpCode::CVBG)
       {
-      TR::Node* BCDCHKNode = cg->getCurrentCheckNodeBeingEvaluated();
-
-      if (BCDCHKNode && BCDCHKNode->getOpCodeValue() == TR::BCDCHK)
-         {
-         // Explicitly mark as a DAA intrinsic instruction
-         instr->setThrowsImplicitException();
-
-         //there might be cases that two or more insts generated will throw exception, and we only need one of the label.
-         //so we will assume that at this moment the second child of BCDCHKNode is the label.
-         TR::LabelSymbol * label = (TR::LabelSymbol *)BCDCHKNode->getChild(1);
-
-         TR::S390RestoreGPR7Snippet * restoreSnippet =
-                        new (INSN_HEAP) TR::S390RestoreGPR7Snippet(cg, n,  TR::LabelSymbol::create(INSN_HEAP,cg), label);
-         cg->addSnippet(restoreSnippet);
-         TR::Instruction* brcInstr = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_NOP, n, restoreSnippet->getSnippetLabel());
-
-         TR::TreeEvaluator::createDAACondDeps(n, cg->getCurrentCheckNodeRegDeps(), instr, cg);
-         }
+      generateS390DAAExceptionRestoreSnippet(cg, n, instr, op, false);
       }
 #endif
 
@@ -1560,27 +1469,14 @@ generateSS2Instruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
       instr = new (INSN_HEAP) TR::S390SS2Instruction(op, n, len1, mf1, len2, mf2, cg);
 
 #ifdef J9_PROJECT_SPECIFIC
-   if (op == TR::InstOpCode::ZAP || op == TR::InstOpCode::CP || op == TR::InstOpCode::AP || op == TR::InstOpCode::SP || op == TR::InstOpCode::MP || op == TR::InstOpCode::DP)
+   if (op == TR::InstOpCode::ZAP ||
+           op == TR::InstOpCode::CP ||
+           op == TR::InstOpCode::AP ||
+           op == TR::InstOpCode::SP ||
+           op == TR::InstOpCode::MP ||
+           op == TR::InstOpCode::DP)
       {
-      TR::Node* BCDCHKNode = cg->getCurrentCheckNodeBeingEvaluated();
-
-      if (BCDCHKNode && BCDCHKNode->getOpCodeValue() == TR::BCDCHK)
-         {
-         // Explicitly mark as a DAA intrinsic instruction
-         instr->setThrowsImplicitException();
-
-         //there might be cases that two or more insts generated will throw exception, and we only need one of the label.
-         //so we will assume that at this moment the second child of BCDCHKNode is the label.
-         TR::LabelSymbol * label = (TR::LabelSymbol *)BCDCHKNode->getChild(1);
-
-         TR::S390RestoreGPR7Snippet * restoreSnippet =
-                        new (INSN_HEAP) TR::S390RestoreGPR7Snippet(cg, n,  TR::LabelSymbol::create(INSN_HEAP,cg), label);
-         cg->addSnippet(restoreSnippet);
-         TR::Instruction* brcInstr = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_NOP, n, restoreSnippet->getSnippetLabel());
-
-         //generate register deps for CVB so that we will not see spills between CVB and the following branch
-         TR::TreeEvaluator::createDAACondDeps(n, cg->getCurrentCheckNodeRegDeps(), instr, cg);
-         }
+      generateS390DAAExceptionRestoreSnippet(cg, n, instr, op, false);
       }
 #endif
 
@@ -1607,25 +1503,7 @@ generateSS3Instruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
 #ifdef J9_PROJECT_SPECIFIC
    if (op == TR::InstOpCode::SRP)
       {
-      TR::Node* BCDCHKNode = cg->getCurrentCheckNodeBeingEvaluated();
-
-      if (BCDCHKNode && BCDCHKNode->getOpCodeValue() == TR::BCDCHK)
-         {
-         // Explicitly mark as a DAA intrinsic instruction
-         instr->setThrowsImplicitException();
-
-         //there might be cases that two or more insts generated will throw exception, and we only need one of the label.
-         //so we will assume that at this moment the second child of BCDCHKNode is the label.
-         TR::LabelSymbol * label = (TR::LabelSymbol *)BCDCHKNode->getChild(1);
-
-         TR::S390RestoreGPR7Snippet * restoreSnippet =
-                        new (INSN_HEAP) TR::S390RestoreGPR7Snippet(cg, n,  TR::LabelSymbol::create(INSN_HEAP,cg), label);
-         cg->addSnippet(restoreSnippet);
-         TR::Instruction* brcInstr = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_NOP, n, restoreSnippet->getSnippetLabel());
-
-         //generate register deps for SRP so that we will not see spills between CVB and the following branch
-         TR::TreeEvaluator::createDAACondDeps(n, cg->getCurrentCheckNodeRegDeps(), instr, cg);
-         }
+      generateS390DAAExceptionRestoreSnippet(cg, n, instr, op, false);
       }
 #endif
    return instr;
@@ -1645,25 +1523,7 @@ generateSS3Instruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
 #ifdef J9_PROJECT_SPECIFIC
    if (op == TR::InstOpCode::SRP)
       {
-      TR::Node* BCDCHKNode = cg->getCurrentCheckNodeBeingEvaluated();
-
-      if (BCDCHKNode && BCDCHKNode->getOpCodeValue() == TR::BCDCHK)
-         {
-         // Explicitly mark as a DAA intrinsic instruction
-         instr->setThrowsImplicitException();
-
-         //there might be cases that two or more insts generated will throw exception, and we only need one of the label.
-         //so we will assume that at this moment the second child of BCDCHKNode is the label.
-         TR::LabelSymbol * label = (TR::LabelSymbol *)BCDCHKNode->getChild(1);
-
-         TR::S390RestoreGPR7Snippet * restoreSnippet =
-                        new (INSN_HEAP) TR::S390RestoreGPR7Snippet(cg, n,  TR::LabelSymbol::create(INSN_HEAP,cg), label);
-         cg->addSnippet(restoreSnippet);
-         TR::Instruction* brcInstr = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_NOP, n, restoreSnippet->getSnippetLabel());
-
-         //generate register deps for SRP so that we will not see spills between CVB and the following branch
-         TR::TreeEvaluator::createDAACondDeps(n, cg->getCurrentCheckNodeRegDeps(), instr, cg);
-         }
+      generateS390DAAExceptionRestoreSnippet(cg, n, instr, op, false);
       }
 #endif
    return instr;
@@ -3380,3 +3240,74 @@ TR::Instruction *generateZeroVector(TR::Node *node, TR::CodeGenerator *cg, TR::R
    {
    return generateVRIaInstruction(cg, TR::InstOpCode::VREPI, node, vecZeroReg, 0, 3);
    }
+
+#ifdef J9_PROJECT_SPECIFIC
+
+/**
+ * \brief
+ *    Determines if an instruction can throw a decimal overflow exceptions.
+ *
+ * \param op
+ *    The instruction to check.
+ *
+ * \return
+ *    true if \p op is designed to throw decimal overflow exception according to the PoP; false otherwise.
+ *
+ * \details
+ *    Linux on z runs a process with this exception disabled. As a result of this, the JIT signal handler
+ *    does not receive a signal in case decimal overflow exception happens. This helper function decides
+ *    whether to rely on condition code in such cases.
+*/
+bool
+canThrowDecimalOverflowException(TR::InstOpCode::Mnemonic op)
+   {
+   switch(op)
+      {
+   case TR::InstOpCode::AP:
+   case TR::InstOpCode::SP:
+   case TR::InstOpCode::SRP:
+   case TR::InstOpCode::ZAP:
+       return true;
+   default:
+       return false;
+      }
+   }
+
+void
+generateS390DAAExceptionRestoreSnippet(TR::CodeGenerator* cg,
+                                       TR::Node* n,
+                                       TR::Instruction* instr,
+                                       TR::InstOpCode::Mnemonic op,
+                                       bool hasNOP)
+   {
+   TR::Node* BCDCHKNode = cg->getCurrentCheckNodeBeingEvaluated();
+
+   if (BCDCHKNode && BCDCHKNode->getOpCodeValue() == TR::BCDCHK)
+      {
+      // Explicitly mark as a DAA intrinsic instruction
+      instr->setThrowsImplicitException();
+
+      //there might be cases that two or more insts generated will throw exception, and we only need one of the label.
+      //so we will assume that at this moment the second child of BCDCHKNode is the label.
+      TR::LabelSymbol * handlerLabel = cg->getCurrentBCDCHKHandlerLabel();
+      TR_ASSERT(handlerLabel, "BCDCHK node handler label should not be null");
+
+      TR::LabelSymbol* restoreGPR7SnippetHandler = TR::LabelSymbol::create(INSN_HEAP,cg);
+      TR::S390RestoreGPR7Snippet * restoreSnippet =
+                     new (INSN_HEAP) TR::S390RestoreGPR7Snippet(cg, n, restoreGPR7SnippetHandler, handlerLabel);
+      cg->addSnippet(restoreSnippet);
+
+      if(hasNOP)
+         {
+         TR::Instruction * nop = new (INSN_HEAP) TR::S390NOPInstruction(TR::InstOpCode::NOP, 2, n, cg);
+         }
+
+      TR::InstOpCode::S390BranchCondition bc = canThrowDecimalOverflowException(op) ? TR::InstOpCode::COND_CC3 : TR::InstOpCode::COND_NOP;
+      generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_NOP, n, restoreGPR7SnippetHandler);
+      generateS390BranchInstruction(cg, TR::InstOpCode::BRC, bc, n, handlerLabel);
+
+      //generate register deps so that we will not see spills between the instruction and the following branch
+      TR::TreeEvaluator::createDAACondDeps(n, cg->getCurrentCheckNodeRegDeps(), instr, cg);
+      }
+   }
+#endif

--- a/compiler/z/codegen/S390GenerateInstructions.hpp
+++ b/compiler/z/codegen/S390GenerateInstructions.hpp
@@ -1112,6 +1112,17 @@ TR::Instruction *generateVirtualGuardNOPInstruction(
                    TR::RegisterDependencyConditions *cond,
                    TR::LabelSymbol                      *sym,
                    TR::Instruction                     *preced = 0);
+
+bool
+canThrowDecimalOverflowException(TR::InstOpCode::Mnemonic op);
+
+void
+generateS390DAAExceptionRestoreSnippet(TR::CodeGenerator* cg,
+                                       TR::Node* n,
+                                       TR::Instruction* instr,
+                                       TR::InstOpCode::Mnemonic op,
+                                       bool hasNOP);
+
 #endif
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Simplify generateS390 instruction functions for packed decimal operations
so that they use the same function to generate restore snippets.

Signed-off-by: Nigel Yu <yunigel@ca.ibm.com>