### PR TITLE
Set the 'swappedChildren' node flag in swapChildren()

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -4049,6 +4049,8 @@ OMR::Node::swapChildren()
    TR::Node *firstChild = self()->getFirstChild();
    self()->setFirst(self()->getSecondChild());
    self()->setSecond(firstChild);
+   if (self()->getOpCode().isIf())
+      self()->setSwappedChildren(!self()->childrenWereSwapped());
    }
 
 TR::Node *


### PR DESCRIPTION
swapChildren() is an utility method used for swapping the children of a node.
When that happens for an 'if' node we also need to set the 'swappedChildren' flag.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>