### PR TITLE
Heapification flag for nodes

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -5699,6 +5699,36 @@ OMR::Node::printIsHeapificationStore()
 
 
 bool
+OMR::Node::isHeapificationAlloc()
+   {
+   TR_ASSERT(self()->getOpCode().isNew(), "Opcode must be isNew");
+   return _flags.testAny(HeapificationAlloc);
+   }
+
+void
+OMR::Node::setHeapificationAlloc(bool v)
+   {
+   TR::Compilation * c = TR::comp();
+   TR_ASSERT(self()->getOpCode().isNew(), "Opcode must be isNew");
+   if (performNodeTransformation2(c,"O^O NODE FLAGS: Setting HeapificationAlloc flag on node %p to %d\n", self(), v))
+      _flags.set(HeapificationAlloc, v);
+   }
+
+bool
+OMR::Node::chkHeapificationAlloc()
+   {
+   return self()->getOpCode().isNew() && _flags.testAny(HeapificationAlloc);
+   }
+
+const char *
+OMR::Node::printIsHeapificationAlloc()
+   {
+   return self()->chkHeapificationAlloc() ? "HeapificationAlloc " : "";
+   }
+
+
+
+bool
 OMR::Node::isLiveMonitorInitStore()
    {
    TR_ASSERT((self()->getOpCode().isStore()), "Opcode must be astore");
@@ -6076,7 +6106,7 @@ OMR::Node::chkArrayTRT()
 const char *
 OMR::Node::printArrayTRT()
    {
-   return self()->chkArrayTRT() ? "arrayTRT" : "";
+   return self()->chkArrayTRT() ? "arrayTRT " : "";
    }
 
 
@@ -6106,7 +6136,7 @@ OMR::Node::chkCharArrayTRT()
 const char *
 OMR::Node::printCharArrayTRT()
    {
-   return self()->chkCharArrayTRT() ? "charArrayTRT" : "";
+   return self()->chkCharArrayTRT() ? "charArrayTRT " : "";
    }
 
 
@@ -6312,7 +6342,7 @@ OMR::Node::chkSourceCellIsTermChar()
 const char *
 OMR::Node::printSourceCellIsTermChar()
    {
-   return self()->chkSourceCellIsTermChar() ? "sourceCellIsTermChar" : "";
+   return self()->chkSourceCellIsTermChar() ? "sourceCellIsTermChar " : "";
    }
 
 
@@ -6372,7 +6402,7 @@ OMR::Node::chkArrayCmpLen()
 const char *
 OMR::Node::printArrayCmpLen()
    {
-   return self()->chkArrayCmpLen() ? "arrayCmpLen" : "";
+   return self()->chkArrayCmpLen() ? "arrayCmpLen " : "";
    }
 
 
@@ -6402,7 +6432,7 @@ OMR::Node::chkArrayCmpSign()
 const char *
 OMR::Node::printArrayCmpSign()
    {
-   return self()->chkArrayCmpSign() ? "arrayCmpSign" : "";
+   return self()->chkArrayCmpSign() ? "arrayCmpSign " : "";
    }
 
 
@@ -6673,7 +6703,7 @@ OMR::Node::chkXorBitOpMem()
 const char *
 OMR::Node::printXorBitOpMem()
    {
-   return self()->chkXorBitOpMem() ? "SubOp=XOR" : "";
+   return self()->chkXorBitOpMem() ? "SubOp=XOR " : "";
    }
 
 
@@ -6704,7 +6734,7 @@ OMR::Node::chkOrBitOpMem()
 const char *
 OMR::Node::printOrBitOpMem()
    {
-   return self()->chkOrBitOpMem() ? "SubOp=OR" : "";
+   return self()->chkOrBitOpMem() ? "SubOp=OR " : "";
    }
 
 
@@ -6735,7 +6765,7 @@ OMR::Node::chkAndBitOpMem()
 const char *
 OMR::Node::printAndBitOpMem()
    {
-   return self()->chkAndBitOpMem() ? "SubOp=AND" : "";
+   return self()->chkAndBitOpMem() ? "SubOp=AND " : "";
    }
 
 
@@ -8000,7 +8030,7 @@ OMR::Node::chkAllocationCanBeRemoved()
 const char *
 OMR::Node::printAllocationCanBeRemoved()
    {
-   return self()->chkAllocationCanBeRemoved() ? "allocationCanBeRemoved" : "";
+   return self()->chkAllocationCanBeRemoved() ? "allocationCanBeRemoved " : "";
    }
 
 

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -978,6 +978,11 @@ public:
    bool chkHeapificationStore();
    const char * printIsHeapificationStore();
 
+   bool isHeapificationAlloc();
+   void setHeapificationAlloc(bool v);
+   bool chkHeapificationAlloc();
+   const char * printIsHeapificationAlloc();
+
    bool isLiveMonitorInitStore();
    void setLiveMonitorInitStore(bool v);
    bool chkLiveMonitorInitStore();
@@ -1924,6 +1929,10 @@ protected:
       localObjectMonitor                    = 0x00008000,
       primitiveLockedRegion                 = 0x00000400,
       monitorClassInNode                    = 0x00010000,
+
+      // Flags only used for isNew() opcodes
+      //
+      HeapificationAlloc                    = 0x00001000,
 
       // Flag used by TR::newarray and TR::anewarray
       //

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1118,6 +1118,7 @@ TR_Debug::nodePrintAllFlags(TR::Node *node, TR_PrettyPrinterString &output)
    output.append(format, node->printIsDontInlineUnsafePutOrderedCall());
 #endif
    output.append(format, node->printIsHeapificationStore());
+   output.append(format, node->printIsHeapificationAlloc());
    output.append(format, node->printIsLiveMonitorInitStore());
    output.append(format, node->printIsMethodEnterExitGuard());
    output.append(format, node->printReturnIsDummy());


### PR DESCRIPTION
This adds a heapification flag for nodes. Used to mark nodes so
that subsequent EA passes don't spend additional time
analyzing them. Moreover, it corrects whitespace for various 
node print functions. The changes were originally made by 
Patrick Doyle but were never merged in.

Signed-off-by: Nicholas Coughlin cnic@ca.ibm.com