### PR TITLE
Deprecate LitPoolRegisterIsFree codegen flag

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -661,9 +661,6 @@ OMR::Z::CodeGenerator::CodeGenerator()
    static char * noGraFIX= feGetEnv("TR_NOGRAFIX");
    if (!noGraFIX)
       {
-      // VETO flag for register usage
-      self()->setLitPoolRegisterIsFree(true);
-
       if ( !comp->getOption(TR_DisableLongDispStackSlot) )
          {
          self()->setExtCodeBaseRegisterIsFree(true);
@@ -920,9 +917,6 @@ bool OMR::Z::CodeGenerator::prepareForGRA()
       static char * noGraFIX= feGetEnv("TR_NOGRAFIX");
       if (noGraFIX)
          {
-         // VETO flag for register usage
-         self()->setLitPoolRegisterIsFree(true);
-
          if ( !self()->comp()->getOption(TR_DisableLongDispStackSlot) )
             {
             self()->setExtCodeBaseRegisterIsFree(true);
@@ -1956,10 +1950,7 @@ OMR::Z::CodeGenerator::isLitPoolFreeForAssignment()
    // If lit on demand is working, we always free up
    // If no lit-on-demand, try to avoid locking up litpool reg anyways
    //
-   if ((self()->isLiteralPoolOnDemandOn() ||
-       (!self()->comp()->hasNativeCall() && (self()->getFirstSnippet() == NULL)))
-       &&
-       self()->getLitPoolRegisterIsFree())
+   if (self()->isLiteralPoolOnDemandOn() || (!self()->comp()->hasNativeCall() && self()->getFirstSnippet() == NULL))
       {
       litPoolRegIsFree = true;
       }

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -601,11 +601,6 @@ public:
    int32_t getPreprologueOffset()               { return _preprologueOffset; }
    int32_t setPreprologueOffset(int32_t offset) { return _preprologueOffset = offset; }
 
-   // Flags to VETO all other policies wrt locked regs
-   //
-   bool getLitPoolRegisterIsFree()         {return _cgFlags.testAny(S390CG_litPoolRegisterIsFree);}
-   void setLitPoolRegisterIsFree(bool val) {_cgFlags.set(S390CG_litPoolRegisterIsFree, val);}
-
    bool supportsBranchPreload()          {return _cgFlags.testAny(S390CG_enableBranchPreload);}
    void setEnableBranchPreload()          {_cgFlags.set(S390CG_enableBranchPreload);}
    void setDisableBranchPreload()          {_cgFlags.reset(S390CG_enableBranchPreload);}
@@ -1213,7 +1208,7 @@ protected:
    /** Miscellaneous S390CG boolean flags. */
    typedef enum
       {
-      S390CG_litPoolRegisterIsFree       = 0x00000001,
+      // Available                       = 0x00000001,
       S390CG_extCodeBaseRegisterIsFree   = 0x00000002,
       S390CG_doingInstructionSelection   = 0x00000004,
       S390CG_addStorageReferenceHints    = 0x00000008,


### PR DESCRIPTION
This codegen flag is true by default and currently serves no particular
purpose. This commit is in preparation for additional cleanup of literal
pool register uses in the z Systems codegen.

Issue: #939
Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>