### PR TITLE
Fix JitBuilder OperandStackTest

### DIFF
--- a/compiler/ilgen/VirtualMachineOperandStack.cpp
+++ b/compiler/ilgen/VirtualMachineOperandStack.cpp
@@ -162,9 +162,7 @@ VirtualMachineOperandStack::Dup(TR::IlBuilder *b)
    {
    TR_ASSERT(_stackTop >= 0, "cannot dup: stack empty");
    TR::IlValue *top = _stack[_stackTop];
-   checkSize();
-   _stack[++_stackTop] = top;
-   _stackTopRegister->Adjust(b, +_pushAmount);
+   Push(b, top);
    }
 
 void

--- a/jitbuilder/release/Makefile
+++ b/jitbuilder/release/Makefile
@@ -66,6 +66,7 @@ all_goal: common_goal
 	./dotproduct
 	./linkedlist
 	./localarray
+	./operandstacktests
 	./pointer
 	./recfib
 	./structarray


### PR DESCRIPTION
Did a tiny bit of refactoring in VirtualMachineOperandStack.

Fixed the OperandStackTest in JitBuilder (issue #629).

Added operandstacktests to the "testall" target in the jitbuilder/release/Makefile.