### PR TITLE
OpCodeTest improvements

### DIFF
--- a/fvtest/compilertest/ilgen/StoreOpIlInjector.hpp
+++ b/fvtest/compilertest/ilgen/StoreOpIlInjector.hpp
@@ -16,6 +16,9 @@
  *    Multiple authors (IBM Corp.) - initial implementation and documentation
  *******************************************************************************/
 
+#ifndef TEST_STORE_OP_IL_INJECTOR_HPP
+#define TEST_STORE_OP_IL_INJECTOR_HPP 
+
 #include "ilgen/OpIlInjector.hpp"
 
 namespace TR { class TypeDictionary; }
@@ -39,3 +42,6 @@ class StoreOpIlInjector : public OpIlInjector
    };
 
 } // namespace TestCompiler
+
+#endif
+

--- a/fvtest/compilertest/tests/OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/OpCodesTest.cpp
@@ -537,67 +537,6 @@ OpCodesTest::compileTestMethods()
    {
    }
 
-uint8_t *
-OpCodesTest::compileDirectCallOpCodeMethod(int32_t opCodeArgsNum,
-      TR::ILOpCodes opCodeCompilee,
-      TR::ILOpCodes opCode,
-      char * compileeResolvedMethodName,
-      char * testResolvedMethodName,
-      TR::DataType * argTypes,
-      TR::DataType returnType,
-      int32_t & returnCode)
-   {
-   TR::TypeDictionary types;
-   ChildlessUnaryOpIlInjector functionIlInjector(&types, this, opCodeCompilee);
-
-   TR::IlType **argIlTypes = new TR::IlType*[opCodeArgsNum];
-   for (int32_t i=0;i < opCodeArgsNum;i++)
-      argIlTypes[i] = types.PrimitiveType(argTypes[i]);
-
-   TR::ResolvedMethod functionCompilee(__FILE__, LINETOSTR(__LINE__), compileeResolvedMethodName, opCodeArgsNum, argIlTypes, types.PrimitiveType(returnType), 0, &functionIlInjector);
-   TR::IlGeneratorMethodDetails functionDetails(&functionCompilee);
-   switch (returnType)
-      {
-      case TR::Int32:
-         _int32Compilee = &functionCompilee;
-         _int32CompiledMethod = (signatureCharI_I_testMethodType *) (compileMethod(functionDetails, warm, returnCode));
-         functionCompilee.setEntryPoint((void *)_int32CompiledMethod);
-         break;
-      case TR::Int64:
-         _int64Compilee = &functionCompilee;
-         _int64CompiledMethod = (signatureCharJ_J_testMethodType *) (compileMethod(functionDetails, warm, returnCode));
-         functionCompilee.setEntryPoint((void *)_int64CompiledMethod);
-         break;
-      case TR::Double:
-         _doubleCompilee = &functionCompilee;
-         _doubleCompiledMethod = (signatureCharD_D_testMethodType *) (compileMethod(functionDetails, warm, returnCode));
-         functionCompilee.setEntryPoint((void *)_doubleCompiledMethod);
-         break;
-      case TR::Float:
-         _floatCompilee = &functionCompilee;
-         _floatCompiledMethod = (signatureCharF_F_testMethodType *) (compileMethod(functionDetails, warm, returnCode));
-         functionCompilee.setEntryPoint((void *)_floatCompiledMethod);
-         break;
-      case TR::Address:
-         _addressCompilee = &functionCompilee;
-         _addressCompiledMethod = (signatureCharL_L_testMethodType *) (compileMethod(functionDetails, warm, returnCode));
-         functionCompilee.setEntryPoint((void *)_addressCompiledMethod);
-         break;
-      default:
-         TR_ASSERT(0, "compilee dataType should be int32, int64, double, float or address");
-      }
-   EXPECT_TRUE(COMPILATION_SUCCEEDED == returnCode || COMPILATION_REQUESTED == returnCode) 
-      << "Compiling callee method " << compileeResolvedMethodName << " failed unexpectedly";
-
-   CallIlInjector callIlInjector(&types, this, opCode);
-   TR::ResolvedMethod callCompilee(__FILE__, LINETOSTR(__LINE__), testResolvedMethodName, opCodeArgsNum, argIlTypes, types.PrimitiveType(returnType), 0, &callIlInjector);
-   TR::IlGeneratorMethodDetails callDetails(&callCompilee);
-   uint8_t *startPC = compileMethod(callDetails, warm, returnCode);
-   EXPECT_TRUE(COMPILATION_SUCCEEDED == returnCode || COMPILATION_REQUESTED == returnCode) 
-      << "Compiling test method " << testResolvedMethodName << " failed unexpectedly";
-   return startPC;
-   }
-
 void
 OpCodesTest::addUnsupportedOpCodeTest(int32_t opCodeArgsNum,
       TR::ILOpCodes opCode,

--- a/fvtest/compilertest/tests/OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/OpCodesTest.cpp
@@ -538,148 +538,6 @@ OpCodesTest::compileTestMethods()
    }
 
 uint8_t *
-OpCodesTest::compileOpCodeMethod(int32_t opCodeArgsNum,
-      TR::ILOpCodes opCode,
-      char * resolvedMethodName,
-      TR::DataType * argTypes,
-      TR::DataType returnType,
-      int32_t & returnCode,
-      uint16_t numArgs,
-      ...)
-   {
-   TR_ASSERT((numArgs % 2) == 0, "Must be called with zero or an even args, numChildArgs = %d", numArgs);
-   if ((numArgs % 2) != 0)
-      {
-      fprintf(stderr, "Error: numArgs must be called with zero or an even args, numArgs is %d", numArgs);
-      exit(-1);
-      }
-
-   OpIlInjector * opCodeInjector = 0;
-   TR::ILOpCode op(opCode);
-
-   TR::TypeDictionary types;
-
-   CmpBranchOpIlInjector cmpBranchIlnjector(&types, this, opCode);
-   BinaryOpIlInjector opCodeBinaryInjector(&types, this, opCode);
-   UnaryOpIlInjector opCodeUnaryInjector(&types, this, opCode);
-   TernaryOpIlInjector ternaryOpIlInjector(&types, this, opCode);
-   ChildlessUnaryOpIlInjector childlessUnaryOpIlInjector(&types, this, opCode);
-   StoreOpIlInjector storeOpIlInjector(&types, this, opCode);
-   IndirectLoadIlInjector indirectLoadIlInjector(&types, this, opCode);
-   IndirectStoreIlInjector indirectStoreIlInjector(&types, this, opCode);
-
-   if (op.isBooleanCompare() && op.isBranch())
-      {
-      opCodeInjector = &cmpBranchIlnjector;
-      }
-   else if (op.isTernary())
-      {
-      opCodeInjector = &ternaryOpIlInjector;
-      }
-   else if (op.isStoreIndirect())
-      {
-      opCodeInjector = &indirectStoreIlInjector;
-      }
-   else if (op.isLoadIndirect())
-      {
-      opCodeInjector = &indirectLoadIlInjector;
-      }
-   else if (((op.isLoadVar() || op.isLoadConst()) && !op.isIndirect()) || op.isReturn() )
-      {
-      opCodeInjector = &childlessUnaryOpIlInjector;
-      }
-   else if (op.isStore() && !op.isStoreIndirect())
-      {
-      opCodeInjector = &storeOpIlInjector;
-      }
-
-   else
-      {
-      if (2 == opCodeArgsNum)
-         {
-         opCodeInjector = &opCodeBinaryInjector;
-         }
-      else
-         {
-         opCodeInjector = &opCodeUnaryInjector;
-         }
-      }
-
-   TR::IlType **argIlTypes = new TR::IlType*[opCodeArgsNum];
-   for (uint32_t a=0;a < opCodeArgsNum;a++)
-      argIlTypes[a] = types.PrimitiveType(argTypes[a]);
-
-   if (numArgs != 0)
-      {
-      va_list args;
-      va_start(args, numArgs);
-      for (int32_t i = 0; i < numArgs; i = i + 2)
-         {
-
-         uint32_t pos = va_arg(args, uint32_t);
-         void * value = va_arg(args, void *);
-
-         switch (argTypes[pos - 1])
-             {
-             case TR::Int8:
-                {
-                int8_t *int8Value = (int8_t *) value;
-                opCodeInjector->bconstParm(pos, *int8Value);
-                break;
-                }
-             case TR::Int16:
-                {
-                int16_t * int16Value = (int16_t *) value;
-                opCodeInjector->sconstParm(pos, *int16Value);
-                break;
-                }
-             case TR::Int32:
-                {
-                int32_t * int32Value = (int32_t *) value;
-                opCodeInjector->iconstParm(pos, *int32Value);
-                break;
-                }
-             case TR::Int64:
-                {
-                int64_t * int64Value = (int64_t *) value;
-                opCodeInjector->lconstParm(pos, *int64Value);
-                break;
-                }
-             case TR::Float:
-                {
-                float * floatValue = (float *) value;
-                opCodeInjector->fconstParm(pos, *floatValue);
-                break;
-                }
-             case TR::Double:
-                {
-                double * doubleValue = (double *) value;
-                opCodeInjector->dconstParm(pos, *doubleValue);
-                break;
-                }
-             case TR::Address:
-                {
-                uintptrj_t * addressValue = (uintptrj_t *) value;
-                opCodeInjector->aconstParm(pos, *addressValue);
-                break;
-                }
-             default:
-                TR_ASSERT(0, "Wrong dataType or not supported dataType");
-             }
-          }
-      va_end(args);
-      }
-   TR::ResolvedMethod opCodeCompilee(__FILE__, LINETOSTR(__LINE__), resolvedMethodName, opCodeArgsNum, argIlTypes, types.PrimitiveType(returnType), 0, opCodeInjector);
-   TR::IlGeneratorMethodDetails opCodeDetails(&opCodeCompilee);
-   uint8_t *startPC= compileMethod(opCodeDetails, warm, returnCode);
-   EXPECT_TRUE(COMPILATION_SUCCEEDED == returnCode || 
-               COMPILATION_IL_GEN_FAILURE == returnCode || 
-               COMPILATION_REQUESTED == returnCode) 
-      << "compileOpCodeMethod: Compiling method " << resolvedMethodName << " failed unexpectedly";
-   return startPC;
-   }
-
-uint8_t *
 OpCodesTest::compileDirectCallOpCodeMethod(int32_t opCodeArgsNum,
       TR::ILOpCodes opCodeCompilee,
       TR::ILOpCodes opCode,
@@ -747,8 +605,11 @@ OpCodesTest::addUnsupportedOpCodeTest(int32_t opCodeArgsNum,
       TR::DataType * argTypes,
       TR::DataType returnType)
    {
+   typedef void (*functype)();
+   functype never_succeeds; 
+
    int32_t returnCode = 0;
-   compileOpCodeMethod(opCodeArgsNum, opCode, resolvedMethodName, argTypes, returnType, returnCode);
+   compileOpCodeMethod(never_succeeds, opCodeArgsNum, opCode, resolvedMethodName, argTypes, returnType, returnCode);
    EXPECT_TRUE(COMPILATION_IL_GEN_FAILURE == returnCode || COMPILATION_REQUESTED == returnCode) 
       << resolvedMethodName << " is " << returnCode << ", expected is 0 or " << COMPILATION_IL_GEN_FAILURE;
    }
@@ -779,12 +640,12 @@ void
 OpCodesTest::compileIntegerArithmeticTestMethods()
    {
    int32_t rc = 0;
-   _iAdd = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iadd, "iAdd", _argTypesBinaryInt, TR::Int32, rc));
-   _iSub = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::isub, "iSub", _argTypesBinaryInt, TR::Int32, rc));
-   _iDiv = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::idiv, "iDiv", _argTypesBinaryInt, TR::Int32, rc));
-   _iMul = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::imul, "iMul", _argTypesBinaryInt, TR::Int32, rc));
-   _iMulh = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::imulh, "iMulh", _argTypesBinaryInt, TR::Int32, rc));
-   _iRem = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::irem, "iRem", _argTypesBinaryInt, TR::Int32, rc));
+   compileOpCodeMethod(_iAdd, _numberOfBinaryArgs, TR::iadd, "iAdd", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iSub, _numberOfBinaryArgs, TR::isub, "iSub", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iDiv, _numberOfBinaryArgs, TR::idiv, "iDiv", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iMul, _numberOfBinaryArgs, TR::imul, "iMul", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iMulh, _numberOfBinaryArgs, TR::imulh, "iMulh", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iRem, _numberOfBinaryArgs, TR::irem, "iRem", _argTypesBinaryInt, TR::Int32, rc);
    }
 
 void
@@ -792,20 +653,20 @@ OpCodesTest::compileMemoryOperationTestMethods()
    {
    int32_t rc = 0;
 
-   _iLoad = (signatureCharI_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iload, "iLoad", _argTypesUnaryInt, TR::Int32, rc));
-   _lLoad = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lload, "lLoad", _argTypesUnaryLong, TR::Int64, rc));
-   _dLoad = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dload, "dLoad", _argTypesUnaryDouble, TR::Double, rc));
-   _fLoad = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::fload, "fLoad", _argTypesUnaryFloat, TR::Float, rc));
+   compileOpCodeMethod(_iLoad, _numberOfUnaryArgs, TR::iload, "iLoad", _argTypesUnaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_lLoad, _numberOfUnaryArgs, TR::lload, "lLoad", _argTypesUnaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_dLoad, _numberOfUnaryArgs, TR::dload, "dLoad", _argTypesUnaryDouble, TR::Double, rc);
+   compileOpCodeMethod(_fLoad, _numberOfUnaryArgs, TR::fload, "fLoad", _argTypesUnaryFloat, TR::Float, rc);
 
-   _iStore = (signatureCharI_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::istore, "iStore", _argTypesUnaryInt, TR::Int32, rc));
+   compileOpCodeMethod(_iStore, _numberOfUnaryArgs, TR::istore, "iStore", _argTypesUnaryInt, TR::Int32, rc);
 
-   _iLoadi = (signatureCharL_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iloadi, "iLoadi", _argTypesUnaryAddress, TR::Int32, rc));
-   _lLoadi = (signatureCharL_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lloadi, "lLoadi", _argTypesUnaryAddress, TR::Int64, rc));
-   _dLoadi = (signatureCharL_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dloadi, "dLoadi", _argTypesUnaryAddress, TR::Double, rc));
-   _fLoadi = (signatureCharL_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::floadi, "fLoadi", _argTypesUnaryAddress, TR::Float, rc));
-   _bLoadi = (signatureCharL_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bloadi, "bLoadi", _argTypesUnaryAddress, TR::Int8, rc));
-   _sLoadi = (signatureCharL_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::sloadi, "sLoadi", _argTypesUnaryAddress, TR::Int16, rc));
-   _aLoadi = (signatureCharL_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::aloadi, "aLoadi", _argTypesUnaryAddress, TR::Address, rc));
+   compileOpCodeMethod(_iLoadi, _numberOfUnaryArgs, TR::iloadi, "iLoadi", _argTypesUnaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_lLoadi, _numberOfUnaryArgs, TR::lloadi, "lLoadi", _argTypesUnaryAddress, TR::Int64, rc);
+   compileOpCodeMethod(_dLoadi, _numberOfUnaryArgs, TR::dloadi, "dLoadi", _argTypesUnaryAddress, TR::Double, rc);
+   compileOpCodeMethod(_fLoadi, _numberOfUnaryArgs, TR::floadi, "fLoadi", _argTypesUnaryAddress, TR::Float, rc);
+   compileOpCodeMethod(_bLoadi, _numberOfUnaryArgs, TR::bloadi, "bLoadi", _argTypesUnaryAddress, TR::Int8, rc);
+   compileOpCodeMethod(_sLoadi, _numberOfUnaryArgs, TR::sloadi, "sLoadi", _argTypesUnaryAddress, TR::Int16, rc);
+   compileOpCodeMethod(_aLoadi, _numberOfUnaryArgs, TR::aloadi, "aLoadi", _argTypesUnaryAddress, TR::Address, rc);
 
    }
 
@@ -814,21 +675,21 @@ OpCodesTest::compileUnaryTestMethods()
    {
    int32_t rc = 0;
 
-   _iNeg = (signatureCharI_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::ineg, "iNeg", _argTypesUnaryInt, TR::Int32, rc));
-   _iAbs = (signatureCharI_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iabs, "iAbs", _argTypesUnaryInt, TR::Int32, rc));
+   compileOpCodeMethod(_iNeg, _numberOfUnaryArgs, TR::ineg, "iNeg", _argTypesUnaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iAbs, _numberOfUnaryArgs, TR::iabs, "iAbs", _argTypesUnaryInt, TR::Int32, rc);
 
-   _iReturn = (signatureCharI_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::ireturn, "iReturn", _argTypesUnaryInt, TR::Int32, rc));
+   compileOpCodeMethod(_iReturn, _numberOfUnaryArgs, TR::ireturn, "iReturn", _argTypesUnaryInt, TR::Int32, rc);
 
-   _i2l = (signatureCharI_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::i2l, "i2l", _argTypesUnaryInt, TR::Int64, rc));
-   _i2b = (signatureCharI_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::i2b, "i2b", _argTypesUnaryInt, TR::Int8, rc));
-   _i2s = (signatureCharI_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::i2s, "i2s", _argTypesUnaryInt, TR::Int16, rc));
+   compileOpCodeMethod(_i2l, _numberOfUnaryArgs, TR::i2l, "i2l", _argTypesUnaryInt, TR::Int64, rc);
+   compileOpCodeMethod(_i2b, _numberOfUnaryArgs, TR::i2b, "i2b", _argTypesUnaryInt, TR::Int8, rc);
+   compileOpCodeMethod(_i2s, _numberOfUnaryArgs, TR::i2s, "i2s", _argTypesUnaryInt, TR::Int16, rc);
 
-   _l2i = (signatureCharJ_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::l2i, "l2i", _argTypesUnaryLong, TR::Int32, rc));
-   _l2b = (signatureCharJ_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::l2b, "l2b", _argTypesUnaryLong, TR::Int8, rc));
-   _l2s = (signatureCharJ_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::l2s, "l2s", _argTypesUnaryLong, TR::Int16, rc));
+   compileOpCodeMethod(_l2i, _numberOfUnaryArgs, TR::l2i, "l2i", _argTypesUnaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_l2b, _numberOfUnaryArgs, TR::l2b, "l2b", _argTypesUnaryLong, TR::Int8, rc);
+   compileOpCodeMethod(_l2s, _numberOfUnaryArgs, TR::l2s, "l2s", _argTypesUnaryLong, TR::Int16, rc);
 
-   _f2i = (signatureCharF_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2i, "f2i", _argTypesUnaryFloat, TR::Int32, rc));
-   _d2i = (signatureCharD_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2i, "d2i", _argTypesUnaryDouble, TR::Int32, rc));
+   compileOpCodeMethod(_f2i, _numberOfUnaryArgs, TR::f2i, "f2i", _argTypesUnaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_d2i, _numberOfUnaryArgs, TR::d2i, "d2i", _argTypesUnaryDouble, TR::Int32, rc);
 
    }
 
@@ -837,9 +698,9 @@ OpCodesTest::compileShiftOrRolTestMethods()
    {
    int32_t rc = 0;
 
-   _iShl = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ishl, "iShl", _argTypesBinaryInt, TR::Int32, rc));
-   _iShr = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ishr, "iShr", _argTypesBinaryInt, TR::Int32, rc));
-   _iuShr = (unsignedSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iushr, "iuShr", _argTypesBinaryInt, TR::Int32, rc));
+   compileOpCodeMethod(_iShl, _numberOfBinaryArgs, TR::ishl, "iShl", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iShr, _numberOfBinaryArgs, TR::ishr, "iShr", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iuShr, _numberOfBinaryArgs, TR::iushr, "iuShr", _argTypesBinaryInt, TR::Int32, rc);
    }
 
 void
@@ -847,9 +708,9 @@ OpCodesTest::compileBitwiseMethods()
    {
    int32_t rc;
 
-   _iAnd = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iand, "iAnd", _argTypesBinaryInt, TR::Int32, rc));
-   _iOr = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ior, "iOr", _argTypesBinaryInt, TR::Int32, rc));
-   _iXor = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ixor, "iXor", _argTypesBinaryInt, TR::Int32, rc));
+   compileOpCodeMethod(_iAnd, _numberOfBinaryArgs, TR::iand, "iAnd", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iOr, _numberOfBinaryArgs, TR::ior, "iOr", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iXor, _numberOfBinaryArgs, TR::ixor, "iXor", _argTypesBinaryInt, TR::Int32, rc);
    }
 
 void
@@ -858,52 +719,52 @@ OpCodesTest::compileCompareTestMethods()
    int32_t rc = 0;
 
    //Compare
-   _iCmpeq = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::icmpeq, "iCmpeq", _argTypesBinaryInt, TR::Int32, rc));
-   _iCmpne = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::icmpne, "iCmpne", _argTypesBinaryInt, TR::Int32, rc));
-   _iCmpgt = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::icmpgt, "iCmpgt", _argTypesBinaryInt, TR::Int32, rc));
-   _iCmplt = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::icmplt, "iCmplt", _argTypesBinaryInt, TR::Int32, rc));
-   _iCmpge = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::icmpge, "iCmpge", _argTypesBinaryInt, TR::Int32, rc));
-   _iCmple = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::icmple, "iCmple", _argTypesBinaryInt, TR::Int32, rc));
+   compileOpCodeMethod(_iCmpeq, _numberOfBinaryArgs, TR::icmpeq, "iCmpeq", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iCmpne, _numberOfBinaryArgs, TR::icmpne, "iCmpne", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iCmpgt, _numberOfBinaryArgs, TR::icmpgt, "iCmpgt", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iCmplt, _numberOfBinaryArgs, TR::icmplt, "iCmplt", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iCmpge, _numberOfBinaryArgs, TR::icmpge, "iCmpge", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iCmple, _numberOfBinaryArgs, TR::icmple, "iCmple", _argTypesBinaryInt, TR::Int32, rc);
 
-   _lCmpne = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lcmpne, "lCmpne", _argTypesBinaryLong, TR::Int32, rc));
-   _lCmpgt = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lcmpgt, "lCmpgt", _argTypesBinaryLong, TR::Int32, rc));
-   _lCmpge = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lcmpge, "lCmpge", _argTypesBinaryLong, TR::Int32, rc));
-   _lCmple = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lcmple, "lCmple", _argTypesBinaryLong, TR::Int32, rc));
+   compileOpCodeMethod(_lCmpne, _numberOfBinaryArgs, TR::lcmpne, "lCmpne", _argTypesBinaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_lCmpgt, _numberOfBinaryArgs, TR::lcmpgt, "lCmpgt", _argTypesBinaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_lCmpge, _numberOfBinaryArgs, TR::lcmpge, "lCmpge", _argTypesBinaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_lCmple, _numberOfBinaryArgs, TR::lcmple, "lCmple", _argTypesBinaryLong, TR::Int32, rc);
 
-   _iuCmplt = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iucmplt, "iuCmplt", _argTypesBinaryInt, TR::Int32, rc));
-   _iuCmpgt = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iucmpgt, "iuCmpgt", _argTypesBinaryInt, TR::Int32, rc));
-   _iuCmple = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iucmple, "iuCmple", _argTypesBinaryInt, TR::Int32, rc));
-   _luCmpeq = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lucmpeq, "luCmpeq", _argTypesBinaryLong, TR::Int32, rc));
-   _luCmpne = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lucmpne, "luCmpne", _argTypesBinaryLong, TR::Int32, rc));
-   _luCmplt = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lucmplt, "luCmplt", _argTypesBinaryLong, TR::Int32, rc));
-   _luCmpge = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lucmpge, "luCmpge", _argTypesBinaryLong, TR::Int32, rc));
-   _luCmpgt = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lucmpgt, "luCmpgt", _argTypesBinaryLong, TR::Int32, rc));
-   _luCmple = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lucmple, "luCmple", _argTypesBinaryLong, TR::Int32, rc));
+   compileOpCodeMethod(_iuCmplt, _numberOfBinaryArgs, TR::iucmplt, "iuCmplt", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iuCmpgt, _numberOfBinaryArgs, TR::iucmpgt, "iuCmpgt", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iuCmple, _numberOfBinaryArgs, TR::iucmple, "iuCmple", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_luCmpeq, _numberOfBinaryArgs, TR::lucmpeq, "luCmpeq", _argTypesBinaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_luCmpne, _numberOfBinaryArgs, TR::lucmpne, "luCmpne", _argTypesBinaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_luCmplt, _numberOfBinaryArgs, TR::lucmplt, "luCmplt", _argTypesBinaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_luCmpge, _numberOfBinaryArgs, TR::lucmpge, "luCmpge", _argTypesBinaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_luCmpgt, _numberOfBinaryArgs, TR::lucmpgt, "luCmpgt", _argTypesBinaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_luCmple, _numberOfBinaryArgs, TR::lucmple, "luCmple", _argTypesBinaryLong, TR::Int32, rc);
 
    //CompareAndBranch
-   _ifIcmpeq = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ificmpeq, "ifIcmpeq", _argTypesBinaryInt, TR::Int32, rc));
-   _ifIcmpne = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ificmpne, "ifIcmpne", _argTypesBinaryInt, TR::Int32, rc));
-   _ifIcmpgt = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ificmpgt, "ifIcmpgt", _argTypesBinaryInt, TR::Int32, rc));
-   _ifIcmplt = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ificmplt, "ifIcmplt", _argTypesBinaryInt, TR::Int32, rc));
-   _ifIcmpge = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ificmpge, "ifIcmpge", _argTypesBinaryInt, TR::Int32, rc));
-   _ifIcmple = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ificmple, "ifIcmple", _argTypesBinaryInt, TR::Int32, rc));
+   compileOpCodeMethod(_ifIcmpeq, _numberOfBinaryArgs, TR::ificmpeq, "ifIcmpeq", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_ifIcmpne, _numberOfBinaryArgs, TR::ificmpne, "ifIcmpne", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_ifIcmpgt, _numberOfBinaryArgs, TR::ificmpgt, "ifIcmpgt", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_ifIcmplt, _numberOfBinaryArgs, TR::ificmplt, "ifIcmplt", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_ifIcmpge, _numberOfBinaryArgs, TR::ificmpge, "ifIcmpge", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_ifIcmple, _numberOfBinaryArgs, TR::ificmple, "ifIcmple", _argTypesBinaryInt, TR::Int32, rc);
 
-   _ifLcmpne = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iflcmpne, "ifLcmpne", _argTypesBinaryLong, TR::Int32, rc));
-   _ifLcmpge = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iflcmpge, "ifLcmpge", _argTypesBinaryLong, TR::Int32, rc));
-   _ifLcmple = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iflcmple, "ifLcmple", _argTypesBinaryLong, TR::Int32, rc));
+   compileOpCodeMethod(_ifLcmpne, _numberOfBinaryArgs, TR::iflcmpne, "ifLcmpne", _argTypesBinaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_ifLcmpge, _numberOfBinaryArgs, TR::iflcmpge, "ifLcmpge", _argTypesBinaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_ifLcmple, _numberOfBinaryArgs, TR::iflcmple, "ifLcmple", _argTypesBinaryLong, TR::Int32, rc);
 
-   _ifIuCmpeq = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifiucmpeq, "ifIuCmpeq", _argTypesBinaryInt, TR::Int32, rc));
-   _ifIuCmpne = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifiucmpne, "ifIuCmpne", _argTypesBinaryInt, TR::Int32, rc));
-   _ifIuCmplt = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifiucmplt, "ifIuCmplt", _argTypesBinaryInt, TR::Int32, rc));
-   _ifIuCmpge = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifiucmpge, "ifIuCmpge", _argTypesBinaryInt, TR::Int32, rc));
-   _ifIuCmpgt = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifiucmpgt, "ifIuCmpgt", _argTypesBinaryInt, TR::Int32, rc));
-   _ifIuCmple = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifiucmple, "ifIuCmple", _argTypesBinaryInt, TR::Int32, rc));
-   _ifLuCmpeq = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iflucmpeq, "ifLuCmpeq", _argTypesBinaryLong, TR::Int32, rc));
-   _ifLuCmpne = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iflucmpne, "ifLuCmpne", _argTypesBinaryLong, TR::Int32, rc));
-   _ifLuCmplt = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iflucmplt, "ifLuCmplt", _argTypesBinaryLong, TR::Int32, rc));
-   _ifLuCmpge = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iflucmpge, "ifLuCmpge", _argTypesBinaryLong, TR::Int32, rc));
-   _ifLuCmpgt = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iflucmpgt, "ifLuCmpgt", _argTypesBinaryLong, TR::Int32, rc));
-   _ifLuCmple = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iflucmple, "ifLuCmple", _argTypesBinaryLong, TR::Int32, rc));
+   compileOpCodeMethod(_ifIuCmpeq, _numberOfBinaryArgs, TR::ifiucmpeq, "ifIuCmpeq", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_ifIuCmpne, _numberOfBinaryArgs, TR::ifiucmpne, "ifIuCmpne", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_ifIuCmplt, _numberOfBinaryArgs, TR::ifiucmplt, "ifIuCmplt", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_ifIuCmpge, _numberOfBinaryArgs, TR::ifiucmpge, "ifIuCmpge", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_ifIuCmpgt, _numberOfBinaryArgs, TR::ifiucmpgt, "ifIuCmpgt", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_ifIuCmple, _numberOfBinaryArgs, TR::ifiucmple, "ifIuCmple", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_ifLuCmpeq, _numberOfBinaryArgs, TR::iflucmpeq, "ifLuCmpeq", _argTypesBinaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_ifLuCmpne, _numberOfBinaryArgs, TR::iflucmpne, "ifLuCmpne", _argTypesBinaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_ifLuCmplt, _numberOfBinaryArgs, TR::iflucmplt, "ifLuCmplt", _argTypesBinaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_ifLuCmpge, _numberOfBinaryArgs, TR::iflucmpge, "ifLuCmpge", _argTypesBinaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_ifLuCmpgt, _numberOfBinaryArgs, TR::iflucmpgt, "ifLuCmpgt", _argTypesBinaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_ifLuCmple, _numberOfBinaryArgs, TR::iflucmple, "ifLuCmple", _argTypesBinaryLong, TR::Int32, rc);
    }
 
 void
@@ -911,7 +772,7 @@ OpCodesTest::compileTernaryTestMethods()
    {
    int32_t rc = 0;
 
-   _iternary = (signatureCharIII_I_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::iternary, "iTernary", _argTypesTernaryInt, TR::Int32, rc));
+   compileOpCodeMethod(_iternary, _numberOfTernaryArgs, TR::iternary, "iTernary", _argTypesTernaryInt, TR::Int32, rc);
    }
 
 void
@@ -919,10 +780,10 @@ OpCodesTest::compileAddressTestMethods()
    {
    int32_t rc = 0;
 
-   _aload = (signatureCharL_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::aload, "aload", _argTypesUnaryAddress, TR::Address, rc));
-   _astore = (signatureCharL_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::astore, "astore", _argTypesUnaryAddress, TR::Address, rc));
-   _areturn = (signatureCharL_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::areturn, "areturn", _argTypesUnaryAddress, TR::Address, rc));
-   _a2i = (signatureCharL_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::a2i, "a2i", _argTypesUnaryAddress, TR::Int32, rc));
+   compileOpCodeMethod(_aload, _numberOfUnaryArgs, TR::aload, "aload", _argTypesUnaryAddress, TR::Address, rc);
+   compileOpCodeMethod(_astore, _numberOfUnaryArgs, TR::astore, "astore", _argTypesUnaryAddress, TR::Address, rc);
+   compileOpCodeMethod(_areturn, _numberOfUnaryArgs, TR::areturn, "areturn", _argTypesUnaryAddress, TR::Address, rc);
+   compileOpCodeMethod(_a2i, _numberOfUnaryArgs, TR::a2i, "a2i", _argTypesUnaryAddress, TR::Int32, rc);
 
    }
 
@@ -931,8 +792,8 @@ OpCodesTest::compileDisabledOpCodesTests()
    {
    int32_t rc = 0;
    //Jazz103 Work item 110364
-   _fRem = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::frem, "fRem", _argTypesBinaryFloat, TR::Float, rc));
-   _dRem = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::drem, "dRem", _argTypesBinaryDouble, TR::Double, rc));
+   compileOpCodeMethod(_fRem, _numberOfBinaryArgs, TR::frem, "fRem", _argTypesBinaryFloat, TR::Float, rc);
+   compileOpCodeMethod(_dRem, _numberOfBinaryArgs, TR::drem, "dRem", _argTypesBinaryDouble, TR::Double, rc);
    }
 
 void
@@ -999,18 +860,18 @@ OpCodesTest::invokeIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_iAdd, add(intAddArr[i][0], intAddArr[i][1]), _iAdd(intAddArr[i][0], intAddArr[i][1]));
 
       sprintf(resolvedMethodName, "iAddConst1_Testcase%d", i);
-      iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iadd,
-            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &intAddArr[i][0], 2, &intAddArr[i][1]));
+      compileOpCodeMethod(iBinaryCons, _numberOfBinaryArgs, TR::iadd,
+            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &intAddArr[i][0], 2, &intAddArr[i][1]);
       OMR_CT_EXPECT_EQ(iBinaryCons, add(intAddArr[i][0], intAddArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iAddConst2_Testcase%d", i);
-      iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iadd,
-            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &intAddArr[i][0]));
+      compileOpCodeMethod(iBinaryCons, _numberOfBinaryArgs, TR::iadd,
+            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &intAddArr[i][0]);
       OMR_CT_EXPECT_EQ(iBinaryCons, add(intAddArr[i][0], intAddArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, intAddArr[i][1]));
 
       sprintf(resolvedMethodName, "iAddConst3_Testcase%d", i);
-      iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iadd,
-            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &intAddArr[i][1]));
+      compileOpCodeMethod(iBinaryCons, _numberOfBinaryArgs, TR::iadd,
+            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &intAddArr[i][1]);
       OMR_CT_EXPECT_EQ(iBinaryCons, add(intAddArr[i][0], intAddArr[i][1]), iBinaryCons(intAddArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -1021,18 +882,18 @@ OpCodesTest::invokeIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_iSub, sub(intSubArr[i][0], intSubArr[i][1]), _iSub(intSubArr[i][0], intSubArr[i][1]));
 
       sprintf(resolvedMethodName, "iSubConst1_Testcase%d", i);
-      iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::isub,
-            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &intSubArr[i][0], 2, &intSubArr[i][1]));
+      compileOpCodeMethod(iBinaryCons, _numberOfBinaryArgs, TR::isub,
+            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &intSubArr[i][0], 2, &intSubArr[i][1]);
       OMR_CT_EXPECT_EQ(iBinaryCons, sub(intSubArr[i][0], intSubArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iSubConst2_Testcase%d", i);
-      iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::isub,
-            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &intSubArr[i][0]));
+      compileOpCodeMethod(iBinaryCons, _numberOfBinaryArgs, TR::isub,
+            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &intSubArr[i][0]);
       OMR_CT_EXPECT_EQ(iBinaryCons, sub(intSubArr[i][0], intSubArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, intSubArr[i][1]));
 
       sprintf(resolvedMethodName, "iSubConst3_Testcase%d", i);
-      iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::isub,
-            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &intSubArr[i][1]));
+      compileOpCodeMethod(iBinaryCons, _numberOfBinaryArgs, TR::isub,
+            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &intSubArr[i][1]);
       OMR_CT_EXPECT_EQ(iBinaryCons, sub(intSubArr[i][0], intSubArr[i][1]), iBinaryCons(intSubArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -1043,18 +904,18 @@ OpCodesTest::invokeIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_iMul, mul(intMulArr[i][0], intMulArr[i][1]), _iMul(intMulArr[i][0], intMulArr[i][1]));
 
       sprintf(resolvedMethodName, "iMulConst1_Testcase%d", i);
-      iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::imul,
-            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &intMulArr[i][0], 2, &intMulArr[i][1]));
+      compileOpCodeMethod(iBinaryCons, _numberOfBinaryArgs, TR::imul,
+            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &intMulArr[i][0], 2, &intMulArr[i][1]);
       OMR_CT_EXPECT_EQ(iBinaryCons, mul(intMulArr[i][0], intMulArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iMulConst2_Testcase%d", i);
-      iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::imul,
-            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &intMulArr[i][0]));
+      compileOpCodeMethod(iBinaryCons, _numberOfBinaryArgs, TR::imul,
+            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &intMulArr[i][0]);
       OMR_CT_EXPECT_EQ(iBinaryCons, mul(intMulArr[i][0], intMulArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, intMulArr[i][1]));
 
       sprintf(resolvedMethodName, "iMulConst3_Testcase%d", i);
-      iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::imul,
-            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &intMulArr[i][1]));
+      compileOpCodeMethod(iBinaryCons, _numberOfBinaryArgs, TR::imul,
+            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &intMulArr[i][1]);
       OMR_CT_EXPECT_EQ(iBinaryCons, mul(intMulArr[i][0], intMulArr[i][1]), iBinaryCons(intMulArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -1065,18 +926,18 @@ OpCodesTest::invokeIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_iMulh, imulh(intMulArr[i][0], intMulArr[i][1]), _iMulh(intMulArr[i][0], intMulArr[i][1]));
 
       sprintf(resolvedMethodName, "iMulhConst1_Testcase%d", i);
-      iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::imulh,
-            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &intMulArr[i][0], 2, &intMulArr[i][1]));
+      compileOpCodeMethod(iBinaryCons, _numberOfBinaryArgs, TR::imulh,
+            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &intMulArr[i][0], 2, &intMulArr[i][1]);
       OMR_CT_EXPECT_EQ(iBinaryCons, imulh(intMulArr[i][0], intMulArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iMulhConst2_Testcase%d", i);
-      iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::imulh,
-            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &intMulArr[i][0]));
+      compileOpCodeMethod(iBinaryCons, _numberOfBinaryArgs, TR::imulh,
+            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &intMulArr[i][0]);
       OMR_CT_EXPECT_EQ(iBinaryCons, imulh(intMulArr[i][0], intMulArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, intMulArr[i][1]));
 
       sprintf(resolvedMethodName, "iMulhConst3_Testcase%d", i);
-      iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::imulh,
-            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &intMulArr[i][1]));
+      compileOpCodeMethod(iBinaryCons, _numberOfBinaryArgs, TR::imulh,
+            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &intMulArr[i][1]);
       OMR_CT_EXPECT_EQ(iBinaryCons, imulh(intMulArr[i][0], intMulArr[i][1]), iBinaryCons(intMulArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -1089,18 +950,18 @@ OpCodesTest::invokeIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_iDiv, div(intDivArr[i][0], intDivArr[i][1]), _iDiv(intDivArr[i][0], intDivArr[i][1]));
 
       sprintf(resolvedMethodName, "iDivConst1_Testcase%d", i);
-      iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::idiv,
-            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &intDivArr[i][0], 2, &intDivArr[i][1]));
+      compileOpCodeMethod(iBinaryCons, _numberOfBinaryArgs, TR::idiv,
+            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &intDivArr[i][0], 2, &intDivArr[i][1]);
       OMR_CT_EXPECT_EQ(iBinaryCons, div(intDivArr[i][0], intDivArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iDivConst2_Testcase%d", i);
-      iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::idiv,
-            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &intDivArr[i][0]));
+      compileOpCodeMethod(iBinaryCons, _numberOfBinaryArgs, TR::idiv,
+            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &intDivArr[i][0]);
       OMR_CT_EXPECT_EQ(iBinaryCons, div(intDivArr[i][0], intDivArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, intDivArr[i][1]));
 
       sprintf(resolvedMethodName, "iDivConst3_Testcase%d", i);
-      iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::idiv,
-            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &intDivArr[i][1]));
+      compileOpCodeMethod(iBinaryCons, _numberOfBinaryArgs, TR::idiv,
+            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &intDivArr[i][1]);
       OMR_CT_EXPECT_EQ(iBinaryCons, div(intDivArr[i][0], intDivArr[i][1]), iBinaryCons(intDivArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -1113,18 +974,18 @@ OpCodesTest::invokeIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_iRem, rem(intRemArr[i][0], intRemArr[i][1]), _iRem(intRemArr[i][0], intRemArr[i][1]));
 
       sprintf(resolvedMethodName, "iRemConst1_Testcase%d", i);
-      iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::irem,
-            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &intRemArr[i][0], 2, &intRemArr[i][1]));
+      compileOpCodeMethod(iBinaryCons, _numberOfBinaryArgs, TR::irem,
+            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &intRemArr[i][0], 2, &intRemArr[i][1]);
       OMR_CT_EXPECT_EQ(iBinaryCons, rem(intRemArr[i][0], intRemArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iRemConst2_Testcase%d", i);
-      iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::irem,
-            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &intRemArr[i][0]));
+      compileOpCodeMethod(iBinaryCons, _numberOfBinaryArgs, TR::irem,
+            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &intRemArr[i][0]);
       OMR_CT_EXPECT_EQ(iBinaryCons, rem(intRemArr[i][0], intRemArr[i][1]), iBinaryCons(INT_PLACEHOLDER_1, intRemArr[i][1]));
 
       sprintf(resolvedMethodName, "iRemConst3_Testcase%d", i);
-      iBinaryCons = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::irem,
-            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &intRemArr[i][1]));
+      compileOpCodeMethod(iBinaryCons, _numberOfBinaryArgs, TR::irem,
+            resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &intRemArr[i][1]);
       OMR_CT_EXPECT_EQ(iBinaryCons, rem(intRemArr[i][0], intRemArr[i][1]), iBinaryCons(intRemArr[i][0], INT_PLACEHOLDER_2));
       }
    }
@@ -1177,7 +1038,7 @@ OpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "iStoreConst%d", i + 1);
       OMR_CT_EXPECT_EQ(_iStore, intDataArray[i], _iStore(intDataArray[i]));
-      iMemCons = (signatureCharI_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::istore, resolvedMethodName, _argTypesUnaryInt, TR::Int32, rc, 2, 1, &(intDataArray[i])));
+compileOpCodeMethod(      iMemCons, _numberOfUnaryArgs, TR::istore, resolvedMethodName, _argTypesUnaryInt, TR::Int32, rc, 2, 1, &(intDataArray[i]));
       OMR_CT_EXPECT_EQ(iMemCons, intDataArray[i], iMemCons(INT_PLACEHOLDER_1));
       }
 
@@ -1271,18 +1132,18 @@ OpCodesTest::invokeShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_iShl, shl(ishlDataArr[i][0], ishlDataArr[i][1]), _iShl(ishlDataArr[i][0], ishlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iShlConst1_TestCase%d", i + 1);
-      iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ishl, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &ishlDataArr[i][0], 2, &ishlDataArr[i][1]));
+      compileOpCodeMethod(iShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::ishl, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &ishlDataArr[i][0], 2, &ishlDataArr[i][1]);
       OMR_CT_EXPECT_EQ(iShiftOrRolConst, shl(ishlDataArr[i][0], ishlDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iShlConst2_TestCase%d", i + 1);
-      iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ishl, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &ishlDataArr[i][0]));
+      compileOpCodeMethod(iShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::ishl, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &ishlDataArr[i][0]);
       OMR_CT_EXPECT_EQ(iShiftOrRolConst, shl(ishlDataArr[i][0], ishlDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, ishlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iShlConst3_TestCase%d", i + 1);
-      iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ishl, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &ishlDataArr[i][1]));
+      compileOpCodeMethod(iShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::ishl, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &ishlDataArr[i][1]);
       OMR_CT_EXPECT_EQ(iShiftOrRolConst, shl(ishlDataArr[i][0], ishlDataArr[i][1]), iShiftOrRolConst(ishlDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -1293,18 +1154,18 @@ OpCodesTest::invokeShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_iShr, shr(ishrDataArr[i][0], ishrDataArr[i][1]), _iShr(ishrDataArr[i][0],ishrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iShrConst1_TestCase%d", i + 1);
-      iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ishr, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &ishrDataArr[i][0], 2, &ishrDataArr[i][1]));
+      compileOpCodeMethod(      iShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::ishr, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &ishrDataArr[i][0], 2, &ishrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(iShiftOrRolConst, shr(ishrDataArr[i][0], ishrDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iShrConst2_TestCase%d", i + 1);
-      iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ishr, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &ishrDataArr[i][0]));
+      compileOpCodeMethod(      iShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::ishr, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &ishrDataArr[i][0]);
       OMR_CT_EXPECT_EQ(iShiftOrRolConst, shr(ishrDataArr[i][0], ishrDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, ishrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iShrConst3_TestCase%d", i + 1);
-      iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ishr, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &ishrDataArr[i][1]));
+      compileOpCodeMethod(      iShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::ishr, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &ishrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(iShiftOrRolConst, shr(ishrDataArr[i][0], ishrDataArr[i][1]), iShiftOrRolConst(ishrDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -1315,18 +1176,18 @@ OpCodesTest::invokeShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_iuShr, shr(iushrDataArr[i][0], iushrDataArr[i][1]), _iuShr(iushrDataArr[i][0],iushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuShrConst1_TestCase%d", i + 1);
-      iuShiftOrRolConst = (unsignedSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iushr, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &iushrDataArr[i][0], 2, &iushrDataArr[i][1]));
+      compileOpCodeMethod(      iuShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::iushr, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &iushrDataArr[i][0], 2, &iushrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(iuShiftOrRolConst, shr(iushrDataArr[i][0], iushrDataArr[i][1]), iuShiftOrRolConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iuShrConst2_TestCase%d", i + 1);
-      iuShiftOrRolConst = (unsignedSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iushr, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &iushrDataArr[i][0]));
+compileOpCodeMethod(      iuShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::iushr, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &iushrDataArr[i][0]);
       OMR_CT_EXPECT_EQ(iuShiftOrRolConst, shr(iushrDataArr[i][0], iushrDataArr[i][1]), iuShiftOrRolConst(INT_PLACEHOLDER_1, iushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuShrConst3_TestCase%d", i + 1);
-      iuShiftOrRolConst = (unsignedSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iushr, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &iushrDataArr[i][1]));
+compileOpCodeMethod(      iuShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::iushr, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &iushrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(iuShiftOrRolConst, shr(iushrDataArr[i][0], iushrDataArr[i][1]), iuShiftOrRolConst(iushrDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -1377,8 +1238,8 @@ OpCodesTest::invokeUnaryTests()
       {
       OMR_CT_EXPECT_EQ(_iNeg, neg(intDataArray[i]), _iNeg(intDataArray[i]));
       sprintf(resolvedMethodName, "iNegConst%d", i + 1);
-      iUnaryCons = (signatureCharI_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::ineg,
-            resolvedMethodName, _argTypesUnaryInt, TR::Int32, rc, 2, 1, &intDataArray[i]));
+      compileOpCodeMethod(      iUnaryCons, _numberOfUnaryArgs, TR::ineg,
+            resolvedMethodName, _argTypesUnaryInt, TR::Int32, rc, 2, 1, &intDataArray[i]);
       OMR_CT_EXPECT_EQ(iUnaryCons, neg(intDataArray[i]), iUnaryCons(INT_PLACEHOLDER_1));
       }
 
@@ -1388,8 +1249,8 @@ OpCodesTest::invokeUnaryTests()
       {
       OMR_CT_EXPECT_EQ(_iAbs, abs(intDataArray[i]), _iAbs(intDataArray[i]));
       sprintf(resolvedMethodName, "iAbsConst%d", i + 1);
-      iUnaryCons = (signatureCharI_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iabs,
-            resolvedMethodName, _argTypesUnaryInt, TR::Int32, rc, 2, 1, &intDataArray[i]));
+      compileOpCodeMethod(      iUnaryCons, _numberOfUnaryArgs, TR::iabs,
+            resolvedMethodName, _argTypesUnaryInt, TR::Int32, rc, 2, 1, &intDataArray[i]);
       OMR_CT_EXPECT_EQ(iUnaryCons, abs(intDataArray[i]), iUnaryCons(INT_PLACEHOLDER_1));
       }
 
@@ -1399,7 +1260,7 @@ OpCodesTest::invokeUnaryTests()
       {
       sprintf(resolvedMethodName, "iReturnCons%d", i + 1);
       OMR_CT_EXPECT_EQ(_iReturn, intDataArray[i], _iReturn(intDataArray[i]));
-      iUnaryCons = (signatureCharI_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::ireturn, resolvedMethodName, _argTypesUnaryInt, TR::Int32, rc, 2, 1, &(intDataArray[i])));
+      compileOpCodeMethod(      iUnaryCons, _numberOfUnaryArgs, TR::ireturn, resolvedMethodName, _argTypesUnaryInt, TR::Int32, rc, 2, 1, &(intDataArray[i]));
       OMR_CT_EXPECT_EQ(iUnaryCons, intDataArray[i], iUnaryCons(INT_PLACEHOLDER_1));
       }
 
@@ -1408,7 +1269,7 @@ OpCodesTest::invokeUnaryTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "iConst%d", i + 1);
-      iUnaryCons = (signatureCharI_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iconst, resolvedMethodName, _argTypesUnaryInt, TR::Int32, rc, 2, 1, &(intDataArray[i])));
+      compileOpCodeMethod(      iUnaryCons, _numberOfUnaryArgs, TR::iconst, resolvedMethodName, _argTypesUnaryInt, TR::Int32, rc, 2, 1, &(intDataArray[i]));
       OMR_CT_EXPECT_EQ(iUnaryCons, intDataArray[i], iUnaryCons(INT_PLACEHOLDER_1));
       }
 
@@ -1416,7 +1277,7 @@ OpCodesTest::invokeUnaryTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "bConst%d", i + 1);
-      bUnaryCons = (signatureCharB_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bconst, resolvedMethodName, _argTypesUnaryByte, TR::Int8, rc, 2, 1, &(byteDataArray[i])));
+      compileOpCodeMethod(      bUnaryCons, _numberOfUnaryArgs, TR::bconst, resolvedMethodName, _argTypesUnaryByte, TR::Int8, rc, 2, 1, &(byteDataArray[i]));
       OMR_CT_EXPECT_EQ(bUnaryCons, byteDataArray[i], bUnaryCons(BYTE_PLACEHOLDER_1));
       }
 
@@ -1424,7 +1285,7 @@ OpCodesTest::invokeUnaryTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "sConst%d", i + 1);
-      sUnaryCons = (signatureCharS_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::sconst, resolvedMethodName, _argTypesUnaryShort, TR::Int16, rc, 2, 1, &(shortDataArray[i])));
+      compileOpCodeMethod(      sUnaryCons, _numberOfUnaryArgs, TR::sconst, resolvedMethodName, _argTypesUnaryShort, TR::Int16, rc, 2, 1, &(shortDataArray[i]));
       OMR_CT_EXPECT_EQ(sUnaryCons, shortDataArray[i], sUnaryCons(SHORT_PLACEHOLDER_1));
       }
 
@@ -1437,19 +1298,19 @@ OpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_EQ(_i2l, convert(intDataArray[i], LONG_POS), _i2l(intDataArray[i]));
 
       sprintf(resolvedMethodName, "i2bConst%d", i + 1);
-      i2bConst = (signatureCharI_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::i2b,
-            resolvedMethodName, _argTypesUnaryInt, TR::Int8, rc, 2, 1, &intDataArray[i]));
+      compileOpCodeMethod(      i2bConst, _numberOfUnaryArgs, TR::i2b,
+            resolvedMethodName, _argTypesUnaryInt, TR::Int8, rc, 2, 1, &intDataArray[i]);
       OMR_CT_EXPECT_EQ(i2bConst, convert(intDataArray[i], BYTE_POS), i2bConst(INT_PLACEHOLDER_1));
 
 
       sprintf(resolvedMethodName, "i2sConst%d", i + 1);
-      i2sConst = (signatureCharI_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::i2s,
-            resolvedMethodName, _argTypesUnaryInt, TR::Int16, rc, 2, 1, &intDataArray[i]));
+compileOpCodeMethod(      i2sConst, _numberOfUnaryArgs, TR::i2s,
+            resolvedMethodName, _argTypesUnaryInt, TR::Int16, rc, 2, 1, &intDataArray[i]);
       OMR_CT_EXPECT_EQ(i2sConst, convert(intDataArray[i], SHORT_POS), i2sConst(INT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "i2lConst%d", i + 1);
-      i2lConst = (signatureCharI_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::i2l,
-            resolvedMethodName, _argTypesUnaryInt, TR::Int64, rc, 2, 1, &intDataArray[i]));
+compileOpCodeMethod(      i2lConst, _numberOfUnaryArgs, TR::i2l,
+            resolvedMethodName, _argTypesUnaryInt, TR::Int64, rc, 2, 1, &intDataArray[i]);
       OMR_CT_EXPECT_EQ(i2lConst, convert(intDataArray[i], LONG_POS), i2lConst(INT_PLACEHOLDER_1));
       }
 
@@ -1462,18 +1323,18 @@ OpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_EQ(_l2i, convert(longDataArray[i], INT_POS), _l2i(longDataArray[i]));
 
       sprintf(resolvedMethodName, "l2bConst%d", i + 1);
-      l2bConst = (signatureCharJ_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::l2b,
-            resolvedMethodName, _argTypesUnaryLong, TR::Int8, rc, 2, 1, &longDataArray[i]));
+compileOpCodeMethod(      l2bConst, _numberOfUnaryArgs, TR::l2b,
+            resolvedMethodName, _argTypesUnaryLong, TR::Int8, rc, 2, 1, &longDataArray[i]);
       OMR_CT_EXPECT_EQ(l2bConst, convert(longDataArray[i], BYTE_POS), l2bConst(LONG_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "l2sConst%d", i + 1);
-      l2sConst = (signatureCharJ_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::l2s,
-            resolvedMethodName, _argTypesUnaryLong, TR::Int16, rc, 2, 1, &longDataArray[i]));
+compileOpCodeMethod(      l2sConst, _numberOfUnaryArgs, TR::l2s,
+            resolvedMethodName, _argTypesUnaryLong, TR::Int16, rc, 2, 1, &longDataArray[i]);
       OMR_CT_EXPECT_EQ(l2sConst, convert(longDataArray[i], SHORT_POS), l2sConst(LONG_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "l2iConst%d", i + 1);
-      l2iConst = (signatureCharJ_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::l2i,
-            resolvedMethodName, _argTypesUnaryLong, TR::Int32, rc, 2, 1, &longDataArray[i]));
+compileOpCodeMethod(      l2iConst, _numberOfUnaryArgs, TR::l2i,
+            resolvedMethodName, _argTypesUnaryLong, TR::Int32, rc, 2, 1, &longDataArray[i]);
       OMR_CT_EXPECT_EQ(l2iConst, convert(longDataArray[i], INT_POS), l2iConst(LONG_PLACEHOLDER_1));
       }
 
@@ -1489,8 +1350,8 @@ OpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_EQ(_f2i, convert(floatDataArray[i], INT_POS), _f2i(floatDataArray[i]));
 
       sprintf(resolvedMethodName, "f2iConst%d", i + 1);
-      f2iConst = (signatureCharF_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2i,
-            resolvedMethodName, _argTypesUnaryFloat, TR::Int32, rc, 2, 1, &floatDataArray[i]));
+      compileOpCodeMethod(      f2iConst, _numberOfUnaryArgs, TR::f2i,
+                                resolvedMethodName, _argTypesUnaryFloat, TR::Int32, rc, 2, 1, &floatDataArray[i]);
       OMR_CT_EXPECT_EQ(f2iConst, convert(floatDataArray[i], INT_POS), f2iConst(FLOAT_PLACEHOLDER_1));
       }
 
@@ -1506,8 +1367,8 @@ OpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_EQ(_d2i, convert(doubleDataArray[i], INT_POS), _d2i(doubleDataArray[i]));
 
       sprintf(resolvedMethodName, "d2iConst%d", i + 1);
-      d2iConst = (signatureCharD_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2i,
-            resolvedMethodName, _argTypesUnaryDouble, TR::Int32, rc, 2, 1, &doubleDataArray[i]));
+      compileOpCodeMethod(      d2iConst, _numberOfUnaryArgs, TR::d2i,
+                                resolvedMethodName, _argTypesUnaryDouble, TR::Int32, rc, 2, 1, &doubleDataArray[i]);
       OMR_CT_EXPECT_EQ(d2iConst, convert(doubleDataArray[i], INT_POS), d2iConst(DOUBLE_PLACEHOLDER_1));
       }
 
@@ -1522,8 +1383,8 @@ OpCodesTest::invokeNoHelperUnaryTests()
    {
    int32_t rc = 0;
 
-   _f2i = (signatureCharF_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2i, "f2i", _argTypesUnaryFloat, TR::Int32, rc));
-   _d2i = (signatureCharD_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2i, "d2i", _argTypesUnaryDouble, TR::Int32, rc));
+   compileOpCodeMethod(   _f2i, _numberOfUnaryArgs, TR::f2i, "f2i", _argTypesUnaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(   _d2i, _numberOfUnaryArgs, TR::d2i, "d2i", _argTypesUnaryDouble, TR::Int32, rc);
 
    _f2i(FLOAT_MAXIMUM);
    _f2i(FLOAT_MINIMUM);
@@ -1567,18 +1428,18 @@ OpCodesTest::invokeBitwiseTests()
       OMR_CT_EXPECT_EQ(_iAnd, tand(intAndArr[i][0], intAndArr[i][1]), _iAnd(intAndArr[i][0], intAndArr[i][1]));
 
       sprintf(resolvedMethodName, "iAndConst1_TestCase%d", i + 1);
-      iBitwiseConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iand, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(intAndArr[i][0]), 2, &(intAndArr[i][1])));
+compileOpCodeMethod(      iBitwiseConst, 
+            _numberOfBinaryArgs, TR::iand, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(intAndArr[i][0]), 2, &(intAndArr[i][1]));
       OMR_CT_EXPECT_EQ(iBitwiseConst, tand(intAndArr[i][0], intAndArr[i][1]), iBitwiseConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iAndConst2_TestCase%d", i + 1);
-      iBitwiseConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iand, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(intAndArr[i][0])));
+compileOpCodeMethod(      iBitwiseConst, 
+            _numberOfBinaryArgs, TR::iand, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(intAndArr[i][0]));
       OMR_CT_EXPECT_EQ(iBitwiseConst, tand(intAndArr[i][0], intAndArr[i][1]), iBitwiseConst(INT_PLACEHOLDER_1, intAndArr[i][1]));
 
       sprintf(resolvedMethodName, "iAndConst3_TestCase%d", i + 1);
-      iBitwiseConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iand, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(intAndArr[i][1])));
+compileOpCodeMethod(      iBitwiseConst, 
+            _numberOfBinaryArgs, TR::iand, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(intAndArr[i][1]));
       OMR_CT_EXPECT_EQ(iBitwiseConst, tand(intAndArr[i][0], intAndArr[i][1]), iBitwiseConst(intAndArr[i][0], INT_PLACEHOLDER_2));
      }
 
@@ -1589,18 +1450,18 @@ OpCodesTest::invokeBitwiseTests()
       OMR_CT_EXPECT_EQ(_iOr, tor(intOrArr[i][0], intOrArr[i][1]), _iOr(intOrArr[i][0], intOrArr[i][1]));
 
       sprintf(resolvedMethodName, "iOrConst1_TestCase%d", i + 1);
-      iBitwiseConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ior, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(intOrArr[i][0]), 2, &(intOrArr[i][1])));
+compileOpCodeMethod(      iBitwiseConst, 
+            _numberOfBinaryArgs, TR::ior, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(intOrArr[i][0]), 2, &(intOrArr[i][1]));
       OMR_CT_EXPECT_EQ(iBitwiseConst, tor(intOrArr[i][0], intOrArr[i][1]), iBitwiseConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iOrConst2_TestCase%d", i + 1);
-      iBitwiseConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ior, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(intOrArr[i][0])));
+compileOpCodeMethod(      iBitwiseConst, 
+            _numberOfBinaryArgs, TR::ior, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(intOrArr[i][0]));
       OMR_CT_EXPECT_EQ(iBitwiseConst, tor(intOrArr[i][0], intOrArr[i][1]), iBitwiseConst(INT_PLACEHOLDER_1, intOrArr[i][1]));
 
       sprintf(resolvedMethodName, "iOrConst3_TestCase%d", i + 1);
-      iBitwiseConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ior, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(intOrArr[i][1])));
+compileOpCodeMethod(      iBitwiseConst, 
+            _numberOfBinaryArgs, TR::ior, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(intOrArr[i][1]));
       OMR_CT_EXPECT_EQ(iBitwiseConst, tor(intOrArr[i][0], intOrArr[i][1]), iBitwiseConst(intOrArr[i][0], INT_PLACEHOLDER_2));
      }
 
@@ -1611,18 +1472,18 @@ OpCodesTest::invokeBitwiseTests()
       OMR_CT_EXPECT_EQ(_iXor, txor(intXorArr[i][0], intXorArr[i][1]), _iXor(intXorArr[i][0], intXorArr[i][1]));
 
       sprintf(resolvedMethodName, "iXorConst1_TestCase%d", i + 1);
-      iBitwiseConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ixor, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(intXorArr[i][0]), 2, &(intXorArr[i][1])));
+compileOpCodeMethod(      iBitwiseConst, 
+            _numberOfBinaryArgs, TR::ixor, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(intXorArr[i][0]), 2, &(intXorArr[i][1]));
       OMR_CT_EXPECT_EQ(iBitwiseConst, txor(intXorArr[i][0], intXorArr[i][1]), iBitwiseConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iXorConst2_TestCase%d", i + 1);
-      iBitwiseConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ixor, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(intXorArr[i][0])));
+compileOpCodeMethod(      iBitwiseConst, 
+            _numberOfBinaryArgs, TR::ixor, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(intXorArr[i][0]));
       OMR_CT_EXPECT_EQ(iBitwiseConst, txor(intXorArr[i][0], intXorArr[i][1]), iBitwiseConst(INT_PLACEHOLDER_1, intXorArr[i][1]));
 
       sprintf(resolvedMethodName, "iXorConst3_TestCase%d", i + 1);
-      iBitwiseConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ixor, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(intXorArr[i][1])));
+compileOpCodeMethod(      iBitwiseConst, 
+            _numberOfBinaryArgs, TR::ixor, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(intXorArr[i][1]));
       OMR_CT_EXPECT_EQ(iBitwiseConst, txor(intXorArr[i][0], intXorArr[i][1]), iBitwiseConst(intXorArr[i][0], INT_PLACEHOLDER_2));
      }
    }
@@ -1914,18 +1775,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_iCmpeq, compareEQ(iCmpeqDataArr[i][0], iCmpeqDataArr[i][1]), _iCmpeq(iCmpeqDataArr[i][0], iCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iCmpeqConst1_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::icmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iCmpeqDataArr[i][0]), 2, &(iCmpeqDataArr[i][1])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::icmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iCmpeqDataArr[i][0]), 2, &(iCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareEQ(iCmpeqDataArr[i][0], iCmpeqDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iCmpeqConst2_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::icmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iCmpeqDataArr[i][0])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::icmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareEQ(iCmpeqDataArr[i][0], iCmpeqDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, iCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iCmpeqConst3_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::icmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iCmpeqDataArr[i][1])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::icmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareEQ(iCmpeqDataArr[i][0], iCmpeqDataArr[i][1]), iCompareConst(iCmpeqDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -1935,18 +1796,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_iCmpne, compareNE(iCmpneDataArr[i][0], iCmpneDataArr[i][1]), _iCmpne(iCmpneDataArr[i][0], iCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iCmpneConst1_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::icmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iCmpneDataArr[i][0]), 2, &(iCmpneDataArr[i][1])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::icmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iCmpneDataArr[i][0]), 2, &(iCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareNE(iCmpneDataArr[i][0], iCmpneDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iCmpneConst2_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::icmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iCmpneDataArr[i][0])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::icmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareNE(iCmpneDataArr[i][0], iCmpneDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, iCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iCmpneConst3_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::icmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iCmpneDataArr[i][1])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::icmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareNE(iCmpneDataArr[i][0], iCmpneDataArr[i][1]), iCompareConst(iCmpneDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -1956,18 +1817,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_iCmpgt, compareGT(iCmpgtDataArr[i][0], iCmpgtDataArr[i][1]), _iCmpgt(iCmpgtDataArr[i][0], iCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iCmpgtConst1_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::icmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iCmpgtDataArr[i][0]), 2, &(iCmpgtDataArr[i][1])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::icmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iCmpgtDataArr[i][0]), 2, &(iCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareGT(iCmpgtDataArr[i][0], iCmpgtDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iCmpgtConst2_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::icmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iCmpgtDataArr[i][0])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::icmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iCmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareGT(iCmpgtDataArr[i][0], iCmpgtDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, iCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iCmpgtConst3_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::icmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iCmpgtDataArr[i][1])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::icmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareGT(iCmpgtDataArr[i][0], iCmpgtDataArr[i][1]), iCompareConst(iCmpgtDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -1977,18 +1838,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_iCmplt, compareLT(iCmpltDataArr[i][0], iCmpltDataArr[i][1]), _iCmplt(iCmpltDataArr[i][0], iCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iCmpltConst1_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::icmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iCmpltDataArr[i][0]), 2, &(iCmpltDataArr[i][1])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::icmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iCmpltDataArr[i][0]), 2, &(iCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareLT(iCmpltDataArr[i][0], iCmpltDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iCmpltConst2_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::icmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iCmpltDataArr[i][0])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::icmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareLT(iCmpltDataArr[i][0], iCmpltDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, iCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iCmpltConst3_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::icmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iCmpltDataArr[i][1])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::icmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareLT(iCmpltDataArr[i][0], iCmpltDataArr[i][1]), iCompareConst(iCmpltDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -1998,18 +1859,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_iCmpge, compareGE(iCmpgeDataArr[i][0], iCmpgeDataArr[i][1]), _iCmpge(iCmpgeDataArr[i][0], iCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iCmpgeConst1_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::icmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iCmpgeDataArr[i][0]), 2, &(iCmpgeDataArr[i][1])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::icmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iCmpgeDataArr[i][0]), 2, &(iCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareGE(iCmpgeDataArr[i][0], iCmpgeDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iCmpgeConst2_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::icmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iCmpgeDataArr[i][0])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::icmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareGE(iCmpgeDataArr[i][0], iCmpgeDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, iCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iCmpgeConst3_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::icmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iCmpgeDataArr[i][1])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::icmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareGE(iCmpgeDataArr[i][0], iCmpgeDataArr[i][1]), iCompareConst(iCmpgeDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -2019,18 +1880,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_iCmple, compareLE(iCmpleDataArr[i][0], iCmpleDataArr[i][1]), _iCmple(iCmpleDataArr[i][0], iCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iCmpleConst1_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::icmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iCmpleDataArr[i][0]), 2, &(iCmpleDataArr[i][1])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::icmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iCmpleDataArr[i][0]), 2, &(iCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareLE(iCmpleDataArr[i][0], iCmpleDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iCmpleConst2_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::icmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iCmpleDataArr[i][0])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::icmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iCmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareLE(iCmpleDataArr[i][0], iCmpleDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, iCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iCmpleConst3_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::icmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iCmpleDataArr[i][1])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::icmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareLE(iCmpleDataArr[i][0], iCmpleDataArr[i][1]), iCompareConst(iCmpleDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -2041,19 +1902,19 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_lCmpne, compareNE(lCmpneDataArr[i][0], lCmpneDataArr[i][1]), _lCmpne(lCmpneDataArr[i][0], lCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpneConst1_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpneDataArr[i][0]), 2, &(lCmpneDataArr[i][1])));
+compileOpCodeMethod(      lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpneDataArr[i][0]), 2, &(lCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareNE(lCmpneDataArr[i][0], lCmpneDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
 #ifndef TR_TARGET_POWER
       sprintf(resolvedMethodName, "lCmpneConst2_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpneDataArr[i][0])));
+compileOpCodeMethod(      lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareNE(lCmpneDataArr[i][0], lCmpneDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpneConst3_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpneDataArr[i][1])));
+compileOpCodeMethod(      lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareNE(lCmpneDataArr[i][0], lCmpneDataArr[i][1]), lCompareConst(lCmpneDataArr[i][0], LONG_PLACEHOLDER_2));
 #endif
       }
@@ -2064,19 +1925,19 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_lCmpgt, compareGT(lCmpgtDataArr[i][0], lCmpgtDataArr[i][1]), _lCmpgt(lCmpgtDataArr[i][0], lCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpgtConst1_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpgtDataArr[i][0]), 2, &(lCmpgtDataArr[i][1])));
+compileOpCodeMethod(      lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpgtDataArr[i][0]), 2, &(lCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareGT(lCmpgtDataArr[i][0], lCmpgtDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
 #ifndef TR_TARGET_POWER
       sprintf(resolvedMethodName, "lCmpgtConst2_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpgtDataArr[i][0])));
+compileOpCodeMethod(      lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareGT(lCmpgtDataArr[i][0], lCmpgtDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpgtConst3_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpgtDataArr[i][1])));
+compileOpCodeMethod(      lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareGT(lCmpgtDataArr[i][0], lCmpgtDataArr[i][1]), lCompareConst(lCmpgtDataArr[i][0], LONG_PLACEHOLDER_2));
 #endif
       }
@@ -2087,18 +1948,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_lCmpge, compareGE(lCmpgeDataArr[i][0], lCmpgeDataArr[i][1]), _lCmpge(lCmpgeDataArr[i][0], lCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpgeConst1_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpgeDataArr[i][0]), 2, &(lCmpgeDataArr[i][1])));
+compileOpCodeMethod(      lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpgeDataArr[i][0]), 2, &(lCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareGE(lCmpgeDataArr[i][0], lCmpgeDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lCmpgeConst2_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpgeDataArr[i][0])));
+compileOpCodeMethod(      lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareGE(lCmpgeDataArr[i][0], lCmpgeDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpgeConst3_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpgeDataArr[i][1])));
+compileOpCodeMethod(      lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareGE(lCmpgeDataArr[i][0], lCmpgeDataArr[i][1]), lCompareConst(lCmpgeDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -2108,18 +1969,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_lCmple, compareLE(lCmpleDataArr[i][0], lCmpleDataArr[i][1]), _lCmple(lCmpleDataArr[i][0], lCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpleConst1_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpleDataArr[i][0]), 2, &(lCmpleDataArr[i][1])));
+compileOpCodeMethod(      lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpleDataArr[i][0]), 2, &(lCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareLE(lCmpleDataArr[i][0], lCmpleDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lCmpleConst2_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpleDataArr[i][0])));
+compileOpCodeMethod(      lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareLE(lCmpleDataArr[i][0], lCmpleDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpleConst3_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpleDataArr[i][1])));
+compileOpCodeMethod(      lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareLE(lCmpleDataArr[i][0], lCmpleDataArr[i][1]), lCompareConst(lCmpleDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -2130,18 +1991,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_iuCmpgt, compareGT(iuCmpgtDataArr[i][0], iuCmpgtDataArr[i][1]), _iuCmpgt(iuCmpgtDataArr[i][0], iuCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpgtConst1_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpgtDataArr[i][0]), 2, &(iuCmpgtDataArr[i][1])));
+compileOpCodeMethod(      iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpgtDataArr[i][0]), 2, &(iuCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareGT(iuCmpgtDataArr[i][0], iuCmpgtDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iuCmpgtConst2_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpgtDataArr[i][0])));
+compileOpCodeMethod(      iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareGT(iuCmpgtDataArr[i][0], iuCmpgtDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpgtConst3_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpgtDataArr[i][1])));
+compileOpCodeMethod(      iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareGT(iuCmpgtDataArr[i][0], iuCmpgtDataArr[i][1]), iuCompareConst(iuCmpgtDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -2151,18 +2012,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_iuCmplt, compareLT(iuCmpltDataArr[i][0], iuCmpltDataArr[i][1]), _iuCmplt(iuCmpltDataArr[i][0], iuCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpltConst1_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpltDataArr[i][0]), 2, &(iuCmpltDataArr[i][1])));
+compileOpCodeMethod(      iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpltDataArr[i][0]), 2, &(iuCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareLT(iuCmpltDataArr[i][0], iuCmpltDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iuCmpltConst2_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpltDataArr[i][0])));
+compileOpCodeMethod(      iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareLT(iuCmpltDataArr[i][0], iuCmpltDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpltConst3_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpltDataArr[i][1])));
+compileOpCodeMethod(      iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareLT(iuCmpltDataArr[i][0], iuCmpltDataArr[i][1]), iuCompareConst(iuCmpltDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -2172,18 +2033,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_iuCmple, compareLE(iuCmpleDataArr[i][0], iuCmpleDataArr[i][1]), _iuCmple(iuCmpleDataArr[i][0], iuCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpleConst1_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpleDataArr[i][0]), 2, &(iuCmpleDataArr[i][1])));
+compileOpCodeMethod(      iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpleDataArr[i][0]), 2, &(iuCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareLE(iuCmpleDataArr[i][0], iuCmpleDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iuCmpleConst2_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpleDataArr[i][0])));
+compileOpCodeMethod(      iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareLE(iuCmpleDataArr[i][0], iuCmpleDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpleConst3_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpleDataArr[i][1])));
+compileOpCodeMethod(      iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareLE(iuCmpleDataArr[i][0], iuCmpleDataArr[i][1]), iuCompareConst(iuCmpleDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -2194,18 +2055,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_luCmpeq, compareEQ(luCmpeqDataArr[i][0], luCmpeqDataArr[i][1]), _luCmpeq(luCmpeqDataArr[i][0], luCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luCmpeqConst1_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lucmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(luCmpeqDataArr[i][0]), 2, &(luCmpeqDataArr[i][1])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::lucmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(luCmpeqDataArr[i][0]), 2, &(luCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareEQ(luCmpeqDataArr[i][0], luCmpeqDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "luCmpeqConst2_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lucmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(luCmpeqDataArr[i][0])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::lucmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(luCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareEQ(luCmpeqDataArr[i][0], luCmpeqDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, luCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luCmpeqConst3_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lucmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(luCmpeqDataArr[i][1])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::lucmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(luCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareEQ(luCmpeqDataArr[i][0], luCmpeqDataArr[i][1]), luCompareConst(luCmpeqDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -2215,18 +2076,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_luCmpne, compareNE(luCmpneDataArr[i][0], luCmpneDataArr[i][1]), _luCmpne(luCmpneDataArr[i][0], luCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luCmpneConst1_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lucmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(luCmpneDataArr[i][0]), 2, &(luCmpneDataArr[i][1])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::lucmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(luCmpneDataArr[i][0]), 2, &(luCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareNE(luCmpneDataArr[i][0], luCmpneDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "luCmpneConst2_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lucmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(luCmpneDataArr[i][0])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::lucmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(luCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareNE(luCmpneDataArr[i][0], luCmpneDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, luCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luCmpneConst3_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lucmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(luCmpneDataArr[i][1])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::lucmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(luCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareNE(luCmpneDataArr[i][0], luCmpneDataArr[i][1]), luCompareConst(luCmpneDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -2236,18 +2097,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_luCmpgt, compareGT(luCmpgtDataArr[i][0], luCmpgtDataArr[i][1]), _luCmpgt(luCmpgtDataArr[i][0], luCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luCmpgtConst1_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lucmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(luCmpgtDataArr[i][0]), 2, &(luCmpgtDataArr[i][1])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::lucmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(luCmpgtDataArr[i][0]), 2, &(luCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareGT(luCmpgtDataArr[i][0], luCmpgtDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "luCmpgtConst2_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lucmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(luCmpgtDataArr[i][0])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::lucmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(luCmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareGT(luCmpgtDataArr[i][0], luCmpgtDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, luCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luCmpgtConst3_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lucmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(luCmpgtDataArr[i][1])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::lucmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(luCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareGT(luCmpgtDataArr[i][0], luCmpgtDataArr[i][1]), luCompareConst(luCmpgtDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -2257,18 +2118,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_luCmplt, compareLT(luCmpltDataArr[i][0], luCmpltDataArr[i][1]), _luCmplt(luCmpltDataArr[i][0], luCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luCmpltConst1_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lucmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(luCmpltDataArr[i][0]), 2, &(luCmpltDataArr[i][1])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::lucmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(luCmpltDataArr[i][0]), 2, &(luCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareLT(luCmpltDataArr[i][0], luCmpltDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "luCmpltConst2_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lucmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(luCmpltDataArr[i][0])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::lucmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(luCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareLT(luCmpltDataArr[i][0], luCmpltDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, luCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luCmpltConst3_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lucmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(luCmpltDataArr[i][1])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::lucmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(luCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareLT(luCmpltDataArr[i][0], luCmpltDataArr[i][1]), luCompareConst(luCmpltDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -2278,18 +2139,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_luCmpge, compareGE(luCmpgeDataArr[i][0], luCmpgeDataArr[i][1]), _luCmpge(luCmpgeDataArr[i][0], luCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luCmpgeConst1_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lucmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(luCmpgeDataArr[i][0]), 2, &(luCmpgeDataArr[i][1])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::lucmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(luCmpgeDataArr[i][0]), 2, &(luCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareGE(luCmpgeDataArr[i][0], luCmpgeDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "luCmpgeConst2_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lucmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(luCmpgeDataArr[i][0])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::lucmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(luCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareGE(luCmpgeDataArr[i][0], luCmpgeDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, luCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luCmpgeConst3_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lucmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(luCmpgeDataArr[i][1])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::lucmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(luCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareGE(luCmpgeDataArr[i][0], luCmpgeDataArr[i][1]), luCompareConst(luCmpgeDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -2299,18 +2160,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_luCmple, compareLE(luCmpleDataArr[i][0], luCmpleDataArr[i][1]), _luCmple(luCmpleDataArr[i][0], luCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luCmpleConst1_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lucmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(luCmpleDataArr[i][0]), 2, &(luCmpleDataArr[i][1])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::lucmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(luCmpleDataArr[i][0]), 2, &(luCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareLE(luCmpleDataArr[i][0], luCmpleDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "luCmpleConst2_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lucmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(luCmpleDataArr[i][0])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::lucmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(luCmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareLE(luCmpleDataArr[i][0], luCmpleDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, luCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luCmpleConst3_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lucmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(luCmpleDataArr[i][1])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::lucmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(luCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareLE(luCmpleDataArr[i][0], luCmpleDataArr[i][1]), luCompareConst(luCmpleDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -2321,18 +2182,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifIcmpeq, compareEQ(ifIcmpeqDataArr[i][0], ifIcmpeqDataArr[i][1]), _ifIcmpeq(ifIcmpeqDataArr[i][0], ifIcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIcmpeqConst1_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ificmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIcmpeqDataArr[i][0]), 2, &(ifIcmpeqDataArr[i][1])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::ificmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIcmpeqDataArr[i][0]), 2, &(ifIcmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareEQ(ifIcmpeqDataArr[i][0], ifIcmpeqDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifIcmpeqConst2_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ificmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIcmpeqDataArr[i][0])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::ificmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIcmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareEQ(ifIcmpeqDataArr[i][0], ifIcmpeqDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, ifIcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIcmpeqConst3_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ificmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIcmpeqDataArr[i][1])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::ificmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIcmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareEQ(ifIcmpeqDataArr[i][0], ifIcmpeqDataArr[i][1]), iCompareConst(ifIcmpeqDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -2342,18 +2203,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifIcmpne, compareNE(ifIcmpneDataArr[i][0], ifIcmpneDataArr[i][1]), _ifIcmpne(ifIcmpneDataArr[i][0], ifIcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIcmpneConst1_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ificmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIcmpneDataArr[i][0]), 2, &(ifIcmpneDataArr[i][1])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::ificmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIcmpneDataArr[i][0]), 2, &(ifIcmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareNE(ifIcmpneDataArr[i][0], ifIcmpneDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifIcmpneConst2_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ificmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIcmpneDataArr[i][0])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::ificmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIcmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareNE(ifIcmpneDataArr[i][0], ifIcmpneDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, ifIcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIcmpneConst3_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ificmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIcmpneDataArr[i][1])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::ificmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIcmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareNE(ifIcmpneDataArr[i][0], ifIcmpneDataArr[i][1]), iCompareConst(ifIcmpneDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -2363,18 +2224,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifIcmpgt, compareGT(ifIcmpgtDataArr[i][0], ifIcmpgtDataArr[i][1]), _ifIcmpgt(ifIcmpgtDataArr[i][0], ifIcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIcmpgtConst1_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ificmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIcmpgtDataArr[i][0]), 2, &(ifIcmpgtDataArr[i][1])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::ificmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIcmpgtDataArr[i][0]), 2, &(ifIcmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareGT(ifIcmpgtDataArr[i][0], ifIcmpgtDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifIcmpgtConst2_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ificmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIcmpgtDataArr[i][0])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::ificmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIcmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareGT(ifIcmpgtDataArr[i][0], ifIcmpgtDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, ifIcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIcmpgtConst3_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ificmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIcmpgtDataArr[i][1])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::ificmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIcmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareGT(ifIcmpgtDataArr[i][0], ifIcmpgtDataArr[i][1]), iCompareConst(ifIcmpgtDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -2384,18 +2245,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifIcmplt, compareLT(ifIcmpltDataArr[i][0], ifIcmpltDataArr[i][1]), _ifIcmplt(ifIcmpltDataArr[i][0], ifIcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIcmpltConst1_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ificmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIcmpltDataArr[i][0]), 2, &(ifIcmpltDataArr[i][1])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::ificmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIcmpltDataArr[i][0]), 2, &(ifIcmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareLT(ifIcmpltDataArr[i][0], ifIcmpltDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifIcmpltConst2_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ificmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIcmpltDataArr[i][0])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::ificmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIcmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareLT(ifIcmpltDataArr[i][0], ifIcmpltDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, ifIcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIcmpltConst3_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ificmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIcmpltDataArr[i][1])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::ificmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIcmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareLT(ifIcmpltDataArr[i][0], ifIcmpltDataArr[i][1]), iCompareConst(ifIcmpltDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -2405,18 +2266,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifIcmpge, compareGE(ifIcmpgeDataArr[i][0], ifIcmpgeDataArr[i][1]), _ifIcmpge(ifIcmpgeDataArr[i][0], ifIcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIcmpgeConst1_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ificmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIcmpgeDataArr[i][0]), 2, &(ifIcmpgeDataArr[i][1])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::ificmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIcmpgeDataArr[i][0]), 2, &(ifIcmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareGE(ifIcmpgeDataArr[i][0], ifIcmpgeDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifIcmpgeConst2_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ificmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIcmpgeDataArr[i][0])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::ificmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIcmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareGE(ifIcmpgeDataArr[i][0], ifIcmpgeDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, ifIcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIcmpgeConst3_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ificmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIcmpgeDataArr[i][1])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::ificmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIcmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareGE(ifIcmpgeDataArr[i][0], ifIcmpgeDataArr[i][1]), iCompareConst(ifIcmpgeDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -2426,18 +2287,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifIcmple, compareLE(ifIcmpleDataArr[i][0], ifIcmpleDataArr[i][1]), _ifIcmple(ifIcmpleDataArr[i][0], ifIcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIcmpleConst1_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ificmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIcmpleDataArr[i][0]), 2, &(ifIcmpleDataArr[i][1])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::ificmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIcmpleDataArr[i][0]), 2, &(ifIcmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareLE(ifIcmpleDataArr[i][0], ifIcmpleDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifIcmpleConst2_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ificmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIcmpleDataArr[i][0])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::ificmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIcmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareLE(ifIcmpleDataArr[i][0], ifIcmpleDataArr[i][1]), iCompareConst(INT_PLACEHOLDER_1, ifIcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIcmpleConst3_TestCase%d", i + 1);
-      iCompareConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ificmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIcmpleDataArr[i][1])));
+compileOpCodeMethod(      iCompareConst, 
+            _numberOfBinaryArgs, TR::ificmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIcmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iCompareConst, compareLE(ifIcmpleDataArr[i][0], ifIcmpleDataArr[i][1]), iCompareConst(ifIcmpleDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -2448,19 +2309,19 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifLcmpne, compareNE(ifLcmpneDataArr[i][0], ifLcmpneDataArr[i][1]), _ifLcmpne(ifLcmpneDataArr[i][0], ifLcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpneConst1_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpneDataArr[i][0]), 2, &(ifLcmpneDataArr[i][1])));
+compileOpCodeMethod(      lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpneDataArr[i][0]), 2, &(ifLcmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareNE(ifLcmpneDataArr[i][0], ifLcmpneDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
 #ifndef TR_TARGET_POWER
       sprintf(resolvedMethodName, "ifLcmpneConst2_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpneDataArr[i][0])));
+compileOpCodeMethod(      lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareNE(ifLcmpneDataArr[i][0], ifLcmpneDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpneConst3_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpneDataArr[i][1])));
+compileOpCodeMethod(      lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareNE(ifLcmpneDataArr[i][0], ifLcmpneDataArr[i][1]), lCompareConst(ifLcmpneDataArr[i][0], LONG_PLACEHOLDER_2));
 #endif
       }
@@ -2471,18 +2332,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifLcmpge, compareGE(ifLcmpgeDataArr[i][0], ifLcmpgeDataArr[i][1]), _ifLcmpge(ifLcmpgeDataArr[i][0], ifLcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpgeConst1_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpgeDataArr[i][0]), 2, &(ifLcmpgeDataArr[i][1])));
+compileOpCodeMethod(      lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpgeDataArr[i][0]), 2, &(ifLcmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareGE(ifLcmpgeDataArr[i][0], ifLcmpgeDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLcmpgeConst2_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpgeDataArr[i][0])));
+compileOpCodeMethod(      lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareGE(ifLcmpgeDataArr[i][0], ifLcmpgeDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpgeConst3_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpgeDataArr[i][1])));
+compileOpCodeMethod(      lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareGE(ifLcmpgeDataArr[i][0], ifLcmpgeDataArr[i][1]), lCompareConst(ifLcmpgeDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -2492,18 +2353,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifLcmple, compareLE(ifLcmpleDataArr[i][0], ifLcmpleDataArr[i][1]), _ifLcmple(ifLcmpleDataArr[i][0], ifLcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpleConst1_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpleDataArr[i][0]), 2, &(ifLcmpleDataArr[i][1])));
+compileOpCodeMethod(      lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpleDataArr[i][0]), 2, &(ifLcmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareLE(ifLcmpleDataArr[i][0], ifLcmpleDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLcmpleConst2_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpleDataArr[i][0])));
+compileOpCodeMethod(      lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareLE(ifLcmpleDataArr[i][0], ifLcmpleDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpleConst3_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpleDataArr[i][1])));
+compileOpCodeMethod(      lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareLE(ifLcmpleDataArr[i][0], ifLcmpleDataArr[i][1]), lCompareConst(ifLcmpleDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -2514,18 +2375,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifIuCmpeq, compareEQ(ifIuCmpeqDataArr[i][0], ifIuCmpeqDataArr[i][1]), _ifIuCmpeq(ifIuCmpeqDataArr[i][0], ifIuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIuCmpeqConst1_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifiucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIuCmpeqDataArr[i][0]), 2, &(ifIuCmpeqDataArr[i][1])));
+compileOpCodeMethod(      iuCompareConst, 
+            _numberOfBinaryArgs, TR::ifiucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIuCmpeqDataArr[i][0]), 2, &(ifIuCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareEQ(ifIuCmpeqDataArr[i][0], ifIuCmpeqDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifIuCmpeqConst2_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifiucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIuCmpeqDataArr[i][0])));
+compileOpCodeMethod(      iuCompareConst, 
+            _numberOfBinaryArgs, TR::ifiucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIuCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareEQ(ifIuCmpeqDataArr[i][0], ifIuCmpeqDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, ifIuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIuCmpeqConst3_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifiucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIuCmpeqDataArr[i][1])));
+compileOpCodeMethod(      iuCompareConst, 
+            _numberOfBinaryArgs, TR::ifiucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIuCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareEQ(ifIuCmpeqDataArr[i][0], ifIuCmpeqDataArr[i][1]), iuCompareConst(ifIuCmpeqDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -2535,18 +2396,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifIuCmpne, compareNE(ifIuCmpneDataArr[i][0], ifIuCmpneDataArr[i][1]), _ifIuCmpne(ifIuCmpneDataArr[i][0], ifIuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIuCmpneConst1_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifiucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIuCmpneDataArr[i][0]), 2, &(ifIuCmpneDataArr[i][1])));
+compileOpCodeMethod(      iuCompareConst, 
+            _numberOfBinaryArgs, TR::ifiucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIuCmpneDataArr[i][0]), 2, &(ifIuCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareNE(ifIuCmpneDataArr[i][0], ifIuCmpneDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifIuCmpneConst2_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifiucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIuCmpneDataArr[i][0])));
+compileOpCodeMethod(      iuCompareConst, 
+            _numberOfBinaryArgs, TR::ifiucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIuCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareNE(ifIuCmpneDataArr[i][0], ifIuCmpneDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, ifIuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIuCmpneConst3_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifiucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIuCmpneDataArr[i][1])));
+compileOpCodeMethod(      iuCompareConst, 
+            _numberOfBinaryArgs, TR::ifiucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIuCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareNE(ifIuCmpneDataArr[i][0], ifIuCmpneDataArr[i][1]), iuCompareConst(ifIuCmpneDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -2556,18 +2417,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifIuCmpgt, compareGT(ifIuCmpgtDataArr[i][0], ifIuCmpgtDataArr[i][1]), _ifIuCmpgt(ifIuCmpgtDataArr[i][0], ifIuCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIuCmpgtConst1_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifiucmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIuCmpgtDataArr[i][0]), 2, &(ifIuCmpgtDataArr[i][1])));
+compileOpCodeMethod(      iuCompareConst, 
+            _numberOfBinaryArgs, TR::ifiucmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIuCmpgtDataArr[i][0]), 2, &(ifIuCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareGT(ifIuCmpgtDataArr[i][0], ifIuCmpgtDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifIuCmpgtConst2_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifiucmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIuCmpgtDataArr[i][0])));
+compileOpCodeMethod(      iuCompareConst, 
+            _numberOfBinaryArgs, TR::ifiucmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIuCmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareGT(ifIuCmpgtDataArr[i][0], ifIuCmpgtDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, ifIuCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIuCmpgtConst3_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifiucmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIuCmpgtDataArr[i][1])));
+compileOpCodeMethod(      iuCompareConst, 
+            _numberOfBinaryArgs, TR::ifiucmpgt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIuCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareGT(ifIuCmpgtDataArr[i][0], ifIuCmpgtDataArr[i][1]), iuCompareConst(ifIuCmpgtDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -2577,18 +2438,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifIuCmplt, compareLT(ifIuCmpltDataArr[i][0], ifIuCmpltDataArr[i][1]), _ifIuCmplt(ifIuCmpltDataArr[i][0], ifIuCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIuCmpltConst1_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifiucmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIuCmpltDataArr[i][0]), 2, &(ifIuCmpltDataArr[i][1])));
+compileOpCodeMethod(      iuCompareConst, 
+            _numberOfBinaryArgs, TR::ifiucmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIuCmpltDataArr[i][0]), 2, &(ifIuCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareLT(ifIuCmpltDataArr[i][0], ifIuCmpltDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifIuCmpltConst2_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifiucmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIuCmpltDataArr[i][0])));
+compileOpCodeMethod(      iuCompareConst, 
+            _numberOfBinaryArgs, TR::ifiucmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIuCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareLT(ifIuCmpltDataArr[i][0], ifIuCmpltDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, ifIuCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIuCmpltConst3_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifiucmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIuCmpltDataArr[i][1])));
+compileOpCodeMethod(      iuCompareConst, 
+            _numberOfBinaryArgs, TR::ifiucmplt, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIuCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareLT(ifIuCmpltDataArr[i][0], ifIuCmpltDataArr[i][1]), iuCompareConst(ifIuCmpltDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -2598,18 +2459,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifIuCmpge, compareGE(ifIuCmpgeDataArr[i][0], ifIuCmpgeDataArr[i][1]), _ifIuCmpge(ifIuCmpgeDataArr[i][0], ifIuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIuCmpgeConst1_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifiucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIuCmpgeDataArr[i][0]), 2, &(ifIuCmpgeDataArr[i][1])));
+compileOpCodeMethod(      iuCompareConst, 
+            _numberOfBinaryArgs, TR::ifiucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIuCmpgeDataArr[i][0]), 2, &(ifIuCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareGE(ifIuCmpgeDataArr[i][0], ifIuCmpgeDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifIuCmpgeConst2_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifiucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIuCmpgeDataArr[i][0])));
+compileOpCodeMethod(      iuCompareConst, 
+            _numberOfBinaryArgs, TR::ifiucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIuCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareGE(ifIuCmpgeDataArr[i][0], ifIuCmpgeDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, ifIuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIuCmpgeConst3_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifiucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIuCmpgeDataArr[i][1])));
+compileOpCodeMethod(      iuCompareConst, 
+            _numberOfBinaryArgs, TR::ifiucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIuCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareGE(ifIuCmpgeDataArr[i][0], ifIuCmpgeDataArr[i][1]), iuCompareConst(ifIuCmpgeDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -2619,18 +2480,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifIuCmple, compareLE(ifIuCmpleDataArr[i][0], ifIuCmpleDataArr[i][1]), _ifIuCmple(ifIuCmpleDataArr[i][0], ifIuCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIuCmpleConst1_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifiucmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIuCmpleDataArr[i][0]), 2, &(ifIuCmpleDataArr[i][1])));
+compileOpCodeMethod(      iuCompareConst, 
+            _numberOfBinaryArgs, TR::ifiucmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(ifIuCmpleDataArr[i][0]), 2, &(ifIuCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareLE(ifIuCmpleDataArr[i][0], ifIuCmpleDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifIuCmpleConst2_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifiucmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIuCmpleDataArr[i][0])));
+compileOpCodeMethod(      iuCompareConst, 
+            _numberOfBinaryArgs, TR::ifiucmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(ifIuCmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareLE(ifIuCmpleDataArr[i][0], ifIuCmpleDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, ifIuCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifIuCmpleConst3_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifiucmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIuCmpleDataArr[i][1])));
+compileOpCodeMethod(      iuCompareConst, 
+            _numberOfBinaryArgs, TR::ifiucmple, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(ifIuCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareLE(ifIuCmpleDataArr[i][0], ifIuCmpleDataArr[i][1]), iuCompareConst(ifIuCmpleDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -2642,18 +2503,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifLuCmpeq, compareEQ(ifLuCmpeqDataArr[i][0], ifLuCmpeqDataArr[i][1]), _ifLuCmpeq(ifLuCmpeqDataArr[i][0], ifLuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLuCmpeqConst1_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflucmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLuCmpeqDataArr[i][0]), 2, &(ifLuCmpeqDataArr[i][1])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::iflucmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLuCmpeqDataArr[i][0]), 2, &(ifLuCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareEQ(ifLuCmpeqDataArr[i][0], ifLuCmpeqDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLuCmpeqConst2_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflucmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLuCmpeqDataArr[i][0])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::iflucmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLuCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareEQ(ifLuCmpeqDataArr[i][0], ifLuCmpeqDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, ifLuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLuCmpeqConst3_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflucmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLuCmpeqDataArr[i][1])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::iflucmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLuCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareEQ(ifLuCmpeqDataArr[i][0], ifLuCmpeqDataArr[i][1]), luCompareConst(ifLuCmpeqDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -2663,18 +2524,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifLuCmpne, compareNE(ifLuCmpneDataArr[i][0], ifLuCmpneDataArr[i][1]), _ifLuCmpne(ifLuCmpneDataArr[i][0], ifLuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLuCmpneConst1_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflucmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLuCmpneDataArr[i][0]), 2, &(ifLuCmpneDataArr[i][1])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::iflucmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLuCmpneDataArr[i][0]), 2, &(ifLuCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareNE(ifLuCmpneDataArr[i][0], ifLuCmpneDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLuCmpneConst2_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflucmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLuCmpneDataArr[i][0])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::iflucmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLuCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareNE(ifLuCmpneDataArr[i][0], ifLuCmpneDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, ifLuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLuCmpneConst3_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflucmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLuCmpneDataArr[i][1])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::iflucmpne, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLuCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareNE(ifLuCmpneDataArr[i][0], ifLuCmpneDataArr[i][1]), luCompareConst(ifLuCmpneDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -2684,18 +2545,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifLuCmpgt, compareGT(ifLuCmpgtDataArr[i][0], ifLuCmpgtDataArr[i][1]), _ifLuCmpgt(ifLuCmpgtDataArr[i][0], ifLuCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLuCmpgtConst1_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflucmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLuCmpgtDataArr[i][0]), 2, &(ifLuCmpgtDataArr[i][1])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::iflucmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLuCmpgtDataArr[i][0]), 2, &(ifLuCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareGT(ifLuCmpgtDataArr[i][0], ifLuCmpgtDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLuCmpgtConst2_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflucmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLuCmpgtDataArr[i][0])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::iflucmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLuCmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareGT(ifLuCmpgtDataArr[i][0], ifLuCmpgtDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, ifLuCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLuCmpgtConst3_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflucmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLuCmpgtDataArr[i][1])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::iflucmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLuCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareGT(ifLuCmpgtDataArr[i][0], ifLuCmpgtDataArr[i][1]), luCompareConst(ifLuCmpgtDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -2705,18 +2566,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifLuCmplt, compareLT(ifLuCmpltDataArr[i][0], ifLuCmpltDataArr[i][1]), _ifLuCmplt(ifLuCmpltDataArr[i][0], ifLuCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLuCmpltConst1_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflucmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLuCmpltDataArr[i][0]), 2, &(ifLuCmpltDataArr[i][1])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::iflucmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLuCmpltDataArr[i][0]), 2, &(ifLuCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareLT(ifLuCmpltDataArr[i][0], ifLuCmpltDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLuCmpltConst2_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflucmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLuCmpltDataArr[i][0])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::iflucmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLuCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareLT(ifLuCmpltDataArr[i][0], ifLuCmpltDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, ifLuCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLuCmpltConst3_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflucmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLuCmpltDataArr[i][1])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::iflucmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLuCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareLT(ifLuCmpltDataArr[i][0], ifLuCmpltDataArr[i][1]), luCompareConst(ifLuCmpltDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -2726,18 +2587,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifLuCmpge, compareGE(ifLuCmpgeDataArr[i][0], ifLuCmpgeDataArr[i][1]), _ifLuCmpge(ifLuCmpgeDataArr[i][0], ifLuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLuCmpgeConst1_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflucmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLuCmpgeDataArr[i][0]), 2, &(ifLuCmpgeDataArr[i][1])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::iflucmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLuCmpgeDataArr[i][0]), 2, &(ifLuCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareGE(ifLuCmpgeDataArr[i][0], ifLuCmpgeDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLuCmpgeConst2_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflucmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLuCmpgeDataArr[i][0])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::iflucmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLuCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareGE(ifLuCmpgeDataArr[i][0], ifLuCmpgeDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, ifLuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLuCmpgeConst3_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflucmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLuCmpgeDataArr[i][1])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::iflucmpge, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLuCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareGE(ifLuCmpgeDataArr[i][0], ifLuCmpgeDataArr[i][1]), luCompareConst(ifLuCmpgeDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -2747,18 +2608,18 @@ OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifLuCmple, compareLE(ifLuCmpleDataArr[i][0], ifLuCmpleDataArr[i][1]), _ifLuCmple(ifLuCmpleDataArr[i][0], ifLuCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLuCmpleConst1_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflucmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLuCmpleDataArr[i][0]), 2, &(ifLuCmpleDataArr[i][1])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::iflucmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLuCmpleDataArr[i][0]), 2, &(ifLuCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareLE(ifLuCmpleDataArr[i][0], ifLuCmpleDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLuCmpleConst2_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflucmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLuCmpleDataArr[i][0])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::iflucmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLuCmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareLE(ifLuCmpleDataArr[i][0], ifLuCmpleDataArr[i][1]), luCompareConst(LONG_PLACEHOLDER_1, ifLuCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLuCmpleConst3_TestCase%d", i + 1);
-      luCompareConst = (unsignedCompareSignatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflucmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLuCmpleDataArr[i][1])));
+compileOpCodeMethod(      luCompareConst, 
+            _numberOfBinaryArgs, TR::iflucmple, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLuCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(luCompareConst, compareLE(ifLuCmpleDataArr[i][0], ifLuCmpleDataArr[i][1]), luCompareConst(ifLuCmpleDataArr[i][0], LONG_PLACEHOLDER_2));
       }
    }
@@ -2808,32 +2669,32 @@ OpCodesTest::invokeTernaryTests()
       sprintf(resolvedMethodName, "iTernaryConst%d", i + 1);
       OMR_CT_EXPECT_EQ(_iternary, ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), _iternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]));
 
-      iTernaryConst = (signatureCharIII_I_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::iternary,
-            resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 6, 1, &iternaryChild1Arr[i], 2, &intArr[i][0], 3, &intArr[i][1]));
+compileOpCodeMethod(      iTernaryConst, _numberOfTernaryArgs, TR::iternary,
+            resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 6, 1, &iternaryChild1Arr[i], 2, &intArr[i][0], 3, &intArr[i][1]);
       OMR_CT_EXPECT_EQ(iTernaryConst, ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2, INT_PLACEHOLDER_3));
 
-      iTernaryConst = (signatureCharIII_I_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::iternary,
-            resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 4, 1, &iternaryChild1Arr[i], 2, &intArr[i][0]));
+compileOpCodeMethod(      iTernaryConst, _numberOfTernaryArgs, TR::iternary,
+            resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 4, 1, &iternaryChild1Arr[i], 2, &intArr[i][0]);
       OMR_CT_EXPECT_EQ(iTernaryConst, ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2, intArr[i][1]));
 
-      iTernaryConst = (signatureCharIII_I_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::iternary,
-            resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 4, 1, &iternaryChild1Arr[i], 3, &intArr[i][1]));
+compileOpCodeMethod(      iTernaryConst, _numberOfTernaryArgs, TR::iternary,
+            resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 4, 1, &iternaryChild1Arr[i], 3, &intArr[i][1]);
       OMR_CT_EXPECT_EQ(iTernaryConst, ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(INT_PLACEHOLDER_1, intArr[i][0], INT_PLACEHOLDER_3));
 
-      iTernaryConst = (signatureCharIII_I_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::iternary,
-            resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 4, 2, &intArr[i][0], 3, &intArr[i][1]));
+compileOpCodeMethod(      iTernaryConst, _numberOfTernaryArgs, TR::iternary,
+            resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 4, 2, &intArr[i][0], 3, &intArr[i][1]);
       OMR_CT_EXPECT_EQ(iTernaryConst, ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(iternaryChild1Arr[i], INT_PLACEHOLDER_2, INT_PLACEHOLDER_3));
 
-      iTernaryConst = (signatureCharIII_I_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::iternary,
-            resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 2, 1, &iternaryChild1Arr[i]));
+compileOpCodeMethod(      iTernaryConst, _numberOfTernaryArgs, TR::iternary,
+            resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 2, 1, &iternaryChild1Arr[i]);
       OMR_CT_EXPECT_EQ(iTernaryConst, ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(INT_PLACEHOLDER_1, intArr[i][0], intArr[i][1]));
 
-      iTernaryConst = (signatureCharIII_I_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::iternary,
-            resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 2, 2, &intArr[i][0]));
+compileOpCodeMethod(      iTernaryConst, _numberOfTernaryArgs, TR::iternary,
+            resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 2, 2, &intArr[i][0]);
       OMR_CT_EXPECT_EQ(iTernaryConst, ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(iternaryChild1Arr[i], INT_PLACEHOLDER_1, intArr[i][1]));
 
-      iTernaryConst = (signatureCharIII_I_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::iternary,
-            resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 2, 3, &intArr[i][1]));
+compileOpCodeMethod(      iTernaryConst, _numberOfTernaryArgs, TR::iternary,
+            resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 2, 3, &intArr[i][1]);
       OMR_CT_EXPECT_EQ(iTernaryConst, ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(iternaryChild1Arr[i], intArr[i][0], INT_PLACEHOLDER_1));
       }
    }
@@ -2868,7 +2729,7 @@ OpCodesTest::invokeAddressTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "aConst%d", i + 1);
-      aUnaryCons = (signatureCharL_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::aconst, resolvedMethodName, _argTypesUnaryAddress, TR::Address, rc, 2, 1, &(aUnaryDataArr[i])));
+compileOpCodeMethod(      aUnaryCons, _numberOfUnaryArgs, TR::aconst, resolvedMethodName, _argTypesUnaryAddress, TR::Address, rc, 2, 1, &(aUnaryDataArr[i]));
       OMR_CT_EXPECT_EQ(aUnaryCons, aUnaryDataArr[i], aUnaryCons(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -2878,7 +2739,7 @@ OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_areturn, aUnaryDataArr[i], _areturn(aUnaryDataArr[i]));
 
       sprintf(resolvedMethodName, "aReturnConst%d", i + 1);
-      aUnaryCons = (signatureCharL_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::areturn, resolvedMethodName, _argTypesUnaryAddress, TR::Address, rc, 2, 1, &(aUnaryDataArr[i])));
+compileOpCodeMethod(      aUnaryCons, _numberOfUnaryArgs, TR::areturn, resolvedMethodName, _argTypesUnaryAddress, TR::Address, rc, 2, 1, &(aUnaryDataArr[i]));
       OMR_CT_EXPECT_EQ(aUnaryCons, aUnaryDataArr[i], aUnaryCons(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -2888,7 +2749,7 @@ OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_astore, aUnaryDataArr[i], _astore(aUnaryDataArr[i]));
 
       sprintf(resolvedMethodName, "aStoreConst%d", i + 1);
-      aUnaryCons = (signatureCharL_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::astore, resolvedMethodName, _argTypesUnaryAddress, TR::Address, rc, 2, 1, &(aUnaryDataArr[i])));
+compileOpCodeMethod(      aUnaryCons, _numberOfUnaryArgs, TR::astore, resolvedMethodName, _argTypesUnaryAddress, TR::Address, rc, 2, 1, &(aUnaryDataArr[i]));
       OMR_CT_EXPECT_EQ(aUnaryCons, aUnaryDataArr[i], aUnaryCons(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -2898,7 +2759,7 @@ OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_a2i, convert(aUnaryDataArr[i], INT_POS), _a2i(aUnaryDataArr[i]));
 
       sprintf(resolvedMethodName, "a2iConst%d", i + 1);
-      a2iConst = (signatureCharL_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::a2i, resolvedMethodName, _argTypesUnaryAddress, TR::Int32, rc, 2, 1, &aUnaryDataArr[i]));
+      compileOpCodeMethod(a2iConst, _numberOfUnaryArgs, TR::a2i, resolvedMethodName, _argTypesUnaryAddress, TR::Int32, rc, 2, 1, &aUnaryDataArr[i]);
       OMR_CT_EXPECT_EQ(a2iConst, convert(aUnaryDataArr[i], INT_POS), a2iConst(ADDRESS_PLACEHOLDER_1));
       }
    }

--- a/fvtest/compilertest/tests/OpCodesTest.hpp
+++ b/fvtest/compilertest/tests/OpCodesTest.hpp
@@ -214,18 +214,18 @@ class OpCodesTest : public TestDriver
 
    TR::TypeDictionary types;
 
-   CmpBranchOpIlInjector cmpBranchIlnjector(&types, this, opCode);
-   BinaryOpIlInjector opCodeBinaryInjector(&types, this, opCode);
-   UnaryOpIlInjector opCodeUnaryInjector(&types, this, opCode);
-   TernaryOpIlInjector ternaryOpIlInjector(&types, this, opCode);
-   ChildlessUnaryOpIlInjector childlessUnaryOpIlInjector(&types, this, opCode);
-   StoreOpIlInjector storeOpIlInjector(&types, this, opCode);
-   IndirectLoadIlInjector indirectLoadIlInjector(&types, this, opCode);
-   IndirectStoreIlInjector indirectStoreIlInjector(&types, this, opCode);
+   CmpBranchOpIlInjector        cmpBranchIlInjector(&types, this, opCode);
+   BinaryOpIlInjector           opCodeBinaryIlInjector(&types, this, opCode);
+   UnaryOpIlInjector            opCodeUnaryInjector(&types, this, opCode);
+   TernaryOpIlInjector          ternaryOpIlInjector(&types, this, opCode);
+   ChildlessUnaryOpIlInjector   childlessUnaryOpIlInjector(&types, this, opCode);
+   StoreOpIlInjector            storeOpIlInjector(&types, this, opCode);
+   IndirectLoadIlInjector       indirectLoadIlInjector(&types, this, opCode);
+   IndirectStoreIlInjector      indirectStoreIlInjector(&types, this, opCode);
 
    if (op.isBooleanCompare() && op.isBranch())
       {
-      opCodeInjector = &cmpBranchIlnjector;
+      opCodeInjector = &cmpBranchIlInjector;
       }
    else if (op.isTernary())
       {
@@ -247,18 +247,23 @@ class OpCodesTest : public TestDriver
       {
       opCodeInjector = &storeOpIlInjector;
       }
-
    else
       {
-      if (2 == opCodeArgsNum)
+      switch (opCodeArgsNum) 
          {
-         opCodeInjector = &opCodeBinaryInjector;
-         }
-      else
-         {
-         opCodeInjector = &opCodeUnaryInjector;
+         case 1:
+            opCodeInjector = &opCodeUnaryInjector;
+            break;
+         case 2:
+            opCodeInjector = &opCodeBinaryIlInjector;
+            break;
+         default:
+            fprintf(stderr, "didn't select an injector based on argument number %d", opCodeArgsNum);
+            exit(-1);
          }
       }
+
+   TR_ASSERT(opCodeInjector, "Didn't select an injector!"); 
 
    TR::IlType **argIlTypes = new TR::IlType*[opCodeArgsNum];
    for (uint32_t a=0;a < opCodeArgsNum;a++)

--- a/fvtest/compilertest/tests/OpCodesTest.hpp
+++ b/fvtest/compilertest/tests/OpCodesTest.hpp
@@ -203,7 +203,6 @@ class OpCodesTest : public TestDriver
          uint16_t numArgs = 0,
          ...)
    {
-   TR_ASSERT((numArgs % 2) == 0, "Must be called with zero or an even args, numChildArgs = %d", numArgs);
    if ((numArgs % 2) != 0)
       {
       fprintf(stderr, "Error: numArgs must be called with zero or an even args, numArgs is %d", numArgs);

--- a/fvtest/compilertest/tests/OpCodesTest.hpp
+++ b/fvtest/compilertest/tests/OpCodesTest.hpp
@@ -335,15 +335,69 @@ class OpCodesTest : public TestDriver
    return returnCode;
    }
 
-   uint8_t *
-   compileDirectCallOpCodeMethod(int32_t opCodeArgsNum,
+   template <typename functiontype>
+   int32_t 
+   compileDirectCallOpCodeMethod(functiontype& resultpointer,
+         int32_t opCodeArgsNum,
          TR::ILOpCodes opCodeCompilee,
          TR::ILOpCodes opCode,
          char * compileeResolvedMethodName,
          char * testResolvedMethodName,
          TR::DataType * argTypes,
          TR::DataType returnType,
-         int32_t & returnCode);
+         int32_t & returnCode)
+      {
+      TR::TypeDictionary types;
+      ChildlessUnaryOpIlInjector functionIlInjector(&types, this, opCodeCompilee);
+
+      TR::IlType **argIlTypes = new TR::IlType*[opCodeArgsNum];
+      for (int32_t i=0;i < opCodeArgsNum;i++)
+         argIlTypes[i] = types.PrimitiveType(argTypes[i]);
+
+      TR::ResolvedMethod functionCompilee(__FILE__, LINETOSTR(__LINE__), compileeResolvedMethodName, opCodeArgsNum, argIlTypes, types.PrimitiveType(returnType), 0, &functionIlInjector);
+      TR::IlGeneratorMethodDetails functionDetails(&functionCompilee);
+      switch (returnType)
+         {
+         case TR::Int32:
+            _int32Compilee = &functionCompilee;
+            _int32CompiledMethod = (signatureCharI_I_testMethodType *) (compileMethod(functionDetails, warm, returnCode));
+            functionCompilee.setEntryPoint((void *)_int32CompiledMethod);
+            break;
+         case TR::Int64:
+            _int64Compilee = &functionCompilee;
+            _int64CompiledMethod = (signatureCharJ_J_testMethodType *) (compileMethod(functionDetails, warm, returnCode));
+            functionCompilee.setEntryPoint((void *)_int64CompiledMethod);
+            break;
+         case TR::Double:
+            _doubleCompilee = &functionCompilee;
+            _doubleCompiledMethod = (signatureCharD_D_testMethodType *) (compileMethod(functionDetails, warm, returnCode));
+            functionCompilee.setEntryPoint((void *)_doubleCompiledMethod);
+            break;
+         case TR::Float:
+            _floatCompilee = &functionCompilee;
+            _floatCompiledMethod = (signatureCharF_F_testMethodType *) (compileMethod(functionDetails, warm, returnCode));
+            functionCompilee.setEntryPoint((void *)_floatCompiledMethod);
+            break;
+         case TR::Address:
+            _addressCompilee = &functionCompilee;
+            _addressCompiledMethod = (signatureCharL_L_testMethodType *) (compileMethod(functionDetails, warm, returnCode));
+            functionCompilee.setEntryPoint((void *)_addressCompiledMethod);
+            break;
+         default:
+            TR_ASSERT(0, "compilee dataType should be int32, int64, double, float or address");
+         }
+      EXPECT_TRUE(COMPILATION_SUCCEEDED == returnCode || COMPILATION_REQUESTED == returnCode) 
+         << "Compiling callee method " << compileeResolvedMethodName << " failed unexpectedly";
+
+      CallIlInjector callIlInjector(&types, this, opCode);
+      TR::ResolvedMethod callCompilee(__FILE__, LINETOSTR(__LINE__), testResolvedMethodName, opCodeArgsNum, argIlTypes, types.PrimitiveType(returnType), 0, &callIlInjector);
+      TR::IlGeneratorMethodDetails callDetails(&callCompilee);
+      uint8_t *startPC = compileMethod(callDetails, warm, returnCode);
+      EXPECT_TRUE(COMPILATION_SUCCEEDED == returnCode || COMPILATION_REQUESTED == returnCode) 
+         << "Compiling test method " << testResolvedMethodName << " failed unexpectedly";
+      resultpointer = reinterpret_cast<functiontype>(startPC);
+      return returnCode;;
+      }
 
    void
    addUnsupportedOpCodeTest(int32_t opCodeArgsNum,

--- a/fvtest/compilertest/tests/PPCOpCodesTest.cpp
+++ b/fvtest/compilertest/tests/PPCOpCodesTest.cpp
@@ -5186,11 +5186,11 @@ PPCOpCodesTest::compileDisabledDirectCallTestMethods()
    int32_t rc = 0;
 
    //Jazz103 Work item 115240
-   _acall = (signatureCharL_L_testMethodType *) (compileDirectCallOpCodeMethod(_numberOfUnaryArgs, TR::areturn, TR::acall, "aCompiledMethod", "acall", _argTypesUnaryAddress, TR::Address, rc));
-   _iCall = (signatureCharI_I_testMethodType *) (compileDirectCallOpCodeMethod(_numberOfUnaryArgs, TR::ireturn, TR::icall, "iCompiledMethod", "iCall", _argTypesUnaryInt, TR::Int32, rc));
-   _lCall = (signatureCharJ_J_testMethodType *) (compileDirectCallOpCodeMethod(_numberOfUnaryArgs, TR::lreturn, TR::lcall, "lCompiledMethod", "lCall", _argTypesUnaryLong, TR::Int64, rc));
-   _dCall = (signatureCharD_D_testMethodType *) (compileDirectCallOpCodeMethod(_numberOfUnaryArgs, TR::dreturn, TR::dcall, "dCompiledMethod", "dCall", _argTypesUnaryDouble, TR::Double, rc));
-   _fCall = (signatureCharF_F_testMethodType *) (compileDirectCallOpCodeMethod(_numberOfUnaryArgs, TR::freturn, TR::fcall, "fCompiledMethod", "fCall", _argTypesUnaryFloat, TR::Float, rc));
+   compileDirectCallOpCodeMethod(_acall, _numberOfUnaryArgs, TR::areturn, TR::acall, "aCompiledMethod", "acall", _argTypesUnaryAddress, TR::Address,    rc);
+   compileDirectCallOpCodeMethod(_iCall, _numberOfUnaryArgs, TR::ireturn, TR::icall, "iCompiledMethod", "iCall", _argTypesUnaryInt,     TR::Int32,      rc);
+   compileDirectCallOpCodeMethod(_lCall, _numberOfUnaryArgs, TR::lreturn, TR::lcall, "lCompiledMethod", "lCall", _argTypesUnaryLong,    TR::Int64,      rc);
+   compileDirectCallOpCodeMethod(_dCall, _numberOfUnaryArgs, TR::dreturn, TR::dcall, "dCompiledMethod", "dCall", _argTypesUnaryDouble,  TR::Double,     rc);
+   compileDirectCallOpCodeMethod(_fCall, _numberOfUnaryArgs, TR::freturn, TR::fcall, "fCompiledMethod", "fCall", _argTypesUnaryFloat,   TR::Float,      rc);
    }
 
 void

--- a/fvtest/compilertest/tests/PPCOpCodesTest.cpp
+++ b/fvtest/compilertest/tests/PPCOpCodesTest.cpp
@@ -32,23 +32,23 @@ void
 PPCOpCodesTest::compileUnaryTestMethods()
    {
    int32_t rc = 0;
-   _d2b = (signatureCharD_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2b, "d2b", _argTypesUnaryDouble, TR::Int8, rc));
-   _d2s = (signatureCharD_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2s, "d2s", _argTypesUnaryDouble, TR::Int16, rc));
-   _f2b = (signatureCharF_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2b, "f2b", _argTypesUnaryFloat, TR::Int8, rc));
-   _f2s = (signatureCharF_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2s, "f2s", _argTypesUnaryFloat, TR::Int16, rc));
+   compileOpCodeMethod(_d2b, _numberOfUnaryArgs, TR::d2b, "d2b", _argTypesUnaryDouble, TR::Int8, rc);
+   compileOpCodeMethod(_d2s, _numberOfUnaryArgs, TR::d2s, "d2s", _argTypesUnaryDouble, TR::Int16, rc);
+   compileOpCodeMethod(_f2b, _numberOfUnaryArgs, TR::f2b, "f2b", _argTypesUnaryFloat, TR::Int8, rc);
+   compileOpCodeMethod(_f2s, _numberOfUnaryArgs, TR::f2s, "f2s", _argTypesUnaryFloat, TR::Int16, rc);
 
-   _b2i = (signatureCharB_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2i, "b2i", _argTypesUnaryByte, TR::Int32, rc));
-   _b2l = (signatureCharB_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2l, "b2l", _argTypesUnaryByte, TR::Int64, rc));
-   _b2s = (signatureCharB_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2s, "b2s", _argTypesUnaryByte, TR::Int16, rc));
-   _bu2i = (unsignedSignatureCharB_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2i, "bu2i", _argTypesUnaryByte, TR::Int32, rc));
-   _bu2l = (unsignedSignatureCharB_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2l, "bu2l", _argTypesUnaryByte, TR::Int64, rc));
-   _bu2s = (unsignedSignatureCharB_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2s, "bu2s", _argTypesUnaryByte, TR::Int16, rc));
+   compileOpCodeMethod(_b2i, _numberOfUnaryArgs, TR::b2i, "b2i", _argTypesUnaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_b2l, _numberOfUnaryArgs, TR::b2l, "b2l", _argTypesUnaryByte, TR::Int64, rc);
+   compileOpCodeMethod(_b2s, _numberOfUnaryArgs, TR::b2s, "b2s", _argTypesUnaryByte, TR::Int16, rc);
+   compileOpCodeMethod(_bu2i, _numberOfUnaryArgs, TR::bu2i, "bu2i", _argTypesUnaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_bu2l, _numberOfUnaryArgs, TR::bu2l, "bu2l", _argTypesUnaryByte, TR::Int64, rc);
+   compileOpCodeMethod(_bu2s, _numberOfUnaryArgs, TR::bu2s, "bu2s", _argTypesUnaryByte, TR::Int16, rc);
 
-   _s2i = (signatureCharS_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2i, "s2i", _argTypesUnaryShort, TR::Int32, rc));
-   _s2l = (signatureCharS_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2l, "s2l", _argTypesUnaryShort, TR::Int64, rc));
-   _s2b = (signatureCharS_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2b, "s2b", _argTypesUnaryShort, TR::Int8, rc));
-   _su2i = (unsignedSignatureCharS_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2i, "su2i", _argTypesUnaryShort, TR::Int32, rc));
-   _su2l = (unsignedSignatureCharS_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2l, "su2l", _argTypesUnaryShort, TR::Int64, rc));
+   compileOpCodeMethod(_s2i, _numberOfUnaryArgs, TR::s2i, "s2i", _argTypesUnaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_s2l, _numberOfUnaryArgs, TR::s2l, "s2l", _argTypesUnaryShort, TR::Int64, rc);
+   compileOpCodeMethod(_s2b, _numberOfUnaryArgs, TR::s2b, "s2b", _argTypesUnaryShort, TR::Int8, rc);
+   compileOpCodeMethod(_su2i, _numberOfUnaryArgs, TR::su2i, "su2i", _argTypesUnaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_su2l, _numberOfUnaryArgs, TR::su2l, "su2l", _argTypesUnaryShort, TR::Int64, rc);
 
    }
 
@@ -57,29 +57,29 @@ PPCOpCodesTest::compileMemoryOperationTestMethods()
    {
    int32_t rc = 0;
 
-   _bLoad = (signatureCharB_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bload, "bLoad", _argTypesUnaryByte, TR::Int8, rc));
-   _sLoad = (signatureCharS_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::sload, "sLoad", _argTypesUnaryShort, TR::Int16, rc));
+   compileOpCodeMethod(_bLoad, _numberOfUnaryArgs, TR::bload, "bLoad", _argTypesUnaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_sLoad, _numberOfUnaryArgs, TR::sload, "sLoad", _argTypesUnaryShort, TR::Int16, rc);
 
-   _bStore = (signatureCharB_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bstore, "bStore", _argTypesUnaryByte, TR::Int8, rc));
-   _sStore = (signatureCharS_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::sstore, "sStore", _argTypesUnaryShort, TR::Int16, rc));
-   _lStore = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lstore, "lStore", _argTypesUnaryLong, TR::Int64, rc));
-   _dStore = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dstore, "dStore", _argTypesUnaryDouble, TR::Double, rc));
-   _fStore = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::fstore, "fStore", _argTypesUnaryFloat, TR::Float, rc));
+   compileOpCodeMethod(_bStore, _numberOfUnaryArgs, TR::bstore, "bStore", _argTypesUnaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_sStore, _numberOfUnaryArgs, TR::sstore, "sStore", _argTypesUnaryShort, TR::Int16, rc);
+   compileOpCodeMethod(_lStore, _numberOfUnaryArgs, TR::lstore, "lStore", _argTypesUnaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_dStore, _numberOfUnaryArgs, TR::dstore, "dStore", _argTypesUnaryDouble, TR::Double, rc);
+   compileOpCodeMethod(_fStore, _numberOfUnaryArgs, TR::fstore, "fStore", _argTypesUnaryFloat, TR::Float, rc);
 
-   _iStorei = (signatureCharLI_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::istorei, "iStorei", _argTypesBinaryAddressInt, TR::Int32, rc));
-   _lStorei = (signatureCharLJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lstorei, "lStorei", _argTypesBinaryAddressLong, TR::Int64, rc));
-   _dStorei = (signatureCharLD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dstorei, "dStorei", _argTypesBinaryAddressDouble, TR::Double, rc));
-   _fStorei = (signatureCharLF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fstorei, "fStorei", _argTypesBinaryAddressFloat, TR::Float, rc));
-   _sStorei = (signatureCharLS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sstorei, "sStorei", _argTypesBinaryAddressShort, TR::Int16, rc));
-   _aStorei = (signatureCharLL_L_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::astorei, "aStorei", _argTypesBinaryAddressAddress, TR::Address, rc));
+   compileOpCodeMethod(_iStorei, _numberOfBinaryArgs, TR::istorei, "iStorei", _argTypesBinaryAddressInt, TR::Int32, rc);
+   compileOpCodeMethod(_lStorei, _numberOfBinaryArgs, TR::lstorei, "lStorei", _argTypesBinaryAddressLong, TR::Int64, rc);
+   compileOpCodeMethod(_dStorei, _numberOfBinaryArgs, TR::dstorei, "dStorei", _argTypesBinaryAddressDouble, TR::Double, rc);
+   compileOpCodeMethod(_fStorei, _numberOfBinaryArgs, TR::fstorei, "fStorei", _argTypesBinaryAddressFloat, TR::Float, rc);
+   compileOpCodeMethod(_sStorei, _numberOfBinaryArgs, TR::sstorei, "sStorei", _argTypesBinaryAddressShort, TR::Int16, rc);
+   compileOpCodeMethod(_aStorei, _numberOfBinaryArgs, TR::astorei, "aStorei", _argTypesBinaryAddressAddress, TR::Address, rc);
    }
 
 void
 PPCOpCodesTest::compileTernaryTestMethods()
    {
    int32_t rc = 0;
-   _bternary = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary, "bTernary", _argTypesTernaryByte, TR::Int8, rc));
-   _sternary = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary, "sTernary", _argTypesTernaryShort, TR::Int16, rc));
+   compileOpCodeMethod(_bternary, _numberOfTernaryArgs, TR::bternary, "bTernary", _argTypesTernaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_sternary, _numberOfTernaryArgs, TR::sternary, "sTernary", _argTypesTernaryShort, TR::Int16, rc);
    }
 
 void
@@ -88,51 +88,51 @@ PPCOpCodesTest::compileCompareTestMethods()
    int32_t rc = 0;
 
    //Compare
-   _sCmpeq = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::scmpeq, "sCmpeq", _argTypesBinaryShort, TR::Int32, rc));
-   _sCmpne = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::scmpne, "sCmpne", _argTypesBinaryShort, TR::Int32, rc));
-   _sCmpgt = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::scmpgt, "sCmpgt", _argTypesBinaryShort, TR::Int32, rc));
-   _sCmplt = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::scmplt, "sCmplt", _argTypesBinaryShort, TR::Int32, rc));
-   _sCmpge = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::scmpge, "sCmpge", _argTypesBinaryShort, TR::Int32, rc));
-   _sCmple = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::scmple, "sCmple", _argTypesBinaryShort, TR::Int32, rc));
+   compileOpCodeMethod(_sCmpeq, _numberOfBinaryArgs, TR::scmpeq, "sCmpeq", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_sCmpne, _numberOfBinaryArgs, TR::scmpne, "sCmpne", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_sCmpgt, _numberOfBinaryArgs, TR::scmpgt, "sCmpgt", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_sCmplt, _numberOfBinaryArgs, TR::scmplt, "sCmplt", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_sCmpge, _numberOfBinaryArgs, TR::scmpge, "sCmpge", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_sCmple, _numberOfBinaryArgs, TR::scmple, "sCmple", _argTypesBinaryShort, TR::Int32, rc);
 
-   _bCmpeq = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bcmpeq, "bCmpeq", _argTypesBinaryByte, TR::Int32, rc));
-   _bCmpgt = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bcmpgt, "bCmpgt", _argTypesBinaryByte, TR::Int32, rc));
+   compileOpCodeMethod(_bCmpeq, _numberOfBinaryArgs, TR::bcmpeq, "bCmpeq", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_bCmpgt, _numberOfBinaryArgs, TR::bcmpgt, "bCmpgt", _argTypesBinaryByte, TR::Int32, rc);
 
-   _iuCmpeq = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iucmpeq, "iuCmpeq", _argTypesBinaryInt, TR::Int32, rc));
-   _iuCmpne = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iucmpne, "iuCmpne", _argTypesBinaryInt, TR::Int32, rc));
-   _iuCmpge = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iucmpge, "iuCmpge", _argTypesBinaryInt, TR::Int32, rc));
+   compileOpCodeMethod(_iuCmpeq, _numberOfBinaryArgs, TR::iucmpeq, "iuCmpeq", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iuCmpne, _numberOfBinaryArgs, TR::iucmpne, "iuCmpne", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iuCmpge, _numberOfBinaryArgs, TR::iucmpge, "iuCmpge", _argTypesBinaryInt, TR::Int32, rc);
 
-   _suCmpeq = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sucmpeq, "suCmpeq", _argTypesBinaryShort, TR::Int32, rc));
-   _suCmpne = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sucmpne, "suCmpne", _argTypesBinaryShort, TR::Int32, rc));
-   _suCmplt = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sucmplt, "suCmplt", _argTypesBinaryShort, TR::Int32, rc));
-   _suCmpge = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sucmpge, "suCmpge", _argTypesBinaryShort, TR::Int32, rc));
-   _suCmpgt = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sucmpgt, "suCmpgt", _argTypesBinaryShort, TR::Int32, rc));
-   _suCmple = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sucmple, "suCmple", _argTypesBinaryShort, TR::Int32, rc));
+   compileOpCodeMethod(_suCmpeq, _numberOfBinaryArgs, TR::sucmpeq, "suCmpeq", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_suCmpne, _numberOfBinaryArgs, TR::sucmpne, "suCmpne", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_suCmplt, _numberOfBinaryArgs, TR::sucmplt, "suCmplt", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_suCmpge, _numberOfBinaryArgs, TR::sucmpge, "suCmpge", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_suCmpgt, _numberOfBinaryArgs, TR::sucmpgt, "suCmpgt", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_suCmple, _numberOfBinaryArgs, TR::sucmple, "suCmple", _argTypesBinaryShort, TR::Int32, rc);
 
    //CompareAndBranch
-   _ifScmpeq = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifscmpeq, "ifScmpeq", _argTypesBinaryShort, TR::Int32, rc));
-   _ifScmpne = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifscmpne, "ifScmpne", _argTypesBinaryShort, TR::Int32, rc));
-   _ifScmpgt = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifscmpgt, "ifScmpgt", _argTypesBinaryShort, TR::Int32, rc));
-   _ifScmplt = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifscmplt, "ifScmplt", _argTypesBinaryShort, TR::Int32, rc));
-   _ifScmpge = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifscmpge, "ifScmpge", _argTypesBinaryShort, TR::Int32, rc));
-   _ifScmple = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifscmple, "ifScmple", _argTypesBinaryShort, TR::Int32, rc));
+   compileOpCodeMethod(_ifScmpeq, _numberOfBinaryArgs, TR::ifscmpeq, "ifScmpeq", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifScmpne, _numberOfBinaryArgs, TR::ifscmpne, "ifScmpne", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifScmpgt, _numberOfBinaryArgs, TR::ifscmpgt, "ifScmpgt", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifScmplt, _numberOfBinaryArgs, TR::ifscmplt, "ifScmplt", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifScmpge, _numberOfBinaryArgs, TR::ifscmpge, "ifScmpge", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifScmple, _numberOfBinaryArgs, TR::ifscmple, "ifScmple", _argTypesBinaryShort, TR::Int32, rc);
 
-   _ifBcmpeq = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbcmpeq, "ifBcmpeq", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBcmpgt = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbcmpgt, "ifBcmpgt", _argTypesBinaryByte, TR::Int32, rc));
+   compileOpCodeMethod(_ifBcmpeq, _numberOfBinaryArgs, TR::ifbcmpeq, "ifBcmpeq", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBcmpgt, _numberOfBinaryArgs, TR::ifbcmpgt, "ifBcmpgt", _argTypesBinaryByte, TR::Int32, rc);
 
-   _ifBuCmpeq = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbucmpeq, "ifBuCmpeq", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBuCmpne = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbucmpne, "ifBuCmpne", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBuCmplt = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbucmplt, "ifBuCmplt", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBuCmpge = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbucmpge, "ifBuCmpge", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBuCmpgt = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbucmpgt, "ifBuCmpgt", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBuCmple = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbucmple, "ifBuCmple", _argTypesBinaryByte, TR::Int32, rc));
+   compileOpCodeMethod(_ifBuCmpeq, _numberOfBinaryArgs, TR::ifbucmpeq, "ifBuCmpeq", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBuCmpne, _numberOfBinaryArgs, TR::ifbucmpne, "ifBuCmpne", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBuCmplt, _numberOfBinaryArgs, TR::ifbucmplt, "ifBuCmplt", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBuCmpge, _numberOfBinaryArgs, TR::ifbucmpge, "ifBuCmpge", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBuCmpgt, _numberOfBinaryArgs, TR::ifbucmpgt, "ifBuCmpgt", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBuCmple, _numberOfBinaryArgs, TR::ifbucmple, "ifBuCmple", _argTypesBinaryByte, TR::Int32, rc);
 
-   _ifSuCmpeq = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifsucmpeq, "ifSuCmpeq", _argTypesBinaryShort, TR::Int32, rc));
-   _ifSuCmpne = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifsucmpne, "ifSuCmpne", _argTypesBinaryShort, TR::Int32, rc));
-   _ifSuCmpgt = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifsucmpgt, "ifSuCmpgt", _argTypesBinaryShort, TR::Int32, rc));
-   _ifSuCmple = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifsucmple, "ifSuCmple", _argTypesBinaryShort, TR::Int32, rc));
-   _ifSuCmplt = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifsucmplt, "ifSuCmplt", _argTypesBinaryShort, TR::Int32, rc));
-   _ifSuCmpge = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifsucmpge, "ifSuCmpge", _argTypesBinaryShort, TR::Int32, rc));
+   compileOpCodeMethod(_ifSuCmpeq, _numberOfBinaryArgs, TR::ifsucmpeq, "ifSuCmpeq", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifSuCmpne, _numberOfBinaryArgs, TR::ifsucmpne, "ifSuCmpne", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifSuCmpgt, _numberOfBinaryArgs, TR::ifsucmpgt, "ifSuCmpgt", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifSuCmple, _numberOfBinaryArgs, TR::ifsucmple, "ifSuCmple", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifSuCmplt, _numberOfBinaryArgs, TR::ifsucmplt, "ifSuCmplt", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifSuCmpge, _numberOfBinaryArgs, TR::ifsucmpge, "ifSuCmpge", _argTypesBinaryShort, TR::Int32, rc);
 
    }
 
@@ -141,28 +141,28 @@ PPCOpCodesTest::compileAddressTestMethods()
    {
    int32_t rc = 0;
 
-   _a2b = (signatureCharL_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::a2b, "a2b", _argTypesUnaryAddress, TR::Int8, rc));
-   _a2s = (signatureCharL_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::a2s, "a2s", _argTypesUnaryAddress, TR::Int16, rc));
-   _a2l = (signatureCharL_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::a2l, "a2l", _argTypesUnaryAddress, TR::Int64, rc));
-   _b2a = (signatureCharB_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2a, "b2a", _argTypesUnaryByte, TR::Address, rc));
-   _s2a = (signatureCharS_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2a, "s2a", _argTypesUnaryShort, TR::Address, rc));
-   _i2a = (signatureCharI_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::i2a, "i2a", _argTypesUnaryInt, TR::Address, rc));
-   _bu2a = (unsignedSignatureCharB_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2a, "bu2a", _argTypesUnaryByte, TR::Address, rc));
-   _lu2a = (unsignedSignatureCharJ_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lu2a, "lu2a", _argTypesUnaryLong, TR::Address, rc));
+   compileOpCodeMethod(_a2b, _numberOfUnaryArgs, TR::a2b, "a2b", _argTypesUnaryAddress, TR::Int8, rc);
+   compileOpCodeMethod(_a2s, _numberOfUnaryArgs, TR::a2s, "a2s", _argTypesUnaryAddress, TR::Int16, rc);
+   compileOpCodeMethod(_a2l, _numberOfUnaryArgs, TR::a2l, "a2l", _argTypesUnaryAddress, TR::Int64, rc);
+   compileOpCodeMethod(_b2a, _numberOfUnaryArgs, TR::b2a, "b2a", _argTypesUnaryByte, TR::Address, rc);
+   compileOpCodeMethod(_s2a, _numberOfUnaryArgs, TR::s2a, "s2a", _argTypesUnaryShort, TR::Address, rc);
+   compileOpCodeMethod(_i2a, _numberOfUnaryArgs, TR::i2a, "i2a", _argTypesUnaryInt, TR::Address, rc);
+   compileOpCodeMethod(_bu2a, _numberOfUnaryArgs, TR::bu2a, "bu2a", _argTypesUnaryByte, TR::Address, rc);
+   compileOpCodeMethod(_lu2a, _numberOfUnaryArgs, TR::lu2a, "lu2a", _argTypesUnaryLong, TR::Address, rc);
 
-   _acmpeq = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::acmpeq, "acmpeq", _argTypesBinaryAddress, TR::Int32, rc));
-   _acmpne = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::acmpne, "acmpne", _argTypesBinaryAddress, TR::Int32, rc));
-   _acmplt = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::acmplt, "acmplt", _argTypesBinaryAddress, TR::Int32, rc));
-   _acmpge = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::acmpge, "acmpge", _argTypesBinaryAddress, TR::Int32, rc));
-   _acmple = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::acmple, "acmple", _argTypesBinaryAddress, TR::Int32, rc));
-   _acmpgt = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::acmpgt, "acmpgt", _argTypesBinaryAddress, TR::Int32, rc));
-   _ifacmpeq = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifacmpeq, "ifacmpeq", _argTypesBinaryAddress, TR::Int32, rc));
-   _ifacmpne = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifacmpne, "ifacmpne", _argTypesBinaryAddress, TR::Int32, rc));
-   _ifacmplt = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifacmplt, "ifacmplt", _argTypesBinaryAddress, TR::Int32, rc));
-   _ifacmpge = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifacmpge, "ifacmpge", _argTypesBinaryAddress, TR::Int32, rc));
-   _ifacmple = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifacmple, "ifacmple", _argTypesBinaryAddress, TR::Int32, rc));
-   _ifacmpgt = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifacmpgt, "ifacmpgt", _argTypesBinaryAddress, TR::Int32, rc));
-   _aternary = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::aternary, "aternary", _argTypesTernaryAddress, TR::Address, rc));
+   compileOpCodeMethod(_acmpeq, _numberOfBinaryArgs, TR::acmpeq, "acmpeq", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_acmpne, _numberOfBinaryArgs, TR::acmpne, "acmpne", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_acmplt, _numberOfBinaryArgs, TR::acmplt, "acmplt", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_acmpge, _numberOfBinaryArgs, TR::acmpge, "acmpge", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_acmple, _numberOfBinaryArgs, TR::acmple, "acmple", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_acmpgt, _numberOfBinaryArgs, TR::acmpgt, "acmpgt", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_ifacmpeq, _numberOfBinaryArgs, TR::ifacmpeq, "ifacmpeq", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_ifacmpne, _numberOfBinaryArgs, TR::ifacmpne, "ifacmpne", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_ifacmplt, _numberOfBinaryArgs, TR::ifacmplt, "ifacmplt", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_ifacmpge, _numberOfBinaryArgs, TR::ifacmpge, "ifacmpge", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_ifacmple, _numberOfBinaryArgs, TR::ifacmple, "ifacmple", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_ifacmpgt, _numberOfBinaryArgs, TR::ifacmpgt, "ifacmpgt", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_aternary, _numberOfTernaryArgs, TR::aternary, "aternary", _argTypesTernaryAddress, TR::Address, rc);
 
    }
 
@@ -171,11 +171,11 @@ PPCOpCodesTest::compileShiftOrRolTestMethods()
    {
    int32_t rc = 0;
 
-   _iRol = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::irol, "iRol", _argTypesBinaryInt, TR::Int32, rc));
+   compileOpCodeMethod(_iRol, _numberOfBinaryArgs, TR::irol, "iRol", _argTypesBinaryInt, TR::Int32, rc);
 
-   _bShl = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bshl, "bShl", _argTypesBinaryByte, TR::Int8, rc));
-   _buShr = (unsignedSignatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bushr, "buShr", _argTypesBinaryByte, TR::Int8, rc));
-   _sShr = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sshr, "sShr", _argTypesBinaryShort, TR::Int16, rc));
+   compileOpCodeMethod(_bShl, _numberOfBinaryArgs, TR::bshl, "bShl", _argTypesBinaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_buShr, _numberOfBinaryArgs, TR::bushr, "buShr", _argTypesBinaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_sShr, _numberOfBinaryArgs, TR::sshr, "sShr", _argTypesBinaryShort, TR::Int16, rc);
    }
 
 void
@@ -183,13 +183,13 @@ PPCOpCodesTest::compileBitwiseTestMethods()
    {
    int32_t rc;
 
-   _sAnd = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sand, "sAnd", _argTypesBinaryShort, TR::Int16, rc));
-   _sOr = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sor, "sOr", _argTypesBinaryShort, TR::Int16, rc));
-   _sXor = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sxor, "sXor", _argTypesBinaryShort, TR::Int16, rc));
+   compileOpCodeMethod(_sAnd, _numberOfBinaryArgs, TR::sand, "sAnd", _argTypesBinaryShort, TR::Int16, rc);
+   compileOpCodeMethod(_sOr, _numberOfBinaryArgs, TR::sor, "sOr", _argTypesBinaryShort, TR::Int16, rc);
+   compileOpCodeMethod(_sXor, _numberOfBinaryArgs, TR::sxor, "sXor", _argTypesBinaryShort, TR::Int16, rc);
 
-   _bAnd = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::band, "bAnd", _argTypesBinaryByte, TR::Int8, rc));
-   _bOr = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bor, "bOr", _argTypesBinaryByte, TR::Int8, rc));
-   _bXor = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bxor, "bXor", _argTypesBinaryByte, TR::Int8, rc));
+   compileOpCodeMethod(_bAnd, _numberOfBinaryArgs, TR::band, "bAnd", _argTypesBinaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_bOr, _numberOfBinaryArgs, TR::bor, "bOr", _argTypesBinaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_bXor, _numberOfBinaryArgs, TR::bxor, "bXor", _argTypesBinaryByte, TR::Int8, rc);
    }
 
 void
@@ -244,13 +244,13 @@ PPCOpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_EQ(_d2s, convert(doubleDataArray[i], SHORT_POS), _d2s(doubleDataArray[i]));
 
       sprintf(resolvedMethodName, "d2bConst%d", i + 1);
-      d2bConst = (signatureCharD_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2b,
-            resolvedMethodName, _argTypesUnaryDouble, TR::Int8, rc, 2, 1, &doubleDataArray[i]));
+      compileOpCodeMethod(d2bConst, _numberOfUnaryArgs, TR::d2b,
+            resolvedMethodName, _argTypesUnaryDouble, TR::Int8, rc, 2, 1, &doubleDataArray[i]);
       OMR_CT_EXPECT_EQ(d2bConst, convert(doubleDataArray[i], BYTE_POS), d2bConst(DOUBLE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "d2sConst%d", i + 1);
-      d2sConst = (signatureCharD_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2s,
-            resolvedMethodName, _argTypesUnaryDouble, TR::Int16, rc, 2, 1, &doubleDataArray[i]));
+      compileOpCodeMethod(d2sConst, _numberOfUnaryArgs, TR::d2s,
+            resolvedMethodName, _argTypesUnaryDouble, TR::Int16, rc, 2, 1, &doubleDataArray[i]);
       OMR_CT_EXPECT_EQ(d2sConst, convert(doubleDataArray[i], SHORT_POS), d2sConst(DOUBLE_PLACEHOLDER_1));
       }
 
@@ -262,13 +262,13 @@ PPCOpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_EQ(_f2s, convert(floatDataArray[i], SHORT_POS), _f2s(floatDataArray[i]));
 
       sprintf(resolvedMethodName, "f2bConst%d", i + 1);
-      f2bConst = (signatureCharF_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2b,
-            resolvedMethodName, _argTypesUnaryFloat, TR::Int8, rc, 2, 1, &floatDataArray[i]));
+      compileOpCodeMethod(f2bConst, _numberOfUnaryArgs, TR::f2b,
+            resolvedMethodName, _argTypesUnaryFloat, TR::Int8, rc, 2, 1, &floatDataArray[i]);
       OMR_CT_EXPECT_EQ(f2bConst, convert(floatDataArray[i], BYTE_POS), f2bConst(FLOAT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "f2sConst%d", i + 1);
-      f2sConst = (signatureCharF_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2s,
-            resolvedMethodName, _argTypesUnaryFloat, TR::Int16, rc, 2, 1, &floatDataArray[i]));
+      compileOpCodeMethod(f2sConst, _numberOfUnaryArgs, TR::f2s,
+            resolvedMethodName, _argTypesUnaryFloat, TR::Int16, rc, 2, 1, &floatDataArray[i]);
       OMR_CT_EXPECT_EQ(f2sConst, convert(floatDataArray[i], SHORT_POS), f2sConst(FLOAT_PLACEHOLDER_1));
       }
 
@@ -281,18 +281,18 @@ PPCOpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_EQ(_b2l, convert(byteDataArray[i], LONG_POS), _b2l(byteDataArray[i]));
 
       sprintf(resolvedMethodName, "b2sConst%d", i + 1);
-      b2sConst = (signatureCharB_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2s,
-            resolvedMethodName, _argTypesUnaryByte, TR::Int16, rc, 2, 1, &byteDataArray[i]));
+      compileOpCodeMethod(b2sConst, _numberOfUnaryArgs, TR::b2s,
+            resolvedMethodName, _argTypesUnaryByte, TR::Int16, rc, 2, 1, &byteDataArray[i]);
       OMR_CT_EXPECT_EQ(b2sConst, convert(byteDataArray[i], SHORT_POS), b2sConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "b2iConst%d", i + 1);
-      b2iConst = (signatureCharB_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2i,
-            resolvedMethodName, _argTypesUnaryByte, TR::Int32, rc, 2, 1, &byteDataArray[i]));
+      compileOpCodeMethod(b2iConst, _numberOfUnaryArgs, TR::b2i,
+            resolvedMethodName, _argTypesUnaryByte, TR::Int32, rc, 2, 1, &byteDataArray[i]);
       OMR_CT_EXPECT_EQ(b2iConst, convert(byteDataArray[i], INT_POS), b2iConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "b2lConst%d", i + 1);
-      b2lConst = (signatureCharB_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2l,
-            resolvedMethodName, _argTypesUnaryByte, TR::Int64, rc, 2, 1, &byteDataArray[i]));
+      compileOpCodeMethod(b2lConst, _numberOfUnaryArgs, TR::b2l,
+            resolvedMethodName, _argTypesUnaryByte, TR::Int64, rc, 2, 1, &byteDataArray[i]);
       OMR_CT_EXPECT_EQ(b2lConst, convert(byteDataArray[i], LONG_POS), b2lConst(BYTE_PLACEHOLDER_1));
       }
 
@@ -305,18 +305,18 @@ PPCOpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_EQ(_bu2l, convert(ubyteDataArray[i], LONG_POS), _bu2l(ubyteDataArray[i]));
 
       sprintf(resolvedMethodName, "bu2sConst%d", i + 1);
-      bu2sConst = (unsignedSignatureCharB_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2s,
-            resolvedMethodName, _argTypesUnaryByte, TR::Int16, rc, 2, 1, &ubyteDataArray[i]));
+      compileOpCodeMethod(bu2sConst, _numberOfUnaryArgs, TR::bu2s,
+            resolvedMethodName, _argTypesUnaryByte, TR::Int16, rc, 2, 1, &ubyteDataArray[i]);
       OMR_CT_EXPECT_EQ(bu2sConst, convert(ubyteDataArray[i], SHORT_POS), bu2sConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "bu2iConst%d", i + 1);
-      bu2iConst = (unsignedSignatureCharB_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2i,
-            resolvedMethodName, _argTypesUnaryByte, TR::Int32, rc, 2, 1, &ubyteDataArray[i]));
+      compileOpCodeMethod(bu2iConst, _numberOfUnaryArgs, TR::bu2i,
+            resolvedMethodName, _argTypesUnaryByte, TR::Int32, rc, 2, 1, &ubyteDataArray[i]);
       OMR_CT_EXPECT_EQ(bu2iConst, convert(ubyteDataArray[i], INT_POS), bu2iConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "bu2lConst%d", i + 1);
-      bu2lConst = (unsignedSignatureCharB_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2l,
-            resolvedMethodName, _argTypesUnaryByte, TR::Int64, rc, 2, 1, &ubyteDataArray[i]));
+      compileOpCodeMethod(bu2lConst, _numberOfUnaryArgs, TR::bu2l,
+            resolvedMethodName, _argTypesUnaryByte, TR::Int64, rc, 2, 1, &ubyteDataArray[i]);
       OMR_CT_EXPECT_EQ(bu2lConst, convert(ubyteDataArray[i], LONG_POS), bu2lConst(BYTE_PLACEHOLDER_1));
       }
 
@@ -329,19 +329,19 @@ PPCOpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_EQ(_s2l, convert(shortDataArray[i], LONG_POS), _s2l(shortDataArray[i]));
 
       sprintf(resolvedMethodName, "s2bConst%d", i + 1);
-      s2bConst = (signatureCharS_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2b,
-            resolvedMethodName, _argTypesUnaryShort, TR::Int8, rc, 2, 1, &shortDataArray[i]));
+      compileOpCodeMethod(s2bConst, _numberOfUnaryArgs, TR::s2b,
+            resolvedMethodName, _argTypesUnaryShort, TR::Int8, rc, 2, 1, &shortDataArray[i]);
       OMR_CT_EXPECT_EQ(s2bConst, convert(shortDataArray[i], BYTE_POS), s2bConst(SHORT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "s2iConst%d", i + 1);
-      s2iConst = (signatureCharS_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2i,
-            resolvedMethodName, _argTypesUnaryShort, TR::Int32, rc, 2, 1, &shortDataArray[i]));
+      compileOpCodeMethod(s2iConst, _numberOfUnaryArgs, TR::s2i,
+            resolvedMethodName, _argTypesUnaryShort, TR::Int32, rc, 2, 1, &shortDataArray[i]);
       OMR_CT_EXPECT_EQ(s2iConst, convert(shortDataArray[i], INT_POS), s2iConst(SHORT_PLACEHOLDER_1));
 
 
       sprintf(resolvedMethodName, "s2lConst%d", i + 1);
-      s2lConst = (signatureCharS_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2l,
-            resolvedMethodName, _argTypesUnaryShort, TR::Int64, rc, 2, 1, &shortDataArray[i]));
+      compileOpCodeMethod(s2lConst, _numberOfUnaryArgs, TR::s2l,
+            resolvedMethodName, _argTypesUnaryShort, TR::Int64, rc, 2, 1, &shortDataArray[i]);
       OMR_CT_EXPECT_EQ(s2lConst, convert(shortDataArray[i], LONG_POS), s2lConst(SHORT_PLACEHOLDER_1));
       }
    //su 2 i,l
@@ -352,14 +352,14 @@ PPCOpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_EQ(_su2l, convert(ushortDataArray[i], LONG_POS), _su2l(ushortDataArray[i]));
 
       sprintf(resolvedMethodName, "s2iConst%d", i + 1);
-      su2iConst = (unsignedSignatureCharS_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2i,
-            resolvedMethodName, _argTypesUnaryShort, TR::Int32, rc, 2, 1, &ushortDataArray[i]));
+      compileOpCodeMethod(su2iConst, _numberOfUnaryArgs, TR::su2i,
+            resolvedMethodName, _argTypesUnaryShort, TR::Int32, rc, 2, 1, &ushortDataArray[i]);
       OMR_CT_EXPECT_EQ(su2iConst, convert(ushortDataArray[i], INT_POS), su2iConst(SHORT_PLACEHOLDER_1));
 
 
       sprintf(resolvedMethodName, "s2lConst%d", i + 1);
-      su2lConst = (unsignedSignatureCharS_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2l,
-            resolvedMethodName, _argTypesUnaryShort, TR::Int64, rc, 2, 1, &ushortDataArray[i]));
+      compileOpCodeMethod(su2lConst, _numberOfUnaryArgs, TR::su2l,
+            resolvedMethodName, _argTypesUnaryShort, TR::Int64, rc, 2, 1, &ushortDataArray[i]);
       OMR_CT_EXPECT_EQ(su2lConst, convert(ushortDataArray[i], LONG_POS), su2lConst(SHORT_PLACEHOLDER_1));
       }
    }
@@ -401,7 +401,7 @@ PPCOpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "bStoreConst%d", i + 1);
       OMR_CT_EXPECT_EQ(_bStore, byteDataArray[i], _bStore(byteDataArray[i]));
-      bMemCons = (signatureCharB_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bstore, resolvedMethodName, _argTypesUnaryByte, TR::Int8, rc, 2, 1, &(byteDataArray[i])));
+      compileOpCodeMethod(bMemCons, _numberOfUnaryArgs, TR::bstore, resolvedMethodName, _argTypesUnaryByte, TR::Int8, rc, 2, 1, &(byteDataArray[i]));
       OMR_CT_EXPECT_EQ(bMemCons, byteDataArray[i], bMemCons(BYTE_PLACEHOLDER_1));
       }
 
@@ -410,7 +410,7 @@ PPCOpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "sStoreConst%d", i + 1);
       OMR_CT_EXPECT_EQ(_sStore, shortDataArray[i], _sStore(shortDataArray[i]));
-      sMemCons = (signatureCharS_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::sstore, resolvedMethodName, _argTypesUnaryShort, TR::Int16, rc, 2, 1, &(shortDataArray[i])));
+      compileOpCodeMethod(sMemCons, _numberOfUnaryArgs, TR::sstore, resolvedMethodName, _argTypesUnaryShort, TR::Int16, rc, 2, 1, &(shortDataArray[i]));
       OMR_CT_EXPECT_EQ(sMemCons, shortDataArray[i], sMemCons(SHORT_PLACEHOLDER_1));
       }
 
@@ -419,7 +419,7 @@ PPCOpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "lStoreConst%d", i + 1);
       OMR_CT_EXPECT_EQ(_lStore, longDataArray[i], _lStore(longDataArray[i]));
-      lMemCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lstore, resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &(longDataArray[i])));
+      compileOpCodeMethod(lMemCons, _numberOfUnaryArgs, TR::lstore, resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &(longDataArray[i]));
       OMR_CT_EXPECT_EQ(lMemCons, longDataArray[i], lMemCons(LONG_PLACEHOLDER_1));
       }
 
@@ -428,7 +428,7 @@ PPCOpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "dStoreConst%d", i + 1);
       OMR_CT_EXPECT_DOUBLE_EQ(_dStore, doubleDataArray[i], _dStore(doubleDataArray[i]));
-      dMemCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dstore, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &(doubleDataArray[i])));
+      compileOpCodeMethod(dMemCons, _numberOfUnaryArgs, TR::dstore, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &(doubleDataArray[i]));
       OMR_CT_EXPECT_DOUBLE_EQ(dMemCons, doubleDataArray[i], dMemCons(DOUBLE_PLACEHOLDER_1));
       }
 
@@ -437,7 +437,7 @@ PPCOpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "fStoreConst%d", i + 1);
       OMR_CT_EXPECT_FLOAT_EQ(_fStore, floatDataArray[i], _fStore(floatDataArray[i]));
-      fMemCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::fstore, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &(floatDataArray[i])));
+      compileOpCodeMethod(fMemCons, _numberOfUnaryArgs, TR::fstore, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &(floatDataArray[i]));
       OMR_CT_EXPECT_FLOAT_EQ(fMemCons, floatDataArray[i], fMemCons(FLOAT_PLACEHOLDER_1));
       }
 
@@ -491,7 +491,7 @@ PPCOpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "iLoadiConst%d", i + 1);
       uintptrj_t intDataAddress = (uintptrj_t)(&intDataArray[i]);
-      iLoadiCons = (signatureCharL_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int32, rc, 2, 1, &intDataAddress));
+      compileOpCodeMethod(iLoadiCons, _numberOfUnaryArgs, TR::iloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int32, rc, 2, 1, &intDataAddress);
       OMR_CT_EXPECT_EQ(iLoadiCons, intDataArray[i], iLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -501,7 +501,7 @@ PPCOpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "sLoadiConst%d", i + 1);
       uintptrj_t shortDataAddress = (uintptrj_t)(&shortDataArray[i]);
-      sLoadiCons = (signatureCharL_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::sloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int16, rc, 2, 1, &shortDataAddress));
+      compileOpCodeMethod(sLoadiCons, _numberOfUnaryArgs, TR::sloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int16, rc, 2, 1, &shortDataAddress);
       OMR_CT_EXPECT_EQ(sLoadiCons, shortDataArray[i], sLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -511,7 +511,7 @@ PPCOpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "bLoadiConst%d", i + 1);
       uintptrj_t byteDataAddress = (uintptrj_t)(&byteDataArray[i]);
-      bLoadiCons = (signatureCharL_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int8, rc, 2, 1, &byteDataAddress));
+      compileOpCodeMethod(bLoadiCons, _numberOfUnaryArgs, TR::bloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int8, rc, 2, 1, &byteDataAddress);
       OMR_CT_EXPECT_EQ(bLoadiCons, byteDataArray[i], bLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -521,7 +521,7 @@ PPCOpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "lLoadiConst%d", i + 1);
       uintptrj_t longDataAddress = (uintptrj_t)(&longDataArray[i]);
-      lLoadiCons = (signatureCharL_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int64, rc, 2, 1, &longDataAddress));
+      compileOpCodeMethod(lLoadiCons, _numberOfUnaryArgs, TR::lloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int64, rc, 2, 1, &longDataAddress);
       OMR_CT_EXPECT_EQ(lLoadiCons, longDataArray[i], lLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -531,7 +531,7 @@ PPCOpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "dLoadiConst%d", i + 1);
       uintptrj_t doubleDataAddress = (uintptrj_t)(&doubleDataArray[i]);
-      dLoadiCons = (signatureCharL_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Double, rc, 2, 1, &doubleDataAddress));
+      compileOpCodeMethod(dLoadiCons, _numberOfUnaryArgs, TR::dloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Double, rc, 2, 1, &doubleDataAddress);
       OMR_CT_EXPECT_EQ(dLoadiCons, doubleDataArray[i], dLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -541,7 +541,7 @@ PPCOpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "fLoadiConst%d", i + 1);
       uintptrj_t floatDataAddress = (uintptrj_t)(&floatDataArray[i]);
-      fLoadiCons = (signatureCharL_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::floadi, resolvedMethodName, _argTypesUnaryAddress, TR::Float, rc, 2, 1, &floatDataAddress));
+      compileOpCodeMethod(fLoadiCons, _numberOfUnaryArgs, TR::floadi, resolvedMethodName, _argTypesUnaryAddress, TR::Float, rc, 2, 1, &floatDataAddress);
       OMR_CT_EXPECT_EQ(fLoadiCons, floatDataArray[i], fLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -551,7 +551,7 @@ PPCOpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "aLoadiConst%d", i + 1);
       uintptrj_t addressDataAddress = (uintptrj_t)(&addressDataArray[i]);
-      aLoadiCons = (signatureCharL_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::aloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Address, rc, 2, 1, &addressDataAddress));
+      compileOpCodeMethod(aLoadiCons, _numberOfUnaryArgs, TR::aloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Address, rc, 2, 1, &addressDataAddress);
       OMR_CT_EXPECT_EQ(aLoadiCons, addressDataArray[i], aLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -816,18 +816,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_sCmpeq, compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), _sCmpeq(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpeqConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpeqDataArr[i][0]), 2, &(sCmpeqDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpeqDataArr[i][0]), 2, &(sCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpeqConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpeqDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpeqConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpeqDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), sCompareConst(sCmpeqDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -837,18 +837,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_sCmpne, compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), _sCmpne(sCmpneDataArr[i][0], sCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpneConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpneDataArr[i][0]), 2, &(sCmpneDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpneDataArr[i][0]), 2, &(sCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpneConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpneDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpneConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpneDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), sCompareConst(sCmpneDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -858,18 +858,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_sCmpgt, compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), _sCmpgt(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpgtConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpgtDataArr[i][0]), 2, &(sCmpgtDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpgtDataArr[i][0]), 2, &(sCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpgtConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpgtDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpgtConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpgtDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), sCompareConst(sCmpgtDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -879,18 +879,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_sCmplt, compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), _sCmplt(sCmpltDataArr[i][0], sCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpltConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpltDataArr[i][0]), 2, &(sCmpltDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpltDataArr[i][0]), 2, &(sCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpltConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpltDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpltConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpltDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), sCompareConst(sCmpltDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -900,18 +900,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_sCmpge, compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), _sCmpge(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpgeConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpgeDataArr[i][0]), 2, &(sCmpgeDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpgeDataArr[i][0]), 2, &(sCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpgeConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpgeDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpgeConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpgeDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), sCompareConst(sCmpgeDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -921,18 +921,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_sCmple, compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), _sCmple(sCmpleDataArr[i][0], sCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpleConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpleDataArr[i][0]), 2, &(sCmpleDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpleDataArr[i][0]), 2, &(sCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpleConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpleDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpleConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpleDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), sCompareConst(sCmpleDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -943,18 +943,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_bCmpeq, compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), _bCmpeq(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpeqConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpeqDataArr[i][0]), 2, &(bCmpeqDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpeqDataArr[i][0]), 2, &(bCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpeqConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpeqDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpeqConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpeqDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), bCompareConst(bCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -964,18 +964,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_bCmpgt, compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), _bCmpgt(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpgtConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpgtDataArr[i][0]), 2, &(bCmpgtDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpgtDataArr[i][0]), 2, &(bCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpgtConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpgtDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpgtConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpgtDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), bCompareConst(bCmpgtDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -986,18 +986,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifScmpeq, compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), _ifScmpeq(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpeqConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpeqDataArr[i][0]), 2, &(ifScmpeqDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpeqDataArr[i][0]), 2, &(ifScmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpeqConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpeqDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpeqConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpeqDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), sCompareConst(ifScmpeqDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -1007,18 +1007,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifScmpne, compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), _ifScmpne(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpneConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpneDataArr[i][0]), 2, &(ifScmpneDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpneDataArr[i][0]), 2, &(ifScmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpneConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpneDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpneConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpneDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), sCompareConst(ifScmpneDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -1028,18 +1028,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifScmpgt, compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), _ifScmpgt(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpgtConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpgtDataArr[i][0]), 2, &(ifScmpgtDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpgtDataArr[i][0]), 2, &(ifScmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpgtConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpgtDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpgtConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpgtDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), sCompareConst(ifScmpgtDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -1049,18 +1049,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifScmplt, compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), _ifScmplt(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpltConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpltDataArr[i][0]), 2, &(ifScmpltDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpltDataArr[i][0]), 2, &(ifScmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpltConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpltDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpltConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpltDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), sCompareConst(ifScmpltDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -1070,18 +1070,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifScmpge, compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), _ifScmpge(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpgeConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpgeDataArr[i][0]), 2, &(ifScmpgeDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpgeDataArr[i][0]), 2, &(ifScmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpgeConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpgeDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpgeConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpgeDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), sCompareConst(ifScmpgeDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -1091,18 +1091,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifScmple, compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), _ifScmple(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpleConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpleDataArr[i][0]), 2, &(ifScmpleDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpleDataArr[i][0]), 2, &(ifScmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpleConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpleDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpleConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpleDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), sCompareConst(ifScmpleDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -1113,18 +1113,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifBcmpeq, compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), _ifBcmpeq(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpeqConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpeqDataArr[i][0]), 2, &(ifBcmpeqDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpeqDataArr[i][0]), 2, &(ifBcmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpeqConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpeqDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpeqConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpeqDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), bCompareConst(ifBcmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -1134,18 +1134,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifBcmpgt, compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), _ifBcmpgt(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpgtConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpgtDataArr[i][0]), 2, &(ifBcmpgtDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpgtDataArr[i][0]), 2, &(ifBcmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpgtConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpgtDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpgtConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpgtDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), bCompareConst(ifBcmpgtDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -1156,18 +1156,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_iuCmpeq, compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), _iuCmpeq(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpeqConst1_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpeqDataArr[i][0]), 2, &(iuCmpeqDataArr[i][1])));
+      compileOpCodeMethod(iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpeqDataArr[i][0]), 2, &(iuCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iuCmpeqConst2_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpeqDataArr[i][0])));
+      compileOpCodeMethod(iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpeqConst3_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpeqDataArr[i][1])));
+      compileOpCodeMethod(iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), iuCompareConst(iuCmpeqDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -1177,18 +1177,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_iuCmpne, compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), _iuCmpne(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpneConst1_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpneDataArr[i][0]), 2, &(iuCmpneDataArr[i][1])));
+      compileOpCodeMethod(iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpneDataArr[i][0]), 2, &(iuCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iuCmpneConst2_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpneDataArr[i][0])));
+      compileOpCodeMethod(iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpneConst3_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpneDataArr[i][1])));
+      compileOpCodeMethod(iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), iuCompareConst(iuCmpneDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -1198,18 +1198,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_iuCmpge, compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), _iuCmpge(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpgeConst1_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpgeDataArr[i][0]), 2, &(iuCmpgeDataArr[i][1])));
+      compileOpCodeMethod(iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpgeDataArr[i][0]), 2, &(iuCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iuCmpgeConst2_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpgeDataArr[i][0])));
+      compileOpCodeMethod(iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpgeConst3_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpgeDataArr[i][1])));
+      compileOpCodeMethod(iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(iuCmpgeDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -1220,18 +1220,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_suCmpeq, compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), _suCmpeq(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1])) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpeqConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpeqDataArr[i][0]), 2, &(suCmpeqDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpeqDataArr[i][0]), 2, &(suCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpeqConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpeqDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpeqDataArr[i][1])) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpeqConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpeqDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), suCompareConst(suCmpeqDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
       }
 
@@ -1241,18 +1241,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_suCmpne, compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), _suCmpne(suCmpneDataArr[i][0], suCmpneDataArr[i][1])) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpneConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpneDataArr[i][0]), 2, &(suCmpneDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpneDataArr[i][0]), 2, &(suCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpneConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpneDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpneDataArr[i][1])) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpneConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpneDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), suCompareConst(suCmpneDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
       }
 
@@ -1262,18 +1262,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_suCmpgt, compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), _suCmpgt(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1])) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgtConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpgtDataArr[i][0]), 2, &(suCmpgtDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpgtDataArr[i][0]), 2, &(suCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgtConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpgtDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpgtDataArr[i][1])) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgtConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpgtDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), suCompareConst(suCmpgtDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
       }
 
@@ -1283,18 +1283,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_suCmplt, compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), _suCmplt(suCmpltDataArr[i][0], suCmpltDataArr[i][1])) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpltConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpltDataArr[i][0]), 2, &(suCmpltDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpltDataArr[i][0]), 2, &(suCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpltConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpltDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpltDataArr[i][1])) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpltConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpltDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), suCompareConst(suCmpltDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
       }
 
@@ -1304,18 +1304,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_suCmpge, compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), _suCmpge(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1])) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgeConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpgeDataArr[i][0]), 2, &(suCmpgeDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpgeDataArr[i][0]), 2, &(suCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgeConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpgeDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpgeDataArr[i][1])) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgeConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpgeDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), suCompareConst(suCmpgeDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
       }
 
@@ -1325,18 +1325,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_suCmple, compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), _suCmple(suCmpleDataArr[i][0], suCmpleDataArr[i][1])) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpleConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpleDataArr[i][0]), 2, &(suCmpleDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpleDataArr[i][0]), 2, &(suCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpleConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpleDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpleDataArr[i][1])) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpleConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpleDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(suCmpleDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
       }
 
@@ -1347,18 +1347,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifBuCmpeq, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), _ifBuCmpeq(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpeqConst1_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpeqDataArr[i][0]), 2, &(ifBuCmpeqDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpeqDataArr[i][0]), 2, &(ifBuCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpeqConst2_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpeqDataArr[i][0])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpeqConst3_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpeqDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(ifBuCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -1368,18 +1368,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifBuCmpne, compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), _ifBuCmpne(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpneConst1_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpneDataArr[i][0]), 2, &(ifBuCmpneDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpneDataArr[i][0]), 2, &(ifBuCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpneConst2_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpneDataArr[i][0])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpneConst3_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpneDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), buCompareConst(ifBuCmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -1391,18 +1391,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifBuCmpgt, compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), _ifBuCmpgt(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpgtConst1_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpgtDataArr[i][0]), 2, &(ifBuCmpgtDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpgtDataArr[i][0]), 2, &(ifBuCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpgtConst2_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpgtDataArr[i][0])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpgtConst3_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpgtDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), buCompareConst(ifBuCmpgtDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -1412,18 +1412,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifBuCmplt, compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), _ifBuCmplt(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpltConst1_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpltDataArr[i][0]), 2, &(ifBuCmpltDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpltDataArr[i][0]), 2, &(ifBuCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpltConst2_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpltDataArr[i][0])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpltConst3_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpltDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), buCompareConst(ifBuCmpltDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -1433,18 +1433,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifBuCmpge, compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), _ifBuCmpge(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpgeConst1_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpgeDataArr[i][0]), 2, &(ifBuCmpgeDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpgeDataArr[i][0]), 2, &(ifBuCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpgeConst2_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpgeDataArr[i][0])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpgeConst3_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpgeDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), buCompareConst(ifBuCmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -1454,18 +1454,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifBuCmple, compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), _ifBuCmple(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpleConst1_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpleDataArr[i][0]), 2, &(ifBuCmpleDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpleDataArr[i][0]), 2, &(ifBuCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpleConst2_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpleDataArr[i][0])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpleConst3_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpleDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), buCompareConst(ifBuCmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -1476,18 +1476,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifSuCmpeq, compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), _ifSuCmpeq(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1])) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpeqConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpeqDataArr[i][0]), 2, &(ifSuCmpeqDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpeqDataArr[i][0]), 2, &(ifSuCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpeqConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpeqDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpeqDataArr[i][1])) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpeqConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpeqDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), suCompareConst(ifSuCmpeqDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
       }
 
@@ -1497,18 +1497,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifSuCmpne, compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), _ifSuCmpne(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1])) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpneConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpneDataArr[i][0]), 2, &(ifSuCmpneDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpneDataArr[i][0]), 2, &(ifSuCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpneConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpneDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpneDataArr[i][1])) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpneConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpneDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), suCompareConst(ifSuCmpneDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
       }
 
@@ -1518,18 +1518,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifSuCmpgt, compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), _ifSuCmpgt(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1])) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgtConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpgtDataArr[i][0]), 2, &(ifSuCmpgtDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpgtDataArr[i][0]), 2, &(ifSuCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgtConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpgtDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpgtDataArr[i][1])) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgtConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpgtDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), suCompareConst(ifSuCmpgtDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
       }
 
@@ -1539,18 +1539,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifSuCmplt, compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), _ifSuCmplt(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1])) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpltConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpltDataArr[i][0]), 2, &(ifSuCmpltDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpltDataArr[i][0]), 2, &(ifSuCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpltConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpltDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpltDataArr[i][1])) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpltConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpltDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), suCompareConst(ifSuCmpltDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
       }
 
@@ -1560,18 +1560,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifSuCmpge, compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), _ifSuCmpge(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1])) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgeConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpgeDataArr[i][0]), 2, &(ifSuCmpgeDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpgeDataArr[i][0]), 2, &(ifSuCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgeConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpgeDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpgeDataArr[i][1])) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgeConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpgeDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), suCompareConst(ifSuCmpgeDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
       }
 
@@ -1581,18 +1581,18 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifSuCmple, compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), _ifSuCmple(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1])) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpleConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpleDataArr[i][0]), 2, &(ifSuCmpleDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpleDataArr[i][0]), 2, &(ifSuCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpleConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpleDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpleDataArr[i][1])) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpleConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpleDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), suCompareConst(ifSuCmpleDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
       }
    }
@@ -1756,8 +1756,8 @@ PPCOpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_b2a, convert(byteDataArr[i], ADDRESS_PLACEHOLDER_1), _b2a(byteDataArr[i]));
 
       sprintf(resolvedMethodName, "b2aConst%d", i + 1);
-      b2aConst = (signatureCharB_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::b2a, resolvedMethodName, _argTypesUnaryByte, TR::Address, rc, 2, 1, &byteDataArr[i]));
+      compileOpCodeMethod(b2aConst, 
+            _numberOfUnaryArgs, TR::b2a, resolvedMethodName, _argTypesUnaryByte, TR::Address, rc, 2, 1, &byteDataArr[i]);
       OMR_CT_EXPECT_EQ(b2aConst, convert(byteDataArr[i], ADDRESS_PLACEHOLDER_1), b2aConst(BYTE_PLACEHOLDER_1));
       }
 
@@ -1767,8 +1767,8 @@ PPCOpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_s2a, convert(shortDataArr[i], ADDRESS_PLACEHOLDER_1), _s2a(shortDataArr[i]));
 
       sprintf(resolvedMethodName, "s2aConst%d", i + 1);
-      s2aConst = (signatureCharS_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::s2a, resolvedMethodName, _argTypesUnaryShort, TR::Address, rc, 2, 1, &shortDataArr[i]));
+      compileOpCodeMethod(s2aConst, 
+            _numberOfUnaryArgs, TR::s2a, resolvedMethodName, _argTypesUnaryShort, TR::Address, rc, 2, 1, &shortDataArr[i]);
       OMR_CT_EXPECT_EQ(s2aConst, convert(shortDataArr[i], ADDRESS_PLACEHOLDER_1), s2aConst(SHORT_PLACEHOLDER_1));
       }
 
@@ -1778,8 +1778,8 @@ PPCOpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_i2a, convert(intDataArr[i], ADDRESS_PLACEHOLDER_1), _i2a(intDataArr[i]));
 
       sprintf(resolvedMethodName, "i2aConst%d", i + 1);
-      i2aConst = (signatureCharI_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::i2a, resolvedMethodName, _argTypesUnaryInt, TR::Address, rc, 2, 1, &intDataArr[i]));
+      compileOpCodeMethod(i2aConst, 
+            _numberOfUnaryArgs, TR::i2a, resolvedMethodName, _argTypesUnaryInt, TR::Address, rc, 2, 1, &intDataArr[i]);
       OMR_CT_EXPECT_EQ(i2aConst, convert(intDataArr[i], ADDRESS_PLACEHOLDER_1), i2aConst(INT_PLACEHOLDER_1));
       }
 
@@ -1789,8 +1789,8 @@ PPCOpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_bu2a, convert(ubyteDataArr[i], ADDRESS_PLACEHOLDER_1), _bu2a(ubyteDataArr[i]));
 
       sprintf(resolvedMethodName, "bu2aConst%d", i + 1);
-      bu2aConst = (unsignedSignatureCharB_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::bu2a, resolvedMethodName, _argTypesUnaryByte, TR::Address, rc, 2, 1, &ubyteDataArr[i]));
+      compileOpCodeMethod(bu2aConst, 
+            _numberOfUnaryArgs, TR::bu2a, resolvedMethodName, _argTypesUnaryByte, TR::Address, rc, 2, 1, &ubyteDataArr[i]);
       OMR_CT_EXPECT_EQ(bu2aConst, convert(ubyteDataArr[i], ADDRESS_PLACEHOLDER_1), bu2aConst(BYTE_PLACEHOLDER_1));
       }
 
@@ -1800,8 +1800,8 @@ PPCOpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_lu2a, convert(ulongDataArr[i], ADDRESS_PLACEHOLDER_1), _lu2a(ulongDataArr[i]));
 
       sprintf(resolvedMethodName, "lu2aConst%d", i + 1);
-      lu2aConst = (unsignedSignatureCharJ_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::lu2a, resolvedMethodName, _argTypesUnaryLong, TR::Address, rc, 2, 1, &ulongDataArr[i]));
+      compileOpCodeMethod(lu2aConst, 
+            _numberOfUnaryArgs, TR::lu2a, resolvedMethodName, _argTypesUnaryLong, TR::Address, rc, 2, 1, &ulongDataArr[i]);
       OMR_CT_EXPECT_EQ(lu2aConst, convert(ulongDataArr[i], ADDRESS_PLACEHOLDER_1), lu2aConst(LONG_PLACEHOLDER_1));
       }
 
@@ -1811,7 +1811,7 @@ PPCOpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_a2l, convert(aUnaryDataArr[i], LONG_POS), _a2l(aUnaryDataArr[i]));
 
       sprintf(resolvedMethodName, "a2lConst%d", i + 1);
-      a2lConst = (signatureCharL_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::a2l, resolvedMethodName, _argTypesUnaryAddress, TR::Int64, rc, 2, 1, &aUnaryDataArr[i]));
+      compileOpCodeMethod(a2lConst, _numberOfUnaryArgs, TR::a2l, resolvedMethodName, _argTypesUnaryAddress, TR::Int64, rc, 2, 1, &aUnaryDataArr[i]);
       OMR_CT_EXPECT_EQ(a2lConst, convert(aUnaryDataArr[i], LONG_POS), a2lConst(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -1821,8 +1821,8 @@ PPCOpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_a2s, convert(aUnaryDataArr[i], SHORT_POS), _a2s(aUnaryDataArr[i]));
 
       sprintf(resolvedMethodName, "a2sConst%d", i + 1);
-      a2sConst = (signatureCharL_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::a2s, resolvedMethodName, _argTypesUnaryAddress, TR::Int16, rc, 2, 1, &aUnaryDataArr[i]));
+      compileOpCodeMethod(a2sConst, 
+            _numberOfUnaryArgs, TR::a2s, resolvedMethodName, _argTypesUnaryAddress, TR::Int16, rc, 2, 1, &aUnaryDataArr[i]);
       OMR_CT_EXPECT_EQ(a2sConst, convert(aUnaryDataArr[i], SHORT_POS), a2sConst(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -1832,8 +1832,8 @@ PPCOpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_a2b, convert(aUnaryDataArr[i], BYTE_POS), _a2b(aUnaryDataArr[i]));
 
       sprintf(resolvedMethodName, "a2bConst%d", i + 1);
-      a2bConst = (signatureCharL_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::a2b, resolvedMethodName, _argTypesUnaryAddress, TR::Int8, rc, 2, 1, &aUnaryDataArr[i]));
+      compileOpCodeMethod(a2bConst, 
+            _numberOfUnaryArgs, TR::a2b, resolvedMethodName, _argTypesUnaryAddress, TR::Int8, rc, 2, 1, &aUnaryDataArr[i]);
       OMR_CT_EXPECT_EQ(a2bConst, convert(aUnaryDataArr[i], BYTE_POS), a2bConst(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -1844,18 +1844,18 @@ PPCOpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_acmpeq, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), _acmpeq(acmpeqDataArr[i][0], acmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpeqConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpeqDataArr[i][0]), 2, &(acmpeqDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpeqDataArr[i][0]), 2, &(acmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "aCmpeqConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpeqDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpeqConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpeqDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(acmpeqDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -1865,18 +1865,18 @@ PPCOpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_acmpne, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), _acmpne(acmpneDataArr[i][0], acmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpneConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpneDataArr[i][0]), 2, &(acmpneDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpneDataArr[i][0]), 2, &(acmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "aCmpneConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpneDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpneConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpneDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(acmpneDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -1886,18 +1886,18 @@ PPCOpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_acmpgt, compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), _acmpgt(acmpgtDataArr[i][0], acmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpgtConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpgtDataArr[i][0]), 2, &(acmpgtDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpgtDataArr[i][0]), 2, &(acmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "acmpgtConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpgtDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpgtConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpgtDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), aCompareConst(acmpgtDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -1907,18 +1907,18 @@ PPCOpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_acmplt, compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), _acmplt(acmpltDataArr[i][0], acmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpltConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpltDataArr[i][0]), 2, &(acmpltDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpltDataArr[i][0]), 2, &(acmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "acmpltConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpltDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpltConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpltDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), aCompareConst(acmpltDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -1928,18 +1928,18 @@ PPCOpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_acmpge, compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), _acmpge(acmpgeDataArr[i][0], acmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpgeConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpgeDataArr[i][0]), 2, &(acmpgeDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpgeDataArr[i][0]), 2, &(acmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "acmpgeConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpgeDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpgeConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpgeDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), aCompareConst(acmpgeDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -1949,18 +1949,18 @@ PPCOpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_acmple, compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), _acmple(acmpleDataArr[i][0], acmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpleConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpleDataArr[i][0]), 2, &(acmpleDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpleDataArr[i][0]), 2, &(acmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "acmpleConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpleDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpleConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpleDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), aCompareConst(acmpleDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -1971,18 +1971,18 @@ PPCOpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_ifacmpeq, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), _ifacmpeq(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpeqConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpeqDataArr[i][0]), 2, &(ifacmpeqDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpeqDataArr[i][0]), 2, &(ifacmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpeqConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpeqDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpeqConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpeqDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ifacmpeqDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -1992,18 +1992,18 @@ PPCOpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_ifacmpne, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), _ifacmpne(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpneConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpneDataArr[i][0]), 2, &(ifacmpneDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpneDataArr[i][0]), 2, &(ifacmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpneConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpneDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpneConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpneDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ifacmpneDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -2013,18 +2013,18 @@ PPCOpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_ifacmpgt, compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), _ifacmpgt(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpgtConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpgtDataArr[i][0]), 2, &(ifacmpgtDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpgtDataArr[i][0]), 2, &(ifacmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpgtConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpgtDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpgtConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpgtDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), aCompareConst(ifacmpgtDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -2034,18 +2034,18 @@ PPCOpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_ifacmplt, compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), _ifacmplt(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpltConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpltDataArr[i][0]), 2, &(ifacmpltDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpltDataArr[i][0]), 2, &(ifacmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpltConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpltDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpltConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpltDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), aCompareConst(ifacmpltDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -2055,18 +2055,18 @@ PPCOpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_ifacmpge, compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), _ifacmpge(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpgeConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpgeDataArr[i][0]), 2, &(ifacmpgeDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpgeDataArr[i][0]), 2, &(ifacmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpgeConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpgeDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpgeConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpgeDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), aCompareConst(ifacmpgeDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -2076,18 +2076,18 @@ PPCOpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_ifacmple, compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), _ifacmple(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpleConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpleDataArr[i][0]), 2, &(ifacmpleDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpleDataArr[i][0]), 2, &(ifacmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpleConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpleDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpleConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpleDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ifacmpleDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -2099,38 +2099,38 @@ PPCOpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_aternary, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), _aternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]));
 
       sprintf(resolvedMethodName, "aTernaryConst1_TestCase%d", i + 1);
-      aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 6, 1, &aternaryChild1Arr[i], 2, &aternaryArr[i][0], 3, &aternaryArr[i][1]));
+      compileOpCodeMethod(aTernaryConst, 
+            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 6, 1, &aternaryChild1Arr[i], 2, &aternaryArr[i][0], 3, &aternaryArr[i][1]);
       OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "aTernaryConst2_TestCase%d", i + 1);
-      aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 1, &aternaryChild1Arr[i], 2, &aternaryArr[i][0]));
+      compileOpCodeMethod(aTernaryConst, 
+            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 1, &aternaryChild1Arr[i], 2, &aternaryArr[i][0]);
       OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, aternaryArr[i][1]));
 
       sprintf(resolvedMethodName, "aTernaryConst3_TestCase%d", i + 1);
-      aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 1, &aternaryChild1Arr[i], 3, &aternaryArr[i][1]));
+      compileOpCodeMethod(aTernaryConst, 
+            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 1, &aternaryChild1Arr[i], 3, &aternaryArr[i][1]);
       OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, aternaryArr[i][0], ADDRESS_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "aTernaryConst4_TestCase%d", i + 1);
-      aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 2, &aternaryArr[i][0], 3, &aternaryArr[i][1]));
+      compileOpCodeMethod(aTernaryConst, 
+            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 2, &aternaryArr[i][0], 3, &aternaryArr[i][1]);
       OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "aTernaryConst5_TestCase%d", i + 1);
-      aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 1, &aternaryChild1Arr[i]));
+      compileOpCodeMethod(aTernaryConst, 
+            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 1, &aternaryChild1Arr[i]);
       OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, aternaryArr[i][0], aternaryArr[i][1]));
 
       sprintf(resolvedMethodName, "aTernaryConst6_TestCase%d", i + 1);
-      aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 2, &aternaryArr[i][0]));
+      compileOpCodeMethod(aTernaryConst, 
+            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 2, &aternaryArr[i][0]);
       OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], ADDRESS_PLACEHOLDER_1, aternaryArr[i][1]));
 
       sprintf(resolvedMethodName, "aTernaryConst7_TestCase%d", i + 1);
-      aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 3, &aternaryArr[i][1]));
+      compileOpCodeMethod(aTernaryConst, 
+            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 3, &aternaryArr[i][1]);
       OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], aternaryArr[i][0], ADDRESS_PLACEHOLDER_1));
       }
 
@@ -2210,38 +2210,38 @@ PPCOpCodesTest::invokeTernaryTests()
       OMR_CT_EXPECT_EQ(_bternary, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), _bternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bTernaryConst1_Testcase%d", i + 1);
-      bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 6, 1, &bternaryChild1Arr[i], 2, &byteDataArr[i][0], 3, &byteDataArr[i][1]));
+      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
+            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 6, 1, &bternaryChild1Arr[i], 2, &byteDataArr[i][0], 3, &byteDataArr[i][1]);
       OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2, BYTE_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "bTernaryConst2_Testcase%d", i + 1);
-      bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 4, 1, &bternaryChild1Arr[i], 2, &byteDataArr[i][0]));
+      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
+            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 4, 1, &bternaryChild1Arr[i], 2, &byteDataArr[i][0]);
       OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2, byteDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bTernaryConst3_Testcase%d", i + 1);
-      bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 4, 1, &bternaryChild1Arr[i], 3, &byteDataArr[i][1]));
+      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
+            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 4, 1, &bternaryChild1Arr[i], 3, &byteDataArr[i][1]);
       OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, byteDataArr[i][0], BYTE_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "bTernaryConst4_Testcase%d", i + 1);
-      bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 4, 2, &byteDataArr[i][0], 3, &byteDataArr[i][1]));
+      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
+            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 4, 2, &byteDataArr[i][0], 3, &byteDataArr[i][1]);
       OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(bternaryChild1Arr[i], BYTE_PLACEHOLDER_2, BYTE_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "bTernaryConst5_Testcase%d", i + 1);
-      bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 2, 1, &bternaryChild1Arr[i]));
+      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
+            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 2, 1, &bternaryChild1Arr[i]);
       OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, byteDataArr[i][0], byteDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bTernaryConst6_Testcase%d", i + 1);
-      bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 2, 2, &byteDataArr[i][0]));
+      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
+            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 2, 2, &byteDataArr[i][0]);
       OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(bternaryChild1Arr[i], BYTE_PLACEHOLDER_1, byteDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bTernaryConst7_Testcase%d", i + 1);
-      bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 2, 3, &byteDataArr[i][1]));
+      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
+            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 2, 3, &byteDataArr[i][1]);
       OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(bternaryChild1Arr[i], byteDataArr[i][0], BYTE_PLACEHOLDER_1));
       }
 
@@ -2253,38 +2253,38 @@ PPCOpCodesTest::invokeTernaryTests()
       OMR_CT_EXPECT_EQ(_sternary, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), _sternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sTernaryConst1_Testcase%d", i + 1);
-      sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 6, 1, &sternaryChild1Arr[i], 2, &shortDataArr[i][0], 3, &shortDataArr[i][1]));
+      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
+            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 6, 1, &sternaryChild1Arr[i], 2, &shortDataArr[i][0], 3, &shortDataArr[i][1]);
       OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2, SHORT_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "sTernaryConst2_Testcase%d", i + 1);
-      sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 4, 1, &sternaryChild1Arr[i], 2, &shortDataArr[i][0]));
+      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
+            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 4, 1, &sternaryChild1Arr[i], 2, &shortDataArr[i][0]);
       OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2, shortDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sTernaryConst3_Testcase%d", i + 1);
-      sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 4, 1, &sternaryChild1Arr[i], 3, &shortDataArr[i][1]));
+      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
+            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 4, 1, &sternaryChild1Arr[i], 3, &shortDataArr[i][1]);
       OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, shortDataArr[i][0], SHORT_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "sTernaryConst4_Testcase%d", i + 1);
-      sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 4, 2, &shortDataArr[i][0], 3, &shortDataArr[i][1]));
+      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
+            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 4, 2, &shortDataArr[i][0], 3, &shortDataArr[i][1]);
       OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(sternaryChild1Arr[i], SHORT_PLACEHOLDER_2, SHORT_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "sTernaryConst5_Testcase%d", i + 1);
-      sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 2, 1, &sternaryChild1Arr[i]));
+      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
+            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 2, 1, &sternaryChild1Arr[i]);
       OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, shortDataArr[i][0], shortDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sTernaryConst6_Testcase%d", i + 1);
-      sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 2, 2, &shortDataArr[i][0]));
+      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
+            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 2, 2, &shortDataArr[i][0]);
       OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(sternaryChild1Arr[i], SHORT_PLACEHOLDER_1, shortDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sTernaryConst7_Testcase%d", i + 1);
-      sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 2, 3, &shortDataArr[i][1]));
+      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
+            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 2, 3, &shortDataArr[i][1]);
       OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(sternaryChild1Arr[i], shortDataArr[i][0], SHORT_PLACEHOLDER_1));
       }
    }
@@ -2359,18 +2359,18 @@ PPCOpCodesTest::invokeShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_iRol, rol(irolDataArr[i][0], irolDataArr[i][1]), _iRol(irolDataArr[i][0], irolDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iRolConst1_TestCase%d", i + 1);
-      iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::irol, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &irolDataArr[i][0], 2, &irolDataArr[i][1]));
+      compileOpCodeMethod(iShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::irol, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &irolDataArr[i][0], 2, &irolDataArr[i][1]);
       OMR_CT_EXPECT_EQ(iShiftOrRolConst, rol(irolDataArr[i][0], irolDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iRolConst2_TestCase%d", i + 1);
-      iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::irol, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &irolDataArr[i][0]));
+      compileOpCodeMethod(iShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::irol, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &irolDataArr[i][0]);
       OMR_CT_EXPECT_EQ(iShiftOrRolConst, rol(irolDataArr[i][0], irolDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, irolDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iRolConst3_TestCase%d", i + 1);
-      iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::irol, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &irolDataArr[i][1]));
+      compileOpCodeMethod(iShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::irol, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &irolDataArr[i][1]);
       OMR_CT_EXPECT_EQ(iShiftOrRolConst, rol(irolDataArr[i][0], irolDataArr[i][1]), iShiftOrRolConst(irolDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -2381,18 +2381,18 @@ PPCOpCodesTest::invokeShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_bShl, shl(bshlDataArr[i][0], bshlDataArr[i][1]), _bShl(bshlDataArr[i][0],bshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bShlConst1_TestCase%d", i + 1);
-      bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bshl, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &bshlDataArr[i][0], 2, &bshlDataArr[i][1]));
+      compileOpCodeMethod(bShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::bshl, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &bshlDataArr[i][0], 2, &bshlDataArr[i][1]);
       OMR_CT_EXPECT_EQ(bShiftOrRolConst, shl(bshlDataArr[i][0], bshlDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bShlConst2_TestCase%d", i + 1);
-      bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bshl, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &bshlDataArr[i][0]));
+      compileOpCodeMethod(bShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::bshl, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &bshlDataArr[i][0]);
       OMR_CT_EXPECT_EQ(bShiftOrRolConst, shl(bshlDataArr[i][0], bshlDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, bshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bShlConst3_TestCase%d", i + 1);
-      bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bshl, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &bshlDataArr[i][1]));
+      compileOpCodeMethod(bShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::bshl, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &bshlDataArr[i][1]);
       OMR_CT_EXPECT_EQ(bShiftOrRolConst, shl(bshlDataArr[i][0], bshlDataArr[i][1]), bShiftOrRolConst(bshlDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -2403,18 +2403,18 @@ PPCOpCodesTest::invokeShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_buShr, shr(bushrDataArr[i][0], bushrDataArr[i][1]), _buShr(bushrDataArr[i][0], bushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buShrConst1_TestCase%d", i + 1);
-      buShiftOrRolConst = (unsignedSignatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bushr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &bushrDataArr[i][0], 2, &bushrDataArr[i][1]));
+      compileOpCodeMethod(buShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::bushr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &bushrDataArr[i][0], 2, &bushrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(buShiftOrRolConst, shr(bushrDataArr[i][0], bushrDataArr[i][1]), buShiftOrRolConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "buShrConst2_TestCase%d", i + 1);
-      buShiftOrRolConst = (unsignedSignatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bushr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &bushrDataArr[i][0]));
+      compileOpCodeMethod(buShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::bushr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &bushrDataArr[i][0]);
       OMR_CT_EXPECT_EQ(buShiftOrRolConst, shr(bushrDataArr[i][0], bushrDataArr[i][1]), buShiftOrRolConst(BYTE_PLACEHOLDER_1, bushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buShrConst3_TestCase%d", i + 1);
-      buShiftOrRolConst = (unsignedSignatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bushr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &bushrDataArr[i][1]));
+      compileOpCodeMethod(buShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::bushr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &bushrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(buShiftOrRolConst, shr(bushrDataArr[i][0], bushrDataArr[i][1]), buShiftOrRolConst(bushrDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -2425,18 +2425,18 @@ PPCOpCodesTest::invokeShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_sShr, shr(sshrDataArr[i][0], sshrDataArr[i][1]), _sShr(sshrDataArr[i][0], sshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sShrConst1_TestCase%d", i + 1);
-      sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sshr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &sshrDataArr[i][0], 2, &sshrDataArr[i][1]));
+      compileOpCodeMethod(sShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::sshr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &sshrDataArr[i][0], 2, &sshrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(sShiftOrRolConst, shr(sshrDataArr[i][0], sshrDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sShrConst2_TestCase%d", i + 1);
-      sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sshr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &sshrDataArr[i][0]));
+      compileOpCodeMethod(sShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::sshr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &sshrDataArr[i][0]);
       OMR_CT_EXPECT_EQ(sShiftOrRolConst, shr(sshrDataArr[i][0], sshrDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, sshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sShrConst3_TestCase%d", i + 1);
-      sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sshr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &sshrDataArr[i][1]));
+      compileOpCodeMethod(sShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::sshr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &sshrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(sShiftOrRolConst, shr(sshrDataArr[i][0], sshrDataArr[i][1]), sShiftOrRolConst(sshrDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
    }
@@ -2502,18 +2502,18 @@ PPCOpCodesTest::invokeBitwiseTests()
       OMR_CT_EXPECT_EQ(_bAnd, tand(byteAndArr[i][0], byteAndArr[i][1]), _bAnd(byteAndArr[i][0], byteAndArr[i][1]));
 
       sprintf(resolvedMethodName, "bAndConst1_TestCase%d", i + 1);
-      bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::band, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &(byteAndArr[i][0]), 2, &(byteAndArr[i][1])));
+      compileOpCodeMethod(bBitwiseConst, 
+            _numberOfBinaryArgs, TR::band, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &(byteAndArr[i][0]), 2, &(byteAndArr[i][1]));
       OMR_CT_EXPECT_EQ(bBitwiseConst, tand(byteAndArr[i][0], byteAndArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bAndConst2_TestCase%d", i + 1);
-      bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::band, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &(byteAndArr[i][0])));
+      compileOpCodeMethod(bBitwiseConst, 
+            _numberOfBinaryArgs, TR::band, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &(byteAndArr[i][0]));
       OMR_CT_EXPECT_EQ(bBitwiseConst, tand(byteAndArr[i][0], byteAndArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, byteAndArr[i][1]));
 
       sprintf(resolvedMethodName, "bAndConst3_TestCase%d", i + 1);
-      bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::band, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &(byteAndArr[i][1])));
+      compileOpCodeMethod(bBitwiseConst, 
+            _numberOfBinaryArgs, TR::band, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &(byteAndArr[i][1]));
       OMR_CT_EXPECT_EQ(bBitwiseConst, tand(byteAndArr[i][0], byteAndArr[i][1]), bBitwiseConst(byteAndArr[i][0], BYTE_PLACEHOLDER_2));
      }
 
@@ -2524,18 +2524,18 @@ PPCOpCodesTest::invokeBitwiseTests()
       OMR_CT_EXPECT_EQ(_bOr, tor(byteOrArr[i][0], byteOrArr[i][1]), _bOr(byteOrArr[i][0], byteOrArr[i][1]));
 
       sprintf(resolvedMethodName, "bOrConst1_TestCase%d", i + 1);
-      bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &(byteOrArr[i][0]), 2, &(byteOrArr[i][1])));
+      compileOpCodeMethod(bBitwiseConst, 
+            _numberOfBinaryArgs, TR::bor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &(byteOrArr[i][0]), 2, &(byteOrArr[i][1]));
       OMR_CT_EXPECT_EQ(bBitwiseConst, tor(byteOrArr[i][0], byteOrArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bOrConst2_TestCase%d", i + 1);
-      bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &(byteOrArr[i][0])));
+      compileOpCodeMethod(bBitwiseConst, 
+            _numberOfBinaryArgs, TR::bor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &(byteOrArr[i][0]));
       OMR_CT_EXPECT_EQ(bBitwiseConst, tor(byteOrArr[i][0], byteOrArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, byteOrArr[i][1]));
 
       sprintf(resolvedMethodName, "bOrConst3_TestCase%d", i + 1);
-      bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &(byteOrArr[i][1])));
+      compileOpCodeMethod(bBitwiseConst, 
+            _numberOfBinaryArgs, TR::bor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &(byteOrArr[i][1]));
       OMR_CT_EXPECT_EQ(bBitwiseConst, tor(byteOrArr[i][0], byteOrArr[i][1]), bBitwiseConst(byteOrArr[i][0], BYTE_PLACEHOLDER_2));
      }
 
@@ -2546,18 +2546,18 @@ PPCOpCodesTest::invokeBitwiseTests()
       OMR_CT_EXPECT_EQ(_bXor, txor(byteXorArr[i][0], byteXorArr[i][1]), _bXor(byteXorArr[i][0], byteXorArr[i][1]));
 
       sprintf(resolvedMethodName, "bXorConst1_TestCase%d", i + 1);
-      bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bxor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &(byteXorArr[i][0]), 2, &(byteXorArr[i][1])));
+      compileOpCodeMethod(bBitwiseConst, 
+            _numberOfBinaryArgs, TR::bxor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &(byteXorArr[i][0]), 2, &(byteXorArr[i][1]));
       OMR_CT_EXPECT_EQ(bBitwiseConst, txor(byteXorArr[i][0], byteXorArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bXorConst2_TestCase%d", i + 1);
-      bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bxor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &(byteXorArr[i][0])));
+      compileOpCodeMethod(bBitwiseConst, 
+            _numberOfBinaryArgs, TR::bxor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &(byteXorArr[i][0]));
       OMR_CT_EXPECT_EQ(bBitwiseConst, txor(byteXorArr[i][0], byteXorArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, byteXorArr[i][1]));
 
       sprintf(resolvedMethodName, "bXorConst3_TestCase%d", i + 1);
-      bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bxor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &(byteXorArr[i][1])));
+      compileOpCodeMethod(bBitwiseConst, 
+            _numberOfBinaryArgs, TR::bxor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &(byteXorArr[i][1]));
       OMR_CT_EXPECT_EQ(bBitwiseConst, txor(byteXorArr[i][0], byteXorArr[i][1]), bBitwiseConst(byteXorArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -2568,18 +2568,18 @@ PPCOpCodesTest::invokeBitwiseTests()
       OMR_CT_EXPECT_EQ(_sAnd, tand(shortAndArr[i][0], shortAndArr[i][1]), _sAnd(shortAndArr[i][0], shortAndArr[i][1]));
 
       sprintf(resolvedMethodName, "sAndConst1_TestCase%d", i + 1);
-      sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sand, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &(shortAndArr[i][0]), 2, &(shortAndArr[i][1])));
+      compileOpCodeMethod(sBitwiseConst, 
+            _numberOfBinaryArgs, TR::sand, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &(shortAndArr[i][0]), 2, &(shortAndArr[i][1]));
       OMR_CT_EXPECT_EQ(sBitwiseConst, tand(shortAndArr[i][0], shortAndArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sAndConst2_TestCase%d", i + 1);
-      sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sand, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &(shortAndArr[i][0])));
+      compileOpCodeMethod(sBitwiseConst, 
+            _numberOfBinaryArgs, TR::sand, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &(shortAndArr[i][0]));
       OMR_CT_EXPECT_EQ(sBitwiseConst, tand(shortAndArr[i][0], shortAndArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, shortAndArr[i][1]));
 
       sprintf(resolvedMethodName, "sAndConst3_TestCase%d", i + 1);
-      sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sand, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &(shortAndArr[i][1])));
+      compileOpCodeMethod(sBitwiseConst, 
+            _numberOfBinaryArgs, TR::sand, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &(shortAndArr[i][1]));
       OMR_CT_EXPECT_EQ(sBitwiseConst, tand(shortAndArr[i][0], shortAndArr[i][1]), sBitwiseConst(shortAndArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -2590,18 +2590,18 @@ PPCOpCodesTest::invokeBitwiseTests()
       OMR_CT_EXPECT_EQ(_sOr, tor(shortOrArr[i][0], shortOrArr[i][1]), _sOr(shortOrArr[i][0], shortOrArr[i][1]));
 
       sprintf(resolvedMethodName, "sOrConst1_TestCase%d", i + 1);
-      sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &(shortOrArr[i][0]), 2, &(shortOrArr[i][1])));
+      compileOpCodeMethod(sBitwiseConst, 
+            _numberOfBinaryArgs, TR::sor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &(shortOrArr[i][0]), 2, &(shortOrArr[i][1]));
       OMR_CT_EXPECT_EQ(sBitwiseConst, tor(shortOrArr[i][0], shortOrArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sOrConst2_TestCase%d", i + 1);
-      sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &(shortOrArr[i][0])));
+      compileOpCodeMethod(sBitwiseConst, 
+            _numberOfBinaryArgs, TR::sor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &(shortOrArr[i][0]));
       OMR_CT_EXPECT_EQ(sBitwiseConst, tor(shortOrArr[i][0], shortOrArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, shortOrArr[i][1]));
 
       sprintf(resolvedMethodName, "sOrConst3_TestCase%d", i + 1);
-      sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &(shortOrArr[i][1])));
+      compileOpCodeMethod(sBitwiseConst, 
+            _numberOfBinaryArgs, TR::sor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &(shortOrArr[i][1]));
       OMR_CT_EXPECT_EQ(sBitwiseConst, tor(shortOrArr[i][0], shortOrArr[i][1]), sBitwiseConst(shortOrArr[i][0], SHORT_PLACEHOLDER_2));
      }
 
@@ -2612,18 +2612,18 @@ PPCOpCodesTest::invokeBitwiseTests()
       OMR_CT_EXPECT_EQ(_sXor, txor(shortXorArr[i][0], shortXorArr[i][1]), _sXor(shortXorArr[i][0], shortXorArr[i][1]));
 
       sprintf(resolvedMethodName, "sXorConst1_TestCase%d", i + 1);
-      sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sxor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &(shortXorArr[i][0]), 2, &(shortXorArr[i][1])));
+      compileOpCodeMethod(sBitwiseConst, 
+            _numberOfBinaryArgs, TR::sxor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &(shortXorArr[i][0]), 2, &(shortXorArr[i][1]));
       OMR_CT_EXPECT_EQ(sBitwiseConst, txor(shortXorArr[i][0], shortXorArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sXorConst2_TestCase%d", i + 1);
-      sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sxor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &(shortXorArr[i][0])));
+      compileOpCodeMethod(sBitwiseConst, 
+            _numberOfBinaryArgs, TR::sxor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &(shortXorArr[i][0]));
       OMR_CT_EXPECT_EQ(sBitwiseConst, txor(shortXorArr[i][0], shortXorArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, shortXorArr[i][1]));
 
       sprintf(resolvedMethodName, "sXorConst3_TestCase%d", i + 1);
-      sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sxor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &(shortXorArr[i][1])));
+      compileOpCodeMethod(sBitwiseConst, 
+            _numberOfBinaryArgs, TR::sxor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &(shortXorArr[i][1]));
       OMR_CT_EXPECT_EQ(sBitwiseConst, txor(shortXorArr[i][0], shortXorArr[i][1]), sBitwiseConst(shortXorArr[i][0], SHORT_PLACEHOLDER_2));
      }
    }
@@ -2635,18 +2635,18 @@ PPCOpCodesTest::compileDisabledConvertTestMethods()
 
    //Jazz103 109976
    //Defect Testarossa 119346
-   _iu2f = (unsignedSignatureCharI_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iu2f, "iU2f", _argTypesUnaryInt, TR::Float, rc));
-   _iu2d = (unsignedSignatureCharI_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iu2d, "iU2d", _argTypesUnaryInt, TR::Double, rc));
-   _iu2l = (unsignedSignatureCharI_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iu2l, "iu2l", _argTypesUnaryInt, TR::Int64, rc));
-   _f2d = (signatureCharF_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2d, "f2d", _argTypesUnaryFloat, TR::Double, rc));
-   _d2f = (signatureCharD_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2f, "d2f", _argTypesUnaryDouble, TR::Float, rc));
-   _bu2f = (unsignedSignatureCharB_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2f, "bu2f", _argTypesUnaryByte, TR::Float, rc));
-   _bu2d = (unsignedSignatureCharB_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2d, "bu2d", _argTypesUnaryByte, TR::Double, rc));
+   compileOpCodeMethod(_iu2f, _numberOfUnaryArgs, TR::iu2f, "iU2f", _argTypesUnaryInt, TR::Float, rc);
+   compileOpCodeMethod(_iu2d, _numberOfUnaryArgs, TR::iu2d, "iU2d", _argTypesUnaryInt, TR::Double, rc);
+   compileOpCodeMethod(_iu2l, _numberOfUnaryArgs, TR::iu2l, "iu2l", _argTypesUnaryInt, TR::Int64, rc);
+   compileOpCodeMethod(_f2d, _numberOfUnaryArgs, TR::f2d, "f2d", _argTypesUnaryFloat, TR::Double, rc);
+   compileOpCodeMethod(_d2f, _numberOfUnaryArgs, TR::d2f, "d2f", _argTypesUnaryDouble, TR::Float, rc);
+   compileOpCodeMethod(_bu2f, _numberOfUnaryArgs, TR::bu2f, "bu2f", _argTypesUnaryByte, TR::Float, rc);
+   compileOpCodeMethod(_bu2d, _numberOfUnaryArgs, TR::bu2d, "bu2d", _argTypesUnaryByte, TR::Double, rc);
 
    //Jazz103 109605
-   _l2a = (signatureCharJ_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::l2a, "l2a", _argTypesUnaryLong, TR::Address, rc));
-   _su2a = (unsignedSignatureCharS_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2a, "su2a", _argTypesUnaryShort, TR::Address, rc));
-   _iu2a = (unsignedSignatureCharI_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iu2a, "iu2a", _argTypesUnaryInt, TR::Address, rc));
+   compileOpCodeMethod(_l2a, _numberOfUnaryArgs, TR::l2a, "l2a", _argTypesUnaryLong, TR::Address, rc);
+   compileOpCodeMethod(_su2a, _numberOfUnaryArgs, TR::su2a, "su2a", _argTypesUnaryShort, TR::Address, rc);
+   compileOpCodeMethod(_iu2a, _numberOfUnaryArgs, TR::iu2a, "iu2a", _argTypesUnaryInt, TR::Address, rc);
 
    }
 
@@ -2684,13 +2684,13 @@ PPCOpCodesTest::invokeDisabledConvertTests()
       OMR_CT_EXPECT_EQ(_iu2d, convert(uintDataArray[i], DOUBLE_POS), _iu2d(uintDataArray[i]));
 
       sprintf(resolvedMethodName, "iu2fConst%d", i + 1);
-      iu2fConst = (unsignedSignatureCharI_F_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::iu2f, resolvedMethodName, _argTypesUnaryInt, TR::Float, rc, 2, 1, &uintDataArray[i]));
+      compileOpCodeMethod(iu2fConst, 
+            _numberOfUnaryArgs, TR::iu2f, resolvedMethodName, _argTypesUnaryInt, TR::Float, rc, 2, 1, &uintDataArray[i]);
       OMR_CT_EXPECT_EQ(iu2fConst, convert(uintDataArray[i], FLOAT_POS), iu2fConst(INT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "iu2dConst%d", i + 1);
-      iu2dConst = (unsignedSignatureCharI_D_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::iu2d, resolvedMethodName, _argTypesUnaryInt, TR::Double, rc, 2, 1, &uintDataArray[i]));
+      compileOpCodeMethod(iu2dConst, 
+            _numberOfUnaryArgs, TR::iu2d, resolvedMethodName, _argTypesUnaryInt, TR::Double, rc, 2, 1, &uintDataArray[i]);
       OMR_CT_EXPECT_EQ(iu2dConst, convert(uintDataArray[i], DOUBLE_POS), iu2dConst(INT_PLACEHOLDER_1));
       }
 
@@ -2701,13 +2701,13 @@ PPCOpCodesTest::invokeDisabledConvertTests()
       OMR_CT_EXPECT_EQ(_bu2d, convert(ubyteDataArray[i], DOUBLE_POS), _bu2d(ubyteDataArray[i]));
 
       sprintf(resolvedMethodName, "bu2fConst%d", i + 1);
-      bu2fConst = (unsignedSignatureCharB_F_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::bu2f, resolvedMethodName, _argTypesUnaryByte, TR::Float, rc, 2, 1, &ubyteDataArray[i]));
+      compileOpCodeMethod(bu2fConst, 
+            _numberOfUnaryArgs, TR::bu2f, resolvedMethodName, _argTypesUnaryByte, TR::Float, rc, 2, 1, &ubyteDataArray[i]);
       OMR_CT_EXPECT_EQ(bu2fConst, convert(ubyteDataArray[i], FLOAT_POS), bu2fConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "bu2dConst%d", i + 1);
-      bu2dConst = (unsignedSignatureCharB_D_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::bu2d, resolvedMethodName, _argTypesUnaryByte, TR::Double, rc, 2, 1, &ubyteDataArray[i]));
+      compileOpCodeMethod(bu2dConst, 
+            _numberOfUnaryArgs, TR::bu2d, resolvedMethodName, _argTypesUnaryByte, TR::Double, rc, 2, 1, &ubyteDataArray[i]);
       OMR_CT_EXPECT_EQ(bu2dConst, convert(ubyteDataArray[i], DOUBLE_POS), bu2dConst(BYTE_PLACEHOLDER_1));
       }
 
@@ -2718,8 +2718,8 @@ PPCOpCodesTest::invokeDisabledConvertTests()
       OMR_CT_EXPECT_EQ(_iu2l, convert(uintDataArray[i], LONG_POS), _iu2l(uintDataArray[i]));
 
       sprintf(resolvedMethodName, "iu2lConst%d", i + 1);
-      iu2lConst = (unsignedSignatureCharI_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iu2l,
-            resolvedMethodName, _argTypesUnaryInt, TR::Int64, rc, 2, 1, &uintDataArray[i]));
+      compileOpCodeMethod(iu2lConst, _numberOfUnaryArgs, TR::iu2l,
+            resolvedMethodName, _argTypesUnaryInt, TR::Int64, rc, 2, 1, &uintDataArray[i]);
       OMR_CT_EXPECT_EQ(iu2lConst, convert(uintDataArray[i], LONG_POS), iu2lConst(INT_PLACEHOLDER_1));
       }
 
@@ -2730,8 +2730,8 @@ PPCOpCodesTest::invokeDisabledConvertTests()
       OMR_CT_EXPECT_DOUBLE_EQ(_f2d, convert(floatDataArray[i], DOUBLE_POS), _f2d(floatDataArray[i]));
 
       sprintf(resolvedMethodName, "f2dConst%d", i + 1);
-      f2dConst = (signatureCharF_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2d,
-            resolvedMethodName, _argTypesUnaryFloat, TR::Double, rc, 2, 1, &floatDataArray[i]));
+      compileOpCodeMethod(f2dConst, _numberOfUnaryArgs, TR::f2d,
+            resolvedMethodName, _argTypesUnaryFloat, TR::Double, rc, 2, 1, &floatDataArray[i]);
       OMR_CT_EXPECT_EQ(f2dConst, convert(floatDataArray[i], DOUBLE_POS), f2dConst(FLOAT_PLACEHOLDER_1));
       }
 
@@ -2742,8 +2742,8 @@ PPCOpCodesTest::invokeDisabledConvertTests()
       OMR_CT_EXPECT_FLOAT_EQ(_d2f, convert(doubleDataArray[i], FLOAT_POS), _d2f(doubleDataArray[i]));
 
       sprintf(resolvedMethodName, "d2fConst%d", i + 1);
-      d2fConst = (signatureCharD_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2f,
-            resolvedMethodName, _argTypesUnaryDouble, TR::Float, rc, 2, 1, &doubleDataArray[i]));
+      compileOpCodeMethod(d2fConst, _numberOfUnaryArgs, TR::d2f,
+            resolvedMethodName, _argTypesUnaryDouble, TR::Float, rc, 2, 1, &doubleDataArray[i]);
       OMR_CT_EXPECT_FLOAT_EQ(d2fConst, convert(doubleDataArray[i], FLOAT_POS), d2fConst(DOUBLE_PLACEHOLDER_1));
       }
 
@@ -2754,8 +2754,8 @@ PPCOpCodesTest::invokeDisabledConvertTests()
       OMR_CT_EXPECT_EQ(_l2a, convert(longDataArray[i], ADDRESS_PLACEHOLDER_1), _l2a(longDataArray[i]));
 
       sprintf(resolvedMethodName, "l2aConst%d", i + 1);
-      l2aConst = (signatureCharJ_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::l2a, resolvedMethodName, _argTypesUnaryLong, TR::Address, rc, 2, 1, &longDataArray[i]));
+      compileOpCodeMethod(l2aConst, 
+            _numberOfUnaryArgs, TR::l2a, resolvedMethodName, _argTypesUnaryLong, TR::Address, rc, 2, 1, &longDataArray[i]);
       OMR_CT_EXPECT_EQ(l2aConst, convert(longDataArray[i], ADDRESS_PLACEHOLDER_1), l2aConst(LONG_PLACEHOLDER_1));
       }
 
@@ -2765,8 +2765,8 @@ PPCOpCodesTest::invokeDisabledConvertTests()
       OMR_CT_EXPECT_EQ(_su2a, convert(ushortDataArray[i], ADDRESS_PLACEHOLDER_1), _su2a(ushortDataArray[i]));
 
       sprintf(resolvedMethodName, "su2aConst%d", i + 1);
-      su2aConst = (unsignedSignatureCharS_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::su2a, resolvedMethodName, _argTypesUnaryShort, TR::Address, rc, 2, 1, &ushortDataArray[i]));
+      compileOpCodeMethod(su2aConst, 
+            _numberOfUnaryArgs, TR::su2a, resolvedMethodName, _argTypesUnaryShort, TR::Address, rc, 2, 1, &ushortDataArray[i]);
       OMR_CT_EXPECT_EQ(su2aConst, convert(ushortDataArray[i], ADDRESS_PLACEHOLDER_1), su2aConst(SHORT_PLACEHOLDER_1));
       }
 
@@ -2776,8 +2776,8 @@ PPCOpCodesTest::invokeDisabledConvertTests()
       OMR_CT_EXPECT_EQ(_iu2a, convert(uintDataArray[i], ADDRESS_PLACEHOLDER_1), _iu2a(uintDataArray[i]));
 
       sprintf(resolvedMethodName, "iu2aConst%d", i + 1);
-      iu2aConst = (unsignedSignatureCharI_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::iu2a, resolvedMethodName, _argTypesUnaryInt, TR::Address, rc, 2, 1, &uintDataArray[i]));
+      compileOpCodeMethod(iu2aConst, 
+            _numberOfUnaryArgs, TR::iu2a, resolvedMethodName, _argTypesUnaryInt, TR::Address, rc, 2, 1, &uintDataArray[i]);
       OMR_CT_EXPECT_EQ(iu2aConst, convert(uintDataArray[i], ADDRESS_PLACEHOLDER_1), iu2aConst(INT_PLACEHOLDER_1));
       }
    }
@@ -2789,59 +2789,59 @@ PPCOpCodesTest::compileDisabledCompareTestMethods()
 
    //Jazz103 Work Item 106531
    //Compare
-   _lCmpeq = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lcmpeq, "lCmpeq", _argTypesBinaryLong, TR::Int32, rc));
-   _lCmplt = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lcmplt, "lCmplt", _argTypesBinaryLong, TR::Int32, rc));
+   compileOpCodeMethod(_lCmpeq, _numberOfBinaryArgs, TR::lcmpeq, "lCmpeq", _argTypesBinaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_lCmplt, _numberOfBinaryArgs, TR::lcmplt, "lCmplt", _argTypesBinaryLong, TR::Int32, rc);
 
-   _dCmpeq = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dcmpeq, "dCmpeq", _argTypesBinaryDouble, TR::Int32, rc));
-   _dCmpne = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dcmpne, "dCmpne", _argTypesBinaryDouble, TR::Int32, rc));
-   _dCmpgt = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dcmpgt, "dCmpgt", _argTypesBinaryDouble, TR::Int32, rc));
-   _dCmplt = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dcmplt, "dCmplt", _argTypesBinaryDouble, TR::Int32, rc));
-   _dCmpge = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dcmpge, "dCmpge", _argTypesBinaryDouble, TR::Int32, rc));
-   _dCmple = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dcmple, "dCmple", _argTypesBinaryDouble, TR::Int32, rc));
+   compileOpCodeMethod(_dCmpeq, _numberOfBinaryArgs, TR::dcmpeq, "dCmpeq", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_dCmpne, _numberOfBinaryArgs, TR::dcmpne, "dCmpne", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_dCmpgt, _numberOfBinaryArgs, TR::dcmpgt, "dCmpgt", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_dCmplt, _numberOfBinaryArgs, TR::dcmplt, "dCmplt", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_dCmpge, _numberOfBinaryArgs, TR::dcmpge, "dCmpge", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_dCmple, _numberOfBinaryArgs, TR::dcmple, "dCmple", _argTypesBinaryDouble, TR::Int32, rc);
 
-   _fCmpeq = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fcmpeq, "fCmpeq", _argTypesBinaryFloat, TR::Int32, rc));
-   _fCmpne = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fcmpne, "fCmpne", _argTypesBinaryFloat, TR::Int32, rc));
-   _fCmpgt = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fcmpgt, "fCmpgt", _argTypesBinaryFloat, TR::Int32, rc));
-   _fCmplt = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fcmplt, "fCmplt", _argTypesBinaryFloat, TR::Int32, rc));
-   _fCmpge = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fcmpge, "fCmpge", _argTypesBinaryFloat, TR::Int32, rc));
-   _fCmple = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fcmple, "fCmple", _argTypesBinaryFloat, TR::Int32, rc));
+   compileOpCodeMethod(_fCmpeq, _numberOfBinaryArgs, TR::fcmpeq, "fCmpeq", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_fCmpne, _numberOfBinaryArgs, TR::fcmpne, "fCmpne", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_fCmpgt, _numberOfBinaryArgs, TR::fcmpgt, "fCmpgt", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_fCmplt, _numberOfBinaryArgs, TR::fcmplt, "fCmplt", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_fCmpge, _numberOfBinaryArgs, TR::fcmpge, "fCmpge", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_fCmple, _numberOfBinaryArgs, TR::fcmple, "fCmple", _argTypesBinaryFloat, TR::Int32, rc);
 
-   _bCmpne = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bcmpne, "bCmpne", _argTypesBinaryByte, TR::Int32, rc));
-   _bCmple = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bcmple, "bCmple", _argTypesBinaryByte, TR::Int32, rc));
-   _bCmplt = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bcmplt, "bCmplt", _argTypesBinaryByte, TR::Int32, rc));
-   _bCmpge = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bcmpge, "bCmpge", _argTypesBinaryByte, TR::Int32, rc));
+   compileOpCodeMethod(_bCmpne, _numberOfBinaryArgs, TR::bcmpne, "bCmpne", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_bCmple, _numberOfBinaryArgs, TR::bcmple, "bCmple", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_bCmplt, _numberOfBinaryArgs, TR::bcmplt, "bCmplt", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_bCmpge, _numberOfBinaryArgs, TR::bcmpge, "bCmpge", _argTypesBinaryByte, TR::Int32, rc);
 
-   _buCmpeq = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bucmpeq, "buCmpeq", _argTypesBinaryByte, TR::Int32, rc));
-   _buCmpne = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bucmpne, "buCmpne", _argTypesBinaryByte, TR::Int32, rc));
+   compileOpCodeMethod(_buCmpeq, _numberOfBinaryArgs, TR::bucmpeq, "buCmpeq", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_buCmpne, _numberOfBinaryArgs, TR::bucmpne, "buCmpne", _argTypesBinaryByte, TR::Int32, rc);
 
-   _lCmp = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lcmp, "lCmp", _argTypesBinaryLong, TR::Int32, rc));
-   _fCmpl = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fcmpl, "fCmpl", _argTypesBinaryFloat, TR::Int32, rc));
-   _fCmpg = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fcmpg, "fCmpg", _argTypesBinaryFloat, TR::Int32, rc));
-   _dCmpl = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dcmpl, "dCmpl", _argTypesBinaryDouble, TR::Int32, rc));
-   _dCmpg = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dcmpg, "dCmpg", _argTypesBinaryDouble, TR::Int32, rc));
+   compileOpCodeMethod(_lCmp, _numberOfBinaryArgs, TR::lcmp, "lCmp", _argTypesBinaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_fCmpl, _numberOfBinaryArgs, TR::fcmpl, "fCmpl", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_fCmpg, _numberOfBinaryArgs, TR::fcmpg, "fCmpg", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_dCmpl, _numberOfBinaryArgs, TR::dcmpl, "dCmpl", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_dCmpg, _numberOfBinaryArgs, TR::dcmpg, "dCmpg", _argTypesBinaryDouble, TR::Int32, rc);
 
-   _ifLcmpeq = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iflcmpeq, "ifLcmpeq", _argTypesBinaryLong, TR::Int32, rc));
-   _ifLcmpgt = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iflcmpgt, "ifLcmpgt", _argTypesBinaryLong, TR::Int32, rc));
-   _ifLcmplt = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iflcmplt, "ifLcmplt", _argTypesBinaryLong, TR::Int32, rc));
+   compileOpCodeMethod(_ifLcmpeq, _numberOfBinaryArgs, TR::iflcmpeq, "ifLcmpeq", _argTypesBinaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_ifLcmpgt, _numberOfBinaryArgs, TR::iflcmpgt, "ifLcmpgt", _argTypesBinaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_ifLcmplt, _numberOfBinaryArgs, TR::iflcmplt, "ifLcmplt", _argTypesBinaryLong, TR::Int32, rc);
 
-   _ifDcmpeq = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifdcmpeq, "ifDcmpeq", _argTypesBinaryDouble, TR::Int32, rc));
-   _ifDcmpne = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifdcmpne, "ifDcmpne", _argTypesBinaryDouble, TR::Int32, rc));
-   _ifDcmpgt = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifdcmpgt, "ifDcmpgt", _argTypesBinaryDouble, TR::Int32, rc));
-   _ifDcmplt = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifdcmplt, "ifDcmplt", _argTypesBinaryDouble, TR::Int32, rc));
-   _ifDcmpge = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifdcmpge, "ifDcmpge", _argTypesBinaryDouble, TR::Int32, rc));
-   _ifDcmple = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifdcmple, "ifDcmple", _argTypesBinaryDouble, TR::Int32, rc));
+   compileOpCodeMethod(_ifDcmpeq, _numberOfBinaryArgs, TR::ifdcmpeq, "ifDcmpeq", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_ifDcmpne, _numberOfBinaryArgs, TR::ifdcmpne, "ifDcmpne", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_ifDcmpgt, _numberOfBinaryArgs, TR::ifdcmpgt, "ifDcmpgt", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_ifDcmplt, _numberOfBinaryArgs, TR::ifdcmplt, "ifDcmplt", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_ifDcmpge, _numberOfBinaryArgs, TR::ifdcmpge, "ifDcmpge", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_ifDcmple, _numberOfBinaryArgs, TR::ifdcmple, "ifDcmple", _argTypesBinaryDouble, TR::Int32, rc);
 
-   _ifFcmpeq = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iffcmpeq, "ifFcmpeq", _argTypesBinaryFloat, TR::Int32, rc));
-   _ifFcmpne = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iffcmpne, "ifFcmpne", _argTypesBinaryFloat, TR::Int32, rc));
-   _ifFcmpgt = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iffcmpgt, "ifFcmpgt", _argTypesBinaryFloat, TR::Int32, rc));
-   _ifFcmplt = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iffcmplt, "ifFcmplt", _argTypesBinaryFloat, TR::Int32, rc));
-   _ifFcmpge = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iffcmpge, "ifFcmpge", _argTypesBinaryFloat, TR::Int32, rc));
-   _ifFcmple = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iffcmple, "ifFcmple", _argTypesBinaryFloat, TR::Int32, rc));
+   compileOpCodeMethod(_ifFcmpeq, _numberOfBinaryArgs, TR::iffcmpeq, "ifFcmpeq", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_ifFcmpne, _numberOfBinaryArgs, TR::iffcmpne, "ifFcmpne", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_ifFcmpgt, _numberOfBinaryArgs, TR::iffcmpgt, "ifFcmpgt", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_ifFcmplt, _numberOfBinaryArgs, TR::iffcmplt, "ifFcmplt", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_ifFcmpge, _numberOfBinaryArgs, TR::iffcmpge, "ifFcmpge", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_ifFcmple, _numberOfBinaryArgs, TR::iffcmple, "ifFcmple", _argTypesBinaryFloat, TR::Int32, rc);
 
-   _ifBcmpne = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbcmpne, "ifBcmpne", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBcmple = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbcmple, "ifBcmple", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBcmplt = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbcmplt, "ifBcmplt", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBcmpge = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbcmpge, "ifBcmpge", _argTypesBinaryByte, TR::Int32, rc));
+   compileOpCodeMethod(_ifBcmpne, _numberOfBinaryArgs, TR::ifbcmpne, "ifBcmpne", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBcmple, _numberOfBinaryArgs, TR::ifbcmple, "ifBcmple", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBcmplt, _numberOfBinaryArgs, TR::ifbcmplt, "ifBcmplt", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBcmpge, _numberOfBinaryArgs, TR::ifbcmpge, "ifBcmpge", _argTypesBinaryByte, TR::Int32, rc);
 
    }
 
@@ -3138,18 +3138,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_lCmpeq, compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), _lCmpeq(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpeqConst1_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpeqDataArr[i][0]), 2, &(lCmpeqDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpeqDataArr[i][0]), 2, &(lCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lCmpeqConst2_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpeqDataArr[i][0])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpeqConst3_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpeqDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), lCompareConst(lCmpeqDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -3160,18 +3160,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_lCmplt, compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), _lCmplt(lCmpltDataArr[i][0], lCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpltConst1_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpltDataArr[i][0]), 2, &(lCmpltDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpltDataArr[i][0]), 2, &(lCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lCmpltConst2_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpltDataArr[i][0])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpltConst3_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpltDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), lCompareConst(lCmpltDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -3182,18 +3182,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_dCmpeq, compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), _dCmpeq(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpeqConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpeqDataArr[i][0]), 2, &(dCmpeqDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpeqDataArr[i][0]), 2, &(dCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpeqConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpeqDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpeqConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpeqDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), dCompareConst(dCmpeqDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -3203,18 +3203,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_dCmpne, compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), _dCmpne(dCmpneDataArr[i][0], dCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpneConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpneDataArr[i][0]), 2, &(dCmpneDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpneDataArr[i][0]), 2, &(dCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpneConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpneDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpneConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpneDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), dCompareConst(dCmpneDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -3224,18 +3224,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_dCmpgt, compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), _dCmpgt(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpgtConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpgtDataArr[i][0]), 2, &(dCmpgtDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpgtDataArr[i][0]), 2, &(dCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpgtConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpgtDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpgtConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpgtDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), dCompareConst(dCmpgtDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -3245,18 +3245,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_dCmplt, compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), _dCmplt(dCmpltDataArr[i][0], dCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpltConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpltDataArr[i][0]), 2, &(dCmpltDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpltDataArr[i][0]), 2, &(dCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpltConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpltDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpltConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpltDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), dCompareConst(dCmpltDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -3266,18 +3266,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_dCmpge, compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), _dCmpge(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpgeConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpgeDataArr[i][0]), 2, &(dCmpgeDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpgeDataArr[i][0]), 2, &(dCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpgeConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpgeDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpgeConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpgeDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), dCompareConst(dCmpgeDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -3287,18 +3287,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_dCmple, compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), _dCmple(dCmpleDataArr[i][0], dCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpleConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpleDataArr[i][0]), 2, &(dCmpleDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpleDataArr[i][0]), 2, &(dCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpleConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpleDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpleConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpleDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), dCompareConst(dCmpleDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -3309,18 +3309,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_fCmpeq, compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), _fCmpeq(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpeqConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpeqDataArr[i][0]), 2, &(fCmpeqDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpeqDataArr[i][0]), 2, &(fCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpeqConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpeqDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpeqConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpeqDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), fCompareConst(fCmpeqDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -3330,18 +3330,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_fCmpne, compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), _fCmpne(fCmpneDataArr[i][0], fCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpneConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpneDataArr[i][0]), 2, &(fCmpneDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpneDataArr[i][0]), 2, &(fCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpneConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpneDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpneConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpneDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), fCompareConst(fCmpneDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -3351,18 +3351,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_fCmpgt, compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), _fCmpgt(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpgtConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpgtDataArr[i][0]), 2, &(fCmpgtDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpgtDataArr[i][0]), 2, &(fCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpgtConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpgtDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpgtConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpgtDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), fCompareConst(fCmpgtDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -3372,18 +3372,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_fCmplt, compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), _fCmplt(fCmpltDataArr[i][0], fCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpltConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpltDataArr[i][0]), 2, &(fCmpltDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpltDataArr[i][0]), 2, &(fCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpltConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpltDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpltConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpltDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), fCompareConst(fCmpltDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -3393,18 +3393,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_fCmpge, compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), _fCmpge(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpgeConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpgeDataArr[i][0]), 2, &(fCmpgeDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpgeDataArr[i][0]), 2, &(fCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpgeConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpgeDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpgeConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpgeDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), fCompareConst(fCmpgeDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -3414,18 +3414,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_fCmple, compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), _fCmple(fCmpleDataArr[i][0], fCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpleConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpleDataArr[i][0]), 2, &(fCmpleDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpleDataArr[i][0]), 2, &(fCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpleConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpleDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpleConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpleDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), fCompareConst(fCmpleDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -3436,18 +3436,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_bCmpne, compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), _bCmpne(bCmpneDataArr[i][0], bCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpneConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpneDataArr[i][0]), 2, &(bCmpneDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpneDataArr[i][0]), 2, &(bCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpneConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpneDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpneConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpneDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), bCompareConst(bCmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3457,18 +3457,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_bCmple, compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), _bCmple(bCmpleDataArr[i][0], bCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpleConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpleDataArr[i][0]), 2, &(bCmpleDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpleDataArr[i][0]), 2, &(bCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpleConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpleDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpleConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpleDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), bCompareConst(bCmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3478,18 +3478,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_bCmplt, compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), _bCmplt(bCmpltDataArr[i][0], bCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpltConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpltDataArr[i][0]), 2, &(bCmpltDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpltDataArr[i][0]), 2, &(bCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpltConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpltDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpltConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpltDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), bCompareConst(bCmpltDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3499,18 +3499,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_bCmpge, compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), _bCmpge(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpgeConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpgeDataArr[i][0]), 2, &(bCmpgeDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpgeDataArr[i][0]), 2, &(bCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpgeConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpgeDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpgeConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpgeDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), bCompareConst(bCmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3521,18 +3521,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_lCmp, comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), _lCmp(lCmpDataArr[i][0], lCmpDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpConst1_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmp, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpDataArr[i][0]), 2, &(lCmpDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmp, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpDataArr[i][0]), 2, &(lCmpDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lCmpConst2_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmp, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpDataArr[i][0])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmp, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpDataArr[i][0]));
       OMR_CT_EXPECT_EQ(lCompareConst, comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpConst3_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmp, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmp, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), lCompareConst(lCmpDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -3544,20 +3544,20 @@ PPCOpCodesTest::invokeDisabledCompareTests()
             dCmplDataArr[i][0] << " : " << dCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmplConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpl, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmplDataArr[i][0]), 2, &(dCmplDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpl, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmplDataArr[i][0]), 2, &(dCmplDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2)) <<
             dCmplDataArr[i][0] << " : " << dCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmplConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpl, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmplDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpl, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmplDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmplDataArr[i][1])) <<
             dCmplDataArr[i][0] << " : " << dCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmplConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpl, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmplDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpl, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmplDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), dCompareConst(dCmplDataArr[i][0], DOUBLE_PLACEHOLDER_2)) <<
             dCmplDataArr[i][0] << " : " << dCmplDataArr[i][1];
       }
@@ -3570,20 +3570,20 @@ PPCOpCodesTest::invokeDisabledCompareTests()
             dCmpgDataArr[i][0] << " : " << dCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmpgConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpg, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpgDataArr[i][0]), 2, &(dCmpgDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpg, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpgDataArr[i][0]), 2, &(dCmpgDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2)) <<
             dCmpgDataArr[i][0] << " : " << dCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmpgConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpg, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpgDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpg, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpgDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpgDataArr[i][1])) <<
             dCmpgDataArr[i][0] << " : " << dCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmpgConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpg, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpgDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpg, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpgDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), dCompareConst(dCmpgDataArr[i][0], DOUBLE_PLACEHOLDER_2)) <<
             dCmpgDataArr[i][0] << " : " << dCmpgDataArr[i][1];
       }
@@ -3596,20 +3596,20 @@ PPCOpCodesTest::invokeDisabledCompareTests()
             fCmplDataArr[i][0] << " : " << fCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmplConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpl, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmplDataArr[i][0]), 2, &(fCmplDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpl, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmplDataArr[i][0]), 2, &(fCmplDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2)) <<
             fCmplDataArr[i][0] << " : " << fCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmplConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpl, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmplDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpl, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmplDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmplDataArr[i][1])) <<
             fCmplDataArr[i][0] << " : " << fCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmplConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpl, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmplDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpl, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmplDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), fCompareConst(fCmplDataArr[i][0], FLOAT_PLACEHOLDER_2)) <<
             fCmplDataArr[i][0] << " : " << fCmplDataArr[i][1];
       }
@@ -3622,20 +3622,20 @@ PPCOpCodesTest::invokeDisabledCompareTests()
             fCmpgDataArr[i][0] << " : " << fCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmpgConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpg, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpgDataArr[i][0]), 2, &(fCmpgDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpg, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpgDataArr[i][0]), 2, &(fCmpgDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2)) <<
             fCmpgDataArr[i][0] << " : " << fCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmpgConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpg, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpgDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpg, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpgDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpgDataArr[i][1])) <<
             fCmpgDataArr[i][0] << " : " << fCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmpgConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpg, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpgDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpg, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpgDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), fCompareConst(fCmpgDataArr[i][0], FLOAT_PLACEHOLDER_2)) <<
             fCmpgDataArr[i][0] << " : " << fCmpgDataArr[i][1];
       }
@@ -3647,18 +3647,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_ifLcmpeq, compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), _ifLcmpeq(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpeqConst1_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpeqDataArr[i][0]), 2, &(ifLcmpeqDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpeqDataArr[i][0]), 2, &(ifLcmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLcmpeqConst2_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpeqDataArr[i][0])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpeqConst3_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpeqDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), lCompareConst(ifLcmpeqDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -3668,18 +3668,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_ifLcmpgt, compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), _ifLcmpgt(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpgtConst1_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpgtDataArr[i][0]), 2, &(ifLcmpgtDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpgtDataArr[i][0]), 2, &(ifLcmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLcmpgtConst2_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpgtDataArr[i][0])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpgtConst3_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpgtDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), lCompareConst(ifLcmpgtDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -3689,18 +3689,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_ifLcmplt, compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), _ifLcmplt(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpltConst1_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpltDataArr[i][0]), 2, &(ifLcmpltDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpltDataArr[i][0]), 2, &(ifLcmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLcmpltConst2_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpltDataArr[i][0])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpltConst3_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpltDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), lCompareConst(ifLcmpltDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -3711,18 +3711,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_ifDcmpeq, compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), _ifDcmpeq(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpeqConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpeqDataArr[i][0]), 2, &(ifDcmpeqDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpeqDataArr[i][0]), 2, &(ifDcmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpeqConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpeqDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpeqConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpeqDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), dCompareConst(ifDcmpeqDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -3732,18 +3732,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_ifDcmpne, compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), _ifDcmpne(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpneConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpneDataArr[i][0]), 2, &(ifDcmpneDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpneDataArr[i][0]), 2, &(ifDcmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpneConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpneDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpneConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpneDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), dCompareConst(ifDcmpneDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -3753,18 +3753,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_ifDcmpgt, compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), _ifDcmpgt(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpgtConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpgtDataArr[i][0]), 2, &(ifDcmpgtDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpgtDataArr[i][0]), 2, &(ifDcmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpgtConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpgtDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpgtConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpgtDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), dCompareConst(ifDcmpgtDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -3774,18 +3774,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_ifDcmplt, compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), _ifDcmplt(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpltConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpltDataArr[i][0]), 2, &(ifDcmpltDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpltDataArr[i][0]), 2, &(ifDcmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpltConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpltDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpltConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpltDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), dCompareConst(ifDcmpltDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -3795,18 +3795,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_ifDcmpge, compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), _ifDcmpge(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpgeConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpgeDataArr[i][0]), 2, &(ifDcmpgeDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpgeDataArr[i][0]), 2, &(ifDcmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpgeConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpgeDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpgeConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpgeDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), dCompareConst(ifDcmpgeDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -3816,18 +3816,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_ifDcmple, compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), _ifDcmple(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpleConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpleDataArr[i][0]), 2, &(ifDcmpleDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpleDataArr[i][0]), 2, &(ifDcmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpleConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpleDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpleConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpleDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), dCompareConst(ifDcmpleDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -3838,18 +3838,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_ifFcmpeq, compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), _ifFcmpeq(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpeqConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpeqDataArr[i][0]), 2, &(ifFcmpeqDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpeqDataArr[i][0]), 2, &(ifFcmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpeqConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpeqDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpeqConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpeqDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), fCompareConst(ifFcmpeqDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -3859,18 +3859,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_ifFcmpne, compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), _ifFcmpne(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpneConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpneDataArr[i][0]), 2, &(ifFcmpneDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpneDataArr[i][0]), 2, &(ifFcmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpneConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpneDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpneConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpneDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), fCompareConst(ifFcmpneDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -3880,18 +3880,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_ifFcmpgt, compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), _ifFcmpgt(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpgtConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpgtDataArr[i][0]), 2, &(ifFcmpgtDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpgtDataArr[i][0]), 2, &(ifFcmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpgtConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpgtDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpgtConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpgtDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), fCompareConst(ifFcmpgtDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -3901,18 +3901,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_ifFcmplt, compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), _ifFcmplt(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpltConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpltDataArr[i][0]), 2, &(ifFcmpltDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpltDataArr[i][0]), 2, &(ifFcmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpltConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpltDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpltConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpltDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), fCompareConst(ifFcmpltDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -3922,18 +3922,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_ifFcmpge, compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), _ifFcmpge(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpgeConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpgeDataArr[i][0]), 2, &(ifFcmpgeDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpgeDataArr[i][0]), 2, &(ifFcmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpgeConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpgeDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpgeConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpgeDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), fCompareConst(ifFcmpgeDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -3943,18 +3943,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_ifFcmple, compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), _ifFcmple(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpleConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpleDataArr[i][0]), 2, &(ifFcmpleDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpleDataArr[i][0]), 2, &(ifFcmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpleConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpleDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpleConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpleDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), fCompareConst(ifFcmpleDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -3965,18 +3965,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_ifBcmpne, compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), _ifBcmpne(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpneConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpneDataArr[i][0]), 2, &(ifBcmpneDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpneDataArr[i][0]), 2, &(ifBcmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpneConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpneDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpneConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpneDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), bCompareConst(ifBcmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3986,18 +3986,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_ifBcmple, compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), _ifBcmple(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpleConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpleDataArr[i][0]), 2, &(ifBcmpleDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpleDataArr[i][0]), 2, &(ifBcmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpleConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpleDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpleConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpleDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(ifBcmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -4007,18 +4007,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_ifBcmplt, compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), _ifBcmplt(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpltConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpltDataArr[i][0]), 2, &(ifBcmpltDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpltDataArr[i][0]), 2, &(ifBcmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpltConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpltDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpltConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpltDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), bCompareConst(ifBcmpltDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -4028,18 +4028,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_ifBcmpge, compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), _ifBcmpge(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpgeConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpgeDataArr[i][0]), 2, &(ifBcmpgeDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpgeDataArr[i][0]), 2, &(ifBcmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpgeConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpgeDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpgeConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpgeDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(ifBcmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -4050,18 +4050,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_buCmpeq, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), _buCmpeq(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buCmpeqConst1_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(buCmpeqDataArr[i][0]), 2, &(buCmpeqDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(buCmpeqDataArr[i][0]), 2, &(buCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "buCmpeqConst2_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(buCmpeqDataArr[i][0])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(buCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, buCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buCmpeqConst3_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(buCmpeqDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(buCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(buCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -4071,18 +4071,18 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(_buCmpne, compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), _buCmpne(buCmpneDataArr[i][0], buCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buCmpneConst1_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(buCmpneDataArr[i][0]), 2, &(buCmpneDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::bucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(buCmpneDataArr[i][0]), 2, &(buCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "buCmpneConst2_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(buCmpneDataArr[i][0])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::bucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(buCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, buCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buCmpneConst3_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(buCmpneDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::bucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(buCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), buCompareConst(buCmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
    }
@@ -4093,17 +4093,17 @@ PPCOpCodesTest::compileDisabledIntegerArithmeticTestMethods()
    int32_t rc = 0;
 
    //Jazz103 Work Item 101901
-   _lAdd = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ladd, "lAdd", _argTypesBinaryLong, TR::Int64, rc));
-   _lSub = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lsub, "lSub", _argTypesBinaryLong, TR::Int64, rc));
-   _lMul = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lmul, "lMul", _argTypesBinaryLong, TR::Int64, rc));
-   _lDiv = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ldiv, "lDiv", _argTypesBinaryLong, TR::Int64, rc));
-   _lRem = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lrem, "lRem", _argTypesBinaryLong, TR::Int64, rc));
+   compileOpCodeMethod(_lAdd, _numberOfBinaryArgs, TR::ladd, "lAdd", _argTypesBinaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_lSub, _numberOfBinaryArgs, TR::lsub, "lSub", _argTypesBinaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_lMul, _numberOfBinaryArgs, TR::lmul, "lMul", _argTypesBinaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_lDiv, _numberOfBinaryArgs, TR::ldiv, "lDiv", _argTypesBinaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_lRem, _numberOfBinaryArgs, TR::lrem, "lRem", _argTypesBinaryLong, TR::Int64, rc);
 
    //Jazz103 Work Item 103809
    //Testrossa Work Item 121966
-   _iuDiv = (unsignedSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iudiv, "iuDiv", _argTypesBinaryInt, TR::Int32, rc));
-   _iuMul = (unsignedSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iumul, "iuMul", _argTypesBinaryInt, TR::Int32, rc));
-   _iuRem = (unsignedSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iurem, "iuRem", _argTypesBinaryInt, TR::Int32, rc));
+   compileOpCodeMethod(_iuDiv, _numberOfBinaryArgs, TR::iudiv, "iuDiv", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iuMul, _numberOfBinaryArgs, TR::iumul, "iuMul", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iuRem, _numberOfBinaryArgs, TR::iurem, "iuRem", _argTypesBinaryInt, TR::Int32, rc);
 
    }
 
@@ -4181,18 +4181,18 @@ PPCOpCodesTest::invokeDisabledIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_lAdd, add(longAddArr[i][0], longAddArr[i][1]), _lAdd(longAddArr[i][0], longAddArr[i][1]));
 
       sprintf(resolvedMethodName, "lAddConst1_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ladd,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longAddArr[i][0], 2, &longAddArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::ladd,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longAddArr[i][0], 2, &longAddArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, add(longAddArr[i][0], longAddArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lAddConst2_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ladd,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longAddArr[i][0]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::ladd,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longAddArr[i][0]);
       OMR_CT_EXPECT_EQ(lBinaryCons, add(longAddArr[i][0], longAddArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longAddArr[i][1]));
 
       sprintf(resolvedMethodName, "lAddConst3_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ladd,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longAddArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::ladd,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longAddArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, add(longAddArr[i][0], longAddArr[i][1]), lBinaryCons(longAddArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -4203,18 +4203,18 @@ PPCOpCodesTest::invokeDisabledIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_lSub, sub(longSubArr[i][0], longSubArr[i][1]), _lSub(longSubArr[i][0], longSubArr[i][1]));
 
       sprintf(resolvedMethodName, "lSubConst1_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lsub,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longSubArr[i][0], 2, &longSubArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::lsub,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longSubArr[i][0], 2, &longSubArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, sub(longSubArr[i][0], longSubArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lSubConst2_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lsub,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longSubArr[i][0]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::lsub,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longSubArr[i][0]);
       OMR_CT_EXPECT_EQ(lBinaryCons, sub(longSubArr[i][0], longSubArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longSubArr[i][1]));
 
       sprintf(resolvedMethodName, "lSubConst3_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lsub,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longSubArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::lsub,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longSubArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, sub(longSubArr[i][0], longSubArr[i][1]), lBinaryCons(longSubArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -4225,18 +4225,18 @@ PPCOpCodesTest::invokeDisabledIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_lMul, mul(longMulArr[i][0], longMulArr[i][1]), _lMul(longMulArr[i][0], longMulArr[i][1]));
 
       sprintf(resolvedMethodName, "lMulConst1_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lmul,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longMulArr[i][0], 2, &longMulArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::lmul,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longMulArr[i][0], 2, &longMulArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, mul(longMulArr[i][0], longMulArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lMulConst2_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lmul,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longMulArr[i][0]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::lmul,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longMulArr[i][0]);
       OMR_CT_EXPECT_EQ(lBinaryCons, mul(longMulArr[i][0], longMulArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longMulArr[i][1]));
 
       sprintf(resolvedMethodName, "lMulConst3_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lmul,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longMulArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::lmul,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longMulArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, mul(longMulArr[i][0], longMulArr[i][1]), lBinaryCons(longMulArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -4248,18 +4248,18 @@ PPCOpCodesTest::invokeDisabledIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_lDiv, div(longDivArr[i][0], longDivArr[i][1]), _lDiv(longDivArr[i][0], longDivArr[i][1]));
 
       sprintf(resolvedMethodName, "lDivConst1_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ldiv, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longDivArr[i][0], 2, &longDivArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, 
+            _numberOfBinaryArgs, TR::ldiv, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longDivArr[i][0], 2, &longDivArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, div(longDivArr[i][0], longDivArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lDivConst2_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ldiv, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longDivArr[i][0]));
+      compileOpCodeMethod(lBinaryCons, 
+            _numberOfBinaryArgs, TR::ldiv, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longDivArr[i][0]);
       OMR_CT_EXPECT_EQ(lBinaryCons, div(longDivArr[i][0], longDivArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longDivArr[i][1]));
 
       sprintf(resolvedMethodName, "lDivConst3_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ldiv, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longDivArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, 
+            _numberOfBinaryArgs, TR::ldiv, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longDivArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, div(longDivArr[i][0], longDivArr[i][1]), lBinaryCons(longDivArr[i][0], LONG_PLACEHOLDER_2));
       }
    //lrem
@@ -4270,18 +4270,18 @@ PPCOpCodesTest::invokeDisabledIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_lRem, rem(longRemArr[i][0], longRemArr[i][1]), _lRem(longRemArr[i][0], longRemArr[i][1]));
 
       sprintf(resolvedMethodName, "lRemConst1_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lrem, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longRemArr[i][0], 2, &longRemArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, 
+            _numberOfBinaryArgs, TR::lrem, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longRemArr[i][0], 2, &longRemArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, rem(longRemArr[i][0], longRemArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lRemConst2_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lrem, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longRemArr[i][0]));
+      compileOpCodeMethod(lBinaryCons, 
+            _numberOfBinaryArgs, TR::lrem, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longRemArr[i][0]);
       OMR_CT_EXPECT_EQ(lBinaryCons, rem(longRemArr[i][0], longRemArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longRemArr[i][1]));
 
       sprintf(resolvedMethodName, "lRemConst3_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lrem, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longRemArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, 
+            _numberOfBinaryArgs, TR::lrem, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longRemArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, rem(longRemArr[i][0], longRemArr[i][1]), lBinaryCons(longRemArr[i][0], LONG_PLACEHOLDER_2));
       }
    }
@@ -4292,14 +4292,14 @@ PPCOpCodesTest::compileDisabledFloatArithmeticTestMethods()
    int32_t rc = 0;
    //Jazz103 Work Item 110358
 
-   _fAdd = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fadd, "fAdd", _argTypesBinaryFloat, TR::Float, rc));
-   _fSub = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fsub, "fSub", _argTypesBinaryFloat, TR::Float, rc));
-   _fMul = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fmul, "fMul", _argTypesBinaryFloat, TR::Float, rc));
-   _fDiv = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fdiv, "fDiv", _argTypesBinaryFloat, TR::Float, rc));
-   _dAdd = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dadd, "dAdd", _argTypesBinaryDouble, TR::Double, rc));
-   _dSub = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dsub, "dSub", _argTypesBinaryDouble, TR::Double, rc));
-   _dMul = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dmul, "dMul", _argTypesBinaryDouble, TR::Double, rc));
-   _dDiv = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ddiv, "dDiv", _argTypesBinaryDouble, TR::Double, rc));
+   compileOpCodeMethod(_fAdd, _numberOfBinaryArgs, TR::fadd, "fAdd", _argTypesBinaryFloat, TR::Float, rc);
+   compileOpCodeMethod(_fSub, _numberOfBinaryArgs, TR::fsub, "fSub", _argTypesBinaryFloat, TR::Float, rc);
+   compileOpCodeMethod(_fMul, _numberOfBinaryArgs, TR::fmul, "fMul", _argTypesBinaryFloat, TR::Float, rc);
+   compileOpCodeMethod(_fDiv, _numberOfBinaryArgs, TR::fdiv, "fDiv", _argTypesBinaryFloat, TR::Float, rc);
+   compileOpCodeMethod(_dAdd, _numberOfBinaryArgs, TR::dadd, "dAdd", _argTypesBinaryDouble, TR::Double, rc);
+   compileOpCodeMethod(_dSub, _numberOfBinaryArgs, TR::dsub, "dSub", _argTypesBinaryDouble, TR::Double, rc);
+   compileOpCodeMethod(_dMul, _numberOfBinaryArgs, TR::dmul, "dMul", _argTypesBinaryDouble, TR::Double, rc);
+   compileOpCodeMethod(_dDiv, _numberOfBinaryArgs, TR::ddiv, "dDiv", _argTypesBinaryDouble, TR::Double, rc);
 
    }
 void
@@ -4384,18 +4384,18 @@ PPCOpCodesTest::invokeDisabledFloatArithmeticTests()
       OMR_CT_EXPECT_FLOAT_EQ(_fAdd, add(floatAddArr[i][0], floatAddArr[i][1]), _fAdd(floatAddArr[i][0], floatAddArr[i][1]));
 
       sprintf(resolvedMethodName, "fAddConst1_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fadd,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatAddArr[i][0], 2, &floatAddArr[i][1]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fadd,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatAddArr[i][0], 2, &floatAddArr[i][1]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, add(floatAddArr[i][0], floatAddArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fAddConst2_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fadd,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatAddArr[i][0]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fadd,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatAddArr[i][0]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, add(floatAddArr[i][0], floatAddArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatAddArr[i][1]));
 
       sprintf(resolvedMethodName, "fAddConst3_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fadd,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatAddArr[i][1]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fadd,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatAddArr[i][1]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, add(floatAddArr[i][0], floatAddArr[i][1]), fBinaryConst(floatAddArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -4406,18 +4406,18 @@ PPCOpCodesTest::invokeDisabledFloatArithmeticTests()
       OMR_CT_EXPECT_FLOAT_EQ(_fSub, sub(floatSubArr[i][0], floatSubArr[i][1]), _fSub(floatSubArr[i][0], floatSubArr[i][1]));
 
       sprintf(resolvedMethodName, "fSubConst1_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fsub,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatSubArr[i][0], 2, &floatSubArr[i][1]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fsub,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatSubArr[i][0], 2, &floatSubArr[i][1]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, sub(floatSubArr[i][0], floatSubArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fSubConst2_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fsub,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatSubArr[i][0]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fsub,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatSubArr[i][0]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, sub(floatSubArr[i][0], floatSubArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatSubArr[i][1]));
 
       sprintf(resolvedMethodName, "fSubConst3_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fsub,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatSubArr[i][1]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fsub,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatSubArr[i][1]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, sub(floatSubArr[i][0], floatSubArr[i][1]), fBinaryConst(floatSubArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -4428,18 +4428,18 @@ PPCOpCodesTest::invokeDisabledFloatArithmeticTests()
       OMR_CT_EXPECT_FLOAT_EQ(_fMul, mul(floatMulArr[i][0], floatMulArr[i][1]), _fMul(floatMulArr[i][0], floatMulArr[i][1]));
 
       sprintf(resolvedMethodName, "fMulConst1_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fmul,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatMulArr[i][0], 2, &floatMulArr[i][1]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fmul,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatMulArr[i][0], 2, &floatMulArr[i][1]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, mul(floatMulArr[i][0], floatMulArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fMulConst2_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fmul,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatMulArr[i][0]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fmul,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatMulArr[i][0]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, mul(floatMulArr[i][0], floatMulArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatMulArr[i][1]));
 
       sprintf(resolvedMethodName, "fMulConst3_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fmul,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatMulArr[i][1]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fmul,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatMulArr[i][1]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, mul(floatMulArr[i][0], floatMulArr[i][1]), fBinaryConst(floatMulArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -4450,18 +4450,18 @@ PPCOpCodesTest::invokeDisabledFloatArithmeticTests()
       OMR_CT_EXPECT_FLOAT_EQ(_fDiv, div(floatDivArr[i][0], floatDivArr[i][1]), _fDiv(floatDivArr[i][0], floatDivArr[i][1]));
 
       sprintf(resolvedMethodName, "fDivConst1_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fdiv,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatDivArr[i][0], 2, &floatDivArr[i][1]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fdiv,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatDivArr[i][0], 2, &floatDivArr[i][1]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, div(floatDivArr[i][0], floatDivArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fDivConst2_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fdiv,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatDivArr[i][0]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fdiv,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatDivArr[i][0]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, div(floatDivArr[i][0], floatDivArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatDivArr[i][1]));
 
       sprintf(resolvedMethodName, "fDivConst3_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fdiv,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatDivArr[i][1]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fdiv,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatDivArr[i][1]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, div(floatDivArr[i][0], floatDivArr[i][1]), fBinaryConst(floatDivArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -4471,18 +4471,18 @@ PPCOpCodesTest::invokeDisabledFloatArithmeticTests()
       OMR_CT_EXPECT_DOUBLE_EQ(_dAdd, add(doubleAddArr[i][0], doubleAddArr[i][1]), _dAdd(doubleAddArr[i][0], doubleAddArr[i][1]));
 
       sprintf(resolvedMethodName, "dAddConst1_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dadd,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleAddArr[i][0], 2, &doubleAddArr[i][1]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::dadd,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleAddArr[i][0], 2, &doubleAddArr[i][1]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, add(doubleAddArr[i][0], doubleAddArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dAddConst2_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dadd,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleAddArr[i][0]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::dadd,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleAddArr[i][0]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, add(doubleAddArr[i][0], doubleAddArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleAddArr[i][1]));
 
       sprintf(resolvedMethodName, "dAddConst3_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dadd,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleAddArr[i][1]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::dadd,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleAddArr[i][1]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, add(doubleAddArr[i][0], doubleAddArr[i][1]), dBinaryConst(doubleAddArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -4492,18 +4492,18 @@ PPCOpCodesTest::invokeDisabledFloatArithmeticTests()
       OMR_CT_EXPECT_DOUBLE_EQ(_dSub, sub(doubleSubArr[i][0], doubleSubArr[i][1]), _dSub(doubleSubArr[i][0], doubleSubArr[i][1]));
 
       sprintf(resolvedMethodName, "dSubConst1_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dsub,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleSubArr[i][0], 2, &doubleSubArr[i][1]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::dsub,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleSubArr[i][0], 2, &doubleSubArr[i][1]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, sub(doubleSubArr[i][0], doubleSubArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dSubConst2_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dsub,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleSubArr[i][0]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::dsub,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleSubArr[i][0]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, sub(doubleSubArr[i][0], doubleSubArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleSubArr[i][1]));
 
       sprintf(resolvedMethodName, "dSubConst3_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dsub,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleSubArr[i][1]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::dsub,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleSubArr[i][1]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, sub(doubleSubArr[i][0], doubleSubArr[i][1]), dBinaryConst(doubleSubArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -4513,18 +4513,18 @@ PPCOpCodesTest::invokeDisabledFloatArithmeticTests()
       OMR_CT_EXPECT_DOUBLE_EQ(_dMul, mul(doubleMulArr[i][0], doubleMulArr[i][1]), _dMul(doubleMulArr[i][0], doubleMulArr[i][1]));
 
       sprintf(resolvedMethodName, "dMulConst1_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dmul,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleMulArr[i][0], 2, &doubleMulArr[i][1]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::dmul,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleMulArr[i][0], 2, &doubleMulArr[i][1]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, mul(doubleMulArr[i][0], doubleMulArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dMulConst2_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dmul,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleMulArr[i][0]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::dmul,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleMulArr[i][0]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, mul(doubleMulArr[i][0], doubleMulArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleMulArr[i][1]));
 
       sprintf(resolvedMethodName, "dMulConst3_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dmul,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleMulArr[i][1]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::dmul,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleMulArr[i][1]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, mul(doubleMulArr[i][0], doubleMulArr[i][1]), dBinaryConst(doubleMulArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -4534,18 +4534,18 @@ PPCOpCodesTest::invokeDisabledFloatArithmeticTests()
       OMR_CT_EXPECT_DOUBLE_EQ(_dDiv, div(doubleDivArr[i][0], doubleDivArr[i][1]), _dDiv(doubleDivArr[i][0], doubleDivArr[i][1]));
 
       sprintf(resolvedMethodName, "dDivConst1_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ddiv,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleDivArr[i][0], 2, &doubleDivArr[i][1]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::ddiv,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleDivArr[i][0], 2, &doubleDivArr[i][1]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, div(doubleDivArr[i][0], doubleDivArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dDivConst2_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ddiv,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleDivArr[i][0]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::ddiv,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleDivArr[i][0]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, div(doubleDivArr[i][0], doubleDivArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleDivArr[i][1]));
 
       sprintf(resolvedMethodName, "dDivConst3_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ddiv,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleDivArr[i][1]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::ddiv,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleDivArr[i][1]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, div(doubleDivArr[i][0], doubleDivArr[i][1]), dBinaryConst(doubleDivArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
    }
@@ -4556,7 +4556,7 @@ PPCOpCodesTest::compileDisabledMemoryOperationTestMethods()
    int32_t rc = 0;
 
    //Jazz103 111411 : bstorei unexpected results
-   _bStorei = (signatureCharLB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bstorei, "bStorei", _argTypesBinaryAddressByte, TR::Int8, rc));
+   compileOpCodeMethod(_bStorei, _numberOfBinaryArgs, TR::bstorei, "bStorei", _argTypesBinaryAddressByte, TR::Int8, rc);
    }
 
 void
@@ -4598,18 +4598,18 @@ PPCOpCodesTest::compileDisabledUnaryTestMethods()
    {
    int32_t rc = 0;
    //Jazz103 Work Item 109977
-   _dNeg = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dneg, "dNeg", _argTypesUnaryDouble, TR::Double, rc));
-   _fNeg = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::fneg, "fNeg", _argTypesUnaryFloat, TR::Float, rc));
-   _lNeg = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lneg, "lNeg", _argTypesUnaryLong, TR::Int64, rc));
+   compileOpCodeMethod(_dNeg, _numberOfUnaryArgs, TR::dneg, "dNeg", _argTypesUnaryDouble, TR::Double, rc);
+   compileOpCodeMethod(_fNeg, _numberOfUnaryArgs, TR::fneg, "fNeg", _argTypesUnaryFloat, TR::Float, rc);
+   compileOpCodeMethod(_lNeg, _numberOfUnaryArgs, TR::lneg, "lNeg", _argTypesUnaryLong, TR::Int64, rc);
 
-   _lAbs = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::labs, "lAbs", _argTypesUnaryLong, TR::Int64, rc));
+   compileOpCodeMethod(_lAbs, _numberOfUnaryArgs, TR::labs, "lAbs", _argTypesUnaryLong, TR::Int64, rc);
 
-   _lReturn = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lreturn, "lReturn", _argTypesUnaryLong, TR::Int64, rc));
-   _dReturn = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dreturn, "dReturn", _argTypesUnaryDouble, TR::Double, rc));
-   _fReturn = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::freturn, "fReturn", _argTypesUnaryFloat, TR::Float, rc));
+   compileOpCodeMethod(_lReturn, _numberOfUnaryArgs, TR::lreturn, "lReturn", _argTypesUnaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_dReturn, _numberOfUnaryArgs, TR::dreturn, "dReturn", _argTypesUnaryDouble, TR::Double, rc);
+   compileOpCodeMethod(_fReturn, _numberOfUnaryArgs, TR::freturn, "fReturn", _argTypesUnaryFloat, TR::Float, rc);
 
-   _fAbs = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::fabs, "fAbs", _argTypesUnaryFloat, TR::Float, rc));
-   _dAbs = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dabs, "dAbs", _argTypesUnaryDouble, TR::Double, rc));
+   compileOpCodeMethod(_fAbs, _numberOfUnaryArgs, TR::fabs, "fAbs", _argTypesUnaryFloat, TR::Float, rc);
+   compileOpCodeMethod(_dAbs, _numberOfUnaryArgs, TR::dabs, "dAbs", _argTypesUnaryDouble, TR::Double, rc);
    }
 
 void
@@ -4635,8 +4635,8 @@ PPCOpCodesTest::invokeDisabledUnaryTests()
       {
       OMR_CT_EXPECT_EQ(_lNeg, neg(longDataArray[i]), _lNeg(longDataArray[i]));
       sprintf(resolvedMethodName, "lNegConst%d", i + 1);
-      lUnaryCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lneg,
-            resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &longDataArray[i]));
+      compileOpCodeMethod(lUnaryCons, _numberOfUnaryArgs, TR::lneg,
+            resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &longDataArray[i]);
       OMR_CT_EXPECT_EQ(lUnaryCons, neg(longDataArray[i]), lUnaryCons(LONG_PLACEHOLDER_1));
       }
 
@@ -4646,8 +4646,8 @@ PPCOpCodesTest::invokeDisabledUnaryTests()
       {
       OMR_CT_EXPECT_FLOAT_EQ(_fNeg, neg(floatDataArray[i]), _fNeg(floatDataArray[i]));
       sprintf(resolvedMethodName, "fNegConst%d", i + 1);
-      fUnaryCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::fneg,
-            resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &floatDataArray[i]));
+      compileOpCodeMethod(fUnaryCons, _numberOfUnaryArgs, TR::fneg,
+            resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &floatDataArray[i]);
       OMR_CT_EXPECT_FLOAT_EQ(fUnaryCons, neg(floatDataArray[i]), fUnaryCons(FLOAT_PLACEHOLDER_1));
       }
 
@@ -4657,8 +4657,8 @@ PPCOpCodesTest::invokeDisabledUnaryTests()
       {
       OMR_CT_EXPECT_DOUBLE_EQ(_dNeg, neg(doubleDataArray[i]), _dNeg(doubleDataArray[i]));
       sprintf(resolvedMethodName, "dNegConst%d", i + 1);
-      dUnaryCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dneg,
-            resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &doubleDataArray[i]));
+      compileOpCodeMethod(dUnaryCons, _numberOfUnaryArgs, TR::dneg,
+            resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &doubleDataArray[i]);
       OMR_CT_EXPECT_DOUBLE_EQ(dUnaryCons, neg(doubleDataArray[i]), dUnaryCons(DOUBLE_PLACEHOLDER_1));
       }
 
@@ -4668,8 +4668,8 @@ PPCOpCodesTest::invokeDisabledUnaryTests()
       {
       OMR_CT_EXPECT_EQ(_lAbs, abs(longDataArray[i]), _lAbs(longDataArray[i]));
       sprintf(resolvedMethodName, "lAbsConst%d", i + 1);
-      lUnaryCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::labs,
-            resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &longDataArray[i]));
+      compileOpCodeMethod(lUnaryCons, _numberOfUnaryArgs, TR::labs,
+            resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &longDataArray[i]);
       OMR_CT_EXPECT_EQ(lUnaryCons, abs(longDataArray[i]), lUnaryCons(LONG_PLACEHOLDER_1));
       }
 
@@ -4679,7 +4679,7 @@ PPCOpCodesTest::invokeDisabledUnaryTests()
       {
       sprintf(resolvedMethodName, "lReturnCons%d", i + 1);
       OMR_CT_EXPECT_EQ(_lReturn, longDataArray[i], _lReturn(longDataArray[i]));
-      lUnaryCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lreturn, resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &(longDataArray[i])));
+      compileOpCodeMethod(lUnaryCons, _numberOfUnaryArgs, TR::lreturn, resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &(longDataArray[i]));
       OMR_CT_EXPECT_EQ(lUnaryCons, longDataArray[i], lUnaryCons(LONG_PLACEHOLDER_1));
       }
 
@@ -4689,7 +4689,7 @@ PPCOpCodesTest::invokeDisabledUnaryTests()
       {
       sprintf(resolvedMethodName, "dReturnCons%d", i + 1);
       OMR_CT_EXPECT_DOUBLE_EQ(_dReturn, doubleDataArray[i], _dReturn(doubleDataArray[i]));
-      dUnaryCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dreturn, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &(doubleDataArray[i])));
+      compileOpCodeMethod(dUnaryCons, _numberOfUnaryArgs, TR::dreturn, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &(doubleDataArray[i]));
       OMR_CT_EXPECT_DOUBLE_EQ(dUnaryCons, doubleDataArray[i], dUnaryCons(DOUBLE_PLACEHOLDER_1));
       }
 
@@ -4699,7 +4699,7 @@ PPCOpCodesTest::invokeDisabledUnaryTests()
       {
       sprintf(resolvedMethodName, "fReturnCons%d", i + 1);
       OMR_CT_EXPECT_FLOAT_EQ(_fReturn, floatDataArray[i], _fReturn(floatDataArray[i]));
-      fUnaryCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::freturn, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &(floatDataArray[i])));
+      compileOpCodeMethod(fUnaryCons, _numberOfUnaryArgs, TR::freturn, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &(floatDataArray[i]));
       OMR_CT_EXPECT_FLOAT_EQ(fUnaryCons, floatDataArray[i], fUnaryCons(FLOAT_PLACEHOLDER_1));
       }
 
@@ -4708,7 +4708,7 @@ PPCOpCodesTest::invokeDisabledUnaryTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "lConst%d", i + 1);
-      lUnaryCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lconst, resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &(longDataArray[i])));
+      compileOpCodeMethod(lUnaryCons, _numberOfUnaryArgs, TR::lconst, resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &(longDataArray[i]));
       OMR_CT_EXPECT_EQ(lUnaryCons, longDataArray[i], lUnaryCons(LONG_PLACEHOLDER_1));
       }
 
@@ -4717,7 +4717,7 @@ PPCOpCodesTest::invokeDisabledUnaryTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "dConst%d", i + 1);
-      dUnaryCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dconst, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &(doubleDataArray[i])));
+      compileOpCodeMethod(dUnaryCons, _numberOfUnaryArgs, TR::dconst, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &(doubleDataArray[i]));
       OMR_CT_EXPECT_DOUBLE_EQ(dUnaryCons, doubleDataArray[i], dUnaryCons(DOUBLE_PLACEHOLDER_1));
       }
 
@@ -4726,7 +4726,7 @@ PPCOpCodesTest::invokeDisabledUnaryTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "fConst%d", i + 1);
-      fUnaryCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::fconst, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &(floatDataArray[i])));
+      compileOpCodeMethod(fUnaryCons, _numberOfUnaryArgs, TR::fconst, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &(floatDataArray[i]));
       OMR_CT_EXPECT_FLOAT_EQ(fUnaryCons, floatDataArray[i], fUnaryCons(FLOAT_PLACEHOLDER_1));
       }
 
@@ -4736,8 +4736,8 @@ PPCOpCodesTest::invokeDisabledUnaryTests()
       {
       OMR_CT_EXPECT_EQ(_fAbs, abs(floatDataArray[i]), _fAbs(floatDataArray[i]));
       sprintf(resolvedMethodName, "fAbsConst%d", i + 1);
-      fUnaryCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::fabs, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &floatDataArray[i]));
+      compileOpCodeMethod(fUnaryCons, 
+            _numberOfUnaryArgs, TR::fabs, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &floatDataArray[i]);
       OMR_CT_EXPECT_EQ(fUnaryCons, abs(floatDataArray[i]), fUnaryCons(FLOAT_PLACEHOLDER_1));
       }
 
@@ -4747,8 +4747,8 @@ PPCOpCodesTest::invokeDisabledUnaryTests()
       {
       OMR_CT_EXPECT_EQ(_dAbs, abs(doubleDataArray[i]), _dAbs(doubleDataArray[i]));
       sprintf(resolvedMethodName, "dAbsConst%d", i + 1);
-      dUnaryCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::dabs, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &doubleDataArray[i]));
+      compileOpCodeMethod(dUnaryCons, 
+            _numberOfUnaryArgs, TR::dabs, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &doubleDataArray[i]);
       OMR_CT_EXPECT_EQ(dUnaryCons, abs(doubleDataArray[i]), dUnaryCons(DOUBLE_PLACEHOLDER_1));
       }
 
@@ -4760,8 +4760,8 @@ PPCOpCodesTest::compileDisabledShiftOrRolTestMethods()
    int32_t rc = 0;
 
    //Jazz103 Work Item 110361
-   _bShr = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bshr, "bShr", _argTypesBinaryByte, TR::Int8, rc));
-   _suShr = (unsignedSignatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sushr, "suShr", _argTypesBinaryShort, TR::Int16, rc));
+   compileOpCodeMethod(_bShr, _numberOfBinaryArgs, TR::bshr, "bShr", _argTypesBinaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_suShr, _numberOfBinaryArgs, TR::sushr, "suShr", _argTypesBinaryShort, TR::Int16, rc);
    }
 void
 PPCOpCodesTest::invokeDisabledShiftOrRolTests()
@@ -4804,18 +4804,18 @@ PPCOpCodesTest::invokeDisabledShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_bShr, shr(bshrDataArr[i][0], bshrDataArr[i][1]), _bShr(bshrDataArr[i][0], bshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bShrConst1_TestCase%d", i + 1);
-      bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bshr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &bshrDataArr[i][0], 2, &bshrDataArr[i][1]));
+      compileOpCodeMethod(bShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::bshr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &bshrDataArr[i][0], 2, &bshrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(bShiftOrRolConst, shr(bshrDataArr[i][0], bshrDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bShrConst2_TestCase%d", i + 1);
-      bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bshr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &bshrDataArr[i][0]));
+      compileOpCodeMethod(bShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::bshr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &bshrDataArr[i][0]);
       OMR_CT_EXPECT_EQ(bShiftOrRolConst, shr(bshrDataArr[i][0], bshrDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, bshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bShrConst3_TestCase%d", i + 1);
-      bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bshr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &bshrDataArr[i][1]));
+      compileOpCodeMethod(bShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::bshr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &bshrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(bShiftOrRolConst, shr(bshrDataArr[i][0], bshrDataArr[i][1]), bShiftOrRolConst(bshrDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -4826,18 +4826,18 @@ PPCOpCodesTest::invokeDisabledShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_suShr, shr(sushrDataArr[i][0], sushrDataArr[i][1]), _suShr(sushrDataArr[i][0], sushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "suShrConst1_TestCase%d", i + 1);
-      suShiftOrRolConst = (unsignedSignatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sushr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &sushrDataArr[i][0], 2, &sushrDataArr[i][1]));
+      compileOpCodeMethod(suShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::sushr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &sushrDataArr[i][0], 2, &sushrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(suShiftOrRolConst, shr(sushrDataArr[i][0], sushrDataArr[i][1]), suShiftOrRolConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "suShrConst2_TestCase%d", i + 1);
-      suShiftOrRolConst = (unsignedSignatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sushr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &sushrDataArr[i][0]));
+      compileOpCodeMethod(suShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::sushr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &sushrDataArr[i][0]);
       OMR_CT_EXPECT_EQ(suShiftOrRolConst, shr(sushrDataArr[i][0], sushrDataArr[i][1]), suShiftOrRolConst(SHORT_PLACEHOLDER_1, sushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "suShrConst3_TestCase%d", i + 1);
-      suShiftOrRolConst = (unsignedSignatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sushr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &sushrDataArr[i][1]));
+      compileOpCodeMethod(suShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::sushr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &sushrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(suShiftOrRolConst, shr(sushrDataArr[i][0], sushrDataArr[i][1]), suShiftOrRolConst(sushrDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -4849,9 +4849,9 @@ PPCOpCodesTest::compileDisabledBitwiseTestMethods()
    int32_t rc;
 
    //Jazz103 Work Item 110362
-   _lAnd = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::land, "lAnd", _argTypesBinaryLong, TR::Int64, rc));
-   _lOr = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lor, "lOr", _argTypesBinaryLong, TR::Int64, rc));
-   _lXor = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lxor, "lXor", _argTypesBinaryLong, TR::Int64, rc));
+   compileOpCodeMethod(_lAnd, _numberOfBinaryArgs, TR::land, "lAnd", _argTypesBinaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_lOr, _numberOfBinaryArgs, TR::lor, "lOr", _argTypesBinaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_lXor, _numberOfBinaryArgs, TR::lxor, "lXor", _argTypesBinaryLong, TR::Int64, rc);
 
    }
 
@@ -4896,18 +4896,18 @@ PPCOpCodesTest::invokeDisabledBitwiseTests()
       OMR_CT_EXPECT_EQ(_lAnd, tand(longAndArr[i][0], longAndArr[i][1]), _lAnd(longAndArr[i][0], longAndArr[i][1]));
 
       sprintf(resolvedMethodName, "lAndConst1_TestCase%d", i + 1);
-      lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::land, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &(longAndArr[i][0]), 2, &(longAndArr[i][1])));
+      compileOpCodeMethod(lBitwiseConst, 
+            _numberOfBinaryArgs, TR::land, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &(longAndArr[i][0]), 2, &(longAndArr[i][1]));
       OMR_CT_EXPECT_EQ(lBitwiseConst, tand(longAndArr[i][0], longAndArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lAndConst2_TestCase%d", i + 1);
-      lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::land, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &(longAndArr[i][0])));
+      compileOpCodeMethod(lBitwiseConst, 
+            _numberOfBinaryArgs, TR::land, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &(longAndArr[i][0]));
       OMR_CT_EXPECT_EQ(lBitwiseConst, tand(longAndArr[i][0], longAndArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, longAndArr[i][1]));
 
       sprintf(resolvedMethodName, "lAndConst3_TestCase%d", i + 1);
-      lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::land, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &(longAndArr[i][1])));
+      compileOpCodeMethod(lBitwiseConst, 
+            _numberOfBinaryArgs, TR::land, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &(longAndArr[i][1]));
       OMR_CT_EXPECT_EQ(lBitwiseConst, tand(longAndArr[i][0], longAndArr[i][1]), lBitwiseConst(longAndArr[i][0], LONG_PLACEHOLDER_2));
      }
 
@@ -4918,18 +4918,18 @@ PPCOpCodesTest::invokeDisabledBitwiseTests()
       OMR_CT_EXPECT_EQ(_lOr, tor(longOrArr[i][0], longOrArr[i][1]), _lOr(longOrArr[i][0], longOrArr[i][1]));
 
       sprintf(resolvedMethodName, "lOrConst1_TestCase%d", i + 1);
-      lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &(longOrArr[i][0]), 2, &(longOrArr[i][1])));
+      compileOpCodeMethod(lBitwiseConst, 
+            _numberOfBinaryArgs, TR::lor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &(longOrArr[i][0]), 2, &(longOrArr[i][1]));
       OMR_CT_EXPECT_EQ(lBitwiseConst, tor(longOrArr[i][0], longOrArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lOrConst2_TestCase%d", i + 1);
-      lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &(longOrArr[i][0])));
+      compileOpCodeMethod(lBitwiseConst, 
+            _numberOfBinaryArgs, TR::lor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &(longOrArr[i][0]));
       OMR_CT_EXPECT_EQ(lBitwiseConst, tor(longOrArr[i][0], longOrArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, longOrArr[i][1]));
 
       sprintf(resolvedMethodName, "lOrConst3_TestCase%d", i + 1);
-      lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &(longOrArr[i][1])));
+      compileOpCodeMethod(lBitwiseConst, 
+            _numberOfBinaryArgs, TR::lor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &(longOrArr[i][1]));
       OMR_CT_EXPECT_EQ(lBitwiseConst, tor(longOrArr[i][0], longOrArr[i][1]), lBitwiseConst(longOrArr[i][0], LONG_PLACEHOLDER_2));
      }
 
@@ -4940,18 +4940,18 @@ PPCOpCodesTest::invokeDisabledBitwiseTests()
       OMR_CT_EXPECT_EQ(_lXor, txor(longXorArr[i][0], longXorArr[i][1]), _lXor(longXorArr[i][0], longXorArr[i][1]));
 
       sprintf(resolvedMethodName, "lXorConst1_TestCase%d", i + 1);
-      lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lxor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &(longXorArr[i][0]), 2, &(longXorArr[i][1])));
+      compileOpCodeMethod(lBitwiseConst, 
+            _numberOfBinaryArgs, TR::lxor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &(longXorArr[i][0]), 2, &(longXorArr[i][1]));
       OMR_CT_EXPECT_EQ(lBitwiseConst, txor(longXorArr[i][0], longXorArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lXorConst2_TestCase%d", i + 1);
-      lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lxor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &(longXorArr[i][0])));
+      compileOpCodeMethod(lBitwiseConst, 
+            _numberOfBinaryArgs, TR::lxor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &(longXorArr[i][0]));
       OMR_CT_EXPECT_EQ(lBitwiseConst, txor(longXorArr[i][0], longXorArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, longXorArr[i][1]));
 
       sprintf(resolvedMethodName, "lXorConst3_TestCase%d", i + 1);
-      lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lxor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &(longXorArr[i][1])));
+      compileOpCodeMethod(lBitwiseConst, 
+            _numberOfBinaryArgs, TR::lxor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &(longXorArr[i][1]));
       OMR_CT_EXPECT_EQ(lBitwiseConst, txor(longXorArr[i][0], longXorArr[i][1]), lBitwiseConst(longXorArr[i][0], LONG_PLACEHOLDER_2));
      }
    }
@@ -4961,9 +4961,9 @@ PPCOpCodesTest::compileDisabledTernaryTestMethods()
    {
    int32_t rc = 0;
    //Jazz103 Work Item 109979
-   _fternary = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary, "fTernary", _argTypesTernaryFloat, TR::Float, rc));
-   _dternary = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary, "dTernary", _argTypesTernaryDouble, TR::Double, rc));
-   _lternary = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary, "lTernary", _argTypesTernaryLong, TR::Int64, rc));
+   compileOpCodeMethod(_fternary, _numberOfTernaryArgs, TR::fternary, "fTernary", _argTypesTernaryFloat, TR::Float, rc);
+   compileOpCodeMethod(_dternary, _numberOfTernaryArgs, TR::dternary, "dTernary", _argTypesTernaryDouble, TR::Double, rc);
+   compileOpCodeMethod(_lternary, _numberOfTernaryArgs, TR::lternary, "lTernary", _argTypesTernaryLong, TR::Int64, rc);
 
    }
 
@@ -5064,38 +5064,38 @@ PPCOpCodesTest::invokeDisabledTernaryTest()
       OMR_CT_EXPECT_EQ(_fternary, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), _fternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fTernaryConst1_Testcase%d", i + 1);
-      fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 6, 1, &fternaryChild1Arr[i], 2, &floatDataArr[i][0], 3, &floatDataArr[i][1]));
+      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
+            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 6, 1, &fternaryChild1Arr[i], 2, &floatDataArr[i][0], 3, &floatDataArr[i][1]);
       OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2, FLOAT_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "fTernaryConst2_Testcase%d", i + 1);
-      fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 4, 1, &fternaryChild1Arr[i], 2, &floatDataArr[i][0]));
+      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
+            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 4, 1, &fternaryChild1Arr[i], 2, &floatDataArr[i][0]);
       OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2, floatDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fTernaryConst3_Testcase%d", i + 1);
-      fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 4, 1, &fternaryChild1Arr[i], 3, &floatDataArr[i][1]));
+      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
+            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 4, 1, &fternaryChild1Arr[i], 3, &floatDataArr[i][1]);
       OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, floatDataArr[i][0], FLOAT_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "fTernaryConst4_Testcase%d", i + 1);
-      fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 4, 2, &floatDataArr[i][0], 3, &floatDataArr[i][1]));
+      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
+            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 4, 2, &floatDataArr[i][0], 3, &floatDataArr[i][1]);
       OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(fternaryChild1Arr[i], FLOAT_PLACEHOLDER_2, FLOAT_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "fTernaryConst5_Testcase%d", i + 1);
-      fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 2, 1, &fternaryChild1Arr[i]));
+      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
+            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 2, 1, &fternaryChild1Arr[i]);
       OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, floatDataArr[i][0], floatDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fTernaryConst6_Testcase%d", i + 1);
-      fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 2, 2, &floatDataArr[i][0]));
+      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
+            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 2, 2, &floatDataArr[i][0]);
       OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(fternaryChild1Arr[i], FLOAT_PLACEHOLDER_1, floatDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fTernaryConst7_Testcase%d", i + 1);
-      fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 2, 3, &floatDataArr[i][1]));
+      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
+            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 2, 3, &floatDataArr[i][1]);
       OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(fternaryChild1Arr[i], floatDataArr[i][0], FLOAT_PLACEHOLDER_1));
       }
 
@@ -5107,38 +5107,38 @@ PPCOpCodesTest::invokeDisabledTernaryTest()
       OMR_CT_EXPECT_EQ(_dternary, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), _dternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dTernaryConst1_Testcase%d", i + 1);
-      dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 6, 1, &dternaryChild1Arr[i], 2, &doubleDataArr[i][0], 3, &doubleDataArr[i][1]));
+      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
+            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 6, 1, &dternaryChild1Arr[i], 2, &doubleDataArr[i][0], 3, &doubleDataArr[i][1]);
       OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2, DOUBLE_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "dTernaryConst2_Testcase%d", i + 1);
-      dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 4, 1, &dternaryChild1Arr[i], 2, &doubleDataArr[i][0]));
+      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
+            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 4, 1, &dternaryChild1Arr[i], 2, &doubleDataArr[i][0]);
       OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2, doubleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dTernaryConst3_Testcase%d", i + 1);
-      dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 4, 1, &dternaryChild1Arr[i], 3, &doubleDataArr[i][1]));
+      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
+            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 4, 1, &dternaryChild1Arr[i], 3, &doubleDataArr[i][1]);
       OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, doubleDataArr[i][0], DOUBLE_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "dTernaryConst4_Testcase%d", i + 1);
-      dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 4, 2, &doubleDataArr[i][0], 3, &doubleDataArr[i][1]));
+      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
+            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 4, 2, &doubleDataArr[i][0], 3, &doubleDataArr[i][1]);
       OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(dternaryChild1Arr[i], DOUBLE_PLACEHOLDER_2, DOUBLE_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "dTernaryConst5_Testcase%d", i + 1);
-      dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 2, 1, &dternaryChild1Arr[i]));
+      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
+            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 2, 1, &dternaryChild1Arr[i]);
       OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, doubleDataArr[i][0], doubleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dTernaryConst6_Testcase%d", i + 1);
-      dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 2, 2, &doubleDataArr[i][0]));
+      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
+            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 2, 2, &doubleDataArr[i][0]);
       OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(dternaryChild1Arr[i], DOUBLE_PLACEHOLDER_1, doubleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dTernaryConst7_Testcase%d", i + 1);
-      dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 2, 3, &doubleDataArr[i][1]));
+      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
+            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 2, 3, &doubleDataArr[i][1]);
       OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(dternaryChild1Arr[i], doubleDataArr[i][0], DOUBLE_PLACEHOLDER_1));
       }
 
@@ -5150,32 +5150,32 @@ PPCOpCodesTest::invokeDisabledTernaryTest()
       sprintf(resolvedMethodName, "lTernaryConst%d", i + 1);
       OMR_CT_EXPECT_EQ(_lternary, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), _lternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]));
 
-      lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 6, 1, &lternaryChild1Arr[i], 2, &longArr[i][0], 3, &longArr[i][1]));
+      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
+            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 6, 1, &lternaryChild1Arr[i], 2, &longArr[i][0], 3, &longArr[i][1]);
       OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
 
-      lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 1, &lternaryChild1Arr[i], 2, &longArr[i][0]));
+      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
+            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 1, &lternaryChild1Arr[i], 2, &longArr[i][0]);
       OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, longArr[i][1]));
 
-      lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 1, &lternaryChild1Arr[i], 3, &longArr[i][1]));
+      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
+            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 1, &lternaryChild1Arr[i], 3, &longArr[i][1]);
       OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, longArr[i][0], LONG_PLACEHOLDER_3));
 
-      lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 2, &longArr[i][0], 3, &longArr[i][1]));
+      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
+            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 2, &longArr[i][0], 3, &longArr[i][1]);
       OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
 
-      lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 1, &lternaryChild1Arr[i]));
+      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
+            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 1, &lternaryChild1Arr[i]);
       OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, longArr[i][0], longArr[i][1]));
 
-      lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 2, &longArr[i][0]));
+      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
+            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 2, &longArr[i][0]);
       OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], LONG_PLACEHOLDER_1, longArr[i][1]));
 
-      lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 3, &longArr[i][1]));
+      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
+            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 3, &longArr[i][1]);
       OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], longArr[i][0], LONG_PLACEHOLDER_1));
       }
    }

--- a/fvtest/compilertest/tests/S390OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/S390OpCodesTest.cpp
@@ -192,10 +192,10 @@ S390OpCodesTest::compileDirectCallTestMethods()
 
    int32_t rc = 0;
 #if !defined(TR_TARGET_64BIT)
-   _iCall = (signatureCharI_I_testMethodType *) (compileDirectCallOpCodeMethod(_numberOfUnaryArgs, TR::ireturn, TR::icall, "iCompiledMethod", "iCall", _argTypesUnaryInt, TR::Int32, rc));
-   _lCall = (signatureCharJ_J_testMethodType *) (compileDirectCallOpCodeMethod(_numberOfUnaryArgs, TR::lreturn, TR::lcall, "lCompiledMethod", "lCall", _argTypesUnaryLong, TR::Int64, rc));
-   _dCall = (signatureCharD_D_testMethodType *) (compileDirectCallOpCodeMethod(_numberOfUnaryArgs, TR::dreturn, TR::dcall, "dCompiledMethod", "dCall", _argTypesUnaryDouble, TR::Double, rc));
-   _fCall = (signatureCharF_F_testMethodType *) (compileDirectCallOpCodeMethod(_numberOfUnaryArgs, TR::freturn, TR::fcall, "fCompiledMethod", "fCall", _argTypesUnaryFloat, TR::Float, rc));
+   compileDirectCallOpCodeMethod(_iCall, _numberOfUnaryArgs, TR::ireturn, TR::icall, "iCompiledMethod", "iCall", _argTypesUnaryInt, TR::Int32, rc);
+   compileDirectCallOpCodeMethod(_lCall, _numberOfUnaryArgs, TR::lreturn, TR::lcall, "lCompiledMethod", "lCall", _argTypesUnaryLong, TR::Int64, rc);
+   compileDirectCallOpCodeMethod(_dCall, _numberOfUnaryArgs, TR::dreturn, TR::dcall, "dCompiledMethod", "dCall", _argTypesUnaryDouble, TR::Double, rc);
+   compileDirectCallOpCodeMethod(_fCall, _numberOfUnaryArgs, TR::freturn, TR::fcall, "fCompiledMethod", "fCall", _argTypesUnaryFloat, TR::Float, rc);
 #endif
    }
 
@@ -208,7 +208,7 @@ S390OpCodesTest::compileAddressTestMethods()
    compileOpCodeMethod(_a2s, _numberOfUnaryArgs, TR::a2s, "a2s", _argTypesUnaryAddress, TR::Int16, rc);
    compileOpCodeMethod(_a2l, _numberOfUnaryArgs, TR::a2l, "a2l", _argTypesUnaryAddress, TR::Int64, rc);
 #if !defined(TR_TARGET_64BIT)
-   _acall = (signatureCharL_L_testMethodType *) (compileDirectCallOpCodeMethod(_numberOfUnaryArgs, TR::areturn, TR::acall, "aCompiledMethod", "acall", _argTypesUnaryAddress, TR::Address, rc));
+   compileDirectCallOpCodeMethod(_acall, _numberOfUnaryArgs, TR::areturn, TR::acall, "aCompiledMethod", "acall", _argTypesUnaryAddress, TR::Address, rc);
    compileOpCodeMethod(_i2a, _numberOfUnaryArgs, TR::i2a, "i2a", _argTypesUnaryInt, TR::Address, rc);
    compileOpCodeMethod(_iu2a, _numberOfUnaryArgs, TR::iu2a, "iu2a", _argTypesUnaryInt, TR::Address, rc);
 #endif
@@ -3777,12 +3777,12 @@ S390OpCodesTest::compileDisabledDirectCallTestMethods()
    //Jazz103 Work Item 103419
    int32_t rc = 0;
 #if defined(TR_TARGET_64BIT)
-   _iCall = (signatureCharI_I_testMethodType *) (compileDirectCallOpCodeMethod(_numberOfUnaryArgs, TR::ireturn, TR::icall, "iCompiledMethod", "iCall", _argTypesUnaryInt, TR::Int32, rc));
-   _lCall = (signatureCharJ_J_testMethodType *) (compileDirectCallOpCodeMethod(_numberOfUnaryArgs, TR::lreturn, TR::lcall, "lCompiledMethod", "lCall", _argTypesUnaryLong, TR::Int64, rc));
-   _fCall = (signatureCharF_F_testMethodType *) (compileDirectCallOpCodeMethod(_numberOfUnaryArgs, TR::freturn, TR::fcall, "fCompiledMethod", "fCall", _argTypesUnaryFloat, TR::Float, rc));
-   _acall = (signatureCharL_L_testMethodType *) (compileDirectCallOpCodeMethod(_numberOfUnaryArgs, TR::areturn, TR::acall, "aCompiledMethod", "acall", _argTypesUnaryAddress, TR::Address, rc));
+   compileDirectCallOpCodeMethod(_iCall, _numberOfUnaryArgs, TR::ireturn, TR::icall, "iCompiledMethod", "iCall", _argTypesUnaryInt, TR::Int32, rc);
+   compileDirectCallOpCodeMethod(_lCall, _numberOfUnaryArgs, TR::lreturn, TR::lcall, "lCompiledMethod", "lCall", _argTypesUnaryLong, TR::Int64, rc);
+   compileDirectCallOpCodeMethod(_fCall, _numberOfUnaryArgs, TR::freturn, TR::fcall, "fCompiledMethod", "fCall", _argTypesUnaryFloat, TR::Float, rc);
+   compileDirectCallOpCodeMethod(_acall, _numberOfUnaryArgs, TR::areturn, TR::acall, "aCompiledMethod", "acall", _argTypesUnaryAddress, TR::Address, rc);
 #endif
-   _dCall = (signatureCharD_D_testMethodType *) (compileDirectCallOpCodeMethod(_numberOfUnaryArgs, TR::dreturn, TR::dcall, "dCompiledMethod", "dCall", _argTypesUnaryDouble, TR::Double, rc));
+   compileDirectCallOpCodeMethod(_dCall, _numberOfUnaryArgs, TR::dreturn, TR::dcall, "dCompiledMethod", "dCall", _argTypesUnaryDouble, TR::Double, rc);
    }
 
 void

--- a/fvtest/compilertest/tests/S390OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/S390OpCodesTest.cpp
@@ -32,14 +32,14 @@ S390OpCodesTest::compileIntegerArithmeticTestMethods()
    {
    int32_t rc = 0;
 
-   _lAdd = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ladd, "lAdd", _argTypesBinaryLong, TR::Int64, rc));
-   _lSub = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lsub, "lSub", _argTypesBinaryLong, TR::Int64, rc));
-   _lMul = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lmul, "lMul", _argTypesBinaryLong, TR::Int64, rc));
-   _lDiv = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ldiv, "lDiv", _argTypesBinaryLong, TR::Int64, rc));
-   _lRem = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lrem, "lRem", _argTypesBinaryLong, TR::Int64, rc));
-   _luDiv = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ludiv, "luDiv", _argTypesBinaryLong, TR::Int64, rc));
+   compileOpCodeMethod(_lAdd, _numberOfBinaryArgs, TR::ladd, "lAdd", _argTypesBinaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_lSub, _numberOfBinaryArgs, TR::lsub, "lSub", _argTypesBinaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_lMul, _numberOfBinaryArgs, TR::lmul, "lMul", _argTypesBinaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_lDiv, _numberOfBinaryArgs, TR::ldiv, "lDiv", _argTypesBinaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_lRem, _numberOfBinaryArgs, TR::lrem, "lRem", _argTypesBinaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_luDiv, _numberOfBinaryArgs, TR::ludiv, "luDiv", _argTypesBinaryLong, TR::Int64, rc);
 
-   _iuMulh = (unsignedSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iumulh, "iuMulh", _argTypesBinaryInt, TR::Int32, rc));
+   compileOpCodeMethod(_iuMulh, _numberOfBinaryArgs, TR::iumulh, "iuMulh", _argTypesBinaryInt, TR::Int32, rc);
    }
 
 void
@@ -47,14 +47,14 @@ S390OpCodesTest::compileFloatArithmeticTestMethods()
    {
    int32_t rc = 0;
 
-   _fAdd = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fadd, "fAdd", _argTypesBinaryFloat, TR::Float, rc));
-   _fSub = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fsub, "fSub", _argTypesBinaryFloat, TR::Float, rc));
-   _fMul = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fmul, "fMul", _argTypesBinaryFloat, TR::Float, rc));
-   _fDiv = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fdiv, "fDiv", _argTypesBinaryFloat, TR::Float, rc));
-   _dAdd = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dadd, "dAdd", _argTypesBinaryDouble, TR::Double, rc));
-   _dSub = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dsub, "dSub", _argTypesBinaryDouble, TR::Double, rc));
-   _dMul = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dmul, "dMul", _argTypesBinaryDouble, TR::Double, rc));
-   _dDiv = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ddiv, "dDiv", _argTypesBinaryDouble, TR::Double, rc));
+   compileOpCodeMethod(_fAdd, _numberOfBinaryArgs, TR::fadd, "fAdd", _argTypesBinaryFloat, TR::Float, rc);
+   compileOpCodeMethod(_fSub, _numberOfBinaryArgs, TR::fsub, "fSub", _argTypesBinaryFloat, TR::Float, rc);
+   compileOpCodeMethod(_fMul, _numberOfBinaryArgs, TR::fmul, "fMul", _argTypesBinaryFloat, TR::Float, rc);
+   compileOpCodeMethod(_fDiv, _numberOfBinaryArgs, TR::fdiv, "fDiv", _argTypesBinaryFloat, TR::Float, rc);
+   compileOpCodeMethod(_dAdd, _numberOfBinaryArgs, TR::dadd, "dAdd", _argTypesBinaryDouble, TR::Double, rc);
+   compileOpCodeMethod(_dSub, _numberOfBinaryArgs, TR::dsub, "dSub", _argTypesBinaryDouble, TR::Double, rc);
+   compileOpCodeMethod(_dMul, _numberOfBinaryArgs, TR::dmul, "dMul", _argTypesBinaryDouble, TR::Double, rc);
+   compileOpCodeMethod(_dDiv, _numberOfBinaryArgs, TR::ddiv, "dDiv", _argTypesBinaryDouble, TR::Double, rc);
 
    }
 
@@ -63,47 +63,47 @@ S390OpCodesTest::compileMemoryOperationTestMethods()
    {
    int32_t rc = 0;
 
-   _lStore = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lstore, "lStore", _argTypesUnaryLong, TR::Int64, rc));
-   _dStore = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dstore, "dStore", _argTypesUnaryDouble, TR::Double, rc));
-   _fStore = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::fstore, "fStore", _argTypesUnaryFloat, TR::Float, rc));
+   compileOpCodeMethod(_lStore, _numberOfUnaryArgs, TR::lstore, "lStore", _argTypesUnaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_dStore, _numberOfUnaryArgs, TR::dstore, "dStore", _argTypesUnaryDouble, TR::Double, rc);
+   compileOpCodeMethod(_fStore, _numberOfUnaryArgs, TR::fstore, "fStore", _argTypesUnaryFloat, TR::Float, rc);
 
-   _iStorei = (signatureCharLI_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::istorei, "iStorei", _argTypesBinaryAddressInt, TR::Int32, rc));
-   _lStorei = (signatureCharLJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lstorei, "lStorei", _argTypesBinaryAddressLong, TR::Int64, rc));
-   _dStorei = (signatureCharLD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dstorei, "dStorei", _argTypesBinaryAddressDouble, TR::Double, rc));
-   _fStorei = (signatureCharLF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fstorei, "fStorei", _argTypesBinaryAddressFloat, TR::Float, rc));
-   _aStorei = (signatureCharLL_L_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::astorei, "aStorei", _argTypesBinaryAddressAddress, TR::Address, rc));
+   compileOpCodeMethod(_iStorei, _numberOfBinaryArgs, TR::istorei, "iStorei", _argTypesBinaryAddressInt, TR::Int32, rc);
+   compileOpCodeMethod(_lStorei, _numberOfBinaryArgs, TR::lstorei, "lStorei", _argTypesBinaryAddressLong, TR::Int64, rc);
+   compileOpCodeMethod(_dStorei, _numberOfBinaryArgs, TR::dstorei, "dStorei", _argTypesBinaryAddressDouble, TR::Double, rc);
+   compileOpCodeMethod(_fStorei, _numberOfBinaryArgs, TR::fstorei, "fStorei", _argTypesBinaryAddressFloat, TR::Float, rc);
+   compileOpCodeMethod(_aStorei, _numberOfBinaryArgs, TR::astorei, "aStorei", _argTypesBinaryAddressAddress, TR::Address, rc);
    }
 
 void
 S390OpCodesTest::compileUnaryTestMethods()
    {
    int32_t rc = 0;
-   _dNeg = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dneg, "dNeg", _argTypesUnaryDouble, TR::Double, rc));
-   _fNeg = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::fneg, "fNeg", _argTypesUnaryFloat, TR::Float, rc));
-   _lNeg = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lneg, "lNeg", _argTypesUnaryLong, TR::Int64, rc));
+   compileOpCodeMethod(_dNeg, _numberOfUnaryArgs, TR::dneg, "dNeg", _argTypesUnaryDouble, TR::Double, rc);
+   compileOpCodeMethod(_fNeg, _numberOfUnaryArgs, TR::fneg, "fNeg", _argTypesUnaryFloat, TR::Float, rc);
+   compileOpCodeMethod(_lNeg, _numberOfUnaryArgs, TR::lneg, "lNeg", _argTypesUnaryLong, TR::Int64, rc);
 
-   _lAbs = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::labs, "lAbs", _argTypesUnaryLong, TR::Int64, rc));
-   _fAbs = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::fabs, "fAbs", _argTypesUnaryFloat, TR::Float, rc));
-   _dAbs = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dabs, "dAbs", _argTypesUnaryDouble, TR::Double, rc));
+   compileOpCodeMethod(_lAbs, _numberOfUnaryArgs, TR::labs, "lAbs", _argTypesUnaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_fAbs, _numberOfUnaryArgs, TR::fabs, "fAbs", _argTypesUnaryFloat, TR::Float, rc);
+   compileOpCodeMethod(_dAbs, _numberOfUnaryArgs, TR::dabs, "dAbs", _argTypesUnaryDouble, TR::Double, rc);
 
-   _lReturn = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lreturn, "lReturn", _argTypesUnaryLong, TR::Int64, rc));
-   _dReturn = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dreturn, "dReturn", _argTypesUnaryDouble, TR::Double, rc));
-   _fReturn = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::freturn, "fReturn", _argTypesUnaryFloat, TR::Float, rc));
+   compileOpCodeMethod(_lReturn, _numberOfUnaryArgs, TR::lreturn, "lReturn", _argTypesUnaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_dReturn, _numberOfUnaryArgs, TR::dreturn, "dReturn", _argTypesUnaryDouble, TR::Double, rc);
+   compileOpCodeMethod(_fReturn, _numberOfUnaryArgs, TR::freturn, "fReturn", _argTypesUnaryFloat, TR::Float, rc);
 
-   _i2f = (signatureCharI_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::i2f, "i2f", _argTypesUnaryInt, TR::Float, rc));
-   _i2d = (signatureCharI_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::i2d, "i2d", _argTypesUnaryInt, TR::Double, rc));
-   _iu2d = (unsignedSignatureCharI_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iu2d, "iU2d", _argTypesUnaryInt, TR::Double, rc));
-   _iu2l = (unsignedSignatureCharI_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iu2l, "iu2l", _argTypesUnaryInt, TR::Int64, rc));
-   _l2f = (signatureCharJ_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::l2f, "l2f", _argTypesUnaryLong, TR::Float, rc));
-   _l2d = (signatureCharJ_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::l2d, "l2d", _argTypesUnaryLong, TR::Double, rc));
-   _f2l = (signatureCharF_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2l, "f2l", _argTypesUnaryFloat, TR::Int64, rc));
-   _f2d = (signatureCharF_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2d, "f2d", _argTypesUnaryFloat, TR::Double, rc));
-   _d2f = (signatureCharD_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2f, "d2f", _argTypesUnaryDouble, TR::Float, rc));
-   _d2l = (signatureCharD_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2l, "d2l", _argTypesUnaryDouble, TR::Int64, rc));
-   _d2b = (signatureCharD_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2b, "d2b", _argTypesUnaryDouble, TR::Int8, rc));
-   _d2s = (signatureCharD_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2s, "d2s", _argTypesUnaryDouble, TR::Int16, rc));
-   _f2b = (signatureCharF_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2b, "f2b", _argTypesUnaryFloat, TR::Int8, rc));
-   _f2s = (signatureCharF_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2s, "f2s", _argTypesUnaryFloat, TR::Int16, rc));
+   compileOpCodeMethod(_i2f, _numberOfUnaryArgs, TR::i2f, "i2f", _argTypesUnaryInt, TR::Float, rc);
+   compileOpCodeMethod(_i2d, _numberOfUnaryArgs, TR::i2d, "i2d", _argTypesUnaryInt, TR::Double, rc);
+   compileOpCodeMethod(_iu2d, _numberOfUnaryArgs, TR::iu2d, "iU2d", _argTypesUnaryInt, TR::Double, rc);
+   compileOpCodeMethod(_iu2l, _numberOfUnaryArgs, TR::iu2l, "iu2l", _argTypesUnaryInt, TR::Int64, rc);
+   compileOpCodeMethod(_l2f, _numberOfUnaryArgs, TR::l2f, "l2f", _argTypesUnaryLong, TR::Float, rc);
+   compileOpCodeMethod(_l2d, _numberOfUnaryArgs, TR::l2d, "l2d", _argTypesUnaryLong, TR::Double, rc);
+   compileOpCodeMethod(_f2l, _numberOfUnaryArgs, TR::f2l, "f2l", _argTypesUnaryFloat, TR::Int64, rc);
+   compileOpCodeMethod(_f2d, _numberOfUnaryArgs, TR::f2d, "f2d", _argTypesUnaryFloat, TR::Double, rc);
+   compileOpCodeMethod(_d2f, _numberOfUnaryArgs, TR::d2f, "d2f", _argTypesUnaryDouble, TR::Float, rc);
+   compileOpCodeMethod(_d2l, _numberOfUnaryArgs, TR::d2l, "d2l", _argTypesUnaryDouble, TR::Int64, rc);
+   compileOpCodeMethod(_d2b, _numberOfUnaryArgs, TR::d2b, "d2b", _argTypesUnaryDouble, TR::Int8, rc);
+   compileOpCodeMethod(_d2s, _numberOfUnaryArgs, TR::d2s, "d2s", _argTypesUnaryDouble, TR::Int16, rc);
+   compileOpCodeMethod(_f2b, _numberOfUnaryArgs, TR::f2b, "f2b", _argTypesUnaryFloat, TR::Int8, rc);
+   compileOpCodeMethod(_f2s, _numberOfUnaryArgs, TR::f2s, "f2s", _argTypesUnaryFloat, TR::Int16, rc);
    }
 
 void
@@ -111,10 +111,10 @@ S390OpCodesTest::compileShiftOrRolTestMethods()
    {
    int32_t rc = 0;
 #if defined(TR_TARGET_64BIT)
-   _lShl = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lshl, "lShl", _argTypesBinaryLong, TR::Int64, rc));
-   _lShr = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lshr, "lShr", _argTypesBinaryLong, TR::Int64, rc));
-   _luShr = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lushr, "luShr", _argTypesBinaryLong, TR::Int64, rc));
-   _lRol = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lrol, "lRol", _argTypesBinaryLong, TR::Int64, rc));
+   compileOpCodeMethod(_lShl, _numberOfBinaryArgs, TR::lshl, "lShl", _argTypesBinaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_lShr, _numberOfBinaryArgs, TR::lshr, "lShr", _argTypesBinaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_luShr, _numberOfBinaryArgs, TR::lushr, "luShr", _argTypesBinaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_lRol, _numberOfBinaryArgs, TR::lrol, "lRol", _argTypesBinaryLong, TR::Int64, rc);
 #endif
    }
 
@@ -123,9 +123,9 @@ S390OpCodesTest::compileBitwiseTestMethods()
    {
    int32_t rc;
 
-   _lAnd = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::land, "lAnd", _argTypesBinaryLong, TR::Int64, rc));
-   _lOr = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lor, "lOr", _argTypesBinaryLong, TR::Int64, rc));
-   _lXor = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lxor, "lXor", _argTypesBinaryLong, TR::Int64, rc));
+   compileOpCodeMethod(_lAnd, _numberOfBinaryArgs, TR::land, "lAnd", _argTypesBinaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_lOr, _numberOfBinaryArgs, TR::lor, "lOr", _argTypesBinaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_lXor, _numberOfBinaryArgs, TR::lxor, "lXor", _argTypesBinaryLong, TR::Int64, rc);
 
    }
 
@@ -133,7 +133,7 @@ void
 S390OpCodesTest::compileTernaryTestMethods()
    {
    int32_t rc = 0;
-   _lternary = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary, "lTernary", _argTypesTernaryLong, TR::Int64, rc));
+   compileOpCodeMethod(_lternary, _numberOfTernaryArgs, TR::lternary, "lTernary", _argTypesTernaryLong, TR::Int64, rc);
 
    }
 
@@ -143,46 +143,46 @@ S390OpCodesTest::compileCompareTestMethods()
    int32_t rc = 0;
 
    //Compare
-   _lCmpeq = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lcmpeq, "lCmpeq", _argTypesBinaryLong, TR::Int32, rc));
-   _lCmplt = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lcmplt, "lCmplt", _argTypesBinaryLong, TR::Int32, rc));
+   compileOpCodeMethod(_lCmpeq, _numberOfBinaryArgs, TR::lcmpeq, "lCmpeq", _argTypesBinaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_lCmplt, _numberOfBinaryArgs, TR::lcmplt, "lCmplt", _argTypesBinaryLong, TR::Int32, rc);
 
-   _dCmpeq = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dcmpeq, "dCmpeq", _argTypesBinaryDouble, TR::Int32, rc));
-   _dCmpne = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dcmpne, "dCmpne", _argTypesBinaryDouble, TR::Int32, rc));
-   _dCmpgt = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dcmpgt, "dCmpgt", _argTypesBinaryDouble, TR::Int32, rc));
-   _dCmplt = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dcmplt, "dCmplt", _argTypesBinaryDouble, TR::Int32, rc));
-   _dCmpge = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dcmpge, "dCmpge", _argTypesBinaryDouble, TR::Int32, rc));
-   _dCmple = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dcmple, "dCmple", _argTypesBinaryDouble, TR::Int32, rc));
+   compileOpCodeMethod(_dCmpeq, _numberOfBinaryArgs, TR::dcmpeq, "dCmpeq", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_dCmpne, _numberOfBinaryArgs, TR::dcmpne, "dCmpne", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_dCmpgt, _numberOfBinaryArgs, TR::dcmpgt, "dCmpgt", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_dCmplt, _numberOfBinaryArgs, TR::dcmplt, "dCmplt", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_dCmpge, _numberOfBinaryArgs, TR::dcmpge, "dCmpge", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_dCmple, _numberOfBinaryArgs, TR::dcmple, "dCmple", _argTypesBinaryDouble, TR::Int32, rc);
 
-   _fCmpeq = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fcmpeq, "fCmpeq", _argTypesBinaryFloat, TR::Int32, rc));
-   _fCmpne = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fcmpne, "fCmpne", _argTypesBinaryFloat, TR::Int32, rc));
-   _fCmpgt = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fcmpgt, "fCmpgt", _argTypesBinaryFloat, TR::Int32, rc));
-   _fCmplt = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fcmplt, "fCmplt", _argTypesBinaryFloat, TR::Int32, rc));
-   _fCmpge = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fcmpge, "fCmpge", _argTypesBinaryFloat, TR::Int32, rc));
-   _fCmple = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fcmple, "fCmple", _argTypesBinaryFloat, TR::Int32, rc));
+   compileOpCodeMethod(_fCmpeq, _numberOfBinaryArgs, TR::fcmpeq, "fCmpeq", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_fCmpne, _numberOfBinaryArgs, TR::fcmpne, "fCmpne", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_fCmpgt, _numberOfBinaryArgs, TR::fcmpgt, "fCmpgt", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_fCmplt, _numberOfBinaryArgs, TR::fcmplt, "fCmplt", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_fCmpge, _numberOfBinaryArgs, TR::fcmpge, "fCmpge", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_fCmple, _numberOfBinaryArgs, TR::fcmple, "fCmple", _argTypesBinaryFloat, TR::Int32, rc);
 
-   _lCmp = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lcmp, "lCmp", _argTypesBinaryLong, TR::Int32, rc));
-   _fCmpl = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fcmpl, "fCmpl", _argTypesBinaryFloat, TR::Int32, rc));
-   _fCmpg = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fcmpg, "fCmpg", _argTypesBinaryFloat, TR::Int32, rc));
-   _dCmpl = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dcmpl, "dCmpl", _argTypesBinaryDouble, TR::Int32, rc));
-   _dCmpg = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dcmpg, "dCmpg", _argTypesBinaryDouble, TR::Int32, rc));
+   compileOpCodeMethod(_lCmp, _numberOfBinaryArgs, TR::lcmp, "lCmp", _argTypesBinaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_fCmpl, _numberOfBinaryArgs, TR::fcmpl, "fCmpl", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_fCmpg, _numberOfBinaryArgs, TR::fcmpg, "fCmpg", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_dCmpl, _numberOfBinaryArgs, TR::dcmpl, "dCmpl", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_dCmpg, _numberOfBinaryArgs, TR::dcmpg, "dCmpg", _argTypesBinaryDouble, TR::Int32, rc);
 
-   _ifLcmpeq = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iflcmpeq, "ifLcmpeq", _argTypesBinaryLong, TR::Int32, rc));
-   _ifLcmpgt = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iflcmpgt, "ifLcmpgt", _argTypesBinaryLong, TR::Int32, rc));
-   _ifLcmplt = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iflcmplt, "ifLcmplt", _argTypesBinaryLong, TR::Int32, rc));
+   compileOpCodeMethod(_ifLcmpeq, _numberOfBinaryArgs, TR::iflcmpeq, "ifLcmpeq", _argTypesBinaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_ifLcmpgt, _numberOfBinaryArgs, TR::iflcmpgt, "ifLcmpgt", _argTypesBinaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_ifLcmplt, _numberOfBinaryArgs, TR::iflcmplt, "ifLcmplt", _argTypesBinaryLong, TR::Int32, rc);
 
-   _ifDcmpeq = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifdcmpeq, "ifDcmpeq", _argTypesBinaryDouble, TR::Int32, rc));
-   _ifDcmpne = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifdcmpne, "ifDcmpne", _argTypesBinaryDouble, TR::Int32, rc));
-   _ifDcmpgt = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifdcmpgt, "ifDcmpgt", _argTypesBinaryDouble, TR::Int32, rc));
-   _ifDcmplt = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifdcmplt, "ifDcmplt", _argTypesBinaryDouble, TR::Int32, rc));
-   _ifDcmpge = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifdcmpge, "ifDcmpge", _argTypesBinaryDouble, TR::Int32, rc));
-   _ifDcmple = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifdcmple, "ifDcmple", _argTypesBinaryDouble, TR::Int32, rc));
+   compileOpCodeMethod(_ifDcmpeq, _numberOfBinaryArgs, TR::ifdcmpeq, "ifDcmpeq", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_ifDcmpne, _numberOfBinaryArgs, TR::ifdcmpne, "ifDcmpne", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_ifDcmpgt, _numberOfBinaryArgs, TR::ifdcmpgt, "ifDcmpgt", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_ifDcmplt, _numberOfBinaryArgs, TR::ifdcmplt, "ifDcmplt", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_ifDcmpge, _numberOfBinaryArgs, TR::ifdcmpge, "ifDcmpge", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_ifDcmple, _numberOfBinaryArgs, TR::ifdcmple, "ifDcmple", _argTypesBinaryDouble, TR::Int32, rc);
 
-   _ifFcmpeq = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iffcmpeq, "ifFcmpeq", _argTypesBinaryFloat, TR::Int32, rc));
-   _ifFcmpne = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iffcmpne, "ifFcmpne", _argTypesBinaryFloat, TR::Int32, rc));
-   _ifFcmpgt = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iffcmpgt, "ifFcmpgt", _argTypesBinaryFloat, TR::Int32, rc));
-   _ifFcmplt = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iffcmplt, "ifFcmplt", _argTypesBinaryFloat, TR::Int32, rc));
-   _ifFcmpge = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iffcmpge, "ifFcmpge", _argTypesBinaryFloat, TR::Int32, rc));
-   _ifFcmple = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iffcmple, "ifFcmple", _argTypesBinaryFloat, TR::Int32, rc));
+   compileOpCodeMethod(_ifFcmpeq, _numberOfBinaryArgs, TR::iffcmpeq, "ifFcmpeq", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_ifFcmpne, _numberOfBinaryArgs, TR::iffcmpne, "ifFcmpne", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_ifFcmpgt, _numberOfBinaryArgs, TR::iffcmpgt, "ifFcmpgt", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_ifFcmplt, _numberOfBinaryArgs, TR::iffcmplt, "ifFcmplt", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_ifFcmpge, _numberOfBinaryArgs, TR::iffcmpge, "ifFcmpge", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_ifFcmple, _numberOfBinaryArgs, TR::iffcmple, "ifFcmple", _argTypesBinaryFloat, TR::Int32, rc);
 
    }
 
@@ -204,30 +204,30 @@ S390OpCodesTest::compileAddressTestMethods()
    {
    int32_t rc = 0;
 
-   _a2b = (signatureCharL_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::a2b, "a2b", _argTypesUnaryAddress, TR::Int8, rc));
-   _a2s = (signatureCharL_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::a2s, "a2s", _argTypesUnaryAddress, TR::Int16, rc));
-   _a2l = (signatureCharL_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::a2l, "a2l", _argTypesUnaryAddress, TR::Int64, rc));
+   compileOpCodeMethod(_a2b, _numberOfUnaryArgs, TR::a2b, "a2b", _argTypesUnaryAddress, TR::Int8, rc);
+   compileOpCodeMethod(_a2s, _numberOfUnaryArgs, TR::a2s, "a2s", _argTypesUnaryAddress, TR::Int16, rc);
+   compileOpCodeMethod(_a2l, _numberOfUnaryArgs, TR::a2l, "a2l", _argTypesUnaryAddress, TR::Int64, rc);
 #if !defined(TR_TARGET_64BIT)
    _acall = (signatureCharL_L_testMethodType *) (compileDirectCallOpCodeMethod(_numberOfUnaryArgs, TR::areturn, TR::acall, "aCompiledMethod", "acall", _argTypesUnaryAddress, TR::Address, rc));
-   _i2a = (signatureCharI_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::i2a, "i2a", _argTypesUnaryInt, TR::Address, rc));
-   _iu2a = (unsignedSignatureCharI_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iu2a, "iu2a", _argTypesUnaryInt, TR::Address, rc));
+   compileOpCodeMethod(_i2a, _numberOfUnaryArgs, TR::i2a, "i2a", _argTypesUnaryInt, TR::Address, rc);
+   compileOpCodeMethod(_iu2a, _numberOfUnaryArgs, TR::iu2a, "iu2a", _argTypesUnaryInt, TR::Address, rc);
 #endif
-   _l2a = (signatureCharJ_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::l2a, "l2a", _argTypesUnaryLong, TR::Address, rc));
-   _lu2a = (unsignedSignatureCharJ_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lu2a, "lu2a", _argTypesUnaryLong, TR::Address, rc));
+   compileOpCodeMethod(_l2a, _numberOfUnaryArgs, TR::l2a, "l2a", _argTypesUnaryLong, TR::Address, rc);
+   compileOpCodeMethod(_lu2a, _numberOfUnaryArgs, TR::lu2a, "lu2a", _argTypesUnaryLong, TR::Address, rc);
 
-   _acmpeq = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::acmpeq, "acmpeq", _argTypesBinaryAddress, TR::Int32, rc));
-   _acmpne = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::acmpne, "acmpne", _argTypesBinaryAddress, TR::Int32, rc));
-   _acmplt = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::acmplt, "acmplt", _argTypesBinaryAddress, TR::Int32, rc));
-   _acmpge = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::acmpge, "acmpge", _argTypesBinaryAddress, TR::Int32, rc));
-   _acmple = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::acmple, "acmple", _argTypesBinaryAddress, TR::Int32, rc));
-   _acmpgt = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::acmpgt, "acmpgt", _argTypesBinaryAddress, TR::Int32, rc));
-   _ifacmpeq = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifacmpeq, "ifacmpeq", _argTypesBinaryAddress, TR::Int32, rc));
-   _ifacmpne = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifacmpne, "ifacmpne", _argTypesBinaryAddress, TR::Int32, rc));
-   _ifacmplt = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifacmplt, "ifacmplt", _argTypesBinaryAddress, TR::Int32, rc));
-   _ifacmpge = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifacmpge, "ifacmpge", _argTypesBinaryAddress, TR::Int32, rc));
-   _ifacmple = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifacmple, "ifacmple", _argTypesBinaryAddress, TR::Int32, rc));
-   _ifacmpgt = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifacmpgt, "ifacmpgt", _argTypesBinaryAddress, TR::Int32, rc));
-   _aternary = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::aternary, "aternary", _argTypesTernaryAddress, TR::Address, rc));
+   compileOpCodeMethod(_acmpeq, _numberOfBinaryArgs, TR::acmpeq, "acmpeq", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_acmpne, _numberOfBinaryArgs, TR::acmpne, "acmpne", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_acmplt, _numberOfBinaryArgs, TR::acmplt, "acmplt", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_acmpge, _numberOfBinaryArgs, TR::acmpge, "acmpge", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_acmple, _numberOfBinaryArgs, TR::acmple, "acmple", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_acmpgt, _numberOfBinaryArgs, TR::acmpgt, "acmpgt", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_ifacmpeq, _numberOfBinaryArgs, TR::ifacmpeq, "ifacmpeq", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_ifacmpne, _numberOfBinaryArgs, TR::ifacmpne, "ifacmpne", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_ifacmplt, _numberOfBinaryArgs, TR::ifacmplt, "ifacmplt", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_ifacmpge, _numberOfBinaryArgs, TR::ifacmpge, "ifacmpge", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_ifacmple, _numberOfBinaryArgs, TR::ifacmple, "ifacmple", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_ifacmpgt, _numberOfBinaryArgs, TR::ifacmpgt, "ifacmpgt", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_aternary, _numberOfTernaryArgs, TR::aternary, "aternary", _argTypesTernaryAddress, TR::Address, rc);
    }
 
 void
@@ -301,18 +301,18 @@ S390OpCodesTest::invokeIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_lAdd, add(longAddArr[i][0], longAddArr[i][1]), _lAdd(longAddArr[i][0], longAddArr[i][1]));
 
       sprintf(resolvedMethodName, "lAddConst1_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ladd,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longAddArr[i][0], 2, &longAddArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::ladd,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longAddArr[i][0], 2, &longAddArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, add(longAddArr[i][0], longAddArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lAddConst2_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ladd,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longAddArr[i][0]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::ladd,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longAddArr[i][0]);
       OMR_CT_EXPECT_EQ(lBinaryCons, add(longAddArr[i][0], longAddArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longAddArr[i][1]));
 
       sprintf(resolvedMethodName, "lAddConst3_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ladd,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longAddArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::ladd,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longAddArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, add(longAddArr[i][0], longAddArr[i][1]), lBinaryCons(longAddArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -323,18 +323,18 @@ S390OpCodesTest::invokeIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_lSub, sub(longSubArr[i][0], longSubArr[i][1]), _lSub(longSubArr[i][0], longSubArr[i][1]));
 
       sprintf(resolvedMethodName, "lSubConst1_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lsub,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longSubArr[i][0], 2, &longSubArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::lsub,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longSubArr[i][0], 2, &longSubArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, sub(longSubArr[i][0], longSubArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lSubConst2_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lsub,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longSubArr[i][0]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::lsub,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longSubArr[i][0]);
       OMR_CT_EXPECT_EQ(lBinaryCons, sub(longSubArr[i][0], longSubArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longSubArr[i][1]));
 
       sprintf(resolvedMethodName, "lSubConst3_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lsub,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longSubArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::lsub,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longSubArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, sub(longSubArr[i][0], longSubArr[i][1]), lBinaryCons(longSubArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -345,18 +345,18 @@ S390OpCodesTest::invokeIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_lMul, mul(longMulArr[i][0], longMulArr[i][1]), _lMul(longMulArr[i][0], longMulArr[i][1]));
 
       sprintf(resolvedMethodName, "lMulConst1_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lmul,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longMulArr[i][0], 2, &longMulArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::lmul,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longMulArr[i][0], 2, &longMulArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, mul(longMulArr[i][0], longMulArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lMulConst2_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lmul,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longMulArr[i][0]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::lmul,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longMulArr[i][0]);
       OMR_CT_EXPECT_EQ(lBinaryCons, mul(longMulArr[i][0], longMulArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longMulArr[i][1]));
 
       sprintf(resolvedMethodName, "lMulConst3_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lmul,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longMulArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::lmul,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longMulArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, mul(longMulArr[i][0], longMulArr[i][1]), lBinaryCons(longMulArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -373,18 +373,18 @@ S390OpCodesTest::invokeIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_lDiv, div(longDivArr[i][0], longDivArr[i][1]), _lDiv(longDivArr[i][0], longDivArr[i][1]));
 
       sprintf(resolvedMethodName, "lDivConst1_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ldiv,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longDivArr[i][0], 2, &longDivArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::ldiv,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longDivArr[i][0], 2, &longDivArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, div(longDivArr[i][0], longDivArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lDivConst2_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ldiv,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longDivArr[i][0]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::ldiv,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longDivArr[i][0]);
       OMR_CT_EXPECT_EQ(lBinaryCons, div(longDivArr[i][0], longDivArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longDivArr[i][1]));
 
       sprintf(resolvedMethodName, "lDivConst3_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ldiv,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longDivArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::ldiv,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longDivArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, div(longDivArr[i][0], longDivArr[i][1]), lBinaryCons(longDivArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -396,18 +396,18 @@ S390OpCodesTest::invokeIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_lRem, rem(longRemArr[i][0], longRemArr[i][1]), _lRem(longRemArr[i][0], longRemArr[i][1]));
 
       sprintf(resolvedMethodName, "lRemConst1_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lrem,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longRemArr[i][0], 2, &longRemArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::lrem,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longRemArr[i][0], 2, &longRemArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, rem(longRemArr[i][0], longRemArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lRemConst2_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lrem,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longRemArr[i][0]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::lrem,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longRemArr[i][0]);
       OMR_CT_EXPECT_EQ(lBinaryCons, rem(longRemArr[i][0], longRemArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longRemArr[i][1]));
 
       sprintf(resolvedMethodName, "lRemConst3_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lrem,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longRemArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::lrem,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longRemArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, rem(longRemArr[i][0], longRemArr[i][1]), lBinaryCons(longRemArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -419,18 +419,18 @@ S390OpCodesTest::invokeIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_luDiv, div(ulongDivArr[i][0], ulongDivArr[i][1]), _luDiv(ulongDivArr[i][0], ulongDivArr[i][1]));
 
       sprintf(resolvedMethodName, "luDivConst1_Testcase%d", i);
-      luBinaryCons = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ludiv, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &ulongDivArr[i][0], 2, &ulongDivArr[i][1]));
+      compileOpCodeMethod(luBinaryCons, 
+            _numberOfBinaryArgs, TR::ludiv, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &ulongDivArr[i][0], 2, &ulongDivArr[i][1]);
       OMR_CT_EXPECT_EQ(luBinaryCons, div(ulongDivArr[i][0], ulongDivArr[i][1]), luBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "luDivConst2_Testcase%d", i);
-      luBinaryCons = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ludiv, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &ulongDivArr[i][0]));
+      compileOpCodeMethod(luBinaryCons, 
+            _numberOfBinaryArgs, TR::ludiv, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &ulongDivArr[i][0]);
       OMR_CT_EXPECT_EQ(luBinaryCons, div(ulongDivArr[i][0], ulongDivArr[i][1]), luBinaryCons(LONG_PLACEHOLDER_1, ulongDivArr[i][1]));
 
       sprintf(resolvedMethodName, "luDivConst3_Testcase%d", i);
-      luBinaryCons = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ludiv, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &ulongDivArr[i][1]));
+      compileOpCodeMethod(luBinaryCons, 
+            _numberOfBinaryArgs, TR::ludiv, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &ulongDivArr[i][1]);
       OMR_CT_EXPECT_EQ(luBinaryCons, div(ulongDivArr[i][0], ulongDivArr[i][1]), luBinaryCons(ulongDivArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -519,18 +519,18 @@ S390OpCodesTest::invokeFloatArithmeticTests()
       OMR_CT_EXPECT_FLOAT_EQ(_fAdd, add(floatAddArr[i][0], floatAddArr[i][1]), _fAdd(floatAddArr[i][0], floatAddArr[i][1]));
 
       sprintf(resolvedMethodName, "fAddConst1_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fadd,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatAddArr[i][0], 2, &floatAddArr[i][1]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fadd,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatAddArr[i][0], 2, &floatAddArr[i][1]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, add(floatAddArr[i][0], floatAddArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fAddConst2_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fadd,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatAddArr[i][0]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fadd,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatAddArr[i][0]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, add(floatAddArr[i][0], floatAddArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatAddArr[i][1]));
 
       sprintf(resolvedMethodName, "fAddConst3_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fadd,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatAddArr[i][1]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fadd,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatAddArr[i][1]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, add(floatAddArr[i][0], floatAddArr[i][1]), fBinaryConst(floatAddArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -541,18 +541,18 @@ S390OpCodesTest::invokeFloatArithmeticTests()
       OMR_CT_EXPECT_FLOAT_EQ(_fSub, sub(floatSubArr[i][0], floatSubArr[i][1]), _fSub(floatSubArr[i][0], floatSubArr[i][1]));
 
       sprintf(resolvedMethodName, "fSubConst1_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fsub,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatSubArr[i][0], 2, &floatSubArr[i][1]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fsub,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatSubArr[i][0], 2, &floatSubArr[i][1]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, sub(floatSubArr[i][0], floatSubArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fSubConst2_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fsub,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatSubArr[i][0]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fsub,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatSubArr[i][0]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, sub(floatSubArr[i][0], floatSubArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatSubArr[i][1]));
 
       sprintf(resolvedMethodName, "fSubConst3_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fsub,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatSubArr[i][1]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fsub,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatSubArr[i][1]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, sub(floatSubArr[i][0], floatSubArr[i][1]), fBinaryConst(floatSubArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -563,18 +563,18 @@ S390OpCodesTest::invokeFloatArithmeticTests()
       OMR_CT_EXPECT_FLOAT_EQ(_fMul, mul(floatMulArr[i][0], floatMulArr[i][1]), _fMul(floatMulArr[i][0], floatMulArr[i][1]));
 
       sprintf(resolvedMethodName, "fMulConst1_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fmul,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatMulArr[i][0], 2, &floatMulArr[i][1]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fmul,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatMulArr[i][0], 2, &floatMulArr[i][1]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, mul(floatMulArr[i][0], floatMulArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fMulConst2_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fmul,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatMulArr[i][0]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fmul,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatMulArr[i][0]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, mul(floatMulArr[i][0], floatMulArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatMulArr[i][1]));
 
       sprintf(resolvedMethodName, "fMulConst3_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fmul,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatMulArr[i][1]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fmul,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatMulArr[i][1]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, mul(floatMulArr[i][0], floatMulArr[i][1]), fBinaryConst(floatMulArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -585,18 +585,18 @@ S390OpCodesTest::invokeFloatArithmeticTests()
       OMR_CT_EXPECT_FLOAT_EQ(_fDiv, div(floatDivArr[i][0], floatDivArr[i][1]), _fDiv(floatDivArr[i][0], floatDivArr[i][1]));
 
       sprintf(resolvedMethodName, "fDivConst1_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fdiv,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatDivArr[i][0], 2, &floatDivArr[i][1]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fdiv,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatDivArr[i][0], 2, &floatDivArr[i][1]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, div(floatDivArr[i][0], floatDivArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fDivConst2_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fdiv,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatDivArr[i][0]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fdiv,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatDivArr[i][0]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, div(floatDivArr[i][0], floatDivArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatDivArr[i][1]));
 
       sprintf(resolvedMethodName, "fDivConst3_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fdiv,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatDivArr[i][1]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fdiv,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatDivArr[i][1]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, div(floatDivArr[i][0], floatDivArr[i][1]), fBinaryConst(floatDivArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -606,18 +606,18 @@ S390OpCodesTest::invokeFloatArithmeticTests()
       OMR_CT_EXPECT_DOUBLE_EQ(_dAdd, add(doubleAddArr[i][0], doubleAddArr[i][1]), _dAdd(doubleAddArr[i][0], doubleAddArr[i][1]));
 
       sprintf(resolvedMethodName, "dAddConst1_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dadd,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleAddArr[i][0], 2, &doubleAddArr[i][1]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::dadd,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleAddArr[i][0], 2, &doubleAddArr[i][1]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, add(doubleAddArr[i][0], doubleAddArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dAddConst2_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dadd,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleAddArr[i][0]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::dadd,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleAddArr[i][0]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, add(doubleAddArr[i][0], doubleAddArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleAddArr[i][1]));
 
       sprintf(resolvedMethodName, "dAddConst3_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dadd,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleAddArr[i][1]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::dadd,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleAddArr[i][1]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, add(doubleAddArr[i][0], doubleAddArr[i][1]), dBinaryConst(doubleAddArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -627,18 +627,18 @@ S390OpCodesTest::invokeFloatArithmeticTests()
       OMR_CT_EXPECT_DOUBLE_EQ(_dSub, sub(doubleSubArr[i][0], doubleSubArr[i][1]), _dSub(doubleSubArr[i][0], doubleSubArr[i][1]));
 
       sprintf(resolvedMethodName, "dSubConst1_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dsub,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleSubArr[i][0], 2, &doubleSubArr[i][1]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::dsub,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleSubArr[i][0], 2, &doubleSubArr[i][1]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, sub(doubleSubArr[i][0], doubleSubArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dSubConst2_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dsub,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleSubArr[i][0]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::dsub,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleSubArr[i][0]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, sub(doubleSubArr[i][0], doubleSubArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleSubArr[i][1]));
 
       sprintf(resolvedMethodName, "dSubConst3_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dsub,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleSubArr[i][1]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::dsub,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleSubArr[i][1]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, sub(doubleSubArr[i][0], doubleSubArr[i][1]), dBinaryConst(doubleSubArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -648,18 +648,18 @@ S390OpCodesTest::invokeFloatArithmeticTests()
       OMR_CT_EXPECT_DOUBLE_EQ(_dMul, mul(doubleMulArr[i][0], doubleMulArr[i][1]), _dMul(doubleMulArr[i][0], doubleMulArr[i][1]));
 
       sprintf(resolvedMethodName, "dMulConst1_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dmul,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleMulArr[i][0], 2, &doubleMulArr[i][1]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::dmul,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleMulArr[i][0], 2, &doubleMulArr[i][1]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, mul(doubleMulArr[i][0], doubleMulArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dMulConst2_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dmul,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleMulArr[i][0]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::dmul,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleMulArr[i][0]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, mul(doubleMulArr[i][0], doubleMulArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleMulArr[i][1]));
 
       sprintf(resolvedMethodName, "dMulConst3_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dmul,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleMulArr[i][1]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::dmul,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleMulArr[i][1]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, mul(doubleMulArr[i][0], doubleMulArr[i][1]), dBinaryConst(doubleMulArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -669,18 +669,18 @@ S390OpCodesTest::invokeFloatArithmeticTests()
       OMR_CT_EXPECT_DOUBLE_EQ(_dDiv, div(doubleDivArr[i][0], doubleDivArr[i][1]), _dDiv(doubleDivArr[i][0], doubleDivArr[i][1]));
 
       sprintf(resolvedMethodName, "dDivConst1_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ddiv,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleDivArr[i][0], 2, &doubleDivArr[i][1]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::ddiv,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleDivArr[i][0], 2, &doubleDivArr[i][1]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, div(doubleDivArr[i][0], doubleDivArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dDivConst2_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ddiv,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleDivArr[i][0]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::ddiv,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleDivArr[i][0]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, div(doubleDivArr[i][0], doubleDivArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleDivArr[i][1]));
 
       sprintf(resolvedMethodName, "dDivConst3_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ddiv,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleDivArr[i][1]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::ddiv,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleDivArr[i][1]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, div(doubleDivArr[i][0], doubleDivArr[i][1]), dBinaryConst(doubleDivArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
    }
@@ -710,7 +710,7 @@ S390OpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "lStoreConst%d", i + 1);
       OMR_CT_EXPECT_EQ(_lStore, longDataArray[i], _lStore(longDataArray[i]));
-      lMemCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lstore, resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &(longDataArray[i])));
+      compileOpCodeMethod(lMemCons, _numberOfUnaryArgs, TR::lstore, resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &(longDataArray[i]));
       OMR_CT_EXPECT_EQ(lMemCons, longDataArray[i], lMemCons(LONG_PLACEHOLDER_1));
       }
 
@@ -719,7 +719,7 @@ S390OpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "dStoreConst%d", i + 1);
       OMR_CT_EXPECT_DOUBLE_EQ(_dStore, doubleDataArray[i], _dStore(doubleDataArray[i]));
-      dMemCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dstore, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &(doubleDataArray[i])));
+      compileOpCodeMethod(dMemCons, _numberOfUnaryArgs, TR::dstore, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &(doubleDataArray[i]));
       OMR_CT_EXPECT_DOUBLE_EQ(dMemCons, doubleDataArray[i], dMemCons(DOUBLE_PLACEHOLDER_1));
       }
 
@@ -728,7 +728,7 @@ S390OpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "fStoreConst%d", i + 1);
       OMR_CT_EXPECT_FLOAT_EQ(_fStore, floatDataArray[i], _fStore(floatDataArray[i]));
-      fMemCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::fstore, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &(floatDataArray[i])));
+      compileOpCodeMethod(fMemCons, _numberOfUnaryArgs, TR::fstore, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &(floatDataArray[i]));
       OMR_CT_EXPECT_FLOAT_EQ(fMemCons, floatDataArray[i], fMemCons(FLOAT_PLACEHOLDER_1));
       }
 
@@ -739,7 +739,7 @@ S390OpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "iLoadiConst%d", i + 1);
       uintptrj_t intDataAddress = (uintptrj_t)(&intDataArray[i]);
-      iLoadiCons = (signatureCharL_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int32, rc, 2, 1, &intDataAddress));
+      compileOpCodeMethod(iLoadiCons, _numberOfUnaryArgs, TR::iloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int32, rc, 2, 1, &intDataAddress);
       OMR_CT_EXPECT_EQ(iLoadiCons, intDataArray[i], iLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -749,7 +749,7 @@ S390OpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "sLoadiConst%d", i + 1);
       uintptrj_t shortDataAddress = (uintptrj_t)(&shortDataArray[i]);
-      sLoadiCons = (signatureCharL_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::sloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int16, rc, 2, 1, &shortDataAddress));
+      compileOpCodeMethod(sLoadiCons, _numberOfUnaryArgs, TR::sloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int16, rc, 2, 1, &shortDataAddress);
       OMR_CT_EXPECT_EQ(sLoadiCons, shortDataArray[i], sLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -759,7 +759,7 @@ S390OpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "bLoadiConst%d", i + 1);
       uintptrj_t byteDataAddress = (uintptrj_t)(&byteDataArray[i]);
-      bLoadiCons = (signatureCharL_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int8, rc, 2, 1, &byteDataAddress));
+      compileOpCodeMethod(bLoadiCons, _numberOfUnaryArgs, TR::bloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int8, rc, 2, 1, &byteDataAddress);
       OMR_CT_EXPECT_EQ(bLoadiCons, byteDataArray[i], bLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -769,7 +769,7 @@ S390OpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "lLoadiConst%d", i + 1);
       uintptrj_t longDataAddress = (uintptrj_t)(&longDataArray[i]);
-      lLoadiCons = (signatureCharL_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int64, rc, 2, 1, &longDataAddress));
+      compileOpCodeMethod(lLoadiCons, _numberOfUnaryArgs, TR::lloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int64, rc, 2, 1, &longDataAddress);
       OMR_CT_EXPECT_EQ(lLoadiCons, longDataArray[i], lLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -779,7 +779,7 @@ S390OpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "dLoadiConst%d", i + 1);
       uintptrj_t doubleDataAddress = (uintptrj_t)(&doubleDataArray[i]);
-      dLoadiCons = (signatureCharL_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Double, rc, 2, 1, &doubleDataAddress));
+      compileOpCodeMethod(dLoadiCons, _numberOfUnaryArgs, TR::dloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Double, rc, 2, 1, &doubleDataAddress);
       OMR_CT_EXPECT_EQ(dLoadiCons, doubleDataArray[i], dLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -789,7 +789,7 @@ S390OpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "fLoadiConst%d", i + 1);
       uintptrj_t floatDataAddress = (uintptrj_t)(&floatDataArray[i]);
-      fLoadiCons = (signatureCharL_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::floadi, resolvedMethodName, _argTypesUnaryAddress, TR::Float, rc, 2, 1, &floatDataAddress));
+      compileOpCodeMethod(fLoadiCons, _numberOfUnaryArgs, TR::floadi, resolvedMethodName, _argTypesUnaryAddress, TR::Float, rc, 2, 1, &floatDataAddress);
       OMR_CT_EXPECT_EQ(fLoadiCons, floatDataArray[i], fLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -799,7 +799,7 @@ S390OpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "aLoadiConst%d", i + 1);
       uintptrj_t addressDataAddress = (uintptrj_t)(&addressDataArray[i]);
-      aLoadiCons = (signatureCharL_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::aloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Address, rc, 2, 1, &addressDataAddress));
+      compileOpCodeMethod(aLoadiCons, _numberOfUnaryArgs, TR::aloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Address, rc, 2, 1, &addressDataAddress);
       OMR_CT_EXPECT_EQ(aLoadiCons, addressDataArray[i], aLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -899,18 +899,18 @@ S390OpCodesTest::invokeShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_lShl, shl(lshlDataArr[i][0], lshlDataArr[i][1]), _lShl(lshlDataArr[i][0], lshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lShlConst1_TestCase%d", i + 1);
-      lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lshl, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lshlDataArr[i][0], 2, &lshlDataArr[i][1]));
+      compileOpCodeMethod(lShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lshl, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lshlDataArr[i][0], 2, &lshlDataArr[i][1]);
       OMR_CT_EXPECT_EQ(lShiftOrRolConst, shl(lshlDataArr[i][0], lshlDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "lShlConst2_TestCase%d", i + 1);
-      lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lshl, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lshlDataArr[i][0]));
+      compileOpCodeMethod(lShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lshl, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lshlDataArr[i][0]);
       OMR_CT_EXPECT_EQ(lShiftOrRolConst, shl(lshlDataArr[i][0], lshlDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, lshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lShlConst3_TestCase%d", i + 1);
-      lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lshl, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lshlDataArr[i][1]));
+      compileOpCodeMethod(lShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lshl, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lshlDataArr[i][1]);
       OMR_CT_EXPECT_EQ(lShiftOrRolConst, shl(lshlDataArr[i][0], lshlDataArr[i][1]), lShiftOrRolConst(lshlDataArr[i][0], LONG_PLACEHOLDER_1));
       }
 
@@ -921,18 +921,18 @@ S390OpCodesTest::invokeShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_lShr, shr(lshrDataArr[i][0], lshrDataArr[i][1]), _lShr(lshrDataArr[i][0], lshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lShrConst1_TestCase%d", i + 1);
-      lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lshr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lshrDataArr[i][0], 2, &lshrDataArr[i][1]));
+      compileOpCodeMethod(lShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lshr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lshrDataArr[i][0], 2, &lshrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(lShiftOrRolConst, shr(lshrDataArr[i][0], lshrDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lShrConst2_TestCase%d", i + 1);
-      lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lshr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lshrDataArr[i][0]));
+      compileOpCodeMethod(lShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lshr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lshrDataArr[i][0]);
       OMR_CT_EXPECT_EQ(lShiftOrRolConst, shr(lshrDataArr[i][0], lshrDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, lshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lShrConst3_TestCase%d", i + 1);
-      lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lshr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lshrDataArr[i][1]));
+      compileOpCodeMethod(lShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lshr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lshrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(lShiftOrRolConst, shr(lshrDataArr[i][0], lshrDataArr[i][1]), lShiftOrRolConst(lshrDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -943,18 +943,18 @@ S390OpCodesTest::invokeShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_luShr, shr(lushrDataArr[i][0], lushrDataArr[i][1]), _luShr(lushrDataArr[i][0], lushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luShrConst1_TestCase%d", i + 1);
-      luShiftOrRolConst = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lushr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lushrDataArr[i][0], 2, &lushrDataArr[i][1]));
+      compileOpCodeMethod(luShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lushr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lushrDataArr[i][0], 2, &lushrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(luShiftOrRolConst, shr(lushrDataArr[i][0], lushrDataArr[i][1]), luShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "luShrConst2_TestCase%d", i + 1);
-      luShiftOrRolConst = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lushr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lushrDataArr[i][0]));
+      compileOpCodeMethod(luShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lushr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lushrDataArr[i][0]);
       OMR_CT_EXPECT_EQ(luShiftOrRolConst, shr(lushrDataArr[i][0], lushrDataArr[i][1]), luShiftOrRolConst(LONG_PLACEHOLDER_1, lushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luShrConst3_TestCase%d", i + 1);
-      luShiftOrRolConst = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lushr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lushrDataArr[i][1]));
+      compileOpCodeMethod(luShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lushr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lushrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(luShiftOrRolConst, shr(lushrDataArr[i][0], lushrDataArr[i][1]), luShiftOrRolConst(lushrDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -965,18 +965,18 @@ S390OpCodesTest::invokeShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_lRol, rol(lrolDataArr[i][0], lrolDataArr[i][1]), _lRol(lrolDataArr[i][0], lrolDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lRolConst1_TestCase%d", i + 1);
-      lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lrol, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lrolDataArr[i][0], 2, &lrolDataArr[i][1]));
+      compileOpCodeMethod(lShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lrol, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lrolDataArr[i][0], 2, &lrolDataArr[i][1]);
       OMR_CT_EXPECT_EQ(lShiftOrRolConst, rol(lrolDataArr[i][0], lrolDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lRolConst2_TestCase%d", i + 1);
-      lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lrol, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lrolDataArr[i][0]));
+      compileOpCodeMethod(lShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lrol, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lrolDataArr[i][0]);
       OMR_CT_EXPECT_EQ(lShiftOrRolConst, rol(lrolDataArr[i][0], lrolDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, lrolDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lRolConst3_TestCase%d", i + 1);
-      lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lrol, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lrolDataArr[i][1]));
+      compileOpCodeMethod(lShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lrol, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lrolDataArr[i][1]);
       OMR_CT_EXPECT_EQ(lShiftOrRolConst, rol(lrolDataArr[i][0], lrolDataArr[i][1]), lShiftOrRolConst(lrolDataArr[i][0], LONG_PLACEHOLDER_2)) << lrolDataArr[i][0] << " : " << lrolDataArr[i][1];
       }
 #endif
@@ -1023,18 +1023,18 @@ S390OpCodesTest::invokeBitwiseTests()
       OMR_CT_EXPECT_EQ(_lAnd, tand(longAndArr[i][0], longAndArr[i][1]), _lAnd(longAndArr[i][0], longAndArr[i][1]));
 
       sprintf(resolvedMethodName, "lAndConst1_TestCase%d", i + 1);
-      lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::land, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &(longAndArr[i][0]), 2, &(longAndArr[i][1])));
+      compileOpCodeMethod(lBitwiseConst, 
+            _numberOfBinaryArgs, TR::land, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &(longAndArr[i][0]), 2, &(longAndArr[i][1]));
       OMR_CT_EXPECT_EQ(lBitwiseConst, tand(longAndArr[i][0], longAndArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lAndConst2_TestCase%d", i + 1);
-      lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::land, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &(longAndArr[i][0])));
+      compileOpCodeMethod(lBitwiseConst, 
+            _numberOfBinaryArgs, TR::land, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &(longAndArr[i][0]));
       OMR_CT_EXPECT_EQ(lBitwiseConst, tand(longAndArr[i][0], longAndArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, longAndArr[i][1]));
 
       sprintf(resolvedMethodName, "lAndConst3_TestCase%d", i + 1);
-      lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::land, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &(longAndArr[i][1])));
+      compileOpCodeMethod(lBitwiseConst, 
+            _numberOfBinaryArgs, TR::land, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &(longAndArr[i][1]));
       OMR_CT_EXPECT_EQ(lBitwiseConst, tand(longAndArr[i][0], longAndArr[i][1]), lBitwiseConst(longAndArr[i][0], LONG_PLACEHOLDER_2));
      }
 
@@ -1045,18 +1045,18 @@ S390OpCodesTest::invokeBitwiseTests()
       OMR_CT_EXPECT_EQ(_lOr, tor(longOrArr[i][0], longOrArr[i][1]), _lOr(longOrArr[i][0], longOrArr[i][1]));
 
       sprintf(resolvedMethodName, "lOrConst1_TestCase%d", i + 1);
-      lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &(longOrArr[i][0]), 2, &(longOrArr[i][1])));
+      compileOpCodeMethod(lBitwiseConst, 
+            _numberOfBinaryArgs, TR::lor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &(longOrArr[i][0]), 2, &(longOrArr[i][1]));
       OMR_CT_EXPECT_EQ(lBitwiseConst, tor(longOrArr[i][0], longOrArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lOrConst2_TestCase%d", i + 1);
-      lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &(longOrArr[i][0])));
+      compileOpCodeMethod(lBitwiseConst, 
+            _numberOfBinaryArgs, TR::lor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &(longOrArr[i][0]));
       OMR_CT_EXPECT_EQ(lBitwiseConst, tor(longOrArr[i][0], longOrArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, longOrArr[i][1]));
 
       sprintf(resolvedMethodName, "lOrConst3_TestCase%d", i + 1);
-      lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &(longOrArr[i][1])));
+      compileOpCodeMethod(lBitwiseConst, 
+            _numberOfBinaryArgs, TR::lor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &(longOrArr[i][1]));
       OMR_CT_EXPECT_EQ(lBitwiseConst, tor(longOrArr[i][0], longOrArr[i][1]), lBitwiseConst(longOrArr[i][0], LONG_PLACEHOLDER_2));
      }
 
@@ -1067,18 +1067,18 @@ S390OpCodesTest::invokeBitwiseTests()
       OMR_CT_EXPECT_EQ(_lXor, txor(longXorArr[i][0], longXorArr[i][1]), _lXor(longXorArr[i][0], longXorArr[i][1]));
 
       sprintf(resolvedMethodName, "lXorConst1_TestCase%d", i + 1);
-      lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lxor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &(longXorArr[i][0]), 2, &(longXorArr[i][1])));
+      compileOpCodeMethod(lBitwiseConst, 
+            _numberOfBinaryArgs, TR::lxor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &(longXorArr[i][0]), 2, &(longXorArr[i][1]));
       OMR_CT_EXPECT_EQ(lBitwiseConst, txor(longXorArr[i][0], longXorArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lXorConst2_TestCase%d", i + 1);
-      lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lxor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &(longXorArr[i][0])));
+      compileOpCodeMethod(lBitwiseConst, 
+            _numberOfBinaryArgs, TR::lxor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &(longXorArr[i][0]));
       OMR_CT_EXPECT_EQ(lBitwiseConst, txor(longXorArr[i][0], longXorArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, longXorArr[i][1]));
 
       sprintf(resolvedMethodName, "lXorConst3_TestCase%d", i + 1);
-      lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lxor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &(longXorArr[i][1])));
+      compileOpCodeMethod(lBitwiseConst, 
+            _numberOfBinaryArgs, TR::lxor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &(longXorArr[i][1]));
       OMR_CT_EXPECT_EQ(lBitwiseConst, txor(longXorArr[i][0], longXorArr[i][1]), lBitwiseConst(longXorArr[i][0], LONG_PLACEHOLDER_2));
      }
    }
@@ -1121,32 +1121,32 @@ S390OpCodesTest::invokeTernaryTests()
       sprintf(resolvedMethodName, "lTernaryConst%d", i + 1);
       OMR_CT_EXPECT_EQ(_lternary, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), _lternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]));
 
-      lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 6, 1, &lternaryChild1Arr[i], 2, &longArr[i][0], 3, &longArr[i][1]));
+      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
+            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 6, 1, &lternaryChild1Arr[i], 2, &longArr[i][0], 3, &longArr[i][1]);
       OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
 
-      lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 1, &lternaryChild1Arr[i], 2, &longArr[i][0]));
+      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
+            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 1, &lternaryChild1Arr[i], 2, &longArr[i][0]);
       OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, longArr[i][1]));
 
-      lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 1, &lternaryChild1Arr[i], 3, &longArr[i][1]));
+      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
+            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 1, &lternaryChild1Arr[i], 3, &longArr[i][1]);
       OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, longArr[i][0], LONG_PLACEHOLDER_3));
 
-      lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 2, &longArr[i][0], 3, &longArr[i][1]));
+      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
+            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 2, &longArr[i][0], 3, &longArr[i][1]);
       OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
 
-      lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 1, &lternaryChild1Arr[i]));
+      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
+            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 1, &lternaryChild1Arr[i]);
       OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, longArr[i][0], longArr[i][1]));
 
-      lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 2, &longArr[i][0]));
+      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
+            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 2, &longArr[i][0]);
       OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], LONG_PLACEHOLDER_1, longArr[i][1]));
 
-      lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 3, &longArr[i][1]));
+      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
+            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 3, &longArr[i][1]);
       OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], longArr[i][0], LONG_PLACEHOLDER_1));
       }
    }
@@ -1384,18 +1384,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_lCmpeq, compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), _lCmpeq(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpeqConst1_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpeqDataArr[i][0]), 2, &(lCmpeqDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpeqDataArr[i][0]), 2, &(lCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lCmpeqConst2_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpeqDataArr[i][0])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpeqConst3_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpeqDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), lCompareConst(lCmpeqDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -1406,18 +1406,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_lCmplt, compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), _lCmplt(lCmpltDataArr[i][0], lCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpltConst1_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpltDataArr[i][0]), 2, &(lCmpltDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpltDataArr[i][0]), 2, &(lCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lCmpltConst2_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpltDataArr[i][0])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpltConst3_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpltDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), lCompareConst(lCmpltDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -1428,18 +1428,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_dCmpeq, compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), _dCmpeq(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpeqConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpeqDataArr[i][0]), 2, &(dCmpeqDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpeqDataArr[i][0]), 2, &(dCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpeqConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpeqDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpeqConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpeqDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), dCompareConst(dCmpeqDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -1449,18 +1449,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_dCmpne, compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), _dCmpne(dCmpneDataArr[i][0], dCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpneConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpneDataArr[i][0]), 2, &(dCmpneDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpneDataArr[i][0]), 2, &(dCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpneConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpneDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpneConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpneDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), dCompareConst(dCmpneDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -1470,18 +1470,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_dCmpgt, compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), _dCmpgt(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpgtConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpgtDataArr[i][0]), 2, &(dCmpgtDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpgtDataArr[i][0]), 2, &(dCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpgtConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpgtDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpgtConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpgtDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), dCompareConst(dCmpgtDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -1491,18 +1491,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_dCmplt, compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), _dCmplt(dCmpltDataArr[i][0], dCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpltConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpltDataArr[i][0]), 2, &(dCmpltDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpltDataArr[i][0]), 2, &(dCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpltConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpltDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpltConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpltDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), dCompareConst(dCmpltDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -1512,18 +1512,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_dCmpge, compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), _dCmpge(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpgeConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpgeDataArr[i][0]), 2, &(dCmpgeDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpgeDataArr[i][0]), 2, &(dCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpgeConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpgeDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpgeConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpgeDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), dCompareConst(dCmpgeDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -1533,18 +1533,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_dCmple, compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), _dCmple(dCmpleDataArr[i][0], dCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpleConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpleDataArr[i][0]), 2, &(dCmpleDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpleDataArr[i][0]), 2, &(dCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpleConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpleDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpleConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpleDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), dCompareConst(dCmpleDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -1555,18 +1555,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_fCmpeq, compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), _fCmpeq(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpeqConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpeqDataArr[i][0]), 2, &(fCmpeqDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpeqDataArr[i][0]), 2, &(fCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpeqConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpeqDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpeqConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpeqDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), fCompareConst(fCmpeqDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -1576,18 +1576,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_fCmpne, compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), _fCmpne(fCmpneDataArr[i][0], fCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpneConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpneDataArr[i][0]), 2, &(fCmpneDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpneDataArr[i][0]), 2, &(fCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpneConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpneDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpneConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpneDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), fCompareConst(fCmpneDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -1597,18 +1597,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_fCmpgt, compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), _fCmpgt(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpgtConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpgtDataArr[i][0]), 2, &(fCmpgtDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpgtDataArr[i][0]), 2, &(fCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpgtConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpgtDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpgtConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpgtDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), fCompareConst(fCmpgtDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -1618,18 +1618,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_fCmplt, compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), _fCmplt(fCmpltDataArr[i][0], fCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpltConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpltDataArr[i][0]), 2, &(fCmpltDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpltDataArr[i][0]), 2, &(fCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpltConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpltDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpltConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpltDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), fCompareConst(fCmpltDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -1639,18 +1639,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_fCmpge, compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), _fCmpge(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpgeConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpgeDataArr[i][0]), 2, &(fCmpgeDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpgeDataArr[i][0]), 2, &(fCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpgeConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpgeDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpgeConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpgeDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), fCompareConst(fCmpgeDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -1660,18 +1660,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_fCmple, compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), _fCmple(fCmpleDataArr[i][0], fCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpleConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpleDataArr[i][0]), 2, &(fCmpleDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpleDataArr[i][0]), 2, &(fCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpleConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpleDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpleConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpleDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), fCompareConst(fCmpleDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -1682,18 +1682,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_lCmp, comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), _lCmp(lCmpDataArr[i][0], lCmpDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpConst1_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmp, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpDataArr[i][0]), 2, &(lCmpDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmp, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpDataArr[i][0]), 2, &(lCmpDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lCmpConst2_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmp, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpDataArr[i][0])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmp, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpDataArr[i][0]));
       OMR_CT_EXPECT_EQ(lCompareConst, comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpConst3_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmp, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmp, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), lCompareConst(lCmpDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -1705,20 +1705,20 @@ S390OpCodesTest::invokeCompareTests()
             dCmplDataArr[i][0] << " : " << dCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmplConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpl, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmplDataArr[i][0]), 2, &(dCmplDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpl, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmplDataArr[i][0]), 2, &(dCmplDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2)) <<
             dCmplDataArr[i][0] << " : " << dCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmplConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpl, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmplDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpl, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmplDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmplDataArr[i][1])) <<
             dCmplDataArr[i][0] << " : " << dCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmplConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpl, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmplDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpl, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmplDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), dCompareConst(dCmplDataArr[i][0], DOUBLE_PLACEHOLDER_2)) <<
             dCmplDataArr[i][0] << " : " << dCmplDataArr[i][1];
       }
@@ -1731,20 +1731,20 @@ S390OpCodesTest::invokeCompareTests()
             dCmpgDataArr[i][0] << " : " << dCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmpgConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpg, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpgDataArr[i][0]), 2, &(dCmpgDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpg, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpgDataArr[i][0]), 2, &(dCmpgDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2)) <<
             dCmpgDataArr[i][0] << " : " << dCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmpgConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpg, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpgDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpg, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpgDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpgDataArr[i][1])) <<
             dCmpgDataArr[i][0] << " : " << dCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmpgConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpg, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpgDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpg, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpgDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), dCompareConst(dCmpgDataArr[i][0], DOUBLE_PLACEHOLDER_2)) <<
             dCmpgDataArr[i][0] << " : " << dCmpgDataArr[i][1];
       }
@@ -1757,20 +1757,20 @@ S390OpCodesTest::invokeCompareTests()
             fCmplDataArr[i][0] << " : " << fCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmplConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpl, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmplDataArr[i][0]), 2, &(fCmplDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpl, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmplDataArr[i][0]), 2, &(fCmplDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2)) <<
             fCmplDataArr[i][0] << " : " << fCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmplConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpl, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmplDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpl, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmplDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmplDataArr[i][1])) <<
             fCmplDataArr[i][0] << " : " << fCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmplConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpl, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmplDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpl, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmplDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), fCompareConst(fCmplDataArr[i][0], FLOAT_PLACEHOLDER_2)) <<
             fCmplDataArr[i][0] << " : " << fCmplDataArr[i][1];
       }
@@ -1783,20 +1783,20 @@ S390OpCodesTest::invokeCompareTests()
             fCmpgDataArr[i][0] << " : " << fCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmpgConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpg, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpgDataArr[i][0]), 2, &(fCmpgDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpg, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpgDataArr[i][0]), 2, &(fCmpgDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2)) <<
             fCmpgDataArr[i][0] << " : " << fCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmpgConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpg, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpgDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpg, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpgDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpgDataArr[i][1])) <<
             fCmpgDataArr[i][0] << " : " << fCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmpgConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpg, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpgDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpg, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpgDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), fCompareConst(fCmpgDataArr[i][0], FLOAT_PLACEHOLDER_2)) <<
             fCmpgDataArr[i][0] << " : " << fCmpgDataArr[i][1];
       }
@@ -1808,18 +1808,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifLcmpeq, compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), _ifLcmpeq(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpeqConst1_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpeqDataArr[i][0]), 2, &(ifLcmpeqDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpeqDataArr[i][0]), 2, &(ifLcmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLcmpeqConst2_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpeqDataArr[i][0])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpeqConst3_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpeqDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), lCompareConst(ifLcmpeqDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -1829,18 +1829,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifLcmpgt, compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), _ifLcmpgt(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpgtConst1_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpgtDataArr[i][0]), 2, &(ifLcmpgtDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpgtDataArr[i][0]), 2, &(ifLcmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLcmpgtConst2_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpgtDataArr[i][0])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpgtConst3_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpgtDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), lCompareConst(ifLcmpgtDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -1850,18 +1850,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifLcmplt, compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), _ifLcmplt(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpltConst1_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpltDataArr[i][0]), 2, &(ifLcmpltDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpltDataArr[i][0]), 2, &(ifLcmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLcmpltConst2_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpltDataArr[i][0])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpltConst3_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpltDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), lCompareConst(ifLcmpltDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -1872,18 +1872,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifDcmpeq, compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), _ifDcmpeq(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpeqConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpeqDataArr[i][0]), 2, &(ifDcmpeqDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpeqDataArr[i][0]), 2, &(ifDcmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpeqConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpeqDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpeqConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpeqDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), dCompareConst(ifDcmpeqDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -1893,18 +1893,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifDcmpne, compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), _ifDcmpne(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpneConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpneDataArr[i][0]), 2, &(ifDcmpneDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpneDataArr[i][0]), 2, &(ifDcmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpneConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpneDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpneConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpneDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), dCompareConst(ifDcmpneDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -1914,18 +1914,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifDcmpgt, compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), _ifDcmpgt(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpgtConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpgtDataArr[i][0]), 2, &(ifDcmpgtDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpgtDataArr[i][0]), 2, &(ifDcmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpgtConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpgtDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpgtConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpgtDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), dCompareConst(ifDcmpgtDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -1935,18 +1935,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifDcmplt, compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), _ifDcmplt(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpltConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpltDataArr[i][0]), 2, &(ifDcmpltDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpltDataArr[i][0]), 2, &(ifDcmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpltConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpltDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpltConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpltDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), dCompareConst(ifDcmpltDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -1956,18 +1956,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifDcmpge, compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), _ifDcmpge(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpgeConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpgeDataArr[i][0]), 2, &(ifDcmpgeDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpgeDataArr[i][0]), 2, &(ifDcmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpgeConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpgeDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpgeConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpgeDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), dCompareConst(ifDcmpgeDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -1977,18 +1977,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifDcmple, compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), _ifDcmple(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpleConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpleDataArr[i][0]), 2, &(ifDcmpleDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpleDataArr[i][0]), 2, &(ifDcmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpleConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpleDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpleConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpleDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), dCompareConst(ifDcmpleDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -1999,18 +1999,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifFcmpeq, compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), _ifFcmpeq(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpeqConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpeqDataArr[i][0]), 2, &(ifFcmpeqDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpeqDataArr[i][0]), 2, &(ifFcmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpeqConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpeqDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpeqConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpeqDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), fCompareConst(ifFcmpeqDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -2020,18 +2020,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifFcmpne, compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), _ifFcmpne(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpneConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpneDataArr[i][0]), 2, &(ifFcmpneDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpneDataArr[i][0]), 2, &(ifFcmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpneConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpneDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpneConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpneDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), fCompareConst(ifFcmpneDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -2041,18 +2041,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifFcmpgt, compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), _ifFcmpgt(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpgtConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpgtDataArr[i][0]), 2, &(ifFcmpgtDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpgtDataArr[i][0]), 2, &(ifFcmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpgtConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpgtDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpgtConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpgtDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), fCompareConst(ifFcmpgtDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -2062,18 +2062,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifFcmplt, compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), _ifFcmplt(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpltConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpltDataArr[i][0]), 2, &(ifFcmpltDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpltDataArr[i][0]), 2, &(ifFcmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpltConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpltDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpltConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpltDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), fCompareConst(ifFcmpltDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -2083,18 +2083,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifFcmpge, compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), _ifFcmpge(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpgeConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpgeDataArr[i][0]), 2, &(ifFcmpgeDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpgeDataArr[i][0]), 2, &(ifFcmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpgeConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpgeDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpgeConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpgeDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), fCompareConst(ifFcmpgeDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -2104,18 +2104,18 @@ S390OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifFcmple, compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), _ifFcmple(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpleConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpleDataArr[i][0]), 2, &(ifFcmpleDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpleDataArr[i][0]), 2, &(ifFcmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpleConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpleDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpleConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpleDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), fCompareConst(ifFcmpleDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -2161,8 +2161,8 @@ S390OpCodesTest::invokeUnaryTests()
       {
       OMR_CT_EXPECT_EQ(_lNeg, neg(longDataArray[i]), _lNeg(longDataArray[i]));
       sprintf(resolvedMethodName, "lNegConst%d", i + 1);
-      lUnaryCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lneg,
-            resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &longDataArray[i]));
+      compileOpCodeMethod(lUnaryCons, _numberOfUnaryArgs, TR::lneg,
+            resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &longDataArray[i]);
       OMR_CT_EXPECT_EQ(lUnaryCons, neg(longDataArray[i]), lUnaryCons(LONG_PLACEHOLDER_1));
       }
 
@@ -2172,8 +2172,8 @@ S390OpCodesTest::invokeUnaryTests()
       {
       OMR_CT_EXPECT_FLOAT_EQ(_fNeg, neg(floatDataArray[i]), _fNeg(floatDataArray[i]));
       sprintf(resolvedMethodName, "fNegConst%d", i + 1);
-      fUnaryCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::fneg,
-            resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &floatDataArray[i]));
+      compileOpCodeMethod(fUnaryCons, _numberOfUnaryArgs, TR::fneg,
+            resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &floatDataArray[i]);
       OMR_CT_EXPECT_FLOAT_EQ(fUnaryCons, neg(floatDataArray[i]), fUnaryCons(FLOAT_PLACEHOLDER_1));
       }
 
@@ -2183,8 +2183,8 @@ S390OpCodesTest::invokeUnaryTests()
       {
       OMR_CT_EXPECT_DOUBLE_EQ(_dNeg, neg(doubleDataArray[i]), _dNeg(doubleDataArray[i]));
       sprintf(resolvedMethodName, "dNegConst%d", i + 1);
-      dUnaryCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dneg,
-            resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &doubleDataArray[i]));
+      compileOpCodeMethod(dUnaryCons, _numberOfUnaryArgs, TR::dneg,
+            resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &doubleDataArray[i]);
       OMR_CT_EXPECT_DOUBLE_EQ(dUnaryCons, neg(doubleDataArray[i]), dUnaryCons(DOUBLE_PLACEHOLDER_1));
       }
 
@@ -2194,8 +2194,8 @@ S390OpCodesTest::invokeUnaryTests()
       {
       OMR_CT_EXPECT_EQ(_lAbs, abs(longDataArray[i]), _lAbs(longDataArray[i]));
       sprintf(resolvedMethodName, "lAbsConst%d", i + 1);
-      lUnaryCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::labs,
-            resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &longDataArray[i]));
+      compileOpCodeMethod(lUnaryCons, _numberOfUnaryArgs, TR::labs,
+            resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &longDataArray[i]);
       OMR_CT_EXPECT_EQ(lUnaryCons, abs(longDataArray[i]), lUnaryCons(LONG_PLACEHOLDER_1));
       }
 
@@ -2205,8 +2205,8 @@ S390OpCodesTest::invokeUnaryTests()
       {
       OMR_CT_EXPECT_EQ(_fAbs, abs(floatDataArray[i]), _fAbs(floatDataArray[i]));
       sprintf(resolvedMethodName, "fAbsConst%d", i + 1);
-      fUnaryCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::fabs, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &floatDataArray[i]));
+      compileOpCodeMethod(fUnaryCons, 
+            _numberOfUnaryArgs, TR::fabs, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &floatDataArray[i]);
       OMR_CT_EXPECT_EQ(fUnaryCons, abs(floatDataArray[i]), fUnaryCons(FLOAT_PLACEHOLDER_1));
       }
 
@@ -2216,8 +2216,8 @@ S390OpCodesTest::invokeUnaryTests()
       {
       OMR_CT_EXPECT_EQ(_dAbs, abs(doubleDataArray[i]), _dAbs(doubleDataArray[i]));
       sprintf(resolvedMethodName, "dAbsConst%d", i + 1);
-      dUnaryCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::dabs, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &doubleDataArray[i]));
+      compileOpCodeMethod(dUnaryCons, 
+            _numberOfUnaryArgs, TR::dabs, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &doubleDataArray[i]);
       OMR_CT_EXPECT_EQ(dUnaryCons, abs(doubleDataArray[i]), dUnaryCons(DOUBLE_PLACEHOLDER_1));
       }
 
@@ -2227,7 +2227,7 @@ S390OpCodesTest::invokeUnaryTests()
       {
       sprintf(resolvedMethodName, "lReturnCons%d", i + 1);
       OMR_CT_EXPECT_EQ(_lReturn, longDataArray[i], _lReturn(longDataArray[i]));
-      lUnaryCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lreturn, resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &(longDataArray[i])));
+      compileOpCodeMethod(lUnaryCons, _numberOfUnaryArgs, TR::lreturn, resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &(longDataArray[i]));
       OMR_CT_EXPECT_EQ(lUnaryCons, longDataArray[i], lUnaryCons(LONG_PLACEHOLDER_1));
       }
 
@@ -2237,7 +2237,7 @@ S390OpCodesTest::invokeUnaryTests()
       {
       sprintf(resolvedMethodName, "dReturnCons%d", i + 1);
       OMR_CT_EXPECT_DOUBLE_EQ(_dReturn, doubleDataArray[i], _dReturn(doubleDataArray[i]));
-      dUnaryCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dreturn, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &(doubleDataArray[i])));
+      compileOpCodeMethod(dUnaryCons, _numberOfUnaryArgs, TR::dreturn, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &(doubleDataArray[i]));
       OMR_CT_EXPECT_DOUBLE_EQ(dUnaryCons, doubleDataArray[i], dUnaryCons(DOUBLE_PLACEHOLDER_1));
       }
 
@@ -2247,7 +2247,7 @@ S390OpCodesTest::invokeUnaryTests()
       {
       sprintf(resolvedMethodName, "fReturnCons%d", i + 1);
       OMR_CT_EXPECT_FLOAT_EQ(_fReturn, floatDataArray[i], _fReturn(floatDataArray[i]));
-      fUnaryCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::freturn, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &(floatDataArray[i])));
+      compileOpCodeMethod(fUnaryCons, _numberOfUnaryArgs, TR::freturn, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &(floatDataArray[i]));
       OMR_CT_EXPECT_FLOAT_EQ(fUnaryCons, floatDataArray[i], fUnaryCons(FLOAT_PLACEHOLDER_1));
       }
 
@@ -2256,7 +2256,7 @@ S390OpCodesTest::invokeUnaryTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "lConst%d", i + 1);
-      lUnaryCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lconst, resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &(longDataArray[i])));
+      compileOpCodeMethod(lUnaryCons, _numberOfUnaryArgs, TR::lconst, resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &(longDataArray[i]));
       OMR_CT_EXPECT_EQ(lUnaryCons, longDataArray[i], lUnaryCons(LONG_PLACEHOLDER_1));
       }
 
@@ -2265,7 +2265,7 @@ S390OpCodesTest::invokeUnaryTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "dConst%d", i + 1);
-      dUnaryCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dconst, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &(doubleDataArray[i])));
+      compileOpCodeMethod(dUnaryCons, _numberOfUnaryArgs, TR::dconst, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &(doubleDataArray[i]));
       OMR_CT_EXPECT_DOUBLE_EQ(dUnaryCons, doubleDataArray[i], dUnaryCons(DOUBLE_PLACEHOLDER_1));
       }
 
@@ -2274,7 +2274,7 @@ S390OpCodesTest::invokeUnaryTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "fConst%d", i + 1);
-      fUnaryCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::fconst, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &(floatDataArray[i])));
+      compileOpCodeMethod(fUnaryCons, _numberOfUnaryArgs, TR::fconst, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &(floatDataArray[i]));
       OMR_CT_EXPECT_FLOAT_EQ(fUnaryCons, floatDataArray[i], fUnaryCons(FLOAT_PLACEHOLDER_1));
       }
 
@@ -2286,13 +2286,13 @@ S390OpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_DOUBLE_EQ(_i2d, convert(intDataArray[i], DOUBLE_POS), _i2d(intDataArray[i]));
 
       sprintf(resolvedMethodName, "i2fConst%d", i + 1);
-      i2fConst = (signatureCharI_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::i2f,
-            resolvedMethodName, _argTypesUnaryInt, TR::Float, rc, 2, 1, &intDataArray[i]));
+      compileOpCodeMethod(i2fConst, _numberOfUnaryArgs, TR::i2f,
+            resolvedMethodName, _argTypesUnaryInt, TR::Float, rc, 2, 1, &intDataArray[i]);
       OMR_CT_EXPECT_FLOAT_EQ(i2fConst, convert(intDataArray[i], FLOAT_POS), i2fConst(INT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "i2dConst%d", i + 1);
-      i2dConst = (signatureCharI_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::i2d,
-            resolvedMethodName, _argTypesUnaryInt, TR::Double, rc, 2, 1, &intDataArray[i]));
+      compileOpCodeMethod(i2dConst, _numberOfUnaryArgs, TR::i2d,
+            resolvedMethodName, _argTypesUnaryInt, TR::Double, rc, 2, 1, &intDataArray[i]);
       OMR_CT_EXPECT_DOUBLE_EQ(i2dConst, convert(intDataArray[i], DOUBLE_POS), i2dConst(INT_PLACEHOLDER_1));
       }
 
@@ -2304,13 +2304,13 @@ S390OpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_DOUBLE_EQ(_l2d, convert(longDataArray[i], DOUBLE_POS), _l2d(longDataArray[i]));
 
       sprintf(resolvedMethodName, "l2fConst%d", i + 1);
-      l2fConst = (signatureCharJ_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::l2f,
-            resolvedMethodName, _argTypesUnaryLong, TR::Float, rc, 2, 1, &longDataArray[i]));
+      compileOpCodeMethod(l2fConst, _numberOfUnaryArgs, TR::l2f,
+            resolvedMethodName, _argTypesUnaryLong, TR::Float, rc, 2, 1, &longDataArray[i]);
       OMR_CT_EXPECT_FLOAT_EQ(l2fConst, convert(longDataArray[i], FLOAT_POS), l2fConst(LONG_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "l2dConst%d", i + 1);
-      l2dConst = (signatureCharJ_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::l2d,
-            resolvedMethodName, _argTypesUnaryLong, TR::Double, rc, 2, 1, &longDataArray[i]));
+      compileOpCodeMethod(l2dConst, _numberOfUnaryArgs, TR::l2d,
+            resolvedMethodName, _argTypesUnaryLong, TR::Double, rc, 2, 1, &longDataArray[i]);
       OMR_CT_EXPECT_DOUBLE_EQ(l2dConst, convert(longDataArray[i], DOUBLE_POS), l2dConst(LONG_PLACEHOLDER_1));
       }
 
@@ -2321,8 +2321,8 @@ S390OpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_EQ(_iu2l, convert(uintDataArray[i], LONG_POS), _iu2l(uintDataArray[i]));
 
       sprintf(resolvedMethodName, "iu2lConst%d", i + 1);
-      iu2lConst = (unsignedSignatureCharI_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iu2l,
-            resolvedMethodName, _argTypesUnaryInt, TR::Int64, rc, 2, 1, &uintDataArray[i]));
+      compileOpCodeMethod(iu2lConst, _numberOfUnaryArgs, TR::iu2l,
+            resolvedMethodName, _argTypesUnaryInt, TR::Int64, rc, 2, 1, &uintDataArray[i]);
       OMR_CT_EXPECT_EQ(iu2lConst, convert(uintDataArray[i], LONG_POS), iu2lConst(INT_PLACEHOLDER_1));
       }
 
@@ -2333,8 +2333,8 @@ S390OpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_EQ(_iu2d, convert(uintDataArray[i], DOUBLE_POS), _iu2d(uintDataArray[i]));
 
       sprintf(resolvedMethodName, "iu2dConst%d", i + 1);
-      iu2dConst = (unsignedSignatureCharI_D_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::iu2d, resolvedMethodName, _argTypesUnaryInt, TR::Double, rc, 2, 1, &uintDataArray[i]));
+      compileOpCodeMethod(iu2dConst, 
+            _numberOfUnaryArgs, TR::iu2d, resolvedMethodName, _argTypesUnaryInt, TR::Double, rc, 2, 1, &uintDataArray[i]);
       OMR_CT_EXPECT_EQ(iu2dConst, convert(uintDataArray[i], DOUBLE_POS), iu2dConst(INT_PLACEHOLDER_1));
       }
 
@@ -2345,8 +2345,8 @@ S390OpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_EQ(_f2l, convert(floatDataArray[i], LONG_POS), _f2l(floatDataArray[i]));
 
       sprintf(resolvedMethodName, "f2lConst%d", i + 1);
-      f2lConst = (signatureCharF_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2l,
-            resolvedMethodName, _argTypesUnaryFloat, TR::Int64, rc, 2, 1, &floatDataArray[i]));
+      compileOpCodeMethod(f2lConst, _numberOfUnaryArgs, TR::f2l,
+            resolvedMethodName, _argTypesUnaryFloat, TR::Int64, rc, 2, 1, &floatDataArray[i]);
       OMR_CT_EXPECT_EQ(f2lConst, convert(floatDataArray[i], LONG_POS), f2lConst(FLOAT_PLACEHOLDER_1));
       }
 
@@ -2357,8 +2357,8 @@ S390OpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_EQ(_d2l, convert(doubleDataArray[i], LONG_POS), _d2l(doubleDataArray[i]));
 
       sprintf(resolvedMethodName, "d2lConst%d", i + 1);
-      d2lConst = (signatureCharD_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2l,
-            resolvedMethodName, _argTypesUnaryDouble, TR::Int64, rc, 2, 1, &doubleDataArray[i]));
+      compileOpCodeMethod(d2lConst, _numberOfUnaryArgs, TR::d2l,
+            resolvedMethodName, _argTypesUnaryDouble, TR::Int64, rc, 2, 1, &doubleDataArray[i]);
       OMR_CT_EXPECT_EQ(d2lConst, convert(doubleDataArray[i], LONG_POS), d2lConst(DOUBLE_PLACEHOLDER_1));
       }
 
@@ -2371,18 +2371,18 @@ S390OpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_FLOAT_EQ(_d2f, convert(doubleDataArray[i], FLOAT_POS), _d2f(doubleDataArray[i]));
 
       sprintf(resolvedMethodName, "d2bConst%d", i + 1);
-      d2bConst = (signatureCharD_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2b,
-            resolvedMethodName, _argTypesUnaryDouble, TR::Int8, rc, 2, 1, &doubleDataArray[i]));
+      compileOpCodeMethod(d2bConst, _numberOfUnaryArgs, TR::d2b,
+            resolvedMethodName, _argTypesUnaryDouble, TR::Int8, rc, 2, 1, &doubleDataArray[i]);
       OMR_CT_EXPECT_EQ(d2bConst, convert(doubleDataArray[i], BYTE_POS), d2bConst(DOUBLE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "d2sConst%d", i + 1);
-      d2sConst = (signatureCharD_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2s,
-            resolvedMethodName, _argTypesUnaryDouble, TR::Int16, rc, 2, 1, &doubleDataArray[i]));
+      compileOpCodeMethod(d2sConst, _numberOfUnaryArgs, TR::d2s,
+            resolvedMethodName, _argTypesUnaryDouble, TR::Int16, rc, 2, 1, &doubleDataArray[i]);
       OMR_CT_EXPECT_EQ(d2sConst, convert(doubleDataArray[i], SHORT_POS), d2sConst(DOUBLE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "d2fConst%d", i + 1);
-      d2fConst = (signatureCharD_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2f,
-            resolvedMethodName, _argTypesUnaryDouble, TR::Float, rc, 2, 1, &doubleDataArray[i]));
+      compileOpCodeMethod(d2fConst, _numberOfUnaryArgs, TR::d2f,
+            resolvedMethodName, _argTypesUnaryDouble, TR::Float, rc, 2, 1, &doubleDataArray[i]);
       OMR_CT_EXPECT_FLOAT_EQ(d2fConst, convert(doubleDataArray[i], FLOAT_POS), d2fConst(DOUBLE_PLACEHOLDER_1));
       }
 
@@ -2395,18 +2395,18 @@ S390OpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_DOUBLE_EQ(_f2d, convert(floatDataArray[i], DOUBLE_POS), _f2d(floatDataArray[i]));
 
       sprintf(resolvedMethodName, "f2bConst%d", i + 1);
-      f2bConst = (signatureCharF_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2b,
-            resolvedMethodName, _argTypesUnaryFloat, TR::Int8, rc, 2, 1, &floatDataArray[i]));
+      compileOpCodeMethod(f2bConst, _numberOfUnaryArgs, TR::f2b,
+            resolvedMethodName, _argTypesUnaryFloat, TR::Int8, rc, 2, 1, &floatDataArray[i]);
       OMR_CT_EXPECT_EQ(f2bConst, convert(floatDataArray[i], BYTE_POS), f2bConst(FLOAT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "f2sConst%d", i + 1);
-      f2sConst = (signatureCharF_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2s,
-            resolvedMethodName, _argTypesUnaryFloat, TR::Int16, rc, 2, 1, &floatDataArray[i]));
+      compileOpCodeMethod(f2sConst, _numberOfUnaryArgs, TR::f2s,
+            resolvedMethodName, _argTypesUnaryFloat, TR::Int16, rc, 2, 1, &floatDataArray[i]);
       OMR_CT_EXPECT_EQ(f2sConst, convert(floatDataArray[i], SHORT_POS), f2sConst(FLOAT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "f2dConst%d", i + 1);
-      f2dConst = (signatureCharF_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2d,
-            resolvedMethodName, _argTypesUnaryFloat, TR::Double, rc, 2, 1, &floatDataArray[i]));
+      compileOpCodeMethod(f2dConst, _numberOfUnaryArgs, TR::f2d,
+            resolvedMethodName, _argTypesUnaryFloat, TR::Double, rc, 2, 1, &floatDataArray[i]);
       OMR_CT_EXPECT_EQ(f2dConst, convert(floatDataArray[i], DOUBLE_POS), f2dConst(FLOAT_PLACEHOLDER_1));
       }
    }
@@ -2436,63 +2436,63 @@ S390OpCodesTest::compileDisabledCompareOpCodesTestMethods()
    int32_t rc = 0;
 
    //Compare
-   _sCmpeq = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::scmpeq, "sCmpeq", _argTypesBinaryShort, TR::Int32, rc));
-   _sCmpne = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::scmpne, "sCmpne", _argTypesBinaryShort, TR::Int32, rc));
-   _sCmpgt = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::scmpgt, "sCmpgt", _argTypesBinaryShort, TR::Int32, rc));
-   _sCmplt = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::scmplt, "sCmplt", _argTypesBinaryShort, TR::Int32, rc));
-   _sCmpge = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::scmpge, "sCmpge", _argTypesBinaryShort, TR::Int32, rc));
-   _sCmple = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::scmple, "sCmple", _argTypesBinaryShort, TR::Int32, rc));
+   compileOpCodeMethod(_sCmpeq, _numberOfBinaryArgs, TR::scmpeq, "sCmpeq", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_sCmpne, _numberOfBinaryArgs, TR::scmpne, "sCmpne", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_sCmpgt, _numberOfBinaryArgs, TR::scmpgt, "sCmpgt", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_sCmplt, _numberOfBinaryArgs, TR::scmplt, "sCmplt", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_sCmpge, _numberOfBinaryArgs, TR::scmpge, "sCmpge", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_sCmple, _numberOfBinaryArgs, TR::scmple, "sCmple", _argTypesBinaryShort, TR::Int32, rc);
 
-   _bCmpeq = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bcmpeq, "bCmpeq", _argTypesBinaryByte, TR::Int32, rc));
-   _bCmpne = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bcmpne, "bCmpne", _argTypesBinaryByte, TR::Int32, rc));
-   _bCmpgt = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bcmpgt, "bCmpgt", _argTypesBinaryByte, TR::Int32, rc));
-   _bCmplt = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bcmplt, "bCmplt", _argTypesBinaryByte, TR::Int32, rc));
-   _bCmpge = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bcmpge, "bCmpge", _argTypesBinaryByte, TR::Int32, rc));
-   _bCmple = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bcmple, "bCmple", _argTypesBinaryByte, TR::Int32, rc));
+   compileOpCodeMethod(_bCmpeq, _numberOfBinaryArgs, TR::bcmpeq, "bCmpeq", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_bCmpne, _numberOfBinaryArgs, TR::bcmpne, "bCmpne", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_bCmpgt, _numberOfBinaryArgs, TR::bcmpgt, "bCmpgt", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_bCmplt, _numberOfBinaryArgs, TR::bcmplt, "bCmplt", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_bCmpge, _numberOfBinaryArgs, TR::bcmpge, "bCmpge", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_bCmple, _numberOfBinaryArgs, TR::bcmple, "bCmple", _argTypesBinaryByte, TR::Int32, rc);
 
-   _iuCmpeq = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iucmpeq, "iuCmpeq", _argTypesBinaryInt, TR::Int32, rc));
-   _iuCmpne = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iucmpne, "iuCmpne", _argTypesBinaryInt, TR::Int32, rc));
-   _iuCmpge = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iucmpge, "iuCmpge", _argTypesBinaryInt, TR::Int32, rc));
+   compileOpCodeMethod(_iuCmpeq, _numberOfBinaryArgs, TR::iucmpeq, "iuCmpeq", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iuCmpne, _numberOfBinaryArgs, TR::iucmpne, "iuCmpne", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iuCmpge, _numberOfBinaryArgs, TR::iucmpge, "iuCmpge", _argTypesBinaryInt, TR::Int32, rc);
 
-   _buCmpeq = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bucmpeq, "buCmpeq", _argTypesBinaryByte, TR::Int32, rc));
-   _buCmpne = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bucmpne, "buCmpne", _argTypesBinaryByte, TR::Int32, rc));
+   compileOpCodeMethod(_buCmpeq, _numberOfBinaryArgs, TR::bucmpeq, "buCmpeq", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_buCmpne, _numberOfBinaryArgs, TR::bucmpne, "buCmpne", _argTypesBinaryByte, TR::Int32, rc);
 
-   _suCmpeq = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sucmpeq, "suCmpeq", _argTypesBinaryShort, TR::Int32, rc));
-   _suCmpne = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sucmpne, "suCmpne", _argTypesBinaryShort, TR::Int32, rc));
-   _suCmplt = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sucmplt, "suCmplt", _argTypesBinaryShort, TR::Int32, rc));
-   _suCmpge = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sucmpge, "suCmpge", _argTypesBinaryShort, TR::Int32, rc));
-   _suCmpgt = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sucmpgt, "suCmpgt", _argTypesBinaryShort, TR::Int32, rc));
-   _suCmple = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sucmple, "suCmple", _argTypesBinaryShort, TR::Int32, rc));
+   compileOpCodeMethod(_suCmpeq, _numberOfBinaryArgs, TR::sucmpeq, "suCmpeq", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_suCmpne, _numberOfBinaryArgs, TR::sucmpne, "suCmpne", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_suCmplt, _numberOfBinaryArgs, TR::sucmplt, "suCmplt", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_suCmpge, _numberOfBinaryArgs, TR::sucmpge, "suCmpge", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_suCmpgt, _numberOfBinaryArgs, TR::sucmpgt, "suCmpgt", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_suCmple, _numberOfBinaryArgs, TR::sucmple, "suCmple", _argTypesBinaryShort, TR::Int32, rc);
 
    //CompareAndBranch
 
-   _ifScmpeq = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifscmpeq, "ifScmpeq", _argTypesBinaryShort, TR::Int32, rc));
-   _ifScmpne = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifscmpne, "ifScmpne", _argTypesBinaryShort, TR::Int32, rc));
-   _ifScmpgt = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifscmpgt, "ifScmpgt", _argTypesBinaryShort, TR::Int32, rc));
-   _ifScmplt = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifscmplt, "ifScmplt", _argTypesBinaryShort, TR::Int32, rc));
-   _ifScmpge = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifscmpge, "ifScmpge", _argTypesBinaryShort, TR::Int32, rc));
-   _ifScmple = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifscmple, "ifScmple", _argTypesBinaryShort, TR::Int32, rc));
+   compileOpCodeMethod(_ifScmpeq, _numberOfBinaryArgs, TR::ifscmpeq, "ifScmpeq", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifScmpne, _numberOfBinaryArgs, TR::ifscmpne, "ifScmpne", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifScmpgt, _numberOfBinaryArgs, TR::ifscmpgt, "ifScmpgt", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifScmplt, _numberOfBinaryArgs, TR::ifscmplt, "ifScmplt", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifScmpge, _numberOfBinaryArgs, TR::ifscmpge, "ifScmpge", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifScmple, _numberOfBinaryArgs, TR::ifscmple, "ifScmple", _argTypesBinaryShort, TR::Int32, rc);
 
-   _ifBcmpeq = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbcmpeq, "ifBcmpeq", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBcmpne = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbcmpne, "ifBcmpne", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBcmpgt = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbcmpgt, "ifBcmpgt", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBcmplt = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbcmplt, "ifBcmplt", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBcmpge = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbcmpge, "ifBcmpge", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBcmple = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbcmple, "ifBcmple", _argTypesBinaryByte, TR::Int32, rc));
+   compileOpCodeMethod(_ifBcmpeq, _numberOfBinaryArgs, TR::ifbcmpeq, "ifBcmpeq", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBcmpne, _numberOfBinaryArgs, TR::ifbcmpne, "ifBcmpne", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBcmpgt, _numberOfBinaryArgs, TR::ifbcmpgt, "ifBcmpgt", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBcmplt, _numberOfBinaryArgs, TR::ifbcmplt, "ifBcmplt", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBcmpge, _numberOfBinaryArgs, TR::ifbcmpge, "ifBcmpge", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBcmple, _numberOfBinaryArgs, TR::ifbcmple, "ifBcmple", _argTypesBinaryByte, TR::Int32, rc);
 
-   _ifBuCmpeq = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbucmpeq, "ifBuCmpeq", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBuCmpne = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbucmpne, "ifBuCmpne", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBuCmplt = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbucmplt, "ifBuCmplt", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBuCmpge = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbucmpge, "ifBuCmpge", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBuCmpgt = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbucmpgt, "ifBuCmpgt", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBuCmple = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbucmple, "ifBuCmple", _argTypesBinaryByte, TR::Int32, rc));
+   compileOpCodeMethod(_ifBuCmpeq, _numberOfBinaryArgs, TR::ifbucmpeq, "ifBuCmpeq", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBuCmpne, _numberOfBinaryArgs, TR::ifbucmpne, "ifBuCmpne", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBuCmplt, _numberOfBinaryArgs, TR::ifbucmplt, "ifBuCmplt", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBuCmpge, _numberOfBinaryArgs, TR::ifbucmpge, "ifBuCmpge", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBuCmpgt, _numberOfBinaryArgs, TR::ifbucmpgt, "ifBuCmpgt", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBuCmple, _numberOfBinaryArgs, TR::ifbucmple, "ifBuCmple", _argTypesBinaryByte, TR::Int32, rc);
 
-   _ifSuCmpeq = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifsucmpeq, "ifSuCmpeq", _argTypesBinaryShort, TR::Int32, rc));
-   _ifSuCmpne = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifsucmpne, "ifSuCmpne", _argTypesBinaryShort, TR::Int32, rc));
-   _ifSuCmpgt = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifsucmpgt, "ifSuCmpgt", _argTypesBinaryShort, TR::Int32, rc));
-   _ifSuCmple = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifsucmple, "ifSuCmple", _argTypesBinaryShort, TR::Int32, rc));
-   _ifSuCmplt = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifsucmplt, "ifSuCmplt", _argTypesBinaryShort, TR::Int32, rc));
-   _ifSuCmpge = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifsucmpge, "ifSuCmpge", _argTypesBinaryShort, TR::Int32, rc));
+   compileOpCodeMethod(_ifSuCmpeq, _numberOfBinaryArgs, TR::ifsucmpeq, "ifSuCmpeq", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifSuCmpne, _numberOfBinaryArgs, TR::ifsucmpne, "ifSuCmpne", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifSuCmpgt, _numberOfBinaryArgs, TR::ifsucmpgt, "ifSuCmpgt", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifSuCmple, _numberOfBinaryArgs, TR::ifsucmple, "ifSuCmple", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifSuCmplt, _numberOfBinaryArgs, TR::ifsucmplt, "ifSuCmplt", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifSuCmpge, _numberOfBinaryArgs, TR::ifsucmpge, "ifSuCmpge", _argTypesBinaryShort, TR::Int32, rc);
    }
 
 void
@@ -2781,18 +2781,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_sCmpeq, compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), _sCmpeq(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpeqConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpeqDataArr[i][0]), 2, &(sCmpeqDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpeqDataArr[i][0]), 2, &(sCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpeqConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpeqDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpeqConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpeqDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), sCompareConst(sCmpeqDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -2802,18 +2802,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_sCmpne, compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), _sCmpne(sCmpneDataArr[i][0], sCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpneConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpneDataArr[i][0]), 2, &(sCmpneDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpneDataArr[i][0]), 2, &(sCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpneConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpneDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpneConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpneDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), sCompareConst(sCmpneDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -2823,18 +2823,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_sCmpgt, compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), _sCmpgt(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpgtConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpgtDataArr[i][0]), 2, &(sCmpgtDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpgtDataArr[i][0]), 2, &(sCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpgtConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpgtDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpgtConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpgtDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), sCompareConst(sCmpgtDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -2844,18 +2844,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_sCmplt, compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), _sCmplt(sCmpltDataArr[i][0], sCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpltConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpltDataArr[i][0]), 2, &(sCmpltDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpltDataArr[i][0]), 2, &(sCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpltConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpltDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpltConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpltDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), sCompareConst(sCmpltDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -2865,18 +2865,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_sCmpge, compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), _sCmpge(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpgeConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpgeDataArr[i][0]), 2, &(sCmpgeDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpgeDataArr[i][0]), 2, &(sCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpgeConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpgeDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpgeConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpgeDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), sCompareConst(sCmpgeDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -2886,18 +2886,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_sCmple, compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), _sCmple(sCmpleDataArr[i][0], sCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpleConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpleDataArr[i][0]), 2, &(sCmpleDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpleDataArr[i][0]), 2, &(sCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpleConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpleDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpleConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpleDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), sCompareConst(sCmpleDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -2908,18 +2908,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_bCmpeq, compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), _bCmpeq(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpeqConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpeqDataArr[i][0]), 2, &(bCmpeqDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpeqDataArr[i][0]), 2, &(bCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpeqConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpeqDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpeqConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpeqDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), bCompareConst(bCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -2929,18 +2929,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_bCmpgt, compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), _bCmpgt(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpgtConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpgtDataArr[i][0]), 2, &(bCmpgtDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpgtDataArr[i][0]), 2, &(bCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpgtConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpgtDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpgtConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpgtDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), bCompareConst(bCmpgtDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -2950,18 +2950,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_bCmplt, compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), _bCmplt(bCmpltDataArr[i][0], bCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpltConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpltDataArr[i][0]), 2, &(bCmpltDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpltDataArr[i][0]), 2, &(bCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpltConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpltDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpltConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpltDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), bCompareConst(bCmpltDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -2971,18 +2971,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_bCmpge, compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), _bCmpge(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpgeConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpgeDataArr[i][0]), 2, &(bCmpgeDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpgeDataArr[i][0]), 2, &(bCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpgeConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpgeDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpgeConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpgeDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), bCompareConst(bCmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -2992,18 +2992,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_bCmpne, compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), _bCmpne(bCmpneDataArr[i][0], bCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpneConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpneDataArr[i][0]), 2, &(bCmpneDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpneDataArr[i][0]), 2, &(bCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpneConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpneDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpneConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpneDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), bCompareConst(bCmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3013,18 +3013,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_bCmple, compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), _bCmple(bCmpleDataArr[i][0], bCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpleConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpleDataArr[i][0]), 2, &(bCmpleDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpleDataArr[i][0]), 2, &(bCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpleConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpleDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpleConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpleDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), bCompareConst(bCmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3035,18 +3035,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_iuCmpeq, compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), _iuCmpeq(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpeqConst1_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpeqDataArr[i][0]), 2, &(iuCmpeqDataArr[i][1])));
+      compileOpCodeMethod(iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpeqDataArr[i][0]), 2, &(iuCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iuCmpeqConst2_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpeqDataArr[i][0])));
+      compileOpCodeMethod(iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpeqConst3_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpeqDataArr[i][1])));
+      compileOpCodeMethod(iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), iuCompareConst(iuCmpeqDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -3056,18 +3056,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_iuCmpne, compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), _iuCmpne(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpneConst1_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpneDataArr[i][0]), 2, &(iuCmpneDataArr[i][1])));
+      compileOpCodeMethod(iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpneDataArr[i][0]), 2, &(iuCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iuCmpneConst2_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpneDataArr[i][0])));
+      compileOpCodeMethod(iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpneConst3_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpneDataArr[i][1])));
+      compileOpCodeMethod(iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), iuCompareConst(iuCmpneDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -3077,18 +3077,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_iuCmpge, compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), _iuCmpge(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpgeConst1_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpgeDataArr[i][0]), 2, &(iuCmpgeDataArr[i][1])));
+      compileOpCodeMethod(iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpgeDataArr[i][0]), 2, &(iuCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iuCmpgeConst2_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpgeDataArr[i][0])));
+      compileOpCodeMethod(iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpgeConst3_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpgeDataArr[i][1])));
+      compileOpCodeMethod(iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(iuCmpgeDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -3099,18 +3099,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_buCmpeq, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), _buCmpeq(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buCmpeqConst1_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(buCmpeqDataArr[i][0]), 2, &(buCmpeqDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(buCmpeqDataArr[i][0]), 2, &(buCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "buCmpeqConst2_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(buCmpeqDataArr[i][0])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(buCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, buCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buCmpeqConst3_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(buCmpeqDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(buCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(buCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3120,18 +3120,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_buCmpne, compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), _buCmpne(buCmpneDataArr[i][0], buCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buCmpneConst1_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(buCmpneDataArr[i][0]), 2, &(buCmpneDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::bucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(buCmpneDataArr[i][0]), 2, &(buCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "buCmpneConst2_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(buCmpneDataArr[i][0])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::bucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(buCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, buCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buCmpneConst3_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(buCmpneDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::bucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(buCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), buCompareConst(buCmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3142,18 +3142,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_suCmpeq, compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), _suCmpeq(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1])) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpeqConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpeqDataArr[i][0]), 2, &(suCmpeqDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpeqDataArr[i][0]), 2, &(suCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpeqConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpeqDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpeqDataArr[i][1])) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpeqConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpeqDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), suCompareConst(suCmpeqDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
       }
 
@@ -3163,18 +3163,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_suCmpne, compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), _suCmpne(suCmpneDataArr[i][0], suCmpneDataArr[i][1])) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpneConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpneDataArr[i][0]), 2, &(suCmpneDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpneDataArr[i][0]), 2, &(suCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpneConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpneDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpneDataArr[i][1])) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpneConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpneDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), suCompareConst(suCmpneDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
       }
 
@@ -3184,18 +3184,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_suCmpgt, compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), _suCmpgt(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1])) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgtConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpgtDataArr[i][0]), 2, &(suCmpgtDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpgtDataArr[i][0]), 2, &(suCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgtConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpgtDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpgtDataArr[i][1])) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgtConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpgtDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), suCompareConst(suCmpgtDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
       }
 
@@ -3205,18 +3205,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_suCmplt, compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), _suCmplt(suCmpltDataArr[i][0], suCmpltDataArr[i][1])) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpltConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpltDataArr[i][0]), 2, &(suCmpltDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpltDataArr[i][0]), 2, &(suCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpltConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpltDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpltDataArr[i][1])) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpltConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpltDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), suCompareConst(suCmpltDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
       }
 
@@ -3226,18 +3226,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_suCmpge, compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), _suCmpge(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1])) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgeConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpgeDataArr[i][0]), 2, &(suCmpgeDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpgeDataArr[i][0]), 2, &(suCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgeConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpgeDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpgeDataArr[i][1])) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgeConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpgeDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), suCompareConst(suCmpgeDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
       }
 
@@ -3247,18 +3247,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_suCmple, compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), _suCmple(suCmpleDataArr[i][0], suCmpleDataArr[i][1])) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpleConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpleDataArr[i][0]), 2, &(suCmpleDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpleDataArr[i][0]), 2, &(suCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpleConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpleDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpleDataArr[i][1])) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpleConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpleDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(suCmpleDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
       }
 
@@ -3269,18 +3269,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_ifScmpeq, compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), _ifScmpeq(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpeqConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpeqDataArr[i][0]), 2, &(ifScmpeqDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpeqDataArr[i][0]), 2, &(ifScmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpeqConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpeqDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpeqConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpeqDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), sCompareConst(ifScmpeqDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -3290,18 +3290,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_ifScmpne, compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), _ifScmpne(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpneConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpneDataArr[i][0]), 2, &(ifScmpneDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpneDataArr[i][0]), 2, &(ifScmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpneConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpneDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpneConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpneDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), sCompareConst(ifScmpneDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -3311,18 +3311,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_ifScmpgt, compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), _ifScmpgt(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpgtConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpgtDataArr[i][0]), 2, &(ifScmpgtDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpgtDataArr[i][0]), 2, &(ifScmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpgtConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpgtDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpgtConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpgtDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), sCompareConst(ifScmpgtDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -3332,18 +3332,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_ifScmplt, compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), _ifScmplt(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpltConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpltDataArr[i][0]), 2, &(ifScmpltDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpltDataArr[i][0]), 2, &(ifScmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpltConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpltDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpltConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpltDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), sCompareConst(ifScmpltDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -3353,18 +3353,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_ifScmpge, compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), _ifScmpge(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpgeConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpgeDataArr[i][0]), 2, &(ifScmpgeDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpgeDataArr[i][0]), 2, &(ifScmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpgeConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpgeDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpgeConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpgeDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), sCompareConst(ifScmpgeDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -3374,18 +3374,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_ifScmple, compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), _ifScmple(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpleConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpleDataArr[i][0]), 2, &(ifScmpleDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpleDataArr[i][0]), 2, &(ifScmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpleConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpleDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpleConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpleDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), sCompareConst(ifScmpleDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -3396,18 +3396,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_ifBcmpeq, compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), _ifBcmpeq(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpeqConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpeqDataArr[i][0]), 2, &(ifBcmpeqDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpeqDataArr[i][0]), 2, &(ifBcmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpeqConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpeqDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpeqConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpeqDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), bCompareConst(ifBcmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3417,18 +3417,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_ifBcmpgt, compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), _ifBcmpgt(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpgtConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpgtDataArr[i][0]), 2, &(ifBcmpgtDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpgtDataArr[i][0]), 2, &(ifBcmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpgtConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpgtDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpgtConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpgtDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), bCompareConst(ifBcmpgtDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3438,18 +3438,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_ifBcmplt, compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), _ifBcmplt(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpltConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpltDataArr[i][0]), 2, &(ifBcmpltDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpltDataArr[i][0]), 2, &(ifBcmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpltConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpltDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpltConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpltDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), bCompareConst(ifBcmpltDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3459,18 +3459,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_ifBcmpge, compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), _ifBcmpge(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpgeConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpgeDataArr[i][0]), 2, &(ifBcmpgeDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpgeDataArr[i][0]), 2, &(ifBcmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpgeConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpgeDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpgeConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpgeDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(ifBcmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3480,18 +3480,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_ifBcmpne, compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), _ifBcmpne(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpneConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpneDataArr[i][0]), 2, &(ifBcmpneDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpneDataArr[i][0]), 2, &(ifBcmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpneConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpneDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpneConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpneDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), bCompareConst(ifBcmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3501,18 +3501,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_ifBcmple, compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), _ifBcmple(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpleConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpleDataArr[i][0]), 2, &(ifBcmpleDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpleDataArr[i][0]), 2, &(ifBcmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpleConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpleDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpleConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpleDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(ifBcmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3523,18 +3523,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_ifBuCmpeq, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), _ifBuCmpeq(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpeqConst1_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpeqDataArr[i][0]), 2, &(ifBuCmpeqDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpeqDataArr[i][0]), 2, &(ifBuCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpeqConst2_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpeqDataArr[i][0])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpeqConst3_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpeqDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(ifBuCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3544,18 +3544,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_ifBuCmpne, compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), _ifBuCmpne(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpneConst1_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpneDataArr[i][0]), 2, &(ifBuCmpneDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpneDataArr[i][0]), 2, &(ifBuCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpneConst2_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpneDataArr[i][0])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpneConst3_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpneDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), buCompareConst(ifBuCmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3565,18 +3565,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_ifBuCmpgt, compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), _ifBuCmpgt(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpgtConst1_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpgtDataArr[i][0]), 2, &(ifBuCmpgtDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpgtDataArr[i][0]), 2, &(ifBuCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpgtConst2_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpgtDataArr[i][0])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpgtConst3_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpgtDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), buCompareConst(ifBuCmpgtDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3586,18 +3586,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_ifBuCmplt, compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), _ifBuCmplt(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpltConst1_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpltDataArr[i][0]), 2, &(ifBuCmpltDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpltDataArr[i][0]), 2, &(ifBuCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpltConst2_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpltDataArr[i][0])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpltConst3_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpltDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), buCompareConst(ifBuCmpltDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3607,18 +3607,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_ifBuCmpge, compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), _ifBuCmpge(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpgeConst1_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpgeDataArr[i][0]), 2, &(ifBuCmpgeDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpgeDataArr[i][0]), 2, &(ifBuCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpgeConst2_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpgeDataArr[i][0])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpgeConst3_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpgeDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), buCompareConst(ifBuCmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3628,18 +3628,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_ifBuCmple, compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), _ifBuCmple(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpleConst1_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpleDataArr[i][0]), 2, &(ifBuCmpleDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpleDataArr[i][0]), 2, &(ifBuCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpleConst2_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpleDataArr[i][0])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpleConst3_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpleDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), buCompareConst(ifBuCmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3650,18 +3650,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_ifSuCmpeq, compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), _ifSuCmpeq(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1])) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpeqConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpeqDataArr[i][0]), 2, &(ifSuCmpeqDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpeqDataArr[i][0]), 2, &(ifSuCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpeqConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpeqDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpeqDataArr[i][1])) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpeqConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpeqDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), suCompareConst(ifSuCmpeqDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
       }
 
@@ -3671,18 +3671,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_ifSuCmpne, compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), _ifSuCmpne(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1])) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpneConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpneDataArr[i][0]), 2, &(ifSuCmpneDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpneDataArr[i][0]), 2, &(ifSuCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpneConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpneDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpneDataArr[i][1])) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpneConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpneDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), suCompareConst(ifSuCmpneDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
       }
 
@@ -3692,18 +3692,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_ifSuCmpgt, compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), _ifSuCmpgt(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1])) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgtConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpgtDataArr[i][0]), 2, &(ifSuCmpgtDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpgtDataArr[i][0]), 2, &(ifSuCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgtConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpgtDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpgtDataArr[i][1])) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgtConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpgtDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), suCompareConst(ifSuCmpgtDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
       }
 
@@ -3713,18 +3713,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_ifSuCmplt, compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), _ifSuCmplt(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1])) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpltConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpltDataArr[i][0]), 2, &(ifSuCmpltDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpltDataArr[i][0]), 2, &(ifSuCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpltConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpltDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpltDataArr[i][1])) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpltConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpltDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), suCompareConst(ifSuCmpltDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
       }
 
@@ -3734,18 +3734,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_ifSuCmpge, compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), _ifSuCmpge(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1])) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgeConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpgeDataArr[i][0]), 2, &(ifSuCmpgeDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpgeDataArr[i][0]), 2, &(ifSuCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgeConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpgeDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpgeDataArr[i][1])) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgeConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpgeDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), suCompareConst(ifSuCmpgeDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
       }
 
@@ -3755,18 +3755,18 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(_ifSuCmple, compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), _ifSuCmple(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1])) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpleConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpleDataArr[i][0]), 2, &(ifSuCmpleDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpleDataArr[i][0]), 2, &(ifSuCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpleConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpleDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpleDataArr[i][1])) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpleConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpleDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), suCompareConst(ifSuCmpleDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
       }
    }
@@ -3823,35 +3823,33 @@ S390OpCodesTest::compileDisabledUnaryTestMethods()
    int32_t rc = 0;
 
    //jazz103 WI 108753
-   _bNeg = (signatureCharB_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bneg, "bNeg", _argTypesUnaryByte, TR::Int8, rc));
-   _sNeg = (signatureCharS_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::sneg, "sNeg", _argTypesUnaryShort, TR::Int16, rc));
+   compileOpCodeMethod(_bNeg, _numberOfUnaryArgs, TR::bneg, "bNeg", _argTypesUnaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_sNeg, _numberOfUnaryArgs, TR::sneg, "sNeg", _argTypesUnaryShort, TR::Int16, rc);
 
-   _b2i = (signatureCharB_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2i, "b2i", _argTypesUnaryByte, TR::Int32, rc));
-   _b2l = (signatureCharB_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2l, "b2l", _argTypesUnaryByte, TR::Int64, rc));
-   _b2s = (signatureCharB_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2s, "b2s", _argTypesUnaryByte, TR::Int16, rc));
-   _b2f = (signatureCharB_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2f, "b2f", _argTypesUnaryByte, TR::Float, rc));
-   _b2d = (signatureCharB_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2d, "b2d", _argTypesUnaryByte, TR::Double, rc));
-   _bu2i = (unsignedSignatureCharB_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2i, "bu2i", _argTypesUnaryByte, TR::Int32, rc));
-   _bu2l = (unsignedSignatureCharB_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2l, "bu2l", _argTypesUnaryByte, TR::Int64, rc));
-   _bu2s = (unsignedSignatureCharB_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2s, "bu2s", _argTypesUnaryByte, TR::Int16, rc));
-   _bu2f = (unsignedSignatureCharB_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2f, "bu2f", _argTypesUnaryByte, TR::Float, rc));
-   _bu2d = (unsignedSignatureCharB_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2d, "bu2d", _argTypesUnaryByte, TR::Double, rc));
+   compileOpCodeMethod(_b2i, _numberOfUnaryArgs, TR::b2i, "b2i", _argTypesUnaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_b2l, _numberOfUnaryArgs, TR::b2l, "b2l", _argTypesUnaryByte, TR::Int64, rc);
+   compileOpCodeMethod(_b2s, _numberOfUnaryArgs, TR::b2s, "b2s", _argTypesUnaryByte, TR::Int16, rc);
+   compileOpCodeMethod(_b2f, _numberOfUnaryArgs, TR::b2f, "b2f", _argTypesUnaryByte, TR::Float, rc);
+   compileOpCodeMethod(_b2d, _numberOfUnaryArgs, TR::b2d, "b2d", _argTypesUnaryByte, TR::Double, rc);
+   compileOpCodeMethod(_bu2i, _numberOfUnaryArgs, TR::bu2i, "bu2i", _argTypesUnaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_bu2l, _numberOfUnaryArgs, TR::bu2l, "bu2l", _argTypesUnaryByte, TR::Int64, rc);
+   compileOpCodeMethod(_bu2s, _numberOfUnaryArgs, TR::bu2s, "bu2s", _argTypesUnaryByte, TR::Int16, rc);
+   compileOpCodeMethod(_bu2f, _numberOfUnaryArgs, TR::bu2f, "bu2f", _argTypesUnaryByte, TR::Float, rc);
+   compileOpCodeMethod(_bu2d, _numberOfUnaryArgs, TR::bu2d, "bu2d", _argTypesUnaryByte, TR::Double, rc);
 
-   _s2i = (signatureCharS_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2i, "s2i", _argTypesUnaryShort, TR::Int32, rc));
-   _s2l = (signatureCharS_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2l, "s2l", _argTypesUnaryShort, TR::Int64, rc));
-   _s2f = (signatureCharS_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2f, "s2f", _argTypesUnaryShort, TR::Float, rc));
-   _s2d = (signatureCharS_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2d, "s2d", _argTypesUnaryShort, TR::Double, rc));
-   _s2b = (signatureCharS_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2b, "s2b", _argTypesUnaryShort, TR::Int8, rc));
-   _su2i = (unsignedSignatureCharS_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2i, "su2i", _argTypesUnaryShort, TR::Int32, rc));
-   _su2l = (unsignedSignatureCharS_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2l, "su2l", _argTypesUnaryShort, TR::Int64, rc));
-   _su2f = (unsignedSignatureCharS_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2f, "su2f", _argTypesUnaryShort, TR::Float, rc));
-   _su2d = (unsignedSignatureCharS_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2d, "su2d", _argTypesUnaryShort, TR::Double, rc));
+   compileOpCodeMethod(_s2i, _numberOfUnaryArgs, TR::s2i, "s2i", _argTypesUnaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_s2l, _numberOfUnaryArgs, TR::s2l, "s2l", _argTypesUnaryShort, TR::Int64, rc);
+   compileOpCodeMethod(_s2f, _numberOfUnaryArgs, TR::s2f, "s2f", _argTypesUnaryShort, TR::Float, rc);
+   compileOpCodeMethod(_s2d, _numberOfUnaryArgs, TR::s2d, "s2d", _argTypesUnaryShort, TR::Double, rc);
+   compileOpCodeMethod(_s2b, _numberOfUnaryArgs, TR::s2b, "s2b", _argTypesUnaryShort, TR::Int8, rc);
+   compileOpCodeMethod(_su2i, _numberOfUnaryArgs, TR::su2i, "su2i", _argTypesUnaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_su2l, _numberOfUnaryArgs, TR::su2l, "su2l", _argTypesUnaryShort, TR::Int64, rc);
+   compileOpCodeMethod(_su2f, _numberOfUnaryArgs, TR::su2f, "su2f", _argTypesUnaryShort, TR::Float, rc);
+   compileOpCodeMethod(_su2d, _numberOfUnaryArgs, TR::su2d, "su2d", _argTypesUnaryShort, TR::Double, rc);
 
-   _iu2f = (unsignedSignatureCharI_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iu2f, "iU2f", _argTypesUnaryInt, TR::Float, rc));
-   _lu2f = (unsignedSignatureCharJ_F_testMethodType *)(compileOpCodeMethod(_numberOfUnaryArgs, TR::lu2f, "lu2f", _argTypesUnaryLong, TR::Float, rc));
-   _lu2d = (unsignedSignatureCharJ_D_testMethodType *)(compileOpCodeMethod(_numberOfUnaryArgs, TR::lu2d, "lu2d", _argTypesUnaryLong, TR::Double, rc));
-
-
+   compileOpCodeMethod(_iu2f, _numberOfUnaryArgs, TR::iu2f, "iU2f", _argTypesUnaryInt, TR::Float, rc);
+   compileOpCodeMethod(_lu2f, _numberOfUnaryArgs, TR::lu2f, "lu2f", _argTypesUnaryLong, TR::Float, rc);
+   compileOpCodeMethod(_lu2d, _numberOfUnaryArgs, TR::lu2d, "lu2d", _argTypesUnaryLong, TR::Double, rc);
 
    }
 
@@ -3901,8 +3899,8 @@ S390OpCodesTest::invokeDisabledUnaryTests()
       {
       OMR_CT_EXPECT_EQ(_bNeg, neg(byteDataArray[i]), _bNeg(byteDataArray[i]));
       sprintf(resolvedMethodName, "bNegConst%d", i + 1);
-      bUnaryCons = (signatureCharB_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bneg,
-            resolvedMethodName, _argTypesUnaryByte, TR::Int8, rc, 2, 1, &byteDataArray[i]));
+      compileOpCodeMethod(bUnaryCons, _numberOfUnaryArgs, TR::bneg,
+            resolvedMethodName, _argTypesUnaryByte, TR::Int8, rc, 2, 1, &byteDataArray[i]);
       OMR_CT_EXPECT_EQ(bUnaryCons, neg(byteDataArray[i]), bUnaryCons(BYTE_PLACEHOLDER_1));
       }
 
@@ -3912,8 +3910,8 @@ S390OpCodesTest::invokeDisabledUnaryTests()
       {
       OMR_CT_EXPECT_EQ(_sNeg, neg(shortDataArray[i]), _sNeg(shortDataArray[i]));
       sprintf(resolvedMethodName, "sNegConst%d", i + 1);
-      sUnaryCons = (signatureCharS_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::sneg,
-            resolvedMethodName, _argTypesUnaryShort, TR::Int16, rc, 2, 1, &shortDataArray[i]));
+      compileOpCodeMethod(sUnaryCons, _numberOfUnaryArgs, TR::sneg,
+            resolvedMethodName, _argTypesUnaryShort, TR::Int16, rc, 2, 1, &shortDataArray[i]);
       OMR_CT_EXPECT_EQ(sUnaryCons, neg(shortDataArray[i]), sUnaryCons(SHORT_PLACEHOLDER_1));
       }
 
@@ -3925,13 +3923,13 @@ S390OpCodesTest::invokeDisabledUnaryTests()
       OMR_CT_EXPECT_DOUBLE_EQ(_b2d, convert(byteDataArray[i], DOUBLE_POS), _b2d(byteDataArray[i]));
 
       sprintf(resolvedMethodName, "b2fConst%d", i + 1);
-      b2fConst = (signatureCharB_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2f,
-            resolvedMethodName, _argTypesUnaryByte, TR::Float, rc, 2, 1, &byteDataArray[i]));
+      compileOpCodeMethod(b2fConst, _numberOfUnaryArgs, TR::b2f,
+            resolvedMethodName, _argTypesUnaryByte, TR::Float, rc, 2, 1, &byteDataArray[i]);
       OMR_CT_EXPECT_FLOAT_EQ(b2fConst, convert(byteDataArray[i], FLOAT_POS), b2fConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "b2dConst%d", i + 1);
-      b2dConst = (signatureCharB_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2d,
-            resolvedMethodName, _argTypesUnaryByte, TR::Double, rc, 2, 1, &byteDataArray[i]));
+      compileOpCodeMethod(b2dConst, _numberOfUnaryArgs, TR::b2d,
+            resolvedMethodName, _argTypesUnaryByte, TR::Double, rc, 2, 1, &byteDataArray[i]);
       OMR_CT_EXPECT_DOUBLE_EQ(b2dConst, convert(byteDataArray[i], DOUBLE_POS), b2dConst(BYTE_PLACEHOLDER_1));
       }
 
@@ -3944,18 +3942,18 @@ S390OpCodesTest::invokeDisabledUnaryTests()
       OMR_CT_EXPECT_EQ(_b2l, convert(byteDataArray[i], LONG_POS), _b2l(byteDataArray[i]));
 
       sprintf(resolvedMethodName, "b2sConst%d", i + 1);
-      b2sConst = (signatureCharB_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2s,
-            resolvedMethodName, _argTypesUnaryByte, TR::Int16, rc, 2, 1, &byteDataArray[i]));
+      compileOpCodeMethod(b2sConst, _numberOfUnaryArgs, TR::b2s,
+            resolvedMethodName, _argTypesUnaryByte, TR::Int16, rc, 2, 1, &byteDataArray[i]);
       OMR_CT_EXPECT_EQ(b2sConst, convert(byteDataArray[i], SHORT_POS), b2sConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "b2iConst%d", i + 1);
-      b2iConst = (signatureCharB_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2i,
-            resolvedMethodName, _argTypesUnaryByte, TR::Int32, rc, 2, 1, &byteDataArray[i]));
+      compileOpCodeMethod(b2iConst, _numberOfUnaryArgs, TR::b2i,
+            resolvedMethodName, _argTypesUnaryByte, TR::Int32, rc, 2, 1, &byteDataArray[i]);
       OMR_CT_EXPECT_EQ(b2iConst, convert(byteDataArray[i], INT_POS), b2iConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "b2lConst%d", i + 1);
-      b2lConst = (signatureCharB_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2l,
-            resolvedMethodName, _argTypesUnaryByte, TR::Int64, rc, 2, 1, &byteDataArray[i]));
+      compileOpCodeMethod(b2lConst, _numberOfUnaryArgs, TR::b2l,
+            resolvedMethodName, _argTypesUnaryByte, TR::Int64, rc, 2, 1, &byteDataArray[i]);
       OMR_CT_EXPECT_EQ(b2lConst, convert(byteDataArray[i], LONG_POS), b2lConst(BYTE_PLACEHOLDER_1));
       }
 
@@ -3968,18 +3966,18 @@ S390OpCodesTest::invokeDisabledUnaryTests()
       OMR_CT_EXPECT_EQ(_bu2l, convert(ubyteDataArray[i], LONG_POS), _bu2l(ubyteDataArray[i]));
 
       sprintf(resolvedMethodName, "bu2sConst%d", i + 1);
-      bu2sConst = (unsignedSignatureCharB_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2s,
-            resolvedMethodName, _argTypesUnaryByte, TR::Int16, rc, 2, 1, &ubyteDataArray[i]));
+      compileOpCodeMethod(bu2sConst, _numberOfUnaryArgs, TR::bu2s,
+            resolvedMethodName, _argTypesUnaryByte, TR::Int16, rc, 2, 1, &ubyteDataArray[i]);
       OMR_CT_EXPECT_EQ(bu2sConst, convert(ubyteDataArray[i], SHORT_POS), bu2sConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "bu2iConst%d", i + 1);
-      bu2iConst = (unsignedSignatureCharB_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2i,
-            resolvedMethodName, _argTypesUnaryByte, TR::Int32, rc, 2, 1, &ubyteDataArray[i]));
+      compileOpCodeMethod(bu2iConst, _numberOfUnaryArgs, TR::bu2i,
+            resolvedMethodName, _argTypesUnaryByte, TR::Int32, rc, 2, 1, &ubyteDataArray[i]);
       OMR_CT_EXPECT_EQ(bu2iConst, convert(ubyteDataArray[i], INT_POS), bu2iConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "bu2lConst%d", i + 1);
-      bu2lConst = (unsignedSignatureCharB_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2l,
-            resolvedMethodName, _argTypesUnaryByte, TR::Int64, rc, 2, 1, &ubyteDataArray[i]));
+      compileOpCodeMethod(bu2lConst, _numberOfUnaryArgs, TR::bu2l,
+            resolvedMethodName, _argTypesUnaryByte, TR::Int64, rc, 2, 1, &ubyteDataArray[i]);
       OMR_CT_EXPECT_EQ(bu2lConst, convert(ubyteDataArray[i], LONG_POS), bu2lConst(BYTE_PLACEHOLDER_1));
       }
 
@@ -3992,19 +3990,19 @@ S390OpCodesTest::invokeDisabledUnaryTests()
       OMR_CT_EXPECT_EQ(_s2l, convert(shortDataArray[i], LONG_POS), _s2l(shortDataArray[i]));
 
       sprintf(resolvedMethodName, "s2bConst%d", i + 1);
-      s2bConst = (signatureCharS_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2b,
-            resolvedMethodName, _argTypesUnaryShort, TR::Int8, rc, 2, 1, &shortDataArray[i]));
+      compileOpCodeMethod(s2bConst, _numberOfUnaryArgs, TR::s2b,
+            resolvedMethodName, _argTypesUnaryShort, TR::Int8, rc, 2, 1, &shortDataArray[i]);
       OMR_CT_EXPECT_EQ(s2bConst, convert(shortDataArray[i], BYTE_POS), s2bConst(SHORT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "s2iConst%d", i + 1);
-      s2iConst = (signatureCharS_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2i,
-            resolvedMethodName, _argTypesUnaryShort, TR::Int32, rc, 2, 1, &shortDataArray[i]));
+      compileOpCodeMethod(s2iConst, _numberOfUnaryArgs, TR::s2i,
+            resolvedMethodName, _argTypesUnaryShort, TR::Int32, rc, 2, 1, &shortDataArray[i]);
       OMR_CT_EXPECT_EQ(s2iConst, convert(shortDataArray[i], INT_POS), s2iConst(SHORT_PLACEHOLDER_1));
 
 
       sprintf(resolvedMethodName, "s2lConst%d", i + 1);
-      s2lConst = (signatureCharS_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2l,
-            resolvedMethodName, _argTypesUnaryShort, TR::Int64, rc, 2, 1, &shortDataArray[i]));
+      compileOpCodeMethod(s2lConst, _numberOfUnaryArgs, TR::s2l,
+            resolvedMethodName, _argTypesUnaryShort, TR::Int64, rc, 2, 1, &shortDataArray[i]);
       OMR_CT_EXPECT_EQ(s2lConst, convert(shortDataArray[i], LONG_POS), s2lConst(SHORT_PLACEHOLDER_1));
       }
    //su 2 i,l
@@ -4015,14 +4013,14 @@ S390OpCodesTest::invokeDisabledUnaryTests()
       OMR_CT_EXPECT_EQ(_su2l, convert(ushortDataArray[i], LONG_POS), _su2l(ushortDataArray[i]));
 
       sprintf(resolvedMethodName, "s2iConst%d", i + 1);
-      su2iConst = (unsignedSignatureCharS_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2i,
-            resolvedMethodName, _argTypesUnaryShort, TR::Int32, rc, 2, 1, &ushortDataArray[i]));
+      compileOpCodeMethod(su2iConst, _numberOfUnaryArgs, TR::su2i,
+            resolvedMethodName, _argTypesUnaryShort, TR::Int32, rc, 2, 1, &ushortDataArray[i]);
       OMR_CT_EXPECT_EQ(su2iConst, convert(ushortDataArray[i], INT_POS), su2iConst(SHORT_PLACEHOLDER_1));
 
 
       sprintf(resolvedMethodName, "s2lConst%d", i + 1);
-      su2lConst = (unsignedSignatureCharS_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2l,
-            resolvedMethodName, _argTypesUnaryShort, TR::Int64, rc, 2, 1, &ushortDataArray[i]));
+      compileOpCodeMethod(su2lConst, _numberOfUnaryArgs, TR::su2l,
+            resolvedMethodName, _argTypesUnaryShort, TR::Int64, rc, 2, 1, &ushortDataArray[i]);
       OMR_CT_EXPECT_EQ(su2lConst, convert(ushortDataArray[i], LONG_POS), su2lConst(SHORT_PLACEHOLDER_1));
       }
 
@@ -4034,13 +4032,13 @@ S390OpCodesTest::invokeDisabledUnaryTests()
       OMR_CT_EXPECT_DOUBLE_EQ(_s2d, convert(shortDataArray[i], DOUBLE_POS), _s2d(shortDataArray[i]));
 
       sprintf(resolvedMethodName, "s2fConst%d", i + 1);
-      s2fConst = (signatureCharS_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2f,
-            resolvedMethodName, _argTypesUnaryShort, TR::Float, rc, 2, 1, &shortDataArray[i]));
+      compileOpCodeMethod(s2fConst, _numberOfUnaryArgs, TR::s2f,
+            resolvedMethodName, _argTypesUnaryShort, TR::Float, rc, 2, 1, &shortDataArray[i]);
       OMR_CT_EXPECT_FLOAT_EQ(s2fConst, convert(shortDataArray[i], FLOAT_POS), s2fConst(SHORT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "s2dConst%d", i + 1);
-      s2dConst = (signatureCharS_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2d,
-            resolvedMethodName, _argTypesUnaryShort, TR::Double, rc, 2, 1, &shortDataArray[i]));
+      compileOpCodeMethod(s2dConst, _numberOfUnaryArgs, TR::s2d,
+            resolvedMethodName, _argTypesUnaryShort, TR::Double, rc, 2, 1, &shortDataArray[i]);
       OMR_CT_EXPECT_DOUBLE_EQ(s2dConst, convert(shortDataArray[i], DOUBLE_POS), s2dConst(SHORT_PLACEHOLDER_1));
       }
 
@@ -4051,8 +4049,8 @@ S390OpCodesTest::invokeDisabledUnaryTests()
       OMR_CT_EXPECT_EQ(_iu2f, convert(uintDataArray[i], FLOAT_POS), _iu2f(uintDataArray[i]));
 
       sprintf(resolvedMethodName, "iu2fConst%d", i + 1);
-      iu2fConst = (unsignedSignatureCharI_F_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::iu2f, resolvedMethodName, _argTypesUnaryInt, TR::Float, rc, 2, 1, &uintDataArray[i]));
+      compileOpCodeMethod(iu2fConst, 
+            _numberOfUnaryArgs, TR::iu2f, resolvedMethodName, _argTypesUnaryInt, TR::Float, rc, 2, 1, &uintDataArray[i]);
       OMR_CT_EXPECT_EQ(iu2fConst, convert(uintDataArray[i], FLOAT_POS), iu2fConst(INT_PLACEHOLDER_1)) << uintDataArray[i];
       }
 
@@ -4064,13 +4062,13 @@ S390OpCodesTest::invokeDisabledUnaryTests()
       OMR_CT_EXPECT_DOUBLE_EQ(_su2d, convert(ushortDataArray[i], DOUBLE_POS), _su2d(ushortDataArray[i]));
 
       sprintf(resolvedMethodName, "su2fConst%d", i + 1);
-      su2fConst = (unsignedSignatureCharS_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2f,
-            resolvedMethodName, _argTypesUnaryShort, TR::Float, rc, 2, 1, &ushortDataArray[i]));
+      compileOpCodeMethod(su2fConst, _numberOfUnaryArgs, TR::su2f,
+            resolvedMethodName, _argTypesUnaryShort, TR::Float, rc, 2, 1, &ushortDataArray[i]);
       OMR_CT_EXPECT_FLOAT_EQ(su2fConst, convert(ushortDataArray[i], FLOAT_POS), su2fConst(SHORT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "su2dConst%d", i + 1);
-      su2dConst = (unsignedSignatureCharS_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2d,
-            resolvedMethodName, _argTypesUnaryShort, TR::Double, rc, 2, 1, &ushortDataArray[i]));
+      compileOpCodeMethod(su2dConst, _numberOfUnaryArgs, TR::su2d,
+            resolvedMethodName, _argTypesUnaryShort, TR::Double, rc, 2, 1, &ushortDataArray[i]);
       OMR_CT_EXPECT_DOUBLE_EQ(su2dConst, convert(ushortDataArray[i], DOUBLE_POS), su2dConst(SHORT_PLACEHOLDER_1));
       }
 
@@ -4082,13 +4080,13 @@ S390OpCodesTest::invokeDisabledUnaryTests()
       OMR_CT_EXPECT_DOUBLE_EQ(_bu2d, convert(ubyteDataArray[i], DOUBLE_POS), _bu2d(ubyteDataArray[i]));
 
       sprintf(resolvedMethodName, "bu2fConst%d", i + 1);
-      bu2fConst = (unsignedSignatureCharB_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2f,
-            resolvedMethodName, _argTypesUnaryByte, TR::Float, rc, 2, 1, &ubyteDataArray[i]));
+      compileOpCodeMethod(bu2fConst, _numberOfUnaryArgs, TR::bu2f,
+            resolvedMethodName, _argTypesUnaryByte, TR::Float, rc, 2, 1, &ubyteDataArray[i]);
       OMR_CT_EXPECT_FLOAT_EQ(bu2fConst, convert(ubyteDataArray[i], FLOAT_POS), bu2fConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "bu2dConst%d", i + 1);
-      bu2dConst = (unsignedSignatureCharB_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2d,
-            resolvedMethodName, _argTypesUnaryByte, TR::Double, rc, 2, 1, &ubyteDataArray[i]));
+      compileOpCodeMethod(bu2dConst, _numberOfUnaryArgs, TR::bu2d,
+            resolvedMethodName, _argTypesUnaryByte, TR::Double, rc, 2, 1, &ubyteDataArray[i]);
       OMR_CT_EXPECT_DOUBLE_EQ(bu2dConst, convert(ubyteDataArray[i], DOUBLE_POS), bu2dConst(BYTE_PLACEHOLDER_1));
       }
 
@@ -4100,13 +4098,13 @@ S390OpCodesTest::invokeDisabledUnaryTests()
       OMR_CT_EXPECT_EQ(_lu2d, convert(ulongDataArray[i], DOUBLE_POS), _lu2d(ulongDataArray[i]));
 
       sprintf(resolvedMethodName, "lu2fConst%d", i + 1);
-      lu2fConst = (unsignedSignatureCharJ_F_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::lu2f, resolvedMethodName, _argTypesUnaryLong, TR::Float, rc, 2, 1, &ulongDataArray[i]));
+      compileOpCodeMethod(lu2fConst, 
+            _numberOfUnaryArgs, TR::lu2f, resolvedMethodName, _argTypesUnaryLong, TR::Float, rc, 2, 1, &ulongDataArray[i]);
       OMR_CT_EXPECT_EQ(lu2fConst, convert(ulongDataArray[i], FLOAT_POS), lu2fConst(LONG_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "lu2dConst%d", i + 1);
-      lu2dConst = (unsignedSignatureCharJ_D_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::lu2d, resolvedMethodName, _argTypesUnaryLong, TR::Double, rc, 2, 1, &ulongDataArray[i]));
+      compileOpCodeMethod(lu2dConst, 
+            _numberOfUnaryArgs, TR::lu2d, resolvedMethodName, _argTypesUnaryLong, TR::Double, rc, 2, 1, &ulongDataArray[i]);
       OMR_CT_EXPECT_EQ(lu2dConst, convert(ulongDataArray[i], DOUBLE_POS), lu2dConst(LONG_PLACEHOLDER_1));
       }
    }
@@ -4117,16 +4115,16 @@ S390OpCodesTest::compileDisabledIntegerArithmeticTestMethods()
    int32_t rc = 0;
 
    //Jazz103 WI 104198
-   _bSub = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bsub, "bSub", _argTypesBinaryByte, TR::Int8, rc));
-   _sSub = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ssub, "sSub", _argTypesBinaryShort, TR::Int16, rc));
-   _bAdd = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::badd, "bAdd", _argTypesBinaryByte, TR::Int8, rc));
-   _sAdd = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sadd, "sAdd", _argTypesBinaryShort, TR::Int16, rc));
+   compileOpCodeMethod(_bSub, _numberOfBinaryArgs, TR::bsub, "bSub", _argTypesBinaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_sSub, _numberOfBinaryArgs, TR::ssub, "sSub", _argTypesBinaryShort, TR::Int16, rc);
+   compileOpCodeMethod(_bAdd, _numberOfBinaryArgs, TR::badd, "bAdd", _argTypesBinaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_sAdd, _numberOfBinaryArgs, TR::sadd, "sAdd", _argTypesBinaryShort, TR::Int16, rc);
 
    //Jazz103 Work Item 103809
    //Testrossa Work Item 121966
-   _iuDiv = (unsignedSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iudiv, "iuDiv", _argTypesBinaryInt, TR::Int32, rc));
-   _iuMul = (unsignedSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iumul, "iuMul", _argTypesBinaryInt, TR::Int32, rc));
-   _iuRem = (unsignedSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iurem, "iuRem", _argTypesBinaryInt, TR::Int32, rc));
+   compileOpCodeMethod(_iuDiv, _numberOfBinaryArgs, TR::iudiv, "iuDiv", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iuMul, _numberOfBinaryArgs, TR::iumul, "iuMul", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iuRem, _numberOfBinaryArgs, TR::iurem, "iuRem", _argTypesBinaryInt, TR::Int32, rc);
 
    }
 
@@ -4197,18 +4195,18 @@ S390OpCodesTest::invokeDisabledIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_bAdd, add(byteAddArr[i][0], byteAddArr[i][1]), _bAdd(byteAddArr[i][0], byteAddArr[i][1]));
 
       sprintf(resolvedMethodName, "bAddConst1_Testcase%d", i);
-      bBinaryCons = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::badd,
-            resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &byteAddArr[i][0], 2, &byteAddArr[i][1]));
+      compileOpCodeMethod(bBinaryCons, _numberOfBinaryArgs, TR::badd,
+            resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &byteAddArr[i][0], 2, &byteAddArr[i][1]);
       OMR_CT_EXPECT_EQ(bBinaryCons, add(byteAddArr[i][0], byteAddArr[i][1]), bBinaryCons(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bAddConst2_Testcase%d", i);
-      bBinaryCons = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::badd,
-            resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &byteAddArr[i][0]));
+      compileOpCodeMethod(bBinaryCons, _numberOfBinaryArgs, TR::badd,
+            resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &byteAddArr[i][0]);
       OMR_CT_EXPECT_EQ(bBinaryCons, add(byteAddArr[i][0], byteAddArr[i][1]), bBinaryCons(BYTE_PLACEHOLDER_1, byteAddArr[i][1]));
 
       sprintf(resolvedMethodName, "bAddConst3_Testcase%d", i);
-      bBinaryCons = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::badd,
-            resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &byteAddArr[i][1]));
+      compileOpCodeMethod(bBinaryCons, _numberOfBinaryArgs, TR::badd,
+            resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &byteAddArr[i][1]);
       OMR_CT_EXPECT_EQ(bBinaryCons, add(byteAddArr[i][0], byteAddArr[i][1]), bBinaryCons(byteAddArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -4219,18 +4217,18 @@ S390OpCodesTest::invokeDisabledIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_bSub, sub(byteSubArr[i][0], byteSubArr[i][1]), _bSub(byteSubArr[i][0], byteSubArr[i][1]));
 
       sprintf(resolvedMethodName, "bSubConst1_Testcase%d", i);
-      bBinaryCons = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bsub,
-            resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &byteSubArr[i][0], 2, &byteSubArr[i][1]));
+      compileOpCodeMethod(bBinaryCons, _numberOfBinaryArgs, TR::bsub,
+            resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &byteSubArr[i][0], 2, &byteSubArr[i][1]);
       OMR_CT_EXPECT_EQ(bBinaryCons, sub(byteSubArr[i][0], byteSubArr[i][1]), bBinaryCons(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bSubConst2_Testcase%d", i);
-      bBinaryCons = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bsub,
-            resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &byteSubArr[i][0]));
+      compileOpCodeMethod(bBinaryCons, _numberOfBinaryArgs, TR::bsub,
+            resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &byteSubArr[i][0]);
       OMR_CT_EXPECT_EQ(bBinaryCons, sub(byteSubArr[i][0], byteSubArr[i][1]), bBinaryCons(BYTE_PLACEHOLDER_1, byteSubArr[i][1]));
 
       sprintf(resolvedMethodName, "bSubConst3_Testcase%d", i);
-      bBinaryCons = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bsub,
-            resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &byteSubArr[i][1]));
+      compileOpCodeMethod(bBinaryCons, _numberOfBinaryArgs, TR::bsub,
+            resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &byteSubArr[i][1]);
       OMR_CT_EXPECT_EQ(bBinaryCons, sub(byteSubArr[i][0], byteSubArr[i][1]), bBinaryCons(byteSubArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -4241,18 +4239,18 @@ S390OpCodesTest::invokeDisabledIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_sAdd, add(shortAddArr[i][0], shortAddArr[i][1]), _sAdd(shortAddArr[i][0], shortAddArr[i][1]));
 
       sprintf(resolvedMethodName, "sAddConst1_Testcase%d", i);
-      sBinaryCons = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sadd,
-            resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &shortAddArr[i][0], 2, &shortAddArr[i][1]));
+      compileOpCodeMethod(sBinaryCons, _numberOfBinaryArgs, TR::sadd,
+            resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &shortAddArr[i][0], 2, &shortAddArr[i][1]);
       OMR_CT_EXPECT_EQ(sBinaryCons, add(shortAddArr[i][0], shortAddArr[i][1]), sBinaryCons(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sAddConst2_Testcase%d", i);
-      sBinaryCons = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sadd,
-            resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &shortAddArr[i][0]));
+      compileOpCodeMethod(sBinaryCons, _numberOfBinaryArgs, TR::sadd,
+            resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &shortAddArr[i][0]);
       OMR_CT_EXPECT_EQ(sBinaryCons, add(shortAddArr[i][0], shortAddArr[i][1]), sBinaryCons(SHORT_PLACEHOLDER_1, shortAddArr[i][1]));
 
       sprintf(resolvedMethodName, "sAddConst3_Testcase%d", i);
-      sBinaryCons = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sadd,
-            resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &shortAddArr[i][1]));
+      compileOpCodeMethod(sBinaryCons, _numberOfBinaryArgs, TR::sadd,
+            resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &shortAddArr[i][1]);
       OMR_CT_EXPECT_EQ(sBinaryCons, add(shortAddArr[i][0], shortAddArr[i][1]), sBinaryCons(shortAddArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -4263,18 +4261,18 @@ S390OpCodesTest::invokeDisabledIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_sSub, sub(shortSubArr[i][0], shortSubArr[i][1]), _sSub(shortSubArr[i][0], shortSubArr[i][1]));
 
       sprintf(resolvedMethodName, "sSubConst1_Testcase%d", i);
-      sBinaryCons = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ssub,
-            resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &shortSubArr[i][0], 2, &shortSubArr[i][1]));
+      compileOpCodeMethod(sBinaryCons, _numberOfBinaryArgs, TR::ssub,
+            resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &shortSubArr[i][0], 2, &shortSubArr[i][1]);
       OMR_CT_EXPECT_EQ(sBinaryCons, sub(shortSubArr[i][0], shortSubArr[i][1]), sBinaryCons(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sSubConst2_Testcase%d", i);
-      sBinaryCons = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ssub,
-            resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &shortSubArr[i][0]));
+      compileOpCodeMethod(sBinaryCons, _numberOfBinaryArgs, TR::ssub,
+            resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &shortSubArr[i][0]);
       OMR_CT_EXPECT_EQ(sBinaryCons, sub(shortSubArr[i][0], shortSubArr[i][1]), sBinaryCons(SHORT_PLACEHOLDER_1, shortSubArr[i][1]));
 
       sprintf(resolvedMethodName, "sSubConst3_Testcase%d", i);
-      sBinaryCons = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ssub,
-            resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &shortSubArr[i][1]));
+      compileOpCodeMethod(sBinaryCons, _numberOfBinaryArgs, TR::ssub,
+            resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &shortSubArr[i][1]);
       OMR_CT_EXPECT_EQ(sBinaryCons, sub(shortSubArr[i][0], shortSubArr[i][1]), sBinaryCons(shortSubArr[i][0], SHORT_PLACEHOLDER_2));
       }
    }
@@ -4286,21 +4284,21 @@ S390OpCodesTest::compileDisabledShiftOrRolTestMethods()
    int32_t rc = 0;
 
    //Jazz103 Work Item 109995
-   _iRol = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::irol, "iRol", _argTypesBinaryInt, TR::Int32, rc));
+   compileOpCodeMethod(_iRol, _numberOfBinaryArgs, TR::irol, "iRol", _argTypesBinaryInt, TR::Int32, rc);
 
-   _bShl = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bshl, "bShl", _argTypesBinaryByte, TR::Int8, rc));
-   _bShr = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bshr, "bShr", _argTypesBinaryByte, TR::Int8, rc));
-   _buShr = (unsignedSignatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bushr, "buShr", _argTypesBinaryByte, TR::Int8, rc));
+   compileOpCodeMethod(_bShl, _numberOfBinaryArgs, TR::bshl, "bShl", _argTypesBinaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_bShr, _numberOfBinaryArgs, TR::bshr, "bShr", _argTypesBinaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_buShr, _numberOfBinaryArgs, TR::bushr, "buShr", _argTypesBinaryByte, TR::Int8, rc);
 
-   _sShl = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sshl, "sShl", _argTypesBinaryShort, TR::Int16, rc));
-   _sShr = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sshr, "sShr", _argTypesBinaryShort, TR::Int16, rc));
-   _suShr = (unsignedSignatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sushr, "suShr", _argTypesBinaryShort, TR::Int16, rc));
+   compileOpCodeMethod(_sShl, _numberOfBinaryArgs, TR::sshl, "sShl", _argTypesBinaryShort, TR::Int16, rc);
+   compileOpCodeMethod(_sShr, _numberOfBinaryArgs, TR::sshr, "sShr", _argTypesBinaryShort, TR::Int16, rc);
+   compileOpCodeMethod(_suShr, _numberOfBinaryArgs, TR::sushr, "suShr", _argTypesBinaryShort, TR::Int16, rc);
 
 #if !defined(TR_TARGET_64BIT)
-   _lShl = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lshl, "lShl", _argTypesBinaryLong, TR::Int64, rc));
-   _lShr = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lshr, "lShr", _argTypesBinaryLong, TR::Int64, rc));
-   _luShr = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lushr, "luShr", _argTypesBinaryLong, TR::Int64, rc));
-   _lRol = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lrol, "lRol", _argTypesBinaryLong, TR::Int64, rc));
+   compileOpCodeMethod(_lShl, _numberOfBinaryArgs, TR::lshl, "lShl", _argTypesBinaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_lShr, _numberOfBinaryArgs, TR::lshr, "lShr", _argTypesBinaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_luShr, _numberOfBinaryArgs, TR::lushr, "luShr", _argTypesBinaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_lRol, _numberOfBinaryArgs, TR::lrol, "lRol", _argTypesBinaryLong, TR::Int64, rc);
 #endif
 
    }
@@ -4431,18 +4429,18 @@ S390OpCodesTest::invokeDisabledShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_iRol, rol(irolDataArr[i][0], irolDataArr[i][1]), _iRol(irolDataArr[i][0], irolDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iRolConst1_TestCase%d", i + 1);
-      iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::irol, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &irolDataArr[i][0], 2, &irolDataArr[i][1]));
+      compileOpCodeMethod(iShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::irol, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &irolDataArr[i][0], 2, &irolDataArr[i][1]);
       OMR_CT_EXPECT_EQ(iShiftOrRolConst, rol(irolDataArr[i][0], irolDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iRolConst2_TestCase%d", i + 1);
-      iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::irol, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &irolDataArr[i][0]));
+      compileOpCodeMethod(iShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::irol, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &irolDataArr[i][0]);
       OMR_CT_EXPECT_EQ(iShiftOrRolConst, rol(irolDataArr[i][0], irolDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, irolDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iRolConst3_TestCase%d", i + 1);
-      iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::irol, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &irolDataArr[i][1]));
+      compileOpCodeMethod(iShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::irol, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &irolDataArr[i][1]);
       OMR_CT_EXPECT_EQ(iShiftOrRolConst, rol(irolDataArr[i][0], irolDataArr[i][1]), iShiftOrRolConst(irolDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -4453,18 +4451,18 @@ S390OpCodesTest::invokeDisabledShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_bShl, shl(bshlDataArr[i][0], bshlDataArr[i][1]), _bShl(bshlDataArr[i][0],bshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bShlConst1_TestCase%d", i + 1);
-      bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bshl, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &bshlDataArr[i][0], 2, &bshlDataArr[i][1]));
+      compileOpCodeMethod(bShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::bshl, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &bshlDataArr[i][0], 2, &bshlDataArr[i][1]);
       OMR_CT_EXPECT_EQ(bShiftOrRolConst, shl(bshlDataArr[i][0], bshlDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bShlConst2_TestCase%d", i + 1);
-      bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bshl, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &bshlDataArr[i][0]));
+      compileOpCodeMethod(bShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::bshl, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &bshlDataArr[i][0]);
       OMR_CT_EXPECT_EQ(bShiftOrRolConst, shl(bshlDataArr[i][0], bshlDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, bshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bShlConst3_TestCase%d", i + 1);
-      bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bshl, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &bshlDataArr[i][1]));
+      compileOpCodeMethod(bShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::bshl, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &bshlDataArr[i][1]);
       OMR_CT_EXPECT_EQ(bShiftOrRolConst, shl(bshlDataArr[i][0], bshlDataArr[i][1]), bShiftOrRolConst(bshlDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -4475,18 +4473,18 @@ S390OpCodesTest::invokeDisabledShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_bShr, shr(bshrDataArr[i][0], bshrDataArr[i][1]), _bShr(bshrDataArr[i][0], bshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bShrConst1_TestCase%d", i + 1);
-      bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bshr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &bshrDataArr[i][0], 2, &bshrDataArr[i][1]));
+      compileOpCodeMethod(bShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::bshr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &bshrDataArr[i][0], 2, &bshrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(bShiftOrRolConst, shr(bshrDataArr[i][0], bshrDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bShrConst2_TestCase%d", i + 1);
-      bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bshr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &bshrDataArr[i][0]));
+      compileOpCodeMethod(bShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::bshr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &bshrDataArr[i][0]);
       OMR_CT_EXPECT_EQ(bShiftOrRolConst, shr(bshrDataArr[i][0], bshrDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, bshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bShrConst3_TestCase%d", i + 1);
-      bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bshr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &bshrDataArr[i][1]));
+      compileOpCodeMethod(bShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::bshr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &bshrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(bShiftOrRolConst, shr(bshrDataArr[i][0], bshrDataArr[i][1]), bShiftOrRolConst(bshrDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -4497,18 +4495,18 @@ S390OpCodesTest::invokeDisabledShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_buShr, shr(bushrDataArr[i][0], bushrDataArr[i][1]), _buShr(bushrDataArr[i][0], bushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buShrConst1_TestCase%d", i + 1);
-      buShiftOrRolConst = (unsignedSignatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bushr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &bushrDataArr[i][0], 2, &bushrDataArr[i][1]));
+      compileOpCodeMethod(buShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::bushr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &bushrDataArr[i][0], 2, &bushrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(buShiftOrRolConst, shr(bushrDataArr[i][0], bushrDataArr[i][1]), buShiftOrRolConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "buShrConst2_TestCase%d", i + 1);
-      buShiftOrRolConst = (unsignedSignatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bushr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &bushrDataArr[i][0]));
+      compileOpCodeMethod(buShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::bushr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &bushrDataArr[i][0]);
       OMR_CT_EXPECT_EQ(buShiftOrRolConst, shr(bushrDataArr[i][0], bushrDataArr[i][1]), buShiftOrRolConst(BYTE_PLACEHOLDER_1, bushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buShrConst3_TestCase%d", i + 1);
-      buShiftOrRolConst = (unsignedSignatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bushr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &bushrDataArr[i][1]));
+      compileOpCodeMethod(buShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::bushr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &bushrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(buShiftOrRolConst, shr(bushrDataArr[i][0], bushrDataArr[i][1]), buShiftOrRolConst(bushrDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -4519,18 +4517,18 @@ S390OpCodesTest::invokeDisabledShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_sShr, shr(sshrDataArr[i][0], sshrDataArr[i][1]), _sShr(sshrDataArr[i][0], sshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sShrConst1_TestCase%d", i + 1);
-      sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sshr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &sshrDataArr[i][0], 2, &sshrDataArr[i][1]));
+      compileOpCodeMethod(sShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::sshr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &sshrDataArr[i][0], 2, &sshrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(sShiftOrRolConst, shr(sshrDataArr[i][0], sshrDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sShrConst2_TestCase%d", i + 1);
-      sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sshr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &sshrDataArr[i][0]));
+      compileOpCodeMethod(sShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::sshr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &sshrDataArr[i][0]);
       OMR_CT_EXPECT_EQ(sShiftOrRolConst, shr(sshrDataArr[i][0], sshrDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, sshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sShrConst3_TestCase%d", i + 1);
-      sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sshr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &sshrDataArr[i][1]));
+      compileOpCodeMethod(sShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::sshr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &sshrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(sShiftOrRolConst, shr(sshrDataArr[i][0], sshrDataArr[i][1]), sShiftOrRolConst(sshrDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -4541,18 +4539,18 @@ S390OpCodesTest::invokeDisabledShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_sShl, shl(sshlDataArr[i][0], sshlDataArr[i][1]), _sShl(sshlDataArr[i][0], sshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sShlConst1_TestCase%d", i + 1);
-      sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sshl, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &sshlDataArr[i][0], 2, &sshlDataArr[i][1]));
+      compileOpCodeMethod(sShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::sshl, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &sshlDataArr[i][0], 2, &sshlDataArr[i][1]);
       OMR_CT_EXPECT_EQ(sShiftOrRolConst, shl(sshlDataArr[i][0], sshlDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sShlConst2_TestCase%d", i + 1);
-      sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sshl, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &sshlDataArr[i][0]));
+      compileOpCodeMethod(sShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::sshl, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &sshlDataArr[i][0]);
       OMR_CT_EXPECT_EQ(sShiftOrRolConst, shl(sshlDataArr[i][0], sshlDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, sshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sShlConst3_TestCase%d", i + 1);
-      sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sshl, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &sshlDataArr[i][1]));
+      compileOpCodeMethod(sShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::sshl, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &sshlDataArr[i][1]);
       OMR_CT_EXPECT_EQ(sShiftOrRolConst, shl(sshlDataArr[i][0], sshlDataArr[i][1]), sShiftOrRolConst(sshlDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -4563,18 +4561,18 @@ S390OpCodesTest::invokeDisabledShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_suShr, shr(sushrDataArr[i][0], sushrDataArr[i][1]), _suShr(sushrDataArr[i][0], sushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "suShrConst1_TestCase%d", i + 1);
-      suShiftOrRolConst = (unsignedSignatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sushr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &sushrDataArr[i][0], 2, &sushrDataArr[i][1]));
+      compileOpCodeMethod(suShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::sushr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &sushrDataArr[i][0], 2, &sushrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(suShiftOrRolConst, shr(sushrDataArr[i][0], sushrDataArr[i][1]), suShiftOrRolConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "suShrConst2_TestCase%d", i + 1);
-      suShiftOrRolConst = (unsignedSignatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sushr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &sushrDataArr[i][0]));
+      compileOpCodeMethod(suShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::sushr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &sushrDataArr[i][0]);
       OMR_CT_EXPECT_EQ(suShiftOrRolConst, shr(sushrDataArr[i][0], sushrDataArr[i][1]), suShiftOrRolConst(SHORT_PLACEHOLDER_1, sushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "suShrConst3_TestCase%d", i + 1);
-      suShiftOrRolConst = (unsignedSignatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sushr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &sushrDataArr[i][1]));
+      compileOpCodeMethod(suShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::sushr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &sushrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(suShiftOrRolConst, shr(sushrDataArr[i][0], sushrDataArr[i][1]), suShiftOrRolConst(sushrDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -4586,18 +4584,18 @@ S390OpCodesTest::invokeDisabledShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_lShl, shl(lshlDataArr[i][0], lshlDataArr[i][1]), _lShl(lshlDataArr[i][0], lshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lShlConst1_TestCase%d", i + 1);
-      lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lshl, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lshlDataArr[i][0], 2, &lshlDataArr[i][1]));
+      compileOpCodeMethod(lShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lshl, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lshlDataArr[i][0], 2, &lshlDataArr[i][1]);
       OMR_CT_EXPECT_EQ(lShiftOrRolConst, shl(lshlDataArr[i][0], lshlDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "lShlConst2_TestCase%d", i + 1);
-      lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lshl, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lshlDataArr[i][0]));
+      compileOpCodeMethod(lShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lshl, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lshlDataArr[i][0]);
       OMR_CT_EXPECT_EQ(lShiftOrRolConst, shl(lshlDataArr[i][0], lshlDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, lshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lShlConst3_TestCase%d", i + 1);
-      lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lshl, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lshlDataArr[i][1]));
+      compileOpCodeMethod(lShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lshl, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lshlDataArr[i][1]);
       OMR_CT_EXPECT_EQ(lShiftOrRolConst, shl(lshlDataArr[i][0], lshlDataArr[i][1]), lShiftOrRolConst(lshlDataArr[i][0], LONG_PLACEHOLDER_1));
       }
 
@@ -4608,18 +4606,18 @@ S390OpCodesTest::invokeDisabledShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_lShr, shr(lshrDataArr[i][0], lshrDataArr[i][1]), _lShr(lshrDataArr[i][0], lshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lShrConst1_TestCase%d", i + 1);
-      lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lshr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lshrDataArr[i][0], 2, &lshrDataArr[i][1]));
+      compileOpCodeMethod(lShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lshr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lshrDataArr[i][0], 2, &lshrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(lShiftOrRolConst, shr(lshrDataArr[i][0], lshrDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lShrConst2_TestCase%d", i + 1);
-      lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lshr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lshrDataArr[i][0]));
+      compileOpCodeMethod(lShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lshr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lshrDataArr[i][0]);
       OMR_CT_EXPECT_EQ(lShiftOrRolConst, shr(lshrDataArr[i][0], lshrDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, lshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lShrConst3_TestCase%d", i + 1);
-      lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lshr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lshrDataArr[i][1]));
+      compileOpCodeMethod(lShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lshr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lshrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(lShiftOrRolConst, shr(lshrDataArr[i][0], lshrDataArr[i][1]), lShiftOrRolConst(lshrDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -4630,18 +4628,18 @@ S390OpCodesTest::invokeDisabledShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_luShr, shr(lushrDataArr[i][0], lushrDataArr[i][1]), _luShr(lushrDataArr[i][0], lushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luShrConst1_TestCase%d", i + 1);
-      luShiftOrRolConst = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lushr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lushrDataArr[i][0], 2, &lushrDataArr[i][1]));
+      compileOpCodeMethod(luShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lushr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lushrDataArr[i][0], 2, &lushrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(luShiftOrRolConst, shr(lushrDataArr[i][0], lushrDataArr[i][1]), luShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "luShrConst2_TestCase%d", i + 1);
-      luShiftOrRolConst = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lushr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lushrDataArr[i][0]));
+      compileOpCodeMethod(luShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lushr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lushrDataArr[i][0]);
       OMR_CT_EXPECT_EQ(luShiftOrRolConst, shr(lushrDataArr[i][0], lushrDataArr[i][1]), luShiftOrRolConst(LONG_PLACEHOLDER_1, lushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luShrConst3_TestCase%d", i + 1);
-      luShiftOrRolConst = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lushr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lushrDataArr[i][1]));
+      compileOpCodeMethod(luShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lushr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lushrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(luShiftOrRolConst, shr(lushrDataArr[i][0], lushrDataArr[i][1]), luShiftOrRolConst(lushrDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -4652,18 +4650,18 @@ S390OpCodesTest::invokeDisabledShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_lRol, rol(lrolDataArr[i][0], lrolDataArr[i][1]), _lRol(lrolDataArr[i][0], lrolDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lRolConst1_TestCase%d", i + 1);
-      lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lrol, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lrolDataArr[i][0], 2, &lrolDataArr[i][1]));
+      compileOpCodeMethod(lShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lrol, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lrolDataArr[i][0], 2, &lrolDataArr[i][1]);
       OMR_CT_EXPECT_EQ(lShiftOrRolConst, rol(lrolDataArr[i][0], lrolDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lRolConst2_TestCase%d", i + 1);
-      lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lrol, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lrolDataArr[i][0]));
+      compileOpCodeMethod(lShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lrol, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lrolDataArr[i][0]);
       OMR_CT_EXPECT_EQ(lShiftOrRolConst, rol(lrolDataArr[i][0], lrolDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, lrolDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lRolConst3_TestCase%d", i + 1);
-      lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lrol, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lrolDataArr[i][1]));
+      compileOpCodeMethod(lShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lrol, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lrolDataArr[i][1]);
       OMR_CT_EXPECT_EQ(lShiftOrRolConst, rol(lrolDataArr[i][0], lrolDataArr[i][1]), lShiftOrRolConst(lrolDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 #endif
@@ -4675,10 +4673,10 @@ S390OpCodesTest::compileDisabledTernaryTestMethods()
    //Jazz103 WI 104092
    //Jazz103 WI 109994
    int32_t rc = 0;
-   _bternary = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary, "bTernary", _argTypesTernaryByte, TR::Int8, rc));
-   _sternary = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary, "sTernary", _argTypesTernaryShort, TR::Int16, rc));
-   _fternary = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary, "fTernary", _argTypesTernaryFloat, TR::Float, rc));
-   _dternary = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary, "dTernary", _argTypesTernaryDouble, TR::Double, rc));
+   compileOpCodeMethod(_bternary, _numberOfTernaryArgs, TR::bternary, "bTernary", _argTypesTernaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_sternary, _numberOfTernaryArgs, TR::sternary, "sTernary", _argTypesTernaryShort, TR::Int16, rc);
+   compileOpCodeMethod(_fternary, _numberOfTernaryArgs, TR::fternary, "fTernary", _argTypesTernaryFloat, TR::Float, rc);
+   compileOpCodeMethod(_dternary, _numberOfTernaryArgs, TR::dternary, "dTernary", _argTypesTernaryDouble, TR::Double, rc);
    }
 
 void
@@ -4814,38 +4812,38 @@ S390OpCodesTest::invokeDisabledTernaryTests()
       OMR_CT_EXPECT_EQ(_bternary, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), _bternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bTernaryConst1_Testcase%d", i + 1);
-      bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 6, 1, &bternaryChild1Arr[i], 2, &byteDataArr[i][0], 3, &byteDataArr[i][1]));
+      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
+            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 6, 1, &bternaryChild1Arr[i], 2, &byteDataArr[i][0], 3, &byteDataArr[i][1]);
       OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2, BYTE_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "bTernaryConst2_Testcase%d", i + 1);
-      bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 4, 1, &bternaryChild1Arr[i], 2, &byteDataArr[i][0]));
+      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
+            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 4, 1, &bternaryChild1Arr[i], 2, &byteDataArr[i][0]);
       OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2, byteDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bTernaryConst3_Testcase%d", i + 1);
-      bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 4, 1, &bternaryChild1Arr[i], 3, &byteDataArr[i][1]));
+      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
+            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 4, 1, &bternaryChild1Arr[i], 3, &byteDataArr[i][1]);
       OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, byteDataArr[i][0], BYTE_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "bTernaryConst4_Testcase%d", i + 1);
-      bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 4, 2, &byteDataArr[i][0], 3, &byteDataArr[i][1]));
+      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
+            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 4, 2, &byteDataArr[i][0], 3, &byteDataArr[i][1]);
       OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(bternaryChild1Arr[i], BYTE_PLACEHOLDER_2, BYTE_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "bTernaryConst5_Testcase%d", i + 1);
-      bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 2, 1, &bternaryChild1Arr[i]));
+      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
+            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 2, 1, &bternaryChild1Arr[i]);
       OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, byteDataArr[i][0], byteDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bTernaryConst6_Testcase%d", i + 1);
-      bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 2, 2, &byteDataArr[i][0]));
+      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
+            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 2, 2, &byteDataArr[i][0]);
       OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(bternaryChild1Arr[i], BYTE_PLACEHOLDER_1, byteDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bTernaryConst7_Testcase%d", i + 1);
-      bTernaryConst = (signatureCharIBB_B_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 2, 3, &byteDataArr[i][1]));
+      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
+            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 2, 3, &byteDataArr[i][1]);
       OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(bternaryChild1Arr[i], byteDataArr[i][0], BYTE_PLACEHOLDER_1));
       }
 
@@ -4857,38 +4855,38 @@ S390OpCodesTest::invokeDisabledTernaryTests()
       OMR_CT_EXPECT_EQ(_sternary, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), _sternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sTernaryConst1_Testcase%d", i + 1);
-      sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 6, 1, &sternaryChild1Arr[i], 2, &shortDataArr[i][0], 3, &shortDataArr[i][1]));
+      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
+            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 6, 1, &sternaryChild1Arr[i], 2, &shortDataArr[i][0], 3, &shortDataArr[i][1]);
       OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2, SHORT_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "sTernaryConst2_Testcase%d", i + 1);
-      sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 4, 1, &sternaryChild1Arr[i], 2, &shortDataArr[i][0]));
+      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
+            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 4, 1, &sternaryChild1Arr[i], 2, &shortDataArr[i][0]);
       OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2, shortDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sTernaryConst3_Testcase%d", i + 1);
-      sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 4, 1, &sternaryChild1Arr[i], 3, &shortDataArr[i][1]));
+      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
+            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 4, 1, &sternaryChild1Arr[i], 3, &shortDataArr[i][1]);
       OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, shortDataArr[i][0], SHORT_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "sTernaryConst4_Testcase%d", i + 1);
-      sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 4, 2, &shortDataArr[i][0], 3, &shortDataArr[i][1]));
+      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
+            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 4, 2, &shortDataArr[i][0], 3, &shortDataArr[i][1]);
       OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(sternaryChild1Arr[i], SHORT_PLACEHOLDER_2, SHORT_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "sTernaryConst5_Testcase%d", i + 1);
-      sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 2, 1, &sternaryChild1Arr[i]));
+      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
+            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 2, 1, &sternaryChild1Arr[i]);
       OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, shortDataArr[i][0], shortDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sTernaryConst6_Testcase%d", i + 1);
-      sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 2, 2, &shortDataArr[i][0]));
+      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
+            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 2, 2, &shortDataArr[i][0]);
       OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(sternaryChild1Arr[i], SHORT_PLACEHOLDER_1, shortDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sTernaryConst7_Testcase%d", i + 1);
-      sTernaryConst = (signatureCharISS_S_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 2, 3, &shortDataArr[i][1]));
+      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
+            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 2, 3, &shortDataArr[i][1]);
       OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(sternaryChild1Arr[i], shortDataArr[i][0], SHORT_PLACEHOLDER_1));
       }
 
@@ -4900,38 +4898,38 @@ S390OpCodesTest::invokeDisabledTernaryTests()
       OMR_CT_EXPECT_EQ(_fternary, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), _fternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fTernaryConst1_Testcase%d", i + 1);
-      fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 6, 1, &fternaryChild1Arr[i], 2, &floatDataArr[i][0], 3, &floatDataArr[i][1]));
+      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
+            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 6, 1, &fternaryChild1Arr[i], 2, &floatDataArr[i][0], 3, &floatDataArr[i][1]);
       OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2, FLOAT_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "fTernaryConst2_Testcase%d", i + 1);
-      fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 4, 1, &fternaryChild1Arr[i], 2, &floatDataArr[i][0]));
+      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
+            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 4, 1, &fternaryChild1Arr[i], 2, &floatDataArr[i][0]);
       OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2, floatDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fTernaryConst3_Testcase%d", i + 1);
-      fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 4, 1, &fternaryChild1Arr[i], 3, &floatDataArr[i][1]));
+      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
+            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 4, 1, &fternaryChild1Arr[i], 3, &floatDataArr[i][1]);
       OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, floatDataArr[i][0], FLOAT_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "fTernaryConst4_Testcase%d", i + 1);
-      fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 4, 2, &floatDataArr[i][0], 3, &floatDataArr[i][1]));
+      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
+            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 4, 2, &floatDataArr[i][0], 3, &floatDataArr[i][1]);
       OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(fternaryChild1Arr[i], FLOAT_PLACEHOLDER_2, FLOAT_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "fTernaryConst5_Testcase%d", i + 1);
-      fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 2, 1, &fternaryChild1Arr[i]));
+      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
+            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 2, 1, &fternaryChild1Arr[i]);
       OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, floatDataArr[i][0], floatDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fTernaryConst6_Testcase%d", i + 1);
-      fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 2, 2, &floatDataArr[i][0]));
+      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
+            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 2, 2, &floatDataArr[i][0]);
       OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(fternaryChild1Arr[i], FLOAT_PLACEHOLDER_1, floatDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fTernaryConst7_Testcase%d", i + 1);
-      fTernaryConst = (signatureCharIFF_F_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 2, 3, &floatDataArr[i][1]));
+      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
+            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 2, 3, &floatDataArr[i][1]);
       OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(fternaryChild1Arr[i], floatDataArr[i][0], FLOAT_PLACEHOLDER_1));
       }
 
@@ -4943,38 +4941,38 @@ S390OpCodesTest::invokeDisabledTernaryTests()
       OMR_CT_EXPECT_EQ(_dternary, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), _dternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dTernaryConst1_Testcase%d", i + 1);
-      dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 6, 1, &dternaryChild1Arr[i], 2, &doubleDataArr[i][0], 3, &doubleDataArr[i][1]));
+      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
+            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 6, 1, &dternaryChild1Arr[i], 2, &doubleDataArr[i][0], 3, &doubleDataArr[i][1]);
       OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2, DOUBLE_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "dTernaryConst2_Testcase%d", i + 1);
-      dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 4, 1, &dternaryChild1Arr[i], 2, &doubleDataArr[i][0]));
+      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
+            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 4, 1, &dternaryChild1Arr[i], 2, &doubleDataArr[i][0]);
       OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2, doubleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dTernaryConst3_Testcase%d", i + 1);
-      dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 4, 1, &dternaryChild1Arr[i], 3, &doubleDataArr[i][1]));
+      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
+            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 4, 1, &dternaryChild1Arr[i], 3, &doubleDataArr[i][1]);
       OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, doubleDataArr[i][0], DOUBLE_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "dTernaryConst4_Testcase%d", i + 1);
-      dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 4, 2, &doubleDataArr[i][0], 3, &doubleDataArr[i][1]));
+      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
+            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 4, 2, &doubleDataArr[i][0], 3, &doubleDataArr[i][1]);
       OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(dternaryChild1Arr[i], DOUBLE_PLACEHOLDER_2, DOUBLE_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "dTernaryConst5_Testcase%d", i + 1);
-      dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 2, 1, &dternaryChild1Arr[i]));
+      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
+            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 2, 1, &dternaryChild1Arr[i]);
       OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, doubleDataArr[i][0], doubleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dTernaryConst6_Testcase%d", i + 1);
-      dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 2, 2, &doubleDataArr[i][0]));
+      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
+            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 2, 2, &doubleDataArr[i][0]);
       OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(dternaryChild1Arr[i], DOUBLE_PLACEHOLDER_1, doubleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dTernaryConst7_Testcase%d", i + 1);
-      dTernaryConst = (signatureCharIDD_D_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 2, 3, &doubleDataArr[i][1]));
+      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
+            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 2, 3, &doubleDataArr[i][1]);
       OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(dternaryChild1Arr[i], doubleDataArr[i][0], DOUBLE_PLACEHOLDER_1));
       }
    }
@@ -4985,15 +4983,15 @@ S390OpCodesTest::compileDisabledMemoryOperationTestMethods()
    int32_t rc = 0;
 
    //Jazz103 Work Item 111018
-   _bLoad = (signatureCharB_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bload, "bLoad", _argTypesUnaryByte, TR::Int8, rc));
-   _sLoad = (signatureCharS_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::sload, "sLoad", _argTypesUnaryShort, TR::Int16, rc));
+   compileOpCodeMethod(_bLoad, _numberOfUnaryArgs, TR::bload, "bLoad", _argTypesUnaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_sLoad, _numberOfUnaryArgs, TR::sload, "sLoad", _argTypesUnaryShort, TR::Int16, rc);
 
-   _bStore = (signatureCharB_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bstore, "bStore", _argTypesUnaryByte, TR::Int8, rc));
-   _sStore = (signatureCharS_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::sstore, "sStore", _argTypesUnaryShort, TR::Int16, rc));
+   compileOpCodeMethod(_bStore, _numberOfUnaryArgs, TR::bstore, "bStore", _argTypesUnaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_sStore, _numberOfUnaryArgs, TR::sstore, "sStore", _argTypesUnaryShort, TR::Int16, rc);
 
    //Jazz103 111410 : bstorei, sstorei unexpected results bstorei, storei
-   _sStorei = (signatureCharLS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sstorei, "sStorei", _argTypesBinaryAddressShort, TR::Int16, rc));
-   _bStorei = (signatureCharLB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bstorei, "bStorei", _argTypesBinaryAddressByte, TR::Int8, rc));
+   compileOpCodeMethod(_sStorei, _numberOfBinaryArgs, TR::sstorei, "sStorei", _argTypesBinaryAddressShort, TR::Int16, rc);
+   compileOpCodeMethod(_bStorei, _numberOfBinaryArgs, TR::bstorei, "bStorei", _argTypesBinaryAddressByte, TR::Int8, rc);
 
    }
 
@@ -5028,7 +5026,7 @@ S390OpCodesTest::invokeDisabledMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "bStoreConst%d", i + 1);
       OMR_CT_EXPECT_EQ(_bStore, byteDataArray[i], _bStore(byteDataArray[i]));
-      bMemCons = (signatureCharB_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bstore, resolvedMethodName, _argTypesUnaryByte, TR::Int8, rc, 2, 1, &(byteDataArray[i])));
+      compileOpCodeMethod(bMemCons, _numberOfUnaryArgs, TR::bstore, resolvedMethodName, _argTypesUnaryByte, TR::Int8, rc, 2, 1, &(byteDataArray[i]));
       OMR_CT_EXPECT_EQ(bMemCons, byteDataArray[i], bMemCons(BYTE_PLACEHOLDER_1));
       }
 
@@ -5037,7 +5035,7 @@ S390OpCodesTest::invokeDisabledMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "sStoreConst%d", i + 1);
       OMR_CT_EXPECT_EQ(_sStore, shortDataArray[i], _sStore(shortDataArray[i]));
-      sMemCons = (signatureCharS_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::sstore, resolvedMethodName, _argTypesUnaryShort, TR::Int16, rc, 2, 1, &(shortDataArray[i])));
+      compileOpCodeMethod(sMemCons, _numberOfUnaryArgs, TR::sstore, resolvedMethodName, _argTypesUnaryShort, TR::Int16, rc, 2, 1, &(shortDataArray[i]));
       OMR_CT_EXPECT_EQ(sMemCons, shortDataArray[i], sMemCons(SHORT_PLACEHOLDER_1));
       }
 
@@ -5066,13 +5064,13 @@ S390OpCodesTest::compileDisabledBitwiseTestMethods()
    int32_t rc;
 
    //Jazz103 Work Item 111019
-   _sAnd = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sand, "sAnd", _argTypesBinaryShort, TR::Int16, rc));
-   _sOr = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sor, "sOr", _argTypesBinaryShort, TR::Int16, rc));
-   _sXor = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sxor, "sXor", _argTypesBinaryShort, TR::Int16, rc));
+   compileOpCodeMethod(_sAnd, _numberOfBinaryArgs, TR::sand, "sAnd", _argTypesBinaryShort, TR::Int16, rc);
+   compileOpCodeMethod(_sOr, _numberOfBinaryArgs, TR::sor, "sOr", _argTypesBinaryShort, TR::Int16, rc);
+   compileOpCodeMethod(_sXor, _numberOfBinaryArgs, TR::sxor, "sXor", _argTypesBinaryShort, TR::Int16, rc);
 
-   _bAnd = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::band, "bAnd", _argTypesBinaryByte, TR::Int8, rc));
-   _bOr = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bor, "bOr", _argTypesBinaryByte, TR::Int8, rc));
-   _bXor = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bxor, "bXor", _argTypesBinaryByte, TR::Int8, rc));
+   compileOpCodeMethod(_bAnd, _numberOfBinaryArgs, TR::band, "bAnd", _argTypesBinaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_bOr, _numberOfBinaryArgs, TR::bor, "bOr", _argTypesBinaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_bXor, _numberOfBinaryArgs, TR::bxor, "bXor", _argTypesBinaryByte, TR::Int8, rc);
 
    }
 
@@ -5137,18 +5135,18 @@ S390OpCodesTest::invokeDisabledBitwiseTests()
       OMR_CT_EXPECT_EQ(_bAnd, tand(byteAndArr[i][0], byteAndArr[i][1]), _bAnd(byteAndArr[i][0], byteAndArr[i][1]));
 
       sprintf(resolvedMethodName, "bAndConst1_TestCase%d", i + 1);
-      bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::band, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &(byteAndArr[i][0]), 2, &(byteAndArr[i][1])));
+      compileOpCodeMethod(bBitwiseConst, 
+            _numberOfBinaryArgs, TR::band, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &(byteAndArr[i][0]), 2, &(byteAndArr[i][1]));
       OMR_CT_EXPECT_EQ(bBitwiseConst, tand(byteAndArr[i][0], byteAndArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bAndConst2_TestCase%d", i + 1);
-      bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::band, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &(byteAndArr[i][0])));
+      compileOpCodeMethod(bBitwiseConst, 
+            _numberOfBinaryArgs, TR::band, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &(byteAndArr[i][0]));
       OMR_CT_EXPECT_EQ(bBitwiseConst, tand(byteAndArr[i][0], byteAndArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, byteAndArr[i][1]));
 
       sprintf(resolvedMethodName, "bAndConst3_TestCase%d", i + 1);
-      bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::band, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &(byteAndArr[i][1])));
+      compileOpCodeMethod(bBitwiseConst, 
+            _numberOfBinaryArgs, TR::band, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &(byteAndArr[i][1]));
       OMR_CT_EXPECT_EQ(bBitwiseConst, tand(byteAndArr[i][0], byteAndArr[i][1]), bBitwiseConst(byteAndArr[i][0], BYTE_PLACEHOLDER_2));
      }
 
@@ -5159,18 +5157,18 @@ S390OpCodesTest::invokeDisabledBitwiseTests()
       OMR_CT_EXPECT_EQ(_bOr, tor(byteOrArr[i][0], byteOrArr[i][1]), _bOr(byteOrArr[i][0], byteOrArr[i][1]));
 
       sprintf(resolvedMethodName, "bOrConst1_TestCase%d", i + 1);
-      bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &(byteOrArr[i][0]), 2, &(byteOrArr[i][1])));
+      compileOpCodeMethod(bBitwiseConst, 
+            _numberOfBinaryArgs, TR::bor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &(byteOrArr[i][0]), 2, &(byteOrArr[i][1]));
       OMR_CT_EXPECT_EQ(bBitwiseConst, tor(byteOrArr[i][0], byteOrArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bOrConst2_TestCase%d", i + 1);
-      bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &(byteOrArr[i][0])));
+      compileOpCodeMethod(bBitwiseConst, 
+            _numberOfBinaryArgs, TR::bor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &(byteOrArr[i][0]));
       OMR_CT_EXPECT_EQ(bBitwiseConst, tor(byteOrArr[i][0], byteOrArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, byteOrArr[i][1]));
 
       sprintf(resolvedMethodName, "bOrConst3_TestCase%d", i + 1);
-      bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &(byteOrArr[i][1])));
+      compileOpCodeMethod(bBitwiseConst, 
+            _numberOfBinaryArgs, TR::bor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &(byteOrArr[i][1]));
       OMR_CT_EXPECT_EQ(bBitwiseConst, tor(byteOrArr[i][0], byteOrArr[i][1]), bBitwiseConst(byteOrArr[i][0], BYTE_PLACEHOLDER_2));
      }
 
@@ -5181,18 +5179,18 @@ S390OpCodesTest::invokeDisabledBitwiseTests()
       OMR_CT_EXPECT_EQ(_bXor, txor(byteXorArr[i][0], byteXorArr[i][1]), _bXor(byteXorArr[i][0], byteXorArr[i][1]));
 
       sprintf(resolvedMethodName, "bXorConst1_TestCase%d", i + 1);
-      bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bxor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &(byteXorArr[i][0]), 2, &(byteXorArr[i][1])));
+      compileOpCodeMethod(bBitwiseConst, 
+            _numberOfBinaryArgs, TR::bxor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &(byteXorArr[i][0]), 2, &(byteXorArr[i][1]));
       OMR_CT_EXPECT_EQ(bBitwiseConst, txor(byteXorArr[i][0], byteXorArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bXorConst2_TestCase%d", i + 1);
-      bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bxor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &(byteXorArr[i][0])));
+      compileOpCodeMethod(bBitwiseConst, 
+            _numberOfBinaryArgs, TR::bxor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &(byteXorArr[i][0]));
       OMR_CT_EXPECT_EQ(bBitwiseConst, txor(byteXorArr[i][0], byteXorArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, byteXorArr[i][1]));
 
       sprintf(resolvedMethodName, "bXorConst3_TestCase%d", i + 1);
-      bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bxor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &(byteXorArr[i][1])));
+      compileOpCodeMethod(bBitwiseConst, 
+            _numberOfBinaryArgs, TR::bxor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &(byteXorArr[i][1]));
       OMR_CT_EXPECT_EQ(bBitwiseConst, txor(byteXorArr[i][0], byteXorArr[i][1]), bBitwiseConst(byteXorArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -5203,18 +5201,18 @@ S390OpCodesTest::invokeDisabledBitwiseTests()
       OMR_CT_EXPECT_EQ(_sAnd, tand(shortAndArr[i][0], shortAndArr[i][1]), _sAnd(shortAndArr[i][0], shortAndArr[i][1]));
 
       sprintf(resolvedMethodName, "sAndConst1_TestCase%d", i + 1);
-      sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sand, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &(shortAndArr[i][0]), 2, &(shortAndArr[i][1])));
+      compileOpCodeMethod(sBitwiseConst, 
+            _numberOfBinaryArgs, TR::sand, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &(shortAndArr[i][0]), 2, &(shortAndArr[i][1]));
       OMR_CT_EXPECT_EQ(sBitwiseConst, tand(shortAndArr[i][0], shortAndArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sAndConst2_TestCase%d", i + 1);
-      sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sand, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &(shortAndArr[i][0])));
+      compileOpCodeMethod(sBitwiseConst, 
+            _numberOfBinaryArgs, TR::sand, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &(shortAndArr[i][0]));
       OMR_CT_EXPECT_EQ(sBitwiseConst, tand(shortAndArr[i][0], shortAndArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, shortAndArr[i][1]));
 
       sprintf(resolvedMethodName, "sAndConst3_TestCase%d", i + 1);
-      sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sand, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &(shortAndArr[i][1])));
+      compileOpCodeMethod(sBitwiseConst, 
+            _numberOfBinaryArgs, TR::sand, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &(shortAndArr[i][1]));
       OMR_CT_EXPECT_EQ(sBitwiseConst, tand(shortAndArr[i][0], shortAndArr[i][1]), sBitwiseConst(shortAndArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -5225,18 +5223,18 @@ S390OpCodesTest::invokeDisabledBitwiseTests()
       OMR_CT_EXPECT_EQ(_sOr, tor(shortOrArr[i][0], shortOrArr[i][1]), _sOr(shortOrArr[i][0], shortOrArr[i][1]));
 
       sprintf(resolvedMethodName, "sOrConst1_TestCase%d", i + 1);
-      sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &(shortOrArr[i][0]), 2, &(shortOrArr[i][1])));
+      compileOpCodeMethod(sBitwiseConst, 
+            _numberOfBinaryArgs, TR::sor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &(shortOrArr[i][0]), 2, &(shortOrArr[i][1]));
       OMR_CT_EXPECT_EQ(sBitwiseConst, tor(shortOrArr[i][0], shortOrArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sOrConst2_TestCase%d", i + 1);
-      sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &(shortOrArr[i][0])));
+      compileOpCodeMethod(sBitwiseConst, 
+            _numberOfBinaryArgs, TR::sor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &(shortOrArr[i][0]));
       OMR_CT_EXPECT_EQ(sBitwiseConst, tor(shortOrArr[i][0], shortOrArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, shortOrArr[i][1]));
 
       sprintf(resolvedMethodName, "sOrConst3_TestCase%d", i + 1);
-      sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &(shortOrArr[i][1])));
+      compileOpCodeMethod(sBitwiseConst, 
+            _numberOfBinaryArgs, TR::sor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &(shortOrArr[i][1]));
       OMR_CT_EXPECT_EQ(sBitwiseConst, tor(shortOrArr[i][0], shortOrArr[i][1]), sBitwiseConst(shortOrArr[i][0], SHORT_PLACEHOLDER_2));
      }
 
@@ -5247,18 +5245,18 @@ S390OpCodesTest::invokeDisabledBitwiseTests()
       OMR_CT_EXPECT_EQ(_sXor, txor(shortXorArr[i][0], shortXorArr[i][1]), _sXor(shortXorArr[i][0], shortXorArr[i][1]));
 
       sprintf(resolvedMethodName, "sXorConst1_TestCase%d", i + 1);
-      sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sxor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &(shortXorArr[i][0]), 2, &(shortXorArr[i][1])));
+      compileOpCodeMethod(sBitwiseConst, 
+            _numberOfBinaryArgs, TR::sxor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &(shortXorArr[i][0]), 2, &(shortXorArr[i][1]));
       OMR_CT_EXPECT_EQ(sBitwiseConst, txor(shortXorArr[i][0], shortXorArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sXorConst2_TestCase%d", i + 1);
-      sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sxor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &(shortXorArr[i][0])));
+      compileOpCodeMethod(sBitwiseConst, 
+            _numberOfBinaryArgs, TR::sxor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &(shortXorArr[i][0]));
       OMR_CT_EXPECT_EQ(sBitwiseConst, txor(shortXorArr[i][0], shortXorArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, shortXorArr[i][1]));
 
       sprintf(resolvedMethodName, "sXorConst3_TestCase%d", i + 1);
-      sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sxor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &(shortXorArr[i][1])));
+      compileOpCodeMethod(sBitwiseConst, 
+            _numberOfBinaryArgs, TR::sxor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &(shortXorArr[i][1]));
       OMR_CT_EXPECT_EQ(sBitwiseConst, txor(shortXorArr[i][0], shortXorArr[i][1]), sBitwiseConst(shortXorArr[i][0], SHORT_PLACEHOLDER_2));
      }
    }
@@ -5427,8 +5425,8 @@ S390OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_i2a, convert(intDataArr[i], ADDRESS_PLACEHOLDER_1), _i2a(intDataArr[i]));
 
       sprintf(resolvedMethodName, "i2aConst%d", i + 1);
-      i2aConst = (signatureCharI_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::i2a, resolvedMethodName, _argTypesUnaryInt, TR::Address, rc, 2, 1, &intDataArr[i]));
+      compileOpCodeMethod(i2aConst, 
+            _numberOfUnaryArgs, TR::i2a, resolvedMethodName, _argTypesUnaryInt, TR::Address, rc, 2, 1, &intDataArr[i]);
       OMR_CT_EXPECT_EQ(i2aConst, convert(intDataArr[i], ADDRESS_PLACEHOLDER_1), i2aConst(INT_PLACEHOLDER_1));
       }
 
@@ -5438,8 +5436,8 @@ S390OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_iu2a, convert(uintDataArr[i], ADDRESS_PLACEHOLDER_1), _iu2a(uintDataArr[i]));
 
       sprintf(resolvedMethodName, "iu2aConst%d", i + 1);
-      iu2aConst = (unsignedSignatureCharI_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::iu2a, resolvedMethodName, _argTypesUnaryInt, TR::Address, rc, 2, 1, &uintDataArr[i]));
+      compileOpCodeMethod(iu2aConst, 
+            _numberOfUnaryArgs, TR::iu2a, resolvedMethodName, _argTypesUnaryInt, TR::Address, rc, 2, 1, &uintDataArr[i]);
       OMR_CT_EXPECT_EQ(iu2aConst, convert(uintDataArr[i], ADDRESS_PLACEHOLDER_1), iu2aConst(INT_PLACEHOLDER_1));
       }
 #endif
@@ -5450,8 +5448,8 @@ S390OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_l2a, convert(longDataArr[i], ADDRESS_PLACEHOLDER_1), _l2a(longDataArr[i]));
 
       sprintf(resolvedMethodName, "l2aConst%d", i + 1);
-      l2aConst = (signatureCharJ_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::l2a, resolvedMethodName, _argTypesUnaryLong, TR::Address, rc, 2, 1, &longDataArr[i]));
+      compileOpCodeMethod(l2aConst, 
+            _numberOfUnaryArgs, TR::l2a, resolvedMethodName, _argTypesUnaryLong, TR::Address, rc, 2, 1, &longDataArr[i]);
       OMR_CT_EXPECT_EQ(l2aConst, convert(longDataArr[i], ADDRESS_PLACEHOLDER_1), l2aConst(LONG_PLACEHOLDER_1));
       }
 
@@ -5461,8 +5459,8 @@ S390OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_lu2a, convert(ulongDataArr[i], ADDRESS_PLACEHOLDER_1), _lu2a(ulongDataArr[i]));
 
       sprintf(resolvedMethodName, "lu2aConst%d", i + 1);
-      lu2aConst = (unsignedSignatureCharJ_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::lu2a, resolvedMethodName, _argTypesUnaryLong, TR::Address, rc, 2, 1, &ulongDataArr[i]));
+      compileOpCodeMethod(lu2aConst, 
+            _numberOfUnaryArgs, TR::lu2a, resolvedMethodName, _argTypesUnaryLong, TR::Address, rc, 2, 1, &ulongDataArr[i]);
       OMR_CT_EXPECT_EQ(lu2aConst, convert(ulongDataArr[i], ADDRESS_PLACEHOLDER_1), lu2aConst(INT_PLACEHOLDER_1));
       }
 
@@ -5472,7 +5470,7 @@ S390OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_a2l, convert(aUnaryDataArr[i], LONG_POS), _a2l(aUnaryDataArr[i]));
 
       sprintf(resolvedMethodName, "a2lConst%d", i + 1);
-      a2lConst = (signatureCharL_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::a2l, resolvedMethodName, _argTypesUnaryAddress, TR::Int64, rc, 2, 1, &aUnaryDataArr[i]));
+      compileOpCodeMethod(a2lConst, _numberOfUnaryArgs, TR::a2l, resolvedMethodName, _argTypesUnaryAddress, TR::Int64, rc, 2, 1, &aUnaryDataArr[i]);
       OMR_CT_EXPECT_EQ(a2lConst, convert(aUnaryDataArr[i], LONG_POS), a2lConst(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -5482,8 +5480,8 @@ S390OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_a2s, convert(aUnaryDataArr[i], SHORT_POS), _a2s(aUnaryDataArr[i]));
 
       sprintf(resolvedMethodName, "a2sConst%d", i + 1);
-      a2sConst = (signatureCharL_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::a2s, resolvedMethodName, _argTypesUnaryAddress, TR::Int16, rc, 2, 1, &aUnaryDataArr[i]));
+      compileOpCodeMethod(a2sConst, 
+            _numberOfUnaryArgs, TR::a2s, resolvedMethodName, _argTypesUnaryAddress, TR::Int16, rc, 2, 1, &aUnaryDataArr[i]);
       OMR_CT_EXPECT_EQ(a2sConst, convert(aUnaryDataArr[i], SHORT_POS), a2sConst(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -5493,8 +5491,8 @@ S390OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_a2b, convert(aUnaryDataArr[i], BYTE_POS), _a2b(aUnaryDataArr[i]));
 
       sprintf(resolvedMethodName, "a2bConst%d", i + 1);
-      a2bConst = (signatureCharL_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::a2b, resolvedMethodName, _argTypesUnaryAddress, TR::Int8, rc, 2, 1, &aUnaryDataArr[i]));
+      compileOpCodeMethod(a2bConst, 
+            _numberOfUnaryArgs, TR::a2b, resolvedMethodName, _argTypesUnaryAddress, TR::Int8, rc, 2, 1, &aUnaryDataArr[i]);
       OMR_CT_EXPECT_EQ(a2bConst, convert(aUnaryDataArr[i], BYTE_POS), a2bConst(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -5505,18 +5503,18 @@ S390OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_acmpeq, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), _acmpeq(acmpeqDataArr[i][0], acmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpeqConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpeqDataArr[i][0]), 2, &(acmpeqDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpeqDataArr[i][0]), 2, &(acmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "aCmpeqConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpeqDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpeqConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpeqDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(acmpeqDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -5526,18 +5524,18 @@ S390OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_acmpne, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), _acmpne(acmpneDataArr[i][0], acmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpneConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpneDataArr[i][0]), 2, &(acmpneDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpneDataArr[i][0]), 2, &(acmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "aCmpneConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpneDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpneConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpneDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(acmpneDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -5547,18 +5545,18 @@ S390OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_acmpgt, compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), _acmpgt(acmpgtDataArr[i][0], acmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpgtConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpgtDataArr[i][0]), 2, &(acmpgtDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpgtDataArr[i][0]), 2, &(acmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "acmpgtConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpgtDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpgtConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpgtDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), aCompareConst(acmpgtDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -5568,18 +5566,18 @@ S390OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_acmplt, compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), _acmplt(acmpltDataArr[i][0], acmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpltConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpltDataArr[i][0]), 2, &(acmpltDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpltDataArr[i][0]), 2, &(acmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "acmpltConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpltDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpltConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpltDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), aCompareConst(acmpltDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -5589,18 +5587,18 @@ S390OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_acmpge, compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), _acmpge(acmpgeDataArr[i][0], acmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpgeConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpgeDataArr[i][0]), 2, &(acmpgeDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpgeDataArr[i][0]), 2, &(acmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "acmpgeConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpgeDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpgeConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpgeDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), aCompareConst(acmpgeDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -5610,18 +5608,18 @@ S390OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_acmple, compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), _acmple(acmpleDataArr[i][0], acmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpleConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpleDataArr[i][0]), 2, &(acmpleDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpleDataArr[i][0]), 2, &(acmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "acmpleConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpleDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpleConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpleDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), aCompareConst(acmpleDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -5632,18 +5630,18 @@ S390OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_ifacmpeq, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), _ifacmpeq(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpeqConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpeqDataArr[i][0]), 2, &(ifacmpeqDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpeqDataArr[i][0]), 2, &(ifacmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpeqConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpeqDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpeqConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpeqDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ifacmpeqDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -5653,18 +5651,18 @@ S390OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_ifacmpne, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), _ifacmpne(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpneConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpneDataArr[i][0]), 2, &(ifacmpneDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpneDataArr[i][0]), 2, &(ifacmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpneConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpneDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpneConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpneDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ifacmpneDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -5674,18 +5672,18 @@ S390OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_ifacmpgt, compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), _ifacmpgt(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpgtConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpgtDataArr[i][0]), 2, &(ifacmpgtDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpgtDataArr[i][0]), 2, &(ifacmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpgtConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpgtDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpgtConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpgtDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), aCompareConst(ifacmpgtDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -5695,18 +5693,18 @@ S390OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_ifacmplt, compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), _ifacmplt(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpltConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpltDataArr[i][0]), 2, &(ifacmpltDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpltDataArr[i][0]), 2, &(ifacmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpltConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpltDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpltConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpltDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), aCompareConst(ifacmpltDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -5716,18 +5714,18 @@ S390OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_ifacmpge, compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), _ifacmpge(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpgeConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpgeDataArr[i][0]), 2, &(ifacmpgeDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpgeDataArr[i][0]), 2, &(ifacmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpgeConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpgeDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpgeConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpgeDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), aCompareConst(ifacmpgeDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -5737,18 +5735,18 @@ S390OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_ifacmple, compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), _ifacmple(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpleConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpleDataArr[i][0]), 2, &(ifacmpleDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpleDataArr[i][0]), 2, &(ifacmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpleConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpleDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpleConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpleDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ifacmpleDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -5761,38 +5759,38 @@ S390OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_aternary, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), _aternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]));
 
       sprintf(resolvedMethodName, "aTernaryConst1_TestCase%d", i + 1);
-      aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 6, 1, &aternaryChild1Arr[i], 2, &aternaryArr[i][0], 3, &aternaryArr[i][1]));
+      compileOpCodeMethod(aTernaryConst, 
+            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 6, 1, &aternaryChild1Arr[i], 2, &aternaryArr[i][0], 3, &aternaryArr[i][1]);
       OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "aTernaryConst2_TestCase%d", i + 1);
-      aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 1, &aternaryChild1Arr[i], 2, &aternaryArr[i][0]));
+      compileOpCodeMethod(aTernaryConst, 
+            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 1, &aternaryChild1Arr[i], 2, &aternaryArr[i][0]);
       OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, aternaryArr[i][1]));
 
       sprintf(resolvedMethodName, "aTernaryConst3_TestCase%d", i + 1);
-      aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 1, &aternaryChild1Arr[i], 3, &aternaryArr[i][1]));
+      compileOpCodeMethod(aTernaryConst, 
+            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 1, &aternaryChild1Arr[i], 3, &aternaryArr[i][1]);
       OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, aternaryArr[i][0], ADDRESS_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "aTernaryConst4_TestCase%d", i + 1);
-      aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 2, &aternaryArr[i][0], 3, &aternaryArr[i][1]));
+      compileOpCodeMethod(aTernaryConst, 
+            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 2, &aternaryArr[i][0], 3, &aternaryArr[i][1]);
       OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "aTernaryConst5_TestCase%d", i + 1);
-      aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 1, &aternaryChild1Arr[i]));
+      compileOpCodeMethod(aTernaryConst, 
+            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 1, &aternaryChild1Arr[i]);
       OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, aternaryArr[i][0], aternaryArr[i][1]));
 
       sprintf(resolvedMethodName, "aTernaryConst6_TestCase%d", i + 1);
-      aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 2, &aternaryArr[i][0]));
+      compileOpCodeMethod(aTernaryConst, 
+            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 2, &aternaryArr[i][0]);
       OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], ADDRESS_PLACEHOLDER_1, aternaryArr[i][1]));
 
       sprintf(resolvedMethodName, "aTernaryConst7_TestCase%d", i + 1);
-      aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 3, &aternaryArr[i][1]));
+      compileOpCodeMethod(aTernaryConst, 
+            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 3, &aternaryArr[i][1]);
       OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], aternaryArr[i][0], ADDRESS_PLACEHOLDER_1));
       }
    }
@@ -5804,13 +5802,13 @@ S390OpCodesTest::compileDisabledS390ConvertToAddressOpCodesTests()
    int32_t rc = 0;
 
    //Jazz103 Work Item 107711
-   _b2a = (signatureCharB_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2a, "b2a", _argTypesUnaryByte, TR::Address, rc));
-   _s2a = (signatureCharS_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2a, "s2a", _argTypesUnaryShort, TR::Address, rc));
-   _bu2a = (unsignedSignatureCharB_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2a, "bu2a", _argTypesUnaryByte, TR::Address, rc));
-   _su2a = (unsignedSignatureCharS_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2a, "su2a", _argTypesUnaryShort, TR::Address, rc));
+   compileOpCodeMethod(_b2a, _numberOfUnaryArgs, TR::b2a, "b2a", _argTypesUnaryByte, TR::Address, rc);
+   compileOpCodeMethod(_s2a, _numberOfUnaryArgs, TR::s2a, "s2a", _argTypesUnaryShort, TR::Address, rc);
+   compileOpCodeMethod(_bu2a, _numberOfUnaryArgs, TR::bu2a, "bu2a", _argTypesUnaryByte, TR::Address, rc);
+   compileOpCodeMethod(_su2a, _numberOfUnaryArgs, TR::su2a, "su2a", _argTypesUnaryShort, TR::Address, rc);
 #if defined(TR_TARGET_64BIT)
-   _i2a = (signatureCharI_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::i2a, "i2a", _argTypesUnaryInt, TR::Address, rc));
-   _iu2a = (unsignedSignatureCharI_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iu2a, "iu2a", _argTypesUnaryInt, TR::Address, rc));
+   compileOpCodeMethod(_i2a, _numberOfUnaryArgs, TR::i2a, "i2a", _argTypesUnaryInt, TR::Address, rc);
+   compileOpCodeMethod(_iu2a, _numberOfUnaryArgs, TR::iu2a, "iu2a", _argTypesUnaryInt, TR::Address, rc);
 #endif
    }
 
@@ -5843,8 +5841,8 @@ S390OpCodesTest::invokeDisabledS390ConvertToAddressOpCodesTests()
       OMR_CT_EXPECT_EQ(_b2a, convert(byteDataArr[i], ADDRESS_PLACEHOLDER_1), _b2a(byteDataArr[i]));
 
       sprintf(resolvedMethodName, "b2aConst%d", i + 1);
-      b2aConst = (signatureCharB_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::b2a, resolvedMethodName, _argTypesUnaryByte, TR::Address, rc, 2, 1, &byteDataArr[i]));
+      compileOpCodeMethod(b2aConst, 
+            _numberOfUnaryArgs, TR::b2a, resolvedMethodName, _argTypesUnaryByte, TR::Address, rc, 2, 1, &byteDataArr[i]);
       OMR_CT_EXPECT_EQ(b2aConst, convert(byteDataArr[i], ADDRESS_PLACEHOLDER_1), b2aConst(BYTE_PLACEHOLDER_1));
       }
 
@@ -5854,8 +5852,8 @@ S390OpCodesTest::invokeDisabledS390ConvertToAddressOpCodesTests()
       OMR_CT_EXPECT_EQ(_s2a, convert(shortDataArr[i], ADDRESS_PLACEHOLDER_1), _s2a(shortDataArr[i]));
 
       sprintf(resolvedMethodName, "s2aConst%d", i + 1);
-      s2aConst = (signatureCharS_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::s2a, resolvedMethodName, _argTypesUnaryShort, TR::Address, rc, 2, 1, &shortDataArr[i]));
+      compileOpCodeMethod(s2aConst, 
+            _numberOfUnaryArgs, TR::s2a, resolvedMethodName, _argTypesUnaryShort, TR::Address, rc, 2, 1, &shortDataArr[i]);
       OMR_CT_EXPECT_EQ(s2aConst, convert(shortDataArr[i], ADDRESS_PLACEHOLDER_1), s2aConst(SHORT_PLACEHOLDER_1));
       }
 
@@ -5865,8 +5863,8 @@ S390OpCodesTest::invokeDisabledS390ConvertToAddressOpCodesTests()
       OMR_CT_EXPECT_EQ(_bu2a, convert(ubyteDataArr[i], ADDRESS_PLACEHOLDER_1), _bu2a(ubyteDataArr[i]));
 
       sprintf(resolvedMethodName, "bu2aConst%d", i + 1);
-      bu2aConst = (unsignedSignatureCharB_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::bu2a, resolvedMethodName, _argTypesUnaryByte, TR::Address, rc, 2, 1, &ubyteDataArr[i]));
+      compileOpCodeMethod(bu2aConst, 
+            _numberOfUnaryArgs, TR::bu2a, resolvedMethodName, _argTypesUnaryByte, TR::Address, rc, 2, 1, &ubyteDataArr[i]);
       OMR_CT_EXPECT_EQ(bu2aConst, convert(ubyteDataArr[i], ADDRESS_PLACEHOLDER_1), bu2aConst(INT_PLACEHOLDER_1));
       }
 
@@ -5876,8 +5874,8 @@ S390OpCodesTest::invokeDisabledS390ConvertToAddressOpCodesTests()
       OMR_CT_EXPECT_EQ(_su2a, convert(ushortDataArr[i], ADDRESS_PLACEHOLDER_1), _su2a(ushortDataArr[i]));
 
       sprintf(resolvedMethodName, "su2aConst%d", i + 1);
-      su2aConst = (unsignedSignatureCharS_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::su2a, resolvedMethodName, _argTypesUnaryShort, TR::Address, rc, 2, 1, &ushortDataArr[i]));
+      compileOpCodeMethod(su2aConst, 
+            _numberOfUnaryArgs, TR::su2a, resolvedMethodName, _argTypesUnaryShort, TR::Address, rc, 2, 1, &ushortDataArr[i]);
       OMR_CT_EXPECT_EQ(su2aConst, convert(ushortDataArr[i], ADDRESS_PLACEHOLDER_1), su2aConst(INT_PLACEHOLDER_1));
       }
 
@@ -5888,8 +5886,8 @@ S390OpCodesTest::invokeDisabledS390ConvertToAddressOpCodesTests()
       OMR_CT_EXPECT_EQ(_i2a, convert(intDataArr[i], ADDRESS_PLACEHOLDER_1), _i2a(intDataArr[i]));
 
       sprintf(resolvedMethodName, "i2aConst%d", i + 1);
-      i2aConst = (signatureCharI_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::i2a, resolvedMethodName, _argTypesUnaryInt, TR::Address, rc, 2, 1, &intDataArr[i]));
+      compileOpCodeMethod(i2aConst, 
+            _numberOfUnaryArgs, TR::i2a, resolvedMethodName, _argTypesUnaryInt, TR::Address, rc, 2, 1, &intDataArr[i]);
       OMR_CT_EXPECT_EQ(i2aConst, convert(intDataArr[i], ADDRESS_PLACEHOLDER_1), i2aConst(INT_PLACEHOLDER_1));
       }
 
@@ -5899,8 +5897,8 @@ S390OpCodesTest::invokeDisabledS390ConvertToAddressOpCodesTests()
       OMR_CT_EXPECT_EQ(_iu2a, convert(uintDataArr[i], ADDRESS_PLACEHOLDER_1), _iu2a(uintDataArr[i]));
 
       sprintf(resolvedMethodName, "iu2aConst%d", i + 1);
-      iu2aConst = (unsignedSignatureCharI_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::iu2a, resolvedMethodName, _argTypesUnaryInt, TR::Address, rc, 2, 1, &uintDataArr[i]));
+      compileOpCodeMethod(iu2aConst, 
+            _numberOfUnaryArgs, TR::iu2a, resolvedMethodName, _argTypesUnaryInt, TR::Address, rc, 2, 1, &uintDataArr[i]);
       OMR_CT_EXPECT_EQ(iu2aConst, convert(uintDataArr[i], ADDRESS_PLACEHOLDER_1), iu2aConst(INT_PLACEHOLDER_1));
       }
 #endif

--- a/fvtest/compilertest/tests/X86OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/X86OpCodesTest.cpp
@@ -183,12 +183,12 @@ X86OpCodesTest::compileDirectCallTestMethods()
    {
    int32_t rc = 0;
 
-   _iCall = (signatureCharI_I_testMethodType *) (compileDirectCallOpCodeMethod(_numberOfUnaryArgs, TR::ireturn, TR::icall, "iCompiledMethod", "iCall", _argTypesUnaryInt, TR::Int32, rc));
-   _dCall = (signatureCharD_D_testMethodType *) (compileDirectCallOpCodeMethod(_numberOfUnaryArgs, TR::dreturn, TR::dcall, "dCompiledMethod", "dCall", _argTypesUnaryDouble, TR::Double, rc));
-   _fCall = (signatureCharF_F_testMethodType *) (compileDirectCallOpCodeMethod(_numberOfUnaryArgs, TR::freturn, TR::fcall, "fCompiledMethod", "fCall", _argTypesUnaryFloat, TR::Float, rc));
+   compileDirectCallOpCodeMethod(_iCall, _numberOfUnaryArgs, TR::ireturn, TR::icall, "iCompiledMethod", "iCall", _argTypesUnaryInt, TR::Int32, rc);
+   compileDirectCallOpCodeMethod(_dCall, _numberOfUnaryArgs, TR::dreturn, TR::dcall, "dCompiledMethod", "dCall", _argTypesUnaryDouble, TR::Double, rc);
+   compileDirectCallOpCodeMethod(_fCall, _numberOfUnaryArgs, TR::freturn, TR::fcall, "fCompiledMethod", "fCall", _argTypesUnaryFloat, TR::Float, rc);
 
 #if defined(TR_TARGET_64BIT)
-   _lCall = (signatureCharJ_J_testMethodType *) (compileDirectCallOpCodeMethod(_numberOfUnaryArgs, TR::lreturn, TR::lcall, "lCompiledMethod", "lCall", _argTypesUnaryLong, TR::Int64, rc));
+   compileDirectCallOpCodeMethod(_lCall, _numberOfUnaryArgs, TR::lreturn, TR::lcall, "lCompiledMethod", "lCall", _argTypesUnaryLong, TR::Int64, rc);
 #endif
    }
 
@@ -314,7 +314,7 @@ X86OpCodesTest::compileAddressTestMethods()
    {
    int32_t rc = 0;
 
-   _acall = (signatureCharL_L_testMethodType *) (compileDirectCallOpCodeMethod(_numberOfUnaryArgs, TR::areturn, TR::acall, "aCompiledMethod", "acall", _argTypesUnaryAddress, TR::Address, rc));
+   compileDirectCallOpCodeMethod(_acall, _numberOfUnaryArgs, TR::areturn, TR::acall, "aCompiledMethod", "acall", _argTypesUnaryAddress, TR::Address, rc);
 
 
 #if defined(TR_TARGET_64BIT)

--- a/fvtest/compilertest/tests/X86OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/X86OpCodesTest.cpp
@@ -31,17 +31,17 @@ void
 X86OpCodesTest::compileIntegerArithmeticTestMethods()
    {
    int32_t rc = 0;
-   _bSub = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bsub, "bSub", _argTypesBinaryByte, TR::Int8, rc));
-   _sSub = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ssub, "sSub", _argTypesBinaryShort, TR::Int16, rc));
-   _bAdd = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::badd, "bAdd", _argTypesBinaryByte, TR::Int8, rc));
-   _sAdd = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sadd, "sAdd", _argTypesBinaryShort, TR::Int16, rc));
-   _lAdd = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ladd, "lAdd", _argTypesBinaryLong, TR::Int64, rc));
-   _lSub = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lsub, "lSub", _argTypesBinaryLong, TR::Int64, rc));
-   _lMul = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lmul, "lMul", _argTypesBinaryLong, TR::Int64, rc));
+   compileOpCodeMethod(_bSub, _numberOfBinaryArgs, TR::bsub, "bSub", _argTypesBinaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_sSub, _numberOfBinaryArgs, TR::ssub, "sSub", _argTypesBinaryShort, TR::Int16, rc);
+   compileOpCodeMethod(_bAdd, _numberOfBinaryArgs, TR::badd, "bAdd", _argTypesBinaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_sAdd, _numberOfBinaryArgs, TR::sadd, "sAdd", _argTypesBinaryShort, TR::Int16, rc);
+   compileOpCodeMethod(_lAdd, _numberOfBinaryArgs, TR::ladd, "lAdd", _argTypesBinaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_lSub, _numberOfBinaryArgs, TR::lsub, "lSub", _argTypesBinaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_lMul, _numberOfBinaryArgs, TR::lmul, "lMul", _argTypesBinaryLong, TR::Int64, rc);
 
 #if defined(TR_TARGET_64BIT)
-   _lDiv = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ldiv, "lDiv", _argTypesBinaryLong, TR::Int64, rc));
-   _lRem = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lrem, "lRem", _argTypesBinaryLong, TR::Int64, rc));
+   compileOpCodeMethod(_lDiv, _numberOfBinaryArgs, TR::ldiv, "lDiv", _argTypesBinaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_lRem, _numberOfBinaryArgs, TR::lrem, "lRem", _argTypesBinaryLong, TR::Int64, rc);
 #endif
    }
 
@@ -50,14 +50,14 @@ X86OpCodesTest::compileFloatArithmeticTestMethods()
    {
    int32_t rc = 0;
 
-   _fAdd = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fadd, "fAdd", _argTypesBinaryFloat, TR::Float, rc));
-   _fSub = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fsub, "fSub", _argTypesBinaryFloat, TR::Float, rc));
-   _fMul = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fmul, "fMul", _argTypesBinaryFloat, TR::Float, rc));
-   _fDiv = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fdiv, "fDiv", _argTypesBinaryFloat, TR::Float, rc));
-   _dAdd = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dadd, "dAdd", _argTypesBinaryDouble, TR::Double, rc));
-   _dSub = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dsub, "dSub", _argTypesBinaryDouble, TR::Double, rc));
-   _dMul = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dmul, "dMul", _argTypesBinaryDouble, TR::Double, rc));
-   _dDiv = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ddiv, "dDiv", _argTypesBinaryDouble, TR::Double, rc));
+   compileOpCodeMethod(_fAdd, _numberOfBinaryArgs, TR::fadd, "fAdd", _argTypesBinaryFloat, TR::Float, rc);
+   compileOpCodeMethod(_fSub, _numberOfBinaryArgs, TR::fsub, "fSub", _argTypesBinaryFloat, TR::Float, rc);
+   compileOpCodeMethod(_fMul, _numberOfBinaryArgs, TR::fmul, "fMul", _argTypesBinaryFloat, TR::Float, rc);
+   compileOpCodeMethod(_fDiv, _numberOfBinaryArgs, TR::fdiv, "fDiv", _argTypesBinaryFloat, TR::Float, rc);
+   compileOpCodeMethod(_dAdd, _numberOfBinaryArgs, TR::dadd, "dAdd", _argTypesBinaryDouble, TR::Double, rc);
+   compileOpCodeMethod(_dSub, _numberOfBinaryArgs, TR::dsub, "dSub", _argTypesBinaryDouble, TR::Double, rc);
+   compileOpCodeMethod(_dMul, _numberOfBinaryArgs, TR::dmul, "dMul", _argTypesBinaryDouble, TR::Double, rc);
+   compileOpCodeMethod(_dDiv, _numberOfBinaryArgs, TR::ddiv, "dDiv", _argTypesBinaryDouble, TR::Double, rc);
 
    }
 
@@ -66,23 +66,23 @@ X86OpCodesTest::compileMemoryOperationTestMethods()
    {
    int32_t rc = 0;
 
-   _bLoad = (signatureCharB_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bload, "bLoad", _argTypesUnaryByte, TR::Int8, rc));
-   _sLoad = (signatureCharS_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::sload, "sLoad", _argTypesUnaryShort, TR::Int16, rc));
+   compileOpCodeMethod(_bLoad, _numberOfUnaryArgs, TR::bload, "bLoad", _argTypesUnaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_sLoad, _numberOfUnaryArgs, TR::sload, "sLoad", _argTypesUnaryShort, TR::Int16, rc);
 
-   _bStore = (signatureCharB_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bstore, "bStore", _argTypesUnaryByte, TR::Int8, rc));
-   _sStore = (signatureCharS_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::sstore, "sStore", _argTypesUnaryShort, TR::Int16, rc));
-   _lStore = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lstore, "lStore", _argTypesUnaryLong, TR::Int64, rc));
-   _dStore = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dstore, "dStore", _argTypesUnaryDouble, TR::Double, rc));
-   _fStore = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::fstore, "fStore", _argTypesUnaryFloat, TR::Float, rc));
+   compileOpCodeMethod(_bStore, _numberOfUnaryArgs, TR::bstore, "bStore", _argTypesUnaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_sStore, _numberOfUnaryArgs, TR::sstore, "sStore", _argTypesUnaryShort, TR::Int16, rc);
+   compileOpCodeMethod(_lStore, _numberOfUnaryArgs, TR::lstore, "lStore", _argTypesUnaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_dStore, _numberOfUnaryArgs, TR::dstore, "dStore", _argTypesUnaryDouble, TR::Double, rc);
+   compileOpCodeMethod(_fStore, _numberOfUnaryArgs, TR::fstore, "fStore", _argTypesUnaryFloat, TR::Float, rc);
 
    //Jazz 111413 : indirect store opcodes get unexpected results
 #if defined(TR_TARGET_64BIT)
-   _iStorei = (signatureCharLI_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::istorei, "iStorei", _argTypesBinaryAddressInt, TR::Int32, rc));
-   _lStorei = (signatureCharLJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lstorei, "lStorei", _argTypesBinaryAddressLong, TR::Int64, rc));
-   _dStorei = (signatureCharLD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dstorei, "dStorei", _argTypesBinaryAddressDouble, TR::Double, rc));
-   _fStorei = (signatureCharLF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fstorei, "fStorei", _argTypesBinaryAddressFloat, TR::Float, rc));
-   _sStorei = (signatureCharLS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sstorei, "sStorei", _argTypesBinaryAddressShort, TR::Int16, rc));
-   _aStorei = (signatureCharLL_L_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::astorei, "aStorei", _argTypesBinaryAddressAddress, TR::Address, rc));
+   compileOpCodeMethod(_iStorei, _numberOfBinaryArgs, TR::istorei, "iStorei", _argTypesBinaryAddressInt, TR::Int32, rc);
+   compileOpCodeMethod(_lStorei, _numberOfBinaryArgs, TR::lstorei, "lStorei", _argTypesBinaryAddressLong, TR::Int64, rc);
+   compileOpCodeMethod(_dStorei, _numberOfBinaryArgs, TR::dstorei, "dStorei", _argTypesBinaryAddressDouble, TR::Double, rc);
+   compileOpCodeMethod(_fStorei, _numberOfBinaryArgs, TR::fstorei, "fStorei", _argTypesBinaryAddressFloat, TR::Float, rc);
+   compileOpCodeMethod(_sStorei, _numberOfBinaryArgs, TR::sstorei, "sStorei", _argTypesBinaryAddressShort, TR::Int16, rc);
+   compileOpCodeMethod(_aStorei, _numberOfBinaryArgs, TR::astorei, "aStorei", _argTypesBinaryAddressAddress, TR::Address, rc);
 #endif
 
    }
@@ -91,51 +91,51 @@ void
 X86OpCodesTest::compileUnaryTestMethods()
    {
    int32_t rc = 0;
-   _bNeg = (signatureCharB_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bneg, "bNeg", _argTypesUnaryByte, TR::Int8, rc));
-   _sNeg = (signatureCharS_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::sneg, "sNeg", _argTypesUnaryShort, TR::Int16, rc));
-   _dNeg = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dneg, "dNeg", _argTypesUnaryDouble, TR::Double, rc));
-   _fNeg = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::fneg, "fNeg", _argTypesUnaryFloat, TR::Float, rc));
-   _lNeg = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lneg, "lNeg", _argTypesUnaryLong, TR::Int64, rc));
+   compileOpCodeMethod(_bNeg, _numberOfUnaryArgs, TR::bneg, "bNeg", _argTypesUnaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_sNeg, _numberOfUnaryArgs, TR::sneg, "sNeg", _argTypesUnaryShort, TR::Int16, rc);
+   compileOpCodeMethod(_dNeg, _numberOfUnaryArgs, TR::dneg, "dNeg", _argTypesUnaryDouble, TR::Double, rc);
+   compileOpCodeMethod(_fNeg, _numberOfUnaryArgs, TR::fneg, "fNeg", _argTypesUnaryFloat, TR::Float, rc);
+   compileOpCodeMethod(_lNeg, _numberOfUnaryArgs, TR::lneg, "lNeg", _argTypesUnaryLong, TR::Int64, rc);
 
-   _lAbs = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::labs, "lAbs", _argTypesUnaryLong, TR::Int64, rc));
+   compileOpCodeMethod(_lAbs, _numberOfUnaryArgs, TR::labs, "lAbs", _argTypesUnaryLong, TR::Int64, rc);
 
-   _lReturn = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lreturn, "lReturn", _argTypesUnaryLong, TR::Int64, rc));
-   _dReturn = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dreturn, "dReturn", _argTypesUnaryDouble, TR::Double, rc));
-   _fReturn = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::freturn, "fReturn", _argTypesUnaryFloat, TR::Float, rc));
+   compileOpCodeMethod(_lReturn, _numberOfUnaryArgs, TR::lreturn, "lReturn", _argTypesUnaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_dReturn, _numberOfUnaryArgs, TR::dreturn, "dReturn", _argTypesUnaryDouble, TR::Double, rc);
+   compileOpCodeMethod(_fReturn, _numberOfUnaryArgs, TR::freturn, "fReturn", _argTypesUnaryFloat, TR::Float, rc);
 
-   _i2f = (signatureCharI_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::i2f, "i2f", _argTypesUnaryInt, TR::Float, rc));
-   _i2d = (signatureCharI_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::i2d, "i2d", _argTypesUnaryInt, TR::Double, rc));
-   _iu2l = (unsignedSignatureCharI_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iu2l, "iu2l", _argTypesUnaryInt, TR::Int64, rc));
+   compileOpCodeMethod(_i2f, _numberOfUnaryArgs, TR::i2f, "i2f", _argTypesUnaryInt, TR::Float, rc);
+   compileOpCodeMethod(_i2d, _numberOfUnaryArgs, TR::i2d, "i2d", _argTypesUnaryInt, TR::Double, rc);
+   compileOpCodeMethod(_iu2l, _numberOfUnaryArgs, TR::iu2l, "iu2l", _argTypesUnaryInt, TR::Int64, rc);
 
-   _l2f = (signatureCharJ_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::l2f, "l2f", _argTypesUnaryLong, TR::Float, rc));
-   _l2d = (signatureCharJ_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::l2d, "l2d", _argTypesUnaryLong, TR::Double, rc));
+   compileOpCodeMethod(_l2f, _numberOfUnaryArgs, TR::l2f, "l2f", _argTypesUnaryLong, TR::Float, rc);
+   compileOpCodeMethod(_l2d, _numberOfUnaryArgs, TR::l2d, "l2d", _argTypesUnaryLong, TR::Double, rc);
 
-   _f2l = (signatureCharF_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2l, "f2l", _argTypesUnaryFloat, TR::Int64, rc));
-   _f2d = (signatureCharF_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2d, "f2d", _argTypesUnaryFloat, TR::Double, rc));
-   _d2f = (signatureCharD_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2f, "d2f", _argTypesUnaryDouble, TR::Float, rc));
-   _d2l = (signatureCharD_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2l, "d2l", _argTypesUnaryDouble, TR::Int64, rc));
+   compileOpCodeMethod(_f2l, _numberOfUnaryArgs, TR::f2l, "f2l", _argTypesUnaryFloat, TR::Int64, rc);
+   compileOpCodeMethod(_f2d, _numberOfUnaryArgs, TR::f2d, "f2d", _argTypesUnaryFloat, TR::Double, rc);
+   compileOpCodeMethod(_d2f, _numberOfUnaryArgs, TR::d2f, "d2f", _argTypesUnaryDouble, TR::Float, rc);
+   compileOpCodeMethod(_d2l, _numberOfUnaryArgs, TR::d2l, "d2l", _argTypesUnaryDouble, TR::Int64, rc);
 
-   _b2i = (signatureCharB_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2i, "b2i", _argTypesUnaryByte, TR::Int32, rc));
-   _b2l = (signatureCharB_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2l, "b2l", _argTypesUnaryByte, TR::Int64, rc));
-   _b2s = (signatureCharB_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2s, "b2s", _argTypesUnaryByte, TR::Int16, rc));
-   _b2f = (signatureCharB_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2f, "b2f", _argTypesUnaryByte, TR::Float, rc));
-   _b2d = (signatureCharB_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2d, "b2d", _argTypesUnaryByte, TR::Double, rc));
-   _bu2i = (unsignedSignatureCharB_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2i, "bu2i", _argTypesUnaryByte, TR::Int32, rc));
-   _bu2l = (unsignedSignatureCharB_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2l, "bu2l", _argTypesUnaryByte, TR::Int64, rc));
-   _bu2s = (unsignedSignatureCharB_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2s, "bu2s", _argTypesUnaryByte, TR::Int16, rc));
-   _bu2f = (unsignedSignatureCharB_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2f, "bu2f", _argTypesUnaryByte, TR::Float, rc));
-   _bu2d = (unsignedSignatureCharB_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2d, "bu2d", _argTypesUnaryByte, TR::Double, rc));
+   compileOpCodeMethod(_b2i, _numberOfUnaryArgs, TR::b2i, "b2i", _argTypesUnaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_b2l, _numberOfUnaryArgs, TR::b2l, "b2l", _argTypesUnaryByte, TR::Int64, rc);
+   compileOpCodeMethod(_b2s, _numberOfUnaryArgs, TR::b2s, "b2s", _argTypesUnaryByte, TR::Int16, rc);
+   compileOpCodeMethod(_b2f, _numberOfUnaryArgs, TR::b2f, "b2f", _argTypesUnaryByte, TR::Float, rc);
+   compileOpCodeMethod(_b2d, _numberOfUnaryArgs, TR::b2d, "b2d", _argTypesUnaryByte, TR::Double, rc);
+   compileOpCodeMethod(_bu2i, _numberOfUnaryArgs, TR::bu2i, "bu2i", _argTypesUnaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_bu2l, _numberOfUnaryArgs, TR::bu2l, "bu2l", _argTypesUnaryByte, TR::Int64, rc);
+   compileOpCodeMethod(_bu2s, _numberOfUnaryArgs, TR::bu2s, "bu2s", _argTypesUnaryByte, TR::Int16, rc);
+   compileOpCodeMethod(_bu2f, _numberOfUnaryArgs, TR::bu2f, "bu2f", _argTypesUnaryByte, TR::Float, rc);
+   compileOpCodeMethod(_bu2d, _numberOfUnaryArgs, TR::bu2d, "bu2d", _argTypesUnaryByte, TR::Double, rc);
 
-   _s2i = (signatureCharS_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2i, "s2i", _argTypesUnaryShort, TR::Int32, rc));
-   _s2l = (signatureCharS_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2l, "s2l", _argTypesUnaryShort, TR::Int64, rc));
-   _s2b = (signatureCharS_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2b, "s2b", _argTypesUnaryShort, TR::Int8, rc));
-   _s2f = (signatureCharS_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2f, "s2f", _argTypesUnaryShort, TR::Float, rc));
-   _s2d = (signatureCharS_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2d, "s2d", _argTypesUnaryShort, TR::Double, rc));
-   _su2i = (unsignedSignatureCharS_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2i, "su2i", _argTypesUnaryShort, TR::Int32, rc));
-   _su2l = (unsignedSignatureCharS_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2l, "su2l", _argTypesUnaryShort, TR::Int64, rc));
-   _su2f = (unsignedSignatureCharS_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2f, "su2f", _argTypesUnaryShort, TR::Float, rc));
-   _su2d = (unsignedSignatureCharS_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2d, "su2d", _argTypesUnaryShort, TR::Double, rc));
-   _iByteswap = (signatureCharI_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::ibyteswap, "iByteswap", _argTypesUnaryInt, TR::Int32, rc));
+   compileOpCodeMethod(_s2i, _numberOfUnaryArgs, TR::s2i, "s2i", _argTypesUnaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_s2l, _numberOfUnaryArgs, TR::s2l, "s2l", _argTypesUnaryShort, TR::Int64, rc);
+   compileOpCodeMethod(_s2b, _numberOfUnaryArgs, TR::s2b, "s2b", _argTypesUnaryShort, TR::Int8, rc);
+   compileOpCodeMethod(_s2f, _numberOfUnaryArgs, TR::s2f, "s2f", _argTypesUnaryShort, TR::Float, rc);
+   compileOpCodeMethod(_s2d, _numberOfUnaryArgs, TR::s2d, "s2d", _argTypesUnaryShort, TR::Double, rc);
+   compileOpCodeMethod(_su2i, _numberOfUnaryArgs, TR::su2i, "su2i", _argTypesUnaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_su2l, _numberOfUnaryArgs, TR::su2l, "su2l", _argTypesUnaryShort, TR::Int64, rc);
+   compileOpCodeMethod(_su2f, _numberOfUnaryArgs, TR::su2f, "su2f", _argTypesUnaryShort, TR::Float, rc);
+   compileOpCodeMethod(_su2d, _numberOfUnaryArgs, TR::su2d, "su2d", _argTypesUnaryShort, TR::Double, rc);
+   compileOpCodeMethod(_iByteswap, _numberOfUnaryArgs, TR::ibyteswap, "iByteswap", _argTypesUnaryInt, TR::Int32, rc);
 }
 
 void
@@ -143,20 +143,20 @@ X86OpCodesTest::compileShiftOrRolTestMethods()
    {
    int32_t rc = 0;
 
-   _iRol = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::irol, "iRol", _argTypesBinaryInt, TR::Int32, rc));
+   compileOpCodeMethod(_iRol, _numberOfBinaryArgs, TR::irol, "iRol", _argTypesBinaryInt, TR::Int32, rc);
 
-   _bShl = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bshl, "bShl", _argTypesBinaryByte, TR::Int8, rc));
-   _bShr = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bshr, "bShr", _argTypesBinaryByte, TR::Int8, rc));
-   _buShr = (unsignedSignatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bushr, "buShr", _argTypesBinaryByte, TR::Int8, rc));
+   compileOpCodeMethod(_bShl, _numberOfBinaryArgs, TR::bshl, "bShl", _argTypesBinaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_bShr, _numberOfBinaryArgs, TR::bshr, "bShr", _argTypesBinaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_buShr, _numberOfBinaryArgs, TR::bushr, "buShr", _argTypesBinaryByte, TR::Int8, rc);
 
-   _sShr = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sshr, "sShr", _argTypesBinaryShort, TR::Int16, rc));
-   _sShl = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sshl, "sShl", _argTypesBinaryShort, TR::Int16, rc));
-   _suShr = (unsignedSignatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sushr, "suShr", _argTypesBinaryShort, TR::Int16, rc));
+   compileOpCodeMethod(_sShr, _numberOfBinaryArgs, TR::sshr, "sShr", _argTypesBinaryShort, TR::Int16, rc);
+   compileOpCodeMethod(_sShl, _numberOfBinaryArgs, TR::sshl, "sShl", _argTypesBinaryShort, TR::Int16, rc);
+   compileOpCodeMethod(_suShr, _numberOfBinaryArgs, TR::sushr, "suShr", _argTypesBinaryShort, TR::Int16, rc);
 
-   _lShl = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lshl, "lShl", _argTypesBinaryLong, TR::Int64, rc));
-   _lShr = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lshr, "lShr", _argTypesBinaryLong, TR::Int64, rc));
-   _luShr = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lushr, "luShr", _argTypesBinaryLong, TR::Int64, rc));
-   _lRol = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lrol, "lRol", _argTypesBinaryLong, TR::Int64, rc));
+   compileOpCodeMethod(_lShl, _numberOfBinaryArgs, TR::lshl, "lShl", _argTypesBinaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_lShr, _numberOfBinaryArgs, TR::lshr, "lShr", _argTypesBinaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_luShr, _numberOfBinaryArgs, TR::lushr, "luShr", _argTypesBinaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_lRol, _numberOfBinaryArgs, TR::lrol, "lRol", _argTypesBinaryLong, TR::Int64, rc);
    }
 
 void
@@ -164,17 +164,17 @@ X86OpCodesTest::compileBitwiseTestMethods()
    {
    int32_t rc;
 
-   _lAnd = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::land, "lAnd", _argTypesBinaryLong, TR::Int64, rc));
-   _lOr = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lor, "lOr", _argTypesBinaryLong, TR::Int64, rc));
-   _lXor = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lxor, "lXor", _argTypesBinaryLong, TR::Int64, rc));
+   compileOpCodeMethod(_lAnd, _numberOfBinaryArgs, TR::land, "lAnd", _argTypesBinaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_lOr, _numberOfBinaryArgs, TR::lor, "lOr", _argTypesBinaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_lXor, _numberOfBinaryArgs, TR::lxor, "lXor", _argTypesBinaryLong, TR::Int64, rc);
 
-   _sAnd = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sand, "sAnd", _argTypesBinaryShort, TR::Int16, rc));
-   _sOr = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sor, "sOr", _argTypesBinaryShort, TR::Int16, rc));
-   _sXor = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sxor, "sXor", _argTypesBinaryShort, TR::Int16, rc));
+   compileOpCodeMethod(_sAnd, _numberOfBinaryArgs, TR::sand, "sAnd", _argTypesBinaryShort, TR::Int16, rc);
+   compileOpCodeMethod(_sOr, _numberOfBinaryArgs, TR::sor, "sOr", _argTypesBinaryShort, TR::Int16, rc);
+   compileOpCodeMethod(_sXor, _numberOfBinaryArgs, TR::sxor, "sXor", _argTypesBinaryShort, TR::Int16, rc);
 
-   _bAnd = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::band, "bAnd", _argTypesBinaryByte, TR::Int8, rc));
-   _bOr = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bor, "bOr", _argTypesBinaryByte, TR::Int8, rc));
-   _bXor = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bxor, "bXor", _argTypesBinaryByte, TR::Int8, rc));
+   compileOpCodeMethod(_bAnd, _numberOfBinaryArgs, TR::band, "bAnd", _argTypesBinaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_bOr, _numberOfBinaryArgs, TR::bor, "bOr", _argTypesBinaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_bXor, _numberOfBinaryArgs, TR::bxor, "bXor", _argTypesBinaryByte, TR::Int8, rc);
 
    }
 
@@ -198,106 +198,106 @@ X86OpCodesTest::compileCompareTestMethods()
    int32_t rc = 0;
 
    //Compare
-   _lCmpeq = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lcmpeq, "lCmpeq", _argTypesBinaryLong, TR::Int32, rc));
-   _lCmplt = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lcmplt, "lCmplt", _argTypesBinaryLong, TR::Int32, rc));
+   compileOpCodeMethod(_lCmpeq, _numberOfBinaryArgs, TR::lcmpeq, "lCmpeq", _argTypesBinaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_lCmplt, _numberOfBinaryArgs, TR::lcmplt, "lCmplt", _argTypesBinaryLong, TR::Int32, rc);
 
-   _dCmpeq = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dcmpeq, "dCmpeq", _argTypesBinaryDouble, TR::Int32, rc));
-   _dCmpne = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dcmpne, "dCmpne", _argTypesBinaryDouble, TR::Int32, rc));
-   _dCmpgt = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dcmpgt, "dCmpgt", _argTypesBinaryDouble, TR::Int32, rc));
-   _dCmplt = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dcmplt, "dCmplt", _argTypesBinaryDouble, TR::Int32, rc));
-   _dCmpge = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dcmpge, "dCmpge", _argTypesBinaryDouble, TR::Int32, rc));
-   _dCmple = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dcmple, "dCmple", _argTypesBinaryDouble, TR::Int32, rc));
+   compileOpCodeMethod(_dCmpeq, _numberOfBinaryArgs, TR::dcmpeq, "dCmpeq", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_dCmpne, _numberOfBinaryArgs, TR::dcmpne, "dCmpne", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_dCmpgt, _numberOfBinaryArgs, TR::dcmpgt, "dCmpgt", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_dCmplt, _numberOfBinaryArgs, TR::dcmplt, "dCmplt", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_dCmpge, _numberOfBinaryArgs, TR::dcmpge, "dCmpge", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_dCmple, _numberOfBinaryArgs, TR::dcmple, "dCmple", _argTypesBinaryDouble, TR::Int32, rc);
 
-   _fCmpeq = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fcmpeq, "fCmpeq", _argTypesBinaryFloat, TR::Int32, rc));
-   _fCmpne = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fcmpne, "fCmpne", _argTypesBinaryFloat, TR::Int32, rc));
-   _fCmpgt = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fcmpgt, "fCmpgt", _argTypesBinaryFloat, TR::Int32, rc));
-   _fCmplt = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fcmplt, "fCmplt", _argTypesBinaryFloat, TR::Int32, rc));
-   _fCmpge = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fcmpge, "fCmpge", _argTypesBinaryFloat, TR::Int32, rc));
-   _fCmple = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fcmple, "fCmple", _argTypesBinaryFloat, TR::Int32, rc));
+   compileOpCodeMethod(_fCmpeq, _numberOfBinaryArgs, TR::fcmpeq, "fCmpeq", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_fCmpne, _numberOfBinaryArgs, TR::fcmpne, "fCmpne", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_fCmpgt, _numberOfBinaryArgs, TR::fcmpgt, "fCmpgt", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_fCmplt, _numberOfBinaryArgs, TR::fcmplt, "fCmplt", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_fCmpge, _numberOfBinaryArgs, TR::fcmpge, "fCmpge", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_fCmple, _numberOfBinaryArgs, TR::fcmple, "fCmple", _argTypesBinaryFloat, TR::Int32, rc);
 
-   _sCmpeq = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::scmpeq, "sCmpeq", _argTypesBinaryShort, TR::Int32, rc));
-   _sCmpne = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::scmpne, "sCmpne", _argTypesBinaryShort, TR::Int32, rc));
-   _sCmpgt = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::scmpgt, "sCmpgt", _argTypesBinaryShort, TR::Int32, rc));
-   _sCmplt = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::scmplt, "sCmplt", _argTypesBinaryShort, TR::Int32, rc));
-   _sCmpge = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::scmpge, "sCmpge", _argTypesBinaryShort, TR::Int32, rc));
-   _sCmple = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::scmple, "sCmple", _argTypesBinaryShort, TR::Int32, rc));
+   compileOpCodeMethod(_sCmpeq, _numberOfBinaryArgs, TR::scmpeq, "sCmpeq", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_sCmpne, _numberOfBinaryArgs, TR::scmpne, "sCmpne", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_sCmpgt, _numberOfBinaryArgs, TR::scmpgt, "sCmpgt", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_sCmplt, _numberOfBinaryArgs, TR::scmplt, "sCmplt", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_sCmpge, _numberOfBinaryArgs, TR::scmpge, "sCmpge", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_sCmple, _numberOfBinaryArgs, TR::scmple, "sCmple", _argTypesBinaryShort, TR::Int32, rc);
 
-   _bCmpeq = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bcmpeq, "bCmpeq", _argTypesBinaryByte, TR::Int32, rc));
-   _bCmpne = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bcmpne, "bCmpne", _argTypesBinaryByte, TR::Int32, rc));
-   _bCmpgt = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bcmpgt, "bCmpgt", _argTypesBinaryByte, TR::Int32, rc));
-   _bCmplt = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bcmplt, "bCmplt", _argTypesBinaryByte, TR::Int32, rc));
-   _bCmpge = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bcmpge, "bCmpge", _argTypesBinaryByte, TR::Int32, rc));
-   _bCmple = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bcmple, "bCmple", _argTypesBinaryByte, TR::Int32, rc));
+   compileOpCodeMethod(_bCmpeq, _numberOfBinaryArgs, TR::bcmpeq, "bCmpeq", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_bCmpne, _numberOfBinaryArgs, TR::bcmpne, "bCmpne", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_bCmpgt, _numberOfBinaryArgs, TR::bcmpgt, "bCmpgt", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_bCmplt, _numberOfBinaryArgs, TR::bcmplt, "bCmplt", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_bCmpge, _numberOfBinaryArgs, TR::bcmpge, "bCmpge", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_bCmple, _numberOfBinaryArgs, TR::bcmple, "bCmple", _argTypesBinaryByte, TR::Int32, rc);
 
-   _iuCmpeq = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iucmpeq, "iuCmpeq", _argTypesBinaryInt, TR::Int32, rc));
-   _iuCmpne = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iucmpne, "iuCmpne", _argTypesBinaryInt, TR::Int32, rc));
-   _iuCmpge = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iucmpge, "iuCmpge", _argTypesBinaryInt, TR::Int32, rc));
+   compileOpCodeMethod(_iuCmpeq, _numberOfBinaryArgs, TR::iucmpeq, "iuCmpeq", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iuCmpne, _numberOfBinaryArgs, TR::iucmpne, "iuCmpne", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iuCmpge, _numberOfBinaryArgs, TR::iucmpge, "iuCmpge", _argTypesBinaryInt, TR::Int32, rc);
 
-   _buCmpeq = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bucmpeq, "buCmpeq", _argTypesBinaryByte, TR::Int32, rc));
-   _buCmpne = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bucmpne, "buCmpne", _argTypesBinaryByte, TR::Int32, rc));
+   compileOpCodeMethod(_buCmpeq, _numberOfBinaryArgs, TR::bucmpeq, "buCmpeq", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_buCmpne, _numberOfBinaryArgs, TR::bucmpne, "buCmpne", _argTypesBinaryByte, TR::Int32, rc);
 
-   _suCmpeq = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sucmpeq, "suCmpeq", _argTypesBinaryShort, TR::Int32, rc));
-   _suCmpne = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sucmpne, "suCmpne", _argTypesBinaryShort, TR::Int32, rc));
-   _suCmplt = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sucmplt, "suCmplt", _argTypesBinaryShort, TR::Int32, rc));
-   _suCmpge = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sucmpge, "suCmpge", _argTypesBinaryShort, TR::Int32, rc));
-   _suCmpgt = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sucmpgt, "suCmpgt", _argTypesBinaryShort, TR::Int32, rc));
-   _suCmple = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sucmple, "suCmple", _argTypesBinaryShort, TR::Int32, rc));
+   compileOpCodeMethod(_suCmpeq, _numberOfBinaryArgs, TR::sucmpeq, "suCmpeq", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_suCmpne, _numberOfBinaryArgs, TR::sucmpne, "suCmpne", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_suCmplt, _numberOfBinaryArgs, TR::sucmplt, "suCmplt", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_suCmpge, _numberOfBinaryArgs, TR::sucmpge, "suCmpge", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_suCmpgt, _numberOfBinaryArgs, TR::sucmpgt, "suCmpgt", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_suCmple, _numberOfBinaryArgs, TR::sucmple, "suCmple", _argTypesBinaryShort, TR::Int32, rc);
 
 
-   _lCmp = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lcmp, "lCmp", _argTypesBinaryLong, TR::Int32, rc));
-   _fCmpl = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fcmpl, "fCmpl", _argTypesBinaryFloat, TR::Int32, rc));
-   _fCmpg = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fcmpg, "fCmpg", _argTypesBinaryFloat, TR::Int32, rc));
-   _dCmpl = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dcmpl, "dCmpl", _argTypesBinaryDouble, TR::Int32, rc));
-   _dCmpg = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dcmpg, "dCmpg", _argTypesBinaryDouble, TR::Int32, rc));
+   compileOpCodeMethod(_lCmp, _numberOfBinaryArgs, TR::lcmp, "lCmp", _argTypesBinaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_fCmpl, _numberOfBinaryArgs, TR::fcmpl, "fCmpl", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_fCmpg, _numberOfBinaryArgs, TR::fcmpg, "fCmpg", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_dCmpl, _numberOfBinaryArgs, TR::dcmpl, "dCmpl", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_dCmpg, _numberOfBinaryArgs, TR::dcmpg, "dCmpg", _argTypesBinaryDouble, TR::Int32, rc);
 
    //CompareAndBranch
-   _ifLcmpeq = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iflcmpeq, "ifLcmpeq", _argTypesBinaryLong, TR::Int32, rc));
-   _ifLcmpgt = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iflcmpgt, "ifLcmpgt", _argTypesBinaryLong, TR::Int32, rc));
-   _ifLcmplt = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iflcmplt, "ifLcmplt", _argTypesBinaryLong, TR::Int32, rc));
+   compileOpCodeMethod(_ifLcmpeq, _numberOfBinaryArgs, TR::iflcmpeq, "ifLcmpeq", _argTypesBinaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_ifLcmpgt, _numberOfBinaryArgs, TR::iflcmpgt, "ifLcmpgt", _argTypesBinaryLong, TR::Int32, rc);
+   compileOpCodeMethod(_ifLcmplt, _numberOfBinaryArgs, TR::iflcmplt, "ifLcmplt", _argTypesBinaryLong, TR::Int32, rc);
 
-   _ifDcmpeq = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifdcmpeq, "ifDcmpeq", _argTypesBinaryDouble, TR::Int32, rc));
-   _ifDcmpne = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifdcmpne, "ifDcmpne", _argTypesBinaryDouble, TR::Int32, rc));
-   _ifDcmpgt = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifdcmpgt, "ifDcmpgt", _argTypesBinaryDouble, TR::Int32, rc));
-   _ifDcmplt = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifdcmplt, "ifDcmplt", _argTypesBinaryDouble, TR::Int32, rc));
-   _ifDcmpge = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifdcmpge, "ifDcmpge", _argTypesBinaryDouble, TR::Int32, rc));
-   _ifDcmple = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifdcmple, "ifDcmple", _argTypesBinaryDouble, TR::Int32, rc));
+   compileOpCodeMethod(_ifDcmpeq, _numberOfBinaryArgs, TR::ifdcmpeq, "ifDcmpeq", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_ifDcmpne, _numberOfBinaryArgs, TR::ifdcmpne, "ifDcmpne", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_ifDcmpgt, _numberOfBinaryArgs, TR::ifdcmpgt, "ifDcmpgt", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_ifDcmplt, _numberOfBinaryArgs, TR::ifdcmplt, "ifDcmplt", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_ifDcmpge, _numberOfBinaryArgs, TR::ifdcmpge, "ifDcmpge", _argTypesBinaryDouble, TR::Int32, rc);
+   compileOpCodeMethod(_ifDcmple, _numberOfBinaryArgs, TR::ifdcmple, "ifDcmple", _argTypesBinaryDouble, TR::Int32, rc);
 
-   _ifFcmpeq = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iffcmpeq, "ifFcmpeq", _argTypesBinaryFloat, TR::Int32, rc));
-   _ifFcmpne = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iffcmpne, "ifFcmpne", _argTypesBinaryFloat, TR::Int32, rc));
-   _ifFcmpgt = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iffcmpgt, "ifFcmpgt", _argTypesBinaryFloat, TR::Int32, rc));
-   _ifFcmplt = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iffcmplt, "ifFcmplt", _argTypesBinaryFloat, TR::Int32, rc));
-   _ifFcmpge = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iffcmpge, "ifFcmpge", _argTypesBinaryFloat, TR::Int32, rc));
-   _ifFcmple = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iffcmple, "ifFcmple", _argTypesBinaryFloat, TR::Int32, rc));
-
-
-   _ifScmpeq = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifscmpeq, "ifScmpeq", _argTypesBinaryShort, TR::Int32, rc));
-   _ifScmpne = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifscmpne, "ifScmpne", _argTypesBinaryShort, TR::Int32, rc));
-   _ifScmpgt = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifscmpgt, "ifScmpgt", _argTypesBinaryShort, TR::Int32, rc));
-   _ifScmplt = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifscmplt, "ifScmplt", _argTypesBinaryShort, TR::Int32, rc));
-   _ifScmpge = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifscmpge, "ifScmpge", _argTypesBinaryShort, TR::Int32, rc));
-   _ifScmple = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifscmple, "ifScmple", _argTypesBinaryShort, TR::Int32, rc));
-
-   _ifBcmpeq = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbcmpeq, "ifBcmpeq", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBcmpne = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbcmpne, "ifBcmpne", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBcmpgt = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbcmpgt, "ifBcmpgt", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBcmplt = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbcmplt, "ifBcmplt", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBcmpge = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbcmpge, "ifBcmpge", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBcmple = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbcmple, "ifBcmple", _argTypesBinaryByte, TR::Int32, rc));
+   compileOpCodeMethod(_ifFcmpeq, _numberOfBinaryArgs, TR::iffcmpeq, "ifFcmpeq", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_ifFcmpne, _numberOfBinaryArgs, TR::iffcmpne, "ifFcmpne", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_ifFcmpgt, _numberOfBinaryArgs, TR::iffcmpgt, "ifFcmpgt", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_ifFcmplt, _numberOfBinaryArgs, TR::iffcmplt, "ifFcmplt", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_ifFcmpge, _numberOfBinaryArgs, TR::iffcmpge, "ifFcmpge", _argTypesBinaryFloat, TR::Int32, rc);
+   compileOpCodeMethod(_ifFcmple, _numberOfBinaryArgs, TR::iffcmple, "ifFcmple", _argTypesBinaryFloat, TR::Int32, rc);
 
 
-   _ifBuCmpeq = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbucmpeq, "ifBuCmpeq", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBuCmpne = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbucmpne, "ifBuCmpne", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBuCmplt = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbucmplt, "ifBuCmplt", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBuCmpge = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbucmpge, "ifBuCmpge", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBuCmpgt = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbucmpgt, "ifBuCmpgt", _argTypesBinaryByte, TR::Int32, rc));
-   _ifBuCmple = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifbucmple, "ifBuCmple", _argTypesBinaryByte, TR::Int32, rc));
+   compileOpCodeMethod(_ifScmpeq, _numberOfBinaryArgs, TR::ifscmpeq, "ifScmpeq", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifScmpne, _numberOfBinaryArgs, TR::ifscmpne, "ifScmpne", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifScmpgt, _numberOfBinaryArgs, TR::ifscmpgt, "ifScmpgt", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifScmplt, _numberOfBinaryArgs, TR::ifscmplt, "ifScmplt", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifScmpge, _numberOfBinaryArgs, TR::ifscmpge, "ifScmpge", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifScmple, _numberOfBinaryArgs, TR::ifscmple, "ifScmple", _argTypesBinaryShort, TR::Int32, rc);
 
-   _ifSuCmpeq = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifsucmpeq, "ifSuCmpeq", _argTypesBinaryShort, TR::Int32, rc));
-   _ifSuCmpne = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifsucmpne, "ifSuCmpne", _argTypesBinaryShort, TR::Int32, rc));
-   _ifSuCmpgt = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifsucmpgt, "ifSuCmpgt", _argTypesBinaryShort, TR::Int32, rc));
-   _ifSuCmple = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifsucmple, "ifSuCmple", _argTypesBinaryShort, TR::Int32, rc));
-   _ifSuCmplt = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifsucmplt, "ifSuCmplt", _argTypesBinaryShort, TR::Int32, rc));
-   _ifSuCmpge = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifsucmpge, "ifSuCmpge", _argTypesBinaryShort, TR::Int32, rc));
+   compileOpCodeMethod(_ifBcmpeq, _numberOfBinaryArgs, TR::ifbcmpeq, "ifBcmpeq", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBcmpne, _numberOfBinaryArgs, TR::ifbcmpne, "ifBcmpne", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBcmpgt, _numberOfBinaryArgs, TR::ifbcmpgt, "ifBcmpgt", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBcmplt, _numberOfBinaryArgs, TR::ifbcmplt, "ifBcmplt", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBcmpge, _numberOfBinaryArgs, TR::ifbcmpge, "ifBcmpge", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBcmple, _numberOfBinaryArgs, TR::ifbcmple, "ifBcmple", _argTypesBinaryByte, TR::Int32, rc);
+
+
+   compileOpCodeMethod(_ifBuCmpeq, _numberOfBinaryArgs, TR::ifbucmpeq, "ifBuCmpeq", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBuCmpne, _numberOfBinaryArgs, TR::ifbucmpne, "ifBuCmpne", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBuCmplt, _numberOfBinaryArgs, TR::ifbucmplt, "ifBuCmplt", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBuCmpge, _numberOfBinaryArgs, TR::ifbucmpge, "ifBuCmpge", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBuCmpgt, _numberOfBinaryArgs, TR::ifbucmpgt, "ifBuCmpgt", _argTypesBinaryByte, TR::Int32, rc);
+   compileOpCodeMethod(_ifBuCmple, _numberOfBinaryArgs, TR::ifbucmple, "ifBuCmple", _argTypesBinaryByte, TR::Int32, rc);
+
+   compileOpCodeMethod(_ifSuCmpeq, _numberOfBinaryArgs, TR::ifsucmpeq, "ifSuCmpeq", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifSuCmpne, _numberOfBinaryArgs, TR::ifsucmpne, "ifSuCmpne", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifSuCmpgt, _numberOfBinaryArgs, TR::ifsucmpgt, "ifSuCmpgt", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifSuCmple, _numberOfBinaryArgs, TR::ifsucmple, "ifSuCmple", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifSuCmplt, _numberOfBinaryArgs, TR::ifsucmplt, "ifSuCmplt", _argTypesBinaryShort, TR::Int32, rc);
+   compileOpCodeMethod(_ifSuCmpge, _numberOfBinaryArgs, TR::ifsucmpge, "ifSuCmpge", _argTypesBinaryShort, TR::Int32, rc);
 
    }
 
@@ -305,7 +305,7 @@ void
 X86OpCodesTest::compileTernaryTestMethods()
    {
    int32_t rc = 0;
-   _lternary = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary, "lTernary", _argTypesTernaryLong, TR::Int64, rc));
+   compileOpCodeMethod(_lternary, _numberOfTernaryArgs, TR::lternary, "lTernary", _argTypesTernaryLong, TR::Int64, rc);
 
    }
 
@@ -318,20 +318,20 @@ X86OpCodesTest::compileAddressTestMethods()
 
 
 #if defined(TR_TARGET_64BIT)
-   _l2a = (signatureCharJ_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::l2a, "l2a", _argTypesUnaryLong, TR::Address, rc));
-   _a2l = (signatureCharL_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::a2l, "a2l", _argTypesUnaryAddress, TR::Int64, rc));
+   compileOpCodeMethod(_l2a, _numberOfUnaryArgs, TR::l2a, "l2a", _argTypesUnaryLong, TR::Address, rc);
+   compileOpCodeMethod(_a2l, _numberOfUnaryArgs, TR::a2l, "a2l", _argTypesUnaryAddress, TR::Int64, rc);
 
-   _acmpeq = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::acmpeq, "acmpeq", _argTypesBinaryAddress, TR::Int32, rc));
-   _acmpne = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::acmpne, "acmpne", _argTypesBinaryAddress, TR::Int32, rc));
-   _ifacmpeq = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifacmpeq, "ifacmpeq", _argTypesBinaryAddress, TR::Int32, rc));
-   _ifacmpne = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifacmpne, "ifacmpne", _argTypesBinaryAddress, TR::Int32, rc));
-   _aternary = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::aternary, "aternary", _argTypesTernaryAddress, TR::Address, rc));
+   compileOpCodeMethod(_acmpeq, _numberOfBinaryArgs, TR::acmpeq, "acmpeq", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_acmpne, _numberOfBinaryArgs, TR::acmpne, "acmpne", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_ifacmpeq, _numberOfBinaryArgs, TR::ifacmpeq, "ifacmpeq", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_ifacmpne, _numberOfBinaryArgs, TR::ifacmpne, "ifacmpne", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_aternary, _numberOfTernaryArgs, TR::aternary, "aternary", _argTypesTernaryAddress, TR::Address, rc);
 #endif
 #if defined(TR_TARGET_32BIT)
-   _a2b = (signatureCharL_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::a2b, "a2b", _argTypesUnaryAddress, TR::Int8, rc));
-   _a2s = (signatureCharL_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::a2s, "a2s", _argTypesUnaryAddress, TR::Int16, rc));
-   _i2a = (signatureCharI_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::i2a, "i2a", _argTypesUnaryInt, TR::Address, rc));
-   _iu2a = (unsignedSignatureCharI_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iu2a, "iu2a", _argTypesUnaryInt, TR::Address, rc));
+   compileOpCodeMethod(_a2b, _numberOfUnaryArgs, TR::a2b, "a2b", _argTypesUnaryAddress, TR::Int8, rc);
+   compileOpCodeMethod(_a2s, _numberOfUnaryArgs, TR::a2s, "a2s", _argTypesUnaryAddress, TR::Int16, rc);
+   compileOpCodeMethod(_i2a, _numberOfUnaryArgs, TR::i2a, "i2a", _argTypesUnaryInt, TR::Address, rc);
+   compileOpCodeMethod(_iu2a, _numberOfUnaryArgs, TR::iu2a, "iu2a", _argTypesUnaryInt, TR::Address, rc);
 #endif
 
    }
@@ -426,18 +426,18 @@ X86OpCodesTest::invokeIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_bAdd, add(byteAddArr[i][0], byteAddArr[i][1]), _bAdd(byteAddArr[i][0], byteAddArr[i][1]));
 
       sprintf(resolvedMethodName, "bAddConst1_Testcase%d", i);
-      bBinaryCons = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::badd,
-            resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &byteAddArr[i][0], 2, &byteAddArr[i][1]));
+      compileOpCodeMethod(bBinaryCons, _numberOfBinaryArgs, TR::badd,
+            resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &byteAddArr[i][0], 2, &byteAddArr[i][1]);
       OMR_CT_EXPECT_EQ(bBinaryCons, add(byteAddArr[i][0], byteAddArr[i][1]), bBinaryCons(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bAddConst2_Testcase%d", i);
-      bBinaryCons = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::badd,
-            resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &byteAddArr[i][0]));
+      compileOpCodeMethod(bBinaryCons, _numberOfBinaryArgs, TR::badd,
+            resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &byteAddArr[i][0]);
       OMR_CT_EXPECT_EQ(bBinaryCons, add(byteAddArr[i][0], byteAddArr[i][1]), bBinaryCons(BYTE_PLACEHOLDER_1, byteAddArr[i][1]));
 
       sprintf(resolvedMethodName, "bAddConst3_Testcase%d", i);
-      bBinaryCons = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::badd,
-            resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &byteAddArr[i][1]));
+      compileOpCodeMethod(bBinaryCons, _numberOfBinaryArgs, TR::badd,
+            resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &byteAddArr[i][1]);
       OMR_CT_EXPECT_EQ(bBinaryCons, add(byteAddArr[i][0], byteAddArr[i][1]), bBinaryCons(byteAddArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -448,18 +448,18 @@ X86OpCodesTest::invokeIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_bSub, sub(byteSubArr[i][0], byteSubArr[i][1]), _bSub(byteSubArr[i][0], byteSubArr[i][1]));
 
       sprintf(resolvedMethodName, "bSubConst1_Testcase%d", i);
-      bBinaryCons = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bsub,
-            resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &byteSubArr[i][0], 2, &byteSubArr[i][1]));
+      compileOpCodeMethod(bBinaryCons, _numberOfBinaryArgs, TR::bsub,
+            resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &byteSubArr[i][0], 2, &byteSubArr[i][1]);
       OMR_CT_EXPECT_EQ(bBinaryCons, sub(byteSubArr[i][0], byteSubArr[i][1]), bBinaryCons(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bSubConst2_Testcase%d", i);
-      bBinaryCons = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bsub,
-            resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &byteSubArr[i][0]));
+      compileOpCodeMethod(bBinaryCons, _numberOfBinaryArgs, TR::bsub,
+            resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &byteSubArr[i][0]);
       OMR_CT_EXPECT_EQ(bBinaryCons, sub(byteSubArr[i][0], byteSubArr[i][1]), bBinaryCons(BYTE_PLACEHOLDER_1, byteSubArr[i][1]));
 
       sprintf(resolvedMethodName, "bSubConst3_Testcase%d", i);
-      bBinaryCons = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bsub,
-            resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &byteSubArr[i][1]));
+      compileOpCodeMethod(bBinaryCons, _numberOfBinaryArgs, TR::bsub,
+            resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &byteSubArr[i][1]);
       OMR_CT_EXPECT_EQ(bBinaryCons, sub(byteSubArr[i][0], byteSubArr[i][1]), bBinaryCons(byteSubArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -470,18 +470,18 @@ X86OpCodesTest::invokeIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_sAdd, add(shortAddArr[i][0], shortAddArr[i][1]), _sAdd(shortAddArr[i][0], shortAddArr[i][1]));
 
       sprintf(resolvedMethodName, "sAddConst1_Testcase%d", i);
-      sBinaryCons = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sadd,
-            resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &shortAddArr[i][0], 2, &shortAddArr[i][1]));
+      compileOpCodeMethod(sBinaryCons, _numberOfBinaryArgs, TR::sadd,
+            resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &shortAddArr[i][0], 2, &shortAddArr[i][1]);
       OMR_CT_EXPECT_EQ(sBinaryCons, add(shortAddArr[i][0], shortAddArr[i][1]), sBinaryCons(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sAddConst2_Testcase%d", i);
-      sBinaryCons = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sadd,
-            resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &shortAddArr[i][0]));
+      compileOpCodeMethod(sBinaryCons, _numberOfBinaryArgs, TR::sadd,
+            resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &shortAddArr[i][0]);
       OMR_CT_EXPECT_EQ(sBinaryCons, add(shortAddArr[i][0], shortAddArr[i][1]), sBinaryCons(SHORT_PLACEHOLDER_1, shortAddArr[i][1]));
 
       sprintf(resolvedMethodName, "sAddConst3_Testcase%d", i);
-      sBinaryCons = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::sadd,
-            resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &shortAddArr[i][1]));
+      compileOpCodeMethod(sBinaryCons, _numberOfBinaryArgs, TR::sadd,
+            resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &shortAddArr[i][1]);
       OMR_CT_EXPECT_EQ(sBinaryCons, add(shortAddArr[i][0], shortAddArr[i][1]), sBinaryCons(shortAddArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -492,18 +492,18 @@ X86OpCodesTest::invokeIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_sSub, sub(shortSubArr[i][0], shortSubArr[i][1]), _sSub(shortSubArr[i][0], shortSubArr[i][1]));
 
       sprintf(resolvedMethodName, "sSubConst1_Testcase%d", i);
-      sBinaryCons = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ssub,
-            resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &shortSubArr[i][0], 2, &shortSubArr[i][1]));
+      compileOpCodeMethod(sBinaryCons, _numberOfBinaryArgs, TR::ssub,
+            resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &shortSubArr[i][0], 2, &shortSubArr[i][1]);
       OMR_CT_EXPECT_EQ(sBinaryCons, sub(shortSubArr[i][0], shortSubArr[i][1]), sBinaryCons(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sSubConst2_Testcase%d", i);
-      sBinaryCons = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ssub,
-            resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &shortSubArr[i][0]));
+      compileOpCodeMethod(sBinaryCons, _numberOfBinaryArgs, TR::ssub,
+            resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &shortSubArr[i][0]);
       OMR_CT_EXPECT_EQ(sBinaryCons, sub(shortSubArr[i][0], shortSubArr[i][1]), sBinaryCons(SHORT_PLACEHOLDER_1, shortSubArr[i][1]));
 
       sprintf(resolvedMethodName, "sSubConst3_Testcase%d", i);
-      sBinaryCons = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ssub,
-            resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &shortSubArr[i][1]));
+      compileOpCodeMethod(sBinaryCons, _numberOfBinaryArgs, TR::ssub,
+            resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &shortSubArr[i][1]);
       OMR_CT_EXPECT_EQ(sBinaryCons, sub(shortSubArr[i][0], shortSubArr[i][1]), sBinaryCons(shortSubArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -514,18 +514,18 @@ X86OpCodesTest::invokeIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_lAdd, add(longAddArr[i][0], longAddArr[i][1]), _lAdd(longAddArr[i][0], longAddArr[i][1]));
 
       sprintf(resolvedMethodName, "lAddConst1_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ladd,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longAddArr[i][0], 2, &longAddArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::ladd,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longAddArr[i][0], 2, &longAddArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, add(longAddArr[i][0], longAddArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lAddConst2_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ladd,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longAddArr[i][0]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::ladd,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longAddArr[i][0]);
       OMR_CT_EXPECT_EQ(lBinaryCons, add(longAddArr[i][0], longAddArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longAddArr[i][1]));
 
       sprintf(resolvedMethodName, "lAddConst3_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ladd,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longAddArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::ladd,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longAddArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, add(longAddArr[i][0], longAddArr[i][1]), lBinaryCons(longAddArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -536,18 +536,18 @@ X86OpCodesTest::invokeIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_lSub, sub(longSubArr[i][0], longSubArr[i][1]), _lSub(longSubArr[i][0], longSubArr[i][1]));
 
       sprintf(resolvedMethodName, "lSubConst1_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lsub,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longSubArr[i][0], 2, &longSubArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::lsub,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longSubArr[i][0], 2, &longSubArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, sub(longSubArr[i][0], longSubArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lSubConst2_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lsub,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longSubArr[i][0]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::lsub,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longSubArr[i][0]);
       OMR_CT_EXPECT_EQ(lBinaryCons, sub(longSubArr[i][0], longSubArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longSubArr[i][1]));
 
       sprintf(resolvedMethodName, "lSubConst3_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lsub,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longSubArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::lsub,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longSubArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, sub(longSubArr[i][0], longSubArr[i][1]), lBinaryCons(longSubArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -558,18 +558,18 @@ X86OpCodesTest::invokeIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_lMul, mul(longMulArr[i][0], longMulArr[i][1]), _lMul(longMulArr[i][0], longMulArr[i][1]));
 
       sprintf(resolvedMethodName, "lMulConst1_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lmul,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longMulArr[i][0], 2, &longMulArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::lmul,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longMulArr[i][0], 2, &longMulArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, mul(longMulArr[i][0], longMulArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lMulConst2_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lmul,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longMulArr[i][0]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::lmul,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longMulArr[i][0]);
       OMR_CT_EXPECT_EQ(lBinaryCons, mul(longMulArr[i][0], longMulArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longMulArr[i][1]));
 
       sprintf(resolvedMethodName, "lMulConst3_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lmul,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longMulArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::lmul,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longMulArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, mul(longMulArr[i][0], longMulArr[i][1]), lBinaryCons(longMulArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -582,18 +582,18 @@ X86OpCodesTest::invokeIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_lDiv, div(longDivArr[i][0], longDivArr[i][1]), _lDiv(longDivArr[i][0], longDivArr[i][1]));
 
       sprintf(resolvedMethodName, "lDivConst1_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ldiv,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longDivArr[i][0], 2, &longDivArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::ldiv,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longDivArr[i][0], 2, &longDivArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, div(longDivArr[i][0], longDivArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lDivConst2_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ldiv,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longDivArr[i][0]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::ldiv,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longDivArr[i][0]);
       OMR_CT_EXPECT_EQ(lBinaryCons, div(longDivArr[i][0], longDivArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longDivArr[i][1]));
 
       sprintf(resolvedMethodName, "lDivConst3_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ldiv,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longDivArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::ldiv,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longDivArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, div(longDivArr[i][0], longDivArr[i][1]), lBinaryCons(longDivArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -605,18 +605,18 @@ X86OpCodesTest::invokeIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_lRem, rem(longRemArr[i][0], longRemArr[i][1]), _lRem(longRemArr[i][0], longRemArr[i][1]));
 
       sprintf(resolvedMethodName, "lRemConst1_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lrem,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longRemArr[i][0], 2, &longRemArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::lrem,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &longRemArr[i][0], 2, &longRemArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, rem(longRemArr[i][0], longRemArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lRemConst2_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lrem,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longRemArr[i][0]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::lrem,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &longRemArr[i][0]);
       OMR_CT_EXPECT_EQ(lBinaryCons, rem(longRemArr[i][0], longRemArr[i][1]), lBinaryCons(LONG_PLACEHOLDER_1, longRemArr[i][1]));
 
       sprintf(resolvedMethodName, "lRemConst3_Testcase%d", i);
-      lBinaryCons = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::lrem,
-            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longRemArr[i][1]));
+      compileOpCodeMethod(lBinaryCons, _numberOfBinaryArgs, TR::lrem,
+            resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &longRemArr[i][1]);
       OMR_CT_EXPECT_EQ(lBinaryCons, rem(longRemArr[i][0], longRemArr[i][1]), lBinaryCons(longRemArr[i][0], LONG_PLACEHOLDER_2));
       }
 #endif
@@ -705,18 +705,18 @@ X86OpCodesTest::invokeFloatArithmeticTests()
       OMR_CT_EXPECT_FLOAT_EQ(_fAdd, add(floatAddArr[i][0], floatAddArr[i][1]), _fAdd(floatAddArr[i][0], floatAddArr[i][1]));
 
       sprintf(resolvedMethodName, "fAddConst1_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fadd,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatAddArr[i][0], 2, &floatAddArr[i][1]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fadd,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatAddArr[i][0], 2, &floatAddArr[i][1]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, add(floatAddArr[i][0], floatAddArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fAddConst2_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fadd,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatAddArr[i][0]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fadd,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatAddArr[i][0]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, add(floatAddArr[i][0], floatAddArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatAddArr[i][1]));
 
       sprintf(resolvedMethodName, "fAddConst3_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fadd,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatAddArr[i][1]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fadd,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatAddArr[i][1]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, add(floatAddArr[i][0], floatAddArr[i][1]), fBinaryConst(floatAddArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -727,18 +727,18 @@ X86OpCodesTest::invokeFloatArithmeticTests()
       OMR_CT_EXPECT_FLOAT_EQ(_fSub, sub(floatSubArr[i][0], floatSubArr[i][1]), _fSub(floatSubArr[i][0], floatSubArr[i][1]));
 
       sprintf(resolvedMethodName, "fSubConst1_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fsub,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatSubArr[i][0], 2, &floatSubArr[i][1]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fsub,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatSubArr[i][0], 2, &floatSubArr[i][1]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, sub(floatSubArr[i][0], floatSubArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fSubConst2_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fsub,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatSubArr[i][0]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fsub,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatSubArr[i][0]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, sub(floatSubArr[i][0], floatSubArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatSubArr[i][1]));
 
       sprintf(resolvedMethodName, "fSubConst3_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fsub,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatSubArr[i][1]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fsub,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatSubArr[i][1]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, sub(floatSubArr[i][0], floatSubArr[i][1]), fBinaryConst(floatSubArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -749,18 +749,18 @@ X86OpCodesTest::invokeFloatArithmeticTests()
       OMR_CT_EXPECT_FLOAT_EQ(_fMul, mul(floatMulArr[i][0], floatMulArr[i][1]), _fMul(floatMulArr[i][0], floatMulArr[i][1]));
 
       sprintf(resolvedMethodName, "fMulConst1_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fmul,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatMulArr[i][0], 2, &floatMulArr[i][1]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fmul,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatMulArr[i][0], 2, &floatMulArr[i][1]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, mul(floatMulArr[i][0], floatMulArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fMulConst2_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fmul,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatMulArr[i][0]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fmul,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatMulArr[i][0]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, mul(floatMulArr[i][0], floatMulArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatMulArr[i][1]));
 
       sprintf(resolvedMethodName, "fMulConst3_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fmul,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatMulArr[i][1]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fmul,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatMulArr[i][1]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, mul(floatMulArr[i][0], floatMulArr[i][1]), fBinaryConst(floatMulArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -771,18 +771,18 @@ X86OpCodesTest::invokeFloatArithmeticTests()
       OMR_CT_EXPECT_FLOAT_EQ(_fDiv, div(floatDivArr[i][0], floatDivArr[i][1]), _fDiv(floatDivArr[i][0], floatDivArr[i][1]));
 
       sprintf(resolvedMethodName, "fDivConst1_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fdiv,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatDivArr[i][0], 2, &floatDivArr[i][1]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fdiv,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 4, 1, &floatDivArr[i][0], 2, &floatDivArr[i][1]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, div(floatDivArr[i][0], floatDivArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fDivConst2_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fdiv,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatDivArr[i][0]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fdiv,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 1, &floatDivArr[i][0]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, div(floatDivArr[i][0], floatDivArr[i][1]), fBinaryConst(FLOAT_PLACEHOLDER_1, floatDivArr[i][1]));
 
       sprintf(resolvedMethodName, "fDivConst3_Testcase%d", i);
-      fBinaryConst = (signatureCharFF_F_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::fdiv,
-            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatDivArr[i][1]));
+      compileOpCodeMethod(fBinaryConst, _numberOfBinaryArgs, TR::fdiv,
+            resolvedMethodName, _argTypesBinaryFloat, TR::Float, rc, 2, 2, &floatDivArr[i][1]);
       OMR_CT_EXPECT_FLOAT_EQ(fBinaryConst, div(floatDivArr[i][0], floatDivArr[i][1]), fBinaryConst(floatDivArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -793,18 +793,18 @@ X86OpCodesTest::invokeFloatArithmeticTests()
       OMR_CT_EXPECT_DOUBLE_EQ(_dAdd, add(doubleAddArr[i][0], doubleAddArr[i][1]), _dAdd(doubleAddArr[i][0], doubleAddArr[i][1]));
 
       sprintf(resolvedMethodName, "dAddConst1_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dadd,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleAddArr[i][0], 2, &doubleAddArr[i][1]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::dadd,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleAddArr[i][0], 2, &doubleAddArr[i][1]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, add(doubleAddArr[i][0], doubleAddArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dAddConst2_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dadd,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleAddArr[i][0]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::dadd,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleAddArr[i][0]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, add(doubleAddArr[i][0], doubleAddArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleAddArr[i][1]));
 
       sprintf(resolvedMethodName, "dAddConst3_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dadd,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleAddArr[i][1]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::dadd,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleAddArr[i][1]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, add(doubleAddArr[i][0], doubleAddArr[i][1]), dBinaryConst(doubleAddArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -815,18 +815,18 @@ X86OpCodesTest::invokeFloatArithmeticTests()
       OMR_CT_EXPECT_DOUBLE_EQ(_dSub, sub(doubleSubArr[i][0], doubleSubArr[i][1]), _dSub(doubleSubArr[i][0], doubleSubArr[i][1]));
 
       sprintf(resolvedMethodName, "dSubConst1_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dsub,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleSubArr[i][0], 2, &doubleSubArr[i][1]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::dsub,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleSubArr[i][0], 2, &doubleSubArr[i][1]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, sub(doubleSubArr[i][0], doubleSubArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dSubConst2_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dsub,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleSubArr[i][0]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::dsub,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleSubArr[i][0]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, sub(doubleSubArr[i][0], doubleSubArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleSubArr[i][1]));
 
       sprintf(resolvedMethodName, "dSubConst3_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dsub,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleSubArr[i][1]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::dsub,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleSubArr[i][1]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, sub(doubleSubArr[i][0], doubleSubArr[i][1]), dBinaryConst(doubleSubArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -837,18 +837,18 @@ X86OpCodesTest::invokeFloatArithmeticTests()
       OMR_CT_EXPECT_DOUBLE_EQ(_dMul, mul(doubleMulArr[i][0], doubleMulArr[i][1]), _dMul(doubleMulArr[i][0], doubleMulArr[i][1]));
 
       sprintf(resolvedMethodName, "dMulConst1_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dmul,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleMulArr[i][0], 2, &doubleMulArr[i][1]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::dmul,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleMulArr[i][0], 2, &doubleMulArr[i][1]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, mul(doubleMulArr[i][0], doubleMulArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dMulConst2_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dmul,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleMulArr[i][0]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::dmul,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleMulArr[i][0]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, mul(doubleMulArr[i][0], doubleMulArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleMulArr[i][1]));
 
       sprintf(resolvedMethodName, "dMulConst3_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::dmul,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleMulArr[i][1]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::dmul,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleMulArr[i][1]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, mul(doubleMulArr[i][0], doubleMulArr[i][1]), dBinaryConst(doubleMulArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -859,18 +859,18 @@ X86OpCodesTest::invokeFloatArithmeticTests()
       OMR_CT_EXPECT_DOUBLE_EQ(_dDiv, div(doubleDivArr[i][0], doubleDivArr[i][1]), _dDiv(doubleDivArr[i][0], doubleDivArr[i][1]));
 
       sprintf(resolvedMethodName, "dDivConst1_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ddiv,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleDivArr[i][0], 2, &doubleDivArr[i][1]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::ddiv,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 4, 1, &doubleDivArr[i][0], 2, &doubleDivArr[i][1]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, div(doubleDivArr[i][0], doubleDivArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dDivConst2_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ddiv,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleDivArr[i][0]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::ddiv,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 1, &doubleDivArr[i][0]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, div(doubleDivArr[i][0], doubleDivArr[i][1]), dBinaryConst(DOUBLE_PLACEHOLDER_1, doubleDivArr[i][1]));
 
       sprintf(resolvedMethodName, "dDivConst3_Testcase%d", i);
-      dBinaryConst = (signatureCharDD_D_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ddiv,
-            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleDivArr[i][1]));
+      compileOpCodeMethod(dBinaryConst, _numberOfBinaryArgs, TR::ddiv,
+            resolvedMethodName, _argTypesBinaryDouble, TR::Double, rc, 2, 2, &doubleDivArr[i][1]);
       OMR_CT_EXPECT_DOUBLE_EQ(dBinaryConst, div(doubleDivArr[i][0], doubleDivArr[i][1]), dBinaryConst(doubleDivArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
    }
@@ -914,7 +914,7 @@ X86OpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "bStoreConst%d", i + 1);
       OMR_CT_EXPECT_EQ(_bStore, byteDataArray[i], _bStore(byteDataArray[i]));
-      bMemCons = (signatureCharB_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bstore, resolvedMethodName, _argTypesUnaryByte, TR::Int8, rc, 2, 1, &(byteDataArray[i])));
+      compileOpCodeMethod(bMemCons, _numberOfUnaryArgs, TR::bstore, resolvedMethodName, _argTypesUnaryByte, TR::Int8, rc, 2, 1, &(byteDataArray[i]));
       OMR_CT_EXPECT_EQ(bMemCons, byteDataArray[i], bMemCons(BYTE_PLACEHOLDER_1));
       }
 
@@ -923,7 +923,7 @@ X86OpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "sStoreConst%d", i + 1);
       OMR_CT_EXPECT_EQ(_sStore, shortDataArray[i], _sStore(shortDataArray[i]));
-      sMemCons = (signatureCharS_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::sstore, resolvedMethodName, _argTypesUnaryShort, TR::Int16, rc, 2, 1, &(shortDataArray[i])));
+      compileOpCodeMethod(sMemCons, _numberOfUnaryArgs, TR::sstore, resolvedMethodName, _argTypesUnaryShort, TR::Int16, rc, 2, 1, &(shortDataArray[i]));
       OMR_CT_EXPECT_EQ(sMemCons, shortDataArray[i], sMemCons(SHORT_PLACEHOLDER_1));
       }
 
@@ -932,7 +932,7 @@ X86OpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "lStoreConst%d", i + 1);
       OMR_CT_EXPECT_EQ(_lStore, longDataArray[i], _lStore(longDataArray[i]));
-      lMemCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lstore, resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &(longDataArray[i])));
+      compileOpCodeMethod(lMemCons, _numberOfUnaryArgs, TR::lstore, resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &(longDataArray[i]));
       OMR_CT_EXPECT_EQ(lMemCons, longDataArray[i], lMemCons(LONG_PLACEHOLDER_1));
       }
 
@@ -941,7 +941,7 @@ X86OpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "dStoreConst%d", i + 1);
       OMR_CT_EXPECT_DOUBLE_EQ(_dStore, doubleDataArray[i], _dStore(doubleDataArray[i]));
-      dMemCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dstore, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &(doubleDataArray[i])));
+      compileOpCodeMethod(dMemCons, _numberOfUnaryArgs, TR::dstore, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &(doubleDataArray[i]));
       OMR_CT_EXPECT_DOUBLE_EQ(dMemCons, doubleDataArray[i], dMemCons(DOUBLE_PLACEHOLDER_1));
       }
 
@@ -950,7 +950,7 @@ X86OpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "fStoreConst%d", i + 1);
       OMR_CT_EXPECT_FLOAT_EQ(_fStore, floatDataArray[i], _fStore(floatDataArray[i]));
-      fMemCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::fstore, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &(floatDataArray[i])));
+      compileOpCodeMethod(fMemCons, _numberOfUnaryArgs, TR::fstore, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &(floatDataArray[i]));
       OMR_CT_EXPECT_FLOAT_EQ(fMemCons, floatDataArray[i], fMemCons(FLOAT_PLACEHOLDER_1));
       }
 
@@ -961,7 +961,7 @@ X86OpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "iLoadiConst%d", i + 1);
       uintptrj_t intDataAddress = (uintptrj_t)(&intDataArray[i]);
-      iLoadiCons = (signatureCharL_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int32, rc, 2, 1, &intDataAddress));
+      compileOpCodeMethod(iLoadiCons, _numberOfUnaryArgs, TR::iloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int32, rc, 2, 1, &intDataAddress);
       OMR_CT_EXPECT_EQ(iLoadiCons, intDataArray[i], iLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -971,7 +971,7 @@ X86OpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "sLoadiConst%d", i + 1);
       uintptrj_t shortDataAddress = (uintptrj_t)(&shortDataArray[i]);
-      sLoadiCons = (signatureCharL_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::sloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int16, rc, 2, 1, &shortDataAddress));
+      compileOpCodeMethod(sLoadiCons, _numberOfUnaryArgs, TR::sloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int16, rc, 2, 1, &shortDataAddress);
       OMR_CT_EXPECT_EQ(sLoadiCons, shortDataArray[i], sLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -981,7 +981,7 @@ X86OpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "bLoadiConst%d", i + 1);
       uintptrj_t byteDataAddress = (uintptrj_t)(&byteDataArray[i]);
-      bLoadiCons = (signatureCharL_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int8, rc, 2, 1, &byteDataAddress));
+      compileOpCodeMethod(bLoadiCons, _numberOfUnaryArgs, TR::bloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int8, rc, 2, 1, &byteDataAddress);
       OMR_CT_EXPECT_EQ(bLoadiCons, byteDataArray[i], bLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -991,7 +991,7 @@ X86OpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "lLoadiConst%d", i + 1);
       uintptrj_t longDataAddress = (uintptrj_t)(&longDataArray[i]);
-      lLoadiCons = (signatureCharL_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int64, rc, 2, 1, &longDataAddress));
+      compileOpCodeMethod(lLoadiCons, _numberOfUnaryArgs, TR::lloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Int64, rc, 2, 1, &longDataAddress);
       OMR_CT_EXPECT_EQ(lLoadiCons, longDataArray[i], lLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -1001,7 +1001,7 @@ X86OpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "dLoadiConst%d", i + 1);
       uintptrj_t doubleDataAddress = (uintptrj_t)(&doubleDataArray[i]);
-      dLoadiCons = (signatureCharL_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Double, rc, 2, 1, &doubleDataAddress));
+      compileOpCodeMethod(dLoadiCons, _numberOfUnaryArgs, TR::dloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Double, rc, 2, 1, &doubleDataAddress);
       OMR_CT_EXPECT_EQ(dLoadiCons, doubleDataArray[i], dLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -1011,7 +1011,7 @@ X86OpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "fLoadiConst%d", i + 1);
       uintptrj_t floatDataAddress = (uintptrj_t)(&floatDataArray[i]);
-      fLoadiCons = (signatureCharL_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::floadi, resolvedMethodName, _argTypesUnaryAddress, TR::Float, rc, 2, 1, &floatDataAddress));
+      compileOpCodeMethod(fLoadiCons, _numberOfUnaryArgs, TR::floadi, resolvedMethodName, _argTypesUnaryAddress, TR::Float, rc, 2, 1, &floatDataAddress);
       OMR_CT_EXPECT_EQ(fLoadiCons, floatDataArray[i], fLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -1021,7 +1021,7 @@ X86OpCodesTest::invokeMemoryOperationTests()
       {
       sprintf(resolvedMethodName, "aLoadiConst%d", i + 1);
       uintptrj_t addressDataAddress = (uintptrj_t)(&addressDataArray[i]);
-      aLoadiCons = (signatureCharL_L_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::aloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Address, rc, 2, 1, &addressDataAddress));
+      compileOpCodeMethod(aLoadiCons, _numberOfUnaryArgs, TR::aloadi, resolvedMethodName, _argTypesUnaryAddress, TR::Address, rc, 2, 1, &addressDataAddress);
       OMR_CT_EXPECT_EQ(aLoadiCons, addressDataArray[i], aLoadiCons(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -1162,18 +1162,18 @@ X86OpCodesTest::invokeShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_iRol, rol(irolDataArr[i][0], irolDataArr[i][1]), _iRol(irolDataArr[i][0], irolDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iRolConst1_TestCase%d", i + 1);
-      iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::irol, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &irolDataArr[i][0], 2, &irolDataArr[i][1]));
+      compileOpCodeMethod(iShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::irol, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &irolDataArr[i][0], 2, &irolDataArr[i][1]);
       OMR_CT_EXPECT_EQ(iShiftOrRolConst, rol(irolDataArr[i][0], irolDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iRolConst2_TestCase%d", i + 1);
-      iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::irol, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &irolDataArr[i][0]));
+      compileOpCodeMethod(iShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::irol, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &irolDataArr[i][0]);
       OMR_CT_EXPECT_EQ(iShiftOrRolConst, rol(irolDataArr[i][0], irolDataArr[i][1]), iShiftOrRolConst(INT_PLACEHOLDER_1, irolDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iRolConst3_TestCase%d", i + 1);
-      iShiftOrRolConst = (signatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::irol, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &irolDataArr[i][1]));
+      compileOpCodeMethod(iShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::irol, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &irolDataArr[i][1]);
       OMR_CT_EXPECT_EQ(iShiftOrRolConst, rol(irolDataArr[i][0], irolDataArr[i][1]), iShiftOrRolConst(irolDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -1184,18 +1184,18 @@ X86OpCodesTest::invokeShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_bShl, shl(bshlDataArr[i][0], bshlDataArr[i][1]), _bShl(bshlDataArr[i][0],bshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bShlConst1_TestCase%d", i + 1);
-      bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bshl, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &bshlDataArr[i][0], 2, &bshlDataArr[i][1]));
+      compileOpCodeMethod(bShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::bshl, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &bshlDataArr[i][0], 2, &bshlDataArr[i][1]);
       OMR_CT_EXPECT_EQ(bShiftOrRolConst, shl(bshlDataArr[i][0], bshlDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bShlConst2_TestCase%d", i + 1);
-      bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bshl, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &bshlDataArr[i][0]));
+      compileOpCodeMethod(bShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::bshl, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &bshlDataArr[i][0]);
       OMR_CT_EXPECT_EQ(bShiftOrRolConst, shl(bshlDataArr[i][0], bshlDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, bshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bShlConst3_TestCase%d", i + 1);
-      bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bshl, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &bshlDataArr[i][1]));
+      compileOpCodeMethod(bShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::bshl, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &bshlDataArr[i][1]);
       OMR_CT_EXPECT_EQ(bShiftOrRolConst, shl(bshlDataArr[i][0], bshlDataArr[i][1]), bShiftOrRolConst(bshlDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -1206,18 +1206,18 @@ X86OpCodesTest::invokeShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_bShr, shr(bshrDataArr[i][0], bshrDataArr[i][1]), _bShr(bshrDataArr[i][0], bshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bShrConst1_TestCase%d", i + 1);
-      bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bshr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &bshrDataArr[i][0], 2, &bshrDataArr[i][1]));
+      compileOpCodeMethod(bShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::bshr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &bshrDataArr[i][0], 2, &bshrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(bShiftOrRolConst, shr(bshrDataArr[i][0], bshrDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bShrConst2_TestCase%d", i + 1);
-      bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bshr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &bshrDataArr[i][0]));
+      compileOpCodeMethod(bShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::bshr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &bshrDataArr[i][0]);
       OMR_CT_EXPECT_EQ(bShiftOrRolConst, shr(bshrDataArr[i][0], bshrDataArr[i][1]), bShiftOrRolConst(BYTE_PLACEHOLDER_1, bshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bShrConst3_TestCase%d", i + 1);
-      bShiftOrRolConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bshr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &bshrDataArr[i][1]));
+      compileOpCodeMethod(bShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::bshr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &bshrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(bShiftOrRolConst, shr(bshrDataArr[i][0], bshrDataArr[i][1]), bShiftOrRolConst(bshrDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -1228,18 +1228,18 @@ X86OpCodesTest::invokeShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_buShr, shr(bushrDataArr[i][0], bushrDataArr[i][1]), _buShr(bushrDataArr[i][0], bushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buShrConst1_TestCase%d", i + 1);
-      buShiftOrRolConst = (unsignedSignatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bushr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &bushrDataArr[i][0], 2, &bushrDataArr[i][1]));
+      compileOpCodeMethod(buShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::bushr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &bushrDataArr[i][0], 2, &bushrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(buShiftOrRolConst, shr(bushrDataArr[i][0], bushrDataArr[i][1]), buShiftOrRolConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "buShrConst2_TestCase%d", i + 1);
-      buShiftOrRolConst = (unsignedSignatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bushr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &bushrDataArr[i][0]));
+      compileOpCodeMethod(buShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::bushr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &bushrDataArr[i][0]);
       OMR_CT_EXPECT_EQ(buShiftOrRolConst, shr(bushrDataArr[i][0], bushrDataArr[i][1]), buShiftOrRolConst(BYTE_PLACEHOLDER_1, bushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buShrConst3_TestCase%d", i + 1);
-      buShiftOrRolConst = (unsignedSignatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bushr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &bushrDataArr[i][1]));
+      compileOpCodeMethod(buShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::bushr, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &bushrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(buShiftOrRolConst, shr(bushrDataArr[i][0], bushrDataArr[i][1]), buShiftOrRolConst(bushrDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -1250,18 +1250,18 @@ X86OpCodesTest::invokeShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_sShr, shr(sshrDataArr[i][0], sshrDataArr[i][1]), _sShr(sshrDataArr[i][0], sshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sShrConst1_TestCase%d", i + 1);
-      sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sshr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &sshrDataArr[i][0], 2, &sshrDataArr[i][1]));
+      compileOpCodeMethod(sShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::sshr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &sshrDataArr[i][0], 2, &sshrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(sShiftOrRolConst, shr(sshrDataArr[i][0], sshrDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sShrConst2_TestCase%d", i + 1);
-      sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sshr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &sshrDataArr[i][0]));
+      compileOpCodeMethod(sShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::sshr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &sshrDataArr[i][0]);
       OMR_CT_EXPECT_EQ(sShiftOrRolConst, shr(sshrDataArr[i][0], sshrDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, sshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sShrConst3_TestCase%d", i + 1);
-      sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sshr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &sshrDataArr[i][1]));
+      compileOpCodeMethod(sShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::sshr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &sshrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(sShiftOrRolConst, shr(sshrDataArr[i][0], sshrDataArr[i][1]), sShiftOrRolConst(sshrDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -1272,18 +1272,18 @@ X86OpCodesTest::invokeShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_suShr, shr(sushrDataArr[i][0], sushrDataArr[i][1]), _suShr(sushrDataArr[i][0], sushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "suShrConst1_TestCase%d", i + 1);
-      suShiftOrRolConst = (unsignedSignatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sushr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &sushrDataArr[i][0], 2, &sushrDataArr[i][1]));
+      compileOpCodeMethod(suShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::sushr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &sushrDataArr[i][0], 2, &sushrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(suShiftOrRolConst, shr(sushrDataArr[i][0], sushrDataArr[i][1]), suShiftOrRolConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "suShrConst2_TestCase%d", i + 1);
-      suShiftOrRolConst = (unsignedSignatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sushr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &sushrDataArr[i][0]));
+      compileOpCodeMethod(suShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::sushr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &sushrDataArr[i][0]);
       OMR_CT_EXPECT_EQ(suShiftOrRolConst, shr(sushrDataArr[i][0], sushrDataArr[i][1]), suShiftOrRolConst(SHORT_PLACEHOLDER_1, sushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "suShrConst3_TestCase%d", i + 1);
-      suShiftOrRolConst = (unsignedSignatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sushr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &sushrDataArr[i][1]));
+      compileOpCodeMethod(suShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::sushr, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &sushrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(suShiftOrRolConst, shr(sushrDataArr[i][0], sushrDataArr[i][1]), suShiftOrRolConst(sushrDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -1295,18 +1295,18 @@ X86OpCodesTest::invokeShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_sShl, shl(sshlDataArr[i][0], sshlDataArr[i][1]), _sShl(sshlDataArr[i][0], sshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sShlConst1_TestCase%d", i + 1);
-      sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sshl, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &sshlDataArr[i][0], 2, &sshlDataArr[i][1]));
+      compileOpCodeMethod(sShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::sshl, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &sshlDataArr[i][0], 2, &sshlDataArr[i][1]);
       OMR_CT_EXPECT_EQ(sShiftOrRolConst, shl(sshlDataArr[i][0], sshlDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sShlConst2_TestCase%d", i + 1);
-      sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sshl, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &sshlDataArr[i][0]));
+      compileOpCodeMethod(sShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::sshl, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &sshlDataArr[i][0]);
       OMR_CT_EXPECT_EQ(sShiftOrRolConst, shl(sshlDataArr[i][0], sshlDataArr[i][1]), sShiftOrRolConst(SHORT_PLACEHOLDER_1, sshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sShlConst3_TestCase%d", i + 1);
-      sShiftOrRolConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sshl, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &sshlDataArr[i][1]));
+      compileOpCodeMethod(sShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::sshl, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &sshlDataArr[i][1]);
       OMR_CT_EXPECT_EQ(sShiftOrRolConst, shl(sshlDataArr[i][0], sshlDataArr[i][1]), sShiftOrRolConst(sshlDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -1354,18 +1354,18 @@ X86OpCodesTest::invokeShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_lShl, shl(lshlDataArr[i][0], lshlDataArr[i][1]), _lShl(lshlDataArr[i][0], lshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lShlConst1_TestCase%d", i + 1);
-      lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lshl, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lshlDataArr[i][0], 2, &lshlDataArr[i][1]));
+      compileOpCodeMethod(lShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lshl, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lshlDataArr[i][0], 2, &lshlDataArr[i][1]);
       OMR_CT_EXPECT_EQ(lShiftOrRolConst, shl(lshlDataArr[i][0], lshlDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "lShlConst2_TestCase%d", i + 1);
-      lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lshl, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lshlDataArr[i][0]));
+      compileOpCodeMethod(lShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lshl, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lshlDataArr[i][0]);
       OMR_CT_EXPECT_EQ(lShiftOrRolConst, shl(lshlDataArr[i][0], lshlDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, lshlDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lShlConst3_TestCase%d", i + 1);
-      lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lshl, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lshlDataArr[i][1]));
+      compileOpCodeMethod(lShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lshl, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lshlDataArr[i][1]);
       OMR_CT_EXPECT_EQ(lShiftOrRolConst, shl(lshlDataArr[i][0], lshlDataArr[i][1]), lShiftOrRolConst(lshlDataArr[i][0], LONG_PLACEHOLDER_1));
       }
 
@@ -1376,18 +1376,18 @@ X86OpCodesTest::invokeShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_lShr, shr(lshrDataArr[i][0], lshrDataArr[i][1]), _lShr(lshrDataArr[i][0], lshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lShrConst1_TestCase%d", i + 1);
-      lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lshr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lshrDataArr[i][0], 2, &lshrDataArr[i][1]));
+      compileOpCodeMethod(lShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lshr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lshrDataArr[i][0], 2, &lshrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(lShiftOrRolConst, shr(lshrDataArr[i][0], lshrDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lShrConst2_TestCase%d", i + 1);
-      lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lshr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lshrDataArr[i][0]));
+      compileOpCodeMethod(lShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lshr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lshrDataArr[i][0]);
       OMR_CT_EXPECT_EQ(lShiftOrRolConst, shr(lshrDataArr[i][0], lshrDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, lshrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lShrConst3_TestCase%d", i + 1);
-      lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lshr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lshrDataArr[i][1]));
+      compileOpCodeMethod(lShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lshr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lshrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(lShiftOrRolConst, shr(lshrDataArr[i][0], lshrDataArr[i][1]), lShiftOrRolConst(lshrDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -1398,18 +1398,18 @@ X86OpCodesTest::invokeShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_luShr, shr(lushrDataArr[i][0], lushrDataArr[i][1]), _luShr(lushrDataArr[i][0], lushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luShrConst1_TestCase%d", i + 1);
-      luShiftOrRolConst = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lushr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lushrDataArr[i][0], 2, &lushrDataArr[i][1]));
+      compileOpCodeMethod(luShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lushr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lushrDataArr[i][0], 2, &lushrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(luShiftOrRolConst, shr(lushrDataArr[i][0], lushrDataArr[i][1]), luShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "luShrConst2_TestCase%d", i + 1);
-      luShiftOrRolConst = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lushr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lushrDataArr[i][0]));
+      compileOpCodeMethod(luShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lushr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lushrDataArr[i][0]);
       OMR_CT_EXPECT_EQ(luShiftOrRolConst, shr(lushrDataArr[i][0], lushrDataArr[i][1]), luShiftOrRolConst(LONG_PLACEHOLDER_1, lushrDataArr[i][1]));
 
       sprintf(resolvedMethodName, "luShrConst3_TestCase%d", i + 1);
-      luShiftOrRolConst = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lushr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lushrDataArr[i][1]));
+      compileOpCodeMethod(luShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lushr, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lushrDataArr[i][1]);
       OMR_CT_EXPECT_EQ(luShiftOrRolConst, shr(lushrDataArr[i][0], lushrDataArr[i][1]), luShiftOrRolConst(lushrDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -1420,18 +1420,18 @@ X86OpCodesTest::invokeShiftOrRolTests()
       OMR_CT_EXPECT_EQ(_lRol, rol(lrolDataArr[i][0], lrolDataArr[i][1]), _lRol(lrolDataArr[i][0], lrolDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lRolConst1_TestCase%d", i + 1);
-      lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lrol, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lrolDataArr[i][0], 2, &lrolDataArr[i][1]));
+      compileOpCodeMethod(lShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lrol, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &lrolDataArr[i][0], 2, &lrolDataArr[i][1]);
       OMR_CT_EXPECT_EQ(lShiftOrRolConst, rol(lrolDataArr[i][0], lrolDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lRolConst2_TestCase%d", i + 1);
-      lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lrol, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lrolDataArr[i][0]));
+      compileOpCodeMethod(lShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lrol, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &lrolDataArr[i][0]);
       OMR_CT_EXPECT_EQ(lShiftOrRolConst, rol(lrolDataArr[i][0], lrolDataArr[i][1]), lShiftOrRolConst(LONG_PLACEHOLDER_1, lrolDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lRolConst3_TestCase%d", i + 1);
-      lShiftOrRolConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lrol, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lrolDataArr[i][1]));
+      compileOpCodeMethod(lShiftOrRolConst, 
+            _numberOfBinaryArgs, TR::lrol, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &lrolDataArr[i][1]);
       OMR_CT_EXPECT_EQ(lShiftOrRolConst, rol(lrolDataArr[i][0], lrolDataArr[i][1]), lShiftOrRolConst(lrolDataArr[i][0], LONG_PLACEHOLDER_2));
       }
    }
@@ -1522,18 +1522,18 @@ X86OpCodesTest::invokeBitwiseTests()
       OMR_CT_EXPECT_EQ(_lAnd, tand(longAndArr[i][0], longAndArr[i][1]), _lAnd(longAndArr[i][0], longAndArr[i][1]));
 
       sprintf(resolvedMethodName, "lAndConst1_TestCase%d", i + 1);
-      lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::land, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &(longAndArr[i][0]), 2, &(longAndArr[i][1])));
+      compileOpCodeMethod(lBitwiseConst, 
+            _numberOfBinaryArgs, TR::land, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &(longAndArr[i][0]), 2, &(longAndArr[i][1]));
       OMR_CT_EXPECT_EQ(lBitwiseConst, tand(longAndArr[i][0], longAndArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lAndConst2_TestCase%d", i + 1);
-      lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::land, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &(longAndArr[i][0])));
+      compileOpCodeMethod(lBitwiseConst, 
+            _numberOfBinaryArgs, TR::land, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &(longAndArr[i][0]));
       OMR_CT_EXPECT_EQ(lBitwiseConst, tand(longAndArr[i][0], longAndArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, longAndArr[i][1]));
 
       sprintf(resolvedMethodName, "lAndConst3_TestCase%d", i + 1);
-      lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::land, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &(longAndArr[i][1])));
+      compileOpCodeMethod(lBitwiseConst, 
+            _numberOfBinaryArgs, TR::land, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &(longAndArr[i][1]));
       OMR_CT_EXPECT_EQ(lBitwiseConst, tand(longAndArr[i][0], longAndArr[i][1]), lBitwiseConst(longAndArr[i][0], LONG_PLACEHOLDER_2));
      }
 
@@ -1544,18 +1544,18 @@ X86OpCodesTest::invokeBitwiseTests()
       OMR_CT_EXPECT_EQ(_lOr, tor(longOrArr[i][0], longOrArr[i][1]), _lOr(longOrArr[i][0], longOrArr[i][1]));
 
       sprintf(resolvedMethodName, "lOrConst1_TestCase%d", i + 1);
-      lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &(longOrArr[i][0]), 2, &(longOrArr[i][1])));
+      compileOpCodeMethod(lBitwiseConst, 
+            _numberOfBinaryArgs, TR::lor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &(longOrArr[i][0]), 2, &(longOrArr[i][1]));
       OMR_CT_EXPECT_EQ(lBitwiseConst, tor(longOrArr[i][0], longOrArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lOrConst2_TestCase%d", i + 1);
-      lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &(longOrArr[i][0])));
+      compileOpCodeMethod(lBitwiseConst, 
+            _numberOfBinaryArgs, TR::lor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &(longOrArr[i][0]));
       OMR_CT_EXPECT_EQ(lBitwiseConst, tor(longOrArr[i][0], longOrArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, longOrArr[i][1]));
 
       sprintf(resolvedMethodName, "lOrConst3_TestCase%d", i + 1);
-      lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &(longOrArr[i][1])));
+      compileOpCodeMethod(lBitwiseConst, 
+            _numberOfBinaryArgs, TR::lor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &(longOrArr[i][1]));
       OMR_CT_EXPECT_EQ(lBitwiseConst, tor(longOrArr[i][0], longOrArr[i][1]), lBitwiseConst(longOrArr[i][0], LONG_PLACEHOLDER_2));
      }
 
@@ -1566,18 +1566,18 @@ X86OpCodesTest::invokeBitwiseTests()
       OMR_CT_EXPECT_EQ(_lXor, txor(longXorArr[i][0], longXorArr[i][1]), _lXor(longXorArr[i][0], longXorArr[i][1]));
 
       sprintf(resolvedMethodName, "lXorConst1_TestCase%d", i + 1);
-      lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lxor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &(longXorArr[i][0]), 2, &(longXorArr[i][1])));
+      compileOpCodeMethod(lBitwiseConst, 
+            _numberOfBinaryArgs, TR::lxor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &(longXorArr[i][0]), 2, &(longXorArr[i][1]));
       OMR_CT_EXPECT_EQ(lBitwiseConst, txor(longXorArr[i][0], longXorArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lXorConst2_TestCase%d", i + 1);
-      lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lxor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &(longXorArr[i][0])));
+      compileOpCodeMethod(lBitwiseConst, 
+            _numberOfBinaryArgs, TR::lxor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &(longXorArr[i][0]));
       OMR_CT_EXPECT_EQ(lBitwiseConst, txor(longXorArr[i][0], longXorArr[i][1]), lBitwiseConst(LONG_PLACEHOLDER_1, longXorArr[i][1]));
 
       sprintf(resolvedMethodName, "lXorConst3_TestCase%d", i + 1);
-      lBitwiseConst = (signatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lxor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &(longXorArr[i][1])));
+      compileOpCodeMethod(lBitwiseConst, 
+            _numberOfBinaryArgs, TR::lxor, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &(longXorArr[i][1]));
       OMR_CT_EXPECT_EQ(lBitwiseConst, txor(longXorArr[i][0], longXorArr[i][1]), lBitwiseConst(longXorArr[i][0], LONG_PLACEHOLDER_2));
      }
 
@@ -1588,18 +1588,18 @@ X86OpCodesTest::invokeBitwiseTests()
       OMR_CT_EXPECT_EQ(_bAnd, tand(byteAndArr[i][0], byteAndArr[i][1]), _bAnd(byteAndArr[i][0], byteAndArr[i][1]));
 
       sprintf(resolvedMethodName, "bAndConst1_TestCase%d", i + 1);
-      bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::band, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &(byteAndArr[i][0]), 2, &(byteAndArr[i][1])));
+      compileOpCodeMethod(bBitwiseConst, 
+            _numberOfBinaryArgs, TR::band, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &(byteAndArr[i][0]), 2, &(byteAndArr[i][1]));
       OMR_CT_EXPECT_EQ(bBitwiseConst, tand(byteAndArr[i][0], byteAndArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bAndConst2_TestCase%d", i + 1);
-      bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::band, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &(byteAndArr[i][0])));
+      compileOpCodeMethod(bBitwiseConst, 
+            _numberOfBinaryArgs, TR::band, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &(byteAndArr[i][0]));
       OMR_CT_EXPECT_EQ(bBitwiseConst, tand(byteAndArr[i][0], byteAndArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, byteAndArr[i][1]));
 
       sprintf(resolvedMethodName, "bAndConst3_TestCase%d", i + 1);
-      bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::band, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &(byteAndArr[i][1])));
+      compileOpCodeMethod(bBitwiseConst, 
+            _numberOfBinaryArgs, TR::band, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &(byteAndArr[i][1]));
       OMR_CT_EXPECT_EQ(bBitwiseConst, tand(byteAndArr[i][0], byteAndArr[i][1]), bBitwiseConst(byteAndArr[i][0], BYTE_PLACEHOLDER_2));
      }
 
@@ -1610,18 +1610,18 @@ X86OpCodesTest::invokeBitwiseTests()
       OMR_CT_EXPECT_EQ(_bOr, tor(byteOrArr[i][0], byteOrArr[i][1]), _bOr(byteOrArr[i][0], byteOrArr[i][1]));
 
       sprintf(resolvedMethodName, "bOrConst1_TestCase%d", i + 1);
-      bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &(byteOrArr[i][0]), 2, &(byteOrArr[i][1])));
+      compileOpCodeMethod(bBitwiseConst, 
+            _numberOfBinaryArgs, TR::bor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &(byteOrArr[i][0]), 2, &(byteOrArr[i][1]));
       OMR_CT_EXPECT_EQ(bBitwiseConst, tor(byteOrArr[i][0], byteOrArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bOrConst2_TestCase%d", i + 1);
-      bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &(byteOrArr[i][0])));
+      compileOpCodeMethod(bBitwiseConst, 
+            _numberOfBinaryArgs, TR::bor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &(byteOrArr[i][0]));
       OMR_CT_EXPECT_EQ(bBitwiseConst, tor(byteOrArr[i][0], byteOrArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, byteOrArr[i][1]));
 
       sprintf(resolvedMethodName, "bOrConst3_TestCase%d", i + 1);
-      bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &(byteOrArr[i][1])));
+      compileOpCodeMethod(bBitwiseConst, 
+            _numberOfBinaryArgs, TR::bor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &(byteOrArr[i][1]));
       OMR_CT_EXPECT_EQ(bBitwiseConst, tor(byteOrArr[i][0], byteOrArr[i][1]), bBitwiseConst(byteOrArr[i][0], BYTE_PLACEHOLDER_2));
      }
 
@@ -1632,18 +1632,18 @@ X86OpCodesTest::invokeBitwiseTests()
       OMR_CT_EXPECT_EQ(_bXor, txor(byteXorArr[i][0], byteXorArr[i][1]), _bXor(byteXorArr[i][0], byteXorArr[i][1]));
 
       sprintf(resolvedMethodName, "bXorConst1_TestCase%d", i + 1);
-      bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bxor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &(byteXorArr[i][0]), 2, &(byteXorArr[i][1])));
+      compileOpCodeMethod(bBitwiseConst, 
+            _numberOfBinaryArgs, TR::bxor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 4, 1, &(byteXorArr[i][0]), 2, &(byteXorArr[i][1]));
       OMR_CT_EXPECT_EQ(bBitwiseConst, txor(byteXorArr[i][0], byteXorArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bXorConst2_TestCase%d", i + 1);
-      bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bxor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &(byteXorArr[i][0])));
+      compileOpCodeMethod(bBitwiseConst, 
+            _numberOfBinaryArgs, TR::bxor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 1, &(byteXorArr[i][0]));
       OMR_CT_EXPECT_EQ(bBitwiseConst, txor(byteXorArr[i][0], byteXorArr[i][1]), bBitwiseConst(BYTE_PLACEHOLDER_1, byteXorArr[i][1]));
 
       sprintf(resolvedMethodName, "bXorConst3_TestCase%d", i + 1);
-      bBitwiseConst = (signatureCharBB_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bxor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &(byteXorArr[i][1])));
+      compileOpCodeMethod(bBitwiseConst, 
+            _numberOfBinaryArgs, TR::bxor, resolvedMethodName, _argTypesBinaryByte, TR::Int8, rc, 2, 2, &(byteXorArr[i][1]));
       OMR_CT_EXPECT_EQ(bBitwiseConst, txor(byteXorArr[i][0], byteXorArr[i][1]), bBitwiseConst(byteXorArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -1654,18 +1654,18 @@ X86OpCodesTest::invokeBitwiseTests()
       OMR_CT_EXPECT_EQ(_sAnd, tand(shortAndArr[i][0], shortAndArr[i][1]), _sAnd(shortAndArr[i][0], shortAndArr[i][1]));
 
       sprintf(resolvedMethodName, "sAndConst1_TestCase%d", i + 1);
-      sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sand, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &(shortAndArr[i][0]), 2, &(shortAndArr[i][1])));
+      compileOpCodeMethod(sBitwiseConst, 
+            _numberOfBinaryArgs, TR::sand, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &(shortAndArr[i][0]), 2, &(shortAndArr[i][1]));
       OMR_CT_EXPECT_EQ(sBitwiseConst, tand(shortAndArr[i][0], shortAndArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sAndConst2_TestCase%d", i + 1);
-      sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sand, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &(shortAndArr[i][0])));
+      compileOpCodeMethod(sBitwiseConst, 
+            _numberOfBinaryArgs, TR::sand, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &(shortAndArr[i][0]));
       OMR_CT_EXPECT_EQ(sBitwiseConst, tand(shortAndArr[i][0], shortAndArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, shortAndArr[i][1]));
 
       sprintf(resolvedMethodName, "sAndConst3_TestCase%d", i + 1);
-      sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sand, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &(shortAndArr[i][1])));
+      compileOpCodeMethod(sBitwiseConst, 
+            _numberOfBinaryArgs, TR::sand, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &(shortAndArr[i][1]));
       OMR_CT_EXPECT_EQ(sBitwiseConst, tand(shortAndArr[i][0], shortAndArr[i][1]), sBitwiseConst(shortAndArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -1676,18 +1676,18 @@ X86OpCodesTest::invokeBitwiseTests()
       OMR_CT_EXPECT_EQ(_sOr, tor(shortOrArr[i][0], shortOrArr[i][1]), _sOr(shortOrArr[i][0], shortOrArr[i][1]));
 
       sprintf(resolvedMethodName, "sOrConst1_TestCase%d", i + 1);
-      sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &(shortOrArr[i][0]), 2, &(shortOrArr[i][1])));
+      compileOpCodeMethod(sBitwiseConst, 
+            _numberOfBinaryArgs, TR::sor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &(shortOrArr[i][0]), 2, &(shortOrArr[i][1]));
       OMR_CT_EXPECT_EQ(sBitwiseConst, tor(shortOrArr[i][0], shortOrArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sOrConst2_TestCase%d", i + 1);
-      sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &(shortOrArr[i][0])));
+      compileOpCodeMethod(sBitwiseConst, 
+            _numberOfBinaryArgs, TR::sor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &(shortOrArr[i][0]));
       OMR_CT_EXPECT_EQ(sBitwiseConst, tor(shortOrArr[i][0], shortOrArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, shortOrArr[i][1]));
 
       sprintf(resolvedMethodName, "sOrConst3_TestCase%d", i + 1);
-      sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &(shortOrArr[i][1])));
+      compileOpCodeMethod(sBitwiseConst, 
+            _numberOfBinaryArgs, TR::sor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &(shortOrArr[i][1]));
       OMR_CT_EXPECT_EQ(sBitwiseConst, tor(shortOrArr[i][0], shortOrArr[i][1]), sBitwiseConst(shortOrArr[i][0], SHORT_PLACEHOLDER_2));
      }
 
@@ -1698,18 +1698,18 @@ X86OpCodesTest::invokeBitwiseTests()
       OMR_CT_EXPECT_EQ(_sXor, txor(shortXorArr[i][0], shortXorArr[i][1]), _sXor(shortXorArr[i][0], shortXorArr[i][1]));
 
       sprintf(resolvedMethodName, "sXorConst1_TestCase%d", i + 1);
-      sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sxor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &(shortXorArr[i][0]), 2, &(shortXorArr[i][1])));
+      compileOpCodeMethod(sBitwiseConst, 
+            _numberOfBinaryArgs, TR::sxor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 4, 1, &(shortXorArr[i][0]), 2, &(shortXorArr[i][1]));
       OMR_CT_EXPECT_EQ(sBitwiseConst, txor(shortXorArr[i][0], shortXorArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sXorConst2_TestCase%d", i + 1);
-      sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sxor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &(shortXorArr[i][0])));
+      compileOpCodeMethod(sBitwiseConst, 
+            _numberOfBinaryArgs, TR::sxor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 1, &(shortXorArr[i][0]));
       OMR_CT_EXPECT_EQ(sBitwiseConst, txor(shortXorArr[i][0], shortXorArr[i][1]), sBitwiseConst(SHORT_PLACEHOLDER_1, shortXorArr[i][1]));
 
       sprintf(resolvedMethodName, "sXorConst3_TestCase%d", i + 1);
-      sBitwiseConst = (signatureCharSS_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sxor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &(shortXorArr[i][1])));
+      compileOpCodeMethod(sBitwiseConst, 
+            _numberOfBinaryArgs, TR::sxor, resolvedMethodName, _argTypesBinaryShort, TR::Int16, rc, 2, 2, &(shortXorArr[i][1]));
       OMR_CT_EXPECT_EQ(sBitwiseConst, txor(shortXorArr[i][0], shortXorArr[i][1]), sBitwiseConst(shortXorArr[i][0], SHORT_PLACEHOLDER_2));
      }
    }
@@ -1772,8 +1772,8 @@ X86OpCodesTest::invokeUnaryTests()
       {
       OMR_CT_EXPECT_EQ(_bNeg, neg(byteDataArray[i]), _bNeg(byteDataArray[i]));
       sprintf(resolvedMethodName, "bNegConst%d", i + 1);
-      bUnaryCons = (signatureCharB_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bneg,
-            resolvedMethodName, _argTypesUnaryByte, TR::Int8, rc, 2, 1, &byteDataArray[i]));
+      compileOpCodeMethod(bUnaryCons, _numberOfUnaryArgs, TR::bneg,
+            resolvedMethodName, _argTypesUnaryByte, TR::Int8, rc, 2, 1, &byteDataArray[i]);
       OMR_CT_EXPECT_EQ(bUnaryCons, neg(byteDataArray[i]), bUnaryCons(BYTE_PLACEHOLDER_1));
       }
 
@@ -1783,8 +1783,8 @@ X86OpCodesTest::invokeUnaryTests()
       {
       OMR_CT_EXPECT_EQ(_sNeg, neg(shortDataArray[i]), _sNeg(shortDataArray[i]));
       sprintf(resolvedMethodName, "sNegConst%d", i + 1);
-      sUnaryCons = (signatureCharS_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::sneg,
-            resolvedMethodName, _argTypesUnaryShort, TR::Int16, rc, 2, 1, &shortDataArray[i]));
+      compileOpCodeMethod(sUnaryCons, _numberOfUnaryArgs, TR::sneg,
+            resolvedMethodName, _argTypesUnaryShort, TR::Int16, rc, 2, 1, &shortDataArray[i]);
       OMR_CT_EXPECT_EQ(sUnaryCons, neg(shortDataArray[i]), sUnaryCons(SHORT_PLACEHOLDER_1));
       }
 
@@ -1794,8 +1794,8 @@ X86OpCodesTest::invokeUnaryTests()
       {
       OMR_CT_EXPECT_EQ(_lNeg, neg(longDataArray[i]), _lNeg(longDataArray[i]));
       sprintf(resolvedMethodName, "lNegConst%d", i + 1);
-      lUnaryCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lneg,
-            resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &longDataArray[i]));
+      compileOpCodeMethod(lUnaryCons, _numberOfUnaryArgs, TR::lneg,
+            resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &longDataArray[i]);
       OMR_CT_EXPECT_EQ(lUnaryCons, neg(longDataArray[i]), lUnaryCons(LONG_PLACEHOLDER_1));
       }
 
@@ -1805,8 +1805,8 @@ X86OpCodesTest::invokeUnaryTests()
       {
       OMR_CT_EXPECT_FLOAT_EQ(_fNeg, neg(floatDataArray[i]), _fNeg(floatDataArray[i]));
       sprintf(resolvedMethodName, "fNegConst%d", i + 1);
-      fUnaryCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::fneg,
-            resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &floatDataArray[i]));
+      compileOpCodeMethod(fUnaryCons, _numberOfUnaryArgs, TR::fneg,
+            resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &floatDataArray[i]);
       OMR_CT_EXPECT_FLOAT_EQ(fUnaryCons, neg(floatDataArray[i]), fUnaryCons(FLOAT_PLACEHOLDER_1));
       }
 
@@ -1816,8 +1816,8 @@ X86OpCodesTest::invokeUnaryTests()
       {
       OMR_CT_EXPECT_DOUBLE_EQ(_dNeg, neg(doubleDataArray[i]), _dNeg(doubleDataArray[i]));
       sprintf(resolvedMethodName, "dNegConst%d", i + 1);
-      dUnaryCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dneg,
-            resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &doubleDataArray[i]));
+      compileOpCodeMethod(dUnaryCons, _numberOfUnaryArgs, TR::dneg,
+            resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &doubleDataArray[i]);
       OMR_CT_EXPECT_DOUBLE_EQ(dUnaryCons, neg(doubleDataArray[i]), dUnaryCons(DOUBLE_PLACEHOLDER_1));
       }
 
@@ -1827,8 +1827,8 @@ X86OpCodesTest::invokeUnaryTests()
       {
       OMR_CT_EXPECT_EQ(_lAbs, abs(longDataArray[i]), _lAbs(longDataArray[i]));
       sprintf(resolvedMethodName, "lAbsConst%d", i + 1);
-      lUnaryCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::labs,
-            resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &longDataArray[i]));
+      compileOpCodeMethod(lUnaryCons, _numberOfUnaryArgs, TR::labs,
+            resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &longDataArray[i]);
       OMR_CT_EXPECT_EQ(lUnaryCons, abs(longDataArray[i]), lUnaryCons(LONG_PLACEHOLDER_1));
       }
 
@@ -1838,7 +1838,7 @@ X86OpCodesTest::invokeUnaryTests()
       {
       sprintf(resolvedMethodName, "lReturnCons%d", i + 1);
       OMR_CT_EXPECT_EQ(_lReturn, longDataArray[i], _lReturn(longDataArray[i]));
-      lUnaryCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lreturn, resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &(longDataArray[i])));
+      compileOpCodeMethod(lUnaryCons, _numberOfUnaryArgs, TR::lreturn, resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &(longDataArray[i]));
       OMR_CT_EXPECT_EQ(lUnaryCons, longDataArray[i], lUnaryCons(LONG_PLACEHOLDER_1));
       }
 
@@ -1848,7 +1848,7 @@ X86OpCodesTest::invokeUnaryTests()
       {
       sprintf(resolvedMethodName, "dReturnCons%d", i + 1);
       OMR_CT_EXPECT_DOUBLE_EQ(_dReturn, doubleDataArray[i], _dReturn(doubleDataArray[i]));
-      dUnaryCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dreturn, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &(doubleDataArray[i])));
+      compileOpCodeMethod(dUnaryCons, _numberOfUnaryArgs, TR::dreturn, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &(doubleDataArray[i]));
       OMR_CT_EXPECT_DOUBLE_EQ(dUnaryCons, doubleDataArray[i], dUnaryCons(DOUBLE_PLACEHOLDER_1));
       }
 
@@ -1858,7 +1858,7 @@ X86OpCodesTest::invokeUnaryTests()
       {
       sprintf(resolvedMethodName, "fReturnCons%d", i + 1);
       OMR_CT_EXPECT_FLOAT_EQ(_fReturn, floatDataArray[i], _fReturn(floatDataArray[i]));
-      fUnaryCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::freturn, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &(floatDataArray[i])));
+      compileOpCodeMethod(fUnaryCons, _numberOfUnaryArgs, TR::freturn, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &(floatDataArray[i]));
       OMR_CT_EXPECT_FLOAT_EQ(fUnaryCons, floatDataArray[i], fUnaryCons(FLOAT_PLACEHOLDER_1));
       }
 
@@ -1867,7 +1867,7 @@ X86OpCodesTest::invokeUnaryTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "lConst%d", i + 1);
-      lUnaryCons = (signatureCharJ_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::lconst, resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &(longDataArray[i])));
+      compileOpCodeMethod(lUnaryCons, _numberOfUnaryArgs, TR::lconst, resolvedMethodName, _argTypesUnaryLong, TR::Int64, rc, 2, 1, &(longDataArray[i]));
       OMR_CT_EXPECT_EQ(lUnaryCons, longDataArray[i], lUnaryCons(LONG_PLACEHOLDER_1));
       }
 
@@ -1876,7 +1876,7 @@ X86OpCodesTest::invokeUnaryTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "dConst%d", i + 1);
-      dUnaryCons = (signatureCharD_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::dconst, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &(doubleDataArray[i])));
+      compileOpCodeMethod(dUnaryCons, _numberOfUnaryArgs, TR::dconst, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &(doubleDataArray[i]));
       OMR_CT_EXPECT_DOUBLE_EQ(dUnaryCons, doubleDataArray[i], dUnaryCons(DOUBLE_PLACEHOLDER_1));
       }
 
@@ -1885,7 +1885,7 @@ X86OpCodesTest::invokeUnaryTests()
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
       sprintf(resolvedMethodName, "fConst%d", i + 1);
-      fUnaryCons = (signatureCharF_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::fconst, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &(floatDataArray[i])));
+      compileOpCodeMethod(fUnaryCons, _numberOfUnaryArgs, TR::fconst, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &(floatDataArray[i]));
       OMR_CT_EXPECT_FLOAT_EQ(fUnaryCons, floatDataArray[i], fUnaryCons(FLOAT_PLACEHOLDER_1));
       }
 
@@ -1897,13 +1897,13 @@ X86OpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_DOUBLE_EQ(_i2d, convert(intDataArray[i], DOUBLE_POS), _i2d(intDataArray[i]));
 
       sprintf(resolvedMethodName, "i2fConst%d", i + 1);
-      i2fConst = (signatureCharI_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::i2f,
-            resolvedMethodName, _argTypesUnaryInt, TR::Float, rc, 2, 1, &intDataArray[i]));
+      compileOpCodeMethod(i2fConst, _numberOfUnaryArgs, TR::i2f,
+            resolvedMethodName, _argTypesUnaryInt, TR::Float, rc, 2, 1, &intDataArray[i]);
       OMR_CT_EXPECT_FLOAT_EQ(i2fConst, convert(intDataArray[i], FLOAT_POS), i2fConst(INT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "i2dConst%d", i + 1);
-      i2dConst = (signatureCharI_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::i2d,
-            resolvedMethodName, _argTypesUnaryInt, TR::Double, rc, 2, 1, &intDataArray[i]));
+      compileOpCodeMethod(i2dConst, _numberOfUnaryArgs, TR::i2d,
+            resolvedMethodName, _argTypesUnaryInt, TR::Double, rc, 2, 1, &intDataArray[i]);
       OMR_CT_EXPECT_DOUBLE_EQ(i2dConst, convert(intDataArray[i], DOUBLE_POS), i2dConst(INT_PLACEHOLDER_1));
       }
 
@@ -1915,13 +1915,13 @@ X86OpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_DOUBLE_EQ(_l2d, convert(longDataArray[i], DOUBLE_POS), _l2d(longDataArray[i]));
 
       sprintf(resolvedMethodName, "l2fConst%d", i + 1);
-      l2fConst = (signatureCharJ_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::l2f,
-            resolvedMethodName, _argTypesUnaryLong, TR::Float, rc, 2, 1, &longDataArray[i]));
+      compileOpCodeMethod(l2fConst, _numberOfUnaryArgs, TR::l2f,
+            resolvedMethodName, _argTypesUnaryLong, TR::Float, rc, 2, 1, &longDataArray[i]);
       OMR_CT_EXPECT_FLOAT_EQ(l2fConst, convert(longDataArray[i], FLOAT_POS), l2fConst(LONG_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "l2dConst%d", i + 1);
-      l2dConst = (signatureCharJ_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::l2d,
-            resolvedMethodName, _argTypesUnaryLong, TR::Double, rc, 2, 1, &longDataArray[i]));
+      compileOpCodeMethod(l2dConst, _numberOfUnaryArgs, TR::l2d,
+            resolvedMethodName, _argTypesUnaryLong, TR::Double, rc, 2, 1, &longDataArray[i]);
       OMR_CT_EXPECT_DOUBLE_EQ(l2dConst, convert(longDataArray[i], DOUBLE_POS), l2dConst(LONG_PLACEHOLDER_1));
       }
 
@@ -1936,8 +1936,8 @@ X86OpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_EQ(_f2l, convert(floatDataArray[i], LONG_POS), _f2l(floatDataArray[i]));
 
       sprintf(resolvedMethodName, "f2lConst%d", i + 1);
-      f2lConst = (signatureCharF_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2l,
-            resolvedMethodName, _argTypesUnaryFloat, TR::Int64, rc, 2, 1, &floatDataArray[i]));
+      compileOpCodeMethod(f2lConst, _numberOfUnaryArgs, TR::f2l,
+            resolvedMethodName, _argTypesUnaryFloat, TR::Int64, rc, 2, 1, &floatDataArray[i]);
       OMR_CT_EXPECT_EQ(f2lConst, convert(floatDataArray[i], LONG_POS), f2lConst(FLOAT_PLACEHOLDER_1));
       }
 
@@ -1952,8 +1952,8 @@ X86OpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_EQ(_d2l, convert(doubleDataArray[i], LONG_POS), _d2l(doubleDataArray[i]));
 
       sprintf(resolvedMethodName, "d2lConst%d", i + 1);
-      d2lConst = (signatureCharD_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2l,
-            resolvedMethodName, _argTypesUnaryDouble, TR::Int64, rc, 2, 1, &doubleDataArray[i]));
+      compileOpCodeMethod(d2lConst, _numberOfUnaryArgs, TR::d2l,
+            resolvedMethodName, _argTypesUnaryDouble, TR::Int64, rc, 2, 1, &doubleDataArray[i]);
       OMR_CT_EXPECT_EQ(d2lConst, convert(doubleDataArray[i], LONG_POS), d2lConst(DOUBLE_PLACEHOLDER_1));
       }
 
@@ -1964,8 +1964,8 @@ X86OpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_DOUBLE_EQ(_f2d, convert(floatDataArray[i], DOUBLE_POS), _f2d(floatDataArray[i]));
 
       sprintf(resolvedMethodName, "f2dConst%d", i + 1);
-      f2dConst = (signatureCharF_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2d,
-            resolvedMethodName, _argTypesUnaryFloat, TR::Double, rc, 2, 1, &floatDataArray[i]));
+      compileOpCodeMethod(f2dConst, _numberOfUnaryArgs, TR::f2d,
+            resolvedMethodName, _argTypesUnaryFloat, TR::Double, rc, 2, 1, &floatDataArray[i]);
       OMR_CT_EXPECT_EQ(f2dConst, convert(floatDataArray[i], DOUBLE_POS), f2dConst(FLOAT_PLACEHOLDER_1));
       }
 
@@ -1976,8 +1976,8 @@ X86OpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_FLOAT_EQ(_d2f, convert(doubleDataArray[i], FLOAT_POS), _d2f(doubleDataArray[i]));
 
       sprintf(resolvedMethodName, "d2fConst%d", i + 1);
-      d2fConst = (signatureCharD_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2f,
-            resolvedMethodName, _argTypesUnaryDouble, TR::Float, rc, 2, 1, &doubleDataArray[i]));
+      compileOpCodeMethod(d2fConst, _numberOfUnaryArgs, TR::d2f,
+            resolvedMethodName, _argTypesUnaryDouble, TR::Float, rc, 2, 1, &doubleDataArray[i]);
       OMR_CT_EXPECT_FLOAT_EQ(d2fConst, convert(doubleDataArray[i], FLOAT_POS), d2fConst(DOUBLE_PLACEHOLDER_1));
       }
 
@@ -1992,28 +1992,28 @@ X86OpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_DOUBLE_EQ(_b2d, convert(byteDataArray[i], DOUBLE_POS), _b2d(byteDataArray[i]));
 
       sprintf(resolvedMethodName, "b2sConst%d", i + 1);
-      b2sConst = (signatureCharB_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2s,
-            resolvedMethodName, _argTypesUnaryByte, TR::Int16, rc, 2, 1, &byteDataArray[i]));
+      compileOpCodeMethod(b2sConst, _numberOfUnaryArgs, TR::b2s,
+            resolvedMethodName, _argTypesUnaryByte, TR::Int16, rc, 2, 1, &byteDataArray[i]);
       OMR_CT_EXPECT_EQ(b2sConst, convert(byteDataArray[i], SHORT_POS), b2sConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "b2iConst%d", i + 1);
-      b2iConst = (signatureCharB_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2i,
-            resolvedMethodName, _argTypesUnaryByte, TR::Int32, rc, 2, 1, &byteDataArray[i]));
+      compileOpCodeMethod(b2iConst, _numberOfUnaryArgs, TR::b2i,
+            resolvedMethodName, _argTypesUnaryByte, TR::Int32, rc, 2, 1, &byteDataArray[i]);
       OMR_CT_EXPECT_EQ(b2iConst, convert(byteDataArray[i], INT_POS), b2iConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "b2lConst%d", i + 1);
-      b2lConst = (signatureCharB_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2l,
-            resolvedMethodName, _argTypesUnaryByte, TR::Int64, rc, 2, 1, &byteDataArray[i]));
+      compileOpCodeMethod(b2lConst, _numberOfUnaryArgs, TR::b2l,
+            resolvedMethodName, _argTypesUnaryByte, TR::Int64, rc, 2, 1, &byteDataArray[i]);
       OMR_CT_EXPECT_EQ(b2lConst, convert(byteDataArray[i], LONG_POS), b2lConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "b2fConst%d", i + 1);
-      b2fConst = (signatureCharB_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2f,
-            resolvedMethodName, _argTypesUnaryByte, TR::Float, rc, 2, 1, &byteDataArray[i]));
+      compileOpCodeMethod(b2fConst, _numberOfUnaryArgs, TR::b2f,
+            resolvedMethodName, _argTypesUnaryByte, TR::Float, rc, 2, 1, &byteDataArray[i]);
       OMR_CT_EXPECT_FLOAT_EQ(b2fConst, convert(byteDataArray[i], FLOAT_POS), b2fConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "b2dConst%d", i + 1);
-      b2dConst = (signatureCharB_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::b2d,
-            resolvedMethodName, _argTypesUnaryByte, TR::Double, rc, 2, 1, &byteDataArray[i]));
+      compileOpCodeMethod(b2dConst, _numberOfUnaryArgs, TR::b2d,
+            resolvedMethodName, _argTypesUnaryByte, TR::Double, rc, 2, 1, &byteDataArray[i]);
       OMR_CT_EXPECT_DOUBLE_EQ(b2dConst, convert(byteDataArray[i], DOUBLE_POS), b2dConst(BYTE_PLACEHOLDER_1));
       }
 
@@ -2028,28 +2028,28 @@ X86OpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_DOUBLE_EQ(_bu2d, convert(ubyteDataArray[i], DOUBLE_POS), _bu2d(ubyteDataArray[i]));
 
       sprintf(resolvedMethodName, "bu2sConst%d", i + 1);
-      bu2sConst = (unsignedSignatureCharB_S_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2s,
-            resolvedMethodName, _argTypesUnaryByte, TR::Int16, rc, 2, 1, &ubyteDataArray[i]));
+      compileOpCodeMethod(bu2sConst, _numberOfUnaryArgs, TR::bu2s,
+            resolvedMethodName, _argTypesUnaryByte, TR::Int16, rc, 2, 1, &ubyteDataArray[i]);
       OMR_CT_EXPECT_EQ(bu2sConst, convert(ubyteDataArray[i], SHORT_POS), bu2sConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "bu2iConst%d", i + 1);
-      bu2iConst = (unsignedSignatureCharB_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2i,
-            resolvedMethodName, _argTypesUnaryByte, TR::Int32, rc, 2, 1, &ubyteDataArray[i]));
+      compileOpCodeMethod(bu2iConst, _numberOfUnaryArgs, TR::bu2i,
+            resolvedMethodName, _argTypesUnaryByte, TR::Int32, rc, 2, 1, &ubyteDataArray[i]);
       OMR_CT_EXPECT_EQ(bu2iConst, convert(ubyteDataArray[i], INT_POS), bu2iConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "bu2lConst%d", i + 1);
-      bu2lConst = (unsignedSignatureCharB_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2l,
-            resolvedMethodName, _argTypesUnaryByte, TR::Int64, rc, 2, 1, &ubyteDataArray[i]));
+      compileOpCodeMethod(bu2lConst, _numberOfUnaryArgs, TR::bu2l,
+            resolvedMethodName, _argTypesUnaryByte, TR::Int64, rc, 2, 1, &ubyteDataArray[i]);
       OMR_CT_EXPECT_EQ(bu2lConst, convert(ubyteDataArray[i], LONG_POS), bu2lConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "bu2fConst%d", i + 1);
-      bu2fConst = (unsignedSignatureCharB_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2f,
-            resolvedMethodName, _argTypesUnaryByte, TR::Float, rc, 2, 1, &ubyteDataArray[i]));
+      compileOpCodeMethod(bu2fConst, _numberOfUnaryArgs, TR::bu2f,
+            resolvedMethodName, _argTypesUnaryByte, TR::Float, rc, 2, 1, &ubyteDataArray[i]);
       OMR_CT_EXPECT_FLOAT_EQ(bu2fConst, convert(ubyteDataArray[i], FLOAT_POS), bu2fConst(BYTE_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "bu2dConst%d", i + 1);
-      bu2dConst = (unsignedSignatureCharB_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::bu2d,
-            resolvedMethodName, _argTypesUnaryByte, TR::Double, rc, 2, 1, &ubyteDataArray[i]));
+      compileOpCodeMethod(bu2dConst, _numberOfUnaryArgs, TR::bu2d,
+            resolvedMethodName, _argTypesUnaryByte, TR::Double, rc, 2, 1, &ubyteDataArray[i]);
       OMR_CT_EXPECT_DOUBLE_EQ(bu2dConst, convert(ubyteDataArray[i], DOUBLE_POS), bu2dConst(BYTE_PLACEHOLDER_1));
       }
 
@@ -2064,29 +2064,29 @@ X86OpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_DOUBLE_EQ(_s2d, convert(shortDataArray[i], DOUBLE_POS), _s2d(shortDataArray[i]));
 
       sprintf(resolvedMethodName, "s2bConst%d", i + 1);
-      s2bConst = (signatureCharS_B_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2b,
-            resolvedMethodName, _argTypesUnaryShort, TR::Int8, rc, 2, 1, &shortDataArray[i]));
+      compileOpCodeMethod(s2bConst, _numberOfUnaryArgs, TR::s2b,
+            resolvedMethodName, _argTypesUnaryShort, TR::Int8, rc, 2, 1, &shortDataArray[i]);
       OMR_CT_EXPECT_EQ(s2bConst, convert(shortDataArray[i], BYTE_POS), s2bConst(SHORT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "s2iConst%d", i + 1);
-      s2iConst = (signatureCharS_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2i,
-            resolvedMethodName, _argTypesUnaryShort, TR::Int32, rc, 2, 1, &shortDataArray[i]));
+      compileOpCodeMethod(s2iConst, _numberOfUnaryArgs, TR::s2i,
+            resolvedMethodName, _argTypesUnaryShort, TR::Int32, rc, 2, 1, &shortDataArray[i]);
       OMR_CT_EXPECT_EQ(s2iConst, convert(shortDataArray[i], INT_POS), s2iConst(SHORT_PLACEHOLDER_1));
 
 
       sprintf(resolvedMethodName, "s2lConst%d", i + 1);
-      s2lConst = (signatureCharS_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2l,
-            resolvedMethodName, _argTypesUnaryShort, TR::Int64, rc, 2, 1, &shortDataArray[i]));
+      compileOpCodeMethod(s2lConst, _numberOfUnaryArgs, TR::s2l,
+            resolvedMethodName, _argTypesUnaryShort, TR::Int64, rc, 2, 1, &shortDataArray[i]);
       OMR_CT_EXPECT_EQ(s2lConst, convert(shortDataArray[i], LONG_POS), s2lConst(SHORT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "s2fConst%d", i + 1);
-      s2fConst = (signatureCharS_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2f,
-            resolvedMethodName, _argTypesUnaryShort, TR::Float, rc, 2, 1, &shortDataArray[i]));
+      compileOpCodeMethod(s2fConst, _numberOfUnaryArgs, TR::s2f,
+            resolvedMethodName, _argTypesUnaryShort, TR::Float, rc, 2, 1, &shortDataArray[i]);
       OMR_CT_EXPECT_FLOAT_EQ(s2fConst, convert(shortDataArray[i], FLOAT_POS), s2fConst(SHORT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "s2dConst%d", i + 1);
-      s2dConst = (signatureCharS_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::s2d,
-            resolvedMethodName, _argTypesUnaryShort, TR::Double, rc, 2, 1, &shortDataArray[i]));
+      compileOpCodeMethod(s2dConst, _numberOfUnaryArgs, TR::s2d,
+            resolvedMethodName, _argTypesUnaryShort, TR::Double, rc, 2, 1, &shortDataArray[i]);
       OMR_CT_EXPECT_DOUBLE_EQ(s2dConst, convert(shortDataArray[i], DOUBLE_POS), s2dConst(SHORT_PLACEHOLDER_1));
       }
 
@@ -2100,24 +2100,24 @@ X86OpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_DOUBLE_EQ(_su2d, convert(ushortDataArray[i], DOUBLE_POS), _su2d(ushortDataArray[i]));
 
       sprintf(resolvedMethodName, "s2iConst%d", i + 1);
-      su2iConst = (unsignedSignatureCharS_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2i,
-            resolvedMethodName, _argTypesUnaryShort, TR::Int32, rc, 2, 1, &ushortDataArray[i]));
+      compileOpCodeMethod(su2iConst, _numberOfUnaryArgs, TR::su2i,
+            resolvedMethodName, _argTypesUnaryShort, TR::Int32, rc, 2, 1, &ushortDataArray[i]);
       OMR_CT_EXPECT_EQ(su2iConst, convert(ushortDataArray[i], INT_POS), su2iConst(SHORT_PLACEHOLDER_1));
 
 
       sprintf(resolvedMethodName, "s2lConst%d", i + 1);
-      su2lConst = (unsignedSignatureCharS_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2l,
-            resolvedMethodName, _argTypesUnaryShort, TR::Int64, rc, 2, 1, &ushortDataArray[i]));
+      compileOpCodeMethod(su2lConst, _numberOfUnaryArgs, TR::su2l,
+            resolvedMethodName, _argTypesUnaryShort, TR::Int64, rc, 2, 1, &ushortDataArray[i]);
       OMR_CT_EXPECT_EQ(su2lConst, convert(ushortDataArray[i], LONG_POS), su2lConst(SHORT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "su2fConst%d", i + 1);
-      su2fConst = (unsignedSignatureCharS_F_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2f,
-            resolvedMethodName, _argTypesUnaryShort, TR::Float, rc, 2, 1, &ushortDataArray[i]));
+      compileOpCodeMethod(su2fConst, _numberOfUnaryArgs, TR::su2f,
+            resolvedMethodName, _argTypesUnaryShort, TR::Float, rc, 2, 1, &ushortDataArray[i]);
       OMR_CT_EXPECT_FLOAT_EQ(su2fConst, convert(ushortDataArray[i], FLOAT_POS), su2fConst(SHORT_PLACEHOLDER_1));
 
       sprintf(resolvedMethodName, "su2dConst%d", i + 1);
-      su2dConst = (unsignedSignatureCharS_D_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::su2d,
-            resolvedMethodName, _argTypesUnaryShort, TR::Double, rc, 2, 1, &ushortDataArray[i]));
+      compileOpCodeMethod(su2dConst, _numberOfUnaryArgs, TR::su2d,
+            resolvedMethodName, _argTypesUnaryShort, TR::Double, rc, 2, 1, &ushortDataArray[i]);
       OMR_CT_EXPECT_DOUBLE_EQ(su2dConst, convert(ushortDataArray[i], DOUBLE_POS), su2dConst(SHORT_PLACEHOLDER_1));
       }
 
@@ -2128,8 +2128,8 @@ X86OpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_EQ(_iu2l, convert(uintDataArray[i], LONG_POS), _iu2l(uintDataArray[i]));
 
       sprintf(resolvedMethodName, "iu2lConst%d", i + 1);
-      iu2lConst = (unsignedSignatureCharI_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::iu2l,
-            resolvedMethodName, _argTypesUnaryInt, TR::Int64, rc, 2, 1, &uintDataArray[i]));
+      compileOpCodeMethod(iu2lConst, _numberOfUnaryArgs, TR::iu2l,
+            resolvedMethodName, _argTypesUnaryInt, TR::Int64, rc, 2, 1, &uintDataArray[i]);
       OMR_CT_EXPECT_EQ(iu2lConst, convert(uintDataArray[i], LONG_POS), iu2lConst(INT_PLACEHOLDER_1));
       }
 
@@ -2139,8 +2139,8 @@ X86OpCodesTest::invokeUnaryTests()
       {
       OMR_CT_EXPECT_EQ(_iByteswap, byteswap(intDataArray[i]), _iByteswap(intDataArray[i]));
       sprintf(resolvedMethodName, "iByteswapConst%d", i + 1);
-      iUnaryCons = (signatureCharI_I_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::ibyteswap,
-            resolvedMethodName, _argTypesUnaryInt, TR::Int32, rc, 2, 1, &intDataArray[i]));
+      compileOpCodeMethod(iUnaryCons, _numberOfUnaryArgs, TR::ibyteswap,
+                          resolvedMethodName, _argTypesUnaryInt, TR::Int32, rc, 2, 1, &intDataArray[i]);
       OMR_CT_EXPECT_EQ(iUnaryCons, byteswap(intDataArray[i]), iUnaryCons(INT_PLACEHOLDER_1));
       }
    }
@@ -2149,8 +2149,8 @@ void
 X86OpCodesTest::invokeNoHelperUnaryTests()
    {
    int32_t rc = 0;
-   _d2l = (signatureCharD_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::d2l, "d2l", _argTypesUnaryDouble, TR::Int64, rc));
-   _f2l = (signatureCharF_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::f2l, "f2l", _argTypesUnaryFloat, TR::Int64, rc));
+   compileOpCodeMethod(_d2l, _numberOfUnaryArgs, TR::d2l, "d2l", _argTypesUnaryDouble, TR::Int64, rc);
+   compileOpCodeMethod(_f2l, _numberOfUnaryArgs, TR::f2l, "f2l", _argTypesUnaryFloat, TR::Int64, rc);
 
    _f2l(FLOAT_MAXIMUM);
    _f2l(FLOAT_MINIMUM);
@@ -2656,18 +2656,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_lCmpeq, compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), _lCmpeq(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpeqConst1_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpeqDataArr[i][0]), 2, &(lCmpeqDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpeqDataArr[i][0]), 2, &(lCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lCmpeqConst2_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpeqDataArr[i][0])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpeqConst3_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpeqDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(lCmpeqDataArr[i][0], lCmpeqDataArr[i][1]), lCompareConst(lCmpeqDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -2678,18 +2678,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_lCmplt, compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), _lCmplt(lCmpltDataArr[i][0], lCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpltConst1_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpltDataArr[i][0]), 2, &(lCmpltDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpltDataArr[i][0]), 2, &(lCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lCmpltConst2_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpltDataArr[i][0])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpltConst3_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpltDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareLT(lCmpltDataArr[i][0], lCmpltDataArr[i][1]), lCompareConst(lCmpltDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -2700,18 +2700,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_dCmpeq, compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), _dCmpeq(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpeqConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpeqDataArr[i][0]), 2, &(dCmpeqDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpeqDataArr[i][0]), 2, &(dCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpeqConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpeqDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpeqConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpeqDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(dCmpeqDataArr[i][0], dCmpeqDataArr[i][1]), dCompareConst(dCmpeqDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -2721,18 +2721,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_dCmpne, compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), _dCmpne(dCmpneDataArr[i][0], dCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpneConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpneDataArr[i][0]), 2, &(dCmpneDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpneDataArr[i][0]), 2, &(dCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpneConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpneDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpneConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpneDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareNE(dCmpneDataArr[i][0], dCmpneDataArr[i][1]), dCompareConst(dCmpneDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -2742,18 +2742,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_dCmpgt, compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), _dCmpgt(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpgtConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpgtDataArr[i][0]), 2, &(dCmpgtDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpgtDataArr[i][0]), 2, &(dCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpgtConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpgtDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpgtConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpgtDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGT(dCmpgtDataArr[i][0], dCmpgtDataArr[i][1]), dCompareConst(dCmpgtDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -2763,18 +2763,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_dCmplt, compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), _dCmplt(dCmpltDataArr[i][0], dCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpltConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpltDataArr[i][0]), 2, &(dCmpltDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpltDataArr[i][0]), 2, &(dCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpltConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpltDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpltConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpltDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLT(dCmpltDataArr[i][0], dCmpltDataArr[i][1]), dCompareConst(dCmpltDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -2784,18 +2784,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_dCmpge, compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), _dCmpge(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpgeConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpgeDataArr[i][0]), 2, &(dCmpgeDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpgeDataArr[i][0]), 2, &(dCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpgeConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpgeDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpgeConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpgeDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGE(dCmpgeDataArr[i][0], dCmpgeDataArr[i][1]), dCompareConst(dCmpgeDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -2805,18 +2805,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_dCmple, compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), _dCmple(dCmpleDataArr[i][0], dCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpleConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpleDataArr[i][0]), 2, &(dCmpleDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpleDataArr[i][0]), 2, &(dCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "dCmpleConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpleDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "dCmpleConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpleDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLE(dCmpleDataArr[i][0], dCmpleDataArr[i][1]), dCompareConst(dCmpleDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -2827,18 +2827,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_fCmpeq, compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), _fCmpeq(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpeqConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpeqDataArr[i][0]), 2, &(fCmpeqDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpeqDataArr[i][0]), 2, &(fCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpeqConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpeqDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpeqConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpeqDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(fCmpeqDataArr[i][0], fCmpeqDataArr[i][1]), fCompareConst(fCmpeqDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -2848,18 +2848,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_fCmpne, compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), _fCmpne(fCmpneDataArr[i][0], fCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpneConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpneDataArr[i][0]), 2, &(fCmpneDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpneDataArr[i][0]), 2, &(fCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpneConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpneDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpneConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpneDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareNE(fCmpneDataArr[i][0], fCmpneDataArr[i][1]), fCompareConst(fCmpneDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -2869,18 +2869,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_fCmpgt, compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), _fCmpgt(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpgtConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpgtDataArr[i][0]), 2, &(fCmpgtDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpgtDataArr[i][0]), 2, &(fCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpgtConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpgtDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpgtConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpgtDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGT(fCmpgtDataArr[i][0], fCmpgtDataArr[i][1]), fCompareConst(fCmpgtDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -2890,18 +2890,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_fCmplt, compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), _fCmplt(fCmpltDataArr[i][0], fCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpltConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpltDataArr[i][0]), 2, &(fCmpltDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpltDataArr[i][0]), 2, &(fCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpltConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpltDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpltConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpltDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLT(fCmpltDataArr[i][0], fCmpltDataArr[i][1]), fCompareConst(fCmpltDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -2911,18 +2911,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_fCmpge, compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), _fCmpge(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpgeConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpgeDataArr[i][0]), 2, &(fCmpgeDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpgeDataArr[i][0]), 2, &(fCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpgeConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpgeDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpgeConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpgeDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGE(fCmpgeDataArr[i][0], fCmpgeDataArr[i][1]), fCompareConst(fCmpgeDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -2932,18 +2932,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_fCmple, compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), _fCmple(fCmpleDataArr[i][0], fCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpleConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpleDataArr[i][0]), 2, &(fCmpleDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpleDataArr[i][0]), 2, &(fCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "fCmpleConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpleDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "fCmpleConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpleDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLE(fCmpleDataArr[i][0], fCmpleDataArr[i][1]), fCompareConst(fCmpleDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -2955,18 +2955,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_sCmpeq, compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), _sCmpeq(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpeqConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpeqDataArr[i][0]), 2, &(sCmpeqDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpeqDataArr[i][0]), 2, &(sCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpeqConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpeqDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpeqConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpeqDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(sCmpeqDataArr[i][0], sCmpeqDataArr[i][1]), sCompareConst(sCmpeqDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -2976,18 +2976,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_sCmpne, compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), _sCmpne(sCmpneDataArr[i][0], sCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpneConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpneDataArr[i][0]), 2, &(sCmpneDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpneDataArr[i][0]), 2, &(sCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpneConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpneDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpneConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpneDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareNE(sCmpneDataArr[i][0], sCmpneDataArr[i][1]), sCompareConst(sCmpneDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -2997,18 +2997,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_sCmpgt, compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), _sCmpgt(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpgtConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpgtDataArr[i][0]), 2, &(sCmpgtDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpgtDataArr[i][0]), 2, &(sCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpgtConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpgtDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpgtConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpgtDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGT(sCmpgtDataArr[i][0], sCmpgtDataArr[i][1]), sCompareConst(sCmpgtDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -3018,18 +3018,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_sCmplt, compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), _sCmplt(sCmpltDataArr[i][0], sCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpltConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpltDataArr[i][0]), 2, &(sCmpltDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpltDataArr[i][0]), 2, &(sCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpltConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpltDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpltConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpltDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLT(sCmpltDataArr[i][0], sCmpltDataArr[i][1]), sCompareConst(sCmpltDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -3039,18 +3039,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_sCmpge, compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), _sCmpge(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpgeConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpgeDataArr[i][0]), 2, &(sCmpgeDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpgeDataArr[i][0]), 2, &(sCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpgeConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpgeDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpgeConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpgeDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGE(sCmpgeDataArr[i][0], sCmpgeDataArr[i][1]), sCompareConst(sCmpgeDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -3060,18 +3060,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_sCmple, compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), _sCmple(sCmpleDataArr[i][0], sCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpleConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpleDataArr[i][0]), 2, &(sCmpleDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(sCmpleDataArr[i][0]), 2, &(sCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "sCmpleConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpleDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(sCmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, sCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "sCmpleConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::scmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpleDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::scmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(sCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLE(sCmpleDataArr[i][0], sCmpleDataArr[i][1]), sCompareConst(sCmpleDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -3082,18 +3082,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_bCmpeq, compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), _bCmpeq(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpeqConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpeqDataArr[i][0]), 2, &(bCmpeqDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpeqDataArr[i][0]), 2, &(bCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpeqConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpeqDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpeqConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpeqDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(bCmpeqDataArr[i][0], bCmpeqDataArr[i][1]), bCompareConst(bCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3103,18 +3103,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_bCmpgt, compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), _bCmpgt(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpgtConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpgtDataArr[i][0]), 2, &(bCmpgtDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpgtDataArr[i][0]), 2, &(bCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpgtConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpgtDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpgtConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpgtDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGT(bCmpgtDataArr[i][0], bCmpgtDataArr[i][1]), bCompareConst(bCmpgtDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3124,18 +3124,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_bCmplt, compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), _bCmplt(bCmpltDataArr[i][0], bCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpltConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpltDataArr[i][0]), 2, &(bCmpltDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpltDataArr[i][0]), 2, &(bCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpltConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpltDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpltConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpltDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLT(bCmpltDataArr[i][0], bCmpltDataArr[i][1]), bCompareConst(bCmpltDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3145,18 +3145,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_bCmpge, compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), _bCmpge(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpgeConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpgeDataArr[i][0]), 2, &(bCmpgeDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpgeDataArr[i][0]), 2, &(bCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpgeConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpgeDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpgeConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpgeDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGE(bCmpgeDataArr[i][0], bCmpgeDataArr[i][1]), bCompareConst(bCmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3167,18 +3167,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_bCmpne, compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), _bCmpne(bCmpneDataArr[i][0], bCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpneConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpneDataArr[i][0]), 2, &(bCmpneDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpneDataArr[i][0]), 2, &(bCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpneConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpneDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpneConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpneDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareNE(bCmpneDataArr[i][0], bCmpneDataArr[i][1]), bCompareConst(bCmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3188,18 +3188,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_bCmple, compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), _bCmple(bCmpleDataArr[i][0], bCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpleConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpleDataArr[i][0]), 2, &(bCmpleDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(bCmpleDataArr[i][0]), 2, &(bCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "bCmpleConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpleDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(bCmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, bCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "bCmpleConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpleDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::bcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(bCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLE(bCmpleDataArr[i][0], bCmpleDataArr[i][1]), bCompareConst(bCmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3210,18 +3210,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_lCmp, comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), _lCmp(lCmpDataArr[i][0], lCmpDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpConst1_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmp, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpDataArr[i][0]), 2, &(lCmpDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmp, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(lCmpDataArr[i][0]), 2, &(lCmpDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "lCmpConst2_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmp, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpDataArr[i][0])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmp, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(lCmpDataArr[i][0]));
       OMR_CT_EXPECT_EQ(lCompareConst, comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, lCmpDataArr[i][1]));
 
       sprintf(resolvedMethodName, "lCmpConst3_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::lcmp, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::lcmp, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(lCmpDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, comparel(lCmpDataArr[i][0], lCmpDataArr[i][1]), lCompareConst(lCmpDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -3233,20 +3233,20 @@ X86OpCodesTest::invokeCompareTests()
             dCmplDataArr[i][0] << " : " << dCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmplConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpl, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmplDataArr[i][0]), 2, &(dCmplDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpl, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmplDataArr[i][0]), 2, &(dCmplDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2)) <<
             dCmplDataArr[i][0] << " : " << dCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmplConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpl, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmplDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpl, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmplDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmplDataArr[i][1])) <<
             dCmplDataArr[i][0] << " : " << dCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmplConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpl, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmplDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpl, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmplDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, comparel(dCmplDataArr[i][0], dCmplDataArr[i][1]), dCompareConst(dCmplDataArr[i][0], DOUBLE_PLACEHOLDER_2)) <<
             dCmplDataArr[i][0] << " : " << dCmplDataArr[i][1];
       }
@@ -3259,20 +3259,20 @@ X86OpCodesTest::invokeCompareTests()
             dCmpgDataArr[i][0] << " : " << dCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmpgConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpg, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpgDataArr[i][0]), 2, &(dCmpgDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpg, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(dCmpgDataArr[i][0]), 2, &(dCmpgDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2)) <<
             dCmpgDataArr[i][0] << " : " << dCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmpgConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpg, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpgDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpg, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(dCmpgDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, dCmpgDataArr[i][1])) <<
             dCmpgDataArr[i][0] << " : " << dCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "dCmpgConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::dcmpg, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpgDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::dcmpg, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(dCmpgDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareg(dCmpgDataArr[i][0], dCmpgDataArr[i][1]), dCompareConst(dCmpgDataArr[i][0], DOUBLE_PLACEHOLDER_2)) <<
             dCmpgDataArr[i][0] << " : " << dCmpgDataArr[i][1];
       }
@@ -3285,20 +3285,20 @@ X86OpCodesTest::invokeCompareTests()
             fCmplDataArr[i][0] << " : " << fCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmplConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpl, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmplDataArr[i][0]), 2, &(fCmplDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpl, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmplDataArr[i][0]), 2, &(fCmplDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2)) <<
             fCmplDataArr[i][0] << " : " << fCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmplConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpl, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmplDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpl, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmplDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmplDataArr[i][1])) <<
             fCmplDataArr[i][0] << " : " << fCmplDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmplConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpl, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmplDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpl, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmplDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, comparel(fCmplDataArr[i][0], fCmplDataArr[i][1]), fCompareConst(fCmplDataArr[i][0], FLOAT_PLACEHOLDER_2)) <<
             fCmplDataArr[i][0] << " : " << fCmplDataArr[i][1];
       }
@@ -3311,20 +3311,20 @@ X86OpCodesTest::invokeCompareTests()
             fCmpgDataArr[i][0] << " : " << fCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmpgConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpg, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpgDataArr[i][0]), 2, &(fCmpgDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpg, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(fCmpgDataArr[i][0]), 2, &(fCmpgDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2)) <<
             fCmpgDataArr[i][0] << " : " << fCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmpgConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpg, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpgDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpg, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(fCmpgDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, fCmpgDataArr[i][1])) <<
             fCmpgDataArr[i][0] << " : " << fCmpgDataArr[i][1];
 
       sprintf(resolvedMethodName, "fCmpgConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::fcmpg, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpgDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::fcmpg, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(fCmpgDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareg(fCmpgDataArr[i][0], fCmpgDataArr[i][1]), fCompareConst(fCmpgDataArr[i][0], FLOAT_PLACEHOLDER_2)) <<
             fCmpgDataArr[i][0] << " : " << fCmpgDataArr[i][1];
       }
@@ -3336,18 +3336,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifLcmpeq, compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), _ifLcmpeq(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpeqConst1_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpeqDataArr[i][0]), 2, &(ifLcmpeqDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpeqDataArr[i][0]), 2, &(ifLcmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLcmpeqConst2_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpeqDataArr[i][0])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpeqConst3_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpeqDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmpeq, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareEQ(ifLcmpeqDataArr[i][0], ifLcmpeqDataArr[i][1]), lCompareConst(ifLcmpeqDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -3357,18 +3357,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifLcmpgt, compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), _ifLcmpgt(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpgtConst1_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpgtDataArr[i][0]), 2, &(ifLcmpgtDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpgtDataArr[i][0]), 2, &(ifLcmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLcmpgtConst2_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpgtDataArr[i][0])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpgtConst3_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpgtDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmpgt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareGT(ifLcmpgtDataArr[i][0], ifLcmpgtDataArr[i][1]), lCompareConst(ifLcmpgtDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -3378,18 +3378,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifLcmplt, compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), _ifLcmplt(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpltConst1_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpltDataArr[i][0]), 2, &(ifLcmpltDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 4, 1, &(ifLcmpltDataArr[i][0]), 2, &(ifLcmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifLcmpltConst2_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpltDataArr[i][0])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 1, &(ifLcmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), lCompareConst(LONG_PLACEHOLDER_1, ifLcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifLcmpltConst3_TestCase%d", i + 1);
-      lCompareConst = (signatureCharJJ_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iflcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpltDataArr[i][1])));
+      compileOpCodeMethod(lCompareConst, 
+            _numberOfBinaryArgs, TR::iflcmplt, resolvedMethodName, _argTypesBinaryLong, TR::Int32, rc, 2, 2, &(ifLcmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(lCompareConst, compareLT(ifLcmpltDataArr[i][0], ifLcmpltDataArr[i][1]), lCompareConst(ifLcmpltDataArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -3400,18 +3400,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifDcmpeq, compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), _ifDcmpeq(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpeqConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpeqDataArr[i][0]), 2, &(ifDcmpeqDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpeqDataArr[i][0]), 2, &(ifDcmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpeqConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpeqDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpeqConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpeqDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpeq, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareEQ(ifDcmpeqDataArr[i][0], ifDcmpeqDataArr[i][1]), dCompareConst(ifDcmpeqDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -3421,18 +3421,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifDcmpne, compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), _ifDcmpne(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpneConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpneDataArr[i][0]), 2, &(ifDcmpneDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpneDataArr[i][0]), 2, &(ifDcmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpneConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpneDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpneConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpneDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpne, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareNE(ifDcmpneDataArr[i][0], ifDcmpneDataArr[i][1]), dCompareConst(ifDcmpneDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -3442,18 +3442,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifDcmpgt, compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), _ifDcmpgt(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpgtConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpgtDataArr[i][0]), 2, &(ifDcmpgtDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpgtDataArr[i][0]), 2, &(ifDcmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpgtConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpgtDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpgtConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpgtDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpgt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGT(ifDcmpgtDataArr[i][0], ifDcmpgtDataArr[i][1]), dCompareConst(ifDcmpgtDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -3463,18 +3463,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifDcmplt, compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), _ifDcmplt(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpltConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpltDataArr[i][0]), 2, &(ifDcmpltDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpltDataArr[i][0]), 2, &(ifDcmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpltConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpltDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpltConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpltDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmplt, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLT(ifDcmpltDataArr[i][0], ifDcmpltDataArr[i][1]), dCompareConst(ifDcmpltDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -3484,18 +3484,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifDcmpge, compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), _ifDcmpge(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpgeConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpgeDataArr[i][0]), 2, &(ifDcmpgeDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpgeDataArr[i][0]), 2, &(ifDcmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpgeConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpgeDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpgeConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpgeDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmpge, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareGE(ifDcmpgeDataArr[i][0], ifDcmpgeDataArr[i][1]), dCompareConst(ifDcmpgeDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -3505,18 +3505,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifDcmple, compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), _ifDcmple(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpleConst1_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpleDataArr[i][0]), 2, &(ifDcmpleDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 4, 1, &(ifDcmpleDataArr[i][0]), 2, &(ifDcmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifDcmpleConst2_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpleDataArr[i][0])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 1, &(ifDcmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), dCompareConst(DOUBLE_PLACEHOLDER_1, ifDcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifDcmpleConst3_TestCase%d", i + 1);
-      dCompareConst = (signatureCharDD_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifdcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpleDataArr[i][1])));
+      compileOpCodeMethod(dCompareConst, 
+            _numberOfBinaryArgs, TR::ifdcmple, resolvedMethodName, _argTypesBinaryDouble, TR::Int32, rc, 2, 2, &(ifDcmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(dCompareConst, compareLE(ifDcmpleDataArr[i][0], ifDcmpleDataArr[i][1]), dCompareConst(ifDcmpleDataArr[i][0], DOUBLE_PLACEHOLDER_2));
       }
 
@@ -3527,18 +3527,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifFcmpeq, compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), _ifFcmpeq(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpeqConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpeqDataArr[i][0]), 2, &(ifFcmpeqDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpeqDataArr[i][0]), 2, &(ifFcmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpeqConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpeqDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpeqConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpeqDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpeq, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareEQ(ifFcmpeqDataArr[i][0], ifFcmpeqDataArr[i][1]), fCompareConst(ifFcmpeqDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -3548,18 +3548,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifFcmpne, compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), _ifFcmpne(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpneConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpneDataArr[i][0]), 2, &(ifFcmpneDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpneDataArr[i][0]), 2, &(ifFcmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpneConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpneDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpneConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpneDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpne, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareNE(ifFcmpneDataArr[i][0], ifFcmpneDataArr[i][1]), fCompareConst(ifFcmpneDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -3569,18 +3569,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifFcmpgt, compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), _ifFcmpgt(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpgtConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpgtDataArr[i][0]), 2, &(ifFcmpgtDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpgtDataArr[i][0]), 2, &(ifFcmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpgtConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpgtDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpgtConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpgtDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpgt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGT(ifFcmpgtDataArr[i][0], ifFcmpgtDataArr[i][1]), fCompareConst(ifFcmpgtDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -3590,18 +3590,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifFcmplt, compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), _ifFcmplt(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpltConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpltDataArr[i][0]), 2, &(ifFcmpltDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpltDataArr[i][0]), 2, &(ifFcmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpltConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpltDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpltConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpltDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmplt, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLT(ifFcmpltDataArr[i][0], ifFcmpltDataArr[i][1]), fCompareConst(ifFcmpltDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -3611,18 +3611,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifFcmpge, compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), _ifFcmpge(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpgeConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpgeDataArr[i][0]), 2, &(ifFcmpgeDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpgeDataArr[i][0]), 2, &(ifFcmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpgeConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpgeDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpgeConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpgeDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmpge, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareGE(ifFcmpgeDataArr[i][0], ifFcmpgeDataArr[i][1]), fCompareConst(ifFcmpgeDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -3632,18 +3632,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifFcmple, compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), _ifFcmple(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpleConst1_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpleDataArr[i][0]), 2, &(ifFcmpleDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 4, 1, &(ifFcmpleDataArr[i][0]), 2, &(ifFcmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifFcmpleConst2_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpleDataArr[i][0])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 1, &(ifFcmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), fCompareConst(FLOAT_PLACEHOLDER_1, ifFcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifFcmpleConst3_TestCase%d", i + 1);
-      fCompareConst = (signatureCharFF_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iffcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpleDataArr[i][1])));
+      compileOpCodeMethod(fCompareConst, 
+            _numberOfBinaryArgs, TR::iffcmple, resolvedMethodName, _argTypesBinaryFloat, TR::Int32, rc, 2, 2, &(ifFcmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(fCompareConst, compareLE(ifFcmpleDataArr[i][0], ifFcmpleDataArr[i][1]), fCompareConst(ifFcmpleDataArr[i][0], FLOAT_PLACEHOLDER_2));
       }
 
@@ -3654,18 +3654,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifScmpeq, compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), _ifScmpeq(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpeqConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpeqDataArr[i][0]), 2, &(ifScmpeqDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpeqDataArr[i][0]), 2, &(ifScmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpeqConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpeqDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpeqConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpeqDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareEQ(ifScmpeqDataArr[i][0], ifScmpeqDataArr[i][1]), sCompareConst(ifScmpeqDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -3675,18 +3675,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifScmpne, compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), _ifScmpne(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpneConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpneDataArr[i][0]), 2, &(ifScmpneDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpneDataArr[i][0]), 2, &(ifScmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpneConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpneDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpneConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpneDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareNE(ifScmpneDataArr[i][0], ifScmpneDataArr[i][1]), sCompareConst(ifScmpneDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -3696,18 +3696,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifScmpgt, compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), _ifScmpgt(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpgtConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpgtDataArr[i][0]), 2, &(ifScmpgtDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpgtDataArr[i][0]), 2, &(ifScmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpgtConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpgtDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpgtConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpgtDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGT(ifScmpgtDataArr[i][0], ifScmpgtDataArr[i][1]), sCompareConst(ifScmpgtDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -3717,18 +3717,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifScmplt, compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), _ifScmplt(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpltConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpltDataArr[i][0]), 2, &(ifScmpltDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpltDataArr[i][0]), 2, &(ifScmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpltConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpltDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpltConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpltDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLT(ifScmpltDataArr[i][0], ifScmpltDataArr[i][1]), sCompareConst(ifScmpltDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -3738,18 +3738,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifScmpge, compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), _ifScmpge(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpgeConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpgeDataArr[i][0]), 2, &(ifScmpgeDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpgeDataArr[i][0]), 2, &(ifScmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpgeConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpgeDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpgeConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpgeDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareGE(ifScmpgeDataArr[i][0], ifScmpgeDataArr[i][1]), sCompareConst(ifScmpgeDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -3759,18 +3759,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifScmple, compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), _ifScmple(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpleConst1_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpleDataArr[i][0]), 2, &(ifScmpleDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifScmpleDataArr[i][0]), 2, &(ifScmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifScmpleConst2_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpleDataArr[i][0])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifScmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), sCompareConst(SHORT_PLACEHOLDER_1, ifScmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifScmpleConst3_TestCase%d", i + 1);
-      sCompareConst = (signatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifscmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpleDataArr[i][1])));
+      compileOpCodeMethod(sCompareConst, 
+            _numberOfBinaryArgs, TR::ifscmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifScmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(sCompareConst, compareLE(ifScmpleDataArr[i][0], ifScmpleDataArr[i][1]), sCompareConst(ifScmpleDataArr[i][0], SHORT_PLACEHOLDER_2));
       }
 
@@ -3781,18 +3781,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifBcmpeq, compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), _ifBcmpeq(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpeqConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpeqDataArr[i][0]), 2, &(ifBcmpeqDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpeqDataArr[i][0]), 2, &(ifBcmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpeqConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpeqDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpeqConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpeqDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareEQ(ifBcmpeqDataArr[i][0], ifBcmpeqDataArr[i][1]), bCompareConst(ifBcmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3802,18 +3802,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifBcmpgt, compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), _ifBcmpgt(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpgtConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpgtDataArr[i][0]), 2, &(ifBcmpgtDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpgtDataArr[i][0]), 2, &(ifBcmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpgtConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpgtDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpgtConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpgtDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGT(ifBcmpgtDataArr[i][0], ifBcmpgtDataArr[i][1]), bCompareConst(ifBcmpgtDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3823,18 +3823,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifBcmplt, compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), _ifBcmplt(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpltConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpltDataArr[i][0]), 2, &(ifBcmpltDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpltDataArr[i][0]), 2, &(ifBcmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpltConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpltDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpltConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpltDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLT(ifBcmpltDataArr[i][0], ifBcmpltDataArr[i][1]), bCompareConst(ifBcmpltDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3844,18 +3844,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifBcmpge, compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), _ifBcmpge(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpgeConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpgeDataArr[i][0]), 2, &(ifBcmpgeDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpgeDataArr[i][0]), 2, &(ifBcmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpgeConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpgeDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpgeConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpgeDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(ifBcmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3865,18 +3865,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifBcmpne, compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), _ifBcmpne(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpneConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpneDataArr[i][0]), 2, &(ifBcmpneDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpneDataArr[i][0]), 2, &(ifBcmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpneConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpneDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpneConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpneDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareNE(ifBcmpneDataArr[i][0], ifBcmpneDataArr[i][1]), bCompareConst(ifBcmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3886,18 +3886,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifBcmple, compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), _ifBcmple(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpleConst1_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpleDataArr[i][0]), 2, &(ifBcmpleDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBcmpleDataArr[i][0]), 2, &(ifBcmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBcmpleConst2_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpleDataArr[i][0])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBcmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(BYTE_PLACEHOLDER_1, ifBcmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBcmpleConst3_TestCase%d", i + 1);
-      bCompareConst = (signatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpleDataArr[i][1])));
+      compileOpCodeMethod(bCompareConst, 
+            _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(ifBcmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3908,18 +3908,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_iuCmpeq, compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), _iuCmpeq(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpeqConst1_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpeqDataArr[i][0]), 2, &(iuCmpeqDataArr[i][1])));
+      compileOpCodeMethod(iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpeqDataArr[i][0]), 2, &(iuCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iuCmpeqConst2_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpeqDataArr[i][0])));
+      compileOpCodeMethod(iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpeqConst3_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpeqDataArr[i][1])));
+      compileOpCodeMethod(iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpeq, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareEQ(iuCmpeqDataArr[i][0], iuCmpeqDataArr[i][1]), iuCompareConst(iuCmpeqDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -3929,18 +3929,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_iuCmpne, compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), _iuCmpne(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpneConst1_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpneDataArr[i][0]), 2, &(iuCmpneDataArr[i][1])));
+      compileOpCodeMethod(iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpneDataArr[i][0]), 2, &(iuCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iuCmpneConst2_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpneDataArr[i][0])));
+      compileOpCodeMethod(iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpneConst3_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpneDataArr[i][1])));
+      compileOpCodeMethod(iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpne, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareNE(iuCmpneDataArr[i][0], iuCmpneDataArr[i][1]), iuCompareConst(iuCmpneDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -3950,18 +3950,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_iuCmpge, compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), _iuCmpge(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpgeConst1_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpgeDataArr[i][0]), 2, &(iuCmpgeDataArr[i][1])));
+      compileOpCodeMethod(iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 4, 1, &(iuCmpgeDataArr[i][0]), 2, &(iuCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "iuCmpgeConst2_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpgeDataArr[i][0])));
+      compileOpCodeMethod(iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 1, &(iuCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(INT_PLACEHOLDER_1, iuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "iuCmpgeConst3_TestCase%d", i + 1);
-      iuCompareConst = (unsignedCompareSignatureCharII_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::iucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpgeDataArr[i][1])));
+      compileOpCodeMethod(iuCompareConst, 
+            _numberOfBinaryArgs, TR::iucmpge, resolvedMethodName, _argTypesBinaryInt, TR::Int32, rc, 2, 2, &(iuCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(iuCompareConst, compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(iuCmpgeDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
@@ -3972,18 +3972,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_buCmpeq, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), _buCmpeq(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buCmpeqConst1_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(buCmpeqDataArr[i][0]), 2, &(buCmpeqDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(buCmpeqDataArr[i][0]), 2, &(buCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "buCmpeqConst2_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(buCmpeqDataArr[i][0])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(buCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, buCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buCmpeqConst3_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(buCmpeqDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(buCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(buCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -3993,18 +3993,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_buCmpne, compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), _buCmpne(buCmpneDataArr[i][0], buCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buCmpneConst1_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(buCmpneDataArr[i][0]), 2, &(buCmpneDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::bucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(buCmpneDataArr[i][0]), 2, &(buCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "buCmpneConst2_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(buCmpneDataArr[i][0])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::bucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(buCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, buCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "buCmpneConst3_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::bucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(buCmpneDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::bucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(buCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareNE(buCmpneDataArr[i][0], buCmpneDataArr[i][1]), buCompareConst(buCmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -4015,18 +4015,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_suCmpeq, compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), _suCmpeq(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1])) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpeqConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpeqDataArr[i][0]), 2, &(suCmpeqDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpeqDataArr[i][0]), 2, &(suCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpeqConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpeqDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpeqDataArr[i][1])) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpeqConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpeqDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(suCmpeqDataArr[i][0], suCmpeqDataArr[i][1]), suCompareConst(suCmpeqDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpeqDataArr[i][0] << " : " << suCmpeqDataArr[i][1];
       }
 
@@ -4036,18 +4036,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_suCmpne, compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), _suCmpne(suCmpneDataArr[i][0], suCmpneDataArr[i][1])) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpneConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpneDataArr[i][0]), 2, &(suCmpneDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpneDataArr[i][0]), 2, &(suCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpneConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpneDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpneDataArr[i][1])) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpneConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpneDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareNE(suCmpneDataArr[i][0], suCmpneDataArr[i][1]), suCompareConst(suCmpneDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpneDataArr[i][0] << " : " << suCmpneDataArr[i][1];
       }
 
@@ -4057,18 +4057,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_suCmpgt, compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), _suCmpgt(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1])) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgtConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpgtDataArr[i][0]), 2, &(suCmpgtDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpgtDataArr[i][0]), 2, &(suCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgtConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpgtDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpgtDataArr[i][1])) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgtConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpgtDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGT(suCmpgtDataArr[i][0], suCmpgtDataArr[i][1]), suCompareConst(suCmpgtDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpgtDataArr[i][0] << " : " << suCmpgtDataArr[i][1];
       }
 
@@ -4078,18 +4078,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_suCmplt, compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), _suCmplt(suCmpltDataArr[i][0], suCmpltDataArr[i][1])) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpltConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpltDataArr[i][0]), 2, &(suCmpltDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpltDataArr[i][0]), 2, &(suCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpltConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpltDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpltDataArr[i][1])) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpltConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpltDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLT(suCmpltDataArr[i][0], suCmpltDataArr[i][1]), suCompareConst(suCmpltDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpltDataArr[i][0] << " : " << suCmpltDataArr[i][1];
       }
 
@@ -4099,18 +4099,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_suCmpge, compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), _suCmpge(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1])) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgeConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpgeDataArr[i][0]), 2, &(suCmpgeDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpgeDataArr[i][0]), 2, &(suCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgeConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpgeDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpgeDataArr[i][1])) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpgeConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpgeDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGE(suCmpgeDataArr[i][0], suCmpgeDataArr[i][1]), suCompareConst(suCmpgeDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpgeDataArr[i][0] << " : " << suCmpgeDataArr[i][1];
       }
 
@@ -4120,18 +4120,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_suCmple, compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), _suCmple(suCmpleDataArr[i][0], suCmpleDataArr[i][1])) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpleConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpleDataArr[i][0]), 2, &(suCmpleDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(suCmpleDataArr[i][0]), 2, &(suCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpleConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpleDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(suCmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, suCmpleDataArr[i][1])) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "suCmpleConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpleDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(suCmpleDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
       }
 
@@ -4142,18 +4142,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifBuCmpeq, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), _ifBuCmpeq(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpeqConst1_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpeqDataArr[i][0]), 2, &(ifBuCmpeqDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpeqDataArr[i][0]), 2, &(ifBuCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpeqConst2_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpeqDataArr[i][0])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpeqConst3_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpeqDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(ifBuCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -4163,18 +4163,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifBuCmpne, compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), _ifBuCmpne(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpneConst1_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpneDataArr[i][0]), 2, &(ifBuCmpneDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpneDataArr[i][0]), 2, &(ifBuCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpneConst2_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpneDataArr[i][0])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpneConst3_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpneDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpne, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareNE(ifBuCmpneDataArr[i][0], ifBuCmpneDataArr[i][1]), buCompareConst(ifBuCmpneDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -4184,18 +4184,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifBuCmpgt, compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), _ifBuCmpgt(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpgtConst1_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpgtDataArr[i][0]), 2, &(ifBuCmpgtDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpgtDataArr[i][0]), 2, &(ifBuCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpgtConst2_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpgtDataArr[i][0])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpgtConst3_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpgtDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpgt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareGT(ifBuCmpgtDataArr[i][0], ifBuCmpgtDataArr[i][1]), buCompareConst(ifBuCmpgtDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -4205,18 +4205,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifBuCmplt, compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), _ifBuCmplt(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpltConst1_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpltDataArr[i][0]), 2, &(ifBuCmpltDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpltDataArr[i][0]), 2, &(ifBuCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpltConst2_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpltDataArr[i][0])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpltConst3_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpltDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmplt, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareLT(ifBuCmpltDataArr[i][0], ifBuCmpltDataArr[i][1]), buCompareConst(ifBuCmpltDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -4226,18 +4226,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifBuCmpge, compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), _ifBuCmpge(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpgeConst1_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpgeDataArr[i][0]), 2, &(ifBuCmpgeDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpgeDataArr[i][0]), 2, &(ifBuCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpgeConst2_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpgeDataArr[i][0])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpgeConst3_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpgeDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmpge, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareGE(ifBuCmpgeDataArr[i][0], ifBuCmpgeDataArr[i][1]), buCompareConst(ifBuCmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -4247,18 +4247,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifBuCmple, compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), _ifBuCmple(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpleConst1_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpleDataArr[i][0]), 2, &(ifBuCmpleDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpleDataArr[i][0]), 2, &(ifBuCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifBuCmpleConst2_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpleDataArr[i][0])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifBuCmpleConst3_TestCase%d", i + 1);
-      buCompareConst = (unsignedCompareSignatureCharBB_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifbucmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpleDataArr[i][1])));
+      compileOpCodeMethod(buCompareConst, 
+            _numberOfBinaryArgs, TR::ifbucmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(buCompareConst, compareLE(ifBuCmpleDataArr[i][0], ifBuCmpleDataArr[i][1]), buCompareConst(ifBuCmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
@@ -4269,18 +4269,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifSuCmpeq, compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), _ifSuCmpeq(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1])) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpeqConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpeqDataArr[i][0]), 2, &(ifSuCmpeqDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpeqDataArr[i][0]), 2, &(ifSuCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpeqConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpeqDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpeqDataArr[i][1])) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpeqConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpeqDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpeq, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareEQ(ifSuCmpeqDataArr[i][0], ifSuCmpeqDataArr[i][1]), suCompareConst(ifSuCmpeqDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpeqDataArr[i][0] << " : " << ifSuCmpeqDataArr[i][1];
       }
 
@@ -4290,18 +4290,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifSuCmpne, compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), _ifSuCmpne(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1])) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpneConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpneDataArr[i][0]), 2, &(ifSuCmpneDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpneDataArr[i][0]), 2, &(ifSuCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpneConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpneDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpneDataArr[i][1])) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpneConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpneDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpne, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareNE(ifSuCmpneDataArr[i][0], ifSuCmpneDataArr[i][1]), suCompareConst(ifSuCmpneDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpneDataArr[i][0] << " : " << ifSuCmpneDataArr[i][1];
       }
 
@@ -4311,18 +4311,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifSuCmpgt, compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), _ifSuCmpgt(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1])) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgtConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpgtDataArr[i][0]), 2, &(ifSuCmpgtDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpgtDataArr[i][0]), 2, &(ifSuCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgtConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpgtDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpgtDataArr[i][1])) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgtConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpgtDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpgt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGT(ifSuCmpgtDataArr[i][0], ifSuCmpgtDataArr[i][1]), suCompareConst(ifSuCmpgtDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpgtDataArr[i][0] << " : " << ifSuCmpgtDataArr[i][1];
       }
 
@@ -4332,18 +4332,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifSuCmplt, compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), _ifSuCmplt(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1])) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpltConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpltDataArr[i][0]), 2, &(ifSuCmpltDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpltDataArr[i][0]), 2, &(ifSuCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpltConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpltDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpltDataArr[i][1])) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpltConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpltDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmplt, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLT(ifSuCmpltDataArr[i][0], ifSuCmpltDataArr[i][1]), suCompareConst(ifSuCmpltDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpltDataArr[i][0] << " : " << ifSuCmpltDataArr[i][1];
       }
 
@@ -4353,18 +4353,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifSuCmpge, compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), _ifSuCmpge(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1])) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgeConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpgeDataArr[i][0]), 2, &(ifSuCmpgeDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpgeDataArr[i][0]), 2, &(ifSuCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgeConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpgeDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpgeDataArr[i][1])) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpgeConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpgeDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmpge, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareGE(ifSuCmpgeDataArr[i][0], ifSuCmpgeDataArr[i][1]), suCompareConst(ifSuCmpgeDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpgeDataArr[i][0] << " : " << ifSuCmpgeDataArr[i][1];
       }
 
@@ -4374,18 +4374,18 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(_ifSuCmple, compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), _ifSuCmple(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1])) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpleConst1_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpleDataArr[i][0]), 2, &(ifSuCmpleDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 4, 1, &(ifSuCmpleDataArr[i][0]), 2, &(ifSuCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2)) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpleConst2_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpleDataArr[i][0])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 1, &(ifSuCmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), suCompareConst(SHORT_PLACEHOLDER_1, ifSuCmpleDataArr[i][1])) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
 
       sprintf(resolvedMethodName, "ifSuCmpleConst3_TestCase%d", i + 1);
-      suCompareConst = (unsignedCompareSignatureCharSS_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifsucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpleDataArr[i][1])));
+      compileOpCodeMethod(suCompareConst, 
+            _numberOfBinaryArgs, TR::ifsucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(ifSuCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLE(ifSuCmpleDataArr[i][0], ifSuCmpleDataArr[i][1]), suCompareConst(ifSuCmpleDataArr[i][0], SHORT_PLACEHOLDER_2)) << ifSuCmpleDataArr[i][0] << " : " << ifSuCmpleDataArr[i][1];
       }
    }
@@ -4504,8 +4504,8 @@ X86OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_i2a, convert(intDataArr[i], ADDRESS_PLACEHOLDER_1), _i2a(intDataArr[i]));
 
       sprintf(resolvedMethodName, "i2aConst%d", i + 1);
-      i2aConst = (signatureCharI_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::i2a, resolvedMethodName, _argTypesUnaryInt, TR::Address, rc, 2, 1, &intDataArr[i]));
+      compileOpCodeMethod(i2aConst, 
+            _numberOfUnaryArgs, TR::i2a, resolvedMethodName, _argTypesUnaryInt, TR::Address, rc, 2, 1, &intDataArr[i]);
       OMR_CT_EXPECT_EQ(i2aConst, convert(intDataArr[i], ADDRESS_PLACEHOLDER_1), i2aConst(INT_PLACEHOLDER_1));
       }
 
@@ -4515,8 +4515,8 @@ X86OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_iu2a, convert(uintDataArr[i], ADDRESS_PLACEHOLDER_1), _iu2a(uintDataArr[i]));
 
       sprintf(resolvedMethodName, "iu2aConst%d", i + 1);
-      iu2aConst = (unsignedSignatureCharI_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::iu2a, resolvedMethodName, _argTypesUnaryInt, TR::Address, rc, 2, 1, &uintDataArr[i]));
+      compileOpCodeMethod(iu2aConst, 
+            _numberOfUnaryArgs, TR::iu2a, resolvedMethodName, _argTypesUnaryInt, TR::Address, rc, 2, 1, &uintDataArr[i]);
       OMR_CT_EXPECT_EQ(iu2aConst, convert(uintDataArr[i], ADDRESS_PLACEHOLDER_1), iu2aConst(INT_PLACEHOLDER_1));
       }
 
@@ -4526,8 +4526,8 @@ X86OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_a2s, convert(aUnaryDataArr[i], SHORT_POS), _a2s(aUnaryDataArr[i]));
 
       sprintf(resolvedMethodName, "a2sConst%d", i + 1);
-      a2sConst = (signatureCharL_S_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::a2s, resolvedMethodName, _argTypesUnaryAddress, TR::Int16, rc, 2, 1, &aUnaryDataArr[i]));
+      compileOpCodeMethod(a2sConst, 
+            _numberOfUnaryArgs, TR::a2s, resolvedMethodName, _argTypesUnaryAddress, TR::Int16, rc, 2, 1, &aUnaryDataArr[i]);
       OMR_CT_EXPECT_EQ(a2sConst, convert(aUnaryDataArr[i], SHORT_POS), a2sConst(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -4537,8 +4537,8 @@ X86OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_a2b, convert(aUnaryDataArr[i], BYTE_POS), _a2b(aUnaryDataArr[i]));
 
       sprintf(resolvedMethodName, "a2bConst%d", i + 1);
-      a2bConst = (signatureCharL_B_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::a2b, resolvedMethodName, _argTypesUnaryAddress, TR::Int8, rc, 2, 1, &aUnaryDataArr[i]));
+      compileOpCodeMethod(a2bConst, 
+            _numberOfUnaryArgs, TR::a2b, resolvedMethodName, _argTypesUnaryAddress, TR::Int8, rc, 2, 1, &aUnaryDataArr[i]);
       OMR_CT_EXPECT_EQ(a2bConst, convert(aUnaryDataArr[i], BYTE_POS), a2bConst(ADDRESS_PLACEHOLDER_1));
       }
 #endif //defined(TR_TARGET_32BIT)
@@ -4551,8 +4551,8 @@ X86OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_l2a, convert(longDataArr[i], ADDRESS_PLACEHOLDER_1), _l2a(longDataArr[i]));
 
       sprintf(resolvedMethodName, "l2aConst%d", i + 1);
-      l2aConst = (signatureCharJ_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::l2a, resolvedMethodName, _argTypesUnaryLong, TR::Address, rc, 2, 1, &longDataArr[i]));
+      compileOpCodeMethod(l2aConst, 
+            _numberOfUnaryArgs, TR::l2a, resolvedMethodName, _argTypesUnaryLong, TR::Address, rc, 2, 1, &longDataArr[i]);
       OMR_CT_EXPECT_EQ(l2aConst, convert(longDataArr[i], ADDRESS_PLACEHOLDER_1), l2aConst(LONG_PLACEHOLDER_1));
       }
 
@@ -4563,8 +4563,8 @@ X86OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_a2l, convert(aUnaryDataArr[i], LONG_POS), _a2l(aUnaryDataArr[i]));
 
       sprintf(resolvedMethodName, "a2lConst%d", i + 1);
-      a2lConst = (signatureCharL_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfUnaryArgs, TR::a2l, resolvedMethodName, _argTypesUnaryAddress, TR::Int64, rc, 2, 1, &aUnaryDataArr[i]));
+      compileOpCodeMethod(a2lConst, 
+            _numberOfUnaryArgs, TR::a2l, resolvedMethodName, _argTypesUnaryAddress, TR::Int64, rc, 2, 1, &aUnaryDataArr[i]);
       OMR_CT_EXPECT_EQ(a2lConst, convert(aUnaryDataArr[i], LONG_POS), a2lConst(ADDRESS_PLACEHOLDER_1));
       }
 
@@ -4575,18 +4575,18 @@ X86OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_acmpeq, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), _acmpeq(acmpeqDataArr[i][0], acmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpeqConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpeqDataArr[i][0]), 2, &(acmpeqDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpeqDataArr[i][0]), 2, &(acmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "aCmpeqConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpeqDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpeqConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpeqDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(acmpeqDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -4597,18 +4597,18 @@ X86OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_acmpne, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), _acmpne(acmpneDataArr[i][0], acmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpneConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpneDataArr[i][0]), 2, &(acmpneDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpneDataArr[i][0]), 2, &(acmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "aCmpneConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpneDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpneConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpneDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(acmpneDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -4619,18 +4619,18 @@ X86OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_ifacmpeq, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), _ifacmpeq(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpeqConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpeqDataArr[i][0]), 2, &(ifacmpeqDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpeqDataArr[i][0]), 2, &(ifacmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpeqConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpeqDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpeqConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpeqDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ifacmpeqDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -4641,18 +4641,18 @@ X86OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_ifacmpne, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), _ifacmpne(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpneConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpneDataArr[i][0]), 2, &(ifacmpneDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpneDataArr[i][0]), 2, &(ifacmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpneConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpneDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpneConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpneDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ifacmpneDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -4665,38 +4665,38 @@ X86OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(_aternary, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), _aternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]));
 
       sprintf(resolvedMethodName, "aTernaryConst1_TestCase%d", i + 1);
-      aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 6, 1, &aternaryChild1Arr[i], 2, &aternaryArr[i][0], 3, &aternaryArr[i][1]));
+      compileOpCodeMethod(aTernaryConst, 
+            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 6, 1, &aternaryChild1Arr[i], 2, &aternaryArr[i][0], 3, &aternaryArr[i][1]);
       OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "aTernaryConst2_TestCase%d", i + 1);
-      aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 1, &aternaryChild1Arr[i], 2, &aternaryArr[i][0]));
+      compileOpCodeMethod(aTernaryConst, 
+            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 1, &aternaryChild1Arr[i], 2, &aternaryArr[i][0]);
       OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, aternaryArr[i][1]));
 
       sprintf(resolvedMethodName, "aTernaryConst3_TestCase%d", i + 1);
-      aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 1, &aternaryChild1Arr[i], 3, &aternaryArr[i][1]));
+      compileOpCodeMethod(aTernaryConst, 
+            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 1, &aternaryChild1Arr[i], 3, &aternaryArr[i][1]);
       OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(ADDRESS_PLACEHOLDER_1, aternaryArr[i][0], ADDRESS_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "aTernaryConst4_TestCase%d", i + 1);
-      aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 2, &aternaryArr[i][0], 3, &aternaryArr[i][1]));
+      compileOpCodeMethod(aTernaryConst, 
+            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 2, &aternaryArr[i][0], 3, &aternaryArr[i][1]);
       OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
 
       sprintf(resolvedMethodName, "aTernaryConst5_TestCase%d", i + 1);
-      aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 1, &aternaryChild1Arr[i]));
+      compileOpCodeMethod(aTernaryConst, 
+            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 1, &aternaryChild1Arr[i]);
       OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(ADDRESS_PLACEHOLDER_1, aternaryArr[i][0], aternaryArr[i][1]));
 
       sprintf(resolvedMethodName, "aTernaryConst6_TestCase%d", i + 1);
-      aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 2, &aternaryArr[i][0]));
+      compileOpCodeMethod(aTernaryConst, 
+            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 2, &aternaryArr[i][0]);
       OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], ADDRESS_PLACEHOLDER_1, aternaryArr[i][1]));
 
       sprintf(resolvedMethodName, "aTernaryConst7_TestCase%d", i + 1);
-      aTernaryConst = (signatureCharILL_L_testMethodType *) (compileOpCodeMethod(
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 3, &aternaryArr[i][1]));
+      compileOpCodeMethod(aTernaryConst, 
+            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 3, &aternaryArr[i][1]);
       OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], aternaryArr[i][0], ADDRESS_PLACEHOLDER_1));
       }
 #endif //defined(TR_TARGET_64BIT)
@@ -4740,32 +4740,32 @@ X86OpCodesTest::invokeTernaryTests()
       sprintf(resolvedMethodName, "lTernaryConst%d", i + 1);
       OMR_CT_EXPECT_EQ(_lternary, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), _lternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]));
 
-      lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 6, 1, &lternaryChild1Arr[i], 2, &longArr[i][0], 3, &longArr[i][1]));
+      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
+            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 6, 1, &lternaryChild1Arr[i], 2, &longArr[i][0], 3, &longArr[i][1]);
       OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
 
-      lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 1, &lternaryChild1Arr[i], 2, &longArr[i][0]));
+      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
+            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 1, &lternaryChild1Arr[i], 2, &longArr[i][0]);
       OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, longArr[i][1]));
 
-      lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 1, &lternaryChild1Arr[i], 3, &longArr[i][1]));
+      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
+            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 1, &lternaryChild1Arr[i], 3, &longArr[i][1]);
       OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, longArr[i][0], LONG_PLACEHOLDER_3));
 
-      lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 2, &longArr[i][0], 3, &longArr[i][1]));
+      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
+            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 2, &longArr[i][0], 3, &longArr[i][1]);
       OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
 
-      lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 1, &lternaryChild1Arr[i]));
+      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
+            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 1, &lternaryChild1Arr[i]);
       OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, longArr[i][0], longArr[i][1]));
 
-      lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 2, &longArr[i][0]));
+      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
+            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 2, &longArr[i][0]);
       OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], LONG_PLACEHOLDER_1, longArr[i][1]));
 
-      lTernaryConst = (signatureCharIJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 3, &longArr[i][1]));
+      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
+            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 3, &longArr[i][1]);
       OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], longArr[i][0], LONG_PLACEHOLDER_1));
       }
    }
@@ -4860,11 +4860,11 @@ X86OpCodesTest::compileDisabledIntegerArithmeticTestMethods()
 
    //Jazz103 Work Item 103809
    //Testrossa Work Item 121966
-   _iuDiv = (unsignedSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iudiv, "iuDiv", _argTypesBinaryInt, TR::Int32, rc));
-   _iuMul = (unsignedSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iumul, "iuMul", _argTypesBinaryInt, TR::Int32, rc));
-   _iuRem = (unsignedSignatureCharII_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::iurem, "iuRem", _argTypesBinaryInt, TR::Int32, rc));
+   compileOpCodeMethod(_iuDiv, _numberOfBinaryArgs, TR::iudiv, "iuDiv", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iuMul, _numberOfBinaryArgs, TR::iumul, "iuMul", _argTypesBinaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iuRem, _numberOfBinaryArgs, TR::iurem, "iuRem", _argTypesBinaryInt, TR::Int32, rc);
 
-   _luDiv = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ludiv, "luDiv", _argTypesBinaryLong, TR::Int64, rc));
+   compileOpCodeMethod(_luDiv, _numberOfBinaryArgs, TR::ludiv, "luDiv", _argTypesBinaryLong, TR::Int64, rc);
    }
 
 void
@@ -4918,18 +4918,18 @@ X86OpCodesTest::invokeDisabledIntegerArithmeticTests()
       OMR_CT_EXPECT_EQ(_luDiv, div(ulongDivArr[i][0], ulongDivArr[i][1]), _luDiv(ulongDivArr[i][0], ulongDivArr[i][1]));
 
       sprintf(resolvedMethodName, "luDivConst1_Testcase%d", i);
-      luBinaryCons = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ludiv, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &ulongDivArr[i][0], 2, &ulongDivArr[i][1]));
+      compileOpCodeMethod(luBinaryCons, 
+            _numberOfBinaryArgs, TR::ludiv, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 4, 1, &ulongDivArr[i][0], 2, &ulongDivArr[i][1]);
       OMR_CT_EXPECT_EQ(luBinaryCons, div(ulongDivArr[i][0], ulongDivArr[i][1]), luBinaryCons(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "luDivConst2_Testcase%d", i);
-      luBinaryCons = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ludiv, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &ulongDivArr[i][0]));
+      compileOpCodeMethod(luBinaryCons, 
+            _numberOfBinaryArgs, TR::ludiv, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 1, &ulongDivArr[i][0]);
       OMR_CT_EXPECT_EQ(luBinaryCons, div(ulongDivArr[i][0], ulongDivArr[i][1]), luBinaryCons(LONG_PLACEHOLDER_1, ulongDivArr[i][1]));
 
       sprintf(resolvedMethodName, "luDivConst3_Testcase%d", i);
-      luBinaryCons = (unsignedSignatureCharJJ_J_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ludiv, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &ulongDivArr[i][1]));
+      compileOpCodeMethod(luBinaryCons, 
+            _numberOfBinaryArgs, TR::ludiv, resolvedMethodName, _argTypesBinaryLong, TR::Int64, rc, 2, 2, &ulongDivArr[i][1]);
       OMR_CT_EXPECT_EQ(luBinaryCons, div(ulongDivArr[i][0], ulongDivArr[i][1]), luBinaryCons(ulongDivArr[i][0], LONG_PLACEHOLDER_2));
       }
 
@@ -4943,18 +4943,18 @@ X86OpCodesTest::compileDisabledCompareOpCodesTest()
    int32_t rc = 0;
    //Jazz103 Work Item 109672
 #if defined(TR_TARGET_32BIT)
-   _acmpeq = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::acmpeq, "acmpeq", _argTypesBinaryAddress, TR::Int32, rc));
-   _acmpne = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::acmpne, "acmpne", _argTypesBinaryAddress, TR::Int32, rc));
-   _acmplt = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::acmplt, "acmplt", _argTypesBinaryAddress, TR::Int32, rc));
-   _acmpge = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::acmpge, "acmpge", _argTypesBinaryAddress, TR::Int32, rc));
-   _acmple = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::acmple, "acmple", _argTypesBinaryAddress, TR::Int32, rc));
-   _acmpgt = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::acmpgt, "acmpgt", _argTypesBinaryAddress, TR::Int32, rc));
-   _ifacmpeq = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifacmpeq, "ifacmpeq", _argTypesBinaryAddress, TR::Int32, rc));
-   _ifacmpne = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifacmpne, "ifacmpne", _argTypesBinaryAddress, TR::Int32, rc));
-   _ifacmplt = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifacmplt, "ifacmplt", _argTypesBinaryAddress, TR::Int32, rc));
-   _ifacmpge = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifacmpge, "ifacmpge", _argTypesBinaryAddress, TR::Int32, rc));
-   _ifacmple = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifacmple, "ifacmple", _argTypesBinaryAddress, TR::Int32, rc));
-   _ifacmpgt = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::ifacmpgt, "ifacmpgt", _argTypesBinaryAddress, TR::Int32, rc));
+   compileOpCodeMethod(_acmpeq, _numberOfBinaryArgs, TR::acmpeq, "acmpeq", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_acmpne, _numberOfBinaryArgs, TR::acmpne, "acmpne", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_acmplt, _numberOfBinaryArgs, TR::acmplt, "acmplt", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_acmpge, _numberOfBinaryArgs, TR::acmpge, "acmpge", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_acmple, _numberOfBinaryArgs, TR::acmple, "acmple", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_acmpgt, _numberOfBinaryArgs, TR::acmpgt, "acmpgt", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_ifacmpeq, _numberOfBinaryArgs, TR::ifacmpeq, "ifacmpeq", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_ifacmpne, _numberOfBinaryArgs, TR::ifacmpne, "ifacmpne", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_ifacmplt, _numberOfBinaryArgs, TR::ifacmplt, "ifacmplt", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_ifacmpge, _numberOfBinaryArgs, TR::ifacmpge, "ifacmpge", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_ifacmple, _numberOfBinaryArgs, TR::ifacmple, "ifacmple", _argTypesBinaryAddress, TR::Int32, rc);
+   compileOpCodeMethod(_ifacmpgt, _numberOfBinaryArgs, TR::ifacmpgt, "ifacmpgt", _argTypesBinaryAddress, TR::Int32, rc);
 #endif
    }
 
@@ -5054,18 +5054,18 @@ X86OpCodesTest::invokeDisabledCompareOpCodesTest()
       OMR_CT_EXPECT_EQ(_acmpeq, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), _acmpeq(acmpeqDataArr[i][0], acmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpeqConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpeqDataArr[i][0]), 2, &(acmpeqDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpeqDataArr[i][0]), 2, &(acmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "aCmpeqConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpeqDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpeqConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpeqDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(acmpeqDataArr[i][0], acmpeqDataArr[i][1]), aCompareConst(acmpeqDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -5075,18 +5075,18 @@ X86OpCodesTest::invokeDisabledCompareOpCodesTest()
       OMR_CT_EXPECT_EQ(_acmpne, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), _acmpne(acmpneDataArr[i][0], acmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpneConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpneDataArr[i][0]), 2, &(acmpneDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpneDataArr[i][0]), 2, &(acmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "aCmpneConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpneDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "aCmpneConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpneDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareNE(acmpneDataArr[i][0], acmpneDataArr[i][1]), aCompareConst(acmpneDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -5096,18 +5096,18 @@ X86OpCodesTest::invokeDisabledCompareOpCodesTest()
       OMR_CT_EXPECT_EQ(_acmpgt, compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), _acmpgt(acmpgtDataArr[i][0], acmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpgtConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpgtDataArr[i][0]), 2, &(acmpgtDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpgtDataArr[i][0]), 2, &(acmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "acmpgtConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpgtDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpgtConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpgtDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGT(acmpgtDataArr[i][0], acmpgtDataArr[i][1]), aCompareConst(acmpgtDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -5117,18 +5117,18 @@ X86OpCodesTest::invokeDisabledCompareOpCodesTest()
       OMR_CT_EXPECT_EQ(_acmplt, compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), _acmplt(acmpltDataArr[i][0], acmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpltConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpltDataArr[i][0]), 2, &(acmpltDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpltDataArr[i][0]), 2, &(acmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "acmpltConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpltDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpltConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpltDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLT(acmpltDataArr[i][0], acmpltDataArr[i][1]), aCompareConst(acmpltDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -5138,18 +5138,18 @@ X86OpCodesTest::invokeDisabledCompareOpCodesTest()
       OMR_CT_EXPECT_EQ(_acmpge, compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), _acmpge(acmpgeDataArr[i][0], acmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpgeConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpgeDataArr[i][0]), 2, &(acmpgeDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpgeDataArr[i][0]), 2, &(acmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "acmpgeConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpgeDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpgeConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpgeDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGE(acmpgeDataArr[i][0], acmpgeDataArr[i][1]), aCompareConst(acmpgeDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -5159,18 +5159,18 @@ X86OpCodesTest::invokeDisabledCompareOpCodesTest()
       OMR_CT_EXPECT_EQ(_acmple, compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), _acmple(acmpleDataArr[i][0], acmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpleConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpleDataArr[i][0]), 2, &(acmpleDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(acmpleDataArr[i][0]), 2, &(acmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "acmpleConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpleDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(acmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, acmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "acmpleConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::acmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpleDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::acmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(acmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLE(acmpleDataArr[i][0], acmpleDataArr[i][1]), aCompareConst(acmpleDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -5181,18 +5181,18 @@ X86OpCodesTest::invokeDisabledCompareOpCodesTest()
       OMR_CT_EXPECT_EQ(_ifacmpeq, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), _ifacmpeq(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpeqConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpeqDataArr[i][0]), 2, &(ifacmpeqDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpeqDataArr[i][0]), 2, &(ifacmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpeqConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpeqDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpeqDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpeqDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpeqConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpeqDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpeq, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpeqDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareEQ(ifacmpeqDataArr[i][0], ifacmpeqDataArr[i][1]), aCompareConst(ifacmpeqDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -5202,18 +5202,18 @@ X86OpCodesTest::invokeDisabledCompareOpCodesTest()
       OMR_CT_EXPECT_EQ(_ifacmpne, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), _ifacmpne(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpneConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpneDataArr[i][0]), 2, &(ifacmpneDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpneDataArr[i][0]), 2, &(ifacmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpneConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpneDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpneDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpneDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpneConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpneDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpne, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpneDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareNE(ifacmpneDataArr[i][0], ifacmpneDataArr[i][1]), aCompareConst(ifacmpneDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -5223,18 +5223,18 @@ X86OpCodesTest::invokeDisabledCompareOpCodesTest()
       OMR_CT_EXPECT_EQ(_ifacmpgt, compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), _ifacmpgt(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpgtConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpgtDataArr[i][0]), 2, &(ifacmpgtDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpgtDataArr[i][0]), 2, &(ifacmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpgtConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpgtDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpgtDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpgtDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpgtConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpgtDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpgt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpgtDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGT(ifacmpgtDataArr[i][0], ifacmpgtDataArr[i][1]), aCompareConst(ifacmpgtDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -5244,18 +5244,18 @@ X86OpCodesTest::invokeDisabledCompareOpCodesTest()
       OMR_CT_EXPECT_EQ(_ifacmplt, compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), _ifacmplt(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpltConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpltDataArr[i][0]), 2, &(ifacmpltDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpltDataArr[i][0]), 2, &(ifacmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpltConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpltDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpltDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpltDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpltConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpltDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmplt, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpltDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLT(ifacmpltDataArr[i][0], ifacmpltDataArr[i][1]), aCompareConst(ifacmpltDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -5265,18 +5265,18 @@ X86OpCodesTest::invokeDisabledCompareOpCodesTest()
       OMR_CT_EXPECT_EQ(_ifacmpge, compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), _ifacmpge(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpgeConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpgeDataArr[i][0]), 2, &(ifacmpgeDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpgeDataArr[i][0]), 2, &(ifacmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpgeConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpgeDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpgeDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpgeDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpgeConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpgeDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmpge, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpgeDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareGE(ifacmpgeDataArr[i][0], ifacmpgeDataArr[i][1]), aCompareConst(ifacmpgeDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
@@ -5286,18 +5286,18 @@ X86OpCodesTest::invokeDisabledCompareOpCodesTest()
       OMR_CT_EXPECT_EQ(_ifacmple, compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), _ifacmple(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpleConst1_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpleDataArr[i][0]), 2, &(ifacmpleDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 4, 1, &(ifacmpleDataArr[i][0]), 2, &(ifacmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2));
 
       sprintf(resolvedMethodName, "ifacmpleConst2_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpleDataArr[i][0])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 1, &(ifacmpleDataArr[i][0]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ADDRESS_PLACEHOLDER_1, ifacmpleDataArr[i][1]));
 
       sprintf(resolvedMethodName, "ifacmpleConst3_TestCase%d", i + 1);
-      aCompareConst = (signatureCharLL_I_testMethodType *) (compileOpCodeMethod(
-            _numberOfBinaryArgs, TR::ifacmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpleDataArr[i][1])));
+      compileOpCodeMethod(aCompareConst, 
+            _numberOfBinaryArgs, TR::ifacmple, resolvedMethodName, _argTypesBinaryAddress, TR::Int32, rc, 2, 2, &(ifacmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(aCompareConst, compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ifacmpleDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 #endif
@@ -5309,7 +5309,7 @@ X86OpCodesTest::compileDisabledConvertOpCodesTest()
    int32_t rc = 0;
    //Jazz103 Work Item 109672
 #if defined(TR_TARGET_32BIT)
-   _a2l = (signatureCharL_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::a2l, "a2l", _argTypesUnaryAddress, TR::Int64, rc));
+   compileOpCodeMethod(_a2l, _numberOfUnaryArgs, TR::a2l, "a2l", _argTypesUnaryAddress, TR::Int64, rc);
 #endif
    }
 
@@ -5339,7 +5339,7 @@ X86OpCodesTest::invokeDisabledConvertOpCodesTest()
       OMR_CT_EXPECT_EQ(_a2l, convert(aUnaryDataArr[i], LONG_POS), _a2l(aUnaryDataArr[i]));
 
       sprintf(resolvedMethodName, "a2lConst%d", i + 1);
-      a2lConst = (signatureCharL_J_testMethodType *) (compileOpCodeMethod(_numberOfUnaryArgs, TR::a2l, resolvedMethodName, _argTypesUnaryAddress, TR::Int64, rc, 2, 1, &aUnaryDataArr[i]));
+      compileOpCodeMethod(a2lConst, _numberOfUnaryArgs, TR::a2l, resolvedMethodName, _argTypesUnaryAddress, TR::Int64, rc, 2, 1, &aUnaryDataArr[i]);
       OMR_CT_EXPECT_EQ(a2lConst, convert(aUnaryDataArr[i], LONG_POS), a2lConst(ADDRESS_PLACEHOLDER_1));
       }
 #endif
@@ -5349,7 +5349,7 @@ X86OpCodesTest::compileDisabledMemoryOpCodesTest()
    {
    int32_t rc = 0;
    ////Jazz 111413 : indirect store opcodes get unexpected results
-   _bStorei = (signatureCharLB_B_testMethodType *) (compileOpCodeMethod(_numberOfBinaryArgs, TR::bstorei, "bStorei", _argTypesBinaryAddressByte, TR::Int8, rc));
+   compileOpCodeMethod(_bStorei, _numberOfBinaryArgs, TR::bstorei, "bStorei", _argTypesBinaryAddressByte, TR::Int8, rc);
 
    }
 


### PR DESCRIPTION
* Add a missing header guard.
* Templatize one of the test compilation functions to reduce the amount of casting required. 