### PR TITLE
Exception asynccheck insertion in ilgen

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1103,7 +1103,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"traceEarlyStackMap",               "L\ttrace early stack map",                        SET_TRACECG_BIT(TR_TraceEarlyStackMap), "P"},
    {"traceEscapeAnalysis",              "L\ttrace escape analysis",                        TR::Options::traceOptimization, escapeAnalysis, 0, "P"},
    {"traceEvaluation",                  "L\tdump output of tree evaluation passes",        SET_TRACECG_BIT(TR_TraceCGEvaluation), "P" },
-   {"traceExceptionAsyncCheckInsertion","L\ttrace async check insertion into exceptions",  TR::Options::traceOptimization, exceptionAsyncCheckInsertion, 0, "P"},  // Java specific option
    {"traceExplicitNewInitialization",   "L\ttrace explicit new initialization",            TR::Options::traceOptimization, explicitNewInitialization, 0, "P"},
    {"traceFieldPrivatization",          "L\ttrace field privatization",                    TR::Options::traceOptimization, fieldPrivatization, 0, "P"},
    {"traceForCodeMining=",              "L{regex}\tadd instruction annotations for code mining",

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -535,7 +535,6 @@ static const OptimizationStrategy ilgenStrategyOpts[] =
    { coldBlockMarker                               },
    { allocationSinking,             IfNews         },
    { invariantArgumentPreexistence, IfNotClassLoadPhaseAndNotProfiling },
-   { exceptionAsyncCheckInsertion                  },
    { osrDefAnalysis                                },
    { osrLiveRangeAnalysis                          },
 #endif

--- a/compiler/optimizer/Optimizations.enum
+++ b/compiler/optimizer/Optimizations.enum
@@ -116,4 +116,3 @@
    OPTIMIZATION(loadExtensions)  // added temporarily for omr optimizer work
    OPTIMIZATION(regDepCopyRemoval)
    OPTIMIZATION(asyncCheckInsertion)
-   OPTIMIZATION(exceptionAsyncCheckInsertion)

--- a/compiler/optimizer/ValuePropagation.cpp
+++ b/compiler/optimizer/ValuePropagation.cpp
@@ -7739,21 +7739,11 @@ void TR::ValuePropagation::doDelayedTransformations()
       TR::TreeTop * firstTT = predictedCatchBlock->getFirstRealTreeTop();
 
       // Find the first real tree in catch block; ignoring the
-      // profiling trees possibly inserted by catch block profiler or
-      // asyncchecks for OSR
-      TR::TreeTop * asyncCheck = NULL;
-      while (firstTT)
-         {
-         if (firstTT->getNode()->isProfilingCode())
-            firstTT = firstTT->getNextRealTreeTop();
-         else if (firstTT->getNode()->getOpCodeValue() == TR::asynccheck)
-            {
-            asyncCheck = firstTT;
-            firstTT = firstTT->getNextRealTreeTop();
-            }
-         else
-            break;
-         }
+      // profiling trees possibly inserted by catch block profiler
+      //
+      while (firstTT &&
+             firstTT->getNode()->isProfilingCode())
+         firstTT = firstTT->getNextRealTreeTop();
 
       if (predictedCatchBlock->specializedDesyncCatchBlock())
          dumpOptDetails(comp(), "%sChanging a throw [%p] to a goto for specializedDesyncCatchBlock\n", OPT_DETAILS, node);
@@ -7779,10 +7769,6 @@ void TR::ValuePropagation::doDelayedTransformations()
       if (debug("traceThrowToGoto"))
          printf("\nthrow converted to goto in %s ", comp()->signature());
       TR::Block * gotoDestination = predictedCatchBlock->split(firstTT, cfg);
-
-      // Duplicate asynccheck to prevent loops without asyncchecks due to the goto
-      if (asyncCheck)
-         gotoDestination->prepend(asyncCheck->duplicateTree());
 
       List<TR::SymbolReference> l1(trMemory()), l2(trMemory()), l3(trMemory());
       TR::ResolvedMethodSymbol * currentSymbol = comp()->getJittedMethodSymbol();


### PR DESCRIPTION
This removes options and enums added for the
ExceptionAsyncCheckInsertion optimization pass.
It also deals with situations where exception handlers
are cloned or split, to ensure the asynccheck remains
in the right place or is duplicated as needed.