### PR TITLE
Add missing binary analyzer support

### DIFF
--- a/compiler/codegen/OMRInstruction.hpp
+++ b/compiler/codegen/OMRInstruction.hpp
@@ -54,7 +54,11 @@ namespace TR { class Snippet; }
 
 namespace OMR
 {
-
+/**
+ * Instruction class
+ *
+ * OMR_EXTENSIBLE
+*/
 class OMR_EXTENSIBLE Instruction
    {
    protected:
@@ -95,11 +99,11 @@ class OMR_EXTENSIBLE Instruction
    /*
     * Instruction stream links.
     */
-   TR::Instruction *getNext() { return _next; };
-   void setNext(TR::Instruction *n) { _next = n; };
+   TR::Instruction *getNext() { return _next; }
+   void setNext(TR::Instruction *n) { _next = n; }
 
-   TR::Instruction *getPrev() { return _prev; };
-   void setPrev(TR::Instruction *p) { _prev = p; };
+   TR::Instruction *getPrev() { return _prev; }
+   void setPrev(TR::Instruction *p) { _prev = p; }
 
    void remove();
    TR::Instruction *move(TR::Instruction *newLocation);
@@ -108,8 +112,8 @@ class OMR_EXTENSIBLE Instruction
     * Address of binary buffer where this instruction was encoded.  The binary buffer
     * is NULL if this instruction has not been encoded yet.
     */
-   uint8_t *getBinaryEncoding() { return _binaryEncodingBuffer; };
-   void setBinaryEncoding(uint8_t *be) { _binaryEncodingBuffer = be; };
+   uint8_t *getBinaryEncoding() { return _binaryEncodingBuffer; }
+   void setBinaryEncoding(uint8_t *be) { _binaryEncodingBuffer = be; }
 
    uint8_t getBinaryLength() { return _binaryLength; }
    void setBinaryLength(uint8_t length) { _binaryLength = length; }

--- a/compiler/infra/ILWalk.cpp
+++ b/compiler/infra/ILWalk.cpp
@@ -126,7 +126,6 @@ bool TR::NodeIterator::isAt(PreorderNodeIterator &other)
    return true;
    }
 
-
 TR::PreorderNodeIterator::PreorderNodeIterator(TR::TreeTop *start, TR::Optimization *opt, const char *name)
    :NodeIterator(start, opt, name)
    {

--- a/compiler/z/codegen/BinaryAnalyser.cpp
+++ b/compiler/z/codegen/BinaryAnalyser.cpp
@@ -121,10 +121,8 @@ TR_S390BinaryAnalyser::genericAnalyser(TR::Node * root,
    bool is16BitMemory2Operand = false;
    if (secondChild->getOpCodeValue() == TR::s2i &&
        secondChild->getFirstChild()->getOpCodeValue() == TR::sloadi &&
-       secondChild->getRegister() == NULL  &&
-       secondChild->getFirstChild()->getRegister() == NULL &&
-       secondChild->getReferenceCount() == 1 &&
-       secondChild->getFirstChild()->getReferenceCount() == 1)
+       secondChild->isSingleRefUnevaluated() &&
+       secondChild->getFirstChild()->isSingleRefUnevaluated())
       {
       bool supported = true;
 
@@ -309,6 +307,20 @@ TR_S390BinaryAnalyser::longSubtractAnalyser(TR::Node * root)
    setInputs(firstChild, firstRegister, secondChild, secondRegister,
              false, false, comp);
 
+   /**  Attempt to use SGH to subtract halfword (64 <- 16).
+    * The second child is a halfword from memory */
+   bool is16BitMemory2Operand = false;
+   if (TR::Compiler->target.cpu.getS390SupportsZNext() &&
+       secondChild->getOpCodeValue() == TR::s2l &&
+       secondChild->getFirstChild()->getOpCodeValue() == TR::sloadi &&
+       secondChild->isSingleRefUnevaluated() &&
+       secondChild->getFirstChild()->isSingleRefUnevaluated())
+      {
+      setMem2();
+      memToRegOpCode = TR::InstOpCode::SGH;
+      is16BitMemory2Operand = true;
+      }
+
    if (getEvalChild1())
       {
       firstRegister = cg()->evaluate(firstChild);
@@ -364,12 +376,18 @@ TR_S390BinaryAnalyser::longSubtractAnalyser(TR::Node * root)
          {
          TR_ASSERT(  !getInvalid(), "TR_S390BinaryAnalyser::invalid case\n");
 
-         TR::MemoryReference * longMR = generateS390MemoryReference(secondChild, cg());
+         TR::Node* baseAddrNode = is16BitMemory2Operand ? secondChild->getFirstChild() : secondChild;
+         TR::MemoryReference * longMR = generateS390MemoryReference(baseAddrNode, cg());
 
          generateRXInstruction(cg(), memToRegOpCode, root, firstRegister, longMR);
 
          longMR->stopUsingMemRefRegister(cg());
          root->setRegister(firstRegister);
+
+         if(is16BitMemory2Operand)
+            {
+            cg()->decReferenceCount(secondChild->getFirstChild());
+            }
          }
 
       }


### PR DESCRIPTION
Add missing binary analyzer support for add, subtract, and multiply
operations exploiting the fact that some of these operations can be
folded into register-memory operations if the memory reference is is not
commoned.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>