### PR TITLE
Add RemoveUnusedLocals codegen phase

### DIFF
--- a/compiler/codegen/CodeGenPhaseToPerform.hpp
+++ b/compiler/codegen/CodeGenPhaseToPerform.hpp
@@ -26,6 +26,7 @@
     ReserveCodeCachePhase,
     LowerTreesPhase,
     SetupForInstructionSelectionPhase,
+    RemoveUnusedLocalsPhase,
     InstructionSelectionPhase,
     CreateStackAtlasPhase,
     RegisterAssigningPhase,


### PR DESCRIPTION
OMR code generators do not perform this phase by default, which means
that any temps created during ilgen or optimization that are
subsequently optimized away are not removed from the native stack
frame. For projects like JitBuilder that produce excessive numbers
of locals that are optimized away, this phase is particularly important.

As an example, one method I was looking at initially has a stack frame
size in the ballpark of 40KB (that's *one* method!). Adding this phase
to the code generator reduced that to 0x70 (yup, 112 bytes).

Added this phase at the OMR layer rather than in JitBuilder so that all
projects (that do not already override this file) can benefit.

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>