### PR TITLE
Add option to disable OSR call site remat

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -450,6 +450,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableOptTransformations=",         "O{regex}\tlist of optimizer transformations to disable",
                                           TR::Options::setRegex, offsetof(OMR::Options, _disabledOptTransformations), 0, "P"},
    {"disableOSR",                         "O\tdisable support for on-stack replacement", SET_OPTION_BIT(TR_DisableOSR), "F"},
+   {"disableOSRCallSiteRemat",              "O\tdisable use of the call stack remat table in on-stack replacement", SET_OPTION_BIT(TR_DisableOSRCallSiteRemat), "F"},
    {"disableOSRExceptionEdgeRemoval",     "O\tdon't trim away unused on-stack replacement points", TR::Options::disableOptimization, osrExceptionEdgeRemoval, 0, "P"},
    {"disableOSRSharedSlots",              "O\tdisable support for shared slots in on-stack replacement", SET_OPTION_BIT(TR_DisableOSRSharedSlots), "F"},
    {"disableOutlinedNew",                 "O\tdo object allocation logic inline instead of using a fast jit helper",  SET_OPTION_BIT(TR_DisableOutlinedNew), "F"},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -557,7 +557,7 @@ enum TR_CompilationOptions
    TR_PoisonDeadSlots                                 = 0x00001000 + 15,
    TR_DisableOSRSharedSlots                           = 0x00002000 + 15,
    TR_DisableIncrementalCCR                           = 0x00004000 + 15, //SRT
-   // Available                                       = 0x00008000 + 15,
+   TR_DisableOSRCallSiteRemat                         = 0x00008000 + 15,
    TR_UseLowerMethodCounts                            = 0x00010000 + 15,
    // Available                                       = 0x00040000 + 15,
    TR_DoNotUsePersistentIprofiler                     = 0x00080000 + 15,

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -1675,6 +1675,9 @@ OMR::ResolvedMethodSymbol::insertRematableStoresFromCallSites(TR::Compilation *c
    TR::TreeTop *next = induceOSRTree;
    TR::SymbolReference *ppSymRef, *loadSymRef;
 
+   if (comp->getOption(TR_DisableOSRCallSiteRemat))
+      return;
+
    while (siteIndex > -1)
       {
       for (uint32_t i = 0; i < comp->getOSRCallSiteRematSize(siteIndex); ++i)

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -2414,9 +2414,8 @@ TR_ParameterToArgumentMapper::lookForModifiedParameters(TR::Node * node)
 void
 TR_ParameterToArgumentMapper::mapOSRCallSiteRematTable(uint32_t siteIndex)
    {
-   static const char *disableOSRCallSiteRemat = feGetEnv("TR_DisableOSRCallSiteRemat");
    if (!comp()->getOption(TR_EnableOSR) || comp()->getOSRMode() != TR::voluntaryOSR ||
-       comp()->osrInfrastructureRemoved() || disableOSRCallSiteRemat)
+       comp()->osrInfrastructureRemoved() || comp()->getOption(TR_DisableOSRCallSiteRemat))
       return;
 
    TR::SymbolReference *ppSymRef, *loadSymRef;


### PR DESCRIPTION
This adds an option to disable OSR call site remat, as there is a
significant risk it could present problems and will assist in
debugging.