### PR TITLE
Clean up aliasing interface

### DIFF
--- a/compiler/il/AliasSetInterface.hpp
+++ b/compiler/il/AliasSetInterface.hpp
@@ -470,7 +470,7 @@ TR_BitContainer TR_NodeAliasSetInterface<mayKillAliasSet>::getTRAliases(bool isD
    if (_node->getOpCode().hasSymbolReference() && (_node->getOpCode().isLikeDef() || _node->mightHaveVolatileSymbolReference())) //we want the old behavior in these cases
       {
       if (_node->getSymbolReference()->sharesSymbol(includeGCSafePoint))
-         bc = _node->getSymbolReference()->getUseDefAliasesBV(comp, isDirectCall, includeGCSafePoint);
+         bc = _node->getSymbolReference()->getUseDefAliasesBV(isDirectCall, includeGCSafePoint);
       else
          bc = _node->getSymbolReference()->getReferenceNumber();
       }

--- a/compiler/il/AliasSetInterface.hpp
+++ b/compiler/il/AliasSetInterface.hpp
@@ -470,7 +470,7 @@ TR_BitContainer TR_NodeAliasSetInterface<mayKillAliasSet>::getTRAliases(bool isD
    if (_node->getOpCode().hasSymbolReference() && (_node->getOpCode().isLikeDef() || _node->mightHaveVolatileSymbolReference())) //we want the old behavior in these cases
       {
       if (_node->getSymbolReference()->sharesSymbol(includeGCSafePoint))
-         bc = _node->getSymbolReference()->getSymRefUseDefAliasesBV(comp, isDirectCall, includeGCSafePoint);
+         bc = _node->getSymbolReference()->getUseDefAliasesBV(comp, isDirectCall, includeGCSafePoint);
       else
          bc = _node->getSymbolReference()->getReferenceNumber();
       }

--- a/compiler/il/AliasSetInterface.hpp
+++ b/compiler/il/AliasSetInterface.hpp
@@ -455,12 +455,7 @@ TR_BitContainer TR_NodeAliasSetInterface<mayUseAliasSet>::getTRAliases(bool isDi
    TR::Compilation *comp = TR::comp();
    TR_BitContainer bc;
 
-   if (!_node->getOpCode().isLikeUse())
-      {
-      return bc;
-      }
-
-   if (_node->getOpCode().hasSymbolReference())
+   if (_node->getOpCode().isLikeUse() && _node->getOpCode().hasSymbolReference())
       bc = _node->getSymbolReference()->getUseonlyAliasesBV(comp->getSymRefTab());
    // else there is no symbol reference associated with the node, we return an empty bit container
 
@@ -472,12 +467,7 @@ TR_BitContainer TR_NodeAliasSetInterface<mayKillAliasSet>::getTRAliases(bool isD
    TR::Compilation *comp = TR::comp();
    TR_BitContainer bc;
 
-   if (!_node->getOpCode().isLikeDef() && !_node->mightHaveVolatileSymbolReference())
-      {
-      return bc;
-      }
-
-   if (_node->getOpCode().hasSymbolReference()) //we want the old behavior in these cases
+   if (_node->getOpCode().hasSymbolReference() && (_node->getOpCode().isLikeDef() || _node->mightHaveVolatileSymbolReference())) //we want the old behavior in these cases
       {
       if (_node->getSymbolReference()->sharesSymbol(includeGCSafePoint))
          bc = _node->getSymbolReference()->getSymRefUseDefAliasesBV(comp, isDirectCall, includeGCSafePoint);

--- a/compiler/il/Aliases.cpp
+++ b/compiler/il/Aliases.cpp
@@ -1064,14 +1064,6 @@ OMR::SymbolReference::setAliasedTo(TR_BitVector &bv, TR::SymbolReferenceTable *s
       }
    }
 
-TR_BitVector *
-OMR::SymbolReference::getUseDefAliasesBV(TR::Compilation *c,
-                                               bool isDirectCall,
-                                               bool gcSafe)
-   {
-   return self()->getUseDefAliasesBV(isDirectCall, gcSafe);
-   }
-
 /**
  * \pre SymRef must be for an ArrayShadow symbol.
  */

--- a/compiler/il/Aliases.cpp
+++ b/compiler/il/Aliases.cpp
@@ -1065,7 +1065,7 @@ OMR::SymbolReference::setAliasedTo(TR_BitVector &bv, TR::SymbolReferenceTable *s
    }
 
 TR_BitVector *
-OMR::SymbolReference::getSymRefUseDefAliasesBV(TR::Compilation *c,
+OMR::SymbolReference::getUseDefAliasesBV(TR::Compilation *c,
                                                bool isDirectCall,
                                                bool gcSafe)
    {

--- a/compiler/il/OMRSymbolReference.hpp
+++ b/compiler/il/OMRSymbolReference.hpp
@@ -302,7 +302,6 @@ protected:
    friend class ::TR_SymAliasSetInterface;
 
    TR_BitVector *getUseonlyAliasesBV(TR::SymbolReferenceTable *symRefTab);
-   TR_BitVector *getUseDefAliasesBV(TR::Compilation *c, bool isDirectCall = false, bool gcSafe = false);
    TR_BitVector *getUseDefAliasesBV( bool isDirectCall = false, bool gcSafe = false);
 
    enum // flags

--- a/compiler/il/OMRSymbolReference.hpp
+++ b/compiler/il/OMRSymbolReference.hpp
@@ -302,7 +302,7 @@ protected:
    friend class ::TR_SymAliasSetInterface;
 
    TR_BitVector *getUseonlyAliasesBV(TR::SymbolReferenceTable *symRefTab);
-   TR_BitVector *getSymRefUseDefAliasesBV(TR::Compilation *c, bool isDirectCall = false, bool gcSafe = false);
+   TR_BitVector *getUseDefAliasesBV(TR::Compilation *c, bool isDirectCall = false, bool gcSafe = false);
    TR_BitVector *getUseDefAliasesBV( bool isDirectCall = false, bool gcSafe = false);
 
    enum // flags

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1724,7 +1724,7 @@ TR_Debug::printAliasInfo(TR::FILE *pOutFile, TR::SymbolReference * symRef)
    // *this    swipeable for debugging purposes
    if (pOutFile == NULL) return;
 
-   TR_BitVector * useDefAliases = symRef->getSymRefUseDefAliasesBV(_comp);
+   TR_BitVector * useDefAliases = symRef->getUseDefAliasesBV(_comp);
    TR_BitVector * useOnlyAliases = symRef->getUseonlyAliasesBV(_comp->getSymRefTab());
    if (useDefAliases || useOnlyAliases)
       {

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1724,7 +1724,7 @@ TR_Debug::printAliasInfo(TR::FILE *pOutFile, TR::SymbolReference * symRef)
    // *this    swipeable for debugging purposes
    if (pOutFile == NULL) return;
 
-   TR_BitVector * useDefAliases = symRef->getUseDefAliasesBV(_comp);
+   TR_BitVector * useDefAliases = symRef->getUseDefAliasesBV();
    TR_BitVector * useOnlyAliases = symRef->getUseonlyAliasesBV(_comp->getSymRefTab());
    if (useDefAliases || useOnlyAliases)
       {


### PR DESCRIPTION
This commit does some minor clean ups to the aliasing interface by:

- combining separate if statements into one when there is no functional need for the separation
- removing functions for which there exists another function that does the same thing

This clean up should simplify later work to be done on the aliasing interface.