### PR TITLE
Fix makefile dependency for JitBuilder tests

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -240,6 +240,7 @@ example:: $(test_prereqs)
 
 fvtest/algotest::$(test_prereqs)
 fvtest/gctest:: $(test_prereqs)
+fvtest/jitbuildertest:: $(test_prereqs)
 fvtest/porttest:: $(test_prereqs)
 fvtest/rastest:: $(test_prereqs)
 fvtest/sigtest:: $(test_prereqs)


### PR DESCRIPTION
This commit updates the makefile to ensure that GTest is built before
the JitBuilder tests that depend on it.

Signed-off-by: Leonardo Banderali <leob@linux.vnet.ibm.com>