### PR TITLE
Substitute usage of stck with stckf

### DIFF
--- a/port/linuxs390/omrrttime.s
+++ b/port/linuxs390/omrrttime.s
@@ -26,7 +26,7 @@ maxprec:
     basr %r1,0
 .LT0:
     
-    stck 48(%r15)
+    stckf 48(%r15)
     lm  %r2,%r3,48(%r15)
     sl  %r3,.LC0-.LT0+4(%r1)
     brc 3,.LCarry

--- a/port/linuxs39064/omrrttime.s
+++ b/port/linuxs39064/omrrttime.s
@@ -25,7 +25,7 @@ maxprec:
 .text
     larl    %r3,.LT0
     
-    stck 64(%r15)
+    stckf 64(%r15)
     lg  %r1,64(%r15)
     sg %r1,.LC0-.LT0(%r3)
     srlg %r1,%r1,9

--- a/port/zos390/omrrttime.s
+++ b/port/zos390/omrrttime.s
@@ -31,7 +31,7 @@ NOBORROW EQU B'0011'
 
          AIF ('&SYSPARM' EQ 'BIT64').JMP1
 maxprec  EDCXPRLG BASEREG=8
-         stck CLOCK31(r4) 
+         stckf CLOCK31(r4)
          lm  r2,r3,CLOCK31(r4)
          sl  r3,LC0+4
          brc NOBORROW,LCarry0
@@ -53,7 +53,7 @@ LCarry1  s   r2,CVTLSO
 
 .JMP1    ANOP
 maxprec  CELQPRLG BASEREG=8
-         stck CLOCK64(r4)
+         stckf CLOCK64(r4)
          lg  r3,CLOCK64(r4)
          sg  r3,LC0
          using PSA,r0


### PR DESCRIPTION
stckf is significantly faster than stck (1 cycle vs hundreds), but looses
the guarantee of uniqueness between calls (which is not needed here).

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>