### PR TITLE
Use a typedef for the standard CFGEdge* container

### DIFF
--- a/compiler/env/ExceptionTable.cpp
+++ b/compiler/env/ExceptionTable.cpp
@@ -65,7 +65,7 @@ TR_ExceptionTableEntryIterator::TR_ExceptionTableEntryIterator(TR::Compilation *
 
          // create exception ranges from the list of exception predecessors
          //
-         TR::list<TR::CFGEdge*> & exceptionPredecessors = catchBlock->getExceptionPredecessors();
+         TR::CFGEdgeList & exceptionPredecessors = catchBlock->getExceptionPredecessors();
          while (!exceptionPredecessors.empty())
             {
             TR::CFGEdge * e = exceptionPredecessors.front();

--- a/compiler/il/OMRBlock.hpp
+++ b/compiler/il/OMRBlock.hpp
@@ -607,7 +607,7 @@ private:
    TR::Block * _nextBlockInExtendedBlock;
    TR::CFG   * _cfg;
    std::list<TR::CFGEdge*, TR::typed_allocator<TR::CFGEdge*, TR::Allocator> >::iterator _iterator;
-   TR::list<TR::CFGEdge*>* _list;
+   TR::CFGEdgeList* _list;
    };
 
 #endif

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -1968,7 +1968,7 @@ OMR::ResolvedMethodSymbol::detectInternalCycles(TR::CFG *cfg, TR::Compilation *c
          if (!node->getExceptionPredecessors().empty())
             {
             //catch block
-            TR::list<TR::CFGEdge*> excepSucc = node->getExceptionSuccessors();
+            TR::CFGEdgeList excepSucc = node->getExceptionSuccessors();
             if (!excepSucc.empty())
                {
                for (auto e = excepSucc.begin(); e != excepSucc.end(); ++e)

--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -493,7 +493,7 @@ void TR::CFGEdge::setExceptionFromTo(TR::CFGNode *pF, TR::CFGNode *pT)
    pT->addExceptionPredecessor(this);
    }
 
-static int32_t getTotalEdgesFrequency(TR::list<TR::CFGEdge*>& edgesList)
+static int32_t getTotalEdgesFrequency(TR::CFGEdgeList& edgesList)
    {
    int32_t totalFreq = 0;
    for (auto edge = edgesList.begin(); edge != edgesList.end(); ++edge)
@@ -592,7 +592,7 @@ TR::CFGEdge *TR::CFGNode::getEdge(TR::CFGNode *n)
    }
 
 template <typename FUNC>
-TR::CFGEdge * TR::CFGNode::getEdgeMatchingNodeInAList (TR::CFGNode * n, TR::list<TR::CFGEdge*>& list, FUNC blockGetter)
+TR::CFGEdge * TR::CFGNode::getEdgeMatchingNodeInAList (TR::CFGNode * n, TR::CFGEdgeList& list, FUNC blockGetter)
 	{
 	for (auto edge = list.begin(); edge != list.end(); ++edge)
 	  {
@@ -1088,7 +1088,7 @@ void OMR::CFG::removeSelfEdge(List<TR::CFGEdge> succList, int32_t selfNumber)
    return;
    }
 
-void OMR::CFG::removeEdge(TR::list<TR::CFGEdge*> succList, int32_t selfNumber, int32_t destNumber)
+void OMR::CFG::removeEdge(TR::CFGEdgeList succList, int32_t selfNumber, int32_t destNumber)
    {
 
    for (auto edge = succList.begin(); edge != succList.end();)
@@ -2395,7 +2395,7 @@ static void
 
 /* This will replace the function above, once the other callees are using STL Lists as Argument 1
 static void
-   summarizeEdgeFrequencies(TR::list<TR::CFGEdge*> list, int32_t *sumEdgeFreq, int32_t *edgeCount)
+   summarizeEdgeFrequencies(TR::CFGEdgeList list, int32_t *sumEdgeFreq, int32_t *edgeCount)
    {
    for (auto e = list.begin(); e != list.end(); ++e)
        {

--- a/compiler/infra/OMRCfg.hpp
+++ b/compiler/infra/OMRCfg.hpp
@@ -200,7 +200,7 @@ class CFG
    bool removeEdge(TR::CFGNode *from, TR::CFGNode *to);
    bool removeEdge(TR::CFGEdge *e, bool recursiveImpl);
    void removeSelfEdge(List<TR::CFGEdge> succList, int32_t selfNumber);
-   void removeEdge(TR::list<TR::CFGEdge*> succList, int32_t selfNumber, int32_t destNumber);
+   void removeEdge(TR::CFGEdgeList succList, int32_t selfNumber, int32_t destNumber);
 
    void removeBlock(TR::Block *);
 
@@ -367,7 +367,7 @@ public: //FIXME: These public members should eventually be wrtapped in an interf
 class TR_CFGIterator
    {
 public:
-   TR_CFGIterator(TR::list<TR::CFGEdge*>& l1, TR::list<TR::CFGEdge*>& l2) : combinedList(l1)
+   TR_CFGIterator(TR::CFGEdgeList& l1, TR::CFGEdgeList& l2) : combinedList(l1)
       {
       combinedList.insert(combinedList.end(), l2.begin(), l2.end());
       currentIterator = combinedList.begin();
@@ -399,7 +399,7 @@ public:
       }
 
 private:
-   TR::list<TR::CFGEdge*> combinedList;
+   TR::CFGEdgeList combinedList;
 
    std::list<TR::CFGEdge*,
              TR::typed_allocator<TR::CFGEdge*,

--- a/compiler/infra/TRCfgNode.hpp
+++ b/compiler/infra/TRCfgNode.hpp
@@ -34,6 +34,7 @@ namespace TR { class Compilation; }
 
 namespace TR
 {
+typedef TR::list<CFGEdge*> CFGEdgeList;
 
 class CFGNode : public ::TR_Link1<CFGNode>
    {
@@ -53,10 +54,10 @@ class CFGNode : public ::TR_Link1<CFGNode>
    TR_HeapMemory   trHeapMemory() { return trMemory(); }
    TR_StackMemory trStackMemory() { return trMemory(); }
 
-   TR::list<CFGEdge*>& getSuccessors()            {return _successors;}
-   TR::list<CFGEdge*>& getPredecessors()          {return _predecessors;}
-   TR::list<CFGEdge*>& getExceptionSuccessors()   {return _exceptionSuccessors;}
-   TR::list<CFGEdge*> & getExceptionPredecessors() {return _exceptionPredecessors;}
+   TR::CFGEdgeList& getSuccessors()            {return _successors;}
+   TR::CFGEdgeList& getPredecessors()          {return _predecessors;}
+   TR::CFGEdgeList& getExceptionSuccessors()   {return _exceptionSuccessors;}
+   TR::CFGEdgeList & getExceptionPredecessors() {return _exceptionPredecessors;}
 
    //getEdge looks in both getSuccessors() and getExceptionSuccessors()
    //use getSuccessorEdge or getExceptionEdge if a search in a particular list is required
@@ -141,15 +142,15 @@ class CFGNode : public ::TR_Link1<CFGNode>
    private:
    TR_Memory * _m;
    template <typename FUNC>
-   CFGEdge * getEdgeMatchingNodeInAList (CFGNode * n, TR::list<CFGEdge*>& list, FUNC blockGetter);
+   CFGEdge * getEdgeMatchingNodeInAList (CFGNode * n, TR::CFGEdgeList& list, FUNC blockGetter);
    static CFGNode * fromBlockGetter (CFGEdge * e) {return e->getFrom();};
    static CFGNode * toBlockGetter (CFGEdge * e)   {return e->getTo();};
 
 
-   TR::list<CFGEdge*> _successors;
-   TR::list<CFGEdge*> _predecessors;
-   TR::list<CFGEdge*> _exceptionSuccessors;
-   TR::list<CFGEdge*> _exceptionPredecessors;
+   TR::CFGEdgeList _successors;
+   TR::CFGEdgeList _predecessors;
+   TR::CFGEdgeList _exceptionSuccessors;
+   TR::CFGEdgeList _exceptionPredecessors;
 
    int32_t          _nodeNumber;
    vcount_t         _visitCount;

--- a/compiler/optimizer/BackwardBitVectorAnalysis.cpp
+++ b/compiler/optimizer/BackwardBitVectorAnalysis.cpp
@@ -72,12 +72,12 @@ template<class Container>bool TR_BackwardDFSetAnalysis<Container *>::canGenAndKi
    if (naturalLoop && naturalLoop->isNaturalLoop())
       {
       TR_StructureSubGraphNode *entryNode = naturalLoop->getEntry();
-      TR::list<TR::CFGEdge*> predList(entryNode->getPredecessors());
+      TR::CFGEdgeList predList(entryNode->getPredecessors());
       predList.insert(predList.end(), entryNode->getExceptionPredecessors().begin(), entryNode->getExceptionPredecessors().end());
       for (auto pred = predList.begin(); pred != predList.end(); ++pred)
          {
          TR_StructureSubGraphNode *predNode = (TR_StructureSubGraphNode *) (*pred)->getFrom();
-         TR::list<TR::CFGEdge*> succList(predNode->getSuccessors());
+         TR::CFGEdgeList succList(predNode->getSuccessors());
          succList.insert(succList.end(), predNode->getExceptionSuccessors().begin(), predNode->getExceptionSuccessors().end());
          bool exitEdgeSeen = false;
          for (auto succ = succList.begin(); succ != succList.end(); ++succ)
@@ -113,7 +113,7 @@ template<class Container>bool TR_BackwardDFSetAnalysis<Container *>::canGenAndKi
         bool seenNonBackEdge = false;
         bool seenLoopBackEdge = false;
 
-        TR::list<TR::CFGEdge*> predList(toNode->getPredecessors());
+        TR::CFGEdgeList predList(toNode->getPredecessors());
         predList.insert(predList.end(), toNode->getExceptionPredecessors().begin(), toNode->getExceptionPredecessors().end());
         for (auto pred = predList.begin(); pred != predList.end(); ++pred)
            {
@@ -259,7 +259,7 @@ template<class Container>void TR_BackwardDFSetAnalysis<Container *>::initializeG
       TR::BitVector seenSuccNodes(this->comp()->allocator());
       TR::BitVector seenNodes(this->comp()->allocator());
          {
-         TR::list<TR::CFGEdge*> succList(nodeStructure->getSuccessors());
+         TR::CFGEdgeList succList(nodeStructure->getSuccessors());
          succList.insert(succList.end(), nodeStructure->getExceptionSuccessors().begin(), nodeStructure->getExceptionSuccessors().end());
          bool firstSucc = true;
          bool stopAnalyzingThisNode = false;
@@ -377,7 +377,7 @@ template<class Container>void TR_BackwardDFSetAnalysis<Container *>::initializeG
          isBlockStructure = true;
 
       typename TR_BasicDFSetAnalysis<Container *>::ExtraAnalysisInfo *regionAnalysisInfo = this->getAnalysisInfo(regionStructure);
-      TR::list<TR::CFGEdge*> succList(nodeStructure->getSuccessors());
+      TR::CFGEdgeList succList(nodeStructure->getSuccessors());
       succList.insert(succList.end(), nodeStructure->getExceptionSuccessors().begin(), nodeStructure->getExceptionSuccessors().end());
       int count = 0;
       for (auto succ = succList.begin(); succ != succList.end(); ++succ)
@@ -681,7 +681,7 @@ template<class Container>void TR_BackwardDFSetAnalysis<Container *>::initializeG
          }
 
 
-      TR::list<TR::CFGEdge*>predList(nodeStructure->getPredecessors());
+      TR::CFGEdgeList predList(nodeStructure->getPredecessors());
       predList.insert(predList.end(), nodeStructure->getExceptionPredecessors().begin(), nodeStructure->getExceptionPredecessors().end());
       for (auto pred = predList.begin(); pred != predList.end(); ++pred)
          {
@@ -1073,7 +1073,7 @@ template<class Container>bool TR_BackwardDFSetAnalysis<Container *>::analyzeNode
       TR::BitVector seenNodes(this->comp()->allocator());
       ///////initializeOutSetInfo();
          {
-         TR::list<TR::CFGEdge*> succList(nodeStructure->getSuccessors());
+         TR::CFGEdgeList succList(nodeStructure->getSuccessors());
          succList.insert(succList.end(), nodeStructure->getExceptionSuccessors().begin(), nodeStructure->getExceptionSuccessors().end());
          bool firstSucc = true;
          bool stopAnalyzingThisNode = false;
@@ -1243,7 +1243,7 @@ template<class Container>bool TR_BackwardDFSetAnalysis<Container *>::analyzeNode
         typename TR_BasicDFSetAnalysis<Container *>::TR_ContainerNodeNumberPair *nodePair;
         if (1 /* || isBlockStructure */)
            {
-           TR::list<TR::CFGEdge*> succList (nodeStructure->getSuccessors());
+           TR::CFGEdgeList succList (nodeStructure->getSuccessors());
            succList.insert(succList.end(), nodeStructure->getExceptionSuccessors().begin(), nodeStructure->getExceptionSuccessors().end());
            int count = 0;
            for (auto succ = succList.begin(); succ != succList.end(); ++succ)
@@ -1420,7 +1420,7 @@ template<class Container>bool TR_BackwardDFSetAnalysis<Container *>::analyzeNode
             }
         }
 
-      TR::list<TR::CFGEdge*> predList(nodeStructure->getPredecessors());
+      TR::CFGEdgeList predList(nodeStructure->getPredecessors());
       predList.insert(predList.end(),nodeStructure->getExceptionPredecessors().begin(), nodeStructure->getExceptionPredecessors().end());
       for (auto pred = predList.begin(); pred != predList.end(); ++pred)
          {

--- a/compiler/optimizer/BitVectorAnalysis.cpp
+++ b/compiler/optimizer/BitVectorAnalysis.cpp
@@ -319,7 +319,7 @@ template<class Container>bool TR_ForwardDFSetAnalysis<Container *>::canGenAndKil
         bool seenNonBackEdge = false;
         bool seenLoopBackEdge = false;
 
-        TR::list<TR::CFGEdge*> predList(toNode->getPredecessors());
+        TR::CFGEdgeList predList(toNode->getPredecessors());
         predList.insert(predList.end(), toNode->getExceptionPredecessors().begin(), toNode->getExceptionPredecessors().end());
         for (auto pred = predList.begin(); pred != predList.end(); ++pred)
            {
@@ -641,7 +641,7 @@ template<class Container>void TR_ForwardDFSetAnalysis<Container *>::initializeGe
       typename TR_BasicDFSetAnalysis<Container *>::ExtraAnalysisInfo *analysisInfo = this->getAnalysisInfo(regionStructure);
       if (node != regionStructure->getEntry())
          {
-         TR::list<TR::CFGEdge*> predList(node->getPredecessors());
+         TR::CFGEdgeList predList(node->getPredecessors());
          predList.insert(predList.end(), node->getExceptionPredecessors().begin(), node->getExceptionPredecessors().end());
          bool firstPred = true;
          bool stopAnalyzingThisNode = false;
@@ -757,7 +757,7 @@ template<class Container>void TR_ForwardDFSetAnalysis<Container *>::initializeGe
 
       *this->_temp = *_currentRegularGenSetInfo;
       *this->_temp2 = *_currentRegularKillSetInfo;
-      TR::list<TR::CFGEdge*> succList(node->getSuccessors());
+      TR::CFGEdgeList succList(node->getSuccessors());
       succList.insert(succList.end(), node->getExceptionSuccessors().begin(), node->getExceptionSuccessors().end());
       int count = 0;
       for (auto succ = succList.begin(); succ != succList.end(); ++succ)
@@ -971,7 +971,7 @@ template<class Container>void TR_BasicDFSetAnalysis<Container *>::initializeAnal
 
 template<class Container>void TR_BasicDFSetAnalysis<Container *>::initializeAnalysisInfo(typename TR_BasicDFSetAnalysis<Container *>::ExtraAnalysisInfo *info, TR::Block *block)
    {
-   TR::list<TR::CFGEdge*> succList(block->getSuccessors());
+   TR::CFGEdgeList succList(block->getSuccessors());
    succList.insert(succList.end() , block->getExceptionSuccessors().begin(), block->getExceptionSuccessors().end());
    for (auto succ = succList.begin(); succ != succList.end(); ++succ)
       {
@@ -1213,7 +1213,7 @@ template<class Container>bool TR_ForwardDFSetAnalysis<Container *>::analyzeNodeI
 
       initializeInSetInfo();
 
-      TR::list<TR::CFGEdge*> predList(node->getPredecessors());
+      TR::CFGEdgeList predList(node->getPredecessors());
       predList.insert(predList.end(), node->getExceptionPredecessors().begin(), node->getExceptionPredecessors().end());
       bool firstPred = true;
       bool stopAnalyzingThisNode = false;
@@ -1291,7 +1291,7 @@ template<class Container>bool TR_ForwardDFSetAnalysis<Container *>::analyzeNodeI
      if (this->supportsGenAndKillSets() &&
          canGenAndKillForStructure(nodeStructure->getStructure()))
         {
-        TR::list<TR::CFGEdge*> succList (node->getSuccessors());
+        TR::CFGEdgeList succList (node->getSuccessors());
         succList.insert(succList.end(), node->getExceptionSuccessors().begin(), node->getExceptionSuccessors().end());
         int count = 0;
         for (auto succ = succList.begin(); succ != succList.end(); ++succ)
@@ -1497,7 +1497,7 @@ template<class Container>bool TR_ForwardDFSetAnalysis<Container *>::analyzeBlock
       }
 
    TR::Block *block = blockStructure->getBlock();
-   TR::list<TR::CFGEdge*> succList(block->getSuccessors());
+   TR::CFGEdgeList succList(block->getSuccessors());
    succList.insert(succList.end(), block->getExceptionSuccessors().begin(), block->getExceptionSuccessors().end());
    int count = 0;
    for (auto succ = succList.begin(); succ != succList.end(); ++succ)

--- a/compiler/optimizer/CFGSimplifier.cpp
+++ b/compiler/optimizer/CFGSimplifier.cpp
@@ -700,7 +700,7 @@ bool TR_CFGSimplifier::simplifyCondCodeBooleanStore(TR::Block *joinBlock, TR::No
 
    // Find the fallthrough and taken blocks
    TR::Block *fallthroughBlock = getFallThroughBlock(joinBlock), *takenBlock = NULL;
-   TR::list<TR::CFGEdge*>& joinBlockSuccessors = joinBlock->getSuccessors();
+   TR::CFGEdgeList& joinBlockSuccessors = joinBlock->getSuccessors();
 
    TR_ASSERT(joinBlockSuccessors.size() == 2, "Block containing only an if tree doesn't have exactly two successors\n");
    TR::CFGEdge* oldTakenEdge = NULL;

--- a/compiler/optimizer/CopyPropagation.cpp
+++ b/compiler/optimizer/CopyPropagation.cpp
@@ -2053,7 +2053,7 @@ bool TR_CopyPropagation::isRedefinedBetweenStoreTreeAnd(TR::list< TR::Node *> & 
          vcount_t visitCount = comp()->getVisitCount();
          block->setVisitCount(visitCount);
 
-         TR::list<TR::CFGEdge*> predList(block->getPredecessors());
+         TR::CFGEdgeList predList(block->getPredecessors());
          predList.insert(predList.end(), block->getExceptionPredecessors().begin(), block->getExceptionPredecessors().end());
          for (auto nextEdge = predList.begin(); nextEdge != predList.end(); ++nextEdge)
             {

--- a/compiler/optimizer/Dominators.cpp
+++ b/compiler/optimizer/Dominators.cpp
@@ -253,7 +253,7 @@ void TR_Dominators::initialize(TR::Block *start, BBInfo *nullParent) {
     * Seed an initial list of successors using a dummy loop edge connecting the start to itself.
     */
    TR::CFGEdge dummyEdge;
-   TR::list<TR::CFGEdge*> startList(getTypedAllocator<TR::CFGEdge*>(comp()->allocator()));
+   TR::CFGEdgeList startList(getTypedAllocator<TR::CFGEdge*>(comp()->allocator()));
    startList.push_front(&dummyEdge);
 
    StackInfo seed(startList, startList.begin(), -1);

--- a/compiler/optimizer/Dominators.hpp
+++ b/compiler/optimizer/Dominators.hpp
@@ -94,7 +94,7 @@ class TR_Dominators
 
    struct StackInfo
       {
-      typedef TR::list<TR::CFGEdge*> list_type;
+      typedef TR::CFGEdgeList list_type;
       typedef std::list<TR::CFGEdge*, TR::typed_allocator<TR::CFGEdge*, TR::Allocator> >::iterator iterator_type;
       StackInfo(list_type &list, iterator_type position, int32_t parent) :
          list(list),

--- a/compiler/optimizer/DominatorsChk.cpp
+++ b/compiler/optimizer/DominatorsChk.cpp
@@ -168,7 +168,7 @@ void TR_DominatorsChk::initialize(TR::Block *start, TR::Block *nullParent)
    // Set up to start at the start block
    //
    TR::CFGEdge dummyEdge;
-   TR::list<TR::CFGEdge*> dummyList(getTypedAllocator<TR::CFGEdge*>(comp()->allocator()));
+   TR::CFGEdgeList dummyList(getTypedAllocator<TR::CFGEdge*>(comp()->allocator()));
    dummyList.push_front(&dummyEdge);
    (*stack)[0].curIterator = dummyList.begin();
    (*stack)[0].list = &dummyList;

--- a/compiler/optimizer/DominatorsChk.hpp
+++ b/compiler/optimizer/DominatorsChk.hpp
@@ -89,7 +89,7 @@ class TR_DominatorsChk
       {
       public:
       std::list<TR::CFGEdge*, TR::typed_allocator<TR::CFGEdge*, TR::Allocator> >::iterator curIterator;
-      TR::list<TR::CFGEdge*> * list;
+      TR::CFGEdgeList * list;
       int32_t                  parent;
       };
 

--- a/compiler/optimizer/GeneralLoopUnroller.cpp
+++ b/compiler/optimizer/GeneralLoopUnroller.cpp
@@ -1454,7 +1454,7 @@ void TR_LoopUnroller::modifyOriginalLoop(TR_RegionStructure *loop, TR_StructureS
          if (1)
             {
             TR_StructureSubGraphNode *origEntryNode;
-            TR::list<TR::CFGEdge*>& list = _spillNode->getStructure()->asRegion()->getEntry()->getSuccessors();
+            TR::CFGEdgeList& list = _spillNode->getStructure()->asRegion()->getEntry()->getSuccessors();
             for (auto edge = list.begin(); edge != list.end(); ++edge)
                {
                TR_StructureSubGraphNode *to = (*edge)->getTo()->asStructureSubGraphNode();

--- a/compiler/optimizer/GlobalRegisterAllocator.cpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.cpp
@@ -169,7 +169,7 @@ class multipleJumpSuccessorIterator : public SuccessorIterator
          return (*_iterator)->getTo()->asBlock();
       }
    std::list<TR::CFGEdge*, TR::typed_allocator<TR::CFGEdge*, TR::Allocator> >::iterator _iterator;
-   TR::list<TR::CFGEdge*>* _list;
+   TR::CFGEdgeList* _list;
    };
 
 
@@ -2255,7 +2255,7 @@ TR_GlobalRegisterAllocator::registerIsLiveAcrossEdge(
    // It may happen that all predecessors have this candidate in register on exit.
    // If there are more than one predecessor and their frequency is higher than that of this block,
    // it's better to extend live range into successor
-   TR::list<TR::CFGEdge*> &predecessors = successorBlock->getPredecessors();
+   TR::CFGEdgeList &predecessors = successorBlock->getPredecessors();
    if (!predecessors.empty() && !(predecessors.size() == 1) &&
        successorBlock->getEntry()->getNode()->getVisitCount() != comp()->getVisitCount())
       {
@@ -3321,7 +3321,7 @@ TR_GlobalRegisterAllocator::findIfThenRegisterCandidates()
 
    for (TR::CFGNode * block = cfg->getFirstNode(); block; block = block->getNext())
       {
-      TR::list<TR::CFGEdge*>& edges = block->getSuccessors();
+      TR::CFGEdgeList& edges = block->getSuccessors();
       TR::Block *currBlock = toBlock(block);
       if ((edges.size() == 2) && currBlock->getExit())
          {

--- a/compiler/optimizer/InductionVariable.cpp
+++ b/compiler/optimizer/InductionVariable.cpp
@@ -6267,10 +6267,10 @@ static bool identicalBranchTrees(TR::Node *node1, TR::Node *node2)
    return true;
    }
 
-static void appendPredecessors(TR::list<TR::CFGEdge*>& dest, TR::Block *block)
+static void appendPredecessors(TR::CFGEdgeList& dest, TR::Block *block)
    {
-   const TR::list<TR::CFGEdge*>& preds = block->getPredecessors();
-   const TR::list<TR::CFGEdge*>& excs = block->getExceptionPredecessors();
+   const TR::CFGEdgeList& preds = block->getPredecessors();
+   const TR::CFGEdgeList& excs = block->getExceptionPredecessors();
    dest.insert(dest.end(), preds.begin(), preds.end());
    dest.insert(dest.end(), excs.begin(), excs.end());
    }
@@ -6296,7 +6296,7 @@ TR_InductionVariableAnalysis::isIVUnchangedInLoop(TR_RegionStructure *loop,
    if (trace())
       traceMsg(comp(), "\tTrying to make sure that candidate IV hasn't been modified elsewhere in the loop\n");
 
-   TR::list<TR::CFGEdge*> workList(
+   TR::CFGEdgeList workList(
       getTypedAllocator<TR::CFGEdge*>(comp()->allocator()));
 
    TR::BlockChecklist nodesDone(comp());

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -228,7 +228,7 @@ int32_t TR_ExtendBasicBlocks::orderBlocksWithoutFrequencyInfo()
       if ( prevNode->getOpCode().isJumpWithMultipleTargets() || !prevBlock->hasSuccessor(block))
          continue;
 
-      TR::list<TR::CFGEdge*> & preds = block->getPredecessors();
+      TR::CFGEdgeList & preds = block->getPredecessors();
 
       bool cannotExtendWithCurrentFallThrough = false;
       if (!(preds.size() == 1))
@@ -288,7 +288,7 @@ int32_t TR_ExtendBasicBlocks::orderBlocksWithoutFrequencyInfo()
          TR::Block * newBlock = 0;
          if (!bestExtension)
             {
-            TR::list<TR::CFGEdge*> & prevSuccessors = prevBlock->getSuccessors();
+            TR::CFGEdgeList & prevSuccessors = prevBlock->getSuccessors();
             for (auto e = prevSuccessors.begin(); e != prevSuccessors.end(); ++e)
                 if ((*e)->getTo()->getPredecessors().size() == 1)
                     { newBlock = toBlock((*e)->getTo()); break; }
@@ -6339,7 +6339,7 @@ int32_t TR_BlockSplitter::perform()
             // set frequencies for incoming/outcoming edges to/from the block itr->_from
             if (origFreq > 0)
                {
-               TR::list<TR::CFGEdge*> & predecessors = itr->_from->getPredecessors();
+               TR::CFGEdgeList & predecessors = itr->_from->getPredecessors();
                for (auto predEdge = predecessors.begin(); predEdge != predecessors.end(); ++predEdge)
                   {
                   int32_t freq = (coldFreq*(*predEdge)->getFrequency())/origFreq;
@@ -6358,7 +6358,7 @@ int32_t TR_BlockSplitter::perform()
                   (*predEdge)->setFrequency(freq);
                   }
 
-               TR::list<TR::CFGEdge*> & successors = itr->_from->getSuccessors();
+               TR::CFGEdgeList & successors = itr->_from->getSuccessors();
                for (auto succEdge = successors.begin(); succEdge != successors.end(); ++succEdge)
                   {
                   int32_t freq = (coldFreq*(*succEdge)->getFrequency())/origFreq;
@@ -8394,7 +8394,7 @@ TR_ColdBlockOutlining::reorderColdBlocks()
      // Also we don't want to move gen asm flow block if one of it's successor is not cold.
 
      // First, check if a predeccessor of this block is genAsmFlow, this block is not it's predeccessor' fall through, continue if yes
-     TR::list<TR::CFGEdge*> & predecessors = ((TR::CFGNode *)currentBlock)->getPredecessors();
+     TR::CFGEdgeList & predecessors = ((TR::CFGNode *)currentBlock)->getPredecessors();
      bool foundAsmGenFlowPredBlock = false;
      for (auto predEdge = predecessors.begin(); predEdge != predecessors.end(); ++predEdge)
        {

--- a/compiler/optimizer/LoopCanonicalizer.cpp
+++ b/compiler/optimizer/LoopCanonicalizer.cpp
@@ -409,7 +409,7 @@ void TR_LoopTransformer::detectWhileLoopsInSubnodesInOrder(ListAppender<TR_Struc
          _nodesInCycle->set(rootNode->getNumber());
 
          bool stopAnalyzingThisNode = false;
-         TR::list<TR::CFGEdge*> predList(rootNode->getPredecessors());
+         TR::CFGEdgeList predList(rootNode->getPredecessors());
          predList.insert(predList.end(), rootNode->getExceptionPredecessors().begin(), rootNode->getExceptionPredecessors().end());
          for (auto pred = predList.begin(); pred != predList.end(); ++pred)
             {
@@ -433,7 +433,7 @@ void TR_LoopTransformer::detectWhileLoopsInSubnodesInOrder(ListAppender<TR_Struc
       pendingList->reset(root->getNumber());
       _analysisStack.pop();
 
-      TR::list<TR::CFGEdge*> succList(rootNode->getSuccessors());
+      TR::CFGEdgeList succList(rootNode->getSuccessors());
       succList.insert(succList.end(), rootNode->getExceptionSuccessors().begin(), rootNode->getExceptionSuccessors().end());
       for (auto succ = succList.begin(); succ != succList.end(); ++succ)
          {

--- a/compiler/optimizer/LoopReducer.cpp
+++ b/compiler/optimizer/LoopReducer.cpp
@@ -2196,7 +2196,7 @@ TR_LoopReducer::generateArraycmp(TR_RegionStructure * whileLoop, TR_InductionVar
 
    // update the CFG
    _cfg->setStructure(NULL);
-   TR::list<TR::CFGEdge*> iSuccList = incrementBlock->getSuccessors();
+   TR::CFGEdgeList iSuccList = incrementBlock->getSuccessors();
    removeEdge(iSuccList, incrementBlock->getNumber(), branchBlock->getNumber());
 
    return true;
@@ -3391,8 +3391,8 @@ TR_LoopReducer::generateArraytranslate(TR_RegionStructure * whileLoop, TR_Induct
 
    if (hasBranch)
       {
-	  TR::list<TR::CFGEdge*> loadSuccList = loadBlock->getSuccessors();
-	  TR::list<TR::CFGEdge*> storeSuccList = storeBlock->getSuccessors();
+	  TR::CFGEdgeList loadSuccList = loadBlock->getSuccessors();
+	  TR::CFGEdgeList storeSuccList = storeBlock->getSuccessors();
 
       removeEdge(loadSuccList, loadBlock->getNumber(), storeBlock->getNumber());
 
@@ -3406,7 +3406,7 @@ TR_LoopReducer::generateArraytranslate(TR_RegionStructure * whileLoop, TR_Induct
          removeEdge(loadSuccList, loadBlock->getNumber(), storeBlock->getNumber());
          removeEdge(storeSuccList, storeBlock->getNumber(), loadBlock->getNumber());
 
-         TR::list<TR::CFGEdge*> cmpSuccList = cmpBlock->getSuccessors();
+         TR::CFGEdgeList cmpSuccList = cmpBlock->getSuccessors();
          removeEdge(cmpSuccList, cmpBlock->getNumber(), loadBlock->getNumber());
          }
 
@@ -3416,7 +3416,7 @@ TR_LoopReducer::generateArraytranslate(TR_RegionStructure * whileLoop, TR_Induct
       }
    else
       {
-	  TR::list<TR::CFGEdge*> loadSuccList = loadBlock->getSuccessors();
+	  TR::CFGEdgeList loadSuccList = loadBlock->getSuccessors();
       removeEdge(loadSuccList, loadBlock->getNumber(), nextBlock->getNumber());
       return true;
       }
@@ -3691,8 +3691,8 @@ TR_LoopReducer::generateArraytranslateAndTest(TR_RegionStructure * whileLoop, TR
       }
    _cfg->setStructure(NULL);
 
-   TR::list<TR::CFGEdge*> loadSuccList = loadBlock->getSuccessors();
-   TR::list<TR::CFGEdge*> cmpSuccList = cmpBlock->getSuccessors();
+   TR::CFGEdgeList loadSuccList = loadBlock->getSuccessors();
+   TR::CFGEdgeList cmpSuccList = cmpBlock->getSuccessors();
 
    removeEdge(loadSuccList, loadBlock->getNumber(), cmpBlock->getNumber());
    removeEdge(cmpSuccList, cmpBlock->getNumber(), nextBlock->getNumber());
@@ -4232,7 +4232,7 @@ TR_LoopReducer::constrainedIndVar(TR_InductionVariable * indVar)
    }
 
 void
-TR_LoopReducer::removeSelfEdge(TR::list<TR::CFGEdge*> succList, int32_t selfNumber)
+TR_LoopReducer::removeSelfEdge(TR::CFGEdgeList succList, int32_t selfNumber)
    {
    for (auto edge = succList.begin(); edge != succList.end();)
       {
@@ -4249,7 +4249,7 @@ TR_LoopReducer::removeSelfEdge(TR::list<TR::CFGEdge*> succList, int32_t selfNumb
    }
 
 void
-TR_LoopReducer::removeEdge(TR::list<TR::CFGEdge*> succList, int32_t selfNumber, int32_t destNumber)
+TR_LoopReducer::removeEdge(TR::CFGEdgeList succList, int32_t selfNumber, int32_t destNumber)
    {
    for (auto edge = succList.begin(); edge != succList.end();)
       {

--- a/compiler/optimizer/LoopReducer.hpp
+++ b/compiler/optimizer/LoopReducer.hpp
@@ -352,10 +352,10 @@ public:
 
 private:
    void reduceNaturalLoop(TR_RegionStructure * whileLoop);
-   void removeSelfEdge(TR::list<TR::CFGEdge*> succList, int32_t selfNumber);
+   void removeSelfEdge(TR::CFGEdgeList succList, int32_t selfNumber);
    int addBlock(TR::Block * newBlock, TR::Block ** blocks, int numBlock, const int maxNumBlock);
    int addRegionBlocks(TR_RegionStructure * region, TR::Block ** blocks, int numBlock, const int maxNumBlock);
-   void removeEdge(TR::list<TR::CFGEdge*> succList, int32_t selfNumber, int32_t destNumber);
+   void removeEdge(TR::CFGEdgeList succList, int32_t selfNumber, int32_t destNumber);
    bool constrainedIndVar(TR_InductionVariable * indVar);
 
    TR::ILOpCodes convertIf(TR::ILOpCodes ifCmp);

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -2039,7 +2039,7 @@ static void partialRedundantCompareElimination(TR::Node * node, TR::Block * bloc
 
       if (hasCommonedChild(node->getSecondChild(), isVisited)) return;
 
-      TR::list<TR::CFGEdge*>   &predecessors  = ((TR::CFGNode *)block)->getPredecessors();
+      TR::CFGEdgeList   &predecessors  = ((TR::CFGNode *)block)->getPredecessors();
       TR::CFG             *cfg           = comp->getFlowGraph();
       TR::TreeTop         *fallThroughTT = block->getExit()->getNextTreeTop();
       TR::Block           *fallThroughBB = fallThroughTT->getNode()->getBlock();
@@ -3413,8 +3413,8 @@ static double doubleRecip(double value)
 // Legal check
 // bbStartNode -- start node of nextBlock
 // inEdge      -- incoming edges of nextBlock
-static bool isLegalToMerge(TR::Node * node, TR::Block * block, TR::Block * nextBlock, TR::list<TR::CFGEdge*>  &nextExcpOut,
-                    TR::Node    * bbStartNode, TR::list<TR::CFGEdge*>& inEdge, TR::Simplifier * s, bool &blockIsEmpty)
+static bool isLegalToMerge(TR::Node * node, TR::Block * block, TR::Block * nextBlock, TR::CFGEdgeList  &nextExcpOut,
+                    TR::Node    * bbStartNode, TR::CFGEdgeList& inEdge, TR::Simplifier * s, bool &blockIsEmpty)
    {
    TR::CFGEdge* outEdge = block->getSuccessors().front();
 
@@ -3441,7 +3441,7 @@ static bool isLegalToMerge(TR::Node * node, TR::Block * block, TR::Block * nextB
    if (nextBlock->hasExceptionPredecessors())
       return false;
 
-   TR::list<TR::CFGEdge*> &excpOut     = block->getExceptionSuccessors();
+   TR::CFGEdgeList &excpOut     = block->getExceptionSuccessors();
    if (excpOut.empty())
       {
       if (!nextExcpOut.empty())
@@ -3517,9 +3517,9 @@ static bool isLegalToMerge(TR::Node * node, TR::Block * block, TR::Block * nextB
 // Changes branch destinations for merge blocks.
 //
 static void changeBranchDestinationsForMergeBlocks(TR::Block * block, TR::Block * nextBlock,
-                    TR::Node    * bbStartNode, TR::list<TR::CFGEdge*> &inEdge, std::list<TR::CFGEdge*, TR::typed_allocator<TR::CFGEdge*, TR::Allocator> >::iterator &inEdgeIter, TR::Simplifier * s)
+                    TR::Node    * bbStartNode, TR::CFGEdgeList &inEdge, std::list<TR::CFGEdge*, TR::typed_allocator<TR::CFGEdge*, TR::Allocator> >::iterator &inEdgeIter, TR::Simplifier * s)
    {
-   TR::list<TR::CFGEdge*> &successors     = block->getSuccessors();
+   TR::CFGEdgeList &successors     = block->getSuccessors();
    TR::CFGEdge* outEdge = successors.front();
 
    //if (inEdge->getNextElement() != NULL)
@@ -14889,9 +14889,9 @@ TR::Node *endBlockSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
    TR_ASSERT(bbStartNode->getOpCodeValue() == TR::BBStart, "Simplification, BBEnd not followed by BBStart");
 
    TR::Block * nextBlock                     = bbStartNode->getBlock();
-   TR::list<TR::CFGEdge*>   &inEdge        = nextBlock->getPredecessors();
+   TR::CFGEdgeList   &inEdge        = nextBlock->getPredecessors();
    std::list<TR::CFGEdge*, TR::typed_allocator<TR::CFGEdge*, TR::Allocator> >::iterator inEdgeIter = inEdge.begin();
-   TR::list<TR::CFGEdge*>        &nextExcpOut     = nextBlock->getExceptionSuccessors();
+   TR::CFGEdgeList        &nextExcpOut     = nextBlock->getExceptionSuccessors();
    bool                     moreThanOnePred = (!(nextBlock->getPredecessors().empty()) && (nextBlock->getPredecessors().size() > 1));
 
    // Exclude all the illegal cases first since we don't want to return in the middle of merging
@@ -15971,7 +15971,7 @@ TR::Node *nullchkSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier *
           // Subsequently, if we iterate over the original list, we will end up
           // with an iterator invalidation problem and hence, use a copy instead.
 
-          TR::list<TR::CFGEdge*> list(block->getSuccessors());
+          TR::CFGEdgeList list(block->getSuccessors());
           for (auto edge = list.begin(); edge != list.end(); ++edge)
              {
              if ((*edge)->getTo() != cfg->getEnd())

--- a/compiler/optimizer/OrderBlocks.cpp
+++ b/compiler/optimizer/OrderBlocks.cpp
@@ -386,11 +386,11 @@ bool TR_OrderBlocks::analyseForHazards(TR::CFGNode *block)
 
 bool TR_OrderBlocks::isCandidateReallyBetter(TR::CFGEdge *candEdge, TR::Compilation *comp)
    {
-   TR::list<TR::CFGEdge*> & predecessors = candEdge->getTo()->getPredecessors();
+   TR::CFGEdgeList & predecessors = candEdge->getTo()->getPredecessors();
    //traceMsg(comp, "iCRB cand block_%d\n", candEdge->getTo()->getNumber());
    for (auto predEdge = predecessors.begin(); predEdge != predecessors.end(); ++predEdge)
       {
-      TR::list<TR::CFGEdge*> & predSuccessors = (*predEdge)->getFrom()->getSuccessors();
+      TR::CFGEdgeList & predSuccessors = (*predEdge)->getFrom()->getSuccessors();
       float numFactor = 1.5;
       for (auto predSuccEdge = predSuccessors.begin(); predSuccEdge != predSuccessors.end(); ++predSuccEdge)
          {
@@ -426,7 +426,7 @@ static bool isCandidateTheHottestSuccessor(TR::CFGEdge *candEdge, TR::Compilatio
    if (!comp->getFlowGraph()->getStructure()) // we cannot trust below checks if someone invalidated structure earlier in this opt
       return true;
 
-   TR::list<TR::CFGEdge*> & predecessors = candEdge->getTo()->getPredecessors();
+   TR::CFGEdgeList & predecessors = candEdge->getTo()->getPredecessors();
    TR_BlockStructure *candBlock = candEdge->getTo()->asBlock()->getStructureOf();
    if (candBlock && candBlock->getContainingLoop() &&
          candBlock->getContainingLoop()->getNumber() == candBlock->getNumber())
@@ -590,7 +590,7 @@ TR::CFGNode *TR_OrderBlocks::chooseBestFallThroughSuccessor(TR::CFG *cfg, TR::CF
    if (trace()) traceMsg(comp(), "Block %d: looking for best successor\n", block->getNumber());
 
    // first, build up a list of potential choices: unvisited successors
-   TR::list<TR::CFGEdge*> & successors = block->getSuccessors();
+   TR::CFGEdgeList & successors = block->getSuccessors();
    for (auto succEdge = successors.begin(); succEdge != successors.end(); ++succEdge)
       {
       TR::Block *succBlock = (*succEdge)->getTo()->asBlock();
@@ -694,7 +694,7 @@ TR::CFGNode *TR_OrderBlocks::chooseBestFallThroughSuccessor(TR::CFG *cfg, TR::CF
             //outer loop does not exist or contains the inner loop
             if (!outerLoop || innerLoop!=outerLoop && outerLoop->contains(innerLoop))
                {
-               TR::list<TR::CFGEdge*>& successors = block->asBlock()->getSuccessors();
+               TR::CFGEdgeList& successors = block->asBlock()->getSuccessors();
                if (successors.size() !=2 )
                   break;
                //get exit edge frequency
@@ -819,7 +819,7 @@ TR::CFGNode *TR_OrderBlocks::chooseBestFallThroughSuccessor(TR::CFG *cfg, TR::CF
 
    if (trace()) traceMsg(comp(), "\tBest successor is %d\n", bestSuccessorEdge->getTo()->getNumber());
 
-   TR::list<TR::CFGEdge*> & predecessors = bestSuccessorEdge->getTo()->getPredecessors();
+   TR::CFGEdgeList & predecessors = bestSuccessorEdge->getTo()->getPredecessors();
    for (auto predEdge = predecessors.begin(); predEdge != predecessors.end(); ++predEdge)
       {
       TR::CFGNode *pred = (*predEdge)->getFrom();
@@ -923,7 +923,7 @@ void TR_OrderBlocks::addRemainingSuccessorsToList(TR::CFGNode *block, TR::CFGNod
 
    if (trace()) traceMsg(comp(), "\tadding remaining successors of block_%d to queue\n", block->getNumber());
 
-   TR::list<TR::CFGEdge*> & successors = block->getSuccessors();
+   TR::CFGEdgeList & successors = block->getSuccessors();
    for (auto succEdge = successors.begin(); succEdge != successors.end(); ++succEdge)
       {
       TR::CFGNode *succBlock = (*succEdge)->getTo();
@@ -944,7 +944,7 @@ void TR_OrderBlocks::addRemainingSuccessorsToList(TR::CFGNode *block, TR::CFGNod
          }
       }
 
-   TR::list<TR::CFGEdge*> & excSuccessors = block->getExceptionSuccessors();
+   TR::CFGEdgeList & excSuccessors = block->getExceptionSuccessors();
    for (auto excSuccEdge = excSuccessors.begin(); excSuccEdge != excSuccessors.end(); ++excSuccEdge)
       {
       TR::CFGNode *succBlock = (*excSuccEdge)->getTo();
@@ -971,7 +971,7 @@ void TR_OrderBlocks::addRemainingSuccessorsToListHWProfile(TR::CFGNode *block, T
 
    if (trace()) traceMsg(comp(), "\tadding remaining successors of block_%d to queue\n", block->getNumber());
 
-   TR::list<TR::CFGEdge*> & successors = block->getSuccessors();
+   TR::CFGEdgeList & successors = block->getSuccessors();
    for (auto succEdge = successors.begin(); succEdge != successors.end(); ++succEdge)
       {
       TR::CFGNode *succBlock = (*succEdge)->getTo();
@@ -984,7 +984,7 @@ void TR_OrderBlocks::addRemainingSuccessorsToListHWProfile(TR::CFGNode *block, T
          }
       }
 
-   TR::list<TR::CFGEdge*> & excSuccessors = block->getExceptionSuccessors();
+   TR::CFGEdgeList & excSuccessors = block->getExceptionSuccessors();
    for (auto excSuccEdge = excSuccessors.begin(); excSuccEdge != excSuccessors.end(); ++excSuccEdge)
       {
       TR::CFGNode *succBlock = (*excSuccEdge)->getTo();
@@ -1273,7 +1273,7 @@ void TR_OrderBlocks::peepHoleBranchAroundSingleGoto(TR::CFG *cfg, TR::Block *blo
       TR::Block *blockAfterFallThrough = fallThroughBlock->getExit()->getNextTreeTop()->getNode()->getBlock();
 
 
-      TR::list<TR::CFGEdge*> &fallThroughSuccessors = fallThroughBlock->getSuccessors();
+      TR::CFGEdgeList &fallThroughSuccessors = fallThroughBlock->getSuccessors();
 #if defined(ENABLE_SPMD_SIMD)
       static const char *e = feGetEnv("TR_DisableSPMD");
       static int disableSPMD = e ? atoi(e) : false;
@@ -1506,7 +1506,7 @@ bool TR_OrderBlocks::doPeepHoleBlockCorrections(TR::Block *block, char *title)
       if (performTransformation(comp(), "%s block_%d has no predecessors so removing it and its out edges from the flow graph\n", title, block->getNumber()))
          {
          // disconnect any out edges
-         TR::list<TR::CFGEdge*> succList(block->getSuccessors());
+         TR::CFGEdgeList succList(block->getSuccessors());
          succList.insert(succList.end(), block->getExceptionSuccessors().begin(), block->getExceptionSuccessors().end());
          for (auto edge=succList.begin(); edge != succList.end(); ++edge)
             cfg->removeEdge((*edge)->getFrom(), (*edge)->getTo());
@@ -2210,7 +2210,7 @@ void checkOrderingConsistency(TR::Compilation *comp)
 
       if (!block->isExtensionOfPreviousBlock())
          {
-         TR::list<TR::CFGEdge*> & successors = prevBlock->getSuccessors();
+         TR::CFGEdgeList & successors = prevBlock->getSuccessors();
          for (auto succEdge = successors.begin(); succEdge != successors.end(); ++succEdge)
             {
             TR::CFGNode *succ = (*succEdge)->getTo();
@@ -2263,7 +2263,7 @@ void TR_BlockOrderingOptimization::dumpBlockOrdering(TR::TreeTop *tt, char *titl
          else
             traceMsg(comp(), "\n");
 #if 0
-         TR::list<TR::CFGEdge*> & successors = block->getSuccessors();
+         TR::CFGEdgeList & successors = block->getSuccessors();
          for (auto succEdge = successors.begin(); succEdge != successors.end(); ++succEdge)
             traceMsg(comp(), "\t -> block_%-4d\tfrequency %d\n", (*succEdge)->getTo()->getNumber(), (*succEdge)->getFrequency());
 #endif

--- a/compiler/optimizer/RedundantAsyncCheckRemoval.cpp
+++ b/compiler/optimizer/RedundantAsyncCheckRemoval.cpp
@@ -2028,7 +2028,7 @@ bool TR_LoopEstimator::isRecognizableExitEdge(TR::CFGEdge *edge, TR::ILOpCodes *
       {
       // if the block has a single predecessor, look at the predecessor instead
       //
-      TR::list<TR::CFGEdge*> &predList = subNode->getPredecessors();
+      TR::CFGEdgeList &predList = subNode->getPredecessors();
       if ((predList.size() == 1) && subNode->getExceptionPredecessors().empty())
          return isRecognizableExitEdge(predList.front(),
                                        op, ref, prog, limit);

--- a/compiler/optimizer/SinkStores.cpp
+++ b/compiler/optimizer/SinkStores.cpp
@@ -2704,7 +2704,7 @@ bool TR_SinkStores::checkLiveMergingPaths(TR_BlockListEntry *blockEntry, int32_t
    // first, if block is a merge point, we need to make sure that the def propagated here along all paths
    int32_t numPredsLONAP=0;
    int32_t numPreds=0;
-   TR::list<TR::CFGEdge*> predList(block->getPredecessors());
+   TR::CFGEdgeList predList(block->getPredecessors());
    predList.insert(predList.end(), block->getExceptionPredecessors().begin(), block->getExceptionPredecessors().end());
    for (auto predEdge = predList.begin(); predEdge != predList.end(); ++predEdge)
       {
@@ -3940,7 +3940,7 @@ bool TR_GeneralSinkStores::sinkStorePlacement(TR_MovableStore *movableStore,
    TR_EdgeStorePlacementList  edgePlacementsForThisStore(trMemory());
 
    // now try to push it along sourceBlock's successor edges
-   TR::list<TR::CFGEdge*> succList(sourceBlock->getSuccessors());
+   TR::CFGEdgeList succList(sourceBlock->getSuccessors());
    succList.insert(succList.end(), sourceBlock->getExceptionSuccessors().begin(), sourceBlock->getExceptionSuccessors().end());
    for (auto succEdge = succList.begin(); succEdge != succList.end(); ++succEdge)
       {
@@ -4173,7 +4173,7 @@ bool TR_GeneralSinkStores::sinkStorePlacement(TR_MovableStore *movableStore,
             int32_t numOfEdgePlacements = 0;
             ListElement<TR_BlockListEntry> *lastAddedEntry = 0;
             placeDefInBlock = false;
-            TR::list<TR::CFGEdge*> succList(block->getSuccessors());
+            TR::CFGEdgeList succList(block->getSuccessors());
             succList.insert(succList.end(), block->getExceptionSuccessors().begin(), block->getExceptionSuccessors().end());
             for (auto succEdge = succList.begin(); succEdge != succList.end(); ++succEdge)
                {

--- a/compiler/optimizer/Structure.cpp
+++ b/compiler/optimizer/Structure.cpp
@@ -1067,7 +1067,7 @@ void TR_RegionStructure::addEdge(TR::CFGEdge *edge, bool isExceptionEdge)
 
    // Add an edge between the nodes if there isn't one already
    //
-   TR::list<TR::CFGEdge*>* list;
+   TR::CFGEdgeList* list;
    if (isExceptionEdge)
       list = &(fromNode->getExceptionSuccessors());
    else

--- a/compiler/optimizer/ValuePropagation.cpp
+++ b/compiler/optimizer/ValuePropagation.cpp
@@ -4807,7 +4807,7 @@ void TR::GlobalValuePropagation::processBlock(TR_StructureSubGraphNode *node, bo
    propagateOutputConstraints(node, lastTimeThrough, false, List1, &List2);
    }
 
-TR::CFGEdge *TR::ValuePropagation::findOutEdge(TR::list<TR::CFGEdge*> &edges, TR::CFGNode *target)
+TR::CFGEdge *TR::ValuePropagation::findOutEdge(TR::CFGEdgeList &edges, TR::CFGNode *target)
    {
    // Find the output edge in the list of edges to the given node
    //
@@ -5593,9 +5593,9 @@ TR::TreeTop* TR::ArraycopyTransformation::createMultipleArrayNodes(TR::TreeTop* 
       cfg->addEdge(TR::CFGEdge::createEdge(forwardArrayCopyBlock,  followOnBlock, trMemory()));
       cfg->copyExceptionSuccessors(ifBlock, forwardArrayCopyBlock);
 
-      TR::list<TR::CFGEdge*> elseSuccList = outerElseBlock->getSuccessors();
+      TR::CFGEdgeList elseSuccList = outerElseBlock->getSuccessors();
       cfg->removeEdge(elseSuccList, outerElseBlock->getNumber(), followOnBlock->getNumber());
-      TR::list<TR::CFGEdge*> condSuccList = arraycopyBlock->getSuccessors();
+      TR::CFGEdgeList condSuccList = arraycopyBlock->getSuccessors();
       cfg->removeEdge(condSuccList, arraycopyBlock->getNumber(), ifBlock->getNumber());
 
       outerArraycopyTree = arraycopyForward;

--- a/compiler/optimizer/ValuePropagation.hpp
+++ b/compiler/optimizer/ValuePropagation.hpp
@@ -530,7 +530,7 @@ class ValuePropagation : public TR::Optimization
    bool canRunTransformToArrayCopy();
    bool transformUnsafeCopyMemoryCall(TR::Node *arraycopyNode);
 
-   static TR::CFGEdge *findOutEdge(TR::list<TR::CFGEdge*> &edges, TR::CFGNode *target);
+   static TR::CFGEdge *findOutEdge(TR::CFGEdgeList &edges, TR::CFGNode *target);
    bool isUnreachablePath(ValueConstraints &valueConstraints);
    bool isUnreachablePath(EdgeConstraints *constraints);
    void setUnreachablePath();

--- a/compiler/optimizer/VirtualGuardCoalescer.cpp
+++ b/compiler/optimizer/VirtualGuardCoalescer.cpp
@@ -434,7 +434,7 @@ TR::Block *TR_VirtualGuardTailSplitter::lookAheadAndSplit(VGInfo *guard, List<TR
          continue;
          }
 
-      TR::list<TR::CFGEdge*> &succs = cursor->getSuccessors();
+      TR::CFGEdgeList &succs = cursor->getSuccessors();
       if (!(succs.size() == 1))
          {
          TR::Block *newCursor = NULL;
@@ -573,7 +573,7 @@ void TR_VirtualGuardTailSplitter::transformLinear(TR::Block *first, TR::Block *l
          {
          TR::Block *dest = NULL;
          TR::Block *otherDest = NULL;
-         TR::list<TR::CFGEdge*> &succs = next->getSuccessors();
+         TR::CFGEdgeList &succs = next->getSuccessors();
          if (succs.size() == 1)
             {
             dest = toBlock(succs.front()->getTo());
@@ -674,7 +674,7 @@ TR_VirtualGuardTailSplitter::VGInfo *TR_VirtualGuardTailSplitter::recognizeVirtu
    if (!block->getLastRealTreeTop()->getNode()->isTheVirtualGuardForAGuardedInlinedCall())
       return 0;
 
-   TR::list<TR::CFGEdge*> &succ = block->getSuccessors();
+   TR::CFGEdgeList &succ = block->getSuccessors();
    if (!(succ.size() == 2))
       {
       block->getLastRealTreeTop()->getNode()->setLocalIndex(MALFORMED_GUARD);

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -49,6 +49,7 @@
 #include "infra/TRlist.hpp"
 #include "optimizer/Optimizations.hpp"      // for Optimizations
 #include "runtime/Runtime.hpp"              // for TR_CCPreLoadedCode
+#include "infra/TRCfgNode.hpp"              // for TR::CFGEdgeList
 
 #include "codegen/RegisterRematerializationInfo.hpp"
 
@@ -617,7 +618,7 @@ public:
    virtual void printNodeInfo(TR::FILE *, TR::Node *);
    virtual void printNodeInfo(TR::Node *, TR_PrettyPrinterString& output, bool);
    virtual void print(TR::FILE *, TR::CFGNode *, uint32_t indentation);
-   virtual void printNodesInEdgeListIterator(TR::FILE *, TR::list<TR::CFGEdge*> &li, bool fromNode);
+   virtual void printNodesInEdgeListIterator(TR::FILE *, TR::CFGEdgeList &li, bool fromNode);
    virtual void print(TR::FILE *, TR::Block * block, uint32_t indentation);
    virtual void print(TR::FILE *, TR_RegionStructure * regionStructure, uint32_t indentation);
    virtual void printSubGraph(TR::FILE *, TR_RegionStructure * regionStructure, uint32_t indentation);

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -734,7 +734,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR_StructureSubGraphNode * node, uint32_t in
    }
 
 void
-TR_Debug::printNodesInEdgeListIterator(TR::FILE *pOutFile, TR::list<TR::CFGEdge*> &li, bool fromNode)
+TR_Debug::printNodesInEdgeListIterator(TR::FILE *pOutFile, TR::CFGEdgeList &li, bool fromNode)
    {
    TR::CFGEdge *edge;
    TR::Block   *b;
@@ -980,7 +980,7 @@ TR_Debug::printBlockOrders(TR::FILE *pOutFile, const char * title, TR::ResolvedM
          else
             trfprintf(pOutFile, "\n");
 
-         TR::list<TR::CFGEdge*> & successors = block->getSuccessors();
+         TR::CFGEdgeList & successors = block->getSuccessors();
          for (auto succEdge = successors.begin(); succEdge != successors.end(); ++succEdge)
             trfprintf(pOutFile, "\t -> block_%-4d\tfrequency %4d\n", (*succEdge)->getTo()->getNumber(), (*succEdge)->getFrequency());
          }

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -2435,7 +2435,7 @@ TR::Block *OMR::X86::TreeEvaluator::getOverflowCatchBlock(TR::Node *node, TR::Co
    {
    //make sure the overflowCHK has a catch block first
    TR::Block *overflowCatchBlock = NULL;
-   TR::list<TR::CFGEdge*> excepSucc =cg->getCurrentEvaluationTreeTop()->getEnclosingBlock()->getExceptionSuccessors();
+   TR::CFGEdgeList excepSucc =cg->getCurrentEvaluationTreeTop()->getEnclosingBlock()->getExceptionSuccessors();
    for (auto e = excepSucc.begin(); e != excepSucc.end(); ++e) 
       {    
       TR::Block *dest = toBlock((*e)->getTo());

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -4444,11 +4444,11 @@ checkForCandidateBlockForConditionalLoadAndStores(TR::Node* node, TR::CodeGenera
 
    TR::Block * candidateBlock = NULL;
 
-   TR::list<TR::CFGEdge*> & fallthroughSuccessors = fallthroughBlock->getSuccessors();
-   TR::list<TR::CFGEdge*> & fallthroughExceptionSuccessors = fallthroughBlock->getExceptionSuccessors();
+   TR::CFGEdgeList & fallthroughSuccessors = fallthroughBlock->getSuccessors();
+   TR::CFGEdgeList & fallthroughExceptionSuccessors = fallthroughBlock->getExceptionSuccessors();
 
-   TR::list<TR::CFGEdge*> & targetSuccessors = targetBlock->getSuccessors();
-   TR::list<TR::CFGEdge*> & targetExceptionSuccessors = targetBlock->getExceptionSuccessors();
+   TR::CFGEdgeList & targetSuccessors = targetBlock->getSuccessors();
+   TR::CFGEdgeList & targetExceptionSuccessors = targetBlock->getExceptionSuccessors();
 
    // We only consider one target of fallthrough and no exception raised
    // To catch the following scenario.


### PR DESCRIPTION
Use of the container type for holding CFGEdge pointers has been
splattered throughout the codebase.  This impedes the ability to modify
the container type used, which is required to resolve performance
issues.

Rather than identifying the container type explicitly, replace the
declarations with a shared typedef.

Instances of this container were found using the regex:
```TR::list<\s*(TR::)?CFGEdge\s*[*]\s*>```


Signed-off-by: Luc des Trois Maisons <lmaisons@ca.ibm.com>