### PR TITLE
Automatically convert untyped scratch allocators

### DIFF
--- a/compiler/cs2/allocator.h
+++ b/compiler/cs2/allocator.h
@@ -27,8 +27,9 @@
 #define CS2_ALLOCATOR_H
 
 #include <stdio.h>
-#include "cs2/cs2.h"
 #include <memory.h>
+#include "cs2/cs2.h"
+#include "env/TypedAllocator.hpp"
 
 namespace CS2 {
 
@@ -365,6 +366,11 @@ namespace CS2 {
       // no need to copy the allocator being shared
       return *this;
     }
+
+    // Enable automatic conversion into a form compatible with C++ standard library containers
+    template <typename T>
+    operator TR::typed_allocator<T, shared_allocator>() { return TR::typed_allocator<T, shared_allocator>(*this); }
+
     friend bool operator ==(const shared_allocator &left, const shared_allocator &right) { return &left.base == &right.base; }
 
     friend bool operator !=(const shared_allocator &left, const shared_allocator &right) { return !(operator ==(left, right)); }

--- a/compiler/env/Region.hpp
+++ b/compiler/env/Region.hpp
@@ -52,6 +52,12 @@ public:
       return !operator ==(lhs, rhs);
       }
 
+   // Enable automatic conversion into a form compatible with C++ standard library containers
+   template<typename T> operator TR::typed_allocator<T, Region& >()
+      {
+      return TR::typed_allocator<T, Region& >(*this);
+      }
+
 private:
    size_t round(size_t bytes);
 

--- a/compiler/env/TypedAllocator.hpp
+++ b/compiler/env/TypedAllocator.hpp
@@ -131,6 +131,7 @@ class typed_allocator : public typed_allocator<void, Alloc>
 
    private:
    typed_allocator() throw(); /* delete */
+   typed_allocator &operator =(const typed_allocator &); /* delete */
    };
 
 }


### PR DESCRIPTION
C++ standard library containers require that their allocator classes be
template specialized to allocate a single type of object.  However, the
standard types that manage the allocation of scratch (per-compile)
memory do not specialize based on the type their allocating.  This in
turn requires that developers desiring to use one of those scratch
allocators explicitly instantiate a TR::typed_allocator with the
appropriate configuration of untyped delegate allocator.

To reduce boilerplate and [hopefully] ease readability, this commit
provides conversion operators for TR::Region and CS2::shared_allocator
(used as TR::Allocator) to allow them to automatically convert to the
appropriate form of TR::typed_allocator, and consequently allow them to
be passed directly as a parameter when constructing a standard library
container.

Signed-off-by: Luc des Trois Maisons <lmaisons@ca.ibm.com>