### PR TITLE
Resolve issue where the operand stack commits to the wrong address

### DIFF
--- a/compiler/ilgen/VirtualMachineOperandStack.cpp
+++ b/compiler/ilgen/VirtualMachineOperandStack.cpp
@@ -56,7 +56,8 @@ VirtualMachineOperandStack::VirtualMachineOperandStack(OMR::VirtualMachineOperan
    _stackMax(other->_stackMax),
    _stackTop(other->_stackTop),
    _elementType(other->_elementType),
-   _pushAmount(other->_pushAmount)
+   _pushAmount(other->_pushAmount),
+   _stackOffset(other->_stackOffset)
    {
    int32_t numBytes = _stackMax * sizeof(TR::IlValue *);
    _stack = (TR::IlValue **) TR::comp()->trMemory()->allocateHeapMemory(numBytes);


### PR DESCRIPTION
When the VirtualMachineOperandStack *copy* constructor is invoked it
does not copy the _stackOffset variable.  This causes commits to the
actual stack to happen at the incorrect location. The solution is to
copy the value of _stackOffset to the new VirtualMachineOperandStack

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>