### PR TITLE
Support MethodBuilders without line or file info

### DIFF
--- a/compiler/ilgen/MethodBuilder.cpp
+++ b/compiler/ilgen/MethodBuilder.cpp
@@ -80,13 +80,13 @@ namespace OMR
 
 MethodBuilder::MethodBuilder(TR::TypeDictionary *types, OMR::VirtualMachineState *vmState)
    : TR::IlBuilder(asMethodBuilder(), types),
-   _methodName(""),
+   _methodName("NoName"),
    _returnType(NoType),
    _numParameters(0),
    _cachedParameterTypes(0),
    _cachedSignature(0),
-   _definingFile(0),
-   _definingLine(0),
+   _definingFile(""),
+   _definingLine(""),
    _symbols(0),
    _newSymbolsAreTemps(false),
    _useBytecodeBuilders(false),

--- a/fvtest/jitbuildertest/AnonymousTest.cpp
+++ b/fvtest/jitbuildertest/AnonymousTest.cpp
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#include "gtest/gtest.h" 
+#include "Jit.hpp"
+#include "JBTestUtil.hpp"
+
+DECLARE_BUILDER(Anonymous);
+DEFINE_BUILDER_CTOR(Anonymous)
+   {
+   // This builder intentionally has no name, line, nor file
+   // as we are testing the creation of 'anonymous' builders. 
+   DefineReturnType(types->toIlType<uint32_t>());
+   }
+
+DEFINE_BUILDIL(Anonymous)
+   {
+   Return(ConstInt32(1024u)); 
+   return true;
+   }
+
+typedef uint32_t (*AnonFunc)();
+
+class AnonymousTest : public JitBuilderTest {};
+
+TEST_F(AnonymousTest, AnonymousTest) 
+   {
+   AnonFunc func; 
+   ASSERT_COMPILE(TR::TypeDictionary, Anonymous, func); 
+
+   ASSERT_EQ( func(), 1024u); 
+   }
+
+

--- a/fvtest/jitbuildertest/Makefile
+++ b/fvtest/jitbuildertest/Makefile
@@ -26,7 +26,8 @@ OBJECTS := \
 	main \
 	selftest \
 	UnionTest \
-	FieldAddressTest
+	FieldAddressTest \
+	AnonymousTest
 
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
 

--- a/jitbuilder/compile/Method.cpp
+++ b/jitbuilder/compile/Method.cpp
@@ -26,11 +26,8 @@
 #include "ilgen/MethodBuilder.hpp"
 #include "ilgen/IlGeneratorMethodDetails_inlines.hpp"
 
-namespace JitBuilder
-{
-
 // needs major overhaul
-ResolvedMethod::ResolvedMethod(TR_OpaqueMethodBlock *method)
+JitBuilder::ResolvedMethod::ResolvedMethod(TR_OpaqueMethodBlock *method)
    {
    // trouble! trouble! where do we get TypeDictionary from now?
    _ilInjector = reinterpret_cast<TR::IlInjector *>(method);
@@ -47,7 +44,7 @@ ResolvedMethod::ResolvedMethod(TR_OpaqueMethodBlock *method)
    strncpy(_signatureChars, resolvedMethod->signatureChars(), 62); // TODO: introduce concept of robustness
    }
 
-ResolvedMethod::ResolvedMethod(TR::MethodBuilder *m)
+JitBuilder::ResolvedMethod::ResolvedMethod(TR::MethodBuilder *m)
    : _fileName(m->getDefiningFile()),
      _lineNumber(m->getDefiningLine()),
      _name((char *)m->getMethodName()), // sad cast
@@ -62,7 +59,7 @@ ResolvedMethod::ResolvedMethod(TR::MethodBuilder *m)
    }
 
 const char *
-ResolvedMethod::signature(TR_Memory * trMemory, TR_AllocationKind allocKind)
+JitBuilder::ResolvedMethod::signature(TR_Memory * trMemory, TR_AllocationKind allocKind)
    {
    if( !_signature )
       {
@@ -79,14 +76,14 @@ ResolvedMethod::signature(TR_Memory * trMemory, TR_AllocationKind allocKind)
    }
 
 TR::DataType
-ResolvedMethod::parmType(uint32_t slot)
+JitBuilder::ResolvedMethod::parmType(uint32_t slot)
    {
    TR_ASSERT((slot < _numParms), "Invalid slot provided for Parameter Type");
    return _parmTypes[slot]->getPrimitiveType();
    }
 
 void
-ResolvedMethod::computeSignatureChars()
+JitBuilder::ResolvedMethod::computeSignatureChars()
    {
    char *name=NULL;
    uint32_t len=3;
@@ -116,7 +113,7 @@ ResolvedMethod::computeSignatureChars()
    }
 
 void
-ResolvedMethod::makeParameterList(TR::ResolvedMethodSymbol *methodSym)
+JitBuilder::ResolvedMethod::makeParameterList(TR::ResolvedMethodSymbol *methodSym)
    {
    ListAppender<TR::ParameterSymbol> la(&methodSym->getParameterList());
    TR::ParameterSymbol *parmSymbol;
@@ -148,7 +145,7 @@ ResolvedMethod::makeParameterList(TR::ResolvedMethodSymbol *methodSym)
    }
 
 char *
-ResolvedMethod::localName(uint32_t slot,
+JitBuilder::ResolvedMethod::localName(uint32_t slot,
                           uint32_t bcIndex,
                           int32_t &nameLength,
                           TR_Memory *trMemory)
@@ -174,7 +171,7 @@ ResolvedMethod::localName(uint32_t slot,
    }
 
 TR::IlInjector *
-ResolvedMethod::getInjector (TR::IlGeneratorMethodDetails * details,
+JitBuilder::ResolvedMethod::getInjector (TR::IlGeneratorMethodDetails * details,
    TR::ResolvedMethodSymbol *methodSymbol,
    TR::FrontEnd *fe,
    TR::SymbolReferenceTable *symRefTab)
@@ -184,8 +181,7 @@ ResolvedMethod::getInjector (TR::IlGeneratorMethodDetails * details,
    }
 
 TR::DataType
-ResolvedMethod::returnType()
+JitBuilder::ResolvedMethod::returnType()
    {
    return _returnType->getPrimitiveType();
    }
-} // namespace JitBuilder


### PR DESCRIPTION
Also adds a test for the same, and, restructures the naming in JitBuilder's method file to make methods easier to find with `grep`-like tools.