### PR TITLE
Use 32-bit shr in x86 arrayset evaluator on 32-bit

### DIFF
--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -3731,7 +3731,7 @@ static void arraySetDefault(TR::Node* node, uint8_t elementSize, TR::Register* a
          break;
       }
 
-   if (shiftAmount) generateRegImmInstruction(SHRRegImm1(cg), node, sizeReg, shiftAmount, cg);
+   if (shiftAmount) generateRegImmInstruction(SHRRegImm1(), node, sizeReg, shiftAmount, cg);
    generateInstruction(repOpcode, node, stosDependencies, cg);
    cg->stopUsingRegister(EAX);
    }


### PR DESCRIPTION
Passing `cg` to `SHRRegImm1` inadvertently selects the overload
`SHRRegImm1(bool is64Bit)`, and `cg` implicitly converts to `true`
because it is non-null. As a result, when `arraySetDefault` generates a
`shr`, it unconditionally generates the 64-bit variant. The 64-bit `shr`
is encoded using a `REX.W` prefix, which in 32-bit code is interpreted
as an additional instruction `dec eax` preceding the desired 32-bit
`shr` instruction. Since `rep stos` gets the value to store from (the
low part of) `eax`, the stored values are off by 1 in this case.

Calling the nullary overload of `SHRRegImm1` determines bitness instead
using `TR::Compiler->target.is64Bit()`.

Signed-off-by: Devin Papineau <devinmp@ca.ibm.com>