### PR TITLE
Remove dead libraryHandle from compiler TestDriver

### DIFF
--- a/fvtest/compilertest/tests/TestDriver.hpp
+++ b/fvtest/compilertest/tests/TestDriver.hpp
@@ -45,15 +45,6 @@ class TestDriver
    int32_t compileMethodBuilder(TR::MethodBuilder *m, uint8_t **entry);
 
    CompileFunctionType *_compileTestMethodFunction;
-
-   private:
-
-   #ifdef MS_WINDOWS
-   HMODULE _libraryHandle;
-   #else
-   void *_libraryHandle;
-   #endif
-
    };
 
 }// namespace TestCompiler


### PR DESCRIPTION
Not clear what the intention of this was, but is no longer used anywhere
and can be safely removed.

Signed-off-by: Matthew Gaudet <magaudet@ca.ibm.com>