### PR TITLE
Support for aborted Concurrent Scavenger during root processing

### DIFF
--- a/gc/base/MemorySubSpaceSemiSpace.hpp
+++ b/gc/base/MemorySubSpaceSemiSpace.hpp
@@ -116,10 +116,12 @@ public:
 	uintptr_t getMaxSpaceForObjectInEvacuateMemory(omrobjectptr_t objectPtr);
 
 	void masterSetupForGC(MM_EnvironmentBase *envBase);
+	void masterTeardownForSuccessfulGC(MM_EnvironmentBase* env);
+	void masterTeardownForAbortedGC(MM_EnvironmentBase *env);
+
 	void poisonEvacuateSpace();
 
-	void rebuildFreeListForEvacuate(MM_EnvironmentBase* env);
-	void rebuildFreeListForBackout(MM_EnvironmentBase *env);
+	void cacheRanges(MM_MemorySubSpace *subSpace, void **base, void **top);
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	virtual void payAllocationTax(MM_EnvironmentBase *env, MM_MemorySubSpace *baseSubSpace, MM_AllocateDescription *allocDescription);


### PR DESCRIPTION
If aborted Scavenge occurs during root processing (rare, but still
possible if a very large object is directly referenced from the roots)
proceed with the rest of the steps in the cycle while still in STW. Currently,
we would resume the app and concurrent scavenge operation, which is
dangerous since not all roots might not properly updated.
The code  changes are contained with CS specific state machine. 

We will now be able to report all the necessary events, and it will be
as clear in verbose gc that aborted cycle occurred, is if it were the
more common case (during main scan phase).

Also, piggybacking some general (not only CS specific) cleanup in
Scavenger - SemiSpace interaction relevant to the cycle
setup/teardown/abort.