### PR TITLE
Fix inconsistent dispatching for TLHs

### DIFF
--- a/gc/base/TLHAllocationInterface.cpp
+++ b/gc/base/TLHAllocationInterface.cpp
@@ -147,7 +147,7 @@ MM_TLHAllocationInterface::allocateFromTLH(MM_EnvironmentBase *env, MM_AllocateD
 #if defined(OMR_GC_NON_ZERO_TLH)
 	/* If requested to skip zero init (NON_ZERO_TLH flag set), and we are in dual TLH (default TLH is batch cleared),
 	 * we have to redirect this allocation to the non zero TLH */
-	if (allocDescription->getNonZeroTLHFlag() && env->getExtensions()->batchClearTLH) {
+	if (allocDescription->getNonZeroTLHFlag()) {
 		result = _tlhAllocationSupportNonZero.allocateFromTLH(env, allocDescription, shouldCollectOnFailure);
 	} else
 #endif /* defined(OMR_GC_NON_ZERO_TLH) */


### PR DESCRIPTION
Fixing the problem in allocation path when refreshed TLH is requested
for nonZero TLH but actually taken for regular TLH. As a result an
object would not be allocated in nonZero TLH but out-of-TLH. The heap
memory taken for refreshed TLH would be lost and also might create a
problem with heap walk ability. This problem exists on non-Batch Clear
TLH platforms

Signed-off-by: dmitripivkine <Dmitri_Pivkine@ca.ibm.com>