### PR TITLE
Add OSR call site remat table

### DIFF
--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -589,6 +589,7 @@ public:
       TR_InlinedCallSite _site;
       TR::ResolvedMethodSymbol *_resolvedMethod;
       TR::SymbolReference *_callSymRef;
+      int32_t *_osrCallSiteRematTable;
       bool _directCall;
 
       public:
@@ -598,7 +599,7 @@ public:
                              TR::ResolvedMethodSymbol *resolvedMethod,
                              TR::SymbolReference *callSymRef,
                              bool directCall):
-         _resolvedMethod(resolvedMethod), _callSymRef(callSymRef), _directCall(directCall)
+         _resolvedMethod(resolvedMethod), _callSymRef(callSymRef), _directCall(directCall), _osrCallSiteRematTable(0)
          {
          _site._methodInfo = methodInfo;
          _site._byteCodeInfo = bcInfo;
@@ -608,6 +609,8 @@ public:
       TR_ResolvedMethod *resolvedMethod() { return _resolvedMethod->getResolvedMethod(); }
       TR::ResolvedMethodSymbol *resolvedMethodSymbol() { return _resolvedMethod; }
       TR::SymbolReference *callSymRef(){ return _callSymRef; }
+      int32_t *osrCallSiteRematTable() { return _osrCallSiteRematTable; }
+      void setOSRCallSiteRematTable(int32_t *array) { _osrCallSiteRematTable = array; }
       bool directCall() { return _directCall; }
       };
 
@@ -617,6 +620,9 @@ public:
    TR_ResolvedMethod  *getInlinedResolvedMethod(uint32_t index);
    TR::ResolvedMethodSymbol  *getInlinedResolvedMethodSymbol(uint32_t index);
    TR::SymbolReference *getInlinedCallerSymRef(uint32_t index);
+   uint32_t getOSRCallSiteRematSize(uint32_t callSiteIndex);
+   void getOSRCallSiteRemat(uint32_t callSiteIndex, uint32_t slot, TR::SymbolReference *&ppSymRef, TR::SymbolReference *&loadSymRef);
+   void setOSRCallSiteRemat(uint32_t callSiteIndex, TR::SymbolReference *ppSymRef, TR::SymbolReference *loadSymRef);
    bool isInlinedDirectCall(uint32_t index);
 
    TR_InlinedCallSite *getCurrentInlinedCallSite();

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
@@ -139,6 +139,7 @@ public:
    bool genIL(TR_FrontEnd *fe, TR::Compilation *comp, TR::SymbolReferenceTable *symRefTab, TR::IlGenRequest & customRequest);
    bool allCallerOSRBlocksArePresent(int32_t inlinedSiteIndex, TR::Compilation *comp);
    void cleanupUnreachableOSRBlocks(int32_t inlinedSiteIndex, TR::Compilation *comp);
+   void insertRematableStoresFromCallSites(TR::Compilation *comp, int32_t siteIndex, TR::TreeTop *induceOSRTree);
    void insertStoresForDeadStackSlotsBeforeInducingOSR(TR::Compilation *comp, int32_t inlinedSiteIndex, TR_ByteCodeInfo &byteCodeInfo, TR::TreeTop *induceOSRTree, TR::ResolvedMethodSymbol *callSymbolForDeadSlots);
    bool sharesStackSlots(TR::Compilation *comp);
    void resetLiveLocalIndices();

--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -467,6 +467,7 @@ class TR_ParameterToArgumentMapper
 
       void                  initialize(TR_CallStack *callStack);
       TR::Node *             map(TR::Node *, TR::ParameterSymbol *, bool);
+      void                   mapOSRCallSiteRematTable(uint32_t siteIndex);
       void                  adjustReferenceCounts();
       TR::Node *             fixCallNodeArgs(bool);
       TR::TreeTop *          firstTempTreeTop()   { return _firstTempTreeTop; }


### PR DESCRIPTION
When OSR is enabled, it is necessary to store the contents of the
stack before a call, as the call may be inlined and could contain
an OSR transition. If this transition were to occur, it would
have to reconstruct the stack for all of the callers.

Often, the stack contains values stored elsewhere which will
not be modified within the inlined call. Therefore, it is safe to
remat the pending push, representing the stack contents, within
OSR code blocks. This change adds the infrastructure for such 
an optimization by adding rematable pending pushes to the call site info.