### PR TITLE
Enhance the Linter to detect accidental upcasts

### DIFF
--- a/compiler/il/symbol/OMRStaticSymbol.cpp
+++ b/compiler/il/symbol/OMRStaticSymbol.cpp
@@ -23,6 +23,12 @@
 #include "il/symbol/LabelSymbol.hpp"   // for LabelSymbol
 #include "il/symbol/StaticSymbol.hpp"  // for StaticSymbolBase, etc
 
+TR::StaticSymbol*
+OMR::StaticSymbol::self()
+   {
+   return static_cast<TR::StaticSymbol*>(this);
+   }
+
 template <typename AllocatorType>
 TR::StaticSymbol * OMR::StaticSymbol::create(AllocatorType m, TR::DataType d)
    {

--- a/compiler/il/symbol/OMRStaticSymbol.hpp
+++ b/compiler/il/symbol/OMRStaticSymbol.hpp
@@ -46,6 +46,8 @@ namespace OMR
  */
 class OMR_EXTENSIBLE StaticSymbol : public TR::Symbol
    {
+protected:
+   TR::StaticSymbol* self();
 
 public:
 

--- a/tools/compiler/OMRChecker/Makefile
+++ b/tools/compiler/OMRChecker/Makefile
@@ -41,11 +41,11 @@ CLANG       ?= clang++
 CXX       	?= g++
 PYTHON      ?= python2
 
-LDFLAGS   	:= -shared `$(LLVM_CONFIG) --ldflags`
+LDFLAGS   	:= -shared `$(LLVM_CONFIG) --ldflags` 
 
 # Clang headers are producing strict aliasing warnings swamping
 # all other output. 
-CXXFLAGS  	:= `$(LLVM_CONFIG) --cxxflags` -Wno-strict-aliasing
+CXXFLAGS  	:= `$(LLVM_CONFIG) --cxxflags` -std=c++0x -Wno-strict-aliasing 
 
 #
 # Build rules
@@ -53,7 +53,7 @@ CXXFLAGS  	:= `$(LLVM_CONFIG) --cxxflags` -Wno-strict-aliasing
 $(OMRCHECKER_OBJECT): $(CHECKER_O)
 	$(CXX) $(LDFLAGS) -o $@ $^
 
-$(CHECKER_O): $(CHECKER_CPP) $(CHECKER_HPP)
+$(CHECKER_O): $(CHECKER_CPP) $(CHECKER_HPP) 
 	$(CXX) $(CXXFLAGS) -c -o $@ $<
 
 #

--- a/tools/compiler/OMRChecker/Makefile
+++ b/tools/compiler/OMRChecker/Makefile
@@ -42,7 +42,10 @@ CXX       	?= g++
 PYTHON      ?= python2
 
 LDFLAGS   	:= -shared `$(LLVM_CONFIG) --ldflags`
-CXXFLAGS  	:= `$(LLVM_CONFIG) --cxxflags` -std=c++0x
+
+# Clang headers are producing strict aliasing warnings swamping
+# all other output. 
+CXXFLAGS  	:= `$(LLVM_CONFIG) --cxxflags` -Wno-strict-aliasing
 
 #
 # Build rules

--- a/tools/compiler/OMRChecker/OMRChecker.hpp
+++ b/tools/compiler/OMRChecker/OMRChecker.hpp
@@ -245,9 +245,10 @@ private:
 class ExtensibleClassCheckingVisitor : public RecursiveASTVisitor<ExtensibleClassCheckingVisitor> {
 public:
    explicit ExtensibleClassCheckingVisitor(ASTContext *Context, ExtensibleClassDiscoveryVisitor &extensible) :
+      currentPass(1),
+      passNumber(),
       Extensible(extensible),
-      Context(Context),
-      currentPass(1)
+      Context(Context)
    { }
 
    /**

--- a/tools/compiler/OMRChecker/OMRChecker.hpp
+++ b/tools/compiler/OMRChecker/OMRChecker.hpp
@@ -36,6 +36,7 @@
 #include "clang/Frontend/FrontendPluginRegistry.h"
 #include "clang/AST/AST.h"
 #include "clang/AST/ASTConsumer.h"
+#include "clang/AST/ASTTypeTraits.h"
 #include "clang/AST/Attr.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/AST/RecursiveASTVisitor.h"
@@ -150,7 +151,11 @@ namespace OMRChecker {
 
    static CXXThisExpr* getThisExpr(Expr*);
 
-#define trace(x) if (getenv("OMR_CHECK_TRACE")) { llvm::errs() << x << "\n"; }
+#define trace(x) \
+   if (getenv("OMR_CHECK_TRACE")) {\
+      llvm::errs() << __FUNCTION__ << ":" << __LINE__ << ":  "; \
+      llvm::errs() << x << "\n"; \
+   }
 
 /**
  * Extensible Class discovery visitor.
@@ -653,8 +658,6 @@ private:
     */
    std::map<CXXRecordDecl*, bool> Types;
 
-
-
    /**
     * The most derived type map.
     */
@@ -681,6 +684,18 @@ public:
    explicit OMRThisCheckingVisitor(ASTContext *Context, OMRClassCheckingVisitor *ClassChecker) : Context(Context), ClassChecker(ClassChecker) {
    }
 
+
+   /**
+    * Record the last seen CXXMethodDecl to determine containment
+    *
+    * Warning: This appears to work, **however** this visitor work 
+    *          by executing callbacks in pre-order.
+    */ 
+   bool VisitCXXMethodDecl(CXXMethodDecl* decl) {
+      lastSeenMethodDecl = decl;
+      return true;
+   }
+
    bool VisitCallExpr(CallExpr *call) {
       if (!isStaticExtensibleMemberCall(call)) {
          return true;
@@ -704,16 +719,30 @@ public:
    }
 
    bool VisitCXXMemberCallExpr(CXXMemberCallExpr *call) {
-      //TODO: Check that this member call expression is inside of an extensible class!
       if (!isExtensibleMemberCall(call)) {
+         trace("Call isn't an Extensible Member Call" << call);
          return true;
       }
-
       Expr *receiver = call->getImplicitObjectArgument()->IgnoreParenImpCasts();
 
       if (receiver->isImplicitCXXThis()) {
+         trace("Reciever is implicit this");
          // Don't diagnose implicit this recievers that are calling self.
-         if (!isSelfCall(call)) {
+         if (isSelfCall(call)) { 
+            trace("callee is self()");
+            // Need still to verify that the self() call is to the right reciever! Otherwise 
+            // we can pass upcasts in the case where we have an extensible class hierarchy
+            // deriving from an extensible class hierarchy. 
+            if (isCorrectSelf(call)) {
+               trace("callee is correct self()");
+               return true;
+            } else { 
+               DiagnosticsEngine &diagEngine = Context->getDiagnostics();
+               unsigned diagID = diagEngine.getCustomDiagID(DiagnosticsEngine::Error,
+                                                            "self call is resolving outside the current extensible class. You probably didn't define self() in all extensible OMR layers.");
+               diagEngine.Report(call->getExprLoc(), diagID);
+            }
+         } else { 
             // Ignore member function calls that specifically call a base class member function
             MemberExpr * memberFunc;
             // hasQualifier checks for a nested name specifier, e.g. the 'IBM::Foo::' part of 'IBM::Foo::baz()'
@@ -727,8 +756,8 @@ public:
             builder.AddFixItHint(FixItHint::CreateInsertion(receiver->getExprLoc(), staticCastHint));
          }
       } else if (isa<CXXStaticCastExpr>(receiver)) {
-         CXXStaticCastExpr *cast = dyn_cast<CXXStaticCastExpr>(receiver);
-         CXXRecordDecl *targetClass = cast->getType()->getAs<PointerType>() ? cast->getType()->getAs<PointerType>()->getPointeeType()->getAsCXXRecordDecl()->getCanonicalDecl() : NULL;
+         CXXStaticCastExpr *cast        = dyn_cast<CXXStaticCastExpr>(receiver);
+         CXXRecordDecl *targetClass     = cast->getType()->getAs<PointerType>() ?  cast->getType()->getAs<PointerType>()->getPointeeType()->getAsCXXRecordDecl()->getCanonicalDecl() : NULL;
          trace("targetClass of static cast" << (targetClass ? targetClass->getQualifiedNameAsString() : "NULL" ) );
          CXXThisExpr *thisExpr = getThisExpr(cast->getSubExpr());
          if (thisExpr) {
@@ -741,7 +770,8 @@ public:
                   DiagnosticBuilder builder = diagEngine.Report(cast->getExprLoc(), diagID);
                   std::string staticCastHint = "self()->";
                   builder.AddFixItHint(FixItHint::CreateReplacement(cast->getExprLoc(), staticCastHint));
-               } else {  // Static cast is correct, but we want a warning.
+               } else {
+                  // Static cast is correct, but, we want a warning.
                   DiagnosticsEngine &diagEngine = Context->getDiagnostics();
                   unsigned diagID = diagEngine.getCustomDiagID(DiagnosticsEngine::Warning, "extensible class dereference prefers calls to self()");
                   DiagnosticBuilder builder = diagEngine.Report(cast->getExprLoc(), diagID);
@@ -777,6 +807,77 @@ public:
       std::string name = nameInfo.getName().getAsString();
       std::string prefix("self");
       return !name.compare(0, prefix.size(), prefix);
+   }
+
+
+   const CXXMethodDecl* getCallerDecl(const clang::Stmt* expr) {
+      return lastSeenMethodDecl; 
+   }
+
+   /**
+    * Return true iff the call is to self, **and** the self call is 
+    * within the correct extensible class string. 
+    *
+    * The correct call depends on what member function we are inside of.
+    *
+    */
+   bool isCorrectSelf(CXXMemberCallExpr *call) { 
+      // This is the callled method decl -- Should be self of one form or another, verified by isSelfCall. 
+      CXXMethodDecl* calleeDecl = call->getMethodDecl();
+      if (!calleeDecl) {
+         trace("Didn't find callee decl. Assuming not correct self call");
+         return false;
+      }
+
+      // This is the class that defines the callee method -- so where self() is defined. 
+      CXXRecordDecl* calleeClassDecl  = calleeDecl->getParent(); 
+      if (!calleeClassDecl) {
+         trace("Didn't find callee class decl. Assuming not correct self call");
+         return false;
+      }
+
+      // Most derived type of the callee. 
+      const CXXRecordDecl* calleeMostDerived = ClassChecker->mostDerivedType(calleeClassDecl); 
+      if (!calleeMostDerived) {
+         trace("Didn't find a most derived type for the callee class. Assuming not correct self call");
+         return false;
+      }
+
+      // This is the method we're analyzing.
+      const CXXMethodDecl* callerMethod = getCallerDecl(call); 
+      if (!callerMethod) {
+         trace("Didn't find a caller method... Assuming not correct self call. Call node: ");
+         call->dump();
+         return false;
+      }
+
+      // This is the class that is making the call (caller) 
+      const CXXRecordDecl* callerDecl = callerMethod->getParent(); 
+      if (!calleeMostDerived) {
+         trace("Didn't didn't find the caller method decl. Assuming not correct self call");
+         return false;
+      }
+
+      // Most dervied type of the caller 
+      const CXXRecordDecl* callerMostDerived = ClassChecker->mostDerivedType(callerDecl);
+     
+      if (getenv("OMR_CHECK_TRACE")) {
+         llvm::errs() << "isCorrectSelf: BestDynamicClassType => ";
+         call->getBestDynamicClassType()->printQualifiedName(llvm::errs());
+         llvm::errs() << "\n";
+
+         llvm::errs() << "isCorrectSelf: calleeDecl            => " << calleeDecl->getQualifiedNameAsString()  << "\n";
+         llvm::errs() << "isCorrectSelf: calleeClassDecl       => " << calleeClassDecl->getQualifiedNameAsString()   << "\n";
+         llvm::errs() << "isCorrectSelf: calleeMostDerived     => " << calleeMostDerived->getQualifiedNameAsString()   << "\n";
+         llvm::errs() << "\n";
+         llvm::errs() << "isCorrectSelf: callerDecl      => " << (callerDecl ? callerDecl->getQualifiedNameAsString() : "NULL")   << "\n";
+         llvm::errs() << "isCorrectSelf: callerMostDerived => " << (callerMostDerived ? callerMostDerived->getQualifiedNameAsString() : "NULL")   << "\n";
+      }
+   
+      if (calleeMostDerived == callerMostDerived && calleeMostDerived != NULL) 
+         return true; 
+      else
+         return false;
    }
 
    /**
@@ -832,10 +933,11 @@ private:
       return ClassChecker->isExtensible(decl);
    }
 
-   //const NamedDecl * getNamedDecl(
-
    ASTContext *Context;
    OMRClassCheckingVisitor *ClassChecker;
+   
+   /* To determine containment */
+   const CXXMethodDecl* lastSeenMethodDecl;
 };
 
 class OMRCheckingConsumer : public ASTConsumer {
@@ -931,7 +1033,6 @@ static CXXThisExpr *getThisExpr(Expr *E) {
      if (ImplicitCastExpr *ICE = dyn_cast<ImplicitCastExpr>(E)) {
        if (ICE->getCastKind() == CK_NoOp ||
            ICE->getCastKind() == CK_LValueToRValue ||
-           ICE->getCastKind() == CK_DerivedToBase ||
            ICE->getCastKind() == CK_UncheckedDerivedToBase) {
          E = ICE->getSubExpr();
          continue;

--- a/tools/compiler/OMRChecker/OMRChecker.hpp
+++ b/tools/compiler/OMRChecker/OMRChecker.hpp
@@ -727,10 +727,10 @@ public:
 
       if (receiver->isImplicitCXXThis()) {
          trace("Reciever is implicit this");
-         // Don't diagnose implicit this recievers that are calling self.
+         // Don't diagnose implicit this receivers that are calling self.
          if (isSelfCall(call)) { 
             trace("callee is self()");
-            // Need still to verify that the self() call is to the right reciever! Otherwise 
+            // Need still to verify that the self() call is to the right receiver! Otherwise 
             // we can pass upcasts in the case where we have an extensible class hierarchy
             // deriving from an extensible class hierarchy. 
             if (isCorrectSelf(call)) {
@@ -822,7 +822,7 @@ public:
     *
     */
    bool isCorrectSelf(CXXMemberCallExpr *call) { 
-      // This is the callled method decl -- Should be self of one form or another, verified by isSelfCall. 
+      // This is the called method decl -- Should be self of one form or another, verified by isSelfCall. 
       CXXMethodDecl* calleeDecl = call->getMethodDecl();
       if (!calleeDecl) {
          trace("Didn't find callee decl. Assuming not correct self call");
@@ -889,15 +889,15 @@ public:
    bool isExtensibleMemberCall(CXXMemberCallExpr* call) {
       // > Retrieves the implicit object argument for the member call.
       // > For example, in "x.f(5)", this returns the sub-expression "x".
-      Expr*             reciever = call->getImplicitObjectArgument()->IgnoreParenImpCasts();
+      Expr*             receiver = call->getImplicitObjectArgument()->IgnoreParenImpCasts();
 
       if (getenv("OMR_CHECK_TRACE")) {
          llvm::errs() << "BestDynamicClassType => ";
-         reciever->getBestDynamicClassType()->printQualifiedName(llvm::errs());
+         receiver->getBestDynamicClassType()->printQualifiedName(llvm::errs());
          llvm::errs() << "\n";
       }
 
-      return isExtensible(reciever->getBestDynamicClassType());
+      return isExtensible(receiver->getBestDynamicClassType());
    }
 
    /**

--- a/tools/compiler/OMRChecker/testing/input/bad/doubleExtension.cpp
+++ b/tools/compiler/OMRChecker/testing/input/bad/doubleExtension.cpp
@@ -1,0 +1,58 @@
+/*******************************************************************************
+*
+* (c) Copyright IBM Corp. 2017, 2017
+*
+*  This program and the accompanying materials are made available
+*  under the terms of the Eclipse Public License v1.0 and
+*  Apache License v2.0 which accompanies this distribution.
+*
+*      The Eclipse Public License is available at
+*      http://www.eclipse.org/legal/epl-v10.html
+*
+*      The Apache License v2.0 is available at
+*      http://www.opensource.org/licenses/apache2.0.php
+*
+* Contributors:
+*    Multiple authors (IBM Corp.) - initial implementation and documentation
+*******************************************************************************/
+
+
+/**
+ * Description: An extensible class inheriting from another: 
+ *      Using self() in the second class before the concrete 
+ *      class is created should be a failure. 
+ */
+#define OMR_EXTENSIBLE __attribute__((annotate("OMR_Extensible")))
+
+namespace TR { class Class1Ext; } 
+namespace OMR
+{
+   class OMR_EXTENSIBLE Class1Ext {
+      public:
+      TR::Class1Ext* self(); 
+   };
+}
+/* Export to TR Namespace */ 
+namespace TR  { class OMR_EXTENSIBLE Class1Ext : public OMR::Class1Ext {}; }
+
+// Declare self function. 
+TR::Class1Ext* OMR::Class1Ext::self() { return static_cast<TR::Class1Ext*>(this);  }
+
+
+namespace TR { class Class3Ext; } 
+namespace OMR
+{
+   class OMR_EXTENSIBLE Class3Ext : public TR::Class1Ext {
+      public:
+//      TR::Class3Ext* self();  // Missed self, means below Self call is an upcast!
+      bool foo() {
+         // Assignment here to ensure the linter has to see through assignment VarDecls to find the caller.
+         bool x = (self() == (void*)0x124);
+         return x;
+      } 
+   };
+}
+
+namespace TR  { class OMR_EXTENSIBLE Class3Ext : public OMR::Class3Ext {}; }
+
+


### PR DESCRIPTION
In an extensible class hierarchy, it is important that each class in the OMR layer define the downcast function `self()`. Normally, missing this would cause a compilation failure.

However, if you have an extensible class hierarchy inheriting from another, there is another possible problem that until this PR, it hasn't  been detected: If the derived extensible class hierarchy never defines `self`, then `self()` will resolve to the parent hierarchy, making it an upcast rather than a downcast.

This PR fixes the only known issue of this type (`OMR::StaticSymbol`) , and enhances the linter to detect this kind of error
