### PR TITLE
Prefer fully qualified namespace for definitions

### DIFF
--- a/doc/CodingStandard.md
+++ b/doc/CodingStandard.md
@@ -1441,3 +1441,21 @@ uint32_t size = getSize();
 uint32_t averageSize = size / count;
 ```
 
+## Specify Namespace in Function Definition
+
+When writing the definition of a C++ function separate from the declaration,
+use the fully qualified name to allow easier search.
+
+Bad
+```
+namespace OMR { 
+
+Foo::Func(int*) ... 
+
+} 
+```
+
+Good 
+```
+OMR::Foo::Func(int*) 
+```


### PR DESCRIPTION
Makes it much easier to search for function names. This is already the
dominant style in the code base.

[ci skip] as documentation only change.

Signed-off-by: Matthew Gaudet <magaudet@ca.ibm.com>