### PR TITLE
Allow TypeDictionary reuse across compilations

### DIFF
--- a/compiler/ilgen/TypeDictionary.cpp
+++ b/compiler/ilgen/TypeDictionary.cpp
@@ -126,10 +126,11 @@ public:
 
    void cacheSymRef(TR::SymbolReference *symRef) { _symRef = symRef; }
    TR::SymbolReference *getSymRef()              { return _symRef; }
+   void clearSymRef()                            { _symRef = NULL; }
 
    TR::IlType *getType()                         { return _type; }
 
-   TR::DataType getPrimitiveType()             { return _type->getPrimitiveType(); }
+   TR::DataType getPrimitiveType()               { return _type->getPrimitiveType(); }
 
    size_t getOffset()                            { return _offset; }
 
@@ -170,6 +171,8 @@ public:
    TR::SymbolReference *getFieldSymRef(const char *name);
    bool isStruct() { return true; }
    virtual size_t getSize() { return _size; }
+
+   void clearSymRefs();
 
 protected:
    FieldInfo * findField(const char *fieldName);
@@ -284,6 +287,18 @@ StructType::getFieldSymRef(const char *fieldName)
    return (TR::IlReference *)symRef;
    }
 
+void
+StructType::clearSymRefs()
+   {
+   FieldInfo *field = _firstField;
+   while (field)
+      {
+      field->clearSymRef();
+      field = field->_next;
+      }
+   }
+
+
 class UnionType : public TR::IlType
    {
 public:
@@ -308,6 +323,8 @@ public:
    TR::SymbolReference *getFieldSymRef(const char *name);
    virtual bool isUnion() { return true; }
    virtual size_t getSize() { return _size; }
+
+   void clearSymRefs();
 
 protected:
    FieldInfo * findField(const char *fieldName);
@@ -400,6 +417,19 @@ UnionType::getFieldSymRef(const char *fieldName)
    return static_cast<TR::IlReference *>(symRef);
    }
 
+void
+UnionType::clearSymRefs()
+   {
+   FieldInfo *field = _firstField;
+   while (field)
+      {
+      field->clearSymRef();
+      field = field->_next;
+      }
+   _symRefBV.init(4, _trMemory);
+   }
+
+
 class PointerType : public TR::IlType
    {
 public:
@@ -407,8 +437,7 @@ public:
 
    PointerType(TR::IlType *baseType) :
       TR::IlType(_nameArray),
-      _baseType(baseType),
-      _symRef(0)
+      _baseType(baseType)
       {
       char *baseName = (char *)_baseType->getName();
       TR_ASSERT(strlen(baseName) < 45, "cannot store name of pointer type");
@@ -424,11 +453,8 @@ public:
 
    virtual size_t getSize() { return TR::DataType::getSize(TR::Address); }
 
-   TR::SymbolReference *getSymRef();
-
 protected:
    TR::IlType          * _baseType;
-   TR::SymbolReference * _symRef;
    char                  _nameArray[48];
    };
 
@@ -662,4 +688,23 @@ TypeDictionary::FieldReference(const char *typeName, const char *fieldName)
    TR_ASSERT(false, "No type with name `%s`", typeName);
    return NULL;
    }
+
+void
+TypeDictionary::NotifyCompilationDone()
+   {
+   // clear all symbol references for fields
+   TR_HashTabIterator structIterator(_structsByName);
+   for (StructType *aStruct = (StructType *)structIterator.getFirst();aStruct;aStruct = (StructType *)structIterator.getNext())
+      {
+      aStruct->clearSymRefs();
+      }
+
+   // clear all symbol references for union fields
+   TR_HashTabIterator unionIterator(_unionsByName);
+   for (UnionType *aUnion = (UnionType *)unionIterator.getFirst();aUnion;aUnion = (UnionType *)unionIterator.getNext())
+      {
+      aUnion->clearSymRefs();
+      }
+   }
+
 } // namespace OMR

--- a/compiler/ilgen/TypeDictionary.hpp
+++ b/compiler/ilgen/TypeDictionary.hpp
@@ -407,6 +407,11 @@ public:
       return PointerTo(toIlType<typename std::remove_pointer<T>::type>());
    }
 
+   /*
+    * @brief advise that compilation is complete so compilation-specific objects like symbol references can be cleared from caches
+    */
+   void NotifyCompilationDone();
+
 protected:
    TR::SegmentProvider *_segmentProvider;
    TR::Region *_memoryRegion;

--- a/jitbuilder/control/Jit.cpp
+++ b/jitbuilder/control/Jit.cpp
@@ -27,6 +27,7 @@
 #include "env/RawAllocator.hpp"
 #include "ilgen/IlGeneratorMethodDetails_inlines.hpp"
 #include "ilgen/MethodBuilder.hpp"
+#include "ilgen/TypeDictionary.hpp"
 #include "runtime/CodeCache.hpp"
 #include "runtime/Runtime.hpp"
 #include "runtime/JBJitConfig.hpp"
@@ -190,6 +191,7 @@ compileMethodBuilder(TR::MethodBuilder *m, uint8_t **entry)
 
    int32_t rc=0;
    *entry = compileMethodFromDetails(NULL, details, warm, rc);
+   m->typeDictionary()->NotifyCompilationDone();
    return rc;
    }
 

--- a/jitbuilder/release/src/StructArray.cpp
+++ b/jitbuilder/release/src/StructArray.cpp
@@ -186,12 +186,11 @@ main(int argc, char *argv[])
       exit(-1);
       }
 
-   printf("Step 2: define type dictionaries\n");
-   StructArrayTypeDictionary createMethodTypes;
-   StructArrayTypeDictionary readMethodTypes;
+   printf("Step 2: define type dictionary\n");
+   StructArrayTypeDictionary methodTypes;
 
    printf("Step 3: compile createMethod builder\n");
-   CreateStructArrayMethod createMethod(&createMethodTypes);
+   CreateStructArrayMethod createMethod(&methodTypes);
    uint8_t *createEntry;
    int32_t rc = compileMethodBuilder(&createMethod, &createEntry);
    if (rc != 0)
@@ -201,7 +200,7 @@ main(int argc, char *argv[])
       }
 
    printf("Step 4: compile readMethod builder\n");
-   ReadStructArrayMethod readMethod(&readMethodTypes);
+   ReadStructArrayMethod readMethod(&methodTypes);
    uint8_t *readEntry;
    rc = compileMethodBuilder(&readMethod, &readEntry);
    if (rc != 0)


### PR DESCRIPTION
TypeDictionary cannot currently be reused across multiple
compilations because it caches TR::SymbolReference pointers
for field references of struct and union types. These pointers
only have meaning in a single compilation.

This commit adds NotifyCompilationDone() to TypeDictionary
which iterates over all defined StructTypes and UnionTypes
and clears their _symRef field back to 0. It also
reinitializes the symrefBV bit vector in each UnionType.
Finally, compileMethodBuilder will call NotifyCompilationDone
on the supplied MethodBuilder's TypeDictionary just before
returning.

To test, I modified the StructArray test, which used to
allocate two identical TypeDictionaries for use to compile
two different methods, so that it reuses a single
TypeDictionary. I then ran structarray 10,000 times without
seeing any crash.

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>