### PR TITLE
Change longSubtractAnalyserImpl arguments type

### DIFF
--- a/compiler/x/codegen/SubtractAnalyser.cpp
+++ b/compiler/x/codegen/SubtractAnalyser.cpp
@@ -279,7 +279,7 @@ void TR_X86SubtractAnalyser::longSubtractAnalyser(TR::Node *root)
 /*
  * users should call the longSubtractAnalyser or longSubtractAnalyserWithExplicitOperands APIs instead of calling this one directly 
  */
-TR::Register* TR_X86SubtractAnalyser::longSubtractAnalyserImpl(TR::Node *root, TR::Node *firstChild, TR::Node *secondChild)
+TR::Register* TR_X86SubtractAnalyser::longSubtractAnalyserImpl(TR::Node *root, TR::Node *&firstChild, TR::Node *&secondChild)
    {
    TR::Register *firstRegister  = firstChild->getRegister();
    TR::Register *secondRegister = secondChild->getRegister();

--- a/compiler/x/codegen/SubtractAnalyser.hpp
+++ b/compiler/x/codegen/SubtractAnalyser.hpp
@@ -73,7 +73,7 @@ class TR_X86SubtractAnalyser  : public TR_Analyser
 
    void longSubtractAnalyser(TR::Node *root);
    void longSubtractAnalyserWithExplicitOperands(TR::Node *root, TR::Node *firstChild, TR::Node *secondChild);
-   TR::Register* longSubtractAnalyserImpl(TR::Node *root, TR::Node *firstChild, TR::Node *secondChild);
+   TR::Register* longSubtractAnalyserImpl(TR::Node *root, TR::Node *&firstChild, TR::Node *&secondChild);
 
    bool getEvalChild1()  {return (_actionMap[getInputs()] & EvalChild1)  ? true : false;}
    bool getEvalChild2()  {return (_actionMap[getInputs()] & EvalChild2)  ? true : false;}


### PR DESCRIPTION
The argument's value is changed in the function so change to
reference type to make sure the change is visible to the caller.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>