### PR TITLE
Add synchronizedFieldLoad codegen symbol

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -162,6 +162,28 @@ class SymbolReferenceTable
       startPCLinkageInfoSymbol,
       instanceShapeFromROMClassSymbol,
 
+      /** \brief
+       *
+       *  This symbol is used by the code generator to recognize and inline a call which emulates the following
+       *  tree sequence:
+       *
+       *  <code>
+       *  monent
+       *    object
+       *  aloadi / iloadi
+       *    ==>object
+       *  monexit
+       *  monexitfence
+       *    ==>object
+       *  </code>
+       *
+       *  Where <c>object</c> is a valid object reference. The sequence represents a field load within a
+       *  synchronized region. Since a full monent / monexit operation for a single load is expensive, some code
+       *  generators can emit an optimized instruction sequence to load the field atomically while conforming
+       *  to the monent / monexit semantics.
+       */
+      synchronizedFieldLoadSymbol,
+
       // common atomic primitives
       atomicAdd32BitSymbol,
       atomicAdd64BitSymbol,

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -410,7 +410,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableLoopReplicatorColdSideEntryCheck","I\tdisable cold side-entry check for replicating loops containing hot inner loops", SET_OPTION_BIT(TR_DisableLoopReplicatorColdSideEntryCheck), "P"},
    {"disableLoopStrider",                 "O\tdisable loop strider",                           TR::Options::disableOptimization, loopStrider, 0, "P"},
    {"disableLoopVersioner",               "O\tdisable loop versioner",                         TR::Options::disableOptimization, loopVersioner, 0, "P"},
-   {"disableLPD",                         "O\tdisable load-pair-disjoint on z196 or newer",    SET_OPTION_BIT(TR_DisableLPD), "F"},
    {"disableMarkingOfHotFields",          "O\tdisable marking of Hot Fields",                  SET_OPTION_BIT(TR_DisableMarkingOfHotFields), "F"},
    {"disableMaskVFTPointers",             "O\tdisable masking of VFT Pointers",                SET_OPTION_BIT(TR_DisableMaskVFTPointers), "F"},
    {"disableMaxMinOptimization",          "O\tdisable masking of VFT Pointers",                SET_OPTION_BIT(TR_DisableMaxMinOptimization), "F"},

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -513,6 +513,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableSupportForCpuSpentInCompilation", "M\tdo not provide CPU spent in compilation",    SET_OPTION_BIT(TR_DisableSupportForCpuSpentInCompilation), "F" },
    {"disableSwitchAnalyzer",              "O\tdisable switch analyzer",                        TR::Options::disableOptimization, switchAnalyzer, 0, "P"},
    {"disableSwitchAwayFromProfilingForHotAndVeryhot", "O\tdisable switch away from profiling for hot and veryhot", SET_OPTION_BIT(TR_DisableSwitchAwayFromProfilingForHotAndVeryhot), "F"},
+   {"disableSynchronizedFieldLoad",       "O\tDisable the use of hardware optimized synchronized field load intrinsics",         SET_OPTION_BIT(TR_DisableSynchronizedFieldLoad), "F"},
    {"disableSyncMethodInlining",          "O\tdisable inlining of synchronized methods",       SET_OPTION_BIT(TR_DisableSyncMethodInlining), "F"},
    {"disableTailRecursion",               "O\tdisable tail recursion",                         SET_OPTION_BIT(TR_DisableTailRecursion), "F"},
    {"disableTarokInlineArrayletAllocation", "O\tdisable Tarok inline Arraylet Allocation in genHeapAlloc", SET_OPTION_BIT(TR_DisableTarokInlineArrayletAllocation), "F"},
@@ -2542,12 +2543,6 @@ OMR::Options::jitPreProcess()
       if (((TR::Compiler->target.cpu.isPower() && TR::Compiler->target.isLinux()) && TR::Compiler->target.numberOfProcessors() >= 8) ||
           ((TR::Compiler->target.cpu.isX86() && TR::Compiler->target.isLinux()) && TR::Compiler->target.numberOfProcessors() >= 4))
           self()->setOption(TR_TurnOffSelectiveNoOptServerIfNoStartupHint);
-
-      // Disable LPD until we have a clearer picture of what exactly is causing all the problem in that code path.
-      // The use of the "appendInstruction" parameter is messing up the ordering of the generated instruction
-      // sequence somehow. Once this problem is addresses LPD should be re-enabled.
-      //
-      self()->setOption(TR_DisableLPD);
 
       self()->setOption(TR_DisableHeapAllocOOL);
       if (!(TR::Compiler->target.cpu.isZ() && TR::Compiler->target.isLinux()))

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -589,7 +589,7 @@ enum TR_CompilationOptions
    TR_DisableShrinkWrapping                           = 0x00008000 + 16,
    TR_EnableAOTStats                                  = 0x00010000 + 16,
    TR_DisableLPD                                      = 0x00020000 + 16,
-   // Available                                       = 0x00040000 + 16,
+   TR_DisableSynchronizedFieldLoad                    = 0x00040000 + 16,
    TR_QuickProfile                                    = 0x00080000 + 16,
    TR_DisableVerification                             = 0x00100000 + 16,
    TR_DisableZHelix                                   = 0x00200000 + 16,

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -588,7 +588,7 @@ enum TR_CompilationOptions
    TR_EnableDeterministicOrientedCompilation          = 0x00004000 + 16,
    TR_DisableShrinkWrapping                           = 0x00008000 + 16,
    TR_EnableAOTStats                                  = 0x00010000 + 16,
-   TR_DisableLPD                                      = 0x00020000 + 16,
+   // Available                                       = 0x00020000 + 16,
    TR_DisableSynchronizedFieldLoad                    = 0x00040000 + 16,
    TR_QuickProfile                                    = 0x00080000 + 16,
    TR_DisableVerification                             = 0x00100000 + 16,

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1651,6 +1651,8 @@ TR_Debug::getName(TR::SymbolReference * symRef)
             return "<killsAllMethod>";
          case TR::SymbolReferenceTable::usesAllMethodSymbol:
             return "<usesAllMethod>";
+         case TR::SymbolReferenceTable::synchronizedFieldLoadSymbol:
+            return "<synchronizedFieldLoad>";
          case TR::SymbolReferenceTable::atomicAdd32BitSymbol:
              return "<atomicAdd32Bit>";
          case TR::SymbolReferenceTable::atomicAdd64BitSymbol:
@@ -2122,6 +2124,7 @@ static const char *commonNonhelperSymbolNames[] =
    "<j9methodExtraField>",
    "<startPCLinkageInfo>",
    "<instanceShapeFromROMClass>",
+   "<synchronizedFieldLoad>",
    "<atomicAdd32Bit>",
    "<atomicAdd64Bit>",
    "<atomicFetchAndAdd32Bit>",


### PR DESCRIPTION
Add a new codegen inlined method call symbol which will model a codegen inlined sequence for reducing a synchronized field load using hardware instructions which support loading memory by means of block-concurrent interlocked fetch. In addition to this we add a new option to support such a feature and deprecate a similar but less documented and intrusive option.