### PR TITLE
Further improve JitBuilder tests

### DIFF
--- a/fvtest/jitbuildertest/FieldAddressTest.cpp
+++ b/fvtest/jitbuildertest/FieldAddressTest.cpp
@@ -33,24 +33,9 @@ union Union
 typedef uint8_t* (GetStructFieldAddressFunction)(Struct*);
 typedef uint8_t* (GetUnionFieldAddressFunction)(Union*);
 
-DECL_TEST_BUILDER(GetStructFieldAddressBuilder);
-DECL_TEST_BUILDER(GetUnionFieldAddressBuilder);
-
-GetStructFieldAddressBuilder::GetStructFieldAddressBuilder(TR::TypeDictionary *d)
-   : MethodBuilder(d)
-   {
-   DefineLine(LINETOSTR(__LINE__));
-   DefineFile(__FILE__);
-
-   auto pStructType = d->PointerTo(d->LookupStruct("Struct"));
-
-   DefineName("getStructFieldAddress");
-   DefineParameter("s", pStructType);
-   DefineReturnType(d->PointerTo(d->GetFieldType("Struct", "f2")));
-   }
-
-bool
-GetStructFieldAddressBuilder::buildIL()
+DEFINE_BUILDER( GetStructFieldAddressBuilder,
+                PointerTo(GetFieldType("Struct", "f2")),
+                PARAM("s", PointerTo(LookupStruct("Struct"))) )
    {
    Return(
           StructFieldInstanceAddress("Struct", "f2",
@@ -59,21 +44,9 @@ GetStructFieldAddressBuilder::buildIL()
    return true;
    }
 
-GetUnionFieldAddressBuilder::GetUnionFieldAddressBuilder(TR::TypeDictionary *d)
-   : MethodBuilder(d)
-   {
-   DefineLine(LINETOSTR(__LINE__));
-   DefineFile(__FILE__);
-
-   auto pUnionType = d->PointerTo(d->LookupUnion("Union"));
-
-   DefineName("getUnionFieldAddress");
-   DefineParameter("u", pUnionType);
-   DefineReturnType(d->toIlType<uint8_t *>());
-   }
-
-bool
-GetUnionFieldAddressBuilder::buildIL()
+DEFINE_BUILDER( GetUnionFieldAddressBuilder,
+                toIlType<uint8_t *>(),
+                PARAM("u", PointerTo(LookupUnion("Union"))) )
    {
    Return(
           UnionFieldInstanceAddress("Union", "f2",

--- a/fvtest/jitbuildertest/JBTestUtil.hpp
+++ b/fvtest/jitbuildertest/JBTestUtil.hpp
@@ -25,6 +25,9 @@
 #include "ilgen/TypeDictionary.hpp"
 #include "ilgen/MethodBuilder.hpp"
 
+#include <vector>
+#include <utility>
+
 /*
  * Convenience macro for defining type dictionary objects. `name` is the name of
  * the class that will be created. The "body" of the macro should contain the
@@ -44,27 +47,158 @@
    inline name::name() : TR::TypeDictionary()
 
 /*
- * Convenience macro for declaring a MethodBuilder class. `name` is the name of
- * the class that will be created. The macro will ensure the class inherits from
- * `TR::MethodBuilder` and that the constructor and `buildIL()` method are
+ * A convenience macro for declaring a MethodBuilder class. `name` is the name
+ * of the class that will be created. The macro will ensure the class inherits
+ * from `TR::MethodBuilder` and that the constructor and `buildIL()` method are
  * declared. A ';' is required at the end of the macro invocation.
  *
  * Example use:
  *
- *    DECL_TEST_BUILDER(MyFunctionBuilder);
+ *    DECLARE_BUILDER(MyFunctionBuilder);
  */
-#define DECL_TEST_BUILDER(name) \
+#define DECLARE_BUILDER(name) \
    class name : public TR::MethodBuilder { \
       public: \
       name(TR::TypeDictionary *); \
       virtual bool buildIL(); \
    }
 
-#define DEF_TEST_BUILDER_CTOR(name) \
+/*
+ * A convenience macro for defining the constructor of a declared builder class.
+ * It will ensure that the parent constructor is invoked correctly.
+ *
+ * The argument is the name of the builder class whose constructor is being defined.
+ * The body should contain the actual definition of the constructor.
+ *
+ * This macro is best used in conjunction with the `DECLARE_BUILDER` macro.
+ *
+ * Example use:
+ *
+ *    DECLARE_BUILDER(MyMethod);
+ *    DEFINE_BUILDER_CTOR(MyMethod)
+ *       {
+ *       DefineLine(LINETOSTR(__LINE__));
+ *       DefineFile(__FILE__);
+ *       DefineName("MyMethod");
+ *       DefineReturnType(NoType);
+ *       }
+ */
+#define DEFINE_BUILDER_CTOR(name) \
    inline name::name(TR::TypeDictionary *types) : TR::MethodBuilder(types)
 
-#define DEF_BUILDIL(name) \
+/*
+ * A convenience macro for defining the `buildIL()` function of a declared
+ * builder class. The argument is the name of the builder class. The body should
+ * be the definition of the `buildIL()` function.
+ *
+ * This macro is intended to be used in conjunction with `DECLARE_BUILDER` and
+ * `DEFINE_BUILDER_CTOR` macros.
+ *
+ * Example use:
+ *
+ *    DECLARE_BUILDER(MyMethod);
+ *
+ *    DEFINE_BUILDER_CTOR(MyMethod)
+ *       {
+ *       DefineLine(LINETOSTR(__LINE__));
+ *       DefineFile(__FILE__);
+ *       DefineName("MyMethod");
+ *       DefineReturnType(NoType);
+ *       }
+ *
+ *    DEFINE_BUILDIL(MyMethod)
+ *       {
+ *       Return();
+ *       return true;
+ *       }
+ */
+#define DEFINE_BUILDIL(name) \
    inline bool name::buildIL()
+
+/*
+ * `DEFINE_BUILDER` is a convenience macro for defining MethodBuilder class
+ * using a compact syntax. The goal of the macro is to abstract away some of the
+ * boiler plate code that is required for defining instances of MethodBuilder.
+ *
+ * The first argument to the macro is the name of the MethodBuilder class that
+ * will be constructed. This is also used as the name of the method built by the
+ * class.
+ *
+ * The second argument is an instance of `TR::IlValue *` that represents the
+ * return type of the method.
+ *
+ * The following variadic argument are pairs with a `const char *` component
+ * and a `TR::IlValue *` component. The first component is the name of parameter
+ * and the second is a `TR::IlValue` instance representing the parameter's type.
+ * The `PARAM` macro should be used when defining these pairs because simple
+ * brace initializers cannot be used when invoking a macro.
+ *
+ * The body of the macro should contain the code that will be used as body for
+ * the `buildIL()` function.
+ *
+ * Because the arguments to the macro are used within the scope of the class
+ * definition, the services provided by `TR::MethodBuilder` are available for
+ * use (e.g. `typeDictionary()` can be used when defining types).
+ *
+ * For convenience, the following methods from `TR::TypeDictionary` are also
+ * made available:
+ *
+ *    toIlType<T>()
+ *    LookupStruct(const char *name)
+ *    LookupUnion(const char *name)
+ *    PointerTo(TR::IlType *type)
+ *    PointerTo(const char *structName)
+ *    PointerTo(TR::DataType type)
+ *    PrimitiveType(TR::DataType type)
+ *    GetFieldType(const char *structName, const char *fieldName)
+ *    UnionFieldType(const char *unionName, const char *fieldName)
+ *
+ * Example use:
+ *
+ *    DEFINE_BUILDER( MyMethod,                                            // name of the builder/method
+ *                    toIlType<int *>(),                                   // return type of the method
+ *                    PARAM("arg1", PointerTo(LookupStruct("MyStruct"))),  // first parameter of the method
+ *                    PARAM("arg2", Double) )                              // second parameter of the method
+ *       {
+ *       // Implementation of `buildIL()`
+ *
+ *       return true;
+ *       }
+ */
+#define DEFINE_BUILDER(name, returnType, ...) \
+   struct name : public TR::MethodBuilder \
+      { \
+      name(TR::TypeDictionary *types) : TR::MethodBuilder(types) \
+         { \
+         DefineLine(LINETOSTR(__LINE__)); \
+         DefineFile(__FILE__); \
+         DefineName(#name); \
+         DefineReturnType(returnType); \
+         std::vector<std::pair<const char *, TR::IlType *> > args = {__VA_ARGS__}; \
+         for (int i = 0, s = args.size(); i < s; ++i) \
+            { \
+            DefineParameter(args[i].first, args[i].second); \
+            } \
+         } \
+      bool buildIL(); \
+      template <typename T> TR::IlType * toIlType() { return typeDictionary()->toIlType<T>(); } \
+      TR::IlType * LookupStruct(const char *name) { return typeDictionary()->LookupStruct(name); } \
+      TR::IlType * LookupUnion(const char *name) { return typeDictionary()->LookupUnion(name); } \
+      TR::IlType * PointerTo(TR::IlType *type) { return typeDictionary()->PointerTo(type); } \
+      TR::IlType * PointerTo(const char *structName) { return typeDictionary()->PointerTo(structName); } \
+      TR::IlType * PointerTo(TR::DataType type) { return typeDictionary()->PointerTo(type); } \
+      TR::IlType * PrimitiveType(TR::DataType type) { return typeDictionary()->PrimitiveType(type); } \
+      TR::IlType * GetFieldType(const char *structName, const char *fieldName) { return typeDictionary()->GetFieldType(structName, fieldName); } \
+      TR::IlType * UnionFieldType(const char *unionName, const char *fieldName) { return typeDictionary()->UnionFieldType(unionName, fieldName); } \
+      }; \
+   inline bool name::buildIL()
+
+/*
+ * A convenience macro for defining MethodBuilder parameter pairs. The first
+ * argument to the macro is the name of the parameter, the second is the the
+ * `TR::IlType` instance representing the type of the parameter.
+ */
+#define PARAM(name, type) {name, type}
 
 /**
  * @brief The JitBuilderTest class is a basic test fixture for JitBuilder test cases.

--- a/fvtest/jitbuildertest/UnionTest.cpp
+++ b/fvtest/jitbuildertest/UnionTest.cpp
@@ -54,27 +54,14 @@ DEFINE_TYPES(UnionTypes)
    CloseUnion("TestUnionInt16Double");
    }
 
-DECL_TEST_BUILDER(TypePunInt32Int32Builder);
-DECL_TEST_BUILDER(TypePunInt16DoubleBuilder);
-
 typedef uint32_t (*TypePunInt32Int32Function)(TestUnionInt32Int32*, uint32_t, uint32_t);
 typedef uint16_t (*TypePunInt16DoubleFunction)(TestUnionInt16Double*, uint16_t, double);
 
-TypePunInt32Int32Builder::TypePunInt32Int32Builder(TR::TypeDictionary *d)
-   : MethodBuilder(d)
-   {
-   DefineLine(LINETOSTR(__LINE__));
-   DefineFile(__FILE__);
-
-   DefineName("typePunInt32Int32Builder");
-   DefineParameter("u", d->PointerTo(d->LookupUnion("TestUnionInt32Int32")));
-   DefineParameter("v1", Int32);
-   DefineParameter("v2", Int32);
-   DefineReturnType(Int32);
-   }
-
-bool
-TypePunInt32Int32Builder::buildIL()
+DEFINE_BUILDER( TypePunInt32Int32Builder,
+                Int32,
+                PARAM("u", PointerTo(LookupUnion("TestUnionInt32Int32"))),
+                PARAM("v1", Int32),
+                PARAM("v2", Int32) )
    {
    StoreIndirect("TestUnionInt32Int32", "f1", Load("u"), Load("v1"));
    StoreIndirect("TestUnionInt32Int32", "f2", Load("u"), Load("v2"));
@@ -83,21 +70,11 @@ TypePunInt32Int32Builder::buildIL()
    return  true;
    }
 
-TypePunInt16DoubleBuilder::TypePunInt16DoubleBuilder(TR::TypeDictionary *d)
-   : MethodBuilder(d)
-   {
-   DefineLine(LINETOSTR(__LINE__));
-   DefineFile(__FILE__);
-
-   DefineName("typePunInt16Double");
-   DefineParameter("u", d->PointerTo(d->LookupUnion("TestUnionInt16Double")));
-   DefineParameter("v1", Int16);
-   DefineParameter("v2", Double);
-   DefineReturnType(Int16);
-   }
-
-bool
-TypePunInt16DoubleBuilder::buildIL()
+DEFINE_BUILDER( TypePunInt16DoubleBuilder,
+                Int16,
+                PARAM("u", PointerTo(LookupUnion("TestUnionInt16Double"))),
+                PARAM("v1", Int16),
+                PARAM("v2", Double) )
    {
    StoreIndirect("TestUnionInt16Double", "v_uint16", Load("u"), Load("v1"));
    StoreIndirect("TestUnionInt16Double", "v_double", Load("u"), Load("v2"));

--- a/fvtest/jitbuildertest/selftest.cpp
+++ b/fvtest/jitbuildertest/selftest.cpp
@@ -29,12 +29,11 @@ DEFINE_TYPES(NoTypes) {}
  * `JustReturn` generates a function that simply returns.
  */
 
-DECL_TEST_BUILDER(JustReturn);
+DECLARE_BUILDER(JustReturn);
 
 typedef void (*JustReturnFunctionType)(void);
 
-JustReturn::JustReturn(TR::TypeDictionary *d)
-   : TR::MethodBuilder(d)
+DEFINE_BUILDER_CTOR(JustReturn)
    {
    DefineLine(LINETOSTR(__LINE__));
    DefineFile(__FILE__);
@@ -43,8 +42,7 @@ JustReturn::JustReturn(TR::TypeDictionary *d)
    DefineReturnType(NoType);
    }
 
-bool
-JustReturn::buildIL()
+DEFINE_BUILDIL(JustReturn)
    {
    Return();
 
@@ -55,12 +53,11 @@ JustReturn::buildIL()
  * `BadBuilder` simply fails to generate any IL. This should lead to a failed compilation.
  */
 
-DECL_TEST_BUILDER(BadBuilder);
+DECLARE_BUILDER(BadBuilder);
 
 typedef void (*BadBuilderFunctionType)(void);
 
-BadBuilder::BadBuilder(TR::TypeDictionary *d)
-   : TR::MethodBuilder(d)
+DEFINE_BUILDER_CTOR(BadBuilder)
    {
    DefineLine(LINETOSTR(__LINE__));
    DefineFile(__FILE__);
@@ -69,8 +66,7 @@ BadBuilder::BadBuilder(TR::TypeDictionary *d)
    DefineReturnType(NoType);
    }
 
-bool
-BadBuilder::buildIL()
+DEFINE_BUILDIL(BadBuilder)
    {
    return false;
    }


### PR DESCRIPTION
These changes introduce the new `DEFINE_BUILDER` macro. It provides a very compact syntax for defining method builder classes. In addition, some of the old macros are renamed and documented.