### PR TITLE
Remove duplicate decrement in simplifyChildren()

### DIFF
--- a/compiler/optimizer/OMRSimplifierHelpers.cpp
+++ b/compiler/optimizer/OMRSimplifierHelpers.cpp
@@ -113,7 +113,6 @@ void simplifyChildren(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       {
       TR::Node * child = node->getChild(i);
       child->decFutureUseCount();
-      child->decFutureUseCount();
       if (child->getVisitCount() != visitCount)
          {
          child = s->simplify(child, block);


### PR DESCRIPTION
The `decFutureUseCount()` call appears to have been accidentally
duplicated. Incorrect future use count values prevent at least the
simplification of cascading `aladd` operations with constants, i.e.

    aladd
      aladd              aladd
        ...        ==>     ...
        lconst a           lconst (a + b)
      lconst b

Signed-off-by: Devin Papineau <devinmp@ca.ibm.com>