### PR TITLE
JitBuilder service so nodes get bytecode indices

### DIFF
--- a/compiler/ilgen/BytecodeBuilder.cpp
+++ b/compiler/ilgen/BytecodeBuilder.cpp
@@ -48,6 +48,19 @@ OMR::BytecodeBuilder::BytecodeBuilder(TR::MethodBuilder *methodBuilder,
    initSequence();
    }
 
+/**
+ * Call this function at the top of your bytecode iteration loop so that all services called
+ * while this bytecode builder is being translated will mark their IL nodes as having this
+ * BytecodeBuilder's _bcIndex (very handy when looking at compiler logs).
+ * Note: *all* generated nodes will be marked with this builder's _bcIndex until another
+ *       BytecodeBuilder's SetCurrentIlGenerator() is called.
+ */
+void
+OMR::BytecodeBuilder::SetCurrentIlGenerator()
+   {
+   comp()->setCurrentIlGenerator((TR_IlGenerator *)this);
+   }
+
 void
 TR::BytecodeBuilder::initialize(TR::IlGeneratorMethodDetails * details,
                                 TR::ResolvedMethodSymbol     * methodSymbol,

--- a/compiler/ilgen/BytecodeBuilder.hpp
+++ b/compiler/ilgen/BytecodeBuilder.hpp
@@ -47,6 +47,10 @@ public:
     * @brief bytecode index for this builder object
     */
    int32_t bcIndex() { return _bcIndex; }
+   virtual int32_t currentByteCodeIndex() { return _bcIndex; } // override from IlGenerator
+
+   /* @brief after calling this, all IL nodes created will have this BytecodeBuilder's _bcIndex */
+   void SetCurrentIlGenerator();
 
    /* The name for this BytecodeBuilder. This can be very helpful for debug output */
    char *name() { return _name; }

--- a/compiler/ilgen/IlInjector.cpp
+++ b/compiler/ilgen/IlInjector.cpp
@@ -114,12 +114,6 @@ OMR::IlInjector::cfg()
    return _methodSymbol->getFlowGraph();
    }
 
-int32_t
-OMR::IlInjector::currentByteCodeIndex()
-   {
-   return -1;
-   }
-
 TR::Block *
 OMR::IlInjector::getCurrentBlock()
    {

--- a/compiler/ilgen/IlInjector.hpp
+++ b/compiler/ilgen/IlInjector.hpp
@@ -72,9 +72,9 @@ public:
                            TR::SymbolReferenceTable     * symRefTab);
 
    bool                           genIL();
-   int32_t                        currentByteCodeIndex();
    TR::Block                    * getCurrentBlock();
-   virtual TR::ResolvedMethodSymbol     * methodSymbol()          const { return _methodSymbol; }
+   virtual TR::ResolvedMethodSymbol * methodSymbol() const { return _methodSymbol; }
+   virtual int32_t currentByteCodeIndex()                  { return -1; }
 
    // Many tests should just need to define their own version of this function
    virtual bool                   injectIL() = 0;


### PR DESCRIPTION
Currently, all IL nodes generated by JitBuilder services
get the practically useless bytecode index of -1. This commit
provides a single service that enables JitBuilder clients
to get correct bytecode indices, but it requires an additional
call to be inserted into their bytecode translation loop.

On a BytecodeBuilder *b, call b->SetCurrentIlGenerator() and
nodes generated from that point forward will be annotated
with b->_bcIndex value, which is stored from the construction
of the object.

Strategically, I think we should make the worklist in
MethodBuilder actually know about the BytecodeBuilder
objects rather than just their bytecode indices, and
that way the worklist could call this new function
transparently before it hands the object back to the
client compiler to translate its operations.

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>