### PR TITLE
Only perform bound checks on deque access in DEBUG or ASSUME

### DIFF
--- a/compiler/infra/deque.hpp
+++ b/compiler/infra/deque.hpp
@@ -95,6 +95,8 @@ template <typename T>
 typename TR::deque<T>::reference
 TR::deque<T>::operator [](size_type index)
    {
+// In DEBUG, at() is used for correctness due to its bound checking
+// whilst [] is used in PROD for performance
 #if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
    return this->at(index);
 #else
@@ -106,6 +108,8 @@ template <typename T>
 typename TR::deque<T>::const_reference
 TR::deque<T>::operator [](size_type index) const
    {
+// In DEBUG, at() is used for correctness due to its bound checking
+// whilst [] is used in PROD for performance
 #if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
    return this->at(index);
 #else

--- a/compiler/infra/deque.hpp
+++ b/compiler/infra/deque.hpp
@@ -95,14 +95,22 @@ template <typename T>
 typename TR::deque<T>::reference
 TR::deque<T>::operator [](size_type index)
    {
+#if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
    return this->at(index);
+#else
+   return container_type::operator[](index);
+#endif // defined(DEBUG) || defined(PROD_WITH_ASSUMES)
    }
 
 template <typename T>
 typename TR::deque<T>::const_reference
 TR::deque<T>::operator [](size_type index) const
    {
+#if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
    return this->at(index);
+#else
+   return container_type::operator[](index);
+#endif // defined(DEBUG) || defined(PROD_WITH_ASSUMES)  
    }
 
 #endif // DEQUE_HPP


### PR DESCRIPTION
To improve performance in production, the accesses for deque
now map to std::deque accesses directly, rather than performing at()
as this incurs a performance penalty due to bound checks.