### PR TITLE
Replace getHighGlobalRegisterNumber call with the correct test for long type

### DIFF
--- a/compiler/p/codegen/OMRRegisterDependency.cpp
+++ b/compiler/p/codegen/OMRRegisterDependency.cpp
@@ -233,7 +233,7 @@ OMR::Power::RegisterDependencyConditions::RegisterDependencyConditions(
 
       if (reg!=NULL /* && reg->getKind()==TR_GPR */)
 	 {
-	 if (child->getHighGlobalRegisterNumber() > -1)
+	 if (TR::Compiler->target.is32Bit() && child->getType().isInt64())
 	    numLongs++;
 	 }
       }
@@ -257,7 +257,7 @@ OMR::Power::RegisterDependencyConditions::RegisterDependencyConditions(
 
       TR::RealRegister::RegNum highRegNum;
 
-      if (child->getHighGlobalRegisterNumber() > -1)
+      if (TR::Compiler->target.is32Bit() && child->getType().isInt64())
          {
          highRegNum = (TR::RealRegister::RegNum)cg->getGlobalRegister(child->getHighGlobalRegisterNumber());
 
@@ -302,7 +302,7 @@ OMR::Power::RegisterDependencyConditions::RegisterDependencyConditions(
 
       TR::RealRegister::RegNum highRegNum;
 
-      if (child->getHighGlobalRegisterNumber() > -1)
+      if (TR::Compiler->target.is32Bit() && child->getType().isInt64())
          {
          highRegNum = (TR::RealRegister::RegNum)cg->getGlobalRegister(child->getHighGlobalRegisterNumber());
          TR::RegisterPair *regPair = reg->getRegisterPair();


### PR DESCRIPTION
Replace getHighGlobalRegisterNumber call with the correct test for 
long type

On 64 bit, getHighGlobalRegisterNumber returns value is undefined and 
unreliable. So we need to replace it with the correct test for long type
test. If the test succeeds, we can then safely call 
getHighGlobalRegisterNumber 

Signed-off-by: Yan Luo <Yan_Luo@ca.ibm.com>