### PR TITLE
JitBuilder fixes

### DIFF
--- a/jitbuilder/release/Makefile
+++ b/jitbuilder/release/Makefile
@@ -26,6 +26,7 @@ CXXFLAGS=-g -std=c++0x -O2 -c -fno-rtti -fPIC -I./include/compiler -I./include
 
 # These tests may not work on all platforms
 ALL_TESTS = \
+            atomicoperations \
             call \
             conststring \
             controlflowtests \
@@ -45,6 +46,7 @@ ALL_TESTS = \
             switch \
             thunks \
             toiltype \
+            transactionaloperations \
             union \
             worklist
 
@@ -52,6 +54,7 @@ ALL_TESTS = \
 all: $(ALL_TESTS)
 
 # These tests should run properly on all platforms
+# If you add to this list, please also add to ALL_TESTS
 common_goal: $(ALL_TESTS)
 	./controlflowtests
 	./issupportedtype
@@ -63,6 +66,7 @@ common_goal: $(ALL_TESTS)
 	./worklist
 
 # Additional tests that may not work properly on all platforms
+# If you add to this list, please also add to ALL_TESTS
 all_goal: common_goal
 	./call
 	./conststring
@@ -77,8 +81,14 @@ all_goal: common_goal
 	./switch
 	./thunks
 	./toiltype
-	./transactionaloperations
 	./union
+
+# Tests that are still on the experimental side
+# If you add to this list and want them to be built under "make", please
+# also add to ALL_TESTS
+experimental_goal: common_goal
+	./atomicoperations
+	./transactionaloperations
 
 
 # In general, only compile and run tests that are known to work on all platforms
@@ -86,6 +96,9 @@ test: common_goal all
 
 # For platforms where everything can run:
 testall: all_goal all
+
+# Even experimental stuff:
+testexperimental: experimental_goal all
 
 
 # Rules for individual examples

--- a/jitbuilder/release/src/DotProduct.cpp
+++ b/jitbuilder/release/src/DotProduct.cpp
@@ -50,7 +50,7 @@ static void printDouble(double val)
 static void printPointer(int64_t val)
    {
    #define PRINTPOINTER_LINE LINETOSTR(__LINE__)
-   printf("%lx", val);
+   printf("%llx", val);
    }
 
 DotProduct::DotProduct(TR::TypeDictionary *types)

--- a/jitbuilder/release/src/LocalArray.cpp
+++ b/jitbuilder/release/src/LocalArray.cpp
@@ -32,13 +32,13 @@ static void printArray(int32_t numLongs, int64_t *array)
    #define PRINTArray_LINE LINETOSTR(__LINE__)
    printf("printArray (%d) :\n", numLongs);
    for (int32_t i=0;i < numLongs;i++)
-      printf("\t%ld\n", array[i]);
+      printf("\t%lld\n", array[i]);
    }
 
 static void printInt64(int64_t num)
    {
    #define PRINTInt64_LINE LINETOSTR(__LINE__)
-   printf("%ld\n", num);
+   printf("%lld\n", num);
    }
 
 

--- a/jitbuilder/release/src/Pow2.cpp
+++ b/jitbuilder/release/src/Pow2.cpp
@@ -115,7 +115,7 @@ main(int argc, char *argv[])
    for (int32_t i=0;i < n;i++)
       r = pow2((int64_t) 45);
 
-   printf("pow2(45) is %ld\n", r);
+   printf("pow2(45) is %lld\n", r);
 
    printf ("Step 5: shutdown JIT\n");
    shutdownJit();

--- a/jitbuilder/release/src/TransactionalOperations.hpp
+++ b/jitbuilder/release/src/TransactionalOperations.hpp
@@ -18,7 +18,7 @@
 
 
 #ifndef TM_INCL
-#define TM_IMPL
+#define TM_INCL
 
 #include "ilgen/MethodBuilder.hpp"
 

--- a/jitbuilder/release/src/Union.cpp
+++ b/jitbuilder/release/src/Union.cpp
@@ -129,6 +129,7 @@ TypePunInt32Int32Builder::buildIL()
    StoreIndirect("TestUnionInt32Int32", "f2", Load("u"), Load("v2"));
    Return(
           LoadIndirect("TestUnionInt32Int32", "f1", Load("u")));
+   return true;
    }
 
 TypePunInt16DoubleBuilder::TypePunInt16DoubleBuilder(TR::TypeDictionary *d)
@@ -151,6 +152,7 @@ TypePunInt16DoubleBuilder::buildIL()
    StoreIndirect("TestUnionInt16Double", "v_double", Load("u"), Load("v2"));
    Return(
           LoadIndirect("TestUnionInt16Double", "v_uint16", Load("u")));
+   return true;
    }
 
 template <typename Function>


### PR DESCRIPTION
Includes mostly minor (cleanup + 2 functional) fixes for JitBuilder:

* cleaned up the Makefile targets and added some comments to hopefully keep them clean.
* corrected a macro typo in the TransactionalMemory sample code's header file
* corrected two ::buildIL() calls in the src/Union.cpp sample code to explicitly return true.
* corrected printf format strings in 3 samples to eliminate compiler warnings and fix display problems if values were to get big enough.