### PR TITLE
Fix hold time and clock skew comparison

### DIFF
--- a/thread/common/threaddef.h
+++ b/thread/common/threaddef.h
@@ -542,7 +542,7 @@ enum {
 				if ((self)->tracing->pause_count == (monitor)->tracing->enter_pause_count) { \
 					omrtime_delta_t holdTime = GET_HIRES_CLOCK() - (monitor)->tracing->enter_time; \
 					if (holdTime > 0) { \
-						if ((0 == (self)->library->clock_skew) || ((omrtime_t)holdTime < (self)->library->clock_skew)) { \
+						if ((0 == (self)->library->clock_skew) || ((omrtime_t)holdTime > (self)->library->clock_skew)) { \
 							uintptr_t holdTimeCount = (monitor)->tracing->holdtime_count + 1; \
 							(monitor)->tracing->holdtime_count = holdTimeCount; \
 							(monitor)->tracing->holdtime_sum += (omrtime_t)holdTime; \


### PR DESCRIPTION
Presently, we evaluate hold time average when clock skew is greater than
the hold time sample. If clock skew is greater than the hold time
sample, then the hold time sample is indeterminate. Evaluating hold time
average using an indeterminate hold time sample will yield an inaccurate
hold time average. Inaccurate hold time average will impact the decision
making process of the adaptive spin heuristic: spin or do not spin. When
clock skew is less than the hold time sample, then the hold time sample
can be considered valid. We must evaluate hold time average using a
valid hold time sample. In order to fix the implementation, the
comparison between clock skew and hold time has been updated.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>