### PR TITLE
Require OSRGuard NOPing in profiling compilations

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -1770,6 +1770,7 @@ bool OMR::Compilation::isVirtualGuardNOPingRequired(TR_VirtualGuard *virtualGuar
          }
       else if ((virtualGuard->getKind() == TR_SideEffectGuard) ||
                (virtualGuard->getKind() == TR_DummyGuard) ||
+               (virtualGuard->getKind() == TR_OSRGuard) ||
                (virtualGuard->getKind() == TR_HCRGuard) ||
                (virtualGuard->getKind() == TR_MutableCallSiteTargetGuard) ||
                ((virtualGuard->getKind() == TR_InterfaceGuard) && (virtualGuard->getTestType() == TR_MethodTest)))


### PR DESCRIPTION
Adds OSRGuard to the kinds of virtual guards that will be
NOPed when conducting a profiling compilation.