### PR TITLE
addition of new constructor to enable growsUp and startinStackOffset

### DIFF
--- a/compiler/ilgen/VirtualMachineOperandStack.cpp
+++ b/compiler/ilgen/VirtualMachineOperandStack.cpp
@@ -48,13 +48,6 @@ namespace OMR
    mb->Store("OperandStack_base", stackTopRegister->Load(mb));
    }
 
-   // compatibility with prior constructor. pass same defaults as before for growup and stackOffset
-   VirtualMachineOperandStack::VirtualMachineOperandStack(TR::MethodBuilder *mb, int32_t sizeHint,
-   TR::IlType *elementType, OMR::VirtualMachineRegister *stackTopRegister)
-   : VirtualMachineOperandStack(mb, sizeHint,elementType,stackTopRegister, true, -1) 
-   { 
-   }
-
 VirtualMachineOperandStack::VirtualMachineOperandStack(OMR::VirtualMachineOperandStack *other)
    : VirtualMachineState(),
    _mb(other->_mb),

--- a/compiler/ilgen/VirtualMachineOperandStack.hpp
+++ b/compiler/ilgen/VirtualMachineOperandStack.hpp
@@ -80,8 +80,31 @@ class VirtualMachineOperandStack : public VirtualMachineState
     * @param sizeHint initial size used to allocate the stack; will grow larger if needed
     * @param elementType TR::IlType representing the underlying type of the virtual machine's operand stack entries
     * @param stackTop previously allocated and initialized VirtualMachineRegister representing the top of stack
+    * Default behaviour for stack direction is "up" (push is sp++) and offset is -1 (push is *++sp = value)
+    * This is for compatibility with earlier versions of this constructor.
     */
    VirtualMachineOperandStack(TR::MethodBuilder *mb, int32_t sizeHint, TR::IlType *elementType, VirtualMachineRegister *stackTop);
+
+  /**
+    * @brief public constructor, must be instantiated inside a compilation because uses heap memory
+    * @param mb TR::MethodBuilder object of the method currently being compiled
+    * @param sizeHint initial size used to allocate the stack; will grow larger if needed
+    * @param elementType TR::IlType representing the underlying type of the virtual machine's operand stack entries
+    * @param stackTop previously allocated and initialized VirtualMachineRegister representing the top of stack
+    * @param growsUp to configure virtual machine stack growth direction, set to true if virtual machine stack grows towards larger addresses, false otherwise 
+    * @param stackInitialOffset to configure virtual machine stack stack offset 
+    * set to the difference in elements between initial stack pointer and actual bottom of stack
+    * Some stacks Push by incrementing stack pointer then storing, some by storing and then
+    * incrementing stack pointer. In the first case, stackInitialOffset should be -1
+    * because the stack pointer initially points one element below the bottom of the stack.
+    * In the second case, stackInitialOffset should be 0, because the stack pointer
+    * initially points at the bottom of the stack. Other values are possible but would be
+    * considered highly unusual. 
+    * Default behaviour for the compatibility constructor will be growsUp is true, and stackInitialOffset is -1.
+    */
+
+   VirtualMachineOperandStack(TR::MethodBuilder *mb, int32_t sizeHint, TR::IlType *elementType, VirtualMachineRegister *stackTop,
+    bool growsUp, int32_t stackInitialOffset);
    /**
     * @brief constructor used to copy the stack from another state
     * @param other the operand stack whose values should be used to initialize this object
@@ -147,24 +170,7 @@ class VirtualMachineOperandStack : public VirtualMachineState
     */
    virtual void Dup(TR::IlBuilder *b);
 
-   /**
-    * @brief virtual function subclasses can use to configure virtual machine stack growth direction
-    * @returns true if the virtual machine stack grows towards larger addresses, false otherwise
-    */
-   virtual bool growsUp() { return true; }
-
-   /**
-    * @brief virtual function subclasses can use to configure virtual machine stack stack offset 
-    * @returns difference in elements between initial stack pointer and actual bottom of stack
-    * Some stacks Push by incrementing stack pointer then storing, some by storing and then
-    * incrementing stack pointer. In the first case, stackPtrStartingOffset() should return -1
-    * because the stack pointer initially points one element below the bottom of the stack.
-    * In the second case, startPtrStartingOffset() should return 0, because the stack pointer
-    * initially points at the bottom of the stack. Other values are possible but would be
-    * considered highly unusual.
-    * Default assumption is the first case, so return -1.
-    */
-   virtual int32_t stackPtrStartingOffset() { return -1; }
+ 
 
    protected:
    void copyTo(OMR::VirtualMachineOperandStack *copy);

--- a/compiler/ilgen/VirtualMachineOperandStack.hpp
+++ b/compiler/ilgen/VirtualMachineOperandStack.hpp
@@ -74,17 +74,7 @@ namespace OMR
 class VirtualMachineOperandStack : public VirtualMachineState
    {
    public:
-   /**
-    * @brief public constructor, must be instantiated inside a compilation because uses heap memory
-    * @param mb TR::MethodBuilder object of the method currently being compiled
-    * @param sizeHint initial size used to allocate the stack; will grow larger if needed
-    * @param elementType TR::IlType representing the underlying type of the virtual machine's operand stack entries
-    * @param stackTop previously allocated and initialized VirtualMachineRegister representing the top of stack
-    * Default behaviour for stack direction is "up" (push is sp++) and offset is -1 (push is *++sp = value)
-    * This is for compatibility with earlier versions of this constructor.
-    */
-   VirtualMachineOperandStack(TR::MethodBuilder *mb, int32_t sizeHint, TR::IlType *elementType, VirtualMachineRegister *stackTop);
-
+  
   /**
     * @brief public constructor, must be instantiated inside a compilation because uses heap memory
     * @param mb TR::MethodBuilder object of the method currently being compiled
@@ -100,11 +90,11 @@ class VirtualMachineOperandStack : public VirtualMachineState
     * In the second case, stackInitialOffset should be 0, because the stack pointer
     * initially points at the bottom of the stack. Other values are possible but would be
     * considered highly unusual. 
-    * Default behaviour for the compatibility constructor will be growsUp is true, and stackInitialOffset is -1.
+    * Default behaviour for compatibility constructor will be optional arguments, growsUp is true, and stackInitialOffset is -1.
     */
 
    VirtualMachineOperandStack(TR::MethodBuilder *mb, int32_t sizeHint, TR::IlType *elementType, VirtualMachineRegister *stackTop,
-    bool growsUp, int32_t stackInitialOffset);
+    bool growsUp = true, int32_t stackInitialOffset = -1);
    /**
     * @brief constructor used to copy the stack from another state
     * @param other the operand stack whose values should be used to initialize this object


### PR DESCRIPTION
The virtual functions growsUp() and stackPtrStartingOffset() were not being called in subclasses because they are being called in the constructor. 

The fix is to add two new parameters to the constructor to set the values for stack direction and offset.  A constructor matching the old constructor sets the values to the old defaults so old code continues to work as before. 

make operandstacktests still passed all tests.
