### PR TITLE
Move TR_*Linkage into TR namespace

### DIFF
--- a/compiler/arm/codegen/ARMDebug.cpp
+++ b/compiler/arm/codegen/ARMDebug.cpp
@@ -1112,7 +1112,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARMCallSnippet * snippet)
    printSnippetLabel(pOutFile, snippet->getSnippetLabel(), bufferPos, getName(snippet), getName(methodSymRef));
 
    TR::Machine *machine = _cg->machine();
-   const TR_ARMLinkageProperties &linkage = _cg->getLinkage(methodSymbol->getLinkageConvention())->getProperties();
+   const TR::ARMLinkageProperties &linkage = _cg->getLinkage(methodSymbol->getLinkageConvention())->getProperties();
 
    uint32_t numIntArgs   = 0;
    uint32_t numFloatArgs = 0;
@@ -1387,7 +1387,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARMStackCheckFailureSnippet * snippet)
    bool saveLR = (_cg->getSnippetList().size() <= 1 &&
                   !bodySymbol->isEHAware()                     &&
                   !_cg->machine()->getLinkRegisterKilled()) ? true : false;
-   const TR_ARMLinkageProperties &linkage = _cg->getLinkage()->getProperties();
+   const TR::ARMLinkageProperties &linkage = _cg->getLinkage()->getProperties();
    uint32_t frameSize = _cg->getFrameSizeInBytes();
    int32_t offset = linkage.getOffsetToFirstLocal();
    uint32_t base, rotate;

--- a/compiler/arm/codegen/ARMSystemLinkage.cpp
+++ b/compiler/arm/codegen/ARMSystemLinkage.cpp
@@ -34,7 +34,7 @@
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
 
-TR_ARMLinkageProperties TR_ARMSystemLinkage::properties =
+TR::ARMLinkageProperties TR::ARMSystemLinkage::properties =
     {                           // TR_System
     IntegersInRegisters|        // linkage properties
 #if defined(__VFP_FP__) && !defined(__SOFTFP__)
@@ -163,7 +163,7 @@ TR_ARMLinkageProperties TR_ARMSystemLinkage::properties =
 #endif
     };
 
-void TR_ARMSystemLinkage::initARMRealRegisterLinkage()
+void TR::ARMSystemLinkage::initARMRealRegisterLinkage()
    {
 #if 0
    // Each real register's weight is set to match this linkage convention
@@ -194,17 +194,17 @@ void TR_ARMSystemLinkage::initARMRealRegisterLinkage()
 #endif
    }
 
-uint32_t TR_ARMSystemLinkage::getRightToLeft()
+uint32_t TR::ARMSystemLinkage::getRightToLeft()
    {
    return getProperties().getRightToLeft();
    }
 
-void TR_ARMSystemLinkage::mapStack(TR::ResolvedMethodSymbol *method)
+void TR::ARMSystemLinkage::mapStack(TR::ResolvedMethodSymbol *method)
    {
 #if 0
    ListIterator<TR::AutomaticSymbol>  automaticIterator(&method->getAutomaticList());
    TR::AutomaticSymbol               *localCursor       = automaticIterator.getFirst();
-   const TR_ARMLinkageProperties&    linkage           = getProperties();
+   const TR::ARMLinkageProperties&    linkage           = getProperties();
    TR_ARMCodeGenerator              *codeGen           = cg();
    TR_ARMMachine                    *machine           = codeGen->getARMMachine();
    uint32_t                          stackIndex;
@@ -300,7 +300,7 @@ void TR_ARMSystemLinkage::mapStack(TR::ResolvedMethodSymbol *method)
 #endif
    }
 
-void TR_ARMSystemLinkage::mapSingleAutomatic(TR::AutomaticSymbol *p, uint32_t &stackIndex)
+void TR::ARMSystemLinkage::mapSingleAutomatic(TR::AutomaticSymbol *p, uint32_t &stackIndex)
    {
 #if 0
    p->setOffset(stackIndex);
@@ -317,26 +317,26 @@ void TR_ARMSystemLinkage::mapSingleAutomatic(TR::AutomaticSymbol *p, uint32_t &s
 #endif
    }
 
-TR_ARMLinkageProperties& TR_ARMSystemLinkage::getProperties()
+TR::ARMLinkageProperties& TR::ARMSystemLinkage::getProperties()
    {
    return properties;
    }
 
-void TR_ARMSystemLinkage::createPrologue(TR::Instruction *cursor)
+void TR::ARMSystemLinkage::createPrologue(TR::Instruction *cursor)
    {
    TR_ASSERT(0, "unimplemented");
    }
 
-void TR_ARMSystemLinkage::createEpilogue(TR::Instruction *cursor)
+void TR::ARMSystemLinkage::createEpilogue(TR::Instruction *cursor)
    {
    TR_ASSERT(0, "unimplemented");
    }
 
-TR::MemoryReference *TR_ARMSystemLinkage::getOutgoingArgumentMemRef(int32_t               totalSize,
+TR::MemoryReference *TR::ARMSystemLinkage::getOutgoingArgumentMemRef(int32_t               totalSize,
                                                                       int32_t               offset,
                                                                       TR::Register          *argReg,
                                                                       TR_ARMOpCodes         opCode,
-                                                                      TR_ARMMemoryArgument &memArg)
+                                                                      TR::ARMMemoryArgument &memArg)
    {
    int32_t                spOffset = offset - (getProperties().getNumIntArgRegs() * TR::Compiler->om.sizeofReferenceAddress());
    TR::RealRegister    *sp       = cg()->machine()->getARMRealRegister(properties.getStackPointerRegister());
@@ -349,7 +349,7 @@ TR::MemoryReference *TR_ARMSystemLinkage::getOutgoingArgumentMemRef(int32_t     
    return result;
    }
 
-int32_t TR_ARMSystemLinkage::buildArgs(TR::Node                            *callNode,
+int32_t TR::ARMSystemLinkage::buildArgs(TR::Node                            *callNode,
                                        TR::RegisterDependencyConditions *dependencies,
                                        TR::Register*                       &vftReg,
                                        bool                                isJNI)
@@ -357,12 +357,12 @@ int32_t TR_ARMSystemLinkage::buildArgs(TR::Node                            *call
    return buildARMLinkageArgs(callNode, dependencies, vftReg, TR_System, isJNI);
    }
 
-TR::Register *TR_ARMSystemLinkage::buildDirectDispatch(TR::Node *callNode)
+TR::Register *TR::ARMSystemLinkage::buildDirectDispatch(TR::Node *callNode)
    {
    return buildARMLinkageDirectDispatch(callNode, true);
    }
 
-TR::Register *TR_ARMSystemLinkage::buildIndirectDispatch(TR::Node *callNode)
+TR::Register *TR::ARMSystemLinkage::buildIndirectDispatch(TR::Node *callNode)
    {
    TR_ASSERT(0, "unimplemented");
    return NULL;

--- a/compiler/arm/codegen/ARMSystemLinkage.hpp
+++ b/compiler/arm/codegen/ARMSystemLinkage.hpp
@@ -17,7 +17,7 @@
  *******************************************************************************/
 
 #ifndef ARM_SYSTEMLINKAGE_INCL
-#define ARM_SYSTEmLINKAGE_INCL
+#define ARM_SYSTEMLINKAGE_INCL
 
 #include "codegen/Linkage.hpp"
 
@@ -32,13 +32,15 @@ namespace TR { class Register; }
 namespace TR { class RegisterDependencyConditions; }
 namespace TR { class ResolvedMethodSymbol; }
 
-class TR_ARMSystemLinkage : public TR::Linkage
+namespace TR {
+
+class ARMSystemLinkage : public TR::Linkage
    {
-   static TR_ARMLinkageProperties properties;
+   static TR::ARMLinkageProperties properties;
 
    public:
 
-   TR_ARMSystemLinkage(TR::CodeGenerator *codeGen) : TR::Linkage(codeGen) {}
+   ARMSystemLinkage(TR::CodeGenerator *codeGen) : TR::Linkage(codeGen) {}
 
    virtual uint32_t getRightToLeft();
    virtual void mapStack(TR::ResolvedMethodSymbol *method);
@@ -49,9 +51,9 @@ class TR_ARMSystemLinkage : public TR::Linkage
                                                             int32_t               argOffset,
                                                             TR::Register          *argReg,
                                                             TR_ARMOpCodes         opCode,
-                                                            TR_ARMMemoryArgument &memArg);
+                                                            TR::ARMMemoryArgument &memArg);
 
-   virtual TR_ARMLinkageProperties& getProperties();
+   virtual TR::ARMLinkageProperties& getProperties();
 
    virtual void createPrologue(TR::Instruction *cursor);
    virtual void createEpilogue(TR::Instruction *cursor);
@@ -64,5 +66,7 @@ class TR_ARMSystemLinkage : public TR::Linkage
    virtual TR::Register *buildDirectDispatch(TR::Node *callNode);
    virtual TR::Register *buildIndirectDispatch(TR::Node *callNode);
    };
+
+}
 
 #endif

--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -57,23 +57,23 @@ TR::Linkage *OMR::ARM::CodeGenerator::createLinkage(TR_LinkageConventions lc)
    switch (lc)
       {
 //    case TR_InterpretedStatic:
-//       linkage = new (self()->trHeapMemory()) TR_ARMInterpretedStaticLinkage(this);
+//       linkage = new (self()->trHeapMemory()) TR::ARMInterpretedStaticLinkage(this);
 //       break;
       case TR_Private:
-         linkage = new (self()->trHeapMemory()) TR_ARMPrivateLinkage(self());
+         linkage = new (self()->trHeapMemory()) TR::ARMPrivateLinkage(self());
          break;
       case TR_System:
-         linkage = new (self()->trHeapMemory()) TR_ARMSystemLinkage(self());
+         linkage = new (self()->trHeapMemory()) TR::ARMSystemLinkage(self());
          break;
 //    case TR_AllRegister:
-//       linkage = new (self()->trHeapMemory()) TR_ARMAllRegisterLinkage(this);
+//       linkage = new (self()->trHeapMemory()) TR::ARMAllRegisterLinkage(this);
 //       break;
       case TR_Helper:
-         linkage = new (self()->trHeapMemory()) TR_ARMHelperLinkage(self());
+         linkage = new (self()->trHeapMemory()) TR::ARMHelperLinkage(self());
          break;
       default :
          TR_ASSERT(0, "using system linkage for unrecognized convention %d\n", lc);
-         linkage = new (self()->trHeapMemory()) TR_ARMSystemLinkage(self());
+         linkage = new (self()->trHeapMemory()) TR::ARMSystemLinkage(self());
       }
    self()->setLinkage(lc, linkage);
    return linkage;
@@ -215,7 +215,7 @@ OMR::ARM::CodeGenerator::CodeGenerator()
      }
 
    // Initialize linkage reg arrays
-   TR_ARMLinkageProperties linkageProperties = self()->getProperties();
+   TR::ARMLinkageProperties linkageProperties = self()->getProperties();
    for (i=0; i < linkageProperties.getNumIntArgRegs(); i++)
      _gprLinkageGlobalRegisterNumbers[i] = globalRegNumbers[linkageProperties.getIntegerArgumentRegister(i)];
    for (i=0; i < linkageProperties.getNumFloatArgRegs(); i++)

--- a/compiler/arm/codegen/OMRCodeGenerator.hpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.hpp
@@ -83,7 +83,7 @@ uint32_t encodeHelperBranch(bool isBranchAndLink, TR::SymbolReference *symRef, u
 class TR_BackingStore;
 namespace TR { class Machine; }
 namespace TR { class CodeGenerator; }
-struct TR_ARMLinkageProperties;
+namespace TR { struct ARMLinkageProperties; }
 namespace TR { class ARMImmInstruction; }
 class TR_ARMOpCode;
 namespace TR { class ARMConstantDataSnippet; }
@@ -144,7 +144,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    TR::Register *gprClobberEvaluate(TR::Node *node);
 
-   const TR_ARMLinkageProperties &getProperties() { return *_linkageProperties; }
+   const TR::ARMLinkageProperties &getProperties() { return *_linkageProperties; }
 
    RegisterAssignmentDirection getAssignmentDirection() {return _assignmentDirection;}
    RegisterAssignmentDirection setAssignmentDirection(RegisterAssignmentDirection d)
@@ -229,7 +229,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    TR::RealRegister            *_methodMetaDataRegister;
    TR::ARMImmInstruction          *_returnTypeInfoInstruction;
    TR::ARMConstantDataSnippet       *_constantData;
-   TR_ARMLinkageProperties   *_linkageProperties;
+   TR::ARMLinkageProperties   *_linkageProperties;
    List<TR_ARMOutOfLineCodeSection> _outOfLineCodeSectionList;
    // Internal Control Flow Depth Counters
    int32_t                          _internalControlFlowNestingDepth;

--- a/compiler/arm/codegen/OMRLinkage.cpp
+++ b/compiler/arm/codegen/OMRLinkage.cpp
@@ -81,7 +81,7 @@ TR::Instruction *OMR::ARM::Linkage::saveArguments(TR::Instruction *cursor)
    TR::ResolvedMethodSymbol   *bodySymbol = codeGen->comp()->getJittedMethodSymbol();
    TR::Node                 *firstNode  = codeGen->comp()->getStartTree()->getNode();
 
-   const TR_ARMLinkageProperties& properties = self()->getProperties();
+   const TR::ARMLinkageProperties& properties = self()->getProperties();
 
    ListIterator<TR::ParameterSymbol> paramIterator(&(bodySymbol->getParameterList()));
    TR::ParameterSymbol *paramCursor = paramIterator.getFirst();
@@ -152,7 +152,7 @@ TR::Instruction *OMR::ARM::Linkage::loadUpArguments(TR::Instruction *cursor)
    ListIterator<TR::ParameterSymbol>   paramIterator(&(bodySymbol->getParameterList()));
    TR::ParameterSymbol      *paramCursor = paramIterator.getFirst();
    uint32_t                 numIntArgs = 0;
-   const TR_ARMLinkageProperties& properties = self()->getProperties();
+   const TR::ARMLinkageProperties& properties = self()->getProperties();
 
    while (paramCursor != NULL && numIntArgs < properties.getNumIntArgRegs())
       {
@@ -215,7 +215,7 @@ TR::Instruction *OMR::ARM::Linkage::flushArguments(TR::Instruction *cursor)
    ListIterator<TR::ParameterSymbol>   paramIterator(&(bodySymbol->getParameterList()));
    TR::ParameterSymbol      *paramCursor = paramIterator.getFirst();
    uint32_t                 numIntArgs = 0;
-   const TR_ARMLinkageProperties& properties = self()->getProperties();
+   const TR::ARMLinkageProperties& properties = self()->getProperties();
 
    while (paramCursor != NULL && numIntArgs < properties.getNumIntArgRegs())
       {
@@ -483,10 +483,10 @@ int32_t OMR::ARM::Linkage::buildARMLinkageArgs(TR::Node                         
                                            TR_LinkageConventions               conventions,
                                            bool                                isVirtualOrJNI)
    {
-   const TR_ARMLinkageProperties &properties = self()->getProperties();
+   const TR::ARMLinkageProperties &properties = self()->getProperties();
    TR::Compilation *comp = TR::comp();
    TR::CodeGenerator  *codeGen      = self()->cg();
-   TR_ARMMemoryArgument *pushToMemory = NULL;
+   TR::ARMMemoryArgument *pushToMemory = NULL;
    void                 *stackMark;
 
    bool isHelper  = (conventions == TR_Helper);
@@ -627,7 +627,7 @@ printf("%s: numIntegerArgs %d numMemArgs %d\n", sig,  numIntegerArgs, numMemArgs
    TR::StackMemoryRegion stackMemoryRegion(*self()->trMemory());
    if (numMemArgs > 0)
       {
-      pushToMemory = new(self()->trStackMemory()) TR_ARMMemoryArgument[numMemArgs];
+      pushToMemory = new(self()->trStackMemory()) TR::ARMMemoryArgument[numMemArgs];
       }
 
    if (specialArgReg)
@@ -1015,7 +1015,7 @@ TR::Register *OMR::ARM::Linkage::buildARMLinkageDirectDispatch(TR::Node *callNod
    TR::MethodSymbol     *callSymbol = callSymRef->getSymbol()->castToMethodSymbol();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(self()->comp()->fe());
 
-   const TR_ARMLinkageProperties &pp = self()->getProperties();
+   const TR::ARMLinkageProperties &pp = self()->getProperties();
    TR::RegisterDependencyConditions *dependencies =
       new (self()->trHeapMemory()) TR::RegisterDependencyConditions(pp.getNumberOfDependencyGPRegisters() + 8 /*pp.getNumFloatArgRegs()*/,
                                              pp.getNumberOfDependencyGPRegisters() + 8 /*pp.getNumFloatArgRegs()*/, self()->trMemory());
@@ -1125,4 +1125,4 @@ TR::Register *OMR::ARM::Linkage::buildARMLinkageDirectDispatch(TR::Node *callNod
    return(returnRegister);
    }
 
-bool TR_ARMLinkageProperties::_isBigEndian;
+bool TR::ARMLinkageProperties::_isBigEndian;

--- a/compiler/arm/codegen/OMRLinkage.hpp
+++ b/compiler/arm/codegen/OMRLinkage.hpp
@@ -39,18 +39,6 @@ namespace OMR { typedef OMR::ARM::Linkage LinkageConnector; }
 namespace TR { class CodeGenerator; }
 namespace TR { class Register; }
 
-class TR_ARMMemoryArgument
-   {
-   public:
-   TR_ALLOC(TR_Memory::ARMMemoryArgument)
-
-   TR::Register           *argRegister;
-   TR::MemoryReference *argMemory;
-   TR_ARMOpCodes          opCode;
-
-//   void *operator new[](size_t s, int flag) {return jitStackAlloc(s);}
-   };
-
 static inline void addDependency(TR::RegisterDependencyConditions *dep,
                           TR::Register *vreg,
                           TR::RealRegister ::RegNum rnum,
@@ -62,6 +50,20 @@ static inline void addDependency(TR::RegisterDependencyConditions *dep,
    dep->addPreCondition(vreg, rnum);
    dep->addPostCondition(vreg, rnum);
    }
+
+namespace TR {
+
+class ARMMemoryArgument
+   {
+   public:
+   TR_ALLOC(TR_Memory::ARMMemoryArgument)
+
+   TR::Register           *argRegister;
+   TR::MemoryReference *argMemory;
+   TR_ARMOpCodes          opCode;
+
+//   void *operator new[](size_t s, int flag) {return jitStackAlloc(s);}
+   };
 
 // linkage properties
 #define CallerCleanup       0x01
@@ -78,7 +80,7 @@ static inline void addDependency(TR::RegisterDependencyConditions *dep,
 #define FloatArgument               0x10
 #define CallerAllocatesBackingStore 0x20
 
-struct TR_ARMLinkageProperties
+struct ARMLinkageProperties
    {
    uint32_t                                _properties;
    uint32_t                                _registerFlags[TR::RealRegister::NumRegisters];
@@ -277,6 +279,8 @@ struct TR_ARMLinkageProperties
 
    };
 
+}
+
 namespace OMR
 {
 namespace ARM
@@ -296,7 +300,7 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
                                                             int32_t               argOffset,
                                                             TR::Register          *argReg,
                                                             TR_ARMOpCodes         opCode,
-                                                            TR_ARMMemoryArgument &memArg) = 0;
+                                                            TR::ARMMemoryArgument &memArg) = 0;
    virtual TR::Instruction *saveArguments(TR::Instruction *cursor);
    virtual TR::Instruction *flushArguments(TR::Instruction *cursor);
    virtual TR::Instruction *loadUpArguments(TR::Instruction *cursor);
@@ -309,7 +313,7 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
    TR::Register *pushFloatArg(TR::Node *child);
    TR::Register *pushDoubleArg(TR::Node *child);
 
-   virtual TR_ARMLinkageProperties& getProperties() = 0;
+   virtual TR::ARMLinkageProperties& getProperties() = 0;
 
    virtual int32_t numArgumentRegisters(TR_RegisterKinds kind);
 

--- a/compiler/arm/codegen/StackCheckFailureSnippet.cpp
+++ b/compiler/arm/codegen/StackCheckFailureSnippet.cpp
@@ -78,7 +78,7 @@ uint8_t *TR::ARMStackCheckFailureSnippet::emitSnippetBody()
    // then the prologue must have already loaded it into R11; otherwise,
    // the snippet needs to load the number into R11.
    //
-   const TR_ARMLinkageProperties &linkage = cg()->getLinkage()->getProperties();
+   const TR::ARMLinkageProperties &linkage = cg()->getLinkage()->getProperties();
    uint32_t frameSize = cg()->getFrameSizeInBytes();
    int32_t offset = linkage.getOffsetToFirstLocal();
    uint32_t base, rotate;
@@ -157,7 +157,7 @@ uint32_t TR::ARMStackCheckFailureSnippet::getLength(int32_t estimatedSnippetStar
    int32_t length = 20; // mov/sub, add, bl, sub, b
    uint32_t base, rotate;
    uint32_t frameSize = cg()->getFrameSizeInBytes();
-//   const TR_ARMLinkageProperties &linkage = cg()->getLinkage()->getProperties();
+//   const TR::ARMLinkageProperties &linkage = cg()->getLinkage()->getProperties();
 //   uint32_t offset = linkage.getOffsetToFirstLocal();
    if (!constantIsImmed8r(frameSize, &base, &rotate)) /* &&
        (constantIsImmed8r(frameSize-offset, &base, &rotate) ||

--- a/compiler/codegen/OMRLinkage.cpp
+++ b/compiler/codegen/OMRLinkage.cpp
@@ -33,7 +33,7 @@ OMR::Linkage::hasToBeOnStack(TR::ParameterSymbol *parm)
    {
    // The "this" pointer of synchronized and JVMPI methods must be on the stack.
    // TODO: The PPC implementation is superior, but it uses
-   // interfaces currently only supported by TR_PPCPrivateLinkage.  The first
+   // interfaces currently only supported by TR::PPCPrivateLinkage.  The first
    // order of business: currently, every platform's Linkage can access the
    // Compilation and/or CodeGenerator, but the common one can't.  This
    // prevents us from checking that the current method is synchronized and so

--- a/compiler/compile/OMRMethod.hpp
+++ b/compiler/compile/OMRMethod.hpp
@@ -37,7 +37,7 @@ class TR_GlobalRegisterAllocator;
 class TR_InlinerBase;
 class TR_OpaqueClassBlock;
 class TR_ResolvedMethod;
-class TR_S390SystemLinkage;
+namespace TR { class S390SystemLinkage; }
 class TR_Value;
 namespace TR { class CodeGenerator; }
 namespace TR { class Compilation; }

--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -805,7 +805,7 @@ TR::Register *OMR::Power::TreeEvaluator::ireturnEvaluator(TR::Node *node, TR::Co
    {
    TR::Compilation *comp = cg->comp();
    TR::Register *returnRegister = cg->evaluate(node->getFirstChild());
-   const TR_PPCLinkageProperties &linkageProperties = cg->getProperties();
+   const TR::PPCLinkageProperties &linkageProperties = cg->getProperties();
    TR::RealRegister::RegNum machineReturnRegister =
                 linkageProperties.getIntegerReturnRegister();
    TR::RegisterDependencyConditions *dependencies = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(1, 0, cg->trMemory());
@@ -820,7 +820,7 @@ TR::Register *OMR::Power::TreeEvaluator::ireturnEvaluator(TR::Node *node, TR::Co
 TR::Register *OMR::Power::TreeEvaluator::lreturnEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Register *returnRegister = cg->evaluate(node->getFirstChild());
-   const TR_PPCLinkageProperties &linkageProperties = cg->getProperties();
+   const TR::PPCLinkageProperties &linkageProperties = cg->getProperties();
    TR::RegisterDependencyConditions *dependencies;
    if (TR::Compiler->target.is64Bit())
       {

--- a/compiler/p/codegen/FPTreeEvaluator.cpp
+++ b/compiler/p/codegen/FPTreeEvaluator.cpp
@@ -994,7 +994,7 @@ TR::Register *OMR::Power::TreeEvaluator::freturnEvaluator(TR::Node *node, TR::Co
    {
    bool isDouble = node->getOpCodeValue() == TR::dreturn;
    TR::Register *returnRegister = cg->evaluate(node->getFirstChild());
-   const TR_PPCLinkageProperties &linkageProperties = cg->getProperties();
+   const TR::PPCLinkageProperties &linkageProperties = cg->getProperties();
    TR::RealRegister::RegNum machineReturnRegister =
                 linkageProperties.getFloatReturnRegister();
    TR::RegisterDependencyConditions *dependencies = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(1, 0, cg->trMemory());
@@ -2507,7 +2507,7 @@ TR::Register *OMR::Power::TreeEvaluator::dsqrtEvaluator(TR::Node *node, TR::Code
 
 TR::Register *OMR::Power::TreeEvaluator::getstackEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   const TR_PPCLinkageProperties &properties = cg->getProperties();
+   const TR::PPCLinkageProperties &properties = cg->getProperties();
 
    TR::Register *spReg = cg->machine()->getPPCRealRegister(properties.getNormalStackPointerRegister());
    TR::Register *trgReg = cg->allocateRegister();
@@ -2522,7 +2522,7 @@ TR::Register *OMR::Power::TreeEvaluator::deallocaEvaluator(TR::Node *node, TR::C
    {
    TR::Node * firstChild = node->getFirstChild();
    TR::Register *srcReg = cg->evaluate(firstChild);
-   const TR_PPCLinkageProperties &properties = cg->getProperties();
+   const TR::PPCLinkageProperties &properties = cg->getProperties();
 
    // TODO: restore stack chain
    TR::Register *spReg = cg->machine()->getPPCRealRegister(properties.getNormalStackPointerRegister());

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -361,7 +361,7 @@ OMR::Power::CodeGenerator::CodeGenerator() :
      }
 
    // Initialize linkage reg arrays
-   TR_PPCLinkageProperties linkageProperties = self()->getProperties();
+   TR::PPCLinkageProperties linkageProperties = self()->getProperties();
    for (i=0; i < linkageProperties.getNumIntArgRegs(); i++)
      _gprLinkageGlobalRegisterNumbers[i] = globalRegNumbers[linkageProperties.getIntegerArgumentRegister(i)];
    for (i=0; i < linkageProperties.getNumFloatArgRegs(); i++)
@@ -1962,11 +1962,11 @@ OMR::Power::CodeGenerator::createLinkage(TR_LinkageConventions lc)
    switch (lc)
       {
       case TR_System:
-         linkage = new (self()->trHeapMemory()) TR_PPCSystemLinkage(self());
+         linkage = new (self()->trHeapMemory()) TR::PPCSystemLinkage(self());
          break;
 
       default:
-         linkage = new (self()->trHeapMemory()) TR_PPCSystemLinkage(self());
+         linkage = new (self()->trHeapMemory()) TR::PPCSystemLinkage(self());
       }
 
    self()->setLinkage(lc, linkage);

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -57,7 +57,7 @@ namespace TR { class CodeGenerator; }
 namespace TR { class ConstantDataSnippet; }
 namespace TR { class PPCImmInstruction; }
 namespace TR { class Snippet; }
-struct TR_PPCLinkageProperties;
+namespace TR { struct PPCLinkageProperties; }
 
 extern TR::Instruction *loadAddressConstantInSnippet(TR::CodeGenerator *cg,
                                     TR::Node        *node,
@@ -213,7 +213,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    // different from evaluateNode in that it returns a clobberable register
    TR::Register *gprClobberEvaluate(TR::Node *node);
 
-   const TR_PPCLinkageProperties &getProperties() { return *_linkageProperties; }
+   const TR::PPCLinkageProperties &getProperties() { return *_linkageProperties; }
 
    RegisterAssignmentDirection getAssignmentDirection() {return _assignmentDirection;}
    RegisterAssignmentDirection setAssignmentDirection(RegisterAssignmentDirection d)
@@ -561,7 +561,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    TR::RealRegister              *_tocBaseRegister;
    TR::PPCImmInstruction            *_returnTypeInfoInstruction;
    TR::ConstantDataSnippet       *_constantData;
-   const TR_PPCLinkageProperties   *_linkageProperties;
+   const TR::PPCLinkageProperties   *_linkageProperties;
    TR_BitVector                    *_blockCallInfo;
    TR_Array<TR::SymbolReference *>  *_trackStatics;
    TR_Array<TR_PPCLoadLabelItem *> *_trackItems;

--- a/compiler/p/codegen/OMRLinkage.cpp
+++ b/compiler/p/codegen/OMRLinkage.cpp
@@ -78,10 +78,10 @@ bool OMR::Power::Linkage::hasToBeOnStack(TR::ParameterSymbol *parm)
    return(false);
    }
 
-TR::MemoryReference *OMR::Power::Linkage::getOutgoingArgumentMemRef(int32_t argSize, TR::Register *argReg, TR::InstOpCode::Mnemonic opCode, TR_PPCMemoryArgument &memArg, uint32_t length)
+TR::MemoryReference *OMR::Power::Linkage::getOutgoingArgumentMemRef(int32_t argSize, TR::Register *argReg, TR::InstOpCode::Mnemonic opCode, TR::PPCMemoryArgument &memArg, uint32_t length)
    {
    TR::Machine *machine = self()->cg()->machine();
-   const TR_PPCLinkageProperties& properties = self()->getProperties();
+   const TR::PPCLinkageProperties& properties = self()->getProperties();
 
    TR::MemoryReference *result = new (self()->trHeapMemory()) TR::MemoryReference(machine->getPPCRealRegister(properties.getNormalStackPointerRegister()),
                                                                               argSize+properties.getOffsetToFirstParm(), length, self()->cg());
@@ -105,7 +105,7 @@ TR::Instruction *OMR::Power::Linkage::saveArguments(TR::Instruction *cursor, boo
    {
    #define  REAL_REGISTER(ri)  machine->getPPCRealRegister(ri)
    #define  REGNUM(ri)         ((TR::RealRegister::RegNum)(ri))
-   const TR_PPCLinkageProperties& properties = self()->getProperties();
+   const TR::PPCLinkageProperties& properties = self()->getProperties();
    TR::Machine *machine = self()->cg()->machine();
    TR::RealRegister      *stackPtr   = self()->cg()->getStackPointerRegister();
    TR::ResolvedMethodSymbol    *bodySymbol = self()->comp()->getJittedMethodSymbol();
@@ -495,7 +495,7 @@ TR::Instruction *OMR::Power::Linkage::loadUpArguments(TR::Instruction *cursor)
    TR::ParameterSymbol      *paramCursor = paramIterator.getFirst();
    TR::Node                 *firstNode = self()->comp()->getStartTree()->getNode();
    int32_t                  numIntArgs = 0, numFloatArgs = 0;
-   const TR_PPCLinkageProperties& properties = self()->getProperties();
+   const TR::PPCLinkageProperties& properties = self()->getProperties();
 
    while ( (paramCursor!=NULL) &&
            ( (numIntArgs < properties.getNumIntArgRegs()) ||
@@ -589,7 +589,7 @@ TR::Instruction *OMR::Power::Linkage::flushArguments(TR::Instruction *cursor)
    TR::ParameterSymbol      *paramCursor = paramIterator.getFirst();
    TR::Node                 *firstNode = self()->comp()->getStartTree()->getNode();
    int32_t                  numIntArgs = 0, numFloatArgs = 0;
-   const TR_PPCLinkageProperties& properties = self()->getProperties();
+   const TR::PPCLinkageProperties& properties = self()->getProperties();
 
    while ( (paramCursor!=NULL) &&
            ( (numIntArgs < properties.getNumIntArgRegs()) ||

--- a/compiler/p/codegen/OMRLinkage.hpp
+++ b/compiler/p/codegen/OMRLinkage.hpp
@@ -51,16 +51,6 @@ namespace TR { class ParameterSymbol; }
 namespace TR { class ResolvedMethodSymbol; }
 template <class T> class List;
 
-class TR_PPCMemoryArgument
-   {
-   public:
-   TR_ALLOC(TR_Memory::PPCMemoryArgument)
-
-   TR::Register           *argRegister;
-   TR::MemoryReference *argMemory;
-   TR::InstOpCode::Mnemonic          opCode;
-   };
-
 inline void
 addDependency(
       TR::RegisterDependencyConditions *dep,
@@ -79,6 +69,18 @@ addDependency(
    dep->addPostCondition(vreg, rnum);
    }
 
+namespace TR {
+
+class PPCMemoryArgument
+   {
+   public:
+   TR_ALLOC(TR_Memory::PPCMemoryArgument)
+
+   TR::Register           *argRegister;
+   TR::MemoryReference *argMemory;
+   TR::InstOpCode::Mnemonic          opCode;
+   };
+
 
 // linkage properties
 #define CallerCleanup       0x01
@@ -96,7 +98,7 @@ addDependency(
 #define CallerAllocatesBackingStore 0x20
 #define PPC_Reserved                0x40
 
-struct TR_PPCLinkageProperties
+struct PPCLinkageProperties
    {
    uint32_t _properties;
    uint32_t _registerFlags[TR::RealRegister::NumRegisters];
@@ -366,6 +368,7 @@ struct TR_PPCLinkageProperties
    uint32_t getNumberOfDependencyGPRegisters() const {return _numberOfDependencyGPRegisters;}
    };
 
+}
 
 namespace OMR
 {
@@ -383,7 +386,7 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
    virtual void mapStack(TR::ResolvedMethodSymbol *method);
    virtual void mapSingleAutomatic(TR::AutomaticSymbol *p, uint32_t &stackIndex);
    virtual void initPPCRealRegisterLinkage();
-   virtual TR::MemoryReference *getOutgoingArgumentMemRef(int32_t argSize, TR::Register *argReg, TR::InstOpCode::Mnemonic opCode, TR_PPCMemoryArgument &memArg, uint32_t len);
+   virtual TR::MemoryReference *getOutgoingArgumentMemRef(int32_t argSize, TR::Register *argReg, TR::InstOpCode::Mnemonic opCode, TR::PPCMemoryArgument &memArg, uint32_t len);
    virtual TR::Instruction *saveArguments(TR::Instruction *cursor, bool fsd=false, bool saveOnly=false);
    virtual TR::Instruction *saveArguments(TR::Instruction *cursor, bool fsd, bool saveOnly, List<TR::ParameterSymbol> &parmList);
    virtual TR::Instruction *loadUpArguments(TR::Instruction *cursor);
@@ -401,7 +404,7 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
 
    TR::Register *pushDoubleArg(TR::Node *child);
 
-   virtual const TR_PPCLinkageProperties& getProperties() = 0;
+   virtual const TR::PPCLinkageProperties& getProperties() = 0;
 
    virtual int32_t numArgumentRegisters(TR_RegisterKinds kind);
 

--- a/compiler/p/codegen/OMRMachine.cpp
+++ b/compiler/p/codegen/OMRMachine.cpp
@@ -135,7 +135,7 @@ void OMR::Power::Machine::initREGAssociations()
    int icount;
    int nextV = 0;
    int lastFPRv, lastVRFv;
-   const TR_PPCLinkageProperties &linkage = _cg->getProperties();
+   const TR::PPCLinkageProperties &linkage = _cg->getProperties();
 
    // We assume the volatile/preserved registers to be consecutive
    // because the private linkage will either be a single volatile set or

--- a/compiler/p/codegen/OMRRegisterDependency.cpp
+++ b/compiler/p/codegen/OMRRegisterDependency.cpp
@@ -96,7 +96,7 @@ TR::RegisterDependencyConditions* TR_PPCScratchRegisterDependencyConditions::cre
       dependencies->addPostCondition(post->_ccrDeps[i].getRegister(), post->_ccrDeps[i].getRealRegister(), post->_ccrDeps[i].getFlags());
       }
 
-   const TR_PPCLinkageProperties& properties = cg->getLinkage()->getProperties();
+   const TR::PPCLinkageProperties& properties = cg->getLinkage()->getProperties();
    if (liveVSXVectorReg)
       {
       for (int32_t i=TR::RealRegister::FirstVSR; i<=TR::RealRegister::LastVSR; i++)

--- a/compiler/p/codegen/PPCSystemLinkage.cpp
+++ b/compiler/p/codegen/PPCSystemLinkage.cpp
@@ -65,7 +65,7 @@
 uint32_t
 mappedOffsetToFirstLocal(
       TR::CodeGenerator *cg,
-      const TR_PPCLinkageProperties &linkage)
+      const TR::PPCLinkageProperties &linkage)
    {
    TR::Machine *machine = cg->machine();
 
@@ -80,7 +80,7 @@ mappedOffsetToFirstLocal(
    }
 
 
-TR_PPCSystemLinkage::TR_PPCSystemLinkage(TR::CodeGenerator *cg)
+TR::PPCSystemLinkage::PPCSystemLinkage(TR::CodeGenerator *cg)
    : TR::Linkage(cg)
    {
    int i = 0;
@@ -354,15 +354,15 @@ TR_PPCSystemLinkage::TR_PPCSystemLinkage(TR::CodeGenerator *cg)
    }
 
 
-const TR_PPCLinkageProperties&
-TR_PPCSystemLinkage::getProperties()
+const TR::PPCLinkageProperties&
+TR::PPCSystemLinkage::getProperties()
    {
    return _properties;
    }
 
 
 void
-TR_PPCSystemLinkage::initPPCRealRegisterLinkage()
+TR::PPCSystemLinkage::initPPCRealRegisterLinkage()
    {
    // *this    swipeable for debugging purposes
    // Each real register's weight is set to match this linkage convention
@@ -419,7 +419,7 @@ TR_PPCSystemLinkage::initPPCRealRegisterLinkage()
 
 
 uint32_t
-TR_PPCSystemLinkage::getRightToLeft()
+TR::PPCSystemLinkage::getRightToLeft()
    {
    // *this    swipeable for debugging purposes
    return getProperties().getRightToLeft();
@@ -427,14 +427,14 @@ TR_PPCSystemLinkage::getRightToLeft()
 
 
 bool
-TR_PPCSystemLinkage::hasToBeOnStack(TR::ParameterSymbol *parm)
+TR::PPCSystemLinkage::hasToBeOnStack(TR::ParameterSymbol *parm)
    {
    return(parm->getAllocatedIndex()>=0  && parm->isParmHasToBeOnStack());
    }
 
 
 uintptr_t
-TR_PPCSystemLinkage::calculateActualParameterOffset(
+TR::PPCSystemLinkage::calculateActualParameterOffset(
       uintptr_t o,
       TR::ParameterSymbol& p)
    {
@@ -455,7 +455,7 @@ TR_PPCSystemLinkage::calculateActualParameterOffset(
    }
 
 
-uintptr_t TR_PPCSystemLinkage::calculateParameterRegisterOffset(uintptr_t o, TR::ParameterSymbol& p)
+uintptr_t TR::PPCSystemLinkage::calculateParameterRegisterOffset(uintptr_t o, TR::ParameterSymbol& p)
    {
    TR::ResolvedMethodSymbol    * bodySymbol = comp()->getJittedMethodSymbol();
    if (1 || (p.getDataType() == TR::Aggregate) || (p.getSize() >= sizeof(uint64_t)))
@@ -474,7 +474,7 @@ uintptr_t TR_PPCSystemLinkage::calculateParameterRegisterOffset(uintptr_t o, TR:
 
 
 void
-TR_PPCSystemLinkage::mapParameters(
+TR::PPCSystemLinkage::mapParameters(
       TR::ResolvedMethodSymbol *method,
       List<TR::ParameterSymbol> &parmList)
    {
@@ -482,7 +482,7 @@ TR_PPCSystemLinkage::mapParameters(
    uint32_t   stackIndex = method->getLocalMappingCursor();
    ListIterator<TR::ParameterSymbol> parameterIterator(&parmList);
    TR::ParameterSymbol              *parmCursor = parameterIterator.getFirst();
-   const TR_PPCLinkageProperties&    linkage           = getProperties();
+   const TR::PPCLinkageProperties&    linkage           = getProperties();
    int32_t                          offsetToFirstParm = linkage.getOffsetToFirstParm();
    int32_t offset_from_top = 0;
    int32_t slot_size = sizeof(uintptrj_t);
@@ -527,12 +527,12 @@ TR_PPCSystemLinkage::mapParameters(
 
 
 void
-TR_PPCSystemLinkage::mapStack(TR::ResolvedMethodSymbol *method)
+TR::PPCSystemLinkage::mapStack(TR::ResolvedMethodSymbol *method)
    {
    // *this    swipeable for debugging purposes
    ListIterator<TR::AutomaticSymbol> automaticIterator(&method->getAutomaticList());
    TR::AutomaticSymbol *localCursor = automaticIterator.getFirst();
-   const TR_PPCLinkageProperties& linkage = getProperties();
+   const TR::PPCLinkageProperties& linkage = getProperties();
    TR::Machine *machine = cg()->machine();
    uint32_t stackIndex;
    int32_t lowGCOffset;
@@ -596,7 +596,7 @@ TR_PPCSystemLinkage::mapStack(TR::ResolvedMethodSymbol *method)
 
 
 void
-TR_PPCSystemLinkage::mapSingleAutomatic(
+TR::PPCSystemLinkage::mapSingleAutomatic(
       TR::AutomaticSymbol *p,
       uint32_t &stackIndex)
    {
@@ -622,20 +622,20 @@ TR_PPCSystemLinkage::mapSingleAutomatic(
 
 
 void
-TR_PPCSystemLinkage::createPrologue(TR::Instruction *cursor)
+TR::PPCSystemLinkage::createPrologue(TR::Instruction *cursor)
    {
    createPrologue(cursor, comp()->getJittedMethodSymbol()->getParameterList());
    }
 
 
 void
-TR_PPCSystemLinkage::createPrologue(
+TR::PPCSystemLinkage::createPrologue(
       TR::Instruction *cursor,
       List<TR::ParameterSymbol> &parmList)
    {
    // *this    swipeable for debugging purposes
    TR::Machine *machine = cg()->machine();
-   const TR_PPCLinkageProperties &properties = getProperties();
+   const TR::PPCLinkageProperties &properties = getProperties();
    TR::ResolvedMethodSymbol        *bodySymbol = comp()->getJittedMethodSymbol();
    // Stack Pointer Register may currently be set to "alternate"
    cg()->setStackPointerRegister(machine->getPPCRealRegister(properties.getNormalStackPointerRegister()));
@@ -757,12 +757,12 @@ TR_PPCSystemLinkage::createPrologue(
 
 
 void
-TR_PPCSystemLinkage::createEpilogue(TR::Instruction *cursor)
+TR::PPCSystemLinkage::createEpilogue(TR::Instruction *cursor)
    {
    // *this    swipeable for debugging purposes
    int32_t blockNumber = cursor->getNext()->getBlockIndex();
    TR::Machine *machine = cg()->machine();
-   const TR_PPCLinkageProperties &properties = getProperties();
+   const TR::PPCLinkageProperties &properties = getProperties();
    TR::ResolvedMethodSymbol *bodySymbol = comp()->getJittedMethodSymbol();
    TR::RealRegister *sp = cg()->getStackPointerRegister();
    TR::RealRegister *sp2 = sp;
@@ -851,13 +851,13 @@ TR_PPCSystemLinkage::createEpilogue(TR::Instruction *cursor)
 
    }
 
-int32_t TR_PPCSystemLinkage::buildArgs(TR::Node *callNode,
+int32_t TR::PPCSystemLinkage::buildArgs(TR::Node *callNode,
                                        TR::RegisterDependencyConditions *dependencies)
 
    {
    // *this    swipeable for debugging purposes
-   const TR_PPCLinkageProperties &properties = getProperties();
-   TR_PPCMemoryArgument *pushToMemory = NULL;
+   const TR::PPCLinkageProperties &properties = getProperties();
+   TR::PPCMemoryArgument *pushToMemory = NULL;
    TR::Register       *tempRegister;
    int32_t   argIndex = 0, memArgs = 0, i;
    int32_t   argSize = 0;
@@ -979,7 +979,7 @@ int32_t TR_PPCSystemLinkage::buildArgs(TR::Node *callNode,
    /* End result of Step 1 - determined number of memory arguments! */
    if (memArgs > 0)
       {
-      pushToMemory = new (trStackMemory()) TR_PPCMemoryArgument[memArgs];
+      pushToMemory = new (trStackMemory()) TR::PPCMemoryArgument[memArgs];
       }
 
    numIntegerArgs = 0;
@@ -1428,10 +1428,10 @@ int32_t TR_PPCSystemLinkage::buildArgs(TR::Node *callNode,
    return argSize;
    }
 
-void TR_PPCSystemLinkage::buildDirectCall(TR::Node *callNode,
+void TR::PPCSystemLinkage::buildDirectCall(TR::Node *callNode,
                                            TR::SymbolReference *callSymRef,
                                            TR::RegisterDependencyConditions *dependencies,
-                                           const TR_PPCLinkageProperties &pp,
+                                           const TR::PPCLinkageProperties &pp,
                                            int32_t argSize)
    {
    TR::Instruction             *gcPoint;
@@ -1467,11 +1467,11 @@ void TR_PPCSystemLinkage::buildDirectCall(TR::Node *callNode,
    }
 
 
-TR::Register *TR_PPCSystemLinkage::buildDirectDispatch(TR::Node *callNode)
+TR::Register *TR::PPCSystemLinkage::buildDirectDispatch(TR::Node *callNode)
    {
    TR::SymbolReference *callSymRef = callNode->getSymbolReference();
 
-   const TR_PPCLinkageProperties &pp = getProperties();
+   const TR::PPCLinkageProperties &pp = getProperties();
    TR::RegisterDependencyConditions *dependencies =
       new (trHeapMemory()) TR::RegisterDependencyConditions(
          pp.getNumberOfDependencyGPRegisters(),
@@ -1535,7 +1535,7 @@ TR::Register *TR_PPCSystemLinkage::buildDirectDispatch(TR::Node *callNode)
    }
 
 
-void TR_PPCSystemLinkage::buildVirtualDispatch(TR::Node                            *callNode,
+void TR::PPCSystemLinkage::buildVirtualDispatch(TR::Node                            *callNode,
                                                TR::RegisterDependencyConditions *dependencies,
                                                uint32_t                            sizeOfArguments)
    {
@@ -1554,10 +1554,10 @@ void TR_PPCSystemLinkage::buildVirtualDispatch(TR::Node                         
    //Ensure we set dependencies on the following registers when building the arguments to the call.
    //Result register
    TR::Register        *gr3=dependencies->searchPreConditionRegister(TR::RealRegister::gr3);
-   TR_ASSERT((gr3 != NULL), "TR_PPCSystemLinkage::buildVirtualDispatch no dependence set on return register gr3.");
+   TR_ASSERT((gr3 != NULL), "TR::PPCSystemLinkage::buildVirtualDispatch no dependence set on return register gr3.");
 #endif
 
-   const TR_PPCLinkageProperties &properties = getProperties();
+   const TR::PPCLinkageProperties &properties = getProperties();
 
    //Scratch register.
    TR::Register        *gr0=dependencies->searchPreConditionRegister(TR::RealRegister::gr0);
@@ -1566,9 +1566,9 @@ void TR_PPCSystemLinkage::buildVirtualDispatch(TR::Node                         
    //Native Stack Pointer (C Stack)
    TR::RealRegister *grSysStackReg=cg()->machine()->getPPCRealRegister(properties.getNormalStackPointerRegister());
 
-   TR_ASSERT((gr0 != NULL),            "TR_PPCSystemLinkage::buildVirtualDispatch no dependence set on scratch register gr0.");
-   TR_ASSERT((grTOCReg != NULL),       "TR_PPCSystemLinkage::buildVirtualDispatch no dependence set on Library TOC register gr2.");
-   TR_ASSERT((grSysStackReg != NULL),  "TR_PPCSystemLinkage::buildVirtualDispatch no dependence set on Native C Stack register gr1.");
+   TR_ASSERT((gr0 != NULL),            "TR::PPCSystemLinkage::buildVirtualDispatch no dependence set on scratch register gr0.");
+   TR_ASSERT((grTOCReg != NULL),       "TR::PPCSystemLinkage::buildVirtualDispatch no dependence set on Library TOC register gr2.");
+   TR_ASSERT((grSysStackReg != NULL),  "TR::PPCSystemLinkage::buildVirtualDispatch no dependence set on Native C Stack register gr1.");
 
    cg()->evaluate(callNode->getChild(0));
    cg()->decReferenceCount(callNode->getChild(0));
@@ -1602,9 +1602,9 @@ void TR_PPCSystemLinkage::buildVirtualDispatch(TR::Node                         
    }
 
 
-TR::Register *TR_PPCSystemLinkage::buildIndirectDispatch(TR::Node *callNode)
+TR::Register *TR::PPCSystemLinkage::buildIndirectDispatch(TR::Node *callNode)
    {
-   const TR_PPCLinkageProperties &pp = getProperties();
+   const TR::PPCLinkageProperties &pp = getProperties();
    TR::RegisterDependencyConditions *dependencies =
       new (trHeapMemory()) TR::RegisterDependencyConditions(
          pp.getNumberOfDependencyGPRegisters(),
@@ -1665,18 +1665,18 @@ TR::Register *TR_PPCSystemLinkage::buildIndirectDispatch(TR::Node *callNode)
    return(returnRegister);
    }
 
-void TR_PPCSystemLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol *method)
+void TR::PPCSystemLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol *method)
    {
    setParameterLinkageRegisterIndex(method, method->getParameterList());
    }
 
-void TR_PPCSystemLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol *method, List<TR::ParameterSymbol> &parmList)
+void TR::PPCSystemLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol *method, List<TR::ParameterSymbol> &parmList)
    {
    // *this    swipeable for debugging purposes
    ListIterator<TR::ParameterSymbol>   paramIterator(&parmList);
    TR::ParameterSymbol      *paramCursor = paramIterator.getFirst();
    int32_t                  numIntArgs = 0, numFloatArgs = 0;
-   const TR_PPCLinkageProperties& properties = getProperties();
+   const TR::PPCLinkageProperties& properties = getProperties();
 
    while ( (paramCursor!=NULL) &&
            ( (numIntArgs < properties.getNumIntArgRegs()) ||

--- a/compiler/p/codegen/PPCSystemLinkage.hpp
+++ b/compiler/p/codegen/PPCSystemLinkage.hpp
@@ -34,17 +34,19 @@ namespace TR { class ResolvedMethodSymbol; }
 namespace TR { class SymbolReference; }
 template <class T> class List;
 
-class TR_PPCSystemLinkage : public TR::Linkage
+namespace TR {
+
+class PPCSystemLinkage : public TR::Linkage
    {
    protected:
 
-   TR_PPCLinkageProperties _properties;
+   TR::PPCLinkageProperties _properties;
 
    public:
 
-   TR_PPCSystemLinkage(TR::CodeGenerator *cg);
+   PPCSystemLinkage(TR::CodeGenerator *cg);
 
-   virtual const TR_PPCLinkageProperties& getProperties();
+   virtual const TR::PPCLinkageProperties& getProperties();
    virtual uintptr_t calculateActualParameterOffset(uintptr_t, TR::ParameterSymbol&);
    virtual uintptr_t calculateParameterRegisterOffset(uintptr_t, TR::ParameterSymbol&);
 
@@ -72,7 +74,7 @@ class TR_PPCSystemLinkage : public TR::Linkage
          TR::Node *callNode,
          TR::SymbolReference *callSymRef,
          TR::RegisterDependencyConditions *dependencies,
-         const TR_PPCLinkageProperties &pp,
+         const TR::PPCLinkageProperties &pp,
          int32_t argSize);
 
    virtual TR::Register *buildDirectDispatch(TR::Node *callNode);
@@ -83,5 +85,7 @@ class TR_PPCSystemLinkage : public TR::Linkage
    virtual void setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol *method, List<TR::ParameterSymbol> &parmList);
    virtual void mapParameters(TR::ResolvedMethodSymbol *method, List<TR::ParameterSymbol> &parmList);
    };
+
+}
 
 #endif

--- a/compiler/x/amd64/codegen/AMD64FPConversionSnippet.cpp
+++ b/compiler/x/amd64/codegen/AMD64FPConversionSnippet.cpp
@@ -61,7 +61,7 @@ uint8_t *TR::AMD64FPConversionSnippet::genFPConversion(uint8_t *buffer)
    TR::RealRegister          *targetRegister  = toRealRegister(_convertInstruction->getTargetRegister());
    TR::RealRegister::RegNum   targetReg       = targetRegister->getRegisterNumber();
    TR::Machine               *machine         = cg()->machine();
-   const TR_X86LinkageProperties &properties = cg()->getProperties();
+   const TR::X86LinkageProperties &properties = cg()->getProperties();
 
    uint8_t *originalBuffer = buffer;
 

--- a/compiler/x/amd64/codegen/AMD64SystemLinkage.cpp
+++ b/compiler/x/amd64/codegen/AMD64SystemLinkage.cpp
@@ -68,8 +68,8 @@ enum
    };
 
 
-TR_AMD64Win64FastCallLinkage::TR_AMD64Win64FastCallLinkage(TR::CodeGenerator *cg)
-   : TR_AMD64SystemLinkage(cg)
+TR::AMD64Win64FastCallLinkage::AMD64Win64FastCallLinkage(TR::CodeGenerator *cg)
+   : TR::AMD64SystemLinkage(cg)
    {
    uint8_t r, p;
 
@@ -263,8 +263,8 @@ TR_AMD64Win64FastCallLinkage::TR_AMD64Win64FastCallLinkage(TR::CodeGenerator *cg
    }
 
 
-TR_AMD64ABILinkage::TR_AMD64ABILinkage(TR::CodeGenerator *cg)
-   : TR_AMD64SystemLinkage(cg)
+TR::AMD64ABILinkage::AMD64ABILinkage(TR::CodeGenerator *cg)
+   : TR::AMD64SystemLinkage(cg)
    {
    uint8_t r, p;
 
@@ -456,7 +456,7 @@ TR_AMD64ABILinkage::TR_AMD64ABILinkage(TR::CodeGenerator *cg)
 
 
 TR::Register *
-TR_AMD64SystemLinkage::buildVolatileAndReturnDependencies(
+TR::AMD64SystemLinkage::buildVolatileAndReturnDependencies(
       TR::Node *callNode,
       TR::RegisterDependencyConditions *deps)
    {
@@ -604,7 +604,7 @@ TR_AMD64SystemLinkage::buildVolatileAndReturnDependencies(
 
 // Build arguments for system linkage dispatch.
 //
-int32_t TR_AMD64SystemLinkage::buildArgs(
+int32_t TR::AMD64SystemLinkage::buildArgs(
       TR::Node *callNode,
       TR::RegisterDependencyConditions *deps)
    {
@@ -620,7 +620,7 @@ int32_t TR_AMD64SystemLinkage::buildArgs(
             numFloatArgs = 0;
    int32_t first, last, direction;
    int32_t numCopiedRegs = 0;
-   TR::Register *copiedRegs[TR_X86LinkageProperties::MaxArgumentRegisters];
+   TR::Register *copiedRegs[TR::X86LinkageProperties::MaxArgumentRegisters];
 
    if (getProperties().passArgsRightToLeft())
       {
@@ -649,18 +649,18 @@ int32_t TR_AMD64SystemLinkage::buildArgs(
    int32_t i;
    for (i = first; i != last; i += direction)
       {
-      parmLayoutResult layoutResult;
+      TR::parmLayoutResult layoutResult;
       TR::RealRegister::RegNum rregIndex = noReg;
       TR::Node *child = callNode->getChild(i);
 
       layoutParm(child, sizeOfOutGoingArgs, numIntArgs, numFloatArgs, layoutResult);
 
-      if (layoutResult.abstract & parmLayoutResult::IN_LINKAGE_REG_PAIR)
+      if (layoutResult.abstract & TR::parmLayoutResult::IN_LINKAGE_REG_PAIR)
          {
          // TODO: AMD64 SysV ABI might put a struct into a pair of linkage registerr
          TR_ASSERT(false, "haven't support linkage_reg_pair yet.\n");
          }
-      else if (layoutResult.abstract & parmLayoutResult::IN_LINKAGE_REG)
+      else if (layoutResult.abstract & TR::parmLayoutResult::IN_LINKAGE_REG)
          {
          TR_RegisterKinds regKind = layoutResult.regs[0].regKind;
          uint32_t regIndex = layoutResult.regs[0].regIndex;
@@ -721,7 +721,7 @@ int32_t TR_AMD64SystemLinkage::buildArgs(
 
 
 TR::Register *
-TR_AMD64SystemLinkage::buildIndirectDispatch(TR::Node *callNode)
+TR::AMD64SystemLinkage::buildIndirectDispatch(TR::Node *callNode)
    {
    TR::SymbolReference *methodSymRef = callNode->getSymbolReference();
    TR_ASSERT(methodSymRef->getSymbol()->castToMethodSymbol()->isComputed(), "system linkage only supports computed indirect call for now %p\n", callNode);
@@ -780,7 +780,7 @@ TR_AMD64SystemLinkage::buildIndirectDispatch(TR::Node *callNode)
    }
 
 
-TR::Register *TR_AMD64SystemLinkage::buildDirectDispatch(
+TR::Register *TR::AMD64SystemLinkage::buildDirectDispatch(
       TR::Node *callNode,
       bool spillFPRegs)
    {
@@ -905,7 +905,7 @@ TR::Register *TR_AMD64SystemLinkage::buildDirectDispatch(
 static const TR::RealRegister::RegNum NOT_ASSIGNED = (TR::RealRegister::RegNum)-1;
 
 uint32_t
-TR_AMD64SystemLinkage::getAlignment(TR::DataType type)
+TR::AMD64SystemLinkage::getAlignment(TR::DataType type)
    {
    switch(type)
       {
@@ -932,7 +932,7 @@ TR_AMD64SystemLinkage::getAlignment(TR::DataType type)
 
 
 void
-TR_AMD64ABILinkage::mapIncomingParms(
+TR::AMD64ABILinkage::mapIncomingParms(
       TR::ResolvedMethodSymbol *method,
       uint32_t &stackIndex)
    {
@@ -948,7 +948,7 @@ TR_AMD64ABILinkage::mapIncomingParms(
 
    // 1st: handle parameters which are passed through stack
    //
-   TR_X86SystemLinkage::mapIncomingParms(method);
+   TR::X86SystemLinkage::mapIncomingParms(method);
 
    // 2nd: handle parameters which are passed through linkage registers, but are
    // not assigned any register after RA (or say, by their first usage point,
@@ -985,11 +985,11 @@ TR_AMD64ABILinkage::mapIncomingParms(
 
 
 bool
-TR_AMD64SystemLinkage::layoutTypeInRegs(
+TR::AMD64SystemLinkage::layoutTypeInRegs(
       TR::DataType type,
       uint16_t &intArgs,
       uint16_t &floatArgs,
-      parmLayoutResult &layoutResult)
+      TR::parmLayoutResult &layoutResult)
    {
    int oldIntArgs = intArgs, oldFloatArgs = floatArgs;
 
@@ -1041,22 +1041,22 @@ FAIL_TO_LAYOUT_IN_REGS:
 
 
 int32_t
-TR_AMD64SystemLinkage::layoutParm(
+TR::AMD64SystemLinkage::layoutParm(
       TR::Node *parmNode,
       int32_t &dataCursor,
       uint16_t &intReg,
       uint16_t &floatReg,
-      parmLayoutResult &layoutResult)
+      TR::parmLayoutResult &layoutResult)
    {
    //AMD64 SysV ABI:  if the size of an object is larger than four eightbytes, or it contains unaligned fields, it has class MEMORY.
    if (parmNode->getSize() > 4*AMD64_STACK_SLOT_SIZE) goto LAYOUT_ON_STACK;
 
    if (layoutTypeInRegs(parmNode->getDataType(), intReg, floatReg, layoutResult))
       {
-      layoutResult.abstract |= parmLayoutResult::IN_LINKAGE_REG;
+      layoutResult.abstract |= TR::parmLayoutResult::IN_LINKAGE_REG;
 
       if (parmNode->getSize() > GPR_REG_WIDTH)
-         layoutResult.abstract |= parmLayoutResult::IN_LINKAGE_REG_PAIR;
+         layoutResult.abstract |= TR::parmLayoutResult::IN_LINKAGE_REG_PAIR;
 
       if (comp()->getOption(TR_TraceCG))
          traceMsg(comp(), "layout param node %p in register\n", parmNode);
@@ -1066,7 +1066,7 @@ TR_AMD64SystemLinkage::layoutParm(
       }
 
 LAYOUT_ON_STACK:
-   layoutResult.abstract |= parmLayoutResult::ON_STACK;
+   layoutResult.abstract |= TR::parmLayoutResult::ON_STACK;
    int32_t align = layoutTypeOnStack(parmNode->getDataType(), dataCursor, layoutResult);
    if (comp()->getOption(TR_TraceCG))
       traceMsg(comp(), "layout param node %p on stack\n", parmNode);
@@ -1076,22 +1076,22 @@ LAYOUT_ON_STACK:
 
 // TODO: Try to combine the 2 layoutParm functions.
 int32_t
-TR_AMD64SystemLinkage::layoutParm(
+TR::AMD64SystemLinkage::layoutParm(
       TR::ParameterSymbol *parmSymbol,
       int32_t &dataCursor,
       uint16_t &intReg,
       uint16_t &floatReg,
-      parmLayoutResult &layoutResult)
+      TR::parmLayoutResult &layoutResult)
    {
    //AMD64 SysV ABI:  if the size of an object is larger than four eightbytes, or it contains unaligned fields, it has class MEMORY.
    if (parmSymbol->getSize() > 4*AMD64_STACK_SLOT_SIZE) goto LAYOUT_ON_STACK;
 
    if (layoutTypeInRegs(parmSymbol->getDataType(), intReg, floatReg, layoutResult))
       {
-      layoutResult.abstract |= parmLayoutResult::IN_LINKAGE_REG;
+      layoutResult.abstract |= TR::parmLayoutResult::IN_LINKAGE_REG;
 
       if (parmSymbol->getSize() > GPR_REG_WIDTH)
-         layoutResult.abstract |= parmLayoutResult::IN_LINKAGE_REG_PAIR;
+         layoutResult.abstract |= TR::parmLayoutResult::IN_LINKAGE_REG_PAIR;
 
       if (comp()->getOption(TR_TraceCG))
          traceMsg(comp(), "layout param symbol %p in register\n", parmSymbol);
@@ -1101,7 +1101,7 @@ TR_AMD64SystemLinkage::layoutParm(
       }
 
 LAYOUT_ON_STACK:
-   layoutResult.abstract |= parmLayoutResult::ON_STACK;
+   layoutResult.abstract |= TR::parmLayoutResult::ON_STACK;
    int32_t align = layoutTypeOnStack(parmSymbol->getDataType(), dataCursor, layoutResult);
    if (comp()->getOption(TR_TraceCG))
       traceMsg(comp(), "layout param symbol %p on stack\n", parmSymbol);
@@ -1110,9 +1110,9 @@ LAYOUT_ON_STACK:
 
 
 void
-TR_AMD64SystemLinkage::setUpStackSizeForCallNode(TR::Node* node)
+TR::AMD64SystemLinkage::setUpStackSizeForCallNode(TR::Node* node)
    {
-   const TR_X86LinkageProperties     &properties = getProperties();
+   const TR::X86LinkageProperties     &properties = getProperties();
    uint16_t intReg = 0, floatReg = 0;
    // AMD64 SysV ABI: The end of the input argument area shall be aligned on a 16 (32, if __m256 is passed on stack) byte boundary. In other words, the value (%rsp + 8) is always a multiple of 16 (32) when control is transferred to the function entry point.
    int32_t alignment = AMD64_DEFAULT_STACK_ALIGNMENT;
@@ -1123,7 +1123,7 @@ TR_AMD64SystemLinkage::setUpStackSizeForCallNode(TR::Node* node)
 
    for (int32_t i= node->getFirstArgumentIndex(); i<node->getNumChildren(); ++i)
       {
-      parmLayoutResult fakeParm;
+      TR::parmLayoutResult fakeParm;
       TR::Node *parmNode = node->getChild(i);
       int32_t parmAlign = layoutParm(parmNode, sizeOfOutGoingArgs, intReg, floatReg, fakeParm);
       if (parmAlign == 32)

--- a/compiler/x/amd64/codegen/AMD64SystemLinkage.hpp
+++ b/compiler/x/amd64/codegen/AMD64SystemLinkage.hpp
@@ -31,7 +31,9 @@ namespace TR { class ParameterSymbol; }
 namespace TR { class RegisterDependencyConditions; }
 namespace TR { class ResolvedMethodSymbol; }
 
-class TR_AMD64SystemLinkage : public TR_X86SystemLinkage
+namespace TR {
+
+class AMD64SystemLinkage : public TR::X86SystemLinkage
    {
    public:
 
@@ -39,10 +41,10 @@ class TR_AMD64SystemLinkage : public TR_X86SystemLinkage
    virtual void setUpStackSizeForCallNode(TR::Node* node);
 
    protected:
-   TR_AMD64SystemLinkage(TR::CodeGenerator *cg) : TR_X86SystemLinkage(cg) {}
+   AMD64SystemLinkage(TR::CodeGenerator *cg) : TR::X86SystemLinkage(cg) {}
 
-   virtual int32_t layoutParm(TR::Node *parmNode, int32_t &dataCursor, uint16_t &intReg, uint16_t &floatReg, parmLayoutResult &layoutResult);
-   virtual int32_t layoutParm(TR::ParameterSymbol *paramSymbol, int32_t &dataCursor, uint16_t &intReg, uint16_t &floatRrgs, parmLayoutResult&);
+   virtual int32_t layoutParm(TR::Node *parmNode, int32_t &dataCursor, uint16_t &intReg, uint16_t &floatReg, TR::parmLayoutResult &layoutResult);
+   virtual int32_t layoutParm(TR::ParameterSymbol *paramSymbol, int32_t &dataCursor, uint16_t &intReg, uint16_t &floatRrgs, TR::parmLayoutResult&);
    virtual uint32_t getAlignment(TR::DataType type);
 
    virtual int32_t buildArgs(TR::Node *callNode, TR::RegisterDependencyConditions *deps);
@@ -52,12 +54,12 @@ class TR_AMD64SystemLinkage : public TR_X86SystemLinkage
 
    TR::Register *buildVolatileAndReturnDependencies(TR::Node *callNode, TR::RegisterDependencyConditions *deps);
    private:
-   bool layoutTypeInRegs(TR::DataType type, uint16_t &intReg, uint16_t &floatReg, parmLayoutResult&);
+   bool layoutTypeInRegs(TR::DataType type, uint16_t &intReg, uint16_t &floatReg, TR::parmLayoutResult&);
 
    };
 
 
-class TR_AMD64Win64FastCallLinkage : public virtual TR_AMD64SystemLinkage
+class AMD64Win64FastCallLinkage : public virtual TR::AMD64SystemLinkage
    {
    // Register                  Status        Use
    // --------                  ------        ---
@@ -92,11 +94,11 @@ class TR_AMD64Win64FastCallLinkage : public virtual TR_AMD64SystemLinkage
 
    public:
 
-   TR_AMD64Win64FastCallLinkage(TR::CodeGenerator *cg);
+   AMD64Win64FastCallLinkage(TR::CodeGenerator *cg);
    };
 
 
-class TR_AMD64ABILinkage : public virtual TR_AMD64SystemLinkage
+class AMD64ABILinkage : public virtual TR::AMD64SystemLinkage
    {
    // Register                  Status        Use
    // --------                  ------        ---
@@ -134,10 +136,12 @@ class TR_AMD64ABILinkage : public virtual TR_AMD64SystemLinkage
 
    public:
 
-   TR_AMD64ABILinkage(TR::CodeGenerator *cg);
+   AMD64ABILinkage(TR::CodeGenerator *cg);
 
    virtual void mapIncomingParms(TR::ResolvedMethodSymbol *method, uint32_t &stackIndex);
 
    };
+
+}
 
 #endif

--- a/compiler/x/amd64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/amd64/codegen/OMRCodeGenerator.cpp
@@ -21,7 +21,7 @@
 #include <limits.h>                       // for INT_MAX
 #include <stdint.h>                       // for uint32_t, int16_t, int32_t, etc
 #include "codegen/FrontEnd.hpp"           // for feGetEnv
-#include "codegen/Linkage.hpp"            // for TR_X86LinkageProperties
+#include "codegen/Linkage.hpp"            // for TR::X86LinkageProperties
 #include "codegen/RealRegister.hpp"       // for TR::RealRegister::RegNum
 #include "codegen/Register.hpp"           // for Register
 #include "codegen/RegisterConstants.hpp"  // for TR_GlobalRegisterNumber

--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -1248,7 +1248,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerReturnEvaluator(TR::Node *node, TR
 
    TR::Node     *firstChild     = node->getFirstChild();
    TR::Register *returnRegister = cg->evaluate(firstChild);
-   const TR_X86LinkageProperties &linkageProperties = cg->getProperties();
+   const TR::X86LinkageProperties &linkageProperties = cg->getProperties();
    TR::RealRegister::RegNum machineReturnRegister =
       linkageProperties.getIntegerReturnRegister();
 

--- a/compiler/x/codegen/FPTreeEvaluator.cpp
+++ b/compiler/x/codegen/FPTreeEvaluator.cpp
@@ -527,7 +527,7 @@ TR::Register *OMR::X86::TreeEvaluator::fpReturnEvaluator(TR::Node *node, TR::Cod
       generateMemInstruction(LDCWMem, node, generateX86MemoryReference(cds, cg), cg);
       }
 
-   const TR_X86LinkageProperties &linkageProperties = cg->getProperties();
+   const TR::X86LinkageProperties &linkageProperties = cg->getProperties();
    TR::RealRegister::RegNum machineReturnRegister =
       (returnRegister->isSinglePrecision())? linkageProperties.getFloatReturnRegister() : linkageProperties.getDoubleReturnRegister();
 
@@ -644,7 +644,7 @@ TR::Register *OMR::X86::TreeEvaluator::fpRemEvaluator(TR::Node *node, TR::CodeGe
    bool         nodeIsDouble = node->getDataType() == TR::Double;
    TR::Register *targetRegister;
    TR::Compilation *comp = cg->comp();
-   const TR_X86LinkageProperties &linkageProperties = cg->getLinkage(comp->getJittedMethodSymbol()->getLinkageConvention())->getProperties();
+   const TR::X86LinkageProperties &linkageProperties = cg->getLinkage(comp->getJittedMethodSymbol()->getLinkageConvention())->getProperties();
 
    if (cg->useSSEForDoublePrecision()) // Note: both float and double helpers use SSE2
       {

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -498,17 +498,17 @@ OMR::X86::CodeGenerator::createLinkage(TR_LinkageConventions lc)
          if (TR::Compiler->target.isLinux() || TR::Compiler->target.isOSX())
             {
 #if defined(TR_TARGET_64BIT)
-            linkage = new (self()->trHeapMemory()) TR_AMD64ABILinkage(self());
+            linkage = new (self()->trHeapMemory()) TR::AMD64ABILinkage(self());
 #else
-            linkage = new (self()->trHeapMemory()) TR_IA32SystemLinkage(self());
+            linkage = new (self()->trHeapMemory()) TR::IA32SystemLinkage(self());
 #endif
             }
          else if (TR::Compiler->target.isWindows())
             {
 #if defined(TR_TARGET_64BIT)
-            linkage = new (self()->trHeapMemory()) TR_AMD64Win64FastCallLinkage(self());
+            linkage = new (self()->trHeapMemory()) TR::AMD64Win64FastCallLinkage(self());
 #else
-            linkage = new (self()->trHeapMemory()) TR_IA32SystemLinkage(self());
+            linkage = new (self()->trHeapMemory()) TR::IA32SystemLinkage(self());
 #endif
             }
          else

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -69,7 +69,7 @@ namespace TR { class X86LabelInstruction;       }
 namespace TR { class X86MemTableInstruction;    }
 namespace TR { class X86ScratchRegisterManager; }
 namespace TR { class X86VFPSaveInstruction;     }
-struct TR_X86LinkageProperties;
+namespace TR { struct X86LinkageProperties; }
 
 namespace TR {
 
@@ -370,7 +370,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    TR::Register *floatClobberEvaluate(TR::Node *node);
    TR::Register *doubleClobberEvaluate(TR::Node *node);
 
-   const TR_X86LinkageProperties &getProperties() { return *_linkageProperties; }
+   const TR::X86LinkageProperties &getProperties() { return *_linkageProperties; }
 
    RegisterAssignmentDirection getAssignmentDirection() {return _assignmentDirection;}
    RegisterAssignmentDirection setAssignmentDirection(RegisterAssignmentDirection d)
@@ -643,7 +643,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    static TR_X86PaddingTable _old32BitPaddingTable;
 
    TR::X86ImmInstruction *_returnTypeInfoInstruction;
-   const TR_X86LinkageProperties  *_linkageProperties;
+   const TR::X86LinkageProperties  *_linkageProperties;
 
    private:
 

--- a/compiler/x/codegen/OMRLinkage.cpp
+++ b/compiler/x/codegen/OMRLinkage.cpp
@@ -56,7 +56,7 @@
 #include "ras/Debug.hpp"                         // for TR_DebugBase
 #include "codegen/X86Instruction.hpp"
 #include "x/codegen/X86Ops.hpp"                  // for ::MOVSSRegMem, etc
-#include "x/codegen/X86SystemLinkage.hpp"        // for toX86SystemLinkage, etc
+#include "x/codegen/X86SystemLinkage.hpp"        // for TR::toX86SystemLinkage, etc
 
 #ifdef DEBUG
 static uint32_t accumOrigSize = 0;
@@ -67,7 +67,7 @@ void OMR::X86::Linkage::mapCompactedStack(TR::ResolvedMethodSymbol *method)
    {
    ListIterator<TR::AutomaticSymbol>  automaticIterator(&method->getAutomaticList());
    TR::AutomaticSymbol               *localCursor       = automaticIterator.getFirst();
-   const TR_X86LinkageProperties&    linkage           = self()->getProperties();
+   const TR::X86LinkageProperties&    linkage           = self()->getProperties();
    int32_t                           offsetToFirstParm = linkage.getOffsetToFirstParm();
    uint32_t                          stackIndex        = linkage.getOffsetToFirstLocal();
    TR::GCStackAtlas                  *atlas             = self()->cg()->getStackAtlas();
@@ -279,7 +279,7 @@ void OMR::X86::Linkage::mapCompactedStack(TR::ResolvedMethodSymbol *method)
    if (self()->comp()->getMethodSymbol()->getLinkageConvention() != TR_System)
       self()->mapIncomingParms(method);
    else
-      toX86SystemLinkage(self()->cg()->getLinkage())->mapIncomingParms(method, stackIndex);
+      TR::toX86SystemLinkage(self()->cg()->getLinkage())->mapIncomingParms(method, stackIndex);
 
    method->setLocalMappingCursor(stackIndex);
 
@@ -327,7 +327,7 @@ void OMR::X86::Linkage::mapStack(TR::ResolvedMethodSymbol *method)
 
    ListIterator<TR::AutomaticSymbol>  automaticIterator(&method->getAutomaticList());
    TR::AutomaticSymbol               *localCursor       = automaticIterator.getFirst();
-   const TR_X86LinkageProperties&    linkage           = self()->getProperties();
+   const TR::X86LinkageProperties&    linkage           = self()->getProperties();
    int32_t                           offsetToFirstParm = linkage.getOffsetToFirstParm();
    uint32_t                          stackIndex        = linkage.getOffsetToFirstLocal();
    TR::GCStackAtlas                  *atlas             = self()->cg()->getStackAtlas();
@@ -415,7 +415,7 @@ void OMR::X86::Linkage::mapStack(TR::ResolvedMethodSymbol *method)
    if (self()->comp()->getMethodSymbol()->getLinkageConvention() != TR_System)
       self()->mapIncomingParms(method);
    else
-      toX86SystemLinkage(self()->cg()->getLinkage())->mapIncomingParms(method, stackIndex);
+      TR::toX86SystemLinkage(self()->cg()->getLinkage())->mapIncomingParms(method, stackIndex);
 
    method->setLocalMappingCursor(stackIndex);
 

--- a/compiler/x/codegen/OMRLinkage.hpp
+++ b/compiler/x/codegen/OMRLinkage.hpp
@@ -85,10 +85,12 @@ typedef enum { Int4, Int8, Float4, Float8, NumMovDataTypes } TR_MovDataTypes;
 
 typedef enum { MemReg, RegMem, RegReg, NumMovOperandTypes }  TR_MovOperandTypes;
 
-struct TR_MovStatus // What kind of RegReg movs must be applied to a given register
+namespace TR {
+
+struct MovStatus // What kind of RegReg movs must be applied to a given register
    {
    // NOTE: sourceReg is not to be moved to targetReg.  Rather, we're building
-   // a kind of doubly-linked list, with a TR_MovStatus for each register R such
+   // a kind of doubly-linked list, with a TR::MovStatus for each register R such
    // that sourceReg will be moved to R and R will be moved to targetReg.
    //
    TR::RealRegister::RegNum sourceReg;        // Which reg will be copied over the given reg
@@ -96,7 +98,7 @@ struct TR_MovStatus // What kind of RegReg movs must be applied to a given regis
    TR_MovDataTypes          outgoingDataType; // Type of data originally in the given reg
    };
 
-struct TR_X86LinkageProperties
+struct X86LinkageProperties
    {
 
    // Limits applicable to all linkages.  They must cover both integer and float registers.
@@ -261,6 +263,8 @@ struct TR_X86LinkageProperties
 
    };
 
+}
+
 namespace OMR
 {
 
@@ -315,7 +319,7 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
       // default of -1.
       }
 
-   virtual const ::TR_X86LinkageProperties& getProperties() = 0;
+   virtual const ::TR::X86LinkageProperties& getProperties() = 0;
 
    virtual int32_t numArgumentRegisters(TR_RegisterKinds kind);
 
@@ -436,4 +440,5 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
    };
 }
 }
+
 #endif

--- a/compiler/x/codegen/OMRMachine.cpp
+++ b/compiler/x/codegen/OMRMachine.cpp
@@ -305,7 +305,7 @@ OMR::X86::Machine::findBestFreeGPRegister(TR::Instruction   *currentInstruction,
    TR_RegisterMask                 interference      = virtReg->getInterference();
    TR_RegisterMask                 byteRegisterInterference = interference & 0x80000000;
    TR::RealRegister             *freeRegister      = NULL;
-   const TR_X86LinkageProperties &linkageProperties = self()->cg()->getProperties();
+   const TR::X86LinkageProperties &linkageProperties = self()->cg()->getProperties();
 
    for (i = first; i <= last; i++)
       {
@@ -1531,7 +1531,7 @@ void OMR::X86::Machine::coerceGPRegisterAssignment(TR::Instruction   *currentIns
 void OMR::X86::Machine::setGPRWeightsFromAssociations()
    {
    // *this    swipeable for debugging purposes
-   const TR_X86LinkageProperties &linkageProperties = self()->cg()->getProperties();
+   const TR::X86LinkageProperties &linkageProperties = self()->cg()->getProperties();
 
    for (int i = TR::RealRegister::FirstGPR;
         i <= TR::RealRegister::LastAssignableGPR;
@@ -1628,7 +1628,7 @@ OMR::X86::Machine::createRegisterAssociationDirective(TR::Instruction *cursor)
 #define UNUSED_WEIGHT       0xFFFF
 
 void
-OMR::X86::Machine::initialiseRegisterFile(const struct TR_X86LinkageProperties &properties)
+OMR::X86::Machine::initialiseRegisterFile(const struct TR::X86LinkageProperties &properties)
    {
    // *this    swipeable for debugging purposes
    int reg;
@@ -1757,7 +1757,7 @@ OMR::X86::Machine::initialiseRegisterFile(const struct TR_X86LinkageProperties &
    }
 
 uint32_t*
-OMR::X86::Machine::getGlobalRegisterTable(const struct TR_X86LinkageProperties& property)
+OMR::X86::Machine::getGlobalRegisterTable(const struct TR::X86LinkageProperties& property)
    {
    uint32_t * allocationOrder = property.getRegisterAllocationOrder();
    for (int i = 0; i < self()->getNumGlobalGPRs() + _numGlobalFPRs; i++)

--- a/compiler/x/codegen/OMRMachine.hpp
+++ b/compiler/x/codegen/OMRMachine.hpp
@@ -51,7 +51,7 @@ namespace TR { class MemoryReference; }
 namespace TR { class Node; }
 namespace TR { class RegisterDependencyConditions; }
 namespace TR { class SymbolReference; }
-struct TR_X86LinkageProperties;
+namespace TR { struct X86LinkageProperties; }
 template <typename ListKind> class List;
 
 #define TR_X86_REGISTER_FILE_SIZE (TR::RealRegister::NumRegisters)
@@ -129,8 +129,8 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
 
 
    public:
-   void initialiseRegisterFile(const struct TR_X86LinkageProperties&);
-   uint32_t* getGlobalRegisterTable(const struct TR_X86LinkageProperties&);
+   void initialiseRegisterFile(const struct TR::X86LinkageProperties&);
+   uint32_t* getGlobalRegisterTable(const struct TR::X86LinkageProperties&);
    int32_t getGlobalReg(TR::RealRegister::RegNum reg);
 
    TR::RealRegister *getX86RealRegister(TR::RealRegister::RegNum regNum)

--- a/compiler/x/codegen/X86Debug.cpp
+++ b/compiler/x/codegen/X86Debug.cpp
@@ -2388,7 +2388,7 @@ TR_Debug::printArgumentFlush(TR::FILE *              pOutFile,
    TR::MethodSymbol *methodSymbol = callNode->getSymbol()->castToMethodSymbol();
    TR::Linkage *linkage = _cg->getLinkage();
 
-   const TR_X86LinkageProperties &linkageProperties = linkage->getProperties();
+   const TR::X86LinkageProperties &linkageProperties = linkage->getProperties();
 
    int32_t   numGPArgs = 0;
    int32_t   numFPArgs = 0;

--- a/compiler/x/codegen/X86SystemLinkage.cpp
+++ b/compiler/x/codegen/X86SystemLinkage.cpp
@@ -43,23 +43,23 @@
 #include "x/codegen/X86Ops.hpp"                // for TR_X86OpCodes, etc
 #include "env/CompilerEnv.hpp"
 
-TR_X86SystemLinkage::TR_X86SystemLinkage(TR::CodeGenerator *cg)
+TR::X86SystemLinkage::X86SystemLinkage(TR::CodeGenerator *cg)
    : TR::Linkage(cg)
    {
    }
 
-const TR_X86LinkageProperties& TR_X86SystemLinkage::getProperties()
+const TR::X86LinkageProperties& TR::X86SystemLinkage::getProperties()
    {
    return _properties;
    }
 
-TR::Register *TR_X86SystemLinkage::buildIndirectDispatch(TR::Node *callNode)
+TR::Register *TR::X86SystemLinkage::buildIndirectDispatch(TR::Node *callNode)
    {
-   TR_ASSERT(0, "TR_X86SystemLinkage::buildIndirectDispatch is not supported");
+   TR_ASSERT(0, "TR::X86SystemLinkage::buildIndirectDispatch is not supported");
    return NULL;
    }
 
-int32_t TR_X86SystemLinkage::computeMemoryArgSize(
+int32_t TR::X86SystemLinkage::computeMemoryArgSize(
       TR::Node *callNode,
       int32_t first,
       int32_t last,
@@ -70,7 +70,7 @@ int32_t TR_X86SystemLinkage::computeMemoryArgSize(
    int32_t i;
    for (i = first; i != last; i += direction)
       {
-      parmLayoutResult layoutResult;
+      TR::parmLayoutResult layoutResult;
       TR::Node *child = callNode->getChild(i);
 
       layoutParm(child, sizeOfOutGoingArgs, numIntArgs, numFloatArgs, layoutResult);
@@ -87,7 +87,7 @@ static const TR::RealRegister::RegNum NOT_ASSIGNED = (TR::RealRegister::RegNum)-
 // to find them (either on stack or in a global register).
 //
 TR::Instruction *
-TR_X86SystemLinkage::copyParametersToHomeLocation(TR::Instruction *cursor)
+TR::X86SystemLinkage::copyParametersToHomeLocation(TR::Instruction *cursor)
    {
    TR::Machine *machine = cg()->machine();
    TR::RealRegister *framePointer = machine->getX86RealRegister(TR::RealRegister::vfp);
@@ -99,7 +99,7 @@ TR_X86SystemLinkage::copyParametersToHomeLocation(TR::Instruction *cursor)
    const TR::RealRegister::RegNum noReg = TR::RealRegister::NoReg;
    TR_ASSERT(noReg == 0, "noReg must be zero so zero-initializing movStatus will work");
 
-   TR_MovStatus movStatus[TR::RealRegister::NumRegisters] = {{(TR::RealRegister::RegNum)0,(TR::RealRegister::RegNum)0,(TR_MovDataTypes)0}};
+   TR::MovStatus movStatus[TR::RealRegister::NumRegisters] = {{(TR::RealRegister::RegNum)0,(TR::RealRegister::RegNum)0,(TR_MovDataTypes)0}};
 
    // We must always do the stores first, then the reg-reg copies, then the
    // loads, so that we never clobber a register we will need later.  However,
@@ -278,7 +278,7 @@ TR_X86SystemLinkage::copyParametersToHomeLocation(TR::Instruction *cursor)
 
 
 TR::Instruction *
-TR_X86SystemLinkage::savePreservedRegisters(TR::Instruction *cursor)
+TR::X86SystemLinkage::savePreservedRegisters(TR::Instruction *cursor)
    {
    // For IA32, if disableShrinkWrapping, usePushForPreservedRegs will be true; otherwise false;
    //          For X64,  shrinkWraping is always on, and usePushForPreservedRegs always false;
@@ -333,7 +333,7 @@ TR_X86SystemLinkage::savePreservedRegisters(TR::Instruction *cursor)
 
 
 void
-TR_X86SystemLinkage::createPrologue(TR::Instruction *cursor)
+TR::X86SystemLinkage::createPrologue(TR::Instruction *cursor)
    {
 #if defined(DEBUG)
    // TODO:AMD64: Get this into the debug DLL
@@ -427,7 +427,7 @@ TR_X86SystemLinkage::createPrologue(TR::Instruction *cursor)
 
    TR::ResolvedMethodSymbol *bodySymbol = comp()->getJittedMethodSymbol();
 
-   const TR_X86LinkageProperties &properties = getProperties();
+   const TR::X86LinkageProperties &properties = getProperties();
 
    const uint32_t outgoingArgSize = cg()->getLargestOutgoingArgSize();
 
@@ -617,7 +617,7 @@ TR_X86SystemLinkage::createPrologue(TR::Instruction *cursor)
 
 
 TR::Instruction *
-TR_X86SystemLinkage::restorePreservedRegisters(TR::Instruction *cursor)
+TR::X86SystemLinkage::restorePreservedRegisters(TR::Instruction *cursor)
    {
    TR::ResolvedMethodSymbol *bodySymbol = comp()->getJittedMethodSymbol();
    const int32_t localSize   = _properties.getOffsetToFirstLocal() - bodySymbol->getLocalMappingCursor();
@@ -675,7 +675,7 @@ TR_X86SystemLinkage::restorePreservedRegisters(TR::Instruction *cursor)
 
 
 void
-TR_X86SystemLinkage::createEpilogue(TR::Instruction *cursor)
+TR::X86SystemLinkage::createEpilogue(TR::Instruction *cursor)
    {
    TR::RealRegister    *espReal      = machine()->getX86RealRegister(TR::RealRegister::esp);
    TR::ResolvedMethodSymbol *bodySymbol = comp()->getJittedMethodSymbol();
@@ -740,11 +740,11 @@ TR_X86SystemLinkage::createEpilogue(TR::Instruction *cursor)
 
 // TODO: add struct/union support in this function
 void
-TR_X86SystemLinkage::copyLinkageInfoToParameterSymbols()
+TR::X86SystemLinkage::copyLinkageInfoToParameterSymbols()
    {
    TR::ResolvedMethodSymbol *bodySymbol = comp()->getJittedMethodSymbol();
    ListIterator<TR::ParameterSymbol>paramIterator(&(bodySymbol->getParameterList()));
-   const TR_X86LinkageProperties &properties = getProperties();
+   const TR::X86LinkageProperties &properties = getProperties();
    uint16_t numIntArgs = 0, numFloatArgs = 0;
    int32_t sizeOfOutGoingArgs = 0;
    int32_t maxIntArgs   = properties.getNumIntegerArgumentRegisters();
@@ -752,13 +752,13 @@ TR_X86SystemLinkage::copyLinkageInfoToParameterSymbols()
 
   for (TR::ParameterSymbol *paramCursor = paramIterator.getFirst(); paramCursor != NULL; paramCursor = paramIterator.getNext())
       {
-      parmLayoutResult layoutResult;
+      TR::parmLayoutResult layoutResult;
       layoutParm(paramCursor, sizeOfOutGoingArgs, numIntArgs, numFloatArgs, layoutResult);
-      if (layoutResult.abstract & parmLayoutResult::IN_LINKAGE_REG_PAIR)
+      if (layoutResult.abstract & TR::parmLayoutResult::IN_LINKAGE_REG_PAIR)
          {
          TR_ASSERT(false, "haven't provide register pair support yet.\n");
          }
-      else if (layoutResult.abstract & parmLayoutResult::IN_LINKAGE_REG)
+      else if (layoutResult.abstract & TR::parmLayoutResult::IN_LINKAGE_REG)
          {
          paramCursor->setLinkageRegisterIndex(layoutResult.regs[0].regIndex);
          }
@@ -772,7 +772,7 @@ TR_X86SystemLinkage::copyLinkageInfoToParameterSymbols()
 
 
 void
-TR_X86SystemLinkage::mapIncomingParms(TR::ResolvedMethodSymbol *method)
+TR::X86SystemLinkage::mapIncomingParms(TR::ResolvedMethodSymbol *method)
    {
    TR_ASSERT(!getProperties().passArgsRightToLeft(), "Right-to-left not yet implemented on AMD64");
    int32_t sizeOfOutGoingArgs = 0;
@@ -782,9 +782,9 @@ TR_X86SystemLinkage::mapIncomingParms(TR::ResolvedMethodSymbol *method)
 
    for (TR::ParameterSymbol *parmCursor = parameterIterator.getFirst(); parmCursor; parmCursor = parameterIterator.getNext())
       {
-      parmLayoutResult layoutResult;
+      TR::parmLayoutResult layoutResult;
       layoutParm(parmCursor, sizeOfOutGoingArgs, numIntArgs, numFloatArgs, layoutResult);
-      if (layoutResult.abstract & parmLayoutResult::ON_STACK)
+      if (layoutResult.abstract & TR::parmLayoutResult::ON_STACK)
          {
          parmCursor->setParameterOffset(layoutResult.offset + bump);
          if (comp()->getOption(TR_TraceCG))
@@ -795,7 +795,7 @@ TR_X86SystemLinkage::mapIncomingParms(TR::ResolvedMethodSymbol *method)
 
 
 void
-TR_X86SystemLinkage::copyGlRegDepsToParameterSymbols(
+TR::X86SystemLinkage::copyGlRegDepsToParameterSymbols(
       TR::Node *bbStart,
       TR::CodeGenerator *cg)
    {
@@ -820,7 +820,7 @@ TR_X86SystemLinkage::copyGlRegDepsToParameterSymbols(
 
 
 int32_t
-TR_X86SystemLinkage::getParameterStartingPos(
+TR::X86SystemLinkage::getParameterStartingPos(
       int32_t &dataCursor,
       uint32_t align)
    {
@@ -839,10 +839,10 @@ TR_X86SystemLinkage::getParameterStartingPos(
 
 
 int32_t
-TR_X86SystemLinkage::layoutTypeOnStack(
+TR::X86SystemLinkage::layoutTypeOnStack(
       TR::DataType type,
       int32_t &dataCursor,
-      parmLayoutResult &layoutResult)
+      TR::parmLayoutResult &layoutResult)
    {
    uint32_t typeAlign = getAlignment(type);
    layoutResult.offset = getParameterStartingPos(dataCursor, typeAlign);

--- a/compiler/x/codegen/X86SystemLinkage.hpp
+++ b/compiler/x/codegen/X86SystemLinkage.hpp
@@ -32,6 +32,8 @@ namespace TR { class ParameterSymbol; }
 namespace TR { class RegisterDependencyConditions; }
 namespace TR { class ResolvedMethodSymbol; }
 
+namespace TR {
+
 typedef struct parmLayoutResult
    {
    enum statusEnum
@@ -56,12 +58,12 @@ typedef struct parmLayoutResult
       }
    } parmLayoutResult;
 
-class TR_X86SystemLinkage : public TR::Linkage
+class X86SystemLinkage : public TR::Linkage
    {
    protected:
-   TR_X86SystemLinkage(TR::CodeGenerator *cg);
+   X86SystemLinkage(TR::CodeGenerator *cg);
 
-   TR_X86LinkageProperties _properties;
+   TR::X86LinkageProperties _properties;
 
    TR::Instruction* copyParametersToHomeLocation(TR::Instruction *cursor);
 
@@ -73,16 +75,16 @@ class TR_X86SystemLinkage : public TR::Linkage
 
    int32_t computeMemoryArgSize(TR::Node *callNode, int32_t first, int32_t last, int8_t direction);
    int32_t getParameterStartingPos(int32_t &dataCursor, uint32_t align);
-   int32_t layoutTypeOnStack(TR::DataType, int32_t&, parmLayoutResult&);
+   int32_t layoutTypeOnStack(TR::DataType, int32_t&, TR::parmLayoutResult&);
    virtual int32_t buildArgs(TR::Node *callNode, TR::RegisterDependencyConditions *deps) = 0;
    virtual uint32_t getAlignment(TR::DataType) = 0;
-   virtual int32_t layoutParm(TR::Node *parmNode, int32_t &dataCursor, uint16_t &intReg, uint16_t &floatReg, parmLayoutResult &layoutResult) = 0;
-   virtual int32_t layoutParm(TR::ParameterSymbol *paramSymbol, int32_t &dataCursor, uint16_t &intReg, uint16_t &floatRrgs, parmLayoutResult&) = 0;
+   virtual int32_t layoutParm(TR::Node *parmNode, int32_t &dataCursor, uint16_t &intReg, uint16_t &floatReg, TR::parmLayoutResult &layoutResult) = 0;
+   virtual int32_t layoutParm(TR::ParameterSymbol *paramSymbol, int32_t &dataCursor, uint16_t &intReg, uint16_t &floatRrgs, TR::parmLayoutResult&) = 0;
 
    virtual TR::Register* buildVolatileAndReturnDependencies(TR::Node*, TR::RegisterDependencyConditions*) = 0;
    public:
 
-   const TR_X86LinkageProperties& getProperties();
+   const TR::X86LinkageProperties& getProperties();
 
    virtual TR::Register *buildIndirectDispatch(TR::Node *callNode) = 0;
    virtual TR::Register *buildDirectDispatch(TR::Node *callNode, bool spillFPRegs) = 0;
@@ -97,6 +99,8 @@ class TR_X86SystemLinkage : public TR::Linkage
    virtual void setUpStackSizeForCallNode(TR::Node *node) = 0;
    };
 
-inline TR_X86SystemLinkage *toX86SystemLinkage(TR::Linkage *l) {return (TR_X86SystemLinkage *)l;}
+inline TR::X86SystemLinkage *toX86SystemLinkage(TR::Linkage *l) {return (TR::X86SystemLinkage *)l;}
+
+}
 
 #endif

--- a/compiler/x/i386/codegen/IA32SystemLinkage.cpp
+++ b/compiler/x/i386/codegen/IA32SystemLinkage.cpp
@@ -21,7 +21,7 @@
 #include <stdio.h>                         // for NULL, printf
 #include "codegen/CodeGenerator.hpp"       // for CodeGenerator
 #include "codegen/IA32LinkageUtils.hpp"    // for IA32LinkageUtils
-#include "codegen/Linkage.hpp"             // for TR_X86LinkageProperties, etc
+#include "codegen/Linkage.hpp"             // for TR::X86LinkageProperties, etc
 #include "codegen/Machine.hpp"             // for Machine
 #include "codegen/RealRegister.hpp"        // for TR::RealRegister::RegNum, etc
 #include "codegen/RegisterConstants.hpp"   // for TR_RegisterKinds::TR_X87
@@ -60,9 +60,9 @@ enum
    IA32_DEFAULT_STACK_ALIGNMENT=4
    };
 
-TR_IA32SystemLinkage::TR_IA32SystemLinkage(
+TR::IA32SystemLinkage::IA32SystemLinkage(
       TR::CodeGenerator *cg) :
-   TR_X86SystemLinkage(cg)
+   TR::X86SystemLinkage(cg)
    {
    _properties._properties = CallerCleanup | AlwaysDedicateFramePointerRegister;
    // for shrinkwrapping, we cannot use pushes for the preserved regs. pushes/pops need to be in sequence and this is not compatible with shrinkwrapping as registers need not be saved/restored in sequenc
@@ -152,7 +152,7 @@ TR_IA32SystemLinkage::TR_IA32SystemLinkage(
    }
 
 uint32_t
-TR_IA32SystemLinkage::getAlignment(TR::DataType type)
+TR::IA32SystemLinkage::getAlignment(TR::DataType type)
    {
    switch(type)
       {
@@ -179,9 +179,9 @@ TR_IA32SystemLinkage::getAlignment(TR::DataType type)
 
 
 int32_t
-TR_IA32SystemLinkage::layoutParm(TR::Node *parmNode, int32_t &dataCursor, uint16_t &intReg, uint16_t &floatReg, parmLayoutResult &layoutResult)
+TR::IA32SystemLinkage::layoutParm(TR::Node *parmNode, int32_t &dataCursor, uint16_t &intReg, uint16_t &floatReg, TR::parmLayoutResult &layoutResult)
    {
-   layoutResult.abstract |= parmLayoutResult::ON_STACK;
+   layoutResult.abstract |= TR::parmLayoutResult::ON_STACK;
    int32_t align = layoutTypeOnStack(parmNode->getDataType(), dataCursor, layoutResult);
    if (comp()->getOption(TR_TraceCG))
       traceMsg(comp(), "layout param node %p on stack\n", parmNode);
@@ -189,9 +189,9 @@ TR_IA32SystemLinkage::layoutParm(TR::Node *parmNode, int32_t &dataCursor, uint16
    }
 
 int32_t
-TR_IA32SystemLinkage::layoutParm(TR::ParameterSymbol *parmSymbol, int32_t &dataCursor, uint16_t &intReg, uint16_t &floatReg, parmLayoutResult &layoutResult)
+TR::IA32SystemLinkage::layoutParm(TR::ParameterSymbol *parmSymbol, int32_t &dataCursor, uint16_t &intReg, uint16_t &floatReg, TR::parmLayoutResult &layoutResult)
    {
-   layoutResult.abstract |= parmLayoutResult::ON_STACK;
+   layoutResult.abstract |= TR::parmLayoutResult::ON_STACK;
    int32_t align = layoutTypeOnStack(parmSymbol->getDataType(), dataCursor, layoutResult);
    if (comp()->getOption(TR_TraceCG))
       traceMsg(comp(), "layout param symbol %p on stack\n", parmSymbol);
@@ -200,14 +200,14 @@ TR_IA32SystemLinkage::layoutParm(TR::ParameterSymbol *parmSymbol, int32_t &dataC
 
 
 void
-TR_IA32SystemLinkage::setUpStackSizeForCallNode(TR::Node* node)
+TR::IA32SystemLinkage::setUpStackSizeForCallNode(TR::Node* node)
    {
-   const TR_X86LinkageProperties     &properties = getProperties();
+   const TR::X86LinkageProperties     &properties = getProperties();
    int32_t  sizeOfOutGoingArgs= 0;
    uint16_t intReg = 0, floatReg = 0;
    for (int32_t i= node->getFirstArgumentIndex(); i<node->getNumChildren(); ++i)
       {
-      parmLayoutResult fakeParm;
+      TR::parmLayoutResult fakeParm;
       TR::Node *parmNode = node->getChild(i);
       layoutParm(parmNode, sizeOfOutGoingArgs, intReg, floatReg, fakeParm);
       }
@@ -222,14 +222,14 @@ TR_IA32SystemLinkage::setUpStackSizeForCallNode(TR::Node* node)
    }
 
 TR::Register *
-TR_IA32SystemLinkage::buildIndirectDispatch(TR::Node *callNode)
+TR::IA32SystemLinkage::buildIndirectDispatch(TR::Node *callNode)
    {
-   TR_ASSERT(false, "TR_IA32SystemLinkage::buildIndirectDispatch is not supported.\n");
+   TR_ASSERT(false, "TR::IA32SystemLinkage::buildIndirectDispatch is not supported.\n");
    return NULL;
    }
 
 TR::Register *
-TR_IA32SystemLinkage::buildVolatileAndReturnDependencies(
+TR::IA32SystemLinkage::buildVolatileAndReturnDependencies(
     TR::Node *callNode,
     TR::RegisterDependencyConditions *deps)
    {
@@ -300,7 +300,7 @@ TR_IA32SystemLinkage::buildVolatileAndReturnDependencies(
    return returnReg;
    }
 
-int32_t TR_IA32SystemLinkage::buildArgs(
+int32_t TR::IA32SystemLinkage::buildArgs(
       TR::Node *callNode,
       TR::RegisterDependencyConditions *deps)
    {
@@ -338,7 +338,7 @@ int32_t TR_IA32SystemLinkage::buildArgs(
    return argSize;
    }
 
-TR::Register *TR_IA32SystemLinkage::buildDirectDispatch(TR::Node *callNode, bool spillFPRegs)
+TR::Register *TR::IA32SystemLinkage::buildDirectDispatch(TR::Node *callNode, bool spillFPRegs)
    {
    TR::RealRegister    *stackPointerReg = machine()->getX86RealRegister(TR::RealRegister::esp);
    TR::SymbolReference *methodSymRef    = callNode->getSymbolReference();

--- a/compiler/x/i386/codegen/IA32SystemLinkage.hpp
+++ b/compiler/x/i386/codegen/IA32SystemLinkage.hpp
@@ -30,29 +30,31 @@ namespace TR { class Node; }
 namespace TR { class ParameterSymbol; }
 namespace TR { class RegisterDependencyConditions; }
 
-class TR_IA32SystemLinkage : public TR_X86SystemLinkage
+namespace TR {
+
+class IA32SystemLinkage : public TR::X86SystemLinkage
    {
    public:
 
-   TR_IA32SystemLinkage(TR::CodeGenerator *cg);
+   IA32SystemLinkage(TR::CodeGenerator *cg);
    void setUpStackSizeForCallNode(TR::Node*);
    protected:
    virtual int32_t buildArgs(TR::Node *callNode, TR::RegisterDependencyConditions *deps);
    virtual TR::Register *buildIndirectDispatch(TR::Node *callNode);
    virtual TR::Register *buildDirectDispatch(TR::Node *callNode, bool spillFPRegs);
-   int32_t layoutParm(TR::Node*, int32_t&, uint16_t&, uint16_t&, parmLayoutResult&);
-   int32_t layoutParm(TR::ParameterSymbol*, int32_t&, uint16_t&, uint16_t&, parmLayoutResult&);
+   int32_t layoutParm(TR::Node*, int32_t&, uint16_t&, uint16_t&, TR::parmLayoutResult&);
+   int32_t layoutParm(TR::ParameterSymbol*, int32_t&, uint16_t&, uint16_t&, TR::parmLayoutResult&);
    virtual TR::Register *buildVolatileAndReturnDependencies(TR::Node *callNode, TR::RegisterDependencyConditions *deps);
    private:
    virtual uint32_t getAlignment(TR::DataType);
    };
 
 #if 0
-class TR_IA32SystemLinkage : public TR_IA32PrivateLinkage
+class IA32SystemLinkage : public TR::IA32PrivateLinkage
    {
    public:
 
-   TR_IA32SystemLinkage(TR::CodeGenerator *cg);
+   IA32SystemLinkage(TR::CodeGenerator *cg);
 
    virtual TR::Register *buildDirectDispatch(TR::Node *callNode, bool spillFPRegs);
    virtual TR::Register *buildIndirectDispatch(TR::Node *callNode);
@@ -66,5 +68,7 @@ class TR_IA32SystemLinkage : public TR_IA32PrivateLinkage
 
    };
 #endif
+
+}
 
 #endif

--- a/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
@@ -606,7 +606,7 @@ TR::Register *OMR::X86::i386::TreeEvaluator::integerPairReturnEvaluator(TR::Node
    TR::Register *lowRegister    = returnRegister->getLowOrder();
    TR::Register *highRegister   = returnRegister->getHighOrder();
 
-   const TR_X86LinkageProperties &linkageProperties = cg->getProperties();
+   const TR::X86LinkageProperties &linkageProperties = cg->getProperties();
    TR::RealRegister::RegNum machineLowReturnRegister =
       linkageProperties.getLongLowReturnRegister();
 
@@ -1474,7 +1474,7 @@ TR::Register *OMR::X86::i386::TreeEvaluator::integerPairMulEvaluator(TR::Node *n
          TR::RegisterDependencyConditions  *dependencies = generateRegisterDependencyConditions((uint8_t)0, 2, cg);
          dependencies->addPostCondition(lowRegister, TR::RealRegister::eax, cg);
          dependencies->addPostCondition(highRegister, TR::RealRegister::edx, cg);
-         TR_IA32PrivateLinkage *linkage = toIA32PrivateLinkage(cg->getLinkage(TR_Private));
+         TR::IA32PrivateLinkage *linkage = TR::toIA32PrivateLinkage(cg->getLinkage(TR_Private));
          TR::IA32LinkageUtils::pushLongArg(secondChild, cg);
          TR::IA32LinkageUtils::pushLongArg(firstChild, cg);
          instr = generateHelperCallInstruction(node, TR_IA32longMultiply, dependencies, cg);
@@ -1566,7 +1566,7 @@ TR::Register *OMR::X86::i386::TreeEvaluator::integerPairDivEvaluator(TR::Node *n
    TR::RegisterDependencyConditions  *dependencies = generateRegisterDependencyConditions((uint8_t)0, 2, cg);
    dependencies->addPostCondition(lowRegister, TR::RealRegister::eax, cg);
    dependencies->addPostCondition(highRegister, TR::RealRegister::edx, cg);
-   TR_IA32PrivateLinkage *linkage = toIA32PrivateLinkage(cg->getLinkage(TR_Private));
+   TR::IA32PrivateLinkage *linkage = TR::toIA32PrivateLinkage(cg->getLinkage(TR_Private));
    TR::IA32LinkageUtils::pushLongArg(secondChild, cg);
    TR::IA32LinkageUtils::pushLongArg(firstChild, cg);
    TR::X86ImmSymInstruction  *instr =
@@ -1680,7 +1680,7 @@ TR::Register *OMR::X86::i386::TreeEvaluator::integerPairRemEvaluator(TR::Node *n
    dependencies->addPostCondition(firstRegister->getLowOrder(), TR::RealRegister::NoReg, cg);
    dependencies->addPostCondition(secondRegister->getLowOrder(), TR::RealRegister::NoReg, cg);
 
-   TR_IA32PrivateLinkage *linkage = toIA32PrivateLinkage(cg->getLinkage(TR_Private));
+   TR::IA32PrivateLinkage *linkage = TR::toIA32PrivateLinkage(cg->getLinkage(TR_Private));
    TR::IA32LinkageUtils::pushLongArg(secondChild, cg);
    TR::IA32LinkageUtils::pushLongArg(firstChild, cg);
    TR::X86ImmSymInstruction  *instr =
@@ -1812,7 +1812,7 @@ TR::Register *OMR::X86::i386::TreeEvaluator::integerPairShlEvaluator(TR::Node *n
       TR::RegisterDependencyConditions  *dependencies = generateRegisterDependencyConditions((uint8_t)0, 2, cg);
       dependencies->addPostCondition(lowRegister, TR::RealRegister::eax, cg);
       dependencies->addPostCondition(highRegister, TR::RealRegister::edx, cg);
-      TR_IA32PrivateLinkage *linkage = toIA32PrivateLinkage(cg->getLinkage(TR_Private));
+      TR::IA32PrivateLinkage *linkage = TR::toIA32PrivateLinkage(cg->getLinkage(TR_Private));
       TR::IA32LinkageUtils::pushLongArg(firstChild, cg);
       TR::IA32LinkageUtils::pushIntegerWordArg(secondChild, cg);
       TR::X86ImmSymInstruction  *instr = generateHelperCallInstruction(node, TR_IA32longShiftLeft, dependencies, cg);
@@ -1958,7 +1958,7 @@ TR::Register *OMR::X86::i386::TreeEvaluator::integerPairShrEvaluator(TR::Node *n
       TR::RegisterDependencyConditions  *dependencies = generateRegisterDependencyConditions((uint8_t)0, 2, cg);
       dependencies->addPostCondition(lowRegister, TR::RealRegister::eax, cg);
       dependencies->addPostCondition(highRegister, TR::RealRegister::edx, cg);
-      TR_IA32PrivateLinkage *linkage = toIA32PrivateLinkage(cg->getLinkage(TR_Private));
+      TR::IA32PrivateLinkage *linkage = TR::toIA32PrivateLinkage(cg->getLinkage(TR_Private));
       TR::IA32LinkageUtils::pushLongArg(firstChild, cg);
       TR::IA32LinkageUtils::pushIntegerWordArg(secondChild, cg);
       TR::X86ImmSymInstruction  *instr = generateHelperCallInstruction(node, TR_IA32longShiftRightArithmetic, dependencies, cg);
@@ -2021,7 +2021,7 @@ TR::Register *OMR::X86::i386::TreeEvaluator::integerPairUshrEvaluator(TR::Node *
       TR::RegisterDependencyConditions  *dependencies = generateRegisterDependencyConditions((uint8_t)0, 2, cg);
       dependencies->addPostCondition(lowRegister, TR::RealRegister::eax, cg);
       dependencies->addPostCondition(highRegister, TR::RealRegister::edx, cg);
-      TR_IA32PrivateLinkage *linkage = toIA32PrivateLinkage(cg->getLinkage(TR_Private));
+      TR::IA32PrivateLinkage *linkage = TR::toIA32PrivateLinkage(cg->getLinkage(TR_Private));
       TR::IA32LinkageUtils::pushLongArg(firstChild, cg);
       TR::IA32LinkageUtils::pushIntegerWordArg(secondChild, cg);
       TR::X86ImmSymInstruction  *instr = generateHelperCallInstruction(node, TR_IA32longShiftRightLogical, dependencies, cg);

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -128,7 +128,7 @@
 
 class TR_IGNode;
 namespace TR { class DebugCounterBase; }
-class TR_S390PrivateLinkage;
+namespace TR { class S390PrivateLinkage; }
 namespace TR { class SimpleRegex; }
 
 #define OPT_DETAILS "O^O CODE GENERATION: "
@@ -1030,7 +1030,7 @@ bool OMR::Z::CodeGenerator::prepareForGRA()
    }
 
 TR::Linkage * OMR::Z::CodeGenerator::getS390Linkage() {return (self()->getLinkage());}
-TR_S390PrivateLinkage * OMR::Z::CodeGenerator::getS390PrivateLinkage() {return toS390PrivateLinkage(self()->getLinkage());}
+TR::S390PrivateLinkage * OMR::Z::CodeGenerator::getS390PrivateLinkage() {return TR::toS390PrivateLinkage(self()->getLinkage());}
 
 
 TR::SystemLinkage * OMR::Z::CodeGenerator::getS390SystemLinkage() {return toSystemLinkage(self()->getLinkage());}
@@ -7858,7 +7858,7 @@ OMR::Z::CodeGenerator::createLinkage(TR_LinkageConventions lc)
    switch (lc)
       {
       case TR_Helper:
-         linkage = new (self()->trHeapMemory()) TR_S390zLinuxSystemLinkage(self());
+         linkage = new (self()->trHeapMemory()) TR::S390zLinuxSystemLinkage(self());
          break;
 
       case TR_Private:
@@ -7866,9 +7866,9 @@ OMR::Z::CodeGenerator::createLinkage(TR_LinkageConventions lc)
 
       case TR_System:
          if (TR::Compiler->target.isLinux())
-            linkage = new (self()->trHeapMemory()) TR_S390zLinuxSystemLinkage(self());
+            linkage = new (self()->trHeapMemory()) TR::S390zLinuxSystemLinkage(self());
          else
-            linkage = new (self()->trHeapMemory()) TR_S390zOSSystemLinkage(self());
+            linkage = new (self()->trHeapMemory()) TR::S390zOSSystemLinkage(self());
          break;
 
       default :

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -96,7 +96,7 @@ namespace TR { class S390ImmInstruction; }
 namespace TR { class S390LabelTableSnippet; }
 namespace TR { class S390LookupSwitchSnippet; }
 class TR_S390OutOfLineCodeSection;
-class TR_S390PrivateLinkage;
+namespace TR { class S390PrivateLinkage; }
 class TR_S390ScratchRegisterManager;
 namespace TR { class S390SortJumpTrampSnippet; }
 namespace TR { class S390TargetAddressSnippet; }
@@ -507,7 +507,7 @@ public:
 
 //Convenience accessor methods
    TR::Linkage *getS390Linkage();
-   TR_S390PrivateLinkage *getS390PrivateLinkage();
+   TR::S390PrivateLinkage *getS390PrivateLinkage();
    TR::SystemLinkage * getS390SystemLinkage();
 
    TR::RealRegister *getStackPointerRealRegister(TR::Symbol *symbol = NULL);

--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -97,7 +97,7 @@ static int32_t getFirstMaskedBit(int16_t mask); ///< formward reference
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390Linkage member functions
+// TR::S390Linkage member functions
 ////////////////////////////////////////////////////////////////////////////////
 
 /**
@@ -1534,7 +1534,7 @@ OMR::Z::Linkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol * met
       // Interface mapping flags take these constraints into account and the
       // flags describe what float registers are used for parameter passing.
       // Use these flags to guide decisions below.
-      TR_S390zOSSystemLinkage *zosLinkage = (TR_S390zOSSystemLinkage *)this;
+      TR::S390zOSSystemLinkage *zosLinkage = (TR::S390zOSSystemLinkage *)this;
       xplinkInterfaceMappingFlags = zosLinkage->calculateInterfaceMappingFlags(method);
       }
 
@@ -1576,7 +1576,7 @@ OMR::Z::Linkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol * met
                {
                if (self()->isFloatParmDescriptors())
                   { // XPLink: handle large separation of float args constraint
-                  int32_t val = TR_S390zOSSystemLinkage::getFloatParmDescriptorFlag(xplinkInterfaceMappingFlags, numFloatArgs);
+                  int32_t val = TR::S390zOSSystemLinkage::getFloatParmDescriptorFlag(xplinkInterfaceMappingFlags, numFloatArgs);
 
                   if (val != 0)
                      index = numFloatArgs;
@@ -1593,7 +1593,7 @@ OMR::Z::Linkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol * met
                {
                if (self()->isFloatParmDescriptors())
                   { // XPLink: handle large separation of float args constraint
-                  int32_t val = TR_S390zOSSystemLinkage::getFloatParmDescriptorFlag(xplinkInterfaceMappingFlags, numFloatArgs);
+                  int32_t val = TR::S390zOSSystemLinkage::getFloatParmDescriptorFlag(xplinkInterfaceMappingFlags, numFloatArgs);
                   if (val != 0)
                      index = numFloatArgs;
                   }
@@ -1616,7 +1616,7 @@ OMR::Z::Linkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol * met
                {
                if (self()->isFloatParmDescriptors())
                   { // XPLink: handle large separation of float args constraint
-                  int32_t val = TR_S390zOSSystemLinkage::getFloatParmDescriptorFlag(xplinkInterfaceMappingFlags, numFloatArgs);
+                  int32_t val = TR::S390zOSSystemLinkage::getFloatParmDescriptorFlag(xplinkInterfaceMappingFlags, numFloatArgs);
                   if (val != 0)
                     index = numFloatArgs;
                   }
@@ -2461,7 +2461,7 @@ OMR::Z::Linkage::buildArgs(TR::Node * callNode, TR::RegisterDependencyConditions
     if (self()->isFloatParmDescriptors())
        { // these flags are used to help determine if float parm is needs to be put in memory
        TR_ASSERT( self()->isXPLinkLinkageType(), "invalid platform target for float parm descriptors");
-       TR_S390zOSSystemLinkage *zosLinkage = (TR_S390zOSSystemLinkage *)this;
+       TR::S390zOSSystemLinkage *zosLinkage = (TR::S390zOSSystemLinkage *)this;
        xplinkCallDescriptorFlags = zosLinkage->calculateCallDescriptorFlags(callNode);
        }
 
@@ -2506,8 +2506,8 @@ OMR::Z::Linkage::buildArgs(TR::Node * callNode, TR::RegisterDependencyConditions
                {
                if (self()->isFloatParmDescriptors() && (numFloatArgs < self()->getNumFloatArgumentRegisters()))
                   { // XPLink: handle large separation of float args constraint
-                  uint32_t val = TR_S390zOSSystemLinkage::getFloatParmDescriptorFlag(xplinkCallDescriptorFlags, numFloatArgs);
-                  if (TR_S390zOSSystemLinkage::isFloatDescriptorFlagUnprototyped(val))
+                  uint32_t val = TR::S390zOSSystemLinkage::getFloatParmDescriptorFlag(xplinkCallDescriptorFlags, numFloatArgs);
+                  if (TR::S390zOSSystemLinkage::isFloatDescriptorFlagUnprototyped(val))
                      self()->setProperty(AllParmsOnStack); // temporarily set so float gets flushed to stack
                   }
                argRegister = self()->pushArg(callNode, child, numIntegerArgs, numFloatArgs, &stackOffset, dependencies);
@@ -2530,8 +2530,8 @@ OMR::Z::Linkage::buildArgs(TR::Node * callNode, TR::RegisterDependencyConditions
          case TR::DecimalDouble:
             if (self()->isFloatParmDescriptors() && (numFloatArgs < self()->getNumFloatArgumentRegisters()))
                { // XPLink: handle large separation of float args constraint
-               int32_t val = TR_S390zOSSystemLinkage::getFloatParmDescriptorFlag(xplinkCallDescriptorFlags, numFloatArgs);
-               if (TR_S390zOSSystemLinkage::isFloatDescriptorFlagUnprototyped(val))
+               int32_t val = TR::S390zOSSystemLinkage::getFloatParmDescriptorFlag(xplinkCallDescriptorFlags, numFloatArgs);
+               if (TR::S390zOSSystemLinkage::isFloatDescriptorFlagUnprototyped(val))
                   self()->setProperty(AllParmsOnStack); // temporarily set so float gets flushed to stack
                }
             argRegister = self()->pushArg(callNode, child, numIntegerArgs, numFloatArgs, &stackOffset, dependencies);
@@ -2558,8 +2558,8 @@ OMR::Z::Linkage::buildArgs(TR::Node * callNode, TR::RegisterDependencyConditions
 
             if (self()->isFloatParmDescriptors() && (numFloatArgs < (self()->getNumFloatArgumentRegisters()-1)))
                { // XPLink: handle large separation of float args constraint
-               int32_t val = TR_S390zOSSystemLinkage::getFloatParmDescriptorFlag(xplinkCallDescriptorFlags, numFloatArgs);
-               if (TR_S390zOSSystemLinkage::isFloatDescriptorFlagUnprototyped(val))
+               int32_t val = TR::S390zOSSystemLinkage::getFloatParmDescriptorFlag(xplinkCallDescriptorFlags, numFloatArgs);
+               if (TR::S390zOSSystemLinkage::isFloatDescriptorFlagUnprototyped(val))
                   self()->setProperty(AllParmsOnStack); // temporarily set so float gets flushed to stack
                }
             argRegister = self()->pushArg(callNode, child, numIntegerArgs, numFloatArgs, &stackOffset, dependencies);
@@ -3111,7 +3111,7 @@ OMR::Z::Linkage::buildNativeDispatch(TR::Node * callNode,
    /*********************************/
    self()->setupBuildArgForLinkage(callNode, dispatchType, deps, isFastJNI, isPassReceiver, killMask, GlobalRegDeps, hasGlRegDeps, systemLinkage);
 
-   // omr todo: this should be cleaned up with TR_S390PrivateLinkage::setupBuildArgForLinkage and JNI Dispatch
+   // omr todo: this should be cleaned up with TR::S390PrivateLinkage::setupBuildArgForLinkage and JNI Dispatch
    //if (dispatchType == TR_JNIDispatch)  return NULL;
 
 

--- a/compiler/z/codegen/OMRLinkage.hpp
+++ b/compiler/z/codegen/OMRLinkage.hpp
@@ -47,7 +47,7 @@ namespace OMR { typedef OMR::Z::Linkage LinkageConnector; }
 
 class TR_FrontEnd;
 namespace TR { class S390JNICallDataSnippet; }
-class TR_S390PrivateLinkage;
+namespace TR { class S390PrivateLinkage; }
 namespace TR { class AutomaticSymbol; }
 namespace TR { class Compilation; }
 namespace TR { class Instruction; }
@@ -205,14 +205,18 @@ enum TR_S390LinkageRelocations
  */
 #define TR_FirstSpecialLinkageIndex  0x10
 
+namespace TR {
+
 /**
  * Pseudo-safe downcast function, since all linkages must be S390 linkages
  */
-inline TR_S390PrivateLinkage *
+inline TR::S390PrivateLinkage *
 toS390PrivateLinkage(TR::Linkage * l)
    {
-   return (TR_S390PrivateLinkage *) l;
+   return (TR::S390PrivateLinkage *) l;
    }
+
+}
 
 /**
  * 390 Automatic Marker Symbol Types
@@ -225,7 +229,7 @@ enum TR_S390AutoMarkers
 
 
 ////////////////////////////////////////////////////////////////////////////////
-//  TR_S390Linkage Definition
+//  TR::S390Linkage Definition
 ////////////////////////////////////////////////////////////////////////////////
 
 // Normal Stack Pointer Register refers to the register defined by the

--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -6545,7 +6545,7 @@ OMR::Z::Machine::initializeGlobalRegisterTable()
    if (!comp->getOption(TR_DisableRegisterPressureSimulation))
       {
       int32_t p = 0;
-      static char *dontInitializeGlobalRegisterTableFromLinkage = feGetEnv("TR_dontInitializeGlobalRegisterTableFromLinkage");
+      static char *dontInitializeGlobalRegisterTableFromLinkage = feGetEnv("TR::dontInitializeGlobalRegisterTableFromLinkage");
       bool enableHighWordGRA = _cg->supportsHighWordFacility() && !comp->getOption(TR_DisableHighWordRA);
       if (dontInitializeGlobalRegisterTableFromLinkage)
          {
@@ -6925,7 +6925,7 @@ OMR::Z::Machine::initializeGlobalRegisterTable()
    self()->setLast8BitGlobalGPRRegisterNumber(25);    // Index of last global 8bit Reg
 
    // additional (forced) restricted regs.
-   // Similar code in TR_S390PrivateLinkage::initS390RealRegisterLinkage() for RA
+   // Similar code in TR::S390PrivateLinkage::initS390RealRegisterLinkage() for RA
 
    for (int32_t i = self()->getFirstGlobalGPRRegisterNumber(); i < self()->getLastGlobalGPRRegisterNumber(); ++i)
       {

--- a/compiler/z/codegen/S390SystemLinkage.hpp
+++ b/compiler/z/codegen/S390SystemLinkage.hpp
@@ -24,8 +24,8 @@
  */
 #ifndef Z_SYSTEMLINKAGE_CONNECTOR
 #define Z_SYSTEMLINKAGE_CONNECTOR
-class TR_S390SystemLinkage;
-namespace OMR { typedef TR_S390SystemLinkage SystemLinkageConnector; }
+namespace TR { class S390SystemLinkage; }
+namespace OMR { typedef TR::S390SystemLinkage SystemLinkageConnector; }
 #endif
 
 #include <stddef.h>                            // for NULL, size_t
@@ -56,26 +56,28 @@ namespace TR { class ResolvedMethodSymbol; }
 namespace TR { class SystemLinkage; }
 template <class T> class List;
 
+namespace TR {
+
 ////////////////////////////////////////////////////////////////////////////////
-//  TR_S390SystemLinkage Definition
+//  TR::S390SystemLinkage Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_AllocaPatchGroup
+class AllocaPatchGroup
    {
 public:
    TR::Instruction *ahi;
    TR::Instruction *mvc;
    TR::Instruction *auxMvc;
 
-   TR_AllocaPatchGroup() : ahi(NULL), mvc(NULL), auxMvc(NULL)
+   AllocaPatchGroup() : ahi(NULL), mvc(NULL), auxMvc(NULL)
       {
       }
    };
 
-class TR_VaStartPatchGroup
+class VaStartPatchGroup
    {
 public:
    TR::Instruction * instrToBePatched[4];
-   TR_VaStartPatchGroup()
+   VaStartPatchGroup()
       {
       for (int i = 0; i < 4; ++i)
          instrToBePatched[i] = NULL;
@@ -83,7 +85,7 @@ public:
    };
 
 
-class TR_S390SystemLinkage : public TR::Linkage
+class S390SystemLinkage : public TR::Linkage
    {
    TR::RealRegister::RegNum _normalStackPointerRegister;
    TR::RealRegister::RegNum _alternateStackPointerRegister;
@@ -201,7 +203,7 @@ public:
 
 
 public:
-   TR_S390SystemLinkage(TR::CodeGenerator * cg, TR_S390LinkageConventions elc=TR_S390LinkageDefault, TR_LinkageConventions lc=TR_System)
+   S390SystemLinkage(TR::CodeGenerator * cg, TR_S390LinkageConventions elc=TR_S390LinkageDefault, TR_LinkageConventions lc=TR_System)
       : TR::Linkage(cg, elc,lc),
         _notifiedOfalloca(false),
         _notifiedOfDebugHooks(false),
@@ -281,5 +283,7 @@ public:
    virtual TR::Instruction *getputHPRs(TR::InstOpCode::Mnemonic opcode, TR::Instruction *cursor, TR::Node *node, TR::RealRegister *spReg=0);
 
    };
+
+}
 
 #endif

--- a/compiler/z/codegen/SystemLinkage.cpp
+++ b/compiler/z/codegen/SystemLinkage.cpp
@@ -75,17 +75,17 @@
 #define  GPREGINDEX(i)   (i-TR::RealRegister::FirstGPR)
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390zOSSystemLinkage for J9
+// TR::S390zOSSystemLinkage for J9
 ////////////////////////////////////////////////////////////////////////////////
 
 TR::SystemLinkage *
-TR_S390SystemLinkage::self()
+TR::S390SystemLinkage::self()
    {
    return static_cast<TR::SystemLinkage *>(this);
    }
 
 void
-TR_S390SystemLinkage::initS390RealRegisterLinkage()
+TR::S390SystemLinkage::initS390RealRegisterLinkage()
    {
    int32_t icount = 0, ret_count=0;
 
@@ -161,7 +161,7 @@ TR_S390SystemLinkage::initS390RealRegisterLinkage()
 
 // Non-Java use
 void
-TR_S390SystemLinkage::initParamOffset(TR::ResolvedMethodSymbol * method, int32_t stackIndex, List<TR::ParameterSymbol> *parameterList)
+TR::S390SystemLinkage::initParamOffset(TR::ResolvedMethodSymbol * method, int32_t stackIndex, List<TR::ParameterSymbol> *parameterList)
 {
    ListIterator<TR::ParameterSymbol> parameterIterator((parameterList != NULL)? parameterList : &method->getParameterList());
    parameterIterator.reset();
@@ -207,7 +207,7 @@ TR_S390SystemLinkage::initParamOffset(TR::ResolvedMethodSymbol * method, int32_t
  * Non-Java use
  */
 TR::SymbolReference *
-TR_S390SystemLinkage::createAutoMarkerSymbol(TR_S390AutoMarkers markerType)
+TR::S390SystemLinkage::createAutoMarkerSymbol(TR_S390AutoMarkers markerType)
    {
    char *name = NULL;
    switch (markerType)
@@ -239,7 +239,7 @@ TR_S390SystemLinkage::createAutoMarkerSymbol(TR_S390AutoMarkers markerType)
  * The operation depends on supplied opcode
  */
 TR::Instruction *
-TR_S390SystemLinkage::getputFPRs(TR::InstOpCode::Mnemonic opcode, TR::Instruction * cursor, TR::Node *node, TR::RealRegister *spReg)
+TR::S390SystemLinkage::getputFPRs(TR::InstOpCode::Mnemonic opcode, TR::Instruction * cursor, TR::Node *node, TR::RealRegister *spReg)
    {
    int16_t FPRSaveMask;
    int32_t offset, firstSaved, lastSaved, beginSaveOffset;
@@ -280,7 +280,7 @@ TR_S390SystemLinkage::getputFPRs(TR::InstOpCode::Mnemonic opcode, TR::Instructio
  * The operation depends on supplied opcode
  */
 TR::Instruction *
-TR_S390SystemLinkage::getputARs(TR::InstOpCode::Mnemonic opcode, TR::Instruction * cursor, TR::Node *node, TR::RealRegister *spReg)
+TR::S390SystemLinkage::getputARs(TR::InstOpCode::Mnemonic opcode, TR::Instruction * cursor, TR::Node *node, TR::RealRegister *spReg)
    {
    int16_t ARSaveMask;
    int32_t offset, firstSaved, lastSaved, beginSaveOffset;
@@ -317,7 +317,7 @@ TR_S390SystemLinkage::getputARs(TR::InstOpCode::Mnemonic opcode, TR::Instruction
    }
 
 TR::Instruction *
-TR_S390SystemLinkage::getputHPRs(TR::InstOpCode::Mnemonic opcode, TR::Instruction * cursor, TR::Node *node, TR::RealRegister *spReg)
+TR::S390SystemLinkage::getputHPRs(TR::InstOpCode::Mnemonic opcode, TR::Instruction * cursor, TR::Node *node, TR::RealRegister *spReg)
    {
    int16_t HPRSaveMask;
    int32_t offset, firstSaved, lastSaved, beginSaveOffset;
@@ -381,7 +381,7 @@ TR_S390SystemLinkage::getputHPRs(TR::InstOpCode::Mnemonic opcode, TR::Instructio
  *   instruction  sequence
  */
 TR::Instruction *
-TR_S390SystemLinkage::addImmediateToRealRegister(TR::RealRegister *targetReg, int32_t value, TR::RealRegister *tempReg, TR::Node *node, TR::Instruction *cursor, bool *checkTempNeeded)
+TR::S390SystemLinkage::addImmediateToRealRegister(TR::RealRegister *targetReg, int32_t value, TR::RealRegister *tempReg, TR::Node *node, TR::Instruction *cursor, bool *checkTempNeeded)
    {
    bool smallPositiveValue = (value<MAXDISP && value>=0);
    bool largeValue = (value<MIN_IMMEDIATE_VAL || value>MAX_IMMEDIATE_VAL);
@@ -420,7 +420,7 @@ TR_S390SystemLinkage::addImmediateToRealRegister(TR::RealRegister *targetReg, in
  * Reverse the bit ordering of the save mask
  */
 uint16_t
-TR_S390SystemLinkage::flipBitsRegisterSaveMask(uint16_t mask)
+TR::S390SystemLinkage::flipBitsRegisterSaveMask(uint16_t mask)
    {
    TR_ASSERT(NUM_S390_GPR == NUM_S390_FPR, "need special flip bits for FPR");
    uint16_t i, outputMask;
@@ -437,7 +437,7 @@ TR_S390SystemLinkage::flipBitsRegisterSaveMask(uint16_t mask)
    }
 
 
-TR_S390zOSSystemLinkage::TR_S390zOSSystemLinkage(TR::CodeGenerator * codeGen)
+TR::S390zOSSystemLinkage::S390zOSSystemLinkage(TR::CodeGenerator * codeGen)
    : TR::ZOSBaseSystemLinkageConnector(codeGen, TR_SystemXPLink)
    {
    // linkage properties
@@ -552,7 +552,7 @@ TR_S390zOSSystemLinkage::TR_S390zOSSystemLinkage(TR::CodeGenerator * codeGen)
  * linkage for incoming floating point parameters.
  */
 uint32_t
-TR_S390zOSSystemLinkage::calculateInterfaceMappingFlags(TR::ResolvedMethodSymbol *method)
+TR::S390zOSSystemLinkage::calculateInterfaceMappingFlags(TR::ResolvedMethodSymbol *method)
    {
    uint32_t callDescValue;
 
@@ -617,7 +617,7 @@ TR_S390zOSSystemLinkage::calculateInterfaceMappingFlags(TR::ResolvedMethodSymbol
  * Calculate "Return value adjust" component of XPLink call descriptor
  */
 uint32_t
-TR_S390zOSSystemLinkage::calculateReturnValueAdjustFlag(TR::DataType dataType, int32_t aggregateLength)
+TR::S390zOSSystemLinkage::calculateReturnValueAdjustFlag(TR::DataType dataType, int32_t aggregateLength)
    {
    // 5 bit values for "return value adjust" field of XPLink descriptor
    #define XPLINK_RVA_RETURN_VOID_OR_UNUSED    0x00
@@ -697,7 +697,7 @@ TR_S390zOSSystemLinkage::calculateReturnValueAdjustFlag(TR::DataType dataType, i
  * determined.
  */
 bool
-TR_S390zOSSystemLinkage::updateFloatParmDescriptorFlags(uint32_t *parmDescriptorFields, TR::Symbol *funcSymbol, int32_t parmCount, int32_t argSize, TR::DataType dataType, int32_t *floatParmNum, uint32_t *lastFloatParmAreaOffset, uint32_t *parmAreaOffset)
+TR::S390zOSSystemLinkage::updateFloatParmDescriptorFlags(uint32_t *parmDescriptorFields, TR::Symbol *funcSymbol, int32_t parmCount, int32_t argSize, TR::DataType dataType, int32_t *floatParmNum, uint32_t *lastFloatParmAreaOffset, uint32_t *parmAreaOffset)
    {
    uint32_t gprSize = cg()->machine()->getGPRSize();
 
@@ -765,7 +765,7 @@ TR_S390zOSSystemLinkage::updateFloatParmDescriptorFlags(uint32_t *parmDescriptor
    }
 
 TR::Register *
-TR_S390zOSSystemLinkage::loadEnvironmentIntoRegister(TR::Node * callNode, TR::RegisterDependencyConditions * deps, bool loadIntoEnvironmentRegister)
+TR::S390zOSSystemLinkage::loadEnvironmentIntoRegister(TR::Node * callNode, TR::RegisterDependencyConditions * deps, bool loadIntoEnvironmentRegister)
    {
    // Important note: this should only be called in pre-prologue phase for routines we know are
    // not leaf routines.
@@ -789,7 +789,7 @@ TR_S390zOSSystemLinkage::loadEnvironmentIntoRegister(TR::Node * callNode, TR::Re
  * WCode use
  */
 int32_t
-TR_S390zOSSystemLinkage::getOutgoingParameterBlockSize()
+TR::S390zOSSystemLinkage::getOutgoingParameterBlockSize()
    {
    //
    // Calculate size of outgoing argument area
@@ -806,9 +806,9 @@ TR_S390zOSSystemLinkage::getOutgoingParameterBlockSize()
    }
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_S390zLinuxSystemLinkage for J9
+// TR::S390zLinuxSystemLinkage for J9
 ////////////////////////////////////////////////////////////////////////////////
-TR_S390zLinuxSystemLinkage::TR_S390zLinuxSystemLinkage(TR::CodeGenerator * codeGen)
+TR::S390zLinuxSystemLinkage::S390zLinuxSystemLinkage(TR::CodeGenerator * codeGen)
    : TR::SystemLinkage(codeGen,TR_SystemLinux)
    {
    // linkage properties
@@ -951,7 +951,7 @@ TR_S390zLinuxSystemLinkage::TR_S390zLinuxSystemLinkage(TR::CodeGenerator * codeG
  * Front-end customization of callNativeFunction
  */
 void
-TR_S390SystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR::RegisterDependencyConditions * deps, intptrj_t targetAddress,
+TR::S390SystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR::RegisterDependencyConditions * deps, intptrj_t targetAddress,
       TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel,
       TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint)
    {
@@ -963,7 +963,7 @@ TR_S390SystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR::Regis
  * @return return value will be return value from system routine copied to private linkage return reg
  */
 TR::Register *
-TR_S390SystemLinkage::callNativeFunction(TR::Node * callNode, TR::RegisterDependencyConditions * deps, intptrj_t targetAddress,
+TR::S390SystemLinkage::callNativeFunction(TR::Node * callNode, TR::RegisterDependencyConditions * deps, intptrj_t targetAddress,
       TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel,
       TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint)
    {
@@ -974,7 +974,7 @@ TR_S390SystemLinkage::callNativeFunction(TR::Node * callNode, TR::RegisterDepend
  * Front-end customization of callNativeFunction
  */
 void
-TR_S390zOSSystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR::RegisterDependencyConditions * deps, intptrj_t targetAddress,
+TR::S390zOSSystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR::RegisterDependencyConditions * deps, intptrj_t targetAddress,
       TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel,
       TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint)
    {
@@ -985,11 +985,11 @@ TR_S390zOSSystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR::Re
    }
 
 /**
- * TR_S390zOSSystemLinkage::callNativeFunction - call System routine
+ * TR::S390zOSSystemLinkage::callNativeFunction - call System routine
  * return value will be return value from system routine copied to private linkage return reg
  */
 TR::Register *
-TR_S390zOSSystemLinkage::callNativeFunction(TR::Node * callNode, TR::RegisterDependencyConditions * deps, intptrj_t targetAddress,
+TR::S390zOSSystemLinkage::callNativeFunction(TR::Node * callNode, TR::RegisterDependencyConditions * deps, intptrj_t targetAddress,
       TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel,
       TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint)
    {
@@ -1106,7 +1106,7 @@ TR_S390zOSSystemLinkage::callNativeFunction(TR::Node * callNode, TR::RegisterDep
  * Front-end customization of callNativeFunction
  */
 void
-TR_S390zLinuxSystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR::RegisterDependencyConditions * deps, intptrj_t targetAddress,
+TR::S390zLinuxSystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR::RegisterDependencyConditions * deps, intptrj_t targetAddress,
       TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel,
       TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint)
    {
@@ -1148,7 +1148,7 @@ TR_S390zLinuxSystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR:
  * @return return value will be return reg
  */
 TR::Register *
-TR_S390zLinuxSystemLinkage::callNativeFunction(TR::Node * callNode,
+TR::S390zLinuxSystemLinkage::callNativeFunction(TR::Node * callNode,
    TR::RegisterDependencyConditions * deps, intptrj_t targetAddress,
    TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel,
    TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint)
@@ -1251,7 +1251,7 @@ TR_S390zLinuxSystemLinkage::callNativeFunction(TR::Node * callNode,
  * @todo (cleanup) should remove this method and use base class version.
  */
 void
-TR_S390zLinuxSystemLinkage::initParamOffset(TR::ResolvedMethodSymbol * method, int32_t stackIndex, List<TR::ParameterSymbol> *parameterList)
+TR::S390zLinuxSystemLinkage::initParamOffset(TR::ResolvedMethodSymbol * method, int32_t stackIndex, List<TR::ParameterSymbol> *parameterList)
 {
    ListIterator<TR::ParameterSymbol> parameterIterator(&method->getParameterList());
    parameterIterator.reset();
@@ -1405,7 +1405,7 @@ TR_S390zLinuxSystemLinkage::initParamOffset(TR::ResolvedMethodSymbol * method, i
 
 #if 0
 void
-TR_S390zLinuxSystemLinkage::mapSingleAutomatic(TR::AutomaticSymbol * p, uint32_t & stackIndex)
+TR::S390zLinuxSystemLinkage::mapSingleAutomatic(TR::AutomaticSymbol * p, uint32_t & stackIndex)
    {
    size_t align = 1;
    size_t size = p->getSize();
@@ -1443,7 +1443,7 @@ TR_S390zLinuxSystemLinkage::mapSingleAutomatic(TR::AutomaticSymbol * p, uint32_t
 #endif
 
 void
-TR_S390SystemLinkage::mapStack(TR::ResolvedMethodSymbol * method)
+TR::S390SystemLinkage::mapStack(TR::ResolvedMethodSymbol * method)
   	{
 		{
      	mapStack(method,0);
@@ -1456,7 +1456,7 @@ TR_S390SystemLinkage::mapStack(TR::ResolvedMethodSymbol * method)
  * The offsets will be fixed up (at the end /in createPrologue) when the stackFrameSize is known
  */
 void
-TR_S390SystemLinkage::mapStack(TR::ResolvedMethodSymbol * method, uint32_t stackIndex)
+TR::S390SystemLinkage::mapStack(TR::ResolvedMethodSymbol * method, uint32_t stackIndex)
    {
    int32_t i;
 
@@ -1595,7 +1595,7 @@ TR_S390SystemLinkage::mapStack(TR::ResolvedMethodSymbol * method, uint32_t stack
    setLocalsAreaEndOffset(stackIndex);
    }
 
-void TR_S390SystemLinkage::mapSingleAutomatic(TR::AutomaticSymbol * p, uint32_t & stackIndex)
+void TR::S390SystemLinkage::mapSingleAutomatic(TR::AutomaticSymbol * p, uint32_t & stackIndex)
    {
    size_t align = 1;
    size_t size = p->getSize();
@@ -1619,14 +1619,14 @@ void TR_S390SystemLinkage::mapSingleAutomatic(TR::AutomaticSymbol * p, uint32_t 
    setStrictestAutoSymbolAlignment(align); // API affected if (align > current strictest)
    }
 
-bool TR_S390SystemLinkage::hasToBeOnStack(TR::ParameterSymbol * parm)
+bool TR::S390SystemLinkage::hasToBeOnStack(TR::ParameterSymbol * parm)
    {
    return parm->getAllocatedIndex() >=  0 &&  parm->isParmHasToBeOnStack();
    }
 
 
 TR::Instruction*
-TR_S390SystemLinkage::saveGPRsInPrologue2(TR::Instruction * cursor)
+TR::S390SystemLinkage::saveGPRsInPrologue2(TR::Instruction * cursor)
    {
    int16_t GPRSaveMask = 0;
    int32_t offset = 0;
@@ -1708,7 +1708,7 @@ TR_S390SystemLinkage::saveGPRsInPrologue2(TR::Instruction * cursor)
    }
 
 TR::Instruction*
-TR_S390SystemLinkage::saveGPRsInPrologue(TR::Instruction * cursor)
+TR::S390SystemLinkage::saveGPRsInPrologue(TR::Instruction * cursor)
    {
    int16_t GPRSaveMask = 0;
    bool hasSavedSP = false;
@@ -1790,7 +1790,7 @@ TR_S390SystemLinkage::saveGPRsInPrologue(TR::Instruction * cursor)
    }
 
 TR::Linkage::FrameType
-TR_S390zLinuxSystemLinkage::checkLeafRoutine(int32_t stackFrameSize, TR::Instruction **callInstruction)
+TR::S390zLinuxSystemLinkage::checkLeafRoutine(int32_t stackFrameSize, TR::Instruction **callInstruction)
    {
    FrameType ft = standardFrame;
 
@@ -1931,9 +1931,9 @@ bool OMR::Z::Linkage::checkPreservedRegisterUsage(bool *regs, int32_t regsSize)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR_390SystemLinkage::createPrologue() - create prolog for System linkage
+// TR::390SystemLinkage::createPrologue() - create prolog for System linkage
 ////////////////////////////////////////////////////////////////////////////////
-void TR_S390SystemLinkage::createPrologue(TR::Instruction * cursor)
+void TR::S390SystemLinkage::createPrologue(TR::Instruction * cursor)
    {
    TR::Delimiter delimiter (comp(), comp()->getOption(TR_TraceCG), "Prologue");
    TR::RealRegister * spReg = getNormalStackPointerRealRegister();
@@ -1966,7 +1966,7 @@ void TR_S390SystemLinkage::createPrologue(TR::Instruction * cursor)
 
    //  We assume frame size is less than 32k
    //TR_ASSERT(stackFrameSize<=MAX_IMMEDIATE_VAL,
-   //      "TR_S390SystemLinkage::createPrologue -- Frame size (0x%x) greater than 0x7FFF\n",stackFrameSize);
+   //      "TR::S390SystemLinkage::createPrologue -- Frame size (0x%x) greater than 0x7FFF\n",stackFrameSize);
 
    //Now that stackFrame size is known, map stack
    mapStack(bodySymbol, stackFrameSize);
@@ -2100,7 +2100,7 @@ void TR_S390SystemLinkage::createPrologue(TR::Instruction * cursor)
 
 
 TR::Instruction*
-TR_S390SystemLinkage::restoreGPRsInEpilogue2(TR::Instruction *cursor)
+TR::S390SystemLinkage::restoreGPRsInEpilogue2(TR::Instruction *cursor)
    {
    int16_t GPRSaveMask = 0;
    int32_t offset = 0;
@@ -2162,7 +2162,7 @@ TR_S390SystemLinkage::restoreGPRsInEpilogue2(TR::Instruction *cursor)
    }
 
 TR::Instruction*
-TR_S390SystemLinkage::restoreGPRsInEpilogue(TR::Instruction *cursor)
+TR::S390SystemLinkage::restoreGPRsInEpilogue(TR::Instruction *cursor)
    {
    int16_t GPRSaveMask = 0;
    bool    hasRestoreSP = false;
@@ -2245,7 +2245,7 @@ TR_S390SystemLinkage::restoreGPRsInEpilogue(TR::Instruction *cursor)
 /**
  * Create epilog for System linkage
  */
-void TR_S390SystemLinkage::createEpilogue(TR::Instruction * cursor)
+void TR::S390SystemLinkage::createEpilogue(TR::Instruction * cursor)
    {
    TR::Delimiter delimiter (comp(), comp()->getOption(TR_TraceCG), "Epilogue");
 
@@ -2332,7 +2332,7 @@ void TR_S390SystemLinkage::createEpilogue(TR::Instruction * cursor)
    ((TR::S390RegInstruction *)cursor)->setJITExit();
    }
 
-void TR_S390SystemLinkage::notifyHasalloca()
+void TR::S390SystemLinkage::notifyHasalloca()
    {
    TR::RealRegister::RegNum alternateSP = getAlternateStackPointerRegister();
    TR::RealRegister * alternateStackReg = getS390RealRegister(getAlternateStackPointerRegister());
@@ -2357,7 +2357,7 @@ void TR_S390SystemLinkage::notifyHasalloca()
    }
 
 int32_t
-TR_S390zLinuxSystemLinkage::getRegisterSaveOffset(TR::RealRegister::RegNum srcReg)
+TR::S390zLinuxSystemLinkage::getRegisterSaveOffset(TR::RealRegister::RegNum srcReg)
    {
    int32_t gpr2Offset = TR::Compiler->target.is64Bit() ? 16 : 8;
    int32_t fpr0Offset = TR::Compiler->target.is64Bit() ? 128 : 64;
@@ -2373,7 +2373,7 @@ TR_S390zLinuxSystemLinkage::getRegisterSaveOffset(TR::RealRegister::RegNum srcRe
       case TR::RealRegister::FPR7:
       case TR::RealRegister::GPR0:
       case TR::RealRegister::GPR1:
-         TR_ASSERT(false,"ERROR: TR_zLinuxSystemLinkage::getRegisterSaveOffset called for volatile reg: %d",srcReg);
+         TR_ASSERT(false,"ERROR: TR::zLinuxSystemLinkage::getRegisterSaveOffset called for volatile reg: %d",srcReg);
          return -1;
       case TR::RealRegister::GPR2: return gpr2Offset;
       default: return gpr2Offset + (srcReg - TR::RealRegister::GPR2) * cg()->machine()->getGPRSize();
@@ -2381,7 +2381,7 @@ TR_S390zLinuxSystemLinkage::getRegisterSaveOffset(TR::RealRegister::RegNum srcRe
    }
 
 int32_t
-TR_S390zOSSystemLinkage::getRegisterSaveOffset(TR::RealRegister::RegNum srcReg)
+TR::S390zOSSystemLinkage::getRegisterSaveOffset(TR::RealRegister::RegNum srcReg)
    {
    int32_t offset;
    if ((srcReg >= TR::RealRegister::GPR4) && (srcReg <= TR::RealRegister::GPR15))
@@ -2391,7 +2391,7 @@ TR_S390zOSSystemLinkage::getRegisterSaveOffset(TR::RealRegister::RegNum srcReg)
       }
    else
       {
-      TR_ASSERT(false, "ERROR: TR_S390zOSSystemLinkage::getRegisterSaveOffset called for volatile reg: %d\n",srcReg);
+      TR_ASSERT(false, "ERROR: TR::S390zOSSystemLinkage::getRegisterSaveOffset called for volatile reg: %d\n",srcReg);
       return -1;
       }
    }
@@ -2576,7 +2576,7 @@ void OMR::Z::Linkage::replaceCallWithJumpInstruction(TR::Instruction *callInstru
 
 bool OMR::Z::Linkage::canDataTypeBePassedByReference(TR::DataType type) { return false; }
 
-bool TR_S390zLinuxSystemLinkage::canDataTypeBePassedByReference(TR::DataType type)
+bool TR::S390zLinuxSystemLinkage::canDataTypeBePassedByReference(TR::DataType type)
    {
 
    if (type == TR::Aggregate)
@@ -2587,7 +2587,7 @@ bool TR_S390zLinuxSystemLinkage::canDataTypeBePassedByReference(TR::DataType typ
 
 bool OMR::Z::Linkage::isSymbolPassedByReference(TR::Symbol *sym) { return false; }
 
-bool TR_S390zLinuxSystemLinkage::isSymbolPassedByReference(TR::Symbol *sym)
+bool TR::S390zLinuxSystemLinkage::isSymbolPassedByReference(TR::Symbol *sym)
    {
    if(!canDataTypeBePassedByReference(sym->getDataType()))
       return false;
@@ -2616,7 +2616,7 @@ TR::Z::ZOSBaseSystemLinkage::isAggregateReturnedInIntRegistersAndMemory(int32_t 
    }
 
 bool
-TR_S390zOSSystemLinkage::isAggregateReturnedInIntRegisters(int32_t aggregateLenth)
+TR::S390zOSSystemLinkage::isAggregateReturnedInIntRegisters(int32_t aggregateLenth)
    {
    return aggregateLenth  <= (getNumIntegerArgumentRegisters()* cg()->machine()->getGPRSize());
    }
@@ -2631,7 +2631,7 @@ TR_S390zOSSystemLinkage::isAggregateReturnedInIntRegisters(int32_t aggregateLent
  * determine floating point register likage for outgoing parameters.
  */
 uint32_t
-TR_S390zOSSystemLinkage::calculateCallDescriptorFlags(TR::Node *callNode)
+TR::S390zOSSystemLinkage::calculateCallDescriptorFlags(TR::Node *callNode)
    {
    #define XPLINK_FLOAT_PARM_UNPROTYPED_CALL 0x08
    uint32_t callDescValue;

--- a/compiler/z/codegen/TRSystemLinkage.hpp
+++ b/compiler/z/codegen/TRSystemLinkage.hpp
@@ -48,7 +48,7 @@ namespace TR { class Symbol; }
 template <class T> class List;
 
 ////////////////////////////////////////////////////////////////////////////////
-//  TR_S390zOSSystemLinkage Definition
+//  TR::S390zOSSystemLinkage Definition
 ////////////////////////////////////////////////////////////////////////////////
 
 enum TR_XPLinkFrameType
@@ -76,13 +76,15 @@ enum TR_XPLinkCallTypes {
    TR_XPLinkCallType_BASR33    =7      ///< BASR  r3,r3
    };
 
-class TR_S390zOSSystemLinkage : public TR::ZOSBaseSystemLinkageConnector
+namespace TR {
+
+class S390zOSSystemLinkage : public TR::ZOSBaseSystemLinkageConnector
    {
    TR::RealRegister::RegNum _environmentPointerRegister;
 
 public:
 
-   TR_S390zOSSystemLinkage(TR::CodeGenerator * cg) ;
+   S390zOSSystemLinkage(TR::CodeGenerator * cg);
 
    virtual void generateInstructionsForCall(TR::Node * callNode, TR::RegisterDependencyConditions * dependencies,
          intptrj_t targetAddress, TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel,
@@ -150,14 +152,14 @@ private:
 
 
 ////////////////////////////////////////////////////////////////////////////////
-//  TR_S390zLinuxSystemLinkage Definition
+//  TR::S390zLinuxSystemLinkage Definition
 ////////////////////////////////////////////////////////////////////////////////
-class TR_S390zLinuxSystemLinkage : public TR::SystemLinkage
+class S390zLinuxSystemLinkage : public TR::SystemLinkage
    {
    TR::RealRegister::RegNum _GOTPointerRegister;
 public:
 
-   TR_S390zLinuxSystemLinkage(TR::CodeGenerator * cg) ;
+   S390zLinuxSystemLinkage(TR::CodeGenerator * cg);
 
    virtual void generateInstructionsForCall(TR::Node * callNode, TR::RegisterDependencyConditions * deps, intptrj_t targetAddress,
          TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel,
@@ -177,9 +179,6 @@ public:
    virtual bool isSymbolPassedByReference(TR::Symbol *sym);
    };
 
-
-////////////////////////////////////////////////////////////////////////////////
-//  TR_S39PLXSystemLinkage Definition
-////////////////////////////////////////////////////////////////////////////////
+}
 
 #endif


### PR DESCRIPTION
This is part of moving all classes from using the TR_ prefix to the TR namespace.