### PR TITLE
Make omrmmap_map_file honor offset on z/OS

### DIFF
--- a/port/common/omrport.tdf
+++ b/port/common/omrport.tdf
@@ -1001,3 +1001,5 @@ TraceException=Trc_PRT_vmem_reserve_using_moservices_failed  Group=mem Overhead=
 TraceExit=Trc_PRT_vmem_reserve_using_moservices_exit Group=mem Overhead=1 Level=5 NoEnv Template="reserve_memory_with_moservices returns %p byteAmount=%u"
 
 TraceException=Trc_PRT_vmem_omrvmem_decommit_nonpageable_memory Group=mem Overhead=1 Level=1 NoEnv Template="omrvmem_decommit_memory attemp to decommit non-pageable memory at address=%p byteAmount=%u"
+
+TraceExit=Trc_PRT_mmap_map_seek_failed Group=mmap Overhead=1 Level=1 NoEnv Template="omrmmap_map_file: Failed to seek to offset = %lld"

--- a/port/zos390/omrmmap.c
+++ b/port/zos390/omrmmap.c
@@ -54,6 +54,11 @@ omrmmap_map_file(struct OMRPortLibrary *portLibrary, intptr_t file, uint64_t off
 		size = buf.st_size;
 	}
 
+	if (0 != portLibrary->file_seek(portLibrary, file, offset, EsSeekSet)) {
+		Trc_PRT_mmap_map_seek_failed(offset);
+		return NULL;
+	}
+
 	/* ensure that allocated memory is 8 byte aligned, just in case it matters */
 	allocPointer = portLibrary->mem_allocate_memory(portLibrary, size + 8, OMR_GET_CALLSITE(), category);
 	Trc_PRT_mmap_map_file_default_allocPointer(allocPointer, size + 8);


### PR DESCRIPTION
Currently offset parameter is ignored on z/OS, leading to unexepected
behaviour when offset != file position

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>