### PR TITLE
Use proper CMP opcode for divide check

### DIFF
--- a/compiler/x/codegen/DivideCheckSnippet.cpp
+++ b/compiler/x/codegen/DivideCheckSnippet.cpp
@@ -41,14 +41,8 @@ uint8_t *TR::X86DivideCheckSnippet::emitSnippetBody()
 
    // CMP realDivisorReg, -1
    //
-   uint8_t rexPrefix = 0;
-   if (TR::Compiler->target.is64Bit())
-      {
-      rexPrefix = realDivisorReg->rexBits(TR::RealRegister::REX_B, false);
-      if (_divOp.isLong())
-         rexPrefix |= TR::RealRegister::REX | TR::RealRegister::REX_W;
-      }
-   buffer = TR_X86OpCode(CMP4RegImms).binary(buffer, rexPrefix);
+   uint8_t rexPrefix = TR::Compiler->target.is64Bit() ? realDivisorReg->rexBits(TR::RealRegister::REX_B, false) : 0;
+   buffer = TR_X86OpCode(CMPRegImms(_divOp.isLong())).binary(buffer, rexPrefix);
    realDivisorReg->setRMRegisterFieldInModRM(buffer-1);
    *buffer++ = -1;
 


### PR DESCRIPTION
The old code generated a long compare by modifying
REX prefix from an int compare instruction, which is
quite confusing and hacky. This changeset correctly
use int or long compare opcode.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>