### PR TITLE
Remove code related to -Xnoquickstart

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -3978,9 +3978,6 @@ OMR::Options::setCounts()
       }
    else // no counts string specified
       {
-      if (self()->getOption(TR_noquickstart) && !self()->getOption(TR_MimicInterpreterFrameShape))
-         _optLevel = hot; // Fixed opt level
-
       // No need for sampling thread if only one level of compilation and
       // interpreted methods are not to be sampled. Also, methods with loops
       // will need a smaller initial count since we won't know if they are hot.
@@ -4037,9 +4034,7 @@ OMR::Options::setCounts()
 
       if (_initialBCount == -1)
          {
-         if (self()->getOption(TR_noquickstart))
-            _initialBCount = 0;
-         else if (_samplingFrequency == 0 || self()->getOption(TR_DisableInterpreterSampling))
+         if (_samplingFrequency == 0 || self()->getOption(TR_DisableInterpreterSampling))
             _initialBCount = std::min(1, _initialCount); // If no help from sampling, then loopy methods need a smaller count
          else
             {
@@ -5224,7 +5219,6 @@ void OMR::Options::setDefaultsForDeterministicMode()
    {
    if (TR::Options::getDeterministicMode() != -1 // if deterministic mode was set
        && OMR::Options::_aggressivenessLevel == -1 // quistart/Xtune:virtualized etc were note set
-       && !self()->getOption(TR_noquickstart)
        && !self()->getOption(TR_AggressiveOpts))
       {
       // Set options common to all deterministic modes

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -188,7 +188,7 @@ enum TR_CompilationOptions
    TR_DisableOnDemandLiteralPoolRegister  = 0x08000000 + 2,
    TR_DisableInternalPointers             = 0x10000000 + 2,
    TR_EnableNodeGC                        = 0x20000000 + 2,
-   TR_noquickstart                        = 0x40000000 + 2,
+   // Available                           = 0x40000000 + 2,
    TR_ForceAOT                            = 0x80000000 + 2,
 
    // Option word 3


### PR DESCRIPTION
-Xnoquickstart is an option introduced as a workaround for micro-benchmarks
that had most/all of the code in a method invoked only once. Thus, even if
the JIT compiled that important method, the transition to the new body
never happened.
This restriction was eliminated with the advent of DLT (dynamic loop transfer) 
which allows the transition from interpreted code to jitted code during the same
invocation. As a consequence -Xnoquickstart is more or less useless now.
This change set deprecates the -Xnoquickstart option (the JIT still recognizes
the option, but does nothing).

For documentation purposes: -Xnoquickstart compiles loopy methods from their
first invocation (count=0) and uses hot opt level.


Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>