### PR TITLE
Misc. CodeCache and Trampoline cleanup

### DIFF
--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -171,7 +171,6 @@ OMR::CodeGenPhase::performProcessRelocationsPhase(TR::CodeGenerator * cg, TR::Co
         }
      }
 
-
    if (comp->getOption(TR_AOT) && (comp->getOption(TR_TraceRelocatableDataCG) || comp->getOption(TR_TraceRelocatableDataDetailsCG) || comp->getOption(TR_TraceReloCG)))
      {
      traceMsg(comp, "\n<relocatableDataCG>\n");
@@ -182,22 +181,6 @@ OMR::CodeGenPhase::performProcessRelocationsPhase(TR::CodeGenerator * cg, TR::Co
         }
      cg->getAheadOfTimeCompile()->dumpRelocationData();
      traceMsg(comp, "</relocatableDataCG>\n");
-     }
-
-   static char *disassemble = feGetEnv("TR_Disassemble");
-   if (disassemble && comp->getDebug())
-     {
-     uint8_t *instrStart;
-     uint8_t *instrEnd;
-     instrStart = comp->cg()->getCodeStart();
-     if (comp->cg()->getColdCodeStart())
-        {
-        instrEnd = comp->cg()->getWarmCodeEnd();
-        comp->getDebug()->print(comp->getOutFile(), instrStart, instrEnd);
-        instrStart = comp->cg()->getColdCodeStart();
-        }
-     instrEnd = comp->cg()->getCodeEnd();
-     comp->getDebug()->print(comp->getOutFile(), instrStart, instrEnd);
      }
 
      if (debug("dumpCodeSizes"))

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -222,14 +222,12 @@ void
 OMR::CodeGenPhase::performEmitSnippetsPhase(TR::CodeGenerator * cg, TR::CodeGenPhase * phase)
    {
    TR::Compilation * comp = cg->comp();
-   uint8_t *crossPoint;
    phase->reportPhase(EmitSnippetsPhase);
 
    TR::LexicalMemProfiler mp("Emit Snippets", comp->phaseMemProfiler());
    LexicalTimer pt("Emit Snippets", comp->phaseTimer());
 
-   crossPoint = cg->emitSnippets();
-   cg->setCrossPoint(crossPoint);
+   cg->emitSnippets();
 
    if (comp->getOption(TR_TraceCG) || comp->getOptions()->getTraceCGOption(TR_TraceCGPostBinaryEncoding))
       {

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -752,8 +752,6 @@ class OMR_EXTENSIBLE CodeGenerator
 
    uint8_t *getBinaryBufferCursor() {return _binaryBufferCursor;}
    uint8_t *setBinaryBufferCursor(uint8_t *b) { return (_binaryBufferCursor = b); }
-   uint8_t *getCrossPoint() {return _crossPoint;}
-   uint8_t *setCrossPoint(uint8_t *b) {return (_crossPoint = b);}
 
    uint8_t *alignBinaryBufferCursor();
 
@@ -1862,7 +1860,6 @@ class OMR_EXTENSIBLE CodeGenerator
    uint8_t *_warmCodeEnd;
    uint8_t *_coldCodeStart;
    uint8_t *_binaryBufferCursor;
-   uint8_t *_crossPoint;
    TR::SparseBitVector _extendedToInt64GlobalRegisters;
 
    TR_BitVector *_liveButMaybeUnreferencedLocals;

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -725,7 +725,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"enableSpecializedEpilogues",         "O\tapply restore non-volatiles selectively",         SET_OPTION_BIT(TR_EnableSpecializedEpilogues), "F"},
    {"enableTailCallOpt",                  "R\tenable tall call optimization in peephole", SET_OPTION_BIT(TR_EnableTailCallOpt), "F"},
    {"enableThisLiveRangeExtension",       "R\tenable this live range extesion to the end of the method", SET_OPTION_BIT(TR_EnableThisLiveRangeExtension), "F"},
-   {"enableTieredCodeCache",              "D\tseparate code cache into cold and warm",   SET_OPTION_BIT(TR_EnableTieredCodeCache), "F", NOT_IN_SUBSET},
    {"enableTreePatternMatching",          "O\tEnable opts that use the TR_Pattern framework", RESET_OPTION_BIT(TR_DisableTreePatternMatching), "F"},
    {"enableTrivialStoreSinking",          "O\tenable trivial store sinking", SET_OPTION_BIT(TR_EnableTrivialStoreSinking), "F"},
    {"enableTrueRegisterModel",            "C\tUse true liveness model in local RA instead of Future Use Count", SET_OPTION_BIT(TR_EnableTrueRegisterModel), "F"},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -733,7 +733,7 @@ enum TR_CompilationOptions
    TR_DisableRedundantBCDSignElimination              = 0x00080000 + 21,
    // Available                                       = 0x00100000 + 21,
    TR_AllowVPRangeNarrowingBasedOnDeclaredType        = 0x00200000 + 21,
-   TR_EnableTieredCodeCache                           = 0x00400000 + 21,
+   // Available                                       = 0x00400000 + 21,
    // Available                                       = 0x00800000 + 21,
    TR_DisableConverterReducer                         = 0x01000000 + 21,
    // Available                                       = 0x02000000 + 21,

--- a/compiler/runtime/Trampoline.cpp
+++ b/compiler/runtime/Trampoline.cpp
@@ -77,7 +77,6 @@ ppcCreateHelperTrampolines(uint8_t *trampPtr, int32_t numHelpers)
    TR::CodeCacheConfig &config = manager.codeCacheConfig();
    char name[256];
 
-   static bool customP4 =  feGetEnv("TR_CustomP4Trampoline") ? true : false;
    static TR_Processor proc = TR_DefaultPPCProcessor;
 
    uint8_t *bufferStart = trampPtr, *buffer;
@@ -123,7 +122,7 @@ ppcCreateHelperTrampolines(uint8_t *trampPtr, int32_t numHelpers)
 
          // Now, if highest bit is on we need to clear the sign extend bits on 64bit CPUs
          // ** POWER4 pref fix **
-         if( (helper & 0x80000000) && (!customP4 || proc == TR_PPCgp))
+         if( helper & 0x80000000 )
             {
             // rlwinm r11,r11,sh=0,mb=0,me=31
             *(int32_t *)buffer = 0x556b003e;
@@ -163,19 +162,10 @@ ppcCreateHelperTrampolines(uint8_t *trampPtr, int32_t numHelpers)
 
 void ppcCodeCacheParameters(int32_t *trampolineSize, void **callBacks, int32_t *numHelpers, int32_t* CCPreLoadedCodeSize)
    {
-   static bool customP4 =  feGetEnv("TR_CustomP4Trampoline") ? true : false;
-
 #if defined(TR_TARGET_64BIT)
    *trampolineSize = TRAMPOLINE_SIZE;
 #else
-   if (customP4)
-      {
-      *trampolineSize = TRAMPOLINE_SIZE;
-      }
-   else
-      {
-      *trampolineSize = TRAMPOLINE_SIZE + 4;
-      }
+   *trampolineSize = TRAMPOLINE_SIZE + 4;
 #endif
    callBacks[0] = (void *)&ppcCodeCacheConfig;
    callBacks[1] = (void *)&ppcCreateHelperTrampolines;

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -242,7 +242,7 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
       {
 
 	 /**
-	  * Due to many verions of Haswell and a small number of Broadwell have defects for TM and then disabled by Intel, 
+	  * Due to many verions of Haswell and a small number of Broadwell have defects for TM and then disabled by Intel,
 	  * we will return false for any versions before Broadwell.
 	  *
 	  * TODO: Need to figure out from which mode of Broadwell start supporting TM
@@ -2227,7 +2227,7 @@ TR_OutlinedInstructions * OMR::X86::CodeGenerator::findOutlinedInstructionsFromM
 
 
 
-TR::IA32ConstantDataSnippet * OMR::X86::CodeGenerator::findOrCreateConstant(TR::Node * n, void * c, uint8_t size, bool isWarm)
+TR::IA32ConstantDataSnippet * OMR::X86::CodeGenerator::findOrCreateConstant(TR::Node * n, void * c, uint8_t size)
    {
    // *this    swipeable for debugging purposes
 
@@ -2239,8 +2239,7 @@ TR::IA32ConstantDataSnippet * OMR::X86::CodeGenerator::findOrCreateConstant(TR::
    for (auto iterator = _dataSnippetList.begin(); iterator != _dataSnippetList.end(); ++iterator)
       {
       if ((*iterator)->getKind() == TR::Snippet::IsConstantData &&
-          ((TR::IA32ConstantDataSnippet*)(*iterator))->getConstantSize() == size &&
-          (*iterator)->isWarmSnippet() == isWarm)
+          ((TR::IA32ConstantDataSnippet*)(*iterator))->getConstantSize() == size)
          {
          switch (size)
             {
@@ -2352,48 +2351,48 @@ void OMR::X86::CodeGenerator::emitDataSnippets(bool isWarm)
       }
    }
 
-TR::IA32ConstantDataSnippet *OMR::X86::CodeGenerator::findOrCreate2ByteConstant(TR::Node * n, int16_t c, bool isWarm)
+TR::IA32ConstantDataSnippet *OMR::X86::CodeGenerator::findOrCreate2ByteConstant(TR::Node * n, int16_t c)
    {
-   return self()->findOrCreateConstant(n, &c, 2, isWarm);
+   return self()->findOrCreateConstant(n, &c, 2);
    }
 
-TR::IA32ConstantDataSnippet *OMR::X86::CodeGenerator::findOrCreate4ByteConstant(TR::Node * n, int32_t c, bool isWarm)
+TR::IA32ConstantDataSnippet *OMR::X86::CodeGenerator::findOrCreate4ByteConstant(TR::Node * n, int32_t c)
    {
-   return self()->findOrCreateConstant(n, &c, 4, isWarm);
+   return self()->findOrCreateConstant(n, &c, 4);
    }
 
-TR::IA32ConstantDataSnippet *OMR::X86::CodeGenerator::findOrCreate8ByteConstant(TR::Node * n, int64_t c, bool isWarm)
+TR::IA32ConstantDataSnippet *OMR::X86::CodeGenerator::findOrCreate8ByteConstant(TR::Node * n, int64_t c)
    {
-   return self()->findOrCreateConstant(n, &c, 8, isWarm);
+   return self()->findOrCreateConstant(n, &c, 8);
    }
 
-TR::IA32ConstantDataSnippet *OMR::X86::CodeGenerator::findOrCreate16ByteConstant(TR::Node * n, void *c, bool isWarm)
+TR::IA32ConstantDataSnippet *OMR::X86::CodeGenerator::findOrCreate16ByteConstant(TR::Node * n, void *c)
    {
-   return self()->findOrCreateConstant(n, c, 16, isWarm);
+   return self()->findOrCreateConstant(n, c, 16);
    }
 
-TR::IA32DataSnippet *OMR::X86::CodeGenerator::create2ByteData(TR::Node *n, int16_t c, bool isWarm)
+TR::IA32DataSnippet *OMR::X86::CodeGenerator::create2ByteData(TR::Node *n, int16_t c)
    {
    TR::IA32DataSnippet *cursor = new (self()->trHeapMemory()) TR::IA32DataSnippet(self(), n, &c, 2);
    _dataSnippetList.push_front(cursor);
    return cursor;
    }
 
-TR::IA32DataSnippet *OMR::X86::CodeGenerator::create4ByteData(TR::Node *n, int32_t c, bool isWarm)
+TR::IA32DataSnippet *OMR::X86::CodeGenerator::create4ByteData(TR::Node *n, int32_t c)
    {
    TR::IA32DataSnippet *cursor = new (self()->trHeapMemory()) TR::IA32DataSnippet(self(), n, &c, 4);
    _dataSnippetList.push_front(cursor);
    return cursor;
    }
 
-TR::IA32DataSnippet *OMR::X86::CodeGenerator::create8ByteData(TR::Node *n, int64_t c, bool isWarm)
+TR::IA32DataSnippet *OMR::X86::CodeGenerator::create8ByteData(TR::Node *n, int64_t c)
    {
    TR::IA32DataSnippet *cursor = new (self()->trHeapMemory()) TR::IA32DataSnippet(self(), n, &c, 8);
    _dataSnippetList.push_front(cursor);
    return cursor;
    }
 
-TR::IA32DataSnippet *OMR::X86::CodeGenerator::create16ByteData(TR::Node *n, void *c, bool isWarm)
+TR::IA32DataSnippet *OMR::X86::CodeGenerator::create16ByteData(TR::Node *n, void *c)
    {
    TR::IA32DataSnippet *cursor = new (self()->trHeapMemory()) TR::IA32DataSnippet(self(), n, c, 16);
    _dataSnippetList.push_front(cursor);

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -581,14 +581,14 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    void dumpDataSnippets(TR::FILE *pOutFile, bool isWarm = 0);
 #endif
 
-   TR::IA32ConstantDataSnippet *findOrCreate2ByteConstant(TR::Node *, int16_t c, bool isWarm = 0);
-   TR::IA32ConstantDataSnippet *findOrCreate4ByteConstant(TR::Node *, int32_t c, bool isWarm = 0);
-   TR::IA32ConstantDataSnippet *findOrCreate8ByteConstant(TR::Node *, int64_t c, bool isWarm = 0);
-   TR::IA32ConstantDataSnippet *findOrCreate16ByteConstant(TR::Node *, void *c, bool isWarm = 0);
-   TR::IA32DataSnippet *create2ByteData(TR::Node *, int16_t c, bool isWarm = 0);
-   TR::IA32DataSnippet *create4ByteData(TR::Node *, int32_t c, bool isWarm = 0);
-   TR::IA32DataSnippet *create8ByteData(TR::Node *, int64_t c, bool isWarm = 0);
-   TR::IA32DataSnippet *create16ByteData(TR::Node *, void *c, bool isWarm = 0);
+   TR::IA32ConstantDataSnippet *findOrCreate2ByteConstant(TR::Node *, int16_t c);
+   TR::IA32ConstantDataSnippet *findOrCreate4ByteConstant(TR::Node *, int32_t c);
+   TR::IA32ConstantDataSnippet *findOrCreate8ByteConstant(TR::Node *, int64_t c);
+   TR::IA32ConstantDataSnippet *findOrCreate16ByteConstant(TR::Node *, void *c);
+   TR::IA32DataSnippet *create2ByteData(TR::Node *, int16_t c);
+   TR::IA32DataSnippet *create4ByteData(TR::Node *, int32_t c);
+   TR::IA32DataSnippet *create8ByteData(TR::Node *, int64_t c);
+   TR::IA32DataSnippet *create16ByteData(TR::Node *, void *c);
 
    bool supportsCMOV() {return (_targetProcessorInfo.supportsCMOVInstructions());}
 
@@ -655,7 +655,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    bool nodeIsFoldableMemOperand(TR::Node *node, TR::Node *parent, TR_RegisterPressureState *state);
 
-   TR::IA32ConstantDataSnippet     *findOrCreateConstant(TR::Node *, void *c, uint8_t size, bool isWarm=0);
+   TR::IA32ConstantDataSnippet     *findOrCreateConstant(TR::Node *, void *c, uint8_t size);
 
    TR::RealRegister             *_frameRegister;
 
@@ -888,4 +888,3 @@ class TR_X86ScratchRegisterManager: public TR_ScratchRegisterManager
    };
 
 #endif
-


### PR DESCRIPTION
* Remove EnableTieredCodeCache option
* Remove ancient TR_CustomP4Trampoline env variable
* Remove ancient relocation debug dump code
* Remove unused codegen CrossPoint field
* Remove unused x86 warm snippet logic
