### PR TITLE
Extend signed comparisons in loop strider widening

### DIFF
--- a/compiler/optimizer/InductionVariable.cpp
+++ b/compiler/optimizer/InductionVariable.cpp
@@ -4658,6 +4658,7 @@ void TR_LoopStrider::walkTreesAndFixUseDefs(
    replaceLoadsInStructure(
       loopStructure,
       _loopDrivingInductionVar,
+      newIntValue,
       newSymbolReference,
       exLoads,
       visited);
@@ -4667,12 +4668,17 @@ void TR_LoopStrider::walkTreesAndFixUseDefs(
    }
 
 /**
- * Change each load of \p iv in \p structure into \c l2i of \c lload \p newSR.
+ * Replace occurrences of \p iv with \p newSR within \p structure.
  *
- * These are the (ex-) \c iload nodes that are added to \p exLoads.
+ * Each load of \p iv becomes \c l2i of \c lload \p newSR. These are the (ex-)
+ * \c iload nodes that are added to \p exLoads.
+ *
+ * Signed 32-bit comparisons made directly against \p iv, or directly against
+ * \p defRHS, are replaced by the corresponding 64-bit comparisons.
  *
  * \param[in]     structure  where to change loads
  * \param[in]     iv         the symbol reference number of the loads to change
+ * \param[in]     defRHS     the right-hand side of the lone store to \p iv
  * \param[in]     newSR      the new symbol reference to use in place of \p iv
  * \param[in,out] exLoads    the checklist to which the changed loads are added
  * \param[in,out] visited    an empty checklist
@@ -4681,6 +4687,7 @@ void TR_LoopStrider::walkTreesAndFixUseDefs(
 void TR_LoopStrider::replaceLoadsInStructure(
    TR_Structure *structure,
    int32_t iv,
+   TR::Node *defRHS,
    TR::SymbolReference *newSR,
    TR::NodeChecklist &exLoads,
    TR::NodeChecklist &visited)
@@ -4690,13 +4697,13 @@ void TR_LoopStrider::replaceLoadsInStructure(
       TR::Block *b = structure->asBlock()->getBlock();
       TR::TreeTop *end = b->getExit();
       for (TR::TreeTop *tt = b->getEntry(); tt != end; tt = tt->getNextTreeTop())
-         replaceLoadsInSubtree(tt->getNode(), iv, newSR, exLoads, visited);
+         replaceLoadsInSubtree(tt->getNode(), iv, defRHS, newSR, exLoads, visited);
       }
    else
       {
       TR_RegionStructure::Cursor it(*structure->asRegion());
       for (TR_StructureSubGraphNode *n = it.getFirst(); n != NULL; n = it.getNext())
-         replaceLoadsInStructure(n->getStructure(), iv, newSR, exLoads, visited);
+         replaceLoadsInStructure(n->getStructure(), iv, defRHS, newSR, exLoads, visited);
       }
    }
 
@@ -4704,6 +4711,7 @@ void TR_LoopStrider::replaceLoadsInStructure(
 void TR_LoopStrider::replaceLoadsInSubtree(
    TR::Node *node,
    int32_t iv,
+   TR::Node *defRHS,
    TR::SymbolReference *newSR,
    TR::NodeChecklist &exLoads,
    TR::NodeChecklist &visited)
@@ -4713,7 +4721,7 @@ void TR_LoopStrider::replaceLoadsInSubtree(
 
    visited.add(node);
    for (int i = 0; i < node->getNumChildren(); i++)
-      replaceLoadsInSubtree(node->getChild(i), iv, newSR, exLoads, visited);
+      replaceLoadsInSubtree(node->getChild(i), iv, defRHS, newSR, exLoads, visited);
 
    if (node->getOpCodeValue() == TR::iload
        && node->getSymbolReference()->getReferenceNumber() == iv)
@@ -4724,6 +4732,110 @@ void TR_LoopStrider::replaceLoadsInSubtree(
       node->setAndIncChild(0, lload);
       exLoads.add(node);
       }
+
+   widenComparison(node, iv, defRHS, exLoads);
+   }
+
+/**
+ * Widen comparisons against \p iv.
+ *
+ * Signed 32-bit comparisons made directly against \p iv, or directly against
+ * the node that produces the new value of \p iv, are changed into the
+ * corresponding 64-bit comparisons, by wrapping each child in \c i2l.
+ *
+ * For example, when replacing the 32-bit \c i with the 64-bit \c k, consider
+ * the following comparison:
+ *
+   \verbatim
+      ificmpge
+        iload i
+        iload n
+   \endverbatim
+ *
+ * In the course of replaceInStructure(TR_Structure*), it will be rewritten as:
+ *
+   \verbatim
+      ificmpge
+        l2i
+          lload k
+        iload n
+   \endverbatim
+ *
+ * In order to make it  into a more obvious test of \c k, we change it into a
+ * 64-bit comparison using \c i2l like so:
+ *
+   \verbatim
+      iflcmpge
+        i2l
+          l2i
+            lload k
+        i2l
+          iload n
+   \endverbatim
+ *
+ * Because the \c l2i node here is an ex-load, it will cancel the \c i2l later:
+ *
+   \verbatim
+      iflcmpge
+        lload k
+        i2l
+          iload n
+   \endverbatim
+ *
+ * \param[in] node     the possible comparison node to process
+ * \param[in] iv       the symbol reference number of the loads being changed
+ * \param[in] defRHS   the right-hand side of the lone store to \p iv
+ * \param[in] exLoads  the set of \c l2i nodes that were loads of \p iv
+ */
+void TR_LoopStrider::widenComparison(
+   TR::Node *node,
+   int32_t iv,
+   TR::Node *defRHS,
+   TR::NodeChecklist &exLoads)
+   {
+   static const char * const disableEnv =
+      feGetEnv("TR_disableLoopStriderWidenComparison");
+   static const bool disable = disableEnv != NULL && disableEnv[0] != '\0';
+   if (disable)
+      return;
+
+   TR::ILOpCode op = node->getOpCode();
+   TR::ILOpCodes icmp = op.isIf() ? op.convertIfCmpToCmp() : op.getOpCodeValue();
+   TR::ILOpCodes lcmp = TR::BadILOp;
+   switch (icmp)
+      {
+      case TR::icmpeq: lcmp = TR::lcmpeq; break;
+      case TR::icmpne: lcmp = TR::lcmpne; break;
+      case TR::icmplt: lcmp = TR::lcmplt; break;
+      case TR::icmple: lcmp = TR::lcmple; break;
+      case TR::icmpgt: lcmp = TR::lcmpgt; break;
+      case TR::icmpge: lcmp = TR::lcmpge; break;
+      default: return; // Not a 32-bit signed integer comparison.
+      }
+
+   TR::Node *left = node->getChild(0);
+   TR::Node *right = node->getChild(1);
+   bool isLeftIV = left == defRHS || exLoads.contains(left);
+   bool isRightIV = right == defRHS || exLoads.contains(right);
+   if (!isLeftIV && !isRightIV)
+      return;
+
+   if (op.isIf())
+      lcmp = TR::ILOpCode(lcmp).convertCmpToIfCmp();
+
+   if (!performTransformation(comp(),
+         "%s [Sign-Extn] Changing n%un %s into %s\n",
+         optDetailString(),
+         node->getGlobalIndex(),
+         node->getOpCode().getName(),
+         TR::ILOpCode(lcmp).getName()))
+      return;
+
+   TR::Node::recreate(node, lcmp);
+   node->setAndIncChild(0, TR::Node::create(node, TR::i2l, 1, left));
+   node->setAndIncChild(1, TR::Node::create(node, TR::i2l, 1, right));
+   left->decReferenceCount();
+   right->decReferenceCount();
    }
 
 /**

--- a/compiler/optimizer/InductionVariable.hpp
+++ b/compiler/optimizer/InductionVariable.hpp
@@ -183,8 +183,9 @@ class TR_LoopStrider : public TR_LoopTransformer
    bool morphExpressionLinearInInductionVariable(TR::Node *, int32_t, TR::Node *, vcount_t);
    TR::Node *getInductionVariableNode(TR::Node *);
    void walkTreesAndFixUseDefs(TR_Structure *, TR::SymbolReference *, TR::NodeChecklist &);
-   void replaceLoadsInStructure(TR_Structure *, int32_t, TR::SymbolReference *, TR::NodeChecklist &, TR::NodeChecklist &);
-   void replaceLoadsInSubtree(TR::Node *, int32_t, TR::SymbolReference *, TR::NodeChecklist &, TR::NodeChecklist &);
+   void replaceLoadsInStructure(TR_Structure *, int32_t, TR::Node *, TR::SymbolReference *, TR::NodeChecklist &, TR::NodeChecklist &);
+   void replaceLoadsInSubtree(TR::Node *, int32_t, TR::Node *, TR::SymbolReference *, TR::NodeChecklist &, TR::NodeChecklist &);
+   void widenComparison(TR::Node *, int32_t, TR::Node *, TR::NodeChecklist &);
    void eliminateSignExtensions(TR::NodeChecklist &);
    void eliminateSignExtensionsInSubtree(TR::Node *, TR::NodeChecklist &, TR::NodeChecklist &, NodeMap &);
    TR::Node *signExtend(TR::Node *, TR::NodeChecklist &, NodeMap &);


### PR DESCRIPTION
As part of its sign-extension pass, loop strider now identifies 32-bit
signed comparisons made directly against any replaced IV (induction
variable), and changes them into 64-bit signed comparisons by wrapping
the children in `i2l`. At least the `i2l` around the replaced IV will
be eliminated, so that afterward it will still be a direct child of the
comparison.

Signed-off-by: Devin Papineau <devinmp@ca.ibm.com>