### PR TITLE
Rewrite post- to pre-increment in loop tests

### DIFF
--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -83,7 +83,7 @@ public:
 
    /// Get the opcode to be used if the children of this opcode are swapped.
    /// e.g. ificmplt --> ificmpgt
-   TR::ILOpCodes getOpCodeForSwapChildren()
+   TR::ILOpCodes getOpCodeForSwapChildren() const
       { return _opCodeProperties[_opCode].swapChildrenOpCode; }
 
    /// Get the opcode to be used if the sense of this (compare) opcode is reversed.

--- a/compiler/optimizer/LoopCanonicalizer.hpp
+++ b/compiler/optimizer/LoopCanonicalizer.hpp
@@ -246,6 +246,9 @@ class TR_LoopCanonicalizer : public TR_LoopTransformer
    bool checkComplexInductionVariableUse(TR_Structure *structure);
    bool checkComplexInductionVariableUseNode(TR::Node *node, bool inAddr);
 
+   void rewritePostToPreIncrementTestInRegion(TR_RegionStructure *region);
+   void rewritePostToPreIncrementTestInBlock(TR::Block *block);
+
    TR::SymbolReference *_symRefBeingReplaced;
    TR::SymbolReference *_primaryInductionVariable;
    TR::Node *_primaryInductionVarStoreInBlock;


### PR DESCRIPTION
Canonicalizer now looks within loops for inequality tests against the
old value of a variable that is incremented or decremented just prior to
the test, and attempts to rewrite those tests in terms of the new value.
As an example in pseudocode, it attempts to change `if (i++ < n)` into
`if (++i <= n)`.

Particularly for loop tests against induction variables, the optimizer
is better attuned to tests against the new value, because those are
commonly generated for typical for-loops (after canonicalization).