### PR TITLE
Correct compare between pointer and number in OMRCompilation.cpp

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -806,10 +806,14 @@ int32_t OMR::Compilation::compile()
       {
       self()->getDebug()->printHeader();
       static char *randomExercisePeriodStr = feGetEnv("TR_randomExercisePeriod");
-      if (self()->getOption(TR_Randomize) || randomExercisePeriodStr > 0)
+      if (self()->getOption(TR_Randomize) || randomExercisePeriodStr != NULL)
          traceMsg(self(), "Random seed is %d%s\n", _options->getRandomSeed(), self()->getOption(TR_RandomSeedSignatureHash)? " hashed with signature":"");
-      if (randomExercisePeriodStr > 0)
-         TR_RandomGenerator::exercise(atoi(randomExercisePeriodStr), self());
+      if (randomExercisePeriodStr != NULL)
+         {
+         auto period = atoi(randomExercisePeriodStr);
+         if (period > 0)
+            TR_RandomGenerator::exercise(period, self());
+         }
       }
 
    if (printCodegenTime) compTime.startTiming(self());


### PR DESCRIPTION
A char * pointer was being compared against 0 using >. The fix
is to correct the pointer comparison against NULL using != and
also to convert the integer value expected to be in that string
and test it for > 0.

Issue: #594 

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>