### PR TITLE
Fix Virtual Guard Head Merger bug

### DIFF
--- a/compiler/optimizer/VirtualGuardHeadMerger.cpp
+++ b/compiler/optimizer/VirtualGuardHeadMerger.cpp
@@ -54,7 +54,7 @@ static TR::Block* splitMonitorStoreFromPrivArg(TR::Block* block, TR::CFG *cfg)
    TR::TreeTop *end = block->getLastRealTreeTop();
    bool hasMonitorStore = false;
    TR::TreeTop *firstPrivArg = NULL;
-   for(TR::TreeTop *tt = start; tt && tt != end; tt = tt->getPrevTreeTop())
+   for(TR::TreeTop *tt = start; tt && tt != end; tt = tt->getNextTreeTop())
       {
       TR::Node * node = tt->getNode();
       if (node->getOpCode().hasSymbolReference() && node->getSymbol()->holdsMonitoredObject())


### PR DESCRIPTION
Fix Virtual Guard Head Merger bug

The intention of the original code is to iterate *forward* from the
start of a block. Fix the code to go forward instead of backward.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>
