### PR TITLE
Add skeleton for concurrent scavenger support

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1833,6 +1833,10 @@ OMR::Options::Options(
       optimizationPlan->setOptLevelDowngraded(false);
       }
 
+   // TODO (GuardedStorage)
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+   self()->setOption (TR_DisableArrayCopyOpts, true);
+#endif
 
    if (self()->getOption(TR_FullSpeedDebug))
       {

--- a/compiler/env/TRMemory.cpp
+++ b/compiler/env/TRMemory.cpp
@@ -264,7 +264,7 @@ const char * objectName[] =
 
    "TR_ZHWProfiler",
    "TR_PPCHWProfiler",
-
+   "TR_ZGuardedStorage",
    "TR_PPCLMGuardedStorage",
 
    "CatchTable",

--- a/compiler/env/TRMemory.hpp
+++ b/compiler/env/TRMemory.hpp
@@ -412,7 +412,7 @@ public:
 
       ZHWProfiler,
       PPCHWProfiler,
-
+      ZGuardedStorage,
       PPCLMGuardedStorage,
 
       CatchTable,

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -2858,7 +2858,12 @@ TR::Node *constrainWrtBar(TR::ValuePropagation *vp, TR::Node *node)
         vp->getCurrentParent() && vp->getCurrentParent()->getOpCodeValue() != TR::ArrayStoreCHK)
       canRemoveWrtBar(vp, node);
 
+   // TODO (GuardedStorage)
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+   static bool doOpt = false;
+#else
    static bool doOpt = feGetEnv("TR_DisableWrtBarOpt") ? false : true;
+#endif
 
    TR_WriteBarrierKind gcMode = vp->comp()->getOptions()->getGcMode();
 

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -2961,7 +2961,17 @@ TR::Register *OMR::Z::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node
                {
                targetRegister = n->getRegister();
                cg->evaluate(reference);
-               cmpOpCode = (n->getOpCode().getSize() > 4)? TR::InstOpCode::CG: TR::InstOpCode::C;
+               
+               // For concurrent scavange the source is loaded and shifted by the guarded load, thus we need to use CG
+               // here for a non-zero compressedrefs shift value
+               if (TR::Compiler->target.cpu.getS390SupportsGuardedStorageFacility())
+                  {
+                  cmpOpCode = TR::InstOpCode::getCmpOpCode();
+                  }
+               else
+                  {
+                  cmpOpCode = (n->getOpCode().getSize() > 4)? TR::InstOpCode::CG: TR::InstOpCode::C;
+                  }
                }
             else
                {

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -541,6 +541,8 @@ OMR::Z::CodeGenerator::CodeGenerator()
    TR::Compilation *comp = self()->comp();
    _cgFlags = 0;
 
+   _evalCompressionSequence = false;
+
    // Initialize Linkage for Code Generator
    self()->initializeLinkage();
 
@@ -6225,6 +6227,18 @@ TR_S390ScratchRegisterManager*
 OMR::Z::CodeGenerator::generateScratchRegisterManager(int32_t capacity)
    {
    return new (self()->trHeapMemory()) TR_S390ScratchRegisterManager(capacity, self());
+   }
+
+// TODO (GuardedStorage)
+void
+OMR::Z::CodeGenerator::setEvalCompressionSequence(bool val)
+   {
+   _evalCompressionSequence= val;
+   }
+bool
+OMR::Z::CodeGenerator::isEvalCompressionSequence()
+   {
+   return _evalCompressionSequence;
    }
 
 void

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -329,6 +329,11 @@ public:
    TR_BranchPreloadCallData _outlineCall;
    TR_BranchPreloadCallData _outlineArrayCall;
 
+   // TODO (GuardedStorage)
+   bool _evalCompressionSequence;
+   void setEvalCompressionSequence(bool val);
+   bool isEvalCompressionSequence();
+
    TR::list<TR_BranchPreloadCallData*> *_callsForPreloadList;
 
    TR::list<TR_BranchPreloadCallData*> * getCallsForPreloadList() { return _callsForPreloadList; }

--- a/compiler/z/codegen/UnaryEvaluator.cpp
+++ b/compiler/z/codegen/UnaryEvaluator.cpp
@@ -485,7 +485,19 @@ OMR::Z::TreeEvaluator::l2aEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR_ASSERT(hasCompPtrs, "no compression sequence found under l2a node [%p]\n", node);
    */
 
-   TR::Register *source = cg->evaluate(firstChild);
+   // TODO (GuardedStorage)
+   TR::Register *source;
+   if (comp->useCompressedPointers() && (TR::Compiler->om.compressedReferenceShift() == 0 || firstChild->containsCompressionSequence()) && !node->isl2aForCompressedArrayletLeafLoad())
+      cg->setEvalCompressionSequence(true);
+
+   if ((TR::Compiler->target.cpu.getS390SupportsGuardedStorageFacility()) && comp->useCompressedPointers() && (firstChild->containsCompressionSequence()) && !node->isl2aForCompressedArrayletLeafLoad())
+      {
+      source = cg->evaluate(firstChild->getFirstChild());
+      }
+   else
+      source = cg->evaluate(firstChild);
+
+   cg->setEvalCompressionSequence(false);
 
    // first child is either iu2l (when shift==0) or
    // the first child is a compression sequence. in the

--- a/compiler/z/env/OMRCPU.hpp
+++ b/compiler/z/env/OMRCPU.hpp
@@ -78,6 +78,8 @@ public:
    bool getS390SupportsRI() { return false; }
 
    bool getS390SupportsVectorFacility() { return false; }
+   
+   bool getS390SupportsGuardedStorageFacility() { return false; }
 
    TR_S390MachineType getS390MachineType() const { return _s390MachineType; }
    void setS390MachineType(TR_S390MachineType t) { _s390MachineType = t; }


### PR DESCRIPTION
Add skeleton support in the compiler for concurrent scavanger, including
querying availability and fixes to JIT optimizations that currently do
not support concurrent scavange.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>