### PR TITLE
Remove "*this swipeable for debugging purposes"

### DIFF
--- a/compiler/arm/codegen/ARMBinaryEncoding.cpp
+++ b/compiler/arm/codegen/ARMBinaryEncoding.cpp
@@ -363,7 +363,6 @@ uint8_t *TR::ARMImmSymInstruction::generateBinaryEncoding()
 
 int32_t TR::ARMImmSymInstruction::estimateBinaryLength(int32_t currentEstimate)
    {
-   // *this   swipeable for debugging purposes
    int32_t length;
    TR::ResolvedMethodSymbol *sym = getSymbolReference()->getSymbol()->getResolvedMethodSymbol();
    TR::Node *node = getNode();

--- a/compiler/arm/codegen/ARMDebug.cpp
+++ b/compiler/arm/codegen/ARMDebug.cpp
@@ -1499,7 +1499,6 @@ void
 TR_Debug::print(TR::FILE *pOutFile, TR::ARMRecompilationSnippet * snippet)
    {
 #ifdef J9_PROJECT_SPECIFIC
-   // *this    swipeable for debugging purposes
    uint8_t             *cursor        = snippet->getSnippetLabel()->getCodeLocation();
 
    printSnippetLabel(pOutFile, snippet->getSnippetLabel(), cursor, "Counting Recompilation Snippet");

--- a/compiler/arm/codegen/ARMInstruction.hpp
+++ b/compiler/arm/codegen/ARMInstruction.hpp
@@ -202,7 +202,6 @@ class ARMImmInstruction : public TR::Instruction
 
    void insertImmediateField(uint32_t *instruction)
       {
-      // *this    swipeable for debugging purposes
       *instruction |= _sourceImmediate & 0xffff;
       }
 
@@ -627,7 +626,6 @@ class ARMTrg1Src2Instruction : public TR::Instruction
 
    void insertTargetRegister(uint32_t *instruction, TR_Memory * m)
       {
-      // *this    swipeable for debugging purposes
       TR::Register *treg = getTarget1Register();
       TR::RealRegister *realtreg = 0;
       if(treg)
@@ -655,7 +653,6 @@ class ARMTrg1Src2Instruction : public TR::Instruction
 
    void insertSource1Register(uint32_t *instruction)
       {
-      // *this    swipeable for debugging purposes
       TR::Register *sreg = getSource1Register();
       if(sreg)  // can be null in trg1src1 subclass
          {
@@ -677,7 +674,6 @@ class ARMTrg1Src2Instruction : public TR::Instruction
 
    void insertSource2Operand(uint32_t *instruction)
       {
-      // *this    swipeable for debugging purposes
       getSource2Operand()->setBinaryEncoding(instruction);
       }
 
@@ -1499,7 +1495,6 @@ class ARMMultipleMoveInstruction : public TR::Instruction
 
    void insertMemoryBaseRegister(uint32_t *instruction, TR_Memory * m)
       {
-      // *this    swipeable for debugging purposes
       TR::Register *treg = getMemoryBaseRegister();
       TR::RealRegister *realtreg = 0;
       if(treg)
@@ -1516,7 +1511,6 @@ class ARMMultipleMoveInstruction : public TR::Instruction
 
    void insertRegisterList(uint32_t *instruction)
       {
-      // *this    swipeable for debugging purposes
       *instruction |= (uint32_t) getRegisterList();
       }
 

--- a/compiler/arm/codegen/BinaryCommutativeAnalyser.cpp
+++ b/compiler/arm/codegen/BinaryCommutativeAnalyser.cpp
@@ -29,7 +29,6 @@ void TR_ARMBinaryCommutativeAnalyser::genericAnalyser(TR::Node       *root,
                                                        TR_ARMOpCodes copyOpCode,
                                                        bool          nonClobberingDestination)
    {
-   // *this    swipeable for debugging purposes
    TR::Node *firstChild;
    TR::Node *secondChild;
    if (cg()->whichChildToEvaluate(root) == 0)
@@ -114,7 +113,6 @@ void TR_ARMBinaryCommutativeAnalyser::genericLongAnalyser(TR::Node       *root,
                                                            TR_ARMOpCodes highMemToRegOpCode,
                                                            TR_ARMOpCodes copyOpCode)
    {
-   // *this    swipeable for debugging purposes
    TR::Node *firstChild;
    TR::Node *secondChild;
    if (cg()->whichChildToEvaluate(root) == 0)
@@ -238,7 +236,6 @@ void TR_ARMBinaryCommutativeAnalyser::genericLongAnalyser(TR::Node       *root,
 void TR_ARMBinaryCommutativeAnalyser::integerAddAnalyser(TR::Node       *root,
                                                          TR_ARMOpCodes regToRegOpCode)
    {
-   // *this    swipeable for debugging purposes
    TR::Node *firstChild;
    TR::Node *secondChild;
    if (cg()->whichChildToEvaluate(root) == 0)
@@ -313,7 +310,6 @@ void TR_ARMBinaryCommutativeAnalyser::integerAddAnalyser(TR::Node       *root,
 
 void TR_ARMBinaryCommutativeAnalyser::longAddAnalyser(TR::Node *root)
    {
-   // *this    swipeable for debugging purposes
    TR::Node *firstChild;
    TR::Node *secondChild;
    if (cg()->whichChildToEvaluate(root) == 0)

--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -372,7 +372,6 @@ void OMR::ARM::CodeGenerator::beginInstructionSelection()
 
 void OMR::ARM::CodeGenerator::endInstructionSelection()
    {
-   // *this    swipeable for debugging purposes
    if (_returnTypeInfoInstruction != NULL)
       {
       _returnTypeInfoInstruction->setSourceImmediate(static_cast<uint32_t>(TR::comp()->getReturnInfo()));
@@ -691,7 +690,6 @@ int32_t OMR::ARM::CodeGenerator::findOrCreateAddressConstant(void *v, TR::DataTy
 // different from evaluate in that it returns a clobberable register
 TR::Register *OMR::ARM::CodeGenerator::gprClobberEvaluate(TR::Node *node)
    {
-   // *this    swipeable for debugging purposes
    if (node->getReferenceCount() > 1)
       {
       if (node->getOpCode().isLong())

--- a/compiler/arm/codegen/OMRLinkage.cpp
+++ b/compiler/arm/codegen/OMRLinkage.cpp
@@ -74,7 +74,6 @@ bool OMR::ARM::Linkage::hasToBeOnStack(TR::ParameterSymbol *parm)
 
 void OMR::ARM::Linkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol *method)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::Instruction *OMR::ARM::Linkage::saveArguments(TR::Instruction *cursor)

--- a/compiler/arm/codegen/OMRMachine.cpp
+++ b/compiler/arm/codegen/OMRMachine.cpp
@@ -50,7 +50,6 @@ TR::RealRegister *OMR::ARM::Machine::findBestFreeRegister(TR_RegisterKinds rk,
 							bool considerUnlatched,
 							bool isSinglePrecision)
    {
-   // *this    swipeable for debugging purposes
    int first;
    int last;
 
@@ -103,7 +102,6 @@ TR::RealRegister *OMR::ARM::Machine::freeBestRegister(TR::Instruction     *curre
                                                     bool                excludeGPR0,
                         							bool isSinglePrecision)
    {
-   // *this    swipeable for debugging purposes
    TR::Register           *candidates[NUM_ARM_MAXR];
    TR::Compilation *comp = TR::comp();
    TR::MemoryReference *tmemref;
@@ -308,7 +306,6 @@ TR::RealRegister *OMR::ARM::Machine::reverseSpillState(TR::Instruction      *cur
                                                      bool                excludeGPR0,
                                                      bool isSinglePrecision)
    {
-   // *this    swipeable for debugging purposes
    TR::MemoryReference *tmemref;
    TR::RealRegister    *sameReg, *crtemp   = NULL;
    TR_BackingStore       *location = spilledRegister->getBackingStorage();
@@ -473,7 +470,6 @@ void OMR::ARM::Machine::coerceRegisterAssignment(TR::Instruction                
                                               TR::Register                             *virtualRegister,
                                               TR::RealRegister::RegNum registerNumber)
    {
-   // *this    swipeable for debugging purposes
    TR::RealRegister *targetRegister          = _registerFile[registerNumber];
    TR::RealRegister    *realReg                 = virtualRegister->getAssignedRealRegister();
    TR::RealRegister *currentAssignedRegister = realReg ? realReg : NULL;
@@ -621,7 +617,6 @@ void OMR::ARM::Machine::coerceRegisterAssignment(TR::Instruction                
 
 void OMR::ARM::Machine::initialiseRegisterFile()
    {
-   // *this    swipeable for debugging purposes
    _cg->_unlatchedRegisterList =
    (TR::RealRegister**)self()->cg()->trMemory()->allocateHeapMemory(sizeof(TR::RealRegister*)*(TR::RealRegister::NumRegisters + 1));
    _cg->_unlatchedRegisterList[0] = 0; // mark that list is empty
@@ -893,7 +888,6 @@ static void registerExchange(TR::Instruction     *precedingInstruction,
 
 TR::RealRegister *OMR::ARM::Machine::assignSingleRegister(TR::Register *virtualRegister, TR::Instruction *currentInstruction)
    {
-   // *this    swipeable for debugging purposes
    TR::RealRegister       *assignedRegister = virtualRegister->getAssignedRealRegister();
    TR_RegisterKinds       kindOfRegister = virtualRegister->getKind();
 

--- a/compiler/arm/codegen/OMRRegisterDependency.cpp
+++ b/compiler/arm/codegen/OMRRegisterDependency.cpp
@@ -220,7 +220,6 @@ OMR::ARM::RegisterDependencyConditions::RegisterDependencyConditions( TR::Node  
 
 bool OMR::ARM::RegisterDependencyConditions::refsRegister(TR::Register *r)
    {
-   // *this    swipeable for debugging purposes
    for (int i = 0; i < _addCursorForPre; i++)
       {
       if (_preConditions->getRegisterDependency(i)->getRegister() == r &&
@@ -242,7 +241,6 @@ bool OMR::ARM::RegisterDependencyConditions::refsRegister(TR::Register *r)
 
 bool OMR::ARM::RegisterDependencyConditions::defsRegister(TR::Register *r)
    {
-   // *this    swipeable for debugging purposes
    for (int i = 0; i < _addCursorForPre; i++)
       {
       if (_preConditions->getRegisterDependency(i)->getRegister() == r &&
@@ -264,7 +262,6 @@ bool OMR::ARM::RegisterDependencyConditions::defsRegister(TR::Register *r)
 
 bool OMR::ARM::RegisterDependencyConditions::defsRealRegister(TR::Register *r)
    {
-   // *this    swipeable for debugging purposes
    for (int i = 0; i < _addCursorForPre; i++)
       {
       if (_preConditions->getRegisterDependency(i)->getRegister()->getAssignedRegister() == r &&
@@ -287,7 +284,6 @@ bool OMR::ARM::RegisterDependencyConditions::defsRealRegister(TR::Register *r)
 
 bool OMR::ARM::RegisterDependencyConditions::usesRegister(TR::Register *r)
    {
-   // *this    swipeable for debugging purposes
    for (int i = 0; i < _addCursorForPre; i++)
       {
       if (_preConditions->getRegisterDependency(i)->getRegister() == r &&
@@ -309,7 +305,6 @@ bool OMR::ARM::RegisterDependencyConditions::usesRegister(TR::Register *r)
 
 void OMR::ARM::RegisterDependencyConditions::incRegisterTotalUseCounts(TR::CodeGenerator * cg)
    {
-   // *this    swipeable for debugging purposes
    for (int i = 0; i < _addCursorForPre; i++)
       {
       _preConditions->getRegisterDependency(i)->getRegister()->incTotalUseCount();
@@ -325,7 +320,6 @@ void TR_ARMRegisterDependencyGroup::assignRegisters(TR::Instruction  *currentIns
                                                     uint32_t         numberOfRegisters,
                                                     TR::CodeGenerator *cg)
    {
-   // *this    swipeable for debugging purposes
    TR::Compilation *comp = TR::comp();
    TR::Machine *machine = cg->machine();
    TR::Register  *virtReg;

--- a/compiler/arm/codegen/SubtractAnalyser.cpp
+++ b/compiler/arm/codegen/SubtractAnalyser.cpp
@@ -29,7 +29,6 @@ void TR_ARMSubtractAnalyser::integerSubtractAnalyser(TR::Node       *root,
                                                       TR_ARMOpCodes regToRegOpCode,
                                                       TR_ARMOpCodes memToRegOpCode)
    {
-   // *this    swipeable for debugging purposes
    TR::Node *firstChild;
    TR::Node *secondChild;
    firstChild  = root->getFirstChild();
@@ -86,7 +85,6 @@ void TR_ARMSubtractAnalyser::integerSubtractAnalyser(TR::Node       *root,
 
 void TR_ARMSubtractAnalyser::longSubtractAnalyser(TR::Node *root)
    {
-   // *this    swipeable for debugging purposes
    TR::Node *firstChild;
    TR::Node *secondChild;
    firstChild  = root->getFirstChild();

--- a/compiler/codegen/Analyser.cpp
+++ b/compiler/codegen/Analyser.cpp
@@ -37,7 +37,6 @@ void TR_Analyser::setInputs(TR::Node     *firstChild,
                             bool         lockedIntoRegister1,
                             bool         lockedIntoRegister2)
    {
-   // *this    swipeable for debugging purposes
    _inputs = 0;
 
    if (firstRegister)

--- a/compiler/codegen/CodeGenPrep.cpp
+++ b/compiler/codegen/CodeGenPrep.cpp
@@ -363,7 +363,6 @@ OMR::CodeGenerator::lowerTreeIfNeeded(
  */
 void OMR::CodeGenerator::identifyUnneededByteConvNodes(TR::Node * parent, TR::TreeTop * treeTop, vcount_t visitCount, TR::DataType storeType)
    {
-   // *this    swipeable for debugging purposes
    parent->setVisitCount(visitCount);
 
    TR::ILOpCode &opCode = parent->getOpCode();
@@ -452,7 +451,6 @@ void OMR::CodeGenerator::identifyUnneededByteConvNodes(TR::Node * parent, TR::Tr
 
 void OMR::CodeGenerator::identifyUnneededByteConvNodes()
    {
-   // *this    swipeable for debugging purposes
    vcount_t visitCount = self()->comp()->incVisitCount();
 
    TR::Block * block = NULL;

--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -428,7 +428,6 @@ OMR::CodeGenerator::prepareRegistersForAssignment()
 TR_BackingStore *
 OMR::CodeGenerator::allocateVMThreadSpill()
    {
-   // *this    swipeable for debugging purposes
    int32_t slot;
    TR::AutomaticSymbol *spillSymbol = TR::AutomaticSymbol::create(self()->trHeapMemory(), self()->IntJ(), self()->comp()->getOption(TR_ForceLargeRAMoves) ? 8 : TR::Compiler->om.sizeofReferenceAddress());
    spillSymbol->setSpillTempAuto();
@@ -754,7 +753,6 @@ TR::Register * OMR::CodeGenerator::allocateRegister(TR_RegisterKinds rk)
 void
 OMR::CodeGenerator::findAndFixCommonedReferences()
    {
-   // *this    swipeable for debugging purposes
    //
    // TODO : Required to re-assess the feasibility of the spill
    // strategy currently adopted at calls (potential GC points) where
@@ -838,7 +836,6 @@ OMR::CodeGenerator::findAndFixCommonedReferences()
 void
 OMR::CodeGenerator::findCommonedReferences(TR::Node *node, TR::TreeTop *treeTop)
    {
-   // *this    swipeable for debugging purposes
    if (node->getVisitCount() == self()->comp()->getVisitCount())
       return;
 
@@ -884,7 +881,6 @@ OMR::CodeGenerator::findCommonedReferences(TR::Node *node, TR::TreeTop *treeTop)
 void
 OMR::CodeGenerator::processReference(TR::Node *reference, TR::Node *parent, TR::TreeTop *treeTop)
    {
-   // *this    swipeable for debugging purposes
 
    // The live reference list appender is used to add and remove elements from the
    // live reference list, so that the list is maintained in the order in which
@@ -943,7 +939,6 @@ OMR::CodeGenerator::processReference(TR::Node *reference, TR::Node *parent, TR::
 void
 OMR::CodeGenerator::spillLiveReferencesToTemps(TR::TreeTop *insertionTree, std::list<TR::SymbolReference*, TR::typed_allocator<TR::SymbolReference*, TR::Allocator> >::iterator firstAvailableSpillTemp)
    {
-   // *this    swipeable for debugging purposes
    if (debug("traceSpill") && !_liveReferenceList.empty())
       diagnostic("Spill at GC safe node [%p]\n",insertionTree->getNextTreeTop()->getNode());
 

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -495,7 +495,6 @@ OMR::CodeGenerator::lowerTreesPostChildrenVisit(TR::Node * parent, TR::TreeTop *
 void
 OMR::CodeGenerator::setUpForInstructionSelection()
   {
-   // *this    swipeable for debugging purposes
    self()->comp()->incVisitCount();
 
    // prepareNodeForInstructionSelection is called during a separate walk of the treetops because
@@ -2617,7 +2616,6 @@ OMR::CodeGenerator::isMemoryUpdate(TR::Node *node)
 void
 OMR::CodeGenerator::processRelocations()
    {
-   // *this    swipeable for debugging purposes
    //
    auto iterator = _relocationList.begin();
    while(iterator != _relocationList.end())
@@ -2906,7 +2904,6 @@ OMR::CodeGenerator::alignBinaryBufferCursor()
 int32_t
 OMR::CodeGenerator::setEstimatedLocationsForSnippetLabels(int32_t estimatedSnippetStart, bool isWarm)
    {
-   // *this    swipeable for debugging purposes
    TR::Snippet *cursor;
 
    self()->setEstimatedSnippetStart(estimatedSnippetStart);
@@ -2936,7 +2933,6 @@ OMR::CodeGenerator::setEstimatedLocationsForSnippetLabels(int32_t estimatedSnipp
 uint8_t *
 OMR::CodeGenerator::emitSnippets(bool isWarm)
    {
-   // *this    swipeable for debugging purposes
    uint8_t *codeOffset;
    uint8_t *retVal;
 
@@ -2979,7 +2975,6 @@ OMR::CodeGenerator::emitSnippets(bool isWarm)
 TR::LabelSymbol *
 OMR::CodeGenerator::lookUpSnippet(int32_t snippetKind, TR::SymbolReference *symRef)
    {
-   // *this    swipeable for debugging purposes
    for (auto iterator = _snippetList.begin(); iterator != _snippetList.end(); ++iterator)
       {
       if (self()->isSnippetMatched(*iterator, snippetKind, symRef))
@@ -2991,7 +2986,6 @@ OMR::CodeGenerator::lookUpSnippet(int32_t snippetKind, TR::SymbolReference *symR
 TR::SymbolReference *
 OMR::CodeGenerator::allocateLocalTemp(TR::DataType dt, bool isInternalPointer)
    {
-   // *this    swipeable for debugging purposes
    //
    TR::AutomaticSymbol * temp;
    if (isInternalPointer)

--- a/compiler/codegen/PreInstructionSelection.cpp
+++ b/compiler/codegen/PreInstructionSelection.cpp
@@ -118,7 +118,6 @@ OMR::CodeGenerator::eliminateLoadsOfLocalsThatAreNotStored(
 void
 OMR::CodeGenerator::prepareNodeForInstructionSelection(TR::Node *node)
    {
-   // *this    swipeable for debugging purposes
    if (node->getVisitCount() == self()->comp()->getVisitCount())
       {
       if (node->getOpCode().hasSymbolReference() && node->getSymbolReference()->isTempVariableSizeSymRef())

--- a/compiler/codegen/Relocation.cpp
+++ b/compiler/codegen/Relocation.cpp
@@ -57,21 +57,18 @@ TR::RelocationDebugInfo* TR::Relocation::getDebugInfo()
    }
 void TR::LabelRelative8BitRelocation::apply(TR::CodeGenerator *codeGen)
    {
-   // *this    swipeable for debugging purposes
    AOTcgDiag2(codeGen->comp(), "TR::LabelRelative8BitRelocation::apply cursor=%x label=%x\n", getUpdateLocation(), getLabel());
    codeGen->apply8BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel());
    }
 
 void TR::LabelRelative12BitRelocation::apply(TR::CodeGenerator *codeGen)
    {
-   // *this    swipeable for debugging purposes
    AOTcgDiag2(codeGen->comp(), "TR::LabelRelative12BitRelocation::apply cursor=%x label=%x\n", getUpdateLocation(), getLabel());
    codeGen->apply12BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel(), isCheckDisp());
    }
 
 void TR::LabelRelative16BitRelocation::apply(TR::CodeGenerator *codeGen)
    {
-   // *this    swipeable for debugging purposes
    AOTcgDiag2(codeGen->comp(), "TR::LabelRelative16BitRelocation::apply cursor=%x label=%x\n", getUpdateLocation(), getLabel());
    if(getAddressDifferenceDivisor() == 1)
    codeGen->apply16BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel());
@@ -81,21 +78,18 @@ void TR::LabelRelative16BitRelocation::apply(TR::CodeGenerator *codeGen)
 
 void TR::LabelRelative24BitRelocation::apply(TR::CodeGenerator *codeGen)
    {
-   // *this    swipeable for debugging purposes
    AOTcgDiag2(codeGen->comp(), "TR::LabelRelative24BitRelocation::apply cursor=%x label=%x\n", getUpdateLocation(), getLabel());
    codeGen->apply24BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel());
    }
 
 void TR::LabelRelative32BitRelocation::apply(TR::CodeGenerator *codeGen)
    {
-   // *this    swipeable for debugging purposes
    AOTcgDiag2(codeGen->comp(), "TR::LabelRelative32BitRelocation::apply cursor=%x label=%x\n", getUpdateLocation(), getLabel());
    codeGen->apply32BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel());
    }
 
 void TR::LabelAbsoluteRelocation::apply(TR::CodeGenerator *codeGen)
    {
-   // *this    swipeable for debugging purposes
    intptrj_t *cursor = (intptrj_t *)getUpdateLocation();
    AOTcgDiag2(codeGen->comp(), "TR::LabelAbsoluteRelocation::apply cursor=%x label=%x\n", cursor, getLabel());
    *cursor = (intptrj_t)getLabel()->getCodeLocation();
@@ -132,7 +126,6 @@ void TR::LoadLabelRelative64BitRelocation::apply(TR::CodeGenerator *codeGen)
 
 uint8_t TR::ExternalRelocation::collectModifier()
    {
-   // *this    swipeable for debugging purposes
    TR::Compilation *comp = TR::comp();
    uint8_t * aotMethodCodeStart = (uint8_t *)comp->getAotMethodCodeStart();
    uint8_t * updateLocation;
@@ -160,7 +153,6 @@ uint8_t TR::ExternalRelocation::collectModifier()
 
 void TR::ExternalRelocation::addAOTRelocation(TR::CodeGenerator *codeGen)
    {
-   // *this    swipeable for debugging purposes
    TR::Compilation *comp = codeGen->comp();
    AOTcgDiag0(comp, "TR::ExternalRelocation::addAOTRelocation\n");
    if (comp->getOption(TR_AOT))
@@ -252,7 +244,6 @@ void TR::ExternalRelocation::addAOTRelocation(TR::CodeGenerator *codeGen)
 
 void TR::ExternalRelocation::apply(TR::CodeGenerator *codeGen)
    {
-   // *this    swipeable for debugging purposes
    TR::Compilation *comp = codeGen->comp();
    AOTcgDiag1(comp, "TR::ExternalRelocation::apply updateLocation=%x \n", getUpdateLocation());
    if (comp->getOption(TR_AOT))
@@ -486,14 +477,12 @@ TR::IteratedExternalRelocation::IteratedExternalRelocation(uint8_t *target, uint
 
 void TR::IteratedExternalRelocation::initialiseRelocation(TR::CodeGenerator *codeGen)
    {
-   // *this    swipeable for debugging purposes
    AOTcgDiag0(TR::comp(), "TR::IteratedExternalRelocation::initialiseRelocation\n");
    _relocationDataCursor = codeGen->getAheadOfTimeCompile()->initialiseAOTRelocationHeader(this);
    }
 
 void TR::IteratedExternalRelocation::addRelocationEntry(uint32_t locationOffset)
    {
-   // *this    swipeable for debugging purposes
    TR::Compilation *comp = TR::comp();
    AOTcgDiag1(comp, "TR::IteratedExternalRelocation::addRelocationEntry _relocationDataCursor=%x\n", _relocationDataCursor);
    if (!needsWideOffsets())

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -1112,7 +1112,6 @@ TR_YesNoMaybe OMR::Compilation::isCpuExpensiveCompilation(int64_t threshold)
 
 void OMR::Compilation::performOptimizations()
    {
-   // *this    swipeable for debugging purposes
 
    _optimizer = TR::Optimizer::createOptimizer(self(), self()->getJittedMethodSymbol(), false);
 
@@ -1799,7 +1798,6 @@ void OMR::Compilation::setUsesPreexistence(bool v)
 //
 void OMR::Compilation::dumpMethodTrees(char *title, TR::ResolvedMethodSymbol * methodSymbol)
    {
-   // *this    swipeable for debugging purposes
    if (self()->getOutFile() == NULL)
       return;
 
@@ -1826,7 +1824,6 @@ void OMR::Compilation::dumpMethodTrees(char *title1, const char *title2, TR::Res
 
 void OMR::Compilation::dumpFlowGraph(TR::CFG * cfg)
    {
-   // *this    swipeable for debugging purposes
    if (cfg == 0) cfg = self()->getFlowGraph();
    if (debug("dumpCFG") || self()->getOption(TR_TraceTrees) || self()->getOption(TR_TraceCG) || self()->getOption(TR_TraceUseDefs))
       {
@@ -1900,7 +1897,6 @@ void OMR::Compilation::verifyCFG(TR::ResolvedMethodSymbol *methodSymbol)
 #ifdef DEBUG
 void OMR::Compilation::dumpMethodGraph(int index, TR::ResolvedMethodSymbol *methodSymbol)
    {
-   // *this    swipeable for debugging purposes
    if (self()->getOutFile() == NULL) return;
 
    if (methodSymbol == 0) methodSymbol = _methodSymbol;

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -2079,7 +2079,6 @@ OMR::ResolvedMethodSymbol::catchBlocksHaveRealPredecessors(TR::CFG *cfg, TR::Com
 void
 OMR::ResolvedMethodSymbol::removeUnusedLocals()
    {
-   // *this    swipeable for debugging purposes
    ListElement<TR::AutomaticSymbol> *cursor = _automaticList.getListHead();
    ListElement<TR::AutomaticSymbol> *prev   = NULL;
    TR::AutomaticSymbol *local;

--- a/compiler/infra/Timer.cpp
+++ b/compiler/infra/Timer.cpp
@@ -35,7 +35,6 @@
 
 void TR_SingleTimer::initialize(const char *title, TR_Memory * trMemory)
    {
-   // *this    swipeable for debugging purposes
    if (title)
       {
       _phaseTitle = (char *)trMemory->allocateHeapMemory( strlen(title)+1 );
@@ -70,7 +69,6 @@ uint32_t TR_SingleTimer::stopTiming(TR::Compilation *comp)
 
 char *TR_SingleTimer::timeTakenString(TR::Compilation *comp)
    {
-   // *this    swipeable for debugging purposes
    static char timeString[32];
    uint32_t    mins,
                uSecs,

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -2211,7 +2211,6 @@ void OMR::Optimizer::enableAllLocalOpts()
 
 int32_t OMR::Optimizer::doStructuralAnalysis()
    {
-   // *this    swipeable for debugging purposes
 
    // Only perform structural analysis if there may be loops in the method
    //
@@ -2238,7 +2237,6 @@ int32_t OMR::Optimizer::doStructuralAnalysis()
 
 int32_t OMR::Optimizer::changeContinueLoopsToNestedLoops()
    {
-   // *this    swipeable for debugging purposes
    TR_RegionStructure *rootStructure = comp()->getFlowGraph()->getStructure()->asRegion();
    if (rootStructure && rootStructure->changeContinueLoopsToNestedLoops(rootStructure))
       {

--- a/compiler/optimizer/OSRDefAnalysis.cpp
+++ b/compiler/optimizer/OSRDefAnalysis.cpp
@@ -447,7 +447,6 @@ void TR_OSRDefInfo::buildOSRDefs(void *vblockInfo, AuxiliaryData &aux)
 
 void TR_OSRDefInfo::buildOSRDefs(TR::Node *node, void *vanalysisInfo, TR_OSRPoint *osrPoint, TR_OSRPoint *osrPoint2, TR::Node *parent, AuxiliaryData &aux)
    {
-   // *this    swipeable for debugging purposes
    vcount_t visitCount = comp()->getVisitCount();
    if (node->getVisitCount() == visitCount)
       return;

--- a/compiler/optimizer/ReachingBlocks.cpp
+++ b/compiler/optimizer/ReachingBlocks.cpp
@@ -48,7 +48,6 @@ TR_ReachingBlocks::TR_ReachingBlocks(TR::Compilation *comp, TR::Optimizer *optim
 
 int32_t TR_ReachingBlocks::perform()
    {
-   // *this    swipeable for debugging purposes
    // Allocate the block info before setting the stack mark - it will be used by
    // the caller
    //
@@ -82,7 +81,6 @@ void TR_ReachingBlocks::analyzeBlockZeroStructure(TR_BlockStructure *blockStruct
 
 void TR_ReachingBlocks::initializeGenAndKillSetInfo()
    {
-   // *this    swipeable for debugging purposes
    // For each block in the CFG build the gen and kill set for this analysis.
    // Go in treetop order, which guarantees that we see the correct (i.e. first)
    // evaluation point for each node.

--- a/compiler/optimizer/ReachingDefinitions.cpp
+++ b/compiler/optimizer/ReachingDefinitions.cpp
@@ -64,7 +64,6 @@ TR_ReachingDefinitions::TR_ReachingDefinitions(TR::Compilation *comp, TR::CFG *c
 int32_t TR_ReachingDefinitions::perform()
    {
    LexicalTimer tlex("reachingDefs_perform", comp()->phaseTimer());
-   // *this    swipeable for debugging purposes
    if (traceRD())
       traceMsg(comp(), "Starting ReachingDefinitions\n");
 
@@ -110,7 +109,6 @@ void TR_ReachingDefinitions::analyzeBlockZeroStructure(TR_BlockStructure *blockS
 
 void TR_ReachingDefinitions::initializeGenAndKillSetInfo()
    {
-   // *this    swipeable for debugging purposes
    // For each block in the CFG build the gen and kill set for this analysis.
    // Go in treetop order, which guarantees that we see the correct (i.e. first)
    // evaluation point for each node.

--- a/compiler/optimizer/UseDefInfo.cpp
+++ b/compiler/optimizer/UseDefInfo.cpp
@@ -109,7 +109,6 @@ void TR_UseDefInfo::prepareUseDefInfo(bool requiresGlobals, bool prefersGlobals,
 
    TR_UseDefInfo::AuxiliaryData aux(comp());
 
-   // *this    swipeable for debugging purposes
    int32_t i;
    dumpOptDetails(comp(), "   (Building use/def info)\n");
 
@@ -1244,7 +1243,6 @@ bool TR_UseDefInfo::skipAnalyzingForCompileTime(TR::Node *node, TR::Block *block
 
 bool TR_UseDefInfo::findUseDefNodes(TR::Block *block, TR::Node *node, TR::Node *parent, TR::TreeTop *treeTop, AuxiliaryData &aux, bool considerImplicitStores)
    {
-   // *this    swipeable for debugging purposes
    vcount_t visitCount = comp()->getVisitCount();
    if (visitCount == node->getVisitCount())
       return true;
@@ -1420,7 +1418,6 @@ bool TR_UseDefInfo::findUseDefNodes(TR::Block *block, TR::Node *node, TR::Node *
 
 bool TR_UseDefInfo::assignAdjustedNodeIndex(TR::Block *block, TR::Node *node, TR::Node *parent, TR::TreeTop *treeTop, AuxiliaryData &aux,bool considerImplicitStores)
    {
-   // *this    swipeable for debugging purposes
    vcount_t visitCount = comp()->getVisitCount();
    if (visitCount == node->getVisitCount())
       return true;
@@ -1568,7 +1565,6 @@ bool TR_UseDefInfo::childIndexIndicatesImplicitStore(TR::Node *node, int32_t chi
 
 void TR_UseDefInfo::insertData(TR::Block *block, TR::Node *node,TR::Node *parent, TR::TreeTop *treeTop, AuxiliaryData &aux, TR::SparseBitVector &expandedLIndexes, bool considerImplicitStores)
    {
-   // *this    swipeable for debugging purposes
    vcount_t visitCount = comp()->getVisitCount();
    if (visitCount == node->getVisitCount())
       return;
@@ -1858,7 +1854,6 @@ void TR_UseDefInfo::processReachingDefinition(void* vblockInfo, AuxiliaryData &a
 
 void TR_UseDefInfo::buildUseDefs(void *vblockInfo, AuxiliaryData &aux)
    {
-   // *this    swipeable for debugging purposes
    TR_Method *method = comp()->getMethodSymbol()->getMethod();
    TR::Block *block;
    TR::TreeTop *treeTop;
@@ -2290,7 +2285,6 @@ bool TR_UseDefInfo::isChildUse(TR::Node* node, int32_t childIndex)
 
 void TR_UseDefInfo::buildUseDefs(TR::Node *node, void *vanalysisInfo, TR::BitVector &nodesToBeDereferenced, TR::Node *parent, AuxiliaryData &aux)
    {
-   // *this    swipeable for debugging purposes
    vcount_t visitCount = comp()->getVisitCount();
    if (node->getVisitCount() == visitCount)
       return;
@@ -2860,7 +2854,6 @@ const TR_UseDefInfo::BitVector &TR_UseDefInfo::getUsesFromDef_ref(int32_t defInd
 
 void TR_UseDefInfo::setUseDef(int32_t useIndex, int32_t defIndex)
    {
-   // *this    swipeable for debugging purposes
    int32_t realIndex = useIndex - getFirstUseIndex();
    _useDefInfo[realIndex][defIndex] = true;
 
@@ -2876,7 +2869,6 @@ void TR_UseDefInfo::setUseDef(int32_t useIndex, int32_t defIndex)
 
 void TR_UseDefInfo::resetUseDef(int32_t useIndex, int32_t defIndex)
    {
-   // *this    swipeable for debugging purposes
    int32_t realIndex = useIndex - getFirstUseIndex();
    _useDefInfo[realIndex][defIndex] = false;
 
@@ -2886,7 +2878,6 @@ void TR_UseDefInfo::resetUseDef(int32_t useIndex, int32_t defIndex)
 
 void TR_UseDefInfo::clearUseDef(int32_t useIndex)
    {
-   // *this    swipeable for debugging purposes
    int32_t realIndex = useIndex - getFirstUseIndex();
    _useDefInfo[realIndex].Clear();
 

--- a/compiler/optimizer/ValueNumberInfo.cpp
+++ b/compiler/optimizer/ValueNumberInfo.cpp
@@ -63,7 +63,6 @@ TR_ValueNumberInfo::TR_ValueNumberInfo(TR::Compilation *comp, TR::Optimizer *opt
      _valueNumbers(comp->allocator()),
      _nextInRing(comp->allocator())
    {
-   // *this    swipeable for debugging purposes
    dumpOptDetails(comp, "PREPARTITION VN   (Building value number info)\n");
 
    // For now, don't allow global value numbering because of
@@ -412,7 +411,6 @@ bool TR_ValueNumberInfo::congruentNodes(TR::Node * node, TR::Node * entryNode)
 
 void TR_ValueNumberInfo::initializeNode(TR::Node *node, int32_t &negativeValueNumber)
    {
-   // *this    swipeable for debugging purposes
    int32_t index = node->getGlobalIndex();
    if (_nodes.ElementAt(index) != NULL)
       {
@@ -635,7 +633,6 @@ void TR_ValueNumberInfo::initializeNode(TR::Node *node, int32_t &negativeValueNu
  */
 int32_t TR_ValueNumberInfo::hash(TR::Node *node)
    {
-   // *this    swipeable for debugging purposes
 
    uint32_t h, g;
    int32_t numChildren = node->getNumChildren();
@@ -684,7 +681,6 @@ int32_t TR_ValueNumberInfo::hash(TR::Node *node)
  */
 void TR_ValueNumberInfo::allocateNonShareableValueNumbers()
    {
-   // *this    swipeable for debugging purposes
 
    int32_t maxValue = _nextValue-1;
    for (int32_t i = 0; i < _numberOfNodes; ++i)
@@ -734,7 +730,6 @@ void TR_ValueNumberInfo::allocateParmValueNumbers()
  */
 void TR_ValueNumberInfo::allocateShareableValueNumbers()
    {
-   // *this    swipeable for debugging purposes
 
    _recursionDepth = 0;
 
@@ -782,7 +777,6 @@ bool TR_ValueNumberInfo::canShareValueNumber(TR::Node *node)
 void TR_ValueNumberInfo::allocateValueNumber(TR::Node *node)
    {
 
-   // *this    swipeable for debugging purposes
    int32_t index = node->getGlobalIndex();
    if (_valueNumbers.ElementAt(index) >= 0 ||
        _valueNumbers.ElementAt(index) <= -3)
@@ -1304,7 +1298,6 @@ TR::Node *TR_ValueNumberInfo::getValueNumberForLoad(TR::Node *node)
 
 void TR_ValueNumberInfo::setValueNumber(TR::Node *node, TR::Node *other)
    {
-   // *this    swipeable for debugging purposes
    int32_t index = node->getGlobalIndex();
    int32_t otherIndex = other->getGlobalIndex();
 
@@ -1340,7 +1333,6 @@ void TR_ValueNumberInfo::setValueNumber(TR::Node *node, TR::Node *other)
 
 void TR_ValueNumberInfo::setUniqueValueNumber(TR::Node *node)
    {
-   // *this    swipeable for debugging purposes
    int32_t index = node->getGlobalIndex();
 
    // Make sure there's enough room in the arrays.
@@ -1373,7 +1365,6 @@ void TR_ValueNumberInfo::setUniqueValueNumber(TR::Node *node)
 
 void TR_ValueNumberInfo::changeValueNumber(TR::Node *node, int32_t newVN)
    {
-   // *this    swipeable for debugging purposes
    // Change the value number of all nodes in the root node's value number chain
    //
    int32_t index = node->getGlobalIndex();
@@ -1444,7 +1435,6 @@ void TR_ValueNumberInfo::growTo(int32_t index)
 
 void TR_ValueNumberInfo::printValueNumberInfo(TR::Node *node)
    {
-   // *this    swipeable for debugging purposes
    traceMsg(comp(), "Node : %p    Index = %d    Value number = %d\n", node, node->getUseDefIndex(), getVN(node));
 
    for (int i = 0; i < node->getNumChildren(); i++)
@@ -1525,7 +1515,6 @@ TR_HashValueNumberInfo::TR_HashValueNumberInfo(TR::Compilation *comp, TR::Optimi
    _optimizer = optimizer;
    _trace = comp->getOption(TR_TraceValueNumbers);
 
-   // *this    swipeable for debugging purposes
    dumpOptDetails(comp, " HASHVN  (Building value number info)\n");
 
    // For now, don't allow global value numbering because of
@@ -1655,7 +1644,6 @@ TR_HashValueNumberInfo::TR_HashValueNumberInfo(TR::Compilation *comp, TR::Optimi
 
 void TR_HashValueNumberInfo::initializeNode(TR::Node * node, int32_t & negativeValueNumber)
 {
-    // *this    swipeable for debugging purposes
       int32_t index = node->getGlobalIndex();
       if (_nodes.ElementAt(index) != NULL)
          {
@@ -1688,7 +1676,6 @@ void TR_HashValueNumberInfo::initializeNode(TR::Node * node, int32_t & negativeV
 
 void TR_HashValueNumberInfo::allocateValueNumber(TR::Node * node)
 {
-      // *this    swipeable for debugging purposes
       int32_t index = node->getGlobalIndex();
       if (_valueNumbers.ElementAt(index) >= 0 ||
           _valueNumbers.ElementAt(index) <= -3)

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -472,7 +472,6 @@ OMR::Power::CodeGenerator::generateSwitchToInterpreterPrePrologue(
 void
 OMR::Power::CodeGenerator::beginInstructionSelection()
    {
-   // *this    swipeable for debugging purposes
 
    TR::Node *firstNode = self()->comp()->getStartTree()->getNode();
    _returnTypeInfoInstruction = NULL;
@@ -487,7 +486,6 @@ OMR::Power::CodeGenerator::beginInstructionSelection()
 void
 OMR::Power::CodeGenerator::endInstructionSelection()
    {
-   // *this    swipeable for debugging purposes
    if (_returnTypeInfoInstruction != NULL)
       {
       _returnTypeInfoInstruction->setSourceImmediate(static_cast<uint32_t>(self()->comp()->getReturnInfo()));
@@ -560,7 +558,6 @@ OMR::Power::CodeGenerator::mulDecompositionCostIsJustified(
 
 void OMR::Power::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
    {
-   // *this    swipeable for debugging purposes
    TR::Instruction *prevInstruction;
 
    // gprs, fprs, and ccrs are all assigned in backward direction
@@ -1955,7 +1952,6 @@ void OMR::Power::CodeGenerator::deleteInst(TR::Instruction* old)
 TR::Linkage *
 OMR::Power::CodeGenerator::createLinkage(TR_LinkageConventions lc)
    {
-   // *this    swipeable for debugging purposes
    TR::Linkage *linkage = NULL;
 
    switch (lc)
@@ -2261,7 +2257,6 @@ void OMR::Power::CodeGenerator::doBinaryEncoding()
 // different from evaluate in that it returns a clobberable register
 TR::Register *OMR::Power::CodeGenerator::gprClobberEvaluate(TR::Node *node)
    {
-   // *this    swipeable for debugging purposes
 
    TR::Register *resultReg = self()->evaluate(node);
    TR_ASSERT( resultReg->getKind() == TR_GPR || resultReg->getKind() == TR_FPR , "gprClobberEvaluate() called for non-GPR or non-FPR.");

--- a/compiler/p/codegen/OMRInstruction.cpp
+++ b/compiler/p/codegen/OMRInstruction.cpp
@@ -94,7 +94,6 @@ OMR::Power::Instruction::getMemoryDataRegister()
 bool
 OMR::Power::Instruction::refsRegister(TR::Register * reg)
    {
-   // *this    swipeable for debugging purposes
    return OMR::Power::Instruction::getDependencyConditions() ? OMR::Power::Instruction::getDependencyConditions()->refsRegister(reg) : false;
    }
 
@@ -113,28 +112,24 @@ OMR::Power::Instruction::defsRealRegister(TR::Register * reg)
 bool
 OMR::Power::Instruction::usesRegister(TR::Register * reg)
    {
-   // *this    swipeable for debugging purposes
    return OMR::Power::Instruction::getDependencyConditions() ? OMR::Power::Instruction::getDependencyConditions()->usesRegister(reg) : false;
    }
 
 bool
 OMR::Power::Instruction::dependencyRefsRegister(TR::Register * reg)
    {
-   // *this    swipeable for debugging purposes
    return OMR::Power::Instruction::getDependencyConditions() ? OMR::Power::Instruction::getDependencyConditions()->refsRegister(reg) : false;
    }
 
 TR::PPCDepImmInstruction *
 OMR::Power::Instruction::getPPCDepImmInstruction()
    {
-   // *this    swipeable for debugging purposes
    return NULL;
    }
 
 TR::PPCConditionalBranchInstruction *
 OMR::Power::Instruction::getPPCConditionalBranchInstruction()
    {
-   // *this    swipeable for debugging purposes
    return NULL;
    }
 
@@ -144,7 +139,6 @@ OMR::Power::Instruction::getPPCConditionalBranchInstruction()
 TR::PPCImmInstruction *
 OMR::Power::Instruction::getPPCImmInstruction()
    {
-   // *this    swipeable for debugging purposes
    return NULL;
    }
 #endif
@@ -153,7 +147,6 @@ OMR::Power::Instruction::getPPCImmInstruction()
 void
 OMR::Power::Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
-   // *this    swipeable for debugging purposes
    if( OMR::Power::Instruction::getDependencyConditions() )
       {
       OMR::Power::Instruction::getDependencyConditions()->assignPostConditionRegisters(self(), kindToBeAssigned, self()->cg());

--- a/compiler/p/codegen/OMRLinkage.cpp
+++ b/compiler/p/codegen/OMRLinkage.cpp
@@ -54,27 +54,22 @@ namespace TR { class Register; }
 
 void OMR::Power::Linkage::mapStack(TR::ResolvedMethodSymbol *method)
    {
-   // *this    swipeable for debugging purposes
    }
 
 void OMR::Power::Linkage::mapSingleAutomatic(TR::AutomaticSymbol *p, uint32_t &stackIndex)
    {
-   // *this    swipeable for debugging purposes
    }
 
 void OMR::Power::Linkage::initPPCRealRegisterLinkage()
    {
-   // *this    swipeable for debugging purposes
    }
 
 void OMR::Power::Linkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol *method)
    {
-   // *this    swipeable for debugging purposes
    }
 
 bool OMR::Power::Linkage::hasToBeOnStack(TR::ParameterSymbol *parm)
    {
-   // *this    swipeable for debugging purposes
    return(false);
    }
 
@@ -684,7 +679,6 @@ TR::Instruction *OMR::Power::Linkage::flushArguments(TR::Instruction *cursor)
 
 TR::Register *OMR::Power::Linkage::pushIntegerWordArg(TR::Node *child)
    {
-   // *this    swipeable for debugging purposes
    TR::Register *pushRegister = NULL;
    TR_ASSERT(child->getDataType() != TR::Address, "assumption violated");
    if (child->getRegister() == NULL && child->getOpCode().isLoadConst())
@@ -703,7 +697,6 @@ TR::Register *OMR::Power::Linkage::pushIntegerWordArg(TR::Node *child)
 
 TR::Register *OMR::Power::Linkage::pushAddressArg(TR::Node *child)
    {
-   // *this    swipeable for debugging purposes
    TR::Register *pushRegister = NULL;
    TR_ASSERT(child->getDataType() == TR::Address, "assumption violated");
    if (child->getRegister() == NULL && child->getOpCode().isLoadConst())
@@ -731,7 +724,6 @@ TR::Register *OMR::Power::Linkage::pushAddressArg(TR::Node *child)
 
 TR::Register *OMR::Power::Linkage::pushThis(TR::Node *child)
    {
-   // *this    swipeable for debugging purposes
    TR::Register *tempRegister = self()->cg()->evaluate(child);
    self()->cg()->decReferenceCount(child);
    return tempRegister;
@@ -739,7 +731,6 @@ TR::Register *OMR::Power::Linkage::pushThis(TR::Node *child)
 
 TR::Register *OMR::Power::Linkage::pushLongArg(TR::Node *child)
    {
-   // *this    swipeable for debugging purposes
    TR::Register *pushRegister = NULL;
    if (child->getRegister() == NULL && child->getOpCode().isLoadConst())
       {
@@ -768,7 +759,6 @@ TR::Register *OMR::Power::Linkage::pushLongArg(TR::Node *child)
 
 TR::Register *OMR::Power::Linkage::pushFloatArg(TR::Node *child)
    {
-   // *this    swipeable for debugging purposes
    TR::Register *pushRegister = self()->cg()->evaluate(child);
    self()->cg()->decReferenceCount(child);
    return(pushRegister);
@@ -776,7 +766,6 @@ TR::Register *OMR::Power::Linkage::pushFloatArg(TR::Node *child)
 
 TR::Register *OMR::Power::Linkage::pushDoubleArg(TR::Node *child)
    {
-   // *this    swipeable for debugging purposes
    TR::Register *pushRegister = self()->cg()->evaluate(child);
    self()->cg()->decReferenceCount(child);
    return(pushRegister);

--- a/compiler/p/codegen/OMRMachine.cpp
+++ b/compiler/p/codegen/OMRMachine.cpp
@@ -194,7 +194,6 @@ TR::RealRegister *OMR::Power::Machine::findBestFreeRegister(TR::Instruction *cur
                                                         bool considerUnlatched,
                                                         TR::Register      *virtualReg)
    {
-   // *this    swipeable for debugging purposes
    uint32_t         preference = (virtualReg==NULL)?0:virtualReg->getAssociation();
    uint64_t         interference = 0;
    int first, maskI;
@@ -423,7 +422,6 @@ TR::RealRegister *OMR::Power::Machine::freeBestRegister(TR::Instruction     *cur
                                                     bool                excludeGPR0)
 
    {
-   // *this    swipeable for debugging purposes
    TR::Register           *candidates[NUM_PPC_MAXR];
    TR::MemoryReference *tmemref;
    TR_BackingStore       *location;
@@ -866,7 +864,6 @@ TR::RealRegister *OMR::Power::Machine::reverseSpillState(TR::Instruction      *c
                                                      TR::RealRegister  *targetRegister,
                                                      bool                excludeGPR0)
    {
-   // *this    swipeable for debugging purposes
    TR::MemoryReference *tmemref;
    TR::Compilation *comp = self()->cg()->comp();
    TR::RealRegister    *sameReg, *crtemp   = NULL;
@@ -1152,7 +1149,6 @@ void OMR::Power::Machine::coerceRegisterAssignment(TR::Instruction              
                                               TR::Register                             *virtualRegister,
                                               TR::RealRegister::RegNum registerNumber)
    {
-   // *this    swipeable for debugging purposes
    TR::RealRegister *targetRegister          = _registerFile[registerNumber];
    TR::RealRegister    *realReg                 = virtualRegister->getAssignedRealRegister();
    TR::RealRegister *currentAssignedRegister = (realReg==NULL)?NULL:toRealRegister(realReg);
@@ -1319,7 +1315,6 @@ void OMR::Power::Machine::coerceRegisterAssignment(TR::Instruction              
 
 void OMR::Power::Machine::initialiseRegisterFile()
    {
-   // *this    swipeable for debugging purposes
 
    _registerFile[TR::RealRegister::NoReg] = NULL;
    _registerFile[TR::RealRegister::SpilledReg] = NULL;

--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -133,7 +133,6 @@ OMR::Power::MemoryReference::MemoryReference(TR::Node *rootLoadOrStore, uint32_t
      _symbolReference(rootLoadOrStore->getSymbolReference()), _offset(0),
      _conditions(NULL), _length(len), _staticRelocation(NULL)
    {
-   // *this    swipeable for debugging purposes
    TR::Compilation *comp = cg->comp();
    TR::SymbolReference *ref = rootLoadOrStore->getSymbolReference();
    TR::Symbol   *symbol = ref->getSymbol();
@@ -214,7 +213,6 @@ OMR::Power::MemoryReference::MemoryReference(TR::Node *node, TR::SymbolReference
      _symbolReference(symRef), _offset(0),
      _conditions(NULL), _length(len), _staticRelocation(NULL)
    {
-   // *this    swipeable for debugging purposes
    TR::Symbol *symbol = symRef->getSymbol();
 
 
@@ -245,7 +243,6 @@ OMR::Power::MemoryReference::MemoryReference(TR::Node *node, TR::SymbolReference
 
 OMR::Power::MemoryReference::MemoryReference(TR::Node *node, TR::MemoryReference& mr, int32_t displacement, uint32_t len, TR::CodeGenerator *cg)
    {
-   // *this    swipeable for debugging purposes
    _baseRegister      = mr._baseRegister;
    _baseNode          = NULL;
    _indexRegister     = mr._indexRegister;
@@ -298,7 +295,6 @@ int32_t OMR::Power::MemoryReference::getTOCOffset()
 
 void OMR::Power::MemoryReference::addToOffset(TR::Node * node, intptrj_t amount, TR::CodeGenerator *cg)
    {
-   // *this    swipeable for debugging purposes
    // in compressedRefs mode, amount maybe heapBase constant, which in
    // most cases is quite large
    //
@@ -383,7 +379,6 @@ void OMR::Power::MemoryReference::addToOffset(TR::Node * node, intptrj_t amount,
 
 void OMR::Power::MemoryReference::forceIndexedForm(TR::Node * node, TR::CodeGenerator *cg, TR::Instruction *cursor)
    {
-   // *this    swipeable for debugging purposes
    if (self()->useIndexedForm())
       return;  // already X-form
 
@@ -441,7 +436,6 @@ void OMR::Power::MemoryReference::forceIndexedForm(TR::Node * node, TR::CodeGene
 
 void OMR::Power::MemoryReference::adjustForResolution(TR::CodeGenerator *cg)
    {
-   // *this    swipeable for debugging purposes
    _modBase = cg->allocateRegister();
    _conditions = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(1, 1, cg->trMemory());
    addDependency(_conditions, _modBase, TR::RealRegister::gr11, TR_GPR, cg);
@@ -449,7 +443,6 @@ void OMR::Power::MemoryReference::adjustForResolution(TR::CodeGenerator *cg)
 
 void OMR::Power::MemoryReference::decNodeReferenceCounts(TR::CodeGenerator *cg)
    {
-   // *this    swipeable for debugging purposes
    if (_baseRegister != NULL)
       {
       if (_baseNode != NULL)
@@ -474,7 +467,6 @@ void OMR::Power::MemoryReference::decNodeReferenceCounts(TR::CodeGenerator *cg)
 
 void OMR::Power::MemoryReference::bookKeepingRegisterUses(TR::Instruction *instr, TR::CodeGenerator *cg)
    {
-   // *this    swipeable for debugging purposes
    if (_baseRegister != NULL)
       {
       instr->useRegister(_baseRegister);
@@ -705,7 +697,6 @@ void OMR::Power::MemoryReference::populateMemoryReference(TR::Node *subTree, TR:
 
 void OMR::Power::MemoryReference::consolidateRegisters(TR::Register *srcReg, TR::Node *srcTree, bool srcModifiable, TR::CodeGenerator *cg)
    {
-   // *this    swipeable for debugging purposes
    TR::Register *tempTargetRegister;
    TR::Compilation *comp = cg->comp();
 
@@ -864,7 +855,6 @@ void OMR::Power::MemoryReference::consolidateRegisters(TR::Register *srcReg, TR:
 
 void OMR::Power::MemoryReference::assignRegisters(TR::Instruction *currentInstruction, TR::CodeGenerator *cg)
    {
-   // *this    swipeable for debugging purposes
    TR::Machine *machine = cg->machine();
    TR::RealRegister *assignedBaseRegister;
    TR::RealRegister *assignedIndexRegister;
@@ -992,7 +982,6 @@ void OMR::Power::MemoryReference::assignRegisters(TR::Instruction *currentInstru
 
 void OMR::Power::MemoryReference::mapOpCode(TR::Instruction *currentInstruction)
    {
-   // *this    swipeable for debugging purposes
    TR::InstOpCode::Mnemonic op = currentInstruction->getOpCodeValue();
    TR::Register  *index = self()->getIndexRegister();
 
@@ -1084,7 +1073,6 @@ void OMR::Power::MemoryReference::mapOpCode(TR::Instruction *currentInstruction)
 
 uint8_t *OMR::Power::MemoryReference::generateBinaryEncoding(TR::Instruction *currentInstruction, uint8_t *cursor, TR::CodeGenerator *cg)
    {
-   // *this    swipeable for debugging purposes
    uint32_t             *wcursor = (uint32_t *)cursor;
    TR::RealRegister   *base, *index;
    TR::Compilation *comp = cg->comp();

--- a/compiler/p/codegen/OMRRegisterDependency.cpp
+++ b/compiler/p/codegen/OMRRegisterDependency.cpp
@@ -345,7 +345,6 @@ void OMR::Power::RegisterDependencyConditions::unionNoRegPostCondition(TR::Regis
 
 bool OMR::Power::RegisterDependencyConditions::refsRegister(TR::Register *r)
    {
-   // *this    swipeable for debugging purposes
    for (int i = 0; i < _addCursorForPre; i++)
       {
       if (_preConditions->getRegisterDependency(i)->getRegister() == r &&
@@ -367,7 +366,6 @@ bool OMR::Power::RegisterDependencyConditions::refsRegister(TR::Register *r)
 
 bool OMR::Power::RegisterDependencyConditions::defsRegister(TR::Register *r)
    {
-   // *this    swipeable for debugging purposes
    for (int i = 0; i < _addCursorForPre; i++)
       {
       if (_preConditions->getRegisterDependency(i)->getRegister() == r &&
@@ -389,7 +387,6 @@ bool OMR::Power::RegisterDependencyConditions::defsRegister(TR::Register *r)
 
 bool OMR::Power::RegisterDependencyConditions::defsRealRegister(TR::Register *r)
    {
-   // *this    swipeable for debugging purposes
    for (int i = 0; i < _addCursorForPre; i++)
       {
       if (_preConditions->getRegisterDependency(i)->getRegister()->getAssignedRegister() == r &&
@@ -414,7 +411,6 @@ bool OMR::Power::RegisterDependencyConditions::defsRealRegister(TR::Register *r)
 
 bool OMR::Power::RegisterDependencyConditions::usesRegister(TR::Register *r)
    {
-   // *this    swipeable for debugging purposes
    for (int i = 0; i < _addCursorForPre; i++)
       {
       if (_preConditions->getRegisterDependency(i)->getRegister() == r &&
@@ -436,7 +432,6 @@ bool OMR::Power::RegisterDependencyConditions::usesRegister(TR::Register *r)
 
 void OMR::Power::RegisterDependencyConditions::bookKeepingRegisterUses(TR::Instruction *instr, TR::CodeGenerator *cg)
    {
-   // *this    swipeable for debugging purposes
    TR::Register *virtReg;
    TR::RealRegister::RegNum regNum;
    TR::RegisterDependencyConditions *assoc;
@@ -617,7 +612,6 @@ static TR::RegisterDependency*
 findDependencyChainHead(TR::RegisterDependency *dep,
                         TR_PPCRegisterDependencyMap& map)
    {
-   // *this    swipeable for debugging purposes
    TR::RegisterDependency *cursor = map.getDependencyWithAssigned(dep->getRealRegister());
 
 
@@ -643,7 +637,6 @@ static void assignFreeRegisters(TR::Instruction              *currentInstruction
                                 TR_PPCRegisterDependencyMap& map,
                                 TR::CodeGenerator            *cg)
    {
-   // *this    swipeable for debugging purposes
    TR::Machine *machine = cg->machine();
 
    // Assign a chain of dependencies where the head of the chain depends on a free reg
@@ -665,7 +658,6 @@ static void assignContendedRegisters(TR::Instruction              *currentInstru
                                      bool                         depsBlocked,
                                      TR::CodeGenerator            *cg)
    {
-   // *this    swipeable for debugging purposes
    TR::Machine *machine = cg->machine();
 
    dep = findDependencyChainHead(dep, map);
@@ -766,7 +758,6 @@ void TR_PPCRegisterDependencyGroup::assignRegisters(TR::Instruction   *currentIn
                                                     uint32_t          numberOfRegisters,
                                                     TR::CodeGenerator *cg)
    {
-   // *this    swipeable for debugging purposes
    TR::Machine *machine = cg->machine();
    TR::Register   *virtReg;
    TR::RealRegister::RegNum dependentRegNum;

--- a/compiler/p/codegen/PPCDebug.cpp
+++ b/compiler/p/codegen/PPCDebug.cpp
@@ -190,7 +190,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Instruction * instr)
             // fall thru
       case OMR::Instruction::IsNotExtended:
          {
-         // *this    swipeable for debugging purposes
          printPrefix(pOutFile, instr);
          trfprintf(pOutFile, "%s", getOpCodeName(&instr->getOpCode()));
          trfflush(_comp->getOutFile());
@@ -210,7 +209,6 @@ TR_Debug::printInstructionComment(TR::FILE *pOutFile, int32_t tabStops, TR::Inst
 void
 TR_Debug::printPrefix(TR::FILE *pOutFile, TR::Instruction * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -237,7 +235,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCDepInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::PPCLabelInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
 
    TR::LabelSymbol *label   = instr->getLabelSymbol();
@@ -301,7 +298,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCDepLabelInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::PPCConditionalBranchInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
    print(pOutFile, instr->getConditionRegister(), TR_WordReg);
@@ -324,7 +320,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCDepConditionalBranchInstruction * ins
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::PPCAdminInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    int i;
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s ", getOpCodeName(&instr->getOpCode()));
@@ -357,7 +352,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCAdminInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::PPCImmInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s \t0x%08x", getOpCodeName(&instr->getOpCode()), instr->getSourceImmediate());
    trfflush(_comp->getOutFile());
@@ -366,7 +360,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCImmInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::PPCSrc1Instruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
    print(pOutFile, instr->getSource1Register(), TR_WordReg);
@@ -379,7 +372,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCSrc1Instruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::PPCDepImmInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s \t" POINTER_PRINTF_FORMAT, getOpCodeName(&instr->getOpCode()), instr->getSourceImmediate());
    if (_comp->getOption(TR_DisableShrinkWrapping) && instr->getDependencyConditions())
@@ -409,7 +401,6 @@ TR_Debug::isBranchToTrampoline(TR::SymbolReference *symRef, uint8_t *cursor, int
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::PPCDepImmSymInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    intptrj_t imm = instr->getAddrImmediate();
    uint8_t *cursor = instr->getBinaryEncoding();
    intptrj_t distance = 0;
@@ -460,7 +451,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCDepImmSymInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::PPCTrg1Instruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
    print(pOutFile, instr->getTargetRegister(), TR_WordReg);
@@ -470,7 +460,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCTrg1Instruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::PPCTrg1Src1Instruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
 
@@ -491,7 +480,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCTrg1Src1Instruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::PPCTrg1ImmInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
 
@@ -515,7 +503,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCTrg1ImmInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::PPCTrg1Src1ImmInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
    print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
@@ -538,7 +525,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCTrg1Src1ImmInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::PPCTrg1Src1Imm2Instruction * instr)
    {
-   // *this    swipeable for debugging purposes
    uint64_t lmask;
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
@@ -557,7 +543,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCTrg1Src1Imm2Instruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::PPCSrc2Instruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
    print(pOutFile, instr->getSource1Register(), TR_WordReg); trfprintf(pOutFile, ", ");
@@ -568,7 +553,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCSrc2Instruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::PPCTrg1Src2Instruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
 
@@ -590,7 +574,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCTrg1Src2Instruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::PPCTrg1Src2ImmInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    uint64_t lmask;
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
@@ -608,7 +591,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCTrg1Src2ImmInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::PPCTrg1Src3Instruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
    print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
@@ -621,7 +603,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCTrg1Src3Instruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::PPCMemSrc1Instruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
 
@@ -639,7 +620,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCMemSrc1Instruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::PPCMemInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
    print(pOutFile, instr->getMemoryReference());
@@ -650,7 +630,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCMemInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::PPCTrg1MemInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
 
@@ -687,7 +666,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCTrg1MemInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::PPCControlFlowInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    int i;
    printPrefix(pOutFile, instr);
 
@@ -772,7 +750,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::RegisterDependencyConditions * condition
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::MemoryReference * mr, bool d_form)
    {
-   // *this    swipeable for debugging purposes
    trfprintf(pOutFile, "[");
 
    if (mr->getBaseRegister() != NULL)

--- a/compiler/p/codegen/PPCHelperCallSnippet.cpp
+++ b/compiler/p/codegen/PPCHelperCallSnippet.cpp
@@ -44,7 +44,6 @@
 
 uint8_t *TR::PPCHelperCallSnippet::emitSnippetBody()
    {
-   // *this    swipeable for debugging purposes
    uint8_t             *buffer = cg()->getBinaryBufferCursor();
    uint8_t             *gtrmpln, *trmpln;
 
@@ -57,7 +56,6 @@ uint8_t *TR::PPCHelperCallSnippet::emitSnippetBody()
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::PPCHelperCallSnippet * snippet)
    {
-   // *this    swipeable for debugging purposes
    uint8_t *cursor = snippet->getSnippetLabel()->getCodeLocation();
    TR::LabelSymbol *restartLabel = snippet->getRestartLabel();
 
@@ -93,7 +91,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCHelperCallSnippet * snippet)
 
 uint32_t TR::PPCHelperCallSnippet::getLength(int32_t estimatedSnippetStart)
    {
-   // *this    swipeable for debugging purposes
    return getHelperCallLength();
    }
 

--- a/compiler/p/codegen/PPCInstruction.cpp
+++ b/compiler/p/codegen/PPCInstruction.cpp
@@ -52,7 +52,6 @@ namespace TR { class SymbolReference; }
 void TR::PPCLabelInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
    TR::Compilation *comp = cg()->comp();
-   // *this    swipeable for debugging purposes
    if( TR::Instruction::getDependencyConditions() )
       {
       TR::Instruction::getDependencyConditions()->assignPostConditionRegisters(this, kindToBeAssigned, cg());
@@ -122,7 +121,6 @@ void TR::PPCLabelInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
 
 void TR::PPCDepInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
-   // *this    swipeable for debugging purposes
    if( getOpCodeValue() != TR::InstOpCode::assocreg )
       {
       getDependencyConditions()->assignPostConditionRegisters(this, kindToBeAssigned, cg());
@@ -144,13 +142,11 @@ void TR::PPCDepInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
 
 bool TR::PPCDepInstruction::refsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    return _conditions->refsRegister(reg);
    }
 
 bool TR::PPCDepInstruction::defsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    return _conditions->defsRegister(reg);
    }
 
@@ -161,7 +157,6 @@ bool TR::PPCDepInstruction::defsRealRegister(TR::Register *reg)
 
 bool TR::PPCDepInstruction::usesRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    return _conditions->usesRegister(reg);
    }
 
@@ -169,7 +164,6 @@ bool TR::PPCDepInstruction::usesRegister(TR::Register *reg)
 
 void TR::PPCDepLabelInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
-   // *this    swipeable for debugging purposes
    getDependencyConditions()->assignPostConditionRegisters(this, kindToBeAssigned, cg());
 
    TR::PPCLabelInstruction::assignRegisters(kindToBeAssigned);
@@ -179,13 +173,11 @@ void TR::PPCDepLabelInstruction::assignRegisters(TR_RegisterKinds kindToBeAssign
 
 bool TR::PPCDepLabelInstruction::refsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    return _conditions->refsRegister(reg);
    }
 
 bool TR::PPCDepLabelInstruction::defsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    return _conditions->defsRegister(reg);
    }
 
@@ -196,7 +188,6 @@ bool TR::PPCDepLabelInstruction::defsRealRegister(TR::Register *reg)
 
 bool TR::PPCDepLabelInstruction::usesRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    return _conditions->usesRegister(reg);
    }
 
@@ -210,7 +201,6 @@ TR::PPCConditionalBranchInstruction::getPPCConditionalBranchInstruction()
 
 void TR::PPCConditionalBranchInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
-   // *this    swipeable for debugging purposes
    TR::Register           *virtualRegister = getConditionRegister();
    TR::RealRegister       *assignedRegister = virtualRegister->getAssignedRealRegister();
    TR::Machine *machine = cg()->machine();
@@ -272,7 +262,6 @@ bool TR::PPCConditionalBranchInstruction::usesRegister(TR::Register *reg)
 
 void TR::PPCDepConditionalBranchInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
-   // *this    swipeable for debugging purposes
    TR::Register     *virtualRegister = getConditionRegister();
 
    virtualRegister->block();
@@ -322,7 +311,6 @@ bool TR::PPCDepConditionalBranchInstruction::usesRegister(TR::Register *reg)
 #if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
 TR::PPCImmInstruction *TR::PPCImmInstruction::getPPCImmInstruction()
    {
-   // *this    swipeable for debugging purposes
    return this;
    }
 #endif
@@ -335,7 +323,6 @@ TR::PPCImmInstruction *TR::PPCImmInstruction::getPPCImmInstruction()
 #if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
 TR::PPCImm2Instruction *TR::PPCImm2Instruction::getPPCImm2Instruction()
    {
-   // *this    swipeable for debugging purposes
    return this;
    }
 #endif
@@ -345,7 +332,6 @@ TR::PPCImm2Instruction *TR::PPCImm2Instruction::getPPCImm2Instruction()
 
 bool TR::PPCSrc1Instruction::refsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (reg == getSource1Register())
       {
       return true;
@@ -355,7 +341,6 @@ bool TR::PPCSrc1Instruction::refsRegister(TR::Register *reg)
 
 void TR::PPCSrc1Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
-   // *this    swipeable for debugging purposes
    TR::Register           *virtualRegister = getSource1Register();
    TR::RealRegister       *assignedRegister = virtualRegister->getAssignedRealRegister();
    TR::Machine *machine = cg()->machine();
@@ -383,7 +368,6 @@ bool TR::PPCSrc1Instruction::defsRealRegister(TR::Register *reg)
 
 bool TR::PPCSrc1Instruction::usesRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (reg == getSource1Register())
       {
       return true;
@@ -395,7 +379,6 @@ bool TR::PPCSrc1Instruction::usesRegister(TR::Register *reg)
 
 TR::PPCDepImmInstruction *TR::PPCDepImmInstruction::getPPCDepImmInstruction()
    {
-   // *this    swipeable for debugging purposes
    return this;
    }
 
@@ -403,7 +386,6 @@ TR::PPCDepImmInstruction *TR::PPCDepImmInstruction::getPPCDepImmInstruction()
 
 bool TR::PPCTrg1Instruction::refsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (reg == getTargetRegister() || TR::Instruction::refsRegister(reg) )
       {
       return true;
@@ -413,7 +395,6 @@ bool TR::PPCTrg1Instruction::refsRegister(TR::Register *reg)
 
 bool TR::PPCTrg1Instruction::defsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (reg == getTargetRegister() || TR::Instruction::defsRegister(reg) )
       {
       return true;
@@ -442,7 +423,6 @@ void TR::PPCTrg1Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
 
 void TR::PPCTrg1Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned, bool excludeGPR0)
    {
-   // *this    swipeable for debugging purposes
    TR::Register           *virtualRegister = getTargetRegister();
    TR::RealRegister       *assignedRegister = virtualRegister->getAssignedRealRegister();
    TR::Machine *machine = cg()->machine();
@@ -513,7 +493,6 @@ TR::PPCTrg1Src1Instruction::PPCTrg1Src1Instruction(
 
 bool TR::PPCTrg1Src1Instruction::refsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (reg == getSource1Register() || TR::PPCTrg1Instruction::refsRegister(reg))
       {
       return true;
@@ -533,7 +512,6 @@ bool TR::PPCTrg1Src1Instruction::defsRealRegister(TR::Register *reg)
 
 bool TR::PPCTrg1Src1Instruction::usesRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (reg == getSource1Register() || TR::PPCTrg1Instruction::usesRegister(reg) )
       {
       return true;
@@ -543,7 +521,6 @@ bool TR::PPCTrg1Src1Instruction::usesRegister(TR::Register *reg)
 
 void TR::PPCTrg1Src1Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
-   // *this    swipeable for debugging purposes
    TR::Register      *sourceVirtual = getSource1Register();
    TR::Register      *targetVirtual = getTargetRegister();
    TR::Machine *machine = cg()->machine();
@@ -598,7 +575,6 @@ void TR::PPCTrg1Src1Instruction::assignRegisters(TR_RegisterKinds kindToBeAssign
 
 bool TR::PPCSrc2Instruction::refsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (reg == getSource1Register() || reg == getSource2Register())
       {
       return true;
@@ -608,19 +584,16 @@ bool TR::PPCSrc2Instruction::refsRegister(TR::Register *reg)
 
 bool TR::PPCSrc2Instruction::defsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    return false;
    }
 
 bool TR::PPCSrc2Instruction::defsRealRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    return false;
    }
 
 bool TR::PPCSrc2Instruction::usesRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if ( reg == getSource1Register()  ||
         reg == getSource2Register())
       {
@@ -631,7 +604,6 @@ bool TR::PPCSrc2Instruction::usesRegister(TR::Register *reg)
 
 void TR::PPCSrc2Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
-   // *this    swipeable for debugging purposes
    TR::Register           *virtualRegister1 = getSource2Register();
    TR::Register           *virtualRegister2 = getSource1Register();
    TR::RealRegister       *assignedRegister;
@@ -665,7 +637,6 @@ void TR::PPCSrc2Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
 
 bool TR::PPCTrg1Src2Instruction::refsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (reg == getTargetRegister() || reg == getSource1Register() || reg == getSource2Register())
       {
       return true;
@@ -675,7 +646,6 @@ bool TR::PPCTrg1Src2Instruction::refsRegister(TR::Register *reg)
 
 bool TR::PPCTrg1Src2Instruction::defsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (reg == getTargetRegister())
       {
       return true;
@@ -685,7 +655,6 @@ bool TR::PPCTrg1Src2Instruction::defsRegister(TR::Register *reg)
 
 bool TR::PPCTrg1Src2Instruction::defsRealRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (reg == getTargetRegister()->getAssignedRegister())
       {
       return true;
@@ -695,7 +664,6 @@ bool TR::PPCTrg1Src2Instruction::defsRealRegister(TR::Register *reg)
 
 bool TR::PPCTrg1Src2Instruction::usesRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if ( reg == getSource1Register()  ||
         reg == getSource2Register())
       {
@@ -706,7 +674,6 @@ bool TR::PPCTrg1Src2Instruction::usesRegister(TR::Register *reg)
 
 void TR::PPCTrg1Src2Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
-   // *this    swipeable for debugging purposes
    TR::Register        *source2Virtual = getSource2Register();
    TR::Machine *machine = cg()->machine();
    TR::RealRegister    *assignedRegister;
@@ -737,7 +704,6 @@ void TR::PPCTrg1Src2Instruction::assignRegisters(TR_RegisterKinds kindToBeAssign
 
 bool TR::PPCTrg1Src3Instruction::refsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (reg == getTargetRegister() || reg == getSource1Register() || reg == getSource2Register() ||
        reg == getSource3Register())
       {
@@ -748,7 +714,6 @@ bool TR::PPCTrg1Src3Instruction::refsRegister(TR::Register *reg)
 
 bool TR::PPCTrg1Src3Instruction::usesRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if ( reg == getSource1Register()  ||
         reg == getSource2Register()  ||
         reg == getSource3Register())
@@ -760,7 +725,6 @@ bool TR::PPCTrg1Src3Instruction::usesRegister(TR::Register *reg)
 
 void TR::PPCTrg1Src3Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
-   // *this    swipeable for debugging purposes
    TR::Register        *source3Virtual = getSource3Register();
    TR::Machine *machine = cg()->machine();
    TR::RealRegister    *assignedRegister;
@@ -818,7 +782,6 @@ TR::PPCMemInstruction::PPCMemInstruction(
    : TR::Instruction(op, n, precedingInstruction, cg),
       _memoryReference(mf)
    {
-   // *this    swipeable for debugging purposes
    if (getOpCode().offsetRequiresWordAlignment())
       {
       mf->setOffsetRequiresWordAlignment(n, cg, getPrev());
@@ -833,19 +796,16 @@ TR::PPCMemInstruction::PPCMemInstruction(
 
 bool TR::PPCMemInstruction::refsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    return getMemoryReference()->refsRegister(reg);
    }
 
 bool TR::PPCMemInstruction::usesRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    return getMemoryReference()->refsRegister(reg);
    }
 
 void TR::PPCMemInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
-   // *this    swipeable for debugging purposes
    getMemoryReference()->assignRegisters(this, cg());
    }
 
@@ -891,7 +851,6 @@ TR::Register *TR::PPCMemSrc1Instruction::getMemoryDataRegister()
 
 bool TR::PPCMemSrc1Instruction::refsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (getMemoryReference()->refsRegister(reg) == true ||
        reg == getSourceRegister())
       {
@@ -902,19 +861,16 @@ bool TR::PPCMemSrc1Instruction::refsRegister(TR::Register *reg)
 
 bool TR::PPCMemSrc1Instruction::defsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    return false;
    }
 
 bool TR::PPCMemSrc1Instruction::defsRealRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    return false;
    }
 
 bool TR::PPCMemSrc1Instruction::usesRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (getMemoryReference()->refsRegister(reg) == true ||
        reg == getSourceRegister())
       {
@@ -925,7 +881,6 @@ bool TR::PPCMemSrc1Instruction::usesRegister(TR::Register *reg)
 
 void TR::PPCMemSrc1Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
-   // *this    swipeable for debugging purposes
    TR::MemoryReference *mref = getMemoryReference();
    TR::Register           *sourceVirtual = getSourceRegister();
    TR::Register           *mBaseVirtual = mref->getModBase();
@@ -1117,7 +1072,6 @@ TR::Register *TR::PPCTrg1MemInstruction::getMemoryDataRegister()
 
 bool TR::PPCTrg1MemInstruction::refsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (reg == getTargetRegister() ||
        getMemoryReference()->refsRegister(reg) == true)
       {
@@ -1128,7 +1082,6 @@ bool TR::PPCTrg1MemInstruction::refsRegister(TR::Register *reg)
 
 bool TR::PPCTrg1MemInstruction::usesRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (getMemoryReference()->refsRegister(reg) == true)
       {
       return true;
@@ -1138,7 +1091,6 @@ bool TR::PPCTrg1MemInstruction::usesRegister(TR::Register *reg)
 
 void TR::PPCTrg1MemInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
-   // *this    swipeable for debugging purposes
    TR::MemoryReference *mref = getMemoryReference();
    TR::Register           *targetVirtual = getTargetRegister();
    TR::Register           *mBaseVirtual = mref->getModBase();

--- a/compiler/p/codegen/PPCInstruction.hpp
+++ b/compiler/p/codegen/PPCInstruction.hpp
@@ -129,7 +129,6 @@ public:
 
    void insertImmediateField(uint32_t *instruction)
       {
-      // *this    swipeable for debugging purposes
       if (getOpCode().useAlternateFormatx())
          {
          // populate 4-bit U field at bit 16
@@ -149,7 +148,6 @@ public:
 
    void insertMaskField(uint32_t *instruction)
       {
-      // *this    swipeable for debugging purposes
       // populate the 8-bit FLM field
       TR_ASSERT(getOpCodeValue() == TR::InstOpCode::mtfsf ||
              getOpCodeValue() == TR::InstOpCode::mtfsfl ||
@@ -196,7 +194,6 @@ class PPCImm2Instruction : public PPCImmInstruction
 
    void insertImmediateField2(uint32_t *instruction)
       {
-      // *this    swipeable for debugging purposes
       // populate 3-bit BF field at bit 6
       TR_ASSERT(getOpCodeValue() == TR::InstOpCode::mtfsfi, "Only configured for mtsfi");
 
@@ -256,7 +253,6 @@ class PPCSrc1Instruction : public PPCImmInstruction
 
    void insertSource1Register(uint32_t *instruction)
       {
-      // *this    swipeable for debugging purposes
       TR::RealRegister *target = toRealRegister(_source1Register);
       if (getOpCode().useAlternateFormatx())
          {
@@ -573,7 +569,6 @@ class PPCConditionalBranchInstruction : public PPCLabelInstruction
 
    void insertConditionRegister(uint32_t *instruction)
       {
-      // *this    swipeable for debugging purposes
       TR::RealRegister *condRegister = toRealRegister(_conditionRegister);
       condRegister->setRegisterFieldBI(instruction);
       }
@@ -823,7 +818,6 @@ class PPCTrg1Instruction : public TR::Instruction
 
    void insertTargetRegister(uint32_t *instruction)
       {
-      // *this    swipeable for debugging purposes
       TR::RealRegister *target = toRealRegister(_target1Register);
       if (isVSX())
          target->setRegisterFieldXT(instruction);
@@ -888,7 +882,6 @@ class PPCTrg1ImmInstruction : public PPCTrg1Instruction
 
    void insertImmediateField(uint32_t *instruction)
       {
-      // *this    swipeable for debugging purposes
       if (!isVMX())
          {
          if (getOpCodeValue() == TR::InstOpCode::addpcis)
@@ -966,14 +959,12 @@ class PPCSrc2Instruction : public TR::Instruction
 
    void insertSource1Register(uint32_t *instruction)
       {
-      // *this    swipeable for debugging purposes
       TR::RealRegister *source2 = toRealRegister(_source1Register);
       source2->setRegisterFieldRA(instruction);
       }
 
    void insertSource2Register(uint32_t *instruction)
       {
-      // *this    swipeable for debugging purposes
       TR::RealRegister *source2 = toRealRegister(_source2Register);
       source2->setRegisterFieldRB(instruction);
       }
@@ -1024,7 +1015,6 @@ class PPCTrg1Src1Instruction : public PPCTrg1Instruction
 
    void insertSource1Register(uint32_t *instruction)
       {
-      // *this    swipeable for debugging purposes
       TR::RealRegister *source1 = toRealRegister(_source1Register);
       if (getOpCode().useAlternateFormat())
          {
@@ -1048,7 +1038,6 @@ class PPCTrg1Src1Instruction : public PPCTrg1Instruction
 
    void insertTargetRegister(uint32_t *instruction)
       {
-      // *this    swipeable for debugging purposes
       TR::RealRegister *target = toRealRegister(getTargetRegister());
       if (getOpCode().useAlternateFormatx())
          {
@@ -1159,7 +1148,6 @@ class PPCTrg1Src1ImmInstruction : public PPCTrg1Src1Instruction
 
    void insertImmediateField(uint32_t *instruction)
       {
-      // *this    swipeable for debugging purposes
       if (!isVMX() && !isVSX())
          *instruction |= _source1Immediate & 0xffff;
       else
@@ -1322,7 +1310,6 @@ class PPCTrg1Src2Instruction : public PPCTrg1Src1Instruction
 
    void insertTargetRegister(uint32_t *instruction)
       {
-      // *this    swipeable for debugging purposes
       TR::RealRegister *target = toRealRegister(getTargetRegister());
       if (getOpCode().useAlternateFormatx())
          {
@@ -1339,7 +1326,6 @@ class PPCTrg1Src2Instruction : public PPCTrg1Src1Instruction
 
    void insertSource1Register(uint32_t *instruction)
       {
-      // *this    swipeable for debugging purposes
       TR::RealRegister *source1 = toRealRegister(getSource1Register());
       if (getOpCode().useAlternateFormatx())
          {
@@ -1356,7 +1342,6 @@ class PPCTrg1Src2Instruction : public PPCTrg1Src1Instruction
 
    void insertSource2Register(uint32_t *instruction)
       {
-      // *this    swipeable for debugging purposes
       TR::RealRegister *source2 = toRealRegister(_source2Register);
       if (getOpCode().useAlternateFormat())
          {
@@ -1473,7 +1458,6 @@ class PPCTrg1Src3Instruction : public PPCTrg1Src2Instruction
 
    void insertTargetRegister(uint32_t *instruction)
       {
-      // *this    swipeable for debugging purposes
       TR::RealRegister *target = toRealRegister(getTargetRegister());
       if (getOpCode().useAlternateFormatx())
          {
@@ -1487,7 +1471,6 @@ class PPCTrg1Src3Instruction : public PPCTrg1Src2Instruction
 
    void insertSource1Register(uint32_t *instruction)
       {
-      // *this    swipeable for debugging purposes
       TR::RealRegister *source1 = toRealRegister(getSource1Register());
       if (getOpCode().useAlternateFormatx())
          {
@@ -1501,7 +1484,6 @@ class PPCTrg1Src3Instruction : public PPCTrg1Src2Instruction
 
    void insertSource2Register(uint32_t *instruction)
       {
-      // *this    swipeable for debugging purposes
       TR::RealRegister *source2 = toRealRegister(getSource2Register());
       if (isFloat())
           source2->setRegisterFieldFRC(instruction);
@@ -1511,7 +1493,6 @@ class PPCTrg1Src3Instruction : public PPCTrg1Src2Instruction
 
    void insertSource3Register(uint32_t *instruction)
       {
-      // *this    swipeable for debugging purposes
       TR::RealRegister *source3 = toRealRegister(_source3Register);
       if (isFloat())
          source3->setRegisterFieldFRB(instruction);
@@ -1676,7 +1657,6 @@ class PPCMemSrc1Instruction : public PPCMemInstruction
 
    void insertSourceRegister(uint32_t *instruction)
       {
-      // *this    swipeable for debugging purposes
       TR::RealRegister *source = toRealRegister(_sourceRegister);
 
       if (isVSX())

--- a/compiler/p/codegen/PPCSystemLinkage.cpp
+++ b/compiler/p/codegen/PPCSystemLinkage.cpp
@@ -364,7 +364,6 @@ TR::PPCSystemLinkage::getProperties()
 void
 TR::PPCSystemLinkage::initPPCRealRegisterLinkage()
    {
-   // *this    swipeable for debugging purposes
    // Each real register's weight is set to match this linkage convention
    TR::Machine *machine = cg()->machine();
    int icount;
@@ -421,7 +420,6 @@ TR::PPCSystemLinkage::initPPCRealRegisterLinkage()
 uint32_t
 TR::PPCSystemLinkage::getRightToLeft()
    {
-   // *this    swipeable for debugging purposes
    return getProperties().getRightToLeft();
    }
 
@@ -529,7 +527,6 @@ TR::PPCSystemLinkage::mapParameters(
 void
 TR::PPCSystemLinkage::mapStack(TR::ResolvedMethodSymbol *method)
    {
-   // *this    swipeable for debugging purposes
    ListIterator<TR::AutomaticSymbol> automaticIterator(&method->getAutomaticList());
    TR::AutomaticSymbol *localCursor = automaticIterator.getFirst();
    const TR::PPCLinkageProperties& linkage = getProperties();
@@ -600,7 +597,6 @@ TR::PPCSystemLinkage::mapSingleAutomatic(
       TR::AutomaticSymbol *p,
       uint32_t &stackIndex)
    {
-   // *this    swipeable for debugging purposes
    size_t align = 1;
    size_t size = p->getSize();
 
@@ -633,7 +629,6 @@ TR::PPCSystemLinkage::createPrologue(
       TR::Instruction *cursor,
       List<TR::ParameterSymbol> &parmList)
    {
-   // *this    swipeable for debugging purposes
    TR::Machine *machine = cg()->machine();
    const TR::PPCLinkageProperties &properties = getProperties();
    TR::ResolvedMethodSymbol        *bodySymbol = comp()->getJittedMethodSymbol();
@@ -759,7 +754,6 @@ TR::PPCSystemLinkage::createPrologue(
 void
 TR::PPCSystemLinkage::createEpilogue(TR::Instruction *cursor)
    {
-   // *this    swipeable for debugging purposes
    int32_t blockNumber = cursor->getNext()->getBlockIndex();
    TR::Machine *machine = cg()->machine();
    const TR::PPCLinkageProperties &properties = getProperties();
@@ -855,7 +849,6 @@ int32_t TR::PPCSystemLinkage::buildArgs(TR::Node *callNode,
                                        TR::RegisterDependencyConditions *dependencies)
 
    {
-   // *this    swipeable for debugging purposes
    const TR::PPCLinkageProperties &properties = getProperties();
    TR::PPCMemoryArgument *pushToMemory = NULL;
    TR::Register       *tempRegister;
@@ -1683,7 +1676,6 @@ void TR::PPCSystemLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSy
 
 void TR::PPCSystemLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol *method, List<TR::ParameterSymbol> &parmList)
    {
-   // *this    swipeable for debugging purposes
    ListIterator<TR::ParameterSymbol>   paramIterator(&parmList);
    TR::ParameterSymbol      *paramCursor = paramIterator.getFirst();
    int32_t                  numIntArgs = 0, numFloatArgs = 0;

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -868,7 +868,6 @@ TR_Debug::printSnippetLabel(TR::FILE *pOutFile, TR::LabelSymbol *label, uint8_t 
 void
 TR_Debug::print(TR::FILE *pOutFile, TR_BitVector * bv)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL) return;
 
    trfprintf(pOutFile,"{");
@@ -908,7 +907,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR_SingleBitContainer *sbc)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::BitVector * bv)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL) return;
 
    trfprintf(pOutFile,"{");
@@ -937,7 +935,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::BitVector * bv)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::SparseBitVector * sparse)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL) return;
 
    trfprintf(pOutFile,"{");
@@ -966,7 +963,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::SparseBitVector * sparse)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::SymbolReference * symRef)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL) return;
 
    TR_PrettyPrinterString  output(this);
@@ -1722,7 +1718,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::SymbolReferenceTable * symRefTab)
 void
 TR_Debug::printAliasInfo(TR::FILE *pOutFile, TR::SymbolReferenceTable * symRefTab)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL) return;
 
    trfprintf(pOutFile, "\nSymbol References with Aliases:\n\n");
@@ -1734,7 +1729,6 @@ TR_Debug::printAliasInfo(TR::FILE *pOutFile, TR::SymbolReferenceTable * symRefTa
 void
 TR_Debug::printAliasInfo(TR::FILE *pOutFile, TR::SymbolReference * symRef)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL) return;
 
    TR_BitVector * useDefAliases = symRef->getUseDefAliasesBV();
@@ -2512,7 +2506,6 @@ TR_Debug::dumpSingleTreeWithInstrs(TR::TreeTop     *treeTop,
 void
 TR_Debug::dumpMethodInstrs(TR::FILE *pOutFile, const char *title, bool dumpTrees, bool header)
    {
-   // *this    swipeable for debugging purposes
    const char * methodName = NULL;
    int32_t bfLineNo = -1;
    int32_t efLineNo = -1;

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -301,7 +301,6 @@ TR_Debug::printLoadConst(TR::Node *node, TR_PrettyPrinterString& output)
 void
 TR_Debug::print(TR::FILE *pOutFile,  TR::CFG * cfg)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -426,7 +425,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR_Structure * structure, uint32_t indentati
 void
 TR_Debug::print(TR::FILE *pOutFile, TR_RegionStructure * regionStructure, uint32_t indentation)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -525,7 +523,6 @@ TR_Debug::printPreds(TR::FILE *pOutFile, TR::CFGNode *node)
 void
 TR_Debug::printSubGraph(TR::FILE *pOutFile, TR_RegionStructure * regionStructure, uint32_t indentation)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -670,7 +667,6 @@ TR_Debug::printSubGraph(TR::FILE *pOutFile, TR_RegionStructure * regionStructure
 void
 TR_Debug::print(TR::FILE *pOutFile, TR_InductionVariable * inductionVariable, uint32_t indentation)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -691,7 +687,6 @@ static const char *structNames[] = { "Blank", "Block", "Region" };
 void
 TR_Debug::printBaseInfo(TR::FILE *pOutFile, TR_Structure * structure, uint32_t indentation)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -709,7 +704,6 @@ TR_Debug::printBaseInfo(TR::FILE *pOutFile, TR_Structure * structure, uint32_t i
 void
 TR_Debug::print(TR::FILE *pOutFile, TR_BlockStructure * blockStructure, uint32_t indentation)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -759,7 +753,6 @@ TR_Debug::printNodesInEdgeListIterator(TR::FILE *pOutFile, TR::CFGEdgeList &li, 
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::Block * block, uint32_t indentation)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -1257,7 +1250,6 @@ TR_Debug::printWithFixedPrefix(TR::FILE *pOutFile, TR::Node * node, uint32_t ind
    TR_PrettyPrinterString globalIndexPrefix(this),
                           output(this);
 
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL) return 0;
 
    _comp->setNodeOpCodeLength(0);
@@ -3698,7 +3690,6 @@ TR_Debug::verifyTreesPass1(TR::Node *node)
 void
 TR_Debug::verifyTreesPass2(TR::Node *node, bool isTreeTop)
    {
-   // *this    swipeable for debugging purposes
 
    // Verify the reference count. Pass 1 should have set the localIndex to the
    // reference count.
@@ -3844,7 +3835,6 @@ TR_Debug::verifyBlocks(TR::ResolvedMethodSymbol * methodSymbol)
 void
 TR_Debug::verifyBlocksPass1(TR::Node *node)
    {
-   // *this    swipeable for debugging purposes
 
    // If this is the first time through this node, verify the children
    //
@@ -3872,7 +3862,6 @@ TR_Debug::verifyBlocksPass1(TR::Node *node)
 void
 TR_Debug::verifyBlocksPass2(TR::Node *node)
    {
-   // *this    swipeable for debugging purposes
 
    // Pass through and make sure that the localIndex == 0 for each child
    //

--- a/compiler/x/amd64/codegen/AMD64FPConversionSnippet.cpp
+++ b/compiler/x/amd64/codegen/AMD64FPConversionSnippet.cpp
@@ -53,8 +53,6 @@ static const uint8_t popBinary[] =
 
 uint8_t *TR::AMD64FPConversionSnippet::genFPConversion(uint8_t *buffer)
    {
-   // *this    swipeable for debugging purposes
-
    // This didn't end up as clean as I thought.  TODO:AMD64: Separate out the 64-bit code into another class.
 
    TR::ILOpCodes              opCode          = _convertInstruction->getNode()->getOpCodeValue();
@@ -216,7 +214,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::AMD64FPConversionSnippet * snippet)
 
 uint32_t TR::AMD64FPConversionSnippet::getLength(int32_t estimatedSnippetStart)
    {
-   // *this    swipeable for debugging purposes
    uint32_t length = 11;
    TR::Machine *machine = cg()->machine();
 

--- a/compiler/x/codegen/BinaryCommutativeAnalyser.cpp
+++ b/compiler/x/codegen/BinaryCommutativeAnalyser.cpp
@@ -137,7 +137,6 @@ TR::Register* TR_X86BinaryCommutativeAnalyser::genericAnalyserImpl(TR::Node     
                                                                    TR_X86OpCodes copyOpCode,
                                                                    bool           nonClobberingDestination)
    {
-   // *this    swipeable for debugging purposes
    TR::Register *targetRegister;
 
    TR::Register *firstRegister  = firstChild->getRegister();
@@ -248,7 +247,6 @@ void TR_X86BinaryCommutativeAnalyser::genericLongAnalyser(TR::Node       *root,
                                                            TR_X86OpCodes highRegMemOpCode,
                                                            TR_X86OpCodes copyOpCode)
    {
-   // *this    swipeable for debugging purposes
    TR::Node *firstChild;
    TR::Node *secondChild;
    if (_cg->whichChildToEvaluate(root) == 0)
@@ -765,7 +763,6 @@ TR::Register *TR_X86BinaryCommutativeAnalyser::integerAddAnalyserImpl(TR::Node  
                                                                       bool          needsEflags,     
                                                                       TR::Node      *carry)
    {
-   // *this    swipeable for debugging purposes
    TR::Register *targetRegister;
    TR::Compilation* comp = TR::comp();
    TR::Register *firstRegister  = firstChild->getRegister();
@@ -988,7 +985,6 @@ void TR_X86BinaryCommutativeAnalyser::longAddAnalyser(TR::Node *root)
  */
 TR::Register* TR_X86BinaryCommutativeAnalyser::longAddAnalyserImpl(TR::Node *root, TR::Node *&firstChild, TR::Node *&secondChild)
    {
-   // *this    swipeable for debugging purposes
    TR::Register *twoLow       = NULL;
    TR::Register *twoHigh      = NULL;
    TR::Register *oneLow       = NULL;
@@ -1581,7 +1577,6 @@ void TR_X86BinaryCommutativeAnalyser::longDualMultiplyAnalyser(TR::Node *root)
 
 void TR_X86BinaryCommutativeAnalyser::longMultiplyAnalyser(TR::Node *root)
    {
-   // *this    swipeable for debugging purposes
    TR::Node *firstChild  = 0;
    TR::Node *secondChild = 0;
    if (_cg->whichChildToEvaluate(root) == 0)

--- a/compiler/x/codegen/CompareAnalyser.cpp
+++ b/compiler/x/codegen/CompareAnalyser.cpp
@@ -200,7 +200,6 @@ void TR_X86CompareAnalyser::longOrderedCompareAndBranchAnalyser(TR::Node       *
                                                                  TR_X86OpCodes highBranchOpCode,
                                                                  TR_X86OpCodes highReversedBranchOpCode)
    {
-   // *this    swipeable for debugging purposes
    TR::Node     *firstChild     = root->getFirstChild();
    TR::Node     *secondChild    = root->getSecondChild();
    TR::Register *firstRegister  = firstChild->getRegister();
@@ -749,7 +748,6 @@ void TR_X86CompareAnalyser::longEqualityCompareAndBranchAnalyser(TR::Node       
                                                                   TR::LabelSymbol *secondBranchLabel,
                                                                   TR_X86OpCodes  secondBranchOp)
    {
-   // *this    swipeable for debugging purposes
    TR::Node     *firstChild     = root->getFirstChild();
    TR::Node     *secondChild    = root->getSecondChild();
    TR::Register *firstRegister  = firstChild->getRegister();
@@ -967,7 +965,6 @@ TR::Register *TR_X86CompareAnalyser::longEqualityBooleanAnalyser(TR::Node       
                                                                  TR_X86OpCodes setOpCode,
                                                                  TR_X86OpCodes combineOpCode)
    {
-   // *this    swipeable for debugging purposes
    TR::Node     *firstChild     = root->getFirstChild();
    TR::Node     *secondChild    = root->getSecondChild();
    TR::Register *firstRegister  = firstChild->getRegister();
@@ -1051,7 +1048,6 @@ TR::Register *TR_X86CompareAnalyser::longOrderedBooleanAnalyser(TR::Node       *
                                                                 TR_X86OpCodes highSetOpCode,
                                                                 TR_X86OpCodes lowSetOpCode)
    {
-   // *this    swipeable for debugging purposes
    TR::Node     *firstChild     = root->getFirstChild();
    TR::Node     *secondChild    = root->getSecondChild();
    TR::Register *firstRegister  = firstChild->getRegister();
@@ -1174,7 +1170,6 @@ TR::Register *TR_X86CompareAnalyser::longOrderedBooleanAnalyser(TR::Node       *
 
 TR::Register *TR_X86CompareAnalyser::longCMPAnalyser(TR::Node *root)
    {
-   // *this    swipeable for debugging purposes
    TR::Node     *firstChild     = root->getFirstChild();
    TR::Node     *secondChild    = root->getSecondChild();
    TR::Register *firstRegister  = firstChild->getRegister();

--- a/compiler/x/codegen/DataSnippet.cpp
+++ b/compiler/x/codegen/DataSnippet.cpp
@@ -69,7 +69,6 @@ TR::IA32DataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
 
 uint8_t *TR::IA32DataSnippet::emitSnippetBody()
    {
-   // *this   swipeable for debugging purposes
 
    uint8_t *cursor = cg()->getBinaryBufferCursor();
 
@@ -142,7 +141,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::IA32DataSnippet * snippet)
 
 uint32_t TR::IA32DataSnippet::getLength(int32_t estimatedSnippetStart)
    {
-   // *this   swipeable for debugging purposes
    return _length;
    }
 

--- a/compiler/x/codegen/DivideCheckSnippet.cpp
+++ b/compiler/x/codegen/DivideCheckSnippet.cpp
@@ -32,7 +32,6 @@
 
 uint8_t *TR::X86DivideCheckSnippet::emitSnippetBody()
    {
-   // *this    swipeable for debugging purposes
    uint8_t *buffer = cg()->getBinaryBufferCursor();
    getSnippetLabel()->setCodeLocation(buffer);
 
@@ -93,7 +92,6 @@ uint8_t *TR::X86DivideCheckSnippet::emitSnippetBody()
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86DivideCheckSnippet  * snippet) // TODO:FIX THIS!!!
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 

--- a/compiler/x/codegen/FPBinaryArithmeticAnalyser.cpp
+++ b/compiler/x/codegen/FPBinaryArithmeticAnalyser.cpp
@@ -66,7 +66,6 @@ void TR_X86FPBinaryArithmeticAnalyser::setInputs(TR::Node     *firstChild,
                                                   TR::Node     *secondChild,
                                                   TR::Register *secondRegister)
    {
-   // *this    swipeable for debugging purposes
 
    if (firstRegister)
       {
@@ -164,7 +163,6 @@ TR_X86FPBinaryArithmeticAnalyser::isIntToFPConversion(TR::Node *child)
 
 void TR_X86FPBinaryArithmeticAnalyser::genericFPAnalyser(TR::Node *root)
    {
-   // *this    swipeable for debugging purposes
 
    TR::Register         *targetRegister     = NULL,
                         *sourceRegister     = NULL,

--- a/compiler/x/codegen/FPCompareAnalyser.cpp
+++ b/compiler/x/codegen/FPCompareAnalyser.cpp
@@ -346,7 +346,6 @@ void TR_X86FPCompareAnalyser::setInputs(TR::Node     *firstChild,
                                          bool         disallowMemoryFormInstructions,
                                          bool         disallowOperandSwapping)
    {
-   // *this    swipeable for debugging purposes
 
 
    if (firstRegister)

--- a/compiler/x/codegen/HelperCallSnippet.cpp
+++ b/compiler/x/codegen/HelperCallSnippet.cpp
@@ -319,7 +319,6 @@ uint8_t *TR::X86HelperCallSnippet::genHelperCall(uint8_t *buffer)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86HelperCallSnippet  * snippet)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
    uint8_t *bufferPos = snippet->getSnippetLabel()->getCodeLocation();
@@ -330,7 +329,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86HelperCallSnippet  * snippet)
 void
 TR_Debug::printBody(TR::FILE *pOutFile, TR::X86HelperCallSnippet  * snippet, uint8_t *bufferPos)
    {
-   // *this    swipeable for debugging purposes
    TR_ASSERT(pOutFile != NULL, "assertion failure");
    TR::MethodSymbol *sym = snippet->getDestination()->getSymbol()->castToMethodSymbol();
 
@@ -424,7 +422,6 @@ TR_Debug::printBody(TR::FILE *pOutFile, TR::X86HelperCallSnippet  * snippet, uin
 
 uint32_t TR::X86HelperCallSnippet::getLength(int32_t estimatedSnippetStart)
    {
-   // *this    swipeable for debugging purposes
    uint32_t length = 35;
 
    if (_callNode)

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -602,7 +602,6 @@ void
 OMR::X86::CodeGenerator::endInstructionSelection()
    {
    TR::Compilation *comp = self()->comp();
-   // *this    swipeable for debugging purposes
    if (_returnTypeInfoInstruction != NULL)
       {
       TR_ReturnInfo returnInfo = comp->getReturnInfo();
@@ -1522,7 +1521,6 @@ void OMR::X86::CodeGenerator::doBackwardsRegisterAssignment(
 
 void OMR::X86::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
    {
-   // *this    swipeable for debugging purposes
    TR::Instruction *instructionCursor;
    TR::Instruction *nextInstruction;
 
@@ -2229,7 +2227,6 @@ TR_OutlinedInstructions * OMR::X86::CodeGenerator::findOutlinedInstructionsFromM
 
 TR::IA32ConstantDataSnippet * OMR::X86::CodeGenerator::findOrCreateConstant(TR::Node * n, void * c, uint8_t size, bool isWarm)
    {
-   // *this    swipeable for debugging purposes
 
     TR::IA32DataSnippet * cursor;
 
@@ -2291,7 +2288,6 @@ TR::IA32ConstantDataSnippet * OMR::X86::CodeGenerator::findOrCreateConstant(TR::
 
 int32_t OMR::X86::CodeGenerator::setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart, bool isWarm)
    {
-   // *this    swipeable for debugging purposes
    bool                                     first;
    int32_t                                  size;
 
@@ -2321,7 +2317,6 @@ int32_t OMR::X86::CodeGenerator::setEstimatedLocationsForDataSnippetLabels(int32
 
 void OMR::X86::CodeGenerator::emitDataSnippets(bool isWarm)
    {
-   // *this    swipeable for debugging purposes
 
    TR::IA32DataSnippet              * cursor;
    uint8_t                                 * codeOffset;
@@ -3759,7 +3754,6 @@ void OMR::X86::CodeGenerator::removeUnavailableRegisters(TR_RegisterCandidate * 
 
 void OMR::X86::CodeGenerator::dumpDataSnippets(TR::FILE *outFile, bool isWarm)
    {
-   // *this    swipeable for debugging purposes
 
    if (outFile == NULL)
       return;

--- a/compiler/x/codegen/OMRLinkage.cpp
+++ b/compiler/x/codegen/OMRLinkage.cpp
@@ -317,7 +317,6 @@ void OMR::X86::Linkage::mapCompactedStack(TR::ResolvedMethodSymbol *method)
 
 void OMR::X86::Linkage::mapStack(TR::ResolvedMethodSymbol *method)
    {
-   // *this    swipeable for debugging purposes
 
    if (self()->cg()->getLocalsIG() && self()->cg()->getSupportsCompactedLocals())
       {

--- a/compiler/x/codegen/OMRMachine.cpp
+++ b/compiler/x/codegen/OMRMachine.cpp
@@ -229,7 +229,6 @@ OMR::X86::Machine::findBestFreeGPRegister(TR::Instruction   *currentInstruction,
                                       TR_RegisterSizes  requestedRegSize,
                                       bool              considerUnlatched)
    {
-   // *this    swipeable for debugging purposes
    int first, last, i;
 
    struct TR_Candidate
@@ -1032,7 +1031,6 @@ TR::RealRegister *OMR::X86::Machine::reverseGPRSpillState(TR::Instruction     *c
                                                         TR::RealRegister *targetRegister,
                                                         TR_RegisterSizes    requestedRegSize)
    {
-   // *this    swipeable for debugging purposes
    TR::Compilation *comp = self()->cg()->comp();
    if (targetRegister == NULL)
       {
@@ -1295,7 +1293,6 @@ void OMR::X86::Machine::coerceXMMRegisterAssignment(TR::Instruction          *cu
                                                 TR::RealRegister::RegNum  regNum,
                                                 bool                     coerceToSatisfyRegDeps)
    {
-   // *this    swipeable for debugging purposes
    TR::RealRegister *targetRegister          = _registerFile[regNum];
    TR::RealRegister    *currentAssignedRegister = virtualRegister->getAssignedRealRegister();
    TR::Instruction     *instr                   = NULL;
@@ -1478,7 +1475,6 @@ void OMR::X86::Machine::swapGPRegisters(TR::Instruction          *currentInstruc
                                     TR::RealRegister::RegNum  regNum1,
                                     TR::RealRegister::RegNum  regNum2)
    {
-   // *this    swipeable for debugging purposes
    TR::RealRegister *realReg1 = self()->getX86RealRegister(regNum1);
    TR::RealRegister *realReg2 = self()->getX86RealRegister(regNum2);
    TR::Instruction *instr = new (self()->cg()->trHeapMemory()) TR::X86RegRegInstruction(currentInstruction, XCHGRegReg(), realReg1, realReg2, self()->cg());
@@ -1530,7 +1526,6 @@ void OMR::X86::Machine::coerceGPRegisterAssignment(TR::Instruction   *currentIns
 
 void OMR::X86::Machine::setGPRWeightsFromAssociations()
    {
-   // *this    swipeable for debugging purposes
    const TR::X86LinkageProperties &linkageProperties = self()->cg()->getProperties();
 
    for (int i = TR::RealRegister::FirstGPR;
@@ -1577,7 +1572,6 @@ void OMR::X86::Machine::setGPRWeightsFromAssociations()
 void
 OMR::X86::Machine::createRegisterAssociationDirective(TR::Instruction *cursor)
    {
-   // *this    swipeable for debugging purposes
    TR::Compilation *comp = self()->cg()->comp();
    TR::RegisterDependencyConditions  *associations =
       generateRegisterDependencyConditions((uint8_t)0, TR::RealRegister::LastAssignableGPR, self()->cg());
@@ -1630,7 +1624,6 @@ OMR::X86::Machine::createRegisterAssociationDirective(TR::Instruction *cursor)
 void
 OMR::X86::Machine::initialiseRegisterFile(const struct TR::X86LinkageProperties &properties)
    {
-   // *this    swipeable for debugging purposes
    int reg;
 
    // Special pseudo-registers
@@ -2401,7 +2394,6 @@ void OMR::X86::Machine::resetFPStackRegisters()
 
 void OMR::X86::Machine::initialiseFPStackRegisterFile()
    {
-   // *this    swipeable for debugging purposes
    _fpStack[TR_X86FPStackRegister::fp0] = new (self()->cg()->trHeapMemory()) TR_X86FPStackRegister(TR_X86FPStackRegister::Free,
                                                                     TR_X86FPStackRegister::fp0,
                                                                     TR::RealRegister::NoReg, self()->cg());
@@ -2442,7 +2434,6 @@ bool OMR::X86::Machine::isFPRTopOfStack(TR::Register *virtReg)
 //
 void OMR::X86::Machine::fpStackPush(TR::Register *virtReg)
    {
-   // *this    swipeable for debugging purposes
 
    _fpTopOfStack++;
 
@@ -2467,7 +2458,6 @@ void OMR::X86::Machine::fpStackPush(TR::Register *virtReg)
 //
 void OMR::X86::Machine::fpStackCoerce(TR::Register *virtReg, int32_t stackLocation)
    {
-   // *this    swipeable for debugging purposes
    //
    // Check for stack overflow.
    //
@@ -2489,7 +2479,6 @@ void OMR::X86::Machine::fpStackCoerce(TR::Register *virtReg, int32_t stackLocati
 //
 TR::Register *OMR::X86::Machine::fpStackPop()
    {
-   // *this    swipeable for debugging purposes
 
    // Check for stack underflow.
    //
@@ -2526,7 +2515,6 @@ TR::Instruction  *OMR::X86::Machine::fpStackFXCH(TR::Instruction *prevInstructio
                                                 TR::Register    *vreg,
                                                 bool            generateCode)
    {
-   // *this    swipeable for debugging purposes
 
    TR_X86FPStackRegister *fpReg   = toX86FPStackRegister(vreg->getAssignedRegister());
    int32_t                vregNum = (int32_t) fpReg->getFPStackRegisterNumber();
@@ -2568,7 +2556,6 @@ TR::Instruction  *OMR::X86::Machine::fpStackFXCH(TR::Instruction *prevInstructio
 TR::Instruction  *OMR::X86::Machine::fpStackFXCH(TR::Instruction *prevInstruction,
                                                 int32_t         stackReg)
    {
-   // *this    swipeable for debugging purposes
    TR_X86FPStackRegister *pTop = _fpStack[_fpTopOfStack];
    int32_t vRegNum             = _fpTopOfStack - stackReg;
 
@@ -2614,7 +2601,6 @@ void OMR::X86::Machine::fpCoerceRegistersToTopOfStack(TR::Instruction *prevInstr
                                                    TR::Register    *Y,
                                                    bool            strict)
    {
-   // *this    swipeable for debugging purposes
 
    TR_X86FPStackRegister *xReg       = toX86FPStackRegister(X->getAssignedRegister());
    int32_t                 x         = (int32_t) xReg->getFPStackRegisterNumber();
@@ -2697,7 +2683,6 @@ void OMR::X86::Machine::fpCoerceRegistersToTopOfStack(TR::Instruction *prevInstr
 //
 TR_X86OpCodes OMR::X86::Machine::fpDetermineReverseOpCode(TR_X86OpCodes op)
    {
-   // *this    swipeable for debugging purposes
 
    switch (op)
       {
@@ -2733,7 +2718,6 @@ TR_X86OpCodes OMR::X86::Machine::fpDetermineReverseOpCode(TR_X86OpCodes op)
 //
 TR_X86OpCodes OMR::X86::Machine::fpDeterminePopOpCode(TR_X86OpCodes op)
    {
-   // *this    swipeable for debugging purposes
 
    switch (op)
       {
@@ -2785,7 +2769,6 @@ TR_X86OpCodes OMR::X86::Machine::fpDeterminePopOpCode(TR_X86OpCodes op)
 //
 TR_X86FPStackRegister *OMR::X86::Machine::findFreeFPRegister()
    {
-   // *this    swipeable for debugging purposes
 
    TR_X86FPStackRegister *freeRegister = NULL;
    int32_t                nextFPReg = _fpTopOfStack + 1;
@@ -2805,7 +2788,6 @@ TR_X86FPStackRegister *OMR::X86::Machine::findFreeFPRegister()
 //
 TR::Instruction *OMR::X86::Machine::freeBestFPRegister(TR::Instruction *prevInstruction)
    {
-   // *this    swipeable for debugging purposes
 
    TR::Register *candidates[TR_X86FPStackRegister::NumRegisters];
    int          numCandidates = 0;
@@ -2859,7 +2841,6 @@ TR::Instruction *OMR::X86::Machine::freeBestFPRegister(TR::Instruction *prevInst
 TR::Instruction *OMR::X86::Machine::fpSpillFPR(TR::Instruction *prevInstruction,
                                            TR::Register    *vreg)
    {
-   // *this    swipeable for debugging purposes
 
    TR_X86FPStackRegister *fpReg = toX86FPStackRegister(vreg->getAssignedRegister());
    TR::Instruction        *cursor = prevInstruction;
@@ -2902,7 +2883,6 @@ TR::Instruction *OMR::X86::Machine::fpSpillFPR(TR::Instruction *prevInstruction,
 TR::Instruction *OMR::X86::Machine::reverseFPRSpillState(TR::Instruction *prevInstruction,
                                                      TR::Register    *spilledRegister)
    {
-   // *this    swipeable for debugging purposes
    TR::Instruction *cursor = prevInstruction;
 
    if (self()->isFPStackFull())
@@ -2935,7 +2915,6 @@ TR::Instruction *OMR::X86::Machine::reverseFPRSpillState(TR::Instruction *prevIn
 //
 TR::Instruction *OMR::X86::Machine::fpSpillStack(TR::Instruction *prevInstruction)
    {
-   // *this    swipeable for debugging purposes
    TR::Instruction *cursor = prevInstruction;
    int32_t top = _fpTopOfStack;
 
@@ -2980,7 +2959,6 @@ void OMR::X86::Machine::printGPRegisterStatus(TR_FrontEnd *fe, TR::RealRegister 
 //
 void OMR::X86::Machine::printFPRegisterStatus(TR_FrontEnd *fe, TR::FILE *pOutFile)
    {
-   // *this    swipeable for debugging purposes
    char buf[32];
    char *cursor;
    int32_t i,j;

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -163,7 +163,6 @@ OMR::X86::MemoryReference::MemoryReference(
    _flags(0),
    _reloKind(-1)
    {
-   // *this    swipeable for debugging purposes
    TR::SymbolReference *symRef = rootLoadOrStore->getSymbolReference();
    TR::Compilation *comp = cg->comp();
 
@@ -343,7 +342,6 @@ OMR::X86::MemoryReference::MemoryReference(
       TR_ScratchRegisterManager *srm) :
    _symbolReference(cg->comp()->getSymRefTab())
    {
-   // *this    swipeable for debugging purposes
    TR::Compilation *comp = cg->comp();
    _baseRegister = mr._baseRegister;
    _baseNode = mr._baseNode;
@@ -414,7 +412,6 @@ OMR::X86::MemoryReference::checkAndDecReferenceCount(
 void
 OMR::X86::MemoryReference::decNodeReferenceCounts(TR::CodeGenerator *cg)
    {
-   // *this    swipeable for debugging purposes
    TR::Register *vmThreadReg = cg->getVMThreadRegister();
 
    if (_baseRegister != NULL)
@@ -467,7 +464,6 @@ OMR::X86::MemoryReference::useRegisters(
       TR::Instruction *instr,
       TR::CodeGenerator *cg)
    {
-   // *this    swipeable for debugging purposes
    if (_baseRegister != NULL)
       {
       instr->useRegister(_baseRegister);
@@ -485,7 +481,6 @@ OMR::X86::MemoryReference::getStrideForNode(
       TR::Node *node,
       TR::CodeGenerator *cg)
    {
-   // *this    swipeable for debugging purposes
    int32_t stride = 0;
    if (node->getOpCodeValue() == TR::imul || node->getOpCodeValue() == TR::lmul)
       {
@@ -872,7 +867,6 @@ OMR::X86::MemoryReference::assignRegisters(
       TR::Instruction *currentInstruction,
       TR::CodeGenerator *cg)
    {
-   // *this    swipeable for debugging purposes
    TR::RealRegister *assignedBaseRegister = NULL;
    TR::RealRegister *assignedIndexRegister;
    TR::UnresolvedDataSnippet *snippet = self()->getUnresolvedDataSnippet();
@@ -1388,7 +1382,6 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
       TR::Instruction *containingInstruction,
       TR::CodeGenerator *cg)
    {
-   // *this    swipeable for debugging purposes
    TR::Compilation *comp = cg->comp();
 
    uint32_t addressTypes =

--- a/compiler/x/codegen/OMRRegisterDependency.cpp
+++ b/compiler/x/codegen/OMRRegisterDependency.cpp
@@ -522,7 +522,6 @@ TR_X86RegisterDependencyIndex OMR::X86::RegisterDependencyConditions::unionRealD
 
 TR::RegisterDependencyConditions  *OMR::X86::RegisterDependencyConditions::clone(TR::CodeGenerator *cg, TR_X86RegisterDependencyIndex additionalRegDeps)
    {
-   // *this    swipeable for debugging purposes
    TR::RegisterDependencyConditions  *other =
       new (cg->trHeapMemory()) TR::RegisterDependencyConditions(_numPreConditions  + additionalRegDeps,
                                               _numPostConditions + additionalRegDeps, cg->trMemory());
@@ -548,7 +547,6 @@ TR::RegisterDependencyConditions  *OMR::X86::RegisterDependencyConditions::clone
 
 bool OMR::X86::RegisterDependencyConditions::refsRegister(TR::Register *r)
    {
-   // *this    swipeable for debugging purposes
 
    for (int i = 0; i < _numPreConditions; i++)
       {
@@ -574,7 +572,6 @@ bool OMR::X86::RegisterDependencyConditions::refsRegister(TR::Register *r)
 
 bool OMR::X86::RegisterDependencyConditions::defsRegister(TR::Register *r)
    {
-   // *this    swipeable for debugging purposes
 
    for (int i = 0; i < _numPreConditions; i++)
       {
@@ -600,7 +597,6 @@ bool OMR::X86::RegisterDependencyConditions::defsRegister(TR::Register *r)
 
 bool OMR::X86::RegisterDependencyConditions::usesRegister(TR::Register *r)
    {
-   // *this    swipeable for debugging purposes
    for (int i = 0; i < _numPreConditions; i++)
       {
       if (_preConditions->getRegisterDependency(i)->getRegister() == r &&
@@ -625,7 +621,6 @@ bool OMR::X86::RegisterDependencyConditions::usesRegister(TR::Register *r)
 
 void OMR::X86::RegisterDependencyConditions::useRegisters(TR::Instruction *instr, TR::CodeGenerator *cg)
    {
-   // *this    swipeable for debugging purposes
    int32_t i;
 
    for (i = 0; i < _numPreConditions; i++)
@@ -679,7 +674,6 @@ void TR_X86RegisterDependencyGroup::assignRegisters(TR::Instruction   *currentIn
                                                     TR_X86RegisterDependencyIndex          numberOfRegisters,
                                                     TR::CodeGenerator *cg)
    {
-   // *this    swipeable for debugging purposes
    TR::Register             *virtReg              = NULL;
    TR::RealRegister         *assignedReg          = NULL;
    TR::RealRegister::RegNum  dependentRegNum      = TR::RealRegister::NoReg;
@@ -1112,7 +1106,6 @@ void TR_X86RegisterDependencyGroup::setDependencyInfo(
 
 void OMR::X86::RegisterDependencyConditions::createRegisterAssociationDirective(TR::Instruction *instruction, TR::CodeGenerator *cg)
    {
-   // *this    swipeable for debugging purposes
 
    TR::Machine *machine = cg->machine();
 
@@ -1142,7 +1135,6 @@ void OMR::X86::RegisterDependencyConditions::createRegisterAssociationDirective(
 
 TR::RealRegister *OMR::X86::RegisterDependencyConditions::getRealRegisterFromVirtual(TR::Register *virtReg, TR::CodeGenerator *cg)
    {
-   // *this    swipeable for debugging purposes
    TR::Machine *machine = cg->machine();
 
    TR_X86RegisterDependencyGroup *depGroup = getPostConditions();
@@ -1178,7 +1170,6 @@ void TR_X86RegisterDependencyGroup::assignFPRegisters(TR::Instruction   *prevIns
                                                        TR::CodeGenerator *cg)
    {
 
-   // *this    swipeable for debugging purposes
    TR::Machine *machine = cg->machine();
    TR::Instruction *cursor  = prevInstruction;
 
@@ -1397,7 +1388,6 @@ void TR_X86RegisterDependencyGroup::orderGlobalRegsOnFPStack(TR::Instruction    
                                                               TR::CodeGenerator  *cg)
    {
 
-   // *this    swipeable for debugging purposes
    //
    TR::Machine *machine = cg->machine();
    int32_t *stackShape = machine->getFPStackShape();

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -163,7 +163,6 @@ TR::X86LabelInstruction::X86LabelInstruction(TR_X86OpCodes    op,
                                                  bool b)
   : TR::Instruction(node, op, cg), _symbol(sym),_needToClearFPStack(b), _outlinedInstructionBranch(NULL), _reloType(TR_NoRelocation), _permitShortening(true)
    {
-   // *this    swipeable for debugging purposes
    if (sym && op == LABEL)
       sym->setInstruction(this);
    else if (sym)
@@ -177,7 +176,6 @@ TR::X86LabelInstruction::X86LabelInstruction(TR::Instruction   *precedingInstruc
                                                  bool b)
   : TR::Instruction(op, precedingInstruction, cg), _symbol(sym), _needToClearFPStack(b), _outlinedInstructionBranch(NULL), _reloType(TR_NoRelocation), _permitShortening(true)
    {
-   // *this    swipeable for debugging purposes
    if (sym && op == LABEL)
       sym->setInstruction(this);
    else if (sym)
@@ -192,7 +190,6 @@ TR::X86LabelInstruction::X86LabelInstruction(TR_X86OpCodes                      
                                                  bool b)
   : TR::Instruction(cond, node, op, cg), _symbol(sym), _needToClearFPStack(b), _outlinedInstructionBranch(NULL), _reloType(TR_NoRelocation), _permitShortening(true)
    {
-   // *this    swipeable for debugging purposes
    if (sym && op == LABEL)
       sym->setInstruction(this);
    else if (sym)
@@ -207,7 +204,6 @@ TR::X86LabelInstruction::X86LabelInstruction(TR::Instruction                    
                                                  bool b)
   : TR::Instruction(cond, op, precedingInstruction, cg), _symbol(sym), _needToClearFPStack(b), _outlinedInstructionBranch(NULL), _reloType(TR_NoRelocation), _permitShortening(true)
    {
-   // *this    swipeable for debugging purposes
    if (sym && op == LABEL)
       sym->setInstruction(this);
    else if (sym)
@@ -221,7 +217,6 @@ TR::X86LabelInstruction  *TR::X86LabelInstruction::getIA32LabelInstruction()
 
 TR::Snippet *TR::X86LabelInstruction::getSnippetForGC()
    {
-   // *this    swipeable for debugging purposes
    return getLabelSymbol() ? getLabelSymbol()->getSnippet() : NULL;
    }
 
@@ -508,7 +503,6 @@ void TR::X86LabelInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned
 TR::X86FenceInstruction::X86FenceInstruction(TR_X86OpCodes op, TR::Node *node, TR::Node * fenceNode, TR::CodeGenerator *cg)
    : TR::Instruction(node, op, cg), _fenceNode(fenceNode)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86FenceInstruction::X86FenceInstruction(TR::Instruction   *precedingInstruction,
@@ -517,7 +511,6 @@ TR::X86FenceInstruction::X86FenceInstruction(TR::Instruction   *precedingInstruc
                                                  TR::CodeGenerator *cg)
    : TR::Instruction(op, precedingInstruction, cg), _fenceNode(node)
    {
-   // *this    swipeable for debugging purposes
    }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -527,7 +520,6 @@ TR::X86FenceInstruction::X86FenceInstruction(TR::Instruction   *precedingInstruc
 TR::X86RestoreVMThreadInstruction::X86RestoreVMThreadInstruction(TR_X86OpCodes op, TR::Node *node, TR::CodeGenerator *cg)
    : TR::Instruction(node, op, cg)
    {
-   // *this    swipeable for debugging purposes
    }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -543,7 +535,6 @@ TR::X86ImmInstruction::X86ImmInstruction(TR_X86OpCodes     op,
      _adjustsFramePointerBy(0),
      _reloKind(reloKind)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86ImmInstruction::X86ImmInstruction(TR::Instruction   *precedingInstruction,
@@ -555,7 +546,6 @@ TR::X86ImmInstruction::X86ImmInstruction(TR::Instruction   *precedingInstruction
      _adjustsFramePointerBy(0),
      _reloKind(reloKind)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86ImmInstruction::X86ImmInstruction(TR_X86OpCodes                       op,
@@ -568,7 +558,6 @@ TR::X86ImmInstruction::X86ImmInstruction(TR_X86OpCodes                       op,
      _adjustsFramePointerBy(0),
      _reloKind(reloKind)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86ImmInstruction::X86ImmInstruction(TR::Instruction                     *precedingInstruction,
@@ -581,7 +570,6 @@ TR::X86ImmInstruction::X86ImmInstruction(TR::Instruction                     *pr
      _adjustsFramePointerBy(0),
      _reloKind(reloKind)
    {
-   // *this    swipeable for debugging purposes
    if (cond && cg->enableRegisterAssociations())
       cond->createRegisterAssociationDirective(this, cg);
    }
@@ -592,7 +580,6 @@ TR::X86ImmInstruction::X86ImmInstruction(TR::Instruction                     *pr
 //
 TR::X86ImmInstruction  *TR::X86ImmInstruction::getIA32ImmInstruction()
    {
-   // *this    swipeable for debugging purposes
    return this;
    }
 #endif
@@ -609,7 +596,6 @@ TR::X86ImmSnippetInstruction::X86ImmSnippetInstruction(TR_X86OpCodes            
                                                          TR::CodeGenerator            *cg)
    : TR::X86ImmInstruction(imm, node, op, cg), _unresolvedSnippet(us)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86ImmSnippetInstruction::X86ImmSnippetInstruction(TR::Instruction              *precedingInstruction,
@@ -619,12 +605,10 @@ TR::X86ImmSnippetInstruction::X86ImmSnippetInstruction(TR::Instruction          
                                                          TR::CodeGenerator            *cg)
    : TR::X86ImmInstruction(imm, op, precedingInstruction, cg), _unresolvedSnippet(us)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::Snippet *TR::X86ImmSnippetInstruction::getSnippetForGC()
    {
-   // *this    swipeable for debugging purposes
    return getUnresolvedSnippet();
    }
 
@@ -640,7 +624,6 @@ TR::X86ImmSymInstruction::X86ImmSymInstruction(TR_X86OpCodes       op,
    : TR::X86ImmInstruction(imm, node, op, cg),
          _symbolReference(sr)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86ImmSymInstruction::X86ImmSymInstruction(TR::Instruction     *precedingInstruction,
@@ -651,7 +634,6 @@ TR::X86ImmSymInstruction::X86ImmSymInstruction(TR::Instruction     *precedingIns
    : TR::X86ImmInstruction(imm, op, precedingInstruction, cg),
          _symbolReference(sr)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86ImmSymInstruction::X86ImmSymInstruction(TR_X86OpCodes                       op,
@@ -663,7 +645,6 @@ TR::X86ImmSymInstruction::X86ImmSymInstruction(TR_X86OpCodes                    
    : TR::X86ImmInstruction(cond, imm, node, op, cg),
          _symbolReference(sr)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86ImmSymInstruction::X86ImmSymInstruction(TR::Instruction                     *precedingInstruction,
@@ -675,7 +656,6 @@ TR::X86ImmSymInstruction::X86ImmSymInstruction(TR::Instruction                  
    : TR::X86ImmInstruction(cond, imm, op, precedingInstruction, cg),
          _symbolReference(sr)
    {
-   // *this    swipeable for debugging purposes
    }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -688,7 +668,6 @@ TR::X86RegInstruction::X86RegInstruction(TR_X86OpCodes op,
                                              TR::CodeGenerator *cg)
    : TR::Instruction(node, op, cg), _targetRegister(reg)
    {
-   // *this    swipeable for debugging purposes
    useRegister(reg);
    getOpCode().trackUpperBitsOnReg(reg, cg);
 
@@ -719,7 +698,6 @@ TR::X86RegInstruction::X86RegInstruction(TR::Instruction *precedingInstruction,
                                              TR::CodeGenerator *cg)
    : TR::Instruction(op, precedingInstruction, cg), _targetRegister(reg)
    {
-   // *this    swipeable for debugging purposes
    useRegister(reg);
    getOpCode().trackUpperBitsOnReg(reg, cg);
    }
@@ -731,7 +709,6 @@ TR::X86RegInstruction::X86RegInstruction(TR_X86OpCodes                       op,
                                              TR::CodeGenerator *cg)
    : TR::Instruction(cond, node, op, cg), _targetRegister(reg)
    {
-   // *this    swipeable for debugging purposes
    useRegister(reg);
    getOpCode().trackUpperBitsOnReg(reg, cg);
 
@@ -763,21 +740,18 @@ TR::X86RegInstruction::X86RegInstruction(TR::Instruction                      *p
                                              TR::CodeGenerator *cg)
    : TR::Instruction(cond, op, precedingInstruction, cg), _targetRegister(reg)
    {
-   // *this    swipeable for debugging purposes
    useRegister(reg);
    getOpCode().trackUpperBitsOnReg(reg, cg);
    }
 
 TR::X86RegInstruction  *TR::X86RegInstruction::getIA32RegInstruction()
    {
-   // *this    swipeable for debugging purposes
    return this;
 }
 
 
 bool TR::X86RegInstruction::refsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (reg == getTargetRegister())
       {
       return true;
@@ -792,7 +766,6 @@ bool TR::X86RegInstruction::refsRegister(TR::Register *reg)
 
 bool TR::X86RegInstruction::defsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (reg == getTargetRegister() && getOpCode().modifiesTarget())
       {
       return true;
@@ -807,7 +780,6 @@ bool TR::X86RegInstruction::defsRegister(TR::Register *reg)
 
 bool TR::X86RegInstruction::usesRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (reg == getTargetRegister())
       {
       return true;
@@ -894,7 +866,6 @@ TR::X86RegRegInstruction::X86RegRegInstruction(TR_X86OpCodes op,
                                                    TR::CodeGenerator *cg)
    : TR::X86RegInstruction(treg, node, op, cg), _sourceRegister(sreg)
    {
-   // *this    swipeable for debugging purposes
    useRegister(sreg);
    }
 
@@ -905,7 +876,6 @@ TR::X86RegRegInstruction::X86RegRegInstruction(TR::Instruction *precedingInstruc
                                                    TR::CodeGenerator *cg)
    : TR::X86RegInstruction(treg, op, precedingInstruction, cg), _sourceRegister(sreg)
    {
-   // *this    swipeable for debugging purposes
    useRegister(sreg);
    }
 
@@ -917,7 +887,6 @@ TR::X86RegRegInstruction::X86RegRegInstruction(TR_X86OpCodes                    
                                                    TR::CodeGenerator *cg)
    : TR::X86RegInstruction(cond, treg, node, op, cg), _sourceRegister(sreg)
    {
-   // *this    swipeable for debugging purposes
    useRegister(sreg);
    }
 
@@ -929,14 +898,12 @@ TR::X86RegRegInstruction::X86RegRegInstruction(TR::Instruction                  
                                                    TR::CodeGenerator *cg)
    : TR::X86RegInstruction(cond, treg, op, precedingInstruction, cg), _sourceRegister(sreg)
    {
-   // *this    swipeable for debugging purposes
    useRegister(sreg);
    }
 
 
 bool TR::X86RegRegInstruction::refsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (reg == getTargetRegister() || reg == getSourceRegister())
       {
       return true;
@@ -951,7 +918,6 @@ bool TR::X86RegRegInstruction::refsRegister(TR::Register *reg)
 
 bool TR::X86RegRegInstruction::defsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if ((reg == getTargetRegister() && getOpCode().modifiesTarget()) ||
        (reg == getSourceRegister() && getOpCode().modifiesSource()))
       {
@@ -967,7 +933,6 @@ bool TR::X86RegRegInstruction::defsRegister(TR::Register *reg)
 
 bool TR::X86RegRegInstruction::usesRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if ((reg == getTargetRegister() &&
         getOpCode().usesTarget())  ||
        reg == getSourceRegister())
@@ -1196,7 +1161,6 @@ TR::X86RegImmInstruction::X86RegImmInstruction(TR_X86OpCodes     op,
                                                  int32_t           reloKind)
    : TR::X86RegInstruction(treg, node, op, cg), _sourceImmediate(imm), _reloKind(reloKind)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86RegImmInstruction::X86RegImmInstruction(TR::Instruction   *precedingInstruction,
@@ -1207,7 +1171,6 @@ TR::X86RegImmInstruction::X86RegImmInstruction(TR::Instruction   *precedingInstr
                                                  int32_t           reloKind)
    : TR::X86RegInstruction(treg, op, precedingInstruction, cg), _sourceImmediate(imm), _reloKind(reloKind)
    {
-   // *this    swipeable for debugging purposes
    }
 
 
@@ -1220,7 +1183,6 @@ TR::X86RegImmInstruction::X86RegImmInstruction(TR_X86OpCodes                    
                                                  int32_t                             reloKind)
    : TR::X86RegInstruction(cond, treg, node, op, cg), _sourceImmediate(imm), _reloKind(reloKind)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86RegImmInstruction::X86RegImmInstruction(TR::Instruction                     *precedingInstruction,
@@ -1232,7 +1194,6 @@ TR::X86RegImmInstruction::X86RegImmInstruction(TR::Instruction                  
                                                  int32_t                             reloKind)
    : TR::X86RegInstruction(cond, treg, op, precedingInstruction, cg), _sourceImmediate(imm), _reloKind(reloKind)
    {
-   // *this    swipeable for debugging purposes
    }
 
 void TR::X86RegImmInstruction::adjustVFPState(TR_VFPState *state, TR::CodeGenerator *cg)
@@ -1276,7 +1237,6 @@ TR::X86RegImmSymInstruction::X86RegImmSymInstruction(TR_X86OpCodes       op,
                                                        TR::CodeGenerator   *cg)
    : TR::X86RegImmInstruction(imm, reg, node, op, cg), _symbolReference(sr)
    {
-   // *this    swipeable for debugging purposes
    autoSetReloKind();
    }
 
@@ -1288,7 +1248,6 @@ TR::X86RegImmSymInstruction::X86RegImmSymInstruction(TR::Instruction     *preced
                                                        TR::CodeGenerator   *cg)
    : TR::X86RegImmInstruction(imm, reg, op, precedingInstruction, cg), _symbolReference(sr)
    {
-   // *this    swipeable for debugging purposes
    autoSetReloKind();
    }
 
@@ -1327,7 +1286,6 @@ TR::X86RegRegImmInstruction::X86RegRegImmInstruction(TR_X86OpCodes     op,
                                                        TR::CodeGenerator *cg)
    : TR::X86RegRegInstruction(sreg, treg, node, op, cg), _sourceImmediate(imm)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86RegRegImmInstruction::X86RegRegImmInstruction(TR::Instruction   *precedingInstruction,
@@ -1338,7 +1296,6 @@ TR::X86RegRegImmInstruction::X86RegRegImmInstruction(TR::Instruction   *precedin
                                                        TR::CodeGenerator *cg)
    : TR::X86RegRegInstruction(sreg, treg, op, precedingInstruction, cg), _sourceImmediate(imm)
    {
-   // *this    swipeable for debugging purposes
    }
 
 
@@ -1354,7 +1311,6 @@ TR::X86RegRegRegInstruction::X86RegRegRegInstruction(TR_X86OpCodes op,
                                                          TR::CodeGenerator *cg)
    : TR::X86RegRegInstruction(slreg, treg, node, op, cg), _sourceRightRegister(srreg)
    {
-   // *this    swipeable for debugging purposes
    useRegister(srreg);
    }
 
@@ -1367,7 +1323,6 @@ TR::X86RegRegRegInstruction::X86RegRegRegInstruction(TR::Instruction *precedingI
    : TR::X86RegRegInstruction(slreg, treg, op, precedingInstruction, cg),
      _sourceRightRegister(srreg)
    {
-   // *this    swipeable for debugging purposes
    useRegister(srreg);
    }
 
@@ -1380,7 +1335,6 @@ TR::X86RegRegRegInstruction::X86RegRegRegInstruction(TR_X86OpCodes              
                                                          TR::CodeGenerator *cg)
    : TR::X86RegRegInstruction(cond, slreg, treg, node, op, cg), _sourceRightRegister(srreg)
    {
-   // *this    swipeable for debugging purposes
    useRegister(srreg);
    }
 
@@ -1393,14 +1347,12 @@ TR::X86RegRegRegInstruction::X86RegRegRegInstruction(TR::Instruction            
                                                          TR::CodeGenerator *cg)
    : TR::X86RegRegInstruction(cond, slreg, treg, op, precedingInstruction, cg), _sourceRightRegister(srreg)
    {
-   // *this    swipeable for debugging purposes
    useRegister(srreg);
    }
 
 
 bool TR::X86RegRegRegInstruction::refsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (reg == getTargetRegister() ||
        reg == getSourceRegister() ||
        reg == getSourceRightRegister())
@@ -1417,7 +1369,6 @@ bool TR::X86RegRegRegInstruction::refsRegister(TR::Register *reg)
 
 bool TR::X86RegRegRegInstruction::defsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (reg == getTargetRegister() && getOpCode().modifiesTarget())
       {
       return true;
@@ -1432,7 +1383,6 @@ bool TR::X86RegRegRegInstruction::defsRegister(TR::Register *reg)
 
 bool TR::X86RegRegRegInstruction::usesRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if ((reg == getTargetRegister() &&
         getOpCode().usesTarget())  ||
        reg == getSourceRegister()  ||
@@ -1752,7 +1702,6 @@ TR::X86MemInstruction::X86MemInstruction(TR_X86OpCodes          op,
                                              TR::Register            *sreg)
    : TR::Instruction(node, op, cg), _memoryReference(mr)
    {
-   // *this    swipeable for debugging purposes
    mr->useRegisters(this, cg);
    if (mr->getUnresolvedDataSnippet() != NULL)
       {
@@ -1785,7 +1734,6 @@ TR::X86MemInstruction::X86MemInstruction(TR::Instruction         *precedingInstr
                                              TR::Register            *sreg)
    : TR::Instruction(op, precedingInstruction, cg), _memoryReference(mr)
    {
-   // *this    swipeable for debugging purposes
    mr->useRegisters(this, cg);
    if (mr->getUnresolvedDataSnippet() != NULL)
       {
@@ -1809,7 +1757,6 @@ TR::X86MemInstruction::X86MemInstruction(TR_X86OpCodes                       op,
                                              TR::Register                         *sreg)
    : TR::Instruction(cond, node, op, cg), _memoryReference(mr)
    {
-   // *this    swipeable for debugging purposes
    mr->useRegisters(this, cg);
    if (mr->getUnresolvedDataSnippet() != NULL)
       {
@@ -1830,7 +1777,6 @@ TR::X86MemInstruction::X86MemInstruction(TR_X86OpCodes                       op,
 
 bool TR::X86MemInstruction::refsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (getMemoryReference()->refsRegister(reg))
       {
       return true;
@@ -1845,7 +1791,6 @@ bool TR::X86MemInstruction::refsRegister(TR::Register *reg)
 
 bool TR::X86MemInstruction::defsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (getDependencyConditions())
       {
       return getDependencyConditions()->defsRegister(reg);
@@ -1858,7 +1803,6 @@ bool TR::X86MemInstruction::defsRegister(TR::Register *reg)
 
 bool TR::X86MemInstruction::usesRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (getMemoryReference()->refsRegister(reg))
       {
       return true;
@@ -1994,7 +1938,6 @@ TR::X86CallMemInstruction::X86CallMemInstruction(TR_X86OpCodes                  
                                                      TR::CodeGenerator *cg)
    : TR::X86MemInstruction(cond, mr, node, op, cg), _adjustsFramePointerBy(0)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86CallMemInstruction::X86CallMemInstruction(TR::Instruction                      *precedingInstruction,
@@ -2004,7 +1947,6 @@ TR::X86CallMemInstruction::X86CallMemInstruction(TR::Instruction                
                                                      TR::CodeGenerator *cg)
    : TR::X86MemInstruction(cond, mr, op, precedingInstruction, cg), _adjustsFramePointerBy(0)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86CallMemInstruction::X86CallMemInstruction(TR_X86OpCodes                       op,
@@ -2013,7 +1955,6 @@ TR::X86CallMemInstruction::X86CallMemInstruction(TR_X86OpCodes                  
                                                      TR::CodeGenerator *cg)
    : TR::X86MemInstruction(mr, node, op, cg), _adjustsFramePointerBy(0)
    {
-   // *this    swipeable for debugging purposes
    }
 
 
@@ -2061,7 +2002,6 @@ TR::X86MemImmInstruction::X86MemImmInstruction(TR_X86OpCodes          op,
                                                  int32_t               reloKind)
    : TR::X86MemInstruction(mr, node, op, cg), _sourceImmediate(imm), _reloKind(reloKind)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86MemImmInstruction::X86MemImmInstruction(TR::Instruction        *precedingInstruction,
@@ -2072,7 +2012,6 @@ TR::X86MemImmInstruction::X86MemImmInstruction(TR::Instruction        *preceding
                                                  int32_t               reloKind)
    : TR::X86MemInstruction(mr, op, precedingInstruction, cg), _sourceImmediate(imm), _reloKind(reloKind)
    {
-   // *this    swipeable for debugging purposes
    }
 
 
@@ -2088,7 +2027,6 @@ TR::X86MemImmSymInstruction::X86MemImmSymInstruction(TR_X86OpCodes          op,
                                                        TR::CodeGenerator      *cg)
    : TR::X86MemImmInstruction(imm, mr, node, op, cg), _symbolReference(sr)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86MemImmSymInstruction::X86MemImmSymInstruction(TR::Instruction        *precedingInstruction,
@@ -2099,7 +2037,6 @@ TR::X86MemImmSymInstruction::X86MemImmSymInstruction(TR::Instruction        *pre
                                                        TR::CodeGenerator      *cg)
    : TR::X86MemImmInstruction(imm, mr, op, precedingInstruction, cg), _symbolReference(sr)
    {
-   // *this    swipeable for debugging purposes
    }
 
 
@@ -2116,7 +2053,6 @@ TR::X86MemRegInstruction::X86MemRegInstruction(TR_X86OpCodes          op,
                                                    TR::CodeGenerator *cg)
    : TR::X86MemInstruction(mr, node, op, cg, sreg), _sourceRegister(sreg)
    {
-   // *this    swipeable for debugging purposes
    useRegister(sreg);
    }
 
@@ -2127,7 +2063,6 @@ TR::X86MemRegInstruction::X86MemRegInstruction(TR::Instruction         *precedin
                                                    TR::CodeGenerator *cg)
    : TR::X86MemInstruction(mr, op, precedingInstruction, cg, sreg), _sourceRegister(sreg)
    {
-   // *this    swipeable for debugging purposes
    useRegister(sreg);
    }
 
@@ -2139,7 +2074,6 @@ TR::X86MemRegInstruction::X86MemRegInstruction(TR_X86OpCodes                    
                                                    TR::CodeGenerator *cg)
    : TR::X86MemInstruction(cond, mr, node, op, cg, sreg), _sourceRegister(sreg)
    {
-   // *this    swipeable for debugging purposes
    useRegister(sreg);
    }
 
@@ -2151,14 +2085,12 @@ TR::X86MemRegInstruction::X86MemRegInstruction(TR::Instruction                  
                                                    TR::CodeGenerator *cg)
    : TR::X86MemInstruction(cond, mr, op, precedingInstruction, cg, sreg), _sourceRegister(sreg)
    {
-   // *this    swipeable for debugging purposes
    useRegister(sreg);
    }
 
 
 bool TR::X86MemRegInstruction::refsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (getMemoryReference()->refsRegister(reg) ||
        reg == getSourceRegister())
       {
@@ -2174,7 +2106,6 @@ bool TR::X86MemRegInstruction::refsRegister(TR::Register *reg)
 
 bool TR::X86MemRegInstruction::defsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (reg == getSourceRegister() && getOpCode().modifiesSource())
       {
       return true;
@@ -2189,7 +2120,6 @@ bool TR::X86MemRegInstruction::defsRegister(TR::Register *reg)
 
 bool TR::X86MemRegInstruction::usesRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (getMemoryReference()->refsRegister(reg) ||
        reg == getSourceRegister())
       {
@@ -2367,7 +2297,6 @@ TR::X86MemRegImmInstruction::X86MemRegImmInstruction(TR_X86OpCodes          op,
                                                        TR::CodeGenerator      *cg)
    : TR::X86MemRegInstruction(sreg, mr, node, op, cg), _sourceImmediate(imm)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86MemRegImmInstruction::X86MemRegImmInstruction(TR::Instruction        *precedingInstruction,
@@ -2378,7 +2307,6 @@ TR::X86MemRegImmInstruction::X86MemRegImmInstruction(TR::Instruction        *pre
                                                        TR::CodeGenerator      *cg)
    : TR::X86MemRegInstruction(sreg, mr, op, precedingInstruction, cg), _sourceImmediate(imm)
    {
-   // *this    swipeable for debugging purposes
    }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2393,7 +2321,6 @@ TR::X86MemRegRegInstruction::X86MemRegRegInstruction(TR_X86OpCodes          op,
                                                          TR::CodeGenerator *cg)
    : TR::X86MemRegInstruction(slreg, mr, node, op, cg), _sourceRightRegister(srreg)
    {
-   // *this    swipeable for debugging purposes
    useRegister(srreg);
    }
 
@@ -2405,7 +2332,6 @@ TR::X86MemRegRegInstruction::X86MemRegRegInstruction(TR::Instruction         *pr
                                                          TR::CodeGenerator *cg)
    : TR::X86MemRegInstruction(slreg, mr, op, precedingInstruction, cg), _sourceRightRegister(srreg)
    {
-   // *this    swipeable for debugging purposes
    useRegister(srreg);
    }
 
@@ -2418,7 +2344,6 @@ TR::X86MemRegRegInstruction::X86MemRegRegInstruction(TR_X86OpCodes              
                                                          TR::CodeGenerator *cg)
    : TR::X86MemRegInstruction(cond, slreg, mr, node, op, cg), _sourceRightRegister(srreg)
    {
-   // *this    swipeable for debugging purposes
    useRegister(srreg);
    }
 
@@ -2431,14 +2356,12 @@ TR::X86MemRegRegInstruction::X86MemRegRegInstruction(TR::Instruction            
                                                          TR::CodeGenerator *cg)
    : TR::X86MemRegInstruction(cond, slreg, mr, op, precedingInstruction, cg), _sourceRightRegister(srreg)
    {
-   // *this    swipeable for debugging purposes
    useRegister(srreg);
    }
 
 
 bool TR::X86MemRegRegInstruction::refsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (getMemoryReference()->refsRegister(reg) ||
        reg == getSourceRegister()              ||
        reg == getSourceRightRegister())
@@ -2455,7 +2378,6 @@ bool TR::X86MemRegRegInstruction::refsRegister(TR::Register *reg)
 //check refsRegister
 bool TR::X86MemRegRegInstruction::usesRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (getMemoryReference()->refsRegister(reg) ||
        reg == getSourceRegister()              ||
        reg == getSourceRightRegister())
@@ -2597,7 +2519,6 @@ TR::X86RegMemInstruction::X86RegMemInstruction(TR_X86OpCodes          op,
                                                    TR::CodeGenerator *cg)
    : TR::X86RegInstruction(treg, node, op, cg), _memoryReference(mr)
    {
-   // *this    swipeable for debugging purposes
    mr->useRegisters(this, cg);
    if (mr->getUnresolvedDataSnippet() != NULL)
       {
@@ -2622,7 +2543,6 @@ TR::X86RegMemInstruction::X86RegMemInstruction(TR::Instruction         *precedin
                                                    TR::CodeGenerator *cg)
    : TR::X86RegInstruction(treg, op, precedingInstruction, cg), _memoryReference(mr)
    {
-   // *this    swipeable for debugging purposes
    mr->useRegisters(this, cg);
    if (mr->getUnresolvedDataSnippet() != NULL)
       {
@@ -2638,7 +2558,6 @@ TR::X86RegMemInstruction::X86RegMemInstruction(TR_X86OpCodes                    
                                                    TR::CodeGenerator *cg)
    : TR::X86RegInstruction(cond, treg, node, op, cg), _memoryReference(mr)
    {
-   // *this    swipeable for debugging purposes
    mr->useRegisters(this, cg);
    if (mr->getUnresolvedDataSnippet() != NULL)
       {
@@ -2664,7 +2583,6 @@ TR::X86RegMemInstruction::X86RegMemInstruction(TR::Instruction                  
                                                    TR::CodeGenerator *cg)
    : TR::X86RegInstruction(cond, treg, op, precedingInstruction, cg), _memoryReference(mr)
    {
-   // *this    swipeable for debugging purposes
    mr->useRegisters(this, cg);
    if (mr->getUnresolvedDataSnippet() != NULL)
       {
@@ -2675,7 +2593,6 @@ TR::X86RegMemInstruction::X86RegMemInstruction(TR::Instruction                  
 
 bool TR::X86RegMemInstruction::refsRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if (reg == getTargetRegister() ||
        getMemoryReference()->refsRegister(reg))
       {
@@ -2691,7 +2608,6 @@ bool TR::X86RegMemInstruction::refsRegister(TR::Register *reg)
 
 bool TR::X86RegMemInstruction::usesRegister(TR::Register *reg)
    {
-   // *this    swipeable for debugging purposes
    if ((reg == getTargetRegister() &&
         getOpCode().usesTarget())  ||
        getMemoryReference()->refsRegister(reg))
@@ -2708,7 +2624,6 @@ bool TR::X86RegMemInstruction::usesRegister(TR::Register *reg)
 
 TR::Snippet *TR::X86RegMemInstruction::getSnippetForGC()
    {
-   // *this    swipeable for debugging purposes
    return getMemoryReference()->getUnresolvedDataSnippet();
    }
 
@@ -2857,7 +2772,6 @@ TR::X86RegMemImmInstruction::X86RegMemImmInstruction(TR_X86OpCodes          op,
                                                        TR::CodeGenerator      *cg)
    : TR::X86RegMemInstruction(mr, treg, node, op, cg), _sourceImmediate(imm)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86RegMemImmInstruction::X86RegMemImmInstruction(TR::Instruction        *precedingInstruction,
@@ -2868,7 +2782,6 @@ TR::X86RegMemImmInstruction::X86RegMemImmInstruction(TR::Instruction        *pre
                                                        TR::CodeGenerator      *cg)
    : TR::X86RegMemInstruction(mr, treg, op, precedingInstruction, cg), _sourceImmediate(imm)
    {
-   // *this    swipeable for debugging purposes
    }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2881,7 +2794,6 @@ TR::X86FPRegInstruction::X86FPRegInstruction(TR_X86OpCodes op,
                                                  TR::CodeGenerator *cg)
    : TR::X86RegInstruction(reg, node, op, cg)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86FPRegInstruction::X86FPRegInstruction(TR::Instruction *precedingInstruction,
@@ -2890,12 +2802,10 @@ TR::X86FPRegInstruction::X86FPRegInstruction(TR::Instruction *precedingInstructi
                                                  TR::CodeGenerator *cg)
    : TR::X86RegInstruction(reg, op, precedingInstruction, cg)
    {
-   // *this    swipeable for debugging purposes
    }
 
 void TR::X86FPRegInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
    {
-   // *this    swipeable for debugging purposes
    if (kindsToBeAssigned & TR_X87_Mask)
       {
       TR::Register            *targetRegister = getTargetRegister();
@@ -2949,7 +2859,6 @@ TR::X86FPRegRegInstruction::X86FPRegRegInstruction(TR_X86OpCodes op,
                                                        TR::CodeGenerator *cg)
    : TR::X86RegRegInstruction(sreg, treg, node, op, cg)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86FPRegRegInstruction::X86FPRegRegInstruction(TR_X86OpCodes op,
@@ -2960,7 +2869,6 @@ TR::X86FPRegRegInstruction::X86FPRegRegInstruction(TR_X86OpCodes op,
                                                        TR::CodeGenerator *cg)
    : TR::X86RegRegInstruction( op, node, treg, sreg, cond, cg)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86FPRegRegInstruction::X86FPRegRegInstruction(TR::Instruction *precedingInstruction,
@@ -2970,7 +2878,6 @@ TR::X86FPRegRegInstruction::X86FPRegRegInstruction(TR::Instruction *precedingIns
                                                        TR::CodeGenerator *cg)
    : TR::X86RegRegInstruction(sreg, treg, op, precedingInstruction, cg)
    {
-   // *this    swipeable for debugging purposes
    }
 
 // General method for coercing the source and target operands onto the FP stack for
@@ -2978,7 +2885,6 @@ TR::X86FPRegRegInstruction::X86FPRegRegInstruction(TR::Instruction *precedingIns
 //
 uint32_t TR::X86FPRegRegInstruction::assignTargetSourceRegisters()
    {
-   // *this    swipeable for debugging purposes
 
    TR::Register *sourceRegister = getSourceRegister();
    TR::Register *targetRegister = getTargetRegister();
@@ -3048,7 +2954,6 @@ TR::X86FPST0ST1RegRegInstruction::X86FPST0ST1RegRegInstruction(TR_X86OpCodes  op
                                                                  TR::CodeGenerator *cg)
    : TR::X86FPRegRegInstruction(sreg, treg, node, op, cg)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86FPST0ST1RegRegInstruction::X86FPST0ST1RegRegInstruction(TR_X86OpCodes  op,
@@ -3059,7 +2964,6 @@ TR::X86FPST0ST1RegRegInstruction::X86FPST0ST1RegRegInstruction(TR_X86OpCodes  op
                                                                  TR::CodeGenerator *cg)
    : TR::X86FPRegRegInstruction( op, node, treg, sreg, cond, cg)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86FPST0ST1RegRegInstruction::X86FPST0ST1RegRegInstruction(TR::Instruction *precedingInstruction,
@@ -3069,12 +2973,10 @@ TR::X86FPST0ST1RegRegInstruction::X86FPST0ST1RegRegInstruction(TR::Instruction *
                                                                  TR::CodeGenerator *cg)
    : TR::X86FPRegRegInstruction(sreg, treg, op, precedingInstruction, cg)
    {
-   // *this    swipeable for debugging purposes
    }
 
 void TR::X86FPST0ST1RegRegInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
    {
-   // *this    swipeable for debugging purposes
 
    if (kindsToBeAssigned & TR_X87_Mask)
       {
@@ -3116,7 +3018,6 @@ TR::X86FPSTiST0RegRegInstruction::X86FPSTiST0RegRegInstruction(TR_X86OpCodes  op
    : TR::X86FPRegRegInstruction(sreg, treg, node, op, cg)
    {
    _forcePop = forcePop;
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86FPSTiST0RegRegInstruction::X86FPSTiST0RegRegInstruction(TR::Instruction *precedingInstruction,
@@ -3127,12 +3028,10 @@ TR::X86FPSTiST0RegRegInstruction::X86FPSTiST0RegRegInstruction(TR::Instruction *
    : TR::X86FPRegRegInstruction(sreg, treg, op, precedingInstruction, cg)
    {
    _forcePop = forcePop;
-   // *this    swipeable for debugging purposes
    }
 
 void TR::X86FPSTiST0RegRegInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
    {
-   // *this    swipeable for debugging purposes
 
    if (kindsToBeAssigned & TR_X87_Mask)
       {
@@ -3210,7 +3109,6 @@ TR::X86FPST0STiRegRegInstruction::X86FPST0STiRegRegInstruction(TR_X86OpCodes  op
                                                                    TR::CodeGenerator *cg)
    : TR::X86FPRegRegInstruction(sreg, treg, node, op, cg)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86FPST0STiRegRegInstruction::X86FPST0STiRegRegInstruction(TR::Instruction *precedingInstruction,
@@ -3220,12 +3118,10 @@ TR::X86FPST0STiRegRegInstruction::X86FPST0STiRegRegInstruction(TR::Instruction *
                                                                    TR::CodeGenerator *cg)
    : TR::X86FPRegRegInstruction(sreg, treg, op, precedingInstruction, cg)
    {
-   // *this    swipeable for debugging purposes
    }
 
 void TR::X86FPST0STiRegRegInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
    {
-   // *this    swipeable for debugging purposes
 
    if (kindsToBeAssigned & TR_X87_Mask)
       {
@@ -3303,7 +3199,6 @@ TR::X86FPArithmeticRegRegInstruction::X86FPArithmeticRegRegInstruction(TR_X86OpC
                                                                            TR::CodeGenerator *cg)
    : TR::X86FPRegRegInstruction(sreg, treg, node, op, cg)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86FPArithmeticRegRegInstruction::X86FPArithmeticRegRegInstruction(TR::Instruction *precedingInstruction,
@@ -3313,12 +3208,10 @@ TR::X86FPArithmeticRegRegInstruction::X86FPArithmeticRegRegInstruction(TR::Instr
                                                                            TR::CodeGenerator *cg)
    : TR::X86FPRegRegInstruction(sreg, treg, op, precedingInstruction, cg)
    {
-   // *this    swipeable for debugging purposes
    }
 
 void TR::X86FPArithmeticRegRegInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
    {
-   // *this    swipeable for debugging purposes
 
    if (kindsToBeAssigned & TR_X87_Mask)
       {
@@ -3404,7 +3297,6 @@ TR::X86FPCompareRegRegInstruction::X86FPCompareRegRegInstruction(TR_X86OpCodes  
                                                                      TR::CodeGenerator *cg)
    : TR::X86FPRegRegInstruction(sreg, treg, node, op, cg)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86FPCompareRegRegInstruction::X86FPCompareRegRegInstruction(TR::Instruction *precedingInstruction,
@@ -3414,12 +3306,10 @@ TR::X86FPCompareRegRegInstruction::X86FPCompareRegRegInstruction(TR::Instruction
                                                                      TR::CodeGenerator *cg)
    : TR::X86FPRegRegInstruction(sreg, treg, op, precedingInstruction, cg)
    {
-   // *this    swipeable for debugging purposes
    }
 
 void TR::X86FPCompareRegRegInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
    {
-   // *this    swipeable for debugging purposes
 
    if (kindsToBeAssigned & TR_X87_Mask)
       {
@@ -3651,7 +3541,6 @@ TR::X86FPCompareEvalInstruction::X86FPCompareEvalInstruction(TR_X86OpCodes  op,
                                                                  TR::CodeGenerator *cg)
    : TR::Instruction(node, op, cg), _accRegister(accRegister)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86FPCompareEvalInstruction::X86FPCompareEvalInstruction(TR_X86OpCodes                       op,
@@ -3661,7 +3550,6 @@ TR::X86FPCompareEvalInstruction::X86FPCompareEvalInstruction(TR_X86OpCodes      
                                                                  TR::CodeGenerator *cg)
    : TR::Instruction(cond, node, op, cg), _accRegister(accRegister)
    {
-   // *this    swipeable for debugging purposes
    }
 
 void TR::X86FPCompareEvalInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
@@ -3896,7 +3784,6 @@ TR::X86FPRemainderRegRegInstruction::X86FPRemainderRegRegInstruction( TR_X86OpCo
                                                                        TR::CodeGenerator *cg)
    : TR::X86FPST0ST1RegRegInstruction( op, node, treg, sreg, cg)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86FPRemainderRegRegInstruction::X86FPRemainderRegRegInstruction( TR_X86OpCodes  op,
@@ -3908,7 +3795,6 @@ TR::X86FPRemainderRegRegInstruction::X86FPRemainderRegRegInstruction( TR_X86OpCo
                                                                        TR::CodeGenerator *cg)
    : TR::X86FPST0ST1RegRegInstruction( op, node, treg, sreg, cond, cg), _accRegister(accReg)
    {
-   // *this    swipeable for debugging purposes
    useRegister(accReg);
    }
 
@@ -3919,12 +3805,10 @@ TR::X86FPRemainderRegRegInstruction::X86FPRemainderRegRegInstruction( TR::Instru
                                                                        TR::CodeGenerator *cg)
    : TR::X86FPST0ST1RegRegInstruction( precedingInstruction, op, treg, sreg, cg)
    {
-   // *this    swipeable for debugging purposes
    }
 
 void TR::X86FPRemainderRegRegInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
    {
-   // *this    swipeable for debugging purposes
 
    if (kindsToBeAssigned & TR_GPR_Mask) //TODO: Move this code generation in FPTreeEvaluator.cpp rather than doing it here
       {
@@ -3975,7 +3859,6 @@ TR::X86FPMemRegInstruction::X86FPMemRegInstruction(TR_X86OpCodes          op,
                                                        TR::CodeGenerator *cg)
    : TR::X86MemRegInstruction(sreg, mr, node, op, cg)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86FPMemRegInstruction::X86FPMemRegInstruction(TR::Instruction         *precedingInstruction,
@@ -3985,12 +3868,10 @@ TR::X86FPMemRegInstruction::X86FPMemRegInstruction(TR::Instruction         *prec
                                                        TR::CodeGenerator *cg)
    : TR::X86MemRegInstruction(sreg, mr, op, precedingInstruction, cg)
    {
-   // *this    swipeable for debugging purposes
    }
 
 void TR::X86FPMemRegInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
    {
-   // *this    swipeable for debugging purposes
    if (kindsToBeAssigned & TR_GPR_Mask)
       {
       getMemoryReference()->assignRegisters(this, cg());
@@ -4064,7 +3945,6 @@ TR::X86FPRegMemInstruction::X86FPRegMemInstruction(TR_X86OpCodes          op,
                                                        TR::CodeGenerator *cg)
    : TR::X86RegMemInstruction(mr, treg, node, op, cg)
    {
-   // *this    swipeable for debugging purposes
    }
 
 TR::X86FPRegMemInstruction::X86FPRegMemInstruction(TR::Instruction         *precedingInstruction,
@@ -4074,12 +3954,10 @@ TR::X86FPRegMemInstruction::X86FPRegMemInstruction(TR::Instruction         *prec
                                                        TR::CodeGenerator *cg)
    : TR::X86RegMemInstruction(mr, treg, op, precedingInstruction, cg)
    {
-   // *this    swipeable for debugging purposes
    }
 
 void TR::X86FPRegMemInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
    {
-   // *this    swipeable for debugging purposes
    if (kindsToBeAssigned & TR_GPR_Mask)
       {
       getMemoryReference()->assignRegisters(this, cg());

--- a/compiler/x/codegen/OMRX86Instruction.hpp
+++ b/compiler/x/codegen/OMRX86Instruction.hpp
@@ -892,7 +892,6 @@ class X86RegInstruction : public TR::Instruction
 
    void applyTargetRegisterToModRMByte(uint8_t *modRM)
       {
-      // *this    swipeable for debugging purposes
       TR::RealRegister *target = toRealRegister(_targetRegister);
       if (getOpCode().hasTargetRegisterInModRM())
          {
@@ -1037,7 +1036,6 @@ class X86RegRegInstruction : public TR::X86RegInstruction
 
    void applySourceRegisterToModRMByte(uint8_t *modRM)
       {
-      // *this    swipeable for debugging purposes
       TR::RealRegister *source = toRealRegister(_sourceRegister);
       if (getOpCode().hasSourceRegisterInModRM())
          {
@@ -2112,7 +2110,6 @@ class X86FPRegInstruction : public TR::X86RegInstruction
 
    void applyTargetRegisterToOpCode(uint8_t *opCode)
       {
-      // *this    swipeable for debugging purposes
       TR::RealRegister *target = toRealRegister(getTargetRegister());
       target->setRegisterFieldInOpcode(opCode);
       }
@@ -2431,7 +2428,6 @@ class X86FPRegRegInstruction : public TR::X86RegRegInstruction
 
    void applyRegistersToOpCode(uint8_t *opCode, TR::Machine * machine)
       {
-      // *this    swipeable for debugging purposes
 
       // At least one of source and target will be in ST0.
       TR::RealRegister *reg = toRealRegister(getTargetRegister());
@@ -2451,7 +2447,6 @@ class X86FPRegRegInstruction : public TR::X86RegRegInstruction
 
    void applySourceRegisterToOpCode(uint8_t *opCode, TR::Machine * machine)
       {
-      // *this    swipeable for debugging purposes
 
       TR::RealRegister *reg = toRealRegister(getSourceRegister());
       if (reg->getRegisterNumber() != TR::RealRegister::st0)
@@ -2462,7 +2457,6 @@ class X86FPRegRegInstruction : public TR::X86RegRegInstruction
 
    void applyTargetRegisterToOpCode(uint8_t *opCode, TR::Machine * machine)
       {
-      // *this    swipeable for debugging purposes
 
       TR::RealRegister *reg = toRealRegister(getTargetRegister());
       if (reg->getRegisterNumber() != TR::RealRegister::st0)
@@ -2588,7 +2582,6 @@ class X86FPArithmeticRegRegInstruction : public TR::X86FPRegRegInstruction
 
    void applyDestinationBitToOpCode(uint8_t *opCode, TR::Machine * machine)
       {
-      // *this    swipeable for debugging purposes
       TR::RealRegister *reg = toRealRegister(getTargetRegister());
       if (reg->getRegisterNumber() != TR::RealRegister::st0)
          {
@@ -2598,7 +2591,6 @@ class X86FPArithmeticRegRegInstruction : public TR::X86FPRegRegInstruction
 
    void applyDirectionBitToOpCode(uint8_t *opCode, TR::Machine * machine)
       {
-      // *this    swipeable for debugging purposes
       uint8_t reverse, destination;
 
       TR::RealRegister *reg = toRealRegister(getTargetRegister());

--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -179,7 +179,6 @@ uint8_t getMemoryBarrierBinaryLengthLowerBound(int32_t barrier, TR::CodeGenerato
 
 uint8_t *OMR::X86::Instruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t *instructionStart = self()->cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
    if (self()->getOpCode().needsRepPrefix())
@@ -195,7 +194,6 @@ uint8_t *OMR::X86::Instruction::generateBinaryEncoding()
 
 int32_t OMR::X86::Instruction::estimateBinaryLength(int32_t currentEstimate)
    {
-   // *this    swipeable for debugging purposes
    self()->setEstimatedBinaryLength(self()->getOpCode().length(self()->rexBits()) + (self()->getOpCode().needsRepPrefix() ? 1 : 0));
    return currentEstimate + self()->getEstimatedBinaryLength();
    }
@@ -398,7 +396,6 @@ TR::X86LabelInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
 
 uint8_t *TR::X86LabelInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
 
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    TR::LabelSymbol *label = getLabelSymbol();
@@ -579,7 +576,6 @@ TR::X86LabelInstruction::enlarge(
 int32_t TR::X86LabelInstruction::estimateBinaryLength(int32_t currentEstimate)
    {
    TR::Compilation *comp = cg()->comp();
-   // *this    swipeable for debugging purposes
    if (getOpCode().isBranchOp())
       {
       uint32_t immediateLength = 1;
@@ -663,7 +659,6 @@ TR::X86FenceInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
 
 uint8_t *TR::X86FenceInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    int i;
 
@@ -725,7 +720,6 @@ uint8_t TR::X86RestoreVMThreadInstruction::getBinaryLengthLowerBound()
 
 uint8_t *TR::X86RestoreVMThreadInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
 
@@ -946,7 +940,6 @@ TR::X86ImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
 
 uint8_t *TR::X86ImmInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
    cursor = getOpCode().binary(cursor, self()->rexBits());
@@ -995,7 +988,6 @@ uint8_t TR::X86ImmInstruction::getBinaryLengthLowerBound()
 
 int32_t TR::X86ImmInstruction::estimateBinaryLength(int32_t currentEstimate)
    {
-   // *this    swipeable for debugging purposes
    uint32_t immediateLength = 1;
    if (getOpCode().hasIntImmediate())
       {
@@ -1031,7 +1023,6 @@ TR::X86ImmSnippetInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
 
 uint8_t *TR::X86ImmSnippetInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor = instructionStart;
    cursor = getOpCode().binary(cursor, self()->rexBits());
@@ -1078,7 +1069,6 @@ uint8_t *TR::X86ImmSnippetInstruction::generateBinaryEncoding()
 
 int32_t TR::X86ImmSymInstruction::estimateBinaryLength(int32_t currentEstimate)
    {
-   // *this    swipeable for debugging purposes
 
    currentEstimate = TR::X86ImmInstruction::estimateBinaryLength(currentEstimate);
 
@@ -1207,7 +1197,6 @@ TR::X86ImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
 
 uint8_t *TR::X86ImmSymInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor = instructionStart;
    TR::Compilation *comp = cg()->comp();
@@ -1393,7 +1382,6 @@ uint8_t *TR::X86ImmSymInstruction::generateBinaryEncoding()
 
 uint8_t *TR::X86RegInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
    cursor = generateRepeatedRexPrefix(cursor);
@@ -1418,7 +1406,6 @@ uint8_t TR::X86RegInstruction::getBinaryLengthLowerBound()
 
 int32_t TR::X86RegInstruction::estimateBinaryLength(int32_t currentEstimate)
    {
-   // *this    swipeable for debugging purposes
    TR_X86OpCode  &opCode = getOpCode();
    setEstimatedBinaryLength(opCode.length(self()->rexBits()) + rexRepeatCount());
    return currentEstimate + getEstimatedBinaryLength();
@@ -1457,7 +1444,6 @@ TR::X86RegInstruction::enlarge(int32_t requestedEnlargementSize, int32_t maxEnla
 
 uint8_t *TR::X86RegRegInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
    cursor = generateRepeatedRexPrefix(cursor);
@@ -1590,7 +1576,6 @@ TR::X86RegImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
 
 uint8_t *TR::X86RegImmInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor = instructionStart;
    TR::Compilation *comp = cg()->comp();
@@ -1640,7 +1625,6 @@ uint8_t TR::X86RegImmInstruction::getBinaryLengthLowerBound()
 
 int32_t TR::X86RegImmInstruction::estimateBinaryLength(int32_t currentEstimate)
    {
-   // *this    swipeable for debugging purposes
    uint32_t immediateLength = 1;
    if (getOpCode().hasIntImmediate())
       {
@@ -1738,7 +1722,6 @@ TR::X86RegImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
 
 uint8_t *TR::X86RegImmSymInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
    TR::Compilation *comp = cg()->comp();
@@ -1783,7 +1766,6 @@ void TR::X86RegRegImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
 
 uint8_t *TR::X86RegRegImmInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor = instructionStart;
    cursor = getOpCode().binary(cursor, self()->rexBits());
@@ -1835,7 +1817,6 @@ uint8_t TR::X86RegRegImmInstruction::getBinaryLengthLowerBound()
 
 int32_t TR::X86RegRegImmInstruction::estimateBinaryLength(int32_t currentEstimate)
    {
-   // *this    swipeable for debugging purposes
    uint32_t immediateLength = 1;
    if (getOpCode().hasIntImmediate())
       {
@@ -1855,7 +1836,6 @@ int32_t TR::X86RegRegImmInstruction::estimateBinaryLength(int32_t currentEstimat
 
 uint8_t *TR::X86MemInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
 
@@ -1997,7 +1977,6 @@ TR::X86MemImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
 
 uint8_t *TR::X86MemImmInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
    setBinaryEncoding(instructionStart);
@@ -2219,7 +2198,6 @@ uint8_t *TR::X86MemImmSymInstruction::generateBinaryEncoding()
 
 uint8_t *TR::X86MemRegInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
 
@@ -2268,7 +2246,6 @@ void TR::X86MemRegImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
 
 uint8_t *TR::X86MemRegImmInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
 
@@ -2567,7 +2544,6 @@ int32_t TR::X86RegMemImmInstruction::estimateBinaryLength(int32_t currentEstimat
 
 uint8_t *TR::X86FPRegInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
    cursor = getOpCode().binary(cursor, self()->rexBits());
@@ -2583,7 +2559,6 @@ uint8_t *TR::X86FPRegInstruction::generateBinaryEncoding()
 
 uint8_t *TR::X86FPRegRegInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
    cursor = getOpCode().binary(cursor, self()->rexBits());
@@ -2601,7 +2576,6 @@ uint8_t *TR::X86FPRegRegInstruction::generateBinaryEncoding()
 
 uint8_t *TR::X86FPST0ST1RegRegInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
    cursor = getOpCode().binary(cursor, self()->rexBits());
@@ -2616,7 +2590,6 @@ uint8_t *TR::X86FPST0ST1RegRegInstruction::generateBinaryEncoding()
 
 uint8_t *TR::X86FPArithmeticRegRegInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
    cursor = getOpCode().binary(cursor, self()->rexBits());
@@ -2647,7 +2620,6 @@ uint8_t *TR::X86FPArithmeticRegRegInstruction::generateBinaryEncoding()
 
 uint8_t *TR::X86FPST0STiRegRegInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
    cursor = getOpCode().binary(cursor, self()->rexBits());
@@ -2666,7 +2638,6 @@ uint8_t *TR::X86FPST0STiRegRegInstruction::generateBinaryEncoding()
 
 uint8_t *TR::X86FPSTiST0RegRegInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
    cursor = getOpCode().binary(cursor, self()->rexBits());
@@ -2685,7 +2656,6 @@ uint8_t *TR::X86FPSTiST0RegRegInstruction::generateBinaryEncoding()
 
 uint8_t *TR::X86FPCompareRegRegInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
    cursor = getOpCode().binary(cursor, self()->rexBits());
@@ -2704,7 +2674,6 @@ uint8_t *TR::X86FPCompareRegRegInstruction::generateBinaryEncoding()
 
 uint8_t *TR::X86FPRegMemInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
 
@@ -2736,7 +2705,6 @@ uint8_t TR::X86FPRegMemInstruction::getBinaryLengthLowerBound()
 
 uint8_t *TR::X86FPMemRegInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
 
@@ -2927,7 +2895,6 @@ uint8_t TR::AMD64RegImm64Instruction::getBinaryLengthLowerBound()
 
 int32_t TR::AMD64RegImm64Instruction::estimateBinaryLength(int32_t currentEstimate)
    {
-   // *this    swipeable for debugging purposes
    setEstimatedBinaryLength(getOpCode().length(self()->rexBits()) + 8);
    return currentEstimate + getEstimatedBinaryLength();
    }

--- a/compiler/x/codegen/X86Debug.cpp
+++ b/compiler/x/codegen/X86Debug.cpp
@@ -349,7 +349,6 @@ TR_Debug::dumpDependencyGroup(TR::FILE *                         pOutFile,
 void
 TR_Debug::dumpDependencies(TR::FILE *pOutFile, TR::Instruction  * instr)
    {
-   // *this    swipeable for debugging purposes
 
    // If we are in instruction selection or register assignment and
    // dependency information is requested, dump it.
@@ -401,7 +400,6 @@ TR_Debug::printReferencedRegisterInfo(TR::FILE *pOutFile, TR::Instruction  * ins
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86PaddingInstruction  * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -428,7 +426,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86PaddingInstruction  * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86AlignmentInstruction  * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -459,7 +456,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86AlignmentInstruction  * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86RestoreVMThreadInstruction  * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -512,7 +508,6 @@ TR_Debug::printBoundaryAvoidanceInfo(TR::FILE *pOutFile, TR::X86BoundaryAvoidanc
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86BoundaryAvoidanceInstruction  * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -536,7 +531,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86BoundaryAvoidanceInstruction  * instr
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86PatchableCodeAlignmentInstruction  * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -560,7 +554,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86PatchableCodeAlignmentInstruction  * 
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86LabelInstruction  * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -608,7 +601,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86LabelInstruction  * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86FenceInstruction  * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -685,7 +677,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86VirtualGuardNOPInstruction  * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86ImmInstruction  * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -720,7 +711,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86ImmInstruction  * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::AMD64Imm64Instruction * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -755,7 +745,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::AMD64Imm64Instruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::AMD64Imm64SymInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -803,7 +792,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::AMD64Imm64SymInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::AMD64RegImm64Instruction * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -912,7 +900,6 @@ void TR_Debug::print(TR::FILE *pOutFile, TR::X86VFPCallCleanupInstruction  *inst
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86ImmSnippetInstruction  * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -931,7 +918,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86ImmSnippetInstruction  * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86ImmSymInstruction  * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -997,7 +983,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86ImmSymInstruction  * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86RegInstruction  * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -1034,7 +1019,6 @@ TR_Debug::printReferencedRegisterInfo(TR::FILE *pOutFile, TR::X86RegInstruction 
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86RegRegInstruction  * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -1077,7 +1061,6 @@ TR_Debug::printReferencedRegisterInfo(TR::FILE *pOutFile, TR::X86RegRegInstructi
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86RegImmInstruction  * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -1100,7 +1083,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86RegImmInstruction  * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86RegRegImmInstruction  * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -1130,7 +1112,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86RegRegImmInstruction  * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86RegRegRegInstruction  * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -1217,7 +1198,6 @@ TR_Debug::printPrefixAndMemoryBarrier(
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86MemInstruction  * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -1255,7 +1235,6 @@ TR_Debug::printReferencedRegisterInfo(TR::FILE *pOutFile, TR::X86MemInstruction 
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86MemImmInstruction  * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -1278,7 +1257,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86MemImmInstruction  * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86MemRegInstruction  * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -1323,7 +1301,6 @@ TR_Debug::printReferencedRegisterInfo(TR::FILE *pOutFile, TR::X86MemRegInstructi
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86MemRegImmInstruction  * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -1351,7 +1328,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86MemRegImmInstruction  * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86MemRegRegInstruction  * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -1407,7 +1383,6 @@ TR_Debug::printReferencedRegisterInfo(TR::FILE *pOutFile, TR::X86MemRegRegInstru
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86RegMemInstruction  * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -1460,7 +1435,6 @@ TR_Debug::printReferencedRegisterInfo(TR::FILE *pOutFile, TR::X86RegMemInstructi
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86RegMemImmInstruction  * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -1489,7 +1463,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86RegMemImmInstruction  * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86FPRegInstruction  * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
    printPrefix(pOutFile, instr);
@@ -1505,7 +1478,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86FPRegInstruction  * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86FPRegRegInstruction  * instr)
    {
-   // *this    swipeable for debugging purposes
 
    if (pOutFile == NULL)
       return;
@@ -1526,7 +1498,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86FPRegRegInstruction  * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86FPMemRegInstruction  * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
    printPrefix(pOutFile, instr);
@@ -1547,7 +1518,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86FPMemRegInstruction  * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86FPRegMemInstruction  * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 
@@ -1574,7 +1544,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86FPRegMemInstruction  * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::MemoryReference  * mr, TR_RegisterSizes operandSize)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       return;
 

--- a/compiler/x/codegen/X86FPConversionSnippet.cpp
+++ b/compiler/x/codegen/X86FPConversionSnippet.cpp
@@ -43,7 +43,6 @@
 
 uint8_t *TR::X86FPConversionSnippet::emitSnippetBody()
    {
-   // *this    swipeable for debugging purposes
    uint8_t *buffer = cg()->getBinaryBufferCursor();
    getSnippetLabel()->setCodeLocation(buffer);
    return genRestartJump(genFPConversion(buffer));
@@ -52,8 +51,6 @@ uint8_t *TR::X86FPConversionSnippet::emitSnippetBody()
 
 uint8_t *TR::X86FPConversionSnippet::emitCallToConversionHelper(uint8_t *buffer)
    {
-   // *this    swipeable for debugging purposes
-
    *buffer++ = 0xe8;      // CallImm4
 
    intptrj_t helperAddress = (intptrj_t)getHelperSymRef()->getMethodAddress();
@@ -73,8 +70,6 @@ uint8_t *TR::X86FPConversionSnippet::emitCallToConversionHelper(uint8_t *buffer)
 
 uint8_t *TR::X86FPConvertToIntSnippet::genFPConversion(uint8_t *buffer)
    {
-   // *this    swipeable for debugging purposes
-
    TR::ILOpCodes              opcode          = _convertInstruction->getNode()->getOpCodeValue();
    TR::RealRegister          *targetRegister  = toRealRegister(_convertInstruction->getTargetRegister());
    TR::RealRegister::RegNum   targetReg       = targetRegister->getRegisterNumber();
@@ -165,8 +160,6 @@ uint8_t *TR::X86FPConvertToIntSnippet::genFPConversion(uint8_t *buffer)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86FPConvertToIntSnippet  * snippet)
    {
-   // *this    swipeable for debugging purposes
-
    if (pOutFile == NULL)
       return;
 
@@ -233,7 +226,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86FPConvertToIntSnippet  * snippet)
 
 uint32_t TR::X86FPConvertToIntSnippet::getLength(int32_t estimatedSnippetStart)
    {
-   // *this    swipeable for debugging purposes
    uint32_t length = 11;
    TR::Machine * machine = cg()->machine();
 
@@ -284,8 +276,6 @@ const uint8_t TR::X86FPConvertToLongSnippet::_registerActions[16] =
 
 uint8_t *TR::X86FPConvertToLongSnippet::genFPConversion(uint8_t *buffer)
    {
-   // *this    swipeable for debugging purposes
-
    // Mask off the FXCH flag.
    //
    uint8_t action = _registerActions[ _action & 0x7f ];
@@ -356,8 +346,6 @@ uint8_t *TR::X86FPConvertToLongSnippet::genFPConversion(uint8_t *buffer)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86FPConvertToLongSnippet  * snippet)
    {
-   // *this    swipeable for debugging purposes
-
    if (pOutFile == NULL)
       return;
 
@@ -455,8 +443,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86FPConvertToLongSnippet  * snippet)
 
 void TR::X86FPConvertToLongSnippet::analyseLongConversion()
    {
-   // *this    swipeable for debugging purposes
-
    // The current assumption is that register assignment will occur prior
    // to the snippets being sized and emitted.
    //
@@ -483,7 +469,6 @@ void TR::X86FPConvertToLongSnippet::analyseLongConversion()
 
 uint32_t TR::X86FPConvertToLongSnippet::getLength(int32_t estimatedSnippetStart)
    {
-   // *this    swipeable for debugging purposes
    uint32_t length = 5;
 
    analyseLongConversion();
@@ -535,7 +520,6 @@ uint32_t TR::X86FPConvertToLongSnippet::getLength(int32_t estimatedSnippetStart)
 
 uint8_t *TR::X86fbits2iSnippet::emitSnippetBody()
    {
-   // *this    swipeable for debugging purposes
    uint8_t *buffer = cg()->getBinaryBufferCursor();
    getSnippetLabel()->setCodeLocation(buffer);
    *buffer++ = 0xf7;
@@ -568,8 +552,6 @@ uint8_t *TR::X86fbits2iSnippet::emitSnippetBody()
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86fbits2iSnippet  * snippet)
    {
-   // *this    swipeable for debugging purposes
-
    if (pOutFile == NULL)
       return;
 
@@ -605,7 +587,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86fbits2iSnippet  * snippet)
 
 uint32_t TR::X86fbits2iSnippet::getLength(int32_t estimatedSnippetStart)
    {
-   // *this    swipeable for debugging purposes
    uint32_t length = 6;  // 6 for test instruction
 
    int32_t location = getRestartLabel()->getEstimatedCodeLocation();

--- a/compiler/x/codegen/XMMBinaryArithmeticAnalyser.cpp
+++ b/compiler/x/codegen/XMMBinaryArithmeticAnalyser.cpp
@@ -60,7 +60,6 @@ void TR_X86XMMBinaryArithmeticAnalyser::setInputs(TR::Node     *firstChild,
                                                   TR::Node     *secondChild,
                                                   TR::Register *secondRegister)
    {
-   // *this    swipeable for debugging purposes
    _inputs = 0;
 
    if (firstRegister)
@@ -126,8 +125,6 @@ TR_X86XMMBinaryArithmeticAnalyser::getX86XMMOpPackage(TR::Node *node)
 
 void TR_X86XMMBinaryArithmeticAnalyser::genericXMMAnalyser(TR::Node *root)
    {
-   // *this    swipeable for debugging purposes
-
    TR::Node                *targetChild = root->getFirstChild(),
                           *sourceChild = root->getSecondChild();
    TR::Register            *targetRegister = targetChild->getRegister(),

--- a/compiler/z/codegen/BinaryAnalyser.cpp
+++ b/compiler/z/codegen/BinaryAnalyser.cpp
@@ -94,7 +94,6 @@ TR_S390BinaryAnalyser::genericAnalyser(TR::Node * root,
                                        TR::InstOpCode::Mnemonic memToRegOpCode,
                                        TR::InstOpCode::Mnemonic copyOpCode)
    {
-   // *this    swipeable for debugging purposes
    TR::Node * firstChild;
    TR::Node * secondChild;
    firstChild = root->getFirstChild();
@@ -270,7 +269,6 @@ TR_S390BinaryAnalyser::genericAnalyser(TR::Node * root,
 void
 TR_S390BinaryAnalyser::longSubtractAnalyser(TR::Node * root)
    {
-   // *this    swipeable for debugging purposes
    TR::Node * firstChild;
    TR::Node * secondChild;
    TR::Instruction * cursor = NULL;

--- a/compiler/z/codegen/BinaryCommutativeAnalyser.cpp
+++ b/compiler/z/codegen/BinaryCommutativeAnalyser.cpp
@@ -147,7 +147,6 @@ TR_S390BinaryCommutativeAnalyser::genericAnalyser(TR::Node * root, TR::InstOpCod
    TR::InstOpCode::Mnemonic copyOpCode, bool nonClobberingDestination,
    TR::LabelSymbol *targetLabel, TR::InstOpCode::S390BranchCondition fBranchOpCond, TR::InstOpCode::S390BranchCondition rBranchOpCond)
    {
-   // *this    swipeable for debugging purposes
    TR::Node * firstChild;
    TR::Node * secondChild;
    TR::Node * initFirstChild = NULL;
@@ -619,7 +618,6 @@ void
 TR_S390BinaryCommutativeAnalyser::genericLongAnalyser(TR::Node * root, TR::InstOpCode::Mnemonic lowRegToRegOpCode,
    TR::InstOpCode::Mnemonic highRegToRegOpCode, TR::InstOpCode::Mnemonic lowMemToRegOpCode, TR::InstOpCode::Mnemonic highMemToRegOpCode, TR::InstOpCode::Mnemonic copyOpCode)
    {
-   // *this    swipeable for debugging purposes
    TR::Node * firstChild;
    TR::Node * secondChild;
    TR::Instruction * cursor = NULL;
@@ -1239,7 +1237,6 @@ TR_S390BinaryCommutativeAnalyser::conversionIsRemoved(TR::Node * root, TR::Node 
 void
 TR_S390BinaryCommutativeAnalyser::integerAddAnalyser(TR::Node * root, TR::InstOpCode::Mnemonic regToRegOpCode, TR::InstOpCode::Mnemonic memToRegOpCode, TR::InstOpCode::Mnemonic copyOpCode)
    {
-   // *this    swipeable for debugging purposes
    TR::Node * firstChild;
    TR::Node * secondChild;
    TR::Instruction * cursor = NULL;
@@ -1467,7 +1464,6 @@ TR_S390BinaryCommutativeAnalyser::integerAddAnalyser(TR::Node * root, TR::InstOp
 void
 TR_S390BinaryCommutativeAnalyser::longAddAnalyser(TR::Node * root, TR::InstOpCode::Mnemonic copyOpCode)
    {
-   // *this    swipeable for debugging purposes
    TR_ASSERT(TR::Compiler->target.is32Bit(), " should call integerAddAnalyser() for 64Bit code-gen!");
    TR::Node * firstChild;
    TR::Node * secondChild;

--- a/compiler/z/codegen/CompareAnalyser.cpp
+++ b/compiler/z/codegen/CompareAnalyser.cpp
@@ -52,7 +52,6 @@ TR_S390CompareAnalyser::longOrderedCompareAndBranchAnalyser(TR::Node * root, TR:
    TR::InstOpCode::S390BranchCondition brCmpHighTrueCond, TR::InstOpCode::S390BranchCondition brCmpHighFalseCond, TR::LabelSymbol * trueTarget, TR::LabelSymbol * falseTarget,
    bool &internalControlFlowStarted)
    {
-   // *this    swipeable for debugging purposes
    TR::Node * firstChild = root->getFirstChild();
    TR::Node * secondChild = root->getSecondChild();
    TR::Register * firstRegister = firstChild->getRegister();

--- a/compiler/z/codegen/ConstantDataSnippet.cpp
+++ b/compiler/z/codegen/ConstantDataSnippet.cpp
@@ -79,7 +79,6 @@ TR::S390ConstantDataSnippet::S390ConstantDataSnippet(TR::CodeGenerator * cg, TR:
 TR::S390ConstantDataSnippet::S390ConstantDataSnippet(TR::CodeGenerator * cg, TR::Node * n, char* c) :
    TR::Snippet(cg, n, TR::LabelSymbol::create(cg->trHeapMemory(),cg), false)
    {
-   // *this   swipeable for debugging purposes
    _length = strlen(c);
    _string = (char *) cg->trMemory()->allocateMemory(_length, heapAlloc);
    memcpy(_string, c, strlen(c));
@@ -269,7 +268,6 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
 uint8_t *
 TR::S390ConstantDataSnippet::emitSnippetBody()
    {
-   // *this   swipeable for debugging purposes
    uint8_t * cursor = cg()->getBinaryBufferCursor();
    TR::Compilation *comp = cg()->comp();
 
@@ -308,7 +306,6 @@ TR::S390ConstantDataSnippet::emitSnippetBody()
 uint32_t
 TR::S390ConstantDataSnippet::getLength(int32_t  estimatedSnippetStart)
    {
-   // *this   swipeable for debugging purposes
    return _length;
    }
 
@@ -410,7 +407,6 @@ TR::S390WarmEyeCatcherDataSnippet::emitSnippetBody()
 TR::S390WritableDataSnippet::S390WritableDataSnippet(TR::CodeGenerator * cg, TR::Node * n, void * c, uint16_t size)
    : TR::S390ConstantDataSnippet(cg, n, c, size)
    {
-   // *this   swipeable for debugging purposes
    }
 
 //////////////////////////////////////////////////////////////////////////////////////
@@ -441,7 +437,6 @@ TR::S390TargetAddressSnippet::S390TargetAddressSnippet(TR::CodeGenerator * cg, T
 uint8_t *
 TR::S390TargetAddressSnippet::emitSnippetBody()
    {
-   // *this   swipeable for debugging purposes
    uint8_t * cursor = cg()->getBinaryBufferCursor();
    AOTcgDiag1(cg()->comp(), "TR::S390TargetAddressSnippet::emitSnippetBody cursor=%x\n", cursor);
    getSnippetLabel()->setCodeLocation(cursor);
@@ -498,7 +493,6 @@ TR::S390TargetAddressSnippet::emitSnippetBody()
 uint32_t
 TR::S390TargetAddressSnippet::getLength(int32_t  estimatedSnippetStart)
    {
-   // *this   swipeable for debugging purposes
    return sizeof(uintptrj_t);
    }
 

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -1440,7 +1440,6 @@ OMR::Z::CodeGenerator::insertPad(TR::Node * theNode, TR::Instruction * insertion
 void
 OMR::Z::CodeGenerator::beginInstructionSelection()
    {
-   // *this    swipeable for debugging purposes
    TR::ResolvedMethodSymbol * methodSymbol = self()->comp()->getJittedMethodSymbol();
    TR::Node * startNode = self()->comp()->getStartTree()->getNode();
    TR::Instruction * cursor = NULL;
@@ -1500,7 +1499,6 @@ OMR::Z::CodeGenerator::endInstructionSelection()
 void
 OMR::Z::CodeGenerator::doInstructionSelection()
    {
-   // *this    swipeable for debugging purposes
 
    _outgoingArgLevelDuringTreeEvaluation = self()->getLinkage()->getNumberOfAllocatedOutgoingArgumentAreas();
 
@@ -2680,7 +2678,6 @@ OMR::Z::CodeGenerator::prepareRegistersForAssignment()
 void
 OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
    {
-   // *this    swipeable for debugging purposes
    TR::Instruction * prevInstruction, * nextInstruction;
 
 #ifdef DEBUG
@@ -7374,7 +7371,6 @@ OMR::Z::CodeGenerator::allocateClobberableRegister(TR::Register *srcRegister)
 TR::Register *
 OMR::Z::CodeGenerator::gprClobberEvaluate(TR::Node * node, bool force_copy, bool ignoreRefCount)
    {
-   // *this    swipeable for debugging purposes
    TR::Instruction * cursor = NULL;
 
    TR_Debug * debugObj = self()->getDebug();
@@ -7521,7 +7517,6 @@ OMR::Z::CodeGenerator::gprClobberEvaluate(TR::Node * node, bool force_copy, bool
 TR::Register *
 OMR::Z::CodeGenerator::fprClobberEvaluate(TR::Node * node)
    {
-   // *this    swipeable for debugging purposes
 
    TR::Register *srcRegister = self()->evaluate(node);
    if (!self()->canClobberNodesRegister(node))
@@ -7993,7 +7988,6 @@ TR_S390OutOfLineCodeSection * OMR::Z::CodeGenerator::findS390OutOfLineCodeSectio
 TR::S390ConstantDataSnippet *
 OMR::Z::CodeGenerator::findOrCreateConstant(TR::Node * node, void * c, uint16_t size, bool isWarm)
    {
-   // *this    swipeable for debugging purposes
    CS2::HashIndex hi;
    TR_S390ConstantDataSnippetKey key;
    key.c      = c;
@@ -8061,7 +8055,6 @@ OMR::Z::CodeGenerator::createConstantInstruction(TR::CodeGenerator * cg, TR::Nod
 TR::S390ConstantDataSnippet *
 OMR::Z::CodeGenerator::CreateConstant(TR::Node * node, void * c, uint16_t size, bool writable)
    {
-   // *this    swipeable for debugging purposes
 
    if (writable)
       {
@@ -8106,7 +8099,6 @@ OMR::Z::CodeGenerator::addDataConstantSnippet(TR::S390ConstantDataSnippet * snip
 int32_t
 OMR::Z::CodeGenerator::setEstimatedOffsetForConstantDataSnippets(int32_t targetAddressSnippetSize, bool isWarm)
    {
-   // *this    swipeable for debugging purposes
    TR::S390ConstantDataSnippet * cursor;
    bool first;
    int32_t size;
@@ -8187,7 +8179,6 @@ OMR::Z::CodeGenerator::setEstimatedOffsetForConstantDataSnippets(int32_t targetA
 int32_t
 OMR::Z::CodeGenerator::setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart, bool isWarm)
    {
-   // *this    swipeable for debugging purposes
    TR::S390ConstantDataSnippet * cursor;
    bool first;
    int32_t size;
@@ -8275,7 +8266,6 @@ OMR::Z::CodeGenerator::setEstimatedLocationsForDataSnippetLabels(int32_t estimat
 void
 OMR::Z::CodeGenerator::emitDataSnippets(bool isWarm)
    {
-   // *this    swipeable for debugging purposes
    // If you change logic here, be sure to do similar change in
    // the method : TR::S390ConstantDataSnippet *OMR::Z::CodeGenerator::getFirstConstantData()
 
@@ -8419,7 +8409,6 @@ OMR::Z::CodeGenerator::create64BitLiteralPoolSnippet(TR::DataType dt, int64_t va
 TR::Linkage *
 OMR::Z::CodeGenerator::createLinkage(TR_LinkageConventions lc)
    {
-   // *this    swipeable for debugging purposes
    TR::Linkage * linkage;
    TR::Compilation *comp = self()->comp();
    switch (lc)
@@ -8648,7 +8637,6 @@ OMR::Z::CodeGenerator::getFirstConstantData()
 int32_t
 OMR::Z::CodeGenerator::setEstimatedOffsetForTargetAddressSnippets()
    {
-   // *this    swipeable for debugging purposes
    int32_t estimatedOffset = 0;
 
    for (auto iterator = _targetList.begin(); iterator != _targetList.end(); ++iterator)
@@ -8671,7 +8659,6 @@ OMR::Z::CodeGenerator::setEstimatedOffsetForTargetAddressSnippets()
 int32_t
 OMR::Z::CodeGenerator::setEstimatedLocationsForTargetAddressSnippetLabels(int32_t estimatedSnippetStart, bool isWarm)
    {
-   // *this    swipeable for debugging purposes
    self()->setEstimatedSnippetStart(estimatedSnippetStart);
    // Conservatively add maximum padding to get to 8 byte alignment.
    estimatedSnippetStart += 6;
@@ -8689,7 +8676,6 @@ OMR::Z::CodeGenerator::setEstimatedLocationsForTargetAddressSnippetLabels(int32_
 void
 OMR::Z::CodeGenerator::emitTargetAddressSnippets(bool isWarm)
    {
-   // *this    swipeable for debugging purposes
    uint8_t * codeOffset;
    int8_t size = 8;
 
@@ -9757,7 +9743,6 @@ OMR::Z::CodeGenerator::copyRestrictedVirtual(TR::Register * virtReg, TR::Node *n
 void
 OMR::Z::CodeGenerator::dumpDataSnippets(TR::FILE *outFile, bool isWarm)
    {
-   // *this    swipeable for debugging purposes
 
    if (outFile == NULL)
       {
@@ -9825,7 +9810,6 @@ OMR::Z::CodeGenerator::dumpDataSnippets(TR::FILE *outFile, bool isWarm)
 void
 OMR::Z::CodeGenerator::dumpTargetAddressSnippets(TR::FILE *outFile, bool isWarm)
    {
-   // *this    swipeable for debugging purposes
 
    if (outFile == NULL)
       {

--- a/compiler/z/codegen/OMRInstruction.cpp
+++ b/compiler/z/codegen/OMRInstruction.cpp
@@ -469,14 +469,12 @@ OMR::Z::Instruction::useRegister(TR::Register * reg, bool isDummy)
 bool
 OMR::Z::Instruction::refsRegister(TR::Register * reg)
    {
-   // *this    swipeable for debugging purposes
    return self()->getDependencyConditions() ? self()->getDependencyConditions()->refsRegister(reg) : false;
    }
 
 bool
 OMR::Z::Instruction::defsAnyRegister(TR::Register * reg)
    {
-   // *this    swipeable for debugging purposes
    TR::Register **_targetReg = self()->targetRegBase();
 
    if (_targetReg)
@@ -493,7 +491,6 @@ OMR::Z::Instruction::defsAnyRegister(TR::Register * reg)
 bool
 OMR::Z::Instruction::defsRegister(TR::Register * reg)
    {
-   // *this    swipeable for debugging purposes
    TR::Register **_targetReg = self()->targetRegBase();
 
    if (_targetReg)
@@ -531,7 +528,6 @@ OMR::Z::Instruction::isDefRegister(TR::Register * reg)
 
 bool OMR::Z::Instruction::usesOnlyRegister(TR::Register *reg)
   {
-   // *this    swipeable for debugging purposes
    int32_t i;
    TR::Register **_sourceReg = self()->sourceRegBase();
    TR::MemoryReference **_sourceMem = self()->sourceMemBase();
@@ -568,7 +564,6 @@ bool OMR::Z::Instruction::usesOnlyRegister(TR::Register *reg)
 bool
 OMR::Z::Instruction::usesRegister(TR::Register * reg)
    {
-   // *this    swipeable for debugging purposes
    int32_t i;
 
    if(self()->usesOnlyRegister(reg) || self()->defsRegister(reg))
@@ -598,7 +593,6 @@ OMR::Z::Instruction::usesRegister(TR::Register * reg)
 
 bool OMR::Z::Instruction::startOfLiveRange(TR::Register * reg)
   {
-   // *this    swipeable for debugging purposes
    int32_t i;
    TR::Register **_targetReg = self()->targetRegBase();
    bool result;
@@ -657,7 +651,6 @@ bool OMR::Z::Instruction::startOfLiveRange(TR::Register * reg)
 
 bool OMR::Z::Instruction::getRegisters(TR::list<TR::Register *> &regs)
   {
-  // *this    swipeable for debugging purposes
    TR::Compilation *comp = self()->cg()->comp();
   int32_t i,n;
   regs.clear();
@@ -778,7 +771,6 @@ bool OMR::Z::Instruction::getRegisters(TR::list<TR::Register *> &regs)
 
 bool OMR::Z::Instruction::getUsedRegisters(TR::list<TR::Register *> &usedRegs)
   {
-  // *this    swipeable for debugging purposes
   int32_t i,n;
   usedRegs.clear();
   TR::Compilation *comp = self()->cg()->comp();
@@ -984,7 +976,6 @@ bool OMR::Z::Instruction::getDefinedRegisters(TR::list<TR::Register *> &defedReg
    OMR::Z::Machine *machine=self()->cg()->machine();
    bool afterRA=self()->cg()->afterRA();
 
-  // *this    swipeable for debugging purposes
   int32_t i,n;
 
   defedRegs.clear();
@@ -1102,7 +1093,6 @@ bool OMR::Z::Instruction::getDefinedRegisters(TR::list<TR::Register *> &defedReg
 
 bool OMR::Z::Instruction::getKilledRegisters(TR::list<TR::Register *> &killedRegs)
   {
-  // *this    swipeable for debugging purposes
   int32_t i,n;
   TR::Compilation *comp = self()->cg()->comp();
 
@@ -1286,7 +1276,6 @@ OMR::Z::Instruction::setupThrowsImplicitNullPointerException(TR::Node *n, TR::Me
 TR::S390ImmInstruction *
 OMR::Z::Instruction::getS390ImmInstruction()
    {
-   // *this    swipeable for debugging purposes
    return NULL;
    }
 #endif
@@ -1294,7 +1283,6 @@ OMR::Z::Instruction::getS390ImmInstruction()
 uint8_t *
 OMR::Z::Instruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = self()->cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,self()->getEstimatedBinaryLength());
@@ -1309,7 +1297,6 @@ OMR::Z::Instruction::generateBinaryEncoding()
 int32_t
 OMR::Z::Instruction::estimateBinaryLength(int32_t  currentEstimate)
    {
-   // *this    swipeable for debugging purposes
    self()->setEstimatedBinaryLength(self()->getOpCode().getInstructionLength());
    return currentEstimate + self()->getEstimatedBinaryLength();
    }
@@ -1317,14 +1304,12 @@ OMR::Z::Instruction::estimateBinaryLength(int32_t  currentEstimate)
 bool
 OMR::Z::Instruction::dependencyRefsRegister(TR::Register * reg)
    {
-   // *this    swipeable for debugging purposes
    return false;
    }
 
 void
 OMR::Z::Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
-   // *this    swipeable for debugging purposes
    TR::Compilation *comp = self()->cg()->comp();
 
    if (self()->getOpCodeValue() != TR::InstOpCode::ASSOCREGS)
@@ -2571,7 +2556,6 @@ OMR::Z::Instruction::assignOrderedRegisters(TR_RegisterKinds kindToBeAssigned)
 void
 OMR::Z::Instruction::assignRegistersAndDependencies(TR_RegisterKinds kindToBeAssigned)
    {
-   // *this    swipeable for debugging purposes
    //
 
    TR::Register **_sourceReg = self()->sourceRegBase();

--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -128,7 +128,6 @@ OMR::Z::Linkage::Linkage(TR::CodeGenerator * codeGen,TR_S390LinkageConventions e
       _firstPrologueInstr(NULL),
       _frameType(standardFrame)
    {
-   // *this    swipeable for debugging purposes
    int32_t i;
    self()->setProperties(0);
    for (i=0; i<TR::RealRegister::NumRegisters;i++)
@@ -2321,7 +2320,6 @@ OMR::Z::Linkage::buildArgs(TR::Node * callNode, TR::RegisterDependencyConditions
    bool isFastJNI, int64_t killMask, TR::Register* &vftReg, bool PassReceiver)
    {
 
-   // *this    swipeable for debugging purposes
    TR::SystemLinkage * systemLinkage = (TR::SystemLinkage *) self()->cg()->getLinkage(TR_System);
 
    self()->clearCachedStackRegisterForOutgoingArguments(true); // outgoing arguments may be accessed via stack register realized lazily via getStackRegisterForOutgoingArgument()

--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -2185,7 +2185,6 @@ bool
 OMR::Z::Machine::findBestFreeRegisterPair(TR::RealRegister ** firstRegister, TR::RealRegister ** lastRegister,
    TR_RegisterKinds rk, TR::Instruction * currInst, uint64_t availRegMask)
    {
-   // *this    swipeable for debugging purposes
    uint32_t interference = 0;
    int32_t first, maskI;
    int32_t last;
@@ -2965,7 +2964,6 @@ OMR::Z::Machine::findBestFreeRegister(TR::Instruction   *currentInstruction,
                                      uint64_t          availRegMask,
                                      bool              needsHighWord)
    {
-   // *this    swipeable for debugging purposes
    uint32_t interference = 0;
    int32_t first, maskI, last;
    uint32_t randomInterference;
@@ -3839,7 +3837,6 @@ OMR::Z::Machine::freeBestRegister(TR::Instruction * currentInstruction, TR::Regi
 
    if (virtReg->containsCollectedReference())
       _cg->traceRegisterAssignment("%R contains collected", virtReg);
-   // *this    swipeable for debugging purposes
    int32_t numCandidates = 0, interference = 0, first, last, maskI;
    TR::Register * candidates[TR::RealRegister::LastVRF];
    TR::Machine *machine = self()->cg()->machine();
@@ -4677,7 +4674,6 @@ OMR::Z::Machine::reverseSpillState(TR::Instruction      *currentInstruction,
                                   TR::Register         *spilledRegister,
                                   TR::RealRegister *targetRegister)
    {
-   // *this    swipeable for debugging purposes
    TR_BackingStore * location = spilledRegister->getBackingStorage();
    TR::Node * currentNode = currentInstruction->getNode();
    TR_RegisterKinds rk = spilledRegister->getKind();
@@ -5046,7 +5042,6 @@ OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction                       
                                          TR::RealRegister::RegNum  registerNumber,
                                          flags32_t                                  instFlags)
    {
-   // *this    swipeable for debugging purposes
    TR::RealRegister * targetRegister = _registerFile[registerNumber];
    TR::RealRegister * realReg = virtualRegister->getAssignedRealRegister();
    if(virtualRegister->isArGprPair()) realReg = virtualRegister->getGPRofArGprPair()->getAssignedRealRegister();
@@ -6128,7 +6123,6 @@ uint64_t OMR::Z::Machine::filterColouredRegisterConflicts(TR::Register *targetRe
 void
 OMR::Z::Machine::initialiseRegisterFile()
    {
-   // *this    swipeable for debugging purposes
 
    // Initialize GPRs
    _registerFile[TR::RealRegister::NoReg] = NULL;
@@ -7314,7 +7308,6 @@ OMR::Z::Machine::getHPRFromGlobalRegisterNumber(TR_GlobalRegisterNumber reg)
 void
 OMR::Z::Machine::setRegisterWeightsFromAssociations()
    {
-   // *this    swipeable for debugging purposes
    TR::Linkage * linkage = _cg->getS390Linkage();
    int32_t first = TR::RealRegister::FirstGPR;
    TR::Compilation *comp = TR::comp();
@@ -7362,7 +7355,6 @@ OMR::Z::Machine::setRegisterWeightsFromAssociations()
 void
 OMR::Z::Machine::createRegisterAssociationDirective(TR::Instruction * cursor)
    {
-   // *this    swipeable for debugging purposes
    TR::Compilation *comp = TR::comp();
    int32_t last = TR::RealRegister::LastAssignableVRF;
    TR::RegisterDependencyConditions * associations;

--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -472,7 +472,6 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node * rootLoadOrStore, TR::CodeGen
    _offset(0),_displacement(0), _flags(0), _storageReference(storageReference), _fixedSizeForAlignment(0), _leftMostByte(0), _name(NULL),
    _incrementedNodesList(cg->comp()->trMemory())
    {
-   // *this    swipeable for debugging purposes
 
    TR::SymbolReference * symRef = rootLoadOrStore->getOpCode().hasSymbolReference() ? rootLoadOrStore->getSymbolReference() : NULL;
    TR::Symbol * symbol = symRef ? symRef->getSymbol() : NULL;
@@ -760,7 +759,6 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node * node, TR::SymbolReference * 
      _incrementedNodesList(cg->comp()->trMemory())
    {
 
-   // *this    swipeable for debugging purposes
    TR::Symbol * symbol = symRef->getSymbol();
    TR::Register * writableLiteralPoolRegister = NULL;
    TR::Compilation *comp = cg->comp();
@@ -1127,7 +1125,6 @@ OMR::Z::MemoryReference::setOriginalSymbolReference(TR::SymbolReference * ref, T
 void
 OMR::Z::MemoryReference::decNodeReferenceCounts(TR::CodeGenerator * cg)
    {
-   // *this    swipeable for debugging purposes
    if (_baseRegister != NULL)
       {
       if (_baseRegister != cg->getLitPoolRealRegister() &&  _baseNode != NULL)
@@ -1178,7 +1175,6 @@ OMR::Z::MemoryReference::stopUsingMemRefRegister(TR::CodeGenerator * cg)
 void
 OMR::Z::MemoryReference::bookKeepingRegisterUses(TR::Instruction * instr, TR::CodeGenerator * cg)
    {
-   // *this    swipeable for debugging purposes
    if (_baseRegister != NULL)
       {
       instr->useRegister(_baseRegister);
@@ -1943,7 +1939,6 @@ OMR::Z::MemoryReference::populateMemoryReference(TR::Node * subTree, TR::CodeGen
 void
 OMR::Z::MemoryReference::consolidateRegisters(TR::Node * node, TR::CodeGenerator * cg)
    {
-   // *this swipeable for debugging purposes
    TR::Register * tempTargetRegister;
    if ((_baseRegister && (_baseRegister->containsCollectedReference() || _baseRegister->containsInternalPointer())) ||
       (_indexRegister && (_indexRegister->containsCollectedReference() || _indexRegister->containsInternalPointer())))
@@ -2131,7 +2126,6 @@ OMR::Z::MemoryReference::enforceVRXFormatLimits(TR::Node * node, TR::CodeGenerat
 TR::Instruction *
 OMR::Z::MemoryReference::enforce4KDisplacementLimit(TR::Node * node, TR::CodeGenerator * cg, TR::Instruction * preced, bool forcePLXFixup, bool forceFixup)
    {
-   // *this    swipeable for debugging purposes
    if (self()->ignoreNegativeOffset())
       return preced;
 
@@ -2201,7 +2195,6 @@ OMR::Z::MemoryReference::markAndAdjustForLongDisplacementIfNeeded(TR::Node * nod
 TR::Instruction *
 OMR::Z::MemoryReference::enforceDisplacementLimit(TR::Node * node, TR::CodeGenerator * cg, TR::Instruction * preced)
    {
-   // *this swipeable for debugging purposes
    if (self()->ignoreNegativeOffset())
       return preced;
 
@@ -2255,7 +2248,6 @@ OMR::Z::MemoryReference::enforceDisplacementLimit(TR::Node * node, TR::CodeGener
 void
 OMR::Z::MemoryReference::eliminateNegativeDisplacement(TR::Node * node, TR::CodeGenerator * cg)
    {
-   // *this    swipeable for debugging purposes
    if (self()->ignoreNegativeOffset())
       return;
 
@@ -2264,7 +2256,6 @@ OMR::Z::MemoryReference::eliminateNegativeDisplacement(TR::Node * node, TR::Code
 
    if (_offset < 0 && !cg->isDispInRange(_offset))
       {
-      // *this    swipeable for debugging purposes
 
       TR::Register * tempTargetRegister;
       if (TR::Compiler->target.is64Bit())
@@ -2308,7 +2299,6 @@ OMR::Z::MemoryReference::separateIndexRegister(TR::Node * node, TR::CodeGenerato
    TR::Compilation *comp = cg->comp();
    if (_indexRegister != NULL)
       {
-      // *this    swipeable for debugging purposes
       if (_baseRegister == NULL)
          {
          // if baseRegister happens to be NULL, we can just set that to be the old index register and be done
@@ -2392,7 +2382,6 @@ OMR::Z::MemoryReference::propagateAlignmentInfo(OMR::Z::MemoryReference *newMemR
 void
 OMR::Z::MemoryReference::assignRegisters(TR::Instruction * currentInstruction, TR::CodeGenerator * cg)
    {
-   // *this    swipeable for debugging purposes
    TR::Machine *machine = cg->machine();
    TR::RealRegister * assignedBaseRegister;
    TR::RealRegister * assignedIndexRegister;
@@ -2595,7 +2584,6 @@ OMR::Z::MemoryReference::getSnippet()
 int32_t
 OMR::Z::MemoryReference::estimateBinaryLength(int32_t  currentEstimate, TR::CodeGenerator * cg, TR::Instruction * instr)
    {
-   // *this    swipeable for debugging purposes
    uint8_t length = 0;
    TR::Compilation *comp = cg->comp();
 

--- a/compiler/z/codegen/OMRRegisterDependency.cpp
+++ b/compiler/z/codegen/OMRRegisterDependency.cpp
@@ -562,7 +562,6 @@ TR::RegisterDependencyConditions  *OMR::Z::RegisterDependencyConditions::clone(T
 bool
 OMR::Z::RegisterDependencyConditions::refsRegister(TR::Register * r)
    {
-   // *this    swipeable for debugging purposes
    for (int32_t i = 0; i < _numPreConditions; i++)
       {
       if (_preConditions->getRegisterDependency(i)->getRegister(_cg) == r &&
@@ -585,7 +584,6 @@ OMR::Z::RegisterDependencyConditions::refsRegister(TR::Register * r)
 bool
 OMR::Z::RegisterDependencyConditions::defsRegister(TR::Register * r)
    {
-   // *this    swipeable for debugging purposes
    for (int32_t i = 0; i < _numPreConditions; i++)
       {
       if (_preConditions->getRegisterDependency(i)->getRegister(_cg) == r &&
@@ -608,7 +606,6 @@ OMR::Z::RegisterDependencyConditions::defsRegister(TR::Register * r)
 bool
 OMR::Z::RegisterDependencyConditions::mayDefineRegister(TR::Register * r)
    {
-   // *this    swipeable for debugging purposes
    for (int32_t j = 0; j < _numPostConditions; j++)
       {
       if (_postConditions->getRegisterDependency(j)->getRegister(_cg) == r &&
@@ -623,7 +620,6 @@ OMR::Z::RegisterDependencyConditions::mayDefineRegister(TR::Register * r)
 bool
 OMR::Z::RegisterDependencyConditions::usesRegister(TR::Register * r)
    {
-   // *this    swipeable for debugging purposes
    for (int32_t i = 0; i < _numPreConditions; i++)
       {
       if (_preConditions->getRegisterDependency(i)->getRegister(_cg) == r &&
@@ -662,7 +658,6 @@ OMR::Z::RegisterDependencyConditions::bookKeepingRegisterUses(TR::Instruction * 
          createRegisterAssociationDirective(instr, cg);
          }
 
-      // *this    swipeable for debugging purposes
       if (_preConditions != NULL)
          {
          for (int32_t i = oldPreCursor; i < _addCursorForPre; i++)
@@ -845,7 +840,6 @@ TR_S390RegisterDependencyGroup::assignRegisters(TR::Instruction   *currentInstru
                                                 uint32_t          numberOfRegisters,
                                                 TR::CodeGenerator *cg)
    {
-   // *this    swipeable for debugging purposes
    TR::Compilation *comp = cg->comp();
    TR::Machine *machine = cg->machine();
    TR::Register * virtReg;
@@ -1661,7 +1655,6 @@ TR_S390RegisterDependencyGroup::assignRegisters(TR::Instruction   *currentInstru
 void
 OMR::Z::RegisterDependencyConditions::createRegisterAssociationDirective(TR::Instruction * instruction, TR::CodeGenerator * cg)
    {
-   // *this    swipeable for debugging purposes
    TR::Machine *machine = cg->machine();
 
    machine->createRegisterAssociationDirective(instruction->getPrev());

--- a/compiler/z/codegen/S390Debug.cpp
+++ b/compiler/z/codegen/S390Debug.cpp
@@ -111,7 +111,6 @@ void
 TR_Debug::printPrefix(TR::FILE *pOutFile, TR::Instruction * instr)
    {
 
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       {
       return;
@@ -462,7 +461,6 @@ void TR_Debug::printS390OOLSequences(TR::FILE *pOutFile)
 void
 TR_Debug::dumpDependencies(TR::FILE *pOutFile, TR::Instruction * instr, bool pre, bool post)
    {
-   // *this    swipeable for debugging purposes
 
    TR::RegisterDependencyConditions *deps = instr->getDependencyConditions();
 
@@ -504,7 +502,6 @@ TR_Debug::printInstructionComment(TR::FILE *pOutFile, int32_t tabStops, TR::Inst
 void
 TR_Debug::printAssocRegDirective(TR::FILE *pOutFile, TR::Instruction * instr)
    {
-   // *this    swipeable for debugging purposes
    TR_S390RegisterDependencyGroup * depGroup = instr->getDependencyConditions()->getPostConditions();
 
    printPrefix(pOutFile, instr);
@@ -547,7 +544,6 @@ TR_Debug::printAssocRegDirective(TR::FILE *pOutFile, TR::Instruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390RRSInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
 
    // Prints RRS format in "Opcode  R1,R2,D4(B4) (mask=M3)"
 
@@ -583,7 +579,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390RRSInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390IEInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       {
       return;
@@ -604,7 +599,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390IEInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390RIEInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
 
 
 
@@ -731,7 +725,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390RIEInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390RISInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
 
    // print opcode
    printPrefix(pOutFile, instr);
@@ -762,7 +755,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390RISInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390LabelInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
 
    TR::LabelSymbol * label = instr->getLabelSymbol();
    const char * symbolName = getName(label);
@@ -816,7 +808,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390LabelInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390VirtualGuardNOPInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
 
    TR::LabelSymbol * label = instr->getLabelSymbol();
@@ -839,7 +830,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390VirtualGuardNOPInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390BranchInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
 
    TR::InstOpCode::S390BranchCondition cond = instr->getBranchCondition();
@@ -880,7 +870,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390BranchInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390BranchOnCountInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
 
    TR::LabelSymbol * label = instr->getLabelSymbol();
@@ -937,7 +926,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390BranchOnIndexInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390AnnotationInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       {
       return;
@@ -950,7 +938,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390AnnotationInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390PseudoInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       {
       return;
@@ -1034,7 +1021,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390PseudoInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390ImmInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       {
       return;
@@ -1049,7 +1035,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390ImmInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390Imm2Instruction * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       {
       return;
@@ -1064,7 +1049,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390Imm2Instruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390ImmSnippetInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       {
       return;
@@ -1077,7 +1061,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390ImmSnippetInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390ImmSymInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%-*s0x%08x", OPCODE_SPACING, getOpCodeName(&instr->getOpCode()), instr->getSourceImmediate());
    trfflush(pOutFile);
@@ -1086,7 +1069,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390ImmSymInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390RegInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
 
    trfprintf(pOutFile, "%-*s", OPCODE_SPACING, getOpCodeName(&instr->getOpCode()));
@@ -1119,7 +1101,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390RegInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390RRInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    int32_t i=1;
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%-*s", OPCODE_SPACING, getOpCodeName(&instr->getOpCode()));
@@ -1178,7 +1159,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390RRInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390TranslateInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%-*s", OPCODE_SPACING, getOpCodeName(&instr->getOpCode()));
 
@@ -1213,7 +1193,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390TranslateInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390RRFInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
 
       {
@@ -1248,7 +1227,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390RRFInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390RRRInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%-*s", OPCODE_SPACING, getOpCodeName(&instr->getOpCode()));
 
@@ -1265,7 +1243,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390RRRInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390RIInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    int16_t imm = instr->getSourceImmediate();
    uint8_t *cursor = (uint8_t *)instr->getBinaryEncoding();
 
@@ -1284,7 +1261,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390RIInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390RILInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    uint8_t * cursor = (uint8_t *)instr->getBinaryEncoding();
 
    printPrefix(pOutFile, instr);
@@ -1434,7 +1410,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390RSLbInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390RSInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%-*s", OPCODE_SPACING, getOpCodeName(&instr->getOpCode()));
 
@@ -1500,7 +1475,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390RSInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390MemInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%-*s", OPCODE_SPACING, getOpCodeName(&instr->getOpCode()));
 
@@ -1554,7 +1528,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390MemInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390SSEInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
 
    // print opcode
    printPrefix(pOutFile, instr);
@@ -1576,7 +1549,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390SSEInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390SS1Instruction * instr)
    {
-   // *this    swipeable for debugging purposes
 
    // print opcode
    printPrefix(pOutFile, instr);
@@ -1598,7 +1570,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390SS1Instruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390SS2Instruction * instr)
    {
-   // *this    swipeable for debugging purposes
 
    // print opcode
    printPrefix(pOutFile, instr);
@@ -1632,7 +1603,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390SS2Instruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390SS4Instruction * instr)
    {
-   // *this    swipeable for debugging purposes
 
    // print opcode
    printPrefix(pOutFile, instr);
@@ -1698,7 +1668,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390SS4Instruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390SSFInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
 
    // print opcode
    printPrefix(pOutFile, instr);
@@ -1724,7 +1693,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390SSFInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390SIInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
 
    // print opcode
    printPrefix(pOutFile, instr);
@@ -1763,7 +1731,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390SIInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390SILInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
 
    // print opcode
    printPrefix(pOutFile, instr);
@@ -1783,7 +1750,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390SILInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390SInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
 
    // print opcode
    printPrefix(pOutFile, instr);
@@ -1814,7 +1780,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390IInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390RXInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%-*s", OPCODE_SPACING, getOpCodeName(&instr->getOpCode()));
    if(instr->getRegisterOperand(1)->getRegisterPair())
@@ -1858,7 +1823,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390RXInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390RXEInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%-*s", OPCODE_SPACING, getOpCodeName(&instr->getOpCode()));
    print(pOutFile, instr->getRegisterOperand(1));
@@ -1871,7 +1835,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390RXEInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390RXFInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%-*s", OPCODE_SPACING, getOpCodeName(&instr->getOpCode()));
    print(pOutFile, instr->getRegisterOperand(1));
@@ -1886,7 +1849,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390RXFInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390MIIInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%-*s", OPCODE_SPACING, getOpCodeName(&instr->getOpCode()));
    trfprintf(pOutFile, "(mask=0x%1x), ", instr->getMask() );
@@ -1916,7 +1878,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390MIIInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390SMIInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%-*s", OPCODE_SPACING, getOpCodeName(&instr->getOpCode()));
    trfprintf(pOutFile, "(mask=0x%1x), ", instr->getMask() );
@@ -1935,7 +1896,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390SMIInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::MemoryReference * mr, TR::Instruction * instr)
    {
-   // *this    swipeable for debugging purposes
 
    TR::SymbolReference * symRef = mr->getSymbolReference();
    TR::Symbol * sym = symRef ? symRef->getSymbol() : NULL;
@@ -2268,7 +2228,6 @@ TR_Debug::printSymbolName(TR::FILE *pOutFile, TR::Symbol *sym,  TR::SymbolRefere
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390NOPInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "NOP");
    trfflush(pOutFile);
@@ -3348,7 +3307,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390VRIInstruction * instr)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390VRRInstruction * instr)
    {
-   // *this    swipeable for debugging purposes
    printPrefix(pOutFile, instr);
 
    trfprintf(pOutFile, "%-*s", OPCODE_SPACING, instr->getExtendedMnemonicName());

--- a/compiler/z/codegen/S390HelperCallSnippet.cpp
+++ b/compiler/z/codegen/S390HelperCallSnippet.cpp
@@ -156,7 +156,6 @@ TR::S390HelperCallSnippet::getLength(int32_t)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390HelperCallSnippet * snippet)
    {
-   // *this    swipeable for debugging purposes
    if (pOutFile == NULL)
       {
       return;

--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -97,7 +97,6 @@ TR::S390RSInstruction::generateAdditionalSourceRegisters(TR::Register * fReg, TR
 uint8_t *
 TR::S390EInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,getEstimatedBinaryLength());
@@ -115,7 +114,6 @@ TR::S390EInstruction::generateBinaryEncoding()
 uint8_t *
 TR::S390IEInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,getEstimatedBinaryLength());
@@ -264,7 +262,6 @@ bool TR::S390LabeledInstruction::isNopCandidate()
 uint8_t *
 TR::S390LabelInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    TR::Compilation *comp = cg()->comp();
 
@@ -535,7 +532,6 @@ TR::S390LabelInstruction::considerForLabelTargetNOPs(bool inEncodingPhase)
 int32_t
 TR::S390LabelInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
-   // *this    swipeable for debugging purposes
    if (getLabelSymbol() != NULL)
       {
       getLabelSymbol()->setEstimatedCodeLocation(currentEstimate);
@@ -594,7 +590,6 @@ TR::S390LabelInstruction::estimateBinaryLength(int32_t  currentEstimate)
 void
 TR::S390LabelInstruction::assignRegistersAndDependencies(TR_RegisterKinds kindToBeAssigned)
    {
-   // *this    swipeable for debugging purposes
    //
    TR::Register **_sourceReg = sourceRegBase();
    TR::Register **_targetReg = targetRegBase();
@@ -639,7 +634,6 @@ TR::S390LabelInstruction::assignRegistersAndDependencies(TR_RegisterKinds kindTo
 void
 TR::S390BranchInstruction::assignRegistersAndDependencies(TR_RegisterKinds kindToBeAssigned)
    {
-   // *this    swipeable for debugging purposes
    //
    // If there are any dependency conditions on this instruction, apply them.
    // Any register or memory references must be blocked before the condition
@@ -734,7 +728,6 @@ TR::S390BranchInstruction::assignRegistersAndDependencies(TR_RegisterKinds kindT
 uint8_t *
 TR::S390BranchInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    TR::LabelSymbol * label = getLabelSymbol();
    TR::Snippet * snippet = getCallSnippet();
@@ -832,7 +825,6 @@ TR::S390BranchInstruction::generateBinaryEncoding()
 int32_t
 TR::S390BranchInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
-   // *this    swipeable for debugging purposes
    int32_t length = 6;
    TR::Compilation *comp = cg()->comp();
 
@@ -868,7 +860,6 @@ TR::S390BranchInstruction::estimateBinaryLength(int32_t  currentEstimate)
 uint8_t *
 TR::S390BranchOnCountInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    TR::LabelSymbol * label = getLabelSymbol();
    TR::Snippet * snippet = getCallSnippet();
@@ -976,7 +967,6 @@ TR::S390BranchOnCountInstruction::generateBinaryEncoding()
 int32_t
 TR::S390BranchOnCountInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
-   // *this    swipeable for debugging purposes
    setEstimatedBinaryLength(getOpCode().getInstructionLength());
    //code could be expanded into BRAS(4)+DC(4)+L(4)+BCT(4) sequence
    setEstimatedBinaryLength(16);
@@ -986,7 +976,6 @@ TR::S390BranchOnCountInstruction::estimateBinaryLength(int32_t  currentEstimate)
 bool
 TR::S390BranchOnCountInstruction::refsRegister(TR::Register * reg)
    {
-   // *this    swipeable for debugging purposes
    if (matchesAnyRegister(reg, getRegisterOperand(1)))
       {
       return true;
@@ -1020,7 +1009,6 @@ TR::S390BranchOnCountInstruction::refsRegister(TR::Register * reg)
 uint8_t *
 TR::S390BranchOnIndexInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    TR::LabelSymbol * label = getLabelSymbol();
    TR::Snippet * snippet = getCallSnippet();
@@ -1146,7 +1134,6 @@ TR::S390BranchOnIndexInstruction::generateBinaryEncoding()
 int32_t
 TR::S390BranchOnIndexInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
-   // *this    swipeable for debugging purposes
    setEstimatedBinaryLength(getOpCode().getInstructionLength());
    //code could be expanded into BRAS(4)+DC(4)+L(4)+BXLE(4) sequence
    //or  BRAS(4)+DC(8)+LG(6)+BXLG(6) sequence
@@ -1164,7 +1151,6 @@ TR::S390BranchOnIndexInstruction::estimateBinaryLength(int32_t  currentEstimate)
 bool
 TR::S390BranchOnIndexInstruction::refsRegister(TR::Register * reg)
    {
-   // *this    swipeable for debugging purposes
    if (matchesAnyRegister(reg, getRegisterOperand(1), getRegisterOperand(2)))
       {
       return true;
@@ -1183,7 +1169,6 @@ TR::S390BranchOnIndexInstruction::refsRegister(TR::Register * reg)
 uint8_t *
 TR::S390PseudoInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    TR::Compilation *comp = cg()->comp();
@@ -1360,7 +1345,6 @@ TR::S390DebugCounterBumpInstruction::generateBinaryEncoding()
 uint8_t *
 TR::S390ImmInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,getEstimatedBinaryLength());
@@ -1418,7 +1402,6 @@ TR::S390ImmInstruction::generateBinaryEncoding()
 TR::S390ImmInstruction *
 TR::S390ImmInstruction::getS390ImmInstruction()
    {
-   // *this    swipeable for debugging purposes
    return this;
    }
 #endif
@@ -1431,7 +1414,6 @@ TR::S390ImmInstruction::getS390ImmInstruction()
 uint8_t *
 TR::S390Imm2Instruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,getEstimatedBinaryLength());
@@ -1468,7 +1450,6 @@ TR::S390Imm2Instruction::generateBinaryEncoding()
 uint8_t *
 TR::S390ImmSnippetInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,getEstimatedBinaryLength());
@@ -1488,7 +1469,6 @@ TR::S390ImmSnippetInstruction::generateBinaryEncoding()
 uint8_t *
 TR::S390ImmSymInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,getEstimatedBinaryLength());
@@ -1510,7 +1490,6 @@ TR::S390ImmSymInstruction::generateBinaryEncoding()
 bool
 TR::S390RegInstruction::refsRegister(TR::Register * reg)
    {
-   // *this    swipeable for debugging purposes
    if (matchesTargetRegister(reg))
       {
       return true;
@@ -1525,7 +1504,6 @@ TR::S390RegInstruction::refsRegister(TR::Register * reg)
 uint8_t *
 TR::S390RegInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,getEstimatedBinaryLength());
@@ -1563,7 +1541,6 @@ TR::S390RegInstruction::assignRegistersNoDependencies(TR_RegisterKinds kindToBeA
 bool
 TR::S390RRInstruction::refsRegister(TR::Register * reg)
    {
-   // *this    swipeable for debugging purposes
    if (matchesTargetRegister(reg) || matchesAnyRegister(reg, getRegisterOperand(2)))
       {
       return true;
@@ -1578,7 +1555,6 @@ TR::S390RRInstruction::refsRegister(TR::Register * reg)
 uint8_t *
 TR::S390RRInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,getEstimatedBinaryLength());
@@ -1648,7 +1624,6 @@ TR::S390TranslateInstruction::refsRegister(TR::Register * reg)
 uint8_t *
 TR::S390TranslateInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,getEstimatedBinaryLength());
@@ -1678,7 +1653,6 @@ TR::S390TranslateInstruction::generateBinaryEncoding()
 bool
 TR::S390RRFInstruction::refsRegister(TR::Register * reg)
    {
-   // *this    swipeable for debugging purposes
    if (matchesTargetRegister(reg) || matchesAnyRegister(reg, getRegisterOperand(2)) ||
          (_isSourceReg2Present &&  matchesAnyRegister(reg, getRegisterOperand(3))))
       {
@@ -1694,7 +1668,6 @@ TR::S390RRFInstruction::refsRegister(TR::Register * reg)
 uint8_t *
 TR::S390RRFInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,getEstimatedBinaryLength());
@@ -1836,7 +1809,6 @@ TR::S390RRFInstruction::generateBinaryEncoding()
 bool
 TR::S390RRRInstruction::refsRegister(TR::Register * reg)
    {
-   // *this    swipeable for debugging purposes
    if (matchesTargetRegister(reg) || matchesAnyRegister(reg, getRegisterOperand(2)) ||
        (matchesAnyRegister(reg, getRegisterOperand(3))))
       {
@@ -1852,7 +1824,6 @@ TR::S390RRRInstruction::refsRegister(TR::Register * reg)
 uint8_t *
 TR::S390RRRInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,getEstimatedBinaryLength());
@@ -1902,7 +1873,6 @@ TR::S390RRRInstruction::generateBinaryEncoding()
 uint8_t *
 TR::S390RIInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,getEstimatedBinaryLength());
@@ -1949,7 +1919,6 @@ TR::S390RIInstruction::generateBinaryEncoding()
 bool
 TR::S390RILInstruction::refsRegister(TR::Register * reg)
    {
-   // *this    swipeable for debugging purposes
    if (reg == getRegisterOperand(1))
       {
       return true;
@@ -2063,7 +2032,6 @@ TR::S390RILInstruction::adjustCallOffsetWithTrampoline(int32_t offset, uint8_t *
 uint8_t *
 TR::S390RILInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,getEstimatedBinaryLength());
@@ -2594,7 +2562,6 @@ TR::S390RILInstruction::generateBinaryEncoding()
 int32_t
 TR::S390RSInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
-   // *this    swipeable for debugging purposes
    if (getMemoryReference() != NULL)
       {
       return getMemoryReference()->estimateBinaryLength(currentEstimate, cg(), this);
@@ -2608,7 +2575,6 @@ TR::S390RSInstruction::estimateBinaryLength(int32_t  currentEstimate)
 uint8_t *
 TR::S390RSInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,getEstimatedBinaryLength());
@@ -2681,7 +2647,6 @@ TR::S390RSInstruction::generateBinaryEncoding()
 uint8_t *
 TR::S390RRSInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
 
    // acquire the current cursor location so we can start generating our
    // instruction there.
@@ -2777,7 +2742,6 @@ TR::S390RRSInstruction::generateBinaryEncoding()
 int32_t
 TR::S390RIEInstruction::estimateBinaryLength(int32_t  currentEstimate)
    {
-   // *this    swipeable for debugging purposes
    if (getBranchDestinationLabel())
       setEstimatedBinaryLength(12);
    else
@@ -2788,7 +2752,6 @@ TR::S390RIEInstruction::estimateBinaryLength(int32_t  currentEstimate)
 uint8_t *
 TR::S390RIEInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
 
 
    // let's determine what form of RIE we are dealing with
@@ -3260,7 +3223,6 @@ TR::S390RIEInstruction::splitIntoCompareAndBranch(TR::Instruction *insertBranchA
 uint8_t *
 TR::S390RISInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
 
    // acquire the current cursor location so we can start generating our
    // instruction there.
@@ -3320,7 +3282,6 @@ TR::S390RISInstruction::generateBinaryEncoding()
 bool
 TR::S390MemInstruction::refsRegister(TR::Register * reg)
    {
-   // *this    swipeable for debugging purposes
    // 64bit mem refs clobber high word regs
    TR::Compilation *comp = cg()->comp();
    bool enableHighWordRA = cg()->supportsHighWordFacility() && !comp->getOption(TR_DisableHighWordRA) &&
@@ -3353,7 +3314,6 @@ TR::S390MemInstruction::refsRegister(TR::Register * reg)
 uint8_t *
 TR::S390MemInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,getEstimatedBinaryLength());
@@ -3378,7 +3338,6 @@ TR::S390MemInstruction::generateBinaryEncoding()
 bool
 TR::S390RXInstruction::refsRegister(TR::Register * reg)
    {
-   // *this    swipeable for debugging purposes
    // 64bit mem refs clobber high word regs
    TR::Compilation *comp = cg()->comp();
    bool enableHighWordRA = cg()->supportsHighWordFacility() && !comp->getOption(TR_DisableHighWordRA) &&
@@ -3428,7 +3387,6 @@ TR::S390RXInstruction::estimateBinaryLength(int32_t  currentEstimate)
 uint8_t *
 TR::S390RXInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    TR::Compilation *comp = cg()->comp();
    uint8_t * cursor = instructionStart;
@@ -3490,7 +3448,6 @@ TR::S390RXEInstruction::estimateBinaryLength(int32_t  currentEstimate)
 uint8_t *
 TR::S390RXEInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,getEstimatedBinaryLength());
@@ -3540,7 +3497,6 @@ TR::S390RXYInstruction::estimateBinaryLength(int32_t  currentEstimate)
 uint8_t *
 TR::S390RXYInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,getEstimatedBinaryLength());
@@ -3597,7 +3553,6 @@ TR::S390RXFInstruction::estimateBinaryLength(int32_t  currentEstimate)
 bool
 TR::S390RXFInstruction::refsRegister(TR::Register * reg)
    {
-   // *this    swipeable for debugging purposes
    // 64bit mem refs clobber high word regs
    TR::Compilation *comp = cg()->comp();
    bool enableHighWordRA = cg()->supportsHighWordFacility() && !comp->getOption(TR_DisableHighWordRA) &&
@@ -3630,7 +3585,6 @@ TR::S390RXFInstruction::refsRegister(TR::Register * reg)
 uint8_t *
 TR::S390RXFInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    int32_t padding = 0, longDispTouchUpPadding = 0;
@@ -3786,7 +3740,6 @@ TR::S390VRIInstruction::getExtendedMnemonicName()
 uint8_t*
 TR::S390VRIInstruction::preGenerateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    memset(static_cast<void*>(instructionStart), 0, getEstimatedBinaryLength());
 
@@ -4218,7 +4171,6 @@ TR::S390VRRInstruction::getExtendedMnemonicName()
 uint8_t *
 TR::S390VRRInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset((void*)cursor, 0, getEstimatedBinaryLength());
@@ -4475,7 +4427,6 @@ TR::S390VRRiInstruction::generateBinaryEncoding()
    TR_ASSERT(r1Reg != NULL, "First Operand should not be NULL!");
    TR_ASSERT(v2Reg != NULL, "2nd Operand should not be NULL!");
 
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset((void*)cursor, 0, getEstimatedBinaryLength());
@@ -4532,7 +4483,6 @@ TR::S390VStorageInstruction::getExtendedMnemonicName()
 uint8_t *
 TR::S390VStorageInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset(static_cast<void*>(cursor), 0, getEstimatedBinaryLength());
@@ -4632,7 +4582,6 @@ TR::S390VRSdInstruction::generateBinaryEncoding()
     TR_ASSERT(r3Reg  != NULL, "R3 in VRS-d should not be NULL!");
     TR_ASSERT(memRef != NULL, "Memory Ref in VRS-d should not be NULL!");
 
-    // *this    swipeable for debugging purposes
     uint8_t * instructionStart = cg()->getBinaryBufferCursor();
     uint8_t * cursor = instructionStart;
     memset((void*)cursor, 0, getEstimatedBinaryLength());
@@ -4685,7 +4634,6 @@ TR::S390VRVInstruction::generateBinaryEncoding()
     TR_ASSERT(getRegisterOperand(1) != NULL, "1st Operand should not be NULL!");
     TR_ASSERT(getRegisterOperand(2) != NULL, "2nd Operand should not be NULL!");
 
-    // *this    swipeable for debugging purposes
     uint8_t * instructionStart = cg()->getBinaryBufferCursor();
     uint8_t * cursor = instructionStart;
     memset(static_cast<void*>(cursor), 0, getEstimatedBinaryLength());
@@ -4809,7 +4757,6 @@ TR::S390MemMemInstruction::estimateBinaryLength(int32_t  currentEstimate)
 uint8_t *
 TR::S390MemMemInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    TR::Compilation *comp = cg()->comp();
@@ -4869,7 +4816,6 @@ TR::S390SS1Instruction::estimateBinaryLength(int32_t  currentEstimate)
 uint8_t *
 TR::S390SS1Instruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    TR::Compilation *comp = cg()->comp();
@@ -4926,7 +4872,6 @@ TR::S390SS1Instruction::generateBinaryEncoding()
 uint8_t *
 TR::S390SS2Instruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,getEstimatedBinaryLength());
@@ -4994,7 +4939,6 @@ TR::S390SS2Instruction::generateBinaryEncoding()
 uint8_t *
 TR::S390SS4Instruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,getEstimatedBinaryLength());
@@ -5052,7 +4996,6 @@ TR::S390SS4Instruction::generateBinaryEncoding()
 bool
 TR::S390SSFInstruction::refsRegister(TR::Register * reg)
    {
-   // *this    swipeable for debugging purposes
    // 64bit mem refs clobber high word regs
    bool enableHighWordRA = cg()->supportsHighWordFacility() && !cg()->comp()->getOption(TR_DisableHighWordRA) &&
                            reg->getKind() != TR_FPR && reg->getKind() != TR_VRF;
@@ -5109,7 +5052,6 @@ TR::S390SSFInstruction::estimateBinaryLength(int32_t  currentEstimate)
 uint8_t *
 TR::S390SSFInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,getEstimatedBinaryLength());
@@ -5169,7 +5111,6 @@ TR::S390RSLInstruction::estimateBinaryLength(int32_t  currentEstimate)
 uint8_t *
 TR::S390RSLInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,getEstimatedBinaryLength());
@@ -5227,7 +5168,6 @@ TR::S390RSLbInstruction::estimateBinaryLength(int32_t  currentEstimate)
 uint8_t *
 TR::S390RSLbInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,getEstimatedBinaryLength());
@@ -5300,7 +5240,6 @@ TR::S390SIInstruction::estimateBinaryLength(int32_t  currentEstimate)
 uint8_t *
 TR::S390SIInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,getEstimatedBinaryLength());
@@ -5356,7 +5295,6 @@ TR::S390SIYInstruction::estimateBinaryLength(int32_t  currentEstimate)
 uint8_t *
 TR::S390SIYInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,getEstimatedBinaryLength());
@@ -5418,7 +5356,6 @@ TR::S390SILInstruction::estimateBinaryLength(int32_t  currentEstimate)
 uint8_t *
 TR::S390SILInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,getEstimatedBinaryLength());
@@ -5473,7 +5410,6 @@ TR::S390SInstruction::estimateBinaryLength(int32_t  currentEstimate)
 uint8_t *
 TR::S390SInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,getEstimatedBinaryLength());
@@ -5526,7 +5462,6 @@ TR::S390NOPInstruction::estimateBinaryLength(int32_t  currentEstimate)
 uint8_t *
 TR::S390NOPInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    uint8_t * cursor = instructionStart;
    memset( (void*)cursor,0,getEstimatedBinaryLength());
@@ -5621,7 +5556,6 @@ TR::S390MIIInstruction::estimateBinaryLength(int32_t  currentEstimate)
 uint8_t *
 TR::S390MIIInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
 
    // acquire the current cursor location so we can start generating our
    // instruction there.
@@ -5710,7 +5644,6 @@ TR::S390SMIInstruction::estimateBinaryLength(int32_t  currentEstimate)
 uint8_t *
 TR::S390SMIInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
 
    // acquire the current cursor location so we can start generating our
    // instruction there.
@@ -5779,7 +5712,6 @@ TR::S390SMIInstruction::generateBinaryEncoding()
 uint8_t *
 TR::S390VirtualGuardNOPInstruction::generateBinaryEncoding()
    {
-   // *this    swipeable for debugging purposes
    uint8_t * instructionStart = cg()->getBinaryBufferCursor();
    TR::LabelSymbol * label = getLabelSymbol();
    uint8_t * cursor = instructionStart;

--- a/compiler/z/codegen/S390Instruction.hpp
+++ b/compiler/z/codegen/S390Instruction.hpp
@@ -3708,7 +3708,6 @@ class S390MemInstruction : public TR::Instruction
                          bool use = true)
       : TR::Instruction(op, n, precedingInstruction, cg), _memAccessMode(-1), _constantField(-1), _memref(mf)
       {
-      // *this    swipeable for debugging purposes
       if (use)
          useSourceMemoryReference(mf);
       setupThrowsImplicitNullPointerException(n,mf);
@@ -3725,7 +3724,6 @@ class S390MemInstruction : public TR::Instruction
                          bool use = true)
       : TR::Instruction(op, n, cond, precedingInstruction, cg), _memAccessMode(-1), _constantField(-1), _memref(mf)
       {
-      // *this    swipeable for debugging purposes
       if (use)
          useSourceMemoryReference(mf);
       setupThrowsImplicitNullPointerException(n,mf);
@@ -3742,7 +3740,6 @@ class S390MemInstruction : public TR::Instruction
                         bool use = true)
       : TR::Instruction(op, n, precedingInstruction, cg), _memAccessMode(memAccessMode), _constantField(-1), _memref(mf)
       {
-      // *this    swipeable for debugging purposes
       if (use)
          useSourceMemoryReference(mf);
       setupThrowsImplicitNullPointerException(n,mf);
@@ -3760,7 +3757,6 @@ class S390MemInstruction : public TR::Instruction
                         bool use = true)
       : TR::Instruction(op, n, precedingInstruction, cg), _memAccessMode(memAccessMode), _constantField(constantField), _memref(mf)
       {
-      // *this    swipeable for debugging purposes
       if (use)
          useSourceMemoryReference(mf);
       setupThrowsImplicitNullPointerException(n,mf);


### PR DESCRIPTION
These comments were introduced to ease live debugging of the this
pointer on very old debuggers in the 1990's and 2000's. The comments are
no longer relevant on modern debuggers.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>