### PR TITLE
Use resolved method for skipping HCR decisions

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -1782,8 +1782,7 @@ TR_InlinerBase::addGuardForVirtual(
 
    static const char *disableHCRGuards = feGetEnv("TR_DisableHCRGuards");
 
-   // TODO : This is a very hacky way of avoiding HCR guards on sensitive String Compression methods which allows idiom recognition to work. Can we do something better?
-   bool skipHCRGuardForCallee = getPolicy()->skipHCRGuardForCallee(calleeSymbol);
+   const bool skipHCRGuardForCallee = getPolicy()->skipHCRGuardForCallee(calleeSymbol->getResolvedMethod());
 
    bool skipHCRGuardCreation = false;
 
@@ -3777,7 +3776,9 @@ bool TR_DirectCallSite::findCallSiteTarget (TR_CallStack* callStack, TR_InlinerB
    TR_VirtualGuardSelection *guard;
    static const char *disableHCRGuards2 = feGetEnv("TR_DisableHCRGuards");
 
-   if (!disableHCRGuards2 && comp()->getHCRMode() != TR::none && !comp()->compileRelocatableCode() && !inliner->getPolicy()->skipHCRGuardForCallee(_initialCalleeSymbol))
+   const bool skipHCRGuardForCallee = inliner->getPolicy()->skipHCRGuardForCallee(_initialCalleeMethod);
+
+   if (!disableHCRGuards2 && comp()->getHCRMode() != TR::none && !comp()->compileRelocatableCode() && !skipHCRGuardForCallee)
       {
       tempreceiverClass = _initialCalleeMethod->classOfMethod();
       guard = new (comp()->trHeapMemory()) TR_VirtualGuardSelection(TR_HCRGuard, TR_NonoverriddenTest);

--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -559,7 +559,21 @@ class OMR_InlinerPolicy : public TR::OptimizationPolicy, public OMR_InlinerHelpe
       bool aggressiveSmallAppOpts() { return TR::Options::getCmdLineOptions()->getOption(TR_AggressiveOpts); }
       virtual bool willBeInlinedInCodeGen(TR::RecognizedMethod method);
       virtual bool canInlineMethodWhileInstrumenting(TR_ResolvedMethod *method);
-      virtual bool skipHCRGuardForCallee(TR::ResolvedMethodSymbol *calleeSymbol){return false;}
+
+      /** \brief
+       *     Determines whether to skip generation of HCR guards for a particular callee during inlining.
+       *
+       *  \param callee
+       *     The callee to be inlined.
+       *
+       *  \return
+       *     true if we can skip generating HCR guards for this \p callee; false otherwise.
+       */
+      virtual bool skipHCRGuardForCallee(TR_ResolvedMethod* callee)
+         {
+         return false;
+         }
+
       virtual bool dontPrivatizeArgumentsForRecognizedMethod(TR::RecognizedMethod recognizedMethod);
       virtual bool replaceSoftwareCheckWithHardwareCheck(TR_ResolvedMethod *calleeMethod);
    protected:


### PR DESCRIPTION
Callee method symbols may be null depending on whether we are peeking
inside of a top-level callee method to be inlined or not. For a method
two call stacks below the current compiled body the callee method symbol
will be null as it has not been constructed yet. This means we are
unable to properly make a decision on whether or not to generate HCR
guards for such methods.

Alternatively a resolved method object should always be available for an
inline callee candidate. Thus we can always use the resolved method
object for determining whether or not to skip generating HCR guards.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>