### PR TITLE
Cleanup for Eclipse CQ11033

### DIFF
--- a/gc/base/SlotObject.hpp
+++ b/gc/base/SlotObject.hpp
@@ -40,7 +40,7 @@ protected:
 public:
 
 private:
-	/* Copied from ObjectAccessBarrier.hpp */
+	/* Inlined version of converting a compressed token to an actual pointer */
 	MMINLINE omrobjectptr_t
 	convertPointerFromToken(fomrobject_t token)
 	{
@@ -50,7 +50,7 @@ private:
 		return (omrobjectptr_t)token;
 #endif
 	}
-	/* Copied from ObjectAccessBarrier.hpp */
+	/* Inlined version of converting a pointer to a compressed token */
 	MMINLINE fomrobject_t
 	convertTokenFromPointer(omrobjectptr_t pointer)
 	{

--- a/gc/base/standard/RSOverflow.hpp
+++ b/gc/base/standard/RSOverflow.hpp
@@ -35,7 +35,7 @@ public:
 protected:
 private:
 	MM_GCExtensionsBase *_extensions;			/**< GC Extensions */
-	MM_MarkMap *_markMap;						/**< Mark Map stolen from Global Collector */
+	MM_MarkMap *_markMap;						/**< Pointer to the mark map used by ParallelGlobalGC */
 	bool _searchMode;							/**< mode switch: initialized in Modify mode, after first nextObject call is switched to Search mode */
 	MM_HeapMapIterator _markedObjectIterator;	/**< Iterator to walk marked objects */
 

--- a/include_core/omrgcconsts.h
+++ b/include_core/omrgcconsts.h
@@ -85,7 +85,7 @@
 #define J9_MU_WALK_IGNORE_NULL_ARRAYLET_LEAF 0x100
 #define J9_MU_WALK_PREINDEX_INTERFACE_FIELDS 0x200
 
-/* When changing the heap alignment below you need to check that the new alignement
+/* When changing the heap alignment below you need to check that the new alignment
  * is compatible with the requirements of compaction and concurrent mark.
  */
 #if defined(OMR_ENV_DATA64)
@@ -116,9 +116,7 @@ struct ModronLnrlOptions {
 	uintptr_t spinCount3;
 };
 
-/* For CMVC 137275. For all dying classes we poison the classObject
- * field to  to investigate the origin of a class object reference whose class has been unloaded.
- */
+/* Flag used to poison collected object pointers for debugging */
 #define J9_INVALID_OBJECT ((omrobjectptr_t)UDATA_MAX)
 
 #define OMRPORT_ACCESS_FROM_ENVIRONMENT(env) OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary())
@@ -147,15 +145,13 @@ struct ModronLnrlOptions {
  * Lightweight Non-Reentrant Locks (LWNR) Spinlock Support
  * We can't use spinlocks on platforms that do not support semaphores.
  * Also, spinlocks can't provide realtime locking.
- * Also, yield causes performance problems on AIX (CMVC 136102, 136484).
+ * Do not use the custom spinlocks on AIX as yield calls create performance issues.
  */
 #if defined(OMR_INTERP_HAS_SEMAPHORES) && !defined(AIXPPC)
 #define J9MODRON_USE_CUSTOM_SPINLOCKS
 #endif
 
 #define J9MODRON_USE_CUSTOM_READERWRITERLOCK
-
-/* TODO Imports from j9modron.h */
 
 /* Since only 1 bit is tagged, we only need to shift 1 bit.
  * These two defines are tightly coupled and should be modified together.
@@ -366,15 +362,7 @@ typedef enum {
 #define OMR_GC_CYCLE_TYPE_VLHGC_GLOBAL_GARBAGE_COLLECT 5
 /** @} */
 
-/* TODO Imports from j9consts.h */
-
-/* These are duplicated in builder J9VMConstantValue.st
- * but cannot be removed from there as the JIT needs these in j9consts.h:
- * 		J9_GC_MULTI_SLOT_HOLE
- * 		J9_GC_SINGLE_SLOT_HOLE
- * 	tr.source\frontend\j9\...
- */
-
+/* Object head object / hole bits */
 #ifndef J9_GC_OBJ_HEAP_HOLE
 #define J9_GC_OBJ_HEAP_HOLE 0x1
 #endif
@@ -390,9 +378,8 @@ typedef enum {
 
 #define J9VMGC_SIZECLASSES_LOG_SMALLEST 0x4
 
+/* Default object age for generational collectors */
 #define J9_OBJECT_HEADER_AGE_DEFAULT 0xA
-
-/* TODO End of imports from j9consts.h" */
 
 #define J9_SCV_TENURE_RATIO_LOW 10
 #define J9_SCV_TENURE_RATIO_HIGH 30
@@ -400,11 +387,7 @@ typedef enum {
 #define J9_SCV_REMSET_FRAGMENT_SIZE 32
 #define J9_SCV_REMSET_SIZE 16384
 
-/* TODO Imports from modron.h */
-
 #define J9MODRON_ALLOCATION_MANAGER_HINT_MAX_WALK 20
-
-/* Copied verbatim from gc_base/modron.h, not these were not generated! */
 
 /* Define the low memory heap ceiling (max heap address when -Xgc:forceLowMemHeap is specified) */
 #if defined(OMR_ENV_DATA64)
@@ -424,9 +407,9 @@ typedef enum {
 
 /* Because SLES zLinux/31 never allocates mmap()ed memory below the 1GB line unless you ask it to, we
  * always request that the heap is allocated low in the address range. This leaves the space above
- * 2GB free for other mmap() allocations (e.g. pthread stacks). See CMVC 102861 */
+ * 2GB free for other mmap() allocations (e.g. pthread stacks).*/
 #if defined(S390) && defined(LINUX) && !defined(OMR_ENV_DATA64)
-#define PREFERRED_HEAP_BASE 0x10000000 /* Value chosen to copy Sovereign behaviour - allows heaps up to 750MB to fit below 1GB line */
+#define PREFERRED_HEAP_BASE 0x10000000
 #else
 #define PREFERRED_HEAP_BASE 0x0
 #endif
@@ -447,7 +430,5 @@ typedef enum {
 #define METRONOME_DEFAULT_BEAT_MICRO 3000
 #define METRONOME_DEFAULT_TIME_WINDOW_MICRO 60000
 #endif /* OMR_GC_REALTIME */
-
-/* TODO End of imports from modron.h" */
 
 #endif /* OMRGCCONSTS_H_ */

--- a/port/aix/rt_time.s
+++ b/port/aix/rt_time.s
@@ -252,24 +252,6 @@ return_millis:
       addi        SP, SP, 40
          b        retry_millis
 
-###########################################################################
-#                                                                         #
-#   IBM Confidential                                                      #
-#                                                                         #
-#   OCO Source Materials                                                  #
-#                                                                         #
-#   VisualAge Micro Edition                                               #
-#                                                                         #
-#   (C) Copyright IBM Corp. 2002                                          #
-#                                                                         #
-#   The source code for this program is not published or otherwise        #
-#   divested of its trade secrets, irrespective of what has been          #
-#   deposited with the U.S. Copyright Office.                             #
-#                                                                         #
-#  sccsid %I%                                                             #
-#                                                                         #
-###########################################################################
-
 # From src/bos/usr/ccs/lib/libc/POWER/divu64.s, libccnv, bos520
 # long long __divu64( long long, long long )
 #

--- a/port/iseries/rt_time.s
+++ b/port/iseries/rt_time.s
@@ -252,24 +252,6 @@ return_millis:
       addi        SP, SP, 40
          b        retry_millis
 
-###########################################################################
-#                                                                         #
-#   IBM Confidential                                                      #
-#                                                                         #
-#   OCO Source Materials                                                  #
-#                                                                         #
-#   VisualAge Micro Edition                                               #
-#                                                                         #
-#   (C) Copyright IBM Corp. 2002                                          #
-#                                                                         #
-#   The source code for this program is not published or otherwise        #
-#   divested of its trade secrets, irrespective of what has been          #
-#   deposited with the U.S. Copyright Office.                             #
-#                                                                         #
-#  sccsid %I%                                                             #
-#                                                                         #
-###########################################################################
-
 # From src/bos/usr/ccs/lib/libc/POWER/divu64.s, libccnv, bos520
 # long long __divu64( long long, long long )
 #

--- a/tools/tracegen/TDFParser.cpp
+++ b/tools/tracegen/TDFParser.cpp
@@ -486,7 +486,7 @@ TDFParser::processAssertTemplate(const char *formatTemplate, unsigned int *count
 }
 
 /****
- * Port of processTemplate from original java code.
+ * Process the template file to create the tracepoints
  * Params:
  * formatTemplate  - the printf style format string
  * str - a malloc'd buffer to hold the result

--- a/util/a2e/atoe_utils.c
+++ b/util/a2e/atoe_utils.c
@@ -59,7 +59,6 @@ typedef struct InstanceData {
 /**************************************************************************
  * name        - pchar
  * description - Print a charater to InstanceData buffer
- *               Taken from util.c used by fnumber and fstring.
  * parameters  - this   Structure holding the receiving buffer
  *               c      Character to add to buffer
  * returns     - int return code, 0 for success
@@ -106,7 +105,6 @@ pchar(InstanceData *this, int c)
 /**************************************************************************
  * name        - fstring
  * description - Print a string to InstanceData buffer
- *               Taken from util.c used by atoe_vsnprintf.
  * parameters  - this           Structure holding the receiving buffer
  *               str            String to add to buffer
  *               left_justify   Left justify string flag
@@ -168,7 +166,6 @@ typedef enum {
 /**************************************************************************
  * name        - fnumber
  * description - Print an integer to InstanceData buffer
- *               Taken from util.c used by atoe_vsnprintf.
  * parameters  - this           Structure containing receiving buffer
  *               value          The value to format
  *               format_type    Character flag specifying format type


### PR DESCRIPTION
As part of the initial contribution CQ there were some files that needed to be cleaned up. These changes clean up some comments and remove copyright headers that should not be present.