### PR TITLE
Avoid unnecessary async checks at scorching

### DIFF
--- a/compiler/optimizer/RedundantAsyncCheckRemoval.cpp
+++ b/compiler/optimizer/RedundantAsyncCheckRemoval.cpp
@@ -154,13 +154,14 @@ int32_t TR_RedundantAsyncCheckRemoval::perform()
    // resulted in the removal of all async checks - then sampling might
    // be effected.  Insert async checks on method exits.
    //
-   if (comp()->getLoopWasVersionedWrtAsyncChecks() ||
+   if ((comp()->getMethodHotness() < scorching) &&	// make sure we don't add unnecessary checks at scorching
+       (comp()->getLoopWasVersionedWrtAsyncChecks() ||
        (_numAsyncChecksInserted == 0 && _foundShortRunningLoops &&
         comp()->getRecompilationInfo() &&
 #ifdef J9_PROJECT_SPECIFIC
         comp()->getRecompilationInfo()->useSampling() &&
 #endif
-        comp()->getRecompilationInfo()->shouldBeCompiledAgain()))
+        comp()->getRecompilationInfo()->shouldBeCompiledAgain())))
       {
       _numAsyncChecksInserted += TR_AsyncCheckInsertion::insertReturnAsyncChecks(comp());
       }


### PR DESCRIPTION
Added a test to avoid unnecessary async checks being added to code
that isn't going to be recompiled because it's already at scorching.

Signed-off-by: JamesKingdon <jkingdon@ca.ibm.com>