### PR TITLE
Use MAP_ANON when MAP_ANONYMOUS not available

### DIFF
--- a/compiler/env/FEBase_t.hpp
+++ b/compiler/env/FEBase_t.hpp
@@ -80,6 +80,19 @@ FEBase<Derived>::allocateCodeMemory(TR::Compilation *comp, uint32_t warmCodeSize
    return warmCode;
    }
 
+// This code does not really belong here (along with allocateRelocationData, really)
+// We should be relying on the port library to allocate memory, but this connection
+// has not yet been made, so as a quick workaround for platforms like OS X <= 10.9,
+// where MAP_ANONYMOUS is not defined, is to map MAP_ANON to MAP_ANONYMOUS ourselves
+#if !defined(MAP_ANONYMOUS)
+  #define NO_MAP_ANONYMOUS
+  #if defined(MAP_ANON)
+    #define MAP_ANONYMOUS MAP_ANON
+  #else
+    #error unexpectedly, no MAP_ANONYMOUS or MAP_ANON definition
+  #endif
+#endif
+
 template <class Derived>
 uint8_t *
 FEBase<Derived>::allocateRelocationData(TR::Compilation* comp, uint32_t size)
@@ -95,6 +108,12 @@ FEBase<Derived>::allocateRelocationData(TR::Compilation* comp, uint32_t size)
                            -1,
                            0);
    }
+
+// keep the impact of this fix localized
+#if defined(NO_MAP_ANONYMOUS)
+  #undef MAP_ANONYMOUS
+  #undef NO_MAP_ANONYMOUS
+#endif
 
 template <class Derived>
 void

--- a/jitbuilder/runtime/JBCodeCacheManager.cpp
+++ b/jitbuilder/runtime/JBCodeCacheManager.cpp
@@ -72,6 +72,18 @@ JitBuilder::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
                                               size_t &codeCacheSizeToAllocate,
                                               void *preferredStartAddress)
    {
+   // We should really rely on the port library to allocate memory, but this connection
+   // has not yet been made, so as a quick workaround for platforms like OS X <= 10.9
+   // where MAP_ANONYMOUS is not defined, is to map MAP_ANON to MAP_ANONYMOUS ourselves
+   #if !defined(MAP_ANONYMOUS)
+      #define NO_MAP_ANONYMOUS
+      #if defined(MAP_ANON)
+         #define MAP_ANONYMOUS MAP_ANON
+      #else
+         #error unexpectedly, no MAP_ANONYMOUS or MAP_ANON definition
+      #endif
+   #endif
+
    // ignore preferredStartAddress for now, since it's NULL anyway
    //   goal would be to allocate code cache segments near the JIT library address
    codeCacheSizeToAllocate = segmentSize;
@@ -85,6 +97,11 @@ JitBuilder::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
                                           0,
                                           0);
 
+   // keep the impact of this fix localized
+   #if defined(NO_MAP_ANONYMOUS)
+      #undef MAP_ANONYMOUS
+      #undef NO_MAP_ANONYMOUS
+   #endif
    TR::CodeCacheMemorySegment *memSegment = (TR::CodeCacheMemorySegment *) ((size_t)memorySlab + codeCacheSizeToAllocate - sizeof(TR::CodeCacheMemorySegment));
    new (memSegment) TR::CodeCacheMemorySegment(memorySlab, reinterpret_cast<uint8_t *>(memSegment));
    return memSegment;


### PR DESCRIPTION
This commit is a temporary requirement for JitBuilder and other
OMR compiler based projects to be able to build on older versions
of OS X where MAP_ANONYMOUS has not been defined. This problem
came up in Issue #902 while building JitBuilder and the OMR compiler
component on Mac OS X 10.9 . In these kinds of environments, MAP_ANON
is usually defined and so we can simply define MAP_ANONYMOUS to
be MAP_ANON where we need it. The port library already does this
swizzling but we have not yet hooked up a depenedency for the
compiler or JitBuilder on the port library to benefit from that
code.

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>