### PR TITLE
Avoid printing guard's callee symbol if not specified

### DIFF
--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -3615,8 +3615,9 @@ TR_Debug::dump(TR::FILE *pOutFile, TR_CHTable * chTable)
          char guardKindName[38];
          sprintf(guardKindName, "%s %s", getVirtualGuardKindName((*info)->getKind()), (*info)->mergedWithHCRGuard()?"+ HCRGuard ":"");
 
-         if ((*info)->getKind() == TR_OSRGuard)
-            trfprintf(pOutFile, "[%4d] %-38s OSRGuard\n", i, guardKindName);
+         if (!(*info)->getSymbolReference())
+            trfprintf(pOutFile, "[%4d] %-38s %s%s\n",
+                  i, guardKindName ,(*info)->isInlineGuard()?"inlined ":"", guardKindName);
          else
             trfprintf(pOutFile, "[%4d] %-38s %scalleeSymbol=" POINTER_PRINTF_FORMAT "\n",
                   i, guardKindName ,(*info)->isInlineGuard()?"inlined ":"", (*info)->getSymbolReference()->getSymbol());


### PR DESCRIPTION
Virtual guards may contain the symbol reference for the method they
guard, however, it is not guaranteed. This can be seen when creating
SideEffect guards in VP, where the guard is constructed using the
current block's start node, rather than a call node. However, when
dumping the CHTable, it was assumed that a guard would always
have this symbol reference specified.