### PR TITLE
Enhance the linter to better understand calls

### DIFF
--- a/tools/compiler/OMRChecker/OMRChecker.hpp
+++ b/tools/compiler/OMRChecker/OMRChecker.hpp
@@ -733,7 +733,7 @@ public:
             // Need still to verify that the self() call is to the right receiver! Otherwise 
             // we can pass upcasts in the case where we have an extensible class hierarchy
             // deriving from an extensible class hierarchy. 
-            if (isCorrectSelf(call)) {
+            if (callerAndCalleeHaveSameMDT(call)) {
                trace("callee is correct self()");
                return true;
             } else { 
@@ -817,25 +817,48 @@ public:
     * the most derived class
     */
    bool isAllowedSelflessCall(CXXMemberCallExpr* call) { 
-      // Ignore member function calls that specifically call a base class member function
+      /*
+       * Ignore member function calls that specifically call a base class member function
+       */
       MemberExpr * memberFunc;
       // hasQualifier checks for a nested name specifier, e.g. the 'IBM::Foo::' part of 'IBM::Foo::baz()'
       if ((memberFunc = dyn_cast<MemberExpr>(call->getCallee())) && memberFunc->hasQualifier()) {
+         trace("isAllowedSelflessCall: True because it's a qualified base class member function"); 
          return true;
+      }
+      
+
+      /*
+       * If the call has resolved to the most derived type, then we 
+       * can allow it. This can only happen inside the most derived 
+       * type.
+       */
+      const CXXMethodDecl* calleeDecl        = call->getMethodDecl();
+      const CXXRecordDecl* calleeClassDecl   = calleeDecl->getParent(); 
+      const CXXRecordDecl* calleeMostDerived = ClassChecker->mostDerivedType(calleeClassDecl); 
+      const CXXMethodDecl* callerMethod = getCallerDecl(call); 
+      const CXXRecordDecl* callerDecl = callerMethod->getParent(); 
+
+      if (calleeMostDerived->getCanonicalDecl() == callerDecl->getCanonicalDecl())  {
+         trace("isAllowedSelflessCall: True because caller is most derived type"); 
+         return true;
+      } else { 
+         trace("isAllowedSelflessCall: false"); 
+         if (getenv("OMR_CHECK_TRACE")) {
+            llvm::errs() << "isAllowedSelflessCall: calleeDecl            => " << calleeDecl->getQualifiedNameAsString()  << "\n";
+            llvm::errs() << "isAllowedSelflessCall: calleeClassDecl       => " << calleeClassDecl->getQualifiedNameAsString()   << "\n";
+            llvm::errs() << "isAllowedSelflessCall: calleeMostDerived     => " << calleeMostDerived->getQualifiedNameAsString()   << "\n";
+            llvm::errs() << "isAllowedSelflessCall: callerDecl            => " << (callerDecl ? callerDecl->getQualifiedNameAsString() : "NULL")   << "\n";
+         }
       }
 
       return false;
    }
 
-   /**
-    * Return true iff the call is to self, **and** the self call is 
-    * within the correct extensible class string. 
-    *
-    * The correct call depends on what member function we are inside of.
-    *
-    */
-   bool isCorrectSelf(CXXMemberCallExpr *call) { 
-      // This is the called method decl -- Should be self of one form or another, verified by isSelfCall. 
+   bool computeCallInformation(const CXXMemberCallExpr* call,
+                               const CXXRecordDecl* &calleeMostDerived,
+                               const CXXRecordDecl* &callerMostDerived) {
+      // This is the called method decl 
       CXXMethodDecl* calleeDecl = call->getMethodDecl();
       if (!calleeDecl) {
          trace("Didn't find callee decl. Assuming not correct self call");
@@ -850,7 +873,7 @@ public:
       }
 
       // Most derived type of the callee. 
-      const CXXRecordDecl* calleeMostDerived = ClassChecker->mostDerivedType(calleeClassDecl); 
+      calleeMostDerived = ClassChecker->mostDerivedType(calleeClassDecl); 
       if (!calleeMostDerived) {
          trace("Didn't find a most derived type for the callee class. Assuming not correct self call");
          return false;
@@ -872,25 +895,30 @@ public:
       }
 
       // Most dervied type of the caller 
-      const CXXRecordDecl* callerMostDerived = ClassChecker->mostDerivedType(callerDecl);
+      callerMostDerived = ClassChecker->mostDerivedType(callerDecl);
      
       if (getenv("OMR_CHECK_TRACE")) {
-         llvm::errs() << "isCorrectSelf: BestDynamicClassType => ";
-         call->getBestDynamicClassType()->printQualifiedName(llvm::errs());
+         llvm::errs() << "computeCallInformation: calleeDecl            => " << calleeDecl->getQualifiedNameAsString()  << "\n";
+         llvm::errs() << "computeCallInformation: calleeClassDecl       => " << calleeClassDecl->getQualifiedNameAsString()   << "\n";
+         llvm::errs() << "computeCallInformation: calleeMostDerived     => " << calleeMostDerived->getQualifiedNameAsString()   << "\n";
          llvm::errs() << "\n";
-
-         llvm::errs() << "isCorrectSelf: calleeDecl            => " << calleeDecl->getQualifiedNameAsString()  << "\n";
-         llvm::errs() << "isCorrectSelf: calleeClassDecl       => " << calleeClassDecl->getQualifiedNameAsString()   << "\n";
-         llvm::errs() << "isCorrectSelf: calleeMostDerived     => " << calleeMostDerived->getQualifiedNameAsString()   << "\n";
-         llvm::errs() << "\n";
-         llvm::errs() << "isCorrectSelf: callerDecl      => " << (callerDecl ? callerDecl->getQualifiedNameAsString() : "NULL")   << "\n";
-         llvm::errs() << "isCorrectSelf: callerMostDerived => " << (callerMostDerived ? callerMostDerived->getQualifiedNameAsString() : "NULL")   << "\n";
+         llvm::errs() << "computeCallInformation: callerDecl            => " << (callerDecl ? callerDecl->getQualifiedNameAsString() : "NULL")   << "\n";
+         llvm::errs() << "computeCallInformation: callerMostDerived     => " << (callerMostDerived ? callerMostDerived->getQualifiedNameAsString() : "NULL")   << "\n";
       }
-   
-      if (calleeMostDerived == callerMostDerived && calleeMostDerived != NULL) 
-         return true; 
-      else
-         return false;
+      return true;  
+   } 
+
+   /**
+    * Return true iff the caller and callee have the same 
+    * most derived type. 
+    */
+   bool callerAndCalleeHaveSameMDT(CXXMemberCallExpr *call) { 
+      const CXXRecordDecl* calleeMostDerived, *callerMostDerived;
+      if (computeCallInformation(call, calleeMostDerived,  callerMostDerived)) {
+         if (calleeMostDerived == callerMostDerived) 
+            return true; 
+      }
+      return false;
    }
 
    /**
@@ -905,8 +933,12 @@ public:
       Expr*             receiver = call->getImplicitObjectArgument()->IgnoreParenImpCasts();
 
       if (getenv("OMR_CHECK_TRACE")) {
+         auto bestDynamic = receiver->getBestDynamicClassType(); 
          llvm::errs() << "BestDynamicClassType => ";
-         receiver->getBestDynamicClassType()->printQualifiedName(llvm::errs());
+         if (bestDynamic) 
+            receiver->getBestDynamicClassType()->printQualifiedName(llvm::errs());
+         else 
+            llvm::errs() << "NULL";
          llvm::errs() << "\n";
       }
 

--- a/tools/compiler/OMRChecker/testing/input/bad/functionCallUsingImplicitThis.cpp
+++ b/tools/compiler/OMRChecker/testing/input/bad/functionCallUsingImplicitThis.cpp
@@ -36,6 +36,17 @@ class OMR_EXTENSIBLE ExtClass
 
 } // namespace OMR
 
+namespace TR
+{ 
+   
+class OMR_EXTENSIBLE ExtClass : public OMR::ExtClass
+   {
+
+
+   };
+
+}
+
 void OMR::ExtClass::functionCalled() {}
 
 void OMR::ExtClass::callingFunction() { functionCalled(); }

--- a/tools/compiler/OMRChecker/testing/input/good/selflessCallsInMostDerived.cpp
+++ b/tools/compiler/OMRChecker/testing/input/good/selflessCallsInMostDerived.cpp
@@ -1,0 +1,58 @@
+/*******************************************************************************
+*
+* (c) Copyright IBM Corp. 2017, 2017
+*
+*  This program and the accompanying materials are made available
+*  under the terms of the Eclipse Public License v1.0 and
+*  Apache License v2.0 which accompanies this distribution.
+*
+*      The Eclipse Public License is available at
+*      http://www.eclipse.org/legal/epl-v10.html
+*
+*      The Apache License v2.0 is available at
+*      http://www.opensource.org/licenses/apache2.0.php
+*
+* Contributors:
+*    Multiple authors (IBM Corp.) - initial implementation and documentation
+*******************************************************************************/
+
+
+/**
+ * Description: Calls an extensible class member function using
+ *    the `self()` function for down casting.
+ */
+
+#define OMR_EXTENSIBLE __attribute__((annotate("OMR_Extensible")))
+
+namespace TR  { class ExtClass; }         // forward declaration required to declared `self()`
+
+namespace OMR
+{
+
+class OMR_EXTENSIBLE ExtClass
+   {
+   public:
+   TR::ExtClass * self();   // declaration of down cast function
+   void functionCalled();   // function to be called
+   };
+
+} // namespace OMR
+
+namespace TR
+{
+   class OMR_EXTENSIBLE ExtClass : public OMR::ExtClass {
+      public:
+      ExtClass(int x) { 
+         functionCalled(); // Inside of TR::ExtClass, needn't call self, as this is already of the correct type. 
+      }
+
+      void frobnicate() { 
+         functionCalled();  // Inside of TR::ExtClass, needn't call self. 
+      }
+   };
+}
+
+TR::ExtClass * OMR::ExtClass::self() { return static_cast<TR::ExtClass *>(this); }
+
+void OMR::ExtClass::functionCalled() {}
+


### PR DESCRIPTION
The linter needs to catch calls that are missing downcasts. What happens
however when the 'downcast' would really resolve to the current type?
This is a case we have encountered in the codebase where a
most-derived concrete TR:: type makes a member function call (see PR#913).

This PR resolves this by teaching the linter to check whether or not a
call resolves to the most derived type, and the current type is the most
derived type. 

Some refactoring is also provided. 