### PR TITLE
Canonicalize while loops with post-inc/decrement

### DIFF
--- a/compiler/optimizer/LoopCanonicalizer.cpp
+++ b/compiler/optimizer/LoopCanonicalizer.cpp
@@ -596,8 +596,10 @@ void TR_LoopTransformer::detectWhileLoops(ListAppender<TR_Structure> &whileLoops
                if (succ1Internal ^ succ2Internal)
                   {
                   TR::TreeTop *firstTree = hdrBlock->getFirstRealTreeTop();
+                  static const bool skipTt = feGetEnv("TR_canonicalizerStopAtTreetop") == NULL;
                   while ((firstTree &&
                           (firstTree->getNode()->getOpCodeValue() == TR::asynccheck ||
+                           (skipTt && firstTree->getNode()->getOpCodeValue() == TR::treetop) ||
                            firstTree->getNode()->getOpCode().isCheck())))
                     firstTree = firstTree->getNextTreeTop();
 


### PR DESCRIPTION
Skipping past `treetop` allows while loops with tests of the following
form to be canonicalized:

        treetop
    n0n   iload i
        istore i
          iadd
            iload i
            iconst -1
        ificmple --> exit
    n0n   ==>iload i
          bound