### PR TITLE
Label TRlist workaround as libc++ only

### DIFF
--- a/compiler/infra/TRlist.hpp
+++ b/compiler/infra/TRlist.hpp
@@ -29,16 +29,19 @@ namespace TR
    template <class T> class list : public std::list<T, TR::typed_allocator<T, TR::Allocator> >
       {
       public:
-         list(TR::typed_allocator<T, TR::Allocator> ta) :
+      list(TR::typed_allocator<T, TR::Allocator> ta) :
          std::list<T, TR::typed_allocator<T, TR::Allocator> > (ta)
-            {
-            }
+         {
+         }
 
-#if defined(OSX)
-         void remove(const T& value)
-            {
-            this->remove_if([value](const T& value2){return value == value2;});
-            }
+#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 4000
+      /* A bug in libc++ before 4.0 caused std::list::remove to call the
+       * default constructor of TR::typed_allocator, which is not implemented.
+       */
+      void remove(const T& value)
+         {
+         this->remove_if([value](const T& value2){return value == value2;});
+         }
 #endif
 
       };


### PR DESCRIPTION
A workaround, previously thought to be caused by OS X, was actually caused by libc++. The issue has been fixed upstream in [LLVM bug 31378](https://llvm.org/bugs/show_bug.cgi?id=31378), and will be in libc++ 4.0. This corrects the include guard and adds a comment describing the reason for the workaround.