### PR TITLE
Small JitBuilder fixes

### DIFF
--- a/compiler/il/OMRDataTypes.cpp
+++ b/compiler/il/OMRDataTypes.cpp
@@ -307,7 +307,7 @@ static int32_t OMRDataTypeSizes[] =
 
 static_assert(TR::NumOMRTypes == (sizeof(OMRDataTypeSizes) / sizeof(OMRDataTypeSizes[0])), "OMRDataTypeSizes is not the correct size");
 
-const int32_t
+int32_t
 OMR::DataType::getSize(TR::DataType dt)
    {
    TR_ASSERT(dt < TR::NumOMRTypes, "dataTypeSizeMap called on unrecognized data type");

--- a/compiler/il/OMRDataTypes.hpp
+++ b/compiler/il/OMRDataTypes.hpp
@@ -257,42 +257,42 @@ enum DataTypes
 namespace TR
 {
 
-   template <TR::DataTypes T> inline const int64_t getMinSigned() { static_assert(T == -1, "getMinSigned is not valid for this type"); return 0; }
-   template <TR::DataTypes T> inline const uint64_t getMinUnsigned() { static_assert(T == -1, "getMinUnsigned is not valid for this type"); return 0; }
-   template <TR::DataTypes T> inline const int64_t getMaxSigned() { static_assert(T == -1, "getMaxSigned is not valid for this type"); return 0; }
-   template <TR::DataTypes T> inline const uint64_t getMaxUnsigned() { static_assert(T == -1, "getMaxUnsigned is not valid for this type"); return 0; }
-   template <TR::DataTypes T> inline const int32_t getMaxSignedPrecision() { static_assert(T == -1, "getMaxSignedPrecision is not valid for this type"); return 0; }
-   template <TR::DataTypes T> inline const int32_t getMaxUnsignedPrecision() { static_assert(T == -1, "getMaxUnsignedPrecision is not valid for this type"); return 0; }
+   template <TR::DataTypes T> inline int64_t getMinSigned() { static_assert(T == -1, "getMinSigned is not valid for this type"); return 0; }
+   template <TR::DataTypes T> inline uint64_t getMinUnsigned() { static_assert(T == -1, "getMinUnsigned is not valid for this type"); return 0; }
+   template <TR::DataTypes T> inline int64_t getMaxSigned() { static_assert(T == -1, "getMaxSigned is not valid for this type"); return 0; }
+   template <TR::DataTypes T> inline uint64_t getMaxUnsigned() { static_assert(T == -1, "getMaxUnsigned is not valid for this type"); return 0; }
+   template <TR::DataTypes T> inline int32_t getMaxSignedPrecision() { static_assert(T == -1, "getMaxSignedPrecision is not valid for this type"); return 0; }
+   template <TR::DataTypes T> inline int32_t getMaxUnsignedPrecision() { static_assert(T == -1, "getMaxUnsignedPrecision is not valid for this type"); return 0; }
 
-   template <> inline const int64_t getMinSigned<TR::Int8 >() { return -128; }
-   template <> inline const int64_t getMinSigned<TR::Int16>() { return -32768; }
-   template <> inline const int64_t getMinSigned<TR::Int32>() { return ((int32_t)0X80000000); }
-   template <> inline const int64_t getMinSigned<TR::Int64>() { return (((int64_t)1)<<63) /**< -9223372036854775808 */; }
+   template <> inline int64_t getMinSigned<TR::Int8 >() { return -128; }
+   template <> inline int64_t getMinSigned<TR::Int16>() { return -32768; }
+   template <> inline int64_t getMinSigned<TR::Int32>() { return ((int32_t)0X80000000); }
+   template <> inline int64_t getMinSigned<TR::Int64>() { return (((int64_t)1)<<63) /**< -9223372036854775808 */; }
 
-   template <> inline const uint64_t getMinUnsigned<TR::Int8 >() { return 0; }
-   template <> inline const uint64_t getMinUnsigned<TR::Int16>() { return 0; }
-   template <> inline const uint64_t getMinUnsigned<TR::Int32>() { return ((uint32_t)0); }
-   template <> inline const uint64_t getMinUnsigned<TR::Int64>() { return ((uint64_t)0); }
+   template <> inline uint64_t getMinUnsigned<TR::Int8 >() { return 0; }
+   template <> inline uint64_t getMinUnsigned<TR::Int16>() { return 0; }
+   template <> inline uint64_t getMinUnsigned<TR::Int32>() { return ((uint32_t)0); }
+   template <> inline uint64_t getMinUnsigned<TR::Int64>() { return ((uint64_t)0); }
 
-   template <> inline const int64_t getMaxSigned<TR::Int8 >() { return 127; }
-   template <> inline const int64_t getMaxSigned<TR::Int16>() { return 32767; }
-   template <> inline const int64_t getMaxSigned<TR::Int32>() { return ((int32_t)0X7FFFFFFF); }
-   template <> inline const int64_t getMaxSigned<TR::Int64>() { return ((int64_t)(((uint64_t)((int64_t)-1))>>1)) /**<  9223372036854775807 */; }
+   template <> inline int64_t getMaxSigned<TR::Int8 >() { return 127; }
+   template <> inline int64_t getMaxSigned<TR::Int16>() { return 32767; }
+   template <> inline int64_t getMaxSigned<TR::Int32>() { return ((int32_t)0X7FFFFFFF); }
+   template <> inline int64_t getMaxSigned<TR::Int64>() { return ((int64_t)(((uint64_t)((int64_t)-1))>>1)) /**<  9223372036854775807 */; }
 
-   template <> inline const uint64_t getMaxUnsigned<TR::Int8 >() { return 255; }
-   template <> inline const uint64_t getMaxUnsigned<TR::Int16>() { return 65535; }
-   template <> inline const uint64_t getMaxUnsigned<TR::Int32>() { return ((uint32_t)0xFFFFFFFF); }
-   template <> inline const uint64_t getMaxUnsigned<TR::Int64>() { return ((uint64_t)-1); }
+   template <> inline uint64_t getMaxUnsigned<TR::Int8 >() { return 255; }
+   template <> inline uint64_t getMaxUnsigned<TR::Int16>() { return 65535; }
+   template <> inline uint64_t getMaxUnsigned<TR::Int32>() { return ((uint32_t)0xFFFFFFFF); }
+   template <> inline uint64_t getMaxUnsigned<TR::Int64>() { return ((uint64_t)-1); }
 
-   template <> inline const int32_t getMaxSignedPrecision<TR::Int8 >() { return 3; }
-   template <> inline const int32_t getMaxSignedPrecision<TR::Int16>() { return 5; }
-   template <> inline const int32_t getMaxSignedPrecision<TR::Int32>() { return 10; }
-   template <> inline const int32_t getMaxSignedPrecision<TR::Int64>() { return 19; }
+   template <> inline int32_t getMaxSignedPrecision<TR::Int8 >() { return 3; }
+   template <> inline int32_t getMaxSignedPrecision<TR::Int16>() { return 5; }
+   template <> inline int32_t getMaxSignedPrecision<TR::Int32>() { return 10; }
+   template <> inline int32_t getMaxSignedPrecision<TR::Int64>() { return 19; }
 
-   template <> inline const int32_t getMaxUnsignedPrecision<TR::Int8 >() { return 3; }
-   template <> inline const int32_t getMaxUnsignedPrecision<TR::Int16>() { return 5; }
-   template <> inline const int32_t getMaxUnsignedPrecision<TR::Int32>() { return 10; }
-   template <> inline const int32_t getMaxUnsignedPrecision<TR::Int64>() { return 20; }
+   template <> inline int32_t getMaxUnsignedPrecision<TR::Int8 >() { return 3; }
+   template <> inline int32_t getMaxUnsignedPrecision<TR::Int16>() { return 5; }
+   template <> inline int32_t getMaxUnsignedPrecision<TR::Int32>() { return 10; }
+   template <> inline int32_t getMaxUnsignedPrecision<TR::Int64>() { return 20; }
 
 } // namespace TR
 
@@ -366,7 +366,7 @@ public:
    static TR::ILOpCodes getDataTypeConversion(TR::DataType t1, TR::DataType t2);
 
    static const char    * getName(TR::DataType dt);
-   static const int32_t   getSize(TR::DataType dt);
+   static int32_t         getSize(TR::DataType dt);
    static void            setSize(TR::DataType dt, int32_t newValue);
    static const char    * getPrefix(TR::DataType dt);
 

--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -144,9 +144,11 @@ IlBuilder::injectIL()
       return false;
 
    rc = connectTrees();
-   comp()->dumpMethodTrees("after connectTrees");
+   if (TraceEnabled)
+      comp()->dumpMethodTrees("after connectTrees");
    cfg()->removeUnreachableBlocks();
-   comp()->dumpMethodTrees("after removing unreachable blocks");
+   if (TraceEnabled)
+      comp()->dumpMethodTrees("after removing unreachable blocks");
    return rc;
    }
 

--- a/compiler/ilgen/IlBuilder.hpp
+++ b/compiler/ilgen/IlBuilder.hpp
@@ -105,6 +105,7 @@ public:
       {
       }
    IlBuilder(TR::IlBuilder *source);
+   virtual ~IlBuilder() { }
 
    void initSequence();
 

--- a/compiler/ilgen/IlGen.hpp
+++ b/compiler/ilgen/IlGen.hpp
@@ -34,6 +34,9 @@ class TR_IlGenerator
    virtual int32_t currentCallSiteIndex() { return -1; }
    virtual void setCallerMethod(TR::ResolvedMethodSymbol * caller) {}
    virtual TR::ResolvedMethodSymbol *methodSymbol() const = 0;
+
+   // contributes to eliminate warnings in JitBuilder builds
+   virtual ~TR_IlGenerator() { }
    };
 
 #endif

--- a/compiler/ilgen/IlInjector.hpp
+++ b/compiler/ilgen/IlInjector.hpp
@@ -64,6 +64,7 @@ public:
 
    IlInjector(TR::TypeDictionary *types);
    IlInjector(TR::IlInjector *source);
+   virtual ~IlInjector() { };
 
    virtual void initPrimitiveTypes();
    virtual void initialize(TR::IlGeneratorMethodDetails * details,

--- a/compiler/ilgen/MethodBuilder.hpp
+++ b/compiler/ilgen/MethodBuilder.hpp
@@ -46,6 +46,8 @@ class MethodBuilder : public TR::IlBuilder
    TR_ALLOC(TR_Memory::IlGenerator)
 
    MethodBuilder(TR::TypeDictionary *types, OMR::VirtualMachineState *vmState = NULL);
+   virtual ~MethodBuilder() { }
+
    virtual void setupForBuildIL();
 
    virtual bool injectIL();

--- a/compiler/ilgen/ThunkBuilder.hpp
+++ b/compiler/ilgen/ThunkBuilder.hpp
@@ -68,6 +68,7 @@ class ThunkBuilder : public TR::MethodBuilder
     */
    ThunkBuilder(TR::TypeDictionary *types, const char *name, TR::IlType *returnType,
                 uint32_t numCalleeParams, TR::IlType **calleeParamTypes);
+   virtual ~ThunkBuilder() { }
 
    virtual bool buildIL();
 

--- a/compiler/ilgen/TypeDictionary.cpp
+++ b/compiler/ilgen/TypeDictionary.cpp
@@ -95,6 +95,8 @@ public:
       TR::IlType(name),
       _type(type)
       { }
+   virtual ~PrimitiveType()
+      { }
 
    virtual TR::DataType getPrimitiveType()
       {
@@ -156,6 +158,8 @@ public:
       _lastField(0),
       _size(0),
       _closed(false)
+      { }
+   virtual ~StructType()
       { }
 
    TR::DataType getPrimitiveType()                 { return TR::Address; }
@@ -297,6 +301,8 @@ public:
       _closed(false),
       _symRefBV(4, trMemory),
       _trMemory(trMemory)
+      { }
+   virtual ~UnionType()
       { }
 
    TR::DataType getPrimitiveType()                 { return TR::Address; }

--- a/compiler/ilgen/TypeDictionary.hpp
+++ b/compiler/ilgen/TypeDictionary.hpp
@@ -57,6 +57,8 @@ public:
    IlType() :
       _name(0)
       { }
+   virtual ~IlType()
+      { }
 
    const char *getName() { return _name; }
    virtual char *getSignatureName();


### PR DESCRIPTION
A few small fixes for JitBuilder:
1. put some exposed ilgen tracing code under option traceIlGen
2. eliminate a bunch of compiler warnings due to const return values in OMRDataTypes.hpp.cpp
3. added virtual destructors to TR_IlGenerator, IlInjector, IlBuilder, MethodBuilder, ThunkBuilder, IlType, PointerType, StructType, UnionType
