### PR TITLE
Validated calls to getHighGlobalRegisterNumber

### DIFF
--- a/compiler/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/codegen/OMRTreeEvaluator.cpp
@@ -147,6 +147,26 @@ bool OMR::TreeEvaluator::instanceOfOrCheckCastNeedSuperTest(TR::Node * node, TR:
    return false;
    }
 
+TR_GlobalRegisterNumber 
+OMR::TreeEvaluator::getHighGlobalRegisterNumberIfAny(TR::Node *node, TR::CodeGenerator *cg)
+   {
+    //No need for register pairs in 64-bit mode
+    if (TR::Compiler->target.is64Bit())
+        return -1;
+
+    //if the node itself doesn't have a type (e.g passthrough) we assume it has a child with a type
+    //However we keep track of the initial node as it will contain the register information.
+    TR::Node *rootNode = node;
+
+    while (node->getType() == TR::NoType) {
+        node = node->getFirstChild();
+        TR_ASSERT(node, "The node should always be valid while looking for a Child with a type");
+    }
+    TR_ASSERT(node->getType() != TR::NoType, "Expecting node %p, to have a specific type here", node);
+
+    //Only need a register pair if the node is a 64bit Int
+    return node->getType().isInt64() ? rootNode->getHighGlobalRegisterNumber() : -1;
+   }
 
 // Returns n where value = 2^n.
 //   If value != 2^n, returns -1

--- a/compiler/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/codegen/OMRTreeEvaluator.hpp
@@ -49,6 +49,8 @@ class OMR_EXTENSIBLE TreeEvaluator
    static bool instanceOfOrCheckCastNeedEqualityTest(TR::Node * castClassNode, TR::CodeGenerator *cg);
    static bool instanceOfOrCheckCastNeedSuperTest(TR::Node * castClassNode, TR::CodeGenerator *cg);
 
+   static TR_GlobalRegisterNumber getHighGlobalRegisterNumberIfAny(TR::Node *node, TR::CodeGenerator *cg); 
+
    static int32_t classDepth(TR::Node * castClassNode, TR::CodeGenerator * cg);
    static int32_t checkNonNegativePowerOfTwo(int32_t value);
    static int32_t checkNonNegativePowerOfTwo(int64_t value);

--- a/compiler/p/codegen/OMRRegisterDependency.cpp
+++ b/compiler/p/codegen/OMRRegisterDependency.cpp
@@ -34,6 +34,7 @@
 #include "codegen/RegisterDependency.hpp"
 #include "codegen/RegisterDependencyStruct.hpp"  // for RegisterDependency
 #include "codegen/RegisterPair.hpp"              // for RegisterPair
+#include "codegen/TreeEvaluator.hpp"             // for getHighGlobalRegisterNumberIfAny()
 #include "compile/Compilation.hpp"               // for Compilation
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
@@ -156,7 +157,7 @@ OMR::Power::RegisterDependencyConditions::RegisterDependencyConditions(
 
       if (reg!=NULL /* && reg->getKind()==TR_GPR */)
 	 {
-	 if (child->getHighGlobalRegisterNumber() > -1)
+	 if (TR::TreeEvaluator::getHighGlobalRegisterNumberIfAny(child, cg) != -1)
 	    numLongs++;
 	 }
       }
@@ -179,15 +180,16 @@ OMR::Power::RegisterDependencyConditions::RegisterDependencyConditions(
       TR::RealRegister::RegNum regNum = (TR::RealRegister::RegNum)cg->getGlobalRegister(child->getGlobalRegisterNumber());
 
       TR::RealRegister::RegNum highRegNum;
+      TR_GlobalRegisterNumber validHighRegNum = TR::TreeEvaluator::getHighGlobalRegisterNumberIfAny(child, cg); 
 
-      if (child->getHighGlobalRegisterNumber() > -1)
+      if (validHighRegNum != -1)
          {
-         highRegNum = (TR::RealRegister::RegNum)cg->getGlobalRegister(child->getHighGlobalRegisterNumber());
 
+         highRegNum = (TR::RealRegister::RegNum)cg->getGlobalRegister(validHighRegNum);
          TR::RegisterPair *regPair = reg->getRegisterPair();
          TR_ASSERT(regPair, "assertion failure");
-	 highReg = regPair->getHighOrder();
-	 reg = regPair->getLowOrder();
+         highReg = regPair->getHighOrder();
+         reg = regPair->getLowOrder();
 
          if (highReg->getAssociation() != highRegNum ||
              reg->getAssociation() != regNum)
@@ -222,12 +224,12 @@ OMR::Power::RegisterDependencyConditions::RegisterDependencyConditions(
       TR::Register *highCopyReg = NULL;
       TR::RealRegister::RegNum regNum = (TR::RealRegister::RegNum)cg->getGlobalRegister(child->getGlobalRegisterNumber());
 
-
       TR::RealRegister::RegNum highRegNum;
+      TR_GlobalRegisterNumber validHighRegNum = TR::TreeEvaluator::getHighGlobalRegisterNumberIfAny(child, cg); 
 
-      if (child->getHighGlobalRegisterNumber() > -1)
+      if (validHighRegNum != -1)
          {
-         highRegNum = (TR::RealRegister::RegNum)cg->getGlobalRegister(child->getHighGlobalRegisterNumber());
+         highRegNum = (TR::RealRegister::RegNum)cg->getGlobalRegister(validHighRegNum);
          TR::RegisterPair *regPair = reg->getRegisterPair();
          TR_ASSERT(regPair, "assertion failure");
 	 highReg = regPair->getHighOrder();


### PR DESCRIPTION
On 64 bit machines, the getHighGlobalRegisterNumber call is not valid nor
needed. On 32 bit machines, a register dependency node's children must
be checked to see if they are of the long type, before performing the
getHighGlobalRegisterNumber call. If the register dependency node has
a child without a type, the node's child's child will be checked.

Signed-off-by: Ryan Santhirarajan <rsanth@ca.ibm.com>