### PR TITLE
Add exception asynccheck insertion opt

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1103,6 +1103,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"traceEarlyStackMap",               "L\ttrace early stack map",                        SET_TRACECG_BIT(TR_TraceEarlyStackMap), "P"},
    {"traceEscapeAnalysis",              "L\ttrace escape analysis",                        TR::Options::traceOptimization, escapeAnalysis, 0, "P"},
    {"traceEvaluation",                  "L\tdump output of tree evaluation passes",        SET_TRACECG_BIT(TR_TraceCGEvaluation), "P" },
+   {"traceExceptionAsyncCheckInsertion","L\ttrace async check insertion into exceptions",  TR::Options::traceOptimization, exceptionAsyncCheckInsertion, 0, "P"},  // Java specific option
    {"traceExplicitNewInitialization",   "L\ttrace explicit new initialization",            TR::Options::traceOptimization, explicitNewInitialization, 0, "P"},
    {"traceFieldPrivatization",          "L\ttrace field privatization",                    TR::Options::traceOptimization, fieldPrivatization, 0, "P"},
    {"traceForCodeMining=",              "L{regex}\tadd instruction annotations for code mining",

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -535,6 +535,7 @@ static const OptimizationStrategy ilgenStrategyOpts[] =
    { coldBlockMarker                               },
    { allocationSinking,             IfNews         },
    { invariantArgumentPreexistence, IfNotClassLoadPhaseAndNotProfiling },
+   { exceptionAsyncCheckInsertion                  },
    { osrDefAnalysis                                },
    { osrLiveRangeAnalysis                          },
 #endif

--- a/compiler/optimizer/Optimizations.enum
+++ b/compiler/optimizer/Optimizations.enum
@@ -116,3 +116,4 @@
    OPTIMIZATION(loadExtensions)  // added temporarily for omr optimizer work
    OPTIMIZATION(regDepCopyRemoval)
    OPTIMIZATION(asyncCheckInsertion)
+   OPTIMIZATION(exceptionAsyncCheckInsertion)


### PR DESCRIPTION
Adds the exception handler asynccheck insertion optimization to the
ilgen opt strategy and a tracing option.

Corrects the case where an asynccheck has been inserted into an
exception handler, which is being split to use a goto. In this
situation, the original asynccheck is retained in the exception
handler and a duplicate is added to the new block. This prevents
the goto edge from creating a loop without an asynccheck and
ensures the exception handler still has its asynccheck.

Signed-off-by: Nicholas Coughlin <cnic@ca.ibm.com>