### PR TITLE
Fix missing GC feature ifdefs

### DIFF
--- a/gc/base/Configuration.cpp
+++ b/gc/base/Configuration.cpp
@@ -169,9 +169,11 @@ MM_Configuration::initializeEnvironment(MM_EnvironmentBase* env)
 	case gc_modron_allocation_type_tlh:
 		env->_objectAllocationInterface = MM_TLHAllocationInterface::newInstance(env);
 		break;
+#if defined(OMR_GC_SEGREGATED_HEAP)
 	case gc_modron_allocation_type_segregated:
 		env->_objectAllocationInterface = MM_SegregatedAllocationInterface::newInstance(env);
 		break;
+#endif /* defined(OMR_GC_SEGREGATED_HEAP) */
 	default:
 		Assert_MM_unreachable();
 		break;

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -464,8 +464,8 @@ public:
 
 	bool payAllocationTax;
 
-	bool concurrentMark;
 #if defined(OMR_GC_MODRON_CONCURRENT_MARK)
+	bool concurrentMark;
 	bool concurrentKickoffEnabled;
 	double concurrentSlackFragmentationAdjustmentWeight; /**< weight(from 0.0 to 5.0) used for calculating free tenure space (how much percentage of the fragmentation need to remove from freeBytes) */
 	bool debugConcurrentMark;
@@ -1148,8 +1148,8 @@ public:
 		, nocompactOnSystemGC(0)
 		, compactToSatisfyAllocate(false)
 #endif /* OMR_GC_MODRON_COMPACTION */
-		, concurrentMark(false)
 #if defined(OMR_GC_MODRON_CONCURRENT_MARK)
+		, concurrentMark(false)
 		, concurrentKickoffEnabled(true)
 		, concurrentSlackFragmentationAdjustmentWeight(0.0)
 		, debugConcurrentMark(false)

--- a/gc/base/standard/ConfigurationStandard.cpp
+++ b/gc/base/standard/ConfigurationStandard.cpp
@@ -42,6 +42,7 @@
 #include "MemoryPoolSplitAddressOrderedList.hpp"
 #include "MemoryPoolHybrid.hpp"
 #include "MemoryPoolLargeObjects.hpp"
+#include "ParallelGlobalGC.hpp"
 #include "SweepPoolManagerAddressOrderedList.hpp"
 #include "SweepPoolManagerSplitAddressOrderedList.hpp"
 #include "SweepPoolManagerHybrid.hpp"

--- a/gc/base/standard/ConfigurationStandard.hpp
+++ b/gc/base/standard/ConfigurationStandard.hpp
@@ -73,17 +73,28 @@ protected:
 private:
 	static MM_GCWriteBarrierType getWriteBarrierType(MM_EnvironmentBase* env)
 	{
+#if defined(OMR_GC_SCAVENGER) || defined(OMR_GC_CONCURRENT_MARK)
 		MM_GCExtensionsBase* extensions = env->getExtensions();
+#endif /* OMR_GC_SCAVENGER || OMR_GC_CONCURRENT_MARK */
 		MM_GCWriteBarrierType writeBarrierType = gc_modron_wrtbar_illegal;
+#if defined(OMR_GC_SCAVENGER)
 		if (extensions->scavengerEnabled) {
+#if defined(OMR_GC_CONCURRENT_MARK)
 			if (extensions->concurrentMark) {
 				writeBarrierType = gc_modron_wrtbar_cardmark_and_oldcheck;
-			} else {
+			} else
+#endif /* OMR_GC_CONCURRENT_MARK */
+			{
 				writeBarrierType = gc_modron_wrtbar_oldcheck;
 			}
-		} else if (extensions->concurrentMark) {
+		} else
+#endif /* OMR_GC_SCAVENGER */
+#if defined(OMR_GC_CONCURRENT_MARK)
+		if (extensions->concurrentMark) {
 			writeBarrierType = gc_modron_wrtbar_cardmark;
-		} else {
+		} else
+#endif /* OMR_GC_CONCURRENT_MARK */
+		{
 			writeBarrierType = gc_modron_wrtbar_none;
 		}
 		return writeBarrierType;


### PR DESCRIPTION
Recent versions of OMR were using some concurrent mark and scavenger
features without the needed `#if defined()` guards. This patch allows
the GC to compile without concurrent or scavenger enabled.