### PR TITLE
Revert "Fix for incorrect MoveDataType"

### DIFF
--- a/compiler/x/codegen/OMRLinkage.hpp
+++ b/compiler/x/codegen/OMRLinkage.hpp
@@ -355,10 +355,8 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
          case TR::Float:
             return Float4;
          case TR::Int64:
-            TR_ASSERT(TR::Compiler->target.is64Bit(), "MOV Int64 on X86-32 is not supported");
-            return TR_MovDataTypes::Int8;
          case TR::Address:
-            return TR::Compiler->target.is64Bit() ? TR_MovDataTypes::Int8 : TR_MovDataTypes::Int4;
+            return TR_MovDataTypes::Int8;
          default:
             return Int4;
          }
@@ -371,7 +369,7 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
       switch(reg->getKind())
          {
          case TR_GPR:
-            return TR::Compiler->target.is64Bit() ? TR_MovDataTypes::Int8 : TR_MovDataTypes::Int4;
+            return TR_MovDataTypes::Int8;
          case TR_FPR:
             return Float8;
          default:


### PR DESCRIPTION
This reverts commit e28a9b987bfcf9a1d339f4d8fb3341520fc65469. The original change exposes several failures in tests and it is reverted for now until we have a better understanding of the problem.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>