### PR TITLE
Remove stale HWProfiler options

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -873,8 +873,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
         TR::Options::set32BitSignedNumeric, offsetof(OMR::Options,_lastOptSubIndex), 0, "F%d"},
    {"lastOptTransformationIndex=", "O<nnn>\tindex of the last optimization transformation to perform",
         TR::Options::set32BitSignedNumeric, offsetof(OMR::Options,_lastOptTransformationIndex), 0, "F%d"},
-   {"listing=",               "L<filename>\twrite listing to filename",
-        TR::Options::setString,  offsetof(OMR::Options,_listingFileName), 0, "P%s"},
    {"lnl=", "C<nnn>\t(labelTargetAddress&0xff) > _labelTargetNOPLimit are padded out with NOPs until the next 256 byte boundary",
       TR::Options::set32BitNumeric, offsetof(OMR::Options,_labelTargetNOPLimit), TR_LABEL_TARGET_NOP_LIMIT , "F%d"},
    {"lockReserveClass=",  "O{regex}\tenable reserving locks for specified classes", TR::Options::setRegex, offsetof(OMR::Options, _lockReserveClass), 0, "P"},
@@ -1617,7 +1615,6 @@ int32_t       OMR::Options::INLINE_ranOutOfBudget                = 0;
 int64_t       OMR::Options::INLINE_calleeToBigSum                = 0;
 int64_t       OMR::Options::INLINE_calleeToDeepSum               = 0;
 int64_t       OMR::Options::INLINE_calleeHasTooManyNodesSum      = 0;
-int32_t       OMR::Options::INLINE_HWProfileHotCallsThreshold    = 45;
 
 int32_t       OMR::Options::_inlinerVeryLargeCompiledMethodAdjustFactor = 20;
 
@@ -2477,7 +2474,6 @@ OMR::Options::jitPreProcess()
    _profilingCount = DEFAULT_PROFILING_COUNT;
    _profilingFrequency = DEFAULT_PROFILING_FREQUENCY;
 #endif
-   _HWProfileSuperColdOnlySteps = 0;
 
 #if defined(TR_HOST_POWER)
    _bigCalleeThreshold = 300;
@@ -2711,9 +2707,6 @@ OMR::Options::jitPreProcess()
       _stackPCDumpNumberOfFrames=5;
       _maxSpreadCountLoopless = TR_MAX_SPREAD_COUNT_LOOPLESS;
       _maxSpreadCountLoopy = TR_MAX_SPREAD_COUNT_LOOPY;
-      _HWProfileFreqCalcMethod = TR::HWProfileFreqCalcMethod::avg_method;
-      _HWProfileFreqCalcInlineHeuristic = 80;
-      _HWProfileHotnessCalc = TR::HWProfileFreqCalcMethod::max_method;
 
       // This call needs to stay at the end of jitPreProcess() because
       // it changes the default values for some options

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1185,34 +1185,6 @@ enum TR_ProcessOptionsFlags
    TR_JITProcessErrorUnknown = 0x00000080
    };
 
-/**
- * Enum describing how the HW profiler frequencies are calculated.
- *
- * When we have wider C++11 support, this should be changed to a declaration
- * closer to the below:
- *
- * \verbatim
- * enum class TR_HWProfileFreqCalcMethod : uint32_t
- * \endverbatim
- *
- * The enum type is defined to a 32 bit value because of the option parsing
- * code.
- *
- * For now, because of z/OS V1.13 XL C/C++, we cannot do sensible things here
- * so resort to the mildly insensible.
- */
-namespace TR
-   {
-   namespace HWProfileFreqCalcMethod
-      {
-      enum
-         {
-         first_method,
-         avg_method,
-         max_method
-         };
-      }
-   }
 
 #define TR_FILTER_EXCLUDE_NAME_ONLY         1
 #define TR_FILTER_EXCLUDE_NAME_AND_SIG      2
@@ -1505,10 +1477,6 @@ public:
    void            setLogFile(TR::FILE * f)  {_logFile = f;}
    char *          getLogFileName()      {return _logFileName;}
 
-   char *          getListingFileName()  {return _listingFileName;}
-
-   char *          getPDFFileName()      {return _pdfFileName;}
-
    char *          getBlockShufflingSequence(){ return _blockShufflingSequence; }
 
    int32_t         getRandomSeed(){ return _randomSeed; }
@@ -1630,10 +1598,6 @@ public:
    int32_t   getDLTOptLevel()                  {return _dltOptLevel;}
    int32_t   getProfilingCount()               {return _profilingCount;}
    int32_t   getProfilingFrequency()           {return _profilingFrequency;}
-   int32_t   getHWProfileSuperColdOnlySteps()  {return _HWProfileSuperColdOnlySteps;}
-   int32_t   getHWProfileHotnessCalc()         {return _HWProfileHotnessCalc;}
-   int32_t   getHWProfileFreqCalc()            {return _HWProfileFreqCalcMethod;}
-   int32_t   getHWProfileFreqCalcInlineHeuristic() {return _HWProfileFreqCalcInlineHeuristic;}
    int32_t   insertDebuggingCounters()         {return _insertDebuggingCounters;}
    int32_t   getLastSearchCount()              {return _lastSearchCount;}
 
@@ -1863,7 +1827,6 @@ public:
    static int64_t INLINE_calleeToBigSum;
    static int64_t INLINE_calleeToDeepSum;
    static int64_t INLINE_calleeHasTooManyNodesSum;
-   static int32_t INLINE_HWProfileHotCallsThreshold;
 
    static int32_t _inlinerVeryLargeCompiledMethodAdjustFactor;
 
@@ -2233,11 +2196,6 @@ private:
    char                       *_suffixLogsFormat;
    TR::FILE *                      _logFile;
 
-   // Listing file option
-   char                       *_listingFileName;
-
-   // Profiling options
-   char                       *_pdfFileName;
 
    char                       *_optFileName;
    int32_t                    *_customStrategy;     // Actually array of TR_OptimizerImpl::Optimizations numbers read from optFileName
@@ -2360,11 +2318,6 @@ private:
    int32_t                     _dltOptLevel;
    int32_t                     _profilingCount;
    int32_t                     _profilingFrequency;
-   int32_t                     _HWProfileSuperColdOnlySteps;   //Used by PDF
-   int32_t                     _HWProfileFreqCalcMethod;
-   int32_t                     _HWProfileFreqCalcInlineHeuristic;
-   int32_t                     _HWProfileHotnessCalc;
-
    int32_t                     _counterBucketGranularity;
    int32_t                     _minCounterFidelity;
    int64_t                     _debugCounterWarmupSeconds;


### PR DESCRIPTION
This changeset removes some old HWProfiler options that are not
referenced by any method.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>