### PR TITLE
Improve struct and union field names in logs

### DIFF
--- a/compiler/ilgen/TypeDictionary.cpp
+++ b/compiler/ilgen/TypeDictionary.cpp
@@ -379,7 +379,9 @@ UnionType::getFieldSymRef(const char *fieldName)
       auto symRefTab = comp->getSymRefTab();
       TR::DataType type = info->getPrimitiveType();
 
-      TR::Symbol *symbol = TR::Symbol::createShadow(comp->trHeapMemory(), type);
+      char *fullName = (char *) comp->trMemory()->allocateHeapMemory((strlen(info->_name) + 1 + strlen(_name) + 1) * sizeof(char));
+      sprintf(fullName, "%s.%s", _name, info->_name);
+      TR::Symbol *symbol = TR::Symbol::createNamedShadow(comp->trHeapMemory(), type, info->_type->getSize(), fullName);
       symRef = new (comp->trHeapMemory()) TR::SymbolReference(symRefTab, symbol, comp->getMethodSymbol()->getResolvedMethodIndex(), -1);
       symRef->setOffset(0);
       symRef->setReallySharesSymbol();

--- a/compiler/ilgen/TypeDictionary.cpp
+++ b/compiler/ilgen/TypeDictionary.cpp
@@ -261,11 +261,9 @@ StructType::getFieldSymRef(const char *fieldName)
 
       TR::DataType type = info->getPrimitiveType();
 
-      TR::Symbol *symbol = NULL;
-      if (TR::Int32 == type)
-         symbol = comp->getSymRefTab()->findOrCreateGenericIntShadowSymbol();
-      else
-         symbol = TR::Symbol::createShadow(comp->trHeapMemory(), type);
+      char *fullName = (char *) comp->trMemory()->allocateHeapMemory((strlen(info->_name) + 1 + strlen(_name) + 1) * sizeof(char));
+      sprintf(fullName, "%s.%s", _name, info->_name);
+      TR::Symbol *symbol = TR::Symbol::createNamedShadow(comp->trHeapMemory(), type, info->_type->getSize(), fullName);
 
       // TBD: should we create a dynamic "constant" pool for accesses made by the method being compiled?
       symRef = new (comp->trHeapMemory()) TR::SymbolReference(comp->getSymRefTab(), symbol, comp->getMethodSymbol()->getResolvedMethodIndex(), -1);


### PR DESCRIPTION
JitBuilder struct and union field names are not well presented in JIT logs because of the way their symbols are created. Using createNamedSymbol instead so names appear as "struct.field" or "union.field" in logs.