### PR TITLE
Allow changing MSVC runtime dll via preprocessor define

### DIFF
--- a/omrsigcompat/omrsig.cpp
+++ b/omrsigcompat/omrsig.cpp
@@ -321,7 +321,7 @@ omrsig_signalOS_internal(int signum, const struct sigaction *act, struct sigacti
 	}
 #else /* defined(POSIX_SIGNAL) */
 	if (NULL == signalOS) {
-		signalOS = (SIGNAL)GetProcAddress(GetModuleHandle(TEXT("MSVCR100.dll")), "signal");
+		signalOS = (SIGNAL)GetProcAddress(GetModuleHandle(TEXT(MSVC_RUNTIME_DLL)), "signal");
 	}
 	if (NULL == signalOS) {
 		rc = -1;

--- a/omrsigcompat/omrsig_internal.hpp
+++ b/omrsigcompat/omrsig_internal.hpp
@@ -73,6 +73,9 @@ struct OMR_SigData {
 #define SIGUNLOCK(sigMutex) \
 	sigMutex.unlock();
 
+#if !defined(MSVC_RUNTIME_DLL)
+#define MSVC_RUNTIME_DLL "MSVCR100.dll"
+#endif /* !defined(MSVC_RUINTIME_DLL) */
 #else /* defined(WIN32) */
 
 #define LockMask sigset_t *previousMask


### PR DESCRIPTION
omrsig has a hard coded dependency on the MSVC runtime dll name. This
patch substitutes the name with a preprocessor macro to allow changing the
name via compile time flags

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>