### PR TITLE
Move forwarded object bit from 0x2 to 0x4

### DIFF
--- a/gc/structs/ForwardedHeader.hpp
+++ b/gc/structs/ForwardedHeader.hpp
@@ -68,7 +68,7 @@ private:
 	omrobjectptr_t _objectPtr;					/**< the object on which to act */
 	MutableHeaderFields _preserved; 			/**< a backup copy of the header fields which may be modified by this class */
 	const uintptr_t _forwardingSlotOffset;		/**< fomrobject_t offset from _objectPtr to fomrobject_t slot that will hold the forwarding pointer */
-	static const uintptr_t _forwardedTag = 2;	/**< bit mask used to mark forwarding slot value as forwarding pointer */
+	static const uintptr_t _forwardedTag = 4;	/**< bit mask used to mark forwarding slot value as forwarding pointer */
 
 /*
  * Function members


### PR DESCRIPTION
This will allow to set forwarded bit and hole bit (0x1) at the same
(which will be needed for a special variant of forwarded object in
future) and be able to distinguish it from a single slot hole (0x3 bits
set).

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>