### PR TITLE
Incremental cleanup toward removing warm snippets

### DIFF
--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -630,11 +630,8 @@ int32_t OMR::ARM::CodeGenerator::setEstimatedLocationsForDataSnippetLabels(int32
    }
 
 #if DEBUG
-void OMR::ARM::CodeGenerator::dumpDataSnippets(TR::FILE *outFile, bool isWarm)
+void OMR::ARM::CodeGenerator::dumpDataSnippets(TR::FILE *outFile)
    {
-   if (isWarm) // PPC currently should not have any warm constant data snippets
-      return;
-
    if (outFile == NULL)
       return;
    _constantData->print(outFile);

--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -624,12 +624,9 @@ void OMR::ARM::CodeGenerator::emitDataSnippets()
    self()->setBinaryBufferCursor(_constantData->emitSnippetBody());
    }
 
-int32_t OMR::ARM::CodeGenerator::setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart, bool isWarm)
+int32_t OMR::ARM::CodeGenerator::setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart)
    {
-   if (isWarm && !self()->comp()->getOption(TR_EnableHCR)) // PPC currently should not have any constant data snippets as warm.
-      return estimatedSnippetStart;
-   else
-      return estimatedSnippetStart+_constantData->getLength();
+   return estimatedSnippetStart+_constantData->getLength();
    }
 
 #if DEBUG

--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -524,22 +524,6 @@ void OMR::ARM::CodeGenerator::doBinaryEncoding()
             }
          }
       estimate          = cursorInstruction->estimateBinaryLength(estimate);
-
-      // If this is the last warm instruction, remember the estimated size up to
-      // this point and add a buffer to the estimated size so that branches
-      // between warm and cold instructions will be forced to be long branches.
-      // The size is rounded up to a multiple of 8 so that double-alignments in
-      // the cold section will have the same amount of padding for the estimate
-      // and the actual code allocation.
-      //
-      if (cursorInstruction->isLastWarmInstruction())
-         {
-         // Estimate Warm Snippets
-         estimate = self()->setEstimatedLocationsForSnippetLabels(estimate, true);
-         warmEstimate = ((estimate)+7) & ~7;
-         estimate = warmEstimate + MIN_DISTANCE_BETWEEN_WARM_AND_COLD_CODE;
-         }
-
       cursorInstruction = cursorInstruction->getNext();
       }
    estimate = self()->setEstimatedLocationsForSnippetLabels(estimate);
@@ -584,21 +568,6 @@ void OMR::ARM::CodeGenerator::doBinaryEncoding()
          TR_ASSERT(0, "bin length estimated too small");
          }
 #endif
-
-      // If this is the last warm instruction, save info about the warm code range
-      // and set up to generate code in the cold code range.
-      //
-      if (cursorInstruction->isLastWarmInstruction())
-         {
-         self()->setWarmCodeEnd(self()->getBinaryBufferCursor());
-         self()->setColdCodeStart(coldCode);
-         self()->setBinaryBufferCursor(coldCode);
-
-         // Adjust the accumulated length error so that distances within the cold
-         // code are calculated properly using the estimated code locations.
-         //
-         self()->addAccumulatedInstructionLengthError(self()->getWarmCodeEnd()-coldCode+MIN_DISTANCE_BETWEEN_WARM_AND_COLD_CODE);
-         }
 
       cursorInstruction = cursorInstruction->getNext();
       if (isPrivateLinkage && cursorInstruction == j2jEntryInstruction)

--- a/compiler/arm/codegen/OMRCodeGenerator.hpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.hpp
@@ -128,7 +128,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    void emitDataSnippets();
    bool hasDataSnippets();
-   int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart, bool isWarm = 0);
+   int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart);
 
 #ifdef DEBUG
    void dumpDataSnippets(TR::FILE *outFile, bool isWarm = 0);

--- a/compiler/arm/codegen/OMRCodeGenerator.hpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.hpp
@@ -131,7 +131,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart);
 
 #ifdef DEBUG
-   void dumpDataSnippets(TR::FILE *outFile, bool isWarm = 0);
+   void dumpDataSnippets(TR::FILE *outFile);
 #endif
 
    TR::Instruction *generateSwitchToInterpreterPrePrologue(TR::Instruction *cursor, TR::Node *node);

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -240,8 +240,7 @@ OMR::CodeGenPhase::performEmitSnippetsPhase(TR::CodeGenerator * cg, TR::CodeGenP
       comp->getDebug()->dumpMethodInstrs(comp->getOutFile(), title, false, true);
 
       traceMsg(comp,"<snippets>");
-      comp->getDebug()->print(comp->getOutFile(), cg->getSnippetList(), true);  // print Warm Snippets
-      comp->getDebug()->print(comp->getOutFile(), cg->getSnippetList(), false); // print the rest
+      comp->getDebug()->print(comp->getOutFile(), cg->getSnippetList());
       traceMsg(comp,"</snippets>\n");
 
       auto iterator = cg->getSnippetList().begin();

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -650,17 +650,6 @@ OMR::CodeGenerator::doInstructionSelection()
             }
 #endif
          }
-      else if (opCode == TR::BBEnd)
-         {
-         TR::Block *b = self()->getCurrentEvaluationBlock();
-         if (b->isLastWarmBlock())
-            {
-            // Mark the split point between warm and cold instructions, so they
-            // can be allocated in different code sections.
-            //
-            prevInstr->setLastWarmInstruction(true);
-            }
-         }
 
       self()->setLiveLocals(liveLocals);
 

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -2891,7 +2891,7 @@ OMR::CodeGenerator::alignBinaryBufferCursor()
 
 
 int32_t
-OMR::CodeGenerator::setEstimatedLocationsForSnippetLabels(int32_t estimatedSnippetStart, bool isWarm)
+OMR::CodeGenerator::setEstimatedLocationsForSnippetLabels(int32_t estimatedSnippetStart)
    {
    TR::Snippet *cursor;
 
@@ -2899,12 +2899,12 @@ OMR::CodeGenerator::setEstimatedLocationsForSnippetLabels(int32_t estimatedSnipp
 
    if (self()->hasTargetAddressSnippets())
       {
-      estimatedSnippetStart = self()->setEstimatedLocationsForTargetAddressSnippetLabels(estimatedSnippetStart, isWarm);
+      estimatedSnippetStart = self()->setEstimatedLocationsForTargetAddressSnippetLabels(estimatedSnippetStart);
       }
 
    for (auto iterator = _snippetList.begin(); iterator != _snippetList.end(); ++iterator)
       {
-      if ((*iterator)->isWarmSnippet() == isWarm)
+      if ((*iterator)->isWarmSnippet() == 0)
          {
     	  (*iterator)->setEstimatedCodeLocation(estimatedSnippetStart);
          estimatedSnippetStart += (*iterator)->getLength(estimatedSnippetStart);
@@ -2913,7 +2913,7 @@ OMR::CodeGenerator::setEstimatedLocationsForSnippetLabels(int32_t estimatedSnipp
 
    if (self()->hasDataSnippets())
       {
-      estimatedSnippetStart = self()->setEstimatedLocationsForDataSnippetLabels(estimatedSnippetStart, isWarm);
+      estimatedSnippetStart = self()->setEstimatedLocationsForDataSnippetLabels(estimatedSnippetStart);
       }
 
    return estimatedSnippetStart;

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1103,7 +1103,7 @@ class OMR_EXTENSIBLE CodeGenerator
    // --------------------------------------------------------------------------
    // Snippets
    //
-   int32_t setEstimatedLocationsForSnippetLabels(int32_t estimatedSnippetStart, bool isWarm = 0);
+   int32_t setEstimatedLocationsForSnippetLabels(int32_t estimatedSnippetStart);
    TR::list<TR::Snippet*>& getSnippetList() {return _snippetList;}
    void addSnippet(TR::Snippet *s);
 
@@ -1117,14 +1117,14 @@ class OMR_EXTENSIBLE CodeGenerator
    //
    void emitDataSnippets() {}
    bool hasDataSnippets() {return false;} // no virt, cast
-   int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart, bool isWarm = 0) {return 0;} // no virt, cast
+   int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart) {return 0;}
 
    // called to emit any target address snippets.  The platform specific code generators
    // should override these methods if they use target address snippets.
    //
    void emitTargetAddressSnippets() {}
    bool hasTargetAddressSnippets() {return false;} // no virt, cast
-   int32_t setEstimatedLocationsForTargetAddressSnippetLabels(int32_t estimatedSnippetStart, bool isWarm = 0) {return 0;} // no virt, cast
+   int32_t setEstimatedLocationsForTargetAddressSnippetLabels(int32_t estimatedSnippetStart) {return 0;}
 
    // --------------------------------------------------------------------------
    // Register pressure

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -978,8 +978,8 @@ class OMR_EXTENSIBLE CodeGenerator
    static void incNumRematerializedXMMRs()     {_totalNumRematerializedXMMRs++;}
 #endif
 
-   void dumpDataSnippets(TR::FILE *outFile, bool isWarm = 0) {} // no virt
-   void dumpTargetAddressSnippets(TR::FILE *outFile, bool isWarm = 0) {} // no virt
+   void dumpDataSnippets(TR::FILE *outFile) {}
+   void dumpTargetAddressSnippets(TR::FILE *outFile) {}
 
    // --------------------------------------------------------------------------
    // Register assignment tracing

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -2427,12 +2427,9 @@ void OMR::Power::CodeGenerator::emitDataSnippets()
    self()->setBinaryBufferCursor(_constantData->emitSnippetBody());
    }
 
-int32_t OMR::Power::CodeGenerator::setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart, bool isWarm)
+int32_t OMR::Power::CodeGenerator::setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart)
    {
-   if (isWarm && !self()->comp()->getOption(TR_EnableHCR)) // PPC currently should not have any constant data snippets as warm.
-      return estimatedSnippetStart;
-   else
-      return estimatedSnippetStart+_constantData->getLength();
+   return estimatedSnippetStart+_constantData->getLength();
    }
 
 inline static bool callInTree(TR::TreeTop *treeTop)

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1941,10 +1941,6 @@ void OMR::Power::CodeGenerator::deleteInst(TR::Instruction* old)
    {
    TR::Instruction* prv = old->getPrev();
    TR::Instruction* nxt = old->getNext();
-   if (old->isLastWarmInstruction())
-      {
-      prv->setLastWarmInstruction(true);
-      }
    prv->setNext(nxt);
    nxt->setPrev(prv);
    }
@@ -2053,22 +2049,6 @@ void OMR::Power::CodeGenerator::doBinaryEncoding()
             }
          }
       data.estimate          = data.cursorInstruction->estimateBinaryLength(data.estimate);
-
-      // If this is the last warm instruction, remember the estimated size up to
-      // this point and add a buffer to the estimated size so that branches
-      // between warm and cold instructions will be forced to be long branches.
-      // The size is rounded up to a multiple of 8 so that double-alignments in
-      // the cold section will have the same amount of padding for the estimate
-      // and the actual code allocation.
-      //
-      if (data.cursorInstruction->isLastWarmInstruction())
-         {
-         // Get estimate for warm snippets
-         data.estimate = self()->setEstimatedLocationsForSnippetLabels(data.estimate, true);
-         data.warmEstimate = ((data.estimate)+7) & ~7;
-         data.estimate = data.warmEstimate + MIN_DISTANCE_BETWEEN_WARM_AND_COLD_CODE;
-         }
-
       data.cursorInstruction = data.cursorInstruction->getNext();
       }
 
@@ -2165,21 +2145,6 @@ void OMR::Power::CodeGenerator::doBinaryEncoding()
          {
          self()->setPrePrologueSize(self()->getBinaryBufferCursor() - self()->getBinaryBufferStart() - self()->getJitMethodEntryPaddingSize());
          self()->comp()->getSymRefTab()->findOrCreateStartPCSymbolRef()->getSymbol()->getStaticSymbol()->setStaticAddress(self()->getBinaryBufferCursor());
-         }
-
-      // If this is the last warm instruction, save info about the warm code range
-      // and set up to generate code in the cold code range.
-      //
-      if (data.cursorInstruction->isLastWarmInstruction())
-         {
-         self()->setWarmCodeEnd(self()->getBinaryBufferCursor());
-         self()->setColdCodeStart(coldCode);
-         self()->setBinaryBufferCursor(coldCode);
-
-         // Adjust the accumulated length error so that distances within the cold
-         // code are calculated properly using the estimated code locations.
-         //
-         self()->addAccumulatedInstructionLengthError(self()->getWarmCodeEnd()-coldCode+MIN_DISTANCE_BETWEEN_WARM_AND_COLD_CODE);
          }
 
       data.cursorInstruction = data.cursorInstruction->getNext();

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -3161,11 +3161,8 @@ void j2Prof_trampolineReport(uint8_t *startP, uint8_t *endP, int32_t num_trampol
 #endif
 
 #if DEBUG
-void OMR::Power::CodeGenerator::dumpDataSnippets(TR::FILE *outFile, bool isWarm)
+void OMR::Power::CodeGenerator::dumpDataSnippets(TR::FILE *outFile)
    {
-   if (isWarm) // PPC currently should not have any warm constant data snippets
-      return;
-
    if (outFile == NULL)
       return;
    _constantData->print(outFile);

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -195,7 +195,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    TR::Instruction *generateSwitchToInterpreterPrePrologue(TR::Instruction *cursor, TR::Node *node);
 
-   int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart, bool isWarm = 0);
+   int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart);
 
 #ifdef DEBUG
    void dumpDataSnippets(TR::FILE *outFile, bool isWarm = 0);

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -198,7 +198,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart);
 
 #ifdef DEBUG
-   void dumpDataSnippets(TR::FILE *outFile, bool isWarm = 0);
+   void dumpDataSnippets(TR::FILE *outFile);
 #endif
 
    int32_t findOrCreateFloatConstant(void *v, TR::DataType t,

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -2897,16 +2897,16 @@ TR_Debug::print(TR::FILE *pOutFile, TR::list<TR::Snippet*> & snippetList, bool i
       return;
 
    if (_comp->cg()->hasTargetAddressSnippets())
-      _comp->cg()->dumpTargetAddressSnippets(pOutFile, isWarm);
+      _comp->cg()->dumpTargetAddressSnippets(pOutFile);
 
    for (auto snippets = snippetList.begin(); snippets != snippetList.end(); ++snippets)
       {
-      if ((*snippets)->isWarmSnippet() == isWarm)
+      if ((*snippets)->isWarmSnippet() == 0)
          print(pOutFile, *snippets);
       }
 
    if (_comp->cg()->hasDataSnippets())
-      _comp->cg()->dumpDataSnippets(pOutFile, isWarm);
+      _comp->cg()->dumpDataSnippets(pOutFile);
    }
 
 
@@ -2917,17 +2917,17 @@ TR_Debug::print(TR::FILE *pOutFile, List<TR::Snippet> & snippetList, bool isWarm
       return;
 
    if (_comp->cg()->hasTargetAddressSnippets())
-      _comp->cg()->dumpTargetAddressSnippets(pOutFile, isWarm);
+      _comp->cg()->dumpTargetAddressSnippets(pOutFile);
 
    ListIterator<TR::Snippet> snippets(&snippetList);
    for (TR::Snippet * snippet = snippets.getFirst(); snippet; snippet = snippets.getNext())
       {
-      if (snippet->isWarmSnippet() == isWarm)
+      if (snippet->isWarmSnippet() == 0)
          print(pOutFile, snippet);
       }
 
    if (_comp->cg()->hasDataSnippets())
-      _comp->cg()->dumpDataSnippets(pOutFile, isWarm);
+      _comp->cg()->dumpDataSnippets(pOutFile);
 
    trfprintf(pOutFile, "\n");
    }

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -3719,7 +3719,7 @@ void OMR::X86::CodeGenerator::removeUnavailableRegisters(TR_RegisterCandidate * 
 
 #if DEBUG
 
-void OMR::X86::CodeGenerator::dumpDataSnippets(TR::FILE *outFile, bool isWarm)
+void OMR::X86::CodeGenerator::dumpDataSnippets(TR::FILE *outFile)
    {
 
    if (outFile == NULL)
@@ -3733,7 +3733,7 @@ void OMR::X86::CodeGenerator::dumpDataSnippets(TR::FILE *outFile, bool isWarm)
       size = 1 << exp;
       for (auto iterator = _dataSnippetList.begin(); iterator != _dataSnippetList.end(); ++iterator)
          {
-         if ((*iterator)->getDataSize() == size && (*iterator)->isWarmSnippet() == isWarm)
+         if ((*iterator)->getDataSize() == size && (*iterator)->isWarmSnippet() == 0)
             {
             self()->getDebug()->print(outFile, *iterator);
             }

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -2253,7 +2253,7 @@ TR::IA32ConstantDataSnippet * OMR::X86::CodeGenerator::findOrCreateConstant(TR::
    return (TR::IA32ConstantDataSnippet*)cursor;
    }
 
-int32_t OMR::X86::CodeGenerator::setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart, bool isWarm)
+int32_t OMR::X86::CodeGenerator::setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart)
    {
    bool                                     first;
    int32_t                                  size;
@@ -2266,7 +2266,7 @@ int32_t OMR::X86::CodeGenerator::setEstimatedLocationsForDataSnippetLabels(int32
       first = true;
       for (auto iterator = _dataSnippetList.begin(); iterator != _dataSnippetList.end(); ++iterator)
          {
-         if ((*iterator)->getDataSize() == size && (*iterator)->isWarmSnippet() == isWarm)
+         if ((*iterator)->getDataSize() == size && (*iterator)->isWarmSnippet() == 0)
             {
             if (first)
                {

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1872,22 +1872,6 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
       if (self()->comp()->getOption(TR_TraceVFPSubstitution))
          self()->getDebug()->dumpInstructionWithVFPState(estimateCursor, &prevState);
 
-      // If this is the last warm instruction, remember the estimated size up to
-      // this point and add a buffer to the estimated size so that branches
-      // between warm and cold instructions will be forced to be long branches.
-      // The size is rounded up to a multiple of 8 so that double-alignments in
-      // the cold section will have the same amount of padding for the estimate
-      // and the actual code allocation.
-      //
-      if (estimateCursor->isLastWarmInstruction())
-         {
-         // Estimate Warm Snippets.
-         estimate = self()->setEstimatedLocationsForSnippetLabels(estimate, true);
-
-         warmEstimate = (estimate+7) & ~7;
-         estimate = warmEstimate + MIN_DISTANCE_BETWEEN_WARM_AND_COLD_CODE;
-         }
-
       if (estimateCursor == _vfpResetInstruction)
          self()->generateDebugCounter(estimateCursor, "cg.prologues:#instructionBytes", estimate - estimatedPrologueStartOffset, TR::DebugCounter::Expensive);
 
@@ -2006,22 +1990,6 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
          }
 
       self()->addToAtlas(cursorInstruction);
-
-      // If this is the last warm instruction, save info about the warm code range
-      // and set up to generate code in the cold code range.
-      //
-      if (cursorInstruction->isLastWarmInstruction())
-         {
-         self()->setWarmCodeEnd(self()->getBinaryBufferCursor());
-         self()->setColdCodeStart(coldCode);
-         self()->setBinaryBufferCursor(coldCode);
-
-         // Adjust the accumulated length error so that distances within the cold
-         // code are calculated properly using the estimated code locations.
-         //
-         self()->addAccumulatedInstructionLengthError(self()->getWarmCodeEnd()-coldCode+MIN_DISTANCE_BETWEEN_WARM_AND_COLD_CODE);
-         }
-
       cursorInstruction = cursorInstruction->getNext();
       }
 

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -578,7 +578,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    void dumpPostGPRegisterAssignment(TR::Instruction *, TR::Instruction *);
 #endif
 #ifdef DEBUG
-   void dumpDataSnippets(TR::FILE *pOutFile, bool isWarm = 0);
+   void dumpDataSnippets(TR::FILE *pOutFile);
 #endif
 
    TR::IA32ConstantDataSnippet *findOrCreate2ByteConstant(TR::Node *, int16_t c);

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -420,7 +420,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    // Note: This leaves the code aligned in the specified manner.
    TR::Instruction *generateSwitchToInterpreterPrePrologue(TR::Instruction *prev, uint8_t alignment, uint8_t alignmentMargin);
 
-   int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart, bool isWarm = 0);
+   int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart);
    void emitDataSnippets();
    bool hasDataSnippets() { return _dataSnippetList.empty() ? false : true; }
 

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -9706,7 +9706,7 @@ OMR::Z::CodeGenerator::copyRestrictedVirtual(TR::Register * virtReg, TR::Node *n
 // OMR::Z::CodeGenerator::dumpDataSnippets
 ////////////////////////////////////////////////////////////////////////////////
 void
-OMR::Z::CodeGenerator::dumpDataSnippets(TR::FILE *outFile, bool isWarm)
+OMR::Z::CodeGenerator::dumpDataSnippets(TR::FILE *outFile)
    {
 
    if (outFile == NULL)
@@ -9724,7 +9724,7 @@ OMR::Z::CodeGenerator::dumpDataSnippets(TR::FILE *outFile, bool isWarm)
       size = 1 << exp;
       for (auto iterator = _constantList.begin(); iterator != _constantList.end(); ++iterator)
          {
-         if (HANDLE_CONSTANT_SNIPPET((*iterator), isWarm, size))
+         if (HANDLE_CONSTANT_SNIPPET((*iterator), 0, size))
             {
             self()->getDebug()->print(outFile, *iterator);
             }
@@ -9733,7 +9733,7 @@ OMR::Z::CodeGenerator::dumpDataSnippets(TR::FILE *outFile, bool isWarm)
       for (hi = _constantHashCur.SetToFirst(); _constantHashCur.Valid(); hi = _constantHashCur.SetToNext())
           {
             cursor = _constantHash.DataAt(hi);
-            if (HANDLE_CONSTANT_SNIPPET(cursor, isWarm, size))
+            if (HANDLE_CONSTANT_SNIPPET(cursor, 0, size))
                 {
                 self()->getDebug()->print(outFile,cursor);
                 }
@@ -9744,7 +9744,7 @@ OMR::Z::CodeGenerator::dumpDataSnippets(TR::FILE *outFile, bool isWarm)
       size = 1 << exp;
       for (auto writeableiterator = _writableList.begin(); writeableiterator != _writableList.end(); ++writeableiterator)
          {
-         if (HANDLE_CONSTANT_SNIPPET((*writeableiterator), isWarm, size))
+         if (HANDLE_CONSTANT_SNIPPET((*writeableiterator), 0, size))
             {
             self()->getDebug()->print(outFile, *writeableiterator);
             }
@@ -9754,7 +9754,7 @@ OMR::Z::CodeGenerator::dumpDataSnippets(TR::FILE *outFile, bool isWarm)
    // Emit Other Misc Data Snippets.
    for (auto snippetDataIterator = _snippetDataList.begin(); snippetDataIterator != _snippetDataList.end(); ++snippetDataIterator)
       {
-      if ((*snippetDataIterator)->isWarmSnippet() == isWarm)
+      if ((*snippetDataIterator)->isWarmSnippet() == 0)
          {
          if((*snippetDataIterator)->getKind() == TR::Snippet::IsEyeCatcherData)
             eyeCatcher = (TR::S390EyeCatcherDataSnippet *)(*snippetDataIterator);
@@ -9773,7 +9773,7 @@ OMR::Z::CodeGenerator::dumpDataSnippets(TR::FILE *outFile, bool isWarm)
 // OMR::Z::CodeGenerator::dumpTargetAddressSnippets
 ////////////////////////////////////////////////////////////////////////////////
 void
-OMR::Z::CodeGenerator::dumpTargetAddressSnippets(TR::FILE *outFile, bool isWarm)
+OMR::Z::CodeGenerator::dumpTargetAddressSnippets(TR::FILE *outFile)
    {
 
    if (outFile == NULL)
@@ -9785,7 +9785,7 @@ OMR::Z::CodeGenerator::dumpTargetAddressSnippets(TR::FILE *outFile, bool isWarm)
 
    for (auto iterator = _targetList.begin(); iterator != _targetList.end(); ++iterator)
       {
-      if ((*iterator)->isWarmSnippet() == isWarm)
+      if ((*iterator)->isWarmSnippet() == 0)
          self()->getDebug()->print(outFile, *iterator);
       }
    }

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -8142,7 +8142,7 @@ OMR::Z::CodeGenerator::setEstimatedOffsetForConstantDataSnippets(int32_t targetA
    }
 
 int32_t
-OMR::Z::CodeGenerator::setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart, bool isWarm)
+OMR::Z::CodeGenerator::setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart)
    {
    TR::S390ConstantDataSnippet * cursor;
    bool first;
@@ -8167,7 +8167,7 @@ OMR::Z::CodeGenerator::setEstimatedLocationsForDataSnippetLabels(int32_t estimat
       first = true;
       for (auto iterator = _constantList.begin(); iterator != _constantList.end(); ++iterator)
          {
-         if (HANDLE_CONSTANT_SNIPPET((*iterator), isWarm, size))
+         if (HANDLE_CONSTANT_SNIPPET((*iterator), 0, size))
             {
             if (first)
                {
@@ -8182,7 +8182,7 @@ OMR::Z::CodeGenerator::setEstimatedLocationsForDataSnippetLabels(int32_t estimat
       for(hi = _constantHashCur.SetToFirst(); _constantHashCur.Valid(); hi = _constantHashCur.SetToNext())
          {
            cursor = _constantHash.DataAt(hi);
-           if (HANDLE_CONSTANT_SNIPPET(cursor, isWarm, size))
+           if (HANDLE_CONSTANT_SNIPPET(cursor, 0, size))
               {
                if (first)
                    {
@@ -8201,7 +8201,7 @@ OMR::Z::CodeGenerator::setEstimatedLocationsForDataSnippetLabels(int32_t estimat
       first = true;
       for (auto writeableiterator = _writableList.begin(); writeableiterator != _writableList.end(); ++writeableiterator)
          {
-         if (HANDLE_CONSTANT_SNIPPET((*writeableiterator), isWarm, size))
+         if (HANDLE_CONSTANT_SNIPPET((*writeableiterator), 0, size))
             {
             if (first)
                {
@@ -8217,7 +8217,7 @@ OMR::Z::CodeGenerator::setEstimatedLocationsForDataSnippetLabels(int32_t estimat
    estimatedSnippetStart = ((estimatedSnippetStart + 7) / 8 * 8);
    for (auto snippetDataIterator = _snippetDataList.begin(); snippetDataIterator != _snippetDataList.end(); ++snippetDataIterator)
       {
-      if ((*snippetDataIterator)->isWarmSnippet() == isWarm)
+      if ((*snippetDataIterator)->isWarmSnippet() == 0)
          {
          (*snippetDataIterator)->getSnippetLabel()->setEstimatedCodeLocation(estimatedSnippetStart);
          estimatedSnippetStart += (*snippetDataIterator)->getLength(estimatedSnippetStart);
@@ -8622,14 +8622,14 @@ OMR::Z::CodeGenerator::setEstimatedOffsetForTargetAddressSnippets()
 // OMR::Z::CodeGenerator::TargetAddressSnippet Functions
 ////////////////////////////////////////////////////////////////////////////////
 int32_t
-OMR::Z::CodeGenerator::setEstimatedLocationsForTargetAddressSnippetLabels(int32_t estimatedSnippetStart, bool isWarm)
+OMR::Z::CodeGenerator::setEstimatedLocationsForTargetAddressSnippetLabels(int32_t estimatedSnippetStart)
    {
    self()->setEstimatedSnippetStart(estimatedSnippetStart);
    // Conservatively add maximum padding to get to 8 byte alignment.
    estimatedSnippetStart += 6;
    for (auto iterator = _targetList.begin(); iterator != _targetList.end(); ++iterator)
       {
-      if ((*iterator)->isWarmSnippet() == isWarm)
+      if ((*iterator)->isWarmSnippet() == 0)
          {
          (*iterator)->setEstimatedCodeLocation(estimatedSnippetStart);
          estimatedSnippetStart += (*iterator)->getLength(estimatedSnippetStart);

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -888,7 +888,7 @@ public:
    TR::Snippet *getFirstSnippet();
    // Constant Data List functions
    int32_t setEstimatedOffsetForConstantDataSnippets(int32_t targetAddressSnippetSize);
-   int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart, bool isWarm = 0);
+   int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart);
    void emitDataSnippets();
    bool hasDataSnippets() { return (_constantList.empty() && _writableList.empty() && _snippetDataList.empty() && _constantHash.IsEmpty()) ? false : true; }
    TR::list<TR::S390ConstantDataSnippet*> &getConstantInstructionSnippets() { return _constantList; }
@@ -936,7 +936,7 @@ public:
 
    // Target Address List functions
    int32_t setEstimatedOffsetForTargetAddressSnippets();
-   int32_t setEstimatedLocationsForTargetAddressSnippetLabels(int32_t estimatedSnippetStart, bool isWarm = 0);
+   int32_t setEstimatedLocationsForTargetAddressSnippetLabels(int32_t estimatedSnippetStart);
    void emitTargetAddressSnippets();
    bool hasTargetAddressSnippets() { return _targetList.empty() ? false : true; }
    TR::S390LookupSwitchSnippet  *CreateLookupSwitchSnippet(TR::Node *,  TR::Snippet* s);

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -724,8 +724,8 @@ public:
     */
    int32_t getMinimumNumberOfNodesBetweenMonitorsForTLE() { return 45; }
 
-   void dumpDataSnippets(TR::FILE *outFile, bool isWarm = 0);
-   void dumpTargetAddressSnippets(TR::FILE *outFile, bool isWarm = 0);
+   void dumpDataSnippets(TR::FILE *outFile);
+   void dumpTargetAddressSnippets(TR::FILE *outFile);
 
    bool specializedEpilogues() { return _cgFlags.testAny(S390CG_specializedEpilogues); }
    void setSpecializedEpilogues(bool b) { _cgFlags.set(S390CG_specializedEpilogues, b); }


### PR DESCRIPTION
* Remove references to last warm block/instruction
* Remove optional `isWarm` parm from snippet generation
* Remove `isWarm` parm from snippet printing