### PR TITLE
Capitalize sentence in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ Key: Value
 ```
 
 When a commit has related issues or commits, explain the relation in the message
-body. you should also leave an `Issue` tag in the footer. For example:
+body. You should also leave an `Issue` tag in the footer. For example:
 
 ```
 This patch eliminates the race condition in issue #1234.


### PR DESCRIPTION
The sentence in question is missing capitalization on the first word.

[ci skip] as documentation change.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>