### PR TITLE
Fix handling of induction offsets in OSR analyses

### DIFF
--- a/compiler/compile/OSRData.cpp
+++ b/compiler/compile/OSRData.cpp
@@ -881,12 +881,9 @@ TR::Compilation& operator<< (TR::Compilation& out, const TR_OSRMethodData& osrMe
    return out;
    }
 
-TR_OSRPoint::TR_OSRPoint(TR::Node *node, int32_t induceOffset, TR_OSRMethodData *methodData, TR_Memory *m)
-   : _methodData(methodData)
+TR_OSRPoint::TR_OSRPoint(TR_ByteCodeInfo &bcInfo, TR_OSRMethodData *methodData, TR_Memory *m)
+   : _methodData(methodData), _bcInfo(bcInfo)
    {
-   _nodeBCInfo = node->getByteCodeInfo();
-   _induceBCInfo = node->getByteCodeInfo();
-   _induceBCInfo.setByteCodeIndex(_induceBCInfo.getByteCodeIndex() + induceOffset);
    }
 
 TR_OSRSlotSharingInfo::TR_OSRSlotSharingInfo(TR::Compilation* _comp) :

--- a/compiler/compile/OSRData.hpp
+++ b/compiler/compile/OSRData.hpp
@@ -305,20 +305,17 @@ class TR_OSRPoint
    public:
    TR_ALLOC(TR_Memory::OSR);
 
-   TR_OSRPoint(TR::Node *node, int32_t induceOffset, TR_OSRMethodData *methodData, TR_Memory *m);
+   TR_OSRPoint(TR_ByteCodeInfo &bcInfo, TR_OSRMethodData *methodData, TR_Memory *m);
    TR_OSRMethodData *getOSRMethodData() { return _methodData; }
 
    void setOSRIndex(uint32_t index) { _index = index; }
    uint32_t getOSRIndex() { return _index; }
-   TR_ByteCodeInfo& getNodeByteCodeInfo() {return _nodeBCInfo;}
-   TR_ByteCodeInfo& getInduceByteCodeInfo() {return _induceBCInfo;}
-   bool induceAfter() { return _induceBCInfo.getByteCodeIndex() > _nodeBCInfo.getByteCodeIndex(); }
+   TR_ByteCodeInfo& getByteCodeInfo() {return _bcInfo;}
 
    private:
    TR_OSRMethodData                   *_methodData;
    uint32_t                            _index;
-   TR_ByteCodeInfo                     _nodeBCInfo;
-   TR_ByteCodeInfo                     _induceBCInfo;
+   TR_ByteCodeInfo                     _bcInfo;
    };
 
 

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -541,9 +541,8 @@ OMR::ResolvedMethodSymbol::genInduceOSRCallNode(TR::TreeTop* insertionPoint,
       }
 
    TR::Node *induceOSRCallNode = TR::Node::createWithSymRef(refNode, TR::call, numChildren - firstArgIndex, induceOSRSymRef);
-   TR_OSRPoint *point = self()->findOSRPoint(refNode);
+   TR_OSRPoint *point = self()->findOSRPoint(refNode->getByteCodeInfo());
    TR_ASSERT(point, "Could not find osr point for bytecode %d:%d!", refNode->getByteCodeInfo().getCallerIndex(), refNode->getByteCodeInfo().getByteCodeIndex());
-   induceOSRCallNode->getByteCodeInfo().setByteCodeIndex(point->getInduceByteCodeInfo().getByteCodeIndex());
 
    if (copyChildren)
       {
@@ -888,13 +887,24 @@ OMR::ResolvedMethodSymbol::genAndAttachOSRCodeBlocks(int32_t currentInlinedSiteI
          TR::Block * block = tt->getEnclosingBlock();
          // Add the OSR point to the list
          TR::Block * OSRCatchBlock = osrMethodData->findOrCreateOSRCatchBlock(ttnode);
-         int32_t osrOffset = self()->comp()->getOSRInductionOffset(ttnode);
-         TR_OSRPoint *osrPoint = new (self()->comp()->trHeapMemory()) TR_OSRPoint(ttnode, osrOffset, osrMethodData, self()->comp()->trMemory());
+         TR_OSRPoint *osrPoint = new (self()->comp()->trHeapMemory()) TR_OSRPoint(ttnode->getByteCodeInfo(), osrMethodData, self()->comp()->trMemory());
          osrPoint->setOSRIndex(self()->addOSRPoint(osrPoint));
          if (self()->comp()->getOption(TR_TraceOSR))
-            traceMsg(self()->comp(), "osr point added for [%p] at %d:%d with induction offset %d\n",
+            traceMsg(self()->comp(), "osr point added for [%p] at %d:%d\n",
                ttnode, ttnode->getByteCodeInfo().getCallerIndex(),
-               ttnode->getByteCodeInfo().getByteCodeIndex(), osrOffset);
+               ttnode->getByteCodeInfo().getByteCodeIndex());
+
+         int32_t osrOffset = self()->comp()->getOSRInductionOffset(ttnode);
+         if (osrOffset > 0)
+            {
+            TR_ByteCodeInfo offsetBCI = ttnode->getByteCodeInfo();
+            offsetBCI.setByteCodeIndex(offsetBCI.getByteCodeIndex() + osrOffset);
+            osrPoint = new (self()->comp()->trHeapMemory()) TR_OSRPoint(offsetBCI, osrMethodData, self()->comp()->trMemory());
+            osrPoint->setOSRIndex(self()->addOSRPoint(osrPoint));
+            if (self()->comp()->getOption(TR_TraceOSR))
+               traceMsg(self()->comp(), "offset osr point added for [%p] at offset bci %d:%d\n",
+                  ttnode, offsetBCI.getCallerIndex(), offsetBCI.getByteCodeIndex());
+            }
 
          // Add an exception edge from the current block to the OSR catch block if there isn't already one
          auto edge = block->getExceptionSuccessors().begin();
@@ -1664,6 +1674,8 @@ OMR::ResolvedMethodSymbol::insertStoresForDeadStackSlotsBeforeInducingOSR(TR::Co
    else
       osrMethodData = comp->getOSRCompilationData()->findOrCreateOSRMethodData(callSite, self());
 
+   traceMsg(comp, "About to do dead store insertion using osrMethodData %p - %d:%d\n", osrMethodData, callSite, byteCodeIndex);
+
    TR::TreeTop *prev = induceOSRTree->getPrevTreeTop();
    TR::TreeTop *next = induceOSRTree;
 
@@ -1710,13 +1722,13 @@ OMR::ResolvedMethodSymbol::insertStoresForDeadStackSlotsBeforeInducingOSR(TR::Co
 
 
 TR_OSRPoint *
-OMR::ResolvedMethodSymbol::findOSRPoint(TR::Node *node)
+OMR::ResolvedMethodSymbol::findOSRPoint(TR_ByteCodeInfo &bcInfo)
    {
    for (intptrj_t i = 0; i < _osrPoints.size(); ++i)
       {
-      TR_ByteCodeInfo& bcinfo = _osrPoints[i]->getNodeByteCodeInfo();
-      if (bcinfo.getByteCodeIndex() == node->getByteCodeIndex() &&
-         bcinfo.getCallerIndex() == node->getInlinedSiteIndex())
+      TR_ByteCodeInfo& pointBCInfo = _osrPoints[i]->getByteCodeInfo();
+      if (pointBCInfo.getByteCodeIndex() == bcInfo.getByteCodeIndex() &&
+         pointBCInfo.getCallerIndex() == bcInfo.getCallerIndex())
          return _osrPoints[i];
       }
 

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
@@ -113,7 +113,7 @@ public:
    void setPendingPushSymRefs(TR_Array<List<TR::SymbolReference> > *l) {_pendingPushSymRefs = l;}
 
    TR_Array<TR_OSRPoint *> &getOSRPoints() { return _osrPoints; }
-   TR_OSRPoint *findOSRPoint(TR::Node *node);
+   TR_OSRPoint *findOSRPoint(TR_ByteCodeInfo &bcInfo);
    uint32_t addOSRPoint(TR_OSRPoint *point) { return _osrPoints.add(point) ; }
    uint32_t getNumOSRPoints() { return _osrPoints.size(); }
    bool sharesStackSlot(TR::SymbolReference *symRef);


### PR DESCRIPTION
Recent changes added an API to allow an OSR point to have an induction offset and when that offset was positive to perform OSR def and liveness analyses differently. It turns out that you not only need the state at the transition after a potential OSR point, you need the state before. This is specifically for calls where inlining the call my require that you are able to obtain the state ahead of the call. This commit removes the induction offset API in favour of adding additional OSR points to track this necessary information.