### PR TITLE
Fix for incorrect MovDataType

### DIFF
--- a/compiler/x/amd64/codegen/AMD64SystemLinkage.cpp
+++ b/compiler/x/amd64/codegen/AMD64SystemLinkage.cpp
@@ -688,7 +688,7 @@ int32_t TR::AMD64SystemLinkage::buildArgs(
             TR::Register *argReg = cg()->allocateRegister();
             if (vreg->containsCollectedReference())
                argReg->setContainsCollectedReference();
-            generateRegRegInstruction(movOpcodes[RegReg][movType(child->getDataType())], child, argReg, vreg, cg());
+            generateRegRegInstruction(TR::Linkage::movOpcodes(RegReg, movType(child->getDataType())), child, argReg, vreg, cg());
             vreg = argReg;
             copiedRegs[numCopiedRegs++] = vreg;
             }
@@ -698,7 +698,7 @@ int32_t TR::AMD64SystemLinkage::buildArgs(
       else
          {
          // Ideally, we would like to push rather than move
-         generateMemRegInstruction(movOpcodes[MemReg][fullRegisterMovType(vreg)],
+         generateMemRegInstruction(TR::Linkage::movOpcodes(MemReg, fullRegisterMovType(vreg)),
                                    child,
                                    generateX86MemoryReference(espReal, offset, cg()),
                                    vreg,

--- a/compiler/x/codegen/OMRLinkage.cpp
+++ b/compiler/x/codegen/OMRLinkage.cpp
@@ -773,7 +773,7 @@ OMR::X86::Linkage::trStackMemory()
    }
 
 
-TR_X86OpCodes OMR::X86::Linkage::movOpcodes[NumMovOperandTypes][NumMovDataTypes] =
+TR_X86OpCodes OMR::X86::Linkage::_movOpcodes[NumMovOperandTypes][NumMovDataTypes] =
    {
    //    Int4         Int8        Float4         Float8
    {    S4MemReg,    S8MemReg,  MOVSSMemReg,  MOVSDMemReg}, // MemReg

--- a/compiler/x/codegen/X86SystemLinkage.cpp
+++ b/compiler/x/codegen/X86SystemLinkage.cpp
@@ -144,7 +144,7 @@ TR::X86SystemLinkage::copyParametersToHomeLocation(TR::Instruction *cursor)
             // ai := stack
             loadCursor = generateRegMemInstruction(
                loadCursor,
-               movOpcodes[RegMem][movDataType],
+               TR::Linkage::movOpcodes(RegMem, movDataType),
                machine->getX86RealRegister(ai),
                generateX86MemoryReference(framePointer, offset, cg()),
                cg()
@@ -166,7 +166,7 @@ TR::X86SystemLinkage::copyParametersToHomeLocation(TR::Instruction *cursor)
             // stack := lri
             cursor = generateMemRegInstruction(
                cursor,
-               movOpcodes[MemReg][movDataType],
+               TR::Linkage::movOpcodes(MemReg, movDataType),
                generateX86MemoryReference(framePointer, offset, cg()),
                machine->getX86RealRegister(sourceIndex),
                cg()
@@ -257,7 +257,7 @@ TR::X86SystemLinkage::copyParametersToHomeLocation(TR::Instruction *cursor)
             // regCursor := regCursor.sourceReg
             cursor = generateRegRegInstruction(
                cursor,
-               movOpcodes[RegReg][movStatus[source].outgoingDataType],
+               TR::Linkage::movOpcodes(RegReg, movStatus[source].outgoingDataType),
                machine->getX86RealRegister(regCursor),
                machine->getX86RealRegister(source),
                cg()
@@ -318,7 +318,7 @@ TR::X86SystemLinkage::savePreservedRegisters(TR::Instruction *cursor)
                {
                cursor = generateMemRegInstruction(
                   cursor,
-                  movOpcodes[MemReg][fullRegisterMovType(reg)],
+                  TR::Linkage::movOpcodes(MemReg, fullRegisterMovType(reg)),
                   generateX86MemoryReference(machine()->getX86RealRegister(TR::RealRegister::vfp), offsetCursor, cg()),
                   reg,
                   cg()
@@ -659,7 +659,7 @@ TR::X86SystemLinkage::restorePreservedRegisters(TR::Instruction *cursor)
                {
                cursor = generateRegMemInstruction(
                   cursor,
-                  movOpcodes[RegMem][fullRegisterMovType(reg)],
+                  TR::Linkage::movOpcodes(RegMem, fullRegisterMovType(reg)),
                   reg,
                   generateX86MemoryReference(machine()->getX86RealRegister(TR::RealRegister::vfp), offsetCursor, cg()),
                   cg()


### PR DESCRIPTION
1. TR::Address and TR_GPR should correspond to TR_MovDataTypes::Int4 on IA32,
while previous code always returns TR_MovDataTypes::Int8
2. Added an assert to movDataTypes to catch incorrect TR_MovDataTypes::Int8
use on IA32 since no single instruction can move a register pair.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>
