### PR TITLE
Extend remat API to analyse beyond one block

### DIFF
--- a/compiler/optimizer/RematTools.hpp
+++ b/compiler/optimizer/RematTools.hpp
@@ -58,13 +58,24 @@ class RematTools
       TR::Node *currentNode, TR::SparseBitVector &scanTargets, 
       TR::SparseBitVector &enabledSymRefs, TR::SparseBitVector &unsafeSymRefs,
       bool trace, TR::SparseBitVector &visitedNodes);
+   static bool getNextTreeTop(TR::TreeTop* &start, TR_BitVector *blocksToFollow,
+      TR::Block *startBlock);
    public:
    static TR_YesNoMaybe gatherNodesToCheck(TR::Compilation *comp,
       TR::Node *privArg, TR::Node *currentNode, TR::SparseBitVector &scanTargets,
       TR::SparseBitVector &symRefsToCheck, bool trace);
+
+   static bool walkTreesCalculatingRematSafety(TR::Compilation *comp,
+      TR::TreeTop *start, TR::TreeTop *end, TR::SparseBitVector &scanTargets, 
+      TR::SparseBitVector &unsafeSymRefs, TR_BitVector *blocksToVisit, bool trace);
    static void walkTreesCalculatingRematSafety(TR::Compilation *comp,
       TR::TreeTop *start, TR::TreeTop *end, TR::SparseBitVector &scanTargets, 
       TR::SparseBitVector &unsafeSymRefs, bool trace);
+
+   static bool walkTreeTopsCalculatingRematFailureAlternatives(TR::Compilation *comp,
+      TR::TreeTop *start, TR::TreeTop *end, TR::list<TR::TreeTop*> &failedArgs,
+      TR::SparseBitVector &scanTargets, RematSafetyInformation &rematInfo,
+      TR_BitVector *blocksToVisit, bool trace);
    static void walkTreeTopsCalculatingRematFailureAlternatives(TR::Compilation *comp,
       TR::TreeTop *start, TR::TreeTop *end, TR::list<TR::TreeTop*> &failedArgs,
       TR::SparseBitVector &scanTargets, RematSafetyInformation &rematInfo, bool trace);


### PR DESCRIPTION
The remat API has several functions that require a start and end
node to be specified. In this form, they are limited to a block
or a continuous set of blocks, as it is not possible to specify
which edges should be taken. This change extends the API to include
a BitVector of allowable blocks. When these functions reach the
end of their current block, the first allowable block in the
set of successors will be taken, allowing for more aggressive
remat.