### PR TITLE
Remove warm snippets and code cache estimation

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -2904,11 +2904,8 @@ OMR::CodeGenerator::setEstimatedLocationsForSnippetLabels(int32_t estimatedSnipp
 
    for (auto iterator = _snippetList.begin(); iterator != _snippetList.end(); ++iterator)
       {
-      if ((*iterator)->isWarmSnippet() == 0)
-         {
-    	  (*iterator)->setEstimatedCodeLocation(estimatedSnippetStart);
-         estimatedSnippetStart += (*iterator)->getLength(estimatedSnippetStart);
-         }
+      (*iterator)->setEstimatedCodeLocation(estimatedSnippetStart);
+      estimatedSnippetStart += (*iterator)->getLength(estimatedSnippetStart);
       }
 
    if (self()->hasDataSnippets())
@@ -2927,18 +2924,15 @@ OMR::CodeGenerator::emitSnippets()
 
    for (auto iterator = _snippetList.begin(); iterator != _snippetList.end(); ++iterator)
       {
-      if ((*iterator)->isWarmSnippet() == 0)
+      codeOffset = (*iterator)->emitSnippet();
+      if (codeOffset != NULL)
          {
-         codeOffset = (*iterator)->emitSnippet();
-         if (codeOffset != NULL)
-            {
-            TR_ASSERT((*iterator)->getLength(self()->getBinaryBufferCursor()-self()->getBinaryBufferStart()) + self()->getBinaryBufferCursor() >= codeOffset,
-                    "%s length estimate must be conservatively large (snippet @ " POINTER_PRINTF_FORMAT ", estimate=%d, actual=%d)",
-                    self()->getDebug()->getName(*iterator), *iterator,
-                    (*iterator)->getLength(self()->getBinaryBufferCursor()-self()->getBinaryBufferStart()),
-                    codeOffset - self()->getBinaryBufferCursor());
-            self()->setBinaryBufferCursor(codeOffset);
-            }
+         TR_ASSERT((*iterator)->getLength(self()->getBinaryBufferCursor()-self()->getBinaryBufferStart()) + self()->getBinaryBufferCursor() >= codeOffset,
+                 "%s length estimate must be conservatively large (snippet @ " POINTER_PRINTF_FORMAT ", estimate=%d, actual=%d)",
+                 self()->getDebug()->getName(*iterator), *iterator,
+                 (*iterator)->getLength(self()->getBinaryBufferCursor()-self()->getBinaryBufferStart()),
+                 codeOffset - self()->getBinaryBufferCursor());
+         self()->setBinaryBufferCursor(codeOffset);
          }
       }
 

--- a/compiler/codegen/OMRSnippet.hpp
+++ b/compiler/codegen/OMRSnippet.hpp
@@ -87,9 +87,6 @@ class OMR_EXTENSIBLE Snippet
    TR::Block *getBlock() { return _block; }
    void setBlock(TR::Block *block) { _block = block; }
 
-   bool isWarmSnippet() { return _flags.testAll(TO_MASK32(WarmSnippet)); }
-   void setWarmSnippet() { _flags.set(TO_MASK32(WarmSnippet)); }
-
    bool needsExceptionTableEntry() { return _flags.testAll(TO_MASK32(NeedsExceptionTableEntry)); }
    void setNeedsExceptionTableEntry() { _flags.set(TO_MASK32(NeedsExceptionTableEntry)); }
    void resetNeedsExceptionTableEntry() { _flags.reset(TO_MASK32(NeedsExceptionTableEntry)); }
@@ -101,7 +98,6 @@ class OMR_EXTENSIBLE Snippet
    enum
       {
       NeedsExceptionTableEntry = 0,
-      WarmSnippet,
 
       NextSnippetFlag,
       MaxSnippetFlag = (sizeof(uint32_t)*8)-1

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -131,7 +131,6 @@ void ppcCodeSync(uint8_t * start, uint32_t size);
 struct TR_PPCBinaryEncodingData : public TR_BinaryEncodingData
    {
    int32_t estimate;
-   int32_t warmEstimate;
    TR::Instruction *cursorInstruction;
    TR::Instruction *jitTojitStart;
    TR::Instruction *preProcInstruction;
@@ -531,8 +530,6 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
       TR::Register *tempReg,
       TR::Instruction **q);
 
-   TR::list<TR::LabelSymbol*>&   getGlobalLabelsEncountered()  { return _globalLabelsEncountered; }
-
    private:
 
    enum // flags
@@ -587,8 +584,6 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    bool                             _specializedEpilogues;
    TR_ReachingBlocks                *_reachingBlocks;
    TR_BitVector                     **_blocksThatModifyRegister;
-
-   TR::list<TR::LabelSymbol*>               _globalLabelsEncountered;
 
    };
 

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -2901,8 +2901,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::list<TR::Snippet*> & snippetList, bool i
 
    for (auto snippets = snippetList.begin(); snippets != snippetList.end(); ++snippets)
       {
-      if ((*snippets)->isWarmSnippet() == 0)
-         print(pOutFile, *snippets);
+      print(pOutFile, *snippets);
       }
 
    if (_comp->cg()->hasDataSnippets())
@@ -2922,8 +2921,7 @@ TR_Debug::print(TR::FILE *pOutFile, List<TR::Snippet> & snippetList, bool isWarm
    ListIterator<TR::Snippet> snippets(&snippetList);
    for (TR::Snippet * snippet = snippets.getFirst(); snippet; snippet = snippets.getNext())
       {
-      if (snippet->isWarmSnippet() == 0)
-         print(pOutFile, snippet);
+      print(pOutFile, snippet);
       }
 
    if (_comp->cg()->hasDataSnippets())

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -2266,7 +2266,7 @@ int32_t OMR::X86::CodeGenerator::setEstimatedLocationsForDataSnippetLabels(int32
       first = true;
       for (auto iterator = _dataSnippetList.begin(); iterator != _dataSnippetList.end(); ++iterator)
          {
-         if ((*iterator)->getDataSize() == size && (*iterator)->isWarmSnippet() == 0)
+         if ((*iterator)->getDataSize() == size)
             {
             if (first)
                {
@@ -2299,7 +2299,7 @@ void OMR::X86::CodeGenerator::emitDataSnippets()
       first = true;
       for (auto iterator = _dataSnippetList.begin(); iterator != _dataSnippetList.end(); ++iterator)
          {
-         if ((*iterator)->getDataSize() == size && (*iterator)->isWarmSnippet() == 0)
+         if ((*iterator)->getDataSize() == size)
             {
             if (first)
                {
@@ -3733,7 +3733,7 @@ void OMR::X86::CodeGenerator::dumpDataSnippets(TR::FILE *outFile)
       size = 1 << exp;
       for (auto iterator = _dataSnippetList.begin(); iterator != _dataSnippetList.end(); ++iterator)
          {
-         if ((*iterator)->getDataSize() == size && (*iterator)->isWarmSnippet() == 0)
+         if ((*iterator)->getDataSize() == size)
             {
             self()->getDebug()->print(outFile, *iterator);
             }

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -96,11 +96,6 @@
 namespace OMR { class RegisterUsage; }
 namespace TR { class RegisterDependencyConditions; }
 
-// Amount to be added to the estimated code size to ensure that there are long
-// branches between warm and cold code sections (must be multiple of 8 bytes).
-//
-#define MIN_DISTANCE_BETWEEN_WARM_AND_COLD_CODE 512
-
 extern "C" bool jitTestOSForSSESupport(void);
 
 // Hack markers
@@ -1713,7 +1708,6 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
 
    TR::Instruction * estimateCursor = self()->comp()->getFirstInstruction();
    int32_t estimate = 0;
-   int32_t warmEstimate = 0;
 
    // Estimate the binary length up to PROCENTRY
    //
@@ -1889,17 +1883,9 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
    // block, then the write could potentially destroy data that resides in the
    // adjacent block. For this reason it is better to overestimate
    // the allocated size by 4.
-   #define OVER_ESTIMATATION 4
-   if (warmEstimate)
-      {
-      self()->setEstimatedWarmLength(warmEstimate + OVER_ESTIMATATION);
-      self()->setEstimatedColdLength(estimate-warmEstimate-MIN_DISTANCE_BETWEEN_WARM_AND_COLD_CODE+OVER_ESTIMATATION);
-      }
-   else
-      {
-      self()->setEstimatedWarmLength(estimate+OVER_ESTIMATATION);
-      self()->setEstimatedColdLength(0);
-      }
+   #define OVER_ESTIMATION 4
+   self()->setEstimatedWarmLength(estimate+OVER_ESTIMATION);
+   self()->setEstimatedColdLength(0);
 
    if (self()->comp()->getOption(TR_TraceCG))
       {

--- a/compiler/z/codegen/ConstantDataSnippet.cpp
+++ b/compiler/z/codegen/ConstantDataSnippet.cpp
@@ -1152,37 +1152,10 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390ConstantDataSnippet * snippet)
       }
    else if (snippet->getKind() == TR::Snippet::IsEyeCatcherData)
       {
-      if (snippet->isWarmSnippet())
-         {
-         // Warm Code Eyecatchers is a smaller version of the eyecatcher.
-         printSnippetLabel(pOutFile, snippet->getSnippetLabel(), bufferPos, "[WARM] EyeCatcher Data Snippet");
-         printPrefix(pOutFile, NULL, bufferPos, 8);
-         trfprintf(pOutFile, "Warm Eye Catcher = JITMETHD\n");
-         intptrj_t * s = (intptrj_t *) (bufferPos + 8);
-         printPrefix(pOutFile, NULL, bufferPos + 8, sizeof(intptrj_t));
-         trfprintf(pOutFile, "Full Eye Catcher Addr = %p\n",*s);
-         }
-      else
-         {
-         // Cold Eyecatcher is used for padding of endPC so that Return Address for exception snippets will never equal the endPC.
-         printSnippetLabel(pOutFile, snippet->getSnippetLabel(), bufferPos, "EyeCatcher Data Snippet");
-         printPrefix(pOutFile, NULL, bufferPos, 4);
-         trfprintf(pOutFile, "Eye Catcher = JITM\n");
-         /*** Old Eyecatcher code.
-         printSnippetLabel(pOutFile, snippet->getSnippetLabel(), bufferPos, "EyeCatcher Data Snippet");
-         printPrefix(pOutFile, NULL, bufferPos, 8);
-         trfprintf(pOutFile, "Eye Catcher = ._.J.I.T\n");
-         intptrj_t * s = (intptrj_t *) (bufferPos + 8);
-         printPrefix(pOutFile, NULL, bufferPos + 8, 8);
-         trfprintf(pOutFile, "TimeStamp = %p\n",*s);
-         s = (intptrj_t *) (bufferPos + 16);
-         printPrefix(pOutFile, NULL, bufferPos + 16, sizeof(intptrj_t));
-         trfprintf(pOutFile, "ramMethod = 0x%p\n", *s);
-         printPrefix(pOutFile, NULL, bufferPos + 16 + sizeof(intptrj_t), sizeof(intptrj_t));
-         s = (intptrj_t *) (bufferPos + 16 + sizeof(intptrj_t));
-         trfprintf(pOutFile, "Signature   = %s\n", s);
-         ***/
-         }
+      // Cold Eyecatcher is used for padding of endPC so that Return Address for exception snippets will never equal the endPC.
+      printSnippetLabel(pOutFile, snippet->getSnippetLabel(), bufferPos, "EyeCatcher Data Snippet");
+      printPrefix(pOutFile, NULL, bufferPos, 4);
+      trfprintf(pOutFile, "Eye Catcher = JITM\n");
       return;
       }
    else if (snippet->getKind() == TR::Snippet::IsConstantInstruction)

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -7959,7 +7959,6 @@ OMR::Z::CodeGenerator::findOrCreateConstant(TR::Node * node, void * c, uint16_t 
    TR_S390ConstantDataSnippetKey key;
    key.c      = c;
    key.size   = size;
-   key.isWarm = false;
    TR::S390ConstantDataSnippet * data;
 
    // Can only share data snippets for literal pool address when inlined site indices are the same
@@ -7996,7 +7995,6 @@ OMR::Z::CodeGenerator::findOrCreateConstant(TR::Node * node, void * c, uint16_t 
    data = new (self()->trHeapMemory()) TR::S390ConstantDataSnippet(self(), node, c, size);
    key.c = (void *)data->getRawData();
    key.size = size;
-   key.isWarm = false;
    if (self()->profiledPointersRequireRelocation() && node &&
        (node->getOpCodeValue() == TR::aconst && (node->isClassPointerConstant() || node->isMethodPointerConstant()) ||
         node->getOpCodeValue() == TR::loadaddr && node->getSymbol()->isClassObject() ||
@@ -8035,7 +8033,6 @@ OMR::Z::CodeGenerator::CreateConstant(TR::Node * node, void * c, uint16_t size, 
       TR_S390ConstantDataSnippetKey key;
       key.c = (void *)cursor->getRawData();
       key.size = size;
-      key.isWarm = false;
       _constantHash.Add(key,cursor);
       return cursor;
       }

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -847,7 +847,6 @@ public:
         {
            void * c;
            uint32_t size;
-           bool isWarm;
            TR::Node *node;
         };
 
@@ -859,8 +858,6 @@ public:
               }
           static bool Equal(const TR_S390ConstantDataSnippetKey & key1,const TR_S390ConstantDataSnippetKey & key2)
               {
-              if (key1.isWarm != key2.isWarm)
-                  return false;
               if(key1.size != key2.size)
                   return false;
               if (key1.node != key2.node)


### PR DESCRIPTION
* Remove deprecated warm code cache estimation logic
* Remove `isWarm` field from Z constant snippet hash
* Remove warm snippet references