### PR TITLE
Enable ArraySet for X86

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -733,7 +733,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"enableVirtualPersistentMemory",      "M\tenable persistent memory to be allocated using virtual memory allocators",
                                           SET_OPTION_BIT(TR_EnableVirtualPersistentMemory), "F", NOT_IN_SUBSET},
    {"enableVpicForResolvedVirtualCalls",  "O\tenable PIC for resolved virtual calls",         SET_OPTION_BIT(TR_EnableVPICForResolvedVirtualCalls), "F"},
-   {"enableX86AdvancedMemorySet",         "C\tEnable advanced memory support on x86", SET_OPTION_BIT(TR_EnableX86AdvancedMemorySet), "F", NOT_IN_SUBSET },
    {"enableYieldVMAccess",                "O\tenable yielding of VM access when GC is waiting", SET_OPTION_BIT(TR_EnableYieldVMAccess), "F"},
    {"enableZAccessRegs",                "O\tenable use of access regs as spill area on 390.", SET_OPTION_BIT(TR_Enable390AccessRegs), "F"},
    {"enableZEpilogue",                  "O\tenable 64-bit 390 load-multiple breakdown.", SET_OPTION_BIT(TR_Enable39064Epilogue), "F"},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -147,7 +147,7 @@ enum TR_CompilationOptions
    TR_DisableAbstractInlining    = 0x00010000 + 1,
    TR_DisableHierarchyInlining   = 0x00020000 + 1,
    TR_DisableDirectMemoryOps     = 0x00040000 + 1,
-   TR_EnableX86AdvancedMemorySet = 0x00100000 + 1,
+   // Available                  = 0x00100000 + 1,
    TR_TraceLiveMonitorMetadata   = 0x00200000 + 1,
    TR_DisableAllocationInlining  = 0x00400000 + 1,
    TR_DisableInlineCheckCast     = 0x00800000 + 1,

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -365,12 +365,12 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
    self()->setSupportsArrayCmp();
    self()->setSupportsArrayCopy();
 
-   if (comp->getOption(TR_EnableX86AdvancedMemorySet))
-      self()->setSupportsArraySet();
-
    static char *disableArraySet = feGetEnv("TR_disableArraySet");
    if (!disableArraySet)
+      {
       self()->setSupportsArraySetToZero();
+      self()->setSupportsArraySet();
+      }
 
    self()->setSupportsScaledIndexAddressing();
    self()->setSupportsConstantOffsetInAddressing();


### PR DESCRIPTION
ArraySet evaluator has been optimized and tested; turing it on.
In addition, SupportsArraySetToZero flag is removed since all CodeGen now either supports arrayset to an arbitrary value or not support arrayset at all. SupportsArraySetToZero flag served only as an intermediate workaround when X86 CodeGen did not properly support arrayset.
