### PR TITLE
Remove vestigial RTSJ comments from compiler

### DIFF
--- a/compiler/env/ProcessorInfo.hpp
+++ b/compiler/env/ProcessorInfo.hpp
@@ -75,10 +75,6 @@ struct TR_X86CPUIDBuffer
    uint32_t _featureFlags8;
    };
 
-/* RTSJ duplicate from struct TR_X86ProcessorInfo/X86CodeGenerator.hpp */
-/* requires code reorganization to make these features available       */
-/* when the JIT DLL is not loaded at runtime for AOT                   */
-
 enum TR_X86ProcessorVendors
    {
    TR_AuthenticAMD                  = 0x01,
@@ -146,6 +142,5 @@ enum TR_TransactionalMemory
    TR_HLE                     = 0x00000010,
    TR_RTM                     = 0x00000800
    };
-/* RTSJ end duplicate */
 
 #endif

--- a/compiler/il/OMRBlock.hpp
+++ b/compiler/il/OMRBlock.hpp
@@ -241,12 +241,8 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
 
    TR::TreeTop *getExceptingTree();
 
-   // { RTSJ Support begins
-
    bool hasExceptionPredecessors();
    bool hasExceptionSuccessors();
-
-   // } RTSJ Support ends
 
    /**
     * Field functions

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -4860,8 +4860,6 @@ bool TR_InlinerBase::inlineCallTarget2(TR_CallStack * callStack, TR_CallTarget *
     in the calleee that wasn' there when we gen'd IL for it
    */
 
-   // RTSJ support: code to compute previousBBStartInCaller moved up
-
    for (tt = callNodeTreeTop->getNextTreeTop(); tt; tt = tt->getNextTreeTop())
       if (tt->getNode()->getOpCodeValue() == TR::BBEnd)
          {

--- a/compiler/x/codegen/RestartSnippet.hpp
+++ b/compiler/x/codegen/RestartSnippet.hpp
@@ -132,12 +132,10 @@ class X86RestartSnippet  : public TR::Snippet
       return estimateRestartJumpLength(estimatedSnippetLocation, _restartLabel);
       }
 
-   // { RTSJ Support begins
    uint32_t estimateRestartJumpLength(TR_X86OpCodes branchOp, int32_t estimatedSnippetLocation)
       {
       return estimateRestartJumpLength(branchOp, estimatedSnippetLocation, _restartLabel);
       }
-   // } RTSJ Support ends
 
    };
 

--- a/compiler/x/codegen/X86Debug.cpp
+++ b/compiler/x/codegen/X86Debug.cpp
@@ -2341,8 +2341,6 @@ void TR_Debug::printX86OOLSequences(TR::FILE *pOutFile)
 
 
 
-// } RTSJ Support ends
-
 //
 // AMD64 Snippets
 //


### PR DESCRIPTION
A long time ago, the compiler component included a whole slough
of adaptations so that it could operate in real-time environments
and support the Real Time Specification for Java (RTSJ). When
that code was initially introduced, it was bracketed by comments
indicating which parts were specifically for RTSJ or real-time.
Support for the RTSJ has been removed at this point (though much
of the code lives on and operates for all languages as part of
the OMR compiler), but there were some vestigial comments still
lying around identifying code as related to the RTSJ. This commit
removes these comments as they are no longer appropriate or
useful.


Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>