### PR TITLE
Update porttest to use logger

### DIFF
--- a/fvtest/porttest/hypervisorTest.cpp
+++ b/fvtest/porttest/hypervisorTest.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2001, 2015
+ * (c) Copyright IBM Corp. 2001, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -27,6 +27,7 @@ TEST(PortHypervisorTest, DISABLED_HypervisorPresent)
 
 	intptr_t rc = 0;
 	BOOLEAN isVirtual = FALSE;
+	portTestEnv->changeIndent(2);
 
 	if (NULL != portTestEnv->hypervisor) {
 		/* -hypervisor *was* specified */
@@ -39,15 +40,15 @@ TEST(PortHypervisorTest, DISABLED_HypervisorPresent)
 		switch (rc) {
 		case J9HYPERVISOR_NOT_PRESENT: {
 			/* Pass case, since -hypervisor was NOT specified; neither was it detected. */
-			outputComment(PORTLIB,
-						  "\t\tTest Passed: No Hypervisor present and j9hypervisor_hypervisor_present()"
+			portTestEnv->log(
+						  "Test Passed: No Hypervisor present and j9hypervisor_hypervisor_present()"
 						  "returned false\n");
 
 			break;
 		}
 		case J9PORT_ERROR_HYPERVISOR_UNSUPPORTED: {
 			/* Pass case; give benefit of doubt since hypervisor detection is NOT supported. */
-			outputComment(PORTLIB, "\t\tThis platform does not support Hypervisor detection\n");
+			portTestEnv->log("This platform does not support Hypervisor detection\n");
 			break;
 		}
 		case J9HYPERVISOR_PRESENT: {
@@ -74,7 +75,7 @@ TEST(PortHypervisorTest, DISABLED_HypervisorPresent)
 		switch (rc) {
 		case J9HYPERVISOR_PRESENT: {
 			/* Pass case, since we detected a hypervisor as also found -hypervisor specified. */
-			outputComment(PORTLIB, "\t\tTest Passed: Expected a hypervisor and"
+			portTestEnv->log("Test Passed: Expected a hypervisor and"
 						  " j9hypervisor_hypervisor_present() returned true\n");
 			break;
 		}
@@ -83,7 +84,7 @@ TEST(PortHypervisorTest, DISABLED_HypervisorPresent)
 				/* If this is a negative test case then we expect hypervisor detection to return
 				 * error code: J9PORT_ERROR_HYPERVISOR_UNSUPPORTED, when -hypervisor is specified.
 				 */
-				outputComment(PORTLIB, "\t\tTest (negative case) passed: Expected an "
+				portTestEnv->log("Test (negative case) passed: Expected an "
 							  "unsupported hypervisor.\n\tj9hypervisor_hypervisor_present() returned "
 							  "-856 (J9PORT_ERROR_HYPERVISOR_UNSUPPORTED).\n");
 			} else {
@@ -104,4 +105,5 @@ TEST(PortHypervisorTest, DISABLED_HypervisorPresent)
 		}
 		};
 	}
+	portTestEnv->changeIndent(-2);
 }

--- a/fvtest/porttest/omrdumpTest.cpp
+++ b/fvtest/porttest/omrdumpTest.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2001, 2016
+ * (c) Copyright IBM Corp. 2001, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -61,6 +61,7 @@ removeDump(OMRPortLibrary *portLib, const char *filename, const char *testName)
 {
 	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
 	bool removeDumpSucceeded = true;
+	portTestEnv->changeIndent(1);
 
 	/* Delete the file if possible. */
 #if defined(J9ZOS390)
@@ -80,10 +81,11 @@ removeDump(OMRPortLibrary *portLib, const char *filename, const char *testName)
 	}
 #endif /* defined(J9ZOS390) */
 	if (removeDumpSucceeded) {
-		outputComment(OMRPORTLIB, "\tremoved: %s\n", filename);
+		portTestEnv->log("removed: %s\n", filename);
 	} else {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "\tfailed to remove %s\n", filename);
 	}
+	portTestEnv->changeIndent(-1);
 }
 
 /**
@@ -131,7 +133,7 @@ TEST(PortDumpTest, dump_test_create_dump_with_NO_name)
 #endif
 
 	/* try out a more sane NULL test */
-	outputComment(OMRPORTLIB, "calling omrdump_create with empty filename\n");
+	portTestEnv->log("calling omrdump_create with empty filename\n");
 
 #if defined(J9ZOS390)
 	rc = omrdump_create(coreFileName, "IEATDUMP", NULL);
@@ -142,7 +144,7 @@ TEST(PortDumpTest, dump_test_create_dump_with_NO_name)
 	if (rc == 0) {
 		uintptr_t verifyFileRC = 99;
 
-		outputComment(OMRPORTLIB, "omrdump_create claims to have written a core file to: %s\n", coreFileName);
+		portTestEnv->log("omrdump_create claims to have written a core file to: %s\n", coreFileName);
 
 
 #if defined(AIXPPC)
@@ -196,7 +198,7 @@ TEST(PortDumpTest, dump_test_create_dump_with_name)
 	strncat(coreFileName, "/", EsMaxPath);	/* make sure the directory ends with a slash */
 	strncat(coreFileName, testName, EsMaxPath);
 
-	outputComment(OMRPORTLIB, "calling omrdump_create with filename: %s\n", coreFileName);
+	portTestEnv->log("calling omrdump_create with filename: %s\n", coreFileName);
 #if !defined(J9ZOS390)
 	rc = omrdump_create(coreFileName, NULL, NULL);
 #else
@@ -206,7 +208,7 @@ TEST(PortDumpTest, dump_test_create_dump_with_name)
 	if (rc == 0) {
 		uintptr_t verifyFileRC = 99;
 
-		outputComment(OMRPORTLIB, "omrdump_create claims to have written a core file to: %s\n", coreFileName);
+		portTestEnv->log("omrdump_create claims to have written a core file to: %s\n", coreFileName);
 		verifyFileRC = verifyFileExists(PORTTEST_ERROR_ARGS, coreFileName);
 		if (verifyFileRC == 0) {
 			removeDump(OMRPORTLIB, coreFileName, testName);
@@ -275,7 +277,7 @@ simpleHandlerFunction(struct OMRPortLibrary *portLibrary, uint32_t gpType, void 
 	const char *testName = info->testName;
 	uintptr_t rc;
 
-	outputComment(OMRPORTLIB, "calling omrdump_create with filename: %s\n", info->coreFileName);
+	portTestEnv->log("calling omrdump_create with filename: %s\n", info->coreFileName);
 
 #if defined(J9ZOS390)
 	rc = omrdump_create(info->coreFileName, "IEATDUMP", NULL);
@@ -286,7 +288,7 @@ simpleHandlerFunction(struct OMRPortLibrary *portLibrary, uint32_t gpType, void 
 	if (rc == 0) {
 		uintptr_t verifyFileRC = 99;
 
-		outputComment(OMRPORTLIB, "omrdump_create claims to have written a core file to: %s\n", info->coreFileName);
+		portTestEnv->log("omrdump_create claims to have written a core file to: %s\n", info->coreFileName);
 		verifyFileRC = verifyFileExists(PORTTEST_ERROR_ARGS, info->coreFileName);
 		if (verifyFileRC == 0) {
 			removeDump(OMRPORTLIB, info->coreFileName, testName);

--- a/fvtest/porttest/omrfileTest.cpp
+++ b/fvtest/porttest/omrfileTest.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2016
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -4011,7 +4011,7 @@ TEST_F(PortFileTest2, file_test_long_file_name)
 		/* now append filePathName with the actual filename */
 		omrstr_printf(filePathName + strlen(filePathName), FILENAME_LENGTH - strlen(filePathName), "\\%s", testName);
 
-		omrtty_printf("\ttesting filename: %s\n", filePathName);
+		portTestEnv->log("\ttesting filename: %s\n", filePathName);
 
 		/* can we open and write to the file? */
 		fd = FILE_OPEN_FUNCTION(OMRPORTLIB, filePathName, EsOpenCreate | EsOpenWrite, 0666);

--- a/fvtest/porttest/omrfileTest.cpp
+++ b/fvtest/porttest/omrfileTest.cpp
@@ -3238,6 +3238,7 @@ omrfile_test25_child_1(OMRPortLibrary *portLibrary)
 	uint64_t length = TEST25_LENGTH;
 
 	reportTestEntry(OMRPORTLIB, testName);
+	portTestEnv->changeIndent(1);
 
 	fd = FILE_OPEN_FUNCTION(OMRPORTLIB, testFile, EsOpenRead | EsOpenWrite, 0);
 
@@ -3249,7 +3250,7 @@ omrfile_test25_child_1(OMRPortLibrary *portLibrary)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "Locking of bytes %lld for %lld failed: lastErrorNumber=%d, lastErrorMessage=%s\n", offset, length, lastErrorNumber, lastErrorMessage);
 		goto exit;
 	}
-	outputComment(OMRPORTLIB, "Child 1: Got read lock on bytes %lld for %lld\n", offset, length);
+	portTestEnv->log("Child 1: Got read lock on bytes %lld for %lld\n", offset, length);
 
 	omrfile_create_status_file(OMRPORTLIB, testFileLock, testName);
 
@@ -3268,7 +3269,7 @@ omrfile_test25_child_1(OMRPortLibrary *portLibrary)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "Unlocking of bytes %lld for %lld failed: lastErrorNumber=%d, lastErrorMessage=%s\n", (offset + 2), (length - 2), lastErrorNumber, lastErrorMessage);
 		goto exit;
 	}
-	outputComment(OMRPORTLIB, "Child 1: Released read lock on bytes %lld for %lld\n", offset, length);
+	portTestEnv->log("Child 1: Released read lock on bytes %lld for %lld\n", offset, length);
 #endif /* defined(_WIN32) || defined(OSX) */
 
 
@@ -3280,7 +3281,7 @@ omrfile_test25_child_1(OMRPortLibrary *portLibrary)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "Locking of bytes %lld for %lld failed: lastErrorNumber=%d, lastErrorMessage=%s\n", (offset + 2), length, lastErrorNumber, lastErrorMessage);
 		goto exit;
 	}
-	outputComment(OMRPORTLIB, "Child 1: Got write lock on bytes %lld for %lld\n", (offset + 2), length);
+	portTestEnv->log("Child 1: Got write lock on bytes %lld for %lld\n", (offset + 2), length);
 
 #if !defined(_WIN32)
 	unlockRc = FILE_UNLOCK_BYTES_FUNCTION(OMRPORTLIB, fd, offset, (length - 2));
@@ -3291,7 +3292,7 @@ omrfile_test25_child_1(OMRPortLibrary *portLibrary)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "Unlocking of bytes %lld for %lld failed: lastErrorNumber=%d, lastErrorMessage=%s\n", offset, (length - 2), lastErrorNumber, lastErrorMessage);
 		goto exit;
 	}
-	outputComment(OMRPORTLIB, "Child 1: Released read lock on bytes %lld for %lld\n", offset, (length - 2));
+	portTestEnv->log("Child 1: Released read lock on bytes %lld for %lld\n", offset, (length - 2));
 #endif
 
 	unlockRc = FILE_UNLOCK_BYTES_FUNCTION(OMRPORTLIB, fd, (offset + 2), length);
@@ -3302,8 +3303,9 @@ omrfile_test25_child_1(OMRPortLibrary *portLibrary)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "Unlocking of bytes %lld for %lld failed: lastErrorNumber=%d, lastErrorMessage=%s\n", (offset + 2), length, lastErrorNumber, lastErrorMessage);
 		goto exit;
 	}
-	outputComment(OMRPORTLIB, "Child 1: Released write lock on bytes %lld for %lld\n", (offset + 2), length);
+	portTestEnv->log("Child 1: Released write lock on bytes %lld for %lld\n", (offset + 2), length);
 
+	portTestEnv->changeIndent(-1);
 	FILE_CLOSE_FUNCTION(OMRPORTLIB, fd);
 
 exit:
@@ -3329,6 +3331,7 @@ omrfile_test25_child_2(OMRPortLibrary *portLibrary)
 	uint64_t length = TEST25_LENGTH;
 
 	reportTestEntry(OMRPORTLIB, testName);
+	portTestEnv->changeIndent(1);
 
 	while (!omrfile_status_file_exists(OMRPORTLIB, testFileLock, testName)) {
 		SleepFor(1);
@@ -3336,7 +3339,7 @@ omrfile_test25_child_2(OMRPortLibrary *portLibrary)
 
 	fd = FILE_OPEN_FUNCTION(OMRPORTLIB, testFile, EsOpenRead | EsOpenWrite, 0);
 
-	outputComment(OMRPORTLIB, "Child 2: Trying for write lock on bytes %lld for %lld\n", offset, length);
+	portTestEnv->log("Child 2: Trying for write lock on bytes %lld for %lld\n", offset, length);
 	omrfile_create_status_file(OMRPORTLIB, testFileTry, testName);
 
 	lockRc = FILE_LOCK_BYTES_FUNCTION(OMRPORTLIB, fd, OMRPORT_FILE_WRITE_LOCK | OMRPORT_FILE_WAIT_FOR_LOCK, offset, length);
@@ -3347,7 +3350,7 @@ omrfile_test25_child_2(OMRPortLibrary *portLibrary)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "Locking of bytes %lld for %lld failed: lastErrorNumber=%d, lastErrorMessage=%s\n", offset, length, lastErrorNumber, lastErrorMessage);
 		goto exit;
 	}
-	outputComment(OMRPORTLIB, "Child 2: Got write lock on bytes %lld for %lld\n", offset, length);
+	portTestEnv->log("Child 2: Got write lock on bytes %lld for %lld\n", offset, length);
 
 	unlockRc = FILE_UNLOCK_BYTES_FUNCTION(OMRPORTLIB, fd, offset, length);
 
@@ -3357,10 +3360,10 @@ omrfile_test25_child_2(OMRPortLibrary *portLibrary)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "Unlocking of bytes %lld for %lld failed: lastErrorNumber=%d, lastErrorMessage=%s\n", offset, length, lastErrorNumber, lastErrorMessage);
 		goto exit;
 	}
-	outputComment(OMRPORTLIB, "Child 2: Released write lock on bytes %lld for %lld\n", offset, length);
+	portTestEnv->log("Child 2: Released write lock on bytes %lld for %lld\n", offset, length);
 
 	FILE_CLOSE_FUNCTION(OMRPORTLIB, fd);
-
+	portTestEnv->changeIndent(-1);
 	omrfile_create_status_file(OMRPORTLIB, testFileDone, testName);
 
 exit:
@@ -3742,7 +3745,7 @@ TEST_F(PortFileTest2, file_test31)
 	}
 
 	if (myGid != fileGid) {
-		outputComment(OMRPORTLIB, "unexpected group ID.  Possibly setgid bit set. Comparing to group of the current directory\n");
+		portTestEnv->log("unexpected group ID.  Possibly setgid bit set. Comparing to group of the current directory\n");
 		rc = omrfile_stat(".", 0, &stat);
 		if (rc != 0) {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat(%s, ..) returned %d expected %d\n", ".", rc, 0);
@@ -3777,11 +3780,12 @@ TEST_F(PortFileTest2, file_test32)
 	J9FileStat stat;
 
 	reportTestEntry(OMRPORTLIB, testName);
+	portTestEnv->changeIndent(1);
 
 	/*
 	 * Test a read-writeable file
 	 */
-	outputComment(OMRPORTLIB, "omrfile_stat() Test a read-writeable file\n");
+	portTestEnv->log("omrfile_stat() Test a read-writeable file\n");
 	omrfile_unlink(localFilename);
 	fd = FILE_OPEN_FUNCTION(OMRPORTLIB, localFilename, EsOpenCreate | EsOpenWrite, 0666);
 	if (fd == -1) {
@@ -3823,7 +3827,7 @@ TEST_F(PortFileTest2, file_test32)
 	/*
 	 * Test a readonly file
 	 */
-	outputComment(OMRPORTLIB, "omrfile_stat() Test a readonly file\n");
+	portTestEnv->log("omrfile_stat() Test a readonly file\n");
 	omrfile_unlink(localFilename);
 	fd = FILE_OPEN_FUNCTION(OMRPORTLIB, localFilename, EsOpenCreate | EsOpenRead, 0444);
 
@@ -3866,7 +3870,7 @@ TEST_F(PortFileTest2, file_test32)
 	/*
 	 * Test a writeable file
 	 */
-	outputComment(OMRPORTLIB, "omrfile_stat() Test a writeable file\n");
+	portTestEnv->log("omrfile_stat() Test a writeable file\n");
 	omrfile_unlink(localFilename);
 	fd = FILE_OPEN_FUNCTION(OMRPORTLIB, localFilename, EsOpenCreate | EsOpenWrite, 0222);
 	if (fd == -1) {
@@ -3916,6 +3920,7 @@ TEST_F(PortFileTest2, file_test32)
 
 done:
 	omrfile_unlink(localFilename);
+	portTestEnv->changeIndent(-1);
 	reportTestExit(OMRPORTLIB, testName);
 }
 
@@ -4120,13 +4125,14 @@ omrfile_test34(struct OMRPortLibrary *portLibrary)
 	const char *fileName = "omrfile_test34.tst";
 
 	reportTestEntry(OMRPORTLIB, testName);
+	portTestEnv->changeIndent(1);
 
 	/* delete fileName to have a clean test, ignore the result */
 	(void)omrfile_unlink(fileName);
 
 	fd = FILE_OPEN_FUNCTION(OMRPORTLIB, fileName, EsOpenCreate | EsOpenRead | EsOpenWrite, 0666);
 	if (-1 == fd) {
-		outputComment(OMRPORTLIB, "%s() failed\n", FILE_OPEN_FUNCTION_NAME);
+		portTestEnv->log(LEVEL_ERROR, "%s() failed\n", FILE_OPEN_FUNCTION_NAME);
 		returnCode = TEST_FAIL;
 		goto exit;
 	}
@@ -4136,26 +4142,26 @@ omrfile_test34(struct OMRPortLibrary *portLibrary)
 #endif /* defined(LINUX) || defined(OSX) */
 	rc = omrfile_stat_filesystem(fileName, 0, &buf_before);
 	if (0 != rc) {
-		outputComment(OMRPORTLIB, "first omrfile_stat_filesystem() returned %d, expected %d\n", rc, 0);
+		portTestEnv->log(LEVEL_ERROR, "first omrfile_stat_filesystem() returned %d, expected %d\n", rc, 0);
 		returnCode = TEST_FAIL;
 		goto exit;
 	}
 	rc = omrfile_stat(fileName, 0, &buf);
 	if (0 != rc) {
-		outputComment(OMRPORTLIB, "first omrfile_stat() returned %d, expected %d\n", rc, 0);
+		portTestEnv->log(LEVEL_ERROR, "first omrfile_stat() returned %d, expected %d\n", rc, 0);
 		returnCode = TEST_FAIL;
 		goto exit;
 	}
 
 	if (buf.isRemote) {
-		outputComment(OMRPORTLIB, "WARNING: Test omrfile_test34 cannot be run on a remote file system.\nSkipping test.\n");
+		portTestEnv->log(LEVEL_WARN, "WARNING: Test omrfile_test34 cannot be run on a remote file system.\nSkipping test.\n");
 		returnCode = TEST_PASS;
 		goto exit;
 	}
 
 	stringToWrite = (char *)omrmem_allocate_memory(J9FILETEST_FILESIZE, OMRMEM_CATEGORY_PORT_LIBRARY);
 	if (NULL == stringToWrite) {
-		outputComment(OMRPORTLIB, "Failed to allocate %zu bytes\n", J9FILETEST_FILESIZE);
+		portTestEnv->log(LEVEL_ERROR, "Failed to allocate %zu bytes\n", J9FILETEST_FILESIZE);
 		returnCode = TEST_FAIL;
 		goto exit;
 	}
@@ -4170,7 +4176,7 @@ omrfile_test34(struct OMRPortLibrary *portLibrary)
 #endif /* defined(LINUX) || defined(OSX) */
 	rc = omrfile_stat_filesystem(fileName, 0, &buf_after);
 	if (0 != rc) {
-		outputComment(OMRPORTLIB, "second omrfile_stat_filesystem() returned %d, expected %d\n", rc, 0);
+		portTestEnv->log(LEVEL_ERROR, "second omrfile_stat_filesystem() returned %d, expected %d\n", rc, 0);
 		returnCode = TEST_FAIL;
 		goto exit;
 	}
@@ -4179,7 +4185,7 @@ omrfile_test34(struct OMRPortLibrary *portLibrary)
 
 	/* Checks if the free disk space changed after the file has been created. */
 	if (0 == freeSpaceDelta) {
-		outputComment(OMRPORTLIB, "The amount of free disk space does not change after the creation of a file.\n\
+		portTestEnv->log("The amount of free disk space does not change after the creation of a file.\n\
 			It can be due to a file of exactly %d bytes being deleted during this test, or omrfile_stat_filesystem failing.\n\
 			The test does not work on a remote file system. Ignore failures on remote file systems.\n", J9FILETEST_FILESIZE);
 		returnCode = TEST_FAIL;
@@ -4187,7 +4193,7 @@ omrfile_test34(struct OMRPortLibrary *portLibrary)
 	}
 
 	if (buf_before.totalSizeBytes != buf_after.totalSizeBytes) {
-		outputComment(OMRPORTLIB, "Total disk space changed between runs, it was %llu changed to %llu.\n\
+		portTestEnv->log("Total disk space changed between runs, it was %llu changed to %llu.\n\
 				The disk space should not change between runs.\n", buf_before.totalSizeBytes, buf_after.totalSizeBytes);
 		returnCode = TEST_FAIL;
 		goto exit;
@@ -4199,18 +4205,19 @@ exit:
 	if (-1 != fd) {
 		rc = FILE_CLOSE_FUNCTION(OMRPORTLIB, fd);
 		if (0 != rc) {
-			outputComment(OMRPORTLIB, "%s() returned %d expected %d\n", FILE_CLOSE_FUNCTION_NAME, rc, 0);
+			portTestEnv->log(LEVEL_ERROR, "%s() returned %d expected %d\n", FILE_CLOSE_FUNCTION_NAME, rc, 0);
 		}
 
 		/* Delete the file, expect success */
 		rc = omrfile_unlink(fileName);
 		if (0 != rc) {
-			outputComment(OMRPORTLIB, "omrfile_unlink() returned %d expected %d\n", rc, 0);
+			portTestEnv->log(LEVEL_ERROR, "omrfile_unlink() returned %d expected %d\n", rc, 0);
 		}
 	}
 
 	omrmem_free_memory(stringToWrite);
 
+	portTestEnv->changeIndent(-1);
 	reportTestExit(OMRPORTLIB, testName);
 
 	return returnCode;
@@ -4439,7 +4446,7 @@ TEST_F(PortFileTest2, file_test38)
 			}
 
 			if (myGid != fileGid) {
-				outputComment(OMRPORTLIB, "Unexpected group ID. Possibly setgid bit set. Comparing to group of the current directory\n");
+				portTestEnv->log("Unexpected group ID. Possibly setgid bit set. Comparing to group of the current directory\n");
 				rc = omrfile_stat(".", 0, &stat);
 				if (0 != rc) {
 					outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat(...) failed for current directory with rc=%d\n", rc);
@@ -4484,13 +4491,14 @@ const char *testName = APPEND_ASYNC(omrfile_test39: test file permission bits us
 	int32_t rc = -1;
 
 	reportTestEntry(OMRPORTLIB, testName);
+	portTestEnv->changeIndent(1);
 
 	memset(&stat, 0, sizeof(J9FileStat));
 
 	/*
 	 * Test a read-writeable file
 	 */
-	outputComment(OMRPORTLIB, "omrfile_fstat() Test a read-writeable file\n");
+	portTestEnv->log("omrfile_fstat() Test a read-writeable file\n");
 	omrfile_unlink(filename);
 
 	mode = 0666;
@@ -4521,7 +4529,7 @@ const char *testName = APPEND_ASYNC(omrfile_test39: test file permission bits us
 	/*
 	 * Test a read-only file
 	 */
-	outputComment(OMRPORTLIB, "omrfile_fstat() Test a read-only file\n");
+	portTestEnv->log("omrfile_fstat() Test a read-only file\n");
 
 	mode = 0444;
 	fd = FILE_OPEN_FUNCTION(OMRPORTLIB, filename, EsOpenCreate | EsOpenRead, mode);
@@ -4551,7 +4559,7 @@ const char *testName = APPEND_ASYNC(omrfile_test39: test file permission bits us
 	/*
 	 * Test a write-only file
 	 */
-	outputComment(OMRPORTLIB, "omrfile_fstat() Test a write-only file\n");
+	portTestEnv->log("omrfile_fstat() Test a write-only file\n");
 
 	mode = 0222;
 	fd = FILE_OPEN_FUNCTION(OMRPORTLIB, filename, EsOpenCreate | EsOpenWrite, mode);
@@ -4581,7 +4589,7 @@ const char *testName = APPEND_ASYNC(omrfile_test39: test file permission bits us
 	/*
 	 * Test a user only read-writeable file
 	 */
-	outputComment(OMRPORTLIB, "omrfile_fstat() Test a user only read-writeable file\n");
+	portTestEnv->log("omrfile_fstat() Test a user only read-writeable file\n");
 	omrfile_unlink(filename);
 
 	mode = 0600;
@@ -4623,7 +4631,7 @@ const char *testName = APPEND_ASYNC(omrfile_test39: test file permission bits us
 	/*
 	 * Test a user only read-only file
 	 */
-	outputComment(OMRPORTLIB, "omrfile_fstat() Test a user only read-only file\n");
+	portTestEnv->log("omrfile_fstat() Test a user only read-only file\n");
 
 	mode = 0400;
 	fd = FILE_OPEN_FUNCTION(OMRPORTLIB, filename, EsOpenCreate | EsOpenRead, mode);
@@ -4664,7 +4672,7 @@ const char *testName = APPEND_ASYNC(omrfile_test39: test file permission bits us
 	/*
 	 * Test a user only write-only file
 	 */
-	outputComment(OMRPORTLIB, "omrfile_fstat() Test a user only write-only file\n");
+	portTestEnv->log("omrfile_fstat() Test a user only write-only file\n");
 
 	mode = 0200;
 	fd = FILE_OPEN_FUNCTION(OMRPORTLIB, filename, EsOpenCreate | EsOpenWrite, mode);
@@ -4703,6 +4711,7 @@ const char *testName = APPEND_ASYNC(omrfile_test39: test file permission bits us
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "5s() failed to create file %s with mode=%d\n", FILE_OPEN_FUNCTION_NAME, filename, mode);
 	}
 
+	portTestEnv->changeIndent(-1);
 	reportTestExit(OMRPORTLIB, testName);
 }
 #endif

--- a/fvtest/porttest/omrfilestreamTest.cpp
+++ b/fvtest/porttest/omrfilestreamTest.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2015, 2016
+ * (c) Copyright IBM Corp. 2015, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -975,7 +975,7 @@ TEST(PortFileStreamTest, omrfilestream_test_long_file_name)
 		/* now append filePathName with the actual filename */
 		omrstr_printf(filePathName + strlen(filePathName), FILENAME_LENGTH - strlen(filePathName), "\\%s", testName);
 
-		omrtty_printf("\ttesting filename: %s\n", filePathName);
+		portTestEnv->log("\ttesting filename: %s\n", filePathName);
 
 		/* can we open and write to the file? */
 		file = omrfilestream_open(filePathName, EsOpenCreate | EsOpenWrite, 0666);

--- a/fvtest/porttest/omrfilestreamTest.cpp
+++ b/fvtest/porttest/omrfilestreamTest.cpp
@@ -697,7 +697,7 @@ TEST(PortFileStreamTest, omrfilestream_test_file_owner_and_group_attributes)
 	}
 
 	if (myGid != fileGid) {
-		outputComment(OMRPORTLIB, "unexpected group ID.  Possibly setgid bit set. Comparing to group of the current directory\n");
+		portTestEnv->log("unexpected group ID.  Possibly setgid bit set. Comparing to group of the current directory\n");
 		rc = omrfile_stat(".", 0, &stat);
 		if (rc != 0) {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat(%s, ..) returned %d expected %d\n", ".", rc, 0);

--- a/fvtest/porttest/omrheapTest.cpp
+++ b/fvtest/porttest/omrheapTest.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2016
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -1426,6 +1426,6 @@ TEST(PortHeapTest, heap_test2)
 		}
 	}
 	/* Output results */
-	omrtty_printf("\nHeap test done%s\n\n", rc == TEST_PASS ? "." : ", failures detected.");
+	portTestEnv->log("\nHeap test done%s\n\n", rc == TEST_PASS ? "." : ", failures detected.");
 	EXPECT_TRUE(TEST_PASS == rc) << "Test Failed!";
 }

--- a/fvtest/porttest/omrintrospectTest.cpp
+++ b/fvtest/porttest/omrintrospectTest.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2016, 2016
+ * (c) Copyright IBM Corp. 2016, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -41,10 +41,11 @@ TEST(PortIntrospectTest, introspect_test_set_signal_offset)
 	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
 	const char *testName = "introspect_test_set_signal_offset";
 	int32_t status = 0;
+	portTestEnv->changeIndent(1);
 
 	reportTestEntry(OMRPORTLIB, testName);
 #if defined(OMR_CONFIGURABLE_SUSPEND_SIGNAL)
-	outputComment(OMRPORTLIB, "test legal offsets\n");
+	portTestEnv->log("test legal offsets\n");
 	for (int32_t i = 0; i <= SIGRTMAX-SIGRTMIN; ++i) {
 #if defined(SIG_RI_INTERRUPT_INDEX)
 		if (SIG_RI_INTERRUPT_INDEX == signalOffset) {
@@ -56,25 +57,26 @@ TEST(PortIntrospectTest, introspect_test_set_signal_offset)
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "omrintrospect_set_suspend_signal_offset failed unexpectedly");
 		}
 	}
-	outputComment(OMRPORTLIB, "test negative offset\n");
+	portTestEnv->log("test negative offset\n");
 	status = omrintrospect_set_suspend_signal_offset(-1);
 	if (0 == status) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrintrospect_set_suspend_signal_offset with negative offset succeeded unexpectedly");
 	}
 
-	outputComment(OMRPORTLIB, "test excessive offset\n");
+	portTestEnv->log("test excessive offset\n");
 	status = omrintrospect_set_suspend_signal_offset(SIGRTMAX);
 	if (0 == status) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrintrospect_set_suspend_signal_offset out of range offset succeeded unexpectedly");
 	}
 #else /* defined(OMR_CONFIGURABLE_SUSPEND_SIGNAL) */
-	outputComment(OMRPORTLIB, "verify that omrintrospect_set_suspend_signal_offset returns failure on unsupported platforms\n");
+	portTestEnv->log("verify that omrintrospect_set_suspend_signal_offset returns failure on unsupported platforms\n");
 	status = omrintrospect_set_suspend_signal_offset(0);
-	outputComment(OMRPORTLIB, "omrintrospect_set_suspend_signal_offset returns %d \n", status);
+	portTestEnv->log("omrintrospect_set_suspend_signal_offset returns %d \n", status);
 	if (0 == status) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrintrospect_set_suspend_signal_offset succeeded unexpectedly");
 	}
 #endif /* defined(OMR_CONFIGURABLE_SUSPEND_SIGNAL) */
+	portTestEnv->changeIndent(-1);
 }
 
 

--- a/fvtest/porttest/omrmemTest.cpp
+++ b/fvtest/porttest/omrmemTest.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2016
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -597,7 +597,7 @@ TEST(PortMemTest, mem_test7_allocate32)
 	if (0 == randomSeed) {
 		randomSeed = (int)omrtime_current_time_millis();
 	}
-	outputComment(OMRPORTLIB, "Random seed value: %d. Add -srand:[seed] to the command line to reproduce this test manually.\n", randomSeed);
+	portTestEnv->log("Random seed value: %d. Add -srand:[seed] to the command line to reproduce this test manually.\n", randomSeed);
 	srand(randomSeed);
 
 	shuffleArray(OMRPORTLIB, allocBlockSizes, allocBlockSizesLength);

--- a/fvtest/porttest/omrmmapTest.cpp
+++ b/fvtest/porttest/omrmmapTest.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2016
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -71,8 +71,7 @@ protected:
 static uintptr_t
 simpleHandlerFunction(struct OMRPortLibrary *portLibrary, uint32_t gpType, void *gpInfo, void *handler_arg)
 {
-	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
-	outputComment(OMRPORTLIB, " A crash occured, signal handler invoked (type = 0x%x)\n", gpType);
+	portTestEnv->log("A crash occured, signal handler invoked (type = 0x%x)\n", gpType);
 	return OMRPORT_SIG_EXCEPTION_RETURN;
 }
 
@@ -273,7 +272,7 @@ TEST_F(PortMmapTest, mmap_test2)
 	reportTestEntry(OMRPORTLIB, testName);
 
 	if (!(mmapCapabilities & OMRPORT_MMAP_CAPABILITY_WRITE)) {
-		outputComment(OMRPORTLIB, "OMRPORT_MMAP_CAPABILITY_WRITE not supported on this platform, bypassing test\n");
+		portTestEnv->log(LEVEL_ERROR, "OMRPORT_MMAP_CAPABILITY_WRITE not supported on this platform, bypassing test\n");
 		goto exit;
 	}
 
@@ -408,7 +407,7 @@ TEST_F(PortMmapTest, mmap_test3)
 	reportTestEntry(OMRPORTLIB, testName);
 
 	if (!(mmapCapabilities & OMRPORT_MMAP_CAPABILITY_COPYONWRITE)) {
-		outputComment(OMRPORTLIB, "OMRPORT_MMAP_CAPABILITY_COPYONWRITE not supported on this platform, bypassing test\n");
+		portTestEnv->log(LEVEL_ERROR, "OMRPORT_MMAP_CAPABILITY_COPYONWRITE not supported on this platform, bypassing test\n");
 		goto exit;
 	}
 
@@ -543,7 +542,7 @@ TEST_F(PortMmapTest, mmap_test4)
 	reportTestEntry(OMRPORTLIB, testName);
 
 	if (!(mmapCapabilities & OMRPORT_MMAP_CAPABILITY_WRITE) || !(mmapCapabilities & OMRPORT_MMAP_CAPABILITY_MSYNC)) {
-		outputComment(OMRPORTLIB, "OMRPORT_MMAP_CAPABILITY_WRITE or _MSYNC not supported on this platform, bypassing test\n");
+		portTestEnv->log(LEVEL_ERROR, "OMRPORT_MMAP_CAPABILITY_WRITE or _MSYNC not supported on this platform, bypassing test\n");
 		goto exit;
 	}
 
@@ -678,7 +677,7 @@ TEST_F(PortMmapTest, mmap_test5)
 	reportTestEntry(OMRPORTLIB, testName);
 
 	if (!(mmapCapabilities & OMRPORT_MMAP_CAPABILITY_WRITE) || !(mmapCapabilities & OMRPORT_MMAP_CAPABILITY_MSYNC)) {
-		outputComment(OMRPORTLIB, "OMRPORT_MMAP_CAPABILITY_WRITE or _MSYNC not supported on this platform, bypassing test\n");
+		portTestEnv->log(LEVEL_ERROR, "OMRPORT_MMAP_CAPABILITY_WRITE or _MSYNC not supported on this platform, bypassing test\n");
 		goto exit;
 	}
 
@@ -724,6 +723,7 @@ omrmmap_test5_child_1(OMRPortLibrary *portLibrary)
 	const char *mappingName = "C:\\full\\path\\to\\mmapTest5.tst";
 	intptr_t fd;
 	intptr_t rc;
+	portTestEnv->changeIndent(1);
 
 #define J9MMAP_TEST5_BUFFER_SIZE 100
 	char buffer[J9MMAP_TEST5_BUFFER_SIZE];
@@ -771,7 +771,7 @@ omrmmap_test5_child_1(OMRPortLibrary *portLibrary)
 		goto exit;
 	}
 
-	outputComment(OMRPORTLIB, "Child 1: Created file\n");
+	portTestEnv->log("Child 1: Created file\n");
 
 	fileLength = omrfile_length(filename);
 	if (-1 == fileLength) {
@@ -805,7 +805,7 @@ omrmmap_test5_child_1(OMRPortLibrary *portLibrary)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "Close of file %s after mapping failed: lastErrorNumber=%d, lastErrorMessage=%s\n", filename, lastErrorNumber, lastErrorMessage);
 	}
 
-	outputComment(OMRPORTLIB, "Child 1: Mapped file, readable text = \"%s\"\n", mapAddr + 30);
+	portTestEnv->log("Child 1: Mapped file, readable text = \"%s\"\n", mapAddr + 30);
 
 	omrfile_create_status_file(OMRPORTLIB, "omrmmap_test5_child_1_mapped_file", testName);
 
@@ -813,7 +813,7 @@ omrmmap_test5_child_1(OMRPortLibrary *portLibrary)
 		SleepFor(1);
 	}
 
-	outputComment(OMRPORTLIB, "Child 1: Child 2 has changed file, readable text = \"%s\"\n", mapAddr + 30);
+	portTestEnv->log("Child 1: Child 2 has changed file, readable text = \"%s\"\n", mapAddr + 30);
 
 	if (strcmp(mapAddr + 30, modifiedText) != 0) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "Modified string does not match in mapped buffer\n");
@@ -821,7 +821,7 @@ omrmmap_test5_child_1(OMRPortLibrary *portLibrary)
 
 	omrmmap_unmap_file(mmapHandle);
 
-
+	portTestEnv->changeIndent(-1);
 	omrfile_create_status_file(OMRPORTLIB, "omrmmap_test5_child_1_checked_file", testName);
 
 exit:
@@ -838,6 +838,7 @@ omrmmap_test5_child_2(OMRPortLibrary *portLibrary)
 	const char *mappingName = "C:\\full\\path\\to\\mmapTest5.tst";
 	intptr_t fd;
 	intptr_t rc;
+	portTestEnv->changeIndent(1);
 
 #define J9MMAP_TEST5_BUFFER_SIZE 100
 	const char *readableText = "Here is some readable text in the file";
@@ -886,7 +887,7 @@ omrmmap_test5_child_2(OMRPortLibrary *portLibrary)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "Close of file %s after mapping failed: lastErrorNumber=%d, lastErrorMessage=%s\n", filename, lastErrorNumber, lastErrorMessage);
 	}
 
-	outputComment(OMRPORTLIB, "Child 2: Mapped file, readable text = \"%s\"\n", mapAddr + 30);
+	portTestEnv->log("Child 2: Mapped file, readable text = \"%s\"\n", mapAddr + 30);
 
 	/* Check mapped area */
 	if (strcmp(mapAddr + 30, readableText) != 0) {
@@ -903,7 +904,7 @@ omrmmap_test5_child_2(OMRPortLibrary *portLibrary)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "Msync failed: lastErrorNumber=%d, lastErrorMessage=%s\n", lastErrorNumber, lastErrorMessage);
 	}
 
-	outputComment(OMRPORTLIB, "Child 2: Changed file, readable text = \"%s\"\n", mapAddr + 30);
+	portTestEnv->log("Child 2: Changed file, readable text = \"%s\"\n", mapAddr + 30);
 
 	omrfile_create_status_file(OMRPORTLIB, "omrmmap_test5_child_2_changed_file", testName);
 
@@ -911,10 +912,10 @@ omrmmap_test5_child_2(OMRPortLibrary *portLibrary)
 		SleepFor(1);
 	}
 
-	outputComment(OMRPORTLIB, "Child 2: Child 1 has checked file, exiting\n");
+	portTestEnv->log("Child 2: Child 1 has checked file, exiting\n");
 
 	omrmmap_unmap_file(mmapHandle);
-
+	portTestEnv->changeIndent(-1);
 
 exit:
 	return reportTestExit(OMRPORTLIB, testName);
@@ -948,7 +949,7 @@ TEST_F(PortMmapTest, mmap_test6)
 	reportTestEntry(OMRPORTLIB, testName);
 
 	if (!(mmapCapabilities & OMRPORT_MMAP_CAPABILITY_WRITE) || !(mmapCapabilities & OMRPORT_MMAP_CAPABILITY_MSYNC)) {
-		outputComment(OMRPORTLIB, "OMRPORT_MMAP_CAPABILITY_WRITE or _MSYNC not supported on this platform, bypassing test\n");
+		portTestEnv->log(LEVEL_ERROR, "OMRPORT_MMAP_CAPABILITY_WRITE or _MSYNC not supported on this platform, bypassing test\n");
 		goto exit;
 	}
 
@@ -1074,12 +1075,12 @@ TEST_F(PortMmapTest, mmap_test7)
 	reportTestEntry(OMRPORTLIB, testName);
 
 	if ((mmapCapabilities & OMRPORT_MMAP_CAPABILITY_PROTECT) == 0) {
-		outputComment(OMRPORTLIB, "OMRPORT_MMAP_CAPABILITY_PROTECT not supported on this platform, bypassing test\n");
+		portTestEnv->log(LEVEL_ERROR, "OMRPORT_MMAP_CAPABILITY_PROTECT not supported on this platform, bypassing test\n");
 		goto exit;
 	}
 
 	if ((mmapCapabilities & OMRPORT_MMAP_CAPABILITY_READ) == 0) {
-		outputComment(OMRPORTLIB, "OMRPORT_MMAP_CAPABILITY_READ not supported on this platform, bypassing test\n");
+		portTestEnv->log(LEVEL_ERROR, "OMRPORT_MMAP_CAPABILITY_READ not supported on this platform, bypassing test\n");
 		goto exit;
 	}
 
@@ -1192,12 +1193,12 @@ TEST_F(PortMmapTest, mmap_test8)
 	reportTestEntry(OMRPORTLIB, testName);
 
 	if ((mmapCapabilities & OMRPORT_MMAP_CAPABILITY_PROTECT) == 0) {
-		outputComment(OMRPORTLIB, "OMRPORT_MMAP_CAPABILITY_PROTECT not supported on this platform, bypassing test\n");
+		portTestEnv->log(LEVEL_ERROR, "OMRPORT_MMAP_CAPABILITY_PROTECT not supported on this platform, bypassing test\n");
 		goto exit;
 	}
 
 	if ((mmapCapabilities & OMRPORT_MMAP_CAPABILITY_WRITE) == 0) {
-		outputComment(OMRPORTLIB, "OMRPORT_MMAP_CAPABILITY_WRITE not supported on this platform, bypassing test\n");
+		portTestEnv->log(LEVEL_ERROR, "OMRPORT_MMAP_CAPABILITY_WRITE not supported on this platform, bypassing test\n");
 		goto exit;
 	}
 
@@ -1340,12 +1341,12 @@ TEST_F(PortMmapTest, mmap_test9)
 	reportTestEntry(OMRPORTLIB, testName);
 
 	if ((mmapCapabilities & OMRPORT_MMAP_CAPABILITY_PROTECT) == 0) {
-		outputComment(OMRPORTLIB, "OMRPORT_MMAP_CAPABILITY_PROTECT not supported on this platform, bypassing test\n");
+		portTestEnv->log(LEVEL_ERROR, "OMRPORT_MMAP_CAPABILITY_PROTECT not supported on this platform, bypassing test\n");
 		goto exit;
 	}
 
 	if ((mmapCapabilities & OMRPORT_MMAP_CAPABILITY_WRITE) == 0) {
-		outputComment(OMRPORTLIB, "OMRPORT_MMAP_CAPABILITY_WRITE not supported on this platform, bypassing test\n");
+		portTestEnv->log(LEVEL_ERROR, "OMRPORT_MMAP_CAPABILITY_WRITE not supported on this platform, bypassing test\n");
 		goto exit;
 	}
 
@@ -1411,7 +1412,7 @@ TEST_F(PortMmapTest, mmap_test9)
 	rc = omrmmap_protect(mapAddr, (uintptr_t)fileLength, OMRPORT_PAGE_PROTECT_READ);
 	if (rc != 0) {
 		if (rc == OMRPORT_PAGE_PROTECT_NOT_SUPPORTED) {
-			outputComment(OMRPORTLIB, "OMRPORT_MMAP_CAPABILITY_PROTECT not supported on this platform, bypassing test\n");
+			portTestEnv->log(LEVEL_ERROR, "OMRPORT_MMAP_CAPABILITY_PROTECT not supported on this platform, bypassing test\n");
 		} else {
 			lastErrorMessage = (char *)omrerror_last_error_message();
 			lastErrorNumber = omrerror_last_error_number();
@@ -1429,7 +1430,7 @@ TEST_F(PortMmapTest, mmap_test9)
 
 	/* try to write to region that was set to read only */
 	if (!omrsig_can_protect(signalHandlerFlags)) {
-		outputComment(OMRPORTLIB, "Signal handling framework not available, can't test readonly functionality without crashing, bypassing test");
+		portTestEnv->log(LEVEL_ERROR, "Signal handling framework not available, can't test readonly functionality without crashing, bypassing test");
 		goto exit;
 	} else {
 
@@ -1439,7 +1440,7 @@ TEST_F(PortMmapTest, mmap_test9)
 		writerInfo.shouldCrash = 1;
 		writerInfo.address = mapAddr + 30;
 
-		outputComment(OMRPORTLIB, "Writing to readonly region - we should crash\n");
+		portTestEnv->log("Writing to readonly region - we should crash\n");
 		protectResult = omrsig_protect(protectedWriter, &writerInfo, simpleHandlerFunction, &handlerInfo, signalHandlerFlags, &result);
 
 		if (protectResult == OMRPORT_SIG_EXCEPTION_OCCURRED) {
@@ -1522,18 +1523,18 @@ TEST_F(PortMmapTest, mmap_test10)
 	reportTestEntry(OMRPORTLIB, testName);
 
 	if ((mmapCapabilities & OMRPORT_MMAP_CAPABILITY_PROTECT) == 0) {
-		outputComment(OMRPORTLIB, "OMRPORT_MMAP_CAPABILITY_PROTECT not supported on this platform, bypassing test\n");
+		portTestEnv->log(LEVEL_ERROR, "OMRPORT_MMAP_CAPABILITY_PROTECT not supported on this platform, bypassing test\n");
 		goto exit;
 	}
 
 	if ((mmapCapabilities & OMRPORT_MMAP_CAPABILITY_WRITE) == 0) {
-		outputComment(OMRPORTLIB, "OMRPORT_MMAP_CAPABILITY_WRITE not supported on this platform, bypassing test\n");
+		portTestEnv->log(LEVEL_ERROR, "OMRPORT_MMAP_CAPABILITY_WRITE not supported on this platform, bypassing test\n");
 		goto exit;
 	}
 
 	/* How big do pages claim to be? */
 	pageSize = omrmmap_get_region_granularity(mapAddr);
-	outputComment(OMRPORTLIB, "Page size is reported as %d\n", pageSize);
+	portTestEnv->log("Page size is reported as %d\n", pageSize);
 	/* Initialize buffer to be written - 128 chars with a string right in the middle */
 	for (i = 0; i < 128 ; i++) {
 		buffer[i] = (char)i;
@@ -1563,7 +1564,7 @@ TEST_F(PortMmapTest, mmap_test10)
 		}
 		i += bufferSize;
 	}
-	outputComment(OMRPORTLIB, "Written out the buffer %d times to fill two pages\n", i / bufferSize);
+	portTestEnv->log("Written out the buffer %d times to fill two pages\n", i / bufferSize);
 
 	rc = omrfile_close(fd);
 	if (-1 == rc) {
@@ -1601,13 +1602,13 @@ TEST_F(PortMmapTest, mmap_test10)
 	}
 	mapAddr = (char *)mmapHandle->pointer;
 
-	outputComment(OMRPORTLIB, "File mapped at location %d\n", mapAddr);
-	outputComment(OMRPORTLIB, "Protecting first page\n");
+	portTestEnv->log("File mapped at location %d\n", mapAddr);
+	portTestEnv->log("Protecting first page\n");
 	/* set the region to read only */
 	rc = omrmmap_protect(mapAddr, (uintptr_t)fileLength / 2, OMRPORT_PAGE_PROTECT_READ);
 	if (rc != 0) {
 		if (rc == OMRPORT_PAGE_PROTECT_NOT_SUPPORTED) {
-			outputComment(OMRPORTLIB, "OMRPORT_MMAP_CAPABILITY_PROTECT not supported on this platform, bypassing test\n");
+			portTestEnv->log(LEVEL_ERROR, "OMRPORT_MMAP_CAPABILITY_PROTECT not supported on this platform, bypassing test\n");
 		} else {
 			lastErrorMessage = (char *)omrerror_last_error_message();
 			lastErrorNumber = omrerror_last_error_number();
@@ -1625,7 +1626,7 @@ TEST_F(PortMmapTest, mmap_test10)
 
 	/* try to write to region that was set to read only */
 	if (!omrsig_can_protect(signalHandlerFlags)) {
-		outputComment(OMRPORTLIB, "Signal handling framework not available, can't test readonly functionality without crashing, bypassing test");
+		portTestEnv->log(LEVEL_ERROR, "Signal handling framework not available, can't test readonly functionality without crashing, bypassing test");
 		goto exit;
 	} else {
 
@@ -1635,7 +1636,7 @@ TEST_F(PortMmapTest, mmap_test10)
 		writerInfo.shouldCrash = 1;
 		writerInfo.address = mapAddr + 30;
 
-		outputComment(OMRPORTLIB, "Writing to readonly region - we should crash\n");
+		portTestEnv->log("Writing to readonly region - we should crash\n");
 		protectResult = omrsig_protect(protectedWriter, &writerInfo, simpleHandlerFunction, &handlerInfo, signalHandlerFlags, &result);
 
 		if (protectResult == OMRPORT_SIG_EXCEPTION_OCCURRED) {
@@ -1647,7 +1648,7 @@ TEST_F(PortMmapTest, mmap_test10)
 
 	/* try to write to region that is still writable */
 	if (!omrsig_can_protect(signalHandlerFlags)) {
-		outputComment(OMRPORTLIB, "Signal handling framework not available, can't test readonly functionality without crashing, bypassing test");
+		portTestEnv->log(LEVEL_ERROR, "Signal handling framework not available, can't test readonly functionality without crashing, bypassing test");
 		goto exit;
 	} else {
 
@@ -1657,7 +1658,7 @@ TEST_F(PortMmapTest, mmap_test10)
 		writerInfo.address = mapAddr + pageSize;
 		writerInfo.shouldCrash = 0;
 
-		outputComment(OMRPORTLIB, "Writing to page two region - should be ok\n");
+		portTestEnv->log("Writing to page two region - should be ok\n");
 		protectResult = omrsig_protect(protectedWriter, &writerInfo, simpleHandlerFunction, &handlerInfo, signalHandlerFlags, &result);
 
 		if (protectResult == OMRPORT_SIG_EXCEPTION_OCCURRED) {
@@ -1737,18 +1738,18 @@ TEST_F(PortMmapTest, mmap_test11)
 	reportTestEntry(OMRPORTLIB, testName);
 
 	if ((mmapCapabilities & OMRPORT_MMAP_CAPABILITY_PROTECT) == 0) {
-		outputComment(OMRPORTLIB, "OMRPORT_MMAP_CAPABILITY_PROTECT not supported on this platform, bypassing test\n");
+		portTestEnv->log(LEVEL_ERROR, "OMRPORT_MMAP_CAPABILITY_PROTECT not supported on this platform, bypassing test\n");
 		goto exit;
 	}
 
 	if ((mmapCapabilities & OMRPORT_MMAP_CAPABILITY_WRITE) == 0) {
-		outputComment(OMRPORTLIB, "OMRPORT_MMAP_CAPABILITY_WRITE not supported on this platform, bypassing test\n");
+		portTestEnv->log(LEVEL_ERROR, "OMRPORT_MMAP_CAPABILITY_WRITE not supported on this platform, bypassing test\n");
 		goto exit;
 	}
 
 	/* How big do pages claim to be? */
 	pageSize = omrmmap_get_region_granularity(mapAddr);
-	outputComment(OMRPORTLIB, "Page size is reported as %d\n", pageSize);
+	portTestEnv->log("Page size is reported as %d\n", pageSize);
 	/* Initialize buffer to be written - 128 chars with a string right in the middle */
 	for (i = 0; i < 128 ; i++) {
 		buffer[i] = (char)i;
@@ -1778,7 +1779,7 @@ TEST_F(PortMmapTest, mmap_test11)
 		}
 		i += bufferSize;
 	}
-	outputComment(OMRPORTLIB, "Written out the buffer %d times to fill three pages\n", i / bufferSize);
+	portTestEnv->log("Written out the buffer %d times to fill three pages\n", i / bufferSize);
 
 	rc = omrfile_close(fd);
 	if (-1 == rc) {
@@ -1816,13 +1817,13 @@ TEST_F(PortMmapTest, mmap_test11)
 	}
 	mapAddr = (char *)mmapHandle->pointer;
 
-	outputComment(OMRPORTLIB, "File mapped at location %d\n", mapAddr);
-	outputComment(OMRPORTLIB, "Protecting first page 4k into that address\n");
+	portTestEnv->log("File mapped at location %d\n", mapAddr);
+	portTestEnv->log("Protecting first page 4k into that address\n");
 	/* set the region to read only */
 	rc = omrmmap_protect(mapAddr + pageSize, pageSize, OMRPORT_PAGE_PROTECT_READ);
 	if (rc != 0) {
 		if (rc == OMRPORT_PAGE_PROTECT_NOT_SUPPORTED) {
-			outputComment(OMRPORTLIB, "OMRPORT_MMAP_CAPABILITY_PROTECT not supported on this platform, bypassing test\n");
+			portTestEnv->log(LEVEL_ERROR, "OMRPORT_MMAP_CAPABILITY_PROTECT not supported on this platform, bypassing test\n");
 		} else {
 			lastErrorMessage = (char *)omrerror_last_error_message();
 			lastErrorNumber = omrerror_last_error_number();
@@ -1842,7 +1843,7 @@ TEST_F(PortMmapTest, mmap_test11)
 
 	/* try to write to region that was set to read only */
 	if (!omrsig_can_protect(signalHandlerFlags)) {
-		outputComment(OMRPORTLIB, "Signal handling framework not available, can't test readonly functionality without crashing, bypassing test");
+		portTestEnv->log(LEVEL_ERROR, "Signal handling framework not available, can't test readonly functionality without crashing, bypassing test");
 		goto exit;
 	} else {
 
@@ -1852,7 +1853,7 @@ TEST_F(PortMmapTest, mmap_test11)
 		writerInfo.shouldCrash = 1;
 		writerInfo.address = mapAddr + 30 + pageSize;
 
-		outputComment(OMRPORTLIB, "Writing to readonly region - we should crash\n");
+		portTestEnv->log("Writing to readonly region - we should crash\n");
 		protectResult = omrsig_protect(protectedWriter, &writerInfo, simpleHandlerFunction, &handlerInfo, signalHandlerFlags, &result);
 
 		if (protectResult == OMRPORT_SIG_EXCEPTION_OCCURRED) {
@@ -1864,7 +1865,7 @@ TEST_F(PortMmapTest, mmap_test11)
 
 	/* try to write to region that is still writable */
 	if (!omrsig_can_protect(signalHandlerFlags)) {
-		outputComment(OMRPORTLIB, "Signal handling framework not available, can't test readonly functionality without crashing, bypassing test");
+		portTestEnv->log(LEVEL_ERROR, "Signal handling framework not available, can't test readonly functionality without crashing, bypassing test");
 		goto exit;
 	} else {
 
@@ -1874,7 +1875,7 @@ TEST_F(PortMmapTest, mmap_test11)
 		writerInfo.address = mapAddr + (2 * pageSize);
 		writerInfo.shouldCrash = 0;
 
-		outputComment(OMRPORTLIB, "Writing to page two region - should be ok\n");
+		portTestEnv->log("Writing to page two region - should be ok\n");
 		protectResult = omrsig_protect(protectedWriter, &writerInfo, simpleHandlerFunction, &handlerInfo, signalHandlerFlags, &result);
 
 		if (protectResult == OMRPORT_SIG_EXCEPTION_OCCURRED) {

--- a/fvtest/porttest/omrsignalTest.cpp
+++ b/fvtest/porttest/omrsignalTest.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2015
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -135,7 +135,7 @@ injectUnixSignal(struct OMRPortLibrary *portLibrary, int pid, int unixSignal)
 	/* this is run by the child process. To see the tty_printf output on the console, set OMRPORT_PROCESS_INHERIT_STDOUT | OMRPORT_PROCESS_INHERIT_STDIN
 	 * in the options passed into j9process_create() in launchChildProcess (in testProcessHelpers.c).
 	 */
-	omrtty_printf("\t\tCHILD:	 calling kill: %i %i\n", pid, unixSignal);
+	portTestEnv->log("\t\tCHILD:	 calling kill: %i %i\n", pid, unixSignal);
 	kill(pid, unixSignal);
 	return;
 }
@@ -609,7 +609,7 @@ TEST(PortSigTest, sig_test0)
 		/* z/OS does not always support this, however, pltest should never be run under a configuration that does not support it.
 		 * See implementation of omrsig_can_proctect() and omrsig_startup()
 		 */
-		omrtty_printf("OMRPORT_SIG_FLAG_MAY_CONTINUE_EXECUTION is not supported if the default settings for TRAP(ON,SPIE) have been changed. The should both be set to 1\n");
+		portTestEnv->log("OMRPORT_SIG_FLAG_MAY_CONTINUE_EXECUTION is not supported if the default settings for TRAP(ON,SPIE) have been changed. The should both be set to 1\n");
 #endif
 	}
 
@@ -617,7 +617,7 @@ TEST(PortSigTest, sig_test0)
 	if (!omrsig_can_protect(OMRPORT_SIG_FLAG_MAY_RETURN | OMRPORT_SIG_FLAG_MAY_CONTINUE_EXECUTION)) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "portLibrary->can_protect() must always support 0 | OMRPORT_SIG_FLAG_MAY_RETURN | OMRPORT_SIG_FLAG_MAY_CONTINUE_EXECUTION\n");
 # if defined(J9ZOS390)
-		omrtty_printf("OMRPORT_SIG_FLAG_MAY_CONTINUE_EXECUTION is not supported if the default settings for TRAP(ON,SPIE) have been changed. The should both be set to 1\n");
+		portTestEnv->log("OMRPORT_SIG_FLAG_MAY_CONTINUE_EXECUTION is not supported if the default settings for TRAP(ON,SPIE) have been changed. The should both be set to 1\n");
 #endif
 
 	}
@@ -934,7 +934,7 @@ TEST(PortSigTest, sig_test6)
 			int signo = (int)(uintptr_t)omrthread_tls_get(omrthread_self(), tlsKeyCurrentSignal);
 			int expectedSigno = 0;
 
-			omrtty_printf("\n testing current signal\n");
+			portTestEnv->log("\n testing current signal\n");
 			if (signo != expectedSigno) {
 				outputErrorMessage(PORTTEST_ERROR_ARGS, "currentSignal corrupt -- got: %d expected: %d\n", signo, expectedSigno);
 			}
@@ -1104,7 +1104,7 @@ TEST(PortSigTest, sig_test_async_unix_handler)
 	int pid = getpid();
 
 	reportTestEntry(OMRPORTLIB, testName);
-	omrtty_printf("\tpid: %i\n", pid);
+	portTestEnv->log("\tpid: %i\n", pid);
 
 	handlerInfo.testName = testName;
 
@@ -1140,7 +1140,7 @@ TEST(PortSigTest, sig_test_async_unix_handler)
 		handlerInfo.expectedType = testSignalMap[index].portLibSignalNo;
 
 
-		omrtty_printf("\n\tTesting %s\n", testSignalMap[index].unixSignalString);
+		portTestEnv->log("\n\tTesting %s\n", testSignalMap[index].unixSignalString);
 
 		/* asyncTestHandler notifies the monitor once it has set controlFlag to 0; */
 		omrthread_monitor_enter(asyncMonitor);
@@ -1176,7 +1176,7 @@ TEST(PortSigTest, sig_test_async_unix_handler)
 
 		/* build the pid and signal number in the form "-child_omrsig_injectSignal_<PID>_<signal>" */
 		omrstr_printf(options, SIG_TEST_SIZE_EXENAME, "-child_omrsig_injectSignal_%i_%i", pid, signum);
-		omrtty_printf("\t\tlaunching child process with arg %s\n", options);
+		portTestEnv->log("\t\tlaunching child process with arg %s\n", options);
 
 		omrthread_monitor_enter(asyncMonitor);
 
@@ -1206,12 +1206,12 @@ TEST(PortSigTest, sig_test_async_unix_handler)
 		 * We will mask the signal on this thread, inject it via kill, and verify that it does
 		 * not get received.
 		 */
-		omrtty_printf("\t\tmasking signal %i on this thread\n", signum);
+		portTestEnv->log("\t\tmasking signal %i on this thread\n", signum);
 		sighold(signum);
 
 		/* build the pid and signal number in the form "-child_omrsig_injectSignal_<PID>_<signal>_unhandled" */
 		omrstr_printf(options, SIG_TEST_SIZE_EXENAME, "-child_omrsig_injectSignal_%i_%i_unhandled", pid, signum);
-		omrtty_printf("\t\tlaunching child process with arg %s\n", options);
+		portTestEnv->log("\t\tlaunching child process with arg %s\n", options);
 
 		omrthread_monitor_enter(asyncMonitor);
 		handlerInfo.controlFlag = 0;
@@ -1234,7 +1234,7 @@ TEST(PortSigTest, sig_test_async_unix_handler)
 		}
 
 		/* unblock the signal and handle it */
-		omrtty_printf("\t\tunmasking signal %i on this thread\n", signum);
+		portTestEnv->log("\t\tunmasking signal %i on this thread\n", signum);
 		sigrelse(signum);
 		(void)omrthread_monitor_wait_timed(asyncMonitor, 20000, 0);
 		if (1 != handlerInfo.controlFlag) {

--- a/fvtest/porttest/omrsignalTest.cpp
+++ b/fvtest/porttest/omrsignalTest.cpp
@@ -115,12 +115,13 @@ asyncTestHandler(struct OMRPortLibrary *portLibrary, uint32_t gpType, void *hand
 	omrthread_monitor_t monitor = *(info->monitor);
 
 	omrthread_monitor_enter(monitor);
-
-	outputComment(OMRPORTLIB, "\t\tasyncTestHandler invoked (type = 0x%x)\n", gpType);
+	portTestEnv->changeIndent(2);
+	portTestEnv->log("asyncTestHandler invoked (type = 0x%x)\n", gpType);
 	if (info->expectedType != gpType) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "asyncTestHandler -- incorrect type. Expecting 0x%x, got 0x%x\n", info->expectedType, gpType);
 	}
 
+	portTestEnv->changeIndent(-2);
 	info->controlFlag = 1;
 	omrthread_monitor_notify(monitor);
 	omrthread_monitor_exit(monitor);
@@ -237,23 +238,23 @@ validateGPInfo(struct OMRPortLibrary *portLibrary, uint32_t gpType, omrsig_handl
 
 			switch (infoKind) {
 			case OMRPORT_SIG_VALUE_16:
-				outputComment(OMRPORTLIB, "info %u:%u: %s=%04X\n", category, index, name, *(U_16 *)value);
+				portTestEnv->log("info %u:%u: %s=%04X\n", category, index, name, *(U_16 *)value);
 				break;
 			case OMRPORT_SIG_VALUE_32:
-				outputComment(OMRPORTLIB, "info %u:%u: %s=%08.8x\n", category, index, name, *(uint32_t *)value);
+				portTestEnv->log("info %u:%u: %s=%08.8x\n", category, index, name, *(uint32_t *)value);
 				break;
 			case OMRPORT_SIG_VALUE_64:
-				outputComment(OMRPORTLIB, "info %u:%u: %s=%016.16llx\n", category, index, name, *(uint64_t *)value);
+				portTestEnv->log("info %u:%u: %s=%016.16llx\n", category, index, name, *(uint64_t *)value);
 				break;
 			case OMRPORT_SIG_VALUE_STRING:
-				outputComment(OMRPORTLIB, "info %u:%u: %s=%s\n", category, index, name, (const char *)value);
+				portTestEnv->log("info %u:%u: %s=%s\n", category, index, name, (const char *)value);
 				break;
 			case OMRPORT_SIG_VALUE_ADDRESS:
-				outputComment(OMRPORTLIB, "info %u:%u: %s=%p\n", category, index, name, *(void **)value);
+				portTestEnv->log("info %u:%u: %s=%p\n", category, index, name, *(void **)value);
 				break;
 			case OMRPORT_SIG_VALUE_FLOAT_64:
 				/* make sure when casting to a float that we get least significant 32-bits. */
-				outputComment(OMRPORTLIB,
+				portTestEnv->log(
 							  "info %u:%u: %s=%016.16llx (f: %f, d: %e)\n",
 							  category, index, name,
 							  *(uint64_t *)value, (float)LOW_U32_FROM_DBL_PTR(value), *(double *)value);
@@ -264,7 +265,7 @@ validateGPInfo(struct OMRPortLibrary *portLibrary, uint32_t gpType, omrsig_handl
 						const uint64_t h = v->high64;
 						const uint64_t l = v->low64;
 
-						outputComment(OMRPORTLIB, "info %u:%u: %s=%016.16llx%016.16llx\n", category, index, name, h, l);
+						portTestEnv->log("info %u:%u: %s=%016.16llx%016.16llx\n", category, index, name, h, l);
 					}
 				break;
 			case OMRPORT_SIG_VALUE_UNDEFINED:
@@ -385,7 +386,7 @@ simpleHandlerFunction(struct OMRPortLibrary *portLibrary, uint32_t gpType, void 
 	SigProtectHandlerInfo *info = (SigProtectHandlerInfo *)handler_arg;
 	const char *testName = info->testName;
 
-	outputComment(OMRPORTLIB, "simpleHandlerFunction invoked (type = 0x%x)\n", gpType);
+	portTestEnv->log("simpleHandlerFunction invoked (type = 0x%x)\n", gpType);
 
 	if (info->expectedType != gpType) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "simpleHandlerFunction -- incorrect type. Expecting 0x%x, got 0x%x\n", info->expectedType, gpType);
@@ -421,7 +422,7 @@ crashingHandlerFunction(struct OMRPortLibrary *portLibrary, uint32_t gpType, voi
 	const char *testName = (const char *)handler_arg;
 	static int recursive = 0;
 
-	outputComment(OMRPORTLIB, "crashingHandlerFunction invoked (type = 0x%x)\n", gpType);
+	portTestEnv->log("crashingHandlerFunction invoked (type = 0x%x)\n", gpType);
 
 	if (recursive++) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "handler invoked recursively\n");
@@ -1061,7 +1062,7 @@ TEST(PortSigTest, sig_test8)
 							simpleHandlerFunction, &handlerInfo,
 							flags,
 							&result);
-		outputComment(OMRPORTLIB, "omrsig_test8 protectResult=%d\n", protectResult);
+		portTestEnv->log("omrsig_test8 protectResult=%d\n", protectResult);
 #if defined(WIN64)
 		if (protectResult != OMRPORT_SIG_EXCEPTION_CONTINUE_SEARCH) {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "portLibrary->sig_protect -- expected OMRPORT_SIG_EXCEPTION_CONTINUE_SEARCH in protectResult\n");

--- a/fvtest/porttest/omrslTest.cpp
+++ b/fvtest/porttest/omrslTest.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2016
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -221,7 +221,7 @@ TEST(PortSlTest, sl_AixDLLMissingDependency)
 	}
 
 	osErrMsg = omrerror_last_error_message();
-	outputComment(OMRPORTLIB, "System error message=\n\"%s\"\n", osErrMsg);
+	portTestEnv->log(LEVEL_ERROR, "System error message=\n\"%s\"\n", osErrMsg);
 	if (!isValidLoadErrorMessage(osErrMsg, possibleMessageStrings)) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, " Cannot find valid error code, should have failed with dependency error\n", sharedLibName, omrerror_last_error_message());
 	}
@@ -259,7 +259,7 @@ TEST(PortSlTest, sl_AixDLLWrongPlatform)
 	}
 
 	osErrMsg = omrerror_last_error_message();
-	outputComment(OMRPORTLIB, "System error message=\n\"%s\"\n", osErrMsg);
+	portTestEnv->log(LEVEL_ERROR, "System error message=\n\"%s\"\n", osErrMsg);
 	if (!isValidLoadErrorMessage(osErrMsg, possibleMessageStrings)) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "Cannot find valid error code, should have failed with wrong platform error\n", sharedLibName, omrerror_last_error_message());
 	}

--- a/fvtest/porttest/omrstrTest.cpp
+++ b/fvtest/porttest/omrstrTest.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2016
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -518,7 +518,7 @@ TEST(PortStrTest, str_test3)
 	reportTestEntry(OMRPORTLIB, testName);
 
 	/* First test: The epoch */
-	omrtty_printf("\t This test could fail if you abut the international dateline (westside of dateline)\n");
+	portTestEnv->log("\t This test could fail if you abut the international dateline (westside of dateline)\n");
 	timeMillis = 0;
 	strncpy(expected, "1970 01 Jan 01 XX:00:00", J9STR_BUFFER_SIZE);
 	test_omrstr_ftime(OMRPORTLIB, testName, buf, J9STR_BUFFER_SIZE, "%Y %m %b %d XX:%M:%S", timeMillis, expected);
@@ -580,7 +580,7 @@ TEST(PortStrTest, str_test4)
 	/* February 29th, 2004, 12:00:00, UTC */
 	timeMillis = J9CONST64(1078056000000);
 
-	omrtty_printf("\t This test will fail if you abut the international dateline\n");
+	portTestEnv->log("\t This test will fail if you abut the international dateline\n");
 	tokens = omrstr_create_tokens(timeMillis);
 	omrstr_set_token(tokens, "longtkn", "Long Token Value");
 	omrstr_set_token(tokens, "yyy", "nope nope nope");
@@ -733,49 +733,49 @@ TEST(PortStrTest, str_test5)
 
 	reportTestEntry(OMRPORTLIB, testName);
 
-	omrtty_printf("\n\tThe results of omrstr_test5 are not evaluated as time conversions are specific to a time zone.\n");
-	omrtty_printf("\tTherefore, this is for your viewing pleasure only.\n");
+	portTestEnv->log("\n\tThe results of omrstr_test5 are not evaluated as time conversions are specific to a time zone.\n");
+	portTestEnv->log("\tTherefore, this is for your viewing pleasure only.\n");
 
 	timeMillis = omrtime_current_time_millis();
-	omrtty_printf("\n\tomrtime_current_time_millis returned: %lli\n", timeMillis);
-	omrtty_printf("\t...creating and substituting tokens...\n");
+	portTestEnv->log("\n\tomrtime_current_time_millis returned: %lli\n", timeMillis);
+	portTestEnv->log("\t...creating and substituting tokens...\n");
 	tokens = omrstr_create_tokens(timeMillis);
 	(void)omrstr_subst_tokens(buf, TEST_BUF_LEN, "%Y/%m/%d %H:%M:%S", tokens);
-	omrtty_printf("\tThe current time was converted to: %s\n", buf);
+	portTestEnv->log("\tThe current time was converted to: %s\n", buf);
 
 	timeMillis = J9CONST64(1139952606740);
-	omrtty_printf("\n\t using UTC timeMillis = %lli. \n\t", timeMillis);
-	omrtty_printf("\t...creating and substituting tokens...\n");
+	portTestEnv->log("\n\t using UTC timeMillis = %lli. \n\t", timeMillis);
+	portTestEnv->log("\t...creating and substituting tokens...\n");
 	tokens = omrstr_create_tokens(timeMillis);
 	(void)omrstr_subst_tokens(buf, TEST_BUF_LEN, "%Y/%m/%d %H:%M:%S", tokens);
-	omrtty_printf("\tExpecting local time (in Ottawa, Eastern Standard Time): 2006/02/14 16:30:06 \n", timeMillis);
-	omrtty_printf("\t                                       ... converted to: %s\n", buf);
+	portTestEnv->log("\tExpecting local time (in Ottawa, Eastern Standard Time): 2006/02/14 16:30:06 \n", timeMillis);
+	portTestEnv->log("\t                                       ... converted to: %s\n", buf);
 
 	timeMillis = J9CONST64(1150320606740);
-	omrtty_printf("\n\t using UTC timeMillis = %lli. \n\t ", timeMillis);
-	omrtty_printf("\t...creating and substituting tokens...\n");
+	portTestEnv->log("\n\t using UTC timeMillis = %lli. \n\t ", timeMillis);
+	portTestEnv->log("\t...creating and substituting tokens...\n");
 	tokens = omrstr_create_tokens(timeMillis);
 	(void)omrstr_subst_tokens(buf, TEST_BUF_LEN, "%Y/%m/%d %H:%M:%S", tokens);
-	omrtty_printf("\tExpecting local time (in Ottawa, Eastern Daylight Time): 2006/06/14 17:30:06 \n", timeMillis);
-	omrtty_printf("\t                                       ... converted to: %s\n", buf);
+	portTestEnv->log("\tExpecting local time (in Ottawa, Eastern Daylight Time): 2006/06/14 17:30:06 \n", timeMillis);
+	portTestEnv->log("\t                                       ... converted to: %s\n", buf);
 
 	timeMillis = J9CONST64(1160688606740);
-	omrtty_printf("\n\t using UTC timeMillis = %lli. \n\t ", timeMillis);
-	omrtty_printf("\t...creating and substituting tokens...\n");
+	portTestEnv->log("\n\t using UTC timeMillis = %lli. \n\t ", timeMillis);
+	portTestEnv->log("\t...creating and substituting tokens...\n");
 	tokens = omrstr_create_tokens(timeMillis);
 	(void)omrstr_subst_tokens(buf, TEST_BUF_LEN, "%Y/%m/%d %H:%M:%S", tokens);
-	omrtty_printf("\tExpecting local time (in Ottawa, Eastern Daylight Time): 2006/10/12 17:30:06 \n", timeMillis);
-	omrtty_printf("\t                                       ... converted to: %s\n", buf);
+	portTestEnv->log("\tExpecting local time (in Ottawa, Eastern Daylight Time): 2006/10/12 17:30:06 \n", timeMillis);
+	portTestEnv->log("\t                                       ... converted to: %s\n", buf);
 
 	timeMillis = J9CONST64(1165872606740);
-	omrtty_printf("\n\t using UTC timeMillis = %lli. \n\t", timeMillis);
-	omrtty_printf("\t...creating and substituting tokens...\n");
+	portTestEnv->log("\n\t using UTC timeMillis = %lli. \n\t", timeMillis);
+	portTestEnv->log("\t...creating and substituting tokens...\n");
 	tokens = omrstr_create_tokens(timeMillis);
 	(void)omrstr_subst_tokens(buf, TEST_BUF_LEN, "%Y/%m/%d %H:%M:%S", tokens);
-	omrtty_printf("\tExpecting local time (in Ottawa, Eastern Standard Time): 2006/12/11 16:30:06 \n", timeMillis);
-	omrtty_printf("\t                                       ... converted to: %s\n", buf);
+	portTestEnv->log("\tExpecting local time (in Ottawa, Eastern Standard Time): 2006/12/11 16:30:06 \n", timeMillis);
+	portTestEnv->log("\t                                       ... converted to: %s\n", buf);
 
-	omrtty_printf("\n");
+	portTestEnv->log("\n");
 	reportTestExit(OMRPORTLIB, testName);
 }
 
@@ -1293,21 +1293,21 @@ TEST(PortStrTest, str_convRoundTrip)
 		++codePoint;
 		++numCodePoints;
 	}
-	omrtty_printf("Testing %d code points\n", numCodePoints);
+	portTestEnv->log("Testing %d code points\n", numCodePoints);
 
 	convertedStringLength = omrstr_convert(J9STR_CODE_WIDE, J9STR_CODE_MUTF8,
 										   (char *)unicodeData, 2 * numCodePoints, (char *)mutf8Buffer, bufferSize);
 	if (convertedStringLength < 0) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "unicode to MUTF8 test failed: %d", convertedStringLength);
 	}
-	omrtty_printf("mutf string length = %d\n", convertedStringLength);
+	portTestEnv->log("mutf string length = %d\n", convertedStringLength);
 
 	convertedStringLength = omrstr_convert(J9STR_CODE_MUTF8, J9STR_CODE_WIDE,
 										   (char *)mutf8Buffer, convertedStringLength, (char *)unicodeResult, bufferSize);
 	if (convertedStringLength < 0) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "MUTF8 to  unicode test failed: %d", convertedStringLength);
 	}
-	omrtty_printf("mutf string length = %d\n", convertedStringLength);
+	portTestEnv->log("mutf string length = %d\n", convertedStringLength);
 	if (!compareBytes((char *)unicodeData, (char *)unicodeResult, 2 * numCodePoints)) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "Converted string wrong.");
 	}
@@ -1406,7 +1406,7 @@ TEST(PortStrTest, str_WinacpToMutf8)
 	{
 		uint32_t defaultACP = GetACP();
 		if (1252 != defaultACP) {
-			omrtty_printf("Default ANSI code page = %d, expecting 1252.  Skipping test.\n", defaultACP);
+			portTestEnv->log("Default ANSI code page = %d, expecting 1252.  Skipping test.\n", defaultACP);
 			reportTestExit(OMRPORTLIB, testName);
 		}
 	}
@@ -1456,22 +1456,22 @@ printToBuffer(struct OMRPortLibrary *portLibrary, BOOLEAN precision, char *buffe
 
 	if (stringLength >= 0) {
 		if (precision) {
-			omrtty_printf("\n\tFinish Testing: String in buffer is: \"%s\", length = %d\n", buffer, stringLength);
+			portTestEnv->log("\n\tFinish Testing: String in buffer is: \"%s\", length = %d\n", buffer, stringLength);
 		} else {
-			omrtty_printf("\n\tFinish Testing without precision specifier: String in buffer is: \"%s\", length = %d\n", buffer, stringLength);
+			portTestEnv->log("\n\tFinish Testing without precision specifier: String in buffer is: \"%s\", length = %d\n", buffer, stringLength);
 		}
 
 		if ((stringLength == strlen(expectedOutput))
 			&& (0 == memcmp(buffer, expectedOutput, stringLength))
 		) {
-			omrtty_printf("\n\tComparing against the expected output: PASSED.\n");
+			portTestEnv->log("\n\tComparing against the expected output: PASSED.\n");
 			return TEST_PASS;
 		} else {
-			omrtty_printf("\n\tComparing against the expected output: FAILED. Expected string: \"%s\", length = %d\n", expectedOutput, strlen(expectedOutput));
+			portTestEnv->log(LEVEL_ERROR, "\n\tComparing against the expected output: FAILED. Expected string: \"%s\", length = %d\n", expectedOutput, strlen(expectedOutput));
 			return TEST_FAIL;
 		}
 	} else {
-		omrtty_printf("\n\tComparing against the expected output: FAILED. stringLength < 0, Expected string: \"%s\", length = %d\n", expectedOutput, strlen(expectedOutput));
+		portTestEnv->log(LEVEL_ERROR, "\n\tComparing against the expected output: FAILED. stringLength < 0, Expected string: \"%s\", length = %d\n", expectedOutput, strlen(expectedOutput));
 	}
 }
 
@@ -1502,42 +1502,42 @@ TEST(PortStrTest, str_test_atoe_vsnprintf)
 	reportTestEntry(OMRPORTLIB, testName);
 
 	/* Neither min_width nor precision is specified for a null terminated input string*/
-	omrtty_printf("\n\tTesting case 1\n");
+	portTestEnv->log("\n\tTesting case 1\n");
 	rc |= printToBuffer(OMRPORTLIB, TRUE, buffer0, bufferLength0, expectedOutput1, "%s", nullTerminatedString);
 
 	/* min_width is less than the length of inputString */
-	omrtty_printf("\n\tTesting case 2\n");
+	portTestEnv->log("\n\tTesting case 2\n");
 	rc |= printToBuffer(OMRPORTLIB, FALSE, buffer2, bufferLength2, expectedOutput2, "%*s", 2, nonNullTerminatedString);
 
 	/* min_width is equal to the length of inputString (buffer length > min_width) */
-	omrtty_printf("\n\tTesting case 3\n");
+	portTestEnv->log("\n\tTesting case 3\n");
 	rc |= printToBuffer(OMRPORTLIB, FALSE, buffer1, bufferLength1, expectedOutput1, "%*s", 4, nullTerminatedString);
 
 	/* min_width is greater than the length of inputString (buffer length > min_width) */
-	omrtty_printf("\n\tTesting case 4\n");
+	portTestEnv->log("\n\tTesting case 4\n");
 	rc |= printToBuffer(OMRPORTLIB, FALSE, buffer3, bufferLength3, expectedOutput3, "%*s", 10, nullTerminatedString);
 
 	/* precision is equal to the length of inputString */
-	omrtty_printf("\n\tTesting case 5\n");
+	portTestEnv->log("\n\tTesting case 5\n");
 	rc |= printToBuffer(OMRPORTLIB, TRUE, buffer0, bufferLength0, expectedOutput1, "%.*s", 4, nonNullTerminatedString);
 
 	/* precision is less than the length of inputString */
-	omrtty_printf("\n\tTesting case 6\n");
+	portTestEnv->log("\n\tTesting case 6\n");
 	rc |= printToBuffer(OMRPORTLIB, TRUE, buffer0, bufferLength0, expectedOutput4, "%.*s", 2, nonNullTerminatedString);
 
 	/* both min_width and precision are equal to the length of inputString */
-	omrtty_printf("\n\tTesting case 7\n");
+	portTestEnv->log("\n\tTesting case 7\n");
 	rc |= printToBuffer(OMRPORTLIB, TRUE, buffer0, bufferLength0, expectedOutput1, "%*.*s", 4, 4, nonNullTerminatedString);
 
 	/* the length of inputString is equal to precision but less than min_width */
-	omrtty_printf("\n\tTesting case 8\n");
+	portTestEnv->log("\n\tTesting case 8\n");
 	rc |= printToBuffer(OMRPORTLIB, TRUE, buffer0, bufferLength0, expectedOutput3, "%*.*s", 10, 4, nonNullTerminatedString);
 
 	if (TEST_PASS != rc) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "\n\tTEST FAILED.\n");
 	}
 
-	omrtty_printf("\n");
+	portTestEnv->log("\n");
 	reportTestExit(OMRPORTLIB, testName);
 }
 #endif /* defined(J9ZOS390) */

--- a/fvtest/porttest/omrtimeTest.cpp
+++ b/fvtest/porttest/omrtimeTest.cpp
@@ -305,7 +305,7 @@ TEST(PortTimeTest, time_test3)
 	if (1 == omrsysinfo_get_number_CPUs_by_type(OMRPORT_CPU_ONLINE)) {
 		/* one CPU means we have no chance of falling into the "difference CPUs have different times" trap.  Let the test begin */
 		/*let's test the others vs current_time_millis*/
-		outputComment(OMRPORTLIB, "%10s %10s %10s %10s %12s %12s\n", "millires", "millis", "msec", "usec", "hires msec ", "hires usec");
+		portTestEnv->log("%10s %10s %10s %10s %12s %12s\n", "millires", "millis", "msec", "usec", "hires msec ", "hires usec");
 		for (i = 0; i < J9TIME_REPEAT_TEST; i++) {
 			uintptr_t failed = 0;
 			uintptr_t success = 0;
@@ -352,19 +352,19 @@ TEST(PortTimeTest, time_test3)
 			utimeDelta = utimeStop - utimeStart;
 			timeDelta = newTime - oldTime;
 
-			outputComment(OMRPORTLIB, "%10d %10d %10d %10d %12d %12d %12d\n",
+			portTestEnv->log("%10d %10d %10d %10d %12d %12d %12d\n",
 						  millires, (int32_t)timeDelta, (int32_t)mtimeDelta, (int32_t)utimeDelta, (int32_t)ntimeDelta, (int32_t)hiresDeltaAsMillis, (int32_t)hiresDeltaAsMicros);
 
 			hiresDeltaAsMillis = hiresDeltaAsMillis > mtimeDelta ? hiresDeltaAsMillis - mtimeDelta : mtimeDelta - hiresDeltaAsMillis;
 			if (hiresDeltaAsMillis > (0.1 * mtimeDelta)) {
-				outputComment(OMRPORTLIB, "\n");
+				portTestEnv->log("\n");
 				outputErrorMessage(PORTTEST_ERROR_ARGS, "omrtime_hires_clock() drift greater than 10%%\n");
 				failed = 1;
 			}
 			
 			ntimeDeltaAsMillis = ntimeDeltaAsMillis > mtimeDelta ? ntimeDeltaAsMillis - mtimeDelta : mtimeDelta - ntimeDeltaAsMillis;
 			if (ntimeDeltaAsMillis > (0.1 * mtimeDelta)) {
-				outputComment(OMRPORTLIB, "\n");
+				portTestEnv->log("\n");
 				outputErrorMessage(PORTTEST_ERROR_ARGS, "omrtime_current_time_nanos() drift greater than 10%%\n");
 				failed = 1;
 			}
@@ -375,9 +375,9 @@ TEST(PortTimeTest, time_test3)
 	} else {
 		/* test is invalid since this is a multi-way machine:  if we get the time on one CPU, then get rescheduled on a different one where we ask for the time,
 		 * there is no reason why the time values need to be monotonically increasing */
-		outputComment(OMRPORTLIB, "Test is invalid since the host machine reports more than one CPU (time may differ across CPUs - makes test results useless - re-enable if we develop thread affinity support)\n");
+		portTestEnv->log(LEVEL_ERROR, "Test is invalid since the host machine reports more than one CPU (time may differ across CPUs - makes test results useless - re-enable if we develop thread affinity support)\n");
 	}
-	outputComment(OMRPORTLIB, "\n");
+	portTestEnv->log("\n");
 
 	reportTestExit(OMRPORTLIB, testName);
 }
@@ -435,21 +435,23 @@ TEST(DISABLED_PortTimeTest, time_test4)
 	uint64_t milliStartInner, milliEndInner, milliDeltaInner;
 	uint64_t delta;
 
-	outputComment(OMRPORTLIB, "\nRunning time test with:\n");
-	outputComment(OMRPORTLIB, "  SLEEP_TIME = %u\n", SLEEP_TIME);
-	outputComment(OMRPORTLIB, "  EPSILON = %u\n", EPSILON);
-	outputComment(OMRPORTLIB, "  NUMBER_OF_ITERATIONS = %u\n", NUMBER_OF_ITERATIONS);
+	portTestEnv->changeIndent(1);
+	portTestEnv->log("\nRunning time test with:\n");
+	portTestEnv->log("SLEEP_TIME = %u\n", SLEEP_TIME);
+	portTestEnv->log("EPSILON = %u\n", EPSILON);
+	portTestEnv->log("NUMBER_OF_ITERATIONS = %u\n", NUMBER_OF_ITERATIONS);
+	portTestEnv->changeIndent(-1);
 
 	for (i = 0; i < NUMBER_OF_ITERATIONS; i++) {
 
-		outputComment(OMRPORTLIB, "\nIteration %u:\n", i);
+		portTestEnv->log("\nIteration %u:\n", i);
 
 		milliStartOuter = omrtime_current_time_millis();
 		nanoStart = portGetNanos(OMRPORTLIB);
 		milliStartInner = omrtime_current_time_millis();
 
 		if (0 != omrthread_sleep(SLEEP_TIME)) {
-			outputComment(OMRPORTLIB, "WARNING: Skipping check due to omrthread_sleep() returning non-zero.\n");
+			portTestEnv->log(LEVEL_WARN, "WARNING: Skipping check due to omrthread_sleep() returning non-zero.\n");
 			continue;
 		}
 
@@ -461,24 +463,24 @@ TEST(DISABLED_PortTimeTest, time_test4)
 		nanoDeltaInMillis = (nanoEnd - nanoStart) / 1000000;
 		milliDeltaOuter = milliEndOuter - milliStartOuter;
 
-		outputComment(OMRPORTLIB, "milliStartOuter = %llu\n", milliStartOuter);
-		outputComment(OMRPORTLIB, "nanoStart = %llu\n", nanoStart);
-		outputComment(OMRPORTLIB, "milliStartInner = %llu\n", milliStartInner);
+		portTestEnv->log("milliStartOuter = %llu\n", milliStartOuter);
+		portTestEnv->log("nanoStart = %llu\n", nanoStart);
+		portTestEnv->log("milliStartInner = %llu\n", milliStartInner);
 
-		outputComment(OMRPORTLIB, "milliEndInner = %llu\n", milliEndInner);
-		outputComment(OMRPORTLIB, "nanoEnd = %llu\n", nanoEnd);
-		outputComment(OMRPORTLIB, "milliEndOuter = %llu\n", milliEndOuter);
+		portTestEnv->log("milliEndInner = %llu\n", milliEndInner);
+		portTestEnv->log("nanoEnd = %llu\n", nanoEnd);
+		portTestEnv->log("milliEndOuter = %llu\n", milliEndOuter);
 
-		outputComment(OMRPORTLIB, "milliDeltaInner = %llu\n", milliDeltaInner);
-		outputComment(OMRPORTLIB, "nanoDeltaInMillis = %llu\n", nanoDeltaInMillis);
-		outputComment(OMRPORTLIB, "milliDeltaOuter = %llu\n", milliDeltaOuter);
+		portTestEnv->log("milliDeltaInner = %llu\n", milliDeltaInner);
+		portTestEnv->log("nanoDeltaInMillis = %llu\n", nanoDeltaInMillis);
+		portTestEnv->log("milliDeltaOuter = %llu\n", milliDeltaOuter);
 
 		/* To avoid false positives, do a sanity check on all the millis values. */
 		if (!compareMillis(milliStartOuter, milliStartInner, EPSILON) ||
 			!compareMillis(SLEEP_TIME, milliDeltaInner, EPSILON) ||
 			!compareMillis(milliEndInner, milliEndOuter, EPSILON) ||
 			(milliDeltaOuter < milliDeltaInner)) {
-			outputComment(OMRPORTLIB, "WARNING: Skipping check due to possible NTP daemon interference.\n");
+			portTestEnv->log(LEVEL_WARN, "WARNING: Skipping check due to possible NTP daemon interference.\n");
 			continue;
 		}
 
@@ -531,7 +533,7 @@ TEST(PortTimeTest, time_nano_time_direction)
 	{
 		LARGE_INTEGER i;
 		if (QueryPerformanceCounter(&i)) {
-			outputComment(OMRPORTLIB, "WARNING: Test is invalid since the host machine uses QueryPerformanceCounter() (time may differ across CPUs - makes test results useless - re-enable if we develop thread affinity support)\n");
+			portTestEnv->log(LEVEL_WARN, "WARNING: Test is invalid since the host machine uses QueryPerformanceCounter() (time may differ across CPUs - makes test results useless - re-enable if we develop thread affinity support)\n");
 			reportTestExit(OMRPORTLIB, testName);
 		}
 	}
@@ -562,15 +564,15 @@ TEST(PortTimeTest, time_nano_time_direction)
 						}
 					}
 
-					outputComment(OMRPORTLIB, "Num threads created: %zu\n", omrtimeTestDirectionNumThreads);
-					outputComment(OMRPORTLIB, "Threads that have finished running: ");
+					portTestEnv->log("Num threads created: %zu\n", omrtimeTestDirectionNumThreads);
+					portTestEnv->log("Threads that have finished running: ");
 
 					/* wait for all threads to finish */
 					while ((0 == waitRetVal) && (tds.finishedCount < omrtimeTestDirectionNumThreads)) {
 						waitRetVal = omrthread_monitor_wait_timed(tds.monitor, J9TIME_TEST_DIRECTION_TIMEOUT_MILLIS, 0);
 					}
 
-					outputComment(OMRPORTLIB, "\n");
+					portTestEnv->log("\n");
 
 					if (0 != waitRetVal) {
 						outputErrorMessage(PORTTEST_ERROR_ARGS, "omrthread_monitor_wait_timed() failed, waitRetVal=%zd", waitRetVal);
@@ -701,7 +703,7 @@ TEST(PortTimeTest, time_test_hires_delta_rounding)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "invalid hires frequency\n");
 		goto exit;
 	}
-	outputComment(OMRPORTLIB, "hires frequency: %llu\n", ticksPerSec);
+	portTestEnv->log("hires frequency: %llu\n", ticksPerSec);
 
 	/* Case 1: ticksPerSec / requiredRes potentially rounds down */
 	/*
@@ -723,7 +725,7 @@ TEST(PortTimeTest, time_test_hires_delta_rounding)
 	if (error > 0.01) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "    Case 1. error is too high");
 	}
-	outputComment(OMRPORTLIB, "Case 1. expected: %llu    actual: %llu    error: %lf\n", requiredRes, delta, error);
+	portTestEnv->log("Case 1. expected: %llu    actual: %llu    error: %lf\n", requiredRes, delta, error);
 
 	/* Case 2: ticks * requiredRes overflows */
 	requiredRes = ((uint64_t)-1) / (ticksPerSec - 1) + ticksPerSec;
@@ -737,7 +739,7 @@ TEST(PortTimeTest, time_test_hires_delta_rounding)
 	if (error > 0.01) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "    Case 2. error is too high");
 	}
-	outputComment(OMRPORTLIB, "Case 2. expected: %llu    actual: %llu    error: %lf\n", requiredRes, delta, error);
+	portTestEnv->log("Case 2. expected: %llu    actual: %llu    error: %lf\n", requiredRes, delta, error);
 
 	/* Case 3: requiredRes = ticksPerSec */
 	requiredRes = ticksPerSec;
@@ -751,7 +753,7 @@ TEST(PortTimeTest, time_test_hires_delta_rounding)
 	if (error > 0.01) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "    Case 3. error is too high");
 	}
-	outputComment(OMRPORTLIB, "Case 3. expected: %llu    actual: %llu    error: %lf\n", requiredRes, delta, error);
+	portTestEnv->log("Case 3. expected: %llu    actual: %llu    error: %lf\n", requiredRes, delta, error);
 
 exit:
 	reportTestExit(OMRPORTLIB, testName);

--- a/fvtest/porttest/omrtimeTest.cpp
+++ b/fvtest/porttest/omrtimeTest.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2016
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -617,7 +617,7 @@ J9THREAD_PROC nanoTimeDirectionTest(void *arg)
 		I_64 start = omrtime_nano_time();
 
 		if (0 != omrthread_sleep(sleepMillis)) {
-			omrtty_printf("\tomrthread_sleep() did not return zero.\n");
+			portTestEnv->log(LEVEL_ERROR, "\tomrthread_sleep() did not return zero.\n");
 			omrthread_monitor_enter(tds->monitor);
 			tds->failed = TRUE;
 			omrthread_monitor_exit(tds->monitor);
@@ -626,7 +626,7 @@ J9THREAD_PROC nanoTimeDirectionTest(void *arg)
 
 		finish = omrtime_nano_time();
 		if (finish <= start) {
-			omrtty_printf("\tTime did not go forward after omrthread_sleep, start=%llu, finish=%llu\n", start, finish);
+			portTestEnv->log(LEVEL_ERROR, "\tTime did not go forward after omrthread_sleep, start=%llu, finish=%llu\n", start, finish);
 			omrthread_monitor_enter(tds->monitor);
 			tds->failed = TRUE;
 			omrthread_monitor_exit(tds->monitor);
@@ -639,7 +639,7 @@ J9THREAD_PROC nanoTimeDirectionTest(void *arg)
 	if (omrtimeTestDirectionNumThreads == tds->finishedCount) {
 		omrthread_monitor_notify(tds->monitor);
 	}
-	omrtty_printf("%zu ", tds->finishedCount);
+	portTestEnv->log("%zu ", tds->finishedCount);
 	omrthread_monitor_exit(tds->monitor);
 
 	return 0;

--- a/fvtest/porttest/omrvmemTest.cpp
+++ b/fvtest/porttest/omrvmemTest.cpp
@@ -213,6 +213,7 @@ TEST(PortVmemTest, vmem_test_verify_there_are_page_sizes)
 	int i = 0;
 
 	reportTestEntry(OMRPORTLIB, testName);
+	portTestEnv->changeIndent(1);
 
 	/* First get all the supported page sizes */
 	pageSizes = omrvmem_supported_page_sizes();
@@ -223,13 +224,13 @@ TEST(PortVmemTest, vmem_test_verify_there_are_page_sizes)
 		goto exit;
 	}
 
-	outputComment(OMRPORTLIB, "\t Supported page sizes:\n");
+	portTestEnv->log("Supported page sizes:\n");
 	for (i = 0 ; pageSizes[i] != 0 ; i++) {
-		outputComment(OMRPORTLIB, "\t 0x%zx ", pageSizes[i]);
-		outputComment(OMRPORTLIB, "\t 0x%zx \n", pageFlags[i]);
+		portTestEnv->log("0x%zx ", pageSizes[i]);
+		portTestEnv->log("0x%zx \n", pageFlags[i]);
 	}
-	outputComment(OMRPORTLIB, "\n");
-
+	portTestEnv->log("\n");
+	portTestEnv->changeIndent(-1);
 exit:
 	reportTestExit(OMRPORTLIB, testName);
 }
@@ -276,6 +277,7 @@ isPageSizeSupportedBelowBar(uintptr_t pageSize, uintptr_t pageFlags)
  */
 TEST(PortVmemTest, vmem_test1)
 {
+	portTestEnv->changeIndent(1);
 	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
 	const char *testName = "omrvmem_test1";
 	char *memPtr = NULL;
@@ -328,14 +330,16 @@ TEST(PortVmemTest, vmem_test1)
 					"\tlastErrorNumber=%d, lastErrorMessage=%s\n ", pageSizes[i], pageSizes[i], lastErrorNumber, lastErrorMessage);
 
 			if (OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES == lastErrorNumber) {
-				outputComment(OMRPORTLIB, "\tPortable error OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES...\n");
-				outputComment(OMRPORTLIB, "\t\tREBOOT THE MACHINE to free up resources AND TRY THE TEST AGAIN\n");
+				portTestEnv->log(LEVEL_ERROR, "Portable error OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES...\n");
+				portTestEnv->changeIndent(1);
+				portTestEnv->log(LEVEL_ERROR, "REBOOT THE MACHINE to free up resources AND TRY THE TEST AGAIN\n");
+				portTestEnv->changeIndent(-1);
 			}
 			goto exit;
 		} else {
 			uintptr_t finalBlocks;
 			uintptr_t finalBytes;
-			outputComment(OMRPORTLIB, "\treserved and committed 0x%zx bytes with page size 0x%zx at address 0x%zx\n", pageSizes[i], vmemID.pageSize, memPtr);
+			portTestEnv->log("reserved and committed 0x%zx bytes with page size 0x%zx at address 0x%zx\n", pageSizes[i], vmemID.pageSize, memPtr);
 
 			getPortLibraryMemoryCategoryData(OMRPORTLIB, &finalBlocks, &finalBytes);
 
@@ -377,7 +381,7 @@ TEST(PortVmemTest, vmem_test1)
 			}
 		}
 	}
-
+	portTestEnv->changeIndent(-1);
 exit:
 
 	reportTestExit(OMRPORTLIB, testName);
@@ -426,6 +430,7 @@ omrvmem_bench_write_and_decommit_memory(struct OMRPortLibrary *portLibrary, uint
 	I_64 deltaMillis;
 	J9PortVmemParams params;
 
+	portTestEnv->changeIndent(1);
 	reportTestEntry(OMRPORTLIB, testName);
 	setDisclaimVirtualMemory(OMRPORTLIB, disclaim);
 
@@ -446,13 +451,16 @@ omrvmem_bench_write_and_decommit_memory(struct OMRPortLibrary *portLibrary, uint
 			PORTTEST_ERROR_ARGS, "unable to reserve 0x%zx bytes with page size 0x%zx.\n"
 			"\tlastErrorNumber=%d, lastErrorMessage=%s\n ", byteAmount, pageSize, lastErrorNumber, lastErrorMessage);
 		if (OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES == lastErrorNumber) {
-			portTestEnv->log(LEVEL_ERROR, "\tPortable error OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES...\n");
-			portTestEnv->log(LEVEL_ERROR, "\t\tREBOOT THE MACHINE to free up resources AND TRY THE TEST AGAIN\n");
+			portTestEnv->log(LEVEL_ERROR, "Portable error OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES...\n");
+			portTestEnv->changeIndent(1);
+			portTestEnv->log(LEVEL_ERROR, "REBOOT THE MACHINE to free up resources AND TRY THE TEST AGAIN\n");
+			portTestEnv->changeIndent(-1);
 		}
 		goto exit;
 	} else {
-		portTestEnv->log("\treserved 0x%zx bytes with page size 0x%zx at 0x%zx\n", byteAmount, vmemID.pageSize, memPtr);
+		portTestEnv->log("reserved 0x%zx bytes with page size 0x%zx at 0x%zx\n", byteAmount, vmemID.pageSize, memPtr);
 	}
+	portTestEnv->changeIndent(-1);
 
 	startTimeNanos = omrtime_nano_time();
 
@@ -521,6 +529,7 @@ omrvmem_bench_force_overcommit_then_decommit(struct OMRPortLibrary *portLibrary,
 	J9PortVmemParams params;
 	uintptr_t byteAmount = physicalMemorySize + D512M;
 
+	portTestEnv->changeIndent(1);
 	reportTestEntry(OMRPORTLIB, testName);
 	setDisclaimVirtualMemory(OMRPORTLIB, disclaim);
 	if (byteAmount < D512M) {
@@ -544,13 +553,16 @@ omrvmem_bench_force_overcommit_then_decommit(struct OMRPortLibrary *portLibrary,
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "unable to reserve and commit 0x%zx bytes with page size 0x%zx.\n"
 						   "\tlastErrorNumber=%d, lastErrorMessage=%s\n ", byteAmount, pageSize, lastErrorNumber, lastErrorMessage);
 		if (OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES == lastErrorNumber) {
-			portTestEnv->log(LEVEL_ERROR, "\tPortable error OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES...\n");
-			portTestEnv->log(LEVEL_ERROR, "\t\tREBOOT THE MACHINE to free up resources AND TRY THE TEST AGAIN\n");
+			portTestEnv->log(LEVEL_ERROR, "Portable error OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES...\n");
+			portTestEnv->changeIndent(1);
+			portTestEnv->log(LEVEL_ERROR, "REBOOT THE MACHINE to free up resources AND TRY THE TEST AGAIN\n");
+			portTestEnv->changeIndent(-1);
 		}
 		goto exit;
 	} else {
 		portTestEnv->log("reserved and committed 0x%zx bytes of pagesize 0x%zx\n", byteAmount, pageSize);
 	}
+	portTestEnv->changeIndent(-1);
 
 	startTimeNanos = omrtime_nano_time();
 
@@ -618,6 +630,7 @@ omrvmem_bench_reserve_write_decommit_and_free_memory(struct OMRPortLibrary *port
 	I_64 deltaMillis;
 	J9PortVmemParams params;
 
+	portTestEnv->changeIndent(1);
 	reportTestEntry(OMRPORTLIB, testName);
 	setDisclaimVirtualMemory(OMRPORTLIB, disclaim);
 
@@ -645,8 +658,10 @@ omrvmem_bench_reserve_write_decommit_and_free_memory(struct OMRPortLibrary *port
 				PORTTEST_ERROR_ARGS, "In iteration %d, unable to reserve and commit 0x%zx bytes with page size 0x%zx.\n"
 				"\tlastErrorNumber=%d, lastErrorMessage=%s\n ", i, byteAmount, pageSize, lastErrorNumber, lastErrorMessage);
 			if (OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES == lastErrorNumber) {
-				portTestEnv->log(LEVEL_ERROR, "\tPortable error OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES...\n");
-				portTestEnv->log(LEVEL_ERROR, "\t\tREBOOT THE MACHINE to free up resources AND TRY THE TEST AGAIN\n");
+				portTestEnv->log(LEVEL_ERROR, "Portable error OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES...\n");
+				portTestEnv->changeIndent(1);
+				portTestEnv->log(LEVEL_ERROR, "REBOOT THE MACHINE to free up resources AND TRY THE TEST AGAIN\n");
+				portTestEnv->changeIndent(-1);
 			}
 			goto exit;
 		}
@@ -667,6 +682,7 @@ omrvmem_bench_reserve_write_decommit_and_free_memory(struct OMRPortLibrary *port
 			goto exit;
 		}
 	}
+	portTestEnv->changeIndent(-1);
 
 	deltaMillis = (omrtime_nano_time() - startTimeNanos) / (1000 * 1000);
 
@@ -708,6 +724,7 @@ omrvmem_exhaust_virtual_memory(struct OMRPortLibrary *portLibrary, uintptr_t pag
 	I_64 deltaMillis;
 	uintptr_t totalAlloc = 0;
 
+	portTestEnv->changeIndent(1);
 	reportTestEntry(OMRPORTLIB, testName);
 	setDisclaimVirtualMemory(OMRPORTLIB, disclaim);
 	startTimeNanos = omrtime_nano_time();
@@ -734,14 +751,16 @@ omrvmem_exhaust_virtual_memory(struct OMRPortLibrary *portLibrary, uintptr_t pag
 				PORTTEST_ERROR_ARGS, "unable to reserve and commit 0x%zx bytes with page size 0x%zx.\n"
 				"\tlastErrorNumber=%d, lastErrorMessage=%s\n ", byteAmount, pageSize, lastErrorNumber, lastErrorMessage);
 			if (OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES == lastErrorNumber) {
-				portTestEnv->log(LEVEL_ERROR, "\tPortable error OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES...\n");
-				portTestEnv->log(LEVEL_ERROR, "\t\tREBOOT THE MACHINE to free up resources AND TRY THE TEST AGAIN\n");
+				portTestEnv->log(LEVEL_ERROR, "Portable error OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES...\n");
+				portTestEnv->changeIndent(1);
+				portTestEnv->log(LEVEL_ERROR, "REBOOT THE MACHINE to free up resources AND TRY THE TEST AGAIN\n");
+				portTestEnv->changeIndent(-1);
 			}
 			goto exit;
 		} else {
-			portTestEnv->log("\treserved 0x%zx bytes\n", byteAmount);
+			portTestEnv->log("reserved 0x%zx bytes\n", byteAmount);
 			totalAlloc = byteAmount + totalAlloc;
-			portTestEnv->log("\ttotal: 0x%zx bytes\n", totalAlloc);
+			portTestEnv->log("total: 0x%zx bytes\n", totalAlloc);
 		}
 
 		/* write to the memory */
@@ -756,6 +775,7 @@ omrvmem_exhaust_virtual_memory(struct OMRPortLibrary *portLibrary, uintptr_t pag
 		}
 
 	}
+	portTestEnv->changeIndent(-1);
 
 	deltaMillis = (omrtime_nano_time() - startTimeNanos) / (1000 * 1000);
 
@@ -785,6 +805,7 @@ exit:
  */
 TEST(PortVmemTest, vmem_decommit_memory_test)
 {
+	portTestEnv->changeIndent(1);
 	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
 	const char *testName = "omrvmem_decommit_memory_test";
 	char *memPtr = NULL;
@@ -831,12 +852,14 @@ TEST(PortVmemTest, vmem_decommit_memory_test)
 				PORTTEST_ERROR_ARGS, "unable to reserve and commit 0x%zx bytes with page size 0x%zx.\n"
 				"\tlastErrorNumber=%d, lastErrorMessage=%s\n ", pageSizes[i], pageSizes[i], lastErrorNumber, lastErrorMessage);
 			if (OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES == lastErrorNumber) {
-				outputComment(OMRPORTLIB, "\tPortable error OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES...\n");
-				outputComment(OMRPORTLIB, "\t\tREBOOT THE MACHINE to free up resources AND TRY THE TEST AGAIN\n");
+				portTestEnv->log(LEVEL_ERROR, "Portable error OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES...\n");
+				portTestEnv->changeIndent(1);
+				portTestEnv->log(LEVEL_ERROR, "REBOOT THE MACHINE to free up resources AND TRY THE TEST AGAIN\n");
+				portTestEnv->changeIndent(-1);
 			}
 			goto exit;
 		} else {
-			outputComment(OMRPORTLIB, "\treserved and committed 0x%zx bytes with page size 0x%zx\n", pageSizes[i], vmemID.pageSize);
+			portTestEnv->log("reserved and committed 0x%zx bytes with page size 0x%zx\n", pageSizes[i], vmemID.pageSize);
 		}
 
 		/* can we read and write to the memory? */
@@ -862,7 +885,7 @@ TEST(PortVmemTest, vmem_decommit_memory_test)
 			goto exit;
 		}
 	}
-
+	portTestEnv->changeIndent(-1);
 exit:
 
 	reportTestExit(OMRPORTLIB, testName);
@@ -879,7 +902,7 @@ TEST(PortVmemTest, vmem_testReserveMemoryEx)
 	if (memoryIsAvailable(OMRPORTLIB, FALSE)) {
 		omrvmem_testReserveMemoryEx_StandardAndQuickMode(OMRPORTLIB, "omrvmem_testReserveMemoryEx", FALSE, FALSE, FALSE, FALSE);
 	} else {
-		outputComment(OMRPORTLIB, "***Did not find enough memory available on system, not running test omrvmem_testReserveMemoryEx\n");
+		portTestEnv->log(LEVEL_ERROR, "***Did not find enough memory available on system, not running test omrvmem_testReserveMemoryEx\n");
 	}
 }
 
@@ -892,7 +915,7 @@ TEST(PortVmemTest, vmem_testReserveMemoryExTopDown)
 	if (memoryIsAvailable(OMRPORTLIB, FALSE)) {
 		omrvmem_testReserveMemoryEx_StandardAndQuickMode(OMRPORTLIB, "omrvmem_testReserveMemoryExTopDown", TRUE, FALSE, FALSE, FALSE);
 	} else {
-		outputComment(OMRPORTLIB, "***Did not find enough memory available on system, not running test omrvmem_testReserveMemoryExTopDown\n");
+		portTestEnv->log(LEVEL_ERROR, "***Did not find enough memory available on system, not running test omrvmem_testReserveMemoryExTopDown\n");
 	}
 }
 
@@ -905,7 +928,7 @@ TEST(PortVmemTest, vmem_testReserveMemoryExStrictAdress)
 	if (memoryIsAvailable(OMRPORTLIB, TRUE)) {
 		omrvmem_testReserveMemoryEx_StandardAndQuickMode(OMRPORTLIB, "omrvmem_testReserveMemoryExStrictAddress", FALSE, TRUE, FALSE, FALSE);
 	} else {
-		outputComment(OMRPORTLIB, "***Did not find enough memory available on system, not running test omrvmem_testReserveMemoryExStrictAddress\n");
+		portTestEnv->log(LEVEL_ERROR, "***Did not find enough memory available on system, not running test omrvmem_testReserveMemoryExStrictAddress\n");
 	}
 }
 
@@ -918,7 +941,7 @@ TEST(PortVmemTest, vmem_testReserveMemoryExStrictPageSize)
 	if (memoryIsAvailable(OMRPORTLIB, FALSE)) {
 		omrvmem_testReserveMemoryEx_StandardAndQuickMode(OMRPORTLIB, "omrvmem_testReserveMemoryExStrictPageSize", FALSE, FALSE, TRUE, FALSE);
 	} else {
-		outputComment(OMRPORTLIB, "***Did not find enough memory available on system, not running test omrvmem_testReserveMemoryExStrictPageSize\n");
+		portTestEnv->log(LEVEL_ERROR, "***Did not find enough memory available on system, not running test omrvmem_testReserveMemoryExStrictPageSize\n");
 	}
 }
 
@@ -938,7 +961,7 @@ TEST(PortVmemTest, vmem_testReserveMemoryEx_use2To32)
 	if (memoryIsAvailable(OMRPORTLIB, FALSE)) {
 		omrvmem_testReserveMemoryEx_StandardAndQuickMode(OMRPORTLIB, "omrvmem_testReserveMemoryEx_use2To32", FALSE, FALSE, FALSE, TRUE);
 	} else {
-		outputComment(OMRPORTLIB, "***Did not find enough memory available on system, not running test omrvmem_testReserveMemoryEx\n");
+		portTestEnv->log(LEVEL_ERROR, "***Did not find enough memory available on system, not running test omrvmem_testReserveMemoryEx\n");
 	}
 }
 
@@ -951,7 +974,7 @@ TEST(PortVmemTest, vmem_testReserveMemoryExTopDown_use2To32)
 	if (memoryIsAvailable(OMRPORTLIB, FALSE)) {
 		omrvmem_testReserveMemoryEx_StandardAndQuickMode(OMRPORTLIB, "omrvmem_testReserveMemoryExTopDown_use2To32", TRUE, FALSE, FALSE, TRUE);
 	} else {
-		outputComment(OMRPORTLIB, "***Did not find enough memory available on system, not running test omrvmem_testReserveMemoryExTopDown\n");
+		portTestEnv->log(LEVEL_ERROR, "***Did not find enough memory available on system, not running test omrvmem_testReserveMemoryExTopDown\n");
 	}
 }
 
@@ -964,7 +987,7 @@ TEST(PortVmemTest, vmem_testReserveMemoryExStrictAddress_use2To32)
 	if (memoryIsAvailable(OMRPORTLIB, TRUE)) {
 		omrvmem_testReserveMemoryEx_StandardAndQuickMode(OMRPORTLIB, "omrvmem_testReserveMemoryExStrictAddress_use2To32", FALSE, TRUE, FALSE, TRUE);
 	} else {
-		outputComment(OMRPORTLIB, "***Did not find enough memory available on system, not running test omrvmem_testReserveMemoryExStrictAddress\n");
+		portTestEnv->log(LEVEL_ERROR, "***Did not find enough memory available on system, not running test omrvmem_testReserveMemoryExStrictAddress\n");
 	}
 }
 
@@ -977,7 +1000,7 @@ TEST(PortVmemTest, vmem_testReserveMemoryExStrictPageSize_use2To32)
 	if (memoryIsAvailable(OMRPORTLIB, FALSE)) {
 		omrvmem_testReserveMemoryEx_StandardAndQuickMode(OMRPORTLIB, "omrvmem_testReserveMemoryExStrictPageSize_use2To32", FALSE, FALSE, TRUE, TRUE);
 	} else {
-		outputComment(OMRPORTLIB, "***Did not find enough memory available on system, not running test omrvmem_testReserveMemoryExStrictPageSize\n");
+		portTestEnv->log(LEVEL_ERROR, "***Did not find enough memory available on system, not running test omrvmem_testReserveMemoryExStrictPageSize\n");
 	}
 }
 #endif /* defined(J9ZOS39064) */
@@ -1027,6 +1050,7 @@ omrvmem_testReserveMemoryEx_StandardAndQuickMode(struct OMRPortLibrary *portLibr
 static int
 omrvmem_testReserveMemoryEx_impl(struct OMRPortLibrary *portLibrary, const char *testName, BOOLEAN topDown, BOOLEAN quickSearch, BOOLEAN strictAddress, BOOLEAN strictPageSize, BOOLEAN use2To32G)
 {
+	portTestEnv->changeIndent(1);
 	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
 #define NUM_SEGMENTS 3
 	char *memPtr[NUM_SEGMENTS];
@@ -1101,7 +1125,7 @@ omrvmem_testReserveMemoryEx_impl(struct OMRPortLibrary *portLibrary, const char 
 				params[j].options |= OMRPORT_VMEM_ZOS_USE2TO32G_AREA;
 			}
 
-			outputComment(OMRPORTLIB, "\tPage Size: 0x%zx Range: [0x%zx,0x%zx] "\
+			portTestEnv->log("Page Size: 0x%zx Range: [0x%zx,0x%zx] "\
 						  "topDown: %s quickSearch: %s strictAddress: %s strictPageSize: %s use2To32G: %s\n", \
 						  params[j].pageSize, params[j].startAddress, params[j].endAddress, \
 						  (0 != (params[j].options & OMRPORT_VMEM_ALLOC_DIR_TOP_DOWN)) ? "true" : "false",
@@ -1116,7 +1140,7 @@ omrvmem_testReserveMemoryEx_impl(struct OMRPortLibrary *portLibrary, const char 
 			/* did we get any memory and is it in range if strict is set? */
 			if (memPtr[j] == NULL) {
 				if (strictPageSize) {
-					outputComment(OMRPORTLIB, "\t! Unable to reserve and commit 0x%zx bytes with page size 0x%zx.\n", pageSizes[i], pageSizes[i]);
+					portTestEnv->log(LEVEL_ERROR, "! Unable to reserve and commit 0x%zx bytes with page size 0x%zx.\n", pageSizes[i], pageSizes[i]);
 				} else {
 					lastErrorMessage = (char *)omrerror_last_error_message();
 					lastErrorNumber = omrerror_last_error_number();
@@ -1125,8 +1149,10 @@ omrvmem_testReserveMemoryEx_impl(struct OMRPortLibrary *portLibrary, const char 
 						"\tlastErrorNumber=%d, lastErrorMessage=%s\n ", pageSizes[i], pageSizes[i], lastErrorNumber, lastErrorMessage);
 
 					if (OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES == lastErrorNumber) {
-						outputComment(OMRPORTLIB, "\tPortable error OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES...\n");
-						outputComment(OMRPORTLIB, "\t\tREBOOT THE MACHINE to free up resources AND TRY THE TEST AGAIN\n");
+						portTestEnv->log(LEVEL_ERROR, "Portable error OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES...\n");
+						portTestEnv->changeIndent(1);
+						portTestEnv->log(LEVEL_ERROR, "REBOOT THE MACHINE to free up resources AND TRY THE TEST AGAIN\n");
+						portTestEnv->changeIndent(-1);
 					}
 				}
 			} else if (strictAddress && (((void *)memPtr[j] < params[j].startAddress) || ((void *)memPtr[j] > params[j].endAddress))) {
@@ -1148,8 +1174,8 @@ omrvmem_testReserveMemoryEx_impl(struct OMRPortLibrary *portLibrary, const char 
 				outputErrorMessage(PORTTEST_ERROR_ARGS, "\t use2To32G flag is set and returned pointer [0x%zx] is outside of range.\n", memPtr[j]);
 #endif /* OMR_ENV_DATA64 */
 			} else {
-				outputComment(
-					OMRPORTLIB, "\t reserved and committed 0x%zx bytes with page size 0x%zx and page flag 0x%zx at address 0x%zx\n", \
+				portTestEnv->log(
+					"reserved and committed 0x%zx bytes with page size 0x%zx and page flag 0x%zx at address 0x%zx\n", \
 					pageSizes[i], vmemID[j].pageSize, vmemID[j].pageFlags, memPtr[j]);
 			}
 
@@ -1219,7 +1245,7 @@ omrvmem_testReserveMemoryEx_impl(struct OMRPortLibrary *portLibrary, const char 
 	}
 
 #undef NUM_SEGMENTS
-
+	portTestEnv->changeIndent(-1);
 	return reportTestExit(OMRPORTLIB, testName);
 }
 
@@ -1237,6 +1263,7 @@ omrvmem_testReserveMemoryEx_impl(struct OMRPortLibrary *portLibrary, const char 
 static BOOLEAN
 memoryIsAvailable(struct OMRPortLibrary *portLibrary, BOOLEAN strictAddress)
 {
+	portTestEnv->changeIndent(1);
 #define NUM_SEGMENTS 3
 	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
 	char *memPtr[NUM_SEGMENTS] = {(char *)NULL, (char *)NULL, (char *)NULL};
@@ -1277,7 +1304,7 @@ memoryIsAvailable(struct OMRPortLibrary *portLibrary, BOOLEAN strictAddress)
 
 			/* did we get any memory */
 			if (memPtr[j] == NULL) {
-				outputComment(OMRPORTLIB, "\t**Could not find 0x%zx bytes available with page size 0x%zx\n", pageSizes[i], pageSizes[i]);
+				portTestEnv->log(LEVEL_ERROR, "**Could not find 0x%zx bytes available with page size 0x%zx\n", pageSizes[i], pageSizes[i]);
 				isMemoryAvailable = FALSE;
 				break;
 			}
@@ -1289,8 +1316,8 @@ memoryIsAvailable(struct OMRPortLibrary *portLibrary, BOOLEAN strictAddress)
 				rc = omrvmem_free_memory(memPtr[j], pageSizes[i], &vmemID[j]);
 				if (rc != 0) {
 					isMemoryAvailable = FALSE;
-					outputComment(
-						OMRPORTLIB, "\t**omrvmem_free_memory returned %i when trying to free 0x%zx bytes at 0x%zx\n",
+					portTestEnv->log(
+						"**omrvmem_free_memory returned %i when trying to free 0x%zx bytes at 0x%zx\n",
 						rc, pageSizes[i], memPtr);
 				}
 			}
@@ -1299,7 +1326,7 @@ memoryIsAvailable(struct OMRPortLibrary *portLibrary, BOOLEAN strictAddress)
 	}
 
 #undef NUM_SEGMENTS
-
+	portTestEnv->changeIndent(-1);
 	return isMemoryAvailable;
 }
 
@@ -1315,6 +1342,7 @@ TEST(PortVmemTest, vmem_testReserveMemoryEx_zOSLargePageBelowBar)
 	const char *testName = "omrvmem_testReserveMemoryEx_zOSLargePageBelowBar";
 	int32_t i = 0;
 
+	portTestEnv->changeIndent(1);
 	reportTestEntry(OMRPORTLIB, testName);
 
 	/* Get all the supported page sizes */
@@ -1340,7 +1368,7 @@ TEST(PortVmemTest, vmem_testReserveMemoryEx_zOSLargePageBelowBar)
 		params.pageFlags = pageFlags[i];
 		params.options = 0;
 
-		outputComment(OMRPORTLIB, "\tPage Size: 0x%zx Range: [0x%zx,0x%zx] "\
+		portTestEnv->log("Page Size: 0x%zx Range: [0x%zx,0x%zx] "\
 					  "topDown: %s strictAddress: %s strictPageSize: %s use2To32G: %s\n", \
 					  params.pageSize, params.startAddress, params.endAddress, \
 					  (0 != (params.options & OMRPORT_VMEM_ALLOC_DIR_TOP_DOWN)) ? "true" : "false",
@@ -1359,7 +1387,7 @@ TEST(PortVmemTest, vmem_testReserveMemoryEx_zOSLargePageBelowBar)
 			goto exit;
 
 		} else {
-			outputComment(OMRPORTLIB, "\t reserved and committed 0x%zx bytes with page size 0x%zx and page flag 0x%x at address 0x%zx\n", \
+			portTestEnv->log("reserved and committed 0x%zx bytes with page size 0x%zx and page flag 0x%x at address 0x%zx\n", \
 						  params.byteAmount, vmemID.pageSize, vmemID.pageFlags, memPtr);
 		}
 
@@ -1375,7 +1403,7 @@ TEST(PortVmemTest, vmem_testReserveMemoryEx_zOSLargePageBelowBar)
 			goto exit;
 		}
 	}
-
+	portTestEnv->changeIndent(-1);
 exit:
 	reportTestExit(OMRPORTLIB, testName);
 }
@@ -1391,6 +1419,7 @@ TEST(PortVmemTest, vmem_testReserveMemoryExStrictAddress_zOSLargePageBelowBar)
 	const char *testName = "omrvmem_testReserveMemoryExStrictAddress_zOSLargePageBelowBar";
 	int32_t i = 0;
 
+	portTestEnv->changeIndent(1);
 	reportTestEntry(OMRPORTLIB, testName);
 
 	/* Get all the supported page sizes */
@@ -1423,7 +1452,7 @@ TEST(PortVmemTest, vmem_testReserveMemoryExStrictAddress_zOSLargePageBelowBar)
 		params.pageFlags = pageFlags[i];
 		params.options = OMRPORT_VMEM_STRICT_ADDRESS;
 
-		outputComment(OMRPORTLIB, "\tPage Size: 0x%zx Range: [0x%zx,0x%zx] "\
+		portTestEnv->log("Page Size: 0x%zx Range: [0x%zx,0x%zx] "\
 					  "topDown: %s strictAddress: %s strictPageSize: %s use2To32G: %s\n", \
 					  params.pageSize, params.startAddress, params.endAddress, \
 					  (0 != (params.options & OMRPORT_VMEM_ALLOC_DIR_TOP_DOWN)) ? "true" : "false",
@@ -1441,7 +1470,7 @@ TEST(PortVmemTest, vmem_testReserveMemoryExStrictAddress_zOSLargePageBelowBar)
 			goto exit;
 
 		} else {
-			outputComment(OMRPORTLIB, "\t reserved and committed 0x%zx bytes with page size 0x%zx and page flag 0x%x at address 0x%zx\n", \
+			portTestEnv->log("reserved and committed 0x%zx bytes with page size 0x%zx and page flag 0x%x at address 0x%zx\n", \
 						  params.byteAmount, vmemID.pageSize, vmemID.pageFlags, memPtr);
 
 			if ((uint64_t) memPtr >= TWO_GIG_BAR) {
@@ -1476,7 +1505,7 @@ TEST(PortVmemTest, vmem_testReserveMemoryExStrictAddress_zOSLargePageBelowBar)
 		}
 
 	}
-
+	portTestEnv->changeIndent(-1);
 exit:
 	reportTestExit(OMRPORTLIB, testName);
 
@@ -1496,6 +1525,7 @@ TEST(PortVmemTest, vmem_testReserveMemoryEx_use2To32_zOSLargePageBelowBar)
 	const char *testName = "omrvmem_testReserveMemoryEx_use2To32_zOSLargePageBelowBar";
 	int32_t i = 0;
 
+	portTestEnv->changeIndent(1);
 	reportTestEntry(OMRPORTLIB, testName);
 
 	/* Get all the supported page sizes */
@@ -1521,7 +1551,7 @@ TEST(PortVmemTest, vmem_testReserveMemoryEx_use2To32_zOSLargePageBelowBar)
 		params.pageFlags = pageFlags[i];
 		params.options = OMRPORT_VMEM_ZOS_USE2TO32G_AREA;
 
-		outputComment(OMRPORTLIB, "\tPage Size: 0x%zx Range: [0x%zx,0x%zx] "\
+		portTestEnv->log("Page Size: 0x%zx Range: [0x%zx,0x%zx] "\
 					  "topDown: %s strictAddress: %s strictPageSize: %s use2To32G: %s\n", \
 					  params.pageSize, params.startAddress, params.endAddress, \
 					  (0 != (params.options & OMRPORT_VMEM_ALLOC_DIR_TOP_DOWN)) ? "true" : "false",
@@ -1540,7 +1570,7 @@ TEST(PortVmemTest, vmem_testReserveMemoryEx_use2To32_zOSLargePageBelowBar)
 			goto exit;
 
 		} else {
-			outputComment(OMRPORTLIB, "\t reserved and committed 0x%zx bytes with page size 0x%zx and page flag 0x%x at address 0x%zx\n", \
+			portTestEnv->log("reserved and committed 0x%zx bytes with page size 0x%zx and page flag 0x%x at address 0x%zx\n", \
 						  params.byteAmount, vmemID.pageSize, vmemID.pageFlags, memPtr);
 
 			if (((uint64_t) memPtr < TWO_GB) ||
@@ -1563,7 +1593,7 @@ TEST(PortVmemTest, vmem_testReserveMemoryEx_use2To32_zOSLargePageBelowBar)
 			goto exit;
 		}
 	}
-
+	portTestEnv->changeIndent(-1);
 exit:
 	reportTestExit(OMRPORTLIB, testName);
 
@@ -1580,6 +1610,7 @@ TEST(PortVmemTest, vmem_testReserveMemoryExStrictAddress_use2To32_zOSLargePageBe
 	const char *testName = "omrvmem_testReserveMemoryExStrictAddress_use2To32_zOSLargePageBelowBar";
 	int32_t i = 0;
 
+	portTestEnv->changeIndent(1);
 	reportTestEntry(OMRPORTLIB, testName);
 
 	/* Get all the supported page sizes */
@@ -1603,7 +1634,7 @@ TEST(PortVmemTest, vmem_testReserveMemoryExStrictAddress_use2To32_zOSLargePageBe
 		params.pageFlags = pageFlags[i];
 		params.options = OMRPORT_VMEM_STRICT_ADDRESS | OMRPORT_VMEM_ZOS_USE2TO32G_AREA;
 
-		outputComment(OMRPORTLIB, "\tPage Size: 0x%zx Range: [0x%zx,0x%zx] "\
+		portTestEnv->log("Page Size: 0x%zx Range: [0x%zx,0x%zx] "\
 					  "topDown: %s strictAddress: %s strictPageSize: %s use2To32G: %s\n", \
 					  params.pageSize, params.startAddress, params.endAddress, \
 					  (0 != (params.options & OMRPORT_VMEM_ALLOC_DIR_TOP_DOWN)) ? "true" : "false",
@@ -1624,10 +1655,10 @@ TEST(PortVmemTest, vmem_testReserveMemoryExStrictAddress_use2To32_zOSLargePageBe
 			omrvmem_free_memory(memPtr, params.byteAmount, &vmemID);
 
 		} else {
-			outputComment(OMRPORTLIB, "\t Expected to fail to allocate large pages in < 2GB range with OMRPORT_VMEM_ZOS_USE2TO32G_AREA and OMRPORT_VMEM_STRICT_ADDRESS set\n");
+			portTestEnv->log(" Expected to fail to allocate large pages in < 2GB range with OMRPORT_VMEM_ZOS_USE2TO32G_AREA and OMRPORT_VMEM_STRICT_ADDRESS set\n");
 		}
 	}
-
+	portTestEnv->changeIndent(-1);
 	reportTestExit(OMRPORTLIB, testName);
 }
 #endif /* defined(OMR_ENV_DATA64) */
@@ -1667,7 +1698,7 @@ TEST(PortVmemTest, vmem_test_commitOutsideOfReservedRange)
 		memPtr = (char *)omrvmem_reserve_memory_ex(&vmemID, &params);
 
 		if (NULL == memPtr) {
-			outputComment(OMRPORTLIB, "! Could not find 0x%zx bytes available with page size 0x%zx\n", params.byteAmount, pageSizes[i]);
+			portTestEnv->log(LEVEL_ERROR, "! Could not find 0x%zx bytes available with page size 0x%zx\n", params.byteAmount, pageSizes[i]);
 		} else {
 			intptr_t rc;
 			void *commitResult;
@@ -1751,7 +1782,7 @@ TEST(PortVmemTest, vmem_test_reserveExecutableMemory)
 		memPtr = omrvmem_reserve_memory_ex(&vmemID, &params);
 
 		if (NULL == memPtr) {
-			outputComment(OMRPORTLIB, "! Could not find 0x%zx bytes available with page size 0x%zx and specified mode\n", params.byteAmount, pageSizes[i]);
+			portTestEnv->log(LEVEL_ERROR, "! Could not find 0x%zx bytes available with page size 0x%zx and specified mode\n", params.byteAmount, pageSizes[i]);
 		} else {
 			intptr_t rc;
 			void (*function)();
@@ -1768,9 +1799,9 @@ TEST(PortVmemTest, vmem_test_reserveExecutableMemory)
 			myDesc.func_addr = (uintptr_t)memPtr;
 
 			function = (void (*)())(void *)&myDesc;
-			outputComment(OMRPORTLIB, "About to call dynamically created function, pageSize=0x%zx...\n", params.pageSize);
+			portTestEnv->log("About to call dynamically created function, pageSize=0x%zx...\n", params.pageSize);
 			function();
-			outputComment(OMRPORTLIB, "Dynamically created function returned successfully\n");
+			portTestEnv->log("Dynamically created function returned successfully\n");
 
 #elif defined(LINUX) || defined(WIN32) || defined(J9ZOS390) || defined(OSX)
 			size_t length;
@@ -1797,16 +1828,16 @@ TEST(PortVmemTest, vmem_test_reserveExecutableMemory)
 					length = pageSizes[i];
 				}
 
-				outputComment(OMRPORTLIB, "function length = %d\n", length);
+				portTestEnv->log("function length = %d\n", length);
 
 				memcpy(memPtr, (void *)&myFunction1, length);
 
-				outputComment(OMRPORTLIB, "*memPtr: 0x%zx\n", *((unsigned int *)memPtr));
+				portTestEnv->log("*memPtr: 0x%zx\n", *((unsigned int *)memPtr));
 
 				function = (void (*)())memPtr;
-				outputComment(OMRPORTLIB, "About to call dynamically created function, pageSize=0x%zx...\n", params.pageSize);
+				portTestEnv->log("About to call dynamically created function, pageSize=0x%zx...\n", params.pageSize);
 				function();
-				outputComment(OMRPORTLIB, "Dynamically created function returned successfully\n");
+				portTestEnv->log("Dynamically created function returned successfully\n");
 #if defined(J9ZOS39064)
 			}
 #endif /* J9ZOS39064 */
@@ -1844,6 +1875,7 @@ TEST(PortVmemTest, vmem_test_numa)
 	uintptr_t totalNumaNodeCount = 0;
 	intptr_t detailReturnCode = 0;
 
+	portTestEnv->changeIndent(1);
 	reportTestEntry(OMRPORTLIB, testName);
 
 	/* First get all the supported page sizes */
@@ -1854,7 +1886,7 @@ TEST(PortVmemTest, vmem_test_numa)
 	detailReturnCode = omrvmem_numa_get_node_details(NULL, &totalNumaNodeCount);
 
 	if ((detailReturnCode != 0) || (0 == totalNumaNodeCount)) {
-		outputComment(OMRPORTLIB, "\tNUMA not available\n");
+		portTestEnv->log(LEVEL_ERROR, "NUMA not available\n");
 	} else {
 		uintptr_t i = 0;
 		uintptr_t nodesWithMemoryCount = 0;
@@ -1923,7 +1955,7 @@ TEST(PortVmemTest, vmem_test_numa)
 						 OMRPORT_VMEM_MEMORY_MODE_READ | OMRPORT_VMEM_MEMORY_MODE_WRITE,
 						 pageSize, OMRMEM_CATEGORY_PORT_LIBRARY);
 
-			outputComment(OMRPORTLIB, "\treserved 0x%zx bytes with page size 0x%zx at address 0x%zx\n", reserveSizeInBytes, vmemID.pageSize, memPtr);
+			portTestEnv->log("reserved 0x%zx bytes with page size 0x%zx at address 0x%zx\n", reserveSizeInBytes, vmemID.pageSize, memPtr);
 
 			/* did we get any memory? */
 			if (memPtr != NULL) {
@@ -1975,7 +2007,7 @@ TEST(PortVmemTest, vmem_test_numa)
 			}
 		}
 	}
-
+	portTestEnv->changeIndent(-1);
 exit:
 
 	reportTestExit(OMRPORTLIB, testName);
@@ -1983,7 +2015,7 @@ exit:
 #endif /* defined(OMR_GC_VLHGC) */
 
 #define PRINT_FIND_VALID_PAGE_SIZE_INPUT(mode, pageSize, pageFlags) \
-	outputComment(OMRPORTLIB, "Input > mode: %zu, requestedPageSize: 0x%zx, requestedPageFlags: 0x%zx\n", mode, pageSize, pageFlags); \
+	portTestEnv->log("Input > mode: %zu, requestedPageSize: 0x%zx, requestedPageFlags: 0x%zx\n", mode, pageSize, pageFlags); \
  
 void
 verifyFindValidPageSizeOutput(struct OMRPortLibrary *portLibrary,
@@ -1998,7 +2030,7 @@ verifyFindValidPageSizeOutput(struct OMRPortLibrary *portLibrary,
 	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
 	uintptr_t result = FALSE;
 
-	outputComment(OMRPORTLIB, "Expected > expectedPageSize: 0x%zx, expectedPageFlags: 0x%zx, isSizeSupported: 0x%zx\n\n",
+	portTestEnv->log("Expected > expectedPageSize: 0x%zx, expectedPageFlags: 0x%zx, isSizeSupported: 0x%zx\n\n",
 				  pageSizeExpected, pageFlagsExpected, isSizeSupportedExpected);
 
 	if ((pageSizeExpected == pageSizeReturned) && (pageFlagsExpected == pageFlagsReturned)) {
@@ -2015,7 +2047,7 @@ verifyFindValidPageSizeOutput(struct OMRPortLibrary *portLibrary,
 	}
 
 	if (TRUE == result) {
-		outputComment(OMRPORTLIB, "PASSED\n");
+		portTestEnv->log("PASSED\n");
 	}
 }
 
@@ -2041,7 +2073,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 
 	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
 
-	outputComment(OMRPORTLIB, "\n");
+	portTestEnv->log("\n");
 	reportTestEntry(OMRPORTLIB, testName);
 
 	/* Linux and Windows support only one large page size
@@ -2051,7 +2083,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 	 */
 	omrvmem_default_large_page_size_ex(0, &defaultLargePageSize, &defaultLargePageFlags);
 	if (0 != defaultLargePageSize) {
-		outputComment(OMRPORTLIB, "defaultLargePageSize: 0x%zx, defaultLargePageFlags: 0x%zx\n", defaultLargePageSize, defaultLargePageFlags);
+		portTestEnv->log("defaultLargePageSize: 0x%zx, defaultLargePageFlags: 0x%zx\n", defaultLargePageSize, defaultLargePageFlags);
 	}
 
 	/* Note that -Xlp<size>, -Xlp:objectheap and -Xlp:codecache are treated same, and
@@ -2061,7 +2093,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 	 * if default large page size is not present.
 	 */
 
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:objectheap:pagesize=4M\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:objectheap:pagesize=4M\n", caseIndex++);
 
 	requestedPageSize = 4 * ONE_MB;
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_NOT_USED;
@@ -2083,7 +2115,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 								  expectedPageSize, expectedPageFlags, expectedIsSizeSupported,
 								  requestedPageSize, requestedPageFlags, isSizeSupported);
 
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:objectheap:pagesize=4K\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:objectheap:pagesize=4K\n", caseIndex++);
 
 	requestedPageSize = FOUR_KB;
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_NOT_USED;
@@ -2099,10 +2131,10 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 								  expectedPageSize, expectedPageFlags, expectedIsSizeSupported,
 								  requestedPageSize, requestedPageFlags, isSizeSupported);
 
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:objectheap:pagesize=<not in 4K, 4M>\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:objectheap:pagesize=<not in 4K, 4M>\n", caseIndex++);
 
 	/* Add any new cases before this line */
-	outputComment(OMRPORTLIB, "%d tests completed\n", caseIndex);
+	portTestEnv->log("%d tests completed\n", caseIndex);
 
 	requestedPageSize = 8 * ONE_MB;
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_NOT_USED;
@@ -2130,7 +2162,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 TEST(PortVmemTest, vmem_testFindValidPageSize)
 {
 	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
-
+	portTestEnv->changeIndent(1);
 #if defined(LINUX) || defined(OSX)
 #define OMRPORT_VMEM_PAGESIZE_COUNT 5	/* This should be same as defined in port/unix_include/j9portpg.h */
 #elif defined(WIN32)
@@ -2183,6 +2215,7 @@ TEST(PortVmemTest, vmem_testFindValidPageSize)
 	memcpy(pageFlags, old_vmem_pageFlags, OMRPORT_VMEM_PAGESIZE_COUNT * sizeof(uintptr_t));
 
 _exit:
+	portTestEnv->changeIndent(-1);
 	EXPECT_TRUE(0 == rc) << "Test Failed!";
 }
 
@@ -2223,7 +2256,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 
 	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
 
-	outputComment(OMRPORTLIB, "\n");
+	portTestEnv->log("\n");
 	reportTestEntry(OMRPORTLIB, testName);
 
 	/* First get all the supported page sizes */
@@ -2257,17 +2290,17 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 	}
 
 #if defined(OMR_ENV_DATA64)
-	outputComment(OMRPORTLIB, "16G page size supported: %s\n", (sixteenGBPageSize) ? "yes" : "no");
+	portTestEnv->log("16G page size supported: %s\n", (sixteenGBPageSize) ? "yes" : "no");
 #endif /* defined(OMR_ENV_DATA64) */
-	outputComment(OMRPORTLIB, "16M page size supported: %s\n", (sixteenMBPageSize) ? "yes" : "no");
-	outputComment(OMRPORTLIB, "64K page size supported: %s\n", (sixtyFourKBPageSize) ? "yes" : "no");
+	portTestEnv->log("16M page size supported: %s\n", (sixteenMBPageSize) ? "yes" : "no");
+	portTestEnv->log("64K page size supported: %s\n", (sixtyFourKBPageSize) ? "yes" : "no");
 
 	/* On AIX default large page size should always be available.
 	 * It is 16M, if available, 64K otherwise
 	 */
 	omrvmem_default_large_page_size_ex(0, &defaultLargePageSize, &defaultLargePageFlags);
 	if (0 != defaultLargePageSize) {
-		outputComment(OMRPORTLIB, "defaultLargePageSize: 0x%zx, defaultLargePageFlags: 0x%zx\n", defaultLargePageSize, defaultLargePageFlags);
+		portTestEnv->log("defaultLargePageSize: 0x%zx, defaultLargePageFlags: 0x%zx\n", defaultLargePageSize, defaultLargePageFlags);
 	}
 
 	/* Note that -Xlp<size> and -Xlp:objectheap are treated same, and
@@ -2278,7 +2311,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 	 */
 
 #if defined(OMR_ENV_DATA64)
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:objectheap:pagesize=16G\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:objectheap:pagesize=16G\n", caseIndex++);
 
 	requestedPageSize = 8 * TWO_GB;
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_NOT_USED;
@@ -2305,7 +2338,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 								  requestedPageSize, requestedPageFlags, isSizeSupported);
 #endif /* defined(OMR_ENV_DATA64) */
 
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:objectheap:pagesize=16M\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:objectheap:pagesize=16M\n", caseIndex++);
 
 	requestedPageSize = 16 * ONE_MB;
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_NOT_USED;
@@ -2331,7 +2364,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 								  expectedPageSize, expectedPageFlags, expectedIsSizeSupported,
 								  requestedPageSize, requestedPageFlags, isSizeSupported);
 
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:objectheap:pagesize=64K\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:objectheap:pagesize=64K\n", caseIndex++);
 
 	requestedPageSize = 16 * FOUR_KB;
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_NOT_USED;
@@ -2353,7 +2386,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 								  expectedPageSize, expectedPageFlags, expectedIsSizeSupported,
 								  requestedPageSize, requestedPageFlags, isSizeSupported);
 
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:objectheap:pagesize=4K\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:objectheap:pagesize=4K\n", caseIndex++);
 
 	requestedPageSize = FOUR_KB;
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_NOT_USED;
@@ -2369,7 +2402,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 								  expectedPageSize, expectedPageFlags, expectedIsSizeSupported,
 								  requestedPageSize, requestedPageFlags, isSizeSupported);
 
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:objectheap:pagesize=<not in 4K, 64K, 16M, 16G>\n", caseIndex++);
+	portTestEnv->log(LEVEL_ERROR, "\nCase %d: -Xlp:objectheap:pagesize=<not in 4K, 64K, 16M, 16G>\n", caseIndex++);
 
 	requestedPageSize = 8 * ONE_MB;
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_NOT_USED;
@@ -2417,10 +2450,10 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 	dataSegmentPageSize = getpagesize();
 #endif /* defined(AIXPPC) */
 
-	outputComment(OMRPORTLIB, "Page size of data segment: 0x%zx\n", dataSegmentPageSize);
+	portTestEnv->log("Page size of data segment: 0x%zx\n", dataSegmentPageSize);
 
 #if defined(OMR_ENV_DATA64)
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:codecache:pagesize=16G\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:codecache:pagesize=16G\n", caseIndex++);
 	mode = OMRPORT_VMEM_MEMORY_MODE_EXECUTE;
 	requestedPageSize = 8 * TWO_GB;
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_NOT_USED;
@@ -2438,7 +2471,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 
 #endif /* defined(OMR_ENV_DATA64) */
 
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:codecache:pagesize=16M\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:codecache:pagesize=16M\n", caseIndex++);
 	mode = OMRPORT_VMEM_MEMORY_MODE_EXECUTE;
 	requestedPageSize = 16 * ONE_MB;
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_NOT_USED;
@@ -2464,7 +2497,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 								  requestedPageSize, requestedPageFlags, isSizeSupported);
 
 #if !defined(OMR_ENV_DATA64)
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:codecache:pagesize=16M with TR_ppcCodeCacheConsolidationEnabled set\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:codecache:pagesize=16M with TR_ppcCodeCacheConsolidationEnabled set\n", caseIndex++);
 	/* No port library API to set the environment variable. Use setenv() */
 	rc = setenv("TR_ppcCodeCacheConsolidationEnabled", "true", 1 /*overwrite any existing value */);
 	if (-1 == rc) {
@@ -2496,7 +2529,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 								  requestedPageSize, requestedPageFlags, isSizeSupported);
 #endif /* !defined(OMR_ENV_DATA64) */
 
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:codecache:pagesize=64K\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:codecache:pagesize=64K\n", caseIndex++);
 	mode = OMRPORT_VMEM_MEMORY_MODE_EXECUTE;
 	requestedPageSize = 16 * FOUR_KB;
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_NOT_USED;
@@ -2513,7 +2546,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 								  requestedPageSize, requestedPageFlags, isSizeSupported);
 
 #if !defined(OMR_ENV_DATA64)
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:codecache:pagesize=64K with TR_ppcCodeCacheConsolidationEnabled set\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:codecache:pagesize=64K with TR_ppcCodeCacheConsolidationEnabled set\n", caseIndex++);
 	/* No port library API to set the environment variable. Use setenv() */
 	rc = setenv("TR_ppcCodeCacheConsolidationEnabled", "true", 1 /*overwrite any existing value */);
 	if (-1 == rc) {
@@ -2539,7 +2572,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 								  requestedPageSize, requestedPageFlags, isSizeSupported);
 #endif /* !defined(OMR_ENV_DATA64) */
 
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:codecache:pagesize=4K\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:codecache:pagesize=4K\n", caseIndex++);
 	mode = OMRPORT_VMEM_MEMORY_MODE_EXECUTE;
 	requestedPageSize = FOUR_KB;
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_NOT_USED;
@@ -2556,7 +2589,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 								  requestedPageSize, requestedPageFlags, isSizeSupported);
 
 #if !defined(OMR_ENV_DATA64)
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:codecache:pagesize=4K with TR_ppcCodeCacheConsolidationEnabled set\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:codecache:pagesize=4K with TR_ppcCodeCacheConsolidationEnabled set\n", caseIndex++);
 	/* No port library API to set the environment variable. Use setenv() */
 	rc = setenv("TR_ppcCodeCacheConsolidationEnabled", "true", 1 /*overwrite any existing value */);
 	if (-1 == rc) {
@@ -2582,7 +2615,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 								  requestedPageSize, requestedPageFlags, isSizeSupported);
 #endif /* !defined(OMR_ENV_DATA64) */
 
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:codecache:pagesize=<not in 16G, 16M, 64K, 4K>\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:codecache:pagesize=<not in 16G, 16M, 64K, 4K>\n", caseIndex++);
 	mode = OMRPORT_VMEM_MEMORY_MODE_EXECUTE;
 	requestedPageSize = 8 * ONE_MB;
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_NOT_USED;
@@ -2599,7 +2632,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 								  requestedPageSize, requestedPageFlags, isSizeSupported);
 
 #if !defined(OMR_ENV_DATA64)
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:codecache:pagesize=<not in 16G, 16M, 64K, 4K> with TR_ppcCodeCacheConsolidationEnabled set\n", caseIndex++);
+	portTestEnv->log(LEVEL_ERROR, "\nCase %d: -Xlp:codecache:pagesize=<not in 16G, 16M, 64K, 4K> with TR_ppcCodeCacheConsolidationEnabled set\n", caseIndex++);
 	/* No port library API to set the environment variable. Use setenv() */
 	rc = setenv("TR_ppcCodeCacheConsolidationEnabled", "true", 1 /*overwrite any existing value */);
 	if (-1 == rc) {
@@ -2751,7 +2784,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 
 	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
 
-	outputComment(OMRPORTLIB, "\n");
+	portTestEnv->log("\n");
 	reportTestEntry(OMRPORTLIB, testName);
 
 	/* First get all the supported page sizes */
@@ -2785,19 +2818,19 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 	}
 
 #if defined(OMR_ENV_DATA64)
-	outputComment(OMRPORTLIB, "2G nonpageable supported: %s\n", (twoGBFixed) ? "yes" : "no");
-	outputComment(OMRPORTLIB, "1M nonpageable supported: %s\n", (oneMBFixed) ? "yes" : "no");
+	portTestEnv->log("2G nonpageable supported: %s\n", (twoGBFixed) ? "yes" : "no");
+	portTestEnv->log("1M nonpageable supported: %s\n", (oneMBFixed) ? "yes" : "no");
 #endif /* defined(OMR_ENV_DATA64) */
-	outputComment(OMRPORTLIB, "1M pageable supported: %s\n", (oneMBPageable) ? "yes" : "no");
+	portTestEnv->log("1M pageable supported: %s\n", (oneMBPageable) ? "yes" : "no");
 
 	omrvmem_default_large_page_size_ex(0, &defaultLargePageSize, &defaultLargePageFlags);
 	if (0 != defaultLargePageSize) {
-		outputComment(OMRPORTLIB, "defaultLargePageSize: 0x%zx, defaultLargePageFlags: 0x%zx\n", defaultLargePageSize, defaultLargePageFlags);
+		portTestEnv->log("defaultLargePageSize: 0x%zx, defaultLargePageFlags: 0x%zx\n", defaultLargePageSize, defaultLargePageFlags);
 	}
 
 	/* Test -Xlp:codecache options */
 
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:codecache:pagesize=1M,pageable\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:codecache:pagesize=1M,pageable\n", caseIndex++);
 	mode = OMRPORT_VMEM_MEMORY_MODE_EXECUTE;
 	requestedPageSize = ONE_MB;
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_PAGEABLE;
@@ -2819,7 +2852,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 								  expectedPageSize, expectedPageFlags, expectedIsSizeSupported,
 								  requestedPageSize, requestedPageFlags, isSizeSupported);
 
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:codecache:pagesize=1M,nonpageable\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:codecache:pagesize=1M,nonpageable\n", caseIndex++);
 	mode = OMRPORT_VMEM_MEMORY_MODE_EXECUTE;
 	requestedPageSize = ONE_MB;
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_FIXED;
@@ -2841,7 +2874,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 								  expectedPageSize, expectedPageFlags, expectedIsSizeSupported,
 								  requestedPageSize, requestedPageFlags, isSizeSupported);
 
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:codecache:pagesize=<not 4K, 1M>,pageable\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:codecache:pagesize=<not 4K, 1M>,pageable\n", caseIndex++);
 	mode = OMRPORT_VMEM_MEMORY_MODE_EXECUTE;
 	requestedPageSize = 8 * ONE_MB;
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_PAGEABLE;
@@ -2863,7 +2896,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 								  expectedPageSize, expectedPageFlags, expectedIsSizeSupported,
 								  requestedPageSize, requestedPageFlags, isSizeSupported);
 
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:codecache:pagesize=<not 4K, 1M>,nonpageable\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:codecache:pagesize=<not 4K, 1M>,nonpageable\n", caseIndex++);
 	mode = OMRPORT_VMEM_MEMORY_MODE_EXECUTE;
 	requestedPageSize = 8 * ONE_MB;
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_FIXED;
@@ -2885,7 +2918,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 								  expectedPageSize, expectedPageFlags, expectedIsSizeSupported,
 								  requestedPageSize, requestedPageFlags, isSizeSupported);
 
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:codecache:pagesize=4K,pageable\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:codecache:pagesize=4K,pageable\n", caseIndex++);
 	mode = OMRPORT_VMEM_MEMORY_MODE_EXECUTE;
 	requestedPageSize = FOUR_KB;
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_PAGEABLE;
@@ -2901,7 +2934,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 								  expectedPageSize, expectedPageFlags, expectedIsSizeSupported,
 								  requestedPageSize, requestedPageFlags, isSizeSupported);
 
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:codecache:pagesize=4K,nonpageable\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:codecache:pagesize=4K,nonpageable\n", caseIndex++);
 	mode = OMRPORT_VMEM_MEMORY_MODE_EXECUTE;
 	requestedPageSize = FOUR_KB;
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_FIXED;
@@ -2920,7 +2953,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 	/* Test -Xlp:objectheap options */
 
 #if defined(OMR_ENV_DATA64)
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:objectheap:pagesize=2G,nonpageable\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:objectheap:pagesize=2G,nonpageable\n", caseIndex++);
 	mode = 0;
 	requestedPageSize = TWO_GB;
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_FIXED;
@@ -2951,7 +2984,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 								  requestedPageSize, requestedPageFlags, isSizeSupported);
 #endif /* defined(OMR_ENV_DATA64) */
 
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:objectheap:pagesize=1M,nonpageable\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:objectheap:pagesize=1M,nonpageable\n", caseIndex++);
 	mode = 0;
 	requestedPageSize = ONE_MB;
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_FIXED;
@@ -2979,7 +3012,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 								  expectedPageSize, expectedPageFlags, expectedIsSizeSupported,
 								  requestedPageSize, requestedPageFlags, isSizeSupported);
 
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:objectheap:pagesize=<not 4K, 1M, 2G>,nonpageable\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:objectheap:pagesize=<not 4K, 1M, 2G>,nonpageable\n", caseIndex++);
 	mode = 0;
 	requestedPageSize = 8 * ONE_MB;
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_FIXED;
@@ -3007,7 +3040,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 								  expectedPageSize, expectedPageFlags, expectedIsSizeSupported,
 								  requestedPageSize, requestedPageFlags, isSizeSupported);
 
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:objectheap:pagesize=1M,pageable\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:objectheap:pagesize=1M,pageable\n", caseIndex++);
 	mode = 0;
 	requestedPageSize = ONE_MB;
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_PAGEABLE;
@@ -3029,7 +3062,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 								  expectedPageSize, expectedPageFlags, expectedIsSizeSupported,
 								  requestedPageSize, requestedPageFlags, isSizeSupported);
 
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:objectheap:pagesize=<not 4K, 1M>,pageable\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:objectheap:pagesize=<not 4K, 1M>,pageable\n", caseIndex++);
 	mode = 0;
 	requestedPageSize = 8 * ONE_MB;
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_PAGEABLE;
@@ -3051,7 +3084,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 								  expectedPageSize, expectedPageFlags, expectedIsSizeSupported,
 								  requestedPageSize, requestedPageFlags, isSizeSupported);
 
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:objectheap:pagesize=4K,pageable\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:objectheap:pagesize=4K,pageable\n", caseIndex++);
 	mode = 0;
 	requestedPageSize = FOUR_KB;
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_PAGEABLE;
@@ -3067,7 +3100,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 								  expectedPageSize, expectedPageFlags, expectedIsSizeSupported,
 								  requestedPageSize, requestedPageFlags, isSizeSupported);
 
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp:objectheap:pagesize=4K,nonpageable\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp:objectheap:pagesize=4K,nonpageable\n", caseIndex++);
 	mode = 0;
 	requestedPageSize = FOUR_KB;
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_FIXED;
@@ -3087,9 +3120,9 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 
 	/* Test -Xlp<size> options */
 
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp2G\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp2G\n", caseIndex++);
 	if (0 == defaultLargePageSize) {
-		outputComment(OMRPORTLIB, "Skip this test as the configuration does not support default large page size\n");
+		portTestEnv->log("Skip this test as the configuration does not support default large page size\n");
 	} else {
 		mode = 0;
 		requestedPageSize = TWO_GB;
@@ -3113,9 +3146,9 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 									  requestedPageSize, requestedPageFlags, isSizeSupported);
 	}
 
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp1M\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp1M\n", caseIndex++);
 	if (0 == defaultLargePageSize) {
-		outputComment(OMRPORTLIB, "Skip this test as the configuration does not support default large page size\n");
+		portTestEnv->log("Skip this test as the configuration does not support default large page size\n");
 	} else {
 		mode = 0;
 		requestedPageSize = ONE_MB;
@@ -3133,9 +3166,9 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 									  requestedPageSize, requestedPageFlags, isSizeSupported);
 	}
 
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp<not 4K, 1M, 2G>\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp<not 4K, 1M, 2G>\n", caseIndex++);
 	if (0 == defaultLargePageSize) {
-		outputComment(OMRPORTLIB, "Skip this test as the configuration does not support default large page size\n");
+		portTestEnv->log("Skip this test as the configuration does not support default large page size\n");
 	} else {
 		mode = 0;
 		requestedPageSize = 8 * ONE_MB;
@@ -3153,9 +3186,9 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 									  requestedPageSize, requestedPageFlags, isSizeSupported);
 	}
 
-	outputComment(OMRPORTLIB, "\nCase %d: -Xlp4K\n", caseIndex++);
+	portTestEnv->log("\nCase %d: -Xlp4K\n", caseIndex++);
 	if (0 == defaultLargePageSize) {
-		outputComment(OMRPORTLIB, "Skip this test as the configuration does not support default large page size\n");
+		portTestEnv->log("Skip this test as the configuration does not support default large page size\n");
 	} else {
 		mode = 0;
 		requestedPageSize = FOUR_KB;
@@ -3303,7 +3336,6 @@ _exit:
 uintptr_t
 getSizeFromString(struct OMRPortLibrary *portLibrary, char *sizeString)
 {
-	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
 	if (0 == strcmp(sizeString, "4K")) {
 		return FOUR_KB;
 	} else if (0 == strcmp(sizeString, "64K")) {
@@ -3329,7 +3361,7 @@ getSizeFromString(struct OMRPortLibrary *portLibrary, char *sizeString)
 		return J9CONST_U64(16) * TWO_GB;
 #endif
 	} else {
-		outputComment(OMRPORTLIB, "\n\nWarning: invalid option (%s)\n\n", sizeString);
+		portTestEnv->log(LEVEL_WARN, "\n\nWarning: invalid option (%s)\n\n", sizeString);
 	}
 	return 0;
 }
@@ -3380,7 +3412,7 @@ omrvmem_disclaimPerfTests(struct OMRPortLibrary *portLibrary, char *disclaimPerf
 	if ((0 == pageSize) || (0 == byteAmount) || (0 == memTotal)) {
 		return -1;
 	} else if (0 == numIterations) {
-		outputComment(OMRPORTLIB, "\n\nWarning: invalid option numIterations = (%s)\n\n", pchar);
+		portTestEnv->log(LEVEL_WARN, "\n\nWarning: invalid option numIterations = (%s)\n\n", pchar);
 		return -1;
 	}
 
@@ -3393,7 +3425,7 @@ omrvmem_disclaimPerfTests(struct OMRPortLibrary *portLibrary, char *disclaimPerf
 	 */
 
 	if (TEST_PASS == rc) {
-		outputComment(OMRPORTLIB, "\npageSize: 0x%zx, byteAmount 0x%zx, memTotal 0x%zx, numIterations %i, disclaim %i\n", pageSize, byteAmount, memTotal, numIterations, shouldDisclaim);
+		portTestEnv->log("\npageSize: 0x%zx, byteAmount 0x%zx, memTotal 0x%zx, numIterations %i, disclaim %i\n", pageSize, byteAmount, memTotal, numIterations, shouldDisclaim);
 		rc |= omrvmem_bench_write_and_decommit_memory(OMRPORTLIB, pageSize, byteAmount, shouldDisclaim, numIterations);
 		rc |= omrvmem_bench_reserve_write_decommit_and_free_memory(OMRPORTLIB, pageSize, byteAmount, shouldDisclaim, numIterations);
 #if defined (OMR_ENV_DATA64)
@@ -3402,7 +3434,7 @@ omrvmem_disclaimPerfTests(struct OMRPortLibrary *portLibrary, char *disclaimPerf
 		rc |= omrvmem_bench_force_overcommit_then_decommit(OMRPORTLIB, memTotal, pageSize, shouldDisclaim);
 
 		/* Output results */
-		outputComment(OMRPORTLIB, "\nDisclaim performance test done%s\n\n", rc == TEST_PASS ? "." : ", failures detected.");
+		portTestEnv->log(LEVEL_ERROR, "\nDisclaim performance test done%s\n\n", rc == TEST_PASS ? "." : ", failures detected.");
 	}
 	return TEST_PASS == rc ? 0 : -1;
 }
@@ -3466,8 +3498,8 @@ TEST(PortVmemTest, vmem_testOverlappingSegments)
 	memset(keepCycles, 0, CYCLES);
 	srand(10);
 
-	outputComment(OMRPORTLIB, "Cycles: %d\n\n", CYCLES);
-	outputComment(OMRPORTLIB, "Segment           Start             End               Size              Keep cycle\n");
+	portTestEnv->log("Cycles: %d\n\n", CYCLES);
+	portTestEnv->log("Segment           Start             End               Size              Keep cycle\n");
 
 	for (i = 0; i < CYCLES; i++) {
 		char *memPtr = NULL;
@@ -3475,20 +3507,20 @@ TEST(PortVmemTest, vmem_testOverlappingSegments)
 		memPtr = (char *)omrvmem_reserve_memory_ex(&vmemID[i], &vmemParams[i]);
 
 		if (NULL == memPtr) {
-			outputComment(OMRPORTLIB, "Failed to get memory. Error: %s.\n", strerror(errno));
-			outputComment(OMRPORTLIB, "Ignoring memory allocation failure(%d of %d loops finished).\n", i, CYCLES);
+			portTestEnv->log(LEVEL_ERROR, "Failed to get memory. Error: %s.\n", strerror(errno));
+			portTestEnv->log(LEVEL_ERROR, "Ignoring memory allocation failure(%d of %d loops finished).\n", i, CYCLES);
 			goto exit;
 		}
 		/* Determine how long to keep the segment */
 		keepCycles[i] = (rand() % (((int)((double)CYCLES / FREE_PROB)) - i)) + i + 1;
-		outputComment(OMRPORTLIB, "%.16d  %.16X  %.16X  %.16X  %d\n", i, (uintptr_t)vmemID[i].address, (uintptr_t)vmemID[i].address + vmemID[i].size, vmemID[i].size, keepCycles[i]);
+		portTestEnv->log("%.16d  %.16X  %.16X  %.16X  %d\n", i, (uintptr_t)vmemID[i].address, (uintptr_t)vmemID[i].address + vmemID[i].size, vmemID[i].size, keepCycles[i]);
 
 		/* Check for overlapping segments */
 		for (j = 0; j < i; j++) {
 			if (keepCycles[j] >= i) { /* If not already freed */
 				if (checkForOverlap(&vmemID[i], &vmemID[j])) {
 					outputErrorMessage(PORTTEST_ERROR_ARGS, "OVERLAP\n");
-					outputComment(OMRPORTLIB, "%.16d  %.16X  %.16X  %.16X  %d\n", j, (uintptr_t)vmemID[j].address, (uintptr_t)vmemID[j].address + vmemID[j].size, vmemID[j].size, keepCycles[j]);
+					portTestEnv->log("%.16d  %.16X  %.16X  %.16X  %d\n", j, (uintptr_t)vmemID[j].address, (uintptr_t)vmemID[j].address + vmemID[j].size, vmemID[j].size, keepCycles[j]);
 					keepCycles[i] = i - 1; /* Pretend this segment is already freed to avoid double freeing overlapping segments */
 					result = -1;
 					goto exit;
@@ -3502,20 +3534,20 @@ TEST(PortVmemTest, vmem_testOverlappingSegments)
 				int32_t rc = omrvmem_free_memory(vmemID[j].address, vmemParams[j].byteAmount, &vmemID[j]);
 				if (0 != rc) {
 					outputErrorMessage(PORTTEST_ERROR_ARGS, "Problem freeing segment...");
-					outputComment(OMRPORTLIB, "%.16d  %.16X  %.16X  %.16X  %d\n", j, (uintptr_t)vmemID[j].address, (uintptr_t)vmemID[j].address + vmemID[j].size, vmemID[j].size, keepCycles[j]);
+					portTestEnv->log("%.16d  %.16X  %.16X  %.16X  %d\n", j, (uintptr_t)vmemID[j].address, (uintptr_t)vmemID[j].address + vmemID[j].size, vmemID[j].size, keepCycles[j]);
 					result = -1;
 					goto exit;
 				} else {
-					outputComment(OMRPORTLIB, "%.16d  Freed\n", j);
+					portTestEnv->log("%.16d  Freed\n", j);
 					freed++;
 				}
 			}
 		}
 	}
 exit:
-	outputComment(OMRPORTLIB, "\n=========================\n");
-	outputComment(OMRPORTLIB, "%d cycles completed\n", i);
-	outputComment(OMRPORTLIB, "%d segments freed\n\n", freed);
+	portTestEnv->log("\n=========================\n");
+	portTestEnv->log("%d cycles completed\n", i);
+	portTestEnv->log("%d segments freed\n\n", freed);
 
 	/* Free remaining segments */
 	freed = 0;
@@ -3527,7 +3559,7 @@ exit:
 			}
 		}
 	}
-	outputComment(OMRPORTLIB, "%d remaining segments freed\n\n", freed);
+	portTestEnv->log("%d remaining segments freed\n\n", freed);
 
 	omrmem_free_memory(vmemParams);
 	omrmem_free_memory(vmemID);
@@ -3566,19 +3598,19 @@ TEST(PortVmemTest, vmem_testGetProcessMemorySize)
 	result = omrvmem_get_process_memory_size(OMRPORT_VMEM_PROCESS_PRIVATE, &size);
 	EXPECT_TRUE(0 == result) << "OMRPORT_VMEM_PROCESS_PRIVATE failed";
 	EXPECT_TRUE(size > 0) << "OMRPORT_VMEM_PROCESS_PRIVATE returned 0";
-	outputComment(OMRPORTLIB, "OMRPORT_VMEM_PROCESS_PRIVATE = %lu.\n", size);
+	portTestEnv->log("OMRPORT_VMEM_PROCESS_PRIVATE = %lu.\n", size);
 #endif /* !defined(OSX) */
 
 #if defined(LINUX) || defined(WIN32) || defined(OSX)
 	result = omrvmem_get_process_memory_size(OMRPORT_VMEM_PROCESS_PHYSICAL, &size);
 	EXPECT_TRUE(0 == result) << "OMRPORT_VMEM_PROCESS_PHYSICAL failed";
 	EXPECT_TRUE(size > 0) << "OMRPORT_VMEM_PROCESS_PHYSICAL returned 0";
-	outputComment(OMRPORTLIB, "OMRPORT_VMEM_PROCESS_PHYSICAL = %lu.\n", size);
+	portTestEnv->log("OMRPORT_VMEM_PROCESS_PHYSICAL = %lu.\n", size);
 
 	result = omrvmem_get_process_memory_size(OMRPORT_VMEM_PROCESS_VIRTUAL, &size);
 	EXPECT_TRUE(0 == result) << "OMRPORT_VMEM_PROCESS_VIRTUAL failed";
 	EXPECT_TRUE(size > 0) << "OMRPORT_VMEM_PROCESS_VIRTUAL returned 0";
-	outputComment(OMRPORTLIB, "OMRPORT_VMEM_PROCESS_VIRTUAL = %lu.\n", size);
+	portTestEnv->log("OMRPORT_VMEM_PROCESS_VIRTUAL = %lu.\n", size);
 #elif defined(AIXPPC)
 	size = 0;
 	result = omrvmem_get_process_memory_size(OMRPORT_VMEM_PROCESS_PHYSICAL, &size);

--- a/fvtest/porttest/omrvmemTest.cpp
+++ b/fvtest/porttest/omrvmemTest.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2016
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -388,10 +388,10 @@ setDisclaimVirtualMemory(struct OMRPortLibrary *portLibrary, BOOLEAN disclaim)
 {
 	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
 	if (disclaim) {
-		omrtty_printf("\n *** Disclaiming virtual memory\n\n");
+		portTestEnv->log("\n *** Disclaiming virtual memory\n\n");
 		omrport_control(OMRPORT_CTLDATA_VMEM_ADVISE_OS_ONFREE, 1);
 	} else {
-		omrtty_printf("\n *** Not disclaiming virtual memory\n\n");
+		portTestEnv->log("\n *** Not disclaiming virtual memory\n\n");
 		omrport_control(OMRPORT_CTLDATA_VMEM_ADVISE_OS_ONFREE, 0);
 	}
 }
@@ -446,12 +446,12 @@ omrvmem_bench_write_and_decommit_memory(struct OMRPortLibrary *portLibrary, uint
 			PORTTEST_ERROR_ARGS, "unable to reserve 0x%zx bytes with page size 0x%zx.\n"
 			"\tlastErrorNumber=%d, lastErrorMessage=%s\n ", byteAmount, pageSize, lastErrorNumber, lastErrorMessage);
 		if (OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES == lastErrorNumber) {
-			omrtty_printf("\tPortable error OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES...\n");
-			omrtty_printf("\t\tREBOOT THE MACHINE to free up resources AND TRY THE TEST AGAIN\n");
+			portTestEnv->log(LEVEL_ERROR, "\tPortable error OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES...\n");
+			portTestEnv->log(LEVEL_ERROR, "\t\tREBOOT THE MACHINE to free up resources AND TRY THE TEST AGAIN\n");
 		}
 		goto exit;
 	} else {
-		omrtty_printf("\treserved 0x%zx bytes with page size 0x%zx at 0x%zx\n", byteAmount, vmemID.pageSize, memPtr);
+		portTestEnv->log("\treserved 0x%zx bytes with page size 0x%zx at 0x%zx\n", byteAmount, vmemID.pageSize, memPtr);
 	}
 
 	startTimeNanos = omrtime_nano_time();
@@ -477,7 +477,7 @@ omrvmem_bench_write_and_decommit_memory(struct OMRPortLibrary *portLibrary, uint
 	}
 
 	deltaMillis = (omrtime_nano_time() - startTimeNanos) / (1000 * 1000);
-	omrtty_printf("%s pageSize 0x%zx, byteAmount 0x%zx, millis for %u iterations: [write_to_all/decommit] test: %lli\n", disclaim ? "disclaim" : "nodisclaim", pageSize, byteAmount, numIterations, deltaMillis);
+	portTestEnv->log("%s pageSize 0x%zx, byteAmount 0x%zx, millis for %u iterations: [write_to_all/decommit] test: %lli\n", disclaim ? "disclaim" : "nodisclaim", pageSize, byteAmount, numIterations, deltaMillis);
 
 	rc = omrvmem_free_memory(memPtr, byteAmount, &vmemID);
 
@@ -544,12 +544,12 @@ omrvmem_bench_force_overcommit_then_decommit(struct OMRPortLibrary *portLibrary,
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "unable to reserve and commit 0x%zx bytes with page size 0x%zx.\n"
 						   "\tlastErrorNumber=%d, lastErrorMessage=%s\n ", byteAmount, pageSize, lastErrorNumber, lastErrorMessage);
 		if (OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES == lastErrorNumber) {
-			omrtty_printf("\tPortable error OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES...\n");
-			omrtty_printf("\t\tREBOOT THE MACHINE to free up resources AND TRY THE TEST AGAIN\n");
+			portTestEnv->log(LEVEL_ERROR, "\tPortable error OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES...\n");
+			portTestEnv->log(LEVEL_ERROR, "\t\tREBOOT THE MACHINE to free up resources AND TRY THE TEST AGAIN\n");
 		}
 		goto exit;
 	} else {
-		omrtty_printf("reserved and committed 0x%zx bytes of pagesize 0x%zx\n", byteAmount, pageSize);
+		portTestEnv->log("reserved and committed 0x%zx bytes of pagesize 0x%zx\n", byteAmount, pageSize);
 	}
 
 	startTimeNanos = omrtime_nano_time();
@@ -573,7 +573,7 @@ omrvmem_bench_force_overcommit_then_decommit(struct OMRPortLibrary *portLibrary,
 	memset(memPtr, 5, D512M);
 
 	deltaMillis = (omrtime_nano_time() - startTimeNanos) / (1000 * 1000);
-	omrtty_printf("%s pageSize 0x%zx, byteAmount 0x%zx, millis: [force page, decommit pagedout region, write decommitted region] test: %lli\n", disclaim ? "disclaim" : "nodisclaim", pageSize, byteAmount, deltaMillis);
+	portTestEnv->log("%s pageSize 0x%zx, byteAmount 0x%zx, millis: [force page, decommit pagedout region, write decommitted region] test: %lli\n", disclaim ? "disclaim" : "nodisclaim", pageSize, byteAmount, deltaMillis);
 
 	rc = omrvmem_free_memory(memPtr, byteAmount, &vmemID);
 
@@ -645,8 +645,8 @@ omrvmem_bench_reserve_write_decommit_and_free_memory(struct OMRPortLibrary *port
 				PORTTEST_ERROR_ARGS, "In iteration %d, unable to reserve and commit 0x%zx bytes with page size 0x%zx.\n"
 				"\tlastErrorNumber=%d, lastErrorMessage=%s\n ", i, byteAmount, pageSize, lastErrorNumber, lastErrorMessage);
 			if (OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES == lastErrorNumber) {
-				omrtty_printf("\tPortable error OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES...\n");
-				omrtty_printf("\t\tREBOOT THE MACHINE to free up resources AND TRY THE TEST AGAIN\n");
+				portTestEnv->log(LEVEL_ERROR, "\tPortable error OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES...\n");
+				portTestEnv->log(LEVEL_ERROR, "\t\tREBOOT THE MACHINE to free up resources AND TRY THE TEST AGAIN\n");
 			}
 			goto exit;
 		}
@@ -670,7 +670,7 @@ omrvmem_bench_reserve_write_decommit_and_free_memory(struct OMRPortLibrary *port
 
 	deltaMillis = (omrtime_nano_time() - startTimeNanos) / (1000 * 1000);
 
-	omrtty_printf("%s pageSize 0x%zx, byteAmount 0x%zx, millis for %u iterations: [reserve/write_to_all/decommit/free] test: %lli\n", disclaim ? "disclaim" : "nodisclaim", pageSize, byteAmount, numIterations, deltaMillis);
+	portTestEnv->log("%s pageSize 0x%zx, byteAmount 0x%zx, millis for %u iterations: [reserve/write_to_all/decommit/free] test: %lli\n", disclaim ? "disclaim" : "nodisclaim", pageSize, byteAmount, numIterations, deltaMillis);
 
 exit:
 	return reportTestExit(OMRPORTLIB, testName);
@@ -734,14 +734,14 @@ omrvmem_exhaust_virtual_memory(struct OMRPortLibrary *portLibrary, uintptr_t pag
 				PORTTEST_ERROR_ARGS, "unable to reserve and commit 0x%zx bytes with page size 0x%zx.\n"
 				"\tlastErrorNumber=%d, lastErrorMessage=%s\n ", byteAmount, pageSize, lastErrorNumber, lastErrorMessage);
 			if (OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES == lastErrorNumber) {
-				omrtty_printf("\tPortable error OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES...\n");
-				omrtty_printf("\t\tREBOOT THE MACHINE to free up resources AND TRY THE TEST AGAIN\n");
+				portTestEnv->log(LEVEL_ERROR, "\tPortable error OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES...\n");
+				portTestEnv->log(LEVEL_ERROR, "\t\tREBOOT THE MACHINE to free up resources AND TRY THE TEST AGAIN\n");
 			}
 			goto exit;
 		} else {
-			omrtty_printf("\treserved 0x%zx bytes\n", byteAmount);
+			portTestEnv->log("\treserved 0x%zx bytes\n", byteAmount);
 			totalAlloc = byteAmount + totalAlloc;
-			omrtty_printf("\ttotal: 0x%zx bytes\n", totalAlloc);
+			portTestEnv->log("\ttotal: 0x%zx bytes\n", totalAlloc);
 		}
 
 		/* write to the memory */
@@ -768,7 +768,7 @@ omrvmem_exhaust_virtual_memory(struct OMRPortLibrary *portLibrary, uintptr_t pag
 		}
 	}
 
-	omrtty_printf("%s pageSize 0x%zx, byteAmount 0x%zx, millis for %u iterations: [reserve/write_to_all/decommit] test: %lli\n", disclaim ? "disclaim" : "nodisclaim", pageSize, byteAmount, NUM_VMEM_IDS, deltaMillis);
+	portTestEnv->log("%s pageSize 0x%zx, byteAmount 0x%zx, millis for %u iterations: [reserve/write_to_all/decommit] test: %lli\n", disclaim ? "disclaim" : "nodisclaim", pageSize, byteAmount, NUM_VMEM_IDS, deltaMillis);
 
 exit:
 	return reportTestExit(OMRPORTLIB, testName);

--- a/fvtest/porttest/si.cpp
+++ b/fvtest/porttest/si.cpp
@@ -148,8 +148,8 @@ TEST(PortSysinfoTest, sysinfo_test0)
 								 executable_name /* found through API */
 								)
 	) {
-		outputComment(OMRPORTLIB, "Executable name test passed.\n"
-					  "  Expected (argv0=%s).\n  Found=%s.\n",
+		portTestEnv->log("Executable name test passed.\n"
+					  "Expected (argv0=%s).\n  Found=%s.\n",
 					  argv0,
 					  executable_name);
 	} else {
@@ -225,14 +225,14 @@ TEST(PortSysinfoTest, sysinfo_test1)
 
 	rc = omrsysinfo_get_username(username, J9SYSINFO_TEST1_USERNAME_LENGTH);
 	if (rc == -1) {
-		outputComment(OMRPORTLIB, "omrsysinfo_get_username returns -1.\n");
-		outputComment(OMRPORTLIB, "If this is a supported platform, consider this as a failure\n");
+		portTestEnv->log(LEVEL_ERROR, "omrsysinfo_get_username returns -1.\n");
+		portTestEnv->log(LEVEL_ERROR, "If this is a supported platform, consider this as a failure\n");
 		reportTestExit(OMRPORTLIB, testName);
 		return;
 	} else {
 		char msg[256] = "";
 		omrstr_printf(msg, sizeof(msg), "User name returned = \"%s\"\n", username);
-		outputComment(OMRPORTLIB, msg);
+		portTestEnv->log(msg);
 	}
 
 	length = strlen(username);
@@ -257,14 +257,14 @@ TEST(PortSysinfoTest, sysinfo_test2)
 
 	rc = omrsysinfo_get_groupname(groupname, J9SYSINFO_TEST2_GROUPNAME_LENGTH);
 	if (rc == -1) {
-		outputComment(OMRPORTLIB, "omrsysinfo_get_groupname returns -1.\n");
-		outputComment(OMRPORTLIB, "If this is a supported platform, consider this as a failure\n");
+		portTestEnv->log(LEVEL_ERROR, "omrsysinfo_get_groupname returns -1.\n");
+		portTestEnv->log(LEVEL_ERROR, "If this is a supported platform, consider this as a failure\n");
 		reportTestExit(OMRPORTLIB, testName);
 		return;
 	} else {
 		char msg[256] = "";
 		omrstr_printf(msg, sizeof(msg), "Group name returned = \"%s\"\n", groupname);
-		outputComment(OMRPORTLIB, msg);
+		portTestEnv->log(msg);
 	}
 
 	length = strlen(groupname);
@@ -295,7 +295,7 @@ TEST(PortSysinfoTest, sysinfo_get_OS_type_test)
 	} else {
 		char msg[256];
 		omrstr_printf(msg, sizeof(msg), "omrsysinfo_get_OS_type returned : \"%s\"\n", osName);
-		outputComment(OMRPORTLIB, msg);
+		portTestEnv->log(msg);
 	}
 
 	osVersion = omrsysinfo_get_OS_version();
@@ -306,7 +306,7 @@ TEST(PortSysinfoTest, sysinfo_get_OS_type_test)
 	} else {
 		char msg[256];
 		omrstr_printf(msg, sizeof(msg), "omrsysinfo_get_OS_version returned : \"%s\"\n", osVersion);
-		outputComment(OMRPORTLIB, msg);
+		portTestEnv->log(msg);
 	}
 
 #if defined(WIN32) || defined(WIN64)
@@ -324,7 +324,6 @@ TEST(PortSysinfoTest, sysinfo_get_OS_type_test)
 		return;
 	}
 #endif
-
 	reportTestExit(OMRPORTLIB, testName);
 }
 
@@ -339,15 +338,15 @@ TEST(PortSysinfoTest, sysinfo_test3)
 
 	rc = omrsysinfo_get_load_average(&loadData);
 	if (rc == -1) {
-		outputComment(OMRPORTLIB, "omrsysinfo_get_load_average returns -1.\n");
-		outputComment(OMRPORTLIB, "If this is a supported platform, consider this as a failure\n");
+		portTestEnv->log(LEVEL_ERROR, "omrsysinfo_get_load_average returns -1.\n");
+		portTestEnv->log(LEVEL_ERROR, "If this is a supported platform, consider this as a failure\n");
 		reportTestExit(OMRPORTLIB, testName);
 		return;
 	} else {
-		outputComment(OMRPORTLIB, "Returned data\n");
-		outputComment(OMRPORTLIB, "One Minute Average: %lf\n", loadData.oneMinuteAverage);
-		outputComment(OMRPORTLIB, "Five Minute Average: %lf\n", loadData.fiveMinuteAverage);
-		outputComment(OMRPORTLIB, "Fifteen Minute Average: %lf\n", loadData.fifteenMinuteAverage);
+		portTestEnv->log("Returned data\n");
+		portTestEnv->log("One Minute Average: %lf\n", loadData.oneMinuteAverage);
+		portTestEnv->log("Five Minute Average: %lf\n", loadData.fiveMinuteAverage);
+		portTestEnv->log("Fifteen Minute Average: %lf\n", loadData.fifteenMinuteAverage);
 	}
 
 	reportTestExit(OMRPORTLIB, testName);
@@ -364,13 +363,14 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_ulimit_iterator)
 	J9SysinfoUserLimitElement element;
 
 	reportTestEntry(OMRPORTLIB, testName);
+	portTestEnv->changeIndent(1);
 
 	rc = omrsysinfo_limit_iterator_init(&state);
 
 	if (0 != rc) {
 
 		if (OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM == rc) {
-			portTestEnv->log(LEVEL_ERROR, "\tThis platform does not support the limit iterator\n");
+			portTestEnv->log(LEVEL_ERROR, "This platform does not support the limit iterator\n");
 		} else {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "\tomrsysinfo_limit_iterator_init returned: %i\n", rc);
 		}
@@ -382,18 +382,18 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_ulimit_iterator)
 		rc = omrsysinfo_limit_iterator_next(&state, &element);
 
 		if (0 == rc) {
-			portTestEnv->log("\t%s:\n", element.name);
+			portTestEnv->log("%s:\n", element.name);
 
 			if (OMRPORT_LIMIT_UNLIMITED == element.softValue) {
-				portTestEnv->log("\t soft: unlimited\n");
+				portTestEnv->log(" soft: unlimited\n");
 			} else {
-				portTestEnv->log("\t soft: 0x%zX\n", element.softValue);
+				portTestEnv->log(" soft: 0x%zX\n", element.softValue);
 			}
 
 			if (OMRPORT_LIMIT_UNLIMITED == element.hardValue) {
-				portTestEnv->log("\t hard: unlimited\n");
+				portTestEnv->log(" hard: unlimited\n");
 			} else {
-				portTestEnv->log("\t hard: 0x%zX\n", element.hardValue);
+				portTestEnv->log(" hard: 0x%zX\n", element.hardValue);
 			}
 
 		} else {
@@ -403,6 +403,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_ulimit_iterator)
 
 done:
 
+	portTestEnv->changeIndent(-1);
 	reportTestExit(OMRPORTLIB, testName);
 }
 
@@ -432,6 +433,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_env_iterator)
 #undef SI_DEBUG
 
 	reportTestEntry(OMRPORTLIB, testName);
+	portTestEnv->changeIndent(1);
 
 	/* Test 1: NULL buffer - Pass in NULL for buffer, make sure we get back a positive integer describing the size, or a crash */
 	buffer = NULL;
@@ -439,7 +441,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_env_iterator)
 
 	if (rc < 0) {
 		if (OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM == rc) {
-			portTestEnv->log(LEVEL_ERROR, "\tThis platform does not support the env iterator\n");
+			portTestEnv->log(LEVEL_ERROR, "This platform does not support the env iterator\n");
 		} else if (OMRPORT_ERROR_SYSINFO_ENV_INIT_CRASHED_COPYING_BUFFER == rc) {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "\tCrash passing in NULL buffer while running single-threaded. This is a failure because no-one else should have been able to modify it\n");
 		} else {
@@ -471,14 +473,14 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_env_iterator)
 		goto done;
 	}
 
-	portTestEnv->log("\tEnvironment:\n\n");
+	portTestEnv->log("Environment:\n\n");
 
 	l = 0;
 	while (omrsysinfo_env_iterator_hasNext(&state)) {
 		rc = omrsysinfo_env_iterator_next(&state, &element);
 
 		if (0 == rc) {
-			portTestEnv->log("\t%s\n", element.nameAndValue);
+			portTestEnv->log("%s\n", element.nameAndValue);
 			l++;
 		} else {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "\tomrsysinfo_env_iterator_next returned: %i when 0 was expected\n", rc);
@@ -519,7 +521,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_env_iterator)
 		rc = omrsysinfo_env_iterator_next(&state, &element);
 
 #if defined(SI_DEBUG)
-		portTestEnv->log("\tsi.c element.nameAndValue @ 0x%p: %s\n", element.nameAndValue, element.nameAndValue);
+		portTestEnv->log("si.c element.nameAndValue @ 0x%p: %s\n", element.nameAndValue, element.nameAndValue);
 #endif
 
 		if (0 == rc) {
@@ -562,7 +564,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_env_iterator)
 		rc = omrsysinfo_env_iterator_next(&state, &element);
 
 #if defined(SI_DEBUG)
-		portTestEnv->log("\tsi.c element.nameAndValue @ 0x%p: %s\n", element.nameAndValue, element.nameAndValue);
+		portTestEnv->log("si.c element.nameAndValue @ 0x%p: %s\n", element.nameAndValue, element.nameAndValue);
 #endif
 
 		if (0 == rc) {
@@ -580,6 +582,7 @@ done:
 		omrmem_free_memory(buffer);
 	}
 
+	portTestEnv->changeIndent(-1);
 	reportTestExit(OMRPORTLIB, testName);
 }
 
@@ -618,7 +621,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_set_limit_ADDRESS_SPACE)
 	rc = omrsysinfo_get_limit(OMRPORT_RESOURCE_ADDRESS_SPACE, &currentLimit);
 
 	if (as1 == currentLimit) {
-		outputComment(OMRPORTLIB, "omrsysinfo_set_limit set ADDRESS_SPACE soft max successful\n");
+		portTestEnv->log("omrsysinfo_set_limit set ADDRESS_SPACE soft max successful\n");
 	} else {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrsysinfo_set_limit set ADDRESS_SPACE soft max FAILED\n");
 		reportTestExit(OMRPORTLIB, testName);
@@ -640,7 +643,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_set_limit_ADDRESS_SPACE)
 
 		rc = omrsysinfo_get_limit(OMRPORT_RESOURCE_ADDRESS_SPACE | OMRPORT_LIMIT_HARD, &currentLimit);
 		if (originalMaxLimit == currentLimit) {
-			outputComment(OMRPORTLIB, "omrsysinfo_set_limit set ADDRESS_SPACE hard max successful\n");
+			portTestEnv->log("omrsysinfo_set_limit set ADDRESS_SPACE hard max successful\n");
 		} else {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "omrsysinfo_set_limit set ADDRESS_SPACE hard max FAILED\n");
 			reportTestExit(OMRPORTLIB, testName);
@@ -659,7 +662,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_set_limit_ADDRESS_SPACE)
 		rc = omrsysinfo_get_limit(OMRPORT_RESOURCE_ADDRESS_SPACE | OMRPORT_LIMIT_HARD, &currentLimit);
 
 		if (as1 + 1 == currentLimit) {
-			outputComment(OMRPORTLIB, "omrsysinfo_set_limit set ADDRESS_SPACE hard max successful\n");
+			portTestEnv->log("omrsysinfo_set_limit set ADDRESS_SPACE hard max successful\n");
 		} else {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "omrsysinfo_set_limit set ADDRESS_SPACE hard max FAILED\n");
 			reportTestExit(OMRPORTLIB, testName);
@@ -721,7 +724,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_set_limit_CORE_FILE)
 	rc = omrsysinfo_get_limit(OMRPORT_RESOURCE_CORE_FILE, &currentLimit);
 
 	if (coreFileSize == currentLimit) {
-		outputComment(OMRPORTLIB, "omrsysinfo_set_limit set CORE_FILE soft max successful\n");
+		portTestEnv->log("omrsysinfo_set_limit set CORE_FILE soft max successful\n");
 	} else {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrsysinfo_set_limit set CORE_FILE soft max FAILED\n");
 		reportTestExit(OMRPORTLIB, testName);
@@ -744,7 +747,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_set_limit_CORE_FILE)
 
 		rc = omrsysinfo_get_limit(OMRPORT_RESOURCE_CORE_FILE | OMRPORT_LIMIT_HARD, &currentLimit);
 		if (originalMaxLimit == currentLimit) {
-			outputComment(OMRPORTLIB, "omrsysinfo_set_limit set CORE_FILE hard max successful\n");
+			portTestEnv->log("omrsysinfo_set_limit set CORE_FILE hard max successful\n");
 		} else {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "omrsysinfo_set_limit set CORE_FILE hard max FAILED\n");
 			reportTestExit(OMRPORTLIB, testName);
@@ -763,7 +766,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_set_limit_CORE_FILE)
 
 		rc = omrsysinfo_get_limit(OMRPORT_RESOURCE_CORE_FILE | OMRPORT_LIMIT_HARD, &currentLimit);
 		if (coreFileSize + 1 == currentLimit) {
-			outputComment(OMRPORTLIB, "omrsysinfo_set_limit set CORE_FILE hard max successful\n");
+			portTestEnv->log("omrsysinfo_set_limit set CORE_FILE hard max successful\n");
 		} else {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "omrsysinfo_set_limit set CORE_FILE hard max FAILED\n");
 			reportTestExit(OMRPORTLIB, testName);
@@ -811,7 +814,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_set_limit_CORE_FLAGS)
 	reportTestEntry(OMRPORTLIB, testName);
 
 	if (geteuid()) {
-		outputComment(OMRPORTLIB, "You must be root to set core flags\n");
+		portTestEnv->log(LEVEL_ERROR, "You must be root to set core flags\n");
 
 		rc = omrsysinfo_get_limit(OMRPORT_RESOURCE_CORE_FLAGS, &currentLimit);
 		if (-1 == rc) {
@@ -824,7 +827,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_set_limit_CORE_FLAGS)
 		lastErrorNumber = omrerror_last_error_number();
 
 		if (OMRPORT_ERROR_FILE_NOPERMISSION == lastErrorNumber) {
-			outputComment(OMRPORTLIB, "omrsysinfo_set_limit CORE_FLAGS failed as expected because we aren't root.\n");
+			portTestEnv->log(LEVEL_ERROR, "omrsysinfo_set_limit CORE_FLAGS failed as expected because we aren't root.\n");
 		} else {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "omrsysinfo_set_limit CORE_FLAGS did not fail with the proper error.\n");
 			reportTestExit(OMRPORTLIB, testName);
@@ -847,7 +850,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_set_limit_CORE_FLAGS)
 		rc = omrsysinfo_get_limit(OMRPORT_RESOURCE_CORE_FLAGS, &currentLimit);
 		if ((rc == OMRPORT_LIMIT_LIMITED) &&
 			(0 == currentLimit)) {
-			outputComment(OMRPORTLIB, "omrsysinfo_set_limit set AIX full core value to 0 successful\n");
+			portTestEnv->log("omrsysinfo_set_limit set AIX full core value to 0 successful\n");
 		} else {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "omrsysinfo_set_limit set CORE_FLAGS FAILED\n");
 			reportTestExit(OMRPORTLIB, testName);
@@ -865,7 +868,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_set_limit_CORE_FLAGS)
 		rc = omrsysinfo_get_limit(OMRPORT_RESOURCE_CORE_FLAGS, &currentLimit);
 		if ((OMRPORT_LIMIT_UNLIMITED == rc) &&
 			(U_64_MAX == currentLimit)) {
-			outputComment(OMRPORTLIB, "omrsysinfo_set_limit set AIX full core value to 1 successful\n");
+			portTestEnv->log("omrsysinfo_set_limit set AIX full core value to 1 successful\n");
 		} else {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "omrsysinfo_set_limit set CORE_FLAGS FAILED\n");
 			reportTestExit(OMRPORTLIB, testName);
@@ -906,7 +909,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_get_limit_FILE_DESCRIPTORS)
 		 * set to implementation-defined limit, RLIM_INFINITY.
 		 */
 		if (RLIM_INFINITY == curLimit) {
-			outputComment(OMRPORTLIB,
+			portTestEnv->log(
 				"omrsysinfo_get_limit(nofiles): soft limit=RLIM_INFINITY (unlimited).\n");
 		} else {
 			outputErrorMessage(PORTTEST_ERROR_ARGS,
@@ -917,7 +920,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_get_limit_FILE_DESCRIPTORS)
 		}
 	} else if (OMRPORT_LIMIT_LIMITED == rc) {
 		if ((((int64_t) curLimit) > 0) && (((int64_t) curLimit) <= INT64_MAX)) {
-			outputComment(OMRPORTLIB, "omrsysinfo_get_limit(nofiles) soft limit: %lld.\n",
+			portTestEnv->log("omrsysinfo_get_limit(nofiles) soft limit: %lld.\n",
 				((int64_t) curLimit));
 		} else {
 			outputErrorMessage(PORTTEST_ERROR_ARGS,
@@ -938,7 +941,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_get_limit_FILE_DESCRIPTORS)
 	if (OMRPORT_LIMIT_UNLIMITED == rc) {
 		/* Not an error, just that it is not configured.  Ok to compare!. */
 		if (RLIM_INFINITY == maxLimit) {
-			outputComment(OMRPORTLIB,
+			portTestEnv->log(
 				"omrsysinfo_get_limit(nofiles): hard limit = RLIM_INFINITY (unlimited).\n");
 		} else {
 			outputErrorMessage(PORTTEST_ERROR_ARGS,
@@ -949,7 +952,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_get_limit_FILE_DESCRIPTORS)
 		}
 	} else if (OMRPORT_LIMIT_LIMITED == rc) {
 		if ((((int64_t) maxLimit) > 0) && (((int64_t) maxLimit) <= INT64_MAX)) {
-			outputComment(OMRPORTLIB, "omrsysinfo_get_limit(nofiles) hard limit: %lld.\n",
+			portTestEnv->log("omrsysinfo_get_limit(nofiles) hard limit: %lld.\n",
 				((int64_t) maxLimit));
 		} else {
 			outputErrorMessage(PORTTEST_ERROR_ARGS,
@@ -995,6 +998,7 @@ TEST(PortSysinfoTest, sysinfo_testMemoryInfo)
 	J9MemoryInfo memInfo = {0};
 
 	reportTestEntry(OMRPORTLIB, testName);
+	portTestEnv->changeIndent(1);
 
 	rc = omrsysinfo_get_memory_info(&memInfo);
 	if (0 != rc) {
@@ -1054,42 +1058,43 @@ TEST(PortSysinfoTest, sysinfo_testMemoryInfo)
 			(memInfo.timestamp > 0)) {
 
 			/* Print out the memory usage statistics. */
-			outputComment(OMRPORTLIB, "Retrieved memory usage statistics.\n");
-			outputComment(OMRPORTLIB, "Total physical memory: %llu bytes.\n", memInfo.totalPhysical);
-			outputComment(OMRPORTLIB, "Available physical memory: %llu bytes.\n", memInfo.availPhysical);
+			portTestEnv->log("Retrieved memory usage statistics.\n");
+			portTestEnv->log("Total physical memory: %llu bytes.\n", memInfo.totalPhysical);
+			portTestEnv->log("Available physical memory: %llu bytes.\n", memInfo.availPhysical);
 #if defined(WIN32) || defined(OSX)
-			outputComment(OMRPORTLIB, "Total virtual memory: %llu bytes.\n", memInfo.totalVirtual);
-			outputComment(OMRPORTLIB, "Available virtual memory: %llu bytes.\n", memInfo.availVirtual);
+			portTestEnv->log("Total virtual memory: %llu bytes.\n", memInfo.totalVirtual);
+			portTestEnv->log("Available virtual memory: %llu bytes.\n", memInfo.availVirtual);
 #else /* defined(WIN32) || defined(OSX) */
 			/* This may or may not be available depending on whether a limit is set. Print out if this
 			 * is available or else, call this parameter "undefined".
 			 */
 			if (OMRPORT_MEMINFO_NOT_AVAILABLE != memInfo.totalVirtual) {
-				outputComment(OMRPORTLIB, "Total virtual memory: %llu bytes.\n", memInfo.totalVirtual);
+				portTestEnv->log("Total virtual memory: %llu bytes.\n", memInfo.totalVirtual);
 			} else {
-				outputComment(OMRPORTLIB, "Total virtual memory: <undefined>.\n");
+				portTestEnv->log("Total virtual memory: <undefined>.\n");
 			}
 			/* Leave Available Virtual memory parameter as it is on non-Windows Platforms. */
-			outputComment(OMRPORTLIB, "Available virtual memory: <undefined>.\n");
+			portTestEnv->log("Available virtual memory: <undefined>.\n");
 #endif /* defined(WIN32) || defined(OSX) */
-			outputComment(OMRPORTLIB, "Total swap memory: %llu bytes.\n", memInfo.totalSwap);
-			outputComment(OMRPORTLIB, "Swap memory free: %llu bytes.\n", memInfo.availSwap);
+			portTestEnv->log("Total swap memory: %llu bytes.\n", memInfo.totalSwap);
+			portTestEnv->log("Swap memory free: %llu bytes.\n", memInfo.availSwap);
 #if defined(OSX)
-			outputComment(OMRPORTLIB, "Cache memory: <undefined>.\n");
+			portTestEnv->log("Cache memory: <undefined>.\n");
 #else /* defined(OSX) */
-			outputComment(OMRPORTLIB, "Cache memory: %llu bytes.\n", memInfo.cached);
+			portTestEnv->log("Cache memory: %llu bytes.\n", memInfo.cached);
 #endif /* defined(OSX) */
 #if defined(AIXPPC) || defined(WIN32) || defined (OSX)
-			outputComment(OMRPORTLIB, "Buffers memory: <undefined>.\n");
+			portTestEnv->log("Buffers memory: <undefined>.\n");
 #else /* defined(AIXPPC) || defined(WIN32) || defined (OSX) */
-			outputComment(OMRPORTLIB, "Buffers memory: %llu bytes.\n", memInfo.buffered);
+			portTestEnv->log("Buffers memory: %llu bytes.\n", memInfo.buffered);
 #endif /* defined(AIXPPC) || defined(WIN32) || defined (OSX) */
-			outputComment(OMRPORTLIB, "Timestamp: %llu.\n", memInfo.timestamp);
+			portTestEnv->log("Timestamp: %llu.\n", memInfo.timestamp);
 		} else {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "Invalid memory usage statistics retrieved.\n");
 		}
 	}
 
+	portTestEnv->changeIndent(-1);
 	reportTestExit(OMRPORTLIB, testName);
 }
 
@@ -1153,6 +1158,7 @@ TEST(PortSysinfoTest, sysinfo_testProcessorInfo)
 	J9ProcessorInfos currInfo = {0};
 
 	reportTestEntry(OMRPORTLIB, testName);
+	portTestEnv->changeIndent(1);
 
 	/* Take a snapshot of processor usage - at t1 (the first iteration). */
 	rc = omrsysinfo_get_processor_info(&prevInfo);
@@ -1199,25 +1205,27 @@ TEST(PortSysinfoTest, sysinfo_testProcessorInfo)
 		(prevInfo.timestamp < currInfo.timestamp)) {
 
 		/* Print out some vital statistics of processor usage - use the current snapshot. */
-		outputComment(OMRPORTLIB, "Available processors: %d.\n", currInfo.totalProcessorCount);
-		outputComment(OMRPORTLIB, "Online processors: %d.\n", n_onln);
-		outputComment(OMRPORTLIB, "Timestamp: %llu.\n", currInfo.timestamp);
+		portTestEnv->log("Available processors: %d.\n", currInfo.totalProcessorCount);
+		portTestEnv->log("Online processors: %d.\n", n_onln);
+		portTestEnv->log("Timestamp: %llu.\n", currInfo.timestamp);
 	}
 
 	/* First, get the diffs in the Totals over iterations t1 to t2. */
 	deltaTotalIdleTime = currInfo.procInfoArray[0].idleTime - prevInfo.procInfoArray[0].idleTime;
 	deltaTotalBusyTime = currInfo.procInfoArray[0].busyTime - prevInfo.procInfoArray[0].busyTime;
 
-	outputComment(OMRPORTLIB, "CPUID: Total\n");
-	outputComment(OMRPORTLIB, "   User time:   %lld.\n", currInfo.procInfoArray[0].userTime);
-	outputComment(OMRPORTLIB, "   System time: %lld.\n", currInfo.procInfoArray[0].systemTime);
-	outputComment(OMRPORTLIB, "   Idle time:   %lld.\n", currInfo.procInfoArray[0].idleTime);
+	portTestEnv->log("CPUID: Total\n");
+	portTestEnv->changeIndent(1);
+	portTestEnv->log("User time:   %lld.\n", currInfo.procInfoArray[0].userTime);
+	portTestEnv->log("System time: %lld.\n", currInfo.procInfoArray[0].systemTime);
+	portTestEnv->log("Idle time:   %lld.\n", currInfo.procInfoArray[0].idleTime);
 #if defined(WIN32) || defined(OSX)
-	outputComment(OMRPORTLIB, "   Wait time:   <undefined>.\n");
+	portTestEnv->log("Wait time:   <undefined>.\n");
 #else /* Non-windows/OSX platforms */
-	outputComment(OMRPORTLIB, "   Wait time:   %lld.\n", currInfo.procInfoArray[0].waitTime);
+	portTestEnv->log("tWait time:   %lld.\n", currInfo.procInfoArray[0].waitTime);
 #endif /* defined(WIN32) || defined(OSX) */
-	outputComment(OMRPORTLIB, "   Busy time:   %lld.\n", currInfo.procInfoArray[0].busyTime);
+	portTestEnv->log("Busy time:   %lld.\n", currInfo.procInfoArray[0].busyTime);
+	portTestEnv->changeIndent(-1);
 
 	/* Start iterating from 1 since 0^th entry represents Totals - already accounted for above. */
 	for (cntr = 1; cntr < currInfo.totalProcessorCount + 1; cntr++) {
@@ -1238,16 +1246,18 @@ TEST(PortSysinfoTest, sysinfo_testProcessorInfo)
 				(OMRPORT_PROCINFO_NOT_AVAILABLE != currInfo.procInfoArray[cntr].busyTime)) {
 
 				/* Print out processor times in each mode for each CPU that is online. */
-				outputComment(OMRPORTLIB, "CPUID: %d\n",  currInfo.procInfoArray[cntr].proc_id);
-				outputComment(OMRPORTLIB, "   User time:   %lld.\n", currInfo.procInfoArray[cntr].userTime);
-				outputComment(OMRPORTLIB, "   System time: %lld.\n", currInfo.procInfoArray[cntr].systemTime);
-				outputComment(OMRPORTLIB, "   Idle time:   %lld.\n", currInfo.procInfoArray[cntr].idleTime);
+				portTestEnv->log("CPUID: %d\n",  currInfo.procInfoArray[cntr].proc_id);
+				portTestEnv->changeIndent(1);
+				portTestEnv->log("User time:   %lld.\n", currInfo.procInfoArray[cntr].userTime);
+				portTestEnv->log("System time: %lld.\n", currInfo.procInfoArray[cntr].systemTime);
+				portTestEnv->log("Idle time:   %lld.\n", currInfo.procInfoArray[cntr].idleTime);
 #if defined(WIN32) || defined(OSX)
-				outputComment(OMRPORTLIB, "   Wait time:   <undefined>.\n");
+				portTestEnv->log("Wait time:   <undefined>.\n");
 #else /* Non-windows/OSX platforms */
-				outputComment(OMRPORTLIB, "   Wait time:   %lld.\n", currInfo.procInfoArray[cntr].waitTime);
+				portTestEnv->log("Wait time:   %lld.\n", currInfo.procInfoArray[cntr].waitTime);
 #endif /* defined(WIN32) || defined(OSX) */
-				outputComment(OMRPORTLIB, "   Busy time:   %lld.\n", currInfo.procInfoArray[cntr].busyTime);
+				portTestEnv->log("Busy time:   %lld.\n", currInfo.procInfoArray[cntr].busyTime);
+				portTestEnv->changeIndent(-1);
 			} else {
 				outputErrorMessage(PORTTEST_ERROR_ARGS, "Invalid processor usage statistics retrieved.\n");
 				goto _cleanup;
@@ -1261,7 +1271,7 @@ TEST(PortSysinfoTest, sysinfo_testProcessorInfo)
 	 * processors that otherwise seem online (actually are in sleep mode); not even the Idle ticks.
 	 */
 	if (0 < (deltaTotalBusyTime + deltaTotalIdleTime)) {
-		outputComment(OMRPORTLIB, "Processor times in monotonically increasing order.\n");
+		portTestEnv->log("Processor times in monotonically increasing order.\n");
 	} else {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "Unexpected change in processor time deltas\ndeltaTotalBusyTime=%lld deltaTotalIdleTime=%lld\n",
 						   deltaTotalBusyTime, deltaTotalIdleTime);
@@ -1270,6 +1280,7 @@ TEST(PortSysinfoTest, sysinfo_testProcessorInfo)
 _cleanup:
 	omrsysinfo_destroy_processor_info(&prevInfo);
 	omrsysinfo_destroy_processor_info(&currInfo);
+	portTestEnv->changeIndent(-1);
 	reportTestExit(OMRPORTLIB, testName);
 }
 
@@ -1314,7 +1325,7 @@ TEST(PortSysinfoTest, sysinfo_testOnlineProcessorCount2)
 
 		if ((n_cpus_online > 0) &&
 			(onlineProcessorCount(&procInfo) == n_cpus_online)) {
-			outputComment(OMRPORTLIB, "Number of online processors: %d\n",  n_cpus_online);
+			portTestEnv->log("Number of online processors: %d\n",  n_cpus_online);
 		} else {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "Invalid online processor count found.\n");
 		}
@@ -1365,7 +1376,7 @@ TEST(PortSysinfoTest, sysinfo_testTotalProcessorCount)
 
 		if ((procInfo.totalProcessorCount > 0) &&
 			(procInfo.totalProcessorCount == n_cpus_total)) {
-			outputComment(OMRPORTLIB, "Total number of processors: %d\n",  n_cpus_total);
+			portTestEnv->log("Total number of processors: %d\n",  n_cpus_total);
 		} else {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "Invalid processor count retrieved.\n");
 		}
@@ -1396,7 +1407,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_CPU_utilization)
 		reportTestExit(OMRPORTLIB, testName);
 		return;
 	} else {
-		outputComment(OMRPORTLIB, "Old utilization timestamp=%llu cpuTime=%lld numberOfCpus=%d.\n",
+		portTestEnv->log("Old utilization timestamp=%llu cpuTime=%lld numberOfCpus=%d.\n",
 					  OldUtil.timestamp, OldUtil.cpuTime, OldUtil.numberOfCpus);
 		if ((OldUtil.cpuTime < 0) || (OldUtil.numberOfCpus <= 0)) {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "omrsysinfo_test_get_CPU_utilization() invalid results.\n");
@@ -1414,9 +1425,9 @@ TEST(PortSysinfoTest, sysinfo_test_get_CPU_utilization)
 		reportTestExit(OMRPORTLIB, testName);
 		return;
 	} else {
-		outputComment(OMRPORTLIB, "New utilization timestamp=%llu cpuTime=%lld numberOfCpus=%d.\n",
+		portTestEnv->log("New utilization timestamp=%llu cpuTime=%lld numberOfCpus=%d.\n",
 					  NewUtil.timestamp, NewUtil.cpuTime, NewUtil.numberOfCpus);
-		outputComment(OMRPORTLIB, "timestamp delta=%llu cpuTime delta=%lld\n",
+		portTestEnv->log("timestamp delta=%llu cpuTime delta=%lld\n",
 					  NewUtil.timestamp - OldUtil.timestamp, NewUtil.cpuTime -  OldUtil.cpuTime);
 		if ((NewUtil.cpuTime < OldUtil.cpuTime) || (NewUtil.numberOfCpus != OldUtil.numberOfCpus)) {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "omrsysinfo_test_get_CPU_utilization() invalid results.\n");
@@ -1446,7 +1457,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_tmp1)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "unexpected return code rc: %d\n", rc);
 	} else {
 		char *buffer = (char *)omrmem_allocate_memory(rc, OMRMEM_CATEGORY_PORT_LIBRARY);
-		outputComment(OMRPORTLIB, "rc = %d\n", rc);
+		portTestEnv->log("rc = %d\n", rc);
 
 		rc = omrsysinfo_get_tmp(buffer, rc, FALSE);
 		if (0 != rc) {
@@ -1477,7 +1488,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_tmp2)
 	if (0 >= rc) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "unexpected return code rc: %d\n", rc);
 	} else {
-		outputComment(OMRPORTLIB, "rc = %d\n", rc);
+		portTestEnv->log("rc = %d\n", rc);
 		omrmem_free_memory(buffer);
 
 		buffer = (char *)omrmem_allocate_memory(rc, OMRMEM_CATEGORY_PORT_LIBRARY);
@@ -1554,7 +1565,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_tmp3)
 	if (0 != rc) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "error failed to get temp directory rc: %d\n", rc);
 	} else {
-		outputComment(OMRPORTLIB, "TMP = %s\n", buffer);
+		portTestEnv->log("TMP = %s\n", buffer);
 	}
 
 	rc = memcmp(utf8, buffer, strlen((const char *)utf8));
@@ -1754,7 +1765,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_cwd1)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "unexpected return code rc: %d\n", rc);
 	} else {
 		char *buffer = (char *)omrmem_allocate_memory(rc, OMRMEM_CATEGORY_PORT_LIBRARY);
-		outputComment(OMRPORTLIB, "rc = %d\n", rc);
+		portTestEnv->log("rc = %d\n", rc);
 
 		rc = omrsysinfo_get_cwd(buffer, rc);
 		if (0 != rc) {
@@ -1784,7 +1795,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_cwd2)
 	if (0 == rc) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "unexpected return code rc: %d\n", rc);
 	} else {
-		outputComment(OMRPORTLIB, "rc = %d\n", rc);
+		portTestEnv->log("rc = %d\n", rc);
 		omrmem_free_memory(buffer);
 
 		buffer = (char *)omrmem_allocate_memory(rc, OMRMEM_CATEGORY_PORT_LIBRARY);
@@ -1844,7 +1855,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_cwd3)
 	if (0 != rc) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "error failed to create directory rc: %d\n", rc);
 	} else {
-		outputComment(OMRPORTLIB, "mkdir %s\n", utf8);
+		portTestEnv->log("mkdir %s\n", utf8);
 	}
 #if defined(J9ZOS390)
 	rc = atoe_chdir(utf8);
@@ -1854,7 +1865,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_cwd3)
 	if (0 != rc) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "cd %s failed rc: %d\n", utf8, rc);
 	} else {
-		outputComment(OMRPORTLIB, "cd %s\n", utf8);
+		portTestEnv->log("cd %s\n", utf8);
 	}
 #endif /* defined(WIN32) */
 
@@ -1864,7 +1875,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_cwd3)
 	if (0 != rc) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "error failed to get current working directory rc: %d\n", rc);
 	} else {
-		outputComment(OMRPORTLIB, "CWD = %s\n", buffer);
+		portTestEnv->log("CWD = %s\n", buffer);
 	}
 
 	rc = memcmp(utf8, buffer, strlen(buffer));
@@ -1911,7 +1922,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_groups)
 	if (-1 != rc) {
 		struct group *grent = NULL;
 
-		outputComment(OMRPORTLIB, "group list size=%zi\n", rc);
+		portTestEnv->log("group list size=%zi\n", rc);
 
 		for (i = 0; i < rc; i++) {
 			int error = 0;
@@ -1920,10 +1931,14 @@ TEST(PortSysinfoTest, sysinfo_test_get_groups)
 			/* No portlib api to get group name for a give group id */
 			grent = getgrgid(gidList[i]);
 			error = errno;
-			outputComment(OMRPORTLIB, "\tgid=%u", gidList[i]);
+			portTestEnv->changeIndent(1);
+			portTestEnv->log("gid=%u", gidList[i]);
+			portTestEnv->changeIndent(-1);
 			if (NULL == grent) {
 				if (0 == error) {
-					outputComment(OMRPORTLIB, "\tthis group id is not found in group database (not an error as per getgrgid documentation)\n");
+					portTestEnv->changeIndent(1);
+					portTestEnv->log("this group id is not found in group database (not an error as per getgrgid documentation)\n");
+					portTestEnv->changeIndent(-1);
 				} else {
 					outputErrorMessage(PORTTEST_ERROR_ARGS, "\ngetgrgid() returned NULL with errno=%d for group id=%u\n", error, gidList[i]);
 					break;
@@ -1931,7 +1946,9 @@ TEST(PortSysinfoTest, sysinfo_test_get_groups)
 			} else {
 				char *group = grent->gr_name;
 				if (NULL != group) {
-					outputComment(OMRPORTLIB, "\tgroup name=%s\n", group);
+					portTestEnv->changeIndent(1);
+					portTestEnv->log("group name=%s\n", group);
+					portTestEnv->changeIndent(-1);
 				} else {
 					outputErrorMessage(PORTTEST_ERROR_ARGS, "\ngetgrgid() returned NULL as the group name for group id=%u\n", gidList[i]);
 					break;
@@ -1970,7 +1987,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_open_file_count)
 		reportTestExit(OMRPORTLIB, testName);
 		return;
 	}
-	outputComment(OMRPORTLIB, "omrsysinfo_get_open_file_count(): Files opened by this process=%lld\n", 
+	portTestEnv->log("omrsysinfo_get_open_file_count(): Files opened by this process=%lld\n", 
 		openCount);
 
 	/* Now, get the current (soft) limit on the resource "nofiles".  We check the current
@@ -1980,7 +1997,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_open_file_count)
 	if (OMRPORT_LIMIT_UNLIMITED == rc) {
 		/* Not really an error, just a sentinel.  Comparisons can still work! */
 		if (RLIM_INFINITY == curLimit) {
-			outputComment(OMRPORTLIB, 
+			portTestEnv->log(
 				"omrsysinfo_get_limit(nofiles): soft limit=RLIM_INFINITY (unlimited).\n");
 		} else {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, 
@@ -1992,7 +2009,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_open_file_count)
 	} else if (OMRPORT_LIMIT_LIMITED == rc) {
 		/* Check that the limits received are sane, before comparing against files opened. */
 		if ((((int64_t) curLimit) > 0) && (((int64_t) curLimit) <= INT64_MAX)) {
-			outputComment(OMRPORTLIB, "omrsysinfo_get_limit(nofiles): soft limit=%lld.\n", 
+			portTestEnv->log("omrsysinfo_get_limit(nofiles): soft limit=%lld.\n", 
 				((int64_t) curLimit));
 		} else {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, 

--- a/fvtest/porttest/si.cpp
+++ b/fvtest/porttest/si.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2016
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -176,34 +176,34 @@ TEST(PortSysinfoTest, sysinfo_test0)
 
 
 	pid = omrsysinfo_get_pid();
-	omrtty_printf("PLT pid=%d\n", pid);
+	portTestEnv->log("PLT pid=%d\n", pid);
 
 	osVersion = omrsysinfo_get_OS_version();
-	omrtty_printf("OSversion=%s\n" osVersion ? osVersion : "NULL");
+	portTestEnv->log("OSversion=%s\n" osVersion ? osVersion : "NULL");
 
 	strcpy(envVar, "PATH");		/*case matters?*/
 	/*check rc before use: -1=BOGUS  0=good else nowrite, rc=varLength*/
 	rc = omrsysinfo_get_env(envVar, infoString, bufSize);
-	omrtty_printf("%s=%s\nbufSize=%d rc=%d\n\n", envVar, infoString, bufSize, rc);
+	portTestEnv->log("%s=%s\nbufSize=%d rc=%d\n\n", envVar, infoString, bufSize, rc);
 	/*
 	 * note:  tty_printf has a implementation-dependent limit on out chars
 	 * printf("\n\n%s=%s bufSize=%d rc=%d\n\n",envVar,infoString,bufSize,rc);
 	 */
 
 	osName = omrsysinfo_get_CPU_architecture();
-	omrtty_printf("CPU architecture=%s\n", osName ? osName : "NULL");
+	portTestEnv->log("CPU architecture=%s\n", osName ? osName : "NULL");
 
 	osType = omrsysinfo_get_OS_type();
-	omrtty_printf("OS type=%s\n", osType ? osType : "NULL");
+	portTestEnv->log("OS type=%s\n", osType ? osType : "NULL");
 
 	/*SHOULD omrmem_free_memory() result, eh!!!!!! argv[0] not really used*/
 	/*check rc before use: 0=good -1=error ???*/
 
 	number_CPUs = omrsysinfo_get_number_CPUs_by_type(OMRPORT_CPU_ONLINE);
-	omrtty_printf("number of CPU(s)=%d\n", number_CPUs);
+	portTestEnv->log("number of CPU(s)=%d\n", number_CPUs);
 
 
-	omrtty_printf("SI test done!\n\n");
+	portTestEnv->log("SI test done!\n\n");
 
 #endif
 done:
@@ -370,7 +370,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_ulimit_iterator)
 	if (0 != rc) {
 
 		if (OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM == rc) {
-			omrtty_printf("\tThis platform does not support the limit iterator\n");
+			portTestEnv->log(LEVEL_ERROR, "\tThis platform does not support the limit iterator\n");
 		} else {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "\tomrsysinfo_limit_iterator_init returned: %i\n", rc);
 		}
@@ -382,18 +382,18 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_ulimit_iterator)
 		rc = omrsysinfo_limit_iterator_next(&state, &element);
 
 		if (0 == rc) {
-			omrtty_printf("\t%s:\n", element.name);
+			portTestEnv->log("\t%s:\n", element.name);
 
 			if (OMRPORT_LIMIT_UNLIMITED == element.softValue) {
-				omrtty_printf("\t soft: unlimited\n");
+				portTestEnv->log("\t soft: unlimited\n");
 			} else {
-				omrtty_printf("\t soft: 0x%zX\n", element.softValue);
+				portTestEnv->log("\t soft: 0x%zX\n", element.softValue);
 			}
 
 			if (OMRPORT_LIMIT_UNLIMITED == element.hardValue) {
-				omrtty_printf("\t hard: unlimited\n");
+				portTestEnv->log("\t hard: unlimited\n");
 			} else {
-				omrtty_printf("\t hard: 0x%zX\n", element.hardValue);
+				portTestEnv->log("\t hard: 0x%zX\n", element.hardValue);
 			}
 
 		} else {
@@ -439,7 +439,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_env_iterator)
 
 	if (rc < 0) {
 		if (OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM == rc) {
-			omrtty_printf("\tThis platform does not support the env iterator\n");
+			portTestEnv->log(LEVEL_ERROR, "\tThis platform does not support the env iterator\n");
 		} else if (OMRPORT_ERROR_SYSINFO_ENV_INIT_CRASHED_COPYING_BUFFER == rc) {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "\tCrash passing in NULL buffer while running single-threaded. This is a failure because no-one else should have been able to modify it\n");
 		} else {
@@ -451,7 +451,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_env_iterator)
 	} else {
 		envSize = rc;
 #if defined(SI_DEBUG)
-		omrtty_printf("Need a buffer of size %x bytes\n", envSize);
+		portTestEnv->log("Need a buffer of size %x bytes\n", envSize);
 #endif
 	}
 
@@ -471,14 +471,14 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_env_iterator)
 		goto done;
 	}
 
-	omrtty_printf("\tEnvironment:\n\n");
+	portTestEnv->log("\tEnvironment:\n\n");
 
 	l = 0;
 	while (omrsysinfo_env_iterator_hasNext(&state)) {
 		rc = omrsysinfo_env_iterator_next(&state, &element);
 
 		if (0 == rc) {
-			omrtty_printf("\t%s\n", element.nameAndValue);
+			portTestEnv->log("\t%s\n", element.nameAndValue);
 			l++;
 		} else {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "\tomrsysinfo_env_iterator_next returned: %i when 0 was expected\n", rc);
@@ -509,7 +509,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_env_iterator)
 	} else {
 		envSize = rc;
 #if defined(SI_DEBUG)
-		omrtty_printf("Should have a buffer of size %x bytes, using one of size %x instead, which will result in a truncated environment\n", envSize, bufferSizeBytes);
+		portTestEnv->log("Should have a buffer of size %x bytes, using one of size %x instead, which will result in a truncated environment\n", envSize, bufferSizeBytes);
 #endif
 	}
 
@@ -519,7 +519,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_env_iterator)
 		rc = omrsysinfo_env_iterator_next(&state, &element);
 
 #if defined(SI_DEBUG)
-		omrtty_printf("\tsi.c element.nameAndValue @ 0x%p: %s\n", element.nameAndValue, element.nameAndValue);
+		portTestEnv->log("\tsi.c element.nameAndValue @ 0x%p: %s\n", element.nameAndValue, element.nameAndValue);
 #endif
 
 		if (0 == rc) {
@@ -552,7 +552,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_env_iterator)
 	} else {
 		envSize = rc;
 #if defined(SI_DEBUG)
-		omrtty_printf("Should have a buffer of size %x bytes, using one of size %x instead, which will result in a truncated environment\n", envSize, bufferSizeBytes);
+		portTestEnv->log("Should have a buffer of size %x bytes, using one of size %x instead, which will result in a truncated environment\n", envSize, bufferSizeBytes);
 #endif
 	}
 
@@ -562,7 +562,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_env_iterator)
 		rc = omrsysinfo_env_iterator_next(&state, &element);
 
 #if defined(SI_DEBUG)
-		omrtty_printf("\tsi.c element.nameAndValue @ 0x%p: %s\n", element.nameAndValue, element.nameAndValue);
+		portTestEnv->log("\tsi.c element.nameAndValue @ 0x%p: %s\n", element.nameAndValue, element.nameAndValue);
 #endif
 
 		if (0 == rc) {

--- a/fvtest/porttest/si_numcpusTest.cpp
+++ b/fvtest/porttest/si_numcpusTest.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2016
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -34,15 +34,19 @@ TEST(PortSysinfoTest, sysinfo_numcpus_test0)
 	const char *testName = "omrsysinfo_numcpus_test0";
 	uintptr_t numberPhysicalCPUs = omrsysinfo_get_number_CPUs_by_type(OMRPORT_CPU_PHYSICAL);
 
-	outputComment(OMRPORTLIB, "\n");
-	outputComment(OMRPORTLIB, "Get number of physical CPUs.\n");
-	outputComment(OMRPORTLIB, "	Expected: >0\n");
-	outputComment(OMRPORTLIB, "	Result:   %d\n", numberPhysicalCPUs);
+	portTestEnv->changeIndent(1);
+	portTestEnv->log("\n");
+	portTestEnv->log("Get number of physical CPUs.\n");
+	portTestEnv->changeIndent(1);
+	portTestEnv->log("Expected: >0\n");
+	portTestEnv->log("Result:   %d\n", numberPhysicalCPUs);
+	portTestEnv->changeIndent(-1);
 
 	if (0 == numberPhysicalCPUs) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "\tomrsysinfo_get_number_CPUs_by_type(OMRPORT_CPU_PHYSICAL) returned invalid value 0.\n");
 	}
 
+	portTestEnv->changeIndent(-1);
 	reportTestExit(OMRPORTLIB, testName);
 }
 
@@ -56,6 +60,7 @@ TEST(PortSysinfoTest, sysinfo_numcpus_test1)
 	uintptr_t numberPhysicalCPUs = omrsysinfo_get_number_CPUs_by_type(OMRPORT_CPU_ONLINE);
 	uintptr_t numberBoundCPUs = omrsysinfo_get_number_CPUs_by_type(OMRPORT_CPU_BOUND);
 
+	portTestEnv->changeIndent(1);
 	intptr_t boundCPUs = 0;
 	char *boundTestArg = NULL;
 	for (int i = 1; i < portTestEnv->_argc; i += 1) {
@@ -64,7 +69,7 @@ TEST(PortSysinfoTest, sysinfo_numcpus_test1)
 			boundTestArg = &portTestEnv->_argv[i][strlen(BOUNDCPUS)];
 			boundCPUs = atoi(boundTestArg);
 			if (-1 == boundCPUs) {
-				outputComment(OMRPORTLIB, "Invalid (non-numeric) format for %s value (%s).\n", BOUNDCPUS, boundTestArg);
+				portTestEnv->log(LEVEL_ERROR, "Invalid (non-numeric) format for %s value (%s).\n", BOUNDCPUS, boundTestArg);
 				boundCPUs = 0;
 			}
 		}
@@ -74,22 +79,24 @@ TEST(PortSysinfoTest, sysinfo_numcpus_test1)
 		uintptr_t numberPhysicalCPUs = omrsysinfo_get_number_CPUs_by_type(OMRPORT_CPU_ONLINE);
 		uintptr_t numberBoundCPUs = omrsysinfo_get_number_CPUs_by_type(OMRPORT_CPU_BOUND);
 		if (numberBoundCPUs < numberPhysicalCPUs) {
-			outputComment(OMRPORTLIB, "The test was configured to run without CPU restrictions (e.g. taskset), but CPU restrictions were detected.\n");
-			outputComment(OMRPORTLIB, "The test will continue with CPU restrictions configuration.\n\n");
+			portTestEnv->log(LEVEL_ERROR, "The test was configured to run without CPU restrictions (e.g. taskset), but CPU restrictions were detected.\n");
+			portTestEnv->log(LEVEL_ERROR, "The test will continue with CPU restrictions configuration.\n\n");
 			boundCPUs = numberBoundCPUs;
 		}
 	}
 	uintptr_t boundTest = boundCPUs;
 
-	outputComment(OMRPORTLIB, "\n");
-	outputComment(OMRPORTLIB, "Get number of bound CPUs.\n");
+	portTestEnv->log("\n");
+	portTestEnv->log("Get number of bound CPUs.\n");
+	portTestEnv->changeIndent(1);
 	if (0 == boundTest) {
-		outputComment(OMRPORTLIB, "	Expected: %d\n", numberPhysicalCPUs);
-		outputComment(OMRPORTLIB, "	Result:   %d\n", numberBoundCPUs);
+		portTestEnv->log("Expected: %d\n", numberPhysicalCPUs);
+		portTestEnv->log("Result:   %d\n", numberBoundCPUs);
 	} else {
-		outputComment(OMRPORTLIB, "	Expected: %d\n", boundTest);
-		outputComment(OMRPORTLIB, "	Result:   %d\n", numberBoundCPUs);
+		portTestEnv->log("Expected: %d\n", boundTest);
+		portTestEnv->log("Result:   %d\n", numberBoundCPUs);
 	}
+	portTestEnv->changeIndent(-1);
 
 	if ((0 == boundTest) && (numberPhysicalCPUs == numberBoundCPUs)) {
 		/* Not bound, bound should be equal to physical */
@@ -99,6 +106,7 @@ TEST(PortSysinfoTest, sysinfo_numcpus_test1)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "\nomrsysinfo_get_number_CPUs_by_type(OMRPORT_CPU_BOUND) returned unexpected value.\n");
 	}
 
+	portTestEnv->changeIndent(-1);
 	reportTestExit(OMRPORTLIB, testName);
 }
 
@@ -111,15 +119,19 @@ TEST(PortSysinfoTest, sysinfo_numcpus_test2)
 	const char *testName = "omrsysinfo_numcpus_test2";
 	uintptr_t numberOnlineCPUs = omrsysinfo_get_number_CPUs_by_type(OMRPORT_CPU_ONLINE);
 
-	outputComment(OMRPORTLIB, "\n");
-	outputComment(OMRPORTLIB, "Get number of online CPUs.\n");
-	outputComment(OMRPORTLIB, "	Expected: >0\n");
-	outputComment(OMRPORTLIB, "	Result:   %d\n", numberOnlineCPUs);
+	portTestEnv->changeIndent(1);
+	portTestEnv->log("\n");
+	portTestEnv->log("Get number of online CPUs.\n");
+	portTestEnv->changeIndent(1);
+	portTestEnv->log("Expected: >0\n");
+	portTestEnv->log("Result:   %d\n", numberOnlineCPUs);
+	portTestEnv->changeIndent(-1);
 
 	if (0 == numberOnlineCPUs) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "\tomrsysinfo_get_number_CPUs_by_type(OMRPORT_CPU_ONLINE) returned invalid value 0.\n");
 	}
 
+	portTestEnv->changeIndent(-1);
 	reportTestExit(OMRPORTLIB, testName);
 }
 
@@ -133,7 +145,7 @@ TEST(PortSysinfoTest, sysinfo_numcpus_test3)
 	uintptr_t numberOnlineCPUs = omrsysinfo_get_number_CPUs_by_type(OMRPORT_CPU_ONLINE);
 	uintptr_t numberPhysicalCPUs = omrsysinfo_get_number_CPUs_by_type(OMRPORT_CPU_PHYSICAL);
 
-	outputComment(OMRPORTLIB, "\nGet number of online and physical CPUs. Validate online <= physical.\n");
+	portTestEnv->log("\nGet number of online and physical CPUs. Validate online <= physical.\n");
 
 	if (numberOnlineCPUs > numberPhysicalCPUs) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "\tomrsysinfo_get_number_CPUs_by_type(OMRPORT_CPU_ONLINE) returned value greater than omrsysinfo_get_number_CPUs_by_type(OMRPORT_CPU_PHYSICAL).\n");
@@ -151,15 +163,19 @@ TEST(PortSysinfoTest, sysinfo_numcpus_test4)
 	const char *testName = "omrsysinfo_numcpus_test4";
 	uintptr_t result = omrsysinfo_get_number_CPUs_by_type(500);
 
-	outputComment(OMRPORTLIB, "\n");
-	outputComment(OMRPORTLIB, "Call omrsysinfo_get_number_CPUs_by_type with invalid type.\n");
-	outputComment(OMRPORTLIB, "	Expected: 0\n");
-	outputComment(OMRPORTLIB, "	Result:   %d\n", result);
+	portTestEnv->changeIndent(1);
+	portTestEnv->log("\n");
+	portTestEnv->log("Call omrsysinfo_get_number_CPUs_by_type with invalid type.\n");
+	portTestEnv->changeIndent(1);
+	portTestEnv->log("Expected: 0\n");
+	portTestEnv->log("Result:   %d\n", result);
+	portTestEnv->changeIndent(-1);
 
 	if (result > 0) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "\tomrsysinfo_get_number_CPUs_by_type returned non-zero value when given invalid type.\n");
 	}
 
+	portTestEnv->changeIndent(-1);
 	reportTestExit(OMRPORTLIB, testName);
 }
 
@@ -209,8 +225,8 @@ int omrsysinfo_numcpus_runTime(OMRPortLibrary *portLibrary, uintptr_t type)
 		testType = "";
 		break;
 	}
-	outputComment(OMRPORTLIB, "\n");
-	outputComment(OMRPORTLIB, "Get number of %s CPUs %d times: %d ns\n",
+	portTestEnv->log("\n");
+	portTestEnv->log("Get number of %s CPUs %d times: %d ns\n",
 				  testType,
 				  J9SYSINFO_NUMCPUS_RUNTIME_LOOPS,
 				  difference);
@@ -262,7 +278,7 @@ TEST(PortSysinfoTest, sysinfo_testOnlineProcessorCount1)
 	intptr_t rc = 0;
 	J9ProcessorInfos procInfo = {0};
 
-	outputComment(OMRPORTLIB, "\n");
+	portTestEnv->log("\n");
 	reportTestEntry(OMRPORTLIB, testName);
 
 	/* Call omrsysinfo_get_processor_info() to retrieve a set of processor records from
@@ -293,7 +309,7 @@ TEST(PortSysinfoTest, sysinfo_testOnlineProcessorCount1)
 
 		if ((n_cpus_online > 0) &&
 			(onlineProcessorCount(&procInfo) == n_cpus_online)) {
-			outputComment(OMRPORTLIB, "Number of online processors: %d\n",  n_cpus_online);
+			portTestEnv->log("Number of online processors: %d\n",  n_cpus_online);
 		} else {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "Invalid online processor count found.\n");
 		}
@@ -316,7 +332,7 @@ TEST(PortSysinfoTest, sysinfo_testtotalProcessorCount)
 	intptr_t rc = 0;
 	J9ProcessorInfos procInfo = {0};
 
-	outputComment(OMRPORTLIB, "\n");
+	portTestEnv->log("\n");
 	reportTestEntry(OMRPORTLIB, testName);
 
 	/* Call omrsysinfo_get_processor_info() to retrieve a set of processor records from
@@ -345,7 +361,7 @@ TEST(PortSysinfoTest, sysinfo_testtotalProcessorCount)
 
 		if ((procInfo.totalProcessorCount > 0) &&
 			((uintptr_t)procInfo.totalProcessorCount == n_cpus_physical)) {
-			outputComment(OMRPORTLIB, "Total number of processors: %d\n",  n_cpus_physical);
+			portTestEnv->log("Total number of processors: %d\n",  n_cpus_physical);
 		} else {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "Invalid processor count retrieved.\n");
 		}

--- a/fvtest/porttest/testHelpers.cpp
+++ b/fvtest/porttest/testHelpers.cpp
@@ -295,6 +295,7 @@ verifyFileExists(struct OMRPortLibrary *portLibrary, const char *pltestFileName,
 {
 	uintptr_t rc = 1;
 	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
+	portTestEnv->changeIndent(1);
 
 #if defined(J9ZOS390)
 	char dumpName[EsMaxPath] = {0};
@@ -307,12 +308,12 @@ verifyFileExists(struct OMRPortLibrary *portLibrary, const char *pltestFileName,
 		strncpy(ending, ".X001", 5);
 	}
 
-	outputComment(OMRPORTLIB, "\tchecking for data set: %s\n", dumpName);
+	portTestEnv->log("checking for data set: %s\n", dumpName);
 	FILE *file = fopen(dumpName, "r");
 	if (NULL == file) {
 		outputErrorMessage(OMRPORTLIB, pltestFileName, lineNumber, testName, "\tdata set: %s does not exist!\n", -1, fileName);
 	} else {
-		outputComment(OMRPORTLIB, "\tdata set: %s exists\n", dumpName);
+		portTestEnv->log("data set: %s exists\n", dumpName);
 		fclose(file);
 		rc = 0;
 	}
@@ -325,7 +326,7 @@ verifyFileExists(struct OMRPortLibrary *portLibrary, const char *pltestFileName,
 
 	if (0 == fileStatRC) {
 		if (fileStat.isFile) {
-			outputComment(OMRPORTLIB, "\tfile: %s exists\n", fileName);
+			portTestEnv->log("file: %s exists\n", fileName);
 			rc = 0;
 		} else {
 			outputErrorMessage(OMRPORTLIB, pltestFileName, lineNumber, testName, "\tfile: %s does not exist!\n", -1, fileName);
@@ -336,6 +337,7 @@ verifyFileExists(struct OMRPortLibrary *portLibrary, const char *pltestFileName,
 	}
 #endif /* defined(J9ZOS390) */
 
+	portTestEnv->changeIndent(-1);
 	return rc;
 }
 

--- a/fvtest/porttest/testHelpers.cpp
+++ b/fvtest/porttest/testHelpers.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2016
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -22,6 +22,8 @@
 
 #include "testHelpers.hpp"
 #include "omrport.h"
+
+extern PortTestEnvironment *portTestEnv;
 
 typedef struct PortTestStruct {
 	char *fileName;
@@ -58,31 +60,6 @@ static int numTestFailures;
 static int numberFailedTestsInComponent;
 
 /**
- * Control terminal output
- *
- * Duplicated function from UTH.  This function determines what level of tracing is
- * available, a command line option of UTH.  The levels supported are application dependent.
- *
- * Application programs thus decide how much tracing they want, it is possible to display
- * only messages requested, or all messages at the determined level and below
- *
- * Following is proposed levels for port test suites
- *
- * \arg 0 = no tracing
- * \arg 1 = method enter\exit tracing
- * \arg 2 = displays not supported messages
- * \arg 3 = displays comments
- * \arg 4 = displays all messages
- *
- * @return the level of tracing enabled
- */
-static int
-engine_getTraceLevel(void)
-{
-	return 1;
-}
-
-/**
  * Display a message indicating the operation is not supported
  *
  * The port library have various configurations to save size on very small VMs.
@@ -92,16 +69,11 @@ engine_getTraceLevel(void)
  *
  * @param[in] portLibrary The port library
  * @param[in] operation The operation that is not supported
- *
- * @internal @note For UTH environment only, displaying the string is controlled by the verbose
- * level expressed by @ref engine_getTraceLevel.  Outside the UTH environment the messages
- * are always displayed.
  */
 void
 operationNotSupported(struct OMRPortLibrary *portLibrary, const char *operationName)
 {
-	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
-	omrtty_printf("%s not supported in this configuration\n", operationName);
+	portTestEnv->log("%s not supported in this configuration\n", operationName);
 }
 
 /**
@@ -110,18 +82,12 @@ operationNotSupported(struct OMRPortLibrary *portLibrary, const char *operationN
  * @param[in] portLibrary The port library
  * @param[in] testName The test that is starting
  *
- * @note Message is only displayed if verbosity level indicated by
- * @ref engine_getTraceLevel is sufficient
- *
  * @note Clears number of failed tests.  @see outputMessage.
  */
 void
 reportTestEntry(struct OMRPortLibrary *portLibrary, const char *testName)
 {
-	if (engine_getTraceLevel()) {
-		OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
-		omrtty_printf("\nStarting test %s\n", testName);
-	}
+	portTestEnv->log("\nStarting test %s\n", testName);
 	numberFailedTestsInComponent = 0;
 }
 
@@ -133,17 +99,11 @@ reportTestEntry(struct OMRPortLibrary *portLibrary, const char *testName)
  *
  * @return TEST_PASS if no tests failed, else TEST_FAILED as reported
  * by @ref outputMessage
- *
- * @note Message is only displayed if verbosity level indicated by
- * @ref engine_getTraceLevel is sufficient
  */
 int
 reportTestExit(struct OMRPortLibrary *portLibrary, const char *testName)
 {
-	if (engine_getTraceLevel()) {
-		OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
-		omrtty_printf("Ending test %s\n", testName);
-	}
+	portTestEnv->log("Ending test %s\n", testName);
 	EXPECT_TRUE(0 == numberFailedTestsInComponent) << "Test failed!";
 	return 0 == numberFailedTestsInComponent ? TEST_PASS : TEST_FAIL;
 }
@@ -164,15 +124,15 @@ dumpTestFailuresToConsole(struct OMRPortLibrary *portLibrary)
 
 	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
 
-	omrtty_printf("-------------------------------------------------------------------------\n");
-	omrtty_printf("-------------------------------------------------------------------------\n\n");
-	omrtty_printf("FAILURES DETECTED. Number of failed tests: %u\n\n", numTestFailures);
+	portTestEnv->log(LEVEL_ERROR, "-------------------------------------------------------------------------\n");
+	portTestEnv->log(LEVEL_ERROR, "-------------------------------------------------------------------------\n\n");
+	portTestEnv->log(LEVEL_ERROR, "FAILURES DETECTED. Number of failed tests: %u\n\n", numTestFailures);
 
 	for (i = 0; i < numTestFailures ; i++) {
-		omrtty_printf("%i: %s\n", i + 1, testFailures[i].testName);
-		omrtty_printf("\t%s line %4zi: %s\n", testFailures[i].fileName, testFailures[i].lineNumber, testFailures[i].errorMessage);
-		omrtty_printf("\t\tLastErrorNumber: %i\n", testFailures[i].portErrorNumber);
-		omrtty_printf("\t\tLastErrorMessage: %s\n\n", testFailures[i].portErrorMessage);
+		portTestEnv->log(LEVEL_ERROR, "%i: %s\n", i + 1, testFailures[i].testName);
+		portTestEnv->log(LEVEL_ERROR, "\t%s line %4zi: %s\n", testFailures[i].fileName, testFailures[i].lineNumber, testFailures[i].errorMessage);
+		portTestEnv->log(LEVEL_ERROR, "\t\tLastErrorNumber: %i\n", testFailures[i].portErrorNumber);
+		portTestEnv->log(LEVEL_ERROR, "\t\tLastErrorMessage: %s\n\n", testFailures[i].portErrorMessage);
 
 		omrmem_free_memory(testFailures[i].fileName);
 		omrmem_free_memory(testFailures[i].testName);
@@ -247,10 +207,6 @@ logTestFailure(struct OMRPortLibrary *portLibrary, const char *fileName, int32_t
  * @param[in] testName Name of the test requesting output
  * @param[in] foramt Format of string to be output
  * @param[in] ... argument list for format string
- *
- * @internal @note For UTH environment only, displaying the string is controlled by the verbose
- * level expressed by @ref engine_getTraceLevel.  Outside the UTH environment the messages
- * are always displayed.
  */
 void
 outputErrorMessage(struct OMRPortLibrary *portLibrary, const char *fileName, int32_t lineNumber, const char *testName, const char *format, ...)
@@ -277,7 +233,7 @@ outputErrorMessage(struct OMRPortLibrary *portLibrary, const char *fileName, int
 	if (NULL != portErrorBuf) {
 		strncpy(portErrorBuf, lastErrorMessage, sizePortErrorBuf);
 	} else {
-		omrtty_printf("\n\n******* omrmem_allocate_memory failed to allocate %i bytes, exiting.\n\n", sizePortErrorBuf);
+		portTestEnv->log(LEVEL_ERROR, "\n\n******* omrmem_allocate_memory failed to allocate %i bytes, exiting.\n\n", sizePortErrorBuf);
 		exit(EXIT_OUT_OF_MEMORY);
 	}
 
@@ -292,15 +248,15 @@ outputErrorMessage(struct OMRPortLibrary *portLibrary, const char *fileName, int
 		omrstr_vprintf(buf, sizeBuf, format, args);
 		va_end(args);
 	} else {
-		omrtty_printf("\n\n******* omrmem_allocate_memory failed to allocate %i bytes, exiting.\n\n", sizeBuf);
+		portTestEnv->log(LEVEL_ERROR, "\n\n******* omrmem_allocate_memory failed to allocate %i bytes, exiting.\n\n", sizeBuf);
 		exit(EXIT_OUT_OF_MEMORY);
 
 	}
 
-	omrtty_printf("%s line %4zi: %s ", fileName, lineNumber, testName);
-	omrtty_printf("%s\n", buf);
-	omrtty_printf("\t\tLastErrorNumber: %i\n", lastErrorNumber);
-	omrtty_printf("\t\tLastErrorMessage: %s\n\n", portErrorBuf);
+	portTestEnv->log(LEVEL_ERROR, "%s line %4zi: %s ", fileName, lineNumber, testName);
+	portTestEnv->log(LEVEL_ERROR, "%s\n", buf);
+	portTestEnv->log(LEVEL_ERROR, "\t\tLastErrorNumber: %i\n", lastErrorNumber);
+	portTestEnv->log(LEVEL_ERROR, "\t\tLastErrorMessage: %s\n\n", portErrorBuf);
 
 	logTestFailure(OMRPORTLIB, fileName, lineNumber, testName, lastErrorNumber, portErrorBuf, buf);
 
@@ -316,9 +272,8 @@ outputErrorMessage(struct OMRPortLibrary *portLibrary, const char *fileName, int
 void
 HEADING(struct OMRPortLibrary *portLibrary, const char *string)
 {
-	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
 	const char *dash = "----------------------------------------";
-	omrtty_printf("%s\n%s\n%s\n\n", dash, string, dash);
+	portTestEnv->log("%s\n%s\n%s\n\n", dash, string, dash);
 }
 
 /**

--- a/fvtest/porttest/testProcessHelpers.cpp
+++ b/fvtest/porttest/testProcessHelpers.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2001, 2016
+ * (c) Copyright IBM Corp. 2001, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -237,9 +237,9 @@ launchChildProcess(OMRPortLibrary *portLibrary, const char *testname, const char
 		int32_t portableErrno = omrerror_last_error_number();
 		const char *errMsg = omrerror_last_error_message();
 		if (NULL == errMsg) {
-			omrtty_printf("%s: launchChildProcess: omrsysinfo_get_executable_name failed!\n\tportableErrno = %d\n", testname, portableErrno);
+			portTestEnv->log(LEVEL_ERROR, "%s: launchChildProcess: omrsysinfo_get_executable_name failed!\n\tportableErrno = %d\n", testname, portableErrno);
 		} else {
-			omrtty_printf("%s: launchChildProcess: omrsysinfo_get_executable_name failed!\n\tportableErrno = %d portableErrMsg = %s\n", testname, portableErrno, errMsg);
+			portTestEnv->log(LEVEL_ERROR, "%s: launchChildProcess: omrsysinfo_get_executable_name failed!\n\tportableErrno = %d portableErrMsg = %s\n", testname, portableErrno, errMsg);
 		}
 		goto done;
 
@@ -254,12 +254,12 @@ launchChildProcess(OMRPortLibrary *portLibrary, const char *testname, const char
 
 	{
 		int i;
-		omrtty_printf("\n\n");
+		portTestEnv->log("\n\n");
 
 		for (i = 0; i < commandLength; i++) {
-			omrtty_printf("\t\tcommand[%i]: %s\n", i, command[i]);
+			portTestEnv->log("\t\tcommand[%i]: %s\n", i, command[i]);
 		}
-		omrtty_printf("\n\n");
+		portTestEnv->log("\n\n");
 
 		exeoptions = OMRPROCESS_DEBUG;
 	}
@@ -271,9 +271,9 @@ launchChildProcess(OMRPortLibrary *portLibrary, const char *testname, const char
 		int32_t portableErrno = omrerror_last_error_number();
 		const char *errMsg = omrerror_last_error_message();
 		if (NULL == errMsg) {
-			omrtty_printf("%s: launchChildProcess: Failed to start process '%s %s'\n\tportableErrno = %d\n", testname, command[0], command[1], portableErrno);
+			portTestEnv->log(LEVEL_ERROR, "%s: launchChildProcess: Failed to start process '%s %s'\n\tportableErrno = %d\n", testname, command[0], command[1], portableErrno);
 		} else {
-			omrtty_printf("%s: launchChildProcess: Failed to start process '%s %s'\n\tportableErrno = %d portableErrMsg = %s\n", testname, command[0], command[1], portableErrno, errMsg);
+			portTestEnv->log(LEVEL_ERROR, "%s: launchChildProcess: Failed to start process '%s %s'\n\tportableErrno = %d portableErrMsg = %s\n", testname, command[0], command[1], portableErrno, errMsg);
 		}
 
 		processHandle = NULL;
@@ -293,7 +293,7 @@ waitForTestProcess(OMRPortLibrary *portLibrary, OMRProcessHandle processHandle)
 	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
 
 	if (NULL == processHandle) {
-		omrtty_printf("waitForTestProcess: processHandle == NULL\n");
+		portTestEnv->log(LEVEL_ERROR, "waitForTestProcess: processHandle == NULL\n");
 		goto done;
 	}
 
@@ -301,9 +301,9 @@ waitForTestProcess(OMRPortLibrary *portLibrary, OMRProcessHandle processHandle)
 		int32_t portableErrno = omrerror_last_error_number();
 		const char *errMsg = omrerror_last_error_message();
 		if (NULL == errMsg) {
-			omrtty_printf("waitForTestProcess: j9process_waitfor() failed\n\tportableErrno = %d\n" , portableErrno);
+			portTestEnv->log(LEVEL_ERROR, "waitForTestProcess: j9process_waitfor() failed\n\tportableErrno = %d\n" , portableErrno);
 		} else {
-			omrtty_printf("waitForTestProcess: j9process_waitfor() failed\n\tportableErrno = %d portableErrMsg = %s\n" , portableErrno, errMsg);
+			portTestEnv->log(LEVEL_ERROR, "waitForTestProcess: j9process_waitfor() failed\n\tportableErrno = %d portableErrMsg = %s\n" , portableErrno, errMsg);
 		}
 
 		goto done;
@@ -315,9 +315,9 @@ waitForTestProcess(OMRPortLibrary *portLibrary, OMRProcessHandle processHandle)
 		int32_t portableErrno = omrerror_last_error_number();
 		const char *errMsg = omrerror_last_error_message();
 		if (NULL == errMsg) {
-			omrtty_printf("waitForTestProcess: j9process_close() failed\n\tportableErrno = %d\n" , portableErrno);
+			portTestEnv->log(LEVEL_ERROR, "waitForTestProcess: j9process_close() failed\n\tportableErrno = %d\n" , portableErrno);
 		} else {
-			omrtty_printf("waitForTestProcess: j9process_close() failed\n\tportableErrno = %d portableErrMsg = %s\n" , portableErrno, errMsg);
+			portTestEnv->log(LEVEL_ERROR, "waitForTestProcess: j9process_close() failed\n\tportableErrno = %d portableErrMsg = %s\n" , portableErrno, errMsg);
 		}
 		goto done;
 	}

--- a/fvtest/porttest/vmemTest.cpp
+++ b/fvtest/porttest/vmemTest.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2015, 2016
+ * (c) Copyright IBM Corp. 2015, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -21,6 +21,8 @@
 #include "omrport.h"
 #include "portTestHelpers.hpp"
 
+extern PortTestEnvironment *portTestEnv;
+
 /**
  * Verify virtual memory functions
  *
@@ -35,7 +37,7 @@ TEST(PortVMemTest, omrvmem_get_available_physical_memory)
 	int32_t status = omrvmem_get_available_physical_memory(&freePhysicalMemorySize);
 #if defined(LINUX) || defined(AIXPPC) || defined(WIN32) || defined(OSX)
 	ASSERT_EQ(0, status) << "Non-zero status from omrvmem_get_available_physical_memory";
-	omrtty_printf("freePhysicalMemorySize = %llu\n", freePhysicalMemorySize);
+	portTestEnv->log("freePhysicalMemorySize = %llu\n", freePhysicalMemorySize);
 #else /*  defined(LINUX) || defined(AIXPPC) || defined(WIN32) || defined(OSX) */
 	ASSERT_EQ(OMRPORT_ERROR_VMEM_NOT_SUPPORTED, status) << "omrvmem_get_available_physical_memory should not be supported";
 #endif /*  defined(LINUX) || defined(AIXPPC) || defined(WIN32) || defined(OSX) */


### PR DESCRIPTION
Implements logger by replacing omrtty_printf and outputComment functions to reduce and control verbosity.
Removes engine_getTraceLevel() since logger allows for control of verbosity.
Replaces the output controlling HEAPTEST_VERBOSE macro with the log level verbose specification.

Resolves issue #713 
@renfeiw  has reviewed these commits. 