### PR TITLE
Remove unused mapTOCEntries codegen phase

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -401,11 +401,6 @@ class OMR_EXTENSIBLE CodeGenerator
    bool afterRA() { return _afterRA; }
    TR::CodeGenPhase& getCodeGeneratorPhase() {return _codeGenPhase;}
 
-
-   // called to assign/map TOC slots for constant items. If any platform chooses to use TOC mechanism,
-   // its codeGen should override this method. Also, any maintenance/details are up to the specific platform.
-   void mapTOCEntries() {} // no virt, default
-
    void prepareNodeForInstructionSelection(TR::Node*node);
    void remapGCIndicesInInternalPtrFormat();
    void processRelocations();

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -517,10 +517,6 @@ OMR::Power::CodeGenerator::itemTracking(
       }
    }
 
-void
-OMR::Power::CodeGenerator::mapTOCEntries()
-   {
-   }
 
 bool
 OMR::Power::CodeGenerator::mulDecompositionCostIsJustified(

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -187,7 +187,6 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    TR::Instruction *generateProbeNop(TR::Node *node , TR::Instruction *preced = 0);
 
    bool isSnippetMatched(TR::Snippet *, int32_t, TR::SymbolReference *);
-   void mapTOCEntries();
 
    bool mulDecompositionCostIsJustified(int numOfOperations, char bitPosition[], char operationType[], int64_t value);
 


### PR DESCRIPTION
Its implementation is empty, as well as in all known downstream projects.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>