### PR TITLE
Improve JitBuilder testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ OMRTraceFormat.dat
 /omralgotest
 /omrgcexample
 /omrgctest
+/omrjitbuildertest
 /omrperfgctest
 /omrporttest
 /omrrastest

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -158,7 +158,7 @@ endif
 # JitBuilder
 ifeq (1,$(OMR_JITBUILDER))
 main_targets += jitbuilder
-test_targets += jitbuilder/release
+test_targets += fvtest/jitbuildertest jitbuilder/release
 endif
 
 DO_TEST_TARGET := yes

--- a/fvtest/jitbuildertest/FieldAddressTest.cpp
+++ b/fvtest/jitbuildertest/FieldAddressTest.cpp
@@ -1,0 +1,124 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#include "JBTestUtil.hpp"
+
+struct Struct
+   {
+   uint16_t f1;
+   uint8_t f2;
+   };
+
+union Union
+   {
+   uint16_t f1;
+   uint8_t f2;
+   };
+
+typedef uint8_t* (GetStructFieldAddressFunction)(Struct*);
+typedef uint8_t* (GetUnionFieldAddressFunction)(Union*);
+
+DECL_TEST_BUILDER(GetStructFieldAddressBuilder);
+DECL_TEST_BUILDER(GetUnionFieldAddressBuilder);
+
+GetStructFieldAddressBuilder::GetStructFieldAddressBuilder(TR::TypeDictionary *d)
+   : MethodBuilder(d)
+   {
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   auto pStructType = d->PointerTo(d->LookupStruct("Struct"));
+
+   DefineName("getStructFieldAddress");
+   DefineParameter("s", pStructType);
+   DefineReturnType(d->PointerTo(d->GetFieldType("Struct", "f2")));
+   }
+
+bool
+GetStructFieldAddressBuilder::buildIL()
+   {
+   Return(
+          StructFieldInstanceAddress("Struct", "f2",
+                             Load("s")));
+
+   return true;
+   }
+
+GetUnionFieldAddressBuilder::GetUnionFieldAddressBuilder(TR::TypeDictionary *d)
+   : MethodBuilder(d)
+   {
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   auto pUnionType = d->PointerTo(d->LookupUnion("Union"));
+
+   DefineName("getUnionFieldAddress");
+   DefineParameter("u", pUnionType);
+   DefineReturnType(d->toIlType<uint8_t *>());
+   }
+
+bool
+GetUnionFieldAddressBuilder::buildIL()
+   {
+   Return(
+          UnionFieldInstanceAddress("Union", "f2",
+                             Load("u")));
+
+   return true;
+   }
+
+DEFINE_TYPES(StructTypeDictionary)
+   {
+   DEFINE_STRUCT(Struct);
+   DEFINE_FIELD(Struct, f1, toIlType<uint16_t>());
+   DEFINE_FIELD(Struct, f2, toIlType<uint8_t>());
+   CLOSE_STRUCT(Struct);
+   }
+
+DEFINE_TYPES(UnionTypeDictionary)
+   {
+   DefineUnion("Union");
+   UnionField("Union", "f1", toIlType<uint16_t>());
+   UnionField("Union", "f2", toIlType<uint8_t>());
+   CloseUnion("Union");
+   }
+
+class FieldAddressTest : public JitBuilderTest {};
+
+TEST_F(FieldAddressTest, StructField)
+   {
+   GetStructFieldAddressFunction *getStructFieldAddress;
+   ASSERT_COMPILE(StructTypeDictionary,GetStructFieldAddressBuilder,getStructFieldAddress);
+
+   Struct s;
+   s.f1 = 1;
+   s.f2 = 2;
+   auto structFieldAddress = getStructFieldAddress(&s);
+   ASSERT_EQ(&(s.f2), structFieldAddress);
+   }
+
+TEST_F(FieldAddressTest, UnionField)
+   {
+   GetUnionFieldAddressFunction *getUnionFieldAddress;
+   ASSERT_COMPILE(UnionTypeDictionary, GetUnionFieldAddressBuilder, getUnionFieldAddress);
+
+   Union u;
+   u.f2 = 2;
+   auto unionFieldAddress = getUnionFieldAddress(&u);
+   ASSERT_EQ(&(u.f2), unionFieldAddress);
+   }

--- a/fvtest/jitbuildertest/JBTestUtil.hpp
+++ b/fvtest/jitbuildertest/JBTestUtil.hpp
@@ -1,0 +1,173 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#ifndef JB_TEST_UTIL_HPP
+#define JB_TEST_UTIL_HPP
+
+#include "gtest/gtest.h"
+
+#include "Jit.hpp"
+#include "ilgen/TypeDictionary.hpp"
+#include "ilgen/MethodBuilder.hpp"
+
+/*
+ * Convenience macro for defining type dictionary objects. `name` is the name of
+ * the class that will be created. The "body" of the macro should contain the
+ * JitBuilder type definitions.
+ *
+ * Example use:
+ *
+ *    DEFINE_TYPES(MyTypeDictionary)
+ *       {
+ *       DefineStruct("MyStruct");
+ *       DefineField("MyStruct", "field", Int32);
+ *       CloseStruct("MyStruct");
+ *       }
+ */
+#define DEFINE_TYPES(name) \
+   struct name : public TR::TypeDictionary { name(); }; \
+   inline name::name() : TR::TypeDictionary()
+
+/*
+ * Convenience macro for declaring a MethodBuilder class. `name` is the name of
+ * the class that will be created. The macro will ensure the class inherits from
+ * `TR::MethodBuilder` and that the constructor and `buildIL()` method are
+ * declared. A ';' is required at the end of the macro invocation.
+ *
+ * Example use:
+ *
+ *    DECL_TEST_BUILDER(MyFunctionBuilder);
+ */
+#define DECL_TEST_BUILDER(name) \
+   class name : public TR::MethodBuilder { \
+      public: \
+      name(TR::TypeDictionary *); \
+      virtual bool buildIL(); \
+   }
+
+#define DEF_TEST_BUILDER_CTOR(name) \
+   inline name::name(TR::TypeDictionary *types) : TR::MethodBuilder(types)
+
+#define DEF_BUILDIL(name) \
+   inline bool name::buildIL()
+
+/**
+ * @brief The JitBuilderTest class is a basic test fixture for JitBuilder test cases.
+ *
+ * Most JitBuilder test case fixtures should publically inherit from this class.
+ *
+ * Example use:
+ *
+ *    class MyTestCase : public JitBuilderTest {};
+ */
+class JitBuilderTest : public ::testing::Test
+   {
+   public:
+
+   static void SetUpTestCase()
+      {
+      ASSERT_TRUE(initializeJit()) << "Failed to initialize the JIT.";
+      }
+
+   static void TearDownTestCase()
+      {
+      shutdownJit();
+      }
+   };
+
+/**
+ * @brief try_compile is a convenience template function for invoking JitBuilder
+ *
+ * Note: directly calling this function in a test is not recommend. Using the
+ * ASSERT_COMPILE macro is preferred.
+ *
+ * The first template argument (`TypeDictionary`) is the class type that should
+ * be passed to construct the MethodBuilder instance. The specified type *must*
+ * inherit from `TR::TypeDictionary`.
+ *
+ * The second template argument (`MethodBuilder`) is the class type of the
+ * MethodBuilder instance that should be constructed. The specified type *must*
+ * inherit from `TR::MethodBuilder`.
+ *
+ * The last template argument (`Function`) is the type of the function pointer
+ * that should be used to store the address of the entry point to the compiled
+ * body.
+ *
+ * The formal parameter to the function is a reference to the variable in which
+ * the address of the entry point will be stored.
+ *
+ * Only the first two template arguments must be specified because that last one
+ * can be deduced by the compiler from the type of the argument passed to the
+ * function.
+ *
+ * If compilation of the method fails, the function will assert and return.
+ * `::testing::Test::HasFatalFailure()` can be used to detect the assert from
+ * the calling test.
+ *
+ * Example use:
+ *
+ *    typedef void (*MyFunctionType)(int);   // define type of entry point
+ *    MyFunctionType myFunction;             // variable to store the entry point
+ *
+ *    try_compile<MyTypeDictionary,MyMethodBuilder>(myFunction);
+ *       // If compilation succeeds, `myFunction` will point to the entry point
+ *       // of the compiled body. Otherwise, the function will assert.
+ *
+ *    if (::testing::Test::HasFatalFailure())
+ *       return;        // return because compilation failed
+ *    else
+ *       myFunction(2); // execute the compiled body
+ */
+template <typename TypeDictionary, typename MethodBuilder, typename Function>
+void try_compile(Function& f)
+   {
+   TypeDictionary types;
+   MethodBuilder builder(&types);
+   uint8_t *entry;
+   int32_t rc = compileMethodBuilder(&builder, &entry);
+   ASSERT_EQ(0, rc) << "Failed to compile method " << builder.getMethodName();
+   f = (Function)entry;
+   }
+
+/**
+ * @brief ASSERT_COMPILE is a convenience macro for invoking JitBuilder
+ *
+ * Note: invoking ASSERT_COMPILE is preferred to directly calling `try_compile()`.
+ *
+ * This macro simply calls `try_compile()` and asserts that compilation
+ * succeeded. It forwards its first argument to the TypeDictionary template
+ * parameter, its second argument to the MethodBuilder template parameter, and
+ * its last last argument becomes the function's argument.
+ *
+ * Example use:
+ *
+ *    typedef void (*MyFunctionType)(int);   // define type of entry point
+ *    MyFunctionType myFunction;             // variable to store the entry point
+ *
+ *    ASSERT_COMPILE(MyTypeDictionary, MyMethodBuilder, myFunction);
+ *       // Compile method and assert that compilation succeeds. If successful,
+ *       // `myFunction` will point to the entry point of the compiled body.
+ *
+ *    myFunction(2); // execute the compiled body
+ */
+#define ASSERT_COMPILE(TypeDictionary, MethodBuilder, function) do {\
+   try_compile<TypeDictionary,MethodBuilder>(function); \
+   ASSERT_FALSE(::testing::Test::HasFatalFailure()); \
+} while (0)
+
+#endif // JB_TEST_UTIL_HPP

--- a/fvtest/jitbuildertest/Makefile
+++ b/fvtest/jitbuildertest/Makefile
@@ -1,0 +1,57 @@
+###############################################################################
+#
+# (c) Copyright IBM Corp. 2017, 2017
+#
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License v1.0 and
+#  Apache License v2.0 which accompanies this distribution.
+#
+#      The Eclipse Public License is available at
+#      http://www.eclipse.org/legal/epl-v10.html
+#
+#      The Apache License v2.0 is available at
+#      http://www.opensource.org/licenses/apache2.0.php
+#
+# Contributors:
+#    Multiple authors (IBM Corp.) - initial implementation and documentation
+###############################################################################
+
+top_srcdir := ../..
+include $(top_srcdir)/omrmakefiles/configure.mk
+
+MODULE_NAME := omrjitbuildertest
+ARTIFACT_TYPE := cxx_executable
+
+OBJECTS := main
+
+OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
+
+MODULE_INCLUDES += \
+  ../util \
+  $(top_srcdir)/jitbuilder/release/include/compiler \
+  $(top_srcdir)/jitbuilder/release/include
+MODULE_INCLUDES += $(OMR_GTEST_INCLUDES)
+MODULE_CXXFLAGS += -std=c++0x $(OMR_GTEST_CXXFLAGS)
+
+MODULE_STATIC_LIBS += \
+  jitbuilder \
+  omrGtest
+
+MODULE_LIBPATH += \
+  $(top_srcdir)/jitbuilder/release
+
+ifeq (linux,$(OMR_HOST_OS))
+  MODULE_SHARED_LIBS += rt pthread
+endif
+ifeq (osx,$(OMR_HOST_OS))
+  MODULE_SHARED_LIBS += iconv pthread
+endif
+ifeq (aix,$(OMR_HOST_OS))
+  MODULE_SHARED_LIBS += iconv perfstat
+endif
+ifeq (win,$(OMR_HOST_OS))
+  MODULE_SHARED_LIBS += ws2_32 shell32 Iphlpapi psapi pdh
+endif
+
+include $(top_srcdir)/omrmakefiles/rules.mk
+

--- a/fvtest/jitbuildertest/Makefile
+++ b/fvtest/jitbuildertest/Makefile
@@ -22,7 +22,9 @@ include $(top_srcdir)/omrmakefiles/configure.mk
 MODULE_NAME := omrjitbuildertest
 ARTIFACT_TYPE := cxx_executable
 
-OBJECTS := main
+OBJECTS := \
+	main \
+	selftest
 
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
 

--- a/fvtest/jitbuildertest/Makefile
+++ b/fvtest/jitbuildertest/Makefile
@@ -25,7 +25,8 @@ ARTIFACT_TYPE := cxx_executable
 OBJECTS := \
 	main \
 	selftest \
-	UnionTest
+	UnionTest \
+	FieldAddressTest
 
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
 

--- a/fvtest/jitbuildertest/Makefile
+++ b/fvtest/jitbuildertest/Makefile
@@ -24,7 +24,8 @@ ARTIFACT_TYPE := cxx_executable
 
 OBJECTS := \
 	main \
-	selftest
+	selftest \
+	UnionTest
 
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
 

--- a/fvtest/jitbuildertest/UnionTest.cpp
+++ b/fvtest/jitbuildertest/UnionTest.cpp
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#include "JBTestUtil.hpp"
+
+union TestUnionInt8pChar
+   {
+   uint8_t v_uint8;
+   const char* v_pchar;
+   };
+
+union TestUnionInt32Int32
+   {
+   uint32_t f1;
+   uint32_t f2;
+   };
+
+union TestUnionInt16Double
+   {
+   uint16_t v_uint16;
+   double v_double;
+   };
+
+DEFINE_TYPES(UnionTypes)
+   {
+   DefineUnion("TestUnionInt8pChar");
+   UnionField("TestUnionInt8pChar", "v_uint8", toIlType<uint8_t>());
+   UnionField("TestUnionInt8pChar", "v_pchar", toIlType<char*>());
+   CloseUnion("TestUnionInt8pChar");
+
+   DefineUnion("TestUnionInt32Int32");
+   UnionField("TestUnionInt32Int32", "f1", Int32);
+   UnionField("TestUnionInt32Int32", "f2", Int32);
+   CloseUnion("TestUnionInt32Int32");
+
+   DefineUnion("TestUnionInt16Double");
+   UnionField("TestUnionInt16Double", "v_uint16", Int16);
+   UnionField("TestUnionInt16Double", "v_double", Double);
+   CloseUnion("TestUnionInt16Double");
+   }
+
+DECL_TEST_BUILDER(TypePunInt32Int32Builder);
+DECL_TEST_BUILDER(TypePunInt16DoubleBuilder);
+
+typedef uint32_t (*TypePunInt32Int32Function)(TestUnionInt32Int32*, uint32_t, uint32_t);
+typedef uint16_t (*TypePunInt16DoubleFunction)(TestUnionInt16Double*, uint16_t, double);
+
+TypePunInt32Int32Builder::TypePunInt32Int32Builder(TR::TypeDictionary *d)
+   : MethodBuilder(d)
+   {
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   DefineName("typePunInt32Int32Builder");
+   DefineParameter("u", d->PointerTo(d->LookupUnion("TestUnionInt32Int32")));
+   DefineParameter("v1", Int32);
+   DefineParameter("v2", Int32);
+   DefineReturnType(Int32);
+   }
+
+bool
+TypePunInt32Int32Builder::buildIL()
+   {
+   StoreIndirect("TestUnionInt32Int32", "f1", Load("u"), Load("v1"));
+   StoreIndirect("TestUnionInt32Int32", "f2", Load("u"), Load("v2"));
+   Return(LoadIndirect("TestUnionInt32Int32", "f1", Load("u")));
+
+   return  true;
+   }
+
+TypePunInt16DoubleBuilder::TypePunInt16DoubleBuilder(TR::TypeDictionary *d)
+   : MethodBuilder(d)
+   {
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   DefineName("typePunInt16Double");
+   DefineParameter("u", d->PointerTo(d->LookupUnion("TestUnionInt16Double")));
+   DefineParameter("v1", Int16);
+   DefineParameter("v2", Double);
+   DefineReturnType(Int16);
+   }
+
+bool
+TypePunInt16DoubleBuilder::buildIL()
+   {
+   StoreIndirect("TestUnionInt16Double", "v_uint16", Load("u"), Load("v1"));
+   StoreIndirect("TestUnionInt16Double", "v_double", Load("u"), Load("v2"));
+   Return(LoadIndirect("TestUnionInt16Double", "v_uint16", Load("u")));
+
+   return true;
+   }
+
+class UnionTest : public JitBuilderTest {};
+
+TEST_F(UnionTest, UnionTypeDictionaryTest)
+   {
+   UnionTypes td;
+   ASSERT_EQ(sizeof(char*),    td.LookupUnion("TestUnionInt8pChar")->getSize());
+   ASSERT_EQ(sizeof(uint32_t), td.LookupUnion("TestUnionInt32Int32")->getSize());
+   ASSERT_EQ(sizeof(double),   td.LookupUnion("TestUnionInt16Double")->getSize());
+   }
+
+TEST_F(UnionTest, TypePunWithEqualTypes)
+   {
+   TypePunInt32Int32Function typePunInt32Int32;
+   ASSERT_COMPILE(UnionTypes, TypePunInt32Int32Builder, typePunInt32Int32);
+
+   TestUnionInt32Int32 testUnion;
+   const uint32_t v1 = 5;
+   const uint32_t v2 = 10;
+   ASSERT_EQ(v2, typePunInt32Int32(&testUnion, v1, v2))
+         << "Value returned by compiled method is wrong.";
+   }
+
+TEST_F(UnionTest, TypePunWithDifferentTypes)
+   {
+   TypePunInt16DoubleFunction typePunInt16Dboule;
+   ASSERT_COMPILE(UnionTypes, TypePunInt16DoubleBuilder, typePunInt16Dboule);
+
+   TestUnionInt16Double testUnion;
+   const uint16_t v1 = 0xFFFF;
+   const double v2 = +0.0;
+   ASSERT_EQ(static_cast<uint16_t>(v2) , typePunInt16Dboule(&testUnion, v1, v2))
+         << "Value returned by compiled method is wrong.";
+   }

--- a/fvtest/jitbuildertest/main.cpp
+++ b/fvtest/jitbuildertest/main.cpp
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#include "gtest/gtest.h"
+
+int main(int argc, char** argv) {
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}
+

--- a/fvtest/jitbuildertest/selftest.cpp
+++ b/fvtest/jitbuildertest/selftest.cpp
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+/*
+ * This file defines some minimal sanity tests for the JitBuilder Test Utilities.
+ */
+
+#include "JBTestUtil.hpp"
+#include "gtest/gtest-spi.h"
+
+DEFINE_TYPES(NoTypes) {}
+
+/*
+ * `JustReturn` generates a function that simply returns.
+ */
+
+DECL_TEST_BUILDER(JustReturn);
+
+typedef void (*JustReturnFunctionType)(void);
+
+JustReturn::JustReturn(TR::TypeDictionary *d)
+   : TR::MethodBuilder(d)
+   {
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   DefineName("JustReturn");
+   DefineReturnType(NoType);
+   }
+
+bool
+JustReturn::buildIL()
+   {
+   Return();
+
+   return true;
+   }
+
+/*
+ * `BadBuilder` simply fails to generate any IL. This should lead to a failed compilation.
+ */
+
+DECL_TEST_BUILDER(BadBuilder);
+
+typedef void (*BadBuilderFunctionType)(void);
+
+BadBuilder::BadBuilder(TR::TypeDictionary *d)
+   : TR::MethodBuilder(d)
+   {
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   DefineName("BadBuilder");
+   DefineReturnType(NoType);
+   }
+
+bool
+BadBuilder::buildIL()
+   {
+   return false;
+   }
+
+class selftest : public JitBuilderTest {};
+
+/*
+ * `JustReturnTest` compiles the `JustReturn` method and executes it. The test
+ * passes if the method is successfully compiled and no fatal failure occurs
+ * from executing the compiled body.
+ */
+
+TEST_F(selftest, JustReturnTest)
+   {
+   JustReturnFunctionType justReturn;
+   ASSERT_COMPILE(NoTypes, JustReturn, justReturn);
+   ASSERT_NO_FATAL_FAILURE(justReturn());
+   }
+
+/*
+ * `BadBuilderTest` attempts to compile the `BadBuilder` method. The test passes
+ * if compilation results in a fatal failure.
+ *
+ * Due to technical limitations of Google Test, the test body must be encapsulated
+ * into a separate function so that `EXPECT_FATAL_FAILURE` can be used to catch
+ * fatal failures (the expected result of this test).
+ */
+
+static void badBuilderRunner()
+   {
+   BadBuilderFunctionType badBuilder;
+   ASSERT_COMPILE(NoTypes,BadBuilder,badBuilder);
+   }
+
+TEST_F(selftest, BadBuilderTest)
+   {
+   EXPECT_FATAL_FAILURE(badBuilderRunner(), "Failed to compile method ");
+   }
+

--- a/fvtest/omrtest.mk
+++ b/fvtest/omrtest.mk
@@ -44,8 +44,11 @@ omr_algotest:
 omr_gctest:
 	./omrgctest -configListFile=fvtest/gctest/configuration/fvConfigListFile.txt
 
-omr_jitbuildertest:
+omr_jitbuilderexamples:
 	make -C jitbuilder/release test
+
+omr_jitbuildertest:
+	./omrjitbuildertest
 
 omr_jittest:
 	./testjit
@@ -95,7 +98,7 @@ ifeq (1,$(OMR_TEST_COMPILER))
 test: omr_jittest
 endif
 ifeq (1,$(OMR_JITBUILDER))
-test: omr_jitbuildertest
+test: omr_jitbuildertest omr_jitbuilderexamples
 endif
 ifeq (1,$(OMR_PORT))
 test: omr_porttest
@@ -107,4 +110,4 @@ ifeq (1,$(OMR_OMRSIG))
 test: omr_sigtest
 endif
 
-.PHONY: all test omr_algotest omr_gctest omr_jitbuildertest omr_jittest omr_porttest omr_rastest omr_subscriberforktest omr_sigtest omr_threadextendedtest omr_threadtest omr_utiltest omr_vmtest 
+.PHONY: all test omr_algotest omr_gctest omr_jitbuilderexamples omr_jitbuildertest omr_jittest omr_porttest omr_rastest omr_subscriberforktest omr_sigtest omr_threadextendedtest omr_threadtest omr_utiltest omr_vmtest 


### PR DESCRIPTION
These changes add some basic infrastructure for writing JitBuilder tests using Google Tests. Their is to simplify the process of developing JitBuilder tests, while also making them easier to read and understand. Two test cases are also included as initial examples of how to use the new infrastructure. 

Eventually, some of the examples in `jitbuilder/release/src` should be replaced by tests in `fvtest/jitbuildertests` because they only exist to test certain corner cases in JitBuilder.

These changes are a starting point for improving JitBuilder testing.