### PR TITLE
Specialized 'fe' option processing routines

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1359,6 +1359,13 @@ OMR::Options::set32BitNumeric(char *option, void *base, TR::OptionTable *entry)
 
 
 char *
+OMR::Options::set32BitNumericInJitConfig(char *option, void *base, TR::OptionTable *entry)
+   {
+   return TR::Options::set32BitNumeric(option, _feBase, entry);
+   }
+
+
+char *
 OMR::Options::set64BitSignedNumeric(char *option, void *base, TR::OptionTable *entry)
    {
    int64_t sign = 1;
@@ -1458,12 +1465,17 @@ OMR::Options::setString(char *option, void *base, TR::OptionTable *entry)
    return dummy_string;
    }
 
+char *
+OMR::Options::setStringInJitConfig(char *option, void *base, TR::OptionTable *entry)
+   {
+   return TR::Options::setString(option, _feBase, entry);
+   }
 
 char *
 OMR::Options::setStringForPrivateBase(char *option, void *base, TR::OptionTable *entry)
    {
 #ifdef J9_PROJECT_SPECIFIC
-   base = TR_J9VMBase::getPrivateConfig(base);
+   base = TR_J9VMBase::getPrivateConfig(_feBase);
    return TR::Options::setString(option, base, entry);
 #else
    return 0;
@@ -4742,7 +4754,7 @@ char *
 OMR::Options::setVerboseBitsInJitPrivateConfig(char *option, void *base, TR::OptionTable *entry)
    {
 #ifdef J9_PROJECT_SPECIFIC
-   TR_JitPrivateConfig *privateConfig = *(TR_JitPrivateConfig**)((char*)base+entry->parm1);
+   TR_JitPrivateConfig *privateConfig = *(TR_JitPrivateConfig**)((char*)_feBase+entry->parm1);
    TR_ASSERT(sizeof(VerboseOptionFlagArray) <= sizeof(privateConfig->verboseFlags), "TR_JitPrivateConfig::verboseFlags field is too small");
    TR::OptionTable privatizedEntry = *entry;
    privatizedEntry.parm1 = offsetof(TR_JitPrivateConfig, verboseFlags);
@@ -4756,7 +4768,7 @@ OMR::Options::setVerboseBitsInJitPrivateConfig(char *option, void *base, TR::Opt
 char *
 OMR::Options::setVerboseBits(char *option, void *base, TR::OptionTable *entry)
    {
-   VerboseOptionFlagArray *verboseOptionFlags = (VerboseOptionFlagArray*)((char*)base+entry->parm1);
+   VerboseOptionFlagArray *verboseOptionFlags = (VerboseOptionFlagArray*)((char*)_feBase+entry->parm1);
    if (entry->parm2 != 0) // This is used for -Xjit:verbose without any options
       {
       // Since no verbose options are specified, add the default options,

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -2064,6 +2064,20 @@ private:
    //
    static char *set32BitNumeric(char *option, void *base, TR::OptionTable *entry);
 
+  /** 
+   * \brief Option processing function for 32 bit numeric fields stored in JitConfig
+   *
+   * Scans the option for a numeric value and set the 32-bit word at offset 
+   * entry->param1 from the start of JitConfig to that value.
+   *
+   * \param [in] option  String representing the value of the option
+   * \param [in] base    Not used
+   * \param [in] entry   OptionTable entry specifying the offset of the JITConfig word
+   *                     32-bit that needs to be set
+   * \return A pointer to the option parameter
+   */
+   static char *set32BitNumericInJitConfig(char *option, void *base, TR::OptionTable *entry);
+
    // Scan the option for a hexadecimal value and set 32bit word at offset "offset"
    // from the base to that value.
    //
@@ -2110,10 +2124,35 @@ private:
    //
    static char *setStaticString(char *option, void *base, TR::OptionTable *entry);
 
-   // Scan the option for a string value and set pointer at offset "offset"
-   // from the base to a copy of the string
-   //
+   /**
+   * \brief Option processing function for strings
+   *
+   * Scans the option parameter for a string value and sets a pointer at
+   * offset entry->param1 from the start of 'base' to a copy of that string.
+   *
+   * \param [in] option  String representing the value of the option
+   * \param [in] base    Base address of the structure that gets modified.
+   *                     Typically an Options object.
+   * \param [in] entry   OptionTable entry specifying the offset of the
+   *                     string field that needs to be set
+   * \return A pointer to the option parameter
+   */
    static char *setString(char *option, void *base, TR::OptionTable *entry);
+
+   /**
+   * \brief Option processing function for string fields stored in JitConfig
+   *
+   * Scans the option parameter for a string value and sets a pointer at offset
+   * entry->param1 from the start of JitConfig to a copy of that string.
+   *
+   * \param [in] option  String representing the value of the option
+   * \param [in] base    Not used
+   * \param [in] entry   OptionTable entry specifying the offset of the JITConfig
+   *                     field (a char pointer) that needs to be set
+   * \return A pointer to the option parameter
+   */
+   static char *setStringInJitConfig(char *option, void *base, TR::OptionTable *entry);
+
 
    // Add "debugString" to the JIT debug strings
    //

--- a/compiler/env/FEBase.cpp
+++ b/compiler/env/FEBase.cpp
@@ -238,20 +238,18 @@ static DebugValue *head = 0;
 TR::OptionTable OMR::Options::_feOptions[] =
    {
    {"code=",              "C<nnn>\tsize of a single code cache, in KB",
-    TR::Options::set32BitNumeric, offsetof(OMR::FrontEnd::JitConfig, options.codeCacheKB), 0, " %d (KB)"},
+    TR::Options::set32BitNumericInJitConfig, offsetof(OMR::FrontEnd::JitConfig, options.codeCacheKB), 0, " %d (KB)"},
    {"exclude=",   "D{regexp}\tdo not compile methods matching regexp", TR::Options::limitOption, 1, 0, "P%s"},
    {"limit=",     "D{regexp}\tonly compile methods matching regexp", TR::Options::limitOption, 0, 0, "P%s"},
    {"limitfile=", "D<filename>\tfilter methods as defined in filename.  "
                   "Use limitfile=(filename,firstLine,lastLine) to limit lines considered from firstLine to lastLine", TR::Options::limitfileOption, 0, 0, "P%s"},
-   {"maxInlinedCalls=",    "O<nnn>\tmaximum number of calls to be inlined",
-        TR::Options::set32BitSignedNumeric, offsetof(TR::Options,_maxInlinedCalls), 0, "F%d"},
    {"verbose",    "L\twrite compiled method names to vlog file or stdout in limitfile format",
     TR::Options::setVerboseBits, offsetof(TR::JitConfig, options.verboseFlags), (1<<TR_VerboseCompileStart)|(1<<TR_VerboseCompileEnd), "F=1"},
    {"verbose=",   "L{regex}\tlist of verbose output to write to vlog or stdout",
     TR::Options::setVerboseBits, offsetof(TR::JitConfig, options.verboseFlags), 0, "F"},
    {"version",     "M\tprint out JIT version", TR::Options::versionOption, 0, 0, "F"},
    {"vlog=",      "L<filename>\twrite verbose output to filename",
-    TR::Options::setString, offsetof(TR::JitConfig, options.vLogFileName), 0, "P%s"},
+    TR::Options::setStringInJitConfig, offsetof(TR::JitConfig, options.vLogFileName), 0, "P%s"},
    {0}
    };
 


### PR DESCRIPTION
Provide specialized functions for option processing functions that need
to operate on JitConfig. The JitConfig is actually cached in a static
field in OMR::Options::_feBase, so it is readily available.
This change paves the way to splitting the option flags into OMR generic
ones and option flags that are only used by subprojects.

Issue: #1055
Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>