### PR TITLE
Only enable JITBuilder on 64-bit SPECs.

### DIFF
--- a/example/glue/configure_includes/configure_linux_x86.mk
+++ b/example/glue/configure_includes/configure_linux_x86.mk
@@ -28,13 +28,17 @@ include $(CONFIG_INCL_DIR)/configure_common.mk
 CONFIGURE_ARGS += \
   --enable-OMR_EXAMPLE \
   --enable-OMR_GC \
-  --enable-OMR_JITBUILDER \
   --enable-OMR_PORT \
   --enable-OMR_TEST_COMPILER \
   --enable-OMR_THREAD \
   --enable-OMR_OMRSIG \
   --enable-OMR_THR_THREE_TIER_LOCKING \
   --enable-OMR_THR_YIELD_ALG
+
+ifneq (,$(findstring -64,$(SPEC)))
+CONFIGURE_ARGS += \
+  --enable-OMR_JITBUILDER 
+endif
 
 ifeq (linux_x86-64_cmprssptrs_cuda, $(SPEC))
   CONFIGURE_ARGS += \


### PR DESCRIPTION
There are a number of outstanding issues before 32-Bit JITBuilder can be
enabled:

- Issue #705
- Issue #704

However, this should resolve Issue #703, and unblock Pull #702, which will allow us to do 32 Bit opcode testing in Travis . 

