### PR TITLE
Fix JitBuilder broken recursive method name test

### DIFF
--- a/compiler/ilgen/MethodBuilder.cpp
+++ b/compiler/ilgen/MethodBuilder.cpp
@@ -380,7 +380,8 @@ MethodBuilder::lookupFunction(const char *name)
    TR_HashId functionsID;
    if (! _functions->locate(name, functionsID))
       {
-      if (strncmp(_methodName, name, strlen(_methodName)) == 0)
+      size_t len = strlen(name);
+      if (len == strlen(_methodName) && strncmp(_methodName, name, len) == 0)
          return static_cast<TR::ResolvedMethod *>(_methodSymbol->getResolvedMethod());
       return NULL;
       }


### PR DESCRIPTION
Hugely silly test to check for a recursive call to the function
being compiled only used strncmp (with the length of the current
function) without also checking that the name to lookup has the same
length as the current method's name (oops). So looking up "mandelhelp"
would actually short circuit the lookup if you were compiling "mandel"
because, well, the substring matched :( . Unanticipated recursions ensue...

This commit adds a first check that the names have the same
length before using strncmp with one of the string's lengths.

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>