### PR TITLE
Improve IVA's usesUnchangedValueInLoopTest analysis

### DIFF
--- a/compiler/infra/ILWalk.cpp
+++ b/compiler/infra/ILWalk.cpp
@@ -126,6 +126,40 @@ bool TR::NodeIterator::isAt(PreorderNodeIterator &other)
    return true;
    }
 
+void TR::NodeIterator::logCurrentLocation()
+   {
+   // TODO: Log even without an _opt.
+
+   if (_name && _opt && _opt->trace() && _opt->comp()->getOption(TR_TraceILWalks))
+      {
+      if (currentTree())
+         {
+         TR::Node *node = currentNode();
+         traceMsg(_opt->comp(), "NODE  %s  ", _name);
+         if (stackDepth() >= 2)
+            {
+            traceMsg(_opt->comp(), " ");
+            for (int32_t i = 0; i < stackDepth()-2; i++)
+               {
+               if (_stack[i]._isBetweenChildren)
+                  traceMsg(_opt->comp(), " |");
+               else
+                  traceMsg(_opt->comp(), "  ");
+               }
+            traceMsg(_opt->comp(), " %d: ", _stack[_stack.topIndex()-1]._child);
+            }
+         traceMsg(_opt->comp(), "%s n%dn [%p]\n", node->getOpCode().getName(), node->getGlobalIndex(), node);
+         }
+      else
+         {
+         // Usualy this one doesn't print, because when the iterator finishes
+         // naturally, logCurrentLocation is not even called.
+         //
+         traceMsg(_opt->comp(), "NODE  %s finished\n", _name );
+         }
+      }
+   }
+
 TR::PreorderNodeIterator::PreorderNodeIterator(TR::TreeTop *start, TR::Optimization *opt, const char *name)
    :NodeIterator(start, opt, name)
    {
@@ -189,40 +223,6 @@ void TR::PreorderNodeIterator::stepForward()
       {
       _stack.top()._child++;
       stepForward();
-      }
-   }
-
-void TR::NodeIterator::logCurrentLocation()
-   {
-   // TODO: Log even without an _opt.
-
-   if (_name && _opt && _opt->trace() && _opt->comp()->getOption(TR_TraceILWalks))
-      {
-      if (currentTree())
-         {
-         TR::Node *node = currentNode();
-         traceMsg(_opt->comp(), "NODE  %s  ", _name);
-         if (stackDepth() >= 2)
-            {
-            traceMsg(_opt->comp(), " ");
-            for (int32_t i = 0; i < stackDepth()-2; i++)
-               {
-               if (_stack[i]._isBetweenChildren)
-                  traceMsg(_opt->comp(), " |");
-               else
-                  traceMsg(_opt->comp(), "  ");
-               }
-            traceMsg(_opt->comp(), " %d: ", _stack[_stack.topIndex()-1]._child);
-            }
-         traceMsg(_opt->comp(), "%s n%dn [%p]\n", node->getOpCode().getName(), node->getGlobalIndex(), node);
-         }
-      else
-         {
-         // Usualy this one doesn't print, because when the iterator finishes
-         // naturally, logCurrentLocation is not even called.
-         //
-         traceMsg(_opt->comp(), "NODE  %s finished\n", _name );
-         }
       }
    }
 

--- a/compiler/infra/ILWalk.hpp
+++ b/compiler/infra/ILWalk.hpp
@@ -39,6 +39,7 @@ class TreeTop;
 //
 class AllBlockIterator;
 class ILValidator;
+class PostorderNodeIterator;
 class PostorderNodeOccurrenceIterator;
 class PreorderNodeIterator;
 class PreorderNodeOccurrenceIterator;
@@ -134,9 +135,12 @@ class NodeIterator: protected TreeTopIteratorImpl // abstract
       return (int32_t)_stack.size();
       }
 
+   void logCurrentLocation();
+
    public:
 
    TR::TreeTop *currentTree()        { return Super::currentTree(); }
+   TR::Node *currentNode()           { return _stack.top()._node; }
    bool isAt(TR::TreeTop *tt)        { return Super::isAt(tt); }
    bool isAt(TreeTopIterator &other) { return isAt(other.currentTree()); }
    bool isAt(PreorderNodeIterator &other);
@@ -156,14 +160,36 @@ class PreorderNodeIterator: public NodeIterator
    bool alreadyBeenPushed(TR::Node *node);
    void push(TR::Node *node);
 
-   void logCurrentLocation();
-
    public:
 
    PreorderNodeIterator(TR::TreeTop *start, TR::Optimization *opt=NULL, const char *name=NULL);
    PreorderNodeIterator(TR::TreeTop *start, TR::Compilation *comp);
 
-   TR::Node    *currentNode();
+   void         stepForward();
+
+   public: // operators
+
+   void operator ++() { stepForward(); }
+   };
+
+// Returns each node once, in postorder.
+//
+// This is the order in which nodes will be evaluated, except more strict.
+// (Actual evaluation does not specify the order that siblings are visited.)
+//
+class PostorderNodeIterator: public NodeIterator
+   {
+   typedef class NodeIterator Super;
+
+   bool alreadyBeenPushed(TR::Node *node);
+   void push(TR::Node *node);
+   void descend();
+
+   public:
+
+   PostorderNodeIterator(TR::TreeTop *start, TR::Optimization *opt=NULL, const char *name=NULL);
+   PostorderNodeIterator(TR::TreeTop *start, TR::Compilation *comp);
+
    void         stepForward();
 
    public: // operators


### PR DESCRIPTION
In induction variable analysis (IVA), when `analyzeExitEdges` sees that `valueNode` is a load, it will now determine the point of evaluation of that load relative to the pertinent stores by iterating through the extended block's nodes in postorder. For this purpose, and for symmetry, the set of node iterators is filled out with a new `PostorderNodeIterator`.