### PR TITLE
Add property to merge guards with OSR guards

### DIFF
--- a/compiler/compile/VirtualGuard.cpp
+++ b/compiler/compile/VirtualGuard.cpp
@@ -58,7 +58,7 @@ TR_VirtualGuard::TR_VirtualGuard(TR_VirtualGuardTestType test, TR_VirtualGuardKi
      _sites(comp->trMemory()),
 #endif
      _mutableCallSiteObject(0),_mutableCallSiteEpoch(0),
-     _evalChildren(true), _mergedWithHCRGuard(false),
+     _evalChildren(true), _mergedWithHCRGuard(false), _mergedWithOSRGuard(false),
      _guardNode(guardNode), _currentInlinedSiteIndex(currentSiteIndex)
    {
    if (callNode)
@@ -88,7 +88,7 @@ TR_VirtualGuard::TR_VirtualGuard(TR_VirtualGuardTestType test, TR_VirtualGuardKi
 TR_VirtualGuard::TR_VirtualGuard(TR_VirtualGuardTestType test, TR_VirtualGuardKind kind,
              TR::Compilation * comp, TR::Node* callNode, TR::Node*guardNode, int32_t currentSiteIndex)
    : _test(test), _kind(kind), _guardedMethod((callNode->getOpCode().hasSymbolReference()) ? callNode->getSymbolReference() : NULL),
-     _thisClass(0), _callNode(callNode), _cannotBeRemoved(false), _mergedWithHCRGuard(false),
+     _thisClass(0), _callNode(callNode), _cannotBeRemoved(false), _mergedWithHCRGuard(false), _mergedWithOSRGuard(false),
      _calleeIndex(callNode->getByteCodeInfo().getCallerIndex()),
      _byteCodeIndex(callNode->getByteCodeInfo().getByteCodeIndex()),
      _innerAssumptions(comp->trMemory()),

--- a/compiler/compile/VirtualGuard.hpp
+++ b/compiler/compile/VirtualGuard.hpp
@@ -255,6 +255,9 @@ class TR_VirtualGuard
    void                    setMergedWithHCRGuard() { _mergedWithHCRGuard=true; _cannotBeRemoved = true; }
    bool                    mergedWithHCRGuard() { return _mergedWithHCRGuard; }
 
+   void                    setMergedWithOSRGuard() { _mergedWithOSRGuard=true; _cannotBeRemoved = true; }
+   bool                    mergedWithOSRGuard() { return _mergedWithOSRGuard; }
+
    int32_t                 getCurrentInlinedSiteIndex() { return _currentInlinedSiteIndex; }
    void                    setCurrentInlinedSiteIndex(int32_t index) { _currentInlinedSiteIndex = index; }
 
@@ -286,6 +289,7 @@ class TR_VirtualGuard
    List<TR_InnerAssumption>  _innerAssumptions;
    bool                      _evalChildren;
    bool                      _mergedWithHCRGuard;
+   bool                      _mergedWithOSRGuard;
 
    // These reference locations are non-null only for MutableCallSiteGuards
    uintptrj_t                *_mutableCallSiteObject;

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -3612,14 +3612,16 @@ TR_Debug::dump(TR::FILE *pOutFile, TR_CHTable * chTable)
       uint32_t i = 0;
       for (auto info = vguards.begin(); info != vguards.end(); ++info, ++i)
          {
-         char guardKindName[38];
-         sprintf(guardKindName, "%s %s", getVirtualGuardKindName((*info)->getKind()), (*info)->mergedWithHCRGuard()?"+ HCRGuard ":"");
+         char guardKindName[49];
+         sprintf(guardKindName, "%s %s%s", getVirtualGuardKindName((*info)->getKind()),
+            (*info)->mergedWithHCRGuard()?"+ HCRGuard ":"",
+            (*info)->mergedWithOSRGuard()?"+ OSRGuard ":"");
 
          if (!(*info)->getSymbolReference())
-            trfprintf(pOutFile, "[%4d] %-38s %s%s\n",
+            trfprintf(pOutFile, "[%4d] %-49s %s%s\n",
                   i, guardKindName ,(*info)->isInlineGuard()?"inlined ":"", guardKindName);
          else
-            trfprintf(pOutFile, "[%4d] %-38s %scalleeSymbol=" POINTER_PRINTF_FORMAT "\n",
+            trfprintf(pOutFile, "[%4d] %-49s %scalleeSymbol=" POINTER_PRINTF_FORMAT "\n",
                   i, guardKindName ,(*info)->isInlineGuard()?"inlined ":"", (*info)->getSymbolReference()->getSymbol());
          ListIterator<TR_VirtualGuardSite> siteIt(&(*info)->getNOPSites());
          for (TR_VirtualGuardSite *site = siteIt.getFirst(); site; site = siteIt.getNext())


### PR DESCRIPTION
Existing guards may be reused to implement OSR transitions. These
guards should be marked appropriately so that they can be
patched when necessary, similar to OSR guards. This change adds
a property to signify this, similar to the existing mergedWithHCR flag.