### PR TITLE
Fix Simplifier::create method

### DIFF
--- a/compiler/optimizer/OMRSimplifier.cpp
+++ b/compiler/optimizer/OMRSimplifier.cpp
@@ -171,6 +171,11 @@ OMR::Simplifier::Simplifier(TR::OptimizationManager *manager)
    _containingStructure = NULL;
    }
 
+TR::Optimization *OMR::Simplifier::create(TR::OptimizationManager *manager)
+   {
+   return new (manager->allocator()) TR::Simplifier(manager);
+   }
+
 void
 OMR::Simplifier::prePerformOnBlocks()
    {

--- a/compiler/optimizer/OMRSimplifier.hpp
+++ b/compiler/optimizer/OMRSimplifier.hpp
@@ -72,10 +72,7 @@ class Simplifier : public TR::Optimization
    public:
 
    Simplifier(TR::OptimizationManager *manager);
-   static TR::Optimization *create(TR::OptimizationManager *manager)
-      {
-      return new (manager->allocator()) Simplifier(manager);
-      }
+   static TR::Optimization *create(TR::OptimizationManager *manager);
 
    // Simplify the whole method.
    //


### PR DESCRIPTION
Change Simplifier::create method to instantiate TR::Simplifier so the
right simplifier will be created for a given project.

Signed-off-by: Xiaoli Liang <xsliang@ca.ibm.com>