### PR TITLE
Jitbuilder vm

### DIFF
--- a/compiler/ilgen/BytecodeBuilder.cpp
+++ b/compiler/ilgen/BytecodeBuilder.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2016
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -215,40 +215,112 @@ OMR::BytecodeBuilder::transferVMState(TR::BytecodeBuilder **b)
    }
 
 void
+OMR::BytecodeBuilder::Goto(TR::BytecodeBuilder **dest)
+   {
+   if (*dest == NULL)
+      *dest = _methodBuilder->OrphanBytecodeBuilder(_bcIndex, _name);
+   Goto(*dest);
+   }
+
+void
 OMR::BytecodeBuilder::Goto(TR::BytecodeBuilder *dest)
    {
    AddSuccessorBuilder(&dest);
-   OMR::IlBuilder::Goto((TR::IlBuilder **)&dest);
+   OMR::IlBuilder::Goto(dest);
    }
 
 void
 OMR::BytecodeBuilder::IfCmpEqual(TR::BytecodeBuilder **dest, TR::IlValue *v1, TR::IlValue *v2)
    {
-   bool added = false;
+   if (*dest == NULL)
+      *dest = _methodBuilder->OrphanBytecodeBuilder(_bcIndex, _name);
+   IfCmpEqual(*dest, v1, v2);
+   }
 
-   if (*dest != NULL)
-      {
-      AddSuccessorBuilder(dest);
-      added = true;
-      }
-   OMR::IlBuilder::IfCmpEqual((TR::IlBuilder **)dest, v1, v2);
+void
+OMR::BytecodeBuilder::IfCmpEqual(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2)
+   {
+   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
+   AddSuccessorBuilder(&dest);
+   OMR::IlBuilder::IfCmpEqual(dest, v1, v2);
+   }
 
-   if (!added)
-      AddSuccessorBuilder(dest); // if dest didn't exist previously, it can't be a merge
+void
+OMR::BytecodeBuilder::IfCmpEqualZero(TR::BytecodeBuilder **dest, TR::IlValue *c)
+   {
+   if (*dest == NULL)
+      *dest = _methodBuilder->OrphanBytecodeBuilder(_bcIndex, _name);
+   IfCmpEqualZero(*dest, c);
+   }
+
+void
+OMR::BytecodeBuilder::IfCmpEqualZero(TR::BytecodeBuilder *dest, TR::IlValue *c)
+   {
+   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
+   AddSuccessorBuilder(&dest);
+   OMR::IlBuilder::IfCmpEqualZero(dest, c);
    }
 
 void
 OMR::BytecodeBuilder::IfCmpNotEqual(TR::BytecodeBuilder **dest, TR::IlValue *v1, TR::IlValue *v2)
    {
-   bool added = false;
+   if (*dest == NULL)
+      *dest = _methodBuilder->OrphanBytecodeBuilder(_bcIndex, _name);
+   IfCmpNotEqual(*dest, v1, v2);
+   }
 
-   if (*dest != NULL)
-      {
-      AddSuccessorBuilder(dest);
-      added = true;
-      }
-   OMR::IlBuilder::IfCmpNotEqual((TR::IlBuilder **)dest, v1, v2);
+void
+OMR::BytecodeBuilder::IfCmpNotEqual(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2)
+   {
+   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
+   AddSuccessorBuilder(&dest);
+   OMR::IlBuilder::IfCmpNotEqual(dest, v1, v2);
+   }
 
-   if (!added)
-      AddSuccessorBuilder(dest); // if dest didn't exist previously, it can't be a merge
+void
+OMR::BytecodeBuilder::IfCmpNotEqualZero(TR::BytecodeBuilder **dest, TR::IlValue *c)
+   {
+   if (*dest == NULL)
+      *dest = _methodBuilder->OrphanBytecodeBuilder(_bcIndex, _name);
+   IfCmpNotEqualZero(*dest, c);
+   }
+
+void
+OMR::BytecodeBuilder::IfCmpNotEqualZero(TR::BytecodeBuilder *dest, TR::IlValue *c)
+   {
+   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
+   AddSuccessorBuilder(&dest);
+   OMR::IlBuilder::IfCmpNotEqualZero(dest, c);
+   }
+
+void
+OMR::BytecodeBuilder::IfCmpLessThan(TR::BytecodeBuilder **dest, TR::IlValue *v1, TR::IlValue *v2)
+   {
+   if (*dest == NULL)
+      *dest = _methodBuilder->OrphanBytecodeBuilder(_bcIndex, _name);
+   IfCmpLessThan(*dest, v1, v2);
+   }
+
+void
+OMR::BytecodeBuilder::IfCmpLessThan(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2)
+   {
+   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
+   AddSuccessorBuilder(&dest);
+   OMR::IlBuilder::IfCmpLessThan(dest, v1, v2);
+   }
+
+void
+OMR::BytecodeBuilder::IfCmpGreaterThan(TR::BytecodeBuilder **dest, TR::IlValue *v1, TR::IlValue *v2)
+   {
+   if (*dest == NULL)
+      *dest = _methodBuilder->OrphanBytecodeBuilder(_bcIndex, _name);
+   IfCmpGreaterThan(*dest, v1, v2);
+   }
+
+void
+OMR::BytecodeBuilder::IfCmpGreaterThan(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2)
+   {
+   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
+   AddSuccessorBuilder(&dest);
+   OMR::IlBuilder::IfCmpGreaterThan(dest, v1, v2);
    }

--- a/compiler/ilgen/BytecodeBuilder.cpp
+++ b/compiler/ilgen/BytecodeBuilder.cpp
@@ -21,6 +21,7 @@
 #include "env/FrontEnd.hpp"
 #include "infra/List.hpp"
 #include "il/Block.hpp"
+#include "ilgen/VirtualMachineState.hpp"
 #include "ilgen/IlBuilder.hpp"
 #include "ilgen/MethodBuilder.hpp"
 #include "ilgen/BytecodeBuilder.hpp"
@@ -37,22 +38,24 @@ OMR::BytecodeBuilder::BytecodeBuilder(TR::MethodBuilder *methodBuilder,
    : TR::IlBuilder(methodBuilder, methodBuilder->typeDictionary()),
    _fallThroughBuilder(0),
    _bcIndex(bcIndex),
-   _name(name)
+   _name(name),
+   _initialVMState(0),
+   _vmState(0)
    {
    _successorBuilders = new (PERSISTENT_NEW) List<TR::BytecodeBuilder>(_types->trMemory());
+   initialize(methodBuilder->details(), methodBuilder->methodSymbol(),
+              methodBuilder->fe(), methodBuilder->symRefTab());
+   initSequence();
    }
 
 void
 TR::BytecodeBuilder::initialize(TR::IlGeneratorMethodDetails * details,
-                           TR::ResolvedMethodSymbol     * methodSymbol,
-                           TR::FrontEnd                 * fe,
-                           TR::SymbolReferenceTable     * symRefTab)
+                                TR::ResolvedMethodSymbol     * methodSymbol,
+                                TR::FrontEnd                 * fe,
+                                TR::SymbolReferenceTable     * symRefTab)
     {
-    _details = details;
-    _methodSymbol = methodSymbol;
-    _fe = fe;
-    _symRefTab = symRefTab;
-    _comp = TR::comp();
+    this->OMR::IlInjector::initialize(details, methodSymbol, fe, symRefTab);
+
     //addBytecodeBuilderToList relies on _comp and it won't be ready until now
     _methodBuilder->addBytecodeBuilderToList(this);
     }
@@ -120,20 +123,34 @@ OMR::BytecodeBuilder::addAllSuccessorBuildersToWorklist()
       _methodBuilder->addToTreeConnectingWorklist(builder);
    }
 
+// Must be called *after* all code has been added to the bytecode builder
+// Also, current VM state is assumed to be what should propagate to the fallthrough builder
 void
 OMR::BytecodeBuilder::AddFallThroughBuilder(TR::BytecodeBuilder *ftb)
-    {
-    TR_ASSERT(comesBack(), "builder does not appear to have a fall through path");
+   {
+   TR_ASSERT(comesBack(), "builder does not appear to have a fall through path");
 
-    _fallThroughBuilder = ftb;
-    TraceIL("IlBuilder[ %p ]:: fallThrough successor [ %p ]\n", this, ftb);
+   TraceIL("IlBuilder[ %p ]:: fallThrough successor [ %p ]\n", this, ftb);
 
-    // add explicit goto the fall-through block
-    // requires that AddFallThroughBuilder() be called *after* any code is added to it
-    TR::IlBuilder *b = ftb;
-    Goto(&b);
-    }
+   TR::BytecodeBuilder *b = ftb;
+   transferVMState(&b);    // may change what b points at!
 
+   if (b != ftb)
+      TraceIL("IlBuilder[ %p ]:: fallThrough successor changed to [ %p ]\n", this, b);
+   _fallThroughBuilder = b;
+
+   // add explicit goto and register the actual fall-through block
+   TR::IlBuilder *tgtb = b;
+   TR::IlBuilder::Goto(&tgtb);
+   }
+
+// AddSuccessorBuilders() should be called with a list of TR::BytecodeBuilder ** pointers.
+// Each one of these pointers could be changed by AddSuccessorBuilders() in the case where
+// some operations need to be inserted along the control flow edges to synchronize the
+// vm state from "this" builder to the target BytecodeBuilder. For this reason, the actual
+// control flow edges should be created (i.e. with Goto, IfCmp*, etc.) *after* calling
+// AddSuccessorBuilders, and the target used when creating those flow edges should take
+// into account that AddSuccessorBuilders may change the builder object provided.
 void
 OMR::BytecodeBuilder::AddSuccessorBuilders(uint32_t numExits, ...)
    {
@@ -141,9 +158,10 @@ OMR::BytecodeBuilder::AddSuccessorBuilders(uint32_t numExits, ...)
    va_start(exits, numExits);
    for (int32_t e=0;e < numExits;e++)
       {
-      TR::BytecodeBuilder *builder = (TR::BytecodeBuilder *) va_arg(exits, TR::BytecodeBuilder *);
-      _successorBuilders->add(builder);
-      TraceIL("IlBuilder[ %p ]:: successor [ %p ]\n", this, builder);
+      TR::BytecodeBuilder **builder = (TR::BytecodeBuilder **) va_arg(exits, TR::BytecodeBuilder **);
+      transferVMState(builder);            // may change what builder points at!
+      _successorBuilders->add(*builder);   // must be the bytecode builder that comes back from transferVMState()
+      TraceIL("IlBuilder[ %p ]:: successor [ %p ]\n", this, *builder);
       }
    va_end(exits);
    }
@@ -156,3 +174,81 @@ OMR::BytecodeBuilder::setHandlerInfo(uint32_t catchType)
    catchBlock->setHandlerInfo(catchType, comp()->getInlineDepth(), -1, _methodSymbol->getResolvedMethod(), comp());
    }
 
+void
+OMR::BytecodeBuilder::propagateVMState(OMR::VirtualMachineState *fromVMState)
+   {
+   _initialVMState = (OMR::VirtualMachineState *) fromVMState->MakeCopy();
+   _vmState = (OMR::VirtualMachineState *) fromVMState->MakeCopy();
+   }
+
+// transferVMState needs to be called before the actual transfer operation (Goto, IfCmp,
+// etc.) is created because we may need to insert a builder object along that control
+// flow edge to synchronize the vm state at the target (in the case of a merge point).
+// On return, the object pointed at by the "b" parameter may have changed. The caller
+// should direct control for this edge to whatever the parameter passed to "b" is
+// pointing at on return
+void
+OMR::BytecodeBuilder::transferVMState(TR::BytecodeBuilder **b)
+   {
+   TR_ASSERT(_vmState != NULL, "asked to transfer a NULL vmState from builder %p [ bci %d ]", this, _bcIndex);
+   if ((*b)->initialVMState())
+      {
+      // there is already a vm state at the target builder
+      // so we need to synchronize this builder's vm state with the target builder's vm state
+      // for example, the local variables holding the elements on the operand stack may not match
+      // create an intermediate builder object to do that work
+      TR::BytecodeBuilder *intermediateBuilder = _methodBuilder->OrphanBytecodeBuilder((*b)->_bcIndex, (*b)->_name);
+
+      _vmState->MergeInto((*b)->initialVMState(), intermediateBuilder);
+      TraceIL("IlBuilder[ %p ]:: transferVMState merged vm state on way to [ %p ] using [ %p ]\n", this, *b, intermediateBuilder);
+
+      TR::IlBuilder *tgtb = *b;
+      intermediateBuilder->IlBuilder::Goto(&tgtb);
+      intermediateBuilder->_fallThroughBuilder = *b;
+      TraceIL("IlBuilder[ %p ]:: fallThrough successor [ %p ]\n", intermediateBuilder, *b);
+      *b = intermediateBuilder; // branches should direct towards intermediateBuilder not original *b
+      }
+   else
+      {
+      (*b)->propagateVMState(_vmState);
+      }
+   }
+
+void
+OMR::BytecodeBuilder::Goto(TR::BytecodeBuilder *dest)
+   {
+   AddSuccessorBuilder(&dest);
+   OMR::IlBuilder::Goto((TR::IlBuilder **)&dest);
+   }
+
+void
+OMR::BytecodeBuilder::IfCmpEqual(TR::BytecodeBuilder **dest, TR::IlValue *v1, TR::IlValue *v2)
+   {
+   bool added = false;
+
+   if (*dest != NULL)
+      {
+      AddSuccessorBuilder(dest);
+      added = true;
+      }
+   OMR::IlBuilder::IfCmpEqual((TR::IlBuilder **)dest, v1, v2);
+
+   if (!added)
+      AddSuccessorBuilder(dest); // if dest didn't exist previously, it can't be a merge
+   }
+
+void
+OMR::BytecodeBuilder::IfCmpNotEqual(TR::BytecodeBuilder **dest, TR::IlValue *v1, TR::IlValue *v2)
+   {
+   bool added = false;
+
+   if (*dest != NULL)
+      {
+      AddSuccessorBuilder(dest);
+      added = true;
+      }
+   OMR::IlBuilder::IfCmpNotEqual((TR::IlBuilder **)dest, v1, v2);
+
+   if (!added)
+      AddSuccessorBuilder(dest); // if dest didn't exist previously, it can't be a merge
+   }

--- a/compiler/ilgen/BytecodeBuilder.hpp
+++ b/compiler/ilgen/BytecodeBuilder.hpp
@@ -29,6 +29,7 @@
 
 namespace TR { class BytecodeBuilder; }
 namespace TR { class MethodBuilder; }
+namespace OMR { class VirtualMachineState; }
 
 namespace OMR
 {
@@ -47,20 +48,31 @@ public:
    void AddFallThroughBuilder(TR::BytecodeBuilder *ftb);
 
    void AddSuccessorBuilders(uint32_t numBuilders, ...);
-   void AddSuccessorBuilder(TR::BytecodeBuilder *b) { AddSuccessorBuilders(1, b); }
+   void AddSuccessorBuilder(TR::BytecodeBuilder **b) { AddSuccessorBuilders(1, b); }
 
+   OMR::VirtualMachineState *initialVMState()                { return _initialVMState; }
+   OMR::VirtualMachineState *vmState()                       { return _vmState; }
+   void setVMState(OMR::VirtualMachineState *vmState)        { _vmState = vmState; }
+
+   void propagateVMState(OMR::VirtualMachineState *fromVMState);
+
+   void Goto(TR::BytecodeBuilder *dest);
+   void IfCmpEqual(TR::BytecodeBuilder **dest, TR::IlValue *v1, TR::IlValue *v2);
+   void IfCmpNotEqual(TR::BytecodeBuilder **dest, TR::IlValue *v1, TR::IlValue *v2);
 
 protected:
-   virtual void appendBlock(TR::Block *block = 0, bool addEdge=true);
-
    TR::BytecodeBuilder       * _fallThroughBuilder;
    List<TR::BytecodeBuilder> * _successorBuilders;
    int32_t                     _bcIndex;
    char                      * _name;
+   OMR::VirtualMachineState  * _initialVMState;
+   OMR::VirtualMachineState  * _vmState;
 
+   virtual void appendBlock(TR::Block *block = 0, bool addEdge=true);
    void addAllSuccessorBuildersToWorklist();
    bool connectTrees();
    virtual void setHandlerInfo(uint32_t catchType);
+   void transferVMState(TR::BytecodeBuilder **b);
    };
 
 } // namespace OMR

--- a/compiler/ilgen/BytecodeBuilder.hpp
+++ b/compiler/ilgen/BytecodeBuilder.hpp
@@ -56,9 +56,25 @@ public:
 
    void propagateVMState(OMR::VirtualMachineState *fromVMState);
 
+   // The following control flow services are meant to hide the similarly named services
+   // provided by the IlBuilder class. The reason these implementations exist is to
+   // automatically manage the propagation of virtual machine states between bytecode
+   // builders. By using these services, and AddFallthroughBuilder(), users do not have
+   // to do anything to propagate VM states; it's all just taken care of under the covers.
+   void Goto(TR::BytecodeBuilder **dest);
    void Goto(TR::BytecodeBuilder *dest);
    void IfCmpEqual(TR::BytecodeBuilder **dest, TR::IlValue *v1, TR::IlValue *v2);
+   void IfCmpEqual(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2);
+   void IfCmpEqualZero(TR::BytecodeBuilder **dest, TR::IlValue *c);
+   void IfCmpEqualZero(TR::BytecodeBuilder *dest, TR::IlValue *c);
    void IfCmpNotEqual(TR::BytecodeBuilder **dest, TR::IlValue *v1, TR::IlValue *v2);
+   void IfCmpNotEqual(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2);
+   void IfCmpNotEqualZero(TR::BytecodeBuilder **dest, TR::IlValue *c);
+   void IfCmpNotEqualZero(TR::BytecodeBuilder *dest, TR::IlValue *c);
+   void IfCmpLessThan(TR::BytecodeBuilder **dest, TR::IlValue *v1, TR::IlValue *v2);
+   void IfCmpLessThan(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2);
+   void IfCmpGreaterThan(TR::BytecodeBuilder **dest, TR::IlValue *v1, TR::IlValue *v2);
+   void IfCmpGreaterThan(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2);
 
 protected:
    TR::BytecodeBuilder       * _fallThroughBuilder;

--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -254,7 +254,7 @@ IlBuilder::newValue(TR::DataType dt)
    }
 
 TR::IlValue *
-IlBuilder::newValue(TR::IlType *dt)
+IlBuilder::NewValue(TR::IlType *dt)
    {
    return newValue(dt->getPrimitiveType());
    }
@@ -432,7 +432,7 @@ IlBuilder::zero(TR::DataType dt)
       {
       case TR::Int8 :  return TR::Node::bconst(0);
       case TR::Int16 : return TR::Node::sconst(0);
-      default :         return TR::Node::create(TR::ILOpCode::constOpCode(dt), 0, 0);
+      default :        return TR::Node::create(TR::ILOpCode::constOpCode(dt), 0, 0);
       }
    }
 
@@ -466,7 +466,6 @@ IlBuilder::OrphanBuilder()
    ILB_REPLAY("%s = %s->OrphanBuilder();", REPLAY_BUILDER(orphan), REPLAY_BUILDER(this));
    return orphan;
    }
-
 
 TR::Block *
 IlBuilder::emptyBlock()
@@ -565,7 +564,7 @@ TR::IlValue *
 IlBuilder::indirectLoadNode(TR::IlType *dt, TR::Node *addr, bool isVectorLoad)
    {
    TR_ASSERT(dt->isPointer(), "indirectLoadNode must apply to pointer type");
-   TR::IlType *baseType = dt->baseType();
+   TR::IlType * baseType = dt->baseType();
    TR::DataType primType = baseType->getPrimitiveType();
    TR::DataType symRefType = primType;
    if (isVectorLoad)
@@ -582,7 +581,7 @@ IlBuilder::indirectLoadNode(TR::IlType *dt, TR::Node *addr, bool isVectorLoad)
 
    TR::Node *loadNode = TR::Node::createWithSymRef(loadOp, 1, 1, addr, storeSymRef);
 
-   TR::IlValue *loadValue = newValue(baseType);
+   TR::IlValue *loadValue = NewValue(baseType);
    storeNode(loadValue, loadNode);
    return loadValue;
    }
@@ -749,8 +748,8 @@ TR::IlValue *
 IlBuilder::LoadAt(TR::IlType *dt, TR::IlValue *address)
    {
    TR_ASSERT(address->getSymbol()->getDataType() == TR::Address, "LoadAt needs an address operand");
-   TraceIL("IlBuilder[ %p ]::LoadAt type %d address %d\n", this, dt->getPrimitiveType(), address->getCPIndex());
    TR::IlValue *returnValue = indirectLoadNode(dt, loadValue(address));
+   TraceIL("IlBuilder[ %p ]::%d is LoadAt type %d address %d\n", this, returnValue->getCPIndex(), dt->getPrimitiveType(), address->getCPIndex());
    ILB_REPLAY("%s = %s->LoadAt(%s, %s);", REPLAY_VALUE(returnValue), REPLAY_BUILDER(this), REPLAY_TYPE(dt), REPLAY_VALUE(address));
    return returnValue;
    }
@@ -759,8 +758,8 @@ TR::IlValue *
 IlBuilder::VectorLoadAt(TR::IlType *dt, TR::IlValue *address)
    {
    TR_ASSERT(address->getSymbol()->getDataType() == TR::Address, "LoadAt needs an address operand");
-   TraceIL("IlBuilder[ %p ]::LoadAt type %d address %d\n", this, dt->getPrimitiveType(), address->getCPIndex());
    TR::IlValue *returnValue = indirectLoadNode(dt, loadValue(address), true);
+   TraceIL("IlBuilder[ %p ]::%d is VectorLoadAt type %d address %d\n", this, returnValue->getCPIndex(), dt->getPrimitiveType(), address->getCPIndex());
    ILB_REPLAY("%s = %s->LoadAt(%s, %s);", REPLAY_VALUE(returnValue), REPLAY_BUILDER(this), REPLAY_TYPE(dt), REPLAY_VALUE(address));
    return returnValue;
    }
@@ -803,10 +802,11 @@ IlBuilder::IndexAt(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index)
    TR::Node *offsetNode = TR::Node::create(mulOp, 2, indexNode, elemSizeNode);
    TR::Node *addrNode = TR::Node::create(addOp, 2, baseNode, offsetNode);
 
-   TR::IlValue *address = newValue(Address);
+   TR::IlValue *address = NewValue(Address);
    storeNode(address, addrNode);
 
    ILB_REPLAY("%s = %s->IndexAt(%s, %s, %s);", REPLAY_VALUE(address), REPLAY_BUILDER(this), REPLAY_TYPE(dt), REPLAY_VALUE(base), REPLAY_VALUE(index));
+   TraceIL("IlBuilder[ %p ]::%d is IndexAt(%s) base %d index %d\n", this, address->getCPIndex(), dt->getName(), base->getCPIndex(), index->getCPIndex());
 
    return address;
    }
@@ -815,7 +815,7 @@ TR::IlValue *
 IlBuilder::NullAddress()
    {
    appendBlock();
-   TR::IlValue *returnValue = newValue(Address);
+   TR::IlValue *returnValue = NewValue(Address);
    storeNode(returnValue, TR::Node::aconst(0));
    ILB_REPLAY("%s = %s->NullAddress();", REPLAY_VALUE(address), REPLAY_BUILDER(this));
    TraceIL("IlBuilder[ %p ]::%d is NullAddress\n", this, returnValue->getCPIndex());
@@ -826,7 +826,7 @@ TR::IlValue *
 IlBuilder::ConstInt8(int8_t value)
    {
    appendBlock();
-   TR::IlValue *returnValue = newValue(Int8);
+   TR::IlValue *returnValue = NewValue(Int8);
    storeNode(returnValue, TR::Node::bconst(value));
    TraceIL("IlBuilder[ %p ]::%d is ConstInt8 %d\n", this, returnValue->getCPIndex(), value);
    ILB_REPLAY("%s = %s->ConstInt8(%d);", REPLAY_VALUE(returnValue), REPLAY_BUILDER(this), value);
@@ -837,7 +837,7 @@ TR::IlValue *
 IlBuilder::ConstInt16(int16_t value)
    {
    appendBlock();
-   TR::IlValue *returnValue = newValue(Int16);
+   TR::IlValue *returnValue = NewValue(Int16);
    storeNode(returnValue, TR::Node::sconst(value));
    TraceIL("IlBuilder[ %p ]::%d is ConstInt16 %d\n", this, returnValue->getCPIndex(), value);
    ILB_REPLAY("%s = %s->ConstInt16(%d);", REPLAY_VALUE(returnValue), REPLAY_BUILDER(this), value);
@@ -848,7 +848,7 @@ TR::IlValue *
 IlBuilder::ConstInt32(int32_t value)
    {
    appendBlock();
-   TR::IlValue *returnValue = newValue(Int32);
+   TR::IlValue *returnValue = NewValue(Int32);
    storeNode(returnValue, TR::Node::iconst(value));
    TraceIL("IlBuilder[ %p ]::%d is ConstInt32 %d\n", this, returnValue->getCPIndex(), value);
    ILB_REPLAY("%s = %s->ConstInt32(%d);", REPLAY_VALUE(returnValue), REPLAY_BUILDER(this), value);
@@ -859,7 +859,7 @@ TR::IlValue *
 IlBuilder::ConstInt64(int64_t value)
    {
    appendBlock();
-   TR::IlValue *returnValue = newValue(Int64);
+   TR::IlValue *returnValue = NewValue(Int64);
    storeNode(returnValue, TR::Node::lconst(value));
    TraceIL("IlBuilder[ %p ]::%d is ConstInt64 %d\n", this, returnValue->getCPIndex(), value);
    ILB_REPLAY("%s = %s->ConstInt64(%ld);", REPLAY_VALUE(returnValue), REPLAY_BUILDER(this), value);
@@ -872,7 +872,7 @@ IlBuilder::ConstFloat(float value)
    appendBlock();
    TR::Node *fconstNode = TR::Node::create(0, TR::fconst, 0);
    fconstNode->setFloat(value);
-   TR::IlValue *returnValue = newValue(Float);
+   TR::IlValue *returnValue = NewValue(Float);
    storeNode(returnValue, fconstNode);
    TraceIL("IlBuilder[ %p ]::%d is ConstFloat %f\n", this, returnValue->getCPIndex(), value);
    ILB_REPLAY("%s = %s->ConstFloat(%f);", REPLAY_VALUE(returnValue), REPLAY_BUILDER(this), value);
@@ -885,7 +885,7 @@ IlBuilder::ConstDouble(double value)
    appendBlock();
    TR::Node *dconstNode = TR::Node::create(0, TR::dconst, 0);
    dconstNode->setDouble(value);
-   TR::IlValue *returnValue = newValue(Double);
+   TR::IlValue *returnValue = NewValue(Double);
    storeNode(returnValue, dconstNode);
    TraceIL("IlBuilder[ %p ]::%d is ConstDouble %lf\n", this, returnValue->getCPIndex(), value);
    ILB_REPLAY("%s = %s->ConstDouble(%lf);", REPLAY_VALUE(returnValue), REPLAY_BUILDER(this), value);
@@ -893,10 +893,10 @@ IlBuilder::ConstDouble(double value)
    }
 
 TR::IlValue *
-IlBuilder::ConstString(const char* value)
+IlBuilder::ConstString(const char * const value)
    {
    appendBlock();
-   TR::IlValue *returnValue = newValue(Address);
+   TR::IlValue *returnValue = NewValue(Address);
    storeNode(returnValue, TR::Node::aconst((uintptrj_t)value));
    TraceIL("IlBuilder[ %p ]::%d is ConstString %p\n", this, returnValue->getCPIndex(), value);
    ILB_REPLAY("%s = %s->ConstString(%p);", REPLAY_VALUE(returnValue), REPLAY_BUILDER(this), value);
@@ -904,27 +904,39 @@ IlBuilder::ConstString(const char* value)
    }
 
 TR::IlValue *
-IlBuilder::ConstAddress(void* value)
+IlBuilder::ConstAddress(const void * const value)
    {
    appendBlock();
-   TR::IlValue *returnValue = newValue(Address);
+   TR::IlValue *returnValue = NewValue(Address);
    storeNode(returnValue, TR::Node::aconst((uintptrj_t)value));
    TraceIL("IlBuilder[ %p ]::%d is ConstAddress %p\n", this, returnValue->getCPIndex(), value);
    ILB_REPLAY("%s = %s->ConstAddress(%p);", REPLAY_VALUE(returnValue), REPLAY_BUILDER(this), value);
    return returnValue;
    }
 
+TR::IlValue *
+IlBuilder::ConstInteger(TR::IlType *intType, int64_t value)
+   {
+   if      (intType == Int8)  return ConstInt8 ((int8_t)  value);
+   else if (intType == Int16) return ConstInt16((int16_t) value);
+   else if (intType == Int32) return ConstInt32((int32_t) value);
+   else if (intType == Int64) return ConstInt64(          value);
+
+   TR_ASSERT(0, "unknown integer type");
+   return NULL;
+   }
 
 TR::IlValue *
 IlBuilder::ConvertTo(TR::IlType *t, TR::IlValue *v)
    {
    appendBlock();
-   TR::IlValue *convertedValue = newValue(t);
+   TR::IlValue *convertedValue = NewValue(t);
    TR::DataType t1 = v->getSymbol()->getDataType();
    TR::DataType t2 = t->getPrimitiveType();
    TR::ILOpCodes convertOp = TR::DataType::getDataTypeConversion(v->getSymbol()->getDataType(), t->getPrimitiveType());
    TR::Node *result = TR::Node::create(convertOp, 1, loadValue(v));
    storeNode(convertedValue, result);
+   TraceIL("IlBuilder[ %p ]::%d is ConvertTo(%s) %d\n", this, convertedValue->getCPIndex(), t->getName(), v->getCPIndex());
    ILB_REPLAY("%s = %s->ConvertTo(%s, %s);", REPLAY_VALUE(convertedValue), REPLAY_BUILDER(this), REPLAY_TYPE(t), REPLAY_VALUE(value));
    return convertedValue;
    }
@@ -1042,8 +1054,8 @@ IlBuilder::NotEqualTo(TR::IlValue *left, TR::IlValue *right)
 void
 IlBuilder::Goto(TR::IlBuilder **dest)
    {
-   TraceIL("IlBuilder[ %p ]::Goto %p\n", this, *dest);
    *dest = createBuilderIfNeeded(*dest);
+   TraceIL("IlBuilder[ %p ]::Goto %p\n", this, *dest);
    appendGoto((*dest)->getEntry());
    setDoesNotComeBack();
 
@@ -1550,7 +1562,7 @@ IlBuilder::IfCmpNotEqualZero(TR::IlBuilder **target, TR::IlValue *condition)
    {
    *target = createBuilderIfNeeded(*target);
    ILB_REPLAY("%s->IfCmpNotEqualZero(%s, %s, %s);", REPLAY_BUILDER(this), REPLAY_BUILDER(target), REPLAY_VALUE(condition));
-   TraceIL("IlBuilder[ %p ]::IfCmpNotEqualZero %d? -> B%d\n", this, condition->getCPIndex(), (*target)->getEntry()->getNumber());
+   TraceIL("IlBuilder[ %p ]::IfCmpNotEqualZero %d? -> [ %p ] B%d\n", this, condition->getCPIndex(), (*target), (*target)->getEntry()->getNumber());
    ifCmpNotEqualZero(condition, (*target)->getEntry());
    }
 
@@ -1559,7 +1571,7 @@ IlBuilder::IfCmpNotEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue 
    {
    *target = createBuilderIfNeeded(*target);
    ILB_REPLAY("%s->IfCmpNotEqual(%s, %s, %s);", REPLAY_BUILDER(this), REPLAY_BUILDER(target), REPLAY_VALUE(left), REPLAY_VALUE(right));
-   TraceIL("IlBuilder[ %p ]::IfCmpNotEqual %d == %d? -> B%d\n", this, left->getCPIndex(), right->getCPIndex(), (*target)->getEntry()->getNumber());
+   TraceIL("IlBuilder[ %p ]::IfCmpNotEqual %d == %d? -> [ %p ] B%d\n", this, left->getCPIndex(), right->getCPIndex(), (*target), (*target)->getEntry()->getNumber());
    ifCmpNotEqual(left, right, (*target)->getEntry());
    }
 
@@ -1568,7 +1580,7 @@ IlBuilder::IfCmpEqualZero(TR::IlBuilder **target, TR::IlValue *condition)
    {
    *target = createBuilderIfNeeded(*target);
    ILB_REPLAY("%s->IfCmpEqualZero(%s, %s, %s);", REPLAY_BUILDER(this), REPLAY_BUILDER(target), REPLAY_VALUE(condition));
-   TraceIL("IlBuilder[ %p ]::IfCmpEqualZero %d == 0? -> B%d\n", this, condition->getCPIndex(), (*target)->getEntry()->getNumber());
+   TraceIL("IlBuilder[ %p ]::IfCmpEqualZero %d == 0? -> [ %p ] B%d\n", this, condition->getCPIndex(), *target, (*target)->getEntry()->getNumber());
    ifCmpEqualZero(condition, (*target)->getEntry());
    }
 
@@ -1577,7 +1589,7 @@ IlBuilder::IfCmpEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *ri
    {
    *target = createBuilderIfNeeded(*target);
    ILB_REPLAY("%s->IfCmpEqual(%s, %s, %s);", REPLAY_BUILDER(this), REPLAY_BUILDER(target), REPLAY_VALUE(left), REPLAY_VALUE(right));
-   TraceIL("IlBuilder[ %p ]::IfCmpEqual %d == %d? -> B%d\n", this, left->getCPIndex(), right->getCPIndex(), (*target)->getEntry()->getNumber());
+   TraceIL("IlBuilder[ %p ]::IfCmpEqual %d == %d? -> [ %p ] B%d\n", this, left->getCPIndex(), right->getCPIndex(), (*target), (*target)->getEntry()->getNumber());
    ifCmpEqual(left, right, (*target)->getEntry());
    }
 
@@ -1586,7 +1598,7 @@ IlBuilder::IfCmpLessThan(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue 
    {
    *target = createBuilderIfNeeded(*target);
    ILB_REPLAY("%s->IfCmpLessThan(%s, %s, %s);", REPLAY_BUILDER(this), REPLAY_BUILDER(target), REPLAY_VALUE(left), REPLAY_VALUE(right));
-   TraceIL("IlBuilder[ %p ]::IfCmpLessThan %d < %d? -> B%d\n", this, left->getCPIndex(), right->getCPIndex(), (*target)->getEntry()->getNumber());
+   TraceIL("IlBuilder[ %p ]::IfCmpLessThan %d < %d? -> [ %p ] B%d\n", this, left->getCPIndex(), right->getCPIndex(), (*target), (*target)->getEntry()->getNumber());
    ifCmpLessThan(left, right, (*target)->getEntry());
    }
 
@@ -1595,7 +1607,7 @@ IlBuilder::IfCmpGreaterThan(TR::IlBuilder **target, TR::IlValue *left, TR::IlVal
    {
    *target = createBuilderIfNeeded(*target);
    ILB_REPLAY("%s->IfCmpGreaterThan(%s, %s, %s);", REPLAY_BUILDER(this), REPLAY_BUILDER(target), REPLAY_VALUE(left), REPLAY_VALUE(right));
-   TraceIL("IlBuilder[ %p ]::IfCmpGreatThan %d < %d? -> B%d\n", this, left->getCPIndex(), right->getCPIndex(), (*target)->getEntry()->getNumber());
+   TraceIL("IlBuilder[ %p ]::IfCmpGreatThan %d < %d? -> [ %p ] B%d\n", this, left->getCPIndex(), right->getCPIndex(), (*target), (*target)->getEntry()->getNumber());
    ifCmpGreaterThan(left, right, (*target)->getEntry());
    }
 

--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -1055,8 +1055,15 @@ void
 IlBuilder::Goto(TR::IlBuilder **dest)
    {
    *dest = createBuilderIfNeeded(*dest);
-   TraceIL("IlBuilder[ %p ]::Goto %p\n", this, *dest);
-   appendGoto((*dest)->getEntry());
+   Goto(*dest);
+   }
+
+void
+IlBuilder::Goto(TR::IlBuilder *dest)
+   {
+   TR_ASSERT(dest != NULL, "This goto implementation requires a non-NULL builder object");
+   TraceIL("IlBuilder[ %p ]::Goto %p\n", this, dest);
+   appendGoto(dest->getEntry());
    setDoesNotComeBack();
 
    ILB_REPLAY("%s->Goto(%s);", REPLAY_BUILDER(this), REPLAY_BUILDER(dest));
@@ -1561,54 +1568,95 @@ void
 IlBuilder::IfCmpNotEqualZero(TR::IlBuilder **target, TR::IlValue *condition)
    {
    *target = createBuilderIfNeeded(*target);
+   IfCmpNotEqualZero(*target, condition);
+   }
+
+void
+IlBuilder::IfCmpNotEqualZero(TR::IlBuilder *target, TR::IlValue *condition)
+   {
+   TR_ASSERT(target != NULL, "This IfCmpNotEqualZero requires a non-NULL builder object");
    ILB_REPLAY("%s->IfCmpNotEqualZero(%s, %s, %s);", REPLAY_BUILDER(this), REPLAY_BUILDER(target), REPLAY_VALUE(condition));
-   TraceIL("IlBuilder[ %p ]::IfCmpNotEqualZero %d? -> [ %p ] B%d\n", this, condition->getCPIndex(), (*target), (*target)->getEntry()->getNumber());
-   ifCmpNotEqualZero(condition, (*target)->getEntry());
+   TraceIL("IlBuilder[ %p ]::IfCmpNotEqualZero %d? -> [ %p ] B%d\n", this, condition->getCPIndex(), target, target->getEntry()->getNumber());
+   ifCmpNotEqualZero(condition, target->getEntry());
    }
 
 void
 IlBuilder::IfCmpNotEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right)
    {
    *target = createBuilderIfNeeded(*target);
+   IfCmpNotEqual(*target, left, right);
+   }
+
+void
+IlBuilder::IfCmpNotEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
+   {
+   TR_ASSERT(target != NULL, "This IfCmpNotEqual requires a non-NULL builder object");
    ILB_REPLAY("%s->IfCmpNotEqual(%s, %s, %s);", REPLAY_BUILDER(this), REPLAY_BUILDER(target), REPLAY_VALUE(left), REPLAY_VALUE(right));
-   TraceIL("IlBuilder[ %p ]::IfCmpNotEqual %d == %d? -> [ %p ] B%d\n", this, left->getCPIndex(), right->getCPIndex(), (*target), (*target)->getEntry()->getNumber());
-   ifCmpNotEqual(left, right, (*target)->getEntry());
+   TraceIL("IlBuilder[ %p ]::IfCmpNotEqual %d == %d? -> [ %p ] B%d\n", this, left->getCPIndex(), right->getCPIndex(), target, target->getEntry()->getNumber());
+   ifCmpNotEqual(left, right, target->getEntry());
    }
 
 void
 IlBuilder::IfCmpEqualZero(TR::IlBuilder **target, TR::IlValue *condition)
    {
    *target = createBuilderIfNeeded(*target);
+   IfCmpEqualZero(*target, condition);
+   }
+
+void
+IlBuilder::IfCmpEqualZero(TR::IlBuilder *target, TR::IlValue *condition)
+   {
+   TR_ASSERT(target != NULL, "This IfCmpEqualZero requires a non-NULL builder object");
    ILB_REPLAY("%s->IfCmpEqualZero(%s, %s, %s);", REPLAY_BUILDER(this), REPLAY_BUILDER(target), REPLAY_VALUE(condition));
-   TraceIL("IlBuilder[ %p ]::IfCmpEqualZero %d == 0? -> [ %p ] B%d\n", this, condition->getCPIndex(), *target, (*target)->getEntry()->getNumber());
-   ifCmpEqualZero(condition, (*target)->getEntry());
+   TraceIL("IlBuilder[ %p ]::IfCmpEqualZero %d == 0? -> [ %p ] B%d\n", this, condition->getCPIndex(), target, target->getEntry()->getNumber());
+   ifCmpEqualZero(condition, target->getEntry());
    }
 
 void
 IlBuilder::IfCmpEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right)
    {
    *target = createBuilderIfNeeded(*target);
+   IfCmpEqual(*target, left, right);
+   }
+
+void
+IlBuilder::IfCmpEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
+   {
+   TR_ASSERT(target != NULL, "This IfCmpEqual requires a non-NULL builder object");
    ILB_REPLAY("%s->IfCmpEqual(%s, %s, %s);", REPLAY_BUILDER(this), REPLAY_BUILDER(target), REPLAY_VALUE(left), REPLAY_VALUE(right));
-   TraceIL("IlBuilder[ %p ]::IfCmpEqual %d == %d? -> [ %p ] B%d\n", this, left->getCPIndex(), right->getCPIndex(), (*target), (*target)->getEntry()->getNumber());
-   ifCmpEqual(left, right, (*target)->getEntry());
+   TraceIL("IlBuilder[ %p ]::IfCmpEqual %d == %d? -> [ %p ] B%d\n", this, left->getCPIndex(), right->getCPIndex(), target, target->getEntry()->getNumber());
+   ifCmpEqual(left, right, target->getEntry());
    }
 
 void
 IlBuilder::IfCmpLessThan(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right)
    {
    *target = createBuilderIfNeeded(*target);
+   IfCmpLessThan(*target, left, right);
+   }
+
+void
+IlBuilder::IfCmpLessThan(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
+   {
+   TR_ASSERT(target != NULL, "This IfCmpLessThan requires a non-NULL builder object");
    ILB_REPLAY("%s->IfCmpLessThan(%s, %s, %s);", REPLAY_BUILDER(this), REPLAY_BUILDER(target), REPLAY_VALUE(left), REPLAY_VALUE(right));
-   TraceIL("IlBuilder[ %p ]::IfCmpLessThan %d < %d? -> [ %p ] B%d\n", this, left->getCPIndex(), right->getCPIndex(), (*target), (*target)->getEntry()->getNumber());
-   ifCmpLessThan(left, right, (*target)->getEntry());
+   TraceIL("IlBuilder[ %p ]::IfCmpLessThan %d < %d? -> [ %p ] B%d\n", this, left->getCPIndex(), right->getCPIndex(), target, target->getEntry()->getNumber());
+   ifCmpLessThan(left, right, target->getEntry());
    }
 
 void
 IlBuilder::IfCmpGreaterThan(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right)
    {
    *target = createBuilderIfNeeded(*target);
+   IfCmpGreaterThan(*target, left, right);
+   }
+
+void
+IlBuilder::IfCmpGreaterThan(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
+   {
    ILB_REPLAY("%s->IfCmpGreaterThan(%s, %s, %s);", REPLAY_BUILDER(this), REPLAY_BUILDER(target), REPLAY_VALUE(left), REPLAY_VALUE(right));
-   TraceIL("IlBuilder[ %p ]::IfCmpGreatThan %d < %d? -> [ %p ] B%d\n", this, left->getCPIndex(), right->getCPIndex(), (*target), (*target)->getEntry()->getNumber());
-   ifCmpGreaterThan(left, right, (*target)->getEntry());
+   TraceIL("IlBuilder[ %p ]::IfCmpGreatThan %d < %d? -> [ %p ] B%d\n", this, left->getCPIndex(), right->getCPIndex(), target, target->getEntry()->getNumber());
+   ifCmpGreaterThan(left, right, target->getEntry());
    }
 
 void

--- a/compiler/ilgen/IlBuilder.hpp
+++ b/compiler/ilgen/IlBuilder.hpp
@@ -214,6 +214,7 @@ public:
    TR::IlValue *ComputedCall(const char *name, int32_t numArgs, TR::IlValue **args);
    TR::IlValue *genCall(TR::SymbolReference *methodSymRef, int32_t numArgs, TR::IlValue ** paramValues, bool isDirectCall = true);
    void Goto(TR::IlBuilder **dest);
+   void Goto(TR::IlBuilder *dest);
    void Return();
    void Return(TR::IlValue *value);
    virtual void ForLoop(bool countsUp,
@@ -287,11 +288,18 @@ public:
       }
 
    void IfCmpNotEqualZero(TR::IlBuilder **target, TR::IlValue *condition);
+   void IfCmpNotEqualZero(TR::IlBuilder *target, TR::IlValue *condition);
    void IfCmpNotEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right);
+   void IfCmpNotEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right);
    void IfCmpEqualZero(TR::IlBuilder **target, TR::IlValue *condition);
+   void IfCmpEqualZero(TR::IlBuilder *target, TR::IlValue *condition);
    void IfCmpEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right);
+   void IfCmpEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right);
    void IfCmpLessThan(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right);
+   void IfCmpLessThan(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right);
    void IfCmpGreaterThan(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right);
+   void IfCmpGreaterThan(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right);
+
    void IfThenElse(TR::IlBuilder **thenPath,
                    TR::IlBuilder **elsePath,
                    TR::IlValue *condition);

--- a/compiler/ilgen/IlBuilder.hpp
+++ b/compiler/ilgen/IlBuilder.hpp
@@ -99,8 +99,8 @@ public:
       _partOfSequence(false),
       _connectedTrees(false),
       _comesBack(true),
-      _haveReplayName(false),
       _isHandler(false),
+      _haveReplayName(false),
       _rpILCpp(0)
       {
       }
@@ -136,6 +136,9 @@ public:
    bool TraceEnabled_log();
    void TraceIL_log(const char *s, ...);
 
+   // create a new local value (temporary variable)
+   TR::IlValue *NewValue(TR::IlType *dt);
+
    // constants
    TR::IlValue *NullAddress();
    TR::IlValue *ConstInt8(int8_t value);
@@ -144,9 +147,19 @@ public:
    TR::IlValue *ConstInt64(int64_t value);
    TR::IlValue *ConstFloat(float value);
    TR::IlValue *ConstDouble(double value);
-   TR::IlValue *ConstAddress(void* value);
-   TR::IlValue *ConstString(const char *value);
+   TR::IlValue *ConstAddress(const void * const value);
+   TR::IlValue *ConstString(const char * const value);
    TR::IlValue *ConstzeroValueForValue(TR::IlValue *v);
+
+   TR::IlValue *Const(int8_t value)             { return ConstInt8(value); }
+   TR::IlValue *Const(int16_t value)            { return ConstInt16(value); }
+   TR::IlValue *Const(int32_t value)            { return ConstInt32(value); }
+   TR::IlValue *Const(int64_t value)            { return ConstInt64(value); }
+   TR::IlValue *Const(float value)              { return ConstFloat(value); }
+   TR::IlValue *Const(double value)             { return ConstDouble(value); }
+   TR::IlValue *Const(const void * const value) { return ConstAddress(value); }
+
+   TR::IlValue *ConstInteger(TR::IlType *intType, int64_t value);
 
    // arithmetic
    TR::IlValue *Add(TR::IlValue *left, TR::IlValue *right);
@@ -319,7 +332,6 @@ protected:
    TR::IlValue *lookupSymbol(const char *name);
    void defineSymbol(const char *name, TR::IlValue *v);
    TR::IlValue *newValue(TR::DataType dt);
-   TR::IlValue *newValue(TR::IlType *dt);
    void defineValue(const char *name, TR::IlType *dt);
 
    TR::Node *loadValue(TR::IlValue *v);

--- a/compiler/ilgen/IlInjector.hpp
+++ b/compiler/ilgen/IlInjector.hpp
@@ -83,9 +83,11 @@ public:
    virtual TR::MethodBuilder    * asMethodBuilder() { return NULL; }
 
    TR::Compilation              * comp()             const { return _comp; }
+   TR::IlGeneratorMethodDetails * details()          const { return _details; }
    TR::FrontEnd                 * fe()               const { return _fe; }
    TR::SymbolReferenceTable     * symRefTab()              { return _symRefTab; }
    TR::CFG                      * cfg();
+   TR::TypeDictionary           * typeDictionary()         { return _types; }
 
    TR::Block                   ** blocks()           const { return _blocks; }
    int32_t                        numBlocks()        const { return _numBlocks; }

--- a/compiler/ilgen/MethodBuilder.hpp
+++ b/compiler/ilgen/MethodBuilder.hpp
@@ -34,6 +34,7 @@ class TR_HashTabInt;
 class TR_HashTabString;
 namespace TR { class BytecodeBuilder; }
 namespace TR { class ResolvedMethod; }
+namespace OMR { class VirtualMachineState; }
 
 namespace OMR
 {
@@ -43,7 +44,7 @@ class MethodBuilder : public TR::IlBuilder
    public:
    TR_ALLOC(TR_Memory::IlGenerator)
 
-   MethodBuilder(TR::TypeDictionary *types);
+   MethodBuilder(TR::TypeDictionary *types, OMR::VirtualMachineState *vmState = NULL);
    virtual void setupForBuildIL();
 
    virtual bool injectIL();
@@ -52,6 +53,9 @@ class MethodBuilder : public TR::IlBuilder
    void setUseBytecodeBuilders()                             { _useBytecodeBuilders = true; }
    void addToTreeConnectingWorklist(TR::BytecodeBuilder *builder);
    void addToBlockCountingWorklist(TR::BytecodeBuilder *builder);
+
+   OMR::VirtualMachineState *vmState()                       { return _vmState; }
+   void setVMState(OMR::VirtualMachineState *vmState)        { _vmState = vmState; }
 
    virtual bool isMethodBuilder()                            { return true; }
    virtual TR::MethodBuilder *asMethodBuilder();
@@ -83,6 +87,9 @@ class MethodBuilder : public TR::IlBuilder
    TR::ResolvedMethod *lookupFunction(const char *name);
 
    TR::BytecodeBuilder *OrphanBytecodeBuilder(int32_t bcIndex=0, char *name=NULL);
+
+   void AppendBuilder(TR::BytecodeBuilder *bb);
+   void AppendBuilder(TR::IlBuilder *b)    { this->OMR::IlBuilder::AppendBuilder(b); }
 
    void DefineFile(const char *file)                         { _definingFile = file; }
    void DefineLine(const char *line)                         { _definingLine = line; }
@@ -144,6 +151,7 @@ class MethodBuilder : public TR::IlBuilder
    List<TR::BytecodeBuilder> * _countBlocksWorklist;
    List<TR::BytecodeBuilder> * _connectTreesWorklist;
    List<TR::BytecodeBuilder> * _allBytecodeBuilders;
+   OMR::VirtualMachineState  * _vmState;
 
    std::fstream              * _rpCpp;
    };
@@ -160,6 +168,9 @@ namespace TR
       public:
          MethodBuilder(TR::TypeDictionary *types)
             : OMR::MethodBuilder(types)
+            { }
+         MethodBuilder(TR::TypeDictionary *types, OMR::VirtualMachineState *vmState)
+            : OMR::MethodBuilder(types, vmState)
             { }
       };
 

--- a/compiler/ilgen/VirtualMachineOperandStack.cpp
+++ b/compiler/ilgen/VirtualMachineOperandStack.cpp
@@ -83,7 +83,7 @@ VirtualMachineOperandStack::Commit(TR::IlBuilder *b)
       b->   IndexAt(pElement,
                stack,
       b->      ConstInt32(i - _stackOffset)),
-            Pick(i)); // should generalize, maybe delegate element storage ?
+            Pick(_stackTop-i)); // should generalize, maybe delegate element storage ?
       }
    }
 

--- a/compiler/ilgen/VirtualMachineOperandStack.cpp
+++ b/compiler/ilgen/VirtualMachineOperandStack.cpp
@@ -1,0 +1,197 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+
+#include "ilgen/VirtualMachineOperandStack.hpp"
+#include "ilgen/VirtualMachineRegister.hpp"
+#include "compile/Compilation.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/symbol/AutomaticSymbol.hpp"
+#include "ilgen/IlBuilder.hpp"
+#include "ilgen/MethodBuilder.hpp"
+#include "ilgen/TypeDictionary.hpp"
+
+namespace OMR
+{
+
+VirtualMachineOperandStack::VirtualMachineOperandStack(TR::MethodBuilder *mb, int32_t sizeHint,
+   TR::IlType *elementType, OMR::VirtualMachineRegister *stackTopRegister)
+   : VirtualMachineState(),
+   _mb(mb),
+   _stackTopRegister(stackTopRegister),
+   _stackMax(sizeHint),
+   _stackTop(-1),
+   _elementType(elementType)
+   {
+   int32_t numBytes = _stackMax * sizeof(TR::IlValue *);
+   _stack = (TR::IlValue **) TR::comp()->trMemory()->allocateHeapMemory(numBytes);
+   memset(_stack, 0, numBytes);
+
+   // store current operand stack pointer base address so we can use it whenever we need
+   // to recreate the stack as the interpreter would have
+   mb->Store("OperandStack_base", stackTopRegister->Load(mb));
+
+   _pushAmount = (growsUp()) ? +1 : -1;
+   _stackOffset = stackPtrStartingOffset();
+   }
+
+VirtualMachineOperandStack::VirtualMachineOperandStack(OMR::VirtualMachineOperandStack *other)
+   : VirtualMachineState(),
+   _mb(other->_mb),
+   _stackTopRegister(other->_stackTopRegister),
+   _stackMax(other->_stackMax),
+   _stackTop(other->_stackTop),
+   _elementType(other->_elementType),
+   _pushAmount(other->_pushAmount)
+   {
+   int32_t numBytes = _stackMax * sizeof(TR::IlValue *);
+   _stack = (TR::IlValue **) TR::comp()->trMemory()->allocateHeapMemory(numBytes);
+   memcpy(_stack, other->_stack, numBytes);
+   }
+
+
+// commits the simulated operand stack of values to the virtual machine state
+// the given builder object is where the operations to commit the state will be inserted
+// the top of the stack is assumed to be managed independently, most likely
+//    as a VirtualMachineRegister or a VirtualMachineRegisterInStruct
+void
+VirtualMachineOperandStack::Commit(TR::IlBuilder *b)
+   {
+   TR::IlType *Element = _elementType;
+   TR::IlType *pElement = _mb->typeDictionary()->PointerTo(Element);
+
+   TR::IlValue *stack = b->Load("OperandStack_base");
+   for (int32_t i = _stackTop;i >= 0;i--)
+      {
+      // TBD: how to handle hitting the end of stack?
+
+      b->StoreAt(
+      b->   IndexAt(pElement,
+               stack,
+      b->      ConstInt32(i - _stackOffset)),
+            Pick(i)); // should generalize, maybe delegate element storage ?
+      }
+   }
+
+void
+VirtualMachineOperandStack::MergeInto(OMR::VirtualMachineOperandStack *other, TR::IlBuilder *b)
+   {
+   TR_ASSERT(_stackTop == other->_stackTop, "stacks are not same size");
+   for (int32_t i=_stackTop;i >= 0;i--)
+      {
+      // only need to do something if the two entries aren't already the same
+      if (other->_stack[i]->getCPIndex() != _stack[i]->getCPIndex())
+         {
+         // what if types don't match? could use ConvertTo, but seems...arbitrary
+         // nobody *should* design bytecode set where corresponding elements of stacks from
+         // two incoming control flow edges can have different primitive types. objects, sure
+         // but not primitive types! Expecting to be disappointed here some day...
+         TR_ASSERT(_stack[i]->getSymbol()->getDataType() == other->_stack[i]->getSymbol()->getDataType(), "disappointing stack merge: primitive type mismatch at same depth stack elements");
+         b->Store(other->_stack[i]->getSymbol()->getAutoSymbol()->getName(),
+               _stack[i]);
+         }
+      }
+   }
+
+// Allocate a new operand stack and copy everything in this state
+// If VirtualMachineOperandStack is subclassed, this function *must* also be implemented in the subclass!
+VirtualMachineState *
+VirtualMachineOperandStack::MakeCopy()
+   {
+   VirtualMachineOperandStack *copy = (VirtualMachineOperandStack *) TR::comp()->trMemory()->allocateHeapMemory(sizeof(VirtualMachineOperandStack));
+   new (copy) VirtualMachineOperandStack(this);
+
+   return copy;
+   }
+
+void
+VirtualMachineOperandStack::Push(TR::IlBuilder *b, TR::IlValue *value)
+   {
+   checkSize();
+   _stack[++_stackTop] = value;
+   _stackTopRegister->Adjust(b, +_pushAmount);
+   }
+
+TR::IlValue *
+VirtualMachineOperandStack::Top()
+   {
+   TR_ASSERT(_stackTop >= 0, "no top: stack empty");
+   return _stack[_stackTop];
+   }
+
+TR::IlValue *
+VirtualMachineOperandStack::Pop(TR::IlBuilder *b)
+   {
+   TR_ASSERT(_stackTop >= 0, "stack underflow");
+   _stackTopRegister->Adjust(b, -_pushAmount);
+   return _stack[_stackTop--];
+   }
+
+TR::IlValue *
+VirtualMachineOperandStack::Pick(int32_t depth)
+   {
+   TR_ASSERT(_stackTop >= depth, "pick request exceeds stack depth");
+   return _stack[_stackTop - depth];
+   }
+
+void
+VirtualMachineOperandStack::Drop(TR::IlBuilder *b, int32_t depth)
+   {
+   TR_ASSERT(_stackTop >= depth-1, "stack underflow");
+   _stackTop-=depth;
+   _stackTopRegister->Adjust(b, -depth * _pushAmount);
+   }
+
+void
+VirtualMachineOperandStack::Dup(TR::IlBuilder *b)
+   {
+   TR_ASSERT(_stackTop >= 0, "cannot dup: stack empty");
+   TR::IlValue *top = _stack[_stackTop];
+   checkSize();
+   _stack[++_stackTop] = top;
+   _stackTopRegister->Adjust(b, +_pushAmount);
+   }
+
+void
+VirtualMachineOperandStack::copyTo(VirtualMachineOperandStack *copy)
+   {
+   }
+
+void
+VirtualMachineOperandStack::checkSize()
+   {
+   if (_stackTop == _stackMax)
+      grow();
+   }
+
+void
+VirtualMachineOperandStack::grow()
+   {
+   int32_t numBytes = _stackMax * sizeof(TR::IlValue *);
+
+   int32_t newMax = _stackMax + (_stackMax >> 1);
+   int32_t newBytes = newMax * sizeof(TR::IlValue *);
+   TR::IlValue ** newStack = (TR::IlValue **) TR::comp()->trMemory()->allocateHeapMemory(newBytes);
+
+   memset(newStack, 0, newBytes);
+   memcpy(newStack, _stack, numBytes);
+
+   _stack = newStack;
+   _stackMax = newMax;
+   }
+
+} // namespace OMR

--- a/compiler/ilgen/VirtualMachineOperandStack.hpp
+++ b/compiler/ilgen/VirtualMachineOperandStack.hpp
@@ -80,7 +80,7 @@ class VirtualMachineOperandStack : public VirtualMachineState
     * @param sizeHint initial size used to allocate the stack; will grow larger if needed
     * @param elementType TR::IlType representing the underlying type of the virtual machine's operand stack entries
     * @param stackTop previously allocated and initialized VirtualMachineRegister representing the top of stack
-    * /
+    */
    VirtualMachineOperandStack(TR::MethodBuilder *mb, int32_t sizeHint, TR::IlType *elementType, VirtualMachineRegister *stackTop);
    /**
     * @brief constructor used to copy the stack from another state

--- a/compiler/ilgen/VirtualMachineOperandStack.hpp
+++ b/compiler/ilgen/VirtualMachineOperandStack.hpp
@@ -1,0 +1,186 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+
+#ifndef OMR_VIRTUALMACHINEOPERANDSTACK_INCL
+#define OMR_VIRTUALMACHINEOPERANDSTACK_INCL
+
+#include <stdint.h>
+#include "ilgen/VirtualMachineRegister.hpp"
+#include "ilgen/IlBuilder.hpp"
+
+namespace TR { class MethodBuilder; }
+
+namespace OMR
+{
+
+/**
+ * @brief simulates an operand stack used by many bytecode based virtual machines
+ * In such virtual machines, the operand stack holds the intermediate expression values
+ * computed by the bytecodes. The compiler simulates this operand stack as well, but
+ * what is pushed to and popped from the simulated operand stack are expression nodes
+ * that represent the value computed by the bytecodes. As each bytecode pops expression
+ * nodes off the operand stack, it combines them to form more complicated expressions
+ * which are then pushed back onto the operand stack for consumption by other bytecodes.
+ *
+ * The stack is represented as an array of pointers to TR::IlValue's, making it
+ * easy to use IlBuilder services to consume and compute new values. Note that,
+ * unlike VirtualMachineRegister, the simulated operand stack is *not* maintained
+ * by the method code as part of the method's stack frame. This approach requires
+ * modelling the state of the operand stack at all program points, which means
+ * there cannot only be one VirtualMachineOperandStack object.
+ *
+ * The current implementation does not share anything among different
+ * VirtualMachineOperandStack objects. Possibly, some of the state could be
+ * shared to save some memory. For now, simplicity is the goal.
+ *
+ * VirtualMachineOperandStack implements VirtualMachineState:
+ * Commit() simply iterates over the simulated operand stack and stores each
+ *   value onto the virtual machine's operand stack (more details at definition).
+ * Reload() is left empty; assumption is that each BytecodeBuilder handler will
+ *   update the state of the operand stack appropriately on return from the
+ *   interpreter.
+ * MakeCopy() copies the state of the operand stack
+ * MergeInto() is slightly subtle. Operations may have been already created
+ *   below the merge point, and those operations will have assumed the
+ *   expressions are stored in the TR::IlValue's for the state being merged
+ *   *to*. So the purpose of MergeInto() is to store the values of the current
+ *   state into the same variables as in the "other" state.
+ * 
+ * VirtualMachineOperandStack provides several stack-y operations:
+ *   Push() pushes a TR::IlValue onto the stack
+ *   Pop() pops and returns a TR::IlValue from the stack
+ *   Top() returns the TR::IlValue at the top of the stack
+ *   Pick() returns the TR::IlValue "depth" elements from the top
+ *   Drop() discards "depth" elements from the stack
+ *   Dup() is a convenience function for Push(Top())
+ *
+ */
+
+class VirtualMachineOperandStack : public VirtualMachineState
+   {
+   public:
+   /**
+    * @brief public constructor, must be instantiated inside a compilation because uses heap memory
+    * @param mb TR::MethodBuilder object of the method currently being compiled
+    * @param sizeHint initial size used to allocate the stack; will grow larger if needed
+    * @param elementType TR::IlType representing the underlying type of the virtual machine's operand stack entries
+    * @param stackTop previously allocated and initialized VirtualMachineRegister representing the top of stack
+    * /
+   VirtualMachineOperandStack(TR::MethodBuilder *mb, int32_t sizeHint, TR::IlType *elementType, VirtualMachineRegister *stackTop);
+   /**
+    * @brief constructor used to copy the stack from another state
+    * @param other the operand stack whose values should be used to initialize this object
+    */
+   VirtualMachineOperandStack(VirtualMachineOperandStack *other);
+
+   /**
+    * @brief write the simulated operand stack to the virtual machine
+    * @param b the builder where the operations will be placed to recreate the virtual machine operand stack
+    */
+   virtual void Commit(TR::IlBuilder *b);
+
+   /**
+    * @brief create an identical copy of the current object.
+    * @returns the copy of the current object
+    */
+   virtual VirtualMachineState *MakeCopy();
+
+   /**
+    * @brief emit operands to store current operand stack values into same variables as used in another operand stack
+    * @param other operand stack for the builder object control is merging into
+    * @param b builder object where the operations will be added to make the current operand stack the same as the other
+    */
+   virtual void MergeInto(VirtualMachineOperandStack *other, TR::IlBuilder *b);
+
+   /**
+    * @brief Push an expression onto the simulated operand stack
+    * @param b builder object to use for any operations used to implement the push (e.g. update the top of stack)
+    * @param value expression to push onto the simulated operand stack
+    */
+   virtual void Push(TR::IlBuilder *b, TR::IlValue *value);
+
+   /**
+    * @brief Pops an expression from the top of the simulated operand stack
+    * @param b builder object to use for any operations used to implement the pop (e.g. to update the top of stack)
+    * @returns expression popped from the stack
+    */
+   virtual TR::IlValue *Pop(TR::IlBuilder *b);
+
+   /**
+    * @brief Returns the expression at the top of the simulated operand stack
+    * @returns the expression at the top of the operand stack
+    */
+   virtual TR::IlValue *Top();
+
+   /**
+    * @brief Returns an expression below the top of the simulated operand stack
+    * @param depth number of values below top (Pick(0) is same as Top())
+    * @returns the requested expression from the operand stack
+    */
+   virtual TR::IlValue *Pick(int32_t depth);
+
+   /**
+    * @brief Removes some number of expressions from the operand stack
+    * @param b builder object to use for any operations used to implement the drop (e.g. to update the top of stack)
+    * @param depth how many values to drop from the stack
+    */
+   virtual void Drop(TR::IlBuilder *b, int32_t depth);
+
+   /**
+    * @brief Duplicates the expression on top of the simulated operand stack
+    * @param b builder object to use for any operations used to duplicate the expression (e.g. to update the top of stack)
+    */
+   virtual void Dup(TR::IlBuilder *b);
+
+   /**
+    * @brief virtual function subclasses can use to configure virtual machine stack growth direction
+    * @returns true if the virtual machine stack grows towards larger addresses, false otherwise
+    */
+   virtual bool growsUp() { return true; }
+
+   /**
+    * @brief virtual function subclasses can use to configure virtual machine stack stack offset 
+    * @returns difference in elements between initial stack pointer and actual bottom of stack
+    * Some stacks Push by incrementing stack pointer then storing, some by storing and then
+    * incrementing stack pointer. In the first case, stackPtrStartingOffset() should return -1
+    * because the stack pointer initially points one element below the bottom of the stack.
+    * In the second case, startPtrStartingOffset() should return 0, because the stack pointer
+    * initially points at the bottom of the stack. Other values are possible but would be
+    * considered highly unusual.
+    * Default assumption is the first case, so return -1.
+    */
+   virtual int32_t stackPtrStartingOffset() { return -1; }
+
+   protected:
+   void copyTo(OMR::VirtualMachineOperandStack *copy);
+   void checkSize();
+   void grow();
+
+   private:
+   TR::MethodBuilder *_mb;
+   OMR::VirtualMachineRegister *_stackTopRegister;
+   int32_t _stackMax;
+   int32_t _stackTop;
+   TR::IlValue **_stack;
+   TR::IlType *_elementType;
+   int32_t _pushAmount;
+   int32_t _stackOffset;
+   };
+}
+
+#endif // !defined(OMR_VIRTUALMACHINEOPERANDSTACK_INCL)

--- a/compiler/ilgen/VirtualMachineRegister.hpp
+++ b/compiler/ilgen/VirtualMachineRegister.hpp
@@ -1,0 +1,179 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+
+#ifndef OMR_VIRTUALMACHINEREGISTER_INCL
+#define OMR_VIRTUALMACHINEREGISTER_INCL
+
+
+#include "ilgen/VirtualMachineState.hpp"
+#include "ilgen/IlBuilder.hpp"
+#include "ilgen/TypeDictionary.hpp"
+
+namespace TR { class IlBuilder; }
+
+namespace OMR
+{
+
+/**
+ * @brief simulate virtual machine state variable via an address
+ * 
+ * VirtualMachineRegister can be used to represent values in the virtual machine
+ * at any address. The value does not need to be a virtual machine register, but
+ * often it is the registers of the virtual machine that are candidates for
+ * VirtualMachineRegister. An alternative is VirtualMachineRegisterInStruct,
+ * which may be more convenient if the virtual machine value is stored in a
+ * structure that the compiled method has easy access to (for example, if the
+ * base address of the struct is a parameter of every compiled method such as
+ * a "thread" structure or a "frame" structure).
+ *
+ * The simulated register value is simply stored in a single local variable in the
+ * native stack frame, which gives the compiler visibility to all changes to the
+ * register (and enables dataflow optimization / simplification). Because there is
+ * just a single local variable, the CopyState() and MergeInto() functions do not
+ * need to do anything (the value can accessible from that variable at all program
+ * locations). The Commit() and Reload() functions simply move the value back and
+ * forth between the local variable and the address of the actual virtual machine
+ * state variable.
+ *
+ * VirtualMachineRegister provides two additional functions:
+ * Load() will load the *simulated* value of the register for use in the builder "b"
+ * Store() will store the provided "value" into the *simulated* register by
+ * appending to the builder "b"
+ */
+
+class VirtualMachineRegister : public OMR::VirtualMachineState
+   {
+   protected:
+   /**
+    * @brief constructor can be used by subclasses to initialize just the const pointer
+    * @param localName the name of the local variable where the simulated value is to be stored
+    */
+   VirtualMachineRegister(const char * const localName)
+      : OMR::VirtualMachineState(),
+      _localName(localName)
+      { }
+
+   public:
+   /**
+    * @brief public constructor used to create a virtual machine state variable
+    * @param b a builder object where the first Reload operations will be inserted
+    * @param localName the name of the local variable where the simulated value is to be stored
+    * @param pointerToRegisterType must be pointer to the type of the register
+    * @param adjustByStep is a multiplier for the value passed to Adjust()
+    * @param addressOfRegister is the address of the actual register
+    */
+   VirtualMachineRegister(TR::IlBuilder *b,
+                          const char * const localName,
+                          TR::IlType * pointerToRegisterType,
+                          uint32_t adjustByStep,
+                          TR::IlValue * addressOfRegister)
+      : OMR::VirtualMachineState(),
+      _localName(localName),
+      _addressOfRegister(addressOfRegister),
+      _pointerToRegisterType(pointerToRegisterType),
+      _elementType(pointerToRegisterType->baseType()),
+      _adjustByStep(adjustByStep)
+      {
+      Reload(b);
+      }
+
+  
+   /**
+    * @brief write the simulated register value to the virtual machine
+    * @param b the builder where the operation will be placed to store the virtual machine value
+    */
+   virtual void Commit(TR::IlBuilder *b)
+      {
+      b->StoreAt(
+            _addressOfRegister,
+      b->   Load(_localName));
+      }
+
+   /**
+    * @brief transfer the current virtual machine register value to the simulated local variable
+    * @param b the builder where the operation will be placed to load the virtual machine value
+    */
+   virtual void Reload(TR::IlBuilder *b)
+      {
+      b->Store(_localName,
+      b->   LoadAt((TR::IlType *)_pointerToRegisterType,
+               _addressOfRegister));
+      }
+
+   /**
+    * @brief used in the compiled method to load the (simulated) register's value
+    * @param b the builder where the operation will be placed to load the simulated value
+    * @returns TR:IlValue * for the loaded simulated register value
+    */
+   TR::IlValue *Load(TR::IlBuilder *b)
+      {
+      return b->Load(_localName);
+      }
+
+   /**
+    * @brief used in the compiled method to store to the (simulated) register's value
+    * @param b the builder where the operation will be placed to store to the simulated value
+    */
+   void Store(TR::IlBuilder *b, TR::IlValue *value)
+      {
+      b->Store(_localName, value);
+      }
+
+   /**
+    * @brief used in the compiled method to add to the (simulated) register's value
+    * @param b the builder where the operation will be placed to add to the simulated value
+    * @param amount the TR::IlValue that should be added to the simulated value, after multiplication by _adjustByStep
+    * Adjust() is really a convenience function for the common operation of adding a value to the register. More
+    * complicated operations (e.g. multiplying the value) can be built using Load() and Store() if needed.
+    */
+   virtual void Adjust(TR::IlBuilder *b, TR::IlValue *amount)
+      {
+      b->Store(_localName,
+      b->   Add(
+      b->      Load(_localName),
+      b->      Mul(
+                  amount,
+      b->         ConstInteger(_elementType, _adjustByStep))));
+      }
+
+   /**
+    * @brief used in the compiled method to add to the (simulated) register's value
+    * @param b the builder where the operation will be placed to add to the simulated value
+    * @param amount the constant value that should be added to the simulated value, after multiplication by _adjustByStep
+    * Adjust() is really a convenience function for the common operation of adding a value to the register. More
+    * complicated operations (e.g. multiplying the value) can be built using Load() and Store() if needed.
+    */
+   virtual void Adjust(TR::IlBuilder *b, int64_t amount)
+      {
+      b->Store(_localName,
+      b->   Add(
+      b->      Load(_localName),
+      b->      ConstInteger(_elementType, amount * _adjustByStep)));
+      }
+
+   protected:
+
+   const char  * const _localName;
+   TR::IlValue * _addressOfRegister;
+   TR::IlType  * _pointerToRegisterType;
+   TR::IlType  * _elementType;
+   uint32_t      _adjustByStep;
+   };
+}
+
+#endif // !defined(OMR_VIRTUALMACHINEREGISTER_INCL)

--- a/compiler/ilgen/VirtualMachineRegisterInStruct.hpp
+++ b/compiler/ilgen/VirtualMachineRegisterInStruct.hpp
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+
+#ifndef OMR_VIRTUALMACHINEREGISTERINSTRUCT_INCL
+#define OMR_VIRTUALMACHINEREGISTERINSTRUCT_INCL
+
+#include "ilgen/VirtualMachineRegister.hpp"
+#include "ilgen/IlBuilder.hpp"
+
+namespace OMR
+{
+
+/**
+ * @brief used to represent virtual machine variables that are maintained in a structure stored in a local variable, such as a thread or frame object passed as a parameter to the method
+ *
+ * The value does not need to be a virtual machine register, but often it is the registers
+ * of the virtual machine that are candidates for VirtualMachineRegisterInStruct. An
+ * alternative is VirtualMachineRegister, which can be more convenient if the virtual
+ * machine value is stored in a more arbitrary place or in a structure that isn't readily
+ * accessible inside the compiled method. 
+ * VirtualMachineRegisterInStruct is a subclass of VirtualMachineRegister
+ *
+ * The simulated register value is simply stored in a single local variable, which
+ * gives the compiler visibility to all changes to the register (and enables
+ * optimization / simplification). Because there is just a single local variable,
+ * the Merge() function does not need to do anything (the value is accessible from
+ * the same location at all locations). The Commit() and Reload() functions simply
+ * move the value back and forth between the local variable and the structure that
+ * holds the actual virtual machine state.
+ */
+
+class VirtualMachineRegisterInStruct : public ::OMR::VirtualMachineRegister
+   {
+   public:
+   /**
+    * @brief public constructor used to create a virtual machine state variable from struct
+    * @param b a builder object where the first Reload operations will be inserted
+    * @param structName the name of the struct type that holds the virtual machine state variable
+    * @param localNameHoldingStructAddress is the name of a local variable holding the struct base address; it must have been stored in this name before control will reach the builder "b"
+    * @param fieldName name of the field in "structName" that holds the virtual machine state variable
+    * @param localName the name of the local variable where the simulated value is to be stored
+    */
+   VirtualMachineRegisterInStruct(TR::IlBuilder *b,
+                          const char * const structName,
+                          const char * const localNameHoldingStructAddress,
+                          const char * const fieldName,
+                          const char * const localName) :
+      ::OMR::VirtualMachineRegister(localName),
+      _structName(structName),
+      _fieldName(fieldName),
+      _localNameHoldingStructAddress(localNameHoldingStructAddress)
+      {
+      _elementType = b->typeDictionary()->GetFieldType(structName, fieldName)->baseType();
+      _adjustByStep = _elementType->getSize();
+      Reload(b);
+      }
+
+   /**
+    * @brief write the simulated register value to the proper field in the struct
+    * @param b a builder object where the operations to do the write will be inserted
+    */
+   virtual void Commit(TR::IlBuilder *b)
+      {
+      b->StoreIndirect(_structName, _fieldName,
+      b->   Load(_localNameHoldingStructAddress),
+      b->   Load(_localName));
+      }
+
+   /**
+    * @brief read the simulated register value from the proper field in the struct
+    * @param b a builder object where the operations to do the write will be inserted
+    */
+   virtual void Reload(TR::IlBuilder *b)
+      {
+      b->Store(_localName,
+      b->   LoadIndirect(_structName, _fieldName,
+      b->      Load(_localNameHoldingStructAddress)));
+      }
+
+   private:
+
+   const char * const _structName;
+   const char * const _fieldName;
+   const char * const _localNameHoldingStructAddress;
+   };
+}
+
+#endif // !defined(OMR_VIRTUALMACHINEREGISTERINSTRUCT_INCL)

--- a/compiler/ilgen/VirtualMachineState.hpp
+++ b/compiler/ilgen/VirtualMachineState.hpp
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+
+#ifndef OMR_VIRTUALMACHINESTATE_INCL
+#define OMR_VIRTUALMACHINESTATE_INCL
+
+
+namespace TR { class IlBuilder; }
+class TR_Memory;
+
+template <class T> class List;
+template <class T> class ListAppender;
+
+namespace OMR
+{
+
+/**
+ * @brief Interface for expressing virtual machine state variables to JitBuilder
+ *
+ * VirtualMachineState is an interface that language compilers will implement
+ * to define all the aspects of the virtual machine state that the JIT compiler will
+ * simulate (operand stacks, virtual registers like "pc", "sp", etc.). The interface
+ * has four functions: 1) Commit() to cause the simulated state to be written to the
+ * actual virtual machine state, 2) Reload() to set the simulated machine state based
+ * on the current virtual machine state, 3) MakeCopy() to make an identical copy of
+ * the curent virtual machine state object, and 4) MergeInto() to perform the actions
+ * needed for the current state to be merged with a second virtual machine state.
+ *
+ * ##Usage
+ *
+ * Commit() is typically called when transitioning from compiled code to the interpreter.
+ *
+ * Reload() is typically called on the transition back from the interpreter to compiled
+ * code.
+ *
+ * MakeCopy() is typically called when control flow edges are created: the current vm state
+ * must also become the initial vm state at the target of the control flow edge and be
+ * able to evolve independently from the current vm state.
+ *
+ * MergeInto() is typically called when one compiled code path needs to merge into a second
+ * compiled code path (think the bottom of an if-then-else control flow diamond). At the
+ * merge point, the locations of all aspects of the simulated machine state must be
+ * identical so that the code below the merge point will compute correct results.
+ * MergeInto() typically causes the current simulated machine state to be written to the
+ * locations that were used by an existing simulated machine state. The "other" object
+ * passed to MergeInto() must have the exact same shape (number of components and each
+ * component must also match in its type).
+ *
+ * Language compilers should extend this base class, add instance variables for all
+ * necessary virtual machine state variables (using classes like VirtualMachineRegister
+ * and VirtualMachineOperandStack) and then implement Commit(), Reload(), MakeCopy(),
+ * and MergeInto() to call Commit(), Reload(), MakeCopy(), and MergeInto(), respectively, on
+ * each individual instance variable. It feels like boilerplate, but this approach makes
+ * it easy for the compiler to reference individual virtual machine state variables and
+ * at the same time permits complete flexibility in how the VM-wide Commit(), Reload(),
+ * MakeCopy(), and MergeInto() operations can be implemented.
+ */
+
+class VirtualMachineState
+   {
+   public:
+
+   /**
+    * @brief Cause all simulated aspects of the virtual machine state to become real.
+    * @param b builder object where the operations will be added to change the virtual machine state.
+    *
+    * The builder object b is assumed to be along a control flow path transitioning
+    * from compiled code to the interpreter. Base implementation does nothing.
+    */
+   virtual void Commit(TR::IlBuilder *b) { }
+
+   /**
+    * @brief Load the current virtual machine state into the simulated variables used by compiled code.
+    * @param b builder object where the operations will be added to reload the virtual machine state.
+    *
+    * The builder object b is assumed to be along a control flow path transitioning
+    * from the interpreter to compiled code. Base implementation does nothing.
+    */
+   virtual void Reload(TR::IlBuilder *b) { }
+
+   /**
+    * @brief create an identical copy of the current object.
+    * @returns the copy of the current object
+    *
+    * Typically used when propagating the current state along a flow edge to another builder to
+    * capture the input state for that other builder.
+    * Default implementation simply returns the current object.
+    */
+   virtual VirtualMachineState *MakeCopy() { return this; }
+
+   /**
+    * @brief cause the current state variables to match those used by another vm state
+    * @param other current state for the builder object control is merging into
+    * @param b builder object where the operations will be added to merge this state into the other
+    *
+    * The builder object is assumed to be along the control flow edge from one builder object S to
+    * another builder object T. "this" vm state is assumed to be the vm state for S. "other"  is
+    * assumed to be the vm state for T. Control from S should be to "b", and "b" should eventually
+    * transfer to T. Base implementation does nothing.
+    */
+   virtual void MergeInto(OMR::VirtualMachineState *other, TR::IlBuilder *b) { }
+
+   };
+
+}
+
+#endif // !defined(OMR_VIRTUALMACHINESTATE_INCL)

--- a/jitbuilder/build/files/common.mk
+++ b/jitbuilder/build/files/common.mk
@@ -201,6 +201,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/ilgen/MethodBuilder.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/BytecodeBuilder.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/TypeDictionary.cpp \
+    $(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineOperandStack.cpp \
     $(JIT_OMR_DIRTY_DIR)/runtime/Alignment.cpp \
     $(JIT_OMR_DIRTY_DIR)/runtime/CodeCacheTypes.cpp \
     $(JIT_OMR_DIRTY_DIR)/runtime/OMRCodeCache.cpp \

--- a/jitbuilder/build/rules/common.mk
+++ b/jitbuilder/build/rules/common.mk
@@ -74,6 +74,18 @@ $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/BytecodeBuilder.hpp: $(FIXED_SRCBA
 $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/TypeDictionary.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/TypeDictionary.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
 	cp -u $< $@ || cp $< $@
 
+$(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineState.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineState.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
+	cp -u $< $@ || cp $< $@
+
+$(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineRegister.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineRegister.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
+	cp -u $< $@ || cp $< $@
+
+$(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineRegisterInStruct.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineRegisterInStruct.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
+	cp -u $< $@ || cp $< $@
+
+$(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineOperandStack.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineOperandStack.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
+	cp -u $< $@ || cp $< $@
+
 $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/IlGen.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/IlGen.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
 	cp -u $< $@ || cp $< $@
 
@@ -92,6 +104,10 @@ JITBUILDER_FILES=$(RELEASE_DIR)/Makefile \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/MethodBuilder.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/BytecodeBuilder.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/TypeDictionary.hpp \
+             $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineState.hpp \
+             $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineRegister.hpp \
+             $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineRegisterInStruct.hpp \
+             $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineOperandStack.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/IlGen.hpp \
              $(RELEASE_SRC)/Call.hpp \
              $(RELEASE_SRC)/Call.cpp \

--- a/jitbuilder/release/.gitignore
+++ b/jitbuilder/release/.gitignore
@@ -18,10 +18,14 @@
 
 include/compiler/
 
+atomicoperations
+badtoiltype
 call
 conststring
+controlflowtests
 dotproduct
 iterfib
+issupportedtype
 jitbuilder.tgz
 linkedlist
 localarray
@@ -33,7 +37,4 @@ pow2
 recfib
 simple
 switch
-controlflowtests
-issupportedtype
 toiltype
-badtoiltype

--- a/jitbuilder/release/Makefile
+++ b/jitbuilder/release/Makefile
@@ -22,28 +22,62 @@ CXXFLAGS=-g -std=c++0x -O2 -c -fno-rtti -fPIC -I./include/compiler -I./include
 
 .SUFFIXES: .cpp .o
 
-goal: call conststring dotproduct iterfib linkedlist localarray mandelbrot nestedloop pointer recfib simple switch pow2 structarray controlflowtests issupportedtype toiltype atomicoperations
+# NOTE: replay purposefully left out of the list
+ALL_TESTS = \
+            atomicoperations \
+            call \
+            conststring \
+            controlflowtests \
+            dotproduct \
+            issupportedtype \
+            iterfib \
+            linkedlist \
+            localarray \
+            nestedloop \
+            pointer \
+            pow2 \
+            recfib \
+            simple \
+            structarray \
+            switch \
+            toiltype
 
-all: goal
-
-test: goal
+goal: $(ALL_TESTS)
+	./atomicoperations
 	./call
 	./conststring
+	./controlflowtests
 	./dotproduct
+	./issupportedtype
 	./iterfib
 	./linkedlist
 	./localarray
 	./nestedloop
 	./pointer
+	./pow2
 	./recfib
 	./simple
-	./switch
-	./pow2
 	./structarray
-	./controlflowtests
-	./issupportedtype
+	./switch
 	./toiltype
-	./atomicoperations
+
+all: goal
+
+test: goal $(ALL_TESTS)
+
+atomicoperations : libjitbuilder.a AtomicOperations.o
+	g++ -g -fno-rtti -o $@ AtomicOperations.o -L. -ljitbuilder -ldl
+
+AtomicOperations.o: src/AtomicOperations.cpp src/AtomicOperations.hpp
+	g++ -o $@ $(CXXFLAGS) $<
+
+
+badtoiltype : libjitbuilder.a BadToIlType.o
+	g++ -g -fno-rtti -o $@ BadToIlType.o -L. -ljitbuilder -ldl
+
+BadToIlType.o: src/ToIlType.cpp
+	g++ -o $@ -DEXPECTED_FAIL $(CXXFLAGS) $<
+
 
 call : libjitbuilder.a Call.o
 	g++ -g -fno-rtti -o $@ Call.o -L. -ljitbuilder -ldl
@@ -51,17 +85,34 @@ call : libjitbuilder.a Call.o
 Call.o: src/Call.cpp src/Call.hpp
 	g++ -o $@ $(CXXFLAGS) $<
 
+
 conststring : libjitbuilder.a ConstString.o	
 	g++ -g -fno-rtti -o $@ ConstString.o -L. -ljitbuilder -ldl
 
 ConstString.o: src/ConstString.cpp src/ConstString.hpp
 	g++ -o $@ $(CXXFLAGS) $<
 
+
+controlflowtests : libjitbuilder.a ControlFlowTests.o
+	g++ -g -fno-rtti -o $@ ControlFlowTests.o -L. -ljitbuilder -ldl
+
+ControlFlowTests.o: src/ControlFlowTests.cpp src/ControlFlowTests.hpp
+	g++ -o $@ $(CXXFLAGS) $<
+
+
 dotproduct : libjitbuilder.a DotProduct.o
 	g++ -g -fno-rtti -o $@ DotProduct.o -L. -ljitbuilder -ldl
 
 DotProduct.o: src/DotProduct.cpp src/DotProduct.hpp
 	g++ -o $@ $(CXXFLAGS) $<
+
+
+issupportedtype : libjitbuilder.a IsSupportedType.o
+	g++ -g -fno-rtti -o $@ IsSupportedType.o -L. -ljitbuilder -ldl
+
+IsSupportedType.o: src/IsSupportedType.cpp
+	g++ -o $@ $(CXXFLAGS) $<
+
 
 iterfib : libjitbuilder.a IterativeFib.o
 	g++ -g -fno-rtti -o $@ IterativeFib.o -L. -ljitbuilder -ldl
@@ -112,6 +163,13 @@ Pointer.o: src/Pointer.cpp src/Pointer.hpp
 	g++ -o $@ $(CXXFLAGS) $<
 
 
+pow2 : libjitbuilder.a Pow2.o
+	g++ -g -fno-rtti -o $@ Pow2.o -L. -ljitbuilder -ldl
+
+Pow2.o: src/Pow2.cpp src/Pow2.hpp
+	g++ -o $@ $(CXXFLAGS) $<
+
+
 recfib : libjitbuilder.a RecursiveFib.o
 	g++ -g -fno-rtti -o $@ RecursiveFib.o -L. -ljitbuilder -ldl
 
@@ -138,25 +196,6 @@ simple : libjitbuilder.a Simple.o
 Simple.o: src/Simple.cpp src/Simple.hpp
 	g++ -o $@ $(CXXFLAGS) $<
 
-atomicoperations : libjitbuilder.a AtomicOperations.o
-	g++ -g -fno-rtti -o $@ AtomicOperations.o -L. -ljitbuilder -ldl
-
-AtomicOperations.o: src/AtomicOperations.cpp src/AtomicOperations.hpp
-	g++ -o $@ $(CXXFLAGS) $<
-
-switch : libjitbuilder.a Switch.o
-	g++ -g -fno-rtti -o $@ Switch.o -L. -ljitbuilder -ldl
-
-Switch.o: src/Switch.cpp src/Switch.hpp
-	g++ -o $@ $(CXXFLAGS) $<
-
-
-pow2 : libjitbuilder.a Pow2.o
-	g++ -g -fno-rtti -o $@ Pow2.o -L. -ljitbuilder -ldl
-
-Pow2.o: src/Pow2.cpp src/Pow2.hpp
-	g++ -o $@ $(CXXFLAGS) $<
-
 
 structarray : libjitbuilder.a StructArray.o
 	g++ -g -fno-rtti -o $@ StructArray.o -L. -ljitbuilder -ldl
@@ -165,17 +204,10 @@ StructArray.o: src/StructArray.cpp src/StructArray.hpp
 	g++ -o $@ $(CXXFLAGS) $<
 
 
-controlflowtests : libjitbuilder.a ControlFlowTests.o
-	g++ -g -fno-rtti -o $@ ControlFlowTests.o -L. -ljitbuilder -ldl
+switch : libjitbuilder.a Switch.o
+	g++ -g -fno-rtti -o $@ Switch.o -L. -ljitbuilder -ldl
 
-ControlFlowTests.o: src/ControlFlowTests.cpp src/ControlFlowTests.hpp
-	g++ -o $@ $(CXXFLAGS) $<
-
-
-issupportedtype : libjitbuilder.a IsSupportedType.o
-	g++ -g -fno-rtti -o $@ IsSupportedType.o -L. -ljitbuilder -ldl
-
-IsSupportedType.o: src/IsSupportedType.cpp
+Switch.o: src/Switch.cpp src/Switch.hpp
 	g++ -o $@ $(CXXFLAGS) $<
 
 
@@ -186,13 +218,6 @@ ToIlType.o: src/ToIlType.cpp
 	g++ -o $@ $(CXXFLAGS) $<
 
 
-badtoiltype : libjitbuilder.a BadToIlType.o
-	g++ -g -fno-rtti -o $@ BadToIlType.o -L. -ljitbuilder -ldl
-
-BadToIlType.o: src/ToIlType.cpp
-	g++ -o $@ -DEXPECTED_FAIL $(CXXFLAGS) $<
-
-
 
 clean:
-	@rm -f call conststring dotproduct iterfib linkedlist localarray mandelbrot matmult nestedloop pointer recfib simple switch pow2 structarray controlflowtests issupportedtype toiltype badtoiltype atomicoperations *.o
+	@rm -f $(ALL_TESTS) replay *.o

--- a/jitbuilder/release/Makefile
+++ b/jitbuilder/release/Makefile
@@ -34,6 +34,7 @@ ALL_TESTS = \
             linkedlist \
             localarray \
             nestedloop \
+            operandstacktests \
             pointer \
             pow2 \
             recfib \
@@ -153,6 +154,13 @@ nestedloop : libjitbuilder.a NestedLoop.o
 	g++ -g -fno-rtti -o $@ NestedLoop.o -L. -ljitbuilder -ldl
 
 NestedLoop.o: src/NestedLoop.cpp src/NestedLoop.hpp
+	g++ -o $@ $(CXXFLAGS) $<
+
+
+operandstacktests : libjitbuilder.a OperandStackTests.o
+	g++ -g -fno-rtti -o $@ OperandStackTests.o -L. -ljitbuilder -ldl
+
+OperandStackTests.o: src/OperandStackTests.cpp src/OperandStackTests.hpp
 	g++ -o $@ $(CXXFLAGS) $<
 
 

--- a/jitbuilder/release/src/AtomicOperations.hpp
+++ b/jitbuilder/release/src/AtomicOperations.hpp
@@ -18,7 +18,7 @@
 
 
 #ifndef ATOMICOPS_INCL
-#define ATOMICOPS_IMPL
+#define ATOMICOPS_INCL
 
 #include "ilgen/MethodBuilder.hpp"
 

--- a/jitbuilder/release/src/OperandStackTests.cpp
+++ b/jitbuilder/release/src/OperandStackTests.cpp
@@ -226,7 +226,7 @@ verifyResult3(STACKVALUETYPE top)
    if (verbose) cout << "\tResult 3: top value == 3: ";
    REPORT1(top == 3, "top", top);
 
-   OperandStackTestMethod::verifyStack("3", 2, 3, 3, 2, 1);
+   OperandStackTestMethod::verifyStack("3", 2, 3, 1, 2, 3);
    }
 
 void
@@ -236,7 +236,7 @@ verifyResult4(STACKVALUETYPE popValue)
    if (verbose) cout << "\tResult 4: pop value == 3: ";
    REPORT1(popValue == 3, "popValue", popValue);
 
-   OperandStackTestMethod::verifyStack("4", 2, 3, 3, 2, 1);
+   OperandStackTestMethod::verifyStack("4", 2, 3, 1, 2, 3);
    }
 
 void
@@ -246,7 +246,7 @@ verifyResult5(STACKVALUETYPE popValue)
    if (verbose) cout << "\tResult 5: pop value == 2: ";
    REPORT1(popValue == 2, "popValue", popValue);
 
-   OperandStackTestMethod::verifyStack("5", 2, 3, 3, 2, 1);
+   OperandStackTestMethod::verifyStack("5", 2, 3, 1, 2, 3);
    }
 
 void
@@ -256,7 +256,7 @@ verifyResult6(STACKVALUETYPE top)
    if (verbose) cout << "\tResult 6: top == 5: ";
    REPORT1(top == 5, "top", top);
 
-   OperandStackTestMethod::verifyStack("6", 2, 2, 5, 1);
+   OperandStackTestMethod::verifyStack("6", 2, 2, 1, 5);
    }
 
 void
@@ -300,7 +300,7 @@ void
 verifyResult11()
    {
    if (verbose) cout << "Commit();\n";
-   OperandStackTestMethod::verifyStack("11", 3, 4, 3, 3, 4, 5);
+   OperandStackTestMethod::verifyStack("11", 3, 4, 5, 4, 3, 3);
    }
 
 void
@@ -309,7 +309,7 @@ verifyResult12(STACKVALUETYPE top)
    if (verbose) cout << "Pop(); Pop(); if (3 " << result12Operator << " 3) { Push(11); } else { Push(99); } Commit(); Top();\n";
    if (verbose) cout << "\tResult 12: top == " << expectedResult12Top << ": ";
    REPORT1(top == expectedResult12Top, "top", top);
-   OperandStackTestMethod::verifyStack("11", 3, 3, expectedResult12Top, 4, 5);
+   OperandStackTestMethod::verifyStack("11", 3, 3, 5, 4, expectedResult12Top);
    }
 
 bool
@@ -440,9 +440,9 @@ OperandStackTestMethod::testStack(TR::BytecodeBuilder *b, bool useEqual)
    TR::IlValue *v1 = POP(b);
    TR::IlValue *v2 = POP(b);
    if (useEqual)
-      b->IfCmpEqual(&thenBB, v1, v2);
+      b->IfCmpEqual(thenBB, v1, v2);
    else
-      b->IfCmpNotEqual(&thenBB, v1, v2);
+      b->IfCmpNotEqual(thenBB, v1, v2);
    b->AddFallThroughBuilder(elseBB);
 
    PUSH(thenBB, thenBB->ConstInteger(_valueType, 11));

--- a/jitbuilder/release/src/OperandStackTests.cpp
+++ b/jitbuilder/release/src/OperandStackTests.cpp
@@ -1,0 +1,505 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+
+#include <iostream>
+#include <stdlib.h>
+#include <stdint.h>
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdarg.h>
+
+#include "Jit.hpp"
+#include "ilgen/TypeDictionary.hpp"
+#include "ilgen/MethodBuilder.hpp"
+#include "ilgen/BytecodeBuilder.hpp"
+#include "ilgen/VirtualMachineOperandStack.hpp"
+#include "ilgen/VirtualMachineRegister.hpp"
+#include "ilgen/VirtualMachineRegisterInStruct.hpp"
+#include "OperandStackTests.hpp"
+
+using std::cout;
+using std::cerr;
+
+typedef struct Thread
+   {
+   int pad;
+   STACKVALUETYPE *sp;
+   } Thread;
+
+class TestState : public OMR::VirtualMachineState
+   {
+   public:
+   TestState()
+      : OMR::VirtualMachineState(),
+      _stack(NULL),
+      _stackTop(NULL)
+      { }
+
+   TestState(OMR::VirtualMachineOperandStack *stack, OMR::VirtualMachineRegister *stackTop)
+      : OMR::VirtualMachineState(),
+      _stack(stack),
+      _stackTop(stackTop)
+      {
+      }
+
+   virtual void Commit(TR::IlBuilder *b)
+      {
+      _stack->Commit(b);
+      _stackTop->Commit(b);
+      }
+
+   virtual void Reload(TR::IlBuilder *b)
+      {
+      _stack->Reload(b);
+      _stackTop->Reload(b);
+      }
+
+   virtual VirtualMachineState *MakeCopy()
+      {
+      TestState *newState = new TestState();
+      newState->_stack = (OMR::VirtualMachineOperandStack *)_stack->MakeCopy();
+      newState->_stackTop = (OMR::VirtualMachineRegister *) _stackTop->MakeCopy();
+      return newState;
+      }
+
+   virtual void MergeInto(VirtualMachineState *other, TR::IlBuilder *b)
+      {
+      TestState *otherState = (TestState *)other;
+      _stack->MergeInto(((TestState *)other)->_stack, b);
+      _stackTop->MergeInto(((TestState *)other)->_stackTop, b);
+      }
+
+   virtual int32_t growsUp()                { return true; }
+   virtual int32_t stackPtrStartingOffset() { return 0; }
+
+   OMR::VirtualMachineOperandStack * _stack;
+   OMR::VirtualMachineRegister     * _stackTop;
+   };
+
+static bool verbose = false;
+static int32_t numFailingTests = 0;
+static int32_t numPassingTests = 0;
+static STACKVALUETYPE **verifySP = NULL;
+static STACKVALUETYPE expectedResult12Top = -1;
+static char * result12Operator;
+
+static void
+setupResult12Equals()
+   {
+   expectedResult12Top = 11;
+   result12Operator = (char *)"==";
+   }
+
+static void
+setupResult12NotEquals()
+   {
+   expectedResult12Top = 99;
+   result12Operator = (char *)"!=";
+   }
+
+int
+main(int argc, char *argv[])
+   {
+   if (argc == 2 && strcmp(argv[1], "--verbose") == 0)
+      verbose = true;
+
+   cout << "Step 1: initialize JIT\n";
+   bool initialized = initializeJit();
+   if (!initialized)
+      {
+      cerr << "FAIL: could not initialize JIT\n";
+      exit(-1);
+      }
+
+   cout << "Step 2: compile operand stack tests using a straight pointer\n";
+   TR::TypeDictionary types2;
+   OperandStackTestMethod pointerMethod(&types2);
+   uint8_t *entry2 = 0;
+   int32_t rc2 = compileMethodBuilder(&pointerMethod, &entry2);
+   if (rc2 != 0)
+      {
+      cerr << "FAIL: compilation error " << rc2 << "\n";
+      exit(-2);
+      }
+
+   cout << "Step 3: invoke compiled code and print results\n";
+   typedef void (OperandStackTestMethodFunction)();
+   OperandStackTestMethodFunction *ptrTest = (OperandStackTestMethodFunction *) entry2;
+   verifySP = pointerMethod.getSPPtr();
+   setupResult12Equals();
+   ptrTest();
+
+   cout << "Step 4: compile operand stack tests using a Thread structure\n";
+   TR::TypeDictionary types4;
+   OperandStackTestUsingStructMethod threadMethod(&types4);
+   uint8_t *entry4 = 0;
+   int32_t rc4 = compileMethodBuilder(&threadMethod, &entry4);
+   if (rc4 != 0)
+      {
+      cerr << "FAIL: compilation error " << rc4 << "\n";
+      exit(-2);
+      }
+
+   cout << "Step 5: invoke compiled code and print results\n";
+   typedef void (OperandStackTestUsingStructMethodFunction)(Thread *thread);
+   OperandStackTestUsingStructMethodFunction *threadTest = (OperandStackTestUsingStructMethodFunction *) entry4;
+
+   Thread thread;
+   thread.sp = threadMethod.getSP();
+   verifySP = &thread.sp;
+   setupResult12NotEquals();
+   threadTest(&thread);
+
+   cout << "Step 6: shutdown JIT\n";
+   shutdownJit();
+
+   if (verbose) cout << "Number passing tests: " << numPassingTests << "\n";
+   if (verbose) cout << "Number failing tests: " << numFailingTests << "\n";
+
+   if (numFailingTests == 0)
+      cout << "ALL PASS\n";
+   }
+
+
+STACKVALUETYPE *OperandStackTestMethod::_realStack = NULL;
+STACKVALUETYPE *OperandStackTestMethod::_realStackTop = _realStack;
+int32_t OperandStackTestMethod::_realStackSize = -1;
+
+static void Fail()
+   {
+   numFailingTests++;
+   }
+
+static void Pass()
+   {
+   numPassingTests++;
+   }
+
+#define REPORT1(c,n,v)         { if (c) { Pass(); if (verbose) cout << "Pass\n"; } else { Fail(); if (verbose) cout << "Fail: " << (n) << " is " << (v) << "\n"; } }
+#define REPORT2(c,n1,v1,n2,v2) { if (c) { Pass(); if (verbose) cout << "Pass\n"; } else { Fail(); if (verbose) cout << "Fail: " << (n1) << " is " << (v1) << ", " << (n2) << " is " << (v2) << "\n"; } }
+
+// Result 0: empty stack even though Push has happened
+void
+verifyResult0()
+   {
+   if (verbose) cout << "Push(1)  [ no commit ]\n";
+   OperandStackTestMethod::verifyStack("0", -1, 0);
+   }
+
+void
+verifyResult1()
+   {
+   if (verbose) cout << "Commit(); Top()\n";
+   OperandStackTestMethod::verifyStack("1", 0, 1, 1);
+   }
+
+void
+verifyResult2(STACKVALUETYPE top)
+   {
+   if (verbose) cout << "Push(2); Push(3); Top()   [ no commit]\n";
+   if (verbose) cout << "\tResult 2: top value == 3: ";
+   REPORT1(top == 3, "top", top);
+
+   OperandStackTestMethod::verifyStack("2", 0, 1, 1);
+   }
+
+void
+verifyResult3(STACKVALUETYPE top)
+   {
+   if (verbose) cout << "Commit(); Top()\n";
+   if (verbose) cout << "\tResult 3: top value == 3: ";
+   REPORT1(top == 3, "top", top);
+
+   OperandStackTestMethod::verifyStack("3", 2, 3, 3, 2, 1);
+   }
+
+void
+verifyResult4(STACKVALUETYPE popValue)
+   {
+   if (verbose) cout << "Pop()    [ no commit]\n";
+   if (verbose) cout << "\tResult 4: pop value == 3: ";
+   REPORT1(popValue == 3, "popValue", popValue);
+
+   OperandStackTestMethod::verifyStack("4", 2, 3, 3, 2, 1);
+   }
+
+void
+verifyResult5(STACKVALUETYPE popValue)
+   {
+   if (verbose) cout << "Pop()    [ no commit]\n";
+   if (verbose) cout << "\tResult 5: pop value == 2: ";
+   REPORT1(popValue == 2, "popValue", popValue);
+
+   OperandStackTestMethod::verifyStack("5", 2, 3, 3, 2, 1);
+   }
+
+void
+verifyResult6(STACKVALUETYPE top)
+   {
+   if (verbose) cout << "Push(Add(popValue1, popValue2)); Commit(); Top()\n";
+   if (verbose) cout << "\tResult 6: top == 5: ";
+   REPORT1(top == 5, "top", top);
+
+   OperandStackTestMethod::verifyStack("6", 2, 2, 5, 1);
+   }
+
+void
+verifyResult7()
+   {
+   if (verbose) cout << "Drop(2); Commit(); [ empty stack ]\n";
+   OperandStackTestMethod::verifyStack("7", 2, 0);
+   }
+
+void
+verifyResult8(STACKVALUETYPE pick)
+   {
+   if (verbose) cout << "Push(5); Push(4); Push(3); Push(2); Push(1); Commit(); Pick(3)\n";
+   if (verbose) cout << "\tResult 8: pick == 4: ";
+   REPORT1(pick == 4, "pick", pick);
+
+   OperandStackTestMethod::verifyStack("8", 2, 0);
+   }
+
+void
+verifyResult9(STACKVALUETYPE top)
+   {
+   if (verbose) cout << "Drop(2); Top()\n";
+   if (verbose) cout << "\tResult 9: top == 3: ";
+   REPORT1(top == 3, "top", top);
+
+   OperandStackTestMethod::verifyStack("9", 2, 0);
+   }
+
+void
+verifyResult10(STACKVALUETYPE pick)
+   {
+   if (verbose) cout << "Dup(); Pick(2)\n";
+   if (verbose) cout << "\tResult 10: pick == 4: ";
+   REPORT1(pick == 4, "pick", pick);
+
+   OperandStackTestMethod::verifyStack("10", 2, 0);
+   }
+
+void
+verifyResult11()
+   {
+   if (verbose) cout << "Commit();\n";
+   OperandStackTestMethod::verifyStack("11", 3, 4, 3, 3, 4, 5);
+   }
+
+void
+verifyResult12(STACKVALUETYPE top)
+   {
+   if (verbose) cout << "Pop(); Pop(); if (3 " << result12Operator << " 3) { Push(11); } else { Push(99); } Commit(); Top();\n";
+   if (verbose) cout << "\tResult 12: top == " << expectedResult12Top << ": ";
+   REPORT1(top == expectedResult12Top, "top", top);
+   OperandStackTestMethod::verifyStack("11", 3, 3, expectedResult12Top, 4, 5);
+   }
+
+bool
+OperandStackTestMethod::verifyUntouched(int32_t maxTouched)
+   {
+   for (int32_t i=maxTouched+1;i < _realStackSize;i++) 
+      if (_realStack[i] != 0)
+         return false;
+   return true;
+   }
+
+void
+OperandStackTestMethod::verifyStack(const char *step, int32_t max, int32_t num, ...)
+   {
+
+   STACKVALUETYPE *realSP = *verifySP;
+
+   if (verbose) cout << "\tResult " << step << ": realSP-_realStack == " << num << ": ";
+   REPORT2((realSP-_realStack) == num, "_realStackTop-_realStack", (realSP-_realStack), "num", num);
+
+   va_list args;
+   va_start(args, num);
+   for (int32_t a=0;a < num;a++)
+      {
+      STACKVALUETYPE val = va_arg(args, STACKVALUETYPE);
+      if (verbose) cout << "\tResult " << step << ": _realStack[" << a << "] == " << val << ": ";
+      REPORT2(_realStack[a] == val, "_realStack[a]", _realStack[a], "val", val);
+      }
+
+   if (verbose) cout << "\tResult " << step << ": upper stack untouched: ";
+   REPORT1(verifyUntouched(max), "max", max);
+   }
+
+
+OperandStackTestMethod::OperandStackTestMethod(TR::TypeDictionary *d)
+   : MethodBuilder(d)
+   {
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   DefineName("test");
+   DefineReturnType(NoType);
+
+   _realStackSize = 32;
+   _realStack = (STACKVALUETYPE *) malloc (_realStackSize * sizeof(STACKVALUETYPE));
+   _realStackTop = _realStack;
+   memset(_realStack, 0, _realStackSize*sizeof(STACKVALUETYPE));
+
+   _valueType = STACKVALUEILTYPE;
+
+   DefineFunction("verifyResult0", "0", "0", (void *)&verifyResult0, NoType, 0);
+   DefineFunction("verifyResult1", "0", "0", (void *)&verifyResult1, NoType, 0);
+   DefineFunction("verifyResult2", "0", "0", (void *)&verifyResult2, NoType, 1, _valueType);
+   DefineFunction("verifyResult3", "0", "0", (void *)&verifyResult3, NoType, 1, _valueType);
+   DefineFunction("verifyResult4", "0", "0", (void *)&verifyResult4, NoType, 1, _valueType);
+   DefineFunction("verifyResult5", "0", "0", (void *)&verifyResult5, NoType, 1, _valueType);
+   DefineFunction("verifyResult6", "0", "0", (void *)&verifyResult6, NoType, 1, _valueType);
+   DefineFunction("verifyResult7", "0", "0", (void *)&verifyResult7, NoType, 0);
+   DefineFunction("verifyResult8", "0", "0", (void *)&verifyResult8, NoType, 1, _valueType);
+   DefineFunction("verifyResult9", "0", "0", (void *)&verifyResult9, NoType, 1, _valueType);
+   DefineFunction("verifyResult10", "0", "0", (void *)&verifyResult10, NoType, 1, _valueType);
+   DefineFunction("verifyResult11", "0", "0", (void *)&verifyResult11, NoType, 0);
+   DefineFunction("verifyResult12", "0", "0", (void *)&verifyResult12, NoType, 1, _valueType);
+   }
+
+// convenience macros
+#define STACK(b)	(((TestState *)(b)->vmState())->_stack)
+#define STACKTOP(b)	(((TestState *)(b)->vmState())->_stackTop)
+#define COMMIT(b)       ((b)->vmState()->Commit(b))
+#define PUSH(b,v)	(STACK(b)->Push(b,v))
+#define POP(b)          (STACK(b)->Pop(b))
+#define TOP(b)          (STACK(b)->Top())
+#define DUP(b)          (STACK(b)->Dup(b))
+#define DROP(b,d)       (STACK(b)->Drop(b,d))
+#define PICK(b,d)       (STACK(b)->Pick(d))
+
+bool
+OperandStackTestMethod::testStack(TR::BytecodeBuilder *b, bool useEqual)
+   {
+   PUSH(b, b->ConstInteger(_valueType, 1));
+   b->Call("verifyResult0", 0);
+
+   COMMIT(b);
+   b->Call("verifyResult1", 0);
+
+   PUSH(b, b->ConstInteger(_valueType, 2));
+   PUSH(b, b->ConstInteger(_valueType, 3));
+   b->Call("verifyResult2", 1, TOP(b));
+
+   COMMIT(b);
+   b->Call("verifyResult3", 1, TOP(b));
+
+   TR::IlValue *val1 = POP(b);
+   b->Call("verifyResult4", 1, val1);
+
+   TR::IlValue *val2 = POP(b);
+   b->Call("verifyResult5", 1, val2);
+
+   TR::IlValue *sum = b->Add(val1, val2);
+   PUSH(b, sum);
+   COMMIT(b);
+   b->Call("verifyResult6", 1, TOP(b));
+
+   DROP(b, 2);
+   COMMIT(b);
+   b->Call("verifyResult7", 0);
+
+   PUSH(b, b->ConstInteger(_valueType, 5));
+   PUSH(b, b->ConstInteger(_valueType, 4));
+   PUSH(b, b->ConstInteger(_valueType, 3));
+   PUSH(b, b->ConstInteger(_valueType, 2));
+   PUSH(b, b->ConstInteger(_valueType, 1));
+   b->Call("verifyResult8", 1, PICK(b, 3));
+
+   DROP(b, 2);
+   b->Call("verifyResult9", 1, TOP(b));
+
+   DUP(b);
+   b->Call("verifyResult10", 1, PICK(b, 2));
+
+   COMMIT(b);
+   b->Call("verifyResult11", 0);
+
+   TR::BytecodeBuilder *thenBB = OrphanBytecodeBuilder(0, (char*)"BCI_then");
+   TR::BytecodeBuilder *elseBB = OrphanBytecodeBuilder(1, (char*)"BCI_else");
+   TR::BytecodeBuilder *mergeBB = OrphanBytecodeBuilder(2, (char*)"BCI_merge");
+
+   TR::IlValue *v1 = POP(b);
+   TR::IlValue *v2 = POP(b);
+   if (useEqual)
+      b->IfCmpEqual(&thenBB, v1, v2);
+   else
+      b->IfCmpNotEqual(&thenBB, v1, v2);
+   b->AddFallThroughBuilder(elseBB);
+
+   PUSH(thenBB, thenBB->ConstInteger(_valueType, 11));
+   thenBB->Goto(mergeBB);
+
+   PUSH(elseBB, elseBB->ConstInteger(_valueType, 99));
+   elseBB->AddFallThroughBuilder(mergeBB);
+
+   COMMIT(mergeBB);
+   mergeBB->Call("verifyResult12", 1, TOP(mergeBB));
+
+   mergeBB->Return();
+
+   return true;
+   }
+
+bool
+OperandStackTestMethod::buildIL()
+   {
+   TR::IlType *pValueType = _types->PointerTo(_valueType);
+   TR::IlValue *realStackTopAddress = ConstAddress(&_realStackTop);
+   OMR::VirtualMachineRegister *stackTop = new OMR::VirtualMachineRegister(this, "SP", pValueType, sizeof(STACKVALUETYPE), realStackTopAddress);
+   OMR::VirtualMachineOperandStack *stack = new OMR::VirtualMachineOperandStack(this, 32, _valueType, stackTop);
+
+   TestState *vmState = new TestState(stack, stackTop);
+   setVMState(vmState);
+
+   TR::BytecodeBuilder *bb = OrphanBytecodeBuilder(0, (char *) "entry");
+   AppendBuilder(bb);
+
+   return testStack(bb, true);
+   }
+
+
+
+
+OperandStackTestUsingStructMethod::OperandStackTestUsingStructMethod(TR::TypeDictionary *d)
+   : OperandStackTestMethod(d)
+   {
+   d->DefineStruct("Thread");
+   d->DefineField("Thread", "sp", d->PointerTo(STACKVALUEILTYPE), offsetof(Thread, sp));
+   d->CloseStruct("Thread");
+
+   DefineParameter("thread", d->PointerTo("Thread"));
+   }
+
+bool
+OperandStackTestUsingStructMethod::buildIL()
+   {
+   OMR::VirtualMachineRegisterInStruct *stackTop = new OMR::VirtualMachineRegisterInStruct(this, "Thread", "thread", "sp", "SP");
+   OMR::VirtualMachineOperandStack *stack = new OMR::VirtualMachineOperandStack(this, 32, _valueType, stackTop);
+
+   TestState *vmState = new TestState(stack, stackTop);
+   setVMState(vmState);
+
+   TR::BytecodeBuilder *bb = OrphanBytecodeBuilder(0, (char *) "entry");
+   AppendBuilder(bb);
+
+   return testStack(bb, false);
+   }

--- a/jitbuilder/release/src/OperandStackTests.hpp
+++ b/jitbuilder/release/src/OperandStackTests.hpp
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+
+#ifndef OPERANDSTACKTESTS_INCL
+#define OPERANDSTACKTESTS_INCL
+
+#include "ilgen/MethodBuilder.hpp"
+
+#define STACKVALUEILTYPE	Int32
+#define	STACKVALUETYPE		int32_t
+
+//#define STACKVALUEILTYPE	Int64
+//#define	STACKVALUETYPE		int64_t
+
+namespace TR { class BytecodeBuilder; }
+
+class OperandStackTestMethod : public TR::MethodBuilder
+   {
+   public:
+   OperandStackTestMethod(TR::TypeDictionary *);
+   virtual bool buildIL();
+
+   static void verifyStack(const char *step, int32_t max, int32_t num, ...);
+   static bool verifyUntouched(int32_t maxTouched);
+
+   STACKVALUETYPE **getSPPtr() { return &_realStackTop; }
+   STACKVALUETYPE *getSP()     { return _realStackTop; }
+
+   protected:
+   bool testStack(TR::BytecodeBuilder *b, bool useEqual);
+
+   TR::IlType                      * _valueType;
+
+   static STACKVALUETYPE           * _realStack;
+   static STACKVALUETYPE           * _realStackTop;
+   static int32_t                    _realStackSize;
+   };
+
+class OperandStackTestUsingStructMethod : public OperandStackTestMethod
+   {
+   public:
+   OperandStackTestUsingStructMethod(TR::TypeDictionary *);
+   virtual bool buildIL();
+   };
+
+#endif // !defined(OPERANDSTACKTESTS_INCL)


### PR DESCRIPTION
Add new support for modelling virtual machine state variables (including an operand stack) to the JitBuilder API. Provides the basis for a poor-person's On Stack "Replacement".

Add tests for the operand stack modelling.

Some minor cleanup also included.

Issue: #570 