### PR TITLE
Fix unused variable errors in CollectorLanguageInterface.cpp

### DIFF
--- a/gc/base/CollectorLanguageInterface.hpp
+++ b/gc/base/CollectorLanguageInterface.hpp
@@ -61,13 +61,7 @@ protected:
 public:
 
 private:
-#if defined(OMR_GC_MODRON_SCAVENGER)
-	MMINLINE void generationalWriteBarrierStore(MM_EnvironmentStandard* env, omrobjectptr_t parentObject, omrobjectptr_t childObject);
-#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
-
-#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
-	MMINLINE void concurrentWriteBarrierStore(MM_EnvironmentBase* env, omrobjectptr_t parentObject);
-#endif /* defined(OMR_GC_MODRON_CONCURRENT_MARK) */
+	MMINLINE void writeBarrier(OMR_VMThread *omrThread, omrobjectptr_t parentObject, omrobjectptr_t childObject);
 
 protected:
 


### PR DESCRIPTION
Must declare unused offending variable (env) only when 
OMR_GC_MODRON_CONCURRENT_MARK or OMR_GC_MODRON_SCAVENGER are defined.

Also did some light refactoring to simplify the methods involved.

Peer reviewer: @youngar 
Senior reviewer: @charliegracie 
Issue: #650 
Signed-off-by: Kim Briggs <briggs@ca.ibm.com>