### PR TITLE
Notify CM when old-to-old ref is created by CS

### DIFF
--- a/gc/base/omrmmprivate.hdf
+++ b/gc/base/omrmmprivate.hdf
@@ -726,12 +726,12 @@
 	</event>
 	
 	<event>
-		<name>J9HOOK_MM_PRIVATE_OBJECT_REMOVED_FROM_REMEMBERED_SET</name>
-		<description>Triggered when an object reference is removed from the remembered set</description>
+		<name>J9HOOK_MM_PRIVATE_OLD_TO_OLD_REFERENCE_CREATED</name>
+		<description>Triggered when old to old reference is created by GC (Scavenger) </description>
 		<condition>defined (__cplusplus)</condition>
-		<struct>MM_ObjectRemovedFromRememberedSetEvent</struct>
+		<struct>MM_OldToOldReferenceCreatedEvent</struct>
 		<data type="struct OMR_VMThread*" name="currentThread" description="the current thread" />
-		<data type="void *" name="objectPtr" description="pointer to the object removed from the remembered set" />
+		<data type="void *" name="objectPtr" description="pointer to the parent object" />
 	</event>	
 	
 	<event>

--- a/gc/base/standard/ConcurrentGC.hpp
+++ b/gc/base/standard/ConcurrentGC.hpp
@@ -311,7 +311,7 @@ private:
 	bool tracingRateDropped(MM_EnvironmentStandard *env);
 #if defined(OMR_GC_MODRON_SCAVENGER)	
 	uintptr_t potentialFreeSpace(MM_EnvironmentStandard *env, MM_AllocateDescription *allocDescription);
-	static void hookObjectRemovedFromRememberedSet(J9HookInterface** hook, uintptr_t eventNum, void* eventData, void* userData);
+	static void hookOldToOldReferenceCreated(J9HookInterface** hook, uintptr_t eventNum, void* eventData, void* userData);
 #endif /*OMR_GC_MODRON_SCAVENGER */	
 	static void hookCardCleanPass2Start(J9HookInterface** hook, uintptr_t eventNum, void* eventData, void* userData);
 
@@ -427,7 +427,7 @@ public:
 	void completeTracing(MM_EnvironmentStandard *env);
 #if defined(OMR_GC_MODRON_SCAVENGER)
 	void scanRememberedSet(MM_EnvironmentStandard *env);
-	void objectRemovedFromRememberedSet(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr);
+	void oldToOldReferenceCreated(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr);
 #endif /* OMR_GC_MODRON_SCAVENGER */
 	
 	void recordCardCleanPass2Start(MM_EnvironmentStandard *env);


### PR DESCRIPTION
When Concurrent Scavenger (CS) creates a new old-to-old reference it has
to notify Concurrent Marker (CM). Otherwise if parent object is already
scanned, the child object will be collected.

CM will dirty the card of the parent object (if marked, since we have no
information if it's scanned), what will eventually through card cleaning
find the child object.

This is generalization of the functionality where regular Scavenger
notifies CM about removed RS slot, which is the case where old-to-old
reference was created from old-to-new reference, when child object is
tenured (thus parent removed from RS). 

In CS, even new-to-new reference is interesting, when both parent and
child object are tenured and old-to-old reference is created. While CS
is in progress, it may overlap with CM in progress, so CM can mark and
scan the parent object BEFORE the child object is tenured.

This last scenario is possible in regular Scavenger, except, since the
world is stopped during Scavenge, the parent object is guaranteed to be
NOT marked/scanned (CM concurrently traces only old objects, and is
stopped). 

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>