### PR TITLE
minor fixes/RAS improvements to fsd

### DIFF
--- a/compiler/compile/OSRData.cpp
+++ b/compiler/compile/OSRData.cpp
@@ -91,7 +91,7 @@ TR_OSRCompilationData::addInstruction(TR::Instruction* instr)
    }
 
 void
-TR_OSRCompilationData::addInstruction(int32_t instructionPC, TR_ByteCodeInfo &bcInfo)
+TR_OSRCompilationData::addInstruction(int32_t instructionPC, TR_ByteCodeInfo bcInfo)
    {
    bool trace = comp->getOption(TR_TraceOSR);
    if (trace)

--- a/compiler/compile/OSRData.hpp
+++ b/compiler/compile/OSRData.hpp
@@ -119,7 +119,7 @@ class TR_OSRCompilationData
                            int32_t symRefOrder, int32_t symSize, bool takesTwoSlots);
    void ensureSlotSharingInfoAt(const TR_ByteCodeInfo& T);
    void addInstruction(TR::Instruction* instr);
-   void addInstruction(int32_t instructionPC, TR_ByteCodeInfo &bcInfo);
+   void addInstruction(int32_t instructionPC, TR_ByteCodeInfo bcInfo);
 
    void checkOSRLimits();
 

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -4966,7 +4966,6 @@ bool TR_InlinerBase::inlineCallTarget2(TR_CallStack * callStack, TR_CallTarget *
             callerCFG->copyExceptionSuccessors(blockContainingTheCall, n, succAndPredAreNotOSRBlocks);
          else
             debugTrace(tracer(),"\ndon't add exception edges from callee OSR block(block_%d) to caller catch blocks\n",n->getNumber());
-         callerCFG->copyExceptionSuccessors(blockContainingTheCall, n, succAndPredAreNotOSRBlocks);
          }
       }
 

--- a/compiler/optimizer/OSRDefAnalysis.cpp
+++ b/compiler/optimizer/OSRDefAnalysis.cpp
@@ -149,7 +149,7 @@ void TR_OSRDefInfo::performFurtherAnalysis(AuxiliaryData &aux)
                for (TR::SymbolReference* symRef = listIt.getFirst(); symRef; symRef = listIt.getNext(), symRefOrder++)
                   if (symRef == defSymRef)
                      break;
-               TR_ASSERT(symRefOrder < list->getSize(), "symref not found\n");
+               TR_ASSERT(symRefOrder < list->getSize(), "symref #%d on node n%dn not found\n", defSymRef->getReferenceNumber(), defNode->getGlobalIndex());
                comp()->getOSRCompilationData()->addSlotSharingInfo(point->getByteCodeInfo(),
                      slot, symRefNum, symRefOrder, defSymRef->getSymbol()->getSize(), takesTwoSlots);
                if (trace())


### PR DESCRIPTION
3 changes are in this PR
1. Add more info to assert msg in OSRDefAnalysis 
2. Fix TR_OSRCompilationData::addInstruction arg type 
    The intention of the loop in this API is just walking up the call stack but not change the bcInfo. Change reference type to normal type to prevent accidentally change the argument value.
3. Delete redundant exception edge copying
     The code's intention was to avoid exception edge copying for OSR blocks. This line was intended to be deleted.
Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>