### PR TITLE
Add opcode ibyteswap and X86 evaluator

### DIFF
--- a/compiler/arm/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/arm/codegen/TreeEvaluatorTable.hpp
@@ -917,4 +917,6 @@
 	TR::TreeEvaluator::longNumberOfTrailingZeros,
 	TR::TreeEvaluator::longBitCount,
 
+   TR::TreeEvaluator::unImpOpEvaluator,                 // TR::ibyteswap
+
    TR::TreeEvaluator::NOPEvaluator,         // Temporarily using for TR::Prefetch

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1038,6 +1038,21 @@ OMR::CodeGenerator::getSupportsTLE()
    return self()->getSupportsTM();
    }
 
+/** \brief
+ *     A query about whether ibyteswap is supported
+ *
+ *  \return
+ *     True if ibyteswap is supported in codegen
+ *
+ *  \note
+ *     Override the query on the platform where ibyteswap is implemented
+ */
+bool
+OMR::CodeGenerator::getSupportsIbyteswap()
+   {
+   return false;
+   }
+
 bool
 OMR::CodeGenerator::getSupportsConstantOffsetInAddressing(int64_t value)
    {

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1533,6 +1533,8 @@ class OMR_EXTENSIBLE CodeGenerator
 
    virtual bool getSupportsTLE();
 
+   virtual bool getSupportsIbyteswap();
+
    bool getSupportsAutoSIMD() { return _flags4.testAny(SupportsAutoSIMD);}
    void setSupportsAutoSIMD() { _flags4.set(SupportsAutoSIMD);}
 

--- a/compiler/il/ILOpCodeProperties.hpp
+++ b/compiler/il/ILOpCodeProperties.hpp
@@ -10937,6 +10937,21 @@
    },
 
    {
+   /* .opcode               = */ TR::ibyteswap,
+   /* .name                 = */ "ibyteswap",
+   /* .properties1          = */ 0,
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::ByteSwap,
+   /* .properties3          = */ 0,
+   /* .properties4          = */ 0,
+   /* .dataType             = */ TR::Int32,
+   /* .typeProperties       = */ ILTypeProp::Size_4 | ILTypeProp::Integer,
+   /* .swapChildrenOpCode   = */ TR::BadILOp,
+   /* .reverseBranchOpCode  = */ TR::BadILOp,
+   /* .booleanCompareOpCode = */ TR::BadILOp,
+   /* .ifCompareOpCode      = */ TR::BadILOp,
+   },
+
+   {
    /* .opcode               = */ TR::Prefetch,
    /* .name                 = */ "Prefetch",
    /* .properties1          = */ ILProp1::TreeTop | ILProp1::HasSymbolRef,

--- a/compiler/il/ILProps.hpp
+++ b/compiler/il/ILProps.hpp
@@ -119,7 +119,7 @@ namespace ILProp2
       New                          = 0x00800000, // object allocation opcodes
       ZeroExtension                = 0x01000000,
       SignExtension                = 0x02000000,
-      // Available                 = 0x04000000,
+      ByteSwap                     = 0x04000000,
       // Available                 = 0x08000000,
       // Available                 = 0x10000000,
       // Available                 = 0x20000000,

--- a/compiler/il/OMRILOpCodesEnum.hpp
+++ b/compiler/il/OMRILOpCodesEnum.hpp
@@ -822,6 +822,8 @@
    lnotz,
    lpopcnt,
 
+   ibyteswap,// swap bytes in an integer
+
    Prefetch, // Prefetch
 
 

--- a/compiler/optimizer/OMRSimplifierTableEnum.hpp
+++ b/compiler/optimizer/OMRSimplifierTableEnum.hpp
@@ -114,6 +114,7 @@
    bnegSimplifier,          // TR::bneg
    snegSimplifier,          // TR::sneg
 
+
    iabsSimplifier,           // TR::iabs
    labsSimplifier,           // TR::labs
    dftSimplifier,            // TR::fabs   todo
@@ -796,6 +797,8 @@
    dftSimplifier, //TR::lnolz
    dftSimplifier, //TR::lnotz
    dftSimplifier, //TR::lpopcnt
+
+   dftSimplifier,            // TR::ibyteswap
 
    dftSimplifier,           // TR::Prefetch
 

--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -938,6 +938,8 @@ const ValuePropagationPtr constraintHandlers[] =
 	constrainLongNumberOfTrailingZeros,
 	constrainLongBitCount,
 
+   constrainChildren,           // TR::ibyteswap
+
    constrainChildren,        // TR::Prefetch
 
 #ifdef J9_PROJECT_SPECIFIC

--- a/compiler/p/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/TreeEvaluatorTable.hpp
@@ -747,4 +747,5 @@
    TR::TreeEvaluator::longNumberOfLeadingZeros,         // TR::lnolz (J9)
    TR::TreeEvaluator::longNumberOfTrailingZeros,        // TR::lnotz (J9)
    TR::TreeEvaluator::longBitCount,                     // TR::lpopcnt (J9)
+   TR::TreeEvaluator::unImpOpEvaluator,                 // TR::ibyteswap
    TR::TreeEvaluator::PrefetchEvaluator,                // TR::Prefetch

--- a/compiler/x/amd64/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/x/amd64/codegen/TreeEvaluatorTable.hpp
@@ -746,4 +746,5 @@
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::lnolz (J9)
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::lnotz (J9)
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::lpopcnt (J9)
+   TR::TreeEvaluator::ibyteswapEvaluator,                  // TR::ibyteswap
    TR::TreeEvaluator::PrefetchEvaluator,                // TR::Prefetch

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1025,6 +1025,12 @@ OMR::X86::CodeGenerator::getSupportsEncodeUtf16BigWithSurrogateTest()
    }
 
 bool
+OMR::X86::CodeGenerator::getSupportsIbyteswap()
+   {
+   return true;
+   }
+
+bool
 OMR::X86::CodeGenerator::supportsMergingOfHCRGuards()
    {
    return self()->getSupportsVirtualGuardNOPing() &&

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -293,6 +293,8 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    bool getSupportsEncodeUtf16LittleWithSurrogateTest();
    bool getSupportsEncodeUtf16BigWithSurrogateTest();
 
+   virtual bool getSupportsIbyteswap();
+
    bool supportsMergingOfHCRGuards();
 
    bool supportsAtomicAdd()                {return true;}

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -5240,3 +5240,16 @@ OMR::X86::TreeEvaluator::VMifArrayCmpEvaluator(TR::Node*, TR::CodeGenerator*)
    {
    return 0;
    }
+
+TR::Register *
+OMR::X86::TreeEvaluator::ibyteswapEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   TR_ASSERT(node->getNumChildren() == 1, "Wrong number of children in byteswapEvaluator");
+   TR::Node *child = node->getFirstChild();
+   bool nodeIs64Bit = TR::TreeEvaluator::getNodeIs64Bit(child, cg);
+   TR::Register *target = TR::TreeEvaluator::intOrLongClobberEvaluate(child, nodeIs64Bit, cg);
+   generateRegInstruction(BSWAPReg(nodeIs64Bit), node, target, cg);
+   node->setRegister(target);
+   cg->decReferenceCount(child);
+   return target;
+   }

--- a/compiler/x/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.hpp
@@ -230,6 +230,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *compressStringEvaluator(TR::Node *node, TR::CodeGenerator *cg, bool japaneseMethod);
    static TR::Register *compressStringNoCheckEvaluator(TR::Node *node, TR::CodeGenerator *cg, bool japaneseMethod);
    static TR::Register *andORStringEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *ibyteswapEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *PrefetchEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *BBStartEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *BBEndEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/x/i386/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/x/i386/codegen/TreeEvaluatorTable.hpp
@@ -749,4 +749,5 @@
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::lnolz (J9)
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::lnotz (J9)
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::lpopcnt (J9)
+   TR::TreeEvaluator::ibyteswapEvaluator,                  // TR::ibyteswap
    TR::TreeEvaluator::PrefetchEvaluator,                // TR::Prefetch

--- a/compiler/z/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/z/codegen/TreeEvaluatorTable.hpp
@@ -803,5 +803,7 @@
    TR::TreeEvaluator::longNumberOfTrailingZeros,         // TR::lnotz (J9)
    TR::TreeEvaluator::longBitCount,                      // TR::lpopcnt
 
+   TR::TreeEvaluator::unImpOpEvaluator,     // TR::ibyteswap
+
    TR::TreeEvaluator::PrefetchEvaluator,    // TR::Prefetch
 

--- a/fvtest/compilertest/tests/OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/OpCodesTest.cpp
@@ -158,6 +158,7 @@ TR::DataType OpCodesTest::_argTypesBinaryAddressFloat[_numberOfBinaryArgs] = {TR
 TR::DataType OpCodesTest::_argTypesBinaryAddressDouble[_numberOfBinaryArgs] = {TR::Address, TR::Double};
 TR::DataType OpCodesTest::_argTypesBinaryAddressAddress[_numberOfBinaryArgs] = {TR::Address, TR::Address};
 
+signatureCharI_I_testMethodType  * OpCodesTest::_iByteswap = 0;
 //Neg
 signatureCharB_B_testMethodType  * OpCodesTest::_bNeg = 0;
 signatureCharS_S_testMethodType  * OpCodesTest::_sNeg = 0;

--- a/fvtest/compilertest/tests/OpCodesTest.hpp
+++ b/fvtest/compilertest/tests/OpCodesTest.hpp
@@ -290,6 +290,7 @@ class OpCodesTest : public TestDriver
    static const uintptrj_t ADDRESS_PLACEHOLDER_3;
 
    protected:
+   static signatureCharI_I_testMethodType *_iByteswap;
    //Neg
    static signatureCharB_B_testMethodType *_bNeg;
    static signatureCharS_S_testMethodType *_sNeg;
@@ -692,6 +693,13 @@ class OpCodesTest : public TestDriver
    static TR::DataType _argTypesBinaryAddressAddress[_numberOfBinaryArgs];
 
    // straight C(++) implementations of testMethodType for initial test validation purposes
+   uint16_t byteswap(uint16_t a) { return (((a & 0xff) << 8) | ((a & 0xff00) >> 8));}
+   uint32_t byteswap(uint32_t a) { return (uint32_t)byteswap(uint16_t(a & 0xffff)) << 16 | (uint32_t)byteswap(uint16_t((a >> 16) & 0xffff)); }
+   uint64_t byteswap(uint64_t a) { return (uint64_t)byteswap(uint32_t(a & 0xffffffff)) << 32 | (uint64_t)byteswap(uint32_t((a >> 32) & 0xffffffff)); }
+   int16_t byteswap(int16_t a) { return byteswap((uint16_t)a); }
+   int32_t byteswap(int32_t a) { return byteswap((uint32_t)a); }
+   int64_t byteswap(int64_t a) { return byteswap((uint64_t)a); }
+
    template <typename T> static T neg(T a) { return -a;}
    template <typename T> static T abs(T a) { return a >= (T) 0 ? a : -a;}
 

--- a/fvtest/compilertest/tests/X86OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/X86OpCodesTest.cpp
@@ -135,6 +135,7 @@ X86OpCodesTest::compileUnaryTestMethods()
    _su2l = (unsignedSignatureCharS_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2l, "su2l", _argTypesUnaryShort, TR::Int64, rc));
    _su2f = (unsignedSignatureCharS_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2f, "su2f", _argTypesUnaryShort, TR::Float, rc));
    _su2d = (unsignedSignatureCharS_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2d, "su2d", _argTypesUnaryShort, TR::Double, rc));
+   _iByteswap = (signatureCharI_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::ibyteswap, "iByteswap", _argTypesUnaryInt, TR::Int32, rc));
 }
 
 void
@@ -1730,6 +1731,7 @@ X86OpCodesTest::invokeUnaryTests()
    uint32_t testCaseNum = 0;
    char resolvedMethodName [RESOLVED_METHOD_NAME_LENGTH];
 
+   signatureCharI_I_testMethodType * iUnaryCons = 0;
    signatureCharS_S_testMethodType * sUnaryCons = 0;
    signatureCharB_B_testMethodType * bUnaryCons = 0;
    signatureCharJ_J_testMethodType  *lUnaryCons = 0;
@@ -2129,6 +2131,17 @@ X86OpCodesTest::invokeUnaryTests()
       iu2lConst = (unsignedSignatureCharI_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iu2l,
             resolvedMethodName, _argTypesUnaryInt, TR::Int64, rc, 2, 1, &uintDataArray[i]));
       OMR_CT_EXPECT_EQ(iu2lConst, convert(uintDataArray[i], LONG_POS), iu2lConst(INT_PLACEHOLDER_1));
+      }
+
+   //ibyteswap
+   testCaseNum = sizeof(intDataArray) / sizeof(intDataArray[0]);
+   for (uint32_t i = 0; i < testCaseNum; ++i)
+      {
+      OMR_CT_EXPECT_EQ(_iByteswap, byteswap(intDataArray[i]), _iByteswap(intDataArray[i]));
+      sprintf(resolvedMethodName, "iByteswapConst%d", i + 1);
+      iUnaryCons = (signatureCharI_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::ibyteswap,
+            resolvedMethodName, _argTypesUnaryInt, TR::Int32, rc, 2, 1, &intDataArray[i]));
+      OMR_CT_EXPECT_EQ(iUnaryCons, byteswap(intDataArray[i]), iUnaryCons(INT_PLACEHOLDER_1));
       }
    }
 


### PR DESCRIPTION
Add ibyteswap opcode to reverse the byte order of a 32-bit integer:
bits 0 to 7 are swapped with bits 24 to 31, and bit 8 to 15 are swapped
with bits 16 to 23. An X86 evaluator is also added in this change.

Signed-off-by: liqunl <liqunl@ca.ibm.com>