### PR TITLE
Fix accidental modification of BCI

### DIFF
--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -1702,10 +1702,9 @@ OMR::ResolvedMethodSymbol::insertRematableStoresFromCallSites(TR::Compilation *c
 TR_ByteCodeInfo&
 OMR::ResolvedMethodSymbol::getOSRByteCodeInfo(TR::Node *node)
    {
-   TR_ByteCodeInfo &nodeBCI = node->getByteCodeInfo();
    if (node->getNumChildren() > 0 && (node->getOpCodeValue() == TR::treetop || node->getOpCode().isCheck()))
-      nodeBCI = node->getFirstChild()->getByteCodeInfo();
-   return nodeBCI;
+      return node->getFirstChild()->getByteCodeInfo();
+   return node->getByteCodeInfo();
    }
 
 /*


### PR DESCRIPTION
When requesting the ByteCodeInfo for an OSR point that is the
child of a treetop, it is necessary to get the child's ByteCodeInfo.
This is required as the treetop may have a different value, confusing
the OSR infrastructure which relies on this value to determine the
transition point.

The API's function to fetch this value would accidentally modify
the treetop's BCI to match that of its child in the described case.
This would limit profiling later on as it relies on these values
to remain consistent.