### PR TITLE
Cleanup uses of option flags

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -4780,14 +4780,11 @@ char *
 OMR::Options::setVerboseBits(char *option, void *base, TR::OptionTable *entry)
    {
    VerboseOptionFlagArray *verboseOptionFlags = (VerboseOptionFlagArray*)((char*)base+entry->parm1);
-   if (entry->parm2 != 0) // This is used for -Xjit:verbose  without any options and will set first and third bit
+   if (entry->parm2 != 0) // This is used for -Xjit:verbose without any options
       {
-      intptrj_t parm2 = entry->parm2;
-      for (int32_t i = 0; parm2; i++, parm2 >>= 1)
-         {
-         if (parm2 & 1)
-            verboseOptionFlags->set((TR_VerboseFlags)i);
-         }
+      // Since no verbose options are specified, add the default options,
+      // specified in parm2 of the options table
+      verboseOptionFlags->maskWord(0, entry->parm2);
       }
    else // This is used for -Xjit:verbose={}  construct
       {

--- a/compiler/il/OMRBlock.hpp
+++ b/compiler/il/OMRBlock.hpp
@@ -510,12 +510,6 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
       _isSpecialized                        = 0x00800000   // Block has been specialized by loop specializer
       };
 
-   enum //  flag bits for _moreflags
-      {
-      // lowest 8 bits are used for partial flags. Public declaration above.
-
-      };
-
    TR::TreeTop *                         _pEntry;
    TR::TreeTop *                         _pExit;
 


### PR DESCRIPTION
The first commit removes an empty enum that was supposed to be used for options, but has not been needed.

The second commit cleans up processing the `verbose` compiler option flag, specifically in how the default options are applied.

Issue: #539