### PR TITLE
WIP: Enable folding for test of array class in VP

### DIFF
--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -7814,6 +7814,25 @@ TR::Node *constrainIand(OMR::ValuePropagation *vp, TR::Node *node)
                         }
                      }
                   }
+                OMR::Node *classChild = firstGrandChild->getFirstChild();
+                if ((classChild->getOpCodeValue() == TR::aloadi) &&
+                    (classChild->getSymbolReference() == vp->comp()->getSymRefTab()->findClassFromJavaLangClassSymbolRef()))
+                   {
+                   bool classChildGlobal;
+                   TR::VPConstraint *classChildConstraint = vp->getConstraint(classChild->getFirstChild(), classChildGlobal);
+                   if (classChildConstraint && classChildConstraint->isJavaLangClassObject() == TR_yes
+                       && classChildConstraint->isNonNullObject()
+                       && classChildConstraint->getClassType()
+                       && classChildConstraint->getClassType()->asFixedClass()
+                       && classChildConstraint->getClass())
+                      {
+                      bool classChildIsArray = TR::Compiler->cls.isClassArray(vp->comp(), classChildConstraint->getClass());
+                      if (classChildIsArray)
+                         constraint = TR::VPIntConst::create(vp, 1);
+                       else
+                         constraint = TR::VPIntConst::create(vp, 0);
+                      }
+                   }
                }
             }
 


### PR DESCRIPTION
Detect Iand operating on a fixed array class so that optimizations
can fold away runtime tests for array types. This extends the
existing functionality in VP for folding an isArray test based on
an object to the case where we don't have an object, but we do have
a Class in hand.

Signed-off-by: JamesKingdon <jkingdon@ca.ibm.com>