### PR TITLE
Refactor runtime assumptions code

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -353,7 +353,7 @@ OMR::Compilation::Compilation(
    // Access to this list must be performed with assumptionTableMutex in hand
    //
    if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableFastAssumptionReclamation))
-      _metadataAssumptionList = new (m->trPersistentMemory()) TR_SentinelRuntimeAssumption();
+      _metadataAssumptionList = new (m->trPersistentMemory()) TR::SentinelRuntimeAssumption();
 #endif
 
    //Random fields must be set before allocating codegen

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -83,7 +83,7 @@ class TR_PrexArgInfo;
 class TR_RandomGenerator;
 class TR_RegisterCandidates;
 class TR_ResolvedMethod;
-class TR_RuntimeAssumption;
+namespace OMR { class RuntimeAssumption; }
 class TR_VirtualGuard;
 class TR_VirtualGuardSite;
 namespace TR { class AOTClassInfo; }
@@ -943,8 +943,8 @@ public:
 
 #ifdef J9_PROJECT_SPECIFIC
    // Access to this list must be performed with assumptionTableMutex in hand
-   TR_RuntimeAssumption** getMetadataAssumptionList() { return &_metadataAssumptionList; }
-   void setMetadataAssumptionList(TR_RuntimeAssumption *a) { _metadataAssumptionList = a; }
+   OMR::RuntimeAssumption** getMetadataAssumptionList() { return &_metadataAssumptionList; }
+   void setMetadataAssumptionList(OMR::RuntimeAssumption *a) { _metadataAssumptionList = a; }
 #endif
 
    // To TransformUtil
@@ -1127,7 +1127,7 @@ private:
 protected:
 #ifdef J9_PROJECT_SPECIFIC
    TR_CHTable *                      _transientCHTable;   // per compilation CHTable
-   TR_RuntimeAssumption *            _metadataAssumptionList; // A special TR_RuntimeAssumption to play the role of a sentinel for a linked list
+   OMR::RuntimeAssumption *            _metadataAssumptionList; // A special OMR::RuntimeAssumption to play the role of a sentinel for a linked list
 #endif
 
 private:

--- a/compiler/env/FEBase.cpp
+++ b/compiler/env/FEBase.cpp
@@ -284,11 +284,11 @@ extern "C" bool jitTestOSForSSESupport(void) { return false; } // TODO there are
 void TR_PatchNOPedGuardSite::compensate(TR_FrontEnd *fe, bool isSMP, uint8_t *location, uint8_t *destination) { notImplemented("TR_PatchNOPedGuardSite::compensate"); }
 void TR_PersistentClassInfo::removeASubClass(TR_PersistentClassInfo *) { notImplemented("TR_PersistentClassInfo::removeASubClass"); }
 bool isOrderedPair(uint8_t recordType) { notImplemented("isOrderedPair"); return false; }
-void TR_RuntimeAssumption::addToRAT(TR_PersistentMemory * persistentMemory, TR_RuntimeAssumptionKind kind, TR_FrontEnd *fe, TR_RuntimeAssumption** sentinel) { notImplemented("addToRAT"); }
-void TR_RuntimeAssumption::dumpInfo(char *subclassName) { notImplemented("dumpInfo"); }
+void OMR::RuntimeAssumption::addToRAT(TR_PersistentMemory * persistentMemory, TR_RuntimeAssumptionKind kind, TR_FrontEnd *fe, OMR::RuntimeAssumption** sentinel) { notImplemented("addToRAT"); }
+void OMR::RuntimeAssumption::dumpInfo(char *subclassName) { notImplemented("dumpInfo"); }
 void TR_PatchJNICallSite::compensate(TR_FrontEnd*, bool, void *) { notImplemented("TR_PatchJNICallSite::compensate"); }
 void TR_PreXRecompile::compensate(TR_FrontEnd*, bool, void *) { notImplemented("TR_PreXRecompile::compensate"); }
-TR_PatchNOPedGuardSiteOnClassPreInitialize *TR_PatchNOPedGuardSiteOnClassPreInitialize::make(TR_FrontEnd *fe, TR_PersistentMemory *, char*, unsigned int, unsigned char*, unsigned char*, TR_RuntimeAssumption**) { notImplemented("TR_PatchNOPedGuardSiteOnClassPreInitialize::allocate"); return 0; }
+TR_PatchNOPedGuardSiteOnClassPreInitialize *TR_PatchNOPedGuardSiteOnClassPreInitialize::make(TR_FrontEnd *fe, TR_PersistentMemory *, char*, unsigned int, unsigned char*, unsigned char*, OMR::RuntimeAssumption**) { notImplemented("TR_PatchNOPedGuardSiteOnClassPreInitialize::allocate"); return 0; }
 #endif
 
 

--- a/compiler/runtime/OMRRuntimeAssumptions.hpp
+++ b/compiler/runtime/OMRRuntimeAssumptions.hpp
@@ -1,0 +1,116 @@
+/******************************************************************************* 
+ *
+ * (c) Copyright IBM Corp. 2000, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+
+
+
+#ifndef OMR_RUNTIME_ASSUMPTIONS_INCL
+#define OMR_RUNTIME_ASSUMPTIONS_INCL
+
+#include <stddef.h>                        // for NULL
+#include <stdint.h>                        // for int32_t, uint8_t, etc
+#include "env/RuntimeAssumptionTable.hpp"  // for TR_RuntimeAssumptionKind, etc
+#include "env/TRMemory.hpp"                // for TR_Memory, etc
+#include "env/jittypes.h"                  // for uintptrj_t
+#include "infra/Link.hpp"                  // for TR_LinkHead0, TR_Link0
+
+
+class TR_FrontEnd;
+class TR_PatchJNICallSite;
+class TR_PatchNOPedGuardSite;
+class TR_PreXRecompile;
+class TR_RedefinedClassPicSite;
+class TR_UnloadedClassPicSite;
+
+
+namespace OMR
+{
+
+class RuntimeAssumption : public TR_Link0<RuntimeAssumption>
+   {
+   friend class ::TR_DebugExt;
+
+   protected:
+   RuntimeAssumption(TR_PersistentMemory *, uintptrj_t key)
+      : _key(key), _nextAssumptionForSameJittedBody(NULL) {}
+
+   void addToRAT(TR_PersistentMemory * persistentMemory, TR_RuntimeAssumptionKind kind,
+                 TR_FrontEnd *fe, RuntimeAssumption **sentinel);
+   public:
+   TR_PERSISTENT_ALLOC_THROW(TR_Memory::Assumption);
+   virtual void     reclaim() {}
+   virtual void     compensate(TR_FrontEnd *vm, bool isSMP, void *data) = 0;
+   virtual bool     equals(RuntimeAssumption &other) = 0;
+   virtual uint8_t *getAssumingPC() = 0;
+   virtual uintptrj_t getKey() { return _key; }
+
+   virtual uintptrj_t hashCode() { return TR_RuntimeAssumptionTable::hashCode(getKey()); }
+   virtual bool matches(uintptrj_t key) { return _key == key; }
+   virtual bool matches(char *sig, uint32_t sigLen) { return false; }
+
+   virtual TR_PatchNOPedGuardSite   *asPNGSite() { return 0; }
+   virtual TR_PreXRecompile         *asPXRecompile() { return 0; }
+   virtual TR_UnloadedClassPicSite  *asUCPSite() { return 0; }
+   virtual TR_RedefinedClassPicSite *asRCPSite() { return 0; }
+   virtual TR_PatchJNICallSite      *asPJNICSite() { return 0; }
+           void dumpInfo(char *subclassName);
+   virtual void dumpInfo() = 0;
+   virtual TR_RuntimeAssumptionKind getAssumptionKind() = 0;
+
+   bool isAssumingMethod(void *metaData, bool reclaimPrePrologueAssumptions = false);
+   bool isAssumingRange(uintptrj_t rangeStartPC, uintptrj_t rangeEndPC, uintptrj_t rangeColdStartPC, uintptrj_t rangeColdEndPC, uintptrj_t rangeStartMD, uintptrj_t rangeEndMD);
+   RuntimeAssumption * getNextAssumptionForSameJittedBody() const { return _nextAssumptionForSameJittedBody; }
+   void setNextAssumptionForSameJittedBody(RuntimeAssumption *link) { _nextAssumptionForSameJittedBody = link; }
+
+   bool enqueueInListOfAssumptionsForJittedBody(RuntimeAssumption **sentinel); // must be executed under assumptionTableMutex
+   void dequeueFromListOfAssumptionsForJittedBody();
+   void paint()
+      {
+      _key = 0xDEADF00D;
+      _nextAssumptionForSameJittedBody = 0;
+      setNext(NULL);
+      }
+
+   protected:
+   RuntimeAssumption *_nextAssumptionForSameJittedBody; // links assumptions that pertain to the same method body
+                                                           // These should form a circular linked list with a sentinel
+   uintptrj_t _key; // key for searching in the hashtable
+   };
+
+}
+
+namespace TR
+{
+
+class SentinelRuntimeAssumption : public OMR::RuntimeAssumption
+   {
+   public:
+   SentinelRuntimeAssumption() :  RuntimeAssumption(NULL, 0)
+      {
+      _nextAssumptionForSameJittedBody = this; // pointing to itself means that the list is empty
+      }
+   virtual TR_RuntimeAssumptionKind getAssumptionKind() { return RuntimeAssumptionSentinel; }
+   virtual void     compensate(TR_FrontEnd *vm, bool isSMP, void *data) {}
+   virtual bool     equals(RuntimeAssumption &other) { return false; }
+
+   virtual uint8_t *getAssumingPC() { return NULL; }
+   virtual void     dumpInfo() {};
+   }; // TR::SentinelRuntimeAssumption
+
+}
+
+#endif


### PR DESCRIPTION
1. Make RuntimeAssumption an OMR abstract class and SentinelRuntimeAssumption a TR concrete class. 
2. Create two new abstract classes LocationRedirectRuntimeAssumption and ValueModRuntimeAssumption that derive from RuntimeAssumption to better categorize different kinds of runtime assumptions.


Signed-off-by: Xiaoli Liang <xsliang@ca.ibm.com>
