### PR TITLE
Run treeSimplification before fieldPrivatization

### DIFF
--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -412,6 +412,7 @@ const OptimizationStrategy loopCanonicalizationOpts[] =
    { loopVersionerGroup                   },
    { deadTreesElimination                 }, // remove dead anchors created by check removal (versioning)
    //{ loopStrider                        }, // use canonicalized loop to insert initializations
+   { treeSimplification                   }, // remove unreachable blocks (with nullchecks etc.) left by LoopVersioner
    { fieldPrivatization                   }, // use canonicalized loop to privatize fields
    { treeSimplification                   }, // might fold expressions created by versioning/induction variables
    { loopSpecializerGroup, IfEnabledAndLoops            }, // specialize the versioned loop if possible


### PR DESCRIPTION
Run treeSimplification before FieldPrivatization to remove redundant code left by LoopVersioner that can prevent field privatization (due to nullchecks, calls, etc.)

Signed-off-by: Gita Koblents <koblents@ca.ibm.com>