### PR TITLE
Shutdown issues

### DIFF
--- a/gc/startup/omrgcstartup.cpp
+++ b/gc/startup/omrgcstartup.cpp
@@ -300,19 +300,10 @@ omr_error_t
 OMR_GC_ShutdownCollector(OMR_VMThread* omrVMThread)
 {
 	MM_GCExtensionsBase *extensions = MM_GCExtensionsBase::getExtensions(omrVMThread->_vm);
-	MM_EnvironmentBase *env = MM_EnvironmentBase::getEnvironment(omrVMThread);
 	MM_Collector *globalCollector = extensions->getGlobalCollector();
 	
 	if (NULL != globalCollector) {
 		globalCollector->collectorShutdown(extensions);
-	}
-
-	if ((NULL != extensions) && (NULL != extensions->heap)) {
-		MM_MemorySpace *defaultSpace = extensions->heap->getDefaultMemorySpace();
-		if (NULL != defaultSpace) {
-			defaultSpace->kill(env);
-			extensions->heap->setDefaultMemorySpace(NULL);
-		}
 	}
 
 	return OMR_ERROR_NONE;
@@ -335,6 +326,14 @@ OMR_GC_ShutdownHeap(OMR_VM *omrVM)
 			extensions->verboseGCManager->disableVerboseGC();
 			extensions->verboseGCManager->kill(&env);
 			extensions->verboseGCManager = NULL;
+		}
+
+		if ((NULL != extensions) && (NULL != extensions->heap)) {
+			MM_MemorySpace *defaultSpace = extensions->heap->getDefaultMemorySpace();
+			if (NULL != defaultSpace) {
+				defaultSpace->kill(&env);
+				extensions->heap->setDefaultMemorySpace(NULL);
+			}
 		}
 
 		if (NULL != extensions->configuration) {

--- a/omr/startup/omrvmstartup.cpp
+++ b/omr/startup/omrvmstartup.cpp
@@ -477,6 +477,8 @@ OMR_Shutdown_VM(OMR_VM *omrVM, OMR_VMThread *omrVMThread)
 		}
 #endif /* OMR_GC */
 
+		omr_ras_cleanupMethodDictionary(omrVM);
+
 		omr_ras_cleanupHealthCenter(omrVM, &(omrVM->_hcAgent));
 
 		rc = omr_ras_cleanupTraceEngine(omrVMThread);


### PR DESCRIPTION
When using the OMR_Initialize_VM and OMR_Shutdown_VM APIs you can get a crash in the flushing TLHs and there was memory being leaked.

The 2 commits in this PR resolve both of those issues.