### PR TITLE
WIP: Add profileInfoIsUntrustworthy to OMR::Node

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -5173,6 +5173,27 @@ OMR::Node::printIsNonZero()
    return self()->isNonZero() ? "X!=0 " : "";
    }
 
+bool                   OMR::Node::profileInfoCannotBeTrusted()    { return _flags.testAny(profileInfoIsUntrustworthy); }
+void                   OMR::Node::setProfileInfoCannotBeTrusted() {  _flags.set(profileInfoIsUntrustworthy); }
+const char *           OMR::Node::printIsProfileInfoCannotBeTrusted() { return self()->profileInfoCannotBeTrusted() ? "profileInfoIsUntrustworthy " : ""; }
+ 
+void OMR::Node::setProfileInfoCannotBeTrusted(bool v)
+       {
+       TR::Compilation * c = TR::comp();
+       if (performNodeTransformation2(c,"O^O NODE FLAGS: Setting profileInfoIsUntrustworthy flag on node %p to %d\n", this, v))
+          _flags.set(profileInfoIsUntrustworthy, v);
+       }
+ 
+bool OMR::Node::canCheckIfProfileInfoCannotBeTrusted()
+       {
+       switch (self()->getOpCodeValue())
+          {
+          case TR::instanceof:
+             return true;
+          default:
+             return false;
+          }
+       }
 
 
 bool

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -892,6 +892,12 @@ public:
    bool isNonNull();
    void setIsNonNull(bool v);
 
+   bool profileInfoCannotBeTrusted();
+   void setProfileInfoCannotBeTrusted();
+   const char * printIsProfileInfoCannotBeTrusted();
+   void setProfileInfoCannotBeTrusted(bool v);
+   bool canCheckIfProfileInfoCannotBeTrusted();
+
    bool pointsToNull();
    void setPointsToNull(bool v);
    bool chkPointsToNull();
@@ -1981,6 +1987,7 @@ protected:
 
       // Flag used by TR::checkcast, TR::checkCastForArrayStore, and TR::instanceof
       referenceIsNonNull                    = 0x00008000, ///< Sometimes we can't mark the child as non-null (because it's not provably non-null everywhere) but we know it's non-null by the time we run this parent
+      profileInfoIsUntrustworthy             = 0x00004000,
 
       // Flag used by TR::Return
       returnIsDummy                         = 0x00001000,


### PR DESCRIPTION
The profileInfoIsUntrustworthy flag can be used to transfer
information between optimisations to avoid generating code that
depends on profiling data that is unlikely to be good.

The following functions have been added relating to the new flag:

   bool profileInfoCannotBeTrusted();
   void setProfileInfoCannotBeTrusted();
   const char * printIsProfileInfoCannotBeTrusted();
   void setProfileInfoCannotBeTrusted(bool v);
   bool canCheckIfProfileInfoCannotBeTrusted();

Signed-off-by: JamesKingdon <jkingdon@ca.ibm.com>