### PR TITLE
Teach arrayset evaluators the size of compressed refs

### DIFF
--- a/compiler/p/codegen/TreeEvaluatorVMX.cpp
+++ b/compiler/p/codegen/TreeEvaluatorVMX.cpp
@@ -51,11 +51,13 @@ TR::Register *OMR::Power::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
    TR::Node *addrNode = node->getFirstChild();
    TR::Node *fillNode = node->getSecondChild();
    TR::Node *lenNode = node->getChild(2);
-   uint32_t fillNodeSize = fillNode->getSize();
-   TR::DataType fillNodeType = fillNode->getDataType();
    bool constLength = lenNode->getOpCode().isLoadConst();
    int32_t length = constLength ? lenNode->getInt() : 0;
    bool constFill = fillNode->getOpCode().isLoadConst();
+
+   const uint32_t fillNodeSize = fillNode->getOpCode().isRef()
+      ? TR::Compiler->om.sizeofReferenceField()
+      : fillNode->getSize();
 
    TR::Register *addrReg = cg->gprClobberEvaluate(addrNode);
    TR::Register *fillReg = NULL;

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -12876,7 +12876,8 @@ OMR::Z::TreeEvaluator::arraysetEvaluator(TR::Node * node, TR::CodeGenerator * cg
 
    if (constType == TR::Address)
       {
-      constType = (TR::Compiler->target.is64Bit() ? TR::Int64 : TR::Int32);
+      bool refs64 = TR::Compiler->target.is64Bit() && !comp->useCompressedPointers();
+      constType = (refs64 ? TR::Int64 : TR::Int32);
       }
 
    if (constExpr->getOpCode().isLoadConst())


### PR DESCRIPTION
With compressed references, the size of a reference in the heap does not
agree with `Node::getSize` for reference-typed nodes.

Signed-off-by: Devin Papineau <devinmp@ca.ibm.com>