### PR TITLE
Add common functions to OSR API concerning PPS

### DIFF
--- a/compiler/compile/OSRData.hpp
+++ b/compiler/compile/OSRData.hpp
@@ -298,7 +298,8 @@ class TR_OSRMethodData
    void setNumSymRefs(int32_t numBits) {_numSymRefs = numBits; }
    int32_t getNumSymRefs() { return _numSymRefs; }
 
-   void addLiveRangeInfo(int32_t byteCodeIndex, TR_BitVector *liveRangeInfo);
+   void addLiveRangeInfo(int32_t byteCodeIndex, TR::OSRPointType osrPoint, TR_BitVector *liveRangeInfo);
+   TR_BitVector *getLiveRangeInfo(int32_t byteCodeIndex, TR::OSRPointType osrPoint);
    TR_BitVector *getLiveRangeInfo(int32_t byteCodeIndex);
 
    bool linkedToCaller() { return _linkedToCaller; }
@@ -309,7 +310,8 @@ class TR_OSRMethodData
    private:
    void createOSRBlocks(TR::Node* n);
 
-   typedef CS2::HashTable<int32_t, TR_BitVector *, TR::Allocator> TR_BCLiveRangeInfoHashTable;
+   typedef CS2::CompoundHashKey<int32_t, TR::OSRPointType> TR_BCLiveRangeInfoHashKey;
+   typedef CS2::HashTable<TR_BCLiveRangeInfoHashKey, TR_BitVector *, TR::Allocator> TR_BCLiveRangeInfoHashTable;
    typedef CS2::HashTable<int32_t, TR_OSRSlotSharingInfo*, TR::Allocator> TR_BCInfoHashTable;
    typedef CS2::HashTable<int32_t, TR_Array<int32_t>, TR::Allocator> TR_Slot2ScratchBufferOffset;
 

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
@@ -119,6 +119,11 @@ public:
    uint32_t getNumOSRPoints() { return _osrPoints.size(); }
    bool sharesStackSlot(TR::SymbolReference *symRef);
 
+   TR_ByteCodeInfo& getOSRByteCodeInfo(TR::Node *node);
+   bool isOSRRelatedNode(TR::Node *node);
+   bool isOSRRelatedNode(TR::Node *node, TR_ByteCodeInfo &bci);
+   TR::TreeTop *getOSRTransitionTreeTop(TR::TreeTop *tt);
+
    uint32_t getNumParameterSlots() const     {return _resolvedMethod->numberOfParameterSlots(); }
 
    uint32_t getNumPPSlots() const            { return _resolvedMethod->numberOfPendingPushes(); }

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -2048,7 +2048,8 @@ bool TR_InlinerBase::heuristicForUsingOSR(TR::Node *callNode, TR::ResolvedMethod
       int32_t osrCallerNumLiveStackSlots = 0;
       totalOSRCallersStackSlots = totalOSRCallersStackSlots + osrCallerNumStackSlots;
 
-      TR_BitVector *deadSymRefs = osrMethodData->getLiveRangeInfo(byteCodeIndex);
+      TR_BitVector *deadSymRefs = osrMethodData->getLiveRangeInfo(byteCodeIndex,
+         comp()->getOSRTransitionTarget() == TR::postExecutionOSR ? TR::analysisOSR : TR::inductionOSR);
       if (deadSymRefs)
          {
          osrCallerNumLiveStackSlots = osrMethodData->getNumSymRefs() - deadSymRefs->elementCount();

--- a/compiler/optimizer/OSRDefAnalysis.hpp
+++ b/compiler/optimizer/OSRDefAnalysis.hpp
@@ -95,8 +95,12 @@ class TR_OSRLiveRangeAnalysis : public TR::Optimization
    private:
 
    bool canAffordAnalysis();
-   void buildOSRLiveRangeInfo(TR::Node *node, TR_BitVector *liveVars, TR_OSRPoint *osrPoint, int32_t *liveLocalIndexToSymRefNumberMap, int32_t maxSymRefNumber, int32_t numBits, TR_OSRMethodData *osrMethodData);
-   void maintainLiveness(TR::Node *node, TR::Node *parent, int32_t childNum, vcount_t  visitCount, TR_Liveness *liveLocals, TR_BitVector *liveVars, TR::Block *block);
+   void buildOSRLiveRangeInfo(TR::Node *node, TR_BitVector *liveVars, TR_OSRPoint *osrPoint,
+      int32_t *liveLocalIndexToSymRefNumberMap, int32_t maxSymRefNumber, int32_t numBits,
+      TR_OSRMethodData *osrMethodData, TR::OSRPointType osrPointType);
+   void maintainLiveness(TR::Node *node, TR::Node *parent, int32_t childNum, vcount_t  visitCount,
+       TR_Liveness *liveLocals, TR_BitVector *liveVars, TR::Block *block);
+   TR::TreeTop *collectPendingPush(TR_ByteCodeInfo bci, TR::TreeTop *pps, TR_BitVector *liveVars);
 
    TR_BitVector *_deadVars;
    TR_BitVector *_liveVars;


### PR DESCRIPTION
OSR points are surrounded by pending push stores, to ensure
the stack is recreated after the transition, and treetops of
pending push loads, to avoid the side effects of the prior mentioned
stores. This adds functionality to determine if a node is one of
these and to extract the transition point for an OSR point based
on the current mode.

Moreover, it corrects an issue with OSR analysis as liveness and
use/def information should be calculated at the transition or
analysis point, not the OSR point.