### PR TITLE
Make DDRgen run without crashing on Linux x86-64

### DIFF
--- a/tools/ddrgen/src/blob_generation/java/genSuperset.cpp
+++ b/tools/ddrgen/src/blob_generation/java/genSuperset.cpp
@@ -168,7 +168,7 @@ JavaSupersetGenerator::getTypeName(Field *f, string *typeName)
 			Type *type = f->_fieldType;
 			string name = type->_name;
 			TypedefUDT *td = dynamic_cast<TypedefUDT *>(type);
-			while ((NULL != td) && (_baseTypedefIgnore.find(name) == _baseTypedefIgnore.end())) {
+			while ((NULL != td) && (_baseTypedefIgnore.find(name) == _baseTypedefIgnore.end()) && (NULL != td->_type)) {
 				type = td->_type;
 				name = td->_type->_name;
 				td = dynamic_cast<TypedefUDT *>(type);


### PR DESCRIPTION
Made minor changes to genSuperset.cpp and DwarfScanner.cpp. 

Signed-off-by: Tony Wang <twlogger@gmail.com>