### PR TITLE
Add isDebuggingMode query to compilation

### DIFF
--- a/compiler/arm/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.cpp
@@ -1346,8 +1346,8 @@ TR::Register *OMR::ARM::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::Code
    TR::Node * fenceNode = TR::Node::createRelative32BitFenceNode(node, &block->getInstructionBoundaries()._startPC);
    TR::Instruction * fence = generateAdminInstruction(cg, ARMOp_fence, node, deps, fenceNode);
 
-   if (block->isCatchBlock() && comp->getOption(TR_FullSpeedDebug))
-      fence->setNeedsGCMap(); // a catch entry is a gc point in FSD mode
+   if (block->isCatchBlock() && comp->isDebuggingMode())
+      fence->setNeedsGCMap(); // a catch entry is a gc point in debugging mode
 
    return NULL;
    }

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -888,6 +888,7 @@ public:
    int32_t getGPUPtxCount() { return _gpuPtxCount; }
 
    bool isDLT() { return _flags.testAny(IsDLTCompile);}
+   bool isDebuggingMode() { return _options->getOption(TR_FullSpeedDebug) || _options->getOption(TR_MimicInterpreterFrameShape);}
 
    // surely J9 specific
    void * getAotMethodCodeStart() const { return _aotMethodCodeStart; }


### PR DESCRIPTION
There are 2 debugging modes, mimic interpreter frame shape
and full speed debug based on OSR. Those 2 are aliased
until recently. Some code checking for mimic interpreter frame
shape is actually asking whether we are in debugging mode and
should be using the new query after the 2 debugging modes are
dis-aliased.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>

  