### PR TITLE
JitBuilder struct/union field address loading

### DIFF
--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -817,6 +817,33 @@ IlBuilder::IndexAt(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index)
    return address;
    }
 
+/**
+ * @brief Generate IL to load the address of a struct field.
+ *
+ * The address of the field is calculated by adding the field's offset to the
+ * base address of the struct. The address is also converted (type casted) to
+ * a pointer to the type of the field.
+ */
+TR::IlValue *
+IlBuilder::StructFieldInstanceAddress(const char* structName, const char* fieldName, TR::IlValue* obj) {
+   auto offset = typeDictionary()->OffsetOf(structName, fieldName);
+   auto ptype = typeDictionary()->PointerTo(typeDictionary()->GetFieldType(structName, fieldName));
+   auto addr = Add(obj, ConstInt64(offset));
+   return ConvertTo(ptype, addr);
+}
+
+/**
+ * @brief Generate IL to load the address of a union field.
+ *
+ * The address of the field is simply the base address of the union, since the
+ * offset of all union fields is zero.
+ */
+TR::IlValue *
+IlBuilder::UnionFieldInstanceAddress(const char* unionName, const char* fieldName, TR::IlValue* obj) {
+   auto ptype = typeDictionary()->PointerTo(typeDictionary()->UnionFieldType(unionName, fieldName));
+   return ConvertTo(ptype, obj);
+}
+
 TR::IlValue *
 IlBuilder::NullAddress()
    {

--- a/compiler/ilgen/IlBuilder.hpp
+++ b/compiler/ilgen/IlBuilder.hpp
@@ -204,7 +204,18 @@ public:
    TR::IlValue *AtomicAdd(TR::IlValue *baseAddress, TR::IlValue * value);
    void Transaction(TR::IlBuilder **persistentFailureBuilder, TR::IlBuilder **transientFailureBuilder, TR::IlBuilder **fallThroughBuilder);
    void TransactionAbort();
-   
+
+   /**
+    * `StructFieldAddress` and `UnionFieldAddress` are two functions that
+    * provide a workaround for a limitation in JitBuilder. Becuase `TR::IlValue`
+    * cannot represent an object type (only pointers to objects), there is no
+    * way to generate a load for a field that is itself an object. The workaround
+    * is to use the field's address instead. This is not an elegent solution and
+    * should be revisited.
+    */
+   TR::IlValue *StructFieldInstanceAddress(const char* structName, const char* fieldName, TR::IlValue* obj);
+   TR::IlValue *UnionFieldInstanceAddress(const char* unionName, const char* fieldName, TR::IlValue* obj);
+
    // vector memory
    TR::IlValue *VectorLoad(const char *name);
    TR::IlValue *VectorLoadAt(TR::IlType *dt, TR::IlValue *address);

--- a/jitbuilder/release/.gitignore
+++ b/jitbuilder/release/.gitignore
@@ -24,6 +24,7 @@ call
 conststring
 controlflowtests
 dotproduct
+fieldaddress
 iterfib
 issupportedtype
 jitbuilder.tgz

--- a/jitbuilder/release/Makefile
+++ b/jitbuilder/release/Makefile
@@ -30,6 +30,7 @@ ALL_TESTS = \
             conststring \
             controlflowtests \
             dotproduct \
+            fieldaddress \
             issupportedtype \
             iterfib \
             linkedlist \
@@ -66,6 +67,7 @@ all_goal: common_goal
 	./call
 	./conststring
 	./dotproduct
+	./fieldaddress
 	./linkedlist
 	./localarray
 	./operandstacktests
@@ -126,6 +128,13 @@ dotproduct : libjitbuilder.a DotProduct.o
 	g++ -g -fno-rtti -o $@ DotProduct.o -L. -ljitbuilder -ldl
 
 DotProduct.o: src/DotProduct.cpp src/DotProduct.hpp
+	g++ -o $@ $(CXXFLAGS) $<
+
+
+fieldaddress : libjitbuilder.a FieldAddress.o
+	g++ -g -fno-rtti -o $@ FieldAddress.o -L. -ljitbuilder -ldl
+
+FieldAddress.o: src/FieldAddress.cpp src/FieldAddress.hpp
 	g++ -o $@ $(CXXFLAGS) $<
 
 

--- a/jitbuilder/release/src/FieldAddress.cpp
+++ b/jitbuilder/release/src/FieldAddress.cpp
@@ -1,0 +1,159 @@
+/******************************************************************************
+ Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <dlfcn.h>
+#include <errno.h>
+#include <assert.h>
+
+#include "Jit.hpp"
+#include "ilgen/TypeDictionary.hpp"
+#include "ilgen/MethodBuilder.hpp"
+#include "FieldAddress.hpp"
+
+
+GetStructFieldAddressBuilder::GetStructFieldAddressBuilder(TR::TypeDictionary *d)
+   : MethodBuilder(d)
+   {
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   pStructType = d->PointerTo(d->LookupStruct("Struct"));
+
+   DefineName("getStructFieldAddress");
+   DefineParameter("s", pStructType);
+   DefineReturnType(d->PointerTo(d->GetFieldType("Struct", "f2")));
+   }
+
+bool
+GetStructFieldAddressBuilder::buildIL()
+   {
+   Return(
+          StructFieldInstanceAddress("Struct", "f2",
+                             Load("s")));
+
+   return true;
+   }
+
+GetUnionFieldAddressBuilder::GetUnionFieldAddressBuilder(TR::TypeDictionary *d)
+   : MethodBuilder(d)
+   {
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   pUnionType = d->PointerTo(d->LookupUnion("Union"));
+
+   DefineName("getUnionFieldAddress");
+   DefineParameter("u", pUnionType);
+   DefineReturnType(d->toIlType<uint8_t *>());
+   }
+
+bool
+GetUnionFieldAddressBuilder::buildIL()
+   {
+   Return(
+          UnionFieldInstanceAddress("Union", "f2",
+                             Load("u")));
+
+   return true;
+   }
+
+class StructTypeDictionary : public TR::TypeDictionary
+   {
+   public:
+   StructTypeDictionary()
+      : TR::TypeDictionary()
+      {
+      DEFINE_STRUCT(Struct);
+      DEFINE_FIELD(Struct, f1, toIlType<uint16_t>());
+      DEFINE_FIELD(Struct, f2, toIlType<uint8_t>());
+      CLOSE_STRUCT(Struct);
+      }
+   };
+
+class UnionTypeDictionary : public TR::TypeDictionary
+   {
+   public:
+   UnionTypeDictionary()
+      : TR::TypeDictionary()
+      {
+      DefineUnion("Union");
+      UnionField("Union", "f1", toIlType<uint16_t>());
+      UnionField("Union", "f2", toIlType<uint8_t>());
+      CloseUnion("Union");
+      }
+   };
+
+
+int
+main(int argc, char *argv[])
+   {
+   printf("Step 1: initialize JIT\n");
+   bool initialized = initializeJit();
+   if (!initialized)
+      {
+      fprintf(stderr, "FAIL: could not initialize JIT\n");
+      exit(-1);
+      }
+
+   printf("Step 2: define type dictionaries\n");
+   StructTypeDictionary structTypes;
+   UnionTypeDictionary unionTypes;
+
+   printf("Step 3: compile getStructFieldAddress builder\n");
+   GetStructFieldAddressBuilder getStructFieldAddressBuilder(&structTypes);
+   uint8_t *getStructFieldAddressEntry;
+   int32_t rc = compileMethodBuilder(&getStructFieldAddressBuilder, &getStructFieldAddressEntry);
+   if (rc != 0)
+      {
+      fprintf(stderr,"FAIL: compilation error %d\n", rc);
+      exit(-2);
+      }
+
+   printf("Step 4: invoke compiled code for getStructFieldAddress and verify results\n");
+   Struct s;
+   s.f1 = 1;
+   s.f2 = 2;
+   auto getStructFieldAddress = (GetStructFieldAddressFunction *) getStructFieldAddressEntry;
+   auto structFieldAddress = getStructFieldAddress(&s);
+   assert(&(s.f2) == structFieldAddress);
+
+   printf("Step 5: compile getUnionFieldAddress builder\n");
+   GetUnionFieldAddressBuilder getUnionFieldAddressBuilder(&unionTypes);
+   uint8_t *getUnionFieldAddressEntry;
+   rc = compileMethodBuilder(&getUnionFieldAddressBuilder, &getUnionFieldAddressEntry);
+   if (rc != 0)
+      {
+      fprintf(stderr,"FAIL: compilation error %d\n", rc);
+      exit(-2);
+      }
+
+   printf("Step 6: invoke compiled code for getUnionFieldAddress and verify results\n");
+   Union u;
+   u.f2 = 2;
+   auto getUnionFieldAddress = (GetUnionFieldAddressFunction  *) getUnionFieldAddressEntry;
+   auto unionFieldAddress = getUnionFieldAddress(&u);
+   assert(&(u.f2) == unionFieldAddress);
+
+   printf ("Step 7: shutdown JIT\n");
+   shutdownJit();
+
+   printf("PASS\n");
+   }

--- a/jitbuilder/release/src/FieldAddress.hpp
+++ b/jitbuilder/release/src/FieldAddress.hpp
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#ifndef FIELDADDRESS_INCL
+#define FIELDADDRESS_INCL
+
+#include "ilgen/MethodBuilder.hpp"
+
+namespace TR { class TypeDictionary; }
+
+struct Struct
+   {
+   uint16_t f1;
+   uint8_t f2;
+   };
+
+union Union
+   {
+   uint16_t f1;
+   uint8_t f2;
+   };
+
+typedef uint8_t* (GetStructFieldAddressFunction)(Struct*);
+typedef uint8_t* (GetUnionFieldAddressFunction)(Union*);
+
+class GetStructFieldAddressBuilder : public TR::MethodBuilder
+   {
+   private:
+   TR::IlType *pStructType;
+
+   public:
+   GetStructFieldAddressBuilder(TR::TypeDictionary *);
+   virtual bool buildIL();
+   };
+
+class GetUnionFieldAddressBuilder : public TR::MethodBuilder
+   {
+   private:
+   TR::IlType *pUnionType;
+
+   public:
+   GetUnionFieldAddressBuilder(TR::TypeDictionary *);
+   virtual bool buildIL();
+   };
+
+#endif // FIELDADDRESS_INCL


### PR DESCRIPTION
This change implements helper functions to IlGen code for loading the address of struct/union fields, as well as some testing for them.