### PR TITLE
Rework README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,153 @@
-# Welcome to the Eclipse OMR Project!
 [![Build Status](https://api.travis-ci.org/eclipse/omr.svg?branch=master)](https://travis-ci.org/eclipse/omr)
+What Is Eclipse OMR?
+====================
 
-The Eclipse OMR project consists of a highly integrated set of open source C and C++ 
-components that can be used to build robust language runtimes that will support 
-many different hardware and operating system platforms. These components include
-but are not limited to: memory management, threading, platform port (abstraction)
-library, diagnostic support, monitoring support, garbage collection, and native 
-Just In Time compilation.
+The Eclipse OMR project is a set of open source C and C++ components that can
+be used to build robust language runtimes that support many different hardware
+and operating system platforms.
 
+Our current components are:
 
-The long term goal for the Eclipse OMR project is to foster an open ecosystem of 
+* **`gc`**:             Garbage collection framework for managed heaps
+* **`compiler`**:       Components for builing compiler technology, such as JIT
+                        compilers.
+* **`jitbuilder`**:     An easy to use high level abstraction on top of the
+                        compiler technology.
+* **`port`**:           Platform porting library
+* **`thread`**:         A cross platform pthread-like threading library
+* **`util`**:           general utilities useful for building cross platform
+                        runtimes
+* **`omrsigcompat`**:   Signal handling compatibility library
+* **`omrtrace`**:       Tracing library for communication with IBM Health Center
+                        monitoring tools
+* **`tool`**:           Code generation tools for the build system
+* **`vm`**:             APIs to manage per-interpreter and per-thread contexts
+* **`example`**:        Demonstration code to show how a language runtime might
+                        consume some Eclipse OMR components
+* **`fvtest`**:         A language-independent test framework so that Eclipse
+                        OMR components can be tested outside of a language runtime
+
+What's the goal?
+================
+
+The long term goal for the Eclipse OMR project is to foster an open ecosystem of
 language runtime developers to collaborate and collectively innovate with
 hardware platform designers, operating system developers, as well as tool and
 framework developers and to provide a robust runtime technology platform so that
 language implementers can much more quickly and easily create more fully
 featured languages to enrich the options available to programmers.
 
-
-All Eclipse OMR project materials are made available under the Eclipse Public License V1.0
-and the Apache 2.0 license. You can choose which license you wish to follow.
-Please see our LICENSE file for more details.
-
-
-The initial set of Eclipse OMR components include:
-* port: platform porting library
-* thread: a cross platform pthread-like threading library
-* util: general utilities useful for building cross platform runtimes
-* omrsigcompat: signal handling compatibility library
-* omrtrace: tracing library for communication with IBM Health Center monitoring tools
-* tool: code generation tools for the build system
-* gc: garbage collection framework for managed heaps
-* vm: APIs to manage per-interpreter and per-thread contexts
-* example: demonstration code to show how a language runtime might consume some Eclipse OMR components
-* fvtest: a language-independent test framework so that Eclipse OMR components can be tested outside of a language runtime
-
-
 It is our community's fervent goal to be one of active contribution, improvement,
-and continual consumption. We will be operating under the [Eclipse Code of Conduct](https://eclipse.org/org/documents/Community_Code_of_Conduct.php)
+and continual consumption.
+
+We will be operating under the [Eclipse Code of Conduct][coc]
 to promote fairness, openness, and inclusion.
 
+[coc]: https://eclipse.org/org/documents/Community_Code_of_Conduct.php
 
+Who is using Eclipse OMR?
+=========================
+
+* The most comprehensive consumer of the Eclipse OMR technology is the IBM J9
+  Virtual Machine: a high performance, scalable, enterprise class Java Virtual
+  Machine implementation representing hundreds of person years of effort, built
+  using the core implementations provided by Eclipse OMR. IBM is working actively
+  to open source J9.
+* The Ruby+OMR Technology Preview has used Eclipse OMR components to add a JIT
+  compiler to the CRuby implementation, and to experiment with replacing the
+  garbage collector in CRuby.
+* A SOM++ Smalltalk runtime has also been modified to use Eclipse OMR
+  componentry.
+* An experimental version of CPython using Eclipse OMR components
+  has also been created but is not yet available in the open. (Our focus
+  has been dominated by getting this code out into the open!)
+
+
+What's the licence?
+===================
+
+All Eclipse OMR project materials are made available under the Eclipse Public
+License V1.0 and the Apache 2.0 license. You can choose which license you wish
+to follow.  Please see our LICENSE file for more details.
+
+
+What's being worked on?
+======================
 
 There are some active contribution projects underway right now:
 
-* documentation: code comments are great, but we need more overview documentation so we're writing that
-* faq: Frequently Asked Questions from real people's questions (request: ask questions!)
-* starters: relatively simple but useful work items meant for people new to the project
-* diag: more diagnostic support for language runtimes to aid developers and users
-* hcagent: the core code for the IBM Health Center agent for interfacing to a runtime
-* jit: Just In Time compiler for generating native code for several platforms into managed code caches
-* gc: adding generational and other GC policies
+* Documentation: code comments are great, but we need more overview documentation
+  so we're writing that
+* FAQ: Frequently Asked Questions from real people's questions (request: ask
+  questions!)
+* [Beginner issues][beg]: relatively simple but useful work items meant for
+  people new to the project.
+* `diag`: more diagnostic support for language runtimes to aid developers and users
+* `hcagent`: the core code for the IBM Health Center agent for interfacing to a runtime
+* `gc`: adding generational and other GC policies
 
+[beg]: https://github.com/eclipse/omr/issues?q=is%3Aopen+is%3Aissue+label%3Abeginner
 
-The most comprehensive consumer of the Eclipse OMR technology is the IBM J9 Virtual Machine:
-a high performance, scalable, enterprise class Java Virtual Machine implementation
-representing hundreds of person years of effort. While not an open source project
-itself, J9 directly implements capabilites for Java using the core implementations
-provided by Eclipse OMR. The Ruby+OMR Technology Preview project also consumes
-the Eclipse OMR components by modifying the CRuby project. A SOM++ Smalltalk runtime has
-also been modified to use Eclipse OMR componentry.  An experimental version of CPython
-using Eclipse OMR componentry has also been created but is not currently available in the
-open. (Our focus has been dominated by getting this code out into the open!)
+How Do I Use it?
+================
 
-## Recent Presentations about Eclipse OMR
+## How to Build Standalone Eclipse OMR
+
+The best way to get an initial understanding of the Eclipse OMR technology is to
+look at a 'standalone' build, which hooks Eclipse OMR up to the its testing system
+only. 
+
+### Basic configuration and compile
+To build standalone Eclipse OMR, run the following commands from the top of the
+source tree. The top of the Eclipe OMR source tree is the directory that contains
+run_configure.mk.
+
+    # Generate autotools makefiles with SPEC-specific presets
+    make -f run_configure.mk SPEC=linux_x86-64 OMRGLUE=./example/glue
+
+    # Build
+    make
+
+    # Run tests (note that no contribution should cause new test failures in "make test")
+    make test
+
+Run `make -f run_configure.mk help` for a list of configure makefile targets.
+Run `make help` for a list of build targets.
+
+### Building Eclipse OMR on Windows
+A shell script interpreter, such as bash, is required to run configure.
+
+### How to Configure with Custom Options
+Run `./configure --help` to see the full list of configure command-line
+options.
+
+To run configure using both `SPEC` presets and custom options, pass the
+`EXTRA_CONFIGURE_ARGS` option to `run_configure.mk`.
+
+For example, to disable optimizations, run configure like this:
+
+    # Example configure
+    make -f run_configure.mk SPEC=linux_x86-64 OMRGLUE=./example/glue 'EXTRA_CONFIGURE_ARGS=--disable-optimized' clean all
+
+To disable building fvtests, run configure like this:
+
+    # Example configure disabling fvtests
+    make -f run_configure.mk SPEC=linux_x86-64 OMRGLUE=./example/glue 'EXTRA_CONFIGURE_ARGS=--disable-fvtest' clean all
+
+Note that the `clean` target of `run_configure.mk` deletes the header files and
+makefiles generated by configure. Invoking the `clean all` targets ensures that
+the header files and makefiles are regenerated using the custom options.
+
+The minimal invocation of configure is:
+
+    # Basic configure example
+    $ ./configure OMRGLUE=./example/glue
+
+Where can I learn more?
+===============================
+
+Presentations about Eclipse OMR
+-------------------------------
 
 * Mark Stoodley's talk at the JVM Languages Summit in August, 2015:
   [A VM is a VM is a VM: The Secret Path to High Performance Multi-Language Runtimes](https://www.youtube.com/watch?v=kOnyJurioyw)
@@ -85,51 +170,10 @@ open. (Our focus has been dominated by getting this code out into the open!)
 
 * Mark Stoodley's slides from EclipseCON in March, 2016
   [Eclipse OMR: a modern toolkit for building language runtimes](http://www.slideshare.net/MarkStoodley/omr-a-modern-toolkit-for-building-language-runtimes)
-  
-## How to Build Standalone Eclipse OMR
-### Basic configuration and compile
-To build standalone Eclipse OMR, run the following commands from the top of the
-source tree. The top of the Eclipe OMR source tree is the directory that contains
-run_configure.mk.
 
-    # Generate autotools makefiles with SPEC-specific presets
-    make -f run_configure.mk SPEC=linux_x86-64 OMRGLUE=./example/glue
+Blog Posts about OMR technologies
+---------------------------------
 
-    # Build
-    make
-
-    # Run tests (note that no contribution should cause new test failures in "make test")
-    make test
-    
-Run "make -f run_configure.mk help" for a list of configure makefile targets.
-Run "make help" for a list of build targets.
-
-#### Building Eclipse OMR on Windows
-A shell script interpreter, such as bash, is required to run configure.
-
-### How to Configure with Custom Options
-Run "./configure --help" to see the full list of configure command-line
-options.
-
-To run configure using both SPEC presets and custom options, pass the
-EXTRA_CONFIGURE_ARGS option to run_configure.mk.
-
-For example, to disable optimizations, run configure like this:
-
-    # Example configure
-    make -f run_configure.mk SPEC=linux_x86-64 OMRGLUE=./example/glue 'EXTRA_CONFIGURE_ARGS=--disable-optimized' clean all
-  
-To disable building fvtests, run configure like this:
-
-    # Example configure disabling fvtests
-    make -f run_configure.mk SPEC=linux_x86-64 OMRGLUE=./example/glue 'EXTRA_CONFIGURE_ARGS=--disable-fvtest' clean all
-
-Note that the "clean" target of run_configure.mk deletes the header files and
-makefiles generated by configure. Invoking the "clean all" targets ensures that
-the header files and makefiles are regenerated using the custom options.
-
-The minimal invocation of configure is:
-
-    # Basic configure example
-    $ ./configure OMRGLUE=./example/glue
+* [Introducing Eclipse OMR: Building Language Runtimes](https://developer.ibm.com/open/2016/03/08/introducing-omr-building-language-runtimes/)
+* [JitBuilder Library and Eclipse OMR: Just-In-Time Compilers made easy](https://developer.ibm.com/open/2016/07/19/jitbuilder-library-and-eclipse-omr-just-in-time-compilers-made-easy/)
 


### PR DESCRIPTION
This attempts to edit the README to make it easier to grok while
skimming, and raise to a higher level the most salient features of
Eclipse OMR.

[ci skip]

Signed-off-by: Matthew Gaudet <magaudet@ca.ibm.com>