### PR TITLE
Add UpdateStack API to handle stack moves

### DIFF
--- a/compiler/ilgen/VirtualMachineOperandStack.cpp
+++ b/compiler/ilgen/VirtualMachineOperandStack.cpp
@@ -93,25 +93,26 @@ VirtualMachineOperandStack::Commit(TR::IlBuilder *b)
       }
    }
 
-   void
-   VirtualMachineOperandStack::Reload(TR::IlBuilder* b)
+void
+VirtualMachineOperandStack::Reload(TR::IlBuilder* b)
    {
-       TR::IlType* Element = _elementType;
-       TR::IlType* pElement = _mb->typeDictionary()->PointerTo(Element);
-       // reload the elements back into the simulated operand stack
-       // If the # of stack element has changed, the user should adjust the # of elements 
-       // using Drop beforehand to add/delete stack elements.
-       TR::IlValue* stack = b->Load("OperandStack_base");
-       for (int32_t i = _stackTop; i >= 0; i--) {
-           _stack[i] = b->LoadAt(pElement,
-               b->IndexAt(pElement,
-                   stack,
-                   b->ConstInt32(i - _stackOffset)));
+   TR::IlType* Element = _elementType;
+   TR::IlType* pElement = _mb->typeDictionary()->PointerTo(Element);
+   // reload the elements back into the simulated operand stack
+   // If the # of stack element has changed, the user should adjust the # of elements
+   // using Drop beforehand to add/delete stack elements.
+   TR::IlValue* stack = b->Load("OperandStack_base");
+   for (int32_t i = _stackTop; i >= 0; i--)
+      {
+      _stack[i] = b->LoadAt(pElement,
+                  b->   IndexAt(pElement,
+                           stack,
+                  b->      ConstInt32(i - _stackOffset)));
        }
    }
 
-   void
-   VirtualMachineOperandStack::MergeInto(OMR::VirtualMachineOperandStack* other, TR::IlBuilder* b)
+void
+VirtualMachineOperandStack::MergeInto(OMR::VirtualMachineOperandStack* other, TR::IlBuilder* b)
    {
    TR_ASSERT(_stackTop == other->_stackTop, "stacks are not same size");
    for (int32_t i=_stackTop;i >= 0;i--)
@@ -128,6 +129,14 @@ VirtualMachineOperandStack::Commit(TR::IlBuilder *b)
          b->StoreOver(other->_stack[i], _stack[i]);
          }
       }
+   }
+
+// Update the OperandStack_base and _stackTopRegister after the Virtual Machine moves the stack.
+// This call will normally be followed by a call to Reload if any of the stack values changed in the move
+void
+VirtualMachineOperandStack::UpdateStack(TR::IlBuilder *b, TR::IlValue *stack)
+   {
+   b->Store("OperandStack_base", stack);
    }
 
 // Allocate a new operand stack and copy everything in this state

--- a/compiler/ilgen/VirtualMachineOperandStack.hpp
+++ b/compiler/ilgen/VirtualMachineOperandStack.hpp
@@ -129,6 +129,13 @@ class VirtualMachineOperandStack : public VirtualMachineState
    virtual void MergeInto(VirtualMachineOperandStack *other, TR::IlBuilder *b);
 
    /**
+    * @brief update the values used to read and write the virtual machine stack
+    * @param b the builder where the values will be placed
+    * @param stack the new stack base address.  It is assumed that the address is already adjusted to _stackOffset
+    */
+   virtual void UpdateStack(TR::IlBuilder *b, TR::IlValue *stack);
+
+   /**
     * @brief Push an expression onto the simulated operand stack
     * @param b builder object to use for any operations used to implement the push (e.g. update the top of stack)
     * @param value expression to push onto the simulated operand stack

--- a/jitbuilder/release/src/OperandStackTests.hpp
+++ b/jitbuilder/release/src/OperandStackTests.hpp
@@ -26,7 +26,7 @@
 #define	STACKVALUETYPE		int32_t
 
 //#define STACKVALUEILTYPE	Int64
-//#define	STACKVALUETYPE		int64_t
+//#define STACKVALUETYPE	int64_t
 
 namespace TR { class BytecodeBuilder; }
 
@@ -40,7 +40,6 @@ class OperandStackTestMethod : public TR::MethodBuilder
    static bool verifyUntouched(int32_t maxTouched);
 
    STACKVALUETYPE **getSPPtr() { return &_realStackTop; }
-   STACKVALUETYPE *getSP()     { return _realStackTop; }
 
    protected:
    bool testStack(TR::BytecodeBuilder *b, bool useEqual);
@@ -50,6 +49,10 @@ class OperandStackTestMethod : public TR::MethodBuilder
    static STACKVALUETYPE           * _realStack;
    static STACKVALUETYPE           * _realStackTop;
    static int32_t                    _realStackSize;
+
+   static void createStack();
+   static STACKVALUETYPE *moveStack();
+   static void freeStack();
    };
 
 class OperandStackTestUsingStructMethod : public OperandStackTestMethod


### PR DESCRIPTION
In a lot of Virtual Machines the Stack is allocated on the heap.  This
means that the Stack may move.  If the Virtual Machine stack moves we
need an API to update the simulated Operand Stack.

The API needs to update OperandStack_base and _stackTopRegister.  I
updated the operandstacktest to move the stack a few times throughout
the execution and cleaned it up so the stack is properly freed.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>