### PR TITLE
Stop inlining MethodHandles in fsd mode

### DIFF
--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -1456,9 +1456,18 @@ int32_t OMR::Optimizer::performOptimization(const OptimizationStrategy *optimiza
          }
          break;
 
+      case IfMethodHandleInvokesNoDebug:
+         {
+         if (!comp()->getOption(TR_FullSpeedDebug) &&
+            comp()->getMethodSymbol()->hasMethodHandleInvokes() && 
+            !comp()->getOption(TR_DisableMethodHandleInvokeOpts))
+            doThisOptimization = true;
+         }
+         break;
       case IfMethodHandleInvokes:
          {
-         if (comp()->getMethodSymbol()->hasMethodHandleInvokes() && !comp()->getOption(TR_DisableMethodHandleInvokeOpts))
+         if (comp()->getMethodSymbol()->hasMethodHandleInvokes() && 
+               !comp()->getOption(TR_DisableMethodHandleInvokeOpts))
             doThisOptimization = true;
          }
          break;

--- a/compiler/optimizer/OMROptimizer.hpp
+++ b/compiler/optimizer/OMROptimizer.hpp
@@ -114,7 +114,8 @@ enum
    IfEnabledAndMoreThanOneBlock,
    IfEnabledAndMoreThanOneBlockMarkLastRun,
    IfAOTAndEnabled,
-   IfMethodHandleInvokes, // JSR292: Extra analysis required to optimize MethodHandle.invoke
+   IfMethodHandleInvokes, //JSR292: Extra analysis required to optimize MethodHandle.invoke
+   IfMethodHandleInvokesNoDebug, // JSR292 optimizations that should only apply in non-debug mode
    IfNotQuickStart,
    IfFullInliningUnderOSRDebug,
    IfNotFullInliningUnderOSRDebug,


### PR DESCRIPTION
We need to stop inlining MethodHandle in fsd because those trees are
generated by JIT out of thin air and dont have corresponding
bytecode for interpreter to transit from. Note that this changeset
only solves part of the problem and there are still trees generated
from ilgen without inlining that will be fixed later.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>