### PR TITLE
Add UnsignedConvertTo service to JitBuilder

### DIFF
--- a/compiler/ilgen/IlBuilder.hpp
+++ b/compiler/ilgen/IlBuilder.hpp
@@ -188,6 +188,7 @@ public:
    TR::IlValue *GreaterThan(TR::IlValue *left, TR::IlValue *right);
    TR::IlValue *GreaterOrEqualTo(TR::IlValue *left, TR::IlValue *right);
    TR::IlValue *ConvertTo(TR::IlType *t, TR::IlValue *v);
+   TR::IlValue *UnsignedConvertTo(TR::IlType *t, TR::IlValue *v);
 
    // memory
    TR::IlValue *CreateLocalArray(int32_t numElements, TR::IlType *elementType);
@@ -368,6 +369,7 @@ protected:
    TR::IlValue *binaryOpFromOpMap(OpCodeMapper mapOp, TR::IlValue *left, TR::IlValue *right);
    TR::IlValue *binaryOpFromOpCode(TR::ILOpCodes op, TR::IlValue *left, TR::IlValue *right);
    TR::IlValue *compareOp(TR_ComparisonTypes ct, bool needUnsigned, TR::IlValue *left, TR::IlValue *right);
+   TR::IlValue *convertTo(TR::IlType *t, TR::IlValue *v, bool needUnsigned);
 
    void ifCmpNotEqualZero(TR::IlValue *condition, TR::Block *target);
    void ifCmpNotEqual(TR::IlValue *condition, TR::IlValue *zero, TR::Block *target);


### PR DESCRIPTION
ConvertTo currently does signed conversions, but sometimes you
really need an unsigned conversion. Introduced UnsignedConvertTo
with same API as ConvertTo. Factored the implementation into
a protected helper called convertTo() which takes a boolean
indicating whether unsigned conversion is required, I also
changed the way the conversion opcode is computed, from using
the service in TR::DataType to TR::ILOpCode::getProperConversion().

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>