### PR TITLE
Add Xjit:enableFpreductionAnnotation option

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -641,6 +641,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"enableExpensiveOptsAtWarm",          "O\tenable store sinking, shrink wrapping and OSR at warm and below", SET_OPTION_BIT(TR_EnableExpensiveOptsAtWarm), "F" },
    {"enableFastHotRecompilation",         "R\ttry to recompile at hot sooner", SET_OPTION_BIT(TR_EnableFastHotRecompilation), "F"},
    {"enableFastScorchingRecompilation",   "R\ttry to recompile at scorching sooner", SET_OPTION_BIT(TR_EnableFastScorchingRecompilation), "F"},
+   {"enableFpreductionAnnotation",        "O\tenable fpreduction annotation", SET_OPTION_BIT(TR_EnableFpreductionAnnotation), "F"},
    {"enableFSDGRA",                       "O\tenable basic GRA in FSD mode", SET_OPTION_BIT(TR_FSDGRA), "F"},
    {"enableGCRPatching",                  "R\tenable patching of the GCR guard", SET_OPTION_BIT(TR_EnableGCRPatching), "F"},
    {"enableGPU",                          "L\tenable GPU support  (basic)",

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -956,7 +956,7 @@ enum TR_CompilationOptions
    TR_IncreaseCountsForMethodsCompiledOutsideStartup  = 0x00200000 + 29,
    TR_EnableMethodTrampolineReservation               = 0x00400000 + 29,
    TR_UseGlueIfMethodTrampolinesAreNotNeeded          = 0x00800000 + 29,
-   // Avaialble                                       = 0x01000000 + 29,
+   TR_EnableFpreductionAnnotation                     = 0x01000000 + 29,
    // Avialable                                       = 0x02000000 + 29,
    TR_DisableCrackedEditOptimization                  = 0x04000000 + 29,
    TR_InhibitRIBufferProcessingDuringDeepSteady       = 0x08000000 + 29,


### PR DESCRIPTION
  - add Xjit:enableFpreductionAnnotation for recognizing @fpreduction
    method annotation

Signed-off-by: Gita Koblents <koblents@ca.ibm.com>