### PR TITLE
Adding new AOTMethodHeader flags to validate StringCompression opt

### DIFF
--- a/compiler/runtime/Runtime.hpp
+++ b/compiler/runtime/Runtime.hpp
@@ -505,7 +505,8 @@ typedef struct TR_AOTMethodHeader {
 #define TR_AOTMethodHeader_NeedsRecursiveMethodTrampolineReservation 0x00000001
 #define TR_AOTMethodHeader_IsNotCapableOfMethodEnterTracing          0x00000002
 #define TR_AOTMethodHeader_IsNotCapableOfMethodExitTracing           0x00000004
-
+#define TR_AOTMethodHeader_UsesEnableStringCompressionFolding        0x00000008
+#define TR_AOTMethodHeader_StringCompressionEnabled                  0x00000010
 
 // J9
 typedef struct TR_AOTInliningStats


### PR DESCRIPTION
The JIT compiler can fold tests for java/lang/String.enableCompression field
which is static and final. To allow the same folding to occur for AOT
bodies we must ensure that the value for this field during an AOT body load
is the same as the value when the AOT body was generated. To enable this
validation we introduce two new flags in the AOTMethodHeader:
1. TR_AOTMethodHeader_UsesEnableStringCompressionFolding  specifies whether
this method body has folded tests around java/lang/String.enableCompression
(this is needed because not all methods may use this field).
2. TR_AOTMethodHeader_StringCompressionEnabled specifies the value for the
java/lang/String.enableCompression when the AOT body was generated.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>