### PR TITLE
Remove atomicOperations test case and add assertion in service

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -370,6 +370,8 @@ class OMR_EXTENSIBLE CodeGenerator
 
    TR_HasRandomGenerator randomizer;
 
+   virtual bool supportsAtomicAdd() {return false;}
+
    // --------------------------------------------------------------------------
    // Infrastructure
    //

--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -1513,6 +1513,7 @@ IlBuilder::genCall(TR::SymbolReference *methodSymRef, int32_t numArgs, TR::IlVal
 TR::IlValue *
 IlBuilder::AtomicAddWithOffset(TR::IlValue * baseAddress, TR::IlValue * offset, TR::IlValue * value)
    {
+   TR_ASSERT(comp()->cg()->supportsAtomicAdd(), "this platform doesn't support AtomicAdd() yet");
    TR_ASSERT(baseAddress->getSymbol()->getDataType() == TR::Address, "baseAddress must be TR::Address");
    TR_ASSERT(offset == NULL || offset->getSymbol()->getDataType() == TR::Int32 || offset->getSymbol()->getDataType() == TR::Int64, "offset must be TR::Int32/64 or NULL");
 

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -237,6 +237,8 @@ struct TR_X86ProcessorInfo
    bool supportsSFence()                   {return _featureFlags.testAny(TR_SSE | TR_MMXInstructions);}
    bool prefersMultiByteNOP()              {return getX86Architecture() && isGenuineIntel() && !isIntelPentium();}
 
+   bool supportsAtomicAdd()                {return true;} //we have common helpers for atomic primitives
+
    uint32_t getCPUStepping(uint32_t signature)       {return (signature & CPUID_SIGNATURE_STEPPING_MASK);}
    uint32_t getCPUModel(uint32_t signature)          {return (signature & CPUID_SIGNATURE_MODEL_MASK) >> 4;}
    uint32_t getCPUFamily(uint32_t signature)         {return (signature & CPUID_SIGNATURE_FAMILY_MASK) >> 8;}

--- a/jitbuilder/release/Makefile
+++ b/jitbuilder/release/Makefile
@@ -24,7 +24,6 @@ CXXFLAGS=-g -std=c++0x -O2 -c -fno-rtti -fPIC -I./include/compiler -I./include
 
 # NOTE: replay purposefully left out of the list
 ALL_TESTS = \
-            atomicoperations \
             call \
             conststring \
             controlflowtests \
@@ -44,7 +43,6 @@ ALL_TESTS = \
             toiltype
 
 goal: $(ALL_TESTS)
-	./atomicoperations
 	./call
 	./conststring
 	./controlflowtests
@@ -71,7 +69,6 @@ atomicoperations : libjitbuilder.a AtomicOperations.o
 
 AtomicOperations.o: src/AtomicOperations.cpp src/AtomicOperations.hpp
 	g++ -o $@ $(CXXFLAGS) $<
-
 
 badtoiltype : libjitbuilder.a BadToIlType.o
 	g++ -g -fno-rtti -o $@ BadToIlType.o -L. -ljitbuilder -ldl


### PR DESCRIPTION
1) Remove atomicOperations.cpp/hpp from main goal of JitBuilder Makefile.
2) Add Assertion in AtomicAddWithOffset() to ensure that the platform supports atomic add. Now we only support it in X.

Signed-off-by: fredqiu <fredqiu@ca.ibm.com>