### PR TITLE
Handle unequal number of children in identicalSubTrees

### DIFF
--- a/compiler/optimizer/PrefetchInsertion.cpp
+++ b/compiler/optimizer/PrefetchInsertion.cpp
@@ -160,6 +160,10 @@ static bool identicalSubTrees(TR::Node *node1, TR::Node *node2)
    if (node1->getOpCode().isLoadVar() &&
        node1->getSymbolReference() != node2->getSymbolReference())
       return false;
+   
+   if (node1->getNumChildren() != node2->getNumChildren())
+      return false;
+   
 
    for (int32_t i = 0; i < node1->getNumChildren(); i++)
       if (!identicalSubTrees(node1->getChild(i), node2->getChild(i)))


### PR DESCRIPTION
This function takes two nodes and traverse the subtrees recursively
to check if we have identical sub trees. When we pass two nodes with
unequal number of children there is a potential of segmentation fault.
Adding another check which will return false if nodes have unequal number
of children.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>