### PR TITLE
Runtime concurrentScavenger flag

### DIFF
--- a/example/glue/ScavengerRootScanner.hpp
+++ b/example/glue/ScavengerRootScanner.hpp
@@ -98,9 +98,7 @@ public:
 		}
 	}
 	
-#if !defined(OMR_GC_CONCURRENT_SCAVENGER)
 	void rescanThreadSlots(MM_EnvironmentStandard *env) { }
-#endif
 
 	void scanClearable(MM_EnvironmentBase *env)
 	{

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -398,7 +398,7 @@ public:
 	bool scavengerRsoScanUnsafe;
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	bool concurrentScavenger;
-#endif	
+#endif	/* OMR_GC_CONCURRENT_SCAVENGER */
 	uintptr_t scavengerFailedTenureThreshold;
 	uintptr_t maxScavengeBeforeGlobal;
 	uintptr_t scvArraySplitMaximumAmount; /**< maximum number of elements to split array scanning work in the scavenger */
@@ -763,6 +763,16 @@ public:
 	MMINLINE void setObjectMap(MM_ObjectMap *objectMap) { _objectMap = objectMap; }
 #endif /* defined(OMR_GC_OBJECT_MAP) */
 
+	MMINLINE bool
+	isConcurrentScavengerEnabled()
+	{
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+		return concurrentScavenger;
+#else
+		return false;
+#endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
+	}
+	
 	MMINLINE bool
 	isScavengerEnabled()
 	{
@@ -1134,7 +1144,7 @@ public:
 		, scvTenureStrategyHistory(true)
 		, scavengerEnabled(false)
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
-		, concurrentScavenger(true)
+		, concurrentScavenger(false)
 #endif		
 		, scavengerFailedTenureThreshold(0)
 		, scvArraySplitMaximumAmount(DEFAULT_ARRAY_SPLIT_MAXIMUM_SIZE)
@@ -1143,12 +1153,7 @@ public:
 		, scavengerScanCacheMinimumSize(DEFAULT_SCAN_CACHE_MINIMUM_SIZE)
 		, tiltedScavenge(true)
 		, debugTiltedScavenge(false)
-#if defined(OMR_GC_CONCURRENT_SCAVENGER)
-		/* until we get dynamic tilting, make default tilting at mild 70% */
-		, survivorSpaceMinimumSizeRatio(0.30)
-#else
 		, survivorSpaceMinimumSizeRatio(0.10)
-#endif /* OMR_GC_CONCURRENT_SCAVENGER */
 		, survivorSpaceMaximumSizeRatio(0.50)
 		, tiltedScavengeMaximumIncrease(0.10)
 		, scavengerCollectorExpandRatio(0.1)

--- a/gc/base/MemorySubSpaceGenerational.cpp
+++ b/gc/base/MemorySubSpaceGenerational.cpp
@@ -259,10 +259,10 @@ void
 MM_MemorySubSpaceGenerational::checkResize(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, bool _systemGC)
 {
 	getMemorySubSpaceOld()->checkResize(env, allocDescription, _systemGC);
-#if defined(OMR_GC_CONCURRENT_SCAVENGER)
-	/* restore Nursery tilt */
-	getMemorySubSpaceNew()->checkResize(env, allocDescription, _systemGC);
-#endif /* OMR_GC_CONCURRENT_SCAVENGER */
+	if (_extensions->isConcurrentScavengerEnabled()) {
+		/* restore Nursery tilt */
+		getMemorySubSpaceNew()->checkResize(env, allocDescription, _systemGC);
+	}
 }
 
 /**

--- a/gc/base/MemorySubSpaceSemiSpace.cpp
+++ b/gc/base/MemorySubSpaceSemiSpace.cpp
@@ -455,6 +455,7 @@ MM_MemorySubSpaceSemiSpace::flip(MM_EnvironmentBase *env, Flip_step step)
 		break;
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	case backout:
+		Assert_MM_true(_extensions->concurrentScavenger);
 		/* We have objects on both sides of Nursery. We will unify the two sides and do a compacting slide (after percolate global GC)
 		 * Enforce Allocate be in low address range, since compact slide in percolate global GC moves objects to low addresses.
 		 * Note: _allocateSpaceBase/Top are stale (not updated in set_allocate), since they are overloaded to point to Evacuate during an active cycle
@@ -489,12 +490,13 @@ MM_MemorySubSpaceSemiSpace::flip(MM_EnvironmentBase *env, Flip_step step)
 		break;
 	case restore_tilt_after_percolate:
 	{
+		Assert_MM_true(_extensions->concurrentScavenger);
 		/* Make Survivor space from the last free entry in the unified Nursery */
 		uintptr_t heapAlignedLastFreeEntrySize = MM_Math::roundToFloor(_extensions->heapAlignment, getDefaultMemorySubSpace()->getMemoryPool()->getLastFreeEntry()->getSize());
 
 		/* for now, assumed fixed size of 64 sections in Nursery */
-		const uint64_t maxSectionCount = 64;
-		uint64_t sectionSize = (getCurrentSize()) / maxSectionCount;
+		const uintptr_t maxSectionCount = 64;
+		uintptr_t sectionSize = (getCurrentSize()) / maxSectionCount;
 
 		heapAlignedLastFreeEntrySize = MM_Math::roundToFloor(sectionSize, heapAlignedLastFreeEntrySize);
 		if(debug) {
@@ -588,10 +590,10 @@ MM_MemorySubSpaceSemiSpace::masterTeardownForSuccessfulGC(MM_EnvironmentBase *en
 	_memorySubSpaceEvacuate->rebuildFreeList(env);
 
 	/* Flip the memory space allocate profile */
-#if !defined(OMR_GC_CONCURRENT_SCAVENGER)
-	flip(env, set_allocate);
-	flip(env, disable_allocation);
-#endif
+	if (!_extensions->isConcurrentScavengerEnabled()) {
+		flip(env, set_allocate);
+		flip(env, disable_allocation);
+	}
 	flip(env, restore_allocation_and_set_survivor);
 
 	/* Adjust memory between the semi spaces where applicable */
@@ -604,14 +606,14 @@ void
 MM_MemorySubSpaceSemiSpace::masterTeardownForAbortedGC(MM_EnvironmentBase *env)
 {
 	/* Build free list in survivor. */
-#if defined(OMR_GC_CONCURRENT_SCAVENGER)
-	/* There might be live objects in Survivor (newly allocated one since the start of Concurrent Scavenge cycle)
-	 * Sweep in percolate global will rebuild it, so we can skip it here
-	 */
-	flip(env, backout);
-#else
-	_memorySubSpaceSurvivor->rebuildFreeList(env);
-#endif /* OMR_GC_CONCURRENT_SCAVENGER */
+	if (_extensions->isConcurrentScavengerEnabled()) {
+		/* There might be live objects in Survivor (newly allocated one since the start of Concurrent Scavenge cycle)
+		 * Sweep in percolate global will rebuild it, so we can skip it here
+		 */
+		flip(env, backout);
+	} else {
+		_memorySubSpaceSurvivor->rebuildFreeList(env);
+	}
 
 }
 
@@ -624,125 +626,125 @@ MM_MemorySubSpaceSemiSpace::checkSubSpaceMemoryPostCollectTilt(MM_EnvironmentBas
 	MM_GCExtensionsBase *extensions = MM_GCExtensionsBase::getExtensions(env->getOmrVM());
 
 	if(extensions->tiltedScavenge) {
-#if defined(OMR_GC_CONCURRENT_SCAVENGER)
-		/* for now, support static tilting only */
-		_desiredSurvivorSpaceRatio = extensions->survivorSpaceMinimumSizeRatio;
-#else
-		uintptr_t flipBytes;
-		uintptr_t flipBytesDelta;
-		bool debug = extensions->debugTiltedScavenge;
-		OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
-
-		/* OMRTODO consider maintaining _flipBytes separately for each NUMA SemiSpace.
-		 * Currently, _flipBytes is cumulative for all SemiSpaces. To compensate, current size is obtained
-		 * for all of SemiSpaces too (from top level New SubSpace). This will result in blended tilt ratio,
-		 * set equally for all of SemiSpaces.
-		 */
-		uintptr_t currentSize = getTopLevelMemorySubSpace(MEMORY_TYPE_NEW)->getCurrentSize();
-
-		if(debug) {
-			omrtty_printf("\nTilt check:\n");
-		}
-
-		flipBytes = extensions->scavengerStats._flipBytes + extensions->scavengerStats._failedFlipBytes;
-
-		if(debug) {
-			omrtty_printf("\tBytes flip:%zu fail:%zu total:%zu\n",
-				extensions->scavengerStats._flipBytes,
-				extensions->scavengerStats._failedFlipBytes,
-				flipBytes);
-		}
-
-		/* Determine the absolute value of the change in bytes flipped since the last scavenge */
-		if(flipBytes > _previousBytesFlipped) {
-			flipBytesDelta = flipBytes - _previousBytesFlipped;
+		if (_extensions->isConcurrentScavengerEnabled()) {
+			/* for now, support static tilting only */
+			_desiredSurvivorSpaceRatio = extensions->survivorSpaceMinimumSizeRatio;
 		} else {
-			flipBytesDelta = _previousBytesFlipped - flipBytes;
-		}
+			uintptr_t flipBytes;
+			uintptr_t flipBytesDelta;
+			bool debug = extensions->debugTiltedScavenge;
+			OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
 
-		if(debug) {
-			omrtty_printf("\tflip delta from last (%zu):%zu\n", _previousBytesFlipped, flipBytesDelta);
-		}
+			/* OMRTODO consider maintaining _flipBytes separately for each NUMA SemiSpace.
+			 * Currently, _flipBytes is cumulative for all SemiSpaces. To compensate, current size is obtained
+			 * for all of SemiSpaces too (from top level New SubSpace). This will result in blended tilt ratio,
+			 * set equally for all of SemiSpaces.
+			 */
+			uintptr_t currentSize = getTopLevelMemorySubSpace(MEMORY_TYPE_NEW)->getCurrentSize();
 
-		/* Current flip count becomes previous */
-		_previousBytesFlipped = flipBytes;
-
-		/* The average bytes flipped weighted average is more heavily affected if the current size is
-		 * greater than the current average
-		 */
-		if(debug) {
-			omrtty_printf("\tcurrent average bytes flipped: %zu (avg delta %zu)\n",
-				_tiltedAverageBytesFlipped,
-				_tiltedAverageBytesFlippedDelta);
-		}
-
-		/* Check if there was any failed to flip objects - which puts us into a bit of a panic mode */
-		if(0 != extensions->scavengerStats._failedFlipCount) {
-			/* Panic mode - the current numbers should heavily influence the averages */
 			if(debug) {
-				omrtty_printf("\tfailed flip weight\n");
+				omrtty_printf("\nTilt check:\n");
 			}
-			_tiltedAverageBytesFlipped = (uintptr_t)MM_Math::weightedAverage((float)_tiltedAverageBytesFlipped, (float)flipBytes, 0.0f);
-			_tiltedAverageBytesFlippedDelta = (uintptr_t)MM_Math::weightedAverage((float)_tiltedAverageBytesFlippedDelta, (float)flipBytesDelta, 0.0f);
-		} else {
-			/* No panic situation - determine the new tilt ratio through normal means */
-			if(flipBytes > _tiltedAverageBytesFlipped) {
-				if(debug) {
-					omrtty_printf("\tincrease flip weight\n");
-				}
-				_tiltedAverageBytesFlipped = (uintptr_t)MM_Math::weightedAverage((float)_tiltedAverageBytesFlipped, (float)flipBytes, 0.2f);
-				_tiltedAverageBytesFlippedDelta = (uintptr_t)MM_Math::weightedAverage((float)_tiltedAverageBytesFlippedDelta, (float)flipBytesDelta, 0.2f);
+
+			flipBytes = extensions->scavengerStats._flipBytes + extensions->scavengerStats._failedFlipBytes;
+
+			if(debug) {
+				omrtty_printf("\tBytes flip:%zu fail:%zu total:%zu\n",
+					extensions->scavengerStats._flipBytes,
+					extensions->scavengerStats._failedFlipBytes,
+					flipBytes);
+			}
+
+			/* Determine the absolute value of the change in bytes flipped since the last scavenge */
+			if(flipBytes > _previousBytesFlipped) {
+				flipBytesDelta = flipBytes - _previousBytesFlipped;
 			} else {
+				flipBytesDelta = _previousBytesFlipped - flipBytes;
+			}
+
+			if(debug) {
+				omrtty_printf("\tflip delta from last (%zu):%zu\n", _previousBytesFlipped, flipBytesDelta);
+			}
+
+			/* Current flip count becomes previous */
+			_previousBytesFlipped = flipBytes;
+
+			/* The average bytes flipped weighted average is more heavily affected if the current size is
+			 * greater than the current average
+			 */
+			if(debug) {
+				omrtty_printf("\tcurrent average bytes flipped: %zu (avg delta %zu)\n",
+					_tiltedAverageBytesFlipped,
+					_tiltedAverageBytesFlippedDelta);
+			}
+
+			/* Check if there was any failed to flip objects - which puts us into a bit of a panic mode */
+			if(0 != extensions->scavengerStats._failedFlipCount) {
+				/* Panic mode - the current numbers should heavily influence the averages */
 				if(debug) {
-					omrtty_printf("\tdecrease flip weight\n");
+					omrtty_printf("\tfailed flip weight\n");
 				}
-				_tiltedAverageBytesFlipped = (uintptr_t)MM_Math::weightedAverage((float)_tiltedAverageBytesFlipped, (float)flipBytes, 0.8f);
-				_tiltedAverageBytesFlippedDelta = (uintptr_t)MM_Math::weightedAverage((float)_tiltedAverageBytesFlippedDelta, (float)flipBytesDelta, 0.8f);
+				_tiltedAverageBytesFlipped = (uintptr_t)MM_Math::weightedAverage((float)_tiltedAverageBytesFlipped, (float)flipBytes, 0.0f);
+				_tiltedAverageBytesFlippedDelta = (uintptr_t)MM_Math::weightedAverage((float)_tiltedAverageBytesFlippedDelta, (float)flipBytesDelta, 0.0f);
+			} else {
+				/* No panic situation - determine the new tilt ratio through normal means */
+				if(flipBytes > _tiltedAverageBytesFlipped) {
+					if(debug) {
+						omrtty_printf("\tincrease flip weight\n");
+					}
+					_tiltedAverageBytesFlipped = (uintptr_t)MM_Math::weightedAverage((float)_tiltedAverageBytesFlipped, (float)flipBytes, 0.2f);
+					_tiltedAverageBytesFlippedDelta = (uintptr_t)MM_Math::weightedAverage((float)_tiltedAverageBytesFlippedDelta, (float)flipBytesDelta, 0.2f);
+				} else {
+					if(debug) {
+						omrtty_printf("\tdecrease flip weight\n");
+					}
+					_tiltedAverageBytesFlipped = (uintptr_t)MM_Math::weightedAverage((float)_tiltedAverageBytesFlipped, (float)flipBytes, 0.8f);
+					_tiltedAverageBytesFlippedDelta = (uintptr_t)MM_Math::weightedAverage((float)_tiltedAverageBytesFlippedDelta, (float)flipBytesDelta, 0.8f);
+				}
+			}
+
+			if(debug) {
+				omrtty_printf("\tnew average bytes flipped: %zu (avg delta %zu)\n",
+					_tiltedAverageBytesFlipped,
+					_tiltedAverageBytesFlippedDelta);
+			}
+
+			/* Calculate the desired survivor space ratio */
+
+			double survivorSizeAmplification = 1.04 + extensions->dispatcher->threadCount() / 100.0;
+			_desiredSurvivorSpaceRatio = (_tiltedAverageBytesFlipped + _tiltedAverageBytesFlippedDelta)
+											* survivorSizeAmplification	/ currentSize;
+
+			if(debug) {
+				omrtty_printf("\tDesired survivor size: %zu  ratio: %zu\n",
+					(uintptr_t)(currentSize * _desiredSurvivorSpaceRatio),	(uintptr_t) (_desiredSurvivorSpaceRatio * 100));
+			}
+
+			/* Sanity check for lowest possible ratio */
+			if (_desiredSurvivorSpaceRatio <  extensions->survivorSpaceMinimumSizeRatio) {
+				_desiredSurvivorSpaceRatio =  extensions->survivorSpaceMinimumSizeRatio;
+			}
+
+			/* Never hand out more than 50% to the survivor */
+			if (_desiredSurvivorSpaceRatio > extensions->survivorSpaceMaximumSizeRatio) {
+				_desiredSurvivorSpaceRatio = extensions->survivorSpaceMaximumSizeRatio;
+			}
+
+			/* we have flipped already, so to get old survivor space ratio we fetch allocate size */
+			double previousSurvivorSpaceRatio = (double) _memorySubSpaceAllocate->getActiveMemorySize() / currentSize;
+
+			/* Do not let survivor space shrink by more than the maximum tilt increase */
+			assume0(previousSurvivorSpaceRatio >= extensions->tiltedScavengeMaximumIncrease);
+			if (_desiredSurvivorSpaceRatio < (previousSurvivorSpaceRatio - extensions->tiltedScavengeMaximumIncrease)) {
+				_desiredSurvivorSpaceRatio = previousSurvivorSpaceRatio -  extensions->tiltedScavengeMaximumIncrease;
+			}
+
+			if(debug) {
+				omrtty_printf("\tPrevious survivor ratio: %zu\n", (uintptr_t) (previousSurvivorSpaceRatio * 100));
+				omrtty_printf("\tAdjusted survivor size: %zu  ratio: %zu\n",(uintptr_t)(currentSize * _desiredSurvivorSpaceRatio),
+					(uintptr_t) (_desiredSurvivorSpaceRatio * 100));
 			}
 		}
-
-		if(debug) {
-			omrtty_printf("\tnew average bytes flipped: %zu (avg delta %zu)\n",
-				_tiltedAverageBytesFlipped,
-				_tiltedAverageBytesFlippedDelta);
-		}
-
-		/* Calculate the desired survivor space ratio */
-		
-		double survivorSizeAmplification = 1.04 + extensions->dispatcher->threadCount() / 100.0;
-		_desiredSurvivorSpaceRatio = (_tiltedAverageBytesFlipped + _tiltedAverageBytesFlippedDelta)
-										* survivorSizeAmplification	/ currentSize;
-										
-		if(debug) {
-			omrtty_printf("\tDesired survivor size: %zu  ratio: %zu\n",
-				(uintptr_t)(currentSize * _desiredSurvivorSpaceRatio),	(uintptr_t) (_desiredSurvivorSpaceRatio * 100));
-		}
-
-		/* Sanity check for lowest possible ratio */
-		if (_desiredSurvivorSpaceRatio <  extensions->survivorSpaceMinimumSizeRatio) {
-			_desiredSurvivorSpaceRatio =  extensions->survivorSpaceMinimumSizeRatio;
-		}
-
-		/* Never hand out more than 50% to the survivor */
-		if (_desiredSurvivorSpaceRatio > extensions->survivorSpaceMaximumSizeRatio) {
-			_desiredSurvivorSpaceRatio = extensions->survivorSpaceMaximumSizeRatio;			
-		}
-		
-		/* we have flipped already, so to get old survivor space ratio we fetch allocate size */
-		double previousSurvivorSpaceRatio = (double) _memorySubSpaceAllocate->getActiveMemorySize() / currentSize;
-		
-		/* Do not let survivor space shrink by more than the maximum tilt increase */
-		assume0(previousSurvivorSpaceRatio >= extensions->tiltedScavengeMaximumIncrease);
-		if (_desiredSurvivorSpaceRatio < (previousSurvivorSpaceRatio - extensions->tiltedScavengeMaximumIncrease)) {
-			_desiredSurvivorSpaceRatio = previousSurvivorSpaceRatio -  extensions->tiltedScavengeMaximumIncrease;
-		}
-		
-		if(debug) {
-			omrtty_printf("\tPrevious survivor ratio: %zu\n", (uintptr_t) (previousSurvivorSpaceRatio * 100));			
-			omrtty_printf("\tAdjusted survivor size: %zu  ratio: %zu\n",(uintptr_t)(currentSize * _desiredSurvivorSpaceRatio),
-				(uintptr_t) (_desiredSurvivorSpaceRatio * 100));
-		}
-#endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 	}
 }
 
@@ -924,7 +926,7 @@ MM_MemorySubSpaceSemiSpace::checkResize(MM_EnvironmentBase *env, MM_AllocateDesc
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	/* this we are called at the end of precolate global GC, due to aborted Concurrent Scavenge,
 	 * we have to restore tilt (that has been set to 100% to do unified sliding compact of Nursery */
-	if (J9MMCONSTANT_IMPLICIT_GC_PERCOLATE_ABORTED_SCAVENGE == env->_cycleState->_gcCode.getCode()) {
+	if (_extensions->concurrentScavenger && J9MMCONSTANT_IMPLICIT_GC_PERCOLATE_ABORTED_SCAVENGE == env->_cycleState->_gcCode.getCode()) {
 		flip(env, MM_MemorySubSpaceSemiSpace::restore_tilt_after_percolate);
 	} else
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
@@ -944,14 +946,15 @@ MM_MemorySubSpaceSemiSpace::performResize(MM_EnvironmentBase *env, MM_AllocateDe
 	if (_desiredSurvivorSpaceRatio > 0.0) {
 		uintptr_t desiredSurvivorSpaceSize = (uintptr_t)(getCurrentSize() * _desiredSurvivorSpaceRatio);
 
-#if defined(OMR_GC_CONCURRENT_SCAVENGER)
-		/* for now, assumed fixed size of 64 sections in Nursery */
-		const uint64_t maxSectionCount = 64;
-		uint64_t sectionSize = (getCurrentSize()) / maxSectionCount;
-		desiredSurvivorSpaceSize = MM_Math::roundToCeiling(sectionSize, desiredSurvivorSpaceSize);
-#else
-		desiredSurvivorSpaceSize = MM_Math::roundToCeiling(regionSize, desiredSurvivorSpaceSize);
-#endif
+		if (_extensions->isConcurrentScavengerEnabled()) {
+			/* for now, assumed fixed size of 64 sections in Nursery */
+			const uintptr_t maxSectionCount = 64;
+			uintptr_t sectionSize = (getCurrentSize()) / maxSectionCount;
+			desiredSurvivorSpaceSize = MM_Math::roundToCeiling(sectionSize, desiredSurvivorSpaceSize);
+		} else {
+			desiredSurvivorSpaceSize = MM_Math::roundToCeiling(regionSize, desiredSurvivorSpaceSize);
+		}
+
 		tilt(env, desiredSurvivorSpaceSize);
 		_desiredSurvivorSpaceRatio = 0.0;
 	}

--- a/gc/base/SlotObject.hpp
+++ b/gc/base/SlotObject.hpp
@@ -93,7 +93,6 @@ public:
 		}
 	}
 
-#if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	/**
 	 * Atomically replace heap reference. It is accepted to fail - some other thread
 	 * might have raced us and put a more up to date value.
@@ -116,7 +115,6 @@ public:
 		
 		return swapResult;
 	}
-#endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
 	/**
 	 *	Update of slot address.

--- a/gc/base/standard/EnvironmentStandard.cpp
+++ b/gc/base/standard/EnvironmentStandard.cpp
@@ -48,7 +48,9 @@ bool
 MM_EnvironmentStandard::initialize(MM_GCExtensionsBase *extensions)
 {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
-	extensions->scavenger->mutatorSetupForGC(this);
+	if (extensions->concurrentScavenger) {
+		extensions->scavenger->mutatorSetupForGC(this);
+	}
 #endif
 
 	/* initialize base class */
@@ -59,7 +61,9 @@ void
 MM_EnvironmentStandard::tearDown(MM_GCExtensionsBase *extensions)
 {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
-	extensions->scavenger->mutatorFinalReleaseCopyCaches(this, this);
+	if (extensions->concurrentScavenger) {
+		extensions->scavenger->mutatorFinalReleaseCopyCaches(this, this);
+	}
 #endif
 	/* tearDown base class */
 	MM_EnvironmentBase::tearDown(extensions);

--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -371,6 +371,7 @@ MM_ParallelGlobalGC::shouldCompactThisCycle(MM_EnvironmentBase *env, MM_Allocate
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	/* Aborted CS need global GC with Nursery compaction */
 	if (J9MMCONSTANT_IMPLICIT_GC_PERCOLATE_ABORTED_SCAVENGE == gcCode.getCode()) {
+		Assert_MM_true(_extensions->concurrentScavenger);
 		compactReason = COMPACT_ABORTED_SCAVENGE;
 		goto compactionReqd;
 	}	

--- a/gc/base/standard/PhysicalSubArenaVirtualMemorySemiSpace.cpp
+++ b/gc/base/standard/PhysicalSubArenaVirtualMemorySemiSpace.cpp
@@ -1007,6 +1007,7 @@ MM_PhysicalSubArenaVirtualMemorySemiSpace::tilt(MM_EnvironmentBase *env, uintptr
 	if (updateMemoryPools) {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 		if (expandBase > expandTop) {
+			Assert_MM_true(extensions->concurrentScavenger);
 			subSpaceAllocate->removeExistingMemory(env, this, ((uintptr_t)expandBase) - ((uintptr_t)expandTop), expandTop, expandBase);
 			subSpaceSurvivor->addExistingMemory(env, this, ((uintptr_t)expandBase) - ((uintptr_t)expandTop), expandTop, expandBase, true);
 		} else

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -101,9 +101,7 @@ private:
 	omrthread_monitor_t _freeCacheMonitor; /**< monitor to synchronize threads on free list */
 	volatile uintptr_t _waitingCount; /**< count of threads waiting  on scan cache queues (blocked via _scanCacheMonitor); threads never wait on _freeCacheMonitor */
 	uintptr_t _cacheLineAlignment; /**< The number of bytes per cache line which is used to determine which boundaries in memory represent the beginning of a cache line */
-#if !defined(OMR_GC_CONCURRENT_SCAVENGER)
 	volatile bool _rescanThreadsForRememberedObjects; /**< Indicates that thread-referenced objects were tenured and threads must be rescanned */
-#endif	
 
 	typedef enum BackOutState {
 		backOutFlagCleared,		/* Normal state, no backout pending or in progress */
@@ -133,7 +131,9 @@ private:
 	
 	/* TODO: put it parent Collector class and share with Balanced? */ 
 	volatile bool _forceConcurrentTermination;
-#endif
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
+
+#define IS_CONCURRENT_ENABLED _extensions->isConcurrentScavengerEnabled()
 
 protected:
 
@@ -395,7 +395,6 @@ public:
 	MMINLINE void setRememberedSetOverflowState() { _extensions->setRememberedSetOverflowState(); }
 	MMINLINE void clearRememberedSetOverflowState() { _extensions->clearRememberedSetOverflowState(); }
 
-#if !defined(OMR_GC_CONCURRENT_SCAVENGER)
 	/* Auto-remember stack objects so JIT can omit generational barriers */
 	void rescanThreadSlots(MM_EnvironmentStandard *env);
 	/**
@@ -417,7 +416,6 @@ public:
 	 * @return true if the object is a remembered thread reference
 	 */
 	bool processRememberedThreadReference(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr);
-#endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
 	void clearGCStats(MM_EnvironmentStandard *env);
 	void mergeGCStats(MM_EnvironmentStandard *env);
@@ -527,11 +525,11 @@ public:
 
 	/* master thread */
 	uintptr_t scavengeConcurrent(MM_EnvironmentBase *env, UDATA totalBytesToScavenge, volatile bool *forceExit);
-	bool scavengeIncremental(MM_EnvironmentBase *env, I_64 scavengeIncrementEndTime);
+	bool scavengeIncremental(MM_EnvironmentBase *env);
 	
-	bool scavengeInit(MM_EnvironmentBase *env, int64_t timeThreshold);
+	bool scavengeInit(MM_EnvironmentBase *env);
 	bool scavengeRoots(MM_EnvironmentBase *env);
-	bool scavengeScan(MM_EnvironmentBase *env, int64_t timeThreshold);
+	bool scavengeScan(MM_EnvironmentBase *env);
 	bool scavengeComplete(MM_EnvironmentBase *env);
 	
 	/* mutator thread */
@@ -658,7 +656,6 @@ public:
 	 */
 	void copyAndForwardThreadSlot(MM_EnvironmentStandard *env, omrobjectptr_t *objectPtrIndirect);
 
-#if !defined(OMR_GC_CONCURRENT_SCAVENGER)
 	/**
 	 * This function is called at the end of scavenging if any stack- (or thread-) referenced
 	 * objects were tenured during the scavenge. It is called by the RootScanner on each thread
@@ -668,7 +665,6 @@ public:
 	 * @param objectPtrIndirect[in] the slot to process
 	 */
 	void rescanThreadSlot(MM_EnvironmentStandard *env, omrobjectptr_t *objectPtrIndirect);
-#endif
 
 	uintptr_t getArraySplitAmount(MM_EnvironmentStandard *env, uintptr_t sizeInElements);
 


### PR DESCRIPTION
Use the flag to decide in runtime whether some part of Scavenger code
runs or not, depending if CS is requested or not. 

This will allow running both plain Scavenger and Concurrent Scavenger
under same build (as long as compile time CONCURRENT_SCAVENGER flag is
enabled in the build).

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>