### PR TITLE
WIP: Simplify integer add/sub under comparison nodes

### DIFF
--- a/compiler/optimizer/OMRSimplifierHandlers.hpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.hpp
@@ -267,5 +267,5 @@ TR::Node * NewSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
 TR::Node * lowerTreeSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * arrayLengthSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 
-
+TR::Node * reduceIntegerCompareArithmetics(TR::Node* node,TR::Simplifier * s);
 #endif


### PR DESCRIPTION
Simplify integer add and subtract operations under integer comparison
nodes to avoid emitting add/sub instructions in the codegen phase.

Signed-off-by: Nigel Yu <yunigel@ca.ibm.com>