### PR TITLE
Implement Reload

### DIFF
--- a/compiler/ilgen/VirtualMachineOperandStack.cpp
+++ b/compiler/ilgen/VirtualMachineOperandStack.cpp
@@ -87,8 +87,25 @@ VirtualMachineOperandStack::Commit(TR::IlBuilder *b)
       }
    }
 
-void
-VirtualMachineOperandStack::MergeInto(OMR::VirtualMachineOperandStack *other, TR::IlBuilder *b)
+   void
+   VirtualMachineOperandStack::Reload(TR::IlBuilder* b)
+   {
+       TR::IlType* Element = _elementType;
+       TR::IlType* pElement = _mb->typeDictionary()->PointerTo(Element);
+       // reload the elements back into the simulated operand stack
+       // If the # of stack element has changed, the user should adjust the # of elements 
+       // using Drop beforehand to add/delete stack elements.
+       TR::IlValue* stack = b->Load("OperandStack_base");
+       for (int32_t i = _stackTop; i >= 0; i--) {
+           _stack[i] = b->LoadAt(pElement,
+               b->IndexAt(pElement,
+                   stack,
+                   b->ConstInt32(i - _stackOffset)));
+       }
+   }
+
+   void
+   VirtualMachineOperandStack::MergeInto(OMR::VirtualMachineOperandStack* other, TR::IlBuilder* b)
    {
    TR_ASSERT(_stackTop == other->_stackTop, "stacks are not same size");
    for (int32_t i=_stackTop;i >= 0;i--)

--- a/compiler/ilgen/VirtualMachineOperandStack.hpp
+++ b/compiler/ilgen/VirtualMachineOperandStack.hpp
@@ -106,6 +106,14 @@ class VirtualMachineOperandStack : public VirtualMachineState
     * @param b the builder where the operations will be placed to recreate the virtual machine operand stack
     */
    virtual void Commit(TR::IlBuilder *b);
+   
+   /**
+    * @brief read the virtual machine stack back into the simulated operand stack
+    * @param b the builder where the operations will be placed to recreate the simulated operand stack 
+    * Users can call Drop beforehand with the appropriate positive or negative count to ensure the simulated
+    * stack accounts for new or dropped virtual machine stack elements. 
+    */
+   virtual void Reload(TR::IlBuilder *b);
 
    /**
     * @brief create an identical copy of the current object.


### PR DESCRIPTION
Implemented a default Reload. It will simply reload all the same values as Commit had saved.  

This version conservatively reloads everything which is probably ok for garbage collected systems where objects may move. 

We should consider some enhancements at some point.
1) option to reload some or all of the elements via selective reload to ensure you don't refetch from memory if not needed. 
2) option to take into account stack size changes before reload. This is be useful in VMs where the virtual machine changes the stack with pops of arguments , and pushed results. In that case, you would adjust the stack for pops, and the reload the number of new elements pushed by the VM. 

