### PR TITLE
WIP: Fail ilgen if involuntary OSR cannot do OSR

### DIFF
--- a/compiler/compile/CompilationException.hpp
+++ b/compiler/compile/CompilationException.hpp
@@ -40,6 +40,11 @@ struct RecoverableILGenException : public virtual CompilationException
    virtual const char* what() const throw() { return "Recoverable IL Gen Exception"; }
    };
 
+struct TransformationUnsupportedUnderInvolentaryOSR: public virtual RecoverableILGenException
+   {
+   virtual const char* what() const throw() { return "cannot do OSR under InvoluntaryOSR mode"; }
+   };
+
 struct ExcessiveComplexity : public virtual CompilationException
    {
    virtual const char* what() const throw() { return "Excessive Complexity"; }

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -1254,6 +1254,14 @@ OMR::ResolvedMethodSymbol::genIL(TR_FrontEnd * fe, TR::Compilation * comp, TR::S
                comp->getOption(TR_EnableOSR) && comp->supportsInduceOSR() &&
                !comp->isPeekingMethod()  && (comp->getOption(TR_EnableNextGenHCR) || !comp->getOption(TR_EnableHCR)) ;
 
+            if (!comp->isPeekingMethod())
+               {
+               if (comp->getOSRMode() == TR::involuntaryOSR && !doOSR)
+                  {
+                  comp->failCompilation<TR::TransformationUnsupportedUnderInvolentaryOSR>("doOSR must be true for involuntaryOSR mode");
+                  }
+               }
+
             optimizer = TR::Optimizer::createOptimizer(comp, self(), true);
             previousOptimizer = comp->getOptimizer();
             comp->setOptimizer(optimizer);


### PR DESCRIPTION
A few non-optional transformations in ilgen can result in OSR failures.
In such cases we need to fail the ilgen by throwing
TransformationUnsupportedUnderInvolentaryOSR excpetion to either abort
the compilation or stop inlininig the callee depending on whether it's
top most method or inlined callee.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>