### PR TITLE
Deprecate JITEntry and JITExit instruction flags

### DIFF
--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -2883,7 +2883,6 @@ TR::Register *OMR::Z::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node
           cursor->setThrowsImplicitException();
           cursor->setExceptBranchOp();
           cg->setCanExceptByTrap(true);
-          cursor->setJITExit();
           cursor->setNeedsGCMap(0x0000FFFF);
           if (TR::Compiler->target.isZOS())
              killRegisterIfNotLocked(cg, TR::RealRegister::GPR4, cursor);
@@ -2924,7 +2923,6 @@ TR::Register *OMR::Z::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node
             appendTo = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BERC, node, snippetLabel, appendTo);
             TR::Instruction *brInstr = appendTo;
             brInstr->setExceptBranchOp();
-            brInstr->setJITExit();
             }
          else
             {
@@ -2982,7 +2980,6 @@ TR::Register *OMR::Z::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node
             appendTo = generateS390CompareAndBranchInstruction(cg, cmpOpCode, node, targetRegister, NULLVALUE, branchOpCond, snippetLabel, false, true, appendTo);
             TR::Instruction * cursor = appendTo;
             cursor->setExceptBranchOp();
-            cursor->setJITExit();
             }
 
          }
@@ -3061,7 +3058,6 @@ TR::Register *OMR::Z::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node
          {
          faultingInstruction->setNeedsGCMap(0x0000FFFF);
          faultingInstruction->setThrowsImplicitNullPointerException();
-         faultingInstruction->setJITExit();
          cg->setCanExceptByTrap(true);
 
          TR_Debug * debugObj = cg->getDebug();

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -2494,10 +2494,6 @@ OMR::Z::CodeGenerator::upgradeToHPRInstruction(TR::Instruction * inst)
          s390NewInst->setThrowsImplicitException();
       if (s390Inst->isOutOfLineEX())
          s390NewInst->setOutOfLineEX();
-      if (s390Inst->isJITEntry())
-         s390NewInst->setJITEntry();
-      if (s390Inst->isJITExit())
-         s390NewInst->setJITExit();
       if (s390Inst->isStartInternalControlFlow())
          s390NewInst->setStartInternalControlFlow();
       if (s390Inst->isEndInternalControlFlow())
@@ -3331,7 +3327,6 @@ TR_S390Peephole::ICMReduction()
          {
          icm->setNeedsGCMap(0x0000FFFF);
          icm->setThrowsImplicitNullPointerException();
-         icm->setJITExit();
          icm->setGCMap(load->getGCMap());
 
          TR_Debug * debugObj = _cg->getDebug();

--- a/compiler/z/codegen/OMRInstruction.cpp
+++ b/compiler/z/codegen/OMRInstruction.cpp
@@ -3464,20 +3464,3 @@ OMR::Z::Instruction::lastOperandIndex(void)
    {
    return self()->numOperands() - 1;
    }
-
-
-void
-OMR::Z::Instruction::setJITEntry()
-   {
-   TR_ASSERT(self()->getOpCodeValue()==TR::InstOpCode::LABEL,
-             "JIT entry point should be a branch instruction\n");
-   _flags.set(JITEntry);
-   }
-
-void
-OMR::Z::Instruction::setJITExit()
-   {
-   TR_ASSERT(self()->getOpCode().isBranchOp() || self()->isExceptBranchOp() || self()->throwsImplicitException(),
-             "JIT exit point should be a branch instruction or Exception branch\n");
-   _flags.set(JITExit);
-   }

--- a/compiler/z/codegen/OMRInstruction.hpp
+++ b/compiler/z/codegen/OMRInstruction.hpp
@@ -116,12 +116,6 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
    bool isExtDisp2()  {return _flags.testAny(ExtDisp2);}
    void setExtDisp2() {_flags.set(ExtDisp2);}
 
-   bool isJITEntry()  {return _flags.testAny(JITEntry);}
-   void setJITEntry();
-
-   bool isJITExit()  {return _flags.testAny(JITExit);}
-   void setJITExit();
-
    bool isExceptBranchOp() { return _flags.testAny(ExceptBranchOp); }
    void setExceptBranchOp() {_flags.set(ExceptBranchOp);}
 
@@ -293,8 +287,8 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
       {
       // Available                        = 0x0001,
       ExtDisp                             = 0x0002, ///< inst has had a late long displacement fixup on the first memRef
-      JITEntry                            = 0x0004,
-      JITExit                             = 0x0008,
+      // Available                        = 0x0004,
+      // Available                        = 0x0008,
       ExceptBranchOp                      = 0x0010,
       ExtDisp2                            = 0x0020, ///< inst has had a late long displacement fixup on the second memRef
       Reserved5                           = 0x0040,

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -12001,12 +12001,6 @@ OMR::Z::TreeEvaluator::BBStartEvaluator(TR::Node * node, TR::CodeGenerator * cg)
          {
          firstInstr->setBreakPoint(true);
          }
-
-      // setJITEntry on first BB's label for zEmulator tracing
-      if (comp->getStartBlock() == node->getBlock() && firstInstr)
-         {
-         firstInstr->setJITEntry();
-         }
       }
 
 

--- a/compiler/z/codegen/S390GenerateInstructions.cpp
+++ b/compiler/z/codegen/S390GenerateInstructions.cpp
@@ -2306,7 +2306,6 @@ generateDirectCall(TR::CodeGenerator * cg, TR::Node * callNode, bool myself, TR:
    if (myself)
       {
       TR::Instruction * instr = new (INSN_HEAP) TR::S390RILInstruction(TR::InstOpCode::BRASL, callNode, RegRA, sym, callSymRef, cg);
-      instr->setJITExit();
 
       return instr;
       }
@@ -2357,7 +2356,6 @@ generateDirectCall(TR::CodeGenerator * cg, TR::Node * callNode, bool myself, TR:
 
          TR::S390RILInstruction *tempInst =
             new (INSN_HEAP) TR::S390RILInstruction(TR::InstOpCode::BRASL, callNode, RegRA, imm, cg);
-         tempInst->setJITExit();
 
          if (isHelper)
             tempInst->setSymbolReference(callSymRef);
@@ -2368,7 +2366,6 @@ generateDirectCall(TR::CodeGenerator * cg, TR::Node * callNode, bool myself, TR:
          {
          genLoadAddressConstant(cg, callNode, imm, RegEP, preced, cond);
          TR::Instruction * instr = new (INSN_HEAP) TR::S390RRInstruction(TR::InstOpCode::BASR, callNode, RegRA, RegEP, cg);
-         instr->setJITExit();
 
          return instr;
          }
@@ -2405,7 +2402,6 @@ generateSnippetCall(TR::CodeGenerator * cg, TR::Node * callNode, TR::Snippet * s
 
       callInstr = new (INSN_HEAP) TR::S390RILInstruction(TR::InstOpCode::BRASL, callNode, killRegRA, s,
          postDeps, callSymRef, cg);
-      callInstr->setJITExit();
 
       cg->stopUsingRegister(killRegRA);
       cg->stopUsingRegister(killRegEP);
@@ -2413,7 +2409,6 @@ generateSnippetCall(TR::CodeGenerator * cg, TR::Node * callNode, TR::Snippet * s
    else
       {
       callInstr = new (INSN_HEAP) TR::S390RILInstruction(TR::InstOpCode::BRASL, callNode, RegRA, s, cond, callSymRef, cg);
-      callInstr->setJITExit();
       }
 
    TR_ASSERT( s->isCallSnippet(), "targetSnippet is NOT CallSnippet ");

--- a/compiler/z/codegen/SystemLinkage.cpp
+++ b/compiler/z/codegen/SystemLinkage.cpp
@@ -2329,7 +2329,6 @@ void TR::S390SystemLinkage::createEpilogue(TR::Instruction * cursor)
    cursor = generateS390RegInstruction(cg(), TR::InstOpCode::BCR, nextNode,
           getS390RealRegister(REGNUM(TR::RealRegister::GPR14)), cursor);
    ((TR::S390RegInstruction *)cursor)->setBranchCondition(TR::InstOpCode::COND_BCR);
-   ((TR::S390RegInstruction *)cursor)->setJITExit();
    }
 
 void TR::S390SystemLinkage::notifyHasalloca()


### PR DESCRIPTION
The two flags in addition to the queries associated with them are not
used within the entire codebase and as per the discussion in Issue #755
they are to be removed.

Issue: #755
Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>