### PR TITLE
Remove references to 'TR Talk' from makefiles

### DIFF
--- a/fvtest/compilertest/iwyu.mk
+++ b/fvtest/compilertest/iwyu.mk
@@ -1,5 +1,3 @@
-# Remember the golden rule -- If you're not sure, ask on TRTalk
-#
 # include-what-you-use, or iwyu, is a open source tool based on clang
 # that is used to analyse C++ source paths. It will check files that it's
 # given for uses of objects, and suggest including the necessary

--- a/fvtest/compilertest/linter.mk
+++ b/fvtest/compilertest/linter.mk
@@ -1,5 +1,3 @@
-# Remember the golden rule -- If you're not sure, ask on TRTalk
-#
 # To lint: 
 #
 # PLATFORM=foo-bar-clang make -f linter.mk 

--- a/fvtest/compilertest/testjit.mk
+++ b/fvtest/compilertest/testjit.mk
@@ -1,12 +1,4 @@
 #
-# For a full explanation of the conventions used in this makefile, please
-# check out the post and FAQ on TRTalk
-#
-# Remember the golden rule -- If you're not sure, ask on TRTalk
-#
-
-#
-#
 # "all" should be the first target to appear so it's the default
 #
 .PHONY: all clean cleanobjs cleandeps cleandll

--- a/jitbuilder/Makefile
+++ b/jitbuilder/Makefile
@@ -17,14 +17,6 @@
 ################################################################################
 
 #
-# For a full explanation of the conventions used in this makefile, please
-# check out the post and FAQ on TRTalk
-#
-# Remember the golden rule -- If you're not sure, ask on TRTalk
-#
-
-#
-#
 # "all" should be the first target to appear so it's the default
 #
 .phony: all clean cleandeps cleandll


### PR DESCRIPTION
'TR Talk' is an IBM-internal discussion forum that pre-dates the contribution
of this code to Eclipse OMR.  The content that it was referring to will be
cleaned and contributed to the documentation in a subsequent commit.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>