### PR TITLE
Remove the initialized check on a class

### DIFF
--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -2072,6 +2072,7 @@ TR::Node *constrainIaload(OMR::ValuePropagation *vp, TR::Node *node)
             break; // OK to attempt compile-time load
          }
 
+      const static char *needInitializedCheck = feGetEnv("TR_needInitializedCheck");
       TR::VPConstraint *base = vp->getConstraint(node->getFirstChild(), isGlobal);
       if (base && node->getOpCode().hasSymbolReference() &&
           (node->getSymbolReference() == vp->comp()->getSymRefTab()->findVftSymbolRef()))
@@ -2162,7 +2163,7 @@ TR::Node *constrainIaload(OMR::ValuePropagation *vp, TR::Node *node)
           && base->getClassType()
           && base->getClassType()->asFixedClass()
           && base->getClass()
-          && TR::Compiler->cls.isClassInitialized(vp->comp(), base->getClass()))
+          && (!needInitializedCheck || TR::Compiler->cls.isClassInitialized(vp->comp(), base->getClass())))
          {
          if (symRef == vp->comp()->getSymRefTab()->findJavaLangClassFromClassSymbolRef())
             {


### PR DESCRIPTION
Loosen the condition on constraining indirect load from a J9Class by
removing the initialized check. This is because java/lang/Class
reference and the component type if the class is an array, are
properties of the class file, and will be initialized before the class
is sufficiently initialized, so it's safe to dereference them at
compile time without the initialized check.

Signed-off-by: liqunl <liqunl@ca.ibm.com>