### PR TITLE
Update compiler options for zOS and zLinux

### DIFF
--- a/fvtest/compilertest/build/toolcfg/gnu/common.mk
+++ b/fvtest/compilertest/build/toolcfg/gnu/common.mk
@@ -123,13 +123,13 @@ endif
 ifeq ($(HOST_ARCH),z)
     ifeq ($(HOST_BITS),32)
         CX_DEFINES+=J9VM_TIERED_CODE_CACHE MAXMOVE S390 FULL_ANSI
-        CX_FLAGS+=-m31 -fPIC -fno-strict-aliasing -march=z900 -mtune=z9-109 -mzarch
+        CX_FLAGS+=-m31 -fPIC -fno-strict-aliasing -mtune=z10 -march=z9-109 -mzarch
         CX_FLAGS_DEBUG+=-gdwarf-2
     endif
     
     ifeq ($(HOST_BITS),64)
         CX_DEFINES+=S390 S39064 FULL_ANSI MAXMOVE J9VM_TIERED_CODE_CACHE
-        CX_FLAGS+=-fPIC -fno-strict-aliasing -march=z900 -mtune=z9-109 -mzarch
+        CX_FLAGS+=-fPIC -fno-strict-aliasing -mtune=z10 -march=z9-109 -mzarch
     endif
 endif
 
@@ -189,7 +189,7 @@ ifeq ($(HOST_ARCH),x)
 endif
 
 ifeq ($(HOST_ARCH),z)
-    S_FLAGS+=-march=z990 -mzarch
+    S_FLAGS+=-march=z9-109 -mzarch
     
     ifeq ($(HOST_BITS),32)
         S_FLAGS+=-m31

--- a/jitbuilder/build/toolcfg/gnu/common.mk
+++ b/jitbuilder/build/toolcfg/gnu/common.mk
@@ -158,12 +158,12 @@ endif
 
 ifeq ($(PLATFORM),s390-linux-gcc)
     CX_DEFINES+=J9VM_TIERED_CODE_CACHE MAXMOVE S390 FULL_ANSI
-    CX_FLAGS+=-m31 -fPIC -fno-strict-aliasing -march=z900 -mtune=z9-109 -mzarch
+    CX_FLAGS+=-m31 -fPIC -fno-strict-aliasing -mtune=z10 -march=z9-109 -mzarch
 endif
 
 ifeq ($(PLATFORM),s390-linux64-gcc)
     CX_DEFINES+=S390 S39064 FULL_ANSI MAXMOVE J9VM_TIERED_CODE_CACHE
-    CX_FLAGS+=-fPIC -fno-strict-aliasing -march=z900 -mtune=z9-109 -mzarch
+    CX_FLAGS+=-fPIC -fno-strict-aliasing -mtune=z10 -march=z9-109 -mzarch
 endif
 
 ifeq ($(C_COMPILER),clang)
@@ -216,11 +216,11 @@ ifeq ($(HOST_ARCH),x)
 endif
 
 ifeq ($(PLATFORM),s390-linux-gcc)
-    S_FLAGS+=-m31 -mzarch -march=z990
+    S_FLAGS+=-m31 -mzarch -march=z9-109
 endif
 
 ifeq ($(PLATFORM),s390-linux64-gcc)
-    S_FLAGS+=-march=z990 -mzarch
+    S_FLAGS+=-march=z9-109 -mzarch
 endif
 
 S_DEFINES+=$(S_DEFINES_EXTRA)

--- a/omrmakefiles/rules.linux.mk
+++ b/omrmakefiles/rules.linux.mk
@@ -125,7 +125,7 @@ else
         ifeq (0,$(OMR_ENV_DATA64))
             GLOBAL_ASFLAGS+= -mzarch
         endif
-        GLOBAL_ASFLAGS+= -march=z990 $(J9M31) -o $*.o
+        GLOBAL_ASFLAGS+= -march=z9-109 $(J9M31) -o $*.o
     else
         ifeq (x86,$(OMR_HOST_ARCH))
             ifeq (0,$(OMR_ENV_DATA64))
@@ -369,7 +369,7 @@ ifeq ($(OMR_OPTIMIZE),1)
                 endif
             else
                 ifeq (s390,$(OMR_HOST_ARCH))
-                    OPTIMIZATION_FLAGS+=-O3 -march=z900  -mtune=z9-109 -mzarch
+                    OPTIMIZATION_FLAGS+=-O3 -mtune=z10 -march=z9-109 -mzarch
                 else
                     OPTIMIZATION_FLAGS+=-O
                 endif

--- a/omrmakefiles/rules.zos.mk
+++ b/omrmakefiles/rules.zos.mk
@@ -19,8 +19,8 @@
 GLOBAL_CPPFLAGS+=-I$(top_srcdir)/util/a2e/headers
 
 # Specify the minimum arch for 64-bit programs
-GLOBAL_CFLAGS+=-Wc,ARCH\(5\)
-GLOBAL_CXXFLAGS+=-Wc,ARCH\(5\)
+GLOBAL_CFLAGS+=-Wc,ARCH\(7\)
+GLOBAL_CXXFLAGS+=-Wc,ARCH\(7\)
 
 # Enable Warnings as Errors
 ifeq ($(OMR_WARNINGS_AS_ERRORS),1)
@@ -37,7 +37,7 @@ endif
 
 # Enable Optimizations
 ifeq ($(OMR_OPTIMIZE),1)
-    COPTFLAGS=-O3 -Wc,TUNE\(9\) -Wc,inline\(auto,noreport,600,5000\)
+    COPTFLAGS=-O3 -Wc,TUNE\(10\) -Wc,inline\(auto,noreport,600,5000\)
 
     # OMRTODO: The COMPAT=ZOSV1R13 option does not appear to be related to
     # optimizations.  This linker option is supplied only on the compile line,


### PR DESCRIPTION
As part of the changed application layer structure (ALS), -march and
-mtune options passed to the compiler on zLinux have been updated.
Similar compiler options have also been updated for zOS.

zLinux changes:
i) '-march=*' to '-march=z9-109'
ii) '-mtune=*' to '-mtune=z10'

zOS changes:
i) -Wc,ARCH\\(\*\\) to -Wc,ARCH\\(7\\)
ii) -Wc,TUNE\\(\*\\) to -Wc,TUNE\\(10\\)
iii) no change required; already set to -Wc,TARGET\\(zOSV1R13\\)

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>