### PR TITLE
WIP: Improve addTargetIfThereIsSingleImplementer

### DIFF
--- a/compiler/optimizer/CallInfo.hpp
+++ b/compiler/optimizer/CallInfo.hpp
@@ -431,7 +431,6 @@ class TR_IndirectCallSite : public TR_CallSite
       TR_CALLSITE_INHERIT_CONSTRUCTOR_AND_TR_ALLOC(TR_IndirectCallSite, TR_CallSite)
       virtual bool findCallSiteTarget (TR_CallStack *callStack, TR_InlinerBase* inliner);
 		virtual const char*  name () { return "TR_IndirectCallSite"; }
-      virtual TR_ResolvedMethod* findSingleJittedImplementer (TR_InlinerBase* inliner);
 
    protected:
       bool hasFixedTypeArgInfo();
@@ -445,7 +444,8 @@ class TR_IndirectCallSite : public TR_CallSite
 		//capabilities
 		bool addTargetIfMethodIsNotOverriden (TR_InlinerBase* inliner);
 		bool addTargetIfMethodIsNotOverridenInReceiversHierarchy (TR_InlinerBase* inliner);
-		bool addTargetIfThereIsSingleImplementer(TR_InlinerBase* inliner);
+		virtual bool addTargetIfThereIsSingleJittedImplementer(TR_InlinerBase* inliner);
+		virtual bool addTargetIfThereIsSingleImplementer(TR_InlinerBase* inliner);
 
       virtual TR_OpaqueClassBlock* getClassFromMethod ()
          {

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -3671,18 +3671,6 @@ TR_ResolvedMethod* TR_IndirectCallSite::getResolvedMethod (TR_OpaqueClassBlock* 
    return _callerResolvedMethod->getResolvedVirtualMethod(comp(), klass, _vftSlot);
    }
 
-
-TR_ResolvedMethod* TR_IndirectCallSite::findSingleJittedImplementer (TR_InlinerBase *inliner)
-   {
-   return inliner->getUtil()->findSingleJittedImplementer(this);
-   }
-
-TR_ResolvedMethod*
-OMR_InlinerUtil::findSingleJittedImplementer(TR_IndirectCallSite *callsite)
-   {
-   return NULL;
-   }
-
 bool TR_IndirectCallSite::hasFixedTypeArgInfo()
    {
    return _ecsPrexArgInfo && _ecsPrexArgInfo->get(0) && _ecsPrexArgInfo->get(0)->classIsFixed();
@@ -3814,28 +3802,31 @@ OMR_InlinerUtil::addTargetIfMethodIsNotOverridenInReceiversHierarchy(TR_Indirect
    }
 
 /**
- * find the single implementer and add it as the target of this callsite
+ * find the single jitted implementer and add it as the target of this callsite.
+ * It should always be the last resort when looking for callsite targets.
  */
 bool
-OMR_InlinerUtil::addTargetIfThereIsSingleImplementer (TR_IndirectCallSite *callsite)
+TR_IndirectCallSite::addTargetIfThereIsSingleJittedImplementer(TR_InlinerBase* inliner)
    {
    return false;
    }
 
+/**
+ * find the only one implementer and add it as the target of this callsite
+ */
 bool
-TR_IndirectCallSite::addTargetIfThereIsSingleImplementer (TR_InlinerBase* inliner)
+TR_IndirectCallSite::addTargetIfThereIsSingleImplementer(TR_InlinerBase* inliner)
    {
-   return inliner->getUtil()->addTargetIfThereIsSingleImplementer(this);
+   return false;
    }
 
 bool TR_IndirectCallSite::findCallSiteTarget (TR_CallStack *callStack, TR_InlinerBase* inliner)
    {
-   //inliner->tracer()->dumpPrexArgInfo(_ecsPrexArgInfo);
-
    if (addTargetIfMethodIsNotOverriden(inliner) ||
        addTargetIfMethodIsNotOverridenInReceiversHierarchy(inliner) ||
        addTargetIfThereIsSingleImplementer(inliner) ||
-       findCallTargetUsingArgumentPreexistence(inliner))
+       findCallTargetUsingArgumentPreexistence(inliner) ||
+       addTargetIfThereIsSingleJittedImplementer(inliner))
       {
       return true;
       }

--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -521,8 +521,6 @@ class OMR_InlinerUtil : public TR::OptimizationUtil, public OMR_InlinerHelper
       OMR_InlinerUtil(TR::Compilation *comp);
       static TR::TreeTop * storeValueInATemp(TR::Compilation *comp, TR::Node *, TR::SymbolReference * &, TR::TreeTop *, TR::ResolvedMethodSymbol *, List<TR::SymbolReference> & tempList, List<TR::SymbolReference> & availableTemps, List<TR::SymbolReference> * moreTemps, bool behavesLikeTemp = true, TR::TreeTop ** newStoreValueATreeTop = NULL, bool isIndirect = false, int32_t offset = 0);
       virtual bool addTargetIfMethodIsNotOverridenInReceiversHierarchy(TR_IndirectCallSite *callsite);
-      virtual TR_ResolvedMethod *findSingleJittedImplementer(TR_IndirectCallSite *callsite);
-      virtual bool addTargetIfThereIsSingleImplementer (TR_IndirectCallSite *callsite);
       virtual TR_PrexArgInfo* createPrexArgInfoForCallTarget(TR_VirtualGuardSelection *guard, TR_ResolvedMethod *implementer);
       virtual TR_InnerPreexistenceInfo *createInnerPrexInfo(TR::Compilation * c, TR::ResolvedMethodSymbol *methodSymbol, TR_CallStack *callStack, TR::TreeTop *callTree, TR::Node *callNode, TR_VirtualGuardKind guardKind);
       virtual TR_InlinerTracer * getInlinerTracer(TR::Optimization *optimization);


### PR DESCRIPTION
There are 2 parts. First, change the name to
addTargetIfThereIsSingleJittedImplementer to more accurately indicate
the intention of the API. Second, change this to be the last resort
when looking for a inlining target.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>