### PR TITLE
Add missing ARM constant re-materialization queries

### DIFF
--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -901,6 +901,26 @@ int32_t OMR::ARM::CodeGenerator::getMaximumNumbersOfAssignableFPRs()
    return TR::RealRegister::LastFPR - TR::RealRegister::FirstFPR  + 1;
    }
 
+
+/**
+ * \brief
+ * Determine if value fits in the immediate field (if any) of instructions that machine provides.
+ *
+ * \details
+ *
+ * A node with a large constant can be materialized and left as commoned nodes.
+ * Smaller constants can be uncommoned so that they re-materialize every time when needed as a call
+ * parameter. This query is platform specific as constant loading can be expensive on some platforms
+ * but cheap on others, depending on their magnitude.
+ */
+bool OMR::ARM::CodeGenerator::shouldValueBeInACommonedNode(int64_t value)
+   {
+   int64_t smallestPos = self()->getSmallestPosConstThatMustBeMaterialized();
+   int64_t largestNeg = self()->getLargestNegConstThatMustBeMaterialized();
+
+   return ((value >= smallestPos) || (value <= largestNeg));
+   }
+
 bool OMR::ARM::CodeGenerator::isGlobalRegisterAvailable(TR_GlobalRegisterNumber i, TR::DataType dt)
    {
    return self()->machine()->getARMRealRegister((TR::RealRegister::RegNum)self()->getGlobalRegister(i))->getState() == TR::RealRegister::Free;

--- a/compiler/arm/codegen/OMRCodeGenerator.hpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.hpp
@@ -162,6 +162,11 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    void apply24BitLabelRelativeRelocation(int32_t * cursor, TR::LabelSymbol *);
    void apply8BitLabelRelativeRelocation(int32_t * cursor, TR::LabelSymbol *);
 
+   // ARM specific thresholds for constant re-materialization
+   int64_t getLargestNegConstThatMustBeMaterialized() {return -32769;}  // minimum 16-bit signed int minus 1
+   int64_t getSmallestPosConstThatMustBeMaterialized() {return 32768;}  // maximum 16-bit signed int plus 1
+   bool shouldValueBeInACommonedNode(int64_t); // no virt, cast
+
    // @@ bool canNullChkBeImplicit(TR::Node *node);
 
    bool hasCall()                 {return _flags.testAny(HasCall);}


### PR DESCRIPTION
Add missing constant re-materialization threshold queries for ARM
to avoid build failures.

Signed-off-by: Nigel Yu <yunigel@ca.ibm.com>