### PR TITLE
Extend OSR API to represent its different modes

### DIFF
--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -817,8 +817,11 @@ public:
     */
    bool isPotentialOSRPoint(TR::Node *node);
    bool isPotentialOSRPointWithSupport(TR::TreeTop *tt);
+
+   TR::OSRMode getOSRMode();
+   TR::OSRTransitionTarget getOSRTransitionTarget();
    int32_t getOSRInductionOffset(TR::Node *node);
-   bool requiresLeadingOSRPoint(TR::Node *node);
+   bool requiresAnalysisOSRPoint(TR::Node *node);
 
    // for OSR
    TR_OSRCompilationData* getOSRCompilationData() {return _osrCompilationData;}

--- a/compiler/compile/OSRData.hpp
+++ b/compiler/compile/OSRData.hpp
@@ -44,6 +44,54 @@ namespace TR
       osr,
       traditional
       };
+
+/*
+ * An OSR transition can occur before or after the OSR point's
+ * side-effect, depending on the current mode.
+ *
+ * In preExecutionOSR, the transition occurs before the side-effects
+ * of executing the OSR point's bytecode, resulting in it being
+ * evaluated in the interpreter.
+ *
+ * In postExecutionOSR, the transition occurs after the side-effects
+ * of executing the OSR point's bytecode, resulting in the interpreter
+ * resuming execution at following bytecode.
+ */
+   enum OSRTransitionTarget
+      {
+      preExecutionOSR,
+      postExecutionOSR
+      };
+
+/*
+ * OSR can operate in two modes, voluntary and involuntary.
+ *
+ * In involuntary OSR, the JITed code does not control when an OSR transition occurs. It can be
+ * initiated externally at any potential OSR point.
+ *
+ * In voluntary OSR, the JITed code does control when an OSR transition occurs, allowing it to
+ * limit the OSR points with transitions.
+ */
+   enum OSRMode
+      {
+      voluntaryOSR,
+      involuntaryOSR
+      };
+
+/*
+ * There are two types of OSR points, induction and analysis.
+ *
+ * An induction point is a normal OSR point, which undergoes the
+ * OSR analysis and may have a transition for it, based on the mode.
+ *
+ * An analysis point is used only for the OSR analysis will not have
+ * a transition point for it.
+ */
+   enum OSRPointType
+      {
+      inductionOSR,
+      analysisOSR 
+      };
    }
 
 /**

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -5009,11 +5009,11 @@ bool TR_InlinerBase::inlineCallTarget2(TR_CallStack * callStack, TR_CallTarget *
             _disableTailRecursion = true;
          }
       }
-   else if (comp()->getOption(TR_FullSpeedDebug) && tif->crossedBasicBlock())
+   else if (comp()->getOSRMode() == TR::involuntaryOSR && tif->crossedBasicBlock())
       {
       /**
-       * In FSD mode, we need to split block even for cases without virtual guard. This is 
-       * because in FSD a block with OSR point must have an exception edge to the osrCatchBlock
+       * In involuntary OSR mode, we need to split block even for cases without virtual guard. This is 
+       * because in involuntary OSR a block with OSR point must have an exception edge to the osrCatchBlock
        * of correct callerIndex. Split the block here so that the OSR points from callee
        * and from caller are separated.
        */


### PR DESCRIPTION
This change adds checks that abstract over the different OSR
modes, specifically whether it is operating in voluntary
or involuntary OSR mode and whether it will insert the OSR
transition before or after the OSR point.

Moreover, it adds the concept of OSR analysis points, which
exist only to hold OSR information at certain bytecode indices and will
not become a transition point.

A further change is partial de-aliasing of the osrInfrastructureRemoved
and the canAffordOSRControlFlow flags. canAffordOSRControlFlow is used
to indicate whether the additional compile time of OSR is afforadable,
whilst osrInfrastructureRemoved indicates that OSR exception edges
have been removed. However, canAffordOSRControlFlow was being used
to achieve the latter in some cases.