### PR TITLE
Add opts for arrayset on short const length array

### DIFF
--- a/compiler/x/codegen/OpBinary.cpp
+++ b/compiler/x/codegen/OpBinary.cpp
@@ -618,6 +618,7 @@ const TR_X86OpCode::TR_OpCodeBinaryEntry TR_X86OpCode::_binaryEncodings[IA32NumO
       {0x38, 0x33, 0xc0, 3},    // PMOVZXWD
       {0x38, 0x40, 0xc0, 3},    // PMULLD
       {0xfe, 0xc0, 0x00, 2},    // PADDD
+      {0x38, 0x00, 0xc0, 3},    // PSHUFBRegReg
       {0x0f, 0x70, 0xc0, 3},    // PSHUFDRegRegImm1
       {0x0f, 0x70, 0x00, 3},    // PSHUFDRegMemImm1
       {0x73, 0xd8, 0x00, 2},    // PSRLDQRegImm1

--- a/compiler/x/codegen/OpProperties.cpp
+++ b/compiler/x/codegen/OpProperties.cpp
@@ -3901,6 +3901,10 @@ const uint32_t TR_X86OpCode::_properties[IA32NumOpCodes] =
 
    IA32OpProp_SourceRegisterInModRM,           // PADDD
 
+   IA32OpProp_ModifiesTarget                 | // PSHUFBRegReg
+   IA32OpProp_SourceRegisterInModRM          |
+   IA32OpProp_UsesTarget,
+
    IA32OpProp_ModifiesTarget                 | // PSHUFDRegRegImm1
    IA32OpProp_ByteImmediate                  |
    IA32OpProp_Needs16BitOperandPrefix        |
@@ -7910,6 +7914,10 @@ const uint32_t TR_X86OpCode::_properties2[IA32NumOpCodes] =
    IA32OpProp2_XMMSource|                      // PADDD
    IA32OpProp2_XMMTarget|
    IA32OpProp2_NeedsSSE42OpcodePrefix,
+
+   IA32OpProp2_XMMSource                     |  // PSHUFBRegReg
+   IA32OpProp2_NeedsSSE42OpcodePrefix        |
+   IA32OpProp2_XMMTarget,
 
    IA32OpProp2_XMMSource                     | // PSHUFDRegRegImm1
    IA32OpProp2_XMMTarget,

--- a/compiler/x/codegen/X86Debug.cpp
+++ b/compiler/x/codegen/X86Debug.cpp
@@ -3315,6 +3315,7 @@ static const char * opCodeToNameMap[IA32NumOpCodes] =
    "PMOVZXWD",
    "PMULLD",
    "PADDD",
+   "PSHUFBRegReg",
    "PSHUFDRegRegImm1",
    "PSHUFDRegMemImm1",
    "PSRLDQRegImm1",
@@ -4202,6 +4203,7 @@ static const char * opCodeToMnemonicMap[IA32NumOpCodes] =
    "pmovzxwd",       // PMOVZXWD
    "pmulld",         // PMULLD
    "paddd",          // PADDD
+   "pshufb",         // PSHUFBRegReg
    "pshufd",         // PSHUFDRegRegImm1
    "pshufd",         // PSHUFDRegMemImm1
    "psrldq",         // PSRLDQRegImm1

--- a/compiler/x/codegen/X86Ops.hpp
+++ b/compiler/x/codegen/X86Ops.hpp
@@ -612,6 +612,7 @@ typedef enum {
    PMOVZXWD,        // move unsigned short in lower 8 bytes to int
    PMULLD,          // mul int32 and keep low 32 bits
    PADDD,           // add int32 and keep low 32 bits
+   PSHUFBRegReg,    // Shuffle Packed Byte Register, Register
    PSHUFDRegRegImm1,// Shuffle Packed Doublewords Register, Register by Immediate config
    PSHUFDRegMemImm1,// Shuffle Packed Doublewords Register, Memory by Immediate config
    PSRLDQRegImm1,   // shift 128 xmm register


### PR DESCRIPTION
Currently in arrayset evaluator on X86, we do not take advantage of
the fact that we can know the length of some arrays at compile time.
Some optimizaitons can be enabled if we have the size of array at
compile time. In particular, two optimizations are implemented.
First, for short constant length array, a better sequence of
instructions will be generated. Second, in additional to the short
constant length array, if the value is also zero, we are able to
generate a even better sequence.

Signed-off-by: Jingge Fu <jingge@ca.ibm.com>