### PR TITLE
Add the name() method

### DIFF
--- a/compiler/ilgen/BytecodeBuilder.hpp
+++ b/compiler/ilgen/BytecodeBuilder.hpp
@@ -48,6 +48,9 @@ public:
     */
    int32_t bcIndex() { return _bcIndex; }
 
+   /* The name for this BytecodeBuilder. This can be very helpful for debug output */
+   char *name() { return _name; }
+
    virtual uint32_t countBlocks();
 
    void AddFallThroughBuilder(TR::BytecodeBuilder *ftb);


### PR DESCRIPTION
The TR::BytecodeBuilder::name() method can be a very useful for
generating debug information into the compiler trace log.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>