### PR TITLE
JitBuilder worklist

### DIFF
--- a/compiler/ilgen/BytecodeBuilder.cpp
+++ b/compiler/ilgen/BytecodeBuilder.cpp
@@ -57,7 +57,7 @@ TR::BytecodeBuilder::initialize(TR::IlGeneratorMethodDetails * details,
     this->OMR::IlInjector::initialize(details, methodSymbol, fe, symRefTab);
 
     //addBytecodeBuilderToList relies on _comp and it won't be ready until now
-    _methodBuilder->addBytecodeBuilderToList(this);
+    _methodBuilder->addToAllBytecodeBuildersList(this);
     }
 
 void
@@ -138,6 +138,7 @@ OMR::BytecodeBuilder::AddFallThroughBuilder(TR::BytecodeBuilder *ftb)
    if (b != ftb)
       TraceIL("IlBuilder[ %p ]:: fallThrough successor changed to [ %p ]\n", this, b);
    _fallThroughBuilder = b;
+    _methodBuilder->addBytecodeBuilderToWorklist(ftb);
 
    // add explicit goto and register the actual fall-through block
    TR::IlBuilder *tgtb = b;
@@ -161,6 +162,7 @@ OMR::BytecodeBuilder::AddSuccessorBuilders(uint32_t numExits, ...)
       TR::BytecodeBuilder **builder = (TR::BytecodeBuilder **) va_arg(exits, TR::BytecodeBuilder **);
       transferVMState(builder);            // may change what builder points at!
       _successorBuilders->add(*builder);   // must be the bytecode builder that comes back from transferVMState()
+      _methodBuilder->addBytecodeBuilderToWorklist(*builder);
       TraceIL("IlBuilder[ %p ]:: successor [ %p ]\n", this, *builder);
       }
    va_end(exits);

--- a/compiler/ilgen/BytecodeBuilder.hpp
+++ b/compiler/ilgen/BytecodeBuilder.hpp
@@ -43,6 +43,11 @@ public:
 
    virtual bool isBytecodeBuilder() { return true; }
 
+   /**
+    * @brief bytecode index for this builder object
+    */
+   int32_t bcIndex() { return _bcIndex; }
+
    virtual uint32_t countBlocks();
 
    void AddFallThroughBuilder(TR::BytecodeBuilder *ftb);

--- a/jitbuilder/release/Makefile
+++ b/jitbuilder/release/Makefile
@@ -42,7 +42,8 @@ ALL_TESTS = \
             simple \
             structarray \
             switch \
-            toiltype
+            toiltype \
+            worklist
 
 # Compile all the tests by default
 all: $(ALL_TESTS)
@@ -56,6 +57,7 @@ common_goal: $(ALL_TESTS)
 	./pow2
 	./simple
 	./toiltype
+	./worklist
 
 # Additional tests that may not work properly on all platforms
 all_goal: common_goal
@@ -68,6 +70,7 @@ all_goal: common_goal
 	./recfib
 	./structarray
 	./switch
+	./toiltype
 
 
 # In general, only compile and run tests that are known to work on all platforms
@@ -237,6 +240,12 @@ toiltype : libjitbuilder.a ToIlType.o
 ToIlType.o: src/ToIlType.cpp
 	g++ -o $@ $(CXXFLAGS) $<
 
+
+worklist : libjitbuilder.a Worklist.o
+	g++ -g -fno-rtti -o $@ Worklist.o -L. -ljitbuilder -ldl
+
+Worklist.o: src/Worklist.cpp
+	g++ -o $@ $(CXXFLAGS) $<
 
 
 clean:

--- a/jitbuilder/release/src/Worklist.cpp
+++ b/jitbuilder/release/src/Worklist.cpp
@@ -1,0 +1,347 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+
+#include <iostream>
+#include <stdlib.h>
+#include <stdint.h>
+#include <dlfcn.h>
+#include <errno.h>
+
+#include "Jit.hpp"
+#include "ilgen/TypeDictionary.hpp"
+#include "ilgen/MethodBuilder.hpp"
+#include "ilgen/BytecodeBuilder.hpp"
+#include "ilgen/VirtualMachineState.hpp"
+#include "Worklist.hpp"
+
+using std::cout;
+using std::cerr;
+
+#define REPORT_BCI(bci,e_bci)   { if ((bci) != (e_bci)) { cerr << "Error: bytecode " << (bci) << " not found in worklist ( expected" << (e_bci) << ")\n"; return false; } }
+
+#define REPORT_VMSTATE(b,s)
+
+//#define REPORT_VMSTATE(b,s)     { if ((b)->vmState() != (s)) { cerr << "Error: bytecode " << ((b)->bcIndex()) << " does not have correct vmState (" << (s) << ")\n"; return false; } }
+
+#define REPORT_RESULT(p,r,e)    { if ((r) == (e)) { success++; } else { cerr << "Error: path " << (p) << " generated wrong result (" << (r) << " versus " << (e) << ")\n"; fails++; } }
+
+
+static bool verbose = false;
+static int32_t fails = 0;
+static int32_t success = 0;
+
+// BC0:  r = p;
+// BC1:  r++;
+//       if (r > 10) goto BC3;
+// BC2:  if (r > 5)  goto BC5;
+// BC4:  if (r < 3)  goto BC1; // loop back
+// BC9:  return 9;
+//
+// BC5:  if (r < 8) goto BC11;
+// BC17: return 17;
+//
+// BC7:  if (r < 17) goto BC1; // loop back
+// BC8:  return 8;
+//
+//
+// BC3:  if (r > 15) goto BC7;
+// BC6:  if (r > 12) goto BC13;
+// BC16: return 16;
+
+// BC7:  return 7;
+// BC11: return 11;
+// BC13: return 13;
+
+// no BC10, BC12, BC14, BC15, BC18, BC19
+
+int32_t
+computeResult(int32_t p)
+   {
+   // BC0
+   int32_t r = p;
+BC1:
+   r++;
+   if (r > 10)
+      {
+      // BC3
+      if (r > 15)
+         {
+         // BC7
+         if (r < 17)
+            goto BC1;
+         else
+            return 8; // BC8
+         }
+      else
+         {
+         // BC6
+         if (r > 12)
+            return 13; // BC13
+         else
+            return 16; // BC16
+         }
+      }
+   else
+      {
+      // BC2
+      if (r > 5)
+         {
+         // BC5
+         if (r < 8)
+            return 11; // BC11
+         else
+            return 17; // BC17
+         }
+      else
+         {
+         // BC4
+         if (r < 3)
+            goto BC1;
+         else
+            return 9; // BC9
+         }
+      }
+   }
+
+
+int
+main(int argc, char *argv[])
+   {
+   if (argc == 2 && strcmp(argv[1], "--verbose") == 0)
+      verbose = true;
+
+   cout << "Step 1: initialize JIT\n";
+   bool initialized = initializeJit();
+   if (!initialized)
+      {
+      cerr << "FAIL: could not initialize JIT\n";
+      exit(-1);
+      }
+
+   cout << "Step 2: define type dictionary\n";
+   TR::TypeDictionary types;
+
+   cout << "Step 3: compile method builder\n";
+   WorklistMethod method(&types);
+   uint8_t *entry = 0;
+   int32_t rc = compileMethodBuilder(&method, &entry);
+   if (rc != 0)
+      {
+      cerr << "fail: compilation error " << rc << "\n";
+      exit(-2);
+      }
+
+   cout << "step 4: invoke compiled code and print results\n";
+   typedef int32_t (WorklistMethodFunction)(int32_t);
+   WorklistMethodFunction *testPath = (WorklistMethodFunction *) entry;
+
+   const int32_t expectation[20] = {
+       9,  9,  9,  9,  9, 11, 11, 17, 17, 17,
+      16, 16, 13, 13, 13,  8,  8,  8,  8,  8 };
+
+   for (int32_t p=0;p < 20;p++)
+      {
+      int32_t r = testPath(p);
+      if (verbose) cout << "\ttestPath(" << p << ") == " << testPath(p) << "\n";
+      //REPORT_RESULT(p, r, expectation[p]);
+      REPORT_RESULT(p, r, computeResult(p));
+      }
+
+   cout << "Step 5: shutdown JIT\n";
+
+   cout << "Failed tests: " << fails << "\n";
+   cout << "Passed tests: " << success << "\n";
+   if (fails == 0)
+      cout << "ALL PASSED\n";
+
+   shutdownJit();
+   }
+
+
+
+WorklistMethod::WorklistMethod(TR::TypeDictionary *d)
+   : MethodBuilder(d)
+   {
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   DefineName("testPath");
+   DefineParameter("path", Int32);
+   DefineReturnType(Int32);
+   }
+
+bool
+WorklistMethod::buildIL()
+   {
+   cout << "WorklistMethod::buildIL() running!\n";
+
+   const char *bcName[20] = {
+      "bc0",  "bc1",  "bc2",  "bc3",  "bc4",  "bc5",  "bc6",  "bc7",  "bc8",  "bc9",
+      "bc10", "bc11", "bc12", "bc13", "bc14", "bc15", "bc16", "bc17", "bc18", "bc19" };
+
+   TR::BytecodeBuilder *builders[20];
+   for (int32_t i=0;i < 20;i++)
+      builders[i] = OrphanBytecodeBuilder(i, (char *)bcName[i]);
+
+   OMR::VirtualMachineState *vmState = new OMR::VirtualMachineState();
+   setVMState(vmState);
+
+   Store("result",
+      Load("path"));
+
+   // should add 0 to the worklist
+   AppendBuilder(builders[0]);
+
+   TR::BytecodeBuilder *b;
+
+   // BCI 0
+   int32_t bci = GetNextBytecodeFromWorklist();
+   REPORT_BCI(bci,0);
+   b = builders[bci];
+   REPORT_VMSTATE(b,vmState);
+   b->AddFallThroughBuilder(builders[1]);
+
+   // BCI 1
+   bci = GetNextBytecodeFromWorklist();
+   REPORT_BCI(bci,1);
+   b = builders[bci];
+   REPORT_VMSTATE(b,vmState);
+   b->Store("result",
+   b->   Add(
+   b->      Load("result"),
+   b->      ConstInt32(1)));
+   b->IfCmpGreaterThan(builders[3],
+   b->   Load("result"),
+   b->   ConstInt32(10));
+   b->AddFallThroughBuilder(builders[2]);
+
+   // BCI 2
+   bci = GetNextBytecodeFromWorklist();
+   REPORT_BCI(bci,2);
+   b = builders[bci];
+   REPORT_VMSTATE(b,vmState);
+   b->IfCmpGreaterThan(builders[5],
+   b->   Load("result"),
+   b->   ConstInt32(5));
+   b->AddFallThroughBuilder(builders[4]);
+
+   // BCI 3
+   bci = GetNextBytecodeFromWorklist();
+   REPORT_BCI(bci,3);
+   b = builders[bci];
+   REPORT_VMSTATE(b,vmState);
+   b->IfCmpGreaterThan(builders[7],
+   b->   Load("result"),
+   b->   ConstInt32(15));
+   b->AddFallThroughBuilder(builders[6]);
+
+   // BCI 4
+   bci = GetNextBytecodeFromWorklist();
+   REPORT_BCI(bci,4);
+   b = builders[bci];
+   REPORT_VMSTATE(b,vmState);
+   b->IfCmpLessThan(builders[1], // should not revisit 1
+   b->   Load("result"),
+   b->   ConstInt32(3));
+   b->AddFallThroughBuilder(builders[9]);
+
+   // BCI 5
+   bci = GetNextBytecodeFromWorklist();
+   REPORT_BCI(bci,5);
+   b = builders[bci];
+   REPORT_VMSTATE(b,vmState);
+   b->IfCmpLessThan(builders[11],
+   b->   Load("result"),
+   b->   ConstInt32(8));
+   b->AddFallThroughBuilder(builders[17]);
+
+   // BCI 6
+   bci = GetNextBytecodeFromWorklist();
+   REPORT_BCI(bci,6);
+   b = builders[bci];
+   REPORT_VMSTATE(b,vmState);
+   b->IfCmpGreaterThan(builders[13],
+   b->   Load("result"),
+   b->   ConstInt32(12));
+   b->AddFallThroughBuilder(builders[16]);
+
+   // BCI 7
+   bci = GetNextBytecodeFromWorklist();
+   REPORT_BCI(bci,7);
+   b = builders[bci];
+   REPORT_VMSTATE(b,vmState);
+   b->IfCmpLessThan(builders[1],   // should not revisit 1
+   b->   Load("result"),
+   b->   ConstInt32(17));
+   b->AddFallThroughBuilder(builders[8]);
+
+   // BCI 8
+   bci = GetNextBytecodeFromWorklist();
+   REPORT_BCI(bci,8);
+   b = builders[bci];
+   REPORT_VMSTATE(b,vmState);
+   b->Return(
+   b->   ConstInt32(8));
+
+   // BCI 9
+   bci = GetNextBytecodeFromWorklist();
+   REPORT_BCI(bci,9);
+   b = builders[bci];
+   REPORT_VMSTATE(b,vmState);
+   b->Return(
+   b->   ConstInt32(9));
+
+   // BCI 11
+   bci = GetNextBytecodeFromWorklist();
+   REPORT_BCI(bci,11);
+   b = builders[bci];
+   REPORT_VMSTATE(b,vmState);
+   b->Return(
+   b->   ConstInt32(11));
+
+   // BCI 13
+   bci = GetNextBytecodeFromWorklist();
+   REPORT_BCI(bci,13);
+   b = builders[bci];
+   REPORT_VMSTATE(b,vmState);
+   b->Return(
+   b->   ConstInt32(13));
+
+   // BCI 16
+   bci = GetNextBytecodeFromWorklist();
+   REPORT_BCI(bci,16);
+   b = builders[bci];
+   REPORT_VMSTATE(b,vmState);
+   b->Return(
+   b->   ConstInt32(16));
+
+   // BCI 17
+   bci = GetNextBytecodeFromWorklist();
+   REPORT_BCI(bci,17);
+   b = builders[bci];
+   REPORT_VMSTATE(b,vmState);
+   b->Return(
+   b->   ConstInt32(17));
+
+   // should be no unvisited bytecodes left
+   bci = GetNextBytecodeFromWorklist();
+   REPORT_BCI(bci,-1);
+
+   return true;
+   }

--- a/jitbuilder/release/src/Worklist.hpp
+++ b/jitbuilder/release/src/Worklist.hpp
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2016
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+
+#ifndef WORKLIST_INCL
+#define WORKLIST_INCL
+
+#include "ilgen/MethodBuilder.hpp"
+
+class WorklistMethod : public TR::MethodBuilder
+   {
+   public:
+   WorklistMethod(TR::TypeDictionary *);
+   virtual bool buildIL();
+   };
+
+#endif // !defined(WORKLIST_INCL)


### PR DESCRIPTION
Add bytecode index worklist service to MethodBuilder
    
The automatic propagation of virtual machine state variables performed by BytecodeBuilders requires that the language compiler visit bytecodes in a particular order. In particular, no bytecode should be visited before at least one of its predecessors has been visited. This requirement stems from the fact that it is the creation of that flow edge from the predecessor to the bytecode that causes the vm state to propagate. If you visit a bytecode before any of its predecessors, it will almost certainly have a NULL vmState.
    
To facilitate the correct traversal of the bytecodes, I'm going to add a worklist facility to MethodBuilder, which will keep track of which bytecode indices have already been visited and which bytecode indices are ready to be visited. A pair of bit vectors serves the purpose nicely. Then, by augmenting the services in MethodBuilder and BytecodeBuilder that create control flow edges between BytecodeBuilder objects, the insertion of bytecode indices to the worklist can be done automatically.
    
The language compiler must create an initial VM state and explicitly store it to the MethodBuilder object. The first control flow edge from the MethodBuilder to the first bytecode (typically at bytecode index 0) must be created by calling AppendBuilder() on the MethodBuilder. From there, the language compiler need only iterate calling GetNextBytecodeFromWorklist() to get the next bytecode index to be processed until it returns -1. When -1 is returned, there are no remaining bytecode builders to visit. If there are any other special entry points, then the bytecode builders for those special entry points will need to be explicitly added to the worklist by passing them to addBytecodeBuilderToWorklist().
    
This commit also adds a test of the worklist, which verifies that the reachable bytecode builders and only those builders are traversed by the worklist. The method will fail to compile if the worklist does not visit exactly the right builders in exactly the expected (from lowest to highest bc index ) order.

Issue: #574

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>
