### PR TITLE
Provide an untyped pointer type in TypeDictionary

### DIFF
--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -574,6 +574,7 @@ IlBuilder::indirectLoadNode(TR::IlType *dt, TR::Node *addr, bool isVectorLoad)
    TR_ASSERT(dt->isPointer(), "indirectLoadNode must apply to pointer type");
    TR::IlType * baseType = dt->baseType();
    TR::DataType primType = baseType->getPrimitiveType();
+   TR_ASSERT(primType != TR::NoType, "Dereferencing an untyped pointer.");
    TR::DataType symRefType = primType;
    if (isVectorLoad)
       symRefType = symRefType.scalarToVector();
@@ -813,7 +814,7 @@ IlBuilder::IndexAt(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index)
    {
    TR::IlType *elemType = dt->baseType();
    TR_ASSERT(elemType != NULL, "IndexAt should be called with pointer type");
-
+   TR_ASSERT(elemType->getPrimitiveType() != TR::NoType, "Cannot use IndexAt with pointer to NoType.");
    TR::Node *baseNode = TR::Node::createLoad(base);
    TR::Node *indexNode = TR::Node::createLoad(index);
    TR::Node *elemSizeNode;

--- a/compiler/ilgen/TypeDictionary.cpp
+++ b/compiler/ilgen/TypeDictionary.cpp
@@ -490,7 +490,7 @@ TypeDictionary::TypeDictionary() :
    VectorDouble = _primitiveType[TR::VectorDouble]          = new (PERSISTENT_NEW) OMR::PrimitiveType("VectorDouble", TR::VectorDouble);
 
    // pointer to primitive types
-                   _pointerToPrimitiveType[TR::NoType]       = NULL;
+   pNoType       = _pointerToPrimitiveType[TR::NoType]       = new (PERSISTENT_NEW) PointerType(NoType);
    pInt8         = _pointerToPrimitiveType[TR::Int8]         = new (PERSISTENT_NEW) PointerType(Int8);
    pInt16        = _pointerToPrimitiveType[TR::Int16]        = new (PERSISTENT_NEW) PointerType(Int16);
    pInt32        = _pointerToPrimitiveType[TR::Int32]        = new (PERSISTENT_NEW) PointerType(Int32);

--- a/compiler/ilgen/TypeDictionary.hpp
+++ b/compiler/ilgen/TypeDictionary.hpp
@@ -440,6 +440,7 @@ protected:
    TR::IlType       * VectorDouble;
 
    TR::IlType       * _pointerToPrimitiveType[TR::NumOMRTypes];
+   TR::IlType       * pNoType;
    TR::IlType       * pInt8;
    TR::IlType       * pInt16;
    TR::IlType       * pInt32;


### PR DESCRIPTION
Add a pNoType definition to TypeDictionary.  This turns various indexing
and derefering oprations into potentially dangerous operations.  To help
prevent forest fires, add asserts to those operations to catch
inadvertent [and nonsensical] dereferences of untyped pointers.

Resolves #511.

Signed-off-by: Luc des Trois Maisons <lmaisons@ca.ibm.com>