### PR TITLE
Add read barrier flags

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -687,7 +687,8 @@ public:
 	uint64_t _masterThreadCpuTimeNanos; /**< Total CPU time used by all master threads */
 
 	bool alwaysCallWriteBarrier; /**< was -Xgc:alwayscallwritebarrier specified? */
-
+	bool alwaysCallReadBarrier; /**< was -Xgc:alwaysCallReadBarrier specified? */
+	
 	bool _holdRandomThreadBeforeHandlingWorkUnit; /**< Whether we should randomly hold up a thread entering MM_ParallelTask::handleNextWorkUnit() */
 	uintptr_t _holdRandomThreadBeforeHandlingWorkUnitPeriod; /** < How often (in terms of number of times MM_ParallelTask::handleNextWorkUnit() is called) to randomly hold up a thread entering MM_ParallelTask::handleNextWorkUnit() */
 	bool _forceRandomBackoutsAfterScan; /** < Whether we should force MM_Scavenger::completeScan() to randomly fail due to backout */
@@ -1306,6 +1307,7 @@ public:
 		, sweepPoolManagerBumpPointer(NULL)
 		, _masterThreadCpuTimeNanos(0)
 		, alwaysCallWriteBarrier(false)
+		, alwaysCallReadBarrier(false)
 		, _holdRandomThreadBeforeHandlingWorkUnit(false)
 		, _holdRandomThreadBeforeHandlingWorkUnitPeriod(100)
 		, _forceRandomBackoutsAfterScan(false)

--- a/include_core/omrgcconsts.h
+++ b/include_core/omrgcconsts.h
@@ -55,6 +55,12 @@ typedef enum MM_GCPolicy {
 #define OMR_GC_WRITE_BARRIER_TYPE_REALTIME 0x7
 #define OMR_GC_WRITE_BARRIER_TYPE_COUNT 0x8
 
+#define OMR_GC_READ_BARRIER_TYPE_ILLEGAL 0x0
+#define OMR_GC_READ_BARRIER_TYPE_NONE 0x1
+#define OMR_GC_READ_BARRIER_TYPE_ALWAYS 0x2
+#define OMR_GC_READ_BARRIER_TYPE_EVACUATE 0x3
+#define OMR_GC_READ_BARRIER_TYPE_COUNT 0x4
+
 typedef enum MM_GCWriteBarrierType {
 	gc_modron_wrtbar_illegal = OMR_GC_WRITE_BARRIER_TYPE_ILLEGAL,
 	gc_modron_wrtbar_none = OMR_GC_WRITE_BARRIER_TYPE_NONE,
@@ -66,6 +72,14 @@ typedef enum MM_GCWriteBarrierType {
 	gc_modron_wrtbar_realtime = OMR_GC_WRITE_BARRIER_TYPE_REALTIME,
 	gc_modron_wrtbar_count = OMR_GC_WRITE_BARRIER_TYPE_COUNT
 } MM_GCWriteBarrierType;
+
+typedef enum MM_GCReadBarrierType {
+	gc_modron_readbar_illegal = OMR_GC_READ_BARRIER_TYPE_ILLEGAL,
+	gc_modron_readbar_none = OMR_GC_READ_BARRIER_TYPE_NONE,
+	gc_modron_readbar_evacuate = OMR_GC_READ_BARRIER_TYPE_EVACUATE,
+	gc_modron_readbar_always = OMR_GC_READ_BARRIER_TYPE_ALWAYS,
+	gc_modron_readbar_count = OMR_GC_READ_BARRIER_TYPE_COUNT
+} MM_GCReadBarrierType;
 
 typedef enum MM_AlignmentType {
 	mm_heapAlignment = 1,


### PR DESCRIPTION
These changes are part of a broader set of changes
that will be added in the future to enable or
disable read barriers with runtime checks instead
of the existing compile flags.

These changes add:
- read barrier flags
- read barrier enum declaration
- add field to GCExtensionsBase to enable or
  disable read barriers

Issue: #910
Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>