### PR TITLE
Fix live registers issue for concurrent scavenge

### DIFF
--- a/compiler/z/codegen/UnaryEvaluator.cpp
+++ b/compiler/z/codegen/UnaryEvaluator.cpp
@@ -520,8 +520,10 @@ OMR::Z::TreeEvaluator::l2aEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    node->setRegister(source);
 
 
-   //printf("Node %p is first child\n", firstChild); fflush(stdout);
-   //traceMsg(comp, "Node %p is first child\n", firstChild);
+   if (shouldGenerateGuardedLoadsForCompressedLoad && firstChild->containsCompressionSequence())
+      {
+      cg->decReferenceCount(firstChild->getFirstChild());
+      }
    cg->decReferenceCount(firstChild);
 
    return source;


### PR DESCRIPTION
When running with compressed refs shift > 0, we are not evaluating shift
child since guarded load does both load and shift. We need to decrement
ref count on the right node. This code will get removed once we will
deliver proper fix for not anchoring l2a nodes for concurrent scavenge.

Signed-off-by: evgeniab@ca.ibm.com <evgeniab@ca.ibm.com>