### PR TITLE
Add ThunkBuilder for libffi-like call building

### DIFF
--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -930,11 +930,20 @@ TR::IlValue *
 IlBuilder::ConvertTo(TR::IlType *t, TR::IlValue *v)
    {
    appendBlock();
-   TR::IlValue *convertedValue = NewValue(t);
    TR::DataType t1 = v->getSymbol()->getDataType();
    TR::DataType t2 = t->getPrimitiveType();
+   if (t1 == t2)
+      {
+      TraceIL("IlBuilder[ %p ]::%d is ConvertTo (already has type %s) %d\n", this, v->getCPIndex(), t->getName(), v->getCPIndex());
+      return v;
+      }
+
    TR::ILOpCodes convertOp = TR::DataType::getDataTypeConversion(v->getSymbol()->getDataType(), t->getPrimitiveType());
+   TR_ASSERT(convertOp != TR::BadILOp, "Builder [ %p ] unknown conversion requested for value %d (TR::DataType %d) to type %s", this, v->getCPIndex(), (int)(v->getSymbol()->getDataType()), t->getName());
+
    TR::Node *result = TR::Node::create(convertOp, 1, loadValue(v));
+
+   TR::IlValue *convertedValue = NewValue(t);
    storeNode(convertedValue, result);
    TraceIL("IlBuilder[ %p ]::%d is ConvertTo(%s) %d\n", this, convertedValue->getCPIndex(), t->getName(), v->getCPIndex());
    ILB_REPLAY("%s = %s->ConvertTo(%s, %s);", REPLAY_VALUE(convertedValue), REPLAY_BUILDER(this), REPLAY_TYPE(t), REPLAY_VALUE(value));

--- a/compiler/ilgen/ThunkBuilder.cpp
+++ b/compiler/ilgen/ThunkBuilder.cpp
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+
+#include <stdint.h>
+#include "compile/Compilation.hpp"
+#include "ilgen/IlBuilder.hpp"
+#include "ilgen/ThunkBuilder.hpp"
+#include "ilgen/TypeDictionary.hpp"
+
+#define OPT_DETAILS "O^O THUNKBUILDER: "
+
+#define TraceEnabled    (comp()->getOption(TR_TraceILGen))
+#define TraceIL(m, ...) {if (TraceEnabled) {traceMsg(comp(), m, ##__VA_ARGS__);}}
+
+/**
+ * ThunkBuilder is a MethodBuilder object representing a thunk for
+ * calling native functions with a particular signature (kind of like
+ * libffi). It is designed to take a target address and an array of
+ * Word-sized arguments and to call that target address with the
+ * provided arguments (after converting to the appropriate parameter
+ * types). The types of the parameters and return type are provided at
+ * construction time so that different ThunkBuilder instances can use
+ * different method signatures.
+ */
+
+namespace OMR
+{
+
+ThunkBuilder::ThunkBuilder(TR::TypeDictionary *types, const char *name, TR::IlType *returnType,
+                           uint32_t numCalleeParams, TR::IlType **calleeParamTypes)
+   : TR::MethodBuilder(types),
+   _numCalleeParams(numCalleeParams),
+   _calleeParamTypes(calleeParamTypes)
+   {
+   DefineLine(__FILE__);
+   DefineFile(LINETOSTR(__LINE__));
+   DefineName(name);
+   DefineReturnType(returnType);
+   DefineParameter("target", Address); // target
+   DefineParameter("args", types->PointerTo(Word));     // array of arguments
+
+   DefineFunction("thunkCallee",
+                  __FILE__,
+                  LINETOSTR(__LINE__),
+                  0, // entry will be a computed value
+                  returnType,
+                  numCalleeParams,
+                  calleeParamTypes);
+   }
+
+bool
+ThunkBuilder::buildIL()
+   {
+   TR::IlType *pWord = typeDictionary()->PointerTo(Word);
+
+   uint32_t numArgs = _numCalleeParams+1;
+   TR::IlValue **args = (TR::IlValue **) comp()->trMemory()->allocateHeapMemory(numArgs * sizeof(TR::IlValue *));
+
+   // first argument is the target address
+   args[0] = Load("target");
+
+   // followed by the actual arguments
+   for (uint32_t p=0; p < _numCalleeParams; p++)
+      {
+      uint32_t a=p+1;
+      args[a] = ConvertTo(_calleeParamTypes[p],
+                   LoadAt(pWord,
+                      IndexAt(pWord,
+                         Load("args"),
+                         ConstInt32(p))));
+      }
+
+   TR::IlValue *retValue = ComputedCall("thunkCallee", numArgs, args);
+
+   if (getReturnType() != NoType)
+      Return(retValue);
+
+   Return();
+
+   return true;
+   }
+
+} // namespace OMR

--- a/compiler/ilgen/ThunkBuilder.hpp
+++ b/compiler/ilgen/ThunkBuilder.hpp
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+
+#ifndef OMR_THUNKBUILDER_INCL
+#define OMR_THUNKBUILDER_INCL
+
+
+#ifndef TR_THUNKBUILDER_DEFINED
+#define TR_THUNKBUILDER_DEFINED
+#define PUT_OMR_THUNKBUILDER_INTO_TR
+#endif
+
+
+#include "ilgen/MethodBuilder.hpp"
+
+
+namespace OMR
+{
+
+/**
+ * @brief provide mechanism to call arbitrary C functions by signature passing array of arguments
+ *
+ * ThunkBuilder provides a mechanism like libffi to be able to construct a call to any C function
+ * by passing arguments in an array. It is not an uncommon scenario when writing a languge runtime
+ * that you have to call a native function, but you cannot write a direct call to it. For example,
+ * a language may provide the name of a native call target along with its signature and arguments,
+ * but the runtime still needs to pass those arguments to particular native function. The runtime
+ * code needs to be able to handle any kind of native call signature: any number of arguments and
+ * any combination of parameter types and any return type. ThunkBuilder provides a convenient way
+ * to generalize the calling of native functions assuming you can describe the signature and have
+ * a function address to call.
+ *
+ * When creating a ThunkBuilder instance, you provide the set of parameters and the return type. After
+ * compiling the ThunkBuilder instance, the resulting thunk can be used to call any function with that
+ * signature. You pass the address of the function as well as a properly sized array of Word sized
+ * arguments. The thunk will convert each argument to the type of its corresponding parameter as it
+ * calls the given function, and will return the return value as expected.
+ */
+
+class ThunkBuilder : public TR::MethodBuilder
+   {
+   public:
+   TR_ALLOC(TR_Memory::IlGenerator)
+
+   /**
+    * @brief construct a ThunkBuilder for a particular signature
+    * @param types TypeDictionary object that will be used by the ThunkBuilder object
+    * @param name primarily used for debug purposes and will appear in the compilation log
+    * @param returnType return type for the thunk's signature
+    * @param numCalleeParams number of parameters in the thunk's signature
+    * @param calleeParamTypes array of parameter types in the thunk's signature, must have numCalleeParams elements
+    */
+   ThunkBuilder(TR::TypeDictionary *types, const char *name, TR::IlType *returnType,
+                uint32_t numCalleeParams, TR::IlType **calleeParamTypes);
+
+   virtual bool buildIL();
+
+   private:
+   uint32_t      _numCalleeParams;
+   TR::IlType ** _calleeParamTypes;
+   };
+
+} // namespace OMR
+
+
+#if defined(PUT_OMR_THUNKBUILDER_INTO_TR)
+
+namespace TR
+{
+   class ThunkBuilder : public OMR::ThunkBuilder
+      {
+      public:
+         ThunkBuilder(TR::TypeDictionary *types, const char *name, TR::IlType *returnType,
+                      uint32_t numCalleeParams, TR::IlType **calleeParamTypes)
+            : OMR::ThunkBuilder(types, name, returnType, numCalleeParams, calleeParamTypes)
+            { }
+      };
+
+} // namespace TR
+
+#endif // defined(PUT_OMR_THUNKBUILDER_INTO_TR)
+
+#endif // !defined(OMR_THUNKBUILDER_INCL)

--- a/jitbuilder/build/files/common.mk
+++ b/jitbuilder/build/files/common.mk
@@ -215,9 +215,10 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/env/OMRIO.cpp \
     $(JIT_OMR_DIRTY_DIR)/env/OMRKnownObjectTable.cpp \
     $(JIT_OMR_DIRTY_DIR)/env/Globals.cpp \
-    $(JIT_OMR_DIRTY_DIR)/ilgen/IlBuilder.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/IlInjector.cpp \
+    $(JIT_OMR_DIRTY_DIR)/ilgen/IlBuilder.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/MethodBuilder.cpp \
+    $(JIT_OMR_DIRTY_DIR)/ilgen/ThunkBuilder.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/BytecodeBuilder.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/TypeDictionary.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineOperandStack.cpp \

--- a/jitbuilder/build/rules/common.mk
+++ b/jitbuilder/build/rules/common.mk
@@ -87,6 +87,9 @@ $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/IlBuilder.hpp: $(FIXED_SRCBASE)/$(
 $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/MethodBuilder.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/MethodBuilder.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
 	cp -u $< $@ || cp $< $@
 
+$(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/ThunkBuilder.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/ThunkBuilder.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
+	cp -u $< $@ || cp $< $@
+
 $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/BytecodeBuilder.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/BytecodeBuilder.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
 	cp -u $< $@ || cp $< $@
 
@@ -121,6 +124,7 @@ JITBUILDER_FILES=$(RELEASE_DIR)/Makefile \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/IlInjector.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/IlBuilder.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/MethodBuilder.hpp \
+             $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/ThunkBuilder.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/BytecodeBuilder.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/TypeDictionary.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineState.hpp \

--- a/jitbuilder/release/Makefile
+++ b/jitbuilder/release/Makefile
@@ -42,6 +42,7 @@ ALL_TESTS = \
             simple \
             structarray \
             switch \
+            thunks \
             toiltype \
             worklist
 
@@ -70,6 +71,7 @@ all_goal: common_goal
 	./recfib
 	./structarray
 	./switch
+	./thunks
 	./toiltype
 
 
@@ -245,6 +247,13 @@ worklist : libjitbuilder.a Worklist.o
 	g++ -g -fno-rtti -o $@ Worklist.o -L. -ljitbuilder -ldl
 
 Worklist.o: src/Worklist.cpp
+	g++ -o $@ $(CXXFLAGS) $<
+
+
+thunks : libjitbuilder.a Thunk.o
+	g++ -g -fno-rtti -o $@ Thunk.o -L. -ljitbuilder -ldl
+
+Thunk.o: src/Thunk.cpp
 	g++ -o $@ $(CXXFLAGS) $<
 
 

--- a/jitbuilder/release/src/Thunk.cpp
+++ b/jitbuilder/release/src/Thunk.cpp
@@ -1,0 +1,150 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+ 
+#include <iostream>
+#include <cstdint>
+#include <cassert>
+
+#include "Jit.hpp"
+#include "ilgen/TypeDictionary.hpp"
+#include "ilgen/ThunkBuilder.hpp"
+
+
+static void
+thunk_1b(int8_t b)
+   {
+   std::cout << "\tthunk_1b: b is " << b << "\n";
+   return;
+   }
+
+static void
+thunk_1b_2(int8_t b)
+   {
+   std::cout << "\tthunk_1b_2: b-1 is " << (char)(b-1) << "\n";
+   return;
+   }
+
+static void
+thunk_1s(int16_t s)
+   {
+   std::cout << "\tthunk_1s: s is " << s << "\n";
+   return;
+   }
+
+static void
+thunk_1s_2(int16_t s)
+   {
+   std::cout << "\tthunk_1s_2: s-1 is " << (s-1) << "\n";
+   return;
+   }
+
+static void
+thunk_1i(int32_t i)
+   {
+   std::cout << "\tthunk_1i: i is " << i << "\n";
+   return;
+   }
+
+static void
+thunk_1i_2(int32_t i)
+   {
+   std::cout << "\tthunk_1i_2: i-1 is " << (i-1) << "\n";
+   return;
+   }
+
+static void
+thunk_1l(int64_t l)
+   {
+   std::cout << "\tthunk_1l: l is " << l << "\n";
+   return;
+   }
+
+static void
+thunk_1l_2(int64_t l)
+   {
+   std::cout << "\tthunk_1l_2: l-1 is " << (l-1) << "\n";
+   return;
+   }
+
+typedef void (VoidThunkType)(void *, uintptr_t *);
+
+int main(int argc, char *argv[])
+   {
+   std::cout << "Step 1: initialize JIT\n";
+   bool jit_initialized = initializeJit();
+   assert(jit_initialized);
+
+   std::cout << "Step 2: create TR::TypeDictionary instance\n";
+   auto d = TR::TypeDictionary{};
+
+   uint32_t rc;
+   uint8_t *startPC;
+
+   std::cout << "Step 3: test primitive thunk returning void\n";
+
+   TR::IlType *NoType = d.PrimitiveType(TR::NoType);
+
+   TR::IlType *parmTypes_1b[] = { d.toIlType<int8_t>() };
+   TR::ThunkBuilder thunk1b(&d, "1b", NoType, 1, parmTypes_1b);
+   rc = compileMethodBuilder(&thunk1b, &startPC);
+   if (rc == 0)
+      {
+      VoidThunkType *f = (VoidThunkType *)startPC;
+      uintptr_t args[] = { (uintptr_t) 'x' };
+      f((void*)&thunk_1b, args);
+      f((void*)&thunk_1b_2, args);
+      }
+
+   TR::IlType *parmTypes_1s[] = { d.toIlType<int16_t>() };
+   TR::ThunkBuilder thunk1s(&d, "1s", NoType, 1, parmTypes_1s);
+   rc = compileMethodBuilder(&thunk1s, &startPC);
+   if (rc == 0)
+      {
+      VoidThunkType *f = (VoidThunkType *)startPC;
+      uintptr_t args[] = { (uintptr_t) 4097 };
+      f((void*)&thunk_1s, args);
+      f((void*)&thunk_1s_2, args);
+      }
+
+   TR::IlType *parmTypes_1i[] = { d.toIlType<int32_t>() };
+   TR::ThunkBuilder thunk1i(&d, "1i", NoType, 1, parmTypes_1i);
+   rc = compileMethodBuilder(&thunk1i, &startPC);
+   if (rc == 0)
+      {
+      VoidThunkType *f = (VoidThunkType *)startPC;
+      uintptr_t args[] = { (uintptr_t) 1233475 };
+      f((void*)&thunk_1i, args);
+      f((void*)&thunk_1i_2, args);
+      }
+
+   TR::IlType *parmTypes_1l[] = { d.toIlType<int64_t>() };
+   TR::ThunkBuilder thunk1l(&d, "1l", NoType, 1, parmTypes_1l);
+   rc = compileMethodBuilder(&thunk1l, &startPC);
+   if (rc == 0)
+      {
+      VoidThunkType *f = (VoidThunkType *)startPC;
+      uintptr_t args[] = { (uintptr_t) 1233475 };
+      f((void*)&thunk_1l, args);
+      f((void*)&thunk_1l_2, args);
+      }
+
+   std::cout << "Step 4: shutdown JIT\n";
+   shutdownJit();
+   
+   std::cout << "PASS\n";
+   }


### PR DESCRIPTION
Provide a new kind of builder object that can call C functions from
an array of argument values. A ThunkBuilder object takes a name, a
return type, a number of parameters, and an array of parameter types.
The compiled code generated by a ThunkBuilder takes two arguments and
returns whatever kind of value was specified by the constructor call.
The first argument is the target call address, and the second argument
is an array of Word sized arguments, which will be passed to the
target method as the types indicated by the ThunkBuilder constructor
call.

Also created Thunk.cpp test that, initially, has only single character
and single short parameters with no return type. To be extended later.

Issue: #573 

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>