### PR TITLE
Free out of line spills on Power

### DIFF
--- a/compiler/p/codegen/OMRMachine.hpp
+++ b/compiler/p/codegen/OMRMachine.hpp
@@ -172,6 +172,7 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
    TR::RegisterDependencyConditions  *createCondForLiveAndSpilledGPRs(bool cleanRegState, TR::list<TR::Register*> *spilledRegisterList = NULL);
 
    void decFutureUseCountAndUnlatch(TR::Register *virtualRegister);
+   void disassociateUnspilledBackingStorage();
    };
 }
 }

--- a/compiler/p/codegen/OMRRegisterDependency.cpp
+++ b/compiler/p/codegen/OMRRegisterDependency.cpp
@@ -819,25 +819,6 @@ void TR_PPCRegisterDependencyGroup::assignRegisters(TR::Instruction   *currentIn
             if (!(std::find(cg->getSpilledRegisterList()->begin(), cg->getSpilledRegisterList()->end(), virtReg) != cg->getSpilledRegisterList()->end()))
                cg->getSpilledRegisterList()->push_front(virtReg);
             }
-         // we also need to free up all locked backing storage if we are exiting the OOL during backwards RA assignment
-         else if (currentInstruction->isLabel() && virtReg->getAssignedRealRegister())
-            {
-            TR::PPCLabelInstruction *labelInstr = (TR::PPCLabelInstruction *)currentInstruction;
-            TR_BackingStore         *location = virtReg->getBackingStorage();
-            TR_RegisterKinds         rk = virtReg->getKind();
-            int32_t                  dataSize;
-            if (labelInstr->getLabelSymbol()->isStartOfColdInstructionStream() && location)
-               {
-               traceMsg(comp,"\nOOL: Releasing backing storage (%p)\n", location);
-               if (rk == TR_GPR)
-                  dataSize = TR::Compiler->om.sizeofReferenceAddress();
-               else
-                  dataSize = 8;
-               location->setMaxSpillDepth(0);
-               cg->freeSpill(location,dataSize,0);
-               virtReg->setBackingStorage(NULL);
-               }
-            }
          }
       }
 

--- a/compiler/p/codegen/PPCInstruction.cpp
+++ b/compiler/p/codegen/PPCInstruction.cpp
@@ -110,10 +110,13 @@ void TR::PPCLabelInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
 
       // Unlock the free spill list.
       //
-      // TODO: live registers that are not spilled at this point should have their backing
-      // storage returned to the free spill list.
-      //
       cg()->unlockFreeSpillList();
+
+      // Disassociate backing storage that was previously reserved for a spilled virtual if
+      // virtual is no longer spilled. This occurs because the the free spill list was
+      // locked.
+      //
+      machine->disassociateUnspilledBackingStorage();
       }
    }
 
@@ -227,10 +230,13 @@ void TR::PPCConditionalBranchInstruction::assignRegisters(TR_RegisterKinds kindT
 
       // Unlock the free spill list.
       //
-      // TODO: live registers that are not spilled at this point should have their backing
-      // storage returned to the free spill list.
-      //
       cg()->unlockFreeSpillList();
+
+      // Disassociate backing storage that was previously reserved for a spilled virtual if
+      // virtual is no longer spilled. This occurs because the the free spill list was
+      // locked.
+      //
+      machine->disassociateUnspilledBackingStorage();
       }
    }
 

--- a/compiler/p/codegen/PPCInstruction.cpp
+++ b/compiler/p/codegen/PPCInstruction.cpp
@@ -102,12 +102,18 @@ void TR::PPCLabelInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
       TR_PPCOutOfLineCodeSection *oi = cg()->findOutLinedInstructionsFromLabel(getLabelSymbol());
       TR_ASSERT(oi, "Could not find PPCOutOfLineCodeSection stream from label.  instr=%p, label=%p\n", this, getLabelSymbol());
 
-      cg()->unlockFreeSpillList();
       if (!oi->hasBeenRegisterAssigned())
          oi->assignRegisters(kindToBeAssigned);
 
       if (cg()->getDebug())
          cg()->traceRegisterAssignment("OOL: Finished register assignment in OOL section\n");
+
+      // Unlock the free spill list.
+      //
+      // TODO: live registers that are not spilled at this point should have their backing
+      // storage returned to the free spill list.
+      //
+      cg()->unlockFreeSpillList();
       }
    }
 
@@ -214,13 +220,17 @@ void TR::PPCConditionalBranchInstruction::assignRegisters(TR_RegisterKinds kindT
       //
       TR_PPCOutOfLineCodeSection *oi = cg()->findOutLinedInstructionsFromLabel(getLabelSymbol());
       TR_ASSERT(oi, "Could not find PPCOutOfLineCodeSection stream from label.  instr=%p, label=%p\n", this, getLabelSymbol());
-
-      cg()->unlockFreeSpillList();
       if (!oi->hasBeenRegisterAssigned())
          oi->assignRegisters(kindToBeAssigned);
-
       if (cg()->getDebug())
             cg()->traceRegisterAssignment("OOL: Finished register assignment in OOL section\n");
+
+      // Unlock the free spill list.
+      //
+      // TODO: live registers that are not spilled at this point should have their backing
+      // storage returned to the free spill list.
+      //
+      cg()->unlockFreeSpillList();
       }
    }
 


### PR DESCRIPTION
Prior attempt at improving the way we handle register spills during out of line register assignment (#908) was not sufficient to deal with the case where a register is spilled between the branch and merge of an out of line section, is also spilled out of line, is subsequently unspilled out of line, and therefore must be re-spilled at the end of out of line RA in order to restore the register file to its expected state. Under these conditions we have to make sure that the unspill of the register does not free the spill slot for re-use, since we will need to forcefully re-spill the register.

This PR reverts #908 and attempts to address this problem by only unlocking the free spill list in out of line code sections in specific, safe circumstances and by freeing spill slots after out of line RA where possible.

First, during out of line RA, we free the spill slot of any register who's future use count hits 0, as dead registers should definitely have no futher need for their spill slots. In order to do this we momentarily unlock the free spill list.

Second, after out of line RA we iterate through all of the currently assigned registers and free any spill slots still held by a register, since at this point out of line RA is complete and the free spill list has been unlocked.