### PR TITLE
Add option to make inliner only inline natives

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -821,7 +821,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
         TR::Options::set32BitNumeric, offsetof(OMR::Options,_inlineCntrWarmCalleeTooBigBucketSize), 0, " %d", NOT_IN_SUBSET},
    {"inlineCntrWarmCallerHasTooManyNodesBucketSize=",    "R<nnn>\tThe unit used to categorize uninlined calls when the warm caller has too many nodes",
         TR::Options::set32BitNumeric, offsetof(OMR::Options,_inlineCntrWarmCallerHasTooManyNodesBucketSize), 0, " %d", NOT_IN_SUBSET},
-
+   {"inlineNativeOnly", "O\tinliner only inline native methods and do not inline other Java methods", SET_OPTION_BIT(TR_InlineNativeOnly), "F" },
    {"inlinerArgumentHeuristicFractionBeyondWarm=", "O<nnn>\tAt hotness above warm, decreases estimated size by 1/N when the inliner's argument heuristic kicks in", TR::Options::set32BitNumeric, offsetof(OMR::Options,_inlinerArgumentHeuristicFractionBeyondWarm), 0, " %d"},
    {"inlinerArgumentHeuristicFractionUpToWarm=",   "O<nnn>\tAt hotness up to and including warm, decreases estimated size by 1/N when the inliner's argument heuristic kicks in", TR::Options::set32BitNumeric, offsetof(OMR::Options,_inlinerArgumentHeuristicFractionUpToWarm), 0, " %d"},
    {"inlinerBorderFrequency=", "O<nnn>\tblock frequency threshold for not inlining at warm", TR::Options::set32BitNumeric, offsetof(OMR::Options, _inlinerBorderFrequency), 0, " %d" },

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -990,7 +990,7 @@ enum TR_CompilationOptions
    TR_EnableMetadataBytecodePCToIAMap                 = 0x00800000 + 30,
    TR_DisableHardwareProfilerReducedWarmUpgrades      = 0x01000000 + 30,
    TR_DontAddHWPDataToIProfiler                       = 0x02000000 + 30,
-   // Available                                       = 0x04000000 + 30,
+   TR_InlineNativeOnly                                = 0x04000000 + 30,
    TR_DisableMultiTargetInlining                      = 0x08000000 + 30,
    TR_DisableHardwareProfilerDuringStartup            = 0x10000000 + 30,
    TR_RestrictInlinerDuringStartup                    = 0x20000000 + 30,

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -4601,6 +4601,8 @@ bool TR_InlinerBase::inlineCallTarget2(TR_CallStack * callStack, TR_CallTarget *
    if (tryToInlineTrivialMethod(callStack, calltarget))
       return true;
 
+   if (comp()->getOption(TR_InlineNativeOnly))
+      return false;
    comp()->getFlowGraph()->setMaxFrequency(-1);
    comp()->getFlowGraph()->setMaxEdgeFrequency(-1);
 


### PR DESCRIPTION
Add this option to help performance investigation when we only care about natives that got inlined.