### PR TITLE
Run ilgen opts at all optLevels

### DIFF
--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -1234,13 +1234,9 @@ OMR::ResolvedMethodSymbol::genIL(TR_FrontEnd * fe, TR::Compilation * comp, TR::S
 
          TR::Optimizer *optimizer = NULL;
          TR::Optimizer *previousOptimizer = NULL;
-         if (doOSR
-             || comp->getMethodHotness() >= cold)
-            {
-            optimizer = TR::Optimizer::createOptimizer(comp, self(), true);
-            previousOptimizer = comp->getOptimizer();
-            comp->setOptimizer(optimizer);
-            }
+         optimizer = TR::Optimizer::createOptimizer(comp, self(), true);
+         previousOptimizer = comp->getOptimizer();
+         comp->setOptimizer(optimizer);
 
          self()->detectInternalCycles(comp->getFlowGraph(), comp);
 


### PR DESCRIPTION
ilgen opts are fundamental opts that modify the tree to a good shape
and if are disabled, funational problems will happen. Currently, ilgen
opt strategy is disabled in noopt. With this fix, it will run at all
optLevels.

issue: #632
Signed-off-by: liqunl <liqunl@ca.ibm.com>