### PR TITLE
Add check for OSR induce block

### DIFF
--- a/compiler/il/OMRBlock.hpp
+++ b/compiler/il/OMRBlock.hpp
@@ -366,6 +366,8 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
    int32_t getNormalizedFrequency(TR::CFG *);
    int32_t getGlobalNormalizedFrequency(TR::CFG *);
 
+   bool isOSRInduceBlock(TR::Compilation *);
+
    /**
     * Field functions end
     */


### PR DESCRIPTION
When OSR transitions are implemented using OSR guards, the taken
side of the guard manages several book keeping aspects of the
transition. For example, it will contain stores to dead symbol
references and will remat symbol references required for the
transition. This block can be ignored by several optimizations.
To allow for this, this change adds a check for such a block.