### PR TITLE
Fix  inliner suitableForRemat

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -1561,23 +1561,25 @@ void TR_InlinerBase::rematerializeCallArguments(TR_TransformInlinedFunction & ti
    static char *disableProfiledGuardRemat = feGetEnv("TR_DisableProfiledGuardRemat");
 
    bool suitableForRemat = !comp()->getOption(TR_DisableGuardedCallArgumentRemat) && !comp()->isProfilingCompilation();
-   // Vijay's Inliner change 02
-   if (guard->_kind == TR_NoGuard)
+   if (suitableForRemat)
       {
-      suitableForRemat = false;
-      }
-   else if (guard->_kind == TR_ProfiledGuard)
-      {
-      if (disableProfiledGuardRemat)
+      if (guard->_kind == TR_NoGuard)
          {
          suitableForRemat = false;
          }
-      else
+      else if (guard->_kind == TR_ProfiledGuard)
          {
-         suitableForRemat = getPolicy()->suitableForRemat(comp(), callNode, guard);
-         if (!suitableForRemat)
+         if (disableProfiledGuardRemat)
             {
-            debugTrace(tracer(),"  skipping remat on profiled guard [%p] due to policy decision",guard);
+            suitableForRemat = false;
+            }
+         else
+            {
+            suitableForRemat = getPolicy()->suitableForRemat(comp(), callNode, guard);
+            if (!suitableForRemat)
+               {
+               debugTrace(tracer(),"  skipping remat on profiled guard [%p] due to policy decision",guard);
+               }
             }
          }
       }


### PR DESCRIPTION
The second part of logic to decide suitableForRemat should
only apply when the first part decide suitableForRemat is true

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>