### PR TITLE
Rematerialize call constant nodes

### DIFF
--- a/compiler/codegen/CodeGenPhaseToPerform.hpp
+++ b/compiler/codegen/CodeGenPhaseToPerform.hpp
@@ -25,6 +25,7 @@
 
     ReserveCodeCachePhase,
     LowerTreesPhase,
+    UncommonCallConstNodesPhase,
     SetupForInstructionSelectionPhase,
     RemoveUnusedLocalsPhase,
     InstructionSelectionPhase,

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -505,6 +505,30 @@ OMR::CodeGenPhase::performLowerTreesPhase(TR::CodeGenerator * cg, TR::CodeGenPha
    }
 
 
+void
+OMR::CodeGenPhase::performUncommonCallConstNodesPhase(TR::CodeGenerator * cg, TR::CodeGenPhase * phase)
+   {
+   TR::Compilation* comp = cg->comp();
+
+   if(comp->getOption(TR_DisableCallConstUncommoning))
+      {
+      traceMsg(comp, "Skipping Uncommon Call Constant Node phase\n");
+      return;
+      }
+
+   phase->reportPhase(UncommonCallConstNodesPhase);
+
+   if (comp->getOption(TR_TraceCG) || comp->getOption(TR_TraceTrees))
+      comp->dumpMethodTrees("Pre Uncommon Call Constant Node Trees");
+
+   TR::LexicalMemProfiler mp(phase->getName(), comp->phaseMemProfiler());
+   LexicalTimer pt(phase->getName(), comp->phaseTimer());
+
+   cg->uncommonCallConstNodes();
+
+   if (comp->getOption(TR_TraceCG) || comp->getOption(TR_TraceTrees))
+      comp->dumpMethodTrees("Post Uncommon Call Constant Node Trees");
+  }
 
 void
 OMR::CodeGenPhase::performReserveCodeCachePhase(TR::CodeGenerator * cg, TR::CodeGenPhase * phase)
@@ -576,6 +600,8 @@ OMR::CodeGenPhase::getName(PhaseValue phase)
    {
    switch (phase)
       {
+      case UncommonCallConstNodesPhase:
+         return "UncommonCallConstNodesPhase";
       case ReserveCodeCachePhase:
          return "ReserveCodeCache";
       case LowerTreesPhase:

--- a/compiler/codegen/OMRCodeGenPhase.hpp
+++ b/compiler/codegen/OMRCodeGenPhase.hpp
@@ -77,6 +77,7 @@ class OMR_EXTENSIBLE CodeGenPhase
     * what the phases need to do. These will be divided up into
     * each extensible layer and can call base class if needed.
     */
+   static void performUncommonCallConstNodesPhase(TR::CodeGenerator * cg, TR::CodeGenPhase *);
    static void performReserveCodeCachePhase(TR::CodeGenerator * cg, TR::CodeGenPhase *);
    static void performLowerTreesPhase(TR::CodeGenerator * cg, TR::CodeGenPhase *);
    static void performSetupForInstructionSelectionPhase(TR::CodeGenerator * cg, TR::CodeGenPhase *);

--- a/compiler/codegen/OMRCodeGenPhaseEnum.hpp
+++ b/compiler/codegen/OMRCodeGenPhaseEnum.hpp
@@ -26,6 +26,7 @@
  // The entries in this file must be kept in sync with compiler/codegen/OMRCodeGenPhaseFunctionTable.hpp
       ReserveCodeCachePhase,
       LowerTreesPhase,
+      UncommonCallConstNodesPhase,
       SetupForInstructionSelectionPhase,
       InstructionSelectionPhase,
       CreateStackAtlasPhase,

--- a/compiler/codegen/OMRCodeGenPhaseFunctionTable.hpp
+++ b/compiler/codegen/OMRCodeGenPhaseFunctionTable.hpp
@@ -25,6 +25,7 @@
  // The entries in this file must be kept in sync with compiler/codegen/OMRCodeGenPhaseEnum.hpp
    TR::CodeGenPhase::performReserveCodeCachePhase,                                           //ReserveCodeCachePhase
    TR::CodeGenPhase::performLowerTreesPhase,                                                 //LowerTreesPhase
+   TR::CodeGenPhase::performUncommonCallConstNodesPhase,                                     //UncommonCallConstNodesPhase
    TR::CodeGenPhase::performSetupForInstructionSelectionPhase,                               //SetupForInstructionSelectionPhase
    TR::CodeGenPhase::performInstructionSelectionPhase,                                       //InstructionSelectionPhase
    TR::CodeGenPhase::performCreateStackAtlasPhase,                                           //CreateStackAtlasPhase

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -94,6 +94,7 @@
 #include "infra/Link.hpp"                           // for TR_LinkHead, etc
 #include "infra/List.hpp"                           // for ListIterator, etc
 #include "infra/Stack.hpp"                          // for TR_Stack
+#include "infra/Checklist.hpp"                      // for TR::NodeCheckList
 #include "infra/TRCfgEdge.hpp"                      // for CFGEdge
 #include "infra/TRCfgNode.hpp"                      // for CFGNode
 #include "optimizer/Optimizations.hpp"
@@ -563,6 +564,91 @@ OMR::CodeGenerator::setUpForInstructionSelection()
       }
 
   }
+
+/**
+ * \brief The uncommon-call-constant-node pass is an extra pre-codegen pass
+ * before instruction selection. It aims to avoid the situation where
+ * a constant integer is made alive across calls and, thereby, lower the preserved register
+ * pressure caused due to this.
+ *
+ * \details
+ *
+ * \verbatim
+ * Take z/Architecture as an example, we could run into the following situation where constant
+ * integer 16 is loaded to a preserved register GPR6, which is then loaded to GPR2 as call
+ * parameter. The GPR6 will be preserved by the callee and can incur extra register shuffling.
+ *
+ * LHI     GPR6,0x10           # immediate value in preserved register
+ * LGR     GPR2,GPR6           # load parameter from preserved register again
+ * LG      GPR14,#609 -216(GPR7)
+ * LGHI    GPR0,0xff28
+ * BASR    GPR14,GPR14         # call virtual function, which will unnecessarily preserve GPR6.
+ * LGR     GPR2,GPR6           # load parameter from preserved register again for the next use
+ * ...
+ *
+ * \endverbatim
+ *
+ * Loading integer constants as immediate values [i.e. LHI GPR2, 0x10] is preferred.
+ * The ranges for immediate value loading on different platforms are governed by the following
+ * platform-specific query:
+ *
+ * \verbatim
+ *   bool materializesLargeConstants()
+ *   bool shouldValueBeInACommonedNode(int64_t value)
+ * \endverbatim
+ *
+*/
+void
+OMR::CodeGenerator::uncommonCallConstNodes()
+   {
+   TR::Compilation* comp = self()->comp();
+   if(comp->getOption(TR_TraceCG))
+      {
+      traceMsg(comp, "Performing uncommon call constant nodes\n");
+      }
+
+   TR::NodeChecklist checklist(comp);
+
+   for (TR::TreeTop* tt = self()->comp()->getStartTree(); tt; tt = tt->getNextTreeTop())
+      {
+       TR::Node* node = tt->getNode();
+       if(node->getNumChildren() >= 1 &&
+               node->getFirstChild()->getOpCode().isFunctionCall())
+          {
+          TR::Node* callNode = node->getFirstChild();
+          if(checklist.contains(callNode))
+             {
+             if(comp->getOption(TR_TraceCG))
+                {
+                traceMsg(comp, "Skipping previously visited call node %d\n", callNode->getGlobalIndex());
+                }
+             continue;
+             }
+
+          checklist.add(callNode);
+
+          for(uint32_t i = 0; i < callNode->getNumChildren(); ++i)
+             {
+             TR::Node* paramNode = callNode->getChild(i);
+             if(paramNode->getReferenceCount() > 1 &&
+                     paramNode->getOpCode().isLoadConst() &&
+                     !self()->isMaterialized(paramNode))
+                {
+                if(self()->comp()->getOption(TR_TraceCG))
+                   {
+                   traceMsg(comp, "Uncommon const node %X [n%dn]\n",
+                            paramNode, paramNode->getGlobalIndex());
+                   }
+
+                TR::Node* newConstNode = TR::Node::create(paramNode->getOpCodeValue(), 0);
+                newConstNode->setConstValue(paramNode->getConstValue());
+                callNode->setAndIncChild(i, newConstNode);
+                paramNode->decReferenceCount();
+                }
+             }
+          }
+      }
+   }
 
 void
 OMR::CodeGenerator::doInstructionSelection()
@@ -3499,27 +3585,8 @@ OMR::CodeGenerator::isMaterialized(TR::Node * node)
    else
       return false;
 
-   return self()->isMaterialized(value);
+   return self()->shouldValueBeInACommonedNode(value);
    }
-
-
-// determine if value fits in the immediate field (if any) of instructions that machine provides
-bool
-OMR::CodeGenerator::isMaterialized(int64_t value)
-   {
-   if(self()->materializesLargeConstants()) //check the int case
-      {
-      int64_t smallestPos = self()->getSmallestPosConstThatMustBeMaterialized();
-      int64_t largestNeg = self()->getLargestNegConstThatMustBeMaterialized();
-
-      if ((value >= smallestPos) ||
-          (value <= largestNeg))
-         return true;
-      }
-   return false;
-   }
-
-
 
 bool
 OMR::CodeGenerator::canNullChkBeImplicit(TR::Node *node)

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -309,6 +309,8 @@ class OMR_EXTENSIBLE CodeGenerator
    TR_FrontEnd *fe();
    TR_Debug *getDebug();
 
+   void uncommonCallConstNodes();
+
    void preLowerTrees();
    void postLowerTrees() {}
 
@@ -614,10 +616,8 @@ class OMR_EXTENSIBLE CodeGenerator
    bool canBeAffectedByStoreTagStalls() { return false; } // no virt, default
 
    bool isMaterialized(TR::Node *); // no virt, cast
-   bool isMaterialized(int64_t); // no virt, cast
-   bool materializesLargeConstants() { return false;}
-   int32_t getLargestNegConstThatMustBeMaterialized() {return -32769;} // no virt, cast
-   int32_t getSmallestPosConstThatMustBeMaterialized() {return 32768;} // no virt, cast
+   bool shouldValueBeInACommonedNode(int64_t) { return false; } // no virt, cast
+   bool materializesLargeConstants() { return false; }
 
    bool canUseImmedInstruction(int64_t v) {return false;} // no virt
    bool needsNormalizationBeforeShifts() { return false; } // no virt, cast

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -255,6 +255,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableBlockVersioner",              "O\tdisable block versioner",                        SET_OPTION_BIT(TR_DisableBlockVersioner), "P"},
    {"disableBranchOnCount",               "O\tdisable branch on count instructions for s390",  SET_OPTION_BIT(TR_DisableBranchOnCount), "F"},
    {"disableBranchPreload",               "O\tdisable return branch preload",                  SET_OPTION_BIT(TR_DisableBranchPreload), "F"},
+   {"disableCallConstUncommoning",        "O\tdisable uncommon call constant node phase",  SET_OPTION_BIT(TR_DisableCallConstUncommoning), "F"},
    {"disableCallGraphInlining",           "O\tdisable Interpreter Profiling based inlining and code size estimation",  SET_OPTION_BIT(TR_DisableCallGraphInlining), "P"},
    {"disableCatchBlockRemoval",           "O\tdisable catch block removal",                    TR::Options::disableOptimization, catchBlockRemoval, 0, "P"},
    {"disableCFGSimplification",           "O\tdisable Control Flow Graph simplification",      TR::Options::disableOptimization, CFGSimplification, 0, "P"},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -713,7 +713,7 @@ enum TR_CompilationOptions
    TR_EnableBranchPreload                             = 0x08000000 + 20,
    TR_TerseRegisterPressureTrace                      = 0x20000000 + 20,
    TR_DisableMutableCallSiteGuards                    = 0x40000000 + 20,  // JSR292
-   // Available                                       = 0x80000000 + 20,
+   TR_DisableCallConstUncommoning                     = 0x80000000 + 20,
 
    // Option word 21
    // Available                                       = 0x00000020 + 21,

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -504,7 +504,7 @@ static void reassociateBigConstants(TR::Node *node, TR::Simplifier *s)
             int64_t diff = node->getSecondChild()->get64bitIntegralValue() -
                            base_node->getSecondChild()->get64bitIntegralValue();
 
-            if (!s->comp()->cg()->isMaterialized(diff) &&
+            if (!s->comp()->cg()->shouldValueBeInACommonedNode(diff) &&
                 performTransformation(s->comp(), "%sReusing big constant from node 0x%p in node 0x%p\n", s->optDetailString(), base_node, node))
                {
                node->getFirstChild()->recursivelyDecReferenceCount();

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -3166,6 +3166,25 @@ int32_t OMR::Power::CodeGenerator::getMaximumNumbersOfAssignableVRs()
    return TR::RealRegister::LastVSR - TR::RealRegister::FirstVSR  + 1;
    }
 
+/**
+ * \brief
+ * Determine if value fits in the immediate field (if any) of instructions that machine provides.
+ *
+ * \details
+ *
+ * A node with a large constant can be materialized and left as commoned nodes.
+ * Smaller constants can be uncommoned so that they re-materialize every time when needed as a call
+ * parameter. This query is platform specific as constant loading can be expensive on some platforms
+ * but cheap on others, depending on their magnitude.
+ */
+bool OMR::Power::CodeGenerator::shouldValueBeInACommonedNode(int64_t value)
+   {
+   int64_t smallestPos = self()->getSmallestPosConstThatMustBeMaterialized();
+   int64_t largestNeg = self()->getLargestNegConstThatMustBeMaterialized();
+
+   return ((value >= smallestPos) || (value <= largestNeg));
+   }
+
 bool OMR::Power::CodeGenerator::isRotateAndMask(TR::Node * node)
    {
    if (!node->getOpCode().isAnd())

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -458,6 +458,11 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    bool isRotateAndMask(TR::Node * node);
 
+   // PPC specific thresholds for constant re-materialization
+   int64_t getLargestNegConstThatMustBeMaterialized() {return -32769;}  // minimum 16-bit signed int minux 1
+   int64_t getSmallestPosConstThatMustBeMaterialized() {return 32768;}  // maximum 16-bit signed int plus 1
+   bool shouldValueBeInACommonedNode(int64_t); // no virt, cast
+
    bool ilOpCodeIsSupported(TR::ILOpCodes);
    // Constant Data update
    bool checkAndFetchRequestor(TR::Instruction *instr, TR::Instruction **q);

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -364,6 +364,9 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    bool supportsAtomicAdd()                {return true;}
    bool hasTMEvaluator()                       {return true;}
 
+   int64_t getLargestNegConstThatMustBeMaterialized() { TR_ASSERT(0, "Not Implemented on x86"); return 0; }
+   int64_t getSmallestPosConstThatMustBeMaterialized() { TR_ASSERT(0, "Not Implemented on x86"); return 0; }
+
    void performNonLinearRegisterAssignmentAtBranch(TR::X86LabelInstruction *branchInstruction, TR_RegisterKinds kindsToBeAssigned);
    void prepareForNonLinearRegisterAssignmentAtMerge(TR::X86LabelInstruction *mergeInstruction);
 

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -2541,6 +2541,25 @@ static TR::Instruction *skipInternalControlFlow(TR::Instruction *insertInstr)
   return insertInstr;
   }
 
+/**
+ * \brief
+ * Determines if a value should be in a commoned constant node or not.
+ *
+ * \details
+ *
+ * A node with a large constant can be materialized and left as commoned nodes.
+ * Smaller constants can be uncommoned so that they re-materialize every time when needed as a call
+ * parameter. This query is platform specific as constant loading can be expensive on some platforms
+ * but cheap on others, depending on their magnitude.
+ */
+bool OMR::Z::CodeGenerator::shouldValueBeInACommonedNode(int64_t value)
+   {
+   int64_t smallestPos = self()->getSmallestPosConstThatMustBeMaterialized();
+   int64_t largestNeg = self()->getLargestNegConstThatMustBeMaterialized();
+
+   return ((value >= smallestPos) || (value <= largestNeg));
+   }
+
 bool OMR::Z::CodeGenerator::supportsNamedVirtualRegisters() { return false; } // TODO : Identitiy needs folding
 
 // This method it mostly for safely moving register spills outside of loops

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -343,6 +343,20 @@ public:
    void insertInstructionPrefetchesForCalls(TR_BranchPreloadCallData * data);
    bool hasWarmCallsBeforeReturn();
 
+   /**
+    * \brief Tells the optimzers and codegen whether a load constant node should be rematerialized.
+    *
+    * \details Large constants should be materialized (constant node should be commoned up)
+    * because loading them as immediate values is expensive.
+    *
+    * A constant is large if it's outside of the range specified by the largest negative
+    * const and smallest positive const. And the ranges are hardware platform dependent.
+    */
+   bool materializesLargeConstants() { return true; }
+   bool shouldValueBeInACommonedNode(int64_t value);
+   int64_t getLargestNegConstThatMustBeMaterialized() {return ((-1ll) << 31) - 1;}   // min 32bit signed integer minus 1
+   int64_t getSmallestPosConstThatMustBeMaterialized() {return ((int64_t)0x000000007FFFFFFF) + 1;}   // max 32bit signed integer plus 1
+
    void setNodeAddressOfCachedStaticTree(TR::Node *n) { _nodeAddressOfCachedStatic=n; }
    TR::Node *getNodeAddressOfCachedStatic() { return _nodeAddressOfCachedStatic; }
 


### PR DESCRIPTION
Constant integers in call parameters can be uncommoned and rematerialized
if it is cheap to load them as immediate values.

1. Add an extra pass before the instruction selection phase to uncommon
constant call parameters

2. Add Z specific rematerialization range, which is the range of signed
32-bit integers.

Signed-off-by: Nigel Yu <yunigel@ca.ibm.com>