### PR TITLE
Correct OSR catch block trace to avoid null pointer

### DIFF
--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -1561,8 +1561,10 @@ OMR::ResolvedMethodSymbol::cannotAttemptOSR(TR_ByteCodeInfo bci,
 
    if (blockToOSRAt && (!OSRCatchBlock || !blockToOSRAt->hasExceptionSuccessor(OSRCatchBlock)))
       {
-      if (comp->getOption(TR_TraceOSR))
+      if (comp->getOption(TR_TraceOSR) && OSRCatchBlock)
          traceMsg(comp, "Missing OSR exception successor block_%d for block_%d - cannot OSR\n", OSRCatchBlock->getNumber(), blockToOSRAt->getNumber());
+      if (comp->getOption(TR_TraceOSR) && !OSRCatchBlock)
+         traceMsg(comp, "Missing OSR exception successor for block_%d - cannot OSR\n", blockToOSRAt->getNumber());
       return true;
       }
 


### PR DESCRIPTION
This check ensures that an OSR catch block has been defined and
that there is an exception edge from the desired block to the catch.
However, the tracing message did not take into account the possibility
of the OSR catch block being null.