### PR TITLE
Remove test for startup failure message

### DIFF
--- a/fvtest/porttest/cudaError.cpp
+++ b/fvtest/porttest/cudaError.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2015, 2015
+ * (c) Copyright IBM Corp. 2015, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -15,7 +15,6 @@
  * Contributors:
  *    Multiple authors (IBM Corp.) - initial implementation and documentation
  *******************************************************************************/
-
 
 #include "cudaTests.hpp"
 
@@ -79,7 +78,6 @@ static const J9CudaError errors[] = {
 	J9CUDA_ERROR_LAUNCH_PENDING_COUNT_EXCEEDED,
 	J9CUDA_ERROR_NOT_PERMITTED,
 	J9CUDA_ERROR_NOT_SUPPORTED,
-	J9CUDA_ERROR_STARTUP_FAILURE,
 	J9CUDA_ERROR_NOT_FOUND
 };
 


### PR DESCRIPTION
If the CUDA runtime failed to start, it's not always reasonable to expect it to be able to translate that error code to a string. Beginning with version 6.0 of the CUDA runtime, `cudaGetErrorString(cudaErrorStartupFailure)` returns NULL instead of a descriptive string. 

Fixes issue #726.

Signed-off-by: Keith W. Campbell <keithc@ca.ibm.com>