### PR TITLE
Add option to limit AOT to methods from bootstrap classes

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -112,6 +112,8 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"alwaysWorthInliningThreshold=", "O<nnn>\t", TR::Options::set32BitNumeric, offsetof(OMR::Options, _alwaysWorthInliningThreshold), 0, " %d" },
    {"aot",                "O\tahead-of-time compilation",
         SET_OPTION_BIT(TR_AOT), NULL, NOT_IN_SUBSET},
+   {"aotOnlyFromBootstrap", "O\tahead-of-time compilation allowed only for methods from bootstrap classes",
+        SET_OPTION_BIT(TR_AOTCompileOnlyFromBootstrap), "F", NOT_IN_SUBSET },
    {"aotrtDebugLevel=", "R<nnn>\tprint aotrt debug output according to level", TR::Options::set32BitNumeric, offsetof(OMR::Options,_newAotrtDebugLevel), 0, " %d"},
    {"aotSecondRunDetection",  "M\tperform second run detection for AOT", RESET_OPTION_BIT(TR_NoAotSecondRunDetection), "F", NOT_IN_SUBSET},
    {"assignEveryGlobalRegister", "I\tnever refuse to assign any possible register for GRA in spite of the resulting potential spills", SET_OPTION_BIT(TR_AssignEveryGlobalRegister), "F"},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -94,7 +94,7 @@ enum TR_CompilationOptions
 
    // Option word 0
    //
-   // Available                  = 0x00000020,
+   TR_AOTCompileOnlyFromBootstrap= 0x00000020,
    TR_AOT                        = 0x00000040,
    TR_ReportMethodEnter          = 0x00000080,
    TR_ReportMethodExit           = 0x00000100,


### PR DESCRIPTION
-Xaot:aotOnlyFromBootstrap

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>