### PR TITLE
Add extension point constrainRecognizedMethod in VP

### DIFF
--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -7167,6 +7167,16 @@ void OMR::ValuePropagation::transformStringCtors(VPTreeTopPair *treeTopPair)
   treeTopPair->_treetop1->unlink(true);
 }
 
+/** \brief
+ *     Extension point for language specific optimizations on recognized methods
+ *
+ * \parm node
+ *     The call node to be constrained
+ */
+void OMR::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
+   {
+   }
+
 void OMR::ValuePropagation::replacePackedArrayLoad(TR::Node *loadNode, TR::Node *packedNode, TR::Node *curNode, vcount_t visitCount)
    {
    if (curNode->getVisitCount() == visitCount)

--- a/compiler/optimizer/OMRValuePropagation.hpp
+++ b/compiler/optimizer/OMRValuePropagation.hpp
@@ -457,7 +457,7 @@ class ValuePropagation : public TR::Optimization
    void launchNode(TR::Node *node, TR::Node *parent, int32_t whichChild);
 
    bool checkAllUnsafeReferences(TR::Node *node, vcount_t visitCount);
-   void doDelayedTransformations();
+   virtual void doDelayedTransformations();
 
    void replacePackedArrayLoad(TR::Node *loadNode, TR::Node *packedNode, TR::Node *curNode, vcount_t visitCount);
 
@@ -606,6 +606,7 @@ class ValuePropagation : public TR::Optimization
    void transformUnknownTypeArrayCopy(TR_TreeTopWrtBarFlag *);
    void transformReferenceArrayCopy(TR_TreeTopWrtBarFlag *);
    void transformReferenceArrayCopyWithoutCreatingStoreTrees(TR_TreeTopWrtBarFlag *arrayTree, TR::SymbolReference *srcObjRef, TR::SymbolReference *dstObjRef, TR::SymbolReference *srcRef, TR::SymbolReference *dstRef, TR::SymbolReference *lenRef);
+   virtual void constrainRecognizedMethod(TR::Node *node);
 
    struct ObjCloneInfo {
       TR_ALLOC(TR_Memory::ValuePropagation)

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -5237,6 +5237,11 @@ TR::Node *constrainCall(OMR::ValuePropagation *vp, TR::Node *node)
          }
       }
 
+   vp->constrainRecognizedMethod(node);
+
+   // Return if the node is not a regular call (xcall/xcalli) anymore
+   if (!node->getOpCode().isCall() || node->getSymbol()->castToMethodSymbol()->isHelper())
+      return node;
 
    if ( symbol )
       {
@@ -5682,6 +5687,10 @@ TR::Node *setCloneClassInNode(OMR::ValuePropagation *vp, TR::Node *node, TR::VPC
 TR::Node *constrainAcall(OMR::ValuePropagation *vp, TR::Node *node)
    {
    constrainCall(vp, node);
+
+   // Return if the node is not a regular call (xcall/xcalli) anymore
+   if (!node->getOpCode().isCall() || node->getSymbol()->castToMethodSymbol()->isHelper())
+      return node;
 
    // This node can be constrained by the return type of the method.
    //


### PR DESCRIPTION
This commit contains the following changes:

1) Add extension point as home to language specific optimizations on
recognized methods.

2) Return if the node is not a call after the transformation.

3) Make doDelayedTransformations virtual so that it can be overriden in
   order to host language specific optimizations that have to be done
   near the end of VP.