### PR TITLE
Experimental AVX Support on X86

### DIFF
--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -211,6 +211,7 @@ uint8_t* OMR::X86::Instruction::generateBinaryEncoding()
       // cursor is NULL when generateOperand() requests to regenerate the binary code, which may happen during encoding of memref with unresolved symbols on 64-bit
       if (cursor)
          {
+         self()->getOpCode().finalize(instructionStart);
          self()->setBinaryLength(cursor - instructionStart);
          self()->cg()->addAccumulatedInstructionLengthError(self()->getEstimatedBinaryLength() - self()->getBinaryLength());
          return cursor;

--- a/compiler/x/codegen/X86Ops_inlines.hpp
+++ b/compiler/x/codegen/X86Ops_inlines.hpp
@@ -19,6 +19,12 @@
 #ifndef X86OPS_INLINES_INCL
 #define X86OPS_INLINES_INCL
 
+inline bool TR_X86OpCode::OpCode_t::allowsAVX()
+   {
+   static bool enable = feGetEnv("TR_EnableAVX") && TR::CodeGenerator::getX86ProcessorInfo().supportsAVX();
+   return enable;
+   }
+
 template <typename TBuffer> inline typename TBuffer::cursor_t TR_X86OpCode::OpCode_t::encode(typename TBuffer::cursor_t cursor, uint8_t rexbits) const
    {
    if (isX87())
@@ -34,54 +40,103 @@ template <typename TBuffer> inline typename TBuffer::cursor_t TR_X86OpCode::OpCo
    // Prefixes
    TR::Instruction::REX rex(rexbits);
    rex.W = rex_w;
-   switch (prefixes)
+   TR_ASSERT(TR::Compiler->target.is64Bit() || !rex.value(), "ERROR: REX.W used on X86-32. OpCode = %d; rex = %02x", opcode, (uint32_t)(uint8_t)rex.value());
+   // Use AVX if possible
+   if (supportsAVX() && allowsAVX())
       {
-      case PREFIX___:
-         break;
-      case PREFIX_66:
-         buffer.append('\x66');
-         break;
-      case PREFIX_F2:
-         buffer.append('\xf2');
-         break;
-      case PREFIX_F3:
-         buffer.append('\xf3');
-         break;
-      default:
-         break;
+      TR::Instruction::VEX<3> vex(rex, modrm_opcode);
+      vex.m = escape;
+      vex.L = vex_l;
+      vex.p = prefixes;
+      vex.opcode = opcode;
+      if(vex.CanBeShortened())
+         {
+         buffer.append(TR::Instruction::VEX<2>(vex));
+         }
+      else
+         {
+         buffer.append(vex);
+         }
       }
-   // REX
-   if (rex.value() || rexbits)
+   else
       {
-      buffer.append(rex);
-      }
-   // OpCode escape
-   switch (escape)
-      {
-      case ESCAPE_____:
-         break;
-      case ESCAPE_0F__:
-         buffer.append('\x0f');
-         break;
-      case ESCAPE_0F38:
-         buffer.append('\x0f');
-         buffer.append('\x38');
-         break;
-      case ESCAPE_0F3A:
-         buffer.append('\x0f');
-         buffer.append('\x3a');
-         break;
-      default:
-         break;
-      }
-   // OpCode
-   buffer.append(opcode);
-   // ModRM
-   if (modrm_form)
-      {
-      buffer.append(TR::Instruction::ModRM(modrm_opcode));
+      switch (prefixes)
+         {
+         case PREFIX___:
+            break;
+         case PREFIX_66:
+            buffer.append('\x66');
+            break;
+         case PREFIX_F2:
+            buffer.append('\xf2');
+            break;
+         case PREFIX_F3:
+            buffer.append('\xf3');
+            break;
+         default:
+            break;
+         }
+      // REX
+      if (rex.value() || rexbits)
+         {
+         buffer.append(rex);
+         }
+      // OpCode escape
+      switch (escape)
+         {
+         case ESCAPE_____:
+            break;
+         case ESCAPE_0F__:
+            buffer.append('\x0f');
+            break;
+         case ESCAPE_0F38:
+            buffer.append('\x0f');
+            buffer.append('\x38');
+            break;
+         case ESCAPE_0F3A:
+            buffer.append('\x0f');
+            buffer.append('\x3a');
+            break;
+         default:
+            break;
+         }
+      // OpCode
+      buffer.append(opcode);
+      // ModRM
+      if (modrm_form)
+         {
+         buffer.append(TR::Instruction::ModRM(modrm_opcode));
+         }
       }
    return buffer;
+   }
+
+inline void TR_X86OpCode::OpCode_t::finalize(uint8_t* cursor) const
+   {
+   // Finalize VEX prefix
+   switch (*cursor)
+      {
+      case 0xC4:
+         {
+         auto pVEX = (TR::Instruction::VEX<3>*)cursor;
+         if (vex_v == VEX_vReg_)
+            {
+            pVEX->v = ~(modrm_form == ModRM_EXT_ ? pVEX->RM() : pVEX->Reg());
+            }
+         }
+         break;
+      case 0xC5:
+         {
+         auto pVEX = (TR::Instruction::VEX<2>*)cursor;
+         if (vex_v == VEX_vReg_)
+            {
+            pVEX->v = ~(modrm_form == ModRM_EXT_ ? pVEX->RM() : pVEX->Reg());
+            }
+         }
+         break;
+      default:
+         break;
+      }
    }
 
 inline void TR_X86OpCode::CheckAndFinishGroup07(uint8_t* cursor)

--- a/doc/compiler/x/OpCodeEncoding.md
+++ b/doc/compiler/x/OpCodeEncoding.md
@@ -87,12 +87,13 @@ enum TR_OpCodeImmediate : uint8_t
 5. Write opcode
 6. Set and write ModR/M field if necessary
 
-# FUTURE WORK
-
 ## Generate AVX Instruction
 1. Obtain REX prefix from operand and set REX.W according to rex_w field.
-2. If REX.X == 0 AND REX.B == 0 AND REX.W == 0 AND escape == ESCAPE____, use 2-byte prefix; otherwise use 3-byte prefix
-3. Setup VEX structure and write it.
+2. Setup 3-byte VEX structure.
+2.1 Convert the 3-byte VEX to 2-byte VEX if possible
+3. Write the VEX prefix
+
+# FUTURE WORK
 
 ## Generate AVX-512 Instruction
 1. Obtain REX prefix from operand and set REX.W according to rex_w field.


### PR DESCRIPTION
Initial support for AVX/AVX2/FMA instructions that uses VEX prefixes.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>