### PR TITLE
Cleanup deadcode in OSRExceptionEdgeRemoval

### DIFF
--- a/compiler/optimizer/OSRDefAnalysis.hpp
+++ b/compiler/optimizer/OSRDefAnalysis.hpp
@@ -117,7 +117,6 @@ class TR_OSRExceptionEdgeRemoval : public TR::Optimization
       }
 
    virtual int32_t perform();
-   virtual void newperform();
    };
 
 #endif


### PR DESCRIPTION
As part of optimization prototyping an alternative implementation of this optimization was added in a method called newperfom. The newperform method has been dormant for some time and is no longer needed. This commit removes this dead code.

Signed-off-by: Andrew Craik <ajcraik@ca.ibm.com>