### PR TITLE
Virtual guard head merger fixes

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -5731,7 +5731,7 @@ OMR::Node::printIsHeapificationAlloc()
 bool
 OMR::Node::isLiveMonitorInitStore()
    {
-   TR_ASSERT((self()->getOpCode().isStore()), "Opcode must be astore");
+   TR_ASSERT(self()->getOpCodeValue() == TR::astore, "Opcode must be astore");
    return (self()->getOpCode().hasSymbolReference() && self()->getSymbol()->holdsMonitoredObject() && _flags.testAny(liveMonitorInitStore));
    }
 
@@ -5748,7 +5748,7 @@ OMR::Node::setLiveMonitorInitStore(bool v)
 bool
 OMR::Node::chkLiveMonitorInitStore()
    {
-   return (self()->getOpCodeValue() == TR::astore) && _flags.testAny(liveMonitorInitStore);
+   return (self()->getOpCodeValue() == TR::astore) && self()->isLiveMonitorInitStore();
    }
 
 const char *
@@ -7187,7 +7187,7 @@ bool
 OMR::Node::isPrivatizedInlinerArg()
    {
    TR_ASSERT(self()->getOpCode().isStoreDirectOrReg(), "assertion failure");
-   return _flags.testAny(privatizedInlinerArg);
+   return _flags.testAny(privatizedInlinerArg) && !self()->chkLiveMonitorInitStore();
    }
 
 void

--- a/compiler/optimizer/SinkStores.cpp
+++ b/compiler/optimizer/SinkStores.cpp
@@ -2438,6 +2438,13 @@ bool TR_SinkStores::treeIsSinkableStore(TR::Node *node, bool sinkIndirectLoads, 
          return false;
          }
 
+      if (node->getOpCode().hasSymbolReference() && node->getSymbol()->holdsMonitoredObject())
+         {
+         if (trace())
+            traceMsg(comp(), "        store holds monitored object, not safe to move it\n");
+         return false;
+         }
+
       if (node->getOpCode().isStore() &&
           (node->dontEliminateStores() ||
           (node->getSymbolReference()->getSymbol()->isAuto() &&


### PR DESCRIPTION
Virtual guard head merger can move trees ahead of a guard up, including
trees ahead of an HCR guard. Those trees can have side effect which
should stay in place. This commit fixes the problem and allows the
merging of a runtime guard when there are only priv arg stores and live
monitor stores ahead of it.

The commit also disaliases the liveMonitorInitStore flag and the
privatizedInlinerArg flag. And code is added to sinkstore to prevent it
from sinking live monitor stores which was protected by
privatizedInlinerArg flag.

issue: #655
Signed-off-by: liqunl <liqunl@ca.ibm.com>