### PR TITLE
Make sure LoopVersioner creates async check guard tests safely

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -1733,6 +1733,14 @@ OMR::Node::duplicateTree(bool duplicateChildren)
    return unsafeNode;
    }
 
+TR::Node *
+OMR::Node::duplicateTreeForCodeMotion()
+   {
+   TR::Node *result = self()->duplicateTree(true);
+   result->resetFlagsForCodeMotion();
+   return result;
+   }
+
 /**
  * Method to duplicate an entire subtree. Tries to do so 'safely' by maintaining a mapping of visited (and duplicated) nodes
  */

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -356,6 +356,7 @@ public:
    TR::Node *             getAndDecChild(int32_t c);
 
    TR::Node *             duplicateTree(bool duplicateChildren = true);
+   TR::Node *             duplicateTreeForCodeMotion();
    TR::Node *             duplicateTreeWithCommoning(TR::Allocator allocator);
    TR::Node *             duplicateTree_DEPRECATED(bool duplicateChildren = true);
    bool                   isUnsafeToDuplicateAndExecuteAgain(int32_t *nodeVisitBudget);

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -4098,13 +4098,15 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
       if (!refineAliases() && _canPredictIters && !comp()->isProfilingCompilation() &&
          performTransformation(comp(), "%s Creating test outside loop for deciding if async check is required\n", OPT_DETAILS_LOOP_VERSIONER))
          {
-         TR::Node *duplicateLoopLimit = _loopTestTree->getNode()->getSecondChild()->duplicateTree();
+         TR::Node *duplicateLoopLimit = _loopTestTree->getNode()->getSecondChild()->duplicateTreeForCodeMotion();
          if (isIncreasing)
-            duplicateLoopLimit = TR::Node::create(TR::isub, 2, duplicateLoopLimit, _loopTestTree->getNode()->getFirstChild()->duplicateTree());
+            {
+            duplicateLoopLimit = TR::Node::create(TR::isub, 2, duplicateLoopLimit, _loopTestTree->getNode()->getFirstChild()->duplicateTreeForCodeMotion());
+            }
          else
             {
             //printf("Eliminating an async on decreasing guard in %s\n", comp()->signature());
-            duplicateLoopLimit = TR::Node::create(TR::isub, 2, _loopTestTree->getNode()->getFirstChild()->duplicateTree(), duplicateLoopLimit);
+            duplicateLoopLimit = TR::Node::create(TR::isub, 2, _loopTestTree->getNode()->getFirstChild()->duplicateTreeForCodeMotion(), duplicateLoopLimit);
             }
          collectAllExpressionsToBeChecked(nullCheckTrees, divCheckTrees, checkCastTrees, arrayStoreCheckTrees, duplicateLoopLimit, &comparisonTrees, clonedLoopInvariantBlock, comp()->incVisitCount());
     TR::Node *nextComparisonNode = TR::Node::createif(comparisonOpCode, duplicateLoopLimit, TR::Node::create(duplicateLoopLimit, TR::iconst, 0, profiledLoopLimit), clonedLoopInvariantBlock->getEntry());

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -4090,47 +4090,39 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
       if (shouldOnlySpecializeLoops())
          {
          int32_t numIters = whileLoop->getEntryBlock()->getFrequency();
-         //if (numIters > 0.90*comp()->getRecompilationInfo()->getMaxBlockCount())
          if (numIters < 0.90*(MAX_BLOCK_COUNT+MAX_COLD_BLOCK_COUNT))
             _canPredictIters = false;
          }
 
       if (!refineAliases() && _canPredictIters && !comp()->isProfilingCompilation() &&
-         performTransformation(comp(), "%s Creating test outside loop for deciding if async check is required\n", OPT_DETAILS_LOOP_VERSIONER))
+          performTransformation(comp(), "%s Creating test outside loop for deciding if async check is required\n", OPT_DETAILS_LOOP_VERSIONER))
          {
-         TR::Node *duplicateLoopLimit = _loopTestTree->getNode()->getSecondChild()->duplicateTreeForCodeMotion();
-         if (isIncreasing)
-            {
-            duplicateLoopLimit = TR::Node::create(TR::isub, 2, duplicateLoopLimit, _loopTestTree->getNode()->getFirstChild()->duplicateTreeForCodeMotion());
-            }
-         else
-            {
-            //printf("Eliminating an async on decreasing guard in %s\n", comp()->signature());
-            duplicateLoopLimit = TR::Node::create(TR::isub, 2, _loopTestTree->getNode()->getFirstChild()->duplicateTreeForCodeMotion(), duplicateLoopLimit);
-            }
-         collectAllExpressionsToBeChecked(nullCheckTrees, divCheckTrees, checkCastTrees, arrayStoreCheckTrees, duplicateLoopLimit, &comparisonTrees, clonedLoopInvariantBlock, comp()->incVisitCount());
-    TR::Node *nextComparisonNode = TR::Node::createif(comparisonOpCode, duplicateLoopLimit, TR::Node::create(duplicateLoopLimit, TR::iconst, 0, profiledLoopLimit), clonedLoopInvariantBlock->getEntry());
+         TR::Node *lowerBound = _loopTestTree->getNode()->getFirstChild()->duplicateTreeForCodeMotion();
+         TR::Node *upperBound = _loopTestTree->getNode()->getSecondChild()->duplicateTreeForCodeMotion();
+         TR::Node *loopLimit = isIncreasing ?
+            TR::Node::create(TR::isub, 2, upperBound, lowerBound) :
+            TR::Node::create(TR::isub, 2, lowerBound, upperBound);
+
+         collectAllExpressionsToBeChecked(nullCheckTrees, divCheckTrees, checkCastTrees, arrayStoreCheckTrees, loopLimit, &comparisonTrees, clonedLoopInvariantBlock, comp()->incVisitCount());
+         TR::Node *nextComparisonNode = TR::Node::createif(comparisonOpCode, loopLimit, TR::Node::create(loopLimit, TR::iconst, 0, profiledLoopLimit), clonedLoopInvariantBlock->getEntry());
          nextComparisonNode->setIsMaxLoopIterationGuard(true);
 
          if (trace())
-         {
-         traceMsg(comp(), "Removing async check %p\n", _asyncCheckTree->getNode());
-         }
-
-         //printf("Found versionable loop in %s\n", comp()->signature());
+            {
+            traceMsg(comp(), "Removing async check %p\n", _asyncCheckTree->getNode());
+            }
 
          comp()->setLoopWasVersionedWrtAsyncChecks(true);
          comparisonTrees.add(nextComparisonNode);
          dumpOptDetails(comp(), "The node %p has been created for testing if async check is required\n", nextComparisonNode);
 
-         bool skipIt = comp()->getOption(TR_DisableAsyncCheckVersioning);
-         if (!skipIt)
+         if (!comp()->getOption(TR_DisableAsyncCheckVersioning))
             {
             TR::TreeTop *prevTree = _asyncCheckTree->getPrevTreeTop();
             TR::TreeTop *nextTree = _asyncCheckTree->getNextTreeTop();
             prevTree->join(nextTree);
             }
-         //_loopTestBlock->getStructureOf()->setIsEntryOfShortRunningLoop();
+
          whileLoop->getEntryBlock()->getStructureOf()->setIsEntryOfShortRunningLoop();
          if (trace())
             traceMsg(comp(), "Marked block %p with entry %p\n", whileLoop->getEntryBlock(), whileLoop->getEntryBlock()->getEntry()->getNode());
@@ -4140,12 +4132,11 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
    // Construct the tests for invariant expressions that need
    // to be null checked.
    //
-  if (
-      comp()->cg()->performsChecksExplicitly() ||
-      (comp()->getMethodHotness() >= veryHot))
+   if (comp()->cg()->performsChecksExplicitly() ||
+       (comp()->getMethodHotness() >= veryHot))
       {
       if (!nullCheckTrees->isEmpty() &&
-         !shouldOnlySpecializeLoops())
+          !shouldOnlySpecializeLoops())
          {
          buildNullCheckComparisonsTree(nullCheckedReferences, nullCheckTrees, boundCheckTrees, divCheckTrees, checkCastTrees, arrayStoreCheckTrees, &comparisonTrees, clonedLoopInvariantBlock);
          }


### PR DESCRIPTION
This patch set fixes LoopVersioner so that it will create guard tests for `asynccheck` versioning safely by making sure that any duplicated trees have their flags reset. The first patch introduces a new `OMR::Node` method that duplicates trees for the purposes of inserting them arbitrarily; the second patch uses it in `LoopVersioner`; the third is cosmetic and cleans up the surrounding code in `LoopVersioner` to improve readability.

Issue: #717