### PR TITLE
Fix block split assert

### DIFF
--- a/compiler/il/OMRBlock.cpp
+++ b/compiler/il/OMRBlock.cpp
@@ -1383,8 +1383,8 @@ OMR::Block::splitEdge(TR::Block *from, TR::Block *to, TR::Compilation *c, TR::Tr
    else
       {
       TR::TreeTop *lastTree = from->getLastRealTreeTop();
-      TR::ILOpCodes opCode = lastTree->getNode()->getOpCodeValue();
-      TR_ASSERT(opCode == TR::athrow || lastTree->getNode()->getOpCode().isReturn(), "edge to EXIT should end in throw or return");
+      TR::ILOpCode &opCode = lastTree->getNode()->getOpCodeValue() == TR::treetop || lastTree->getNode()->getOpCode().isCheck() ? lastTree->getNode()->getFirstChild()->getOpCode() : lastTree->getNode()->getOpCode();
+      TR_ASSERT(opCode.getOpCodeValue() == TR::athrow || opCode.isReturn(), "edge to EXIT should end in throw or return");
 
       newBlock = self()->split(lastTree, cfg, true);
       }


### PR DESCRIPTION
There is an assert in the edge splitting code which asserts a block
connected to the exit must end in a throw or a return. It checks this
by looking at the treetop. These nodes are allowed to appear under check
treetops and this change fixes the assert to correctly handle these
cases.

Signed-off-by: Andrew Craik <ajcraik@ca.ibm.com>