### PR TITLE
Handle exceptions thrown in ilgen opts

### DIFF
--- a/compiler/compile/CompilationException.hpp
+++ b/compiler/compile/CompilationException.hpp
@@ -35,6 +35,11 @@ struct ILGenFailure : public virtual CompilationException
    virtual const char* what() const throw() { return "IL Gen Failure"; }
    };
 
+struct RecoverableILGenException : public virtual CompilationException
+   {
+   virtual const char* what() const throw() { return "Recoverable IL Gen Exception"; }
+   };
+
 struct ExcessiveComplexity : public virtual CompilationException
    {
    virtual const char* what() const throw() { return "Excessive Complexity"; }

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -1282,7 +1282,17 @@ OMR::ResolvedMethodSymbol::genIL(TR_FrontEnd * fe, TR::Compilation * comp, TR::S
 
          if (optimizer)
             {
-            optimizer->optimize();
+            try
+               {
+               optimizer->optimize();
+               }
+            catch (const TR::RecoverableILGenException &e)
+               {
+               if (self()->comp()->isOutermostMethod())
+                  throw;
+               _methodFlags.set(IlGenSuccess, false);
+               }
+
             comp->setOptimizer(previousOptimizer);
             }
          else


### PR DESCRIPTION
optimizations can throw exceptions, including ilgen opts. Exceptions
thrown from non-ilgen opts will be catched by compilation object and
in most cases will cause a compilation to abort which is a desired
behavior. However, aborting the compilation during ilgen opts triggered
by inlining will stop jit from compiling a compilable method, leading
to potential performance issues. Thus, we should only abort the
compilation when not in inliner.

This commit introduces a recoverable ilgen exception class, who can be
inherited by project specific exceptions with potential to be recovered
in ilgen. genIL will catch the base class of the recoverable ilgen
exceptions and choose the right action.

Signed-off-by: liqunl <liqunl@ca.ibm.com>