### PR TITLE
Correct copyright messages in jitbuilder files

### DIFF
--- a/jitbuilder/Makefile
+++ b/jitbuilder/Makefile
@@ -1,3 +1,21 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 #
 # For a full explanation of the conventions used in this makefile, please
 # check out the post and FAQ on TRTalk

--- a/jitbuilder/build/files/common.mk
+++ b/jitbuilder/build/files/common.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/compile/OSRData.cpp \
     $(JIT_OMR_DIRTY_DIR)/compile/Method.cpp \

--- a/jitbuilder/build/files/host/p.mk
+++ b/jitbuilder/build/files/host/p.mk
@@ -1,3 +1,21 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/p/runtime/OMRCodeCacheConfig.cpp \
     $(JIT_PRODUCT_DIR)/p/runtime/AsmUtil.spp \

--- a/jitbuilder/build/files/host/x.mk
+++ b/jitbuilder/build/files/host/x.mk
@@ -1,3 +1,21 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_PRODUCT_DIR)/x/runtime/AsmUtil64.asm \
     $(JIT_OMR_DIRTY_DIR)/x/runtime/CPUID.asm

--- a/jitbuilder/build/files/host/z.mk
+++ b/jitbuilder/build/files/host/z.mk
@@ -1,1 +1,19 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 JIT_PRODUCT_BACKEND_SOURCES+=

--- a/jitbuilder/build/files/target/amd64.mk
+++ b/jitbuilder/build/files/target/amd64.mk
@@ -1,3 +1,21 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/x/amd64/codegen/OMRCodeGenerator.cpp \
     $(JIT_OMR_DIRTY_DIR)/x/amd64/codegen/OMRMachine.cpp \

--- a/jitbuilder/build/files/target/i386.mk
+++ b/jitbuilder/build/files/target/i386.mk
@@ -1,3 +1,21 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/x/i386/codegen/OMRCodeGenerator.cpp \
     $(JIT_OMR_DIRTY_DIR)/x/i386/codegen/OMRMachine.cpp \

--- a/jitbuilder/build/files/target/p.mk
+++ b/jitbuilder/build/files/target/p.mk
@@ -1,3 +1,21 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/p/codegen/BinaryEvaluator.cpp \
     $(JIT_OMR_DIRTY_DIR)/p/codegen/ControlFlowEvaluator.cpp \

--- a/jitbuilder/build/files/target/x.mk
+++ b/jitbuilder/build/files/target/x.mk
@@ -1,3 +1,21 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/x/codegen/BinaryCommutativeAnalyser.cpp \
     $(JIT_OMR_DIRTY_DIR)/x/codegen/BinaryEvaluator.cpp \

--- a/jitbuilder/build/files/target/z.mk
+++ b/jitbuilder/build/files/target/z.mk
@@ -1,3 +1,21 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/z/codegen/BinaryAnalyser.cpp \
     $(JIT_OMR_DIRTY_DIR)/z/codegen/BinaryCommutativeAnalyser.cpp \

--- a/jitbuilder/build/platform/common.mk
+++ b/jitbuilder/build/platform/common.mk
@@ -1,3 +1,21 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 #
 # Common file for setting platform tokens
 # Mostly just guesses the platform and includes the relevant

--- a/jitbuilder/build/platform/host/amd64-linux-gcc.mk
+++ b/jitbuilder/build/platform/host/amd64-linux-gcc.mk
@@ -1,3 +1,21 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 HOST_ARCH=x
 HOST_SUBARCH=i386
 HOST_BITS=32

--- a/jitbuilder/build/platform/host/amd64-linux64-clang.mk
+++ b/jitbuilder/build/platform/host/amd64-linux64-clang.mk
@@ -1,3 +1,21 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 HOST_ARCH=x
 HOST_SUBARCH=amd64
 HOST_BITS=64

--- a/jitbuilder/build/platform/host/amd64-linux64-gcc.mk
+++ b/jitbuilder/build/platform/host/amd64-linux64-gcc.mk
@@ -1,3 +1,21 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 HOST_ARCH=x
 HOST_SUBARCH=amd64
 HOST_BITS=64

--- a/jitbuilder/build/platform/host/amd64-osx-clang.mk
+++ b/jitbuilder/build/platform/host/amd64-osx-clang.mk
@@ -1,3 +1,21 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 HOST_ARCH=x
 HOST_SUBARCH=amd64
 HOST_BITS=64

--- a/jitbuilder/build/platform/host/ppc64-linux64-gcc.mk
+++ b/jitbuilder/build/platform/host/ppc64-linux64-gcc.mk
@@ -1,3 +1,21 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 HOST_ARCH=p
 HOST_SUBARCH=
 HOST_BITS=64

--- a/jitbuilder/build/platform/host/ppc64le-linux64-gcc.mk
+++ b/jitbuilder/build/platform/host/ppc64le-linux64-gcc.mk
@@ -1,3 +1,21 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 HOST_ARCH=p
 HOST_SUBARCH=
 HOST_BITS=64

--- a/jitbuilder/build/platform/host/s390-linux-gcc.mk
+++ b/jitbuilder/build/platform/host/s390-linux-gcc.mk
@@ -1,3 +1,21 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 HOST_ARCH=z
 HOST_SUBARCH=
 HOST_BITS=32

--- a/jitbuilder/build/platform/host/s390-linux64-gcc.mk
+++ b/jitbuilder/build/platform/host/s390-linux64-gcc.mk
@@ -1,3 +1,21 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 HOST_ARCH=z
 HOST_SUBARCH=
 HOST_BITS=64

--- a/jitbuilder/build/platform/target/all.mk
+++ b/jitbuilder/build/platform/target/all.mk
@@ -1,3 +1,21 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 #
 # If user didn't pass a target arch, assume same as host
 #

--- a/jitbuilder/build/rules/common.mk
+++ b/jitbuilder/build/rules/common.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 # Add our targets to the global targets
 all: jit jitbuilder
 clean: jit_clean

--- a/jitbuilder/build/rules/gnu/common.mk
+++ b/jitbuilder/build/rules/gnu/common.mk
@@ -1,3 +1,21 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 #
 # Defines rules for compiling source files into object files
 #

--- a/jitbuilder/build/rules/gnu/filetypes.mk
+++ b/jitbuilder/build/rules/gnu/filetypes.mk
@@ -1,4 +1,22 @@
-#
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 # These are the rules to compile files of type ".x" into object files
 # as well as to generate clean and cleandeps rules
 #

--- a/jitbuilder/build/toolcfg/common.mk
+++ b/jitbuilder/build/toolcfg/common.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 J9_VERSION?=29
 
 ifdef J9SRC

--- a/jitbuilder/build/toolcfg/gnu/common.mk
+++ b/jitbuilder/build/toolcfg/gnu/common.mk
@@ -1,3 +1,21 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 #
 # These are the prefixes and suffixes that all GNU tools use for things
 #

--- a/jitbuilder/build/toolcfg/host/32.mk
+++ b/jitbuilder/build/toolcfg/host/32.mk
@@ -1,1 +1,19 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 HOST_DEFINES+=TR_HOST_32BIT

--- a/jitbuilder/build/toolcfg/host/64.mk
+++ b/jitbuilder/build/toolcfg/host/64.mk
@@ -1,1 +1,19 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 HOST_DEFINES+=TR_HOST_64BIT BITVECTOR_64BIT

--- a/jitbuilder/build/toolcfg/host/aix.mk
+++ b/jitbuilder/build/toolcfg/host/aix.mk
@@ -1,1 +1,19 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 HOST_DEFINES+=AIX

--- a/jitbuilder/build/toolcfg/host/arm.mk
+++ b/jitbuilder/build/toolcfg/host/arm.mk
@@ -1,1 +1,19 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 HOST_DEFINES+=TR_HOST_ARM

--- a/jitbuilder/build/toolcfg/host/linux.mk
+++ b/jitbuilder/build/toolcfg/host/linux.mk
@@ -1,1 +1,19 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 HOST_DEFINES+=LINUX

--- a/jitbuilder/build/toolcfg/host/osx.mk
+++ b/jitbuilder/build/toolcfg/host/osx.mk
@@ -1,1 +1,19 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 HOST_DEFINES+=OSX

--- a/jitbuilder/build/toolcfg/host/p.mk
+++ b/jitbuilder/build/toolcfg/host/p.mk
@@ -1,1 +1,19 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 HOST_DEFINES+=TR_HOST_POWER

--- a/jitbuilder/build/toolcfg/host/win.mk
+++ b/jitbuilder/build/toolcfg/host/win.mk
@@ -1,1 +1,19 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 HOST_DEFINES+=WINDOWS

--- a/jitbuilder/build/toolcfg/host/x.mk
+++ b/jitbuilder/build/toolcfg/host/x.mk
@@ -1,1 +1,19 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 HOST_DEFINES+=TR_HOST_X86

--- a/jitbuilder/build/toolcfg/host/z.mk
+++ b/jitbuilder/build/toolcfg/host/z.mk
@@ -1,1 +1,19 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 HOST_DEFINES+=TR_HOST_S390

--- a/jitbuilder/build/toolcfg/host/zos.mk
+++ b/jitbuilder/build/toolcfg/host/zos.mk
@@ -1,1 +1,19 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 HOST_DEFINES+=ZOS

--- a/jitbuilder/build/toolcfg/target/32.mk
+++ b/jitbuilder/build/toolcfg/target/32.mk
@@ -1,1 +1,19 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 TARGET_DEFINES+=TR_TARGET_32BIT

--- a/jitbuilder/build/toolcfg/target/64.mk
+++ b/jitbuilder/build/toolcfg/target/64.mk
@@ -1,1 +1,19 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 TARGET_DEFINES+=TR_TARGET_64BIT

--- a/jitbuilder/build/toolcfg/target/arm.mk
+++ b/jitbuilder/build/toolcfg/target/arm.mk
@@ -1,1 +1,19 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 TARGET_DEFINES+=TR_TARGET_ARM

--- a/jitbuilder/build/toolcfg/target/p.mk
+++ b/jitbuilder/build/toolcfg/target/p.mk
@@ -1,1 +1,19 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 TARGET_DEFINES+=TR_TARGET_POWER

--- a/jitbuilder/build/toolcfg/target/x.mk
+++ b/jitbuilder/build/toolcfg/target/x.mk
@@ -1,1 +1,19 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 TARGET_DEFINES+=TR_TARGET_X86

--- a/jitbuilder/build/toolcfg/target/z.mk
+++ b/jitbuilder/build/toolcfg/target/z.mk
@@ -1,1 +1,19 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2016
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 TARGET_DEFINES+=TR_TARGET_S390

--- a/jitbuilder/codegen/CodeGenerator.hpp
+++ b/jitbuilder/codegen/CodeGenerator.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2016, 2016
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and

--- a/jitbuilder/codegen/JBCodeGenerator.hpp
+++ b/jitbuilder/codegen/JBCodeGenerator.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2016, 2016
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and

--- a/jitbuilder/compile/Method.cpp
+++ b/jitbuilder/compile/Method.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2014, 2016
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and

--- a/jitbuilder/compile/Method.hpp
+++ b/jitbuilder/compile/Method.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2014, 2016
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and

--- a/jitbuilder/control/Jit.cpp
+++ b/jitbuilder/control/Jit.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2014, 2016
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and

--- a/jitbuilder/env/ConcreteFE.hpp
+++ b/jitbuilder/env/ConcreteFE.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2014, 2016
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and

--- a/jitbuilder/env/JBObjectModel.hpp
+++ b/jitbuilder/env/JBObjectModel.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2014, 2016
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and

--- a/jitbuilder/env/ObjectModel.hpp
+++ b/jitbuilder/env/ObjectModel.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2014, 2016
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and

--- a/jitbuilder/ilgen/IlGeneratorMethodDetails.hpp
+++ b/jitbuilder/ilgen/IlGeneratorMethodDetails.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2014, 2016
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and

--- a/jitbuilder/ilgen/JBIlGeneratorMethodDetails.cpp
+++ b/jitbuilder/ilgen/JBIlGeneratorMethodDetails.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2014, 2016
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and

--- a/jitbuilder/ilgen/JBIlGeneratorMethodDetails.hpp
+++ b/jitbuilder/ilgen/JBIlGeneratorMethodDetails.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2014, 2016
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and

--- a/jitbuilder/optimizer/JBOptimizer.hpp
+++ b/jitbuilder/optimizer/JBOptimizer.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2014, 2016
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and

--- a/jitbuilder/optimizer/Optimizer.hpp
+++ b/jitbuilder/optimizer/Optimizer.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2014, 2016
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and

--- a/jitbuilder/p/codegen/Evaluator.cpp
+++ b/jitbuilder/p/codegen/Evaluator.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2014, 2016
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and

--- a/jitbuilder/runtime/CodeCacheManager.hpp
+++ b/jitbuilder/runtime/CodeCacheManager.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2014, 2016
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and

--- a/jitbuilder/runtime/JBJitConfig.hpp
+++ b/jitbuilder/runtime/JBJitConfig.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2014, 2016
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and

--- a/jitbuilder/runtime/StackAtlasPOD.hpp
+++ b/jitbuilder/runtime/StackAtlasPOD.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2014, 2016
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and

--- a/jitbuilder/z/codegen/JBCodeGenerator.cpp
+++ b/jitbuilder/z/codegen/JBCodeGenerator.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2014, 2016
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and

--- a/jitbuilder/z/codegen/JBCodeGenerator.hpp
+++ b/jitbuilder/z/codegen/JBCodeGenerator.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2014, 2016
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and


### PR DESCRIPTION
Add missing copyright / license headers to files in the jitbuilder
directory (particularly underneath its build directory) and update
several incorrect copyright dates based on the origins of the files
in the jitbuilder directory.

Issue: #575

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>