### PR TITLE
Fix grammar error in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ Signed-off-by: Robert Young <rwy0717@gmail.com>
 ```
 
 The first line is meaningful and imperative. The body contains enough
-information that the reader understands the why and how of the commit, and it's
+information that the reader understands the why and how of the commit, and its
 relation to any issues. The issue is properly tagged and the commit is signed
 off.
 


### PR DESCRIPTION
Thanks to @pdbain-ibm in comments on Issue #787 for pointing out this
grammar error.

[ci skip] as documentation change.

Signed-off-by: Matthew Gaudet <magaudet@ca.ibm.com>