### PR TITLE
Track all CP symbols using cpSymRefs

### DIFF
--- a/compiler/compile/OMRAliasBuilder.cpp
+++ b/compiler/compile/OMRAliasBuilder.cpp
@@ -46,6 +46,7 @@ OMR::AliasBuilder::AliasBuilder(TR::SymbolReferenceTable *symRefTab, size_t size
      _unsafeSymRefNumbers(sizeHint, c->trMemory(), heapAlloc, growable),
      _unsafeArrayElementSymRefs(sizeHint, c->trMemory(), heapAlloc, growable),
      _gcSafePointSymRefNumbers(sizeHint, c->trMemory(), heapAlloc, growable),
+     _cpConstantSymRefs(sizeHint, c->trMemory(), heapAlloc, growable),
      _cpSymRefs(sizeHint, c->trMemory(), heapAlloc, growable),
      _refinedNonIntPrimitiveArrayShadows(1, c->trMemory(), heapAlloc, growable),
      _refinedAddressArrayShadows(1, c->trMemory(), heapAlloc, growable),

--- a/compiler/compile/OMRAliasBuilder.hpp
+++ b/compiler/compile/OMRAliasBuilder.hpp
@@ -87,7 +87,9 @@ public:
    TR_BitVector & unsafeArrayElementSymRefs() { return _unsafeArrayElementSymRefs; }
 
    TR_BitVector & gcSafePointSymRefNumbers() { return _gcSafePointSymRefNumbers; }
+   TR_BitVector & cpConstantSymRefs() { return _cpConstantSymRefs; }
    TR_BitVector & cpSymRefs() { return _cpSymRefs; }
+
    TR_BitVector & catchLocalUseSymRefs() { return _catchLocalUseSymRefs; }
 
    TR_BitVector & defaultMethodDefAliases() { return _defaultMethodDefAliases; }
@@ -161,7 +163,9 @@ protected:
    TR_BitVector _unsafeSymRefNumbers;
    TR_BitVector _unsafeArrayElementSymRefs;  // subset of _unsafeSymRefNumbers
    TR_BitVector _gcSafePointSymRefNumbers;
+   TR_BitVector _cpConstantSymRefs;
    TR_BitVector _cpSymRefs;
+
    TR_BitVector _catchLocalUseSymRefs;
    TR_BitVector _defaultMethodDefAliases;
    TR_BitVector _defaultMethodUseAliases;

--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -1366,7 +1366,7 @@ OMR::SymbolReferenceTable::findOrCreateCPSymbol(
    TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex, TR::DataType dataType, bool resolved, void * dataAddress)
    {
    TR::StaticSymbol *sym;
-   TR_SymRefIterator i(aliasBuilder.cpSymRefs(), self());
+   TR_SymRefIterator i(aliasBuilder.cpConstantSymRefs(), self());
    TR::SymbolReference * symRef = i.getNext();
    for (; symRef; symRef = i.getNext())
       {
@@ -1407,7 +1407,9 @@ OMR::SymbolReferenceTable::findOrCreateCPSymbol(
       symRef->setCanGCandExcept();
       }
 
+   aliasBuilder.cpConstantSymRefs().set(symRef->getReferenceNumber());
    aliasBuilder.cpSymRefs().set(symRef->getReferenceNumber());
+
    return symRef;
    }
 


### PR DESCRIPTION
See Issue #781 for high level rational.

In this PR:
-  rename cpSymRefs into cpConstantSymRefs since this bitvector currently tracks only constants in CP
-  add new cpSymRefs bitvector for tracking *all* symbol references in CP
-  set cpSymRefs whenever cpConstantSymRefs is set 

cpSymRefs can now be used for tracking any symbol in CP. These symbols will be automatically dis-aliased from unsafe array shadows since there is already code for that in Aliases.cpp. The only difference is that this used to be done only for constants and now all CP symbols will be dis-aliased from unsafe array shadows, as long as they are included into cpSymRefs by a particular language implementation.

Issue: #781
Signed-off-by: Gita Koblents <koblents@ca.ibm.com>