### PR TITLE
Fix IfAnd and IfOr to call setComesBack()

### DIFF
--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -1527,6 +1527,9 @@ IlBuilder::IfAnd(TR::IlBuilder **allTrueBuilder, TR::IlBuilder **anyFalseBuilder
    Goto(mergePoint);
 
    AppendBuilder(mergePoint);
+
+   // return state for "this" can get confused by the Goto's in this service
+   setComesBack();
    }
 
 /*
@@ -1582,6 +1585,9 @@ IlBuilder::IfOr(TR::IlBuilder **anyTrueBuilder, TR::IlBuilder **allFalseBuilder,
    Goto(mergePoint);
 
    AppendBuilder(mergePoint);
+
+   // return state for "this" can get confused by the Goto's in this service
+   setComesBack();
    }
 
 TR::IlValue *


### PR DESCRIPTION
IfAnd and IfOr call Goto on their receiver builder object, which confuses
JitBuilder's control flow analysis because it believes control does not
flow out of the builder object. This commit overrides that knowledge by
explicitly calling setComesBack() so JitBuilder does the right thing.