### PR TITLE
Rename setSupportsArrayCopy

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1435,8 +1435,8 @@ class OMR_EXTENSIBLE CodeGenerator
    bool getSupportsPrimitiveArrayCopy() {return _flags2.testAny(SupportsPrimitiveArrayCopy);}
    void setSupportsPrimitiveArrayCopy() {_flags2.set(SupportsPrimitiveArrayCopy);}
 
-   bool getSupportsReferenceArrayCopy() {return _flags2.testAny(SupportsReferenceArrayCopy);}
-   void setSupportsReferenceArrayCopy() {_flags2.set(SupportsReferenceArrayCopy);}
+   bool getSupportsReferenceArrayCopy() {return _flags1.testAny(SupportsReferenceArrayCopy);}
+   void setSupportsReferenceArrayCopy() {_flags1.set(SupportsReferenceArrayCopy);}
 
    bool getSupportsEfficientNarrowIntComputation() {return _flags2.testAny(SupportsEfficientNarrowIntComputation);}
    void setSupportsEfficientNarrowIntComputation() {_flags2.set(SupportsEfficientNarrowIntComputation);}

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1432,11 +1432,11 @@ class OMR_EXTENSIBLE CodeGenerator
    bool getSupportsDivCheck() {return _flags1.testAny(SupportsDivCheck);}
    void setSupportsDivCheck() {_flags1.set(SupportsDivCheck);}
 
-   bool getSupportsArrayCopy() {return _flags1.testAny(SupportsArrayCopy);}
-   void setSupportsArrayCopy() {_flags1.set(SupportsArrayCopy);}
-
    bool getSupportsPrimitiveArrayCopy() {return _flags2.testAny(SupportsPrimitiveArrayCopy);}
    void setSupportsPrimitiveArrayCopy() {_flags2.set(SupportsPrimitiveArrayCopy);}
+
+   bool getSupportsReferenceArrayCopy() {return _flags2.testAny(SupportsReferenceArrayCopy);}
+   void setSupportsReferenceArrayCopy() {_flags2.set(SupportsReferenceArrayCopy);}
 
    bool getSupportsEfficientNarrowIntComputation() {return _flags2.testAny(SupportsEfficientNarrowIntComputation);}
    void setSupportsEfficientNarrowIntComputation() {_flags2.set(SupportsEfficientNarrowIntComputation);}
@@ -1706,7 +1706,7 @@ class OMR_EXTENSIBLE CodeGenerator
       HasResumableTrapHandler                            = 0x00000040,
       //                                                 = 0x00000080,   // Available
       SupportsPartialInlineOfMethodHooks                 = 0x00000100,
-      SupportsArrayCopy                                  = 0x00000200,
+      SupportsReferenceArrayCopy                         = 0x00000200,
       SupportsJavaFloatSemantics                         = 0x00000400,
       SupportsInliningOfTypeCoersionMethods              = 0x00000800,
       VMThreadRequired                                   = 0x00001000,

--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -5727,7 +5727,7 @@ int32_t TR::ArraycopyTransformation::perform()
    // ValuePropagation arraycopy creation.
    // it is intended for platforms that want to generate inline code for both forward
    // and backward arraycopy but don't want to do control flow in the platform code
-   bool mustSpecializeForDirection = comp()->cg()->getSupportsPostProcessArrayCopy() && comp()->cg()->getSupportsPrimitiveArrayCopy();
+   bool mustSpecializeForDirection = comp()->cg()->getSupportsPostProcessArrayCopy();
 
    TR::CFG *cfg = comp()->getFlowGraph();
    TR::TreeTop* lastTreeTop  = cfg->findLastTreeTop();

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -1157,13 +1157,14 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
         !(dstObject && dstObject->isNullObject()) &&
         srcOffHigh >= 0 && dstOffHigh >= 0 && copyLenHigh >= 0)
       {
-      transformTheCall = true;
+      transformTheCall = primitiveTransform && referenceTransform;
 
       if (srcObject && srcObject->getClassType())
          {
          primitiveArray1 = srcObject->getClassType()->isPrimitiveArray(comp());
          referenceArray1 = srcObject->getClassType()->isReferenceArray(comp());
          }
+
       if (dstObject && dstObject->getClassType())
          {
          primitiveArray2 = dstObject->getClassType()->isPrimitiveArray(comp());

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -1175,7 +1175,7 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
          transformTheCall = primitiveTransform;
          }
 
-      if (primitiveArray1 || primitiveArray2)
+      if (referenceArray1 || referenceArray2)
          {
          transformTheCall = referenceTransform;
          }

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -1071,8 +1071,7 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
    bool needWriteBarrier = true;
 
    bool primitiveTransform = cg()->getSupportsPrimitiveArrayCopy();
-   bool fullTransform = cg()->getSupportsArrayCopy();
-   bool transformReferenceArray = false;
+   bool referenceTransform = cg()->getSupportsReferenceArrayCopy();
 
    bool isSrcPossiblyNull = true; // pessimistic
    bool isDstPossiblyNull = true;
@@ -1149,7 +1148,7 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
    // If it is OK to convert this call to a possible call to the (fast)
    // arraycopy helper, do it.
    //
-   if ((primitiveTransform || fullTransform) &&
+   if ((primitiveTransform || referenceTransform) &&
        !comp()->getOption(TR_DisableArrayCopyOpts) &&
        !node->isDontTransformArrayCopyCall() &&
         comp()->fej9()->callTheJitsArrayCopyHelper() &&
@@ -1159,6 +1158,7 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
         srcOffHigh >= 0 && dstOffHigh >= 0 && copyLenHigh >= 0)
       {
       transformTheCall = true;
+
       if (srcObject && srcObject->getClassType())
          {
          primitiveArray1 = srcObject->getClassType()->isPrimitiveArray(comp());
@@ -1168,6 +1168,16 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
          {
          primitiveArray2 = dstObject->getClassType()->isPrimitiveArray(comp());
          referenceArray2 = dstObject->getClassType()->isReferenceArray(comp());
+         }
+
+      if (primitiveArray1 || primitiveArray2)
+         {
+         transformTheCall = primitiveTransform;
+         }
+
+      if (primitiveArray1 || primitiveArray2)
+         {
+         transformTheCall = referenceTransform;
          }
 
       if (comp()->generateArraylets() &&
@@ -1204,14 +1214,16 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
                   needArrayCheck = false;
                   }
                else
-                  // Different types - arraycopy will fail
-                  //
+                  {
+                  // Array types are different types so the arraycopy will fail
                   transformTheCall = false;
+                  }
                }
             else if (referenceArray2)
-               // Different types - arraycopy will fail
-               //
+               {
+               // Array types are different types so the arraycopy will fail
                transformTheCall = false;
+               }
             }
          else if (referenceArray1)
             {
@@ -1248,32 +1260,16 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
                   }
 
                needArrayCheck = false;
-               transformTheCall = fullTransform;
-               transformReferenceArray = primitiveTransform;
-               static char *enableTransformReferenceArray = feGetEnv("TR_enableTRA");
-               if (enableTransformReferenceArray)
-                  {
-                  transformReferenceArray = true; // for reference array transformation
-                  }
                }
             else if (primitiveArray2)
                {
-               // Different types - arraycopy will fail
-               //
+               // Array types are different types so the arraycopy will fail
                transformTheCall = false;
                }
             else if (comp()->getOptions()->alwaysCallWriteBarrier())
                {
                transformTheCall = false;
                }
-            else
-               {
-               transformTheCall = fullTransform;
-               }
-            }
-         else
-            {
-            transformTheCall = fullTransform;
             }
          }
 
@@ -1282,6 +1278,7 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
          type = primitiveArray1 ?
             srcObject->getClassType()->getPrimitiveArrayDataType() :
             dstObject->getClassType()->getPrimitiveArrayDataType();
+
          elementSize = TR::Symbol::convertTypeToSize(type);
          }
 
@@ -1352,25 +1349,8 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
                else if (!isRecognizedMultiLeafArrayCopy)
                   needSameLeafCheckForDst = true;
                }
-
-            //if (transformTheCall &&
-            //  !needSameLeafCheckForSrc && !needSameLeafCheckForDst)
-            // printf("******transformation in compile %p\n",node);fflush(stdout);
-
             }
          }
-      }
-
-   if (transformReferenceArray && !comp()->generateArraylets() )
-      {
-      // If only primitive arraycopy is supported for this target, and the call is known to
-      // go to a reference arraycopy (both src and dst are known to be ref arrays)
-      // then transform the arraycopy into a call to
-      // java/lang/System.arraycopy(Object[], Object[], int, Object[], int, int)
-      // which is a private method in the java.lang.System class we ship
-      //
-      TR_ResolvedMethod * newMethod =
-         findResolvedClassMethod(comp(), "Ljava/lang/System;", "arraycopy", "([Ljava/lang/Object;I[Ljava/lang/Object;II)V");
       }
 #else
    bool isStringCompressedArrayCopy = false;
@@ -3638,20 +3618,23 @@ void OMR::ValuePropagation::transformArrayCloneCall(TR::TreeTop *callTree, TR_Op
          case 4: arraycopy->setArrayCopyElementType(TR::Int32); break;
          case 8: arraycopy->setArrayCopyElementType(TR::Int64); break;
          }
-      if (!comp()->cg()->getSupportsPrimitiveArrayCopy())
+
+      switch (elementSize)
          {
-         switch (elementSize)
-            {
-            case 2: arraycopy->setHalfWordElementArrayCopy(true); break;
-            case 4: case 8: arraycopy->setWordElementArrayCopy(true); break;
-            }
+         case 2:
+            arraycopy->setHalfWordElementArrayCopy(true);
+            break;
+
+         case 4:
+         case 8:
+            arraycopy->setWordElementArrayCopy(true);
+            break;
          }
       }
    else
       {
       arraycopy->setArrayCopyElementType(TR::Address);
-      if (!comp()->cg()->getSupportsPrimitiveArrayCopy())
-         arraycopy->setWordElementArrayCopy(true);
+      arraycopy->setWordElementArrayCopy(true);
       }
 
    callTree->insertBefore(TR::TreeTop::create(comp(), TR::Node::create(callNode, TR::treetop, 1, newArray)));

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -224,7 +224,8 @@ OMR::Power::CodeGenerator::CodeGenerator() :
 
     self()->setSupportsConstantOffsetInAddressing();
     self()->setSupportsVirtualGuardNOPing();
-    self()->setSupportsArrayCopy();
+    self()->setSupportsPrimitiveArrayCopy();
+    self()->setSupportsReferenceArrayCopy();
 
     // disabled for now
     //

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -361,7 +361,8 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
    self()->setLiveRegisters(new (self()->trHeapMemory()) TR_LiveRegisters(comp), TR_FPR);
 
    self()->setSupportsArrayCmp();
-   self()->setSupportsArrayCopy();
+   self()->setSupportsPrimitiveArrayCopy();
+   self()->setSupportsReferenceArrayCopy();
 
    if (!comp->getOption(TR_DisableArraySetOpts))
       {

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -686,8 +686,6 @@ OMR::Z::CodeGenerator::CodeGenerator()
    // Support divided by power of 2 logic in ldivSimplifier
    self()->setSupportsLoweringConstLDivPower2();
 
-   self()->setSupportsPrimitiveArrayCopy();
-
    //enable LM/STM for volatile longs in 32 bit
    self()->setSupportsInlinedAtomicLongVolatiles();
 
@@ -809,7 +807,8 @@ OMR::Z::CodeGenerator::CodeGenerator()
    self()->setLiveRegisters(new (self()->trHeapMemory()) TR_LiveRegisters(comp), TR_AR);
    self()->setLiveRegisters(new (self()->trHeapMemory()) TR_LiveRegisters(comp), TR_VRF);
 
-   self()->setSupportsArrayCopy();
+   self()->setSupportsPrimitiveArrayCopy();
+   self()->setSupportsReferenceArrayCopy();
 
    self()->setSupportsPartialInlineOfMethodHooks();
 


### PR DESCRIPTION
Rename setSupportsArrayCopy to setSupportsReferenceArrayCopy. The 
setSupportsArrayCopy API is currently overloaded for both primitive
and reference array copies. There already exists an API
setSupportsPrimitiveArrayCopy which only seems to be active on z
Systems.

This commit decouples z Systems from setSupportsPrimitiveArrayCopy and
in addition decouples setSupportsArrayCopy into
setSupportsReferenceArrayCopy and setSupportsPrimitiveArrayCopy. All
codegens currently supporting J9 are marked to reduce array copies, both
primititive and reference.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>