### PR TITLE
Crash when -Xjit:timingCumulative option is used

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -1956,10 +1956,10 @@ OMR::Compilation::shutdown(TR_FrontEnd * fe)
    bool printCummStats = ((fe!=0) && TR::Options::getCmdLineOptions() && TR::Options::getCmdLineOptions()->getOption(TR_CummTiming));
    if (printCummStats)
       {
-      fprintf(stderr, "Compilation Time   = %s\n", compTime.timeTakenString(TR::comp()));
-      fprintf(stderr, "Gen IL Time        = %s\n", genILTime.timeTakenString(TR::comp()));
-      fprintf(stderr, "Optimization Time  = %s\n", optTime.timeTakenString(TR::comp()));
-      fprintf(stderr, "Code Gen Time      = %s\n", codegenTime.timeTakenString(TR::comp()));
+      fprintf(stderr, "Compilation Time   = %9.6f\n", compTime.secondsTaken());
+      fprintf(stderr, "Gen IL Time        = %9.6f\n", genILTime.secondsTaken());
+      fprintf(stderr, "Optimization Time  = %9.6f\n", optTime.secondsTaken());
+      fprintf(stderr, "Code Gen Time      = %9.6f\n", codegenTime.secondsTaken());
       }
 
 #ifdef DEBUG

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1066,7 +1066,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"test390StackBufferSize=", "L\tInsert buffer in stack to force testing of large stack sizes",
         TR::Options::set32BitNumeric,offsetof(OMR::Options,_test390StackBuffer), 0, "F%d"},
    {"timing", "M\ttime individual phases and optimizations", SET_OPTION_BIT(TR_Timing), "F" },
-   {"timingCummulative", "M\ttime cummulative phases (ILgen,Optimizer,codegen)", SET_OPTION_BIT(TR_CummTiming), "F" },
+   {"timingCumulative", "M\ttime cumulative phases (ILgen,Optimizer,codegen)", SET_OPTION_BIT(TR_CummTiming), "F" },
 #if defined(TR_HOST_X86) || defined(TR_HOST_POWER)
    {"tlhPrefetch",  "D\tenable software prefetch on allocation ",   SET_OPTION_BIT(TR_TLHPrefetch),  "F" },
 #endif // defined(TR_HOST_X86) || defined(TR_HOST_POWER)

--- a/compiler/env/OMRVMEnv.cpp
+++ b/compiler/env/OMRVMEnv.cpp
@@ -107,13 +107,7 @@ static uint64_t highResClockResolution()
    }
 
 uint64_t
-OMR::VMEnv::getHighResClockResolution(TR::Compilation *comp)
-   {
-   return ::highResClockResolution();
-   }
-
-uint64_t
-OMR::VMEnv::getHighResClockResolution(OMR_VMThread *omrVMThread)
+OMR::VMEnv::getHighResClockResolution()
    {
    return ::highResClockResolution();
    }

--- a/compiler/env/OMRVMEnv.hpp
+++ b/compiler/env/OMRVMEnv.hpp
@@ -63,8 +63,7 @@ public:
    uint64_t getHighResClock(TR::Compilation *comp);
    uint64_t getHighResClock(OMR_VMThread *omrVMThread);
 
-   uint64_t getHighResClockResolution(TR::Compilation *comp);
-   uint64_t getHighResClockResolution(OMR_VMThread *omrVMThread);
+   uint64_t getHighResClockResolution();
 
    uintptrj_t thisThreadGetPendingExceptionOffset() { return 0; }
 

--- a/compiler/infra/Timer.cpp
+++ b/compiler/infra/Timer.cpp
@@ -67,30 +67,9 @@ uint32_t TR_SingleTimer::stopTiming(TR::Compilation *comp)
    }
 
 
-char *TR_SingleTimer::timeTakenString(TR::Compilation *comp)
+double TR_SingleTimer::secondsTaken()
    {
-   static char timeString[32];
-   uint32_t    mins,
-               uSecs,
-               totalSecs,
-               frequency;
-   double      fSecs;
-
-   frequency = TR::Compiler->vm.getHighResClockResolution(comp);
-   if (frequency != 0)
-      {
-      totalSecs = _total / frequency;
-      uSecs =     _total % frequency;
-
-      mins = totalSecs / 60;
-      fSecs = totalSecs % 60;
-      fSecs += (double)uSecs / (double)frequency;
-
-      sprintf(timeString,"%2d:%.6f", mins, fSecs);
-      }
-   else
-      {
-      sprintf(timeString,"* * * * timer not supported!\n");
-      }
-   return timeString;
+   uint64_t frequency = TR::Compiler->vm.getHighResClockResolution();
+   return frequency ? (double)_total / (double)frequency : 0.0;
    }
+

--- a/compiler/infra/Timer.hpp
+++ b/compiler/infra/Timer.hpp
@@ -40,8 +40,7 @@ class TR_SingleTimer
 
    char    *title()                       { return _phaseTitle; }
    uint64_t timeTaken()                   { return _total; }
-   char    *timeTakenString(TR::Compilation *);
-
+   double   secondsTaken();
    bool isTimerRunning() const            { return _timerRunning; }
 
    private:

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -1707,7 +1707,7 @@ int32_t OMR::Optimizer::performOptimization(const OptimizationStrategy *optimiza
          if (doTiming)
             {
             myTimer.stopTiming(comp());
-            statStructuralAnalysisTiming.update((double)myTimer.timeTaken()*1000.0/TR::Compiler->vm.getHighResClockResolution(comp()));
+            statStructuralAnalysisTiming.update((double)myTimer.timeTaken()*1000.0/TR::Compiler->vm.getHighResClockResolution());
             }
 #endif
          }
@@ -1772,7 +1772,7 @@ int32_t OMR::Optimizer::performOptimization(const OptimizationStrategy *optimiza
             if (doTiming)
                {
                myTimer.stopTiming(comp());
-               statUseDefsTiming.update((double)myTimer.timeTaken()*1000.0/TR::Compiler->vm.getHighResClockResolution(comp()));
+               statUseDefsTiming.update((double)myTimer.timeTaken()*1000.0/TR::Compiler->vm.getHighResClockResolution());
                }
 #endif
 
@@ -1819,7 +1819,7 @@ int32_t OMR::Optimizer::performOptimization(const OptimizationStrategy *optimiza
             if (doTiming)
                {
                myTimer.stopTiming(comp());
-               statUseDefsTiming.update((double)myTimer.timeTaken()*1000.0/TR::Compiler->vm.getHighResClockResolution(comp()));
+               statUseDefsTiming.update((double)myTimer.timeTaken()*1000.0/TR::Compiler->vm.getHighResClockResolution());
                }
 #endif
 
@@ -1864,7 +1864,7 @@ int32_t OMR::Optimizer::performOptimization(const OptimizationStrategy *optimiza
             if (doTiming)
                {
                myTimer.stopTiming(comp());
-               statGlobalValNumTiming.update((double)myTimer.timeTaken()*1000.0/TR::Compiler->vm.getHighResClockResolution(comp()));
+               statGlobalValNumTiming.update((double)myTimer.timeTaken()*1000.0/TR::Compiler->vm.getHighResClockResolution());
                }
 #endif
 
@@ -1897,7 +1897,7 @@ int32_t OMR::Optimizer::performOptimization(const OptimizationStrategy *optimiza
             if (doTiming)
                {
                myTimer.stopTiming(comp());
-               statGlobalValNumTiming.update((double)myTimer.timeTaken()*1000.0/TR::Compiler->vm.getHighResClockResolution(comp()));
+               statGlobalValNumTiming.update((double)myTimer.timeTaken()*1000.0/TR::Compiler->vm.getHighResClockResolution());
                }
 #endif
             if (valueNumberInfo->infoIsValid())
@@ -2080,7 +2080,7 @@ int32_t OMR::Optimizer::performOptimization(const OptimizationStrategy *optimiza
       if (doTiming)
          {
            myTimer.stopTiming(comp());
-           statOptTiming[optNum].update((double)myTimer.timeTaken()*1000.0/TR::Compiler->vm.getHighResClockResolution(comp()));
+           statOptTiming[optNum].update((double)myTimer.timeTaken()*1000.0/TR::Compiler->vm.getHighResClockResolution());
          }
 #endif
 

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -318,10 +318,10 @@ void TR::ValuePropagation::initialize()
             if (comp()->getOutFile() != NULL)
                {
                trfprintf(comp()->getOutFile(), "Time taken for %s = ", myTimer.title());
-               trfprintf(comp()->getOutFile(), "%s seconds\n", myTimer.timeTakenString(comp()));
+               trfprintf(comp()->getOutFile(), "%9.6f seconds\n", myTimer.secondsTaken());
                }
 #ifdef OPT_TIMING
-            statStructuralAnalysisTiming.update((double)myTimer.timeTaken()*1000.0/TR::Compiler->vm.getHighResClockResolution(comp()));
+            statStructuralAnalysisTiming.update((double)myTimer.timeTaken()*1000.0/TR::Compiler->vm.getHighResClockResolution());
 #endif
             }
          }


### PR DESCRIPTION
The option -Xjit:timingCumulative is used to print ilGen/optimizer/codegen
times across all compilations. This is performed at shutdown time in a
static method OMR::Compilation::shutdown(TR_FrontEnd * fe).
However, this method internally makes use of the compilation object
retried from local thread storage: TR::comp(). This is invalid because
the shutdown() routine is not executed on a compilation thread.
There is another bug related to  TR_SingleTimer code: the function used
to print the time taken uses a static char buffer which makes this routine
not multithreaded safe. I have replaced this timeTakenString() method
with a new one, secondsTaken(), that can be used in a multithreaded
environment.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>