### PR TITLE
Treat OSR Guards appropriately in codegen

### DIFF
--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -4016,12 +4016,12 @@ static bool virtualGuardHelper(TR::Node *node, TR::CodeGenerator *cg)
    {
 #ifdef J9_PROJECT_SPECIFIC
    TR::Compilation *comp = cg->comp();
-   if ((!node->isNopableInlineGuard() && !node->isHCRGuard()) ||
+   if ((!node->isNopableInlineGuard() && !node->isHCRGuard() && !node->isOSRGuard()) ||
        !cg->getSupportsVirtualGuardNOPing())
       return false;
 
    TR_VirtualGuard *virtualGuard = comp->findVirtualGuardInfo(node);
-   if (!((comp->performVirtualGuardNOPing() || node->isHCRGuard()) &&
+   if (!((comp->performVirtualGuardNOPing() || node->isHCRGuard() || node->isOSRGuard()) &&
          comp->isVirtualGuardNOPingRequired(virtualGuard)) &&
        virtualGuard->canBeRemoved())
       return false;

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -457,14 +457,14 @@ TR::Register *OMR::Power::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::Code
             {
             checkNode = tt->getNode();
             if (cg->getSupportsVirtualGuardNOPing() &&
-               (checkNode->isNopableInlineGuard() || checkNode->isHCRGuard()) &&
+               (checkNode->isNopableInlineGuard() || checkNode->isHCRGuard() || checkNode->isOSRGuard()) &&
                (checkNode->getOpCodeValue() == TR::ificmpne || checkNode->getOpCodeValue() == TR::iflcmpne ||
                 checkNode->getOpCodeValue() == TR::ifacmpne) &&
                 checkNode->getFirstChild() == node)
                {
                // Try get the virtual guard
                TR_VirtualGuard *virtualGuard = comp->findVirtualGuardInfo(checkNode);
-               if (!((comp->performVirtualGuardNOPing() || node->isHCRGuard()) &&
+               if (!((comp->performVirtualGuardNOPing() || node->isHCRGuard() || node->isOSRGuard()) &&
                    comp->isVirtualGuardNOPingRequired(virtualGuard)) &&
                    virtualGuard->canBeRemoved())
                   {

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -140,14 +140,14 @@ virtualGuardHelper(TR::Node * node, TR::CodeGenerator * cg)
    {
 #ifdef J9_PROJECT_SPECIFIC
    TR::Compilation *comp = cg->comp();
-   if ((!node->isNopableInlineGuard() && !node->isHCRGuard()) ||
+   if ((!node->isNopableInlineGuard() && !node->isHCRGuard() && !node->isOSRGuard()) ||
       !cg->getSupportsVirtualGuardNOPing())
       {
       return false;
       }
 
    TR_VirtualGuard * virtualGuard = comp->findVirtualGuardInfo(node);
-   if (!node->isHCRGuard() && !(comp->performVirtualGuardNOPing() &&
+   if (!node->isHCRGuard() && !node->isOSRGuard() && !(comp->performVirtualGuardNOPing() &&
          comp->isVirtualGuardNOPingRequired(virtualGuard)) &&
          virtualGuard->canBeRemoved())
       {

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -227,7 +227,7 @@ OMR::Z::CodeGenerator::checkIsUnneededIALoad(TR::Node *parent, TR::Node *node, T
          else
             {
             TR_VirtualGuard * virtualGuard = self()->comp()->findVirtualGuardInfo(parent);
-            if (!parent->isHCRGuard() && !self()->comp()->performVirtualGuardNOPing() &&
+            if (!parent->isHCRGuard() && !parent->isOSRGuard() && !self()->comp()->performVirtualGuardNOPing() &&
                 self()->comp()->isVirtualGuardNOPingRequired(virtualGuard) &&
                 virtualGuard->canBeRemoved())
                {

--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -5785,7 +5785,7 @@ TR::S390VirtualGuardNOPInstruction::generateBinaryEncoding()
    // in) if the patching occurs during GC pause times.  The patching of up to 6-bytes is potentially
    // not atomic.
 
-   bool performEmptyPatch = getNode()->isHCRGuard() || getNode()->isProfiledGuard();
+   bool performEmptyPatch = getNode()->isHCRGuard() || getNode()->isProfiledGuard() || getNode()->isOSRGuard();
 
    // HCR guards that are merged with profiled guards never need to generate NOPs for patching because
    // the profiled guard will generate the NOP branch to the same location the HCR guard needs to branch


### PR DESCRIPTION
OSR guards are NOP patch sites, which are patched at a GC point
into an unconditional branch, much like HCR guards. This change
updates Z and Power codegen to treat them appropriately.