### PR TITLE
Get extended block whilst walking in OSR check

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -712,8 +712,7 @@ bool OMR::Compilation::isPotentialOSRPointWithSupport(TR::TreeTop *tt)
          if (node->getReferenceCount() > 1)
             {
             TR::TreeTop *cursor = tt->getPrevTreeTop();
-            TR::TreeTop *extendedBlockStart = tt->getNode()->getBlock()->startOfExtendedBlock()->getEntry();
-            while (cursor && cursor != extendedBlockStart)
+            while (cursor)
                {
                if ((cursor->getNode()->getOpCode().isCheck() || cursor->getNode()->getOpCodeValue() == TR::treetop)
                    && cursor->getNode()->getFirstChild() == node)
@@ -721,6 +720,9 @@ bool OMR::Compilation::isPotentialOSRPointWithSupport(TR::TreeTop *tt)
                   potentialOSRPoint = false;
                   break;
                   }
+               if (cursor->getNode()->getOpCodeValue() == TR::BBStart &&
+                   !cursor->getNode()->getBlock()->isExtensionOfPreviousBlock())
+                  break;
                cursor = cursor->getPrevTreeTop();
                }
             }


### PR DESCRIPTION
Rather than performing the walk back to the start of the current block
to determine whether it is currently in an extended block and then
repeating the walk to perform its check, both can be done in a single
pass.