### PR TITLE
Complete CS cycle in progress before starting STW global GC

### DIFF
--- a/gc/base/Collector.cpp
+++ b/gc/base/Collector.cpp
@@ -16,14 +16,18 @@
  *    Multiple authors (IBM Corp.) - initial implementation and documentation
  ******************************************************************************/
 
+#include "AllocateDescription.hpp"
 #include "Collector.hpp"
 #include "CollectorLanguageInterface.hpp"
 #include "GCExtensionsBase.hpp"
-#include "ModronAssertions.h"
 #include "Heap.hpp"
-#include "AllocateDescription.hpp"
-#include "OMRVMThreadListIterator.hpp"
 #include "MemorySubSpace.hpp"
+#include "ModronAssertions.h"
+#include "OMRVMThreadListIterator.hpp"
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+#include "Scavenger.hpp"
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
+
 
 class MM_MemorySubSpace;
 class MM_MemorySpace;
@@ -191,6 +195,10 @@ void
 MM_Collector::preCollect(MM_EnvironmentBase* env, MM_MemorySubSpace* subSpace, MM_AllocateDescription* allocDescription, uint32_t gcCode)
 {
 	MM_GCExtensionsBase* extensions = env->getExtensions();
+
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	completeConcurrentScavenge(env);
+#endif
 
 	/* Record the master GC thread CPU time at the start to diff later */
 	_masterThreadCpuTimeStart = omrthread_get_self_cpu_time(env->getOmrVMThread()->_os_thread);
@@ -397,3 +405,23 @@ MM_Collector::isMarked(void *objectPtr)
 	Assert_MM_unreachable();
 	return false;
 }
+
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+void
+MM_Collector::completeConcurrentScavenge(MM_EnvironmentBase *env)
+{
+	MM_GCExtensionsBase* extensions = env->getExtensions();
+
+	/* if we are about to start STW GC that is different then Scavenger (Concurrent STW phase or plain Parallel Global GC), we have to complete the Scavenger cycle first */
+	if (extensions->concurrentScavenger && (OMR_GC_CYCLE_TYPE_SCAVENGE != _cycleType) && extensions->scavenger->isConcurrentInProgress()) {
+		/* we do not have the cycle state yet, so we will build a temp one to give an idea to scavenger it's triggered from an external cycle */
+		Assert_MM_true(NULL == env->_cycleState);
+		MM_CycleState tempCycleState;
+		env->_cycleState = &tempCycleState;
+		env->_cycleState->_type = _cycleType;
+		extensions->scavenger->triggerConcurrentScavengerTransition(env, NULL);
+		env->_cycleState = NULL;
+	}
+}
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
+

--- a/gc/base/Collector.hpp
+++ b/gc/base/Collector.hpp
@@ -279,6 +279,11 @@ public:
 	virtual	void postConcurrentUpdateStatsAndReport(MM_EnvironmentBase *env, MM_ConcurrentGMPStats *stats, UDATA bytesConcurrentlyScanned) {}
 	virtual void forceConcurrentFinish() {}
 	
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	void completeConcurrentScavenge(MM_EnvironmentBase *env);
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
+	
+	
 	MM_Collector(MM_CollectorLanguageInterface *cli)
 		: MM_BaseVirtual()
 		, _exclusiveAccessCount(0)

--- a/gc/base/standard/ConcurrentGC.cpp
+++ b/gc/base/standard/ConcurrentGC.cpp
@@ -67,9 +67,6 @@
 #include "MemorySubSpaceFlat.hpp"
 #include "MemorySubSpaceSemiSpace.hpp"
 #include "ObjectModel.hpp"
-#if defined(OMR_GC_CONCURRENT_SCAVENGER)
-#include "Scavenger.hpp"
-#endif /* OMR_GC_CONCURRENT_SCAVENGER */
 #include "SpinLimiter.hpp"
 #include "SublistIterator.hpp"
 #include "SublistPuddle.hpp"
@@ -2375,23 +2372,6 @@ MM_ConcurrentGC::completeConcurrentSweepForKickoff(MM_EnvironmentStandard *env)
 }
 #endif /* OMR_GC_CONCURRENT_SWEEP */
 
-#if defined(OMR_GC_CONCURRENT_SCAVENGER)
-void
-MM_ConcurrentGC::completeConcurrentScavenge(MM_EnvironmentStandard *env)
-{
-	if (_extensions->concurrentScavenger && _extensions->scavenger->isConcurrentInProgress()) {
-		/* we do not have the cycle state yet, so we will build a temp one to give an idea to scavenger it's triggered from an external cycle */
-		Assert_MM_true(NULL == env->_cycleState);
-		MM_CycleState tempCycleState;
-		env->_cycleState = &tempCycleState;
-		env->_cycleState->_type = _cycleType;
-		_extensions->scavenger->triggerConcurrentScavengerTransition(env, NULL);
-		env->_cycleState = NULL;
-	}
-}
-#endif /* OMR_GC_CONCURRENT_SCAVENGER */
-
-
 /**
  *
  * Do some initialization work.
@@ -2921,10 +2901,6 @@ MM_ConcurrentGC::internalPreCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *
 	 */
 	completeConcurrentSweep(envStandard);
 #endif /* OMR_GC_CONCURRENT_SWEEP */
-
-#if defined(OMR_GC_CONCURRENT_SCAVENGER)
-	completeConcurrentScavenge(envStandard);
-#endif
 
 	/* Ensure caller acquired exclusive VM access before calling */
 	Assert_MM_true(env->inquireExclusiveVMAccessForGC());

--- a/gc/base/standard/ConcurrentGC.hpp
+++ b/gc/base/standard/ConcurrentGC.hpp
@@ -351,10 +351,6 @@ private:
 	void completeConcurrentSweepForKickoff(MM_EnvironmentStandard *env);
 #endif /* OMR_GC_CONCURRENT_SWEEP */
 
-#if defined(OMR_GC_CONCURRENT_SCAVENGER)
-	void completeConcurrentScavenge(MM_EnvironmentStandard *env);
-#endif /* OMR_GC_CONCURRENT_SCAVENGER */
-
 #if defined(OMR_GC_LARGE_OBJECT_AREA)		
 	void updateMeteringHistoryBeforeGC(MM_EnvironmentStandard *env);
 	void updateMeteringHistoryAfterGC(MM_EnvironmentStandard *env);


### PR DESCRIPTION
More generic solution of https://github.com/eclipse/omr/pull/579. This
one additionally covers the case of plain Parallel Global GC, rather
than more typical ConcurrentGC (STW phase of it).

An example is running Java's Gencon GC policy with Concurrent Marking
explicitly disabled.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>