### PR TITLE
Fix disableLongDispStackSlot option on Z

### DIFF
--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -6723,7 +6723,12 @@ OMR::Z::Machine::initializeGlobalRegisterTable()
                if (linkage->getPreserved(reg))
                   {
                      // Dangling else above
-                     if (reg != linkage->getStaticBaseRegister() &&
+                     if (reg == linkage->getExtCodeBaseRegister())
+                        {
+                        if (_cg->isExtCodeBaseFreeForAssignment())
+                           p = self()->addGlobalReg(reg, p);
+                        }
+                     else if (reg != linkage->getStaticBaseRegister() &&
                            reg != linkage->getPrivateStaticBaseRegister() &&
                            reg != linkage->getStackPointerRegister())
                         p = self()->addGlobalReg(reg, p);
@@ -6743,7 +6748,12 @@ OMR::Z::Machine::initializeGlobalRegisterTable()
                if (linkage->getPreserved(reg))
                   {
                      // Dangling else above
-                     if (reg != linkage->getLitPoolRegister() &&
+                     if (reg == linkage->getExtCodeBaseRegister())
+                        {
+                        if (_cg->isExtCodeBaseFreeForAssignment())
+                           p = self()->addGlobalReg(reg, p);
+                        }
+                     else if (reg != linkage->getLitPoolRegister() &&
                            reg != linkage->getStaticBaseRegister() &&
                            reg != linkage->getPrivateStaticBaseRegister() &&
                            reg != linkage->getStackPointerRegister())
@@ -6783,7 +6793,11 @@ OMR::Z::Machine::initializeGlobalRegisterTable()
                // might use GPR6 on 64-bit for lit pool reg
                p = self()->addGlobalReg(TR::RealRegister::HPR6, p);
                }
-            p = self()->addGlobalReg(TR::RealRegister::HPR7, p);
+            if (linkage->getExtCodeBaseRegister() == TR::RealRegister::GPR7 && _cg->isExtCodeBaseFreeForAssignment())
+               {
+               // register 7 is hard coded for now
+               p = self()->addGlobalReg(TR::RealRegister::HPR7, p);
+               }
             p = self()->addGlobalReg(TR::RealRegister::HPR8, p);
             p = self()->addGlobalReg(TR::RealRegister::HPR9, p);
             p = self()->addGlobalReg(TR::RealRegister::HPR10, p);

--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -2132,18 +2132,20 @@ TR::S390RILInstruction::generateBinaryEncoding()
             {
             scratchReg = cg()->getExtCodeBaseRealRegister();
             }
-         else if (getOpCode().getOpCodeValue() == TR::InstOpCode::LGRL  ||
-                  getOpCode().getOpCodeValue() == TR::InstOpCode::LGFRL  ||
-                  getOpCode().getOpCodeValue() == TR::InstOpCode::LLGFRL )
+
+         if (getOpCode().getOpCodeValue() == TR::InstOpCode::LGRL  ||
+             getOpCode().getOpCodeValue() == TR::InstOpCode::LGFRL  ||
+             getOpCode().getOpCodeValue() == TR::InstOpCode::LLGFRL )
             {
-            scratchReg = (TR::RealRegister * )((TR::S390RegInstruction *)this)->getRegisterOperand(1);
+            sourceReg = (TR::RealRegister * )((TR::S390RegInstruction *)this)->getRegisterOperand(1);
+            if (!scratchReg) scratchReg = sourceReg;
             }
          else if (getOpCode().getOpCodeValue() == TR::InstOpCode::STGRL ||
                   getOpCode().getOpCodeValue() == TR::InstOpCode::STRL ||
                   getOpCode().getOpCodeValue() == TR::InstOpCode::LRL)
             {
-            scratchReg  = assignBestSpillRegister();
-            sourceReg  = (TR::RealRegister * )((TR::S390RegInstruction *)this)->getRegisterOperand(1);
+            sourceReg = (TR::RealRegister * )((TR::S390RegInstruction *)this)->getRegisterOperand(1);
+            if (!scratchReg) scratchReg  = assignBestSpillRegister();
 
             spillNeeded = true;
             }
@@ -2199,10 +2201,10 @@ TR::S390RILInstruction::generateBinaryEncoding()
 
          if (getOpCode().getOpCodeValue() == TR::InstOpCode::LGRL)
             {
-            // LG scratchReg, 0(,scratchReg)
+            // LG sourceReg, 0(,scratchReg)
             //
-            *(int32_t *) cursor  = boi(0xE3000000);                  // LG  scratchReg, 0(,scratchReg)
-            scratchReg->setRegisterField((uint32_t *)cursor);
+            *(int32_t *) cursor  = boi(0xE3000000);                  // LG  sourceReg, 0(,scratchReg)
+            sourceReg->setRegisterField((uint32_t *)cursor);
             scratchReg->setBaseRegisterField((uint32_t *)cursor);
             cursor += 4;
             *(int16_t *) cursor  = bos(0x0004);
@@ -2210,10 +2212,10 @@ TR::S390RILInstruction::generateBinaryEncoding()
             }
          else if (getOpCode().getOpCodeValue() == TR::InstOpCode::LGFRL)
             {
-            // LGF scratchReg, 0(,scratchReg)
+            // LGF sourceReg, 0(,scratchReg)
             //
-            *(int32_t *) cursor  = boi(0xE3000000);                  // LGF scratchReg, 0(,scratchReg)
-            scratchReg->setRegisterField((uint32_t *)cursor);
+            *(int32_t *) cursor  = boi(0xE3000000);                  // LGF sourceReg, 0(,scratchReg)
+            sourceReg->setRegisterField((uint32_t *)cursor);
             scratchReg->setRegister2Field((uint32_t *)cursor);
             cursor += 4;
             *(int16_t *) cursor  = bos(0x0014);
@@ -2221,10 +2223,10 @@ TR::S390RILInstruction::generateBinaryEncoding()
             }
          else if (getOpCode().getOpCodeValue() == TR::InstOpCode::LLGFRL)
             {
-            // LGF scratchReg, 0(,scratchReg)
+            // LLGF sourceReg, 0(,scratchReg)
             //
-            *(int32_t *) cursor  = boi(0xE3000000);                  // LLGF scratchReg, 0(,scratchReg)
-            scratchReg->setRegisterField((uint32_t *)cursor);
+            *(int32_t *) cursor  = boi(0xE3000000);                  // LLGF sourceReg, 0(,scratchReg)
+            sourceReg->setRegisterField((uint32_t *)cursor);
             scratchReg->setRegister2Field((uint32_t *)cursor);
             cursor += 4;
             *(int16_t *) cursor  = bos(0x0016);


### PR DESCRIPTION
`GPR7` and `HPR7` are locked when the long displacement stack slot is disabled, however they are still added to the Global Register table for GRA. This change implements the missing conditions in  `initializeGlobalRegisterTable()` to fix this problem.

The binary encoding for `LG, LGF, and LLGF` assumes the source and target registers are the same `scratchReg` taken from `getRegisterOperand(1)`. However, this is not true when the `scratchReg` is taken from `ExtCodeBaseRealRegister`, where the source and target are different. This is fixed by correctly differentiating the `scratchReg` and `sourceReg` locals.

Signed-off-by: John Xu <xujohn@ca.ibm.com>