### PR TITLE
correct concurrent sweepStates after heap resize

### DIFF
--- a/gc/base/MemoryPool.hpp
+++ b/gc/base/MemoryPool.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2015
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -330,6 +330,12 @@ public:
 	MMINLINE void incrementDarkMatterSamples(uintptr_t samples) { _darkMatterSamples += samples; }
 
 	MMINLINE virtual uintptr_t getDarkMatterSamples() { return _darkMatterSamples; }
+
+	/**
+	 * @return HeapResizeType, can be HEAP_NO_RESIZE(default), HEAP_LOA_CONTRACT
+	 */
+	virtual uintptr_t postCollect(MM_EnvironmentBase* env) {return HEAP_NO_RESIZE;}
+
 	/**
 	 * Create a MemoryPool object.
 	 */

--- a/gc/base/MemoryPoolLargeObjects.hpp
+++ b/gc/base/MemoryPoolLargeObjects.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2015
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -118,7 +118,7 @@ public:
 	virtual void unlock(MM_EnvironmentBase* env);
 
 	void preCollect(MM_EnvironmentBase* env, bool systemGC, bool aggressive, uintptr_t bytesRequested);
-	virtual void postCollect(MM_EnvironmentBase* env);
+	virtual uintptr_t postCollect(MM_EnvironmentBase* env);
 	virtual bool completeFreelistRebuildRequired(MM_EnvironmentBase* env);
 
 	virtual MM_MemoryPool* getMemoryPool(void* addr);

--- a/gc/base/standard/ConcurrentSweepScheme.cpp
+++ b/gc/base/standard/ConcurrentSweepScheme.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2015
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -649,7 +649,6 @@ MM_ConcurrentSweepScheme::calculateApproximateFree(
 	}
 	
 	memoryPool->setApproximateFreeMemorySize(approximateFree);
-	
 }	
 
 /**
@@ -1528,6 +1527,116 @@ omrtty_printf("]");
 
 	return minimumSizeFound;
 }
+
+/**
+ * Due to heap resize at the end of global gc(after sweepForMinimumSize),
+ * some concurrent sweepStates (SweepChunk, heapSizeToConnect, heapSizeConnected, ApproximateFree...) need to be updated
+ * without this updating, the free memory, which is shifted from LOA to SOA, would be lost until the next global gc and memory pool reportings
+ * in verbose gc and mxbean are wrong.
+ */
+void
+MM_ConcurrentSweepScheme::updateSweepStates(MM_EnvironmentBase* env, uintptr_t resizeType)
+{
+	/* currently we only try to contract LOA at the end of global GC, in order to simplify code, we only handle HEAP_LOA_CONTRACT case here and
+	 * also we assume LOA memorypool is after SOA memorypool, in future,
+	 * if we do other types heap resize or change memory space layout, then we need to update the below code to handle the new cases.
+	 */
+	if (HEAP_LOA_CONTRACT == resizeType) {
+		MM_MemorySpace *defaultMemorySpace = _extensions->heap->getDefaultMemorySpace();
+		MM_MemorySubSpace *tenureMemorySubspace = defaultMemorySpace->getTenureMemorySubSpace();
+		MM_MemoryPool *memoryPool = tenureMemorySubspace->getMemoryPool();
+		MM_MemoryPool *memoryPoolLOA = memoryPool->getMemoryPool(_extensions->largeObjectMinimumSize);
+		MM_MemoryPool *memoryPoolSOA = memoryPool->getMemoryPool(_extensions->largeObjectMinimumSize-1);
+		MM_ConcurrentSweepPoolState *stateLOA = (MM_ConcurrentSweepPoolState *)getPoolState(memoryPoolLOA);
+		MM_ConcurrentSweepPoolState *stateSOA = (MM_ConcurrentSweepPoolState *)getPoolState(memoryPoolSOA);
+		uintptr_t spaceDelta = 0;
+		MM_ParallelSweepChunk *chunk = NULL;
+		MM_ParallelSweepChunk *moveChunks = NULL;
+		MM_ParallelSweepChunk *previousChunk = NULL;
+		void *poolHighAddr = NULL;
+		MM_MemoryPool *pool = NULL;
+
+		if (memoryPoolLOA->getActualFreeMemorySize() == memoryPoolLOA->getApproximateFreeMemorySize()) {
+			/* all of SweepChunks in LOA has been swept */
+			return;
+		}
+
+		/* update _heapSizeConnected and _heapSizeToConnect for swept chunks(which are shifted from LOA to SOA) in LOA (unlikely happens) */
+		chunk = stateLOA->_currentSweepChunk;
+		if (NULL != chunk) {
+			chunk = chunk->_previous;
+			while (NULL != chunk) {
+				if ((pool = memoryPool->getMemoryPool(env, chunk->chunkBase, chunk->chunkTop, poolHighAddr)) != chunk->memoryPool) {
+					Assert_MM_true(modron_concurrentsweep_state_unprocessed != chunk->_concurrentSweepState);
+					chunk->memoryPool = pool;
+					stateLOA->_heapSizeToConnect -= chunk->size();
+					stateLOA->_heapSizeConnected -= chunk->size();;
+					stateSOA->_heapSizeToConnect += chunk->size();
+					stateSOA->_heapSizeConnected += chunk->size();;
+				} else {
+					break;
+				}
+			}
+		}
+
+		/* upate _heapSizeToConnect for chunks which are shifted from LOA to SOA(have not been swept) */
+		/* remove sweepChunk from LOA */
+		chunk = stateLOA->_currentSweepChunk;
+		while (NULL != chunk) {
+			if ((pool = memoryPool->getMemoryPool(env, chunk->chunkBase, chunk->chunkTop, poolHighAddr)) != chunk->memoryPool) {
+				Assert_MM_true(modron_concurrentsweep_state_unprocessed == chunk->_concurrentSweepState);
+				chunk->memoryPool = pool;
+				stateLOA->_heapSizeToConnect -= chunk->size();
+				spaceDelta += chunk->size();
+				if (NULL == moveChunks) {
+					moveChunks = chunk;
+				} else {
+					previousChunk->_nextChunk = chunk;
+				}
+				stateLOA->_currentSweepChunk = chunk->_nextChunk;
+				if (stateLOA->_connectCurrentChunk == chunk) {
+					stateLOA->_connectCurrentChunk = chunk->_nextChunk;
+				}
+				previousChunk = chunk;
+				chunk = chunk->_nextChunk;
+			} else {
+				break;
+			}
+		}
+		if (NULL == chunk) {
+			stateLOA->_currentInitChunk = NULL;
+			stateLOA->_currentSweepChunkReverse = NULL;
+		}
+		/* append sweepChunk to SOA */
+		if (NULL != moveChunks) {
+			if (NULL != stateSOA->_currentInitChunk) {
+				stateSOA->_currentInitChunk->_nextChunk = moveChunks;
+			}
+			if (NULL != previousChunk) {
+				stateSOA->_currentInitChunk = previousChunk;
+				stateSOA->_currentSweepChunkReverse = previousChunk;
+			}
+			if (NULL == stateSOA->_currentSweepChunk) {
+				stateSOA->_currentSweepChunk = moveChunks;
+			}
+			if (NULL == stateSOA->_connectCurrentChunk) {
+				stateSOA->_connectCurrentChunk = moveChunks;
+			}
+			stateSOA->_heapSizeToConnect += spaceDelta;
+		}
+
+		/* reset approximate free for LOA and SOA */
+		calculateApproximateFree(env, memoryPoolSOA, stateSOA);
+		calculateApproximateFree(env, memoryPoolLOA, stateLOA);
+	}
+}
+
+void
+MM_ConcurrentSweepScheme::postCollect(MM_EnvironmentBase* env, uintptr_t resizeType)
+{
+	updateSweepStates(env, resizeType);
+}
+
 
 /**
  * Complete the sweeping phase for all memory pools concurrently.

--- a/gc/base/standard/ConcurrentSweepScheme.hpp
+++ b/gc/base/standard/ConcurrentSweepScheme.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2015
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -131,6 +131,8 @@ private:
 
 	void calculateApproximateFree(MM_EnvironmentBase* env, MM_MemoryPool *memoryPool, MM_ConcurrentSweepPoolState *sweepState);
 
+	void updateSweepStates(MM_EnvironmentBase* env, uintptr_t resizeType);
+
 protected:
 	virtual bool initialize(MM_EnvironmentBase *env);
 	virtual void tearDown(MM_EnvironmentBase *env);
@@ -160,6 +162,8 @@ public:
 
 	virtual bool replenishPoolForAllocate(MM_EnvironmentBase *env, MM_MemoryPool *memoryPool, UDATA size);
 	void payAllocationTax(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace,  MM_AllocateDescription *allocDescriptionn);
+
+	virtual void postCollect(MM_EnvironmentBase* env, uintptr_t resizeType);
 
 	MM_ConcurrentSweepScheme(MM_EnvironmentBase *env, MM_GlobalCollector *collector)
 		: MM_ParallelSweepScheme(env)

--- a/gc/base/standard/ParallelGlobalGC.hpp
+++ b/gc/base/standard/ParallelGlobalGC.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2015
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -178,6 +178,10 @@ private:
 	 */
 	void cleanupAfterGC(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription);
 
+	/**
+	 * redistribute free memory in tenure after global collection (move free memory from LOA to SOA)
+	 */
+	void tenureMemoryPoolPostCollect(MM_EnvironmentBase *env);
 protected:
 	bool initialize(MM_EnvironmentBase *env);
 	void tearDown(MM_EnvironmentBase *env);

--- a/gc/base/standard/ParallelSweepScheme.hpp
+++ b/gc/base/standard/ParallelSweepScheme.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2015
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -204,6 +204,8 @@ public:
 	 * @return the dark matter, measured in bytes, in the range
 	 */
 	uintptr_t performSamplingCalculations(MM_ParallelSweepChunk *sweepChunk, uintptr_t* markMapCurrent, uintptr_t* heapSlotFreeCurrent);
+
+	virtual void postCollect(MM_EnvironmentBase* env, uintptr_t resizeType) {}
 
 	/**
 	 * Create a ParallelSweepScheme object.

--- a/gc/stats/CollectionStatisticsVLHGC.hpp
+++ b/gc/stats/CollectionStatisticsVLHGC.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2016
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -42,6 +42,7 @@ public:
 
 	uintptr_t _edenFreeHeapSize; /**< Eden free heap size in bytes */
 	uintptr_t _edenHeapSize;	/**< Eden heap size in bytes */
+	uintptr_t _scheduledEdenHeapSize;	/**< Scheduled Eden heap size in bytes */
 
 	uintptr_t _arrayletReferenceObjects; /**< Count of non-contiguous reference arraylets */
 	uintptr_t _arrayletReferenceLeaves;	/**< Count (total) of reference arraylet leaves */
@@ -95,6 +96,7 @@ public:
 		,_incrementCount(0)
 		,_edenFreeHeapSize(0)
 		,_edenHeapSize(0)
+		,_scheduledEdenHeapSize(0)
 		,_arrayletReferenceObjects(0)
 		,_arrayletReferenceLeaves(0)
 		,_largestReferenceArraylet(0)

--- a/gc/verbose/schema.xsd
+++ b/gc/verbose/schema.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-(c) Copyright IBM Corp. 2010, 2016
+(c) Copyright IBM Corp. 2010, 2017
 
  This program and the accompanying materials are made available
  under the terms of the Eclipse Public License v1.0 and
@@ -167,6 +167,7 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 			<element ref="vgc:numa" maxOccurs="1" minOccurs="0" />
 			<element ref="vgc:pending-finalizers" maxOccurs="1" minOccurs="0" />
 			<element ref="vgc:remembered-set" maxOccurs="1" minOccurs="0" />
+			<element ref="vgc:warning" maxOccurs="1" minOccurs="0" />
 		</sequence>
 		<attribute name="id" type="integer" use="required" />
 		<attributeGroup ref="vgc:mem"/>


### PR DESCRIPTION
 - update concurrent sweepStates after heap resize at end of global gc
to avoid losting free memory and wrong memory usgage reporting
 - update verbosegc schema to allow warning in <mem-info>

Signed-off-by: Lin Hu <linhu@ca.ibm.com>