### PR TITLE
Use proper macro to detect Windows specific code

### DIFF
--- a/compiler/x/amd64/runtime/AMD64AsmUtil.inc
+++ b/compiler/x/amd64/runtime/AMD64AsmUtil.inc
@@ -41,7 +41,7 @@ endm
 
 prepareCompareAndExchangeArguments macro
         ;; TODO: this generates Rex prefixes that are only needed for the 8-byte case
-IFDEF WIN32
+IFDEF WINDOWS
         ;; rcx=address, rdx=old, r8=new
         mov     rax, rdx
         mov     rdx, r8
@@ -92,7 +92,7 @@ compareAndExchange8 ENDP
         Align16
 _patchingFence16 PROC
         mfence
-IFDEF WIN32
+IFDEF WINDOWS
         clflush [rcx]
         clflush [rcx+8]
 ELSE
@@ -106,7 +106,7 @@ _patchingFence16 ENDP
         Align16
 _patchingFence24 PROC
         mfence
-IFDEF WIN32
+IFDEF WINDOWS
         clflush [rcx]
         clflush [rcx+8]
         clflush [rcx+16]

--- a/compiler/x/amd64/runtime/AMD64cpuid.inc
+++ b/compiler/x/amd64/runtime/AMD64cpuid.inc
@@ -18,7 +18,7 @@
 
 OPTION NOSCOPED
 
-ifndef WIN32
+ifndef WINDOWS
 ; hardcoded CPUID instruction
 cpuid macro
 	db	00Fh
@@ -58,7 +58,7 @@ jitGetCPUID	proc
 	mov	rbp, rsp	; create new frame at current stack top
 	push	rbx		; preserve registers
 
-ifdef WIN64
+ifdef WINDOWS
         push    rdi
         mov     rdi, rcx        ; preserve 1st arg
 endif
@@ -99,7 +99,7 @@ endif
    mov   rax, eq_true
 L2:
 
-ifdef WIN64
+ifdef WINDOWS
         pop     rdi
 endif
 	pop     rbx


### PR DESCRIPTION
According to the build files (<PATH>\build\toolcfg\host\win.mk),
"WINDOWS" is the correct macro to detect Windows OS.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>