### PR TITLE
Explicitly set PLATFORM for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,6 @@
 language: c++
 sudo: false
 
-os:
-  - linux
-  - osx
-
 # https://docs.travis-ci.com/user/caching/
 cache: ccache
 
@@ -46,22 +42,16 @@ before_script:
 # core_pattern and don't have apport installed.  This can be removed when
 # apport is available in apt whitelist
 
-env:
-  - SPEC=osx_x86-64
-  - SPEC=linux_x86-64
-  - SPEC=linux_x86-64_cmprssptrs
-  - SPEC=linux_x86
-
 matrix:
-  exclude:
+  include:
     - os: linux
+      env: SPEC=linux_x86               PLATFORM=amd64-linux-gcc
+    - os: linux
+      env: SPEC=linux_x86-64            PLATFORM=amd64-linux64-gcc
+    - os: linux
+      env: SPEC=linux_x86-64_cmprssptrs PLATFORM=amd64-linux64-gcc
+    - os: osx
       env: SPEC=osx_x86-64
-    - os: osx
-      env: SPEC=linux_x86-64
-    - os: osx
-      env: SPEC=linux_x86-64_cmprssptrs
-    - os: osx
-      env: SPEC=linux_x86
 
 script:
   - make -f run_configure.mk OMRGLUE=./example/glue


### PR DESCRIPTION
The JIT makefiles haven't been hooked up to use SPEC, they use their own
indicator of build configuration PLATFORM. When PLATFORM isn't set, a
script guessPlatform is invoked, which as you might suspect, guesses
what the host machine is, and sets PLATFORM appropriately.

In this case, despite SPEC being set for 32-bit linux, we end up testing
the 64 Bit test compiler in Travis builds.

This hardcodes the PLATFORM for our build matrix.

Fixes Issue #699

Signed-off-by: Matthew Gaudet <magaudet@ca.ibm.com>