### PR TITLE
VirtualMachineOperandStack fixes

### DIFF
--- a/compiler/ilgen/VirtualMachineOperandStack.cpp
+++ b/compiler/ilgen/VirtualMachineOperandStack.cpp
@@ -174,20 +174,27 @@ VirtualMachineOperandStack::copyTo(VirtualMachineOperandStack *copy)
 void
 VirtualMachineOperandStack::checkSize()
    {
-   if (_stackTop == _stackMax)
+   if (_stackTop == _stackMax - 1)
       grow();
    }
 
 void
-VirtualMachineOperandStack::grow()
+VirtualMachineOperandStack::grow(int32_t growAmount)
    {
-   int32_t numBytes = _stackMax * sizeof(TR::IlValue *);
+   if (growAmount == 0)
+      growAmount = (_stackMax >> 1);
 
-   int32_t newMax = _stackMax + (_stackMax >> 1);
+   // if _stackMax == 1, growAmount would still be zero, so bump to 1
+   if (growAmount == 0)
+      growAmount = 1;
+
+   int32_t newMax = _stackMax + growAmount;
    int32_t newBytes = newMax * sizeof(TR::IlValue *);
    TR::IlValue ** newStack = (TR::IlValue **) TR::comp()->trMemory()->allocateHeapMemory(newBytes);
 
    memset(newStack, 0, newBytes);
+
+   int32_t numBytes = _stackMax * sizeof(TR::IlValue *);
    memcpy(newStack, _stack, numBytes);
 
    _stack = newStack;

--- a/compiler/ilgen/VirtualMachineOperandStack.cpp
+++ b/compiler/ilgen/VirtualMachineOperandStack.cpp
@@ -100,8 +100,9 @@ VirtualMachineOperandStack::MergeInto(OMR::VirtualMachineOperandStack *other, TR
          // what if types don't match? could use ConvertTo, but seems...arbitrary
          // nobody *should* design bytecode set where corresponding elements of stacks from
          // two incoming control flow edges can have different primitive types. objects, sure
-         // but not primitive types! Expecting to be disappointed here some day...
-         TR_ASSERT(_stack[i]->getSymbol()->getDataType() == other->_stack[i]->getSymbol()->getDataType(), "disappointing stack merge: primitive type mismatch at same depth stack elements");
+         // but not primitive types (even different types of objects should have same primitive
+         // type: Address. Expecting to be disappointed here some day...
+         TR_ASSERT(_stack[i]->getSymbol()->getDataType() == other->_stack[i]->getSymbol()->getDataType(), "invalid stack merge: primitive type mismatch at same depth stack elements");
          b->Store(other->_stack[i]->getSymbol()->getAutoSymbol()->getName(),
                _stack[i]);
          }

--- a/compiler/ilgen/VirtualMachineOperandStack.hpp
+++ b/compiler/ilgen/VirtualMachineOperandStack.hpp
@@ -169,7 +169,7 @@ class VirtualMachineOperandStack : public VirtualMachineState
    protected:
    void copyTo(OMR::VirtualMachineOperandStack *copy);
    void checkSize();
-   void grow();
+   void grow(int32_t growAmount = 0);
 
    private:
    TR::MethodBuilder *_mb;

--- a/compiler/ilgen/VirtualMachineRegister.hpp
+++ b/compiler/ilgen/VirtualMachineRegister.hpp
@@ -143,12 +143,9 @@ class VirtualMachineRegister : public OMR::VirtualMachineState
     */
    virtual void Adjust(TR::IlBuilder *b, TR::IlValue *amount)
       {
-      b->Store(_localName,
-      b->   Add(
-      b->      Load(_localName),
-      b->      Mul(
-                  amount,
-      b->         ConstInteger(_elementType, _adjustByStep))));
+      TR::IlValue *off=b->Mul(amount,
+                       b->    ConstInteger(_elementType, _adjustByStep));
+      adjust(b, off);
       }
 
    /**
@@ -160,14 +157,17 @@ class VirtualMachineRegister : public OMR::VirtualMachineState
     */
    virtual void Adjust(TR::IlBuilder *b, int64_t amount)
       {
-      b->Store(_localName,
-      b->   Add(
-      b->      Load(_localName),
-      b->      ConstInteger(_elementType, amount * _adjustByStep)));
+      adjust(b, b->ConstInteger(_elementType, amount * _adjustByStep));
       }
 
    protected:
-
+   void adjust(TR::IlBuilder *b, TR::IlValue *rawAmount)
+      {
+      b->Store(_localName,
+      b->   Add(
+      b->      Load(_localName),
+               rawAmount));
+      }
    const char  * const _localName;
    TR::IlValue * _addressOfRegister;
    TR::IlType  * _pointerToRegisterType;

--- a/jitbuilder/release/.gitignore
+++ b/jitbuilder/release/.gitignore
@@ -32,9 +32,12 @@ localarray
 structarray
 mandelbrot
 nestedloop
+operandstacktests
 pointer
 pow2
 recfib
 simple
 switch
+thunks
 toiltype
+worklist

--- a/jitbuilder/release/src/OperandStackTests.cpp
+++ b/jitbuilder/release/src/OperandStackTests.cpp
@@ -464,7 +464,7 @@ OperandStackTestMethod::buildIL()
    TR::IlType *pElementType = _types->PointerTo(Word);
    TR::IlValue *realStackTopAddress = ConstAddress(&_realStackTop);
    OMR::VirtualMachineRegister *stackTop = new OMR::VirtualMachineRegister(this, "SP", pElementType, sizeof(STACKVALUETYPE), realStackTopAddress);
-   OMR::VirtualMachineOperandStack *stack = new OMR::VirtualMachineOperandStack(this, 32, _valueType, stackTop);
+   OMR::VirtualMachineOperandStack *stack = new OMR::VirtualMachineOperandStack(this, 1, _valueType, stackTop);
 
    TestState *vmState = new TestState(stack, stackTop);
    setVMState(vmState);
@@ -492,7 +492,7 @@ bool
 OperandStackTestUsingStructMethod::buildIL()
    {
    OMR::VirtualMachineRegisterInStruct *stackTop = new OMR::VirtualMachineRegisterInStruct(this, "Thread", "thread", "sp", "SP");
-   OMR::VirtualMachineOperandStack *stack = new OMR::VirtualMachineOperandStack(this, 32, _valueType, stackTop);
+   OMR::VirtualMachineOperandStack *stack = new OMR::VirtualMachineOperandStack(this, 1, _valueType, stackTop);
 
    TestState *vmState = new TestState(stack, stackTop);
    setVMState(vmState);


### PR DESCRIPTION
A collection of straight-forward fixes for the JitBuilder, mostly for VirtualMachineOperandStack:
   - improved assertion message and comments
   - fixes to how checkSize() and grow() work
   - update to OperandStackTests.cpp to stress out checkSize() and grow() (was untested)
   - added recent additions to release tests to .gitignore
   - refactored the Adjust() functions in VirtualMachineRegister