### PR TITLE
Split block containing the call under FSD mode

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -5011,6 +5011,18 @@ bool TR_InlinerBase::inlineCallTarget2(TR_CallStack * callStack, TR_CallTarget *
             _disableTailRecursion = true;
          }
       }
+   else if (comp()->getOption(TR_FullSpeedDebug) && tif->crossedBasicBlock())
+      {
+      /**
+       * In FSD mode, we need to split block even for cases without virtual guard. This is 
+       * because in FSD a block with OSR point must have an exception edge to the osrCatchBlock
+       * of correct callerIndex. Split the block here so that the OSR points from callee
+       * and from caller are separated.
+       */
+      TR::Block * blockOfCaller = previousBBStartInCaller->getNode()->getBlock();
+      TR::Block * blockOfCallerInCalleeCFG = nextBBEndInCaller->getNode()->getBlock()->split(callNodeTreeTop, callerCFG);
+      callerCFG->copyExceptionSuccessors(blockOfCaller, blockOfCallerInCalleeCFG);
+      }
 
    // move the NULLCHK to before the inlined code
    //


### PR DESCRIPTION
In FSD, we need to split block even for cases without virtual
guard. This is because under FSD a block with OSR point must have an
exception edge to the osrCatchBlock of correct callerIndex. Split
the block here so that the OSR points from callee and from caller
are separated.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>