### PR TITLE
Fix ternaryEvaluator syntax error

### DIFF
--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -3741,7 +3741,7 @@ OMR::Z::TreeEvaluator::ternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 
          if (comp->getOption(TR_TraceCG))
             {
-            traceMsg(comp, "firstReg = %p secondReg = %p trueReg = %p falseReg = %p trueReg->is64BitReg() = %d falseReg->is64BitReg() = %d isLongCompare = %d\n",firstReg,secondReg,trueReg,falseReg,trueReg->is64BitReg(),falseReg->is64BitReg(), condition->getOpCode().isLongCompare());nalLoad,condition->getOpCode().isLongCompare());
+            traceMsg(comp, "firstReg = %p secondReg = %p trueReg = %p falseReg = %p trueReg->is64BitReg() = %d falseReg->is64BitReg() = %d isLongCompare = %d\n", firstReg, secondReg, trueReg, falseReg, trueReg->is64BitReg(), falseReg->is64BitReg(), condition->getOpCode().isLongCompare());
             }
          }
       }


### PR DESCRIPTION
An artifact was introduced at the end of the line that was not caught by
TravisCI builds. This is a syntax error which will result in compile
time failures on z Systems. This commit fixes the syntactical issues.

Issue: #667
Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>