### PR TITLE
Use proper macro to detect Windows specific code

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -754,7 +754,7 @@ OMR::Compilation::isProfilingCompilation()
    return _recompilationInfo ? _recompilationInfo->isProfilingCompilation() : false;
    }
 
-#if defined(AIXPPC) || defined(LINUX) || defined(J9ZOS390) || defined(WIN32)
+#if defined(AIXPPC) || defined(LINUX) || defined(J9ZOS390) || defined(WINDOWS)
 static void stopBeforeCompile()
    {
    static int first = 1;
@@ -831,7 +831,7 @@ int32_t OMR::Compilation::compile()
       self()->getDebug()->setupDebugger((void *) *((long*)&(stopBeforeCompile)));
       stopBeforeCompile();
       }
-#elif defined(LINUX) || defined(J9ZOS390) || (defined(WIN32))
+#elif defined(LINUX) || defined(J9ZOS390) || defined(WINDOWS)
    if (self()->getOption(TR_DebugBeforeCompile))
       {
 #if defined(LINUXPPC64)
@@ -1082,7 +1082,7 @@ int32_t OMR::Compilation::compile()
       self()->getDebug()->setupDebugger((void *)jitTojitStart, self()->cg()->getCodeEnd(), false);
 #endif
       }
-#elif defined(LINUX) || defined(J9ZOS390) || (defined(WIN32))
+#elif defined(LINUX) || defined(J9ZOS390) || defined(WINDOWS)
    if (self()->getOption(TR_DebugOnEntry))
       {
       self()->getDebug()->setupDebugger(self()->cg()->getCodeStart(),self()->cg()->getCodeEnd(),false);

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -2599,7 +2599,7 @@ OMR::Options::jitPreProcess()
       #elif defined(J9ZOS390)
          _userSpaceVirtualMemoryMB = -1; // Compute userspace dynamically on z/OS
       #endif //#if defined(LINUX)
-   #elif !defined(WIN32)
+   #elif !defined(WINDOWS)
       _userSpaceVirtualMemoryMB = 0; // Disabled for 64 bit or non-windows production
    #endif //#if defined(TR_TARGET_32BIT) && defined(PROD_WITH_ASSUMES)
 

--- a/compiler/cs2/timer.h
+++ b/compiler/cs2/timer.h
@@ -33,7 +33,7 @@
 #include "cs2/listof.h"
 #include "cs2/hashtab.h"
 
-#if defined(_WIN32)
+#if defined(WINDOWS)
 #include <time.h>
 #include "windows_api.h"
 #else
@@ -107,7 +107,7 @@ private:
 };
 
 typedef BSDTimer PlatformTimer;
-#elif defined(_WIN32)
+#elif defined(WINDOWS)
 /**
  * \brief Windows-specific timer class.
  *

--- a/compiler/cs2/windows_api.h
+++ b/compiler/cs2/windows_api.h
@@ -16,16 +16,16 @@
  *    Multiple authors (IBM Corp.) - initial implementation and documentation
  ******************************************************************************/
 
-#if defined(WIN32) || defined (WIN64)
+#ifdef WINDOWS
 
 #ifdef BOOLEAN
-/* There is a collision between J9's definition of BOOLEAN and WIN32 headers */
+/* There is a collision between J9's definition of BOOLEAN and Windows headers */
 #define BOOLEAN_COLLISION_DETECTED BOOLEAN
 #undef BOOLEAN
 #endif
 
 #ifdef boolean
-/* There is a collision between J9's definition of boolean and WIN32 headers */
+/* There is a collision between J9's definition of boolean and Windows headers */
 #define boolean_COLLISION_DETECTED boolean
 #undef boolean
 #endif
@@ -44,4 +44,4 @@
 #undef BOOLEAN_COLLISION_DETECTED
 #endif
 
-#endif /* defined(WIN32) || defined (WIN64) */
+#endif

--- a/compiler/infra/Annotations.hpp
+++ b/compiler/infra/Annotations.hpp
@@ -78,7 +78,7 @@
 // OMR_LIKELY and OMR_UNLIKELY
 // TODO: check if the definition of these macros is too broad,
 //       __builtin_expect() may not have any effect on xlC
-#if defined(TR_HOST_X86) && defined(WIN32)
+#if defined(TR_HOST_X86) && defined(WINDOWS)
    #define OMR_LIKELY(expr) (expr)
    #define OMR_UNLIKELY(expr) (expr)
 #else

--- a/compiler/infra/Bit.hpp
+++ b/compiler/infra/Bit.hpp
@@ -27,7 +27,7 @@
 #include "il/DataTypes.hpp"  // for CONSTANT64, TR::getMaxSignedPrecision<TR::Int64>(), etc
 #include "infra/Assert.hpp"  // for TR_ASSERT
 
-#if defined(TR_TARGET_X86) && defined(WIN32)
+#if defined(TR_TARGET_X86) && defined(WINDOWS)
    #define abs64 _abs64
 #else
    #define abs64 labs

--- a/compiler/infra/OMRMonitor.cpp
+++ b/compiler/infra/OMRMonitor.cpp
@@ -78,7 +78,7 @@ OMR::Monitor::destroy(TR::Monitor *monitor)
 void
 OMR::Monitor::destroy()
    {
-#ifdef WIN32
+#ifdef WINDOWS
    MUTEX_DESTROY(_monitor);
 #else
    int32_t rc = MUTEX_DESTROY(_monitor);
@@ -89,7 +89,7 @@ OMR::Monitor::destroy()
 void
 OMR::Monitor::enter()
    {
-#ifdef WIN32
+#ifdef WINDOWS
    MUTEX_ENTER(_monitor);
 #else
    int32_t rc = MUTEX_ENTER(_monitor);
@@ -100,7 +100,7 @@ OMR::Monitor::enter()
 int32_t
 OMR::Monitor::exit()
    {
-#ifdef WIN32
+#ifdef WINDOWS
    MUTEX_EXIT(_monitor);
    return 0;
 #else

--- a/compiler/infra/ThreadLocal.h
+++ b/compiler/infra/ThreadLocal.h
@@ -21,8 +21,8 @@
 
 #if defined(SUPPORTS_THREAD_LOCAL)
 
-#if defined(WIN32) || defined(LINUX) || defined(OSX) || defined(AIXPPC)
- #if defined(WIN32)
+#if defined(WINDOWS) || defined(LINUX) || defined(OSX) || defined(AIXPPC)
+ #if defined(WINDOWS)
   #include "windows.h"
   #define tlsDeclare(type, variable) extern DWORD variable
   #define tlsDefine(type, variable) DWORD variable = TLS_OUT_OF_INDEXES
@@ -38,7 +38,7 @@
   #define tlsSet(variable, value) variable = value
   #define tlsGet(variable, type) (variable)
  #endif
-#else /* !(defined(WIN32) || defined(LINUX) || defined(OSX) || defined(AIXPPC)) */  /* mainly defined(J9ZOS390) */
+#else /* !(defined(WINDOWS) || defined(LINUX) || defined(OSX) || defined(AIXPPC)) */  /* mainly defined(J9ZOS390) */
  #include <pthread.h>
 
  #define tlsDeclare(type, variable) extern pthread_key_t variable

--- a/compiler/ras/CallStack.cpp
+++ b/compiler/ras/CallStack.cpp
@@ -324,7 +324,7 @@ bool TR_MvsCallStackIterator::getNext ()
    return true;
    }
 
-#elif defined(WIN32) && defined(TR_HOST_X86) && defined(TR_HOST_32BIT)
+#elif defined(WINDOWS) && defined(TR_HOST_X86) && defined(TR_HOST_32BIT)
 
 #include "ras/CallStack.hpp"
 #include <windows.h>
@@ -494,6 +494,6 @@ bool TR_WinCallStackIterator::getNext()
    return !_done;
    }
 
-#elif !(defined(WIN32) && defined(TR_HOST_X86) && defined(TR_HOST_32BIT))
+#elif !(defined(WINDOWS) && defined(TR_HOST_X86) && defined(TR_HOST_32BIT))
 
 #endif

--- a/compiler/ras/CallStackIterator.hpp
+++ b/compiler/ras/CallStackIterator.hpp
@@ -161,7 +161,7 @@ private:
 
 typedef TR_MvsCallStackIterator TR_CallStackIteratorImpl;
 
-#elif defined(WIN32) && defined(TR_HOST_X86) && defined(TR_HOST_32BIT)
+#elif defined(WINDOWS) && defined(TR_HOST_X86) && defined(TR_HOST_32BIT)
 
 class TR_WinCallStackIterator : public TR_CallStackIterator
    {
@@ -185,7 +185,7 @@ public:
 
 typedef TR_WinCallStackIterator TR_CallStackIteratorImpl;
 
-#elif !(defined(WIN32) && defined(TR_HOST_X86) && defined(TR_HOST_32BIT))
+#elif !(defined(WINDOWS) && defined(TR_HOST_X86) && defined(TR_HOST_32BIT))
 
 typedef TR_CallStackIterator TR_CallStackIteratorImpl;
 

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -162,7 +162,7 @@ TR_Debug * createDebugObject(TR::Compilation * comp)
 
 
 
-#if defined(AIXPPC) || defined(LINUX) || defined(J9ZOS390) || defined(WIN32)
+#if defined(AIXPPC) || defined(LINUX) || defined(J9ZOS390) || defined(WINDOWS)
 static void stopOnCreate()
    {
    static int first = 1;
@@ -207,7 +207,7 @@ TR_Debug::debugOnCreate()
 #elif defined(AIXPPC)
    setupDebugger((void *) *((long*)&(stopOnCreate)));
    stopOnCreate();
-#elif defined(LINUX) || defined(J9ZOS390) || (defined(WIN32))
+#elif defined(LINUX) || defined(J9ZOS390) || (defined(WINDOWS))
    setupDebugger((void *) &stopOnCreate,(void *) &stopOnCreate,true);
    stopOnCreate();
 #endif
@@ -5496,7 +5496,7 @@ void TR_Debug::setupDebugger(void *startaddr, void *endaddr, bool before)
          else printf("Could not open %s, skipping break !\n",cfname);
          }
    }
-#elif defined(WIN32)
+#elif defined(WINDOWS)
 #ifndef WINDOWS_API_INCLUDED
 extern "C"
    {

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -599,7 +599,7 @@ public:
 
 #if defined(AIXPPC)
    virtual void setupDebugger(void *);
-#elif defined(LINUX) || defined(J9ZOS390) || (defined(WIN32))
+#elif defined(LINUX) || defined(J9ZOS390) || defined(WINDOWS)
    virtual void setupDebugger(void *, void *, bool);
 #endif
 

--- a/compiler/ras/DebugCounter.cpp
+++ b/compiler/ras/DebugCounter.cpp
@@ -44,7 +44,7 @@
 #include "infra/CriticalSection.hpp"         // for createCounter race conditions
 
 #if defined(_MSC_VER)
-#include <malloc.h> // alloca on Win32
+#include <malloc.h> // alloca on Windows
 #endif
 
 

--- a/compiler/ras/IgnoreLocale.hpp
+++ b/compiler/ras/IgnoreLocale.hpp
@@ -31,7 +31,7 @@ int strnicmp_ignore_locale(const char *s1, const char *s2, size_t n);
 #include <strings.h>
    #define STRICMP strcasecmp
    #define STRNICMP strncasecmp
-#elif defined(WIN32)
+#elif defined(WINDOWS)
    #define STRICMP _stricmp
    #define STRNICMP _strnicmp
 #elif PILOT

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -961,7 +961,7 @@ bool OMR::X86::CodeGenerator::allowVMThreadRematerialization()
 
 bool OMR::X86::CodeGenerator::supportsFS0VMThreadRematerialization()
    {
-#ifdef WIN32
+#ifdef WINDOWS
    return allowVMThreadRematerialization();
 #else
    return false;


### PR DESCRIPTION
According to the build files (\build\toolcfg\host\win.mk),
"WINDOWS" is the correct macro to detect Windows OS.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>