### PR TITLE
Add ARM definition of unionNoRegPostCondition

### DIFF
--- a/compiler/arm/codegen/OMRRegisterDependency.cpp
+++ b/compiler/arm/codegen/OMRRegisterDependency.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -650,4 +650,9 @@ TR::RegisterDependencyConditions *OMR::ARM::RegisterDependencyConditions::cloneA
                               singlePair->getFlags());
       }
    return result;
+   }
+
+void OMR::ARM::RegisterDependencyConditions::unionNoRegPostCondition(TR::Register *reg, TR::CodeGenerator *cg)
+   {
+   addPostCondition(reg, TR::RealRegister::NoReg);
    }


### PR DESCRIPTION
This change adds an implementation for the function
`OMR::ARM::RegisterDependencyConditions::unionNoRegPostCondition`.
This implementation was copied from the implementation for POWER.

I am marking this change with [ci skip] because there are no tests
currently setup for ARM.

Signed-off-by: Leonardo Banderali <leob@linux.vnet.ibm.com>