### PR TITLE
Restore id field on CFGEdge

### DIFF
--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -426,7 +426,7 @@ TR_OrderedExceptionHandlerIterator::getCurrent()
 
 
 TR::CFGEdge::CFGEdge(TR::CFGNode *pF, TR::CFGNode *pT, TR_AllocationKind allocKind)
-   : _pFrom(pF), _pTo(pT), _visitCount(0), _frequency(0)
+   : _pFrom(pF), _pTo(pT), _visitCount(0), _frequency(0), _id(-1)
    {}
 
 TR::CFGEdge * TR::CFGEdge::createEdge (TR::CFGNode *pF, TR::CFGNode *pT, TR_Memory* trMemory, TR_AllocationKind allocKind)

--- a/compiler/infra/TRCfgEdge.hpp
+++ b/compiler/infra/TRCfgEdge.hpp
@@ -38,7 +38,7 @@ class CFGEdge : public TR_Link<CFGEdge>
    TR_ALLOC(TR_Memory::CFGEdge)
 
 
-   CFGEdge() : _pFrom(NULL), _pTo(NULL), _visitCount(0), _frequency(0)
+   CFGEdge() : _pFrom(NULL), _pTo(NULL), _visitCount(0), _frequency(0), _id(-1)
    {}
 
    // Construct a normal edge between two nodes
@@ -71,8 +71,8 @@ class CFGEdge : public TR_Link<CFGEdge>
       {
       return ++_visitCount;
       }
-   int32_t    getId()            {return -1;}
-   int32_t    setId(int32_t id)  {return -1;}
+   int32_t    getId()            {return _id;}
+   int32_t    setId(int32_t id)  {return (_id = id);}
 
    int16_t    getFrequency()          { return _frequency; }
 
@@ -106,6 +106,7 @@ class CFGEdge : public TR_Link<CFGEdge>
 
    int16_t _frequency;
 
+   int32_t _id;
    };
 
 }


### PR DESCRIPTION
It can be very handy, during optimization, to be able to identify CFG
edges by an ID number. The OMR code has all the required APIs, but the
backing field is not present. This change restores the backing field so
that an optimization can store an ID number of a CFGEdge to simplify
booking keeping and analysis data structures. There is no requirement
for IDs to be unique or to have any meaning outside of a single
optimization - it is simply a convenience field.

Signed-off-by: Andrew Craik <ajcraik@ca.ibm.com>