### PR TITLE
Correct off by 1 mistake in test for real method call

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -677,7 +677,7 @@ bool OMR::Compilation::isPotentialOSRPoint(TR::Node *node)
          {
          TR::Node *callNode = node->getFirstChild();
          TR::SymbolReference *callSymRef = callNode->getSymbolReference();
-         if (callSymRef->getReferenceNumber() >
+         if (callSymRef->getReferenceNumber() >=
              self()->getSymRefTab()->getNonhelperIndex(self()->getSymRefTab()->getLastCommonNonhelperSymbol()))
             potentialOSRPoint = (disableGuardedCallOSR == NULL);
          }


### PR DESCRIPTION
Whilst calls are potential OSR points, helper calls and
common non-helper symbols are not. This distinction is tested by
comparing the call's symbol reference number with the index of the
last common non-helper symbol. This index marks the end of the
predefined symbols, but can be used as the reference number for a
real method call.