### PR TITLE
Flag for OSR infrastructure removal

### DIFF
--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -486,6 +486,9 @@ public:
    bool osrStateIsReliable() { return _osrStateIsReliable;}
    void setOsrStateIsReliable(bool b) { _osrStateIsReliable = b;}
 
+   bool osrInfrastructureRemoved() { return _osrInfrastructureRemoved; }
+   void setOSRInfrastructureRemoved(bool b) { _osrInfrastructureRemoved = b; }
+
    bool mayHaveLoops();
    bool hasLargeNumberOfLoops();
    bool hasNews();
@@ -1083,6 +1086,7 @@ private:
 
    bool                              _osrStateIsReliable;
    bool                              _canAffordOSRControlFlow;
+   bool                              _osrInfrastructureRemoved;
 
    TR_Hotness                        _nextOptLevel;
    int32_t                           _errorCode;

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -1239,7 +1239,7 @@ OMR::ResolvedMethodSymbol::genIL(TR_FrontEnd * fe, TR::Compilation * comp, TR::S
          // add OSR points.
          //
          bool doOSR =
-            comp->getOption(TR_EnableOSR) &&
+            comp->getOption(TR_EnableOSR) && comp->supportsInduceOSR() &&
             !comp->isPeekingMethod()  && (comp->getOption(TR_EnableNextGenHCR) || !comp->getOption(TR_EnableHCR)) ;
 
          TR::Optimizer *optimizer = NULL;

--- a/compiler/optimizer/OSRDefAnalysis.cpp
+++ b/compiler/optimizer/OSRDefAnalysis.cpp
@@ -1228,5 +1228,7 @@ int32_t TR_OSRExceptionEdgeRemoval::perform()
          }
       }
 
+   comp()->setOSRInfrastructureRemoved(true);
+
    return 1;
    }


### PR DESCRIPTION
OSR infrastructure must be present to support induce OSR, however,
components of this infrastructure, particularly exception edges, may
have been removed. This adds a flag to determine if the exception
edges have been removed and extends existing functions to consider it.

Also modifies conditions for induce OSR, such that it is supported
along side MimicInterpreterFrameShape in the event of full speed
debugging.