### PR TITLE
Add infra to save basic block offset and frequency

### DIFF
--- a/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
@@ -40,6 +40,7 @@ namespace OMR { typedef OMR::ResolvedMethodSymbol ResolvedMethodSymbolConnector;
 #include "infra/Assert.hpp"            // for TR_ASSERT
 #include "infra/Flags.hpp"             // for flags32_t
 #include "infra/List.hpp"              // for List, etc
+#include "infra/TRlist.hpp"            // for TR::list
 
 class TR_BitVector;
 class TR_ExtraLinkageInfo;
@@ -291,6 +292,13 @@ public:
 
    TR::SymbolReference *getPythonConstsSymbolRef() { return _pythonConstsSymRef; }
 
+   int32_t getProfilingByteCodeIndex(int32_t bytecodeIndex);
+   void addProfilingOffsetInfo(int32_t startBCI, int32_t endBCI);
+   void setProfilerFrequency(int32_t bytecodeIndex, int32_t frequency);
+   int32_t getProfilerFrequency(int32_t bytecodeIndex);
+   void clearProfilingOffsetInfo();
+   void dumpProfilingOffsetInfo(TR::Compilation *comp);
+
 protected:
    enum Properties
       {
@@ -347,6 +355,8 @@ private:
    TR_BitVector                              *_cannotAttemptOSR;
    TR_BitVector                              *_shouldNotAttemptOSR;
    uint8_t                                   _unimplementedOpcode;
+
+   TR::list< std::pair<int32_t, std::pair<int32_t, int32_t> > > _bytecodeProfilingOffsets;
 
    //used if estimateCodeSize is called
    enum


### PR DESCRIPTION
Reassociating profiling information can be very tricky. In general the
OMR compiler will use bytecode metadata stored alongside profiling data
to faciliate re-associating the profiling data with basic blocks. It is
general practice in the compiler to reset all block frequencies post
inlining to regenerate a re-nomalized set of frequency data for the
composed method as a whole. This means we can see blocks which have been
split by inlining and we need to find the correct bytecode index at
which to lookup their frequency data. It is also possible that we are
not able to recompute a frequency for a block even though a frequency
was computed for it when it was IL generated in isolation. For this
reason it would be desirable to save frequency information from il
generation as a fallback. This change adds the infrastructure to save
bytecode ranges for basic blocks as seen by IL generation and their
associated frequencies for later use during profile re-association.

Signed-off-by: Andrew Craik <ajcraik@ca.ibm.com>