### PR TITLE
Add efficient single bit dataflow analysis

### DIFF
--- a/compiler/infra/BitVector.cpp
+++ b/compiler/infra/BitVector.cpp
@@ -211,6 +211,15 @@ void TR_BitVector::print(TR::Compilation *comp, TR::FILE *file)
       }
    }
 
+void TR_SingleBitContainer::print(TR::Compilation *comp, TR::FILE *file)
+   {
+   if (comp->getDebug())
+      {
+      if (file == NULL)
+         file = comp->getOutFile();
+      comp->getDebug()->print(file, this);
+      }
+   }
 
 // Compare this with a bit vector
 //

--- a/compiler/infra/BitVector.hpp
+++ b/compiler/infra/BitVector.hpp
@@ -88,6 +88,55 @@ class TR_BitContainer
    friend class TR_BitContainerIterator;
    };
 
+/**
+ * A simple datastructure for use in single-bit dataflow analyses.
+ *
+ * The normal BitVecotr and BitContainer classes used with the dataflow engine
+ * can have a significant overhead when only a single bit is being propagated
+ * owing to their backing storage. This class encapsulates a simple bool value
+ * and implemetns a BitVector-style interface making it compatibile with the
+ * data flow engine.
+ */
+class TR_SingleBitContainer
+   {
+   public:
+   TR_ALLOC(TR_Memory::BitVector)
+   typedef int32_t containerCharacteristic; // used by data flow
+   static const containerCharacteristic nullContainerCharacteristic = -1;
+
+   TR_SingleBitContainer() : _value(false) {}
+   TR_SingleBitContainer(int64_t initBits, TR_Memory * m, TR_AllocationKind allocKind = heapAlloc) : _value(false) { }
+   int32_t get(int32_t n) { TR_ASSERT(n == 0, "SingleBitContainers only contain one bit\n"); return _value; }
+   int32_t get() { return _value; }
+   void set() { _value = true; }
+   void set(int32_t n) { TR_ASSERT(n == 0, "SingleBitContainers only contain one bit\n"); _value = true; }
+   bool isEmpty() { return !_value; }
+
+   bool intersects(TR_SingleBitContainer &other) { return _value && other._value; }
+   bool operator==(TR_SingleBitContainer &other) { return _value == other._value; }
+   bool operator!=(TR_SingleBitContainer &other) { return !operator==(other); }
+   void operator|=(TR_SingleBitContainer &other) { _value = _value || other._value; }
+   void operator&=(TR_SingleBitContainer &other) { _value = _value && other._value; }
+   void operator-=(TR_SingleBitContainer &other) { if (other._value) { _value = false; } }
+   void operator=(TR_SingleBitContainer &other) { _value = other._value; }
+
+   void setAll(int64_t n) { TR_ASSERT(n < 2, "SingleBitContainers only contain one bit\n"); if (n > 0) { _value = true; } }
+   void setAll(int64_t m, int64_t n) { if (m == 0 && n == 1) { _value = true; } }
+
+   void resetAll(int64_t n) { TR_ASSERT(n < 2, "SingleBitContainers only contain one bit\n"); if (n > 0) { _value = false; } }
+   void resetAll(int64_t m, int64_t n) { if (m == 0 && n == 1) { _value = false; } }
+
+   void empty() { _value = false; }
+   bool hasMoreThanOneElement() { return false; }
+   int32_t elementCount() { return 1; }
+   int32_t numUsedChunks() { return 1; }
+   int32_t numNonZeroChunks() { return _value ? 1 : 0; }
+
+   void print(TR::Compilation *comp, TR::FILE *file = NULL);
+
+   private:
+   bool _value;
+   };
 
 enum TR_BitVectorGrowable
    {

--- a/compiler/optimizer/BackwardBitVectorAnalysis.cpp
+++ b/compiler/optimizer/BackwardBitVectorAnalysis.cpp
@@ -1628,3 +1628,4 @@ template<class Container>TR_DataFlowAnalysis::Kind TR_BackwardDFSetAnalysis<Cont
    }
 
 template class TR_BackwardDFSetAnalysis<TR_BitVector *>;
+template class TR_BackwardDFSetAnalysis<TR_SingleBitContainer *>;

--- a/compiler/optimizer/BackwardUnionBitVectorAnalysis.cpp
+++ b/compiler/optimizer/BackwardUnionBitVectorAnalysis.cpp
@@ -80,3 +80,4 @@ template<class Container>TR_DataFlowAnalysis::Kind TR_BackwardUnionDFSetAnalysis
 
 
 template class TR_BackwardUnionDFSetAnalysis<TR_BitVector *>;
+template class TR_BackwardUnionDFSetAnalysis<TR_SingleBitContainer *>;

--- a/compiler/optimizer/BitVectorAnalysis.cpp
+++ b/compiler/optimizer/BitVectorAnalysis.cpp
@@ -1617,3 +1617,5 @@ template<class Container>typename TR_BasicDFSetAnalysis<Container *>::TR_Contain
 
 template class TR_BasicDFSetAnalysis<TR_BitVector *>;
 template class TR_ForwardDFSetAnalysis<TR_BitVector *>;
+template class TR_BasicDFSetAnalysis<TR_SingleBitContainer *>;
+template class TR_ForwardDFSetAnalysis<TR_SingleBitContainer *>;

--- a/compiler/optimizer/DataFlowAnalysis.hpp
+++ b/compiler/optimizer/DataFlowAnalysis.hpp
@@ -459,6 +459,14 @@ class TR_UnionBitVectorAnalysis : public TR_UnionDFSetAnalysis<TR_BitVector *>
    	TR_UnionDFSetAnalysis<TR_BitVector *>(comp, cfg, optimizer, trace) {}
    };
 
+class TR_UnionSingleBitContainerAnalysis : public TR_UnionDFSetAnalysis<TR_SingleBitContainer *>
+  {
+  public:
+  typedef TR_SingleBitContainer ContainerType;
+  TR_UnionSingleBitContainerAnalysis(TR::Compilation *comp, TR::CFG *cfg, TR::Optimizer *optimizer, bool trace) :
+      TR_UnionDFSetAnalysis<TR_SingleBitContainer *>(comp, cfg, optimizer, trace) {}
+  };
+
 class TR_ReachingDefinitions : public TR_UnionBitVectorAnalysis
    {
    public:
@@ -608,6 +616,14 @@ class TR_BackwardUnionBitVectorAnalysis :
    public:
    TR_BackwardUnionBitVectorAnalysis(TR::Compilation *comp, TR::CFG *cfg, TR::Optimizer *optimizer, bool trace)
       : TR_BackwardUnionDFSetAnalysis<TR_BitVector *>(comp, cfg, optimizer, trace) { }
+   };
+
+class TR_BackwardUnionSingleBitContainerAnalysis :
+   public TR_BackwardUnionDFSetAnalysis<TR_SingleBitContainer *>
+   {
+   public:
+   TR_BackwardUnionSingleBitContainerAnalysis(TR::Compilation *comp, TR::CFG *cfg, TR::Optimizer *optimizer, bool trace)
+      : TR_BackwardUnionDFSetAnalysis<TR_SingleBitContainer *>(comp, cfg, optimizer, trace) { }
    };
 
 // First dataflow analysis in Partial Redundancy Elimination

--- a/compiler/optimizer/UnionBitVectorAnalysis.cpp
+++ b/compiler/optimizer/UnionBitVectorAnalysis.cpp
@@ -75,3 +75,4 @@ template<class Container>TR_DataFlowAnalysis::Kind TR_UnionDFSetAnalysis<Contain
 
 
 template class TR_UnionDFSetAnalysis<TR_BitVector *>;
+template class TR_UnionDFSetAnalysis<TR_SingleBitContainer *>;

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -895,6 +895,17 @@ TR_Debug::print(TR::FILE *pOutFile, TR_BitVector * bv)
    }
 
 void
+TR_Debug::print(TR::FILE *pOutFile, TR_SingleBitContainer *sbc)
+   {
+   if (pOutFile == NULL) return;
+
+   if (sbc->isEmpty())
+      trfprintf(pOutFile,"{}");
+   else
+      trfprintf(pOutFile,"{0}");
+   }
+
+void
 TR_Debug::print(TR::FILE *pOutFile, TR::BitVector * bv)
    {
    // *this    swipeable for debugging purposes

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -477,6 +477,7 @@ public:
    virtual void         print(TR::FILE *, TR::LabelSymbol *);
    virtual void         print(TR::LabelSymbol *, TR_PrettyPrinterString&);
    virtual void         print(TR::FILE *, TR_BitVector *);
+   virtual void         print(TR::FILE *, TR_SingleBitContainer *);
    virtual void         print(TR::FILE *pOutFile, TR::BitVector * bv);
    virtual void         print(TR::FILE *pOutFile, TR::SparseBitVector * sparse);
    virtual void         print(TR::FILE *, TR::SymbolReferenceTable *);


### PR DESCRIPTION
The current dataflow engine is instantiated using BitVectors as backing storage to support analysis requiring an arbitrary number of bits. While flexible, the use of BitVectors is especially inefficient for single-bit data flow analyses. This change introduces a new TR_SingleBitContainer which implements the BitVector API used by the dataflow engine, but which stores only a single boolean value. The dataflow framework is
instantiated for this new container to allow for much cheaper single-bit dataflow analyses to be written.

Signed-off-by: Andrew Craik <ajcraik@ca.ibm.com>