### PR TITLE
Adding new option to change number of profiled classes

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -893,6 +893,8 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
         TR::Options::setStaticNumeric, (intptrj_t)&OMR::Options::_maxNumVisitedSubclasses, 0, "P%d", NOT_IN_SUBSET},
    {"maxPeekedBytecodeSize=", "O<nnn>\tmaximum number of bytecodes that can be peeked into",
         TR::Options::setStaticNumeric, (intptrj_t)&OMR::Options::_maxPeekedBytecodeSize, 0, "F%d", NOT_IN_SUBSET},
+   {"maxCheckcastProfiledClasses=", "O<nnn>\tmaximum number of inlined profiled classes",
+        TR::Options::set32BitNumeric, offsetof(OMR::Options,_numCheckcastProfiledClasses), 0,"%d"},
    {"maxSizeForVPInliningAtWarm=", "O<nnn>\tMax size for methods inlined during VP", TR::Options::set32BitNumeric, offsetof(OMR::Options, _maxSzForVPInliningWarm), 0, " %d" },
    {"maxSleepTimeMsForCompThrottling=", "M<nnn>\tUpper bound for sleep time during compilation throttling (ms)",
                        TR::Options::setStaticNumeric, (intptrj_t)&OMR::Options::_maxSleepTimeMsForCompThrottling, 0, "F%d", NOT_IN_SUBSET },
@@ -2690,6 +2692,7 @@ OMR::Options::jitPreProcess()
       _GCRDecCount = TR_DEFAULT_GCR_DEC_COUNT;
       _numInterfaceCallCacheSlots = 4;
       _numInterfaceCallStaticSlots = 1;
+      _numCheckcastProfiledClasses = 3;
       _stackPCDumpNumberOfBuffers=4;
       _stackPCDumpNumberOfFrames=5;
       _maxSpreadCountLoopless = TR_MAX_SPREAD_COUNT_LOOPLESS;

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1619,6 +1619,7 @@ public:
    void      enableTracing(OMR::Optimizations o)    {_traceOptimizations[o] = true; }
    bool      tracingOptimization()             {return _tracingOptimization; }
    int32_t   getMaxUnloadedAddressRanges()     {return _maxUnloadedAddressRanges;}
+   int32_t   getInstanceOfOrCheckcastMaxProfiledClasses()           {return _numCheckcastProfiledClasses;}
    int32_t   getMaxStaticPICSlots(TR_Hotness h){return (h >= hot)? _hotMaxStaticPICSlots : _maxStaticPICSlots; }
    int32_t   getMaxNumPrexAssumptions()        {return _maxNumPrexAssumptions;}
    int32_t   getMaxNumVisitedSubclasses()      {return _maxNumVisitedSubclasses;}
@@ -2329,6 +2330,7 @@ private:
    int32_t                     _numRestrictedGPRs;
    int32_t                     _numInterfaceCallCacheSlots;
    int32_t                     _numInterfaceCallStaticSlots;
+   int32_t                     _numCheckcastProfiledClasses;
    int32_t                     _storeSinkingLastOpt;
    int32_t                     _test390StackBuffer;   // Buffer to force a large stack on 390
    int32_t                     _test390LitPoolBuffer; // Buffer to force a large lit pool on 390


### PR DESCRIPTION
In all cases we used to set number of profiled classes for profiledClassTest
using preprocessor directive #define. This commit will allow us to change the
number of inlined profiled class using option.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>