### PR TITLE
Add flag for pending push symbols

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -1766,7 +1766,9 @@ OMR::SymbolReferenceTable::findOrCreatePendingPushTemporary(
 #ifdef J9_PROJECT_SPECIFIC
    TR_ASSERT(!type.isBCD() || size,"binary coded decimal types must provide a size\n");
 #endif
-   return findOrCreateAutoSymbol(owningMethodSymbol, -(slot + 1), type, true, false, false, false, size);
+   TR::SymbolReference *tempSymRef = findOrCreateAutoSymbol(owningMethodSymbol, -(slot + 1), type, true, false, false, false, size);
+   tempSymRef->getSymbol()->setIsPendingPush();
+   return tempSymRef;
    }
 
 TR::SymbolReference *

--- a/compiler/il/symbol/OMRSymbol.hpp
+++ b/compiler/il/symbol/OMRSymbol.hpp
@@ -435,6 +435,9 @@ public:
    void setImmutableField() { _flags2.set(ImmutableField); }
    bool isImmutableField()  { return _flags2.testAny(ImmutableField); }
 
+   void setIsPendingPush() { _flags2.set(PendingPush); }
+   bool isPendingPush()    { return _flags2.testAny(PendingPush); }
+
    /**
     * Enum values for _flags field.
     */
@@ -560,6 +563,7 @@ public:
       UnsafeShadow              = 0x00000100,
       NamedShadow               = 0x00000200,
       ImmutableField            = 0x00000400,
+      PendingPush               = 0x00000800,
       };
 
 protected:

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1815,7 +1815,7 @@ TR_Debug::getAutoName(TR::SymbolReference * symRef)
       TR::AutomaticSymbol *sym = symRef->getSymbol()->getVariableSizeSymbol();
       sprintf(name, "<%s rc=%d>",getVSSName(sym),sym->getReferenceCount());
       }
-   else if (slot < 0)
+   else if (symRef->getSymbol()->isPendingPush())
       {
       sprintf(name, "<pending push temp %d>", -slot - 1);
       }


### PR DESCRIPTION
The current method to determine if a symbol is a pending push is to
check if it is stored in the method's array of pending pushes or by
checking its CP index. This adds a flag to determine if a symbol is
a pending push, applied to it when it is created.