### PR TITLE
Introduce JIT option to disable arrayset optimizations

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -235,6 +235,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableAOTWarmRunThroughputImprovement", "O\tdisable change iprofiler entry choosing heuristic to improve aot warm run throughput",                      SET_OPTION_BIT(TR_DisableAOTWarmRunThroughputImprovement), "F"},
    {"disableArch11PackedToDFP",           "O\tdisable arch(11) packed to DFP conversion instructions",            SET_OPTION_BIT(TR_DisableArch11PackedToDFP), "F",},
    {"disableArrayCopyOpts",               "O\tdisable array copy optimiations",                SET_OPTION_BIT(TR_DisableArrayCopyOpts), "F"},
+   {"disableArraySetOpts",                "O\tdisable array set optimiations",                 SET_OPTION_BIT(TR_DisableArraySetOpts), "F"},
    {"disableArraySetStoreElimination",     "O\tdisable arrayset store elimination",                SET_OPTION_BIT(TR_DisableArraysetStoreElimination), "F"},
    {"disableArrayStoreCheckOpts",          "O\tdisable array store check optimizations",SET_OPTION_BIT(TR_DisableArrayStoreCheckOpts), "F"},
    {"disableAsyncCheckInsertion",         "O\tdisable insertion of async checks in large loopless methods", TR::Options::disableOptimization, asyncCheckInsertion, 0, "F" },

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -147,7 +147,7 @@ enum TR_CompilationOptions
    TR_DisableAbstractInlining    = 0x00010000 + 1,
    TR_DisableHierarchyInlining   = 0x00020000 + 1,
    TR_DisableDirectMemoryOps     = 0x00040000 + 1,
-   // Available                  = 0x00100000 + 1,
+   TR_DisableArraySetOpts        = 0x00100000 + 1,
    TR_TraceLiveMonitorMetadata   = 0x00200000 + 1,
    TR_DisableAllocationInlining  = 0x00400000 + 1,
    TR_DisableInlineCheckCast     = 0x00800000 + 1,

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -233,9 +233,12 @@ OMR::Power::CodeGenerator::CodeGenerator() :
 
     // disabled for now
     //
-    static bool disableArraySet = (feGetEnv("TR_disableArraySet") != NULL);
-    if (TR::Options::getCmdLineOptions()->getOption(TR_AggressiveOpts) && !disableArraySet)
+    if (self()->comp()->getOption(TR_AggressiveOpts) &&
+        !self()->comp()->getOption(TR_DisableArraySetOpts))
+       {
+       self()->setSupportsArraySetToZero();
        self()->setSupportsArraySet();
+       }
     self()->setSupportsArrayCmp();
 
     if (TR::Compiler->target.cpu.getPPCSupportsVSX())

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -365,8 +365,7 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
    self()->setSupportsArrayCmp();
    self()->setSupportsArrayCopy();
 
-   static char *disableArraySet = feGetEnv("TR_disableArraySet");
-   if (!disableArraySet)
+   if (!comp->getOption(TR_DisableArraySetOpts))
       {
       self()->setSupportsArraySetToZero();
       self()->setSupportsArraySet();

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -680,8 +680,11 @@ OMR::Z::CodeGenerator::CodeGenerator()
       {
       self()->setSupportsVirtualGuardNOPing();
       }
-   self()->setSupportsArraySet();
-   self()->setSupportsArraySetToZero();
+   if (!comp->getOption(TR_DisableArraySetOpts))
+      {
+      self()->setSupportsArraySet();
+      self()->setSupportsArraySetToZero();
+      }
    self()->setSupportsArrayCmp();
    self()->setSupportsArrayCmpSign();
    if (!comp->compileRelocatableCode())


### PR DESCRIPTION
Added new JIT option, disableArraySetOpts By applying this options,
CodeGen would not declare support for arrayset.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>