### PR TITLE
Add async check for exception handlers for fsd

### DIFF
--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -2016,7 +2016,7 @@ OMR::ResolvedMethodSymbol::detectInternalCycles(TR::CFG *cfg, TR::Compilation *c
                      // As this method is performed soon after ilgen, the exception handler
                      // may be prepended with an asynccheck and pending pushes
                      // These should be retained in the copy, so skip them when ripping out trees
-                     if (comp->getOSRTransitionTarget() == TR::postExecutionOSR)
+                     if (comp->getOSRTransitionTarget() == TR::postExecutionOSR || comp->getOSRMode() == TR::involuntaryOSR)
                         {
                         TR::TreeTop *next = retain->getNextTreeTop();
                         if (next && next->getNode()->getOpCodeValue() == TR::asynccheck)


### PR DESCRIPTION
Catch event could make JIT yield to vm in involuntary OSR mode and
the inserted async check is used as an indication of an OSR point
for the start of the catch block. This change is to prevent the
syncchk from being removed.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>