### PR TITLE
Allow region sizes greater or equal than 2G

### DIFF
--- a/gc/base/Configuration.cpp
+++ b/gc/base/Configuration.cpp
@@ -386,7 +386,7 @@ MM_Configuration::initializeRegionSize(MM_EnvironmentBase* env)
 		result = false;
 	} else {
 		/* set the log and the power of two size */
-		uintptr_t powerOfTwoRegionSize = (1 << shift);
+		uintptr_t powerOfTwoRegionSize = ((uintptr_t)1 << shift);
 		extensions->regionSize = powerOfTwoRegionSize;
 		result = verifyRegionSize(env, powerOfTwoRegionSize);
 	}


### PR DESCRIPTION
During region size rounding-to-power-of-2 calculation, the region size
would effectively be casted to signed 32 bit int, limiting the size of
region size.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>