### PR TITLE
Add JitBuilder support for unions

### DIFF
--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -1232,7 +1232,9 @@ OMR::ResolvedMethodSymbol::genIL(TR_FrontEnd * fe, TR::Compilation * comp, TR::S
 
       TR_IlGenerator *ilGen = customRequest.getIlGenerator(self(), fe, comp, symRefTab);
 
-      _methodFlags.set(IlGenSuccess, ilGen->genIL());
+      auto genIL_rc = ilGen->genIL();
+      _methodFlags.set(IlGenSuccess, genIL_rc);
+      traceMsg(self()->comp(), "genIL() returned %d\n", genIL_rc);
 
       if (_methodFlags.testAny(IlGenSuccess))
          {

--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -132,15 +132,18 @@ IlBuilder::initSequence()
 bool
 IlBuilder::injectIL()
    {
+   TraceIL("Inside injectIL()\n");
    TraceIL("original entry %p\n", cfg()->getStart());
    TraceIL("original exit %p\n", cfg()->getEnd());
 
    setupForBuildIL();
 
-   if (!buildIL())
+   bool rc = buildIL();
+   TraceIL("buildIL() returned %d\n", rc);
+   if (!rc)
       return false;
 
-   bool rc = connectTrees();
+   rc = connectTrees();
    comp()->dumpMethodTrees("after connectTrees");
    cfg()->removeUnreachableBlocks();
    comp()->dumpMethodTrees("after removing unreachable blocks");

--- a/compiler/ilgen/IlBuilder.hpp
+++ b/compiler/ilgen/IlBuilder.hpp
@@ -195,10 +195,10 @@ public:
    TR::IlValue *CreateLocalStruct(TR::IlType *structType);
    TR::IlValue *Load(const char *name);
    void Store(const char *name, TR::IlValue *value);
-   void StoreAt(TR::IlValue *address, TR::IlValue *value);
    TR::IlValue *LoadAt(TR::IlType *dt, TR::IlValue *address);
+   void StoreAt(TR::IlValue *address, TR::IlValue *value);
    TR::IlValue *LoadIndirect(const char *type, const char *field, TR::IlValue *object);
-   TR::IlValue *StoreField(const char *name, TR::IlValue *object, TR::IlValue *value);
+   void StoreIndirect(const char *type, const char *field, TR::IlValue *object, TR::IlValue *value);
    TR::IlValue *IndexAt(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index);
    TR::IlValue *AtomicAddWithOffset(TR::IlValue *baseAddress, TR::IlValue *offset, TR::IlValue *value);
    TR::IlValue *AtomicAdd(TR::IlValue *baseAddress, TR::IlValue * value);
@@ -212,7 +212,6 @@ public:
    void VectorStoreAt(TR::IlValue *address, TR::IlValue *value);
 
    // control
-   void StoreIndirect(const char *type, const char *field, TR::IlValue *object, TR::IlValue *value);
    void AppendBuilder(TR::IlBuilder *builder);
    TR::IlValue *Call(const char *name, int32_t numArgs, ...);
    TR::IlValue *Call(const char *name, int32_t numArgs, TR::IlValue **argValues);

--- a/compiler/ilgen/TypeDictionary.cpp
+++ b/compiler/ilgen/TypeDictionary.cpp
@@ -371,8 +371,7 @@ TR::IlReference *
 UnionType::getFieldSymRef(const char *fieldName)
    {
    FieldInfo *info = findField(fieldName);
-   if (NULL == info)
-      return NULL;
+   TR_ASSERT(info, "Struct %s has no field with name %s\n", getName(), fieldName);
 
    TR::SymbolReference *symRef = info->getSymRef();
    if (NULL == symRef)

--- a/compiler/ilgen/TypeDictionary.cpp
+++ b/compiler/ilgen/TypeDictionary.cpp
@@ -28,6 +28,7 @@
 #include "env/Region.hpp"
 #include "env/SystemSegmentProvider.hpp"
 #include "env/TRMemory.hpp"
+#include "infra/BitVector.hpp"
 
 
 namespace OMR
@@ -285,6 +286,121 @@ StructType::getFieldSymRef(const char *fieldName)
    return (TR::IlReference *)symRef;
    }
 
+class UnionType : public TR::IlType
+   {
+public:
+   TR_ALLOC(TR_Memory::IlGenerator)
+
+   UnionType(const char *name, TR_Memory* trMemory) :
+      TR::IlType(name),
+      _firstField(0),
+      _lastField(0),
+      _size(0),
+      _closed(false),
+      _symRefBV(4, trMemory),
+      _trMemory(trMemory)
+      { }
+
+   TR::DataType getPrimitiveType()                 { return TR::Address; }
+   void Close();
+
+   void AddField(const char *name, TR::IlType *fieldType);
+   TR::IlType * getFieldType(const char *fieldName);
+
+   TR::SymbolReference *getFieldSymRef(const char *name);
+   virtual bool isUnion() { return true; }
+   virtual size_t getSize() { return _size; }
+
+protected:
+   FieldInfo * findField(const char *fieldName);
+
+   FieldInfo * _firstField;
+   FieldInfo * _lastField;
+   size_t      _size;
+   bool        _closed;
+   TR_BitVector _symRefBV;
+   TR_Memory* _trMemory;
+   };
+
+void
+UnionType::AddField(const char *name, TR::IlType *typeInfo)
+   {
+   if (_closed)
+      return;
+
+   auto fieldSize = typeInfo->getSize();
+   if (fieldSize > _size) _size = fieldSize;
+
+   FieldInfo *fieldInfo = new (PERSISTENT_NEW) FieldInfo(name, 0 /* no offset */, typeInfo);
+   if (0 != _lastField)
+      _lastField->setNext(fieldInfo);
+   else
+      _firstField = fieldInfo;
+   _lastField = fieldInfo;
+   }
+
+void
+UnionType::Close()
+   {
+   _closed = true;
+   }
+
+FieldInfo *
+UnionType::findField(const char *fieldName)
+   {
+   FieldInfo *info = _firstField;
+   while (NULL != info)
+      {
+      if (strncmp(info->_name, fieldName, strlen(fieldName)) == 0)
+         return info;
+      info = info->_next;
+      }
+   return NULL;
+   }
+
+TR::IlType *
+UnionType::getFieldType(const char *fieldName)
+   {
+   FieldInfo *info = findField(fieldName);
+   if (NULL == info)
+      return NULL;
+   return info->_type;
+   }
+
+TR::IlReference *
+UnionType::getFieldSymRef(const char *fieldName)
+   {
+   FieldInfo *info = findField(fieldName);
+   if (NULL == info)
+      return NULL;
+
+   TR::SymbolReference *symRef = info->getSymRef();
+   if (NULL == symRef)
+      {
+      // create a symref for the new field and set its bitvector
+      TR::Compilation *comp = TR::comp();
+      auto symRefTab = comp->getSymRefTab();
+      TR::DataType type = info->getPrimitiveType();
+
+      TR::Symbol *symbol = TR::Symbol::createShadow(comp->trHeapMemory(), type);
+      symRef = new (comp->trHeapMemory()) TR::SymbolReference(symRefTab, symbol, comp->getMethodSymbol()->getResolvedMethodIndex(), -1);
+      symRef->setOffset(0);
+      symRef->setReallySharesSymbol();
+
+      TR_SymRefIterator sit(_symRefBV, symRefTab);
+      for (TR::SymbolReference *sr = sit.getNext(); sr; sr = sit.getNext())
+          {
+          symRefTab->makeSharedAliases(symRef, sr);
+          }
+
+      _symRefBV.set(symRef->getReferenceNumber());
+
+      info->cacheSymRef(symRef);
+      }
+
+   return static_cast<TR::IlReference *>(symRef);
+   }
+
 class PointerType : public TR::IlType
    {
 public:
@@ -324,6 +440,7 @@ TypeDictionary::TypeDictionary() :
    _trMemory( new(TR::Compiler->persistentAllocator()) TR_Memory(*::trPersistentMemory, *_memoryRegion) )
    {
    _structsByName = new (PERSISTENT_NEW) TR_HashTabString(trMemory());
+   _unionsByName = new (PERSISTENT_NEW) TR_HashTabString(trMemory());
 
    // primitive types
    NoType       = _primitiveType[TR::NoType]                = new (PERSISTENT_NEW) OMR::PrimitiveType("NoType", TR::NoType);
@@ -475,11 +592,25 @@ TypeDictionary::PointerTo(TR::IlType *baseType)
    }
 
 TR::IlReference *
-TypeDictionary::FieldReference(const char *structName, const char *fieldName)
+TypeDictionary::FieldReference(const char *typeName, const char *fieldName)
    {
    TR_HashId structID = 0;
-   _structsByName->locate(structName, structID);
-   StructType *theStruct = (StructType *) _structsByName->getData(structID);
-   return theStruct->getFieldSymRef(fieldName);
+
+   auto found = _structsByName->locate(typeName, structID);
+   if (found)
+      {
+      StructType *theStruct = (StructType *) _structsByName->getData(structID);
+      return theStruct->getFieldSymRef(fieldName);
+      }
+
+   found = _unionsByName->locate(typeName, structID);
+   if (found)
+      {
+      UnionType *theUnion = (UnionType *) _unionsByName->getData(structID);
+      return theUnion->getFieldSymRef(fieldName);
+      }
+
+   TR_ASSERT(false, "No type with name `%s`", typeName);
+   return NULL;
    }
 } // namespace OMR

--- a/compiler/ilgen/TypeDictionary.hpp
+++ b/compiler/ilgen/TypeDictionary.hpp
@@ -68,6 +68,8 @@ public:
    virtual TR::IlType *baseType() { return NULL; }
 
    virtual bool isStruct() {return false; }
+   virtual bool isUnion() { return false; }
+
    virtual size_t getSize();
 
 protected:
@@ -224,7 +226,7 @@ public:
    TR::IlType *PointerTo(const char *structName);
    TR::IlType *PointerTo(TR::DataType baseType)  { return PointerTo(_primitiveType[baseType]); }
 
-   TR::IlReference *FieldReference(const char *structName, const char *fieldName);
+   TR::IlReference *FieldReference(const char *typeName, const char *fieldName);
    TR_Memory *trMemory() { return _trMemory; }
 
    //TR::IlReference *ArrayReference(TR::IlType *arrayType);

--- a/compiler/ilgen/TypeDictionary.hpp
+++ b/compiler/ilgen/TypeDictionary.hpp
@@ -133,6 +133,7 @@ public:
    ~TypeDictionary() throw();
 
    TR::IlType * LookupStruct(const char *structName);
+   TR::IlType * LookupUnion(const char *unionName);
 
    /**
     * @brief Begin definition of a new structure type
@@ -214,6 +215,11 @@ public:
     * @return the memory offset of the field in bytes
     */
    size_t OffsetOf(const char *structName, const char *fieldName);
+
+   TR::IlType * DefineUnion(const char *unionName);
+   void UnionField(const char *unionName, const char *fieldName, TR::IlType *type);
+   void CloseUnion(const char *unionName);
+   TR::IlType * UnionFieldType(const char *unionName, const char *fieldName);
 
    TR::IlType *PrimitiveType(TR::DataType primitiveType)
       {
@@ -406,6 +412,7 @@ protected:
    TR::Region *_memoryRegion;
    TR_Memory *_trMemory;
    TR_HashTabString * _structsByName;
+   TR_HashTabString * _unionsByName;
 
    // convenience for primitive types
    TR::IlType       * _primitiveType[TR::NumOMRTypes];

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1747,6 +1747,10 @@ TR_Debug::printAliasInfo(TR::FILE *pOutFile, TR::SymbolReference * symRef)
          trfprintf(pOutFile, "   Usedef Aliases: NULL ");
       trfprintf(pOutFile, "\n");
       }
+   else
+      {
+      trfprintf(pOutFile, "Symref #%d %s has no aliases\n", symRef->getReferenceNumber(), getName(symRef));
+      }
    }
 
 TR::ResolvedMethodSymbol *

--- a/jitbuilder/release/.gitignore
+++ b/jitbuilder/release/.gitignore
@@ -41,4 +41,5 @@ switch
 thunks
 toiltype
 transactionaloperations
+union
 worklist

--- a/jitbuilder/release/Makefile
+++ b/jitbuilder/release/Makefile
@@ -44,6 +44,7 @@ ALL_TESTS = \
             switch \
             thunks \
             toiltype \
+            union \
             worklist
 
 # Compile all the tests by default
@@ -75,6 +76,7 @@ all_goal: common_goal
 	./thunks
 	./toiltype
 	./transactionaloperations
+	./union
 
 
 # In general, only compile and run tests that are known to work on all platforms
@@ -248,6 +250,12 @@ transactionaloperations : libjitbuilder.a TransactionalOperations.o
 	g++ -g -fno-rtti -o $@ TransactionalOperations.o -L. -ljitbuilder -ldl
 
 TransactionalOperations.o: src/TransactionalOperations.cpp src/TransactionalOperations.hpp
+	g++ -o $@ $(CXXFLAGS) $<
+
+union : libjitbuilder.a Union.o
+	g++ -g -fno-rtti -o $@ Union.o -L. -ljitbuilder -ldl
+
+Union.o: src/Union.cpp src/Union.hpp
 	g++ -o $@ $(CXXFLAGS) $<
 
 worklist : libjitbuilder.a Worklist.o

--- a/jitbuilder/release/src/Union.cpp
+++ b/jitbuilder/release/src/Union.cpp
@@ -1,0 +1,268 @@
+/******************************************************************************
+ Copyright IBM Corp. 2016, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#include <iostream>
+#include <assert.h>
+
+#include "Jit.hpp"
+#include "ilgen/TypeDictionary.hpp"
+#include "ilgen/MethodBuilder.hpp"
+#include "Union.hpp"
+
+SetUnionByteBuilder::SetUnionByteBuilder(TR::TypeDictionary *d)
+   : MethodBuilder(d)
+   {
+   DefineFile(__FILE__);
+   DefineLine(LINETOSTR(__LINE__));
+
+   DefineName("setUnionByte");
+   DefineParameter("u", d->PointerTo(d->LookupUnion("TestUnionInt8pChar")));
+   DefineParameter("v", Int8);
+   DefineReturnType(NoType);
+   }
+
+bool
+SetUnionByteBuilder::buildIL()
+   {
+   StoreIndirect("TestUnionInt8pChar", "v_uint8",
+                 Load("u"),
+                 Load("v"));
+   Return();
+   return true;
+   }
+
+GetUnionByteBuilder::GetUnionByteBuilder(TR::TypeDictionary *d)
+   : MethodBuilder(d)
+   {
+   DefineFile(__FILE__);
+   DefineLine(LINETOSTR(__LINE__));
+
+   DefineName("getUnionByte");
+   DefineParameter("u", d->PointerTo(d->LookupUnion("TestUnionInt8pChar")));
+   DefineReturnType(Int8);
+   }
+
+bool
+GetUnionByteBuilder::buildIL()
+   {
+   Return(
+          LoadIndirect("TestUnionInt8pChar", "v_uint8",
+                        Load("u")));
+
+   return true;
+   }
+
+SetUnionStrBuilder::SetUnionStrBuilder(TR::TypeDictionary *d)
+   : MethodBuilder(d)
+   {
+   DefineFile(__FILE__);
+   DefineLine(LINETOSTR(__LINE__));
+
+   DefineName("setUnionStr");
+   DefineParameter("u", d->PointerTo(d->LookupUnion("TestUnionInt8pChar")));
+   DefineParameter("v", d->toIlType<char*>());
+   DefineReturnType(NoType);
+   }
+
+bool
+SetUnionStrBuilder::buildIL()
+   {
+   StoreIndirect("TestUnionInt8pChar", "v_pchar",
+                 Load("u"),
+                 Load("v"));
+   Return();
+   return true;
+   }
+
+GetUnionStrBuilder::GetUnionStrBuilder(TR::TypeDictionary *d)
+   : MethodBuilder(d)
+   {
+   DefineFile(__FILE__);
+   DefineLine(LINETOSTR(__LINE__));
+
+   DefineName("getUnionStr");
+   DefineParameter("u", d->PointerTo(d->LookupUnion("TestUnionInt8pChar")));
+   DefineReturnType(d->toIlType<char*>());
+   }
+
+bool
+GetUnionStrBuilder::buildIL()
+   {
+   Return(
+          LoadIndirect("TestUnionInt8pChar", "v_pchar",
+                        Load("u")));
+
+   return true;
+   }
+
+TypePunInt32Int32Builder::TypePunInt32Int32Builder(TR::TypeDictionary *d)
+   : MethodBuilder(d)
+   {
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   DefineName("typePunInt32Int32Builder");
+   DefineParameter("u", d->PointerTo(d->LookupUnion("TestUnionInt32Int32")));
+   DefineParameter("v1", Int32);
+   DefineParameter("v2", Int32);
+   DefineReturnType(Int32);
+   }
+
+bool
+TypePunInt32Int32Builder::buildIL()
+   {
+   StoreIndirect("TestUnionInt32Int32", "f1", Load("u"), Load("v1"));
+   StoreIndirect("TestUnionInt32Int32", "f2", Load("u"), Load("v2"));
+   Return(
+          LoadIndirect("TestUnionInt32Int32", "f1", Load("u")));
+   }
+
+TypePunInt16DoubleBuilder::TypePunInt16DoubleBuilder(TR::TypeDictionary *d)
+   : MethodBuilder(d)
+   {
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   DefineName("typePunInt16Double");
+   DefineParameter("u", d->PointerTo(d->LookupUnion("TestUnionInt16Double")));
+   DefineParameter("v1", Int16);
+   DefineParameter("v2", Double);
+   DefineReturnType(Int16);
+   }
+
+bool
+TypePunInt16DoubleBuilder::buildIL()
+   {
+   StoreIndirect("TestUnionInt16Double", "v_uint16", Load("u"), Load("v1"));
+   StoreIndirect("TestUnionInt16Double", "v_double", Load("u"), Load("v2"));
+   Return(
+          LoadIndirect("TestUnionInt16Double", "v_uint16", Load("u")));
+   }
+
+template <typename Function>
+static Function assert_compile(TR::MethodBuilder* m)
+   {
+   uint8_t* entry;
+   assert(0 == compileMethodBuilder(m, &entry));
+   return (Function)entry;
+   }
+
+int
+main()
+   {
+   std::cout << "Step 1: initialize JIT\n";
+   assert(initializeJit());
+
+   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+   {
+   std::cout << "Step 2: create UnionTypeDictionary\n";
+   UnionTypeDictionary typeDictionary;
+
+   std::cout << "Step 3: assert that the size of each union is the size of its largest member\n";
+   assert(sizeof(char*) == typeDictionary.LookupUnion("TestUnionInt8pChar")->getSize());
+   assert(sizeof(uint32_t) == typeDictionary.LookupUnion("TestUnionInt32Int32")->getSize());
+   assert(sizeof(double) == typeDictionary.LookupUnion("TestUnionInt16Double")->getSize());
+   }
+
+   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+   {
+   UnionTypeDictionary setUnionByteTypes;
+   UnionTypeDictionary getUnionByteTypes;
+   TestUnionInt8pChar testUnion;
+   const uint8_t constval = 3;
+
+   std::cout << "Step 4: compile setUnionByte\n";
+   SetUnionByteBuilder setUnionByte(&setUnionByteTypes);
+   auto setByte = assert_compile<SetUnionByteFunction>(&setUnionByte);
+
+   std::cout << "Step 5: invoke setUnionByte\n";
+   setByte(&testUnion, constval);
+   assert(constval == testUnion.v_uint8);
+
+   std::cout << "Step 6: compile getUnionByte\n";
+   GetUnionByteBuilder getUnionByte(&getUnionByteTypes);
+   auto getByte = assert_compile<GetUnionByteFunction>(&getUnionByte);
+
+   std::cout << "Step 7: invoke getUnionByte\n";
+   auto expectedByte = testUnion.v_uint8;
+   assert(expectedByte == getByte(&testUnion));
+   }
+
+   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+   {
+   UnionTypeDictionary setUnionStrTypes;
+   UnionTypeDictionary getUnionStrTypes;
+   TestUnionInt8pChar testUnion;
+   const char* msg = "Hello World!\n";
+
+   std::cout << "Step 8: compile setUnionStr\n";
+   SetUnionStrBuilder setUnionStr(&setUnionStrTypes);
+   auto setStr = assert_compile<SetUnionStrFunction>(&setUnionStr);
+
+   std::cout << "Step 9: invoke setUnionStr\n";
+   setStr(&testUnion, msg);
+   assert(msg == testUnion.v_pchar);
+
+   std::cout << "Step 10: compile getUnionStr\n";
+   GetUnionStrBuilder getUnionStr(&getUnionStrTypes);
+   auto getStr = assert_compile<GetUnionStrFunction>(&getUnionStr);
+
+   std::cout << "Step 11: invoke getUnionStr\n";
+   auto expectedStr = testUnion.v_pchar;
+   assert(expectedStr == getStr(&testUnion));
+   }
+
+   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+   {
+   UnionTypeDictionary typeDictionary;
+   TestUnionInt32Int32 testUnion;
+   const uint32_t v1 = 5;
+   const uint32_t v2 = 10;
+
+   std::cout << "Step 12: compile typePunInt32Int32\n";
+   TypePunInt32Int32Builder builder(&typeDictionary);
+   auto typePunInt32Int32 = assert_compile<TypePunInt32Int32Function>(&builder);
+
+   std::cout << "Step 13: invoke typePunInt32Int32\n";
+   assert(v2 == typePunInt32Int32(&testUnion, v1, v2));
+   }
+
+   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+   {
+   UnionTypeDictionary typeDictionary;
+   TestUnionInt16Double testUnion;
+   const uint16_t v1 = 0xFFFF;
+   const double v2 = +0.0;
+
+   std::cout << "Step 14: compile typePunInt16Double\n";
+   TypePunInt16DoubleBuilder builder(&typeDictionary);
+   auto typePunInt16Dboule = assert_compile<TypePunInt16DoubleFunction>(&builder);
+
+   std::cout << "Step 15: invoke typePunInt16Double\n";
+   assert(static_cast<uint16_t>(v2) == typePunInt16Dboule(&testUnion, v1, v2));
+   }
+
+   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+   std::cout << "Step 16: shutdown JIT\n";
+   shutdownJit();
+   }

--- a/jitbuilder/release/src/Union.hpp
+++ b/jitbuilder/release/src/Union.hpp
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#ifndef UNION_INCL
+#define UNION_INCL
+
+#include "ilgen/MethodBuilder.hpp"
+#include "ilgen/TypeDictionary.hpp"
+
+namespace TR { class TypeDictionary; }
+
+union TestUnionInt8pChar
+   {
+   uint8_t v_uint8;
+   const char* v_pchar;
+   };
+
+union TestUnionInt32Int32
+   {
+   uint32_t f1;
+   uint32_t f2;
+   };
+
+union TestUnionInt16Double
+   {
+   uint16_t v_uint16;
+   double v_double;
+   };
+
+typedef void (*SetUnionByteFunction)(TestUnionInt8pChar*, uint8_t);
+typedef uint8_t (*GetUnionByteFunction)(TestUnionInt8pChar*);
+typedef void (*SetUnionStrFunction)(TestUnionInt8pChar*, const char*);
+typedef const char* (*GetUnionStrFunction)(TestUnionInt8pChar*);
+typedef uint32_t (*TypePunInt32Int32Function)(TestUnionInt32Int32*, uint32_t, uint32_t);
+typedef uint16_t (*TypePunInt16DoubleFunction)(TestUnionInt16Double*, uint16_t, double);
+
+class UnionTypeDictionary : public TR::TypeDictionary
+   {
+   public:
+   UnionTypeDictionary() :
+      TR::TypeDictionary()
+      {
+      DefineUnion("TestUnionInt8pChar");
+      UnionField("TestUnionInt8pChar", "v_uint8", toIlType<uint8_t>());
+      UnionField("TestUnionInt8pChar", "v_pchar", toIlType<char*>());
+      CloseUnion("TestUnionInt8pChar");
+
+      DefineUnion("TestUnionInt32Int32");
+      UnionField("TestUnionInt32Int32", "f1", Int32);
+      UnionField("TestUnionInt32Int32", "f2", Int32);
+      CloseUnion("TestUnionInt32Int32");
+
+      DefineUnion("TestUnionInt16Double");
+      UnionField("TestUnionInt16Double", "v_uint16", Int16);
+      UnionField("TestUnionInt16Double", "v_double", Double);
+      CloseUnion("TestUnionInt16Double");
+      }
+   };
+
+class SetUnionByteBuilder : public TR::MethodBuilder
+   {
+   public:
+   SetUnionByteBuilder(TR::TypeDictionary *);
+   virtual bool buildIL();
+   };
+
+class GetUnionByteBuilder : public TR::MethodBuilder
+   {
+   public:
+   GetUnionByteBuilder(TR::TypeDictionary *);
+   virtual bool buildIL();
+   };
+
+class SetUnionStrBuilder : public TR::MethodBuilder
+   {
+   public:
+   SetUnionStrBuilder(TR::TypeDictionary *);
+   virtual bool buildIL();
+   };
+
+class GetUnionStrBuilder : public TR::MethodBuilder
+   {
+   public:
+   GetUnionStrBuilder(TR::TypeDictionary *);
+   virtual bool buildIL();
+   };
+
+class TypePunInt32Int32Builder : public TR::MethodBuilder
+   {
+   public:
+   TypePunInt32Int32Builder(TR::TypeDictionary *);
+   virtual bool buildIL();
+   };
+
+class TypePunInt16DoubleBuilder : public TR::MethodBuilder
+   {
+   public:
+   TypePunInt16DoubleBuilder(TR::TypeDictionary *);
+   virtual bool buildIL();
+   };
+
+#endif // UNION_INCL


### PR DESCRIPTION
This implements JitBuilder support for union types. Some minor code clean ups are also done.

The implementation is split into two commits. One commit implements the underlying structures used to represent unions. The other adds the interface methods to `TypeDictionary` used to create and interact with union types. The remaining commits do some light code clean up and add testing for JitBuilder unions.

Fixes #643