### PR TITLE
Value Propagation performance bug fix

### DIFF
--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -4043,7 +4043,7 @@ TR::TreeTop *TR::LocalValuePropagation::processBlock(TR::TreeTop *startTree)
       {
       if (!((((comp()->getMethodHotness() < warm)  && (_curBlock->getFrequency() > 1500)) ||
              ((comp()->getMethodHotness() == warm) && (_curBlock->getFrequency() > 500)) ||
-             ((comp()->getMethodHotness() > warm)  && (_curBlock->isCold())))))
+             ((comp()->getMethodHotness() > warm)  && (!_curBlock->isCold())))))
          {
          if (trace())
             traceMsg(comp(), "\nSkipping block_%d (low frequency)\n", _curBlock->getNumber());


### PR DESCRIPTION
A feature that avoids doing VP on low frequency blocks (in order
to save compilation time) has a bug such that the JIT will not
do VP at hot/scorching opt levels for blocks that are NOT cold.
The condition should be reversed so that the JIT avoids VP for
basic blocks that ARE cold.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>