### PR TITLE
Fix linting errors on P and Z

### DIFF
--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -180,12 +180,12 @@ OMR::ResolvedMethodSymbol::ResolvedMethodSymbol(TR_ResolvedMethod * method, TR::
         ((_resolvedMethod->getRecognizedMethod() == TR::java_lang_Math_copySign_F) ||
          (_resolvedMethod->getRecognizedMethod() == TR::java_lang_Math_copySign_D))))
       {
-      setCanReplaceWithHWInstr(true);
+      self()->setCanReplaceWithHWInstr(true);
       }
 
    if (_resolvedMethod->isJNINative())
       {
-      setJNI();
+      self()->setJNI();
 #if defined(TR_TARGET_POWER)
       switch(_resolvedMethod->getRecognizedMethod())
          {

--- a/compiler/p/codegen/BinaryEvaluator.cpp
+++ b/compiler/p/codegen/BinaryEvaluator.cpp
@@ -821,9 +821,9 @@ TR::Register *OMR::Power::TreeEvaluator::isubEvaluator(TR::Node *node, TR::CodeG
 TR::Register *OMR::Power::TreeEvaluator::asubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (TR::Compiler->target.is64Bit())
-      return lsubEvaluator(node, cg);
+      return TR::TreeEvaluator::lsubEvaluator(node, cg);
    else
-      return isubEvaluator(node, cg);
+      return TR::TreeEvaluator::isubEvaluator(node, cg);
    }
 
 // also handles TR::asub  in 64-bit mode
@@ -1367,11 +1367,11 @@ OMR::Power::TreeEvaluator::dualMulEvaluator(TR::Node * node, TR::CodeGenerator *
 
    if (TR::Compiler->target.is64Bit())
          {
-         return dualMulHelper64(node, lmulNode, lumulhNode, cg);
+         return TR::TreeEvaluator::dualMulHelper64(node, lmulNode, lumulhNode, cg);
          }
       else
          {
-         return dualMulHelper32(node, lmulNode, lumulhNode, cg);
+         return TR::TreeEvaluator::dualMulHelper32(node, lmulNode, lumulhNode, cg);
          }
       }
    }
@@ -1383,7 +1383,7 @@ TR::Register *OMR::Power::TreeEvaluator::lmulEvaluator(TR::Node *node, TR::CodeG
 
    if (node->isDualCyclic())
       {
-      return dualMulEvaluator(node, cg);
+      return TR::TreeEvaluator::dualMulEvaluator(node, cg);
       }
 
    if (TR::Compiler->target.is64Bit())
@@ -1616,7 +1616,7 @@ TR::Register *OMR::Power::TreeEvaluator::lmulhEvaluator(TR::Node *node, TR::Code
    bool needsUnsignedHighMulOnly = (node->getOpCodeValue() == TR::lumulh) && !node->isDualCyclic();
    if (node->isDualCyclic() || needsUnsignedHighMulOnly)
       {
-      return dualMulEvaluator(node, cg);
+      return TR::TreeEvaluator::dualMulEvaluator(node, cg);
       }
 
    // lmulh is generated for constant ldiv and the second child is the magic number

--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -429,7 +429,7 @@ TR::Register *OMR::Power::TreeEvaluator::compareIntsForOrder(TR::InstOpCode::Mne
 
 TR::Register *OMR::Power::TreeEvaluator::compareIntsForOrder(TR::InstOpCode::Mnemonic branchOp, TR::Node *node, TR::CodeGenerator *cg, bool isSigned)
    {
-   return compareIntsForOrder(branchOp, node->getBranchDestination()->getNode()->getLabel(), node, cg, isSigned, false, false);
+   return TR::TreeEvaluator::compareIntsForOrder(branchOp, node->getBranchDestination()->getNode()->getLabel(), node, cg, isSigned, false, false);
    }
 
 static void fixDepsForLongCompare(TR::RegisterDependencyConditions *deps, TR::Register *src1High, TR::Register *src1Low, TR::Register *src2High, TR::Register *src2Low)
@@ -751,7 +751,7 @@ TR::Register *OMR::Power::TreeEvaluator::compareLongsForOrder(TR::InstOpCode::Mn
 
 TR::Register *OMR::Power::TreeEvaluator::compareLongsForOrder(TR::InstOpCode::Mnemonic branchOp, TR::InstOpCode::Mnemonic reversedBranchOp, TR::Node *node, TR::CodeGenerator *cg, bool isSigned)
    {
-   return compareLongsForOrder(branchOp, reversedBranchOp, node->getBranchDestination()->getNode()->getLabel(), node, cg, isSigned, false, false);
+   return TR::TreeEvaluator::compareLongsForOrder(branchOp, reversedBranchOp, node->getBranchDestination()->getNode()->getLabel(), node, cg, isSigned, false, false);
    }
 
 TR::Register *compareLongAndSetOrderedBoolean(TR::InstOpCode::Mnemonic compareOp, TR::InstOpCode::Mnemonic branchOp, TR::Node *node, TR::CodeGenerator *cg)
@@ -1228,7 +1228,7 @@ TR::Register *OMR::Power::TreeEvaluator::iternaryEvaluator(TR::Node *node, TR::C
 TR::Register *OMR::Power::TreeEvaluator::compareIntsForEquality(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::InstOpCode::Mnemonic branchOp = node->getOpCode().isCompareTrueIfEqual() ? TR::InstOpCode::beq : TR::InstOpCode::bne;
-   return compareIntsForEquality(branchOp, node->getBranchDestination()->getNode()->getLabel(),
+   return TR::TreeEvaluator::compareIntsForEquality(branchOp, node->getBranchDestination()->getNode()->getLabel(),
                                  node, cg, false, false);
    }
 
@@ -1491,7 +1491,7 @@ TR::Register *OMR::Power::TreeEvaluator::compareIntsForEquality(TR::InstOpCode::
 // for ifacmpeq, opcode has been temporarily set to ificmpeq
 TR::Register *OMR::Power::TreeEvaluator::ificmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareIntsForEquality(node, cg);
+   TR::TreeEvaluator::compareIntsForEquality(node, cg);
    return NULL;
    }
 
@@ -1500,7 +1500,7 @@ TR::Register *OMR::Power::TreeEvaluator::ificmpeqEvaluator(TR::Node *node, TR::C
 TR::Register *OMR::Power::TreeEvaluator::ificmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node *firstChild=node->getFirstChild(), *secondChild=node->getSecondChild();
-   compareIntsForOrder(TR::InstOpCode::blt, node, cg, true);
+   TR::TreeEvaluator::compareIntsForOrder(TR::InstOpCode::blt, node, cg, true);
    if (secondChild->getOpCode().isLoadConst() && secondChild->getInt()>=0)
       firstChild->setIsNonNegative(true);
    return NULL;
@@ -1508,50 +1508,50 @@ TR::Register *OMR::Power::TreeEvaluator::ificmpltEvaluator(TR::Node *node, TR::C
 
 TR::Register *OMR::Power::TreeEvaluator::ificmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareIntsForOrder(TR::InstOpCode::bge, node, cg, true);
+   TR::TreeEvaluator::compareIntsForOrder(TR::InstOpCode::bge, node, cg, true);
    return NULL;
    }
 
 TR::Register *OMR::Power::TreeEvaluator::ificmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareIntsForOrder(TR::InstOpCode::bgt, node, cg, true);
+   TR::TreeEvaluator::compareIntsForOrder(TR::InstOpCode::bgt, node, cg, true);
    return NULL;
    }
 
 TR::Register *OMR::Power::TreeEvaluator::ificmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareIntsForOrder(TR::InstOpCode::ble, node, cg, true);
+   TR::TreeEvaluator::compareIntsForOrder(TR::InstOpCode::ble, node, cg, true);
    return NULL;
    }
 
 TR::Register *OMR::Power::TreeEvaluator::ifiucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareIntsForOrder(TR::InstOpCode::blt, node, cg, false);
+   TR::TreeEvaluator::compareIntsForOrder(TR::InstOpCode::blt, node, cg, false);
    return NULL;
    }
 
 TR::Register *OMR::Power::TreeEvaluator::ifiucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareIntsForOrder(TR::InstOpCode::bge, node, cg, false);
+   TR::TreeEvaluator::compareIntsForOrder(TR::InstOpCode::bge, node, cg, false);
    return NULL;
    }
 
 TR::Register *OMR::Power::TreeEvaluator::ifiucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareIntsForOrder(TR::InstOpCode::bgt, node, cg, false);
+   TR::TreeEvaluator::compareIntsForOrder(TR::InstOpCode::bgt, node, cg, false);
    return NULL;
    }
 
 TR::Register *OMR::Power::TreeEvaluator::ifiucmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareIntsForOrder(TR::InstOpCode::ble, node, cg, false);
+   TR::TreeEvaluator::compareIntsForOrder(TR::InstOpCode::ble, node, cg, false);
    return NULL;
    }
 
 TR::Register *OMR::Power::TreeEvaluator::compareLongsForEquality(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::InstOpCode::Mnemonic branchOp = node->getOpCode().isCompareTrueIfEqual() ? TR::InstOpCode::beq : TR::InstOpCode::bne;
-   return compareLongsForEquality(branchOp, node->getBranchDestination()->getNode()->getLabel(),
+   return TR::TreeEvaluator::compareLongsForEquality(branchOp, node->getBranchDestination()->getNode()->getLabel(),
                                  node, cg, false, false);
    }
 
@@ -1608,7 +1608,7 @@ TR::Register *OMR::Power::TreeEvaluator::compareLongsForEquality(TR::InstOpCode:
                {
                TR::Node::recreate(node, node->getOpCode().isCompareTrueIfEqual() ? TR::icmpeq : TR::icmpne);
                }
-            return compareIntsForEquality(branchOp, dstLabel, node, cg, isHint, likeliness);
+            return TR::TreeEvaluator::compareIntsForEquality(branchOp, dstLabel, node, cg, isHint, likeliness);
             }
          }
       }
@@ -1731,56 +1731,56 @@ TR::Register *OMR::Power::TreeEvaluator::compareLongsForEquality(TR::InstOpCode:
 // for ifacmpeq, opcode has been temporarily set to iflcmpeq
 TR::Register *OMR::Power::TreeEvaluator::iflcmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareLongsForEquality(node, cg);
+   TR::TreeEvaluator::compareLongsForEquality(node, cg);
    return NULL;
    }
 
 
 TR::Register *OMR::Power::TreeEvaluator::iflcmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareLongsForOrder(TR::InstOpCode::blt, TR::InstOpCode::bgt, node, cg, true);
+   TR::TreeEvaluator::compareLongsForOrder(TR::InstOpCode::blt, TR::InstOpCode::bgt, node, cg, true);
    return NULL;
    }
 
 TR::Register *OMR::Power::TreeEvaluator::iflcmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareLongsForOrder(TR::InstOpCode::bge, TR::InstOpCode::ble, node, cg, true);
+   TR::TreeEvaluator::compareLongsForOrder(TR::InstOpCode::bge, TR::InstOpCode::ble, node, cg, true);
    return NULL;
    }
 
 TR::Register *OMR::Power::TreeEvaluator::iflcmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareLongsForOrder(TR::InstOpCode::bgt, TR::InstOpCode::blt, node, cg, true);
+   TR::TreeEvaluator::compareLongsForOrder(TR::InstOpCode::bgt, TR::InstOpCode::blt, node, cg, true);
    return NULL;
    }
 
 TR::Register *OMR::Power::TreeEvaluator::iflcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareLongsForOrder(TR::InstOpCode::ble, TR::InstOpCode::bge, node, cg, true);
+   TR::TreeEvaluator::compareLongsForOrder(TR::InstOpCode::ble, TR::InstOpCode::bge, node, cg, true);
    return NULL;
    }
 
 TR::Register *OMR::Power::TreeEvaluator::iflucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareLongsForOrder(TR::InstOpCode::blt, TR::InstOpCode::bgt, node, cg, false);
+   TR::TreeEvaluator::compareLongsForOrder(TR::InstOpCode::blt, TR::InstOpCode::bgt, node, cg, false);
    return NULL;
    }
 
 TR::Register *OMR::Power::TreeEvaluator::iflucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareLongsForOrder(TR::InstOpCode::bge, TR::InstOpCode::ble, node, cg, false);
+   TR::TreeEvaluator::compareLongsForOrder(TR::InstOpCode::bge, TR::InstOpCode::ble, node, cg, false);
    return NULL;
    }
 
 TR::Register *OMR::Power::TreeEvaluator::iflucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareLongsForOrder(TR::InstOpCode::bgt, TR::InstOpCode::blt, node, cg, false);
+   TR::TreeEvaluator::compareLongsForOrder(TR::InstOpCode::bgt, TR::InstOpCode::blt, node, cg, false);
    return NULL;
    }
 
 TR::Register *OMR::Power::TreeEvaluator::iflucmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   compareLongsForOrder(TR::InstOpCode::ble, TR::InstOpCode::bge, node, cg, false);
+   TR::TreeEvaluator::compareLongsForOrder(TR::InstOpCode::ble, TR::InstOpCode::bge, node, cg, false);
    return NULL;
    }
 
@@ -1789,12 +1789,12 @@ TR::Register *OMR::Power::TreeEvaluator::ifacmpeqEvaluator(TR::Node *node, TR::C
    if (TR::Compiler->target.is64Bit())
       {
       TR::Node::recreate(node, TR::iflcmpeq);
-      iflcmpeqEvaluator(node, cg);
+      TR::TreeEvaluator::iflcmpeqEvaluator(node, cg);
       }
    else
       {
       TR::Node::recreate(node, TR::ificmpeq);
-      ificmpeqEvaluator(node, cg);
+      TR::TreeEvaluator::ificmpeqEvaluator(node, cg);
       }
    TR::Node::recreate(node, TR::ifacmpeq);
    return NULL;
@@ -1805,12 +1805,12 @@ TR::Register *OMR::Power::TreeEvaluator::ifacmpneEvaluator(TR::Node *node, TR::C
    if (TR::Compiler->target.is64Bit())
       {
       TR::Node::recreate(node, TR::iflcmpne);
-      iflcmpeqEvaluator(node, cg);
+      TR::TreeEvaluator::iflcmpeqEvaluator(node, cg);
       }
    else
       {
       TR::Node::recreate(node, TR::ificmpne);
-      ificmpeqEvaluator(node, cg);
+      TR::TreeEvaluator::ificmpeqEvaluator(node, cg);
       }
    TR::Node::recreate(node, TR::ifacmpne);
    return NULL;
@@ -2029,7 +2029,7 @@ TR::Register *OMR::Power::TreeEvaluator::icmpltEvaluator(TR::Node *node, TR::Cod
    else
       {
       TR::Register   *src2Reg = cg->evaluate(secondChild);
-      genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::blt, TR::InstOpCode::cmp4, cg);
+      TR::TreeEvaluator::genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::blt, TR::InstOpCode::cmp4, cg);
       }
    node->setRegister(trgReg);
    cg->decReferenceCount(firstChild);
@@ -2079,7 +2079,7 @@ TR::Register *OMR::Power::TreeEvaluator::icmpleEvaluator(TR::Node *node, TR::Cod
    else
       {
       TR::Register   *src2Reg = cg->evaluate(secondChild);
-      genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::ble, TR::InstOpCode::cmp4, cg);
+      TR::TreeEvaluator::genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::ble, TR::InstOpCode::cmp4, cg);
       }
    node->setRegister(trgReg);
    cg->decReferenceCount(firstChild);
@@ -2126,7 +2126,7 @@ TR::Register *OMR::Power::TreeEvaluator::icmpgeEvaluator(TR::Node *node, TR::Cod
    else
       {
       TR::Register   *src2Reg = cg->evaluate(secondChild);
-      genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::bge, TR::InstOpCode::cmp4, cg);
+      TR::TreeEvaluator::genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::bge, TR::InstOpCode::cmp4, cg);
       }
    node->setRegister(trgReg);
    cg->decReferenceCount(firstChild);
@@ -2173,7 +2173,7 @@ TR::Register *OMR::Power::TreeEvaluator::icmpgtEvaluator(TR::Node *node, TR::Cod
    else
       {
       TR::Register   *src2Reg = cg->evaluate(secondChild);
-      genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::bgt, TR::InstOpCode::cmp4, cg);
+      TR::TreeEvaluator::genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::bgt, TR::InstOpCode::cmp4, cg);
       }
    node->setRegister(trgReg);
    cg->decReferenceCount(firstChild);
@@ -2198,7 +2198,7 @@ TR::Register *OMR::Power::TreeEvaluator::iucmpltEvaluator(TR::Node *node, TR::Co
    else
       {
       TR::Register   *src2Reg = cg->evaluate(secondChild);
-      genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::blt, TR::InstOpCode::cmpl4, cg);
+      TR::TreeEvaluator::genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::blt, TR::InstOpCode::cmpl4, cg);
       }
    node->setRegister(trgReg);
    cg->decReferenceCount(firstChild);
@@ -2215,7 +2215,7 @@ TR::Register *OMR::Power::TreeEvaluator::iucmpleEvaluator(TR::Node *node, TR::Co
    TR::Register   *src2Reg = cg->evaluate(secondChild);
    TR::Register *trgReg    = cg->allocateRegister();
 
-   genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::ble, TR::InstOpCode::cmpl4, cg);
+   TR::TreeEvaluator::genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::ble, TR::InstOpCode::cmpl4, cg);
    node->setRegister(trgReg);
    cg->decReferenceCount(firstChild);
    cg->decReferenceCount(secondChild);
@@ -2239,7 +2239,7 @@ TR::Register *OMR::Power::TreeEvaluator::iucmpgeEvaluator(TR::Node *node, TR::Co
    else
       {
       TR::Register   *src2Reg = cg->evaluate(secondChild);
-      genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::bge, TR::InstOpCode::cmpl4, cg);
+      TR::TreeEvaluator::genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::bge, TR::InstOpCode::cmpl4, cg);
       }
    node->setRegister(trgReg);
    cg->decReferenceCount(firstChild);
@@ -2256,7 +2256,7 @@ TR::Register *OMR::Power::TreeEvaluator::iucmpgtEvaluator(TR::Node *node, TR::Co
    TR::Register   *src2Reg = cg->evaluate(secondChild);
    TR::Register *trgReg    = cg->allocateRegister();
 
-   genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::bgt, TR::InstOpCode::cmpl4, cg);
+   TR::TreeEvaluator::genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::bgt, TR::InstOpCode::cmpl4, cg);
    node->setRegister(trgReg);
    cg->decReferenceCount(firstChild);
    cg->decReferenceCount(secondChild);
@@ -2419,7 +2419,7 @@ TR::Register *OMR::Power::TreeEvaluator::lcmpltEvaluator(TR::Node *node, TR::Cod
    else
       {
       TR::Register   *src2Reg = cg->evaluate(secondChild);
-      genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::blt, TR::InstOpCode::cmp8, cg);
+      TR::TreeEvaluator::genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::blt, TR::InstOpCode::cmp8, cg);
       }
    node->setRegister(trgReg);
    cg->decReferenceCount(firstChild);
@@ -2468,7 +2468,7 @@ TR::Register *OMR::Power::TreeEvaluator::lcmpleEvaluator(TR::Node *node, TR::Cod
    else
       {
       TR::Register   *src2Reg = cg->evaluate(secondChild);
-      genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::ble, TR::InstOpCode::cmp8, cg);
+      TR::TreeEvaluator::genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::ble, TR::InstOpCode::cmp8, cg);
       }
    node->setRegister(trgReg);
    cg->decReferenceCount(firstChild);
@@ -2522,7 +2522,7 @@ TR::Register *OMR::Power::TreeEvaluator::lcmpgeEvaluator(TR::Node *node, TR::Cod
    else
       {
       TR::Register   *src2Reg = cg->evaluate(secondChild);
-      genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::bge, TR::InstOpCode::cmp8, cg);
+      TR::TreeEvaluator::genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::bge, TR::InstOpCode::cmp8, cg);
       }
    node->setRegister(trgReg);
    cg->decReferenceCount(firstChild);
@@ -2576,7 +2576,7 @@ TR::Register *OMR::Power::TreeEvaluator::lcmpgtEvaluator(TR::Node *node, TR::Cod
    else
       {
       TR::Register   *src2Reg = cg->evaluate(secondChild);
-      genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::bgt, TR::InstOpCode::cmp8, cg);
+      TR::TreeEvaluator::genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::bgt, TR::InstOpCode::cmp8, cg);
       }
 
    node->setRegister(trgReg);
@@ -2596,7 +2596,7 @@ TR::Register *OMR::Power::TreeEvaluator::lucmpltEvaluator(TR::Node *node, TR::Co
    TR::Register *src1Reg = cg->evaluate(firstChild);
    TR::Register *src2Reg = cg->evaluate(secondChild);
    TR::Register *trgReg  = cg->allocateRegister();
-   genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::blt, TR::InstOpCode::cmpl8, cg);
+   TR::TreeEvaluator::genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::blt, TR::InstOpCode::cmpl8, cg);
 
    node->setRegister(trgReg);
    cg->decReferenceCount(firstChild);
@@ -2615,7 +2615,7 @@ TR::Register *OMR::Power::TreeEvaluator::lucmpleEvaluator(TR::Node *node, TR::Co
    TR::Register *src1Reg = cg->evaluate(firstChild);
    TR::Register *src2Reg = cg->evaluate(secondChild);
    TR::Register *trgReg  = cg->allocateRegister();
-   genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::ble, TR::InstOpCode::cmpl8, cg);
+   TR::TreeEvaluator::genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::ble, TR::InstOpCode::cmpl8, cg);
 
    node->setRegister(trgReg);
    cg->decReferenceCount(firstChild);
@@ -2634,7 +2634,7 @@ TR::Register *OMR::Power::TreeEvaluator::lucmpgeEvaluator(TR::Node *node, TR::Co
    TR::Register *src1Reg = cg->evaluate(firstChild);
    TR::Register *src2Reg = cg->evaluate(secondChild);
    TR::Register *trgReg  = cg->allocateRegister();
-   genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::bge, TR::InstOpCode::cmpl8, cg);
+   TR::TreeEvaluator::genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::bge, TR::InstOpCode::cmpl8, cg);
 
    node->setRegister(trgReg);
    cg->decReferenceCount(firstChild);
@@ -2653,7 +2653,7 @@ TR::Register *OMR::Power::TreeEvaluator::lucmpgtEvaluator(TR::Node *node, TR::Co
    TR::Register *src1Reg = cg->evaluate(firstChild);
    TR::Register *src2Reg = cg->evaluate(secondChild);
    TR::Register *trgReg  = cg->allocateRegister();
-   genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::bgt, TR::InstOpCode::cmpl8, cg);
+   TR::TreeEvaluator::genBranchSequence(node, src1Reg, src2Reg, trgReg, TR::InstOpCode::bgt, TR::InstOpCode::cmpl8, cg);
 
    node->setRegister(trgReg);
    cg->decReferenceCount(firstChild);
@@ -2765,17 +2765,17 @@ TR::Register *OMR::Power::TreeEvaluator::lcmpEvaluator(TR::Node *node, TR::CodeG
 TR::Register *OMR::Power::TreeEvaluator::acmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (TR::Compiler->target.is64Bit())
-      return lcmpeqEvaluator(node, cg);
+      return TR::TreeEvaluator::lcmpeqEvaluator(node, cg);
    else
-      return icmpeqEvaluator(node, cg);
+      return TR::TreeEvaluator::icmpeqEvaluator(node, cg);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::acmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (TR::Compiler->target.is64Bit())
-      return lcmpneEvaluator(node, cg);
+      return TR::TreeEvaluator::lcmpneEvaluator(node, cg);
    else
-      return icmpneEvaluator(node, cg);
+      return TR::TreeEvaluator::icmpneEvaluator(node, cg);
    }
 
 
@@ -3819,7 +3819,7 @@ TR::Register *OMR::Power::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::
    TR::Register *trgReg = cg->evaluate(reference);
    TR::Instruction *gcPoint;
 
-   gcPoint = generateNullTestInstructions(cg, trgReg, node);
+   gcPoint = TR::TreeEvaluator::generateNullTestInstructions(cg, trgReg, node);
 
    gcPoint->PPCNeedsGCMap(0xFFFFFFFF);
 
@@ -3880,7 +3880,7 @@ TR::Register *OMR::Power::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::
 
 TR::Register *OMR::Power::TreeEvaluator::NULLCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return evaluateNULLCHKWithPossibleResolve(node, false, cg);
+   return TR::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(node, false, cg);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::ZEROCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -3938,14 +3938,14 @@ TR::Register *OMR::Power::TreeEvaluator::ZEROCHKEvaluator(TR::Node *node, TR::Co
             // which corresponds to an ifcmp fall-through
             TR::InstOpCode::Mnemonic branchOp = cmp2branch(valueToCheck->getOpCode().getOpCodeForReverseBranch(), cg);
             TR::InstOpCode::Mnemonic reverseBranchOp = cmp2branch(valueToCheck->getOpCodeValue(), cg);
-            compareLongsForOrder(branchOp, reverseBranchOp, slowPathLabel, valueToCheck, cg,
+            TR::TreeEvaluator::compareLongsForOrder(branchOp, reverseBranchOp, slowPathLabel, valueToCheck, cg,
                                  valueToCheck->getOpCode().isUnsignedCompare(), true, PPCOpProp_BranchUnlikely);
             }
          else
             {
             // switch branches since we want to go to OOL on node evaluating to 0
             // which corresponds to an ifcmp fall-through
-            compareIntsForOrder(cmp2branch(valueToCheck->getOpCode().getOpCodeForReverseBranch(), cg),
+            TR::TreeEvaluator::compareIntsForOrder(cmp2branch(valueToCheck->getOpCode().getOpCodeForReverseBranch(), cg),
                                 slowPathLabel, valueToCheck, cg, valueToCheck->getOpCode().isUnsignedCompare(),
                                 true, PPCOpProp_BranchUnlikely);
             }
@@ -3958,12 +3958,12 @@ TR::Register *OMR::Power::TreeEvaluator::ZEROCHKEvaluator(TR::Node *node, TR::Co
             {
             // switch branches since we want to go to OOL on node evaluating to 0
             // which corresponds to an ifcmp fall-through
-            compareLongsForEquality(cmp2branch(valueToCheck->getOpCode().getOpCodeForReverseBranch(), cg),
+            TR::TreeEvaluator::compareLongsForEquality(cmp2branch(valueToCheck->getOpCode().getOpCodeForReverseBranch(), cg),
                                     slowPathLabel, valueToCheck, cg, true, PPCOpProp_BranchUnlikely);
             }
          else
             {
-            compareIntsForEquality(cmp2branch(valueToCheck->getOpCode().getOpCodeForReverseBranch(), cg),
+            TR::TreeEvaluator::compareIntsForEquality(cmp2branch(valueToCheck->getOpCode().getOpCodeForReverseBranch(), cg),
                                    slowPathLabel, valueToCheck, cg, true, PPCOpProp_BranchUnlikely);
             }
          }
@@ -3992,7 +3992,7 @@ TR::Register *OMR::Power::TreeEvaluator::ZEROCHKEvaluator(TR::Node *node, TR::Co
 
 TR::Register *OMR::Power::TreeEvaluator::resolveAndNULLCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return evaluateNULLCHKWithPossibleResolve(node, true, cg);
+   return TR::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(node, true, cg);
    }
 
 

--- a/compiler/p/codegen/FPTreeEvaluator.cpp
+++ b/compiler/p/codegen/FPTreeEvaluator.cpp
@@ -458,7 +458,7 @@ TR::Register *OMR::Power::TreeEvaluator::floadEvaluator(TR::Node *node, TR::Code
    generateTrg1MemInstruction(cg, TR::InstOpCode::lfs, node, tempReg, tempMR);
    if (needSync)
       {
-      postSyncConditions(node, cg, tempReg, tempMR, TR::InstOpCode::isync);
+      TR::TreeEvaluator::postSyncConditions(node, cg, tempReg, tempMR, TR::InstOpCode::isync);
       }
    tempMR->decNodeReferenceCounts(cg);
 
@@ -546,7 +546,7 @@ TR::Register *OMR::Power::TreeEvaluator::dloadHelper(TR::Node *node, TR::CodeGen
       generateTrg1MemInstruction(cg, opcode, node, tempReg, tempMR);
       if (needSync)
          {
-         postSyncConditions(node, cg, tempReg, tempMR, TR::InstOpCode::isync);
+         TR::TreeEvaluator::postSyncConditions(node, cg, tempReg, tempMR, TR::InstOpCode::isync);
          }
       }
 
@@ -559,7 +559,7 @@ TR::Register *OMR::Power::TreeEvaluator::dloadHelper(TR::Node *node, TR::CodeGen
 TR::Register *OMR::Power::TreeEvaluator::dloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Register *tempReg = node->setRegister(cg->allocateRegister(TR_FPR));
-   return dloadHelper(node, cg, tempReg, TR::InstOpCode::lfd);
+   return TR::TreeEvaluator::dloadHelper(node, cg, tempReg, TR::InstOpCode::lfd);
    }
 
 
@@ -685,7 +685,7 @@ TR::Register *OMR::Power::TreeEvaluator::vsplatsEvaluator(TR::Node *node, TR::Co
 
    if (child->getOpCode().isLoadConst())
       {
-      TR::Register *resReg = dconstEvaluator(node, cg);
+      TR::Register *resReg = TR::TreeEvaluator::dconstEvaluator(node, cg);
       cg->decReferenceCount(child);
       return resReg;
       }
@@ -702,7 +702,7 @@ TR::Register *OMR::Power::TreeEvaluator::vsplatsEvaluator(TR::Node *node, TR::Co
          }
 
       TR::Register *resReg = node->setRegister(cg->allocateRegister(TR_VSX_VECTOR));
-      return dloadHelper(child, cg, resReg, TR::InstOpCode::lxvdsx);
+      return TR::TreeEvaluator::dloadHelper(child, cg, resReg, TR::InstOpCode::lxvdsx);
       }
    else
       {
@@ -795,7 +795,7 @@ TR::Register *OMR::Power::TreeEvaluator::vdsetelemEvaluator(TR::Node *node, TR::
             secondChild = newNode;
             }
 
-         dloadHelper(secondChild, cg, resReg, TR::InstOpCode::lxsdx);
+         TR::TreeEvaluator::dloadHelper(secondChild, cg, resReg, TR::InstOpCode::lxsdx);
 	      }
          else
 	      {
@@ -867,7 +867,7 @@ TR::Register *OMR::Power::TreeEvaluator::fstoreEvaluator(TR::Node *node, TR::Cod
       else
          node->setChild(childIndex, child->getFirstChild());
       TR::Node::recreate(node, indirect?TR::istorei:TR::istore);
-      istoreEvaluator(node, cg);
+      TR::TreeEvaluator::istoreEvaluator(node, cg);
       node->setChild(childIndex, child);
       TR::Node::recreate(node, indirect?TR::fstorei:TR::fstore);
       cg->decReferenceCount(child);
@@ -887,7 +887,7 @@ TR::Register *OMR::Power::TreeEvaluator::fstoreEvaluator(TR::Node *node, TR::Cod
    generateMemSrc1Instruction(cg, TR::InstOpCode::stfs, node, tempMR, valueReg);
    if (needSync)
       {
-      postSyncConditions(node, cg, valueReg, tempMR, TR::InstOpCode::sync);
+      TR::TreeEvaluator::postSyncConditions(node, cg, valueReg, tempMR, TR::InstOpCode::sync);
       }
    cg->decReferenceCount(child);
    tempMR->decNodeReferenceCounts(cg);
@@ -913,7 +913,7 @@ TR::Register* OMR::Power::TreeEvaluator::dstoreEvaluator(TR::Node *node, TR::Cod
       else
          node->setChild(childIndex, child->getFirstChild());
       TR::Node::recreate(node, indirect?TR::lstorei:TR::lstore);
-      lstoreEvaluator(node, cg);
+      TR::TreeEvaluator::lstoreEvaluator(node, cg);
       node->setChild(childIndex, child);
       TR::Node::recreate(node, indirect?TR::dstorei:TR::dstore);
       cg->decReferenceCount(child);
@@ -981,7 +981,7 @@ TR::Register* OMR::Power::TreeEvaluator::dstoreEvaluator(TR::Node *node, TR::Cod
       generateMemSrc1Instruction(cg, TR::InstOpCode::stfd, node, tempMR, valueReg);
       if (needSync)
          {
-         postSyncConditions(node, cg, valueReg, tempMR, TR::InstOpCode::sync);
+         TR::TreeEvaluator::postSyncConditions(node, cg, valueReg, tempMR, TR::InstOpCode::sync);
          }
       }
    tempMR->decNodeReferenceCounts(cg);
@@ -1183,7 +1183,7 @@ TR::Register *OMR::Power::TreeEvaluator::fremEvaluator(TR::Node *node, TR::CodeG
    addDependency(dependencies, NULL, TR::RealRegister::fp3, TR_FPR, cg);
    addDependency(dependencies, NULL, TR::RealRegister::fp4, TR_FPR, cg);
    addDependency(dependencies, NULL, TR::RealRegister::fp5, TR_FPR, cg);
-   generateHelperBranchAndLinkInstruction(TR_PPCdoubleRemainder, node, dependencies, cg);
+   TR::TreeEvaluator::generateHelperBranchAndLinkInstruction(TR_PPCdoubleRemainder, node, dependencies, cg);
 
    // all registers on dep are now not used any longer, except source1
    dependencies->stopUsingDepRegs(cg, source1Reg);
@@ -1235,7 +1235,7 @@ TR::Register *OMR::Power::TreeEvaluator::dremEvaluator(TR::Node *node, TR::CodeG
    addDependency(dependencies, NULL, TR::RealRegister::fp3, TR_FPR, cg);
    addDependency(dependencies, NULL, TR::RealRegister::fp4, TR_FPR, cg);
    addDependency(dependencies, NULL, TR::RealRegister::fp5, TR_FPR, cg);
-   generateHelperBranchAndLinkInstruction(TR_PPCdoubleRemainder, node, dependencies, cg);
+   TR::TreeEvaluator::generateHelperBranchAndLinkInstruction(TR_PPCdoubleRemainder, node, dependencies, cg);
 
    node->setRegister(source1Reg);
    cg->decReferenceCount(child1);
@@ -1389,7 +1389,7 @@ TR::Register *OMR::Power::TreeEvaluator::int2dbl(TR::Node * node, TR::Register *
       addDependency(dependencies, NULL, TR::RealRegister::gr4, TR_GPR, cg);
       addDependency(dependencies, NULL, TR::RealRegister::gr11, TR_GPR, cg);
       addDependency(dependencies, NULL, TR::RealRegister::fp1, TR_FPR, cg);
-      generateHelperBranchAndLinkInstruction(TR_PPCinteger2Double, node, dependencies, cg);
+      TR::TreeEvaluator::generateHelperBranchAndLinkInstruction(TR_PPCinteger2Double, node, dependencies, cg);
       if (node->getOpCodeValue() == TR::i2f || node->getOpCodeValue() == TR::iu2f)
          generateTrg1Src1Instruction(cg, TR::InstOpCode::frsp, node, trgReg, trgReg);
 
@@ -1440,7 +1440,7 @@ TR::Register *OMR::Power::TreeEvaluator::i2fEvaluator(TR::Node *node, TR::CodeGe
       }
    else
       {
-      trgReg = int2dbl(node, cg->evaluate(child), cg->canClobberNodesRegister(child), cg);
+      trgReg = TR::TreeEvaluator::int2dbl(node, cg->evaluate(child), cg->canClobberNodesRegister(child), cg);
       trgReg->setIsSinglePrecision();
       cg->decReferenceCount(child);
       }
@@ -1480,7 +1480,7 @@ TR::Register *OMR::Power::TreeEvaluator::i2dEvaluator(TR::Node *node, TR::CodeGe
       }
    else
       {
-      trgReg = int2dbl(node, cg->evaluate(child), cg->canClobberNodesRegister(child), cg);
+      trgReg = TR::TreeEvaluator::int2dbl(node, cg->evaluate(child), cg->canClobberNodesRegister(child), cg);
       cg->decReferenceCount(child);
       }
    node->setRegister(trgReg);
@@ -1538,7 +1538,7 @@ TR::Register *OMR::Power::TreeEvaluator::long2dbl(TR::Node *node, TR::CodeGenera
       addDependency(dependencies, NULL, TR::RealRegister::fp1, TR_FPR, cg);
       addDependency(dependencies, NULL, TR::RealRegister::fp2, TR_FPR, cg);
 
-      generateHelperBranchAndLinkInstruction(TR_PPClong2Double, node, dependencies, cg);
+      TR::TreeEvaluator::generateHelperBranchAndLinkInstruction(TR_PPClong2Double, node, dependencies, cg);
 
       dependencies->stopUsingDepRegs(cg, trgReg);
 
@@ -1593,7 +1593,7 @@ TR::Register *OMR::Power::TreeEvaluator::long2float(TR::Node *node, TR::CodeGene
       addDependency(dependencies, NULL, TR::RealRegister::gr4, TR_GPR, cg);
       addDependency(dependencies, NULL, TR::RealRegister::gr11, TR_GPR, cg);
 
-      generateHelperBranchAndLinkInstruction(TR_PPClong2Float, node, dependencies, cg);
+      TR::TreeEvaluator::generateHelperBranchAndLinkInstruction(TR_PPClong2Float, node, dependencies, cg);
 
       dependencies->stopUsingDepRegs(cg, trgReg);
 
@@ -1628,7 +1628,7 @@ TR::Register *OMR::Power::TreeEvaluator::long2float(TR::Node *node, TR::CodeGene
       addDependency(dependencies, NULL, TR::RealRegister::fp1, TR_FPR, cg);
       addDependency(dependencies, NULL, TR::RealRegister::fp2, TR_FPR, cg);
 
-      generateHelperBranchAndLinkInstruction(TR_PPClong2Float, node, dependencies, cg);
+      TR::TreeEvaluator::generateHelperBranchAndLinkInstruction(TR_PPClong2Float, node, dependencies, cg);
 
       dependencies->stopUsingDepRegs(cg, trgReg);
 
@@ -1661,7 +1661,7 @@ TR::Register *OMR::Power::TreeEvaluator::l2fEvaluator(TR::Node *node, TR::CodeGe
       }
    else
       {
-      trgReg = long2float(node, cg);
+      trgReg = TR::TreeEvaluator::long2float(node, cg);
       }
    node->setRegister(trgReg);
    return trgReg;
@@ -1688,7 +1688,7 @@ TR::Register *OMR::Power::TreeEvaluator::l2dEvaluator(TR::Node *node, TR::CodeGe
       }
    else
       {
-      trgReg = long2dbl(node, cg);
+      trgReg = TR::TreeEvaluator::long2dbl(node, cg);
       }
    node->setRegister(trgReg);
    return trgReg;
@@ -1862,7 +1862,7 @@ TR::Register *OMR::Power::TreeEvaluator::d2lEvaluator(TR::Node *node, TR::CodeGe
       addDependency(dependencies, NULL, TR::RealRegister::fp6, TR_FPR, cg);
       addDependency(dependencies, NULL, TR::RealRegister::fp7, TR_FPR, cg);
 
-      generateHelperBranchAndLinkInstruction(TR_PPCdouble2Long, node, dependencies, cg);
+      TR::TreeEvaluator::generateHelperBranchAndLinkInstruction(TR_PPCdouble2Long, node, dependencies, cg);
 
       dependencies->stopUsingDepRegs(cg, trgReg->getHighOrder(), trgReg->getLowOrder());
       cg->machine()->setLinkRegisterKilled(true);
@@ -2342,7 +2342,7 @@ TR::Register *OMR::Power::TreeEvaluator::dxfrsEvaluator(TR::Node *node, TR::Code
 
    TR::Node *tmp_node = TR::Node::create(node, TR::dconst, 0);
    tmp_node->setDouble(0.0);
-   TR::Register *tmpReg = dconstEvaluator(tmp_node, cg);
+   TR::Register *tmpReg = TR::TreeEvaluator::dconstEvaluator(tmp_node, cg);
    tmp_node->unsetRegister();
 
    TR::Register *condReg = cg->allocateRegister(TR_CCR);
@@ -2409,13 +2409,13 @@ TR::Register *OMR::Power::TreeEvaluator::dnintEvaluator(TR::Node *node, TR::Code
       {
       const_node = TR::Node::create(node, TR::dconst, 0);
       const_node->setDouble(CONSTANT64(0x10000000000000));   // 2**52
-      tmp1Reg = dconstEvaluator(const_node, cg);
+      tmp1Reg = TR::TreeEvaluator::dconstEvaluator(const_node, cg);
       }
    else
       {
       const_node = TR::Node::create(node, TR::fconst, 0);
       const_node->setFloat(0x800000);   // 2**23
-      tmp1Reg = fconstEvaluator(const_node, cg);
+      tmp1Reg = TR::TreeEvaluator::fconstEvaluator(const_node, cg);
       }
 
    const_node->unsetRegister();
@@ -2434,12 +2434,12 @@ TR::Register *OMR::Power::TreeEvaluator::dnintEvaluator(TR::Node *node, TR::Code
 
    const_node = TR::Node::create(node, TR::fconst, 0);
    const_node->setFloat(0.5);
-   tmp1Reg = fconstEvaluator(const_node, cg);
+   tmp1Reg = TR::TreeEvaluator::fconstEvaluator(const_node, cg);
    const_node->unsetRegister();
 
    const_node = TR::Node::create(node, TR::fconst, 0);
    const_node->setFloat(-0.5);
-   tmp2Reg = fconstEvaluator(const_node, cg);
+   tmp2Reg = TR::TreeEvaluator::fconstEvaluator(const_node, cg);
    const_node->unsetRegister();
 
    generateTrg1Src2Instruction(cg, TR::InstOpCode::fadd, node, tmp1Reg, srcReg, tmp1Reg);

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -395,7 +395,7 @@ TR::Register *OMR::Power::TreeEvaluator::iloadEvaluator(TR::Node *node, TR::Code
       }
    if (needSync)
       {
-      postSyncConditions(node, cg, tempReg, tempMR, TR::Compiler->target.cpu.id() >= TR_PPCp7 ? TR::InstOpCode::lwsync : TR::InstOpCode::isync);
+      TR::TreeEvaluator::postSyncConditions(node, cg, tempReg, tempMR, TR::Compiler->target.cpu.id() >= TR_PPCp7 ? TR::InstOpCode::lwsync : TR::InstOpCode::isync);
       }
 
    tempMR->decNodeReferenceCounts(cg);
@@ -574,7 +574,7 @@ TR::Register *OMR::Power::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::Code
 
    if (needSync)
       {
-      postSyncConditions(node, cg, tempReg, tempMR, TR::Compiler->target.cpu.id() >= TR_PPCp7 ? TR::InstOpCode::lwsync : TR::InstOpCode::isync);
+      TR::TreeEvaluator::postSyncConditions(node, cg, tempReg, tempMR, TR::Compiler->target.cpu.id() >= TR_PPCp7 ? TR::InstOpCode::lwsync : TR::InstOpCode::isync);
       }
    tempMR->decNodeReferenceCounts(cg);
 
@@ -615,7 +615,7 @@ TR::Register *OMR::Power::TreeEvaluator::lloadEvaluator(TR::Node *node, TR::Code
          generateTrg1MemInstruction(cg, TR::InstOpCode::ld, node, trgReg, tempMR);
       if (needSync)
          {
-         postSyncConditions(node, cg, trgReg, tempMR, TR::Compiler->target.cpu.id() >= TR_PPCp7 ? TR::InstOpCode::lwsync : TR::InstOpCode::isync);
+         TR::TreeEvaluator::postSyncConditions(node, cg, trgReg, tempMR, TR::Compiler->target.cpu.id() >= TR_PPCp7 ? TR::InstOpCode::lwsync : TR::InstOpCode::isync);
          }
 
       tempMR->decNodeReferenceCounts(cg);
@@ -778,7 +778,7 @@ TR::Register *OMR::Power::TreeEvaluator::commonByteLoadEvaluator(TR::Node *node,
    generateTrg1MemInstruction(cg, TR::InstOpCode::lbz, node, trgReg, tempMR);
    if (needSync)
       {
-      postSyncConditions(node, cg, trgReg, tempMR, TR::Compiler->target.cpu.id() >= TR_PPCp7 ? TR::InstOpCode::lwsync : TR::InstOpCode::isync);
+      TR::TreeEvaluator::postSyncConditions(node, cg, trgReg, tempMR, TR::Compiler->target.cpu.id() >= TR_PPCp7 ? TR::InstOpCode::lwsync : TR::InstOpCode::isync);
       }
 
    if (signExtend)
@@ -793,14 +793,14 @@ TR::Register *OMR::Power::TreeEvaluator::commonByteLoadEvaluator(TR::Node *node,
 TR::Register *OMR::Power::TreeEvaluator::buloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    // Never sign extend an unsigned byte load.
-   return commonByteLoadEvaluator(node, false, cg);
+   return TR::TreeEvaluator::commonByteLoadEvaluator(node, false, cg);
    }
 
 // also handles ibload
 TR::Register *OMR::Power::TreeEvaluator::bloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    // Java only loads and stores byte values so sign extension after the lbz is not required.
-   return commonByteLoadEvaluator(node, false, cg);
+   return TR::TreeEvaluator::commonByteLoadEvaluator(node, false, cg);
    }
 
 // also handles isload
@@ -831,7 +831,7 @@ TR::Register *OMR::Power::TreeEvaluator::sloadEvaluator(TR::Node *node, TR::Code
 
    if (needSync)
       {
-      postSyncConditions(node, cg, tempReg, tempMR, TR::Compiler->target.cpu.id() >= TR_PPCp7 ? TR::InstOpCode::lwsync : TR::InstOpCode::isync);
+      TR::TreeEvaluator::postSyncConditions(node, cg, tempReg, tempMR, TR::Compiler->target.cpu.id() >= TR_PPCp7 ? TR::InstOpCode::lwsync : TR::InstOpCode::isync);
       }
 
    tempMR->decNodeReferenceCounts(cg);
@@ -854,7 +854,7 @@ TR::Register *OMR::Power::TreeEvaluator::cloadEvaluator(TR::Node *node, TR::Code
    generateTrg1MemInstruction(cg, TR::InstOpCode::lhz, node, tempReg, tempMR);
    if (needSync)
       {
-      postSyncConditions(node, cg, tempReg, tempMR, TR::Compiler->target.cpu.id() >= TR_PPCp7 ? TR::InstOpCode::lwsync : TR::InstOpCode::isync);
+      TR::TreeEvaluator::postSyncConditions(node, cg, tempReg, tempMR, TR::Compiler->target.cpu.id() >= TR_PPCp7 ? TR::InstOpCode::lwsync : TR::InstOpCode::isync);
       }
 
    tempMR->decNodeReferenceCounts(cg);
@@ -945,7 +945,7 @@ TR::Register *OMR::Power::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::Cod
             {
             node->setChild(1, valueChild->getFirstChild());
             TR::Node::recreate(node, TR::fstorei);
-            fstoreEvaluator(node, cg);
+            TR::TreeEvaluator::fstoreEvaluator(node, cg);
             node->setChild(1, valueChild);
             TR::Node::recreate(node, TR::istorei);
             }
@@ -953,7 +953,7 @@ TR::Register *OMR::Power::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::Cod
             {
             node->setChild(0, valueChild->getFirstChild());
             TR::Node::recreate(node, TR::fstore);
-            fstoreEvaluator(node, cg);
+            TR::TreeEvaluator::fstoreEvaluator(node, cg);
             node->setChild(0, valueChild);
             TR::Node::recreate(node, TR::istore);
             }
@@ -1006,7 +1006,7 @@ TR::Register *OMR::Power::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::Cod
       // ordered and lazySet operations will not generate a post-write sync
       // and will not mark unresolved snippets with in sync sequence to avoid
       // PicBuilder overwriting the instruction that normally would have been sync
-      postSyncConditions(node, cg, srcReg, tempMR, TR::InstOpCode::sync, lazyVolatile);
+      TR::TreeEvaluator::postSyncConditions(node, cg, srcReg, tempMR, TR::InstOpCode::sync, lazyVolatile);
       }
 
    cg->decReferenceCount(valueChild);
@@ -1084,7 +1084,7 @@ TR::Register *OMR::Power::TreeEvaluator::astoreEvaluator(TR::Node *node, TR::Cod
       // ordered and lazySet operations will not generate a post-write sync
       // and will not mark unresolved snippets with in sync sequence to avoid
       // PicBuilder overwriting the instruction that normally would have been sync
-      postSyncConditions(node, cg, valueChild, tempMR, TR::InstOpCode::sync, lazyVolatile);
+      TR::TreeEvaluator::postSyncConditions(node, cg, valueChild, tempMR, TR::InstOpCode::sync, lazyVolatile);
       }
    tempMR->decNodeReferenceCounts(cg);
    cg->decReferenceCount(nodeChild);
@@ -1126,7 +1126,7 @@ TR::Register *OMR::Power::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::Cod
             {
             node->setChild(1, valueChild->getFirstChild());
             TR::Node::recreate(node, TR::dstorei);
-            dstoreEvaluator(node, cg);
+            TR::TreeEvaluator::dstoreEvaluator(node, cg);
             node->setChild(1, valueChild);
             TR::Node::recreate(node, TR::lstorei);
             }
@@ -1134,7 +1134,7 @@ TR::Register *OMR::Power::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::Cod
             {
             node->setChild(0, valueChild->getFirstChild());
             TR::Node::recreate(node, TR::dstore);
-            dstoreEvaluator(node, cg);
+            TR::TreeEvaluator::dstoreEvaluator(node, cg);
             node->setChild(0, valueChild);
             TR::Node::recreate(node, TR::lstore);
             }
@@ -1190,7 +1190,7 @@ TR::Register *OMR::Power::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::Cod
          // ordered and lazySet operations will not generate a post-write sync
          // and will not mark unresolved snippets with in sync sequence to avoid
          // PicBuilder overwriting the instruction that normally would have been sync
-         postSyncConditions(node, cg, valueReg, tempMR, TR::InstOpCode::sync);
+         TR::TreeEvaluator::postSyncConditions(node, cg, valueReg, tempMR, TR::InstOpCode::sync);
          }
       tempMR->decNodeReferenceCounts(cg);
       }
@@ -1391,7 +1391,7 @@ TR::Register *OMR::Power::TreeEvaluator::bstoreEvaluator(TR::Node *node, TR::Cod
    generateMemSrc1Instruction(cg, TR::InstOpCode::stb, node, tempMR, valueReg);
    if (needSync)
       {
-      postSyncConditions(node, cg, valueReg, tempMR, TR::InstOpCode::sync);
+      TR::TreeEvaluator::postSyncConditions(node, cg, valueReg, tempMR, TR::InstOpCode::sync);
       }
    cg->decReferenceCount(valueChild);
    tempMR->decNodeReferenceCounts(cg);
@@ -1438,7 +1438,7 @@ TR::Register *OMR::Power::TreeEvaluator::sstoreEvaluator(TR::Node *node, TR::Cod
       generateMemSrc1Instruction(cg, TR::InstOpCode::sth, node, tempMR, valueReg);
    if (needSync)
       {
-      postSyncConditions(node, cg, valueReg, tempMR, TR::InstOpCode::sync);
+      TR::TreeEvaluator::postSyncConditions(node, cg, valueReg, tempMR, TR::InstOpCode::sync);
       }
    cg->decReferenceCount(valueChild);
    tempMR->decNodeReferenceCounts(cg);
@@ -1474,7 +1474,7 @@ TR::Register *OMR::Power::TreeEvaluator::cstoreEvaluator(TR::Node *node, TR::Cod
    generateMemSrc1Instruction(cg, TR::InstOpCode::sth, node, tempMR, valueReg);
    if (needSync)
       {
-      postSyncConditions(node, cg, valueReg, tempMR, TR::InstOpCode::sync);
+      TR::TreeEvaluator::postSyncConditions(node, cg, valueReg, tempMR, TR::InstOpCode::sync);
       }
    cg->decReferenceCount(valueChild);
    tempMR->decNodeReferenceCounts(cg);
@@ -1666,27 +1666,27 @@ TR::Register *OMR::Power::TreeEvaluator::inlineVectorTernaryOp(TR::Node *node, T
 
 TR::Register *OMR::Power::TreeEvaluator::viminEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorBinaryOp(node, cg, TR::InstOpCode::vminsw);
+   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::vminsw);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vimaxEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorBinaryOp(node, cg, TR::InstOpCode::vmaxsw);
+   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::vmaxsw);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vandEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorBinaryOp(node, cg, TR::InstOpCode::vand);
+   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::vand);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorBinaryOp(node, cg, TR::InstOpCode::vor);
+   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::vor);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vxorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorBinaryOp(node, cg, TR::InstOpCode::vxor);
+   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::vxor);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vnotEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -2025,49 +2025,49 @@ TR::Register *OMR::Power::TreeEvaluator::vimergeEvaluator(TR::Node *node, TR::Co
 
 TR::Register *OMR::Power::TreeEvaluator::vdmaddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorTernaryOp(node, cg, TR::InstOpCode::xvmaddadp);
+   return TR::TreeEvaluator::inlineVectorTernaryOp(node, cg, TR::InstOpCode::xvmaddadp);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdnmsubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorTernaryOp(node, cg, TR::InstOpCode::xvnmsubadp);
+   return TR::TreeEvaluator::inlineVectorTernaryOp(node, cg, TR::InstOpCode::xvnmsubadp);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdmsubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorTernaryOp(node, cg, TR::InstOpCode::xvmsubadp);
+   return TR::TreeEvaluator::inlineVectorTernaryOp(node, cg, TR::InstOpCode::xvmsubadp);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdselEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorTernaryOp(node, cg, TR::InstOpCode::xxsel);
+   return TR::TreeEvaluator::inlineVectorTernaryOp(node, cg, TR::InstOpCode::xxsel);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdcmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvcmpgtdp);
+   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvcmpgtdp);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdcmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvcmpgedp);
+   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvcmpgedp);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdcmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvcmpeqdp);
+   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvcmpeqdp);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    node->swapChildren();
-   return inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvcmpgedp);
+   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvcmpgedp);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdcmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    node->swapChildren();
-   return inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvcmpgtdp);
+   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvcmpgtdp);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdcmpanyHelper(TR::Node *node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op)
@@ -2123,65 +2123,65 @@ TR::Register *OMR::Power::TreeEvaluator::vdcmpallHelper(TR::Node *node, TR::Code
 
 TR::Register *OMR::Power::TreeEvaluator::vdcmpalleqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return vdcmpallHelper(node, cg, TR::InstOpCode::xvcmpeqdp_r);
+   return TR::TreeEvaluator::vdcmpallHelper(node, cg, TR::InstOpCode::xvcmpeqdp_r);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdcmpallgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return vdcmpallHelper(node, cg, TR::InstOpCode::xvcmpgedp_r);
+   return TR::TreeEvaluator::vdcmpallHelper(node, cg, TR::InstOpCode::xvcmpgedp_r);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdcmpallgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return vdcmpallHelper(node, cg, TR::InstOpCode::xvcmpgtdp_r);
+   return TR::TreeEvaluator::vdcmpallHelper(node, cg, TR::InstOpCode::xvcmpgtdp_r);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdcmpallleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    node->swapChildren();
-   return vdcmpallHelper(node, cg, TR::InstOpCode::xvcmpgedp_r);
+   return TR::TreeEvaluator::vdcmpallHelper(node, cg, TR::InstOpCode::xvcmpgedp_r);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdcmpallltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    node->swapChildren();
-   return vdcmpallHelper(node, cg, TR::InstOpCode::xvcmpgtdp_r);
+   return TR::TreeEvaluator::vdcmpallHelper(node, cg, TR::InstOpCode::xvcmpgtdp_r);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdcmpanyeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return vdcmpanyHelper(node, cg, TR::InstOpCode::xvcmpeqdp_r);
+   return TR::TreeEvaluator::vdcmpanyHelper(node, cg, TR::InstOpCode::xvcmpeqdp_r);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdcmpanygeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return vdcmpanyHelper(node, cg, TR::InstOpCode::xvcmpgedp_r);
+   return TR::TreeEvaluator::vdcmpanyHelper(node, cg, TR::InstOpCode::xvcmpgedp_r);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdcmpanygtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return vdcmpanyHelper(node, cg, TR::InstOpCode::xvcmpgtdp_r);
+   return TR::TreeEvaluator::vdcmpanyHelper(node, cg, TR::InstOpCode::xvcmpgtdp_r);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdcmpanyleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    node->swapChildren();
-   return vdcmpanyHelper(node, cg, TR::InstOpCode::xvcmpgedp_r);
+   return TR::TreeEvaluator::vdcmpanyHelper(node, cg, TR::InstOpCode::xvcmpgedp_r);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdcmpanyltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    node->swapChildren();
-   return vdcmpanyHelper(node, cg, TR::InstOpCode::xvcmpgtdp_r);
+   return TR::TreeEvaluator::vdcmpanyHelper(node, cg, TR::InstOpCode::xvcmpgtdp_r);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vaddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    switch(node->getDataType())
      {
-     case TR::VectorInt32:  return inlineVectorBinaryOp(node, cg, TR::InstOpCode::vadduwm);
-     case TR::VectorFloat: return inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvaddsp);
-     case TR::VectorDouble: return inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvadddp);
+     case TR::VectorInt32:  return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::vadduwm);
+     case TR::VectorFloat: return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvaddsp);
+     case TR::VectorDouble: return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvadddp);
      default: TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
      }
    }
@@ -2191,9 +2191,9 @@ TR::Register *OMR::Power::TreeEvaluator::vsubEvaluator(TR::Node *node, TR::CodeG
    {
    switch(node->getDataType())
      {
-     case TR::VectorInt32:  return inlineVectorBinaryOp(node, cg, TR::InstOpCode::vsubuwm);
-     case TR::VectorFloat: return inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvsubsp);
-     case TR::VectorDouble: return inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvsubdp);
+     case TR::VectorInt32:  return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::vsubuwm);
+     case TR::VectorFloat: return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvsubsp);
+     case TR::VectorDouble: return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvsubdp);
      default: TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
      }
    }
@@ -2203,11 +2203,11 @@ TR::Register *OMR::Power::TreeEvaluator::vnegEvaluator(TR::Node *node, TR::CodeG
    switch(node->getDataType())
      {
      case TR::VectorInt32:
-       return vnegInt32Helper(node,cg);
+       return TR::TreeEvaluator::vnegInt32Helper(node,cg);
      case TR::VectorFloat:
-       return vnegFloatHelper(node,cg);
+       return TR::TreeEvaluator::vnegFloatHelper(node,cg);
      case TR::VectorDouble:
-       return vnegDoubleHelper(node,cg);
+       return TR::TreeEvaluator::vnegDoubleHelper(node,cg);
      default:
        TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
      }
@@ -2233,12 +2233,12 @@ TR::Register *OMR::Power::TreeEvaluator::vnegInt32Helper(TR::Node *node, TR::Cod
 
 TR::Register *OMR::Power::TreeEvaluator::vnegFloatHelper(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorUnaryOp(node, cg, TR::InstOpCode::xvnegsp);
+   return TR::TreeEvaluator::inlineVectorUnaryOp(node, cg, TR::InstOpCode::xvnegsp);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vnegDoubleHelper(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorUnaryOp(node, cg, TR::InstOpCode::xvnegdp);
+   return TR::TreeEvaluator::inlineVectorUnaryOp(node, cg, TR::InstOpCode::xvnegdp);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vmulEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -2246,11 +2246,11 @@ TR::Register *OMR::Power::TreeEvaluator::vmulEvaluator(TR::Node *node, TR::CodeG
    switch(node->getDataType())
      {
      case TR::VectorInt32:
-       return vmulInt32Helper(node,cg);
+       return TR::TreeEvaluator::vmulInt32Helper(node,cg);
      case TR::VectorFloat:
-       return vmulFloatHelper(node,cg);
+       return TR::TreeEvaluator::vmulFloatHelper(node,cg);
      case TR::VectorDouble:
-       return vmulDoubleHelper(node,cg);
+       return TR::TreeEvaluator::vmulDoubleHelper(node,cg);
      default:
        TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
      }
@@ -2297,12 +2297,12 @@ TR::Register *OMR::Power::TreeEvaluator::vmulInt32Helper(TR::Node *node, TR::Cod
 
 TR::Register *OMR::Power::TreeEvaluator::vmulFloatHelper(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvmulsp);
+   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvmulsp);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vmulDoubleHelper(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvmuldp);
+   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvmuldp);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdivEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -2310,11 +2310,11 @@ TR::Register *OMR::Power::TreeEvaluator::vdivEvaluator(TR::Node *node, TR::CodeG
    switch(node->getDataType())
      {
      case TR::VectorInt32:
-	return vdivInt32Helper(node, cg);
+	return TR::TreeEvaluator::vdivInt32Helper(node, cg);
      case TR::VectorFloat:
-	return vdivFloatHelper(node, cg);
+	return TR::TreeEvaluator::vdivFloatHelper(node, cg);
      case TR::VectorDouble:
-	return vdivDoubleHelper(node, cg);
+	return TR::TreeEvaluator::vdivDoubleHelper(node, cg);
      default:
        TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
      }
@@ -2322,12 +2322,12 @@ TR::Register *OMR::Power::TreeEvaluator::vdivEvaluator(TR::Node *node, TR::CodeG
 
 TR::Register *OMR::Power::TreeEvaluator::vdivFloatHelper(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvdivsp);
+   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvdivsp);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdivDoubleHelper(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvdivdp);
+   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvdivdp);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdivInt32Helper(TR::Node *node, TR::CodeGenerator *cg)
@@ -2383,28 +2383,28 @@ TR::Register *OMR::Power::TreeEvaluator::vdivInt32Helper(TR::Node *node, TR::Cod
 
 TR::Register *OMR::Power::TreeEvaluator::vdminEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvmindp);
+   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvmindp);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdmaxEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvmaxdp);
+   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvmaxdp);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vicmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorBinaryOp(node, cg, TR::InstOpCode::vcmpequw);
+   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::vcmpequw);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vicmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorBinaryOp(node, cg, TR::InstOpCode::vcmpgtsw);
+   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::vcmpgtsw);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vicmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    node->swapChildren();
-   return inlineVectorBinaryOp(node, cg, TR::InstOpCode::vcmpgtsw);
+   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::vcmpgtsw);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vicmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -2432,17 +2432,17 @@ TR::Register *OMR::Power::TreeEvaluator::vicmpgeEvaluator(TR::Node *node, TR::Co
 TR::Register *OMR::Power::TreeEvaluator::vicmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    node->swapChildren();
-   return vicmpgeEvaluator(node, cg);
+   return TR::TreeEvaluator::vicmpgeEvaluator(node, cg);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vselectEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorTernaryOp(node, cg, TR::InstOpCode::vsel);
+   return TR::TreeEvaluator::inlineVectorTernaryOp(node, cg, TR::InstOpCode::vsel);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vpermEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return inlineVectorTernaryOp(node, cg, TR::InstOpCode::vperm);
+   return TR::TreeEvaluator::inlineVectorTernaryOp(node, cg, TR::InstOpCode::vperm);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdmergeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -2463,7 +2463,7 @@ TR::Register *OMR::Power::TreeEvaluator::vdmergeEvaluator(TR::Node *node, TR::Co
 
 TR::Register *OMR::Power::TreeEvaluator::vdsqrtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
     {
-    return inlineVectorUnaryOp(node, cg, TR::InstOpCode::xvsqrtdp);
+    return TR::TreeEvaluator::inlineVectorUnaryOp(node, cg, TR::InstOpCode::xvsqrtdp);
     }
 
 TR::Register *OMR::Power::TreeEvaluator::vdlogEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -2473,7 +2473,7 @@ TR::Register *OMR::Power::TreeEvaluator::vdlogEvaluator(TR::Node *node, TR::Code
     TR::Node::recreate(node, TR::vcall);
     node->setSymbolReference(helper);
 
-    return directCallEvaluator(node, cg);
+    return TR::TreeEvaluator::directCallEvaluator(node, cg);
     }
 
 
@@ -2646,59 +2646,59 @@ TR::Register *OMR::Power::TreeEvaluator::vicmpanyHelper(TR::Node *node, TR::Code
 
 TR::Register *OMR::Power::TreeEvaluator::vicmpalleqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return vicmpallHelper(node, cg, TR::InstOpCode::vcmpeuwr, 25);
+   return TR::TreeEvaluator::vicmpallHelper(node, cg, TR::InstOpCode::vcmpeuwr, 25);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vicmpallneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return unImpOpEvaluator(node, cg);
+   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
    }
 TR::Register *OMR::Power::TreeEvaluator::vicmpallgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return vicmpallHelper(node, cg, TR::InstOpCode::vcmpgswr, 25);
+   return TR::TreeEvaluator::vicmpallHelper(node, cg, TR::InstOpCode::vcmpgswr, 25);
    }
 TR::Register *OMR::Power::TreeEvaluator::vicmpallgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    node->swapChildren();
-   return vicmpallHelper(node, cg, TR::InstOpCode::vcmpgswr, 27);
+   return TR::TreeEvaluator::vicmpallHelper(node, cg, TR::InstOpCode::vcmpgswr, 27);
    }
 TR::Register *OMR::Power::TreeEvaluator::vicmpallltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    node->swapChildren();
-   return vicmpallHelper(node, cg, TR::InstOpCode::vcmpgswr, 25);
+   return TR::TreeEvaluator::vicmpallHelper(node, cg, TR::InstOpCode::vcmpgswr, 25);
    }
 TR::Register *OMR::Power::TreeEvaluator::vicmpallleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return vicmpallHelper(node, cg, TR::InstOpCode::vcmpgswr, 27);
+   return TR::TreeEvaluator::vicmpallHelper(node, cg, TR::InstOpCode::vcmpgswr, 27);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vicmpanyeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return vicmpanyHelper(node, cg, TR::InstOpCode::vcmpeuwr, 27);
+   return TR::TreeEvaluator::vicmpanyHelper(node, cg, TR::InstOpCode::vcmpeuwr, 27);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vicmpanyneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return unImpOpEvaluator(node, cg);
+   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vicmpanygtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return vicmpanyHelper(node, cg, TR::InstOpCode::vcmpgswr, 27);
+   return TR::TreeEvaluator::vicmpanyHelper(node, cg, TR::InstOpCode::vcmpgswr, 27);
    }
 TR::Register *OMR::Power::TreeEvaluator::vicmpanygeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    node->swapChildren();
-   return vicmpanyHelper(node, cg, TR::InstOpCode::vcmpgswr, 25);
+   return TR::TreeEvaluator::vicmpanyHelper(node, cg, TR::InstOpCode::vcmpgswr, 25);
    }
 TR::Register *OMR::Power::TreeEvaluator::vicmpanyltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    node->swapChildren();
-   return vicmpanyHelper(node, cg, TR::InstOpCode::vcmpgswr, 27);
+   return TR::TreeEvaluator::vicmpanyHelper(node, cg, TR::InstOpCode::vcmpgswr, 27);
    }
 TR::Register *OMR::Power::TreeEvaluator::vicmpanyleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return vicmpanyHelper(node, cg, TR::InstOpCode::vcmpgswr, 25);
+   return TR::TreeEvaluator::vicmpanyHelper(node, cg, TR::InstOpCode::vcmpgswr, 25);
    }
 
 
@@ -4082,7 +4082,7 @@ TR::Register *OMR::Power::TreeEvaluator::setmemoryEvaluator(TR::Node *node, TR::
    TR::Register         *dstAddrReg, *lengthReg, *valueReg;
    bool stopUsingCopyReg1, stopUsingCopyReg2, stopUsingCopyReg3 = false;
 
-   stopUsingCopyReg1 = stopUsingCopyReg(dstAddrNode, dstAddrReg, cg);
+   stopUsingCopyReg1 = TR::TreeEvaluator::stopUsingCopyReg(dstAddrNode, dstAddrReg, cg);
 
    lengthReg = cg->evaluate(lengthNode);
    if (!cg->canClobberNodesRegister(lengthNode))
@@ -4194,7 +4194,7 @@ TR::Register *OMR::Power::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::
       {
       TR::ILOpCodes opCode = node->getOpCodeValue();
       TR::Node::recreate(node, TR::call);
-      TR::Register *targetRegister = directCallEvaluator(node, cg);
+      TR::Register *targetRegister = TR::TreeEvaluator::directCallEvaluator(node, cg);
       TR::Node::recreate(node, opCode);
       return targetRegister;
       }
@@ -4244,10 +4244,10 @@ TR::Register *OMR::Power::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::
       lengthNode = node->getChild(4);
       }
 
-   stopUsingCopyReg1 = stopUsingCopyReg(srcObjNode, srcObjReg, cg);
-   stopUsingCopyReg2 = stopUsingCopyReg(dstObjNode, dstObjReg, cg);
-   stopUsingCopyReg3 = stopUsingCopyReg(srcAddrNode, srcAddrReg, cg);
-   stopUsingCopyReg4 = stopUsingCopyReg(dstAddrNode, dstAddrReg, cg);
+   stopUsingCopyReg1 = TR::TreeEvaluator::stopUsingCopyReg(srcObjNode, srcObjReg, cg);
+   stopUsingCopyReg2 = TR::TreeEvaluator::stopUsingCopyReg(dstObjNode, dstObjReg, cg);
+   stopUsingCopyReg3 = TR::TreeEvaluator::stopUsingCopyReg(srcAddrNode, srcAddrReg, cg);
+   stopUsingCopyReg4 = TR::TreeEvaluator::stopUsingCopyReg(dstAddrNode, dstAddrReg, cg);
 
    // Inline forward arrayCopy with constant length, call the wrtbar if needed after the copy
    if ((simpleCopy || !arrayStoreCheckIsNeeded) &&
@@ -4484,7 +4484,7 @@ TR::Register *OMR::Power::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::
                   }
                }
             }
-         generateHelperBranchAndLinkInstruction(helper, node, conditions, cg);
+         TR::TreeEvaluator::generateHelperBranchAndLinkInstruction(helper, node, conditions, cg);
          }
    conditions->stopUsingDepRegs(cg);
 

--- a/compiler/p/codegen/UnaryEvaluator.cpp
+++ b/compiler/p/codegen/UnaryEvaluator.cpp
@@ -135,7 +135,7 @@ TR::Register *OMR::Power::TreeEvaluator::lnegEvaluator(TR::Node *node, TR::CodeG
 
    if (TR::Compiler->target.is64Bit())
       {
-      return inegEvaluator(node, cg);
+      return TR::TreeEvaluator::inegEvaluator(node, cg);
       }
    else
       {
@@ -267,9 +267,9 @@ TR::Register *OMR::Power::TreeEvaluator::b2iEvaluator(TR::Node *node, TR::CodeGe
 TR::Register *OMR::Power::TreeEvaluator::b2aEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (TR::Compiler->target.is64Bit())
-      return b2lEvaluator(node, cg);
+      return TR::TreeEvaluator::b2lEvaluator(node, cg);
    else
-      return b2iEvaluator(node, cg);
+      return TR::TreeEvaluator::b2iEvaluator(node, cg);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::s2iEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -443,9 +443,9 @@ TR::Register *OMR::Power::TreeEvaluator::iu2lEvaluator(TR::Node *node, TR::CodeG
 TR::Register *OMR::Power::TreeEvaluator::su2aEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (TR::Compiler->target.is64Bit())
-      return iu2lEvaluator(node, cg);
+      return TR::TreeEvaluator::iu2lEvaluator(node, cg);
    else
-      return s2iEvaluator(node, cg);
+      return TR::TreeEvaluator::s2iEvaluator(node, cg);
    }
 
 
@@ -475,9 +475,9 @@ TR::Register *OMR::Power::TreeEvaluator::su2iEvaluator(TR::Node *node, TR::CodeG
 TR::Register *OMR::Power::TreeEvaluator::s2aEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (TR::Compiler->target.is64Bit())
-      return s2lEvaluator(node, cg);
+      return TR::TreeEvaluator::s2lEvaluator(node, cg);
    else
-      return s2iEvaluator(node, cg);
+      return TR::TreeEvaluator::s2iEvaluator(node, cg);
    }
 
 // also handles s2b
@@ -541,17 +541,17 @@ TR::Register *OMR::Power::TreeEvaluator::i2sEvaluator(TR::Node *node, TR::CodeGe
 TR::Register *OMR::Power::TreeEvaluator::i2aEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (TR::Compiler->target.is64Bit())
-      return s2lEvaluator(node, cg);
+      return TR::TreeEvaluator::s2lEvaluator(node, cg);
    else
-      return passThroughEvaluator(node, cg);
+      return TR::TreeEvaluator::passThroughEvaluator(node, cg);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::iu2aEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (TR::Compiler->target.is64Bit())
-      return iu2lEvaluator(node, cg);
+      return TR::TreeEvaluator::iu2lEvaluator(node, cg);
    else
-      return passThroughEvaluator(node, cg);
+      return TR::TreeEvaluator::passThroughEvaluator(node, cg);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::l2bEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -775,10 +775,10 @@ TR::Register *OMR::Power::TreeEvaluator::l2aEvaluator(TR::Node *node, TR::CodeGe
          return source;
          }
       else
-         return passThroughEvaluator(node, cg);
+         return TR::TreeEvaluator::passThroughEvaluator(node, cg);
       }
    else
-      return l2iEvaluator(node, cg);
+      return TR::TreeEvaluator::l2iEvaluator(node, cg);
    }
 
 
@@ -913,41 +913,41 @@ TR::Register *OMR::Power::TreeEvaluator::bu2lEvaluator(TR::Node *node, TR::CodeG
 TR::Register *OMR::Power::TreeEvaluator::bu2aEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (TR::Compiler->target.is64Bit())
-      return bu2lEvaluator(node, cg);
+      return TR::TreeEvaluator::bu2lEvaluator(node, cg);
    else
-      return bu2iEvaluator(node, cg);
+      return TR::TreeEvaluator::bu2iEvaluator(node, cg);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::a2iEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (TR::Compiler->target.is64Bit())
-      return l2iEvaluator(node, cg);
+      return TR::TreeEvaluator::l2iEvaluator(node, cg);
    else
-      return passThroughEvaluator(node, cg);
+      return TR::TreeEvaluator::passThroughEvaluator(node, cg);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::a2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (TR::Compiler->target.is64Bit())
-      return passThroughEvaluator(node, cg);
+      return TR::TreeEvaluator::passThroughEvaluator(node, cg);
    else
-      return iu2lEvaluator(node, cg);
+      return TR::TreeEvaluator::iu2lEvaluator(node, cg);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::a2bEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (TR::Compiler->target.is64Bit())
-      return l2bEvaluator(node, cg);
+      return TR::TreeEvaluator::l2bEvaluator(node, cg);
    else
-      return i2bEvaluator(node, cg);
+      return TR::TreeEvaluator::i2bEvaluator(node, cg);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::a2sEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (TR::Compiler->target.is64Bit())
-      return l2sEvaluator(node, cg);
+      return TR::TreeEvaluator::l2sEvaluator(node, cg);
    else
-      return i2sEvaluator(node, cg);
+      return TR::TreeEvaluator::i2sEvaluator(node, cg);
    }
 
 #if 1
@@ -955,86 +955,86 @@ TR::Register *OMR::Power::TreeEvaluator::a2sEvaluator(TR::Node *node, TR::CodeGe
 TR::Register *OMR::Power::TreeEvaluator::ifacmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (TR::Compiler->target.is64Bit())
-      return iflucmpltEvaluator(node, cg);
+      return TR::TreeEvaluator::iflucmpltEvaluator(node, cg);
    else
-      return ifiucmpltEvaluator(node, cg);
+      return TR::TreeEvaluator::ifiucmpltEvaluator(node, cg);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::ifacmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (TR::Compiler->target.is64Bit())
-      return iflucmpgeEvaluator(node, cg);
+      return TR::TreeEvaluator::iflucmpgeEvaluator(node, cg);
    else
-      return ifiucmpgeEvaluator(node, cg);
+      return TR::TreeEvaluator::ifiucmpgeEvaluator(node, cg);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::ifacmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (TR::Compiler->target.is64Bit())
-      return iflucmpgtEvaluator(node, cg);
+      return TR::TreeEvaluator::iflucmpgtEvaluator(node, cg);
    else
-      return ifiucmpgtEvaluator(node, cg);
+      return TR::TreeEvaluator::ifiucmpgtEvaluator(node, cg);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::ifacmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (TR::Compiler->target.is64Bit())
-      return iflucmpleEvaluator(node, cg);
+      return TR::TreeEvaluator::iflucmpleEvaluator(node, cg);
    else
-      return ifiucmpleEvaluator(node, cg);
+      return TR::TreeEvaluator::ifiucmpleEvaluator(node, cg);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::acmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (TR::Compiler->target.is64Bit())
-      return lucmpltEvaluator(node, cg);
+      return TR::TreeEvaluator::lucmpltEvaluator(node, cg);
    else
-      return iucmpltEvaluator(node, cg);
+      return TR::TreeEvaluator::iucmpltEvaluator(node, cg);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::acmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (TR::Compiler->target.is64Bit())
-      return lucmpgeEvaluator(node, cg);
+      return TR::TreeEvaluator::lucmpgeEvaluator(node, cg);
    else
-      return iucmpgeEvaluator(node, cg);
+      return TR::TreeEvaluator::iucmpgeEvaluator(node, cg);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::acmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (TR::Compiler->target.is64Bit())
-      return lucmpgtEvaluator(node, cg);
+      return TR::TreeEvaluator::lucmpgtEvaluator(node, cg);
    else
-      return iucmpgtEvaluator(node, cg);
+      return TR::TreeEvaluator::iucmpgtEvaluator(node, cg);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::acmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (TR::Compiler->target.is64Bit())
-      return lucmpleEvaluator(node, cg);
+      return TR::TreeEvaluator::lucmpleEvaluator(node, cg);
    else
-      return iucmpleEvaluator(node, cg);
+      return TR::TreeEvaluator::iucmpleEvaluator(node, cg);
    }
 #endif
 
 TR::Register *OMR::Power::TreeEvaluator::libmFuncEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node::recreate(node, TR::dcall);
-   TR::Register *trgReg = directCallEvaluator(node, cg);
+   TR::Register *trgReg = TR::TreeEvaluator::directCallEvaluator(node, cg);
    return trgReg;
    }
 
 TR::Register *OMR::Power::TreeEvaluator::strcmpEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node::recreate(node, TR::icall);
-   TR::Register *trgReg = directCallEvaluator(node, cg);
+   TR::Register *trgReg = TR::TreeEvaluator::directCallEvaluator(node, cg);
    return trgReg;
    }
 
 TR::Register *OMR::Power::TreeEvaluator::strcFuncEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node::recreate(node, TR::acall);
-   TR::Register *trgReg = directCallEvaluator(node, cg);
+   TR::Register *trgReg = TR::TreeEvaluator::directCallEvaluator(node, cg);
    return trgReg;
    }
 
@@ -1062,11 +1062,11 @@ TR::Register *OMR::Power::TreeEvaluator::dfloorEvaluator(TR::Node *node, TR::Cod
       }
       else
         const_node->setDouble(-1.0);
-      tmp1Reg = dconstEvaluator(const_node, cg);
+      tmp1Reg = TR::TreeEvaluator::dconstEvaluator(const_node, cg);
 
       const_node_max = TR::Node::create(node, TR::dconst, 0);
       const_node_max->setDouble(CONSTANT64(0x10000000000000));                      // 2**52
-      tmp5Reg = dconstEvaluator(const_node_max, cg);
+      tmp5Reg = TR::TreeEvaluator::dconstEvaluator(const_node_max, cg);
    }
    else
    {
@@ -1081,11 +1081,11 @@ TR::Register *OMR::Power::TreeEvaluator::dfloorEvaluator(TR::Node *node, TR::Cod
       }
       else
         const_node->setFloat(-1.0);
-      tmp1Reg = fconstEvaluator(const_node, cg);
+      tmp1Reg = TR::TreeEvaluator::fconstEvaluator(const_node, cg);
 
       const_node_max = TR::Node::create( node, TR::fconst, 0);
       const_node_max->setFloat(0x800000);
-      tmp5Reg = fconstEvaluator(const_node_max, cg);
+      tmp5Reg = TR::TreeEvaluator::fconstEvaluator(const_node_max, cg);
    }
 
    const_node->unsetRegister();

--- a/compiler/z/codegen/OMRCodeGenPhase.hpp
+++ b/compiler/z/codegen/OMRCodeGenPhase.hpp
@@ -39,7 +39,7 @@ namespace OMR
 namespace Z
 {
 
-class CodeGenPhase : public OMR::CodeGenPhase
+class OMR_EXTENSIBLE CodeGenPhase : public OMR::CodeGenPhase
    {
    protected:
 


### PR DESCRIPTION
Travis CI doesn't run the linter on Power and Z specific code. This resolves the linting errors that slipped through.

These changes allow the compiler to correctly apply static polymorphism to the calls. Two of these changes do so by adding `self()->` to calls to member functions, while the rest add `TR::TreeEvaluator::` to calls to TreeEvaluator static functions.