### PR TITLE
Consolidate logics related to ModRM/SIB byte

### DIFF
--- a/compiler/x/amd64/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.cpp
@@ -622,8 +622,8 @@ OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(
          {
          // Addresses in the low 2GB (or high 2GB) can be accessed using a SIB byte
          //
-         self()->setModField(modRM, IA32SIBPresent);
-         *cursor++ = 0x25; // [disp32] encoding
+         self()->ModRM(modRM)->setBase()->setHasSIB();
+         self()->SIB(cursor++)->setScale()->setNoIndex()->setIndexDisp32();
          *(uint32_t*)cursor = (uint32_t)displacement;
          }
       else
@@ -631,7 +631,7 @@ OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(
          TR_ASSERT(IS_32BIT_RIP(displacement, rip), "assertion failure");
          TR_ASSERT(!(comp->getOption(TR_EnableHCR) && sr.getSymbol() && sr.getSymbol()->isClassObject()),
             "HCR runtime assumptions currently can't patch RIP-relative offsets");
-         self()->setModField(modRM, IA32Offset32);
+         self()->ModRM(modRM)->setIndexOnlyDisp32();
          *(uint32_t*)cursor = (uint32_t)(displacement - (intptrj_t)rip);
          }
 

--- a/compiler/x/codegen/OMRInstruction.hpp
+++ b/compiler/x/codegen/OMRInstruction.hpp
@@ -69,6 +69,95 @@ class EnlargementResult
 
 class OMR_EXTENSIBLE Instruction : public OMR::Instruction
    {
+   public:
+
+   struct REX
+      {
+      uint8_t B : 1;
+      uint8_t X : 1;
+      uint8_t R : 1;
+      uint8_t W : 1;
+      uint8_t _padding : 4;
+      REX(uint8_t val = 0)
+         {
+         *((uint8_t*)this) = val;
+         }
+      operator uint8_t() const
+         {
+         return 0x40 | value();
+         }
+      uint8_t value() const
+         {
+         return *((uint8_t*)this);
+         }
+      };
+   struct ModRM
+      {
+      uint8_t rm : 3;
+      uint8_t reg : 3;
+      uint8_t mod : 2;
+      ModRM(uint8_t val = 0)
+         {
+         *((uint8_t*)this) = val;
+         }
+      operator uint8_t() const
+         {
+         return *((uint8_t*)this);
+         }
+      inline ModRM* setMod(uint8_t mod = 0x03) // 0b11
+         {
+         this->mod = mod;
+         return this;
+         }
+      inline ModRM* setBase()
+         {
+         return setMod(0x00); // 0b00
+         }
+      inline ModRM* setBaseDisp8()
+         {
+         return setMod(0x01); // 0b01
+         }
+      inline ModRM* setBaseDisp32()
+         {
+         return setMod(0x02); // 0b10
+         }
+      inline ModRM* setIndexOnlyDisp32()
+         {
+         rm = 0x05; // 0b101
+         return setMod(0x00); // 0b00
+         }
+      inline ModRM* setHasSIB()
+         {
+         rm = 0x04; // 0b100
+         return this;
+         }
+      };
+   struct SIB
+      {
+      uint8_t base : 3;
+      uint8_t index : 3;
+      uint8_t scale : 2;
+      operator uint8_t() const
+         {
+         return *((uint8_t*)this);
+         }
+      inline SIB* setScale(uint8_t scale = 0)
+         {
+         this->scale = scale;
+         return this;
+         }
+      inline SIB* setNoIndex()
+         {
+         index = 0x04; // 0b100
+         return this;
+         }
+      inline SIB* setIndexDisp32()
+         {
+         base = 0x05; // 0b101
+         return this;
+         }
+      };
+
    private:
    uint8_t _rexRepeatCount;
 

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -1427,20 +1427,20 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
 
          if (base->needsDisp())
             {
-            self()->setModField(modRM, IA32BaseOffset8);
+            self()->ModRM(modRM)->setBaseDisp8();
             base->setRMRegisterFieldInModRM(modRM);
             *++cursor = 0x00;
             }
          else if (base->needsSIB())
             {
-            self()->setModField(modRM, IA32BaseIndex);
+            self()->ModRM(modRM)->setBase()->setHasSIB();
             *++cursor = 0x00;
-            self()->setModField(cursor, IA32SIBNoIndex);
+            self()->SIB(cursor)->setNoIndex();
             base->setBaseRegisterFieldInSIB(cursor);
             }
          else
             {
-            self()->setModField(modRM, IA32Base);
+            self()->ModRM(modRM)->setBase();
             base->setRMRegisterFieldInModRM(modRM);
             }
 
@@ -1452,9 +1452,9 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
       case 2:
          {
          index = toRealRegister(self()->getIndexRegister());
-         self()->setModField(modRM, IA32IndexOffset32);
+         self()->ModRM(modRM)->setBase()->setHasSIB();
          *++cursor = 0x00;
-         self()->setModField(cursor, IA32SIBIndexOffset32);
+         self()->SIB(cursor)->setIndexDisp32();
          index->setIndexRegisterFieldInSIB(cursor);
          self()->setStrideFieldInSIB(cursor);
          cursor++;
@@ -1497,12 +1497,12 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
             {
             // Need a sib byte with 8bit displacement field of zero to get ebp as a base register
             //
-            self()->setModField(modRM, IA32BaseIndexOffset8);
+            self()->ModRM(modRM)->setBaseDisp8()->setHasSIB();
             *++cursor = 0x00;
             }
          else
             {
-            self()->setModField(modRM, IA32BaseIndex);
+            self()->ModRM(modRM)->setBase()->setHasSIB();
             }
          ++cursor;
          break;
@@ -1510,7 +1510,7 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
 
       case 4:
          {
-         self()->setModField(modRM, IA32Offset32);
+         self()->ModRM(modRM)->setIndexOnlyDisp32();
          cursor++;
          symbol = self()->getSymbolReference().getSymbol();
          immediateCursor = cursor;
@@ -1613,8 +1613,8 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
          if (base->needsSIB() || self()->isForceSIBByte())
             {
             *++cursor = 0x00;
-            self()->setSIBPresent(modRM);
-            self()->setModField(cursor, IA32SIBNoIndex);
+            self()->ModRM(modRM)->setBase()->setHasSIB();
+            self()->SIB(cursor)->setNoIndex();
             }
 
          displacement = self()->getDisplacement();
@@ -1627,13 +1627,13 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
              !base->needsDisp() &&
              !self()->isForceWideDisplacement())
             {
-            self()->setModField(modRM, IA32Base);
+            self()->ModRM(modRM)->setBase();
             }
          else if (displacement >= -128 &&
                   displacement <= 127  &&
                   !self()->isForceWideDisplacement())
             {
-            self()->setModField(modRM, IA32BaseOffset8);
+            self()->ModRM(modRM)->setBaseDisp8();
             *cursor = (uint8_t)displacement;
             ++cursor;
             }
@@ -1642,7 +1642,7 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
             // If there is a symbol or if the displacement will not fit in a byte,
             // then displacement will be 4 bytes.
             //
-            self()->setModField(modRM, IA32BaseOffset32);
+            self()->ModRM(modRM)->setBaseDisp32();
             *(int32_t *)cursor = (int32_t)displacement;
             if (self()->getUnresolvedDataSnippet() != NULL)
                {
@@ -1684,7 +1684,7 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
              displacement <= 127  &&
              !self()->isForceWideDisplacement())
             {
-            self()->setModField(modRM, IA32BaseIndexOffset8);
+            self()->ModRM(modRM)->setBaseDisp8()->setHasSIB();
             *cursor++ = (uint8_t)displacement;
             }
          else
@@ -1692,7 +1692,7 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
             // If there is a symbol or if the displacement will not fit in a byte,
             // then displacement will be 4 bytes.
             //
-            self()->setModField(modRM, IA32BaseIndexOffset32);
+            self()->ModRM(modRM)->setBaseDisp32()->setHasSIB();
             *(int32_t *)cursor = (int32_t)displacement;
             if (self()->getUnresolvedDataSnippet() != NULL)
                {

--- a/compiler/x/codegen/OMRMemoryReference.hpp
+++ b/compiler/x/codegen/OMRMemoryReference.hpp
@@ -54,16 +54,7 @@ namespace OMR { typedef OMR::X86::MemoryReference MemoryReferenceConnector; }
 #define HIGHEST_STRIDE_SHIFT      3
 
 #define IA32SIBPresent             0x04
-#define IA32Base                   0x00
-#define IA32BaseOffset8            0x40
-#define IA32BaseOffset32           0x80
-#define IA32Offset32               0x05
-#define IA32BaseIndex              (IA32Base         | IA32SIBPresent)
-#define IA32BaseIndexOffset8       (IA32BaseOffset8  | IA32SIBPresent)
-#define IA32BaseIndexOffset32      (IA32BaseOffset32 | IA32SIBPresent)
-#define IA32IndexOffset32          (IA32Base         | IA32SIBPresent)
 #define IA32SIBNoIndex             0x20
-#define IA32SIBIndexOffset32       0x05
 
 #define MemRef_ForceWideDisplacement              0x0001
 #define MemRef_UnresolvedDataSnippet              0x0002
@@ -358,19 +349,18 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
       TR::Node *node,
       TR::CodeGenerator *cg);
 
-   void setModField(uint8_t *modRM, uint8_t addressingMode)
+   inline TR::Instruction::ModRM* ModRM(uint8_t* modrm) const
       {
-      *modRM |= addressingMode;
+      return (TR::Instruction::ModRM*)modrm;
       }
-
-   void setSIBPresent(uint8_t *modRM)
+   inline TR::Instruction::SIB* SIB(uint8_t* sib) const
       {
-      *modRM |= IA32SIBPresent;
+      return (TR::Instruction::SIB*)sib;
       }
 
    void setStrideFieldInSIB(uint8_t *SIBByte)
       {
-      *SIBByte |= _stride << 6;  // stride is in top two bits of SIB byte
+      ((TR::Instruction::SIB*)SIBByte)->setScale(_stride);
       }
 
    virtual void blockRegisters()


### PR DESCRIPTION
1. Provide unified APIs to construct ModRM and SIB bytes.
2. Properly set the bits without assuming the memory being set to zero.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>