### PR TITLE
Fix git ignores for executable targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,24 +55,24 @@ J9TraceFormat.dat
 OMRTestTraceFormat.dat
 OMRTraceFormat.dat
 
-omralgotest
-omrgcexample
-omrgctest
-omrperfgctest
-omrporttest
-omrrastest
-omrsigtest
-omrsubscribertest
-omrthreadextendedtest
-omrthreadtest
-omrtraceoptiontest
-omrutiltest
-omrvmtest
-testjit
-utTrcCounters
+/omralgotest
+/omrgcexample
+/omrgctest
+/omrperfgctest
+/omrporttest
+/omrrastest
+/omrsigtest
+/omrsubscribertest
+/omrthreadextendedtest
+/omrthreadtest
+/omrtraceoptiontest
+/omrutiltest
+/omrvmtest
+/testjit
+/utTrcCounters
 
 # hook generation tool
-hookgen
+/hookgen
 
 # trace
 /tracegen


### PR DESCRIPTION
Change .gitignore to only target executable targets in top level directory.
Previously gitignore lines also targeted the directory. This means that
while git would pick up changes to existing files in the directory, it
would ignore any new files.