### PR TITLE
Add runtime flag for concurrent scavenge support

### DIFF
--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -420,11 +420,11 @@ OMR::CodeGenPhase::performSetupForInstructionSelectionPhase(TR::CodeGenerator * 
    {
    TR::Compilation *comp = cg->comp();
 
-   if (cg->supportsConcurrentScavange())
+   if (cg->isConcurrentScavengeEnabled())
       {
       // TODO (GuardedStorage): We need to come up with a better solution than anchoring tree tops of compressedrefs
       // sequences to enforce certain evaluation order. Perhaps not lowering compressedrefs in the first place when
-      // concurrent scavange is supported is the correct solution here.
+      // concurrent scavenge is supported is the correct solution here.
       traceMsg(comp, "GuardedStorage: in performSetupForInstructionSelectionPhase\n");
 
       auto mapAllocator = getTypedAllocator<std::pair<TR::TreeTop*, TR::TreeTop*> >(comp->allocator());

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -419,39 +419,43 @@ void
 OMR::CodeGenPhase::performSetupForInstructionSelectionPhase(TR::CodeGenerator * cg, TR::CodeGenPhase * phase)
    {
    TR::Compilation *comp = cg->comp();
-   // TODO (GuardedStorage)
-#if defined(OMR_GC_CONCURRENT_SCAVENGER)
-   traceMsg(comp, "GuardedStorage: in performSetupForInstructionSelectionPhase\n");
 
-   auto mapAllocator = getTypedAllocator<std::pair<TR::TreeTop*, TR::TreeTop*> >(comp->allocator());
-
-   std::map<TR::TreeTop*, TR::TreeTop*, std::less<TR::TreeTop*>, TR::typed_allocator<std::pair<TR::TreeTop*, TR::TreeTop*>, TR::Allocator> >
-      currentTreeTopToappendTreeTop(std::less<TR::TreeTop*> (), mapAllocator);
-
-   for (TR::PreorderNodeIterator iter(comp->getStartTree(), comp); iter != NULL; ++iter)
+   if (cg->supportsConcurrentScavange())
       {
-      TR::Node *node = iter.currentNode();
+      // TODO (GuardedStorage): We need to come up with a better solution than anchoring tree tops of compressedrefs
+      // sequences to enforce certain evaluation order. Perhaps not lowering compressedrefs in the first place when
+      // concurrent scavange is supported is the correct solution here.
+      traceMsg(comp, "GuardedStorage: in performSetupForInstructionSelectionPhase\n");
 
-      traceMsg(comp, "GuardedStorage: Examining node = %p\n", node);
+      auto mapAllocator = getTypedAllocator<std::pair<TR::TreeTop*, TR::TreeTop*> >(comp->allocator());
 
-      if ((comp->useCompressedPointers() && node->getOpCodeValue() == TR::l2a) || (!comp->useCompressedPointers() && node->getOpCodeValue() == TR::aloadi))
+      std::map<TR::TreeTop*, TR::TreeTop*, std::less<TR::TreeTop*>, TR::typed_allocator<std::pair<TR::TreeTop*, TR::TreeTop*>, TR::Allocator> >
+         currentTreeTopToappendTreeTop(std::less<TR::TreeTop*> (), mapAllocator);
+
+      for (TR::PreorderNodeIterator iter(comp->getStartTree(), comp); iter != NULL; ++iter)
          {
-         TR::TreeTop* anchorTreeTop = TR::TreeTop::create(comp, TR::Node::create(TR::treetop, 1, node));
-         TR::TreeTop* appendTreeTop = iter.currentTree();
+         TR::Node *node = iter.currentNode();
 
-         if (currentTreeTopToappendTreeTop.count(appendTreeTop) > 0)
+         traceMsg(comp, "GuardedStorage: Examining node = %p\n", node);
+
+         if ((comp->useCompressedPointers() && node->getOpCodeValue() == TR::l2a) || (!comp->useCompressedPointers() && node->getOpCodeValue() == TR::aloadi))
             {
-            appendTreeTop = currentTreeTopToappendTreeTop[appendTreeTop];
+            TR::TreeTop* anchorTreeTop = TR::TreeTop::create(comp, TR::Node::create(TR::treetop, 1, node));
+            TR::TreeTop* appendTreeTop = iter.currentTree();
+
+            if (currentTreeTopToappendTreeTop.count(appendTreeTop) > 0)
+               {
+               appendTreeTop = currentTreeTopToappendTreeTop[appendTreeTop];
+               }
+
+            // Anchor the l2a before the current treetop
+            appendTreeTop->insertBefore(anchorTreeTop);
+            currentTreeTopToappendTreeTop[iter.currentTree()] = anchorTreeTop;
+
+            traceMsg(comp, "GuardedStorage: Anchored  %p to treetop = %p\n", node, anchorTreeTop);
             }
-
-         // Anchor the l2a before the current treetop
-         appendTreeTop->insertBefore(anchorTreeTop);
-         currentTreeTopToappendTreeTop[iter.currentTree()] = anchorTreeTop;
-
-         traceMsg(comp, "GuardedStorage: Anchored  %p to treetop = %p\n", node, anchorTreeTop);
          }
       }
-#endif
 
    if (cg->shouldBuildStructure() &&
        (comp->getFlowGraph()->getStructure() != NULL))

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -494,6 +494,18 @@ class OMR_EXTENSIBLE CodeGenerator
    bool supportsMarshallingUnmarshallingIntrinsics() {return true;} // no virt, default
    bool supportsMergingOfHCRGuards() {return false;} // no virt, default
 
+   /** \brief
+    *     Determines whether this code generator supports concurrent scavange of objects during garbage collection.
+    *
+    *  \return
+    *     true if the code generator will emit read barriers for loads of object references from the heap in support
+    *     of concurrent scavange; false otherwise.
+    */
+   bool supportsConcurrentScavange()
+   {
+      return false;
+   }
+
    // --------------------------------------------------------------------------
    // Z only
    //

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -495,13 +495,13 @@ class OMR_EXTENSIBLE CodeGenerator
    bool supportsMergingOfHCRGuards() {return false;} // no virt, default
 
    /** \brief
-    *     Determines whether this code generator supports concurrent scavange of objects during garbage collection.
+    *     Determines whether concurrent scavenge of objects during garbage collection is enabled.
     *
     *  \return
     *     true if the code generator will emit read barriers for loads of object references from the heap in support
-    *     of concurrent scavange; false otherwise.
+    *     of concurrent scavenge; false otherwise.
     */
-   bool supportsConcurrentScavange()
+   bool isConcurrentScavengeEnabled()
    {
       return false;
    }

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1832,11 +1832,6 @@ OMR::Options::Options(
       optimizationPlan->setOptLevelDowngraded(false);
       }
 
-   // TODO (GuardedStorage)
-#if defined(OMR_GC_CONCURRENT_SCAVENGER)
-   self()->setOption (TR_DisableArrayCopyOpts, true);
-#endif
-
    if (self()->getOption(TR_FullSpeedDebug))
       {
       if (self()->getOption(TR_MimicInterpreterFrameShape))

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -2860,7 +2860,7 @@ TR::Node *constrainWrtBar(TR::ValuePropagation *vp, TR::Node *node)
 
    static bool doOpt = feGetEnv("TR_DisableWrtBarOpt") ? false : true;
 
-   if (vp->cg()->supportsConcurrentScavange())
+   if (vp->cg()->isConcurrentScavengeEnabled())
       {
       // TODO (GuardedStorage): Why do we need this restriction?
       doOpt = false;

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -2858,12 +2858,13 @@ TR::Node *constrainWrtBar(TR::ValuePropagation *vp, TR::Node *node)
         vp->getCurrentParent() && vp->getCurrentParent()->getOpCodeValue() != TR::ArrayStoreCHK)
       canRemoveWrtBar(vp, node);
 
-   // TODO (GuardedStorage)
-#if defined(OMR_GC_CONCURRENT_SCAVENGER)
-   static bool doOpt = false;
-#else
    static bool doOpt = feGetEnv("TR_DisableWrtBarOpt") ? false : true;
-#endif
+
+   if (vp->cg()->supportsConcurrentScavange())
+      {
+      // TODO (GuardedStorage): Why do we need this restriction?
+      doOpt = false;
+      }
 
    TR_WriteBarrierKind gcMode = vp->comp()->getOptions()->getGcMode();
 

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -2962,13 +2962,13 @@ TR::Register *OMR::Z::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node
                
                // For concurrent scavange the source is loaded and shifted by the guarded load, thus we need to use CG
                // here for a non-zero compressedrefs shift value
-               if (TR::Compiler->target.cpu.getS390SupportsGuardedStorageFacility())
+               if (cg->supportsConcurrentScavange())
                   {
                   cmpOpCode = TR::InstOpCode::getCmpOpCode();
                   }
                else
                   {
-                  cmpOpCode = (n->getOpCode().getSize() > 4)? TR::InstOpCode::CG: TR::InstOpCode::C;
+                  cmpOpCode = (n->getOpCode().getSize() > 4) ? TR::InstOpCode::CG: TR::InstOpCode::C;
                   }
                }
             else

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -2960,9 +2960,9 @@ TR::Register *OMR::Z::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node
                targetRegister = n->getRegister();
                cg->evaluate(reference);
                
-               // For concurrent scavange the source is loaded and shifted by the guarded load, thus we need to use CG
+               // For concurrent scavenge the source is loaded and shifted by the guarded load, thus we need to use CG
                // here for a non-zero compressedrefs shift value
-               if (cg->supportsConcurrentScavange())
+               if (cg->isConcurrentScavengeEnabled())
                   {
                   cmpOpCode = TR::InstOpCode::getCmpOpCode();
                   }

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -531,12 +531,11 @@ OMR::Z::CodeGenerator::CodeGenerator()
      _previouslyAssignedTo(self()->comp()->allocator("LocalRA")),
      _bucketPlusIndexRegisters(self()->comp()->allocator()),
      _currentDEPEND(NULL),
-     _outgoingArgLevelDuringTreeEvaluation(0)
+     _outgoingArgLevelDuringTreeEvaluation(0),
+     _evaluatingCompressionSequenceCounter(0)
    {
    TR::Compilation *comp = self()->comp();
    _cgFlags = 0;
-
-   _evalCompressionSequence = false;
 
    // Initialize Linkage for Code Generator
    self()->initializeLinkage();
@@ -6236,14 +6235,25 @@ OMR::Z::CodeGenerator::generateScratchRegisterManager(int32_t capacity)
 
 // TODO (GuardedStorage)
 void
-OMR::Z::CodeGenerator::setEvalCompressionSequence(bool val)
+OMR::Z::CodeGenerator::incEvaluatingCompressionSequence()
    {
-   _evalCompressionSequence= val;
+   TR_ASSERT(_evaluatingCompressionSequenceCounter != 0x7FFFFFFF, "_evaluatingCompressionSequenceCounter overflow");
+
+   ++_evaluatingCompressionSequenceCounter;
    }
-bool
-OMR::Z::CodeGenerator::isEvalCompressionSequence()
+
+void
+OMR::Z::CodeGenerator::decEvaluatingCompressionSequence()
    {
-   return _evalCompressionSequence;
+   TR_ASSERT(_evaluatingCompressionSequenceCounter != 0x00000000, "_evaluatingCompressionSequenceCounter overflow");
+
+   --_evaluatingCompressionSequenceCounter;
+   }
+
+bool
+OMR::Z::CodeGenerator::isEvaluatingCompressionSequence()
+   {
+   return _evaluatingCompressionSequenceCounter != 0;
    }
 
 void

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -858,7 +858,7 @@ OMR::Z::CodeGenerator::CodeGenerator()
    self()->getS390Linkage()->initS390RealRegisterLinkage();
    self()->setAccessStaticsIndirectly(true);
 
-   if (self()->supportsConcurrentScavange())
+   if (self()->isConcurrentScavengeEnabled())
       {
       // TODO (GuardedStorage): Is there a way to relax this condition? Currently we have to disable array copy opts to
       // avoid missing guarded loads on memory to memory copies of reference objects. However this restriction seems too
@@ -6087,7 +6087,7 @@ OMR::Z::CodeGenerator::supportsMergingOfHCRGuards()
    }
 
 bool
-OMR::Z::CodeGenerator::supportsConcurrentScavange()
+OMR::Z::CodeGenerator::isConcurrentScavengeEnabled()
    {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
    return TR::Compiler->target.cpu.getS390SupportsGuardedStorageFacility();

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -857,6 +857,14 @@ OMR::Z::CodeGenerator::CodeGenerator()
 
    self()->getS390Linkage()->initS390RealRegisterLinkage();
    self()->setAccessStaticsIndirectly(true);
+
+   if (self()->supportsConcurrentScavange())
+      {
+      // TODO (GuardedStorage): Is there a way to relax this condition? Currently we have to disable array copy opts to
+      // avoid missing guarded loads on memory to memory copies of reference objects. However this restriction seems too
+      // strict as we are disabling primitive array copies as well.
+      comp->setOption(TR_DisableArrayCopyOpts);
+      }
    }
 
 TR_GlobalRegisterNumber
@@ -6076,6 +6084,16 @@ OMR::Z::CodeGenerator::supportsMergingOfHCRGuards()
    return self()->getSupportsVirtualGuardNOPing() &&
           self()->comp()->performVirtualGuardNOPing() &&
           !self()->comp()->compileRelocatableCode();
+   }
+
+bool
+OMR::Z::CodeGenerator::supportsConcurrentScavange()
+   {
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+   return TR::Compiler->target.cpu.getS390SupportsGuardedStorageFacility();
+#else
+   return false;
+#endif
    }
 
 // Helpers for profiled interface slots

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -418,13 +418,13 @@ public:
    bool supportsMergingOfHCRGuards();
 
    /** \brief
-    *     Determines whether this code generator supports concurrent scavange of objects during garbage collection.
+    *     Determines whether concurrent scavenge of objects during garbage collection is enabled.
     *
     *  \return
     *     true if the code generator will emit read barriers for loads of object references from the heap in support
-    *     of concurrent scavange; false otherwise.
+    *     of concurrent scavenge; false otherwise.
     */
-   bool supportsConcurrentScavange();
+   bool isConcurrentScavengeEnabled();
 
    bool supportsDirectJNICallsForAOT() { return true;}
 

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -417,6 +417,15 @@ public:
 
    bool supportsMergingOfHCRGuards();
 
+   /** \brief
+    *     Determines whether this code generator supports concurrent scavange of objects during garbage collection.
+    *
+    *  \return
+    *     true if the code generator will emit read barriers for loads of object references from the heap in support
+    *     of concurrent scavange; false otherwise.
+    */
+   bool supportsConcurrentScavange();
+
    bool supportsDirectJNICallsForAOT() { return true;}
 
    bool shouldYankCompressedRefs() { return true; }

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -329,10 +329,12 @@ public:
    TR_BranchPreloadCallData _outlineCall;
    TR_BranchPreloadCallData _outlineArrayCall;
 
-   // TODO (GuardedStorage)
-   bool _evalCompressionSequence;
-   void setEvalCompressionSequence(bool val);
-   bool isEvalCompressionSequence();
+   // TODO (GuardedStorage): This needs to be revisited. We need to avoid lowering compressedrefs trees if concurrent
+   // scavenge is enabled, rather than trying to pattern match and avoid evaluating them
+   int32_t _evaluatingCompressionSequenceCounter;
+   void incEvaluatingCompressionSequence();
+   void decEvaluatingCompressionSequence();
+   bool isEvaluatingCompressionSequence();
 
    TR::list<TR_BranchPreloadCallData*> *_callsForPreloadList;
 

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -5061,7 +5061,7 @@ genericLoadHelper(TR::Node * node, TR::CodeGenerator * cg, TR::MemoryReference *
          }
       else //if (form == MemReg)
          {
-         if (cg->supportsConcurrentScavange())
+         if (cg->isConcurrentScavengeEnabled())
             {
             // TODO (GuardedStorage): If we are in the evaluation of a compressedrefs sequence and are about to generate
             // compressed load we override the instruction opcode to generate a guarded load and shift instead. We should
@@ -6120,7 +6120,7 @@ aloadHelper(TR::Node * node, TR::CodeGenerator * cg, TR::MemoryReference * tempM
                   auto mnemonic = TR::InstOpCode::getLoadOpCode();
 
                   // TODO (GuardedStorage): Do we need the useCompressedPointers check here? All aloads should have been lowered by now.
-                  if (cg->supportsConcurrentScavange() && !comp->useCompressedPointers())
+                  if (cg->isConcurrentScavengeEnabled() && !comp->useCompressedPointers())
                      {
                      if (node->getOpCodeValue() == TR::aloadi && tempReg->containsCollectedReference())
                         {

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -5056,14 +5056,22 @@ genericLoadHelper(TR::Node * node, TR::CodeGenerator * cg, TR::MemoryReference *
       // However, have to deal with old architectures, strange data types and register pairs
       TR::InstOpCode::Mnemonic load = loadInstrs[form][numberOfBytesLog2][isSourceSigned][numberOfExtendBits/32-1];
       if (form == RegReg)
+         {
          generateRRInstruction(cg, load, node, targetRegister, srcRegister);
-
-      // TODO (GuardedStorage)
+         }
       else //if (form == MemReg)
          {
-         if (load == TR::InstOpCode::LLGF && cg->isEvalCompressionSequence()
-               && (TR::Compiler->target.cpu.getS390SupportsGuardedStorageFacility()))
-            load = TR::InstOpCode::LLGFSG;
+         if (cg->supportsConcurrentScavange())
+            {
+            // TODO (GuardedStorage): If we are in the evaluation of a compressedrefs sequence and are about to generate
+            // compressed load we override the instruction opcode to generate a guarded load and shift instead. We should
+            // figure out a better way to handle this.
+            if (cg->isEvalCompressionSequence() && load == TR::InstOpCode::LLGF)
+               {
+               load = TR::InstOpCode::LLGFSG;
+               }
+            }
+
          generateRXInstruction(cg, load, node, targetRegister, tempMR);
          }
       }
@@ -6109,14 +6117,18 @@ aloadHelper(TR::Node * node, TR::CodeGenerator * cg, TR::MemoryReference * tempM
                   generateRXInstruction(cg, TR::InstOpCode::LLGF, node, tempReg, tempMR);
                else
                   {
-                  // TODO (GuardedStorage)
-                  if (!comp->useCompressedPointers() && (node->getOpCodeValue() == TR::aloadi) &&
-                        tempReg->containsCollectedReference() && TR::Compiler->target.cpu.getS390SupportsGuardedStorageFacility())
-                  {
-                     generateRXInstruction(cg, TR::InstOpCode::LGG, node, tempReg, tempMR);
-                  }
-                  else
-                     generateRXInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, tempReg, tempMR);
+                  auto mnemonic = TR::InstOpCode::getLoadOpCode();
+
+                  // TODO (GuardedStorage): Do we need the useCompressedPointers check here? All aloads should have been lowered by now.
+                  if (cg->supportsConcurrentScavange() && !comp->useCompressedPointers())
+                     {
+                     if (node->getOpCodeValue() == TR::aloadi && tempReg->containsCollectedReference())
+                        {
+                        mnemonic = TR::InstOpCode::LGG;
+                        }
+                     }
+
+                  generateRXInstruction(cg, mnemonic, node, tempReg, tempMR);
                   }
                }
             }

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -5066,7 +5066,7 @@ genericLoadHelper(TR::Node * node, TR::CodeGenerator * cg, TR::MemoryReference *
             // TODO (GuardedStorage): If we are in the evaluation of a compressedrefs sequence and are about to generate
             // compressed load we override the instruction opcode to generate a guarded load and shift instead. We should
             // figure out a better way to handle this.
-            if (cg->isEvalCompressionSequence() && load == TR::InstOpCode::LLGF)
+            if (cg->isEvaluatingCompressionSequence() && load == TR::InstOpCode::LLGF)
                {
                load = TR::InstOpCode::LLGFSG;
                }

--- a/compiler/z/codegen/UnaryEvaluator.cpp
+++ b/compiler/z/codegen/UnaryEvaluator.cpp
@@ -485,19 +485,21 @@ OMR::Z::TreeEvaluator::l2aEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR_ASSERT(hasCompPtrs, "no compression sequence found under l2a node [%p]\n", node);
    */
 
-   // TODO (GuardedStorage)
-   TR::Register *source;
-   if (comp->useCompressedPointers() && (TR::Compiler->om.compressedReferenceShift() == 0 || firstChild->containsCompressionSequence()) && !node->isl2aForCompressedArrayletLeafLoad())
+   TR::Register* source = NULL;
+
+   // TODO (GuardedStorage): Why is isl2aForCompressedArrayletLeafLoad check necessary?
+   if (cg->supportsConcurrentScavange() && comp->useCompressedPointers() && firstChild->containsCompressionSequence() && !node->isl2aForCompressedArrayletLeafLoad())
+      {
       cg->setEvalCompressionSequence(true);
 
-   if ((TR::Compiler->target.cpu.getS390SupportsGuardedStorageFacility()) && comp->useCompressedPointers() && (firstChild->containsCompressionSequence()) && !node->isl2aForCompressedArrayletLeafLoad())
-      {
       source = cg->evaluate(firstChild->getFirstChild());
+
+      cg->setEvalCompressionSequence(false);
       }
    else
+      {
       source = cg->evaluate(firstChild);
-
-   cg->setEvalCompressionSequence(false);
+      }
 
    // first child is either iu2l (when shift==0) or
    // the first child is a compression sequence. in the

--- a/compiler/z/codegen/UnaryEvaluator.cpp
+++ b/compiler/z/codegen/UnaryEvaluator.cpp
@@ -488,7 +488,7 @@ OMR::Z::TreeEvaluator::l2aEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::Register* source = NULL;
 
    // TODO (GuardedStorage): Why is isl2aForCompressedArrayletLeafLoad check necessary?
-   if (cg->supportsConcurrentScavange() && comp->useCompressedPointers() && firstChild->containsCompressionSequence() && !node->isl2aForCompressedArrayletLeafLoad())
+   if (cg->isConcurrentScavengeEnabled() && comp->useCompressedPointers() && firstChild->containsCompressionSequence() && !node->isl2aForCompressedArrayletLeafLoad())
       {
       cg->setEvalCompressionSequence(true);
 


### PR DESCRIPTION
Concurrent scavanger related code enabling the code generator to emit
read barriers for object reference loads is currently guarded by a
compile time OMR_GC_CONCURRENT_SCAVENGER define.

This change effectively deprecates the OMR_GC_CONCURRENT_SCAVENGER flag
in the JIT in favor of a runtime check. This is a pre-emptive change in
preparation of full deprecation of the OMR_GC_CONCURRENT_SCAVENGER flag.
However this removal has to come from the OMR GC front and a
correpsonding runtime flag for concurrent scavanger needs to be
introduced in the GC. Only at this point may we remove the final
reference to OMR_GC_CONCURRENT_SCAVENGER in the JIT.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>