### PR TITLE
Run linter in debug mode

### DIFF
--- a/compiler/il/symbol/OMRAutomaticSymbol.cpp
+++ b/compiler/il/symbol/OMRAutomaticSymbol.cpp
@@ -88,25 +88,116 @@ OMR::AutomaticSymbol::init()
    _name = NULL;
    }
 
+TR::ILOpCodes
+OMR::AutomaticSymbol::getKind()
+  {
+  TR_ASSERT(self()->isLocalObject(), "Should be local object");
+  return _kind;
+  }
+
 TR::SymbolReference *
 OMR::AutomaticSymbol::getClassSymbolReference()
    {
-   TR_ASSERT(isLocalObject(), "Should be tagged as local object");
+   TR_ASSERT(self()->isLocalObject(), "Should be tagged as local object");
    return _kind != TR::newarray ? _classSymRef : 0;
    }
 
 TR::SymbolReference *
 OMR::AutomaticSymbol::setClassSymbolReference(TR::SymbolReference *s)
    {
-   TR_ASSERT(isLocalObject(), "Should be tagged as local object");
+   TR_ASSERT(self()->isLocalObject(), "Should be tagged as local object");
    return (_classSymRef = s);
    }
 
 int32_t
 OMR::AutomaticSymbol::getArrayType()
    {
-   TR_ASSERT(isLocalObject(), "Should be tagged as local object");
+   TR_ASSERT(self()->isLocalObject(), "Should be tagged as local object");
    return _kind == TR::newarray ? _arrayType : 0;
+   }
+
+TR::AutomaticSymbol *
+OMR::AutomaticSymbol::getPinningArrayPointer()
+   {
+   TR_ASSERT(self()->isInternalPointer(), "Should be internal pointer");
+   return _pinningArrayPointer;
+   }
+
+TR::AutomaticSymbol *
+OMR::AutomaticSymbol::setPinningArrayPointer(TR::AutomaticSymbol *s)
+   {
+   TR_ASSERT(self()->isInternalPointer(), "Should be internal pointer");
+   return (_pinningArrayPointer = s);
+   }
+
+uint32_t
+OMR::AutomaticSymbol::getActiveSize()
+   {
+   TR_ASSERT(self()->isVariableSizeSymbol(), "Should be variable sized symbol");
+   return _activeSize;
+   }
+
+uint32_t
+OMR::AutomaticSymbol::setActiveSize(uint32_t s)
+   {
+   TR_ASSERT(self()->isVariableSizeSymbol(), "Should be variable sized symbol");
+   return (_activeSize = s);
+   }
+
+bool
+OMR::AutomaticSymbol::isReferenced()
+   {
+   TR_ASSERT(self()->isVariableSizeSymbol(), "Should be variable sized symbol");
+   return _variableSizeSymbolFlags.testAny(IsReferenced);
+   }
+
+void
+OMR::AutomaticSymbol::setIsReferenced(bool b)
+   {
+   TR_ASSERT(self()->isVariableSizeSymbol(), "Should be variable sized symbol");
+   _variableSizeSymbolFlags.set(IsReferenced, b);
+   }
+
+bool
+OMR::AutomaticSymbol::isAddressTaken()
+   {
+   TR_ASSERT(self()->isVariableSizeSymbol(), "Should be variable sized symbol");
+   return _variableSizeSymbolFlags.testAny(IsAddressTaken);
+   }
+
+void
+OMR::AutomaticSymbol::setIsAddressTaken(bool b)
+   {
+   TR_ASSERT(self()->isVariableSizeSymbol(), "Should be variable sized symbol");
+   _variableSizeSymbolFlags.set(IsAddressTaken, b);
+   }
+
+bool
+OMR::AutomaticSymbol::isSingleUse()
+   {
+   TR_ASSERT(self()->isVariableSizeSymbol(), "Should be variable sized symbol");
+   return _variableSizeSymbolFlags.testAny(IsSingleUse);
+   }
+
+void
+OMR::AutomaticSymbol::setIsSingleUse(bool b)
+   {
+   TR_ASSERT(self()->isVariableSizeSymbol(), "Should be variable sized symbol");
+   _variableSizeSymbolFlags.set(IsSingleUse, b);
+   }
+
+TR::Node *
+OMR::AutomaticSymbol::getNodeToFreeAfter()
+   {
+   TR_ASSERT(self()->isVariableSizeSymbol(), "Should be variable sized symbol");
+   return _nodeToFreeAfter;
+   }
+
+TR::Node *
+OMR::AutomaticSymbol::setNodeToFreeAfter(TR::Node *n)
+   {
+   TR_ASSERT(self()->isVariableSizeSymbol(), "Should be variable sized symbol");
+   return _nodeToFreeAfter = n;
    }
 
 

--- a/compiler/il/symbol/OMRAutomaticSymbol.hpp
+++ b/compiler/il/symbol/OMRAutomaticSymbol.hpp
@@ -176,11 +176,7 @@ public:
                                                    uint32_t               s,
                                                    TR_FrontEnd *          fe);
 
-   TR::ILOpCodes getKind()
-      {
-      TR_ASSERT(isLocalObject(), "Should be local object");
-      return _kind;
-      }
+   TR::ILOpCodes getKind();
 
    TR::SymbolReference *getClassSymbolReference();
    TR::SymbolReference *setClassSymbolReference(TR::SymbolReference *s);
@@ -228,20 +224,12 @@ public:
    template <typename AllocatorType>
    static TR::AutomaticSymbol * createInternalPointer(AllocatorType m, TR::DataType d, uint32_t s, TR_FrontEnd * fe);
 
-   TR::AutomaticSymbol *getPinningArrayPointer()
-      {
-      TR_ASSERT(isInternalPointer(), "Should be internal pointer");
-      return _pinningArrayPointer;
-      }
+   TR::AutomaticSymbol *getPinningArrayPointer();
 
    // Expose base name on derived calls.
    using TR::Symbol::setPinningArrayPointer;
 
-   TR::AutomaticSymbol *setPinningArrayPointer(TR::AutomaticSymbol *s)
-      {
-      TR_ASSERT(isInternalPointer(), "Should be internal pointer");
-      return (_pinningArrayPointer = s);
-      }
+   TR::AutomaticSymbol *setPinningArrayPointer(TR::AutomaticSymbol *s);
 
 private:
 
@@ -262,17 +250,9 @@ public:
    template <typename AllocatorType>
    static TR::AutomaticSymbol * createVariableSized(AllocatorType m, uint32_t s);
 
-   uint32_t getActiveSize()
-      {
-      TR_ASSERT(isVariableSizeSymbol(), "Should be variable sized symbol");
-      return _activeSize;
-      }
+   uint32_t getActiveSize();
 
-   uint32_t setActiveSize(uint32_t s)
-      {
-      TR_ASSERT(isVariableSizeSymbol(), "Should be variable sized symbol");
-      return (_activeSize = s);
-      }
+   uint32_t setActiveSize(uint32_t s);
 
    /**
     * Flags for variable size symbols
@@ -284,53 +264,21 @@ public:
       IsSingleUse                   = 0x04, ///< a temp ref created for a one off privatization in a single evaluator (doesn't use refCounts so automatically freed)
       };
 
-   bool isReferenced()
-      {
-      TR_ASSERT(isVariableSizeSymbol(), "Should be variable sized symbol");
-      return _variableSizeSymbolFlags.testAny(IsReferenced);
-      }
+   bool isReferenced();
 
-   void setIsReferenced(bool b = true)
-      {
-      TR_ASSERT(isVariableSizeSymbol(), "Should be variable sized symbol");
-      _variableSizeSymbolFlags.set(IsReferenced, b);
-      }
+   void setIsReferenced(bool b = true);
 
-   bool isAddressTaken()
-      {
-      TR_ASSERT(isVariableSizeSymbol(), "Should be variable sized symbol");
-      return _variableSizeSymbolFlags.testAny(IsAddressTaken);
-      }
+   bool isAddressTaken();
 
-   void setIsAddressTaken(bool b = true)
-      {
-      TR_ASSERT(isVariableSizeSymbol(), "Should be variable sized symbol");
-      _variableSizeSymbolFlags.set(IsAddressTaken, b);
-      }
+   void setIsAddressTaken(bool b = true);
 
-   bool isSingleUse()
-      {
-      TR_ASSERT(isVariableSizeSymbol(), "Should be variable sized symbol");
-      return _variableSizeSymbolFlags.testAny(IsSingleUse);
-      }
+   bool isSingleUse();
 
-   void setIsSingleUse(bool b = true)
-      {
-      TR_ASSERT(isVariableSizeSymbol(), "Should be variable sized symbol");
-      _variableSizeSymbolFlags.set(IsSingleUse, b);
-      }
+   void setIsSingleUse(bool b = true);
 
-   TR::Node *getNodeToFreeAfter()
-      {
-      TR_ASSERT(isVariableSizeSymbol(), "Should be variable sized symbol");
-      return _nodeToFreeAfter;
-      }
+   TR::Node *getNodeToFreeAfter();
 
-   TR::Node *setNodeToFreeAfter(TR::Node *n)
-      {
-      TR_ASSERT(isVariableSizeSymbol(), "Should be variable sized symbol");
-      return _nodeToFreeAfter = n;
-      }
+   TR::Node *setNodeToFreeAfter(TR::Node *n);
 
 private:
 

--- a/compiler/il/symbol/OMRLabelSymbol.cpp
+++ b/compiler/il/symbol/OMRLabelSymbol.cpp
@@ -139,6 +139,13 @@ OMR::LabelSymbol::makeRelativeLabelSymbol(intptr_t offset)
    self()->setName(name);
    }
 
+intptr_t
+OMR::LabelSymbol::getDistance()
+   {
+   TR_ASSERT(self()->isRelativeLabel(), "Must be a relative label to have a valid offset!");
+   return _offset;
+   }
+
 TR::LabelSymbol *
 generateLabelSymbol(TR::CodeGenerator *cg)
    {

--- a/compiler/il/symbol/OMRLabelSymbol.hpp
+++ b/compiler/il/symbol/OMRLabelSymbol.hpp
@@ -133,7 +133,7 @@ public:
     */
    void makeRelativeLabelSymbol(intptr_t offset);
 
-   intptr_t getDistance() { TR_ASSERT(isRelativeLabel(), "Must be a relative label to have a valid offset!");  return _offset; }
+   intptr_t getDistance();
 private:
    intptr_t     _offset;
   };

--- a/compiler/il/symbol/OMRRegisterMappedSymbol.cpp
+++ b/compiler/il/symbol/OMRRegisterMappedSymbol.cpp
@@ -100,6 +100,20 @@ OMR::RegisterMappedSymbol::setLiveLocalIndexUninitialized()
    _liveLocalIndex = USHRT_MAX;
    }
 
+TR_MethodMetaDataType
+OMR::RegisterMappedSymbol::getMethodMetaDataType()
+   {
+   TR_ASSERT(self()->isMethodMetaData(), "should be method metadata!");
+   return _type;
+   }
+
+void
+OMR::RegisterMappedSymbol::setMethodMetaDataType(TR_MethodMetaDataType type)
+   {
+   TR_ASSERT(self()->isMethodMetaData(), "should be method metadata!");
+   _type = type;
+}
+
 template <typename AllocatorType>
 TR::RegisterMappedSymbol *
 OMR::RegisterMappedSymbol::createMethodMetaDataSymbol(AllocatorType m, const char *name, TR_MethodMetaDataType type)

--- a/compiler/il/symbol/OMRRegisterMappedSymbol.hpp
+++ b/compiler/il/symbol/OMRRegisterMappedSymbol.hpp
@@ -122,8 +122,8 @@ public:
    template <typename AllocatorType>
    static TR::RegisterMappedSymbol * createMethodMetaDataSymbol(AllocatorType m, const char *name, TR_MethodMetaDataType type = TR_MethodMetaDataType_Default);
 
-   TR_MethodMetaDataType   getMethodMetaDataType()                            { TR_ASSERT(isMethodMetaData(), "should be method metadata!"); return _type;   }
-   void                    setMethodMetaDataType(TR_MethodMetaDataType type)  { TR_ASSERT(isMethodMetaData(), "should be method metadata!"); _type = type;   }
+   TR_MethodMetaDataType getMethodMetaDataType();
+   void                  setMethodMetaDataType(TR_MethodMetaDataType type);
 
 protected:
    friend class ::TR_DebugExt;

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -991,7 +991,7 @@ OMR::ResolvedMethodSymbol::genOSRHelperCall(int32_t currentInlinedSiteIndex, TR:
    {
    bool trace = self()->comp()->getOption(TR_TraceOSR);
    // Use first node of the method for bytecode info
-   TR_ASSERT(self()->getFirstTreeTop(), "first tree top is NULL in %s", signature(self()->comp()->trMemory()));
+   TR_ASSERT(self()->getFirstTreeTop(), "first tree top is NULL in %s", self()->signature(self()->comp()->trMemory()));
    TR::Node *firstNode = self()->getFirstTreeTop()->getNode();
 
    // Create the OSR helper symbol reference
@@ -2130,6 +2130,99 @@ OMR::ResolvedMethodSymbol::getArrayCopyTempSlot(TR_FrontEnd * fe)
    if (_arrayCopyTempSlot == -1)
       _arrayCopyTempSlot = self()->incTempIndex(fe);
    return _arrayCopyTempSlot;
+   }
+
+// Getters
+
+uint32_t&
+OMR::ResolvedMethodSymbol::getLocalMappingCursor()
+   {
+   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   return _localMappingCursor;
+   }
+void
+OMR::ResolvedMethodSymbol::setLocalMappingCursor(uint32_t i)
+   {
+   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   _localMappingCursor = i;
+   }
+
+uint32_t
+OMR::ResolvedMethodSymbol::getProloguePushSlots()
+   {
+   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   return _prologuePushSlots;
+   }
+uint32_t
+OMR::ResolvedMethodSymbol::setProloguePushSlots(uint32_t s)
+   {
+   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   return (_prologuePushSlots = s);
+   }
+
+uint32_t
+OMR::ResolvedMethodSymbol::getScalarTempSlots()
+   {
+   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   return _scalarTempSlots;
+   }
+uint32_t
+OMR::ResolvedMethodSymbol::setScalarTempSlots(uint32_t s)
+   {
+   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   return (_scalarTempSlots = s);
+   }
+
+uint32_t
+OMR::ResolvedMethodSymbol::getObjectTempSlots()
+   {
+   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   return _objectTempSlots;
+   }
+uint32_t
+OMR::ResolvedMethodSymbol::setObjectTempSlots(uint32_t s)
+   {
+   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   return (_objectTempSlots = s);
+   }
+
+bool
+OMR::ResolvedMethodSymbol::containsOnlySinglePrecision()
+   {
+   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   return _methodFlags.testAny(OnlySinglePrecision);
+   }
+void
+OMR::ResolvedMethodSymbol::setContainsOnlySinglePrecision(bool b)
+   {
+   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   _methodFlags.set(OnlySinglePrecision, b);
+   }
+
+bool
+OMR::ResolvedMethodSymbol::usesSinglePrecisionMode()
+   {
+   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   return _methodFlags.testAny(SinglePrecisionMode);
+   }
+void
+OMR::ResolvedMethodSymbol::setUsesSinglePrecisionMode(bool b)
+   {
+   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   _methodFlags.set(SinglePrecisionMode, b);
+   }
+
+bool
+OMR::ResolvedMethodSymbol::isNoTemps()
+   {
+   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   return _methodFlags.testAny(NoTempsSet);
+   }
+void
+OMR::ResolvedMethodSymbol::setNoTemps(bool b)
+   {
+   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   _methodFlags.set(NoTempsSet, b);
    }
 
 //Explicit instantiations

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
@@ -373,26 +373,26 @@ public:
    template <typename AllocatorType>
    static TR::ResolvedMethodSymbol * createJittedMethodSymbol(AllocatorType m, TR_ResolvedMethod *, TR::Compilation *);
 
-   uint32_t&   getLocalMappingCursor()                { TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method."); return _localMappingCursor;}
-   void        setLocalMappingCursor(uint32_t i)      { TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method."); _localMappingCursor = i;}
+   uint32_t&   getLocalMappingCursor();
+   void        setLocalMappingCursor(uint32_t i);
 
-   uint32_t    getProloguePushSlots()                 { TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method."); return _prologuePushSlots;}
-   uint32_t    setProloguePushSlots(uint32_t s)       { TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method."); return (_prologuePushSlots = s);}
+   uint32_t    getProloguePushSlots();
+   uint32_t    setProloguePushSlots(uint32_t s);
 
-   uint32_t    getScalarTempSlots()                   { TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method."); return _scalarTempSlots;}
-   uint32_t    setScalarTempSlots(uint32_t s)         { TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method."); return (_scalarTempSlots = s);}
+   uint32_t    getScalarTempSlots();
+   uint32_t    setScalarTempSlots(uint32_t s);
 
-   uint32_t    getObjectTempSlots()                   { TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method."); return _objectTempSlots;}
-   uint32_t    setObjectTempSlots(uint32_t s)         { TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method."); return (_objectTempSlots = s);}
+   uint32_t    getObjectTempSlots();
+   uint32_t    setObjectTempSlots(uint32_t s);
 
-   bool        containsOnlySinglePrecision()          { TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method."); return _methodFlags.testAny(OnlySinglePrecision);}
-   void        setContainsOnlySinglePrecision(bool b) { TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method."); _methodFlags.set(OnlySinglePrecision, b);}
+   bool        containsOnlySinglePrecision();
+   void        setContainsOnlySinglePrecision(bool b);
 
-   bool        usesSinglePrecisionMode()              { TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method."); return _methodFlags.testAny(SinglePrecisionMode);}
-   void        setUsesSinglePrecisionMode(bool b)     { TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method."); _methodFlags.set(SinglePrecisionMode, b);}
+   bool        usesSinglePrecisionMode();
+   void        setUsesSinglePrecisionMode(bool b);
 
-   bool        isNoTemps()                            { TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method."); return _methodFlags.testAny(NoTempsSet);}
-   void        setNoTemps(bool b=true)                { TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method."); _methodFlags.set(NoTempsSet, b);}
+   bool        isNoTemps();
+   void        setNoTemps(bool b=true);
 
 private:
    uint32_t                                  _localMappingCursor;

--- a/compiler/il/symbol/OMRStaticSymbol.cpp
+++ b/compiler/il/symbol/OMRStaticSymbol.cpp
@@ -61,6 +61,14 @@ TR::StaticSymbol * OMR::StaticSymbol::createNamed(AllocatorType m, TR::DataType 
    }
 
 
+const char *
+OMR::StaticSymbol::getName()
+   {
+   TR_ASSERT(self()->isNamed(),"Must have called makeNamed() to get a valid name");
+   return _name;
+   }
+
+
 //Explicit Instantiations
 template TR::StaticSymbol * OMR::StaticSymbol::createNamed(TR_HeapMemory m, TR::DataType d, const char * name) ;
 template TR::StaticSymbol * OMR::StaticSymbol::createNamed(TR_HeapMemory m, TR::DataType d, void * addr, const char * name) ;

--- a/compiler/il/symbol/OMRStaticSymbol.hpp
+++ b/compiler/il/symbol/OMRStaticSymbol.hpp
@@ -122,11 +122,7 @@ public:
    template <typename AllocatorType>
    static TR::StaticSymbol * createNamed(AllocatorType m, TR::DataType d, void * addr, const char * name);
 
-   const char *getName()
-      {
-      TR_ASSERT(isNamed(),"Must have called makeNamed() to get a valid name");
-      return _name;
-      }
+   const char *getName();
 
 private:
 

--- a/compiler/il/symbol/OMRSymbol.cpp
+++ b/compiler/il/symbol/OMRSymbol.cpp
@@ -181,6 +181,119 @@ OMR::Symbol::getOffset()
    }
 
 /**
+ * Cast to symbol type
+ */
+TR::RegisterMappedSymbol * OMR::Symbol::castToRegisterMappedSymbol()
+   {
+   TR_ASSERT(self()->isRegisterMappedSymbol(), "OMR::Symbol::castToRegisterMappedSymbol, symbol is not a register mapped symbol");
+   return (TR::RegisterMappedSymbol *)this;
+   }
+
+TR::AutomaticSymbol * OMR::Symbol::castToAutoSymbol()
+   {
+   TR_ASSERT(self()->isAuto(), "OMR::Symbol::castToAutoSymbo, symbol is not an automatic symbol");
+   return (TR::AutomaticSymbol *)this;
+   }
+
+TR::ParameterSymbol * OMR::Symbol::castToParmSymbol()
+   {
+   TR_ASSERT(self()->isParm(), "OMR::Symbol::castToParmSymbol, symbol is not a parameter symbol");
+   return (TR::ParameterSymbol *)this;
+   }
+
+TR::AutomaticSymbol * OMR::Symbol::castToInternalPointerAutoSymbol()
+   {
+   TR_ASSERT(self()->isInternalPointerAuto(), "OMR::Symbol::castToInternalAutoSymbol, symbol is not an internal pointer automatic symbol");
+   return (TR::AutomaticSymbol *)this;
+   }
+
+TR::AutomaticSymbol * OMR::Symbol::castToLocalObjectSymbol()
+   {
+   TR_ASSERT(self()->isLocalObject(), "OMR::Symbol::castToLocalObjectSymbol, symbol is not an internal pointer automatic symbol");
+   return (TR::AutomaticSymbol *)this;
+   }
+
+TR::StaticSymbol * OMR::Symbol::castToStaticSymbol()
+   {
+   TR_ASSERT(self()->isStatic(), "OMR::Symbol::castToStaticSymbol, symbol is not a static symbol");
+   return (TR::StaticSymbol *)this;
+   }
+
+TR::StaticSymbol * OMR::Symbol::castToNamedStaticSymbol()
+   {
+   TR_ASSERT(self()->isNamed() && self()->isStatic(), "OMR::Symbol::castToNamedStaticSymbol, symbol is not a named static symbol");
+   return (TR::StaticSymbol *)this;
+   }
+
+TR::MethodSymbol * OMR::Symbol::castToMethodSymbol()
+   {
+   TR_ASSERT(self()->isMethod(), "OMR::Symbol::castToMethodSymbol, symbol[%p] is not a method symbol",
+         this);
+   return (TR::MethodSymbol *)this;
+   }
+
+TR::ResolvedMethodSymbol * OMR::Symbol::castToResolvedMethodSymbol()
+   {
+   TR_ASSERT(self()->isResolvedMethod(), "OMR::Symbol::castToResolvedMethodSymbol, symbol is not a resolved method symbol");
+   return (TR::ResolvedMethodSymbol *)this;
+   }
+
+TR::Symbol * OMR::Symbol::castToShadowSymbol()
+   {
+   TR_ASSERT(self()->isShadow(), "OMR::Symbol::castToShadowSymbol, symbol is not a shadow symbol");
+   return (TR::Symbol *)this;
+   }
+
+TR::RegisterMappedSymbol * OMR::Symbol::castToMethodMetaDataSymbol()
+   {
+   TR_ASSERT(self()->isMethodMetaData(), "OMR::Symbol::castToMethodMetaDataSymbol, symbol is not a meta data symbol");
+   return (TR::RegisterMappedSymbol *)this;
+   }
+
+TR::LabelSymbol * OMR::Symbol::castToLabelSymbol()
+   {
+   TR_ASSERT(self()->isLabel(), "OMR::Symbol::castToLabelSymbol, symbol is not a label symbol");
+   return (TR::LabelSymbol *)this;
+   }
+
+TR::ResolvedMethodSymbol * OMR::Symbol::castToJittedMethodSymbol()
+   {
+   TR_ASSERT(self()->isJittedMethod(), "OMR::Symbol::castToJittedMethodSymbol, symbol is not a resolved method symbol");
+   return (TR::ResolvedMethodSymbol *)this;
+   }
+
+TR::StaticSymbol *OMR::Symbol::castToCallSiteTableEntrySymbol()
+   {
+   TR_ASSERT(self()->isCallSiteTableEntry(), "OMR::Symbol::castToCallSiteTableEntrySymbol expected a call site table entry symbol");
+   return (TR::StaticSymbol*)this;
+   }
+
+TR::StaticSymbol *OMR::Symbol::castToMethodTypeTableEntrySymbol()
+   {
+   TR_ASSERT(self()->isMethodTypeTableEntry(), "OMR::Symbol::castToMethodTypeTableEntrySymbol expected a method type table entry symbol");
+   return (TR::StaticSymbol*)this;
+   }
+
+
+TR::AutomaticSymbol *OMR::Symbol::castToRegisterSymbol()
+   {
+   TR_ASSERT(self()->isRegisterSymbol(), "OMR::Symbol::castToRegisterSymbol expected a register symbol");
+   return (TR::AutomaticSymbol*)this;
+   }
+
+TR::AutomaticSymbol * OMR::Symbol::castToAutoMarkerSymbol()
+   {
+   TR_ASSERT(self()->isAutoMarkerSymbol(), "OMR::Symbol::castToAutoMarkerSymbol, symbol is not a auto marker symbol");
+   return (TR::AutomaticSymbol *)this;
+   }
+
+TR::AutomaticSymbol * OMR::Symbol::castToVariableSizeSymbol()
+   {
+   TR_ASSERT(self()->isVariableSizeSymbol(), "OMR::Symbol::castToVariableSizeSymbol, symbol is not a VariableSizeSymbol symbol");
+   return (TR::AutomaticSymbol *)this;
+   }
+
+/**
  * Flag functions
  */
 
@@ -367,7 +480,7 @@ OMR::Symbol::isReferencedParameter()
 void
 OMR::Symbol::setReinstatedReceiver()
    {
-   TR_ASSERT(isParm(), "assertion failure");
+   TR_ASSERT(self()->isParm(), "assertion failure");
    _flags.set(ReinstatedReceiver);
    }
 
@@ -732,7 +845,7 @@ OMR::Symbol::isFixedObjectRef()
 void
 OMR::Symbol::setCallSiteTableEntry()
    {
-   TR_ASSERT(isStatic(), "assertion failure");
+   TR_ASSERT(self()->isStatic(), "assertion failure");
    _flags2.set(CallSiteTableEntry);
    }
 

--- a/compiler/il/symbol/OMRSymbol.hpp
+++ b/compiler/il/symbol/OMRSymbol.hpp
@@ -146,28 +146,28 @@ public:
    TR::StaticSymbol                           *getMethodTypeTableEntrySymbol();
    TR::AutomaticSymbol                        *getRegisterSymbol();
 
-   // The inline To methods perform an explicit (debug) assume that the symbol is a correct type
+   // These methods perform an explicit (debug) assume that the symbol is a correct type
    // and then return the symbol explicitly cast to the type.
    //
-   inline TR::RegisterMappedSymbol            *castToRegisterMappedSymbol();
-   inline TR::AutomaticSymbol                 *castToAutoSymbol();
-   inline TR::AutomaticSymbol                 *castToVariableSizeSymbol();
-   inline TR::AutomaticSymbol                 *castToAutoMarkerSymbol();
-   inline TR::ParameterSymbol                 *castToParmSymbol();
-   inline TR::AutomaticSymbol                 *castToInternalPointerAutoSymbol();
-   inline TR::AutomaticSymbol                 *castToLocalObjectSymbol();
-   inline TR::ResolvedMethodSymbol            *castToResolvedMethodSymbol();
-   inline TR::MethodSymbol                    *castToMethodSymbol();
-   inline TR::Symbol                          *castToShadowSymbol();
-   inline TR::RegisterMappedSymbol            *castToMethodMetaDataSymbol();
-   inline TR::LabelSymbol                     *castToLabelSymbol();
-   inline TR::ResolvedMethodSymbol            *castToJittedMethodSymbol();
-   inline TR::AutomaticSymbol                 *castToRegisterSymbol();
+   TR::RegisterMappedSymbol            *castToRegisterMappedSymbol();
+   TR::AutomaticSymbol                 *castToAutoSymbol();
+   TR::AutomaticSymbol                 *castToVariableSizeSymbol();
+   TR::AutomaticSymbol                 *castToAutoMarkerSymbol();
+   TR::ParameterSymbol                 *castToParmSymbol();
+   TR::AutomaticSymbol                 *castToInternalPointerAutoSymbol();
+   TR::AutomaticSymbol                 *castToLocalObjectSymbol();
+   TR::ResolvedMethodSymbol            *castToResolvedMethodSymbol();
+   TR::MethodSymbol                    *castToMethodSymbol();
+   TR::Symbol                          *castToShadowSymbol();
+   TR::RegisterMappedSymbol            *castToMethodMetaDataSymbol();
+   TR::LabelSymbol                     *castToLabelSymbol();
+   TR::ResolvedMethodSymbol            *castToJittedMethodSymbol();
+   TR::AutomaticSymbol                 *castToRegisterSymbol();
 
-   inline TR::StaticSymbol                    *castToStaticSymbol();
-   inline TR::StaticSymbol                    *castToNamedStaticSymbol();
-   inline TR::StaticSymbol                    *castToCallSiteTableEntrySymbol();
-   inline TR::StaticSymbol                    *castToMethodTypeTableEntrySymbol();
+   TR::StaticSymbol                    *castToStaticSymbol();
+   TR::StaticSymbol                    *castToNamedStaticSymbol();
+   TR::StaticSymbol                    *castToCallSiteTableEntrySymbol();
+   TR::StaticSymbol                    *castToMethodTypeTableEntrySymbol();
 
    int32_t getOffset();
 
@@ -604,116 +604,5 @@ public:
 
    };
 }
-
-// If these implementations are to be moved, they need to be un-defined as inline.
-TR::RegisterMappedSymbol * OMR::Symbol::castToRegisterMappedSymbol()
-   {
-   TR_ASSERT(isRegisterMappedSymbol(), "OMR::Symbol::castToRegisterMappedSymbol, symbol is not a register mapped symbol");
-   return (TR::RegisterMappedSymbol *)this;
-   }
-
-TR::AutomaticSymbol * OMR::Symbol::castToAutoSymbol()
-   {
-   TR_ASSERT(isAuto(), "OMR::Symbol::castToAutoSymbo, symbol is not an automatic symbol");
-   return (TR::AutomaticSymbol *)this;
-   }
-
-TR::ParameterSymbol * OMR::Symbol::castToParmSymbol()
-   {
-   TR_ASSERT(isParm(), "OMR::Symbol::castToParmSymbol, symbol is not a parameter symbol");
-   return (TR::ParameterSymbol *)this;
-   }
-
-TR::AutomaticSymbol * OMR::Symbol::castToInternalPointerAutoSymbol()
-   {
-   TR_ASSERT(isInternalPointerAuto(), "OMR::Symbol::castToInternalAutoSymbol, symbol is not an internal pointer automatic symbol");
-   return (TR::AutomaticSymbol *)this;
-   }
-
-TR::AutomaticSymbol * OMR::Symbol::castToLocalObjectSymbol()
-   {
-   TR_ASSERT(isLocalObject(), "OMR::Symbol::castToLocalObjectSymbol, symbol is not an internal pointer automatic symbol");
-   return (TR::AutomaticSymbol *)this;
-   }
-
-TR::StaticSymbol * OMR::Symbol::castToStaticSymbol()
-   {
-   TR_ASSERT(isStatic(), "OMR::Symbol::castToStaticSymbol, symbol is not a static symbol");
-   return (TR::StaticSymbol *)this;
-   }
-
-TR::StaticSymbol * OMR::Symbol::castToNamedStaticSymbol()
-   {
-   TR_ASSERT(isNamed() && isStatic(), "OMR::Symbol::castToNamedStaticSymbol, symbol is not a named static symbol");
-   return (TR::StaticSymbol *)this;
-   }
-
-TR::MethodSymbol * OMR::Symbol::castToMethodSymbol()
-   {
-   TR_ASSERT(isMethod(), "OMR::Symbol::castToMethodSymbol, symbol[%p] is not a method symbol",
-         this);
-   return (TR::MethodSymbol *)this;
-   }
-
-TR::ResolvedMethodSymbol * OMR::Symbol::castToResolvedMethodSymbol()
-   {
-   TR_ASSERT(isResolvedMethod(), "OMR::Symbol::castToResolvedMethodSymbol, symbol is not a resolved method symbol");
-   return (TR::ResolvedMethodSymbol *)this;
-   }
-
-TR::Symbol * OMR::Symbol::castToShadowSymbol()
-   {
-   TR_ASSERT(isShadow(), "OMR::Symbol::castToShadowSymbol, symbol is not a shadow symbol");
-   return (TR::Symbol *)this;
-   }
-
-TR::RegisterMappedSymbol * OMR::Symbol::castToMethodMetaDataSymbol()
-   {
-   TR_ASSERT(isMethodMetaData(), "OMR::Symbol::castToMethodMetaDataSymbol, symbol is not a meta data symbol");
-   return (TR::RegisterMappedSymbol *)this;
-   }
-
-TR::LabelSymbol * OMR::Symbol::castToLabelSymbol()
-   {
-   TR_ASSERT(isLabel(), "OMR::Symbol::castToLabelSymbol, symbol is not a label symbol");
-   return (TR::LabelSymbol *)this;
-   }
-
-TR::ResolvedMethodSymbol * OMR::Symbol::castToJittedMethodSymbol()
-   {
-   TR_ASSERT(isJittedMethod(), "OMR::Symbol::castToJittedMethodSymbol, symbol is not a resolved method symbol");
-   return (TR::ResolvedMethodSymbol *)this;
-   }
-
-TR::StaticSymbol *OMR::Symbol::castToCallSiteTableEntrySymbol()
-   {
-   TR_ASSERT(isCallSiteTableEntry(), "OMR::Symbol::castToCallSiteTableEntrySymbol expected a call site table entry symbol");
-   return (TR::StaticSymbol*)this;
-   }
-
-TR::StaticSymbol *OMR::Symbol::castToMethodTypeTableEntrySymbol()
-   {
-   TR_ASSERT(isMethodTypeTableEntry(), "OMR::Symbol::castToMethodTypeTableEntrySymbol expected a method type table entry symbol");
-   return (TR::StaticSymbol*)this;
-   }
-
-
-TR::AutomaticSymbol *OMR::Symbol::castToRegisterSymbol()
-   {
-   TR_ASSERT(isRegisterSymbol(), "OMR::Symbol::castToRegisterSymbol expected a register symbol");
-   return (TR::AutomaticSymbol*)this;
-   }
-
-TR::AutomaticSymbol * OMR::Symbol::castToAutoMarkerSymbol()
-   {
-   TR_ASSERT(isAutoMarkerSymbol(), "OMR::Symbol::castToAutoMarkerSymbol, symbol is not a auto marker symbol");
-   return (TR::AutomaticSymbol *)this;
-   }
-
-TR::AutomaticSymbol * OMR::Symbol::castToVariableSizeSymbol()
-   {
-   TR_ASSERT(isVariableSizeSymbol(), "OMR::Symbol::castToVariableSizeSymbol, symbol is not a VariableSizeSymbol symbol");
-   return (TR::AutomaticSymbol *)this;
-   }
 
 #endif

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -135,12 +135,12 @@ TR::Register *OMR::X86::TreeEvaluator::intOrLongClobberEvaluate(TR::Node *node, 
    // TODO:AMD64: This belongs in CodeGenerator.  In fact, this whole clobberEvaluate interface needs another look.
    if (nodeIs64Bit)
       {
-      TR_ASSERT(getNodeIs64Bit(node, cg), "nodeIs64Bit must be consistent with node size");
+      TR_ASSERT(TR::TreeEvaluator::getNodeIs64Bit(node, cg), "nodeIs64Bit must be consistent with node size");
       return cg->longClobberEvaluate(node);
       }
    else
       {
-      TR_ASSERT(!getNodeIs64Bit(node, cg), "nodeIs64Bit must be consistent with node size");
+      TR_ASSERT(!TR::TreeEvaluator::getNodeIs64Bit(node, cg), "nodeIs64Bit must be consistent with node size");
       return cg->intClobberEvaluate(node);
       }
    }

--- a/fvtest/compilertest/linter.mk
+++ b/fvtest/compilertest/linter.mk
@@ -35,8 +35,11 @@ FIXED_SRCBASE=$(subst \,/,$(JIT_SRCBASE))
 FIXED_OBJBASE=$(subst \,/,$(JIT_OBJBASE))
 FIXED_DLL_DIR=$(subst \,/,$(JIT_DLL_DIR))
 
-# TODO - "debug" as default?
-BUILD_CONFIG?=prod
+#
+# Default to debug build to catch linting errors in code guarded by
+# `#ifdef DEBUG`
+#
+BUILD_CONFIG?=debug
 
 #
 # This is where we setup our component dirs


### PR DESCRIPTION
Default to running the linter in debug mode. This allows the linter to lint code guarded by `#ifdef DEBUG`.

This pull request also resolves all related linting errors related to this change.