### PR TITLE
Unlock free spill list during out of line RA on P

### DIFF
--- a/compiler/p/codegen/PPCInstruction.cpp
+++ b/compiler/p/codegen/PPCInstruction.cpp
@@ -102,18 +102,12 @@ void TR::PPCLabelInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
       TR_PPCOutOfLineCodeSection *oi = cg()->findOutLinedInstructionsFromLabel(getLabelSymbol());
       TR_ASSERT(oi, "Could not find PPCOutOfLineCodeSection stream from label.  instr=%p, label=%p\n", this, getLabelSymbol());
 
+      cg()->unlockFreeSpillList();
       if (!oi->hasBeenRegisterAssigned())
          oi->assignRegisters(kindToBeAssigned);
 
       if (cg()->getDebug())
          cg()->traceRegisterAssignment("OOL: Finished register assignment in OOL section\n");
-
-      // Unlock the free spill list.
-      //
-      // TODO: live registers that are not spilled at this point should have their backing
-      // storage returned to the free spill list.
-      //
-      cg()->unlockFreeSpillList();
       }
    }
 
@@ -220,17 +214,13 @@ void TR::PPCConditionalBranchInstruction::assignRegisters(TR_RegisterKinds kindT
       //
       TR_PPCOutOfLineCodeSection *oi = cg()->findOutLinedInstructionsFromLabel(getLabelSymbol());
       TR_ASSERT(oi, "Could not find PPCOutOfLineCodeSection stream from label.  instr=%p, label=%p\n", this, getLabelSymbol());
+
+      cg()->unlockFreeSpillList();
       if (!oi->hasBeenRegisterAssigned())
          oi->assignRegisters(kindToBeAssigned);
+
       if (cg()->getDebug())
             cg()->traceRegisterAssignment("OOL: Finished register assignment in OOL section\n");
-
-      // Unlock the free spill list.
-      //
-      // TODO: live registers that are not spilled at this point should have their backing
-      // storage returned to the free spill list.
-      //
-      cg()->unlockFreeSpillList();
       }
    }
 


### PR DESCRIPTION
Keeping the free list locked during RA on out of line code sections prevents any spills freed in from ever being re-used. For large methods with many out of line sections this causes us to allocate many spill slots that are ever only used once, leading to excessively bloated stack frames and metadata, and compilation failure if we exceed our compilation memory budget.

Locking the spill list is required for RA between the branch to and merge back from an out of line section, in order to insure that any unspilled registers in that path don't return their spill slots to the free list so we can re-unspill the register to the same location once we move to RA in the out of line path, but keeping the free list locked during RA in the out of line section appears to be completely unnecessary and detrimental. Registers can and should return their spill slots to the free list once unspilled out of line because they may never be used again, let alone spilled again, and will have no further opportunity of relinquishing their spill slots.

Regression tested against Java and by inspecting a few select compilation logs for the desired behaviour.