### PR TITLE
Provide managed destruction of Region allocations

### DIFF
--- a/compiler/env/Region.hpp
+++ b/compiler/env/Region.hpp
@@ -35,11 +35,77 @@ class SegmentProvider;
 
 class Region
    {
+
+   /**
+    * @brief The Destructable class provides a common base class, providing an
+    * interface or invoking the destructor of allocated objects of arbitrary type.
+    */
+   class Destructable
+      {
+   public:
+      Destructable(Destructable * const prev) :
+         _prev(prev)
+         {
+         }
+
+      Destructable * prev() { return _prev; }
+
+      virtual ~Destructable() throw() {}
+
+   private:
+      Destructable * const _prev;
+      };
+
+   /**
+    * @brief A class template allowing the creation of allocation instances of arbitrary
+    * type, all of which have a predictable means of accessing their destructor.
+    */
+   template <typename T>
+   class Instance : public Destructable
+      {
+   public:
+      Instance(Destructable *prev, const T& value) :
+         Destructable(prev),
+         _instance(value)
+         {
+         }
+
+      ~Instance() throw()
+         {
+         }
+
+      T& value() { return _instance; }
+
+   private:
+      T _instance;
+      };
+
 public:
    Region(TR::SegmentProvider &segmentProvider, TR::RawAllocator rawAllocator);
    Region(const Region &prototype);
    virtual ~Region() throw();
    void * allocate(const size_t bytes, void * hint = 0);
+
+   /**
+    * @brief A function template to allocate a Region-managed object instance.
+    *
+    * @param[in] prototype A copy-constructible instance used to initialize the Region-managed instance.
+    *
+    * Object instances allocated in this form will be destroyed in LIFO order when the owning
+    * Region is destroyed.\n
+    * NOTE: If, using a region R0, a second Region R1 is allocated (directly or indirectly)
+    * in this manner, any objects allocated in R0 after the allocation of R1 will have a
+    * shorter life span than all the objects allocated in R1:\n
+    * \n
+    * Objects Allocated in R0 before R1 > Objects allocated in R1 > Objects allocated in R0 after R1\n
+    * \n
+    * This is most likely going to be invoked using a temporary:\n
+    * ```region.allocate( MyClass(arg0, ...argN) );```\n
+    * Or, if using the default constructor, use extra parentheses to avoid the 'most vexing parse':\n
+    * ```region.allocate( (MyClass()) );```
+    */
+   template <typename T> inline T& allocate(const T& prototype);
+
    void deallocate(void * allocation, size_t = 0) throw();
 
    friend bool operator ==(const TR::Region &lhs, const TR::Region &rhs)
@@ -66,6 +132,8 @@ private:
    TR::MemorySegment _initialSegment;
    TR::reference_wrapper<TR::MemorySegment> _currentSegment;
 
+   Destructable *_lastDestructable;
+
    static const size_t INITIAL_SEGMENT_SIZE = 4096;
 
    union {
@@ -81,5 +149,14 @@ inline void operator delete(void * p, TR::Region &region) { region.deallocate(p)
 
 inline void * operator new[](size_t size, TR::Region &region) { return region.allocate(size); }
 inline void operator delete[](void * p, TR::Region &region) { region.deallocate(p); }
+
+template <typename T>
+T &
+TR::Region::allocate(const T &value)
+   {
+   Instance<T> *instance = new (*this) Instance<T>(_lastDestructable, value);
+   _lastDestructable = static_cast<Destructable *>(instance);
+   return instance->value();
+   }
 
 #endif // OMR_REGION_HPP

--- a/compiler/env/TRMemory.hpp
+++ b/compiler/env/TRMemory.hpp
@@ -556,6 +556,7 @@ public:
    void * allocateMemory(size_t size, TR_AllocationKind kind, ObjectType ot = UnknownType);
    void freeMemory(void *p, TR_AllocationKind kind, ObjectType ot = UnknownType);
    TR::PersistentInfo * getPersistentInfo() { return _trPersistentMemory->getPersistentInfo(); }
+   TR::Region& currentStackRegion();
 
 private:
 
@@ -563,7 +564,6 @@ private:
    friend class TR::Region;
 
    /* These are intended to be used exclusively by TR::StackMemoryRegion. */
-   TR::Region& currentStackRegion();
    TR::Region& registerStackRegion(TR::Region &stackRegion);
    void unregisterStackRegion(TR::Region &current, TR::Region &previous) throw();
 


### PR DESCRIPTION
Under some circumstances, we will want to Region-allocate objects that
require having their destructors invoked when they are destroyed.
Currently there is no mechanism for doing this.  This change set
provides such a mechanism for types that would allow themselves to be
copy-constructed into the Region.

In order to provide this new facility, the allocate function is extended
via a new function template such that invocations passing a parameter
that is not coercable to size_t are treated as instead providing an
object prototype with which to construct a new instance via copying.
When the Region is itself destroyed, it will iterate through these
managed objects, destroying them in LIFO ordering.

Signed-off-by: Luc des Trois Maisons <lmaisons@ca.ibm.com>