### PR TITLE
Relax CFGEdgeList implementation dependencies

### DIFF
--- a/compiler/il/OMRBlock.hpp
+++ b/compiler/il/OMRBlock.hpp
@@ -606,7 +606,7 @@ private:
    TR::Block * _firstBlock;
    TR::Block * _nextBlockInExtendedBlock;
    TR::CFG   * _cfg;
-   std::list<TR::CFGEdge*, TR::typed_allocator<TR::CFGEdge*, TR::Allocator> >::iterator _iterator;
+   TR::CFGEdgeList::iterator _iterator;
    TR::CFGEdgeList* _list;
    };
 

--- a/compiler/infra/OMRCfg.hpp
+++ b/compiler/infra/OMRCfg.hpp
@@ -340,6 +340,10 @@ protected:
    TR_BitVector            *_frequencySet;
    double                  *_edgeProbabilities; // temp array
 
+private:
+   bool removeEdge(TR::CFGEdge *edge, TR::CFGNode &from, TR::CFGNode &to);
+   void removeEdge(TR::CFGEdge *edge, TR::CFGEdgeList &successorList, TR::CFGEdgeList &predecessorList);
+
 public: //FIXME: These public members should eventually be wrtapped in an interface.
    int32_t                  _max_edge_freq;
    int32_t                  _calledFrequency;
@@ -401,10 +405,7 @@ public:
 private:
    TR::CFGEdgeList combinedList;
 
-   std::list<TR::CFGEdge*,
-             TR::typed_allocator<TR::CFGEdge*,
-             TR::Allocator>
-            >::iterator currentIterator;
+   TR::CFGEdgeList::iterator currentIterator;
    };
 
 class TR_SuccessorIterator : public TR_CFGIterator

--- a/compiler/infra/TRCfgNode.hpp
+++ b/compiler/infra/TRCfgNode.hpp
@@ -22,12 +22,14 @@
 #include <limits.h>             // for SHRT_MAX
 #include <stddef.h>             // for NULL
 #include <stdint.h>             // for int32_t, int16_t
+#include <algorithm>
 #include "env/TRMemory.hpp"     // for TR_Memory, etc
 #include "il/Node.hpp"          // for vcount_t
 #include "infra/Link.hpp"       // for TR_Link1
 #include "infra/List.hpp"       // for List
 #include "infra/TRCfgEdge.hpp"  // for CFGEdge
 #include "infra/TRlist.hpp"
+
 class TR_StructureSubGraphNode;
 namespace TR { class Block; }
 namespace TR { class Compilation; }
@@ -75,10 +77,29 @@ class CFGNode : public ::TR_Link1<CFGNode>
    void addExceptionPredecessor(CFGEdge *p)                              {_exceptionPredecessors.push_front(p);}
    void addExceptionPredecessor(CFGEdge *p, TR_AllocationKind allocKind) {_exceptionPredecessors.push_front(p);}
 
-   void removeSuccessor(CFGEdge *p)  { _successors.remove(p);}
-   void removePredecessor(CFGEdge *p){ _predecessors.remove(p);}
-   void removeExceptionSuccessor(CFGEdge *p)  { _exceptionSuccessors.remove(p);}
-   void removeExceptionPredecessor(CFGEdge *p){ _exceptionPredecessors.remove(p);}
+   void removeSuccessor(CFGEdge *p)
+      {
+      auto iterator = std::find(_successors.begin(), _successors.end(), p);
+      if (iterator != _successors.end()) _successors.erase(iterator);
+      }
+
+   void removePredecessor(CFGEdge *p)
+      {
+      auto iterator = std::find(_predecessors.begin(), _predecessors.end(), p);
+      if (iterator != _predecessors.end()) _predecessors.erase(iterator);
+      }
+
+   void removeExceptionSuccessor(CFGEdge *p)
+      {
+      auto iterator = std::find(_exceptionSuccessors.begin(), _exceptionSuccessors.end(), p);
+      if (iterator != _exceptionSuccessors.end()) _exceptionSuccessors.erase(iterator);
+      }
+
+   void removeExceptionPredecessor(CFGEdge *p)
+      {
+      auto iterator = std::find(_exceptionPredecessors.begin(), _exceptionPredecessors.end(), p);
+      if (iterator != _exceptionPredecessors.end()) _exceptionPredecessors.erase(iterator);
+      }
 
    bool hasSuccessor(CFGNode * n);
    bool hasExceptionSuccessor(CFGNode * n);

--- a/compiler/optimizer/Dominators.hpp
+++ b/compiler/optimizer/Dominators.hpp
@@ -95,7 +95,7 @@ class TR_Dominators
    struct StackInfo
       {
       typedef TR::CFGEdgeList list_type;
-      typedef std::list<TR::CFGEdge*, TR::typed_allocator<TR::CFGEdge*, TR::Allocator> >::iterator iterator_type;
+      typedef TR::CFGEdgeList::iterator iterator_type;
       StackInfo(list_type &list, iterator_type position, int32_t parent) :
          list(list),
          listPosition(position),

--- a/compiler/optimizer/DominatorsChk.hpp
+++ b/compiler/optimizer/DominatorsChk.hpp
@@ -88,7 +88,7 @@ class TR_DominatorsChk
    class StackInfo
       {
       public:
-      std::list<TR::CFGEdge*, TR::typed_allocator<TR::CFGEdge*, TR::Allocator> >::iterator curIterator;
+      TR::CFGEdgeList::iterator curIterator;
       TR::CFGEdgeList * list;
       int32_t                  parent;
       };

--- a/compiler/optimizer/GeneralLoopUnroller.hpp
+++ b/compiler/optimizer/GeneralLoopUnroller.hpp
@@ -273,6 +273,9 @@ class TR_LoopUnroller
       };
    TR_ScratchList<ListsOfArrayAccesses> _listOfListsOfArrayAccesses;
    friend class TR_SPMDKernelParallelizer;
+
+private:
+   void manuallyRemoveEdgeFromCFG(TR::CFGEdge &edge);
    };
 
 

--- a/compiler/optimizer/GlobalRegisterAllocator.cpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.cpp
@@ -168,7 +168,7 @@ class multipleJumpSuccessorIterator : public SuccessorIterator
       else
          return (*_iterator)->getTo()->asBlock();
       }
-   std::list<TR::CFGEdge*, TR::typed_allocator<TR::CFGEdge*, TR::Allocator> >::iterator _iterator;
+   TR::CFGEdgeList::iterator _iterator;
    TR::CFGEdgeList* _list;
    };
 


### PR DESCRIPTION
Currently there are many locations where we make the assumption that
TR::CFGEdgeList is implemented using std::list. The most prolific
assumption is assuming the availability of a remove() function.

This change set eliminates those dependancies enabling us to use any of
the standard sequence containers.

**NOTE: This change does not attempt to address or in any way rectify
iterator and reference invalidation safety.  Attempting to use a
container with stricter requirements would require a thorough review and
updating of our container usage.**

Signed-off-by: Luc des Trois Maisons <lmaisons@ca.ibm.com>