### PR TITLE
Enable on-demand method lookup for JitBuilder

### DIFF
--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -1720,6 +1720,10 @@ IlBuilder::ComputedCall(const char *functionName, int32_t numArgs, ...)
    TR::IlValue **argValues = processCallArgs(_comp, numArgs, args);
    va_end(args);
    TR::ResolvedMethod *resolvedMethod = _methodBuilder->lookupFunction(functionName);
+   if (resolvedMethod == NULL && _methodBuilder->RequestFunction(functionName))
+      resolvedMethod = _methodBuilder->lookupFunction(functionName);
+   TR_ASSERT(resolvedMethod, "Could not identify function %s\n", functionName);
+
    TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateComputedStaticMethodSymbol(JITTED_METHOD_INDEX, -1, resolvedMethod);
    return genCall(methodSymRef, numArgs, argValues, false /*isDirectCall*/);
    }
@@ -1736,6 +1740,10 @@ IlBuilder::ComputedCall(const char *functionName, int32_t numArgs, TR::IlValue *
    // TODO: figure out Call REPLAY
    TraceIL("IlBuilder[ %p ]::ComputedCall %s\n", this, functionName);
    TR::ResolvedMethod *resolvedMethod = _methodBuilder->lookupFunction(functionName);
+   if (resolvedMethod == NULL && _methodBuilder->RequestFunction(functionName))
+      resolvedMethod = _methodBuilder->lookupFunction(functionName);
+   TR_ASSERT(resolvedMethod, "Could not identify function %s\n", functionName);
+
    TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateComputedStaticMethodSymbol(JITTED_METHOD_INDEX, -1, resolvedMethod);
    return genCall(methodSymRef, numArgs, argValues, false /*isDirectCall*/);
    }
@@ -1750,6 +1758,10 @@ IlBuilder::Call(const char *functionName, int32_t numArgs, ...)
    TR::IlValue **argValues = processCallArgs(_comp, numArgs, args);
    va_end(args);
    TR::ResolvedMethod *resolvedMethod = _methodBuilder->lookupFunction(functionName);
+   if (resolvedMethod == NULL && _methodBuilder->RequestFunction(functionName))
+      resolvedMethod = _methodBuilder->lookupFunction(functionName);
+   TR_ASSERT(resolvedMethod, "Could not identify function %s\n", functionName);
+
    TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateStaticMethodSymbol(JITTED_METHOD_INDEX, -1, resolvedMethod);
    return genCall(methodSymRef, numArgs, argValues);
    }
@@ -1760,6 +1772,10 @@ IlBuilder::Call(const char *functionName, int32_t numArgs, TR::IlValue ** argVal
    // TODO: figure out Call REPLAY
    TraceIL("IlBuilder[ %p ]::Call %s\n", this, functionName);
    TR::ResolvedMethod *resolvedMethod = _methodBuilder->lookupFunction(functionName);
+   if (resolvedMethod == NULL && _methodBuilder->RequestFunction(functionName))
+      resolvedMethod = _methodBuilder->lookupFunction(functionName);
+   TR_ASSERT(resolvedMethod, "Could not identify function %s\n", functionName);
+
    TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateStaticMethodSymbol(JITTED_METHOD_INDEX, -1, resolvedMethod);
    return genCall(methodSymRef, numArgs, argValues);
    }

--- a/compiler/ilgen/MethodBuilder.hpp
+++ b/compiler/ilgen/MethodBuilder.hpp
@@ -121,6 +121,14 @@ class MethodBuilder : public TR::IlBuilder
                        TR::IlType     ** parmTypes);
 
    /**
+    * @brief will be called if a Call is issued to a function that has not yet been defined, provides a
+    *        mechanism for MethodBuilder subclasses to provide method lookup on demand rather than all up
+    *        front via the constructor.
+    * @returns true if the function was found and DefineFunction has been called for it, otherwise false
+    */
+   virtual bool RequestFunction(const char *name) { return false; }
+
+   /**
     * @brief append the first bytecode builder object to this method
     * @param builder the bytecode builder object to add, usually for bytecode index 0
     * A side effect of this call is that the builder is added to the worklist so that

--- a/jitbuilder/release/src/Switch.cpp
+++ b/jitbuilder/release/src/Switch.cpp
@@ -46,6 +46,22 @@ SwitchMethod::SwitchMethod(TR::TypeDictionary *d)
    DefineParameter("selector", Int32);
 
    DefineReturnType(NoType);
+   }
+
+/**
+ * Example to show how RequestFunction can be used to define functions
+ * on demand, rather than up front. A perfectly viable approach (especially
+ * in this sample) would be to call DefineFunction in the MethodBuilder's
+ * constructor. But it is also possible to implement RequestFunction in
+ * a MethodBuilder subclass to define functions when they are first called.
+ * Typically used in JIT compilers rather than examples like this where
+ * "printString" is always going to be called anyway.
+ */
+bool
+SwitchMethod::RequestFunction(const char *name)
+   {
+   if (strncmp(name, "printString", 12) != 0)
+      return false;
 
    DefineFunction((char *)"printString", 
                   (char *)__FILE__,
@@ -54,6 +70,8 @@ SwitchMethod::SwitchMethod(TR::TypeDictionary *d)
                   NoType,
                   1,
                   Int64);
+
+   return true;
    }
 
 void

--- a/jitbuilder/release/src/Switch.hpp
+++ b/jitbuilder/release/src/Switch.hpp
@@ -34,6 +34,8 @@ class SwitchMethod : public TR::MethodBuilder
    public:
    SwitchMethod(TR::TypeDictionary *);
    virtual bool buildIL();
+
+   virtual bool RequestFunction(const char *name);
    };
 
 #endif // !defined(SWITCH_INCL)


### PR DESCRIPTION
Currently if JitBuilder clients want to Call a function using either
Call or ComputedCall, that function must have been described to
JitBuilder via the DefineFunction call on the MethodBuilder object.
All Calls lookup the function name provided and will fail to call it
if DefineFunction has not yet been called. The only way to make sure
the function has been defined is to make sure you call it yourself
before that function name is called.

This commit adds one check inside the Call services so that, if the
first lookup fails, it will call a virtual instance on MethodBuilder
called RequestFunction. Clients can implement this instance function
in their subclass of MethodBuilder to locate and call DefineFunction
for the requested function name. When RequestFunction() comes back,
the Call service will try to look the function up again and will
proceed if it has now been defined. This approach frees JitBuilder
clients from having to define all possible functions up front, which
may not be practical. Instead, required functions can be defined
on demand.

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>