### PR TITLE
WIP: Make sure LoopVersioner creates various guard tests safely

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -1733,6 +1733,14 @@ OMR::Node::duplicateTree(bool duplicateChildren)
    return unsafeNode;
    }
 
+TR::Node *
+OMR::Node::duplicateTreeForCodeMotion()
+   {
+   TR::Node *result = self()->duplicateTree(true);
+   result->resetFlagsForCodeMotion();
+   return result;
+   }
+
 /**
  * Method to duplicate an entire subtree. Tries to do so 'safely' by maintaining a mapping of visited (and duplicated) nodes
  */

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -356,6 +356,7 @@ public:
    TR::Node *             getAndDecChild(int32_t c);
 
    TR::Node *             duplicateTree(bool duplicateChildren = true);
+   TR::Node *             duplicateTreeForCodeMotion();
    TR::Node *             duplicateTreeWithCommoning(TR::Allocator allocator);
    TR::Node *             duplicateTree_DEPRECATED(bool duplicateChildren = true);
    bool                   isUnsafeToDuplicateAndExecuteAgain(int32_t *nodeVisitBudget);

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -4098,13 +4098,15 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
       if (!refineAliases() && _canPredictIters && !comp()->isProfilingCompilation() &&
          performTransformation(comp(), "%s Creating test outside loop for deciding if async check is required\n", OPT_DETAILS_LOOP_VERSIONER))
          {
-         TR::Node *duplicateLoopLimit = _loopTestTree->getNode()->getSecondChild()->duplicateTree();
+         TR::Node *duplicateLoopLimit = _loopTestTree->getNode()->getSecondChild()->duplicateTreeForCodeMotion();
          if (isIncreasing)
-            duplicateLoopLimit = TR::Node::create(TR::isub, 2, duplicateLoopLimit, _loopTestTree->getNode()->getFirstChild()->duplicateTree());
+            {
+            duplicateLoopLimit = TR::Node::create(TR::isub, 2, duplicateLoopLimit, _loopTestTree->getNode()->getFirstChild()->duplicateTreeForCodeMotion());
+            }
          else
             {
             //printf("Eliminating an async on decreasing guard in %s\n", comp()->signature());
-            duplicateLoopLimit = TR::Node::create(TR::isub, 2, _loopTestTree->getNode()->getFirstChild()->duplicateTree(), duplicateLoopLimit);
+            duplicateLoopLimit = TR::Node::create(TR::isub, 2, _loopTestTree->getNode()->getFirstChild()->duplicateTreeForCodeMotion(), duplicateLoopLimit);
             }
          collectAllExpressionsToBeChecked(nullCheckTrees, divCheckTrees, checkCastTrees, arrayStoreCheckTrees, duplicateLoopLimit, &comparisonTrees, clonedLoopInvariantBlock, comp()->incVisitCount());
     TR::Node *nextComparisonNode = TR::Node::createif(comparisonOpCode, duplicateLoopLimit, TR::Node::create(duplicateLoopLimit, TR::iconst, 0, profiledLoopLimit), clonedLoopInvariantBlock->getEntry());

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -4090,47 +4090,39 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
       if (shouldOnlySpecializeLoops())
          {
          int32_t numIters = whileLoop->getEntryBlock()->getFrequency();
-         //if (numIters > 0.90*comp()->getRecompilationInfo()->getMaxBlockCount())
          if (numIters < 0.90*(MAX_BLOCK_COUNT+MAX_COLD_BLOCK_COUNT))
             _canPredictIters = false;
          }
 
       if (!refineAliases() && _canPredictIters && !comp()->isProfilingCompilation() &&
-         performTransformation(comp(), "%s Creating test outside loop for deciding if async check is required\n", OPT_DETAILS_LOOP_VERSIONER))
+          performTransformation(comp(), "%s Creating test outside loop for deciding if async check is required\n", OPT_DETAILS_LOOP_VERSIONER))
          {
-         TR::Node *duplicateLoopLimit = _loopTestTree->getNode()->getSecondChild()->duplicateTreeForCodeMotion();
-         if (isIncreasing)
-            {
-            duplicateLoopLimit = TR::Node::create(TR::isub, 2, duplicateLoopLimit, _loopTestTree->getNode()->getFirstChild()->duplicateTreeForCodeMotion());
-            }
-         else
-            {
-            //printf("Eliminating an async on decreasing guard in %s\n", comp()->signature());
-            duplicateLoopLimit = TR::Node::create(TR::isub, 2, _loopTestTree->getNode()->getFirstChild()->duplicateTreeForCodeMotion(), duplicateLoopLimit);
-            }
-         collectAllExpressionsToBeChecked(nullCheckTrees, divCheckTrees, checkCastTrees, arrayStoreCheckTrees, duplicateLoopLimit, &comparisonTrees, clonedLoopInvariantBlock, comp()->incVisitCount());
-    TR::Node *nextComparisonNode = TR::Node::createif(comparisonOpCode, duplicateLoopLimit, TR::Node::create(duplicateLoopLimit, TR::iconst, 0, profiledLoopLimit), clonedLoopInvariantBlock->getEntry());
+         TR::Node *lowerBound = _loopTestTree->getNode()->getFirstChild()->duplicateTreeForCodeMotion();
+         TR::Node *upperBound = _loopTestTree->getNode()->getSecondChild()->duplicateTreeForCodeMotion();
+         TR::Node *loopLimit = isIncreasing ?
+            TR::Node::create(TR::isub, 2, upperBound, lowerBound) :
+            TR::Node::create(TR::isub, 2, lowerBound, upperBound);
+
+         collectAllExpressionsToBeChecked(nullCheckTrees, divCheckTrees, checkCastTrees, arrayStoreCheckTrees, loopLimit, &comparisonTrees, clonedLoopInvariantBlock, comp()->incVisitCount());
+         TR::Node *nextComparisonNode = TR::Node::createif(comparisonOpCode, loopLimit, TR::Node::create(loopLimit, TR::iconst, 0, profiledLoopLimit), clonedLoopInvariantBlock->getEntry());
          nextComparisonNode->setIsMaxLoopIterationGuard(true);
 
          if (trace())
-         {
-         traceMsg(comp(), "Removing async check %p\n", _asyncCheckTree->getNode());
-         }
-
-         //printf("Found versionable loop in %s\n", comp()->signature());
+            {
+            traceMsg(comp(), "Removing async check %p\n", _asyncCheckTree->getNode());
+            }
 
          comp()->setLoopWasVersionedWrtAsyncChecks(true);
          comparisonTrees.add(nextComparisonNode);
          dumpOptDetails(comp(), "The node %p has been created for testing if async check is required\n", nextComparisonNode);
 
-         bool skipIt = comp()->getOption(TR_DisableAsyncCheckVersioning);
-         if (!skipIt)
+         if (!comp()->getOption(TR_DisableAsyncCheckVersioning))
             {
             TR::TreeTop *prevTree = _asyncCheckTree->getPrevTreeTop();
             TR::TreeTop *nextTree = _asyncCheckTree->getNextTreeTop();
             prevTree->join(nextTree);
             }
-         //_loopTestBlock->getStructureOf()->setIsEntryOfShortRunningLoop();
+
          whileLoop->getEntryBlock()->getStructureOf()->setIsEntryOfShortRunningLoop();
          if (trace())
             traceMsg(comp(), "Marked block %p with entry %p\n", whileLoop->getEntryBlock(), whileLoop->getEntryBlock()->getEntry()->getNode());
@@ -4140,12 +4132,11 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
    // Construct the tests for invariant expressions that need
    // to be null checked.
    //
-  if (
-      comp()->cg()->performsChecksExplicitly() ||
-      (comp()->getMethodHotness() >= veryHot))
+   if (comp()->cg()->performsChecksExplicitly() ||
+       (comp()->getMethodHotness() >= veryHot))
       {
       if (!nullCheckTrees->isEmpty() &&
-         !shouldOnlySpecializeLoops())
+          !shouldOnlySpecializeLoops())
          {
          buildNullCheckComparisonsTree(nullCheckedReferences, nullCheckTrees, boundCheckTrees, divCheckTrees, checkCastTrees, arrayStoreCheckTrees, &comparisonTrees, clonedLoopInvariantBlock);
          }

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -4896,18 +4896,11 @@ void TR_LoopVersioner::buildIwrtbarComparisonsTree(List<TR::TreeTop> *iwrtbarTre
       TR::TreeTop *iwrtbarTree = nextTree->getData();
       TR::Node *iwrtbarNode = iwrtbarTree->getNode();
       if (iwrtbarNode->getOpCodeValue() != TR::wrtbari)
-        iwrtbarNode = iwrtbarNode->getFirstChild();
-
-      //traceMsg(comp(), "iwrtbar node %p\n", iwrtbarNode);
-
-      //vcount_t visitCount = comp()->incVisitCount();
-      //collectAllExpressionsToBeChecked(nullCheckTrees, divCheckTrees, checkCastTrees, arrayStoreCheckTrees, divCheckNode->getFirstChild()->getSecondChild(), comparisonTrees, exitGotoBlock, visitCount);
+         iwrtbarNode = iwrtbarNode->getFirstChild();
 
       if (performTransformation(comp(), "%s Creating test outside loop for checking if %p is iwrtbar is required\n", OPT_DETAILS_LOOP_VERSIONER, iwrtbarNode))
          {
-         TR::Node *duplicateBase = iwrtbarNode->getLastChild()->duplicateTree();
-         duplicateBase->setIsNull(false);
-         duplicateBase->setIsNonNull(false);
+         TR::Node *duplicateBase = iwrtbarNode->getLastChild()->duplicateTreeForCodeMotion();
          TR::Node *ifNode, *ifNode1, *ifNode2;
 
          bool isX86 = false;
@@ -4925,57 +4918,48 @@ void TR_LoopVersioner::buildIwrtbarComparisonsTree(List<TR::TreeTop> *iwrtbarTre
          if (!isX86 && (isVariableHeapBase || isVariableHeapSize))
             {
             if (TR::Compiler->target.is64Bit())
-               ifNode1 =  TR::Node::create(TR::lucmpge, 2, TR::Node::create(TR::a2l, 1, duplicateBase), TR::Node::createWithSymRef(TR::lload, 0, comp()->getSymRefTab()->findOrCreateThreadLowTenureAddressSymbolRef()));
+               ifNode1 = TR::Node::create(TR::lucmpge, 2, TR::Node::create(TR::a2l, 1, duplicateBase), TR::Node::createWithSymRef(TR::lload, 0, comp()->getSymRefTab()->findOrCreateThreadLowTenureAddressSymbolRef()));
             else
-               ifNode1 =  TR::Node::create(TR::iucmpge, 2, TR::Node::create(TR::a2i, 1, duplicateBase), TR::Node::createWithSymRef(TR::iload, 0, comp()->getSymRefTab()->findOrCreateThreadLowTenureAddressSymbolRef()));
+               ifNode1 = TR::Node::create(TR::iucmpge, 2, TR::Node::create(TR::a2i, 1, duplicateBase), TR::Node::createWithSymRef(TR::iload, 0, comp()->getSymRefTab()->findOrCreateThreadLowTenureAddressSymbolRef()));
             }
          else
             {
             if (TR::Compiler->target.is64Bit())
                {
-               ifNode1 =  TR::Node::create(TR::lucmpge, 2, TR::Node::create(TR::a2l, 1, duplicateBase), TR::Node::create(duplicateBase, TR::lconst, 0, 0));
+               ifNode1 = TR::Node::create(TR::lucmpge, 2, TR::Node::create(TR::a2l, 1, duplicateBase), TR::Node::create(duplicateBase, TR::lconst, 0, 0));
                ifNode1->getSecondChild()->setLongInt(fej9->getLowTenureAddress());
                }
             else
-               ifNode1 =  TR::Node::create(TR::iucmpge, 2, TR::Node::create(TR::a2i, 1, duplicateBase), TR::Node::create(duplicateBase, TR::iconst, 0, fej9->getLowTenureAddress()));
+               ifNode1 = TR::Node::create(TR::iucmpge, 2, TR::Node::create(TR::a2i, 1, duplicateBase), TR::Node::create(duplicateBase, TR::iconst, 0, fej9->getLowTenureAddress()));
             }
-
-         //comparisonTrees->add(ifNode);
 
          dumpOptDetails(comp(), "1 The node %p has been created for testing if iwrtbar is required\n", ifNode1);
 
-         duplicateBase = iwrtbarNode->getLastChild()->duplicateTree();
-         duplicateBase->setIsNull(false);
-         duplicateBase->setIsNonNull(false);
-
-         //printf(" stack compare value %p\n", stackCompareValue);
+         duplicateBase = iwrtbarNode->getLastChild()->duplicateTreeForCodeMotion();
 
          if (!isX86 && (isVariableHeapBase || isVariableHeapSize))
             {
             if (TR::Compiler->target.is64Bit())
-               ifNode2 =  TR::Node::create(TR::lucmplt, 2, TR::Node::create(TR::a2l, 1, duplicateBase), TR::Node::createWithSymRef(TR::lload, 0, comp()->getSymRefTab()->findOrCreateThreadHighTenureAddressSymbolRef()));
+               ifNode2 = TR::Node::create(TR::lucmplt, 2, TR::Node::create(TR::a2l, 1, duplicateBase), TR::Node::createWithSymRef(TR::lload, 0, comp()->getSymRefTab()->findOrCreateThreadHighTenureAddressSymbolRef()));
             else
-               ifNode2 =  TR::Node::create(TR::iucmplt, 2, TR::Node::create(TR::a2i, 1, duplicateBase), TR::Node::createWithSymRef(TR::iload, 0, comp()->getSymRefTab()->findOrCreateThreadHighTenureAddressSymbolRef()));
+               ifNode2 = TR::Node::create(TR::iucmplt, 2, TR::Node::create(TR::a2i, 1, duplicateBase), TR::Node::createWithSymRef(TR::iload, 0, comp()->getSymRefTab()->findOrCreateThreadHighTenureAddressSymbolRef()));
             }
          else
             {
             if (TR::Compiler->target.is64Bit())
                {
-               ifNode2 =  TR::Node::create(TR::lucmplt, 2, TR::Node::create(TR::a2l, 1, duplicateBase), TR::Node::create(duplicateBase, TR::lconst, 0, 0));
+               ifNode2 = TR::Node::create(TR::lucmplt, 2, TR::Node::create(TR::a2l, 1, duplicateBase), TR::Node::create(duplicateBase, TR::lconst, 0, 0));
                ifNode2->getSecondChild()->setLongInt(fej9->getHighTenureAddress());
                }
             else
-               ifNode2 =  TR::Node::create(TR::iucmplt, 2, TR::Node::create(TR::a2i, 1, duplicateBase), TR::Node::create(duplicateBase, TR::iconst, 0, fej9->getHighTenureAddress()));
+               ifNode2 = TR::Node::create(TR::iucmplt, 2, TR::Node::create(TR::a2i, 1, duplicateBase), TR::Node::create(duplicateBase, TR::iconst, 0, fej9->getHighTenureAddress()));
             }
 
-         ifNode =  TR::Node::createif(TR::ificmpne, TR::Node::create(TR::iand, 2, ifNode1, ifNode2), TR::Node::create(duplicateBase, TR::iconst, 0, 0), exitGotoBlock->getEntry());
+         ifNode = TR::Node::createif(TR::ificmpne, TR::Node::create(TR::iand, 2, ifNode1, ifNode2), TR::Node::create(duplicateBase, TR::iconst, 0, 0), exitGotoBlock->getEntry());
 
          comparisonTrees->add(ifNode);
 
          dumpOptDetails(comp(), "2 The node %p has been created for testing if iwrtbar is required\n", ifNode2);
-
-
-         //printf("Found opportunity for skipping wrtbar %p in %s at freq %d\n", iwrtbarNode, comp()->signature(), iwrtbarTree->getEnclosingBlock()->getFrequency()); fflush(stdout);
 
          iwrtbarNode->setSkipWrtBar(true);
          }


### PR DESCRIPTION
`LoopVersioner` creates various guards unsafely. See #718 for one example. This PR will be used to fix other cases that appear problematic but that haven't caused any known issues yet.