### PR TITLE
Thread vs Concurrent Scavenger Cycle check

### DIFF
--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -523,6 +523,10 @@ public:
 	bool isConcurrentInProgress() {
 		return concurrent_state_idle != _concurrentState;
 	}
+	
+	bool isMutatorThreadInSyncWithCycle(MM_EnvironmentBase *env) {
+		return (env->_concurrentScavengerSwitchCount == _concurrentScavengerSwitchCount);
+	}
 
 	/**
 	 * Enabled/disable approriate thread local resources when starting or finishing Concurrent Scavenger Cycle


### PR DESCRIPTION
Public  API that will allow to check if a mutator thread is in sync with
the cycle

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>