### PR TITLE
Prevent gotoElim from skipping asynccheck in OSR

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1992,9 +1992,6 @@ OMR::Options::jitLatePostProcess(TR::OptionSet *optionSet, void * jitConfig)
       // TM results in difficult situations when determining where the transition should occur,
       // so it is currently disabled. The implications of disabling TM should be investigated further.
       self()->setOption(TR_DisableTM);
-      // RedundantGotoElimination creates complications for NextGenHCR, potentially due to
-      // the manipulation of asyncchecks. The implications of disabling it should be investigated further.
-      self()->setDisabled(redundantGotoElimination, true);
       // Asynchecks cannot be removed in NextGenHCR as they may be used for transitions
       self()->setDisabled(redundantAsyncCheckRemoval, true);
       }

--- a/compiler/optimizer/LocalOpts.hpp
+++ b/compiler/optimizer/LocalOpts.hpp
@@ -147,7 +147,7 @@ public:
    int32_t process(TR::TreeTop *, TR::TreeTop *);
 
 private:
-   void placeAsyncCheck(TR::Block *);
+   void placeAsyncCheckBefore(TR::TreeTop *);
    void renumberInAncestors(TR_Structure *str, int32_t newNumber);
    void renumberExitEdges(TR_RegionStructure *region, int32_t oldN, int32_t newN);
    };


### PR DESCRIPTION
Goto elimination will attempt to remove blocks that contain
a series of asyncchecks followed by a goto. To ensure the asynccheck
is still present, it is currently moved to all of its predecessors.
However, these may have other successors, some of which may not
correctly manage the addition of a yield point. To correct this,
the asynccheck is shifted to the start of the goto's destination block
which should contain anything needed to account for the yield.