### PR TITLE
Move remove duplicates to gen superset

### DIFF
--- a/tools/ddrgen/src/blob_generation/java/genSuperset.hpp
+++ b/tools/ddrgen/src/blob_generation/java/genSuperset.hpp
@@ -23,7 +23,6 @@
 #define __IBMCPP_TR1__ 1
 #endif /* defined(AIXPPC) || defined(J9ZOS390) */
 
-#include <set>
 #include <sstream>
 #include <stdio.h>
 #include <string.h>
@@ -35,7 +34,6 @@
 #include "Symbol_IR.hpp"
 
 using std::string;
-using std::set;
 using std::stringstream;
 #if defined(AIXPPC) || defined(J9ZOS390)
 using std::tr1::unordered_map;

--- a/tools/ddrgen/src/cmdline_tool/main.cpp
+++ b/tools/ddrgen/src/cmdline_tool/main.cpp
@@ -77,7 +77,6 @@ main(int argc, char *argv[])
 	if (DDR_RC_OK == rc) {
 		rc = ir.removeDuplicates();
 	}
-
 	MacroTool macroTool;
 	/* Read macros. */
 	if ((DDR_RC_OK == rc) && (NULL != macroFile)) {

--- a/tools/ddrgen/src/intermediate_representation/ClassUDT.cpp
+++ b/tools/ddrgen/src/intermediate_representation/ClassUDT.cpp
@@ -83,3 +83,32 @@ ClassUDT::printToSuperset(SupersetGenerator *supersetGenerator, bool addFieldsOn
 {
 	return supersetGenerator->dispatchPrintToSuperset(this, addFieldsOnly, prefix);
 }
+
+DDR_RC
+ClassUDT::checkDuplicate(Symbol_IR *ir)
+{
+	DDR_RC rc = DDR_RC_OK;
+	if ((!this->isAnonymousType()) && (this->_fieldMembers.size() > 0)) {
+		string fullName = ir->getUDTname(this);
+		if (NULL != this->_superClass) {
+			fullName += ir->getUDTname(this->_superClass);
+		}
+		if (ir->_fullTypeNames.end() != ir->_fullTypeNames.find(fullName)) {
+			this->_isDuplicate = true;
+		} else {
+			ir->_fullTypeNames.insert(fullName);
+		}
+	}
+
+	/* Still check the sub UDTs. This is because a previous duplicate of this UDT could have
+	 * contained an empty version of the same sub UDT as this one, which was skipped over due
+	 * to its emptiness.
+	 */
+	for (vector<UDT *>::iterator v = this->_subUDTs.begin(); v != this->_subUDTs.end(); ++v) {
+		rc = (*v)->checkDuplicate(ir);
+		if (DDR_RC_OK != rc) {
+			break;
+		}
+	}
+	return rc;
+}

--- a/tools/ddrgen/src/intermediate_representation/ClassUDT.hpp
+++ b/tools/ddrgen/src/intermediate_representation/ClassUDT.hpp
@@ -39,6 +39,7 @@ public:
 	virtual DDR_RC enumerateType(BlobGenerator *blobGenerator, bool addFieldsOnly);
 	virtual DDR_RC buildBlob(BlobGenerator *blobGenerator, bool addFieldsOnly, string prefix);
 	virtual DDR_RC printToSuperset(SupersetGenerator *supersetGenerator, bool addFieldsOnly, string prefix);
+	virtual DDR_RC checkDuplicate(Symbol_IR *ir);
 };
 
 #endif /* CLASSUDT_HPP */

--- a/tools/ddrgen/src/intermediate_representation/EnumUDT.cpp
+++ b/tools/ddrgen/src/intermediate_representation/EnumUDT.cpp
@@ -105,3 +105,17 @@ EnumUDT::printToSuperset(SupersetGenerator *supersetGenerator, bool addFieldsOnl
 {
 	return supersetGenerator->dispatchPrintToSuperset(this, addFieldsOnly, prefix);
 }
+
+DDR_RC
+EnumUDT::checkDuplicate(Symbol_IR *ir)
+{
+		if ((!this->isAnonymousType()) && (this->_enumMembers.size() > 0)) {
+		string fullName = ir->getUDTname(this);
+		if (ir->_fullTypeNames.end() != ir->_fullTypeNames.find(fullName)) {
+			this->_isDuplicate = true;
+		} else {
+			ir->_fullTypeNames.insert(fullName);
+		}
+	}
+	return DDR_RC_OK;
+}

--- a/tools/ddrgen/src/intermediate_representation/EnumUDT.hpp
+++ b/tools/ddrgen/src/intermediate_representation/EnumUDT.hpp
@@ -41,6 +41,7 @@ public:
 	virtual DDR_RC enumerateType(BlobGenerator *blobGenerator, bool addFieldsOnly);
 	virtual DDR_RC buildBlob(BlobGenerator *blobGenerator, bool addFieldsOnly, string prefix);
 	virtual DDR_RC printToSuperset(SupersetGenerator *supersetGenerator, bool addFieldsOnly, string prefix);
+	virtual DDR_RC checkDuplicate(Symbol_IR *ir);
 };
 
 #endif /* ENUMUDT_HPP */

--- a/tools/ddrgen/src/intermediate_representation/NamespaceUDT.cpp
+++ b/tools/ddrgen/src/intermediate_representation/NamespaceUDT.cpp
@@ -111,3 +111,29 @@ NamespaceUDT::printToSuperset(SupersetGenerator *supersetGenerator, bool addFiel
 {
 	return supersetGenerator->dispatchPrintToSuperset(this, addFieldsOnly, prefix);
 }
+
+DDR_RC
+NamespaceUDT::checkDuplicate(Symbol_IR *ir)
+{
+	DDR_RC rc = DDR_RC_OK;
+	if (!this->isAnonymousType()) {
+		string fullName = ir->getUDTname(this);
+		if (ir->_fullTypeNames.end() != ir->_fullTypeNames.find(fullName)) {
+			this->_isDuplicate = true;
+		} else {
+			ir->_fullTypeNames.insert(fullName);
+		}
+	}
+
+	/* Still check the sub UDTs. This is because a previous duplicate of this UDT could have
+	 * contained an empty version of the same sub UDT as this one, which was skipped over due
+	 * to its emptiness.
+	 */
+	for (vector<UDT *>::iterator v = this->_subUDTs.begin(); v != this->_subUDTs.end(); ++v) {
+		rc = (*v)->checkDuplicate(ir);
+		if (DDR_RC_OK != rc) {
+			break;
+		}
+	}
+	return rc;
+}

--- a/tools/ddrgen/src/intermediate_representation/NamespaceUDT.hpp
+++ b/tools/ddrgen/src/intermediate_representation/NamespaceUDT.hpp
@@ -40,6 +40,7 @@ public:
 	virtual DDR_RC enumerateType(BlobGenerator *blobGenerator, bool addFieldsOnly);
 	virtual DDR_RC buildBlob(BlobGenerator *blobGenerator, bool addFieldsOnly, string prefix);
 	virtual DDR_RC printToSuperset(SupersetGenerator *supersetGenerator, bool addFieldsOnly, string prefix);
+	virtual DDR_RC checkDuplicate(Symbol_IR *ir);
 };
 
 #endif /* NAMESPACEUDT_HPP */

--- a/tools/ddrgen/src/intermediate_representation/Symbol_IR.cpp
+++ b/tools/ddrgen/src/intermediate_representation/Symbol_IR.cpp
@@ -18,6 +18,7 @@
 
 #include "Symbol_IR.hpp"
 
+#include <assert.h>
 #include <algorithm>
 #include <map>
 #include <stdlib.h>
@@ -25,10 +26,31 @@
 #include <vector>
 
 #include "ClassType.hpp"
+#include "EnumUDT.hpp"
+#include "NamespaceUDT.hpp"
+#include "TypedefUDT.hpp"
+#include "ClassUDT.hpp"
+#include "UnionUDT.hpp"
 #include "config.hpp"
 #include "Field.hpp"
 
 using std::map;
+
+string
+Symbol_IR::getUDTname(Type *type)
+{
+	UDT *udt = dynamic_cast<UDT *>(type);
+	assert(NULL != udt);
+
+	string name;
+	if (NULL != udt->_outerUDT) {
+		name = getUDTname(udt->_outerUDT) + udt->_name;
+	} else {
+		name = udt->_name;
+	}
+
+	return name;
+}
 
 Symbol_IR::~Symbol_IR()
 {
@@ -278,41 +300,10 @@ DDR_RC
 Symbol_IR::removeDuplicates()
 {
 	DDR_RC rc = DDR_RC_OK;
-	map<string, vector<Type *> > typeNames;
-
-	/* Create a map of type name to vector of types to check all types
-	 * which share a name for duplicates.
-	 */
-	for (vector<Type *>::iterator it = _types.begin(); it != _types.end();) {
-		Type *type = *it;
-		if (type->_name.empty()) {
-			it += 1;
-			continue;
-		}
-		vector<Type *> *typesWithName = &typeNames[type->_name];
-
-		/* Check all other types with the same name for a duplicate type. */
-		Type *duplicateType = NULL;
-		for (vector<Type *>::iterator it2 = typesWithName->begin(); it2 != typesWithName->end(); it2 += 1) {
-			Type *compareType = *it2;
-			if (*type == *compareType) {
-				duplicateType = compareType;
-				break;
-			}
-		}
-
-		if (NULL == duplicateType) {
-			typesWithName->push_back(type);
-			it += 1;
-		} else {
-			/* If a duplicate type is found, replace all pointers to it, remove
-			 * it from the IR, and free it.
-			 */
-			for (vector<Type *>::iterator it2 = _types.begin(); it2 != _types.end(); it2 += 1) {
-				(*it2)->replaceType(type, duplicateType);
-			}
-			it = _types.erase(it);
-			free(type);
+	for (vector<Type *>::iterator it = _types.begin(); it != _types.end(); ++it) {
+		rc = (*it)->checkDuplicate(this);
+		if (DDR_RC_OK != rc) {
+			break;
 		}
 	}
 	return rc;

--- a/tools/ddrgen/src/intermediate_representation/Symbol_IR.hpp
+++ b/tools/ddrgen/src/intermediate_representation/Symbol_IR.hpp
@@ -20,6 +20,7 @@
 #define SYMBOL_IR_HPP
 
 #include <vector>
+#include <set>
 
 #include "omrport.h"
 
@@ -27,10 +28,18 @@
 #include "Type.hpp"
 
 using std::vector;
+using std::set;
 
 class Symbol_IR {
 public:
-	std::vector<Type *> _types;
+	vector<Type *> _types;
+	/* Keep a set of names of structures already printed, to avoid printing duplicates in the superset. 
+	 * Currently, only use this approach for AIX, where removeDuplicates() runs too slowly. Using this
+	 * method on other platforms has not been tested yet. There may still be issues related to differences
+	 * in the DWARF/intermediate representation structures between platforms which may be revealed by this
+	 * approach.
+	 */
+	set<string> _fullTypeNames;
 
 	~Symbol_IR();
 
@@ -38,6 +47,7 @@ public:
 	DDR_RC computeOffsets();
 	DDR_RC removeDuplicates();
 
+	string getUDTname(Type *type);
 private:
 	DDR_RC applyOverrides(OMRPortLibrary *portLibrary, const char *overrideFile);
 	DDR_RC computeFieldOffsets(Type *type);

--- a/tools/ddrgen/src/intermediate_representation/Type.cpp
+++ b/tools/ddrgen/src/intermediate_representation/Type.cpp
@@ -19,7 +19,7 @@
 #include "Type.hpp"
 
 Type::Type(SymbolType symbolType, size_t size)
-	: _symbolType(symbolType), _sizeOf(size)
+	: _symbolType(symbolType), _sizeOf(size), _isDuplicate(false)
 {
 }
 
@@ -93,4 +93,11 @@ DDR_RC
 Type::printToSuperset(SupersetGenerator *supersetGenerator, bool addFieldsOnly, string prefix = "")
 {
 	return supersetGenerator->dispatchPrintToSuperset(this, addFieldsOnly, prefix);
+}
+
+DDR_RC
+Type::checkDuplicate(Symbol_IR *ir)
+{
+	/* No-op: since Types aren't printed, there's no need to check if they're duplicates either */
+	return DDR_RC_OK;
 }

--- a/tools/ddrgen/src/intermediate_representation/Type.hpp
+++ b/tools/ddrgen/src/intermediate_representation/Type.hpp
@@ -25,6 +25,7 @@
 #include "config.hpp"
 #include "genBlob.hpp"
 #include "Scanner.hpp"
+#include "Symbol_IR.hpp"
 
 using std::set;
 using std::string;
@@ -47,6 +48,7 @@ protected:
 public:
 	std::string _name;
 	size_t _sizeOf; /* Size of type in bytes */
+	bool _isDuplicate;
 
 	Type(SymbolType symbolType, size_t size);
 	virtual ~Type();
@@ -60,11 +62,12 @@ public:
 	virtual string getFullName();
 	virtual string getSymbolTypeName();
 
-	/* Visitor pattern functions to allow the scanner/generator to dispatch functionality based on type. */
+	/* Visitor pattern functions to allow the scanner/generator/IR to dispatch functionality based on type. */
 	virtual DDR_RC scanChildInfo(Scanner *scanner, void *data);
 	virtual DDR_RC enumerateType(BlobGenerator *blobGenerator, bool addFieldsOnly);
 	virtual DDR_RC buildBlob(BlobGenerator *blobGenerator, bool addFieldsOnly, string prefix);
 	virtual DDR_RC printToSuperset(SupersetGenerator *supersetGenerator, bool addFieldsOnly, string prefix);
+	virtual DDR_RC checkDuplicate(Symbol_IR *ir);
 };
 
 #endif /* TYPE_HPP */

--- a/tools/ddrgen/src/intermediate_representation/TypedefUDT.cpp
+++ b/tools/ddrgen/src/intermediate_representation/TypedefUDT.cpp
@@ -77,3 +77,10 @@ TypedefUDT::printToSuperset(SupersetGenerator *supersetGenerator, bool addFields
 {
 	return supersetGenerator->dispatchPrintToSuperset(this, addFieldsOnly, prefix);
 }
+
+DDR_RC
+TypedefUDT::checkDuplicate(Symbol_IR *ir)
+{
+	/* No-op: since TypedefUDTs aren't printed, there's no need to check if they're duplicates either */
+	return DDR_RC_OK;
+}

--- a/tools/ddrgen/src/intermediate_representation/TypedefUDT.hpp
+++ b/tools/ddrgen/src/intermediate_representation/TypedefUDT.hpp
@@ -40,6 +40,7 @@ public:
 	virtual DDR_RC enumerateType(BlobGenerator *blobGenerator, bool addFieldsOnly);
 	virtual DDR_RC buildBlob(BlobGenerator *blobGenerator, bool addFieldsOnly, string prefix);
 	virtual DDR_RC printToSuperset(SupersetGenerator *supersetGenerator, bool addFieldsOnly, string prefix);
+	virtual DDR_RC checkDuplicate(Symbol_IR *ir);
 };
 
 #endif /* TYPEDEFUDT_HPP */

--- a/tools/ddrgen/src/intermediate_representation/UnionUDT.cpp
+++ b/tools/ddrgen/src/intermediate_representation/UnionUDT.cpp
@@ -48,3 +48,29 @@ UnionUDT::printToSuperset(SupersetGenerator *supersetGenerator, bool addFieldsOn
 {
 	return supersetGenerator->dispatchPrintToSuperset(this, addFieldsOnly, prefix);
 }
+
+DDR_RC
+UnionUDT::checkDuplicate(Symbol_IR *ir)
+{
+	DDR_RC rc = DDR_RC_OK;
+	if ((!this->isAnonymousType()) && (this->_fieldMembers.size() > 0)) {
+		string fullName = ir->getUDTname(this);
+		if (ir->_fullTypeNames.end() != ir->_fullTypeNames.find(fullName)) {
+			this->_isDuplicate = true;
+		} else {
+			ir->_fullTypeNames.insert(fullName);
+		}
+	}
+
+	/* Still check the sub UDTs. This is because a previous duplicate of this UDT could have
+	 * contained an empty version of the same sub UDT as this one, which was skipped over due
+	 * to its emptiness.
+	 */
+	for (vector<UDT *>::iterator v = this->_subUDTs.begin(); v != this->_subUDTs.end(); ++v) {
+		rc = (*v)->checkDuplicate(ir);
+		if (DDR_RC_OK != rc) {
+			break;
+		}
+	}
+	return rc;
+}

--- a/tools/ddrgen/src/intermediate_representation/UnionUDT.hpp
+++ b/tools/ddrgen/src/intermediate_representation/UnionUDT.hpp
@@ -32,6 +32,7 @@ public:
 	virtual DDR_RC enumerateType(BlobGenerator *blobGenerator, bool addFieldsOnly);
 	virtual DDR_RC buildBlob(BlobGenerator *blobGenerator, bool addFieldsOnly, string prefix);
 	virtual DDR_RC printToSuperset(SupersetGenerator *supersetGenerator, bool addFieldsOnly, string prefix);
+	virtual DDR_RC checkDuplicate(Symbol_IR *ir);
 };
 
 #endif /* UNIONUDT_HPP */

--- a/tools/ddrgen/src/scanners/dwarf/AixSymbolTableParser.cpp
+++ b/tools/ddrgen/src/scanners/dwarf/AixSymbolTableParser.cpp
@@ -15,7 +15,7 @@
  *    Multiple authors (IBM Corp.) - initial implementation and documentation
  *******************************************************************************/
 
-#include "AixSymbolTableParser.cpp"
+#include "AixSymbolTableParser.hpp"
 
 /* Statics to create: */
 static die_map createdDies;
@@ -55,6 +55,7 @@ static int parseTypeDef(const string data, const string dieName, Dwarf_Die curre
 static void populateAttributeReferences();
 static int populateBuiltInTypeDies(Dwarf_Error *error);
 static void populateNestedClasses();
+static void removeUselessStubs();
 static int setDieAttributes(const string dieName, const unsigned int dieSize, Dwarf_Die currentDie, Dwarf_Error *error);
 
 int
@@ -137,6 +138,11 @@ dwarf_init(int fd,
 	if (NULL != fp) {
 		pclose(fp);
 	}
+
+	/* Populate the references and nested classes of the last file to get parsed */
+	populateAttributeReferences();
+	populateNestedClasses();
+	removeUselessStubs();
 
 	/* Must set _currentCU to null for dwarf_next_cu_header to work */
 	Dwarf_CU_Context::_currentCU = NULL;
@@ -604,23 +610,19 @@ parseDeclarationLine(const string data,
 					members = stripLeading(members.substr(indexOfFirstParenthesis), '(');
 					*format = NEW_FORMAT;
 					/* Check if the declaration is for a class, structure or union */
-					if (0 == isCompilerGenerated(members)) {
-						switch(sizeAndType[indexOfFirstNonInteger]) {
-						case 'c':
-							ret = DW_TAG_class_type;
-							break;
-						case 's':
-							ret = DW_TAG_structure_type;
-							break;
-						case 'u':
-							ret = DW_TAG_union_type;
-							break;
-						default:
-							ret = DW_TAG_unknown;
-							break;
-						}
-					} else {
+					switch(sizeAndType[indexOfFirstNonInteger]) {
+					case 'c':
+						ret = DW_TAG_class_type;
+						break;
+					case 's':
+						ret = DW_TAG_structure_type;
+						break;
+					case 'u':
+						ret = DW_TAG_union_type;
+						break;
+					default:
 						ret = DW_TAG_unknown;
+						break;
 					}
 				} else if ('e' == members[0]) {
 					ret = DW_TAG_enumeration_type;
@@ -655,7 +657,6 @@ parseStabstringDeclarationIntoDwarfDie(const string line, Dwarf_Error *error)
 	int typeID = 0;
 	declFormat format = NO_FORMAT;
 	string declarationData;
-	string type;
 	string name;
 	string members;
 
@@ -687,7 +688,7 @@ parseStabstringDeclarationIntoDwarfDie(const string line, Dwarf_Error *error)
 				newDie->_context = Dwarf_CU_Context::_currentCU;
 				newDie->_attribute = NULL;
 
-				/* Insert the DIE into an unordered_map corresponding to current file being parsed, and insert that unordered_map into createdDies */
+				/* Insert the DIE into createdDies */
 				createdDies[typeID] = make_pair<Dwarf_Off, Dwarf_Die>((Dwarf_Off)refNumber, (Dwarf_Die)newDie);
 
 				refNumber = refNumber + 1;
@@ -711,19 +712,15 @@ parseStabstringDeclarationIntoDwarfDie(const string line, Dwarf_Error *error)
 		} else if (DW_TAG_unknown != tag) {
 			/* Do some preliminary parsing of the declarationData */
 			str_vect tmp = split(declarationData, '=');
-			type = tmp[1];
-			size_t indexOfFirstEqualsSign = declarationData.find('=');
-			if (string::npos != indexOfFirstEqualsSign) {
-				members = stripLeading(declarationData.substr(indexOfFirstEqualsSign), '=');
-			}
+			members = tmp[1];
 
 			/* Populate the dies */
 			switch (tag) {
 			case DW_TAG_array_type:
-				ret = parseArray(type, newDie, error);
+				ret = parseArray(members, newDie, error);
 				break;
 			case DW_TAG_base_type:
-				ret = parseBaseType(type, newDie, error);
+				ret = parseBaseType(members, newDie, error);
 				break;
 			case DW_TAG_class_type:
 				ret = parseNewFormat(members, name, newDie, error);
@@ -732,14 +729,14 @@ parseStabstringDeclarationIntoDwarfDie(const string line, Dwarf_Error *error)
 			case DW_TAG_pointer_type:
 			case DW_TAG_volatile_type:
 			case DW_TAG_subroutine_type:
-				ret = parseNamelessReference(type, newDie, error);
+				ret = parseNamelessReference(members, newDie, error);
 				break;
 			case DW_TAG_enumeration_type:
 				ret = parseEnum(members, name, newDie, error);
 				break;
 			case DW_TAG_typedef:
 				/* Note: AIX label is the same as DWARF typedef */
-				ret = parseTypeDef(type, name, newDie, error);
+				ret = parseTypeDef(members, name, newDie, error);
 				break;
 			case DW_TAG_structure_type:
 			case DW_TAG_union_type:
@@ -789,7 +786,10 @@ parseSymbolTable(const char *line, Dwarf_Error *error)
 						/* Populate the attribute references and nested classes from the previous file that we parsed */
 						populateAttributeReferences();
 						populateNestedClasses();
-						
+
+						/* Remove DIEs which have no children, no size, and are not referred to by any other DIE */
+						removeUselessStubs();
+
 						/* Clear the unordered_maps we maintained from the last file */
 						createdDies.clear();
 						nestedClassesToPopulate.clear();
@@ -940,7 +940,7 @@ parseSymbolTable(const char *line, Dwarf_Error *error)
 
 /**
  * Parses data passed in as an enumerator and populates a DIE
- * param[in] data: the data to be parsed, should be in the format T(TYPE_ID)=e(INTEGER):(NAME):(INTEGER),(NAME):(INTEGER),(...),;
+ * param[in] data: the data to be parsed, should be in the format e(INTEGER):(NAME):(INTEGER),(NAME):(INTEGER),(...),;
  * param[in] dieName: the name of the enumerator
  * param[out] currentDie: the DIE to populate with the parsed data.
  */
@@ -1066,9 +1066,8 @@ parseFields(const string data, Dwarf_Die currentDie, Dwarf_Error *error)
 	Dwarf_Attribute name = new Dwarf_Attribute_s();
 	Dwarf_Attribute type = new Dwarf_Attribute_s();
 	Dwarf_Attribute declFile = new Dwarf_Attribute_s();
-	Dwarf_Attribute declLine = new Dwarf_Attribute_s();
 
-	if ((NULL == name) || (NULL == type) || (NULL == declFile) || (NULL == declLine)) {
+	if ((NULL == name) || (NULL == type) || (NULL == declFile)) {
 		ret = DW_DLV_ERROR;
 		setError(error, DW_DLE_MAF);
 	} else {
@@ -1087,6 +1086,7 @@ parseFields(const string data, Dwarf_Die currentDie, Dwarf_Error *error)
 
 		int ID = extractTypeID(fieldAttributes[0],0);
 		type->_udata = 0;
+		type->_sdata = 0;
 		type->_refdata = 0;
 		type->_ref = NULL;
 
@@ -1094,22 +1094,13 @@ parseFields(const string data, Dwarf_Die currentDie, Dwarf_Error *error)
 		refsToPopulate.push_back(make_pair<int, Dwarf_Attribute>((int)ID, (Dwarf_Attribute)type));
 		declFile->_type = DW_AT_decl_file;
 		declFile->_form = DW_FORM_udata;
-		declFile->_nextAttr = declLine;
+		declFile->_nextAttr = NULL;
 		declFile->_sdata = 0;
 		/* The declaration file number cannot be zero, as DwarfScanner subtracts by one to get the index to the filename string */
 		declFile->_udata = Dwarf_CU_Context::_fileList.size();
 		declFile->_refdata = 0;
 		declFile->_ref = NULL;
 
-		declLine->_type = DW_AT_decl_line;
-		declLine->_form = DW_FORM_udata;
-		declLine->_nextAttr = NULL;
-		declLine->_sdata = 0;
-		/* DwarfScanner uses declLine+declFile to determine Type uniqueness */
-		declLine->_udata = declarationLine;
-		declLine->_refdata = 0;
-		declLine->_ref = NULL;
-		
 		/* Do a preliminary check if the field requires a bitSize or not */
 		bool bitSizeNeeded = true;
 		if (0 > ID) {
@@ -1120,7 +1111,7 @@ parseFields(const string data, Dwarf_Die currentDie, Dwarf_Error *error)
 		}
 		if (bitSizeNeeded) {
 			Dwarf_Attribute bitSize = new Dwarf_Attribute_s();
-			declLine->_nextAttr = bitSize;
+			declFile->_nextAttr = bitSize;
 
 			/* Set the bit size */
 			bitSize->_type = DW_AT_bit_size;
@@ -1134,14 +1125,13 @@ parseFields(const string data, Dwarf_Die currentDie, Dwarf_Error *error)
 			bitFieldsToCheck.push_back(currentDie);
 		}
 		currentDie->_attribute = name;
-		declarationLine = declarationLine + 1;
 	}
 	return ret;
 }
 
 /**
  * Parses the data passed in as a C-style structure/union
- * param[in] data: data to be parsed, in the format T(TYPE_ID)=(s|u)(INTEGER)(NAME):(TYPE),(BIT_OFFSET),(NUM_BITS);(NAME):(TYPE),(BIT_OFFSET),(NUM_BITS);(...);;
+ * param[in] data: data to be parsed, in the format (s|u)(INTEGER)(NAME):(TYPE),(BIT_OFFSET),(NUM_BITS);(NAME):(TYPE),(BIT_OFFSET),(NUM_BITS);(...);;
  * param[in] dieName: the name of the structure/union
  * param[out] currentDie: the DIE to populate with the parsed data.
  */
@@ -1217,7 +1207,7 @@ parseOldFormat(const string data,
 
 /**
  * Parses data passed in as a C++ style class/union/struct
- * param[in] data: the data to be parsed, in the format T(TYPE_ID)=Y(TYPE)(c|u|s)((MEMBERS);;
+ * param[in] data: the data to be parsed, in the format Y(TYPE)(c|u|s){1}(V)?:(TYPE)((MEMBERS);;
  * param[in] dieName: the name of the class/structure/union
  * param[out] currentDie: the DIE to populate with the parsed data.
  */
@@ -1230,14 +1220,61 @@ parseNewFormat(const string data,
 	int ret = DW_DLV_OK;
 	size_t indexOfFirstParenthesis = data.find('(');
 	if (string::npos != indexOfFirstParenthesis) {
-		string sizeAndType = stripLeading(data.substr(0, indexOfFirstParenthesis), 'Y');
-		size_t indexOfFirstNonInteger = sizeAndType.find_first_not_of("1234567890");
+		string sizeTypeAndInheritance = stripLeading(data.substr(0, indexOfFirstParenthesis), 'Y');
+		size_t indexOfFirstNonInteger = sizeTypeAndInheritance.find_first_not_of("1234567890");
 		if (string::npos != indexOfFirstNonInteger) {
 			string unparsedMembers = stripLeading(data.substr(indexOfFirstParenthesis), '(');
-			unsigned int size = toInt(sizeAndType.substr(0, indexOfFirstNonInteger));
 
+			unsigned int size = toInt(sizeTypeAndInheritance.substr(0, indexOfFirstNonInteger));
+
+			/* If there is a parent class, create a DW_TAG_inheritance DIE. The numbers after the colon denote the ID of the parent class this class inherits from */
+			size_t indexOfColon = sizeTypeAndInheritance.find(':');
+			if (string::npos != indexOfColon) {
+				/* A parent class exists */
+				int parentClassID = toInt(stripLeading(sizeTypeAndInheritance.substr(indexOfColon), ':'));
+
+				/* Create a Dwarf Die to record the inheritance */
+				Dwarf_Die inheritanceDie = new Dwarf_Die_s();
+				Dwarf_Attribute type = new Dwarf_Attribute_s();
+
+				if ((NULL == type) || (NULL == inheritanceDie)) {
+					ret = DW_DLV_ERROR;
+					setError(error, DW_DLE_MAF);
+				} else {
+					inheritanceDie->_tag = DW_TAG_inheritance;
+					inheritanceDie->_parent = currentDie;
+					inheritanceDie->_sibling = NULL;
+					inheritanceDie->_previous = NULL;
+					inheritanceDie->_child = NULL;
+					inheritanceDie->_context = Dwarf_CU_Context::_currentCU;
+					inheritanceDie->_attribute = type;
+					
+					type->_type = DW_AT_type;
+					type->_nextAttr = NULL;
+					type->_form = DW_FORM_ref1;
+					type->_udata = 0;
+					type->_sdata = 0;
+					type->_refdata = 0;
+					type->_ref = NULL;
+
+					/* push the type into a vector to populate in a second pass */
+					refsToPopulate.push_back(make_pair<int, Dwarf_Attribute>((int)parentClassID, (Dwarf_Attribute)type));
+
+					if (NULL == currentDie->_child) {
+					currentDie->_child = inheritanceDie;
+					} else {
+						Dwarf_Die lastChild = currentDie->_child;
+						while (NULL != lastChild) {
+							lastChild = lastChild->_sibling;
+						}
+					}
+				}
+			}
+
+			if (DW_DLV_OK == ret) {
 			/* Set DIE attributes */
 			ret = setDieAttributes(dieName, size, currentDie, error);
+			}
 
 			if (DW_DLV_OK == ret) {
 				/* Parse the members */
@@ -1580,7 +1617,7 @@ populateBuiltInTypeDies(Dwarf_Error *error)
 					refNumber = refNumber + 1;
 				} else {
 					/* Delete to prevent a memory leak */
-					delete (newDie);
+					delete(newDie);
 				}
 			}
 		}
@@ -1637,6 +1674,51 @@ populateNestedClasses()
 				}
 			}
 		}
+	}
+}
+
+static void
+removeUselessStubs()
+{
+	die_map::iterator it = createdDies.begin();
+	while (it != createdDies.end()) {
+		Dwarf_Die dieToCheck = it->second.second;
+		Dwarf_Off refNumberToCheck = it->second.first;
+		if (Dwarf_Die_s::refMap.end() == Dwarf_Die_s::refMap.find(refNumberToCheck)) {
+			/* For now, only get rid of empty struct/union/class DIEs */
+			if ((DW_TAG_class_type == dieToCheck->_tag) || (DW_TAG_union_type == dieToCheck->_tag) || (DW_TAG_structure_type == dieToCheck->_tag)) {
+				if ((Dwarf_CU_Context::_currentCU->_die == dieToCheck->_parent) && (NULL == dieToCheck->_child)) {
+					/* If the DIE has a size of zero, has no children, and is not being referred to by any other DIE, it's useless */
+					bool zeroSize = true;
+					Dwarf_Attribute attributeToCheck = dieToCheck->_attribute;
+					while (NULL != attributeToCheck) {
+						if (DW_AT_byte_size == attributeToCheck->_type) {
+							if (0 != attributeToCheck->_udata) {
+								zeroSize = false;
+								break;
+							}
+						}
+						attributeToCheck = attributeToCheck->_nextAttr;
+					}
+					if (zeroSize) {
+						/* Remove the DIE and delete it */
+						if (dieToCheck->_parent->_child == dieToCheck) {
+							dieToCheck->_parent->_child = dieToCheck->_sibling;
+						}
+						if (NULL != dieToCheck->_previous) {
+							dieToCheck->_previous->_sibling = dieToCheck->_sibling;
+						}
+						if (NULL != dieToCheck->_sibling) {
+							dieToCheck->_sibling->_previous = dieToCheck->_previous;
+						}
+						delete(dieToCheck);
+					}
+				}
+			}
+		}
+
+		/* Have to increment iterator this way or it won't compile on AIX */
+		it++;
 	}
 }
 


### PR DESCRIPTION
The old removeDuplicates() algorithm has been replaced entirely with a new one which simply checks that only one structure with a given full name is printed in the superset and blob, significantly improving performance.

As a side-effect of this change, several missing structures in the generated superset have been fixed. In addition, minor tweaks to the DwarfScanner have fixed additional missing structures.

Some missing JVM structures (around ~200) caused by bugs in the AIX parser are also fixed.

Signed-off-by: Tony Wang <twlogger@gmail.com>