### PR TITLE
Complete CS cycle in progress before starting STW global GC

### DIFF
--- a/gc/base/standard/ConcurrentGC.hpp
+++ b/gc/base/standard/ConcurrentGC.hpp
@@ -351,6 +351,10 @@ private:
 	void completeConcurrentSweepForKickoff(MM_EnvironmentStandard *env);
 #endif /* OMR_GC_CONCURRENT_SWEEP */
 
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	void completeConcurrentScavenge(MM_EnvironmentStandard *env);
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
+
 #if defined(OMR_GC_LARGE_OBJECT_AREA)		
 	void updateMeteringHistoryBeforeGC(MM_EnvironmentStandard *env);
 	void updateMeteringHistoryAfterGC(MM_EnvironmentStandard *env);


### PR DESCRIPTION
If a Stop-The-World Global GC is triggered while Concurrent Scavenger
(CS) is still in progress, we have to complete CS first.

This is similar scenario to triggering a premature completion of CS when
percolate GC is to be done. The difference is that completion is now
triggered from an external cycle, so that cycle state is not properly
set. 

Building Global GC cycle state is already tightly coupled with reporting
GC cycle start. To avoid overlapping cycles (easily visible in verbose
GC), we want to complete CS cycle (and report its cycle end) before
Global GC cycle start is reported. 

Thus we build a temp cycle state, before reporting Global cycle start
(and build proper Global cycle state), which signals Scavenger it's
called externally and needs to build its Scavenger cycle state from
scratch.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>