### PR TITLE
Add OSR points after monents

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -718,10 +718,10 @@ OMR::Compilation::getOSRInductionOffset(TR::Node *node)
    }
 
 bool
-OMR::Compilation::requiresPreOSRPoint(TR::Node *node)
+OMR::Compilation::requiresLeadingOSRPoint(TR::Node *node)
    {
-   // When there is no OSR induction offset, a pre OSR point is required
-   // This currently only covers async checks as they save the state when the check is performed
+   // Without an induction offset, a leading OSR point is required
+   // This point results in analysis of liveness before the side effect has occured
    if (getOSRInductionOffset(node) == 0)
       {
       return true;
@@ -729,11 +729,10 @@ OMR::Compilation::requiresPreOSRPoint(TR::Node *node)
 
    switch (node->getOpCodeValue())
       {
-      // Monents only require an offset OSR point as they will perform OSR when executing the
-      // monitor and there is no side effect due to the monent
+      // Monents only require a trailing OSR point as they will perform OSR when executing the
+      // monitor and there is no change in liveness due to the monent
       case TR::monent: return false;
-      // Calls require pre and offset OSR points as they may have to store the original and the
-      // modified state, for example when inlining
+      // Calls require leading and trailing OSR points as liveness may change across them
       default: return true;
       }
    }

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -722,7 +722,7 @@ OMR::Compilation::requiresLeadingOSRPoint(TR::Node *node)
    {
    // Without an induction offset, a leading OSR point is required
    // This point results in analysis of liveness before the side effect has occured
-   if (getOSRInductionOffset(node) == 0)
+   if (self()->getOSRInductionOffset(node) == 0)
       {
       return true;
       }

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -815,6 +815,7 @@ public:
    bool isPotentialOSRPoint(TR::Node *node);
    bool isPotentialOSRPointWithSupport(TR::TreeTop *tt);
    int32_t getOSRInductionOffset(TR::Node *node);
+   bool requiresPreOSRPoint(TR::Node *node);
 
    // for OSR
    TR_OSRCompilationData* getOSRCompilationData() {return _osrCompilationData;}

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -815,7 +815,7 @@ public:
    bool isPotentialOSRPoint(TR::Node *node);
    bool isPotentialOSRPointWithSupport(TR::TreeTop *tt);
    int32_t getOSRInductionOffset(TR::Node *node);
-   bool requiresPreOSRPoint(TR::Node *node);
+   bool requiresLeadingOSRPoint(TR::Node *node);
 
    // for OSR
    TR_OSRCompilationData* getOSRCompilationData() {return _osrCompilationData;}

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -889,7 +889,7 @@ OMR::ResolvedMethodSymbol::genAndAttachOSRCodeBlocks(int32_t currentInlinedSiteI
          TR::Block * OSRCatchBlock = osrMethodData->findOrCreateOSRCatchBlock(ttnode);
          TR_OSRPoint *osrPoint = NULL;
 
-         if (self()->comp()->requiresPreOSRPoint(ttnode))
+         if (self()->comp()->requiresLeadingOSRPoint(ttnode))
             {
             osrPoint = new (self()->comp()->trHeapMemory()) TR_OSRPoint(ttnode->getByteCodeInfo(), osrMethodData, self()->comp()->trMemory());
             osrPoint->setOSRIndex(self()->addOSRPoint(osrPoint));
@@ -912,7 +912,7 @@ OMR::ResolvedMethodSymbol::genAndAttachOSRCodeBlocks(int32_t currentInlinedSiteI
             }
 
          if (self()->comp()->getOption(TR_TraceOSR))
-            TR_ASSERT(osrPoint != NULL, "osr point could not be added for [%p] at or offset from %d:%d\n",
+            TR_ASSERT(osrPoint != NULL, "neither leading nor trailing osr point could be added for [%p] at or offset from %d:%d\n",
                ttnode, ttnode->getByteCodeInfo().getCallerIndex(),
                ttnode->getByteCodeInfo().getByteCodeIndex());
 

--- a/compiler/optimizer/OSRDefAnalysis.cpp
+++ b/compiler/optimizer/OSRDefAnalysis.cpp
@@ -383,7 +383,7 @@ void TR_OSRDefInfo::buildOSRDefs(void *vblockInfo, AuxiliaryData &aux)
 
       TR_OSRPoint *osrPoint = NULL;
       bool isPotentialOSRPoint = comp()->isPotentialOSRPointWithSupport(treeTop);
-      if (isPotentialOSRPoint && comp()->requiresPreOSRPoint(node))
+      if (isPotentialOSRPoint && comp()->requiresLeadingOSRPoint(node))
          {
          osrPoint = _methodSymbol->findOSRPoint(node->getByteCodeInfo());
          TR_ASSERT(osrPoint != NULL, "Cannot find an OSR point for node %p", node);
@@ -849,7 +849,7 @@ int32_t TR_OSRLiveRangeAnalysis::perform()
          TR_OSRPoint *offsetOSRPoint = NULL;
          if (comp()->isPotentialOSRPointWithSupport(tt))
             {
-            if (comp()->requiresPreOSRPoint(tt->getNode()))
+            if (comp()->requiresLeadingOSRPoint(tt->getNode()))
                {
                osrPoint = comp()->getMethodSymbol()->findOSRPoint(tt->getNode()->getByteCodeInfo());
                TR_ASSERT(osrPoint != NULL, "Cannot find an OSR point for node %p", tt->getNode());

--- a/compiler/optimizer/OSRDefAnalysis.cpp
+++ b/compiler/optimizer/OSRDefAnalysis.cpp
@@ -383,7 +383,7 @@ void TR_OSRDefInfo::buildOSRDefs(void *vblockInfo, AuxiliaryData &aux)
 
       TR_OSRPoint *osrPoint = NULL;
       bool isPotentialOSRPoint = comp()->isPotentialOSRPointWithSupport(treeTop);
-      if (isPotentialOSRPoint)
+      if (isPotentialOSRPoint && comp()->requiresPreOSRPoint(node))
          {
          osrPoint = _methodSymbol->findOSRPoint(node->getByteCodeInfo());
          TR_ASSERT(osrPoint != NULL, "Cannot find an OSR point for node %p", node);
@@ -849,8 +849,12 @@ int32_t TR_OSRLiveRangeAnalysis::perform()
          TR_OSRPoint *offsetOSRPoint = NULL;
          if (comp()->isPotentialOSRPointWithSupport(tt))
             {
-            osrPoint = comp()->getMethodSymbol()->findOSRPoint(tt->getNode()->getByteCodeInfo());
-            TR_ASSERT(osrPoint != NULL, "Cannot find an OSR point for node %p", tt->getNode());
+            if (comp()->requiresPreOSRPoint(tt->getNode()))
+               {
+               osrPoint = comp()->getMethodSymbol()->findOSRPoint(tt->getNode()->getByteCodeInfo());
+               TR_ASSERT(osrPoint != NULL, "Cannot find an OSR point for node %p", tt->getNode());
+               }
+
             int32_t offset = comp()->getOSRInductionOffset(tt->getNode());
             if (offset > 0)
                {


### PR DESCRIPTION
This extends OSR to add points after a monent, similar to what is done
with calls and asyncchecks. These points are used for analysis and
may result in the insertion of OSR guards. This breaks the assumption
that OSR points are always before and optionally after a node. The
code has been altered to make them both optional, but one mandatory.

Signed-off-by: Nicholas Coughlin <cnic@ca.ibm.com>