### PR TITLE
WIP: Add new makefile variable OMR_ZOS_TARGET

### DIFF
--- a/configure
+++ b/configure
@@ -741,6 +741,7 @@ LDFLAGS
 CFLAGS
 CC
 OMR_CROSS_CONFIGURE
+OMR_ZOS_TARGET
 OMR_TOOLCHAIN
 OMR_TARGET_DATASIZE
 OMR_HOST_ARCH
@@ -896,6 +897,7 @@ OMR_HOST_OS
 OMR_HOST_ARCH
 OMR_TARGET_DATASIZE
 OMR_TOOLCHAIN
+OMR_ZOS_TARGET
 OMR_CROSS_CONFIGURE
 CC
 CFLAGS
@@ -1690,6 +1692,8 @@ Some influential environment variables:
               One of: 31,32,64
   OMR_TOOLCHAIN
               The toolchain used to build the package. One of: gcc,xlc,msvc
+  OMR_ZOS_TARGET
+              The zOS target used during compilation. One of: zOSV1R13,zOSV2R1
   OMR_CROSS_CONFIGURE
               Indicates that configure is not being run on a system that is
               capable of building the package. Compiler and feature detection
@@ -2732,6 +2736,7 @@ case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
 ###
 ### Options
 ###
+
 
 
 
@@ -4274,6 +4279,23 @@ case $OMR_TOOLCHAIN in #(
 esac
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $OMR_TOOLCHAIN" >&5
 $as_echo "$OMR_TOOLCHAIN" >&6; }
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking OMR_ZOS_TARGET" >&5
+$as_echo_n "checking OMR_ZOS_TARGET... " >&6; }
+if test "x$OMR_ZOS_TARGET" = "x"; then :
+  OMR_ZOS_TARGET=zOSV1R13
+fi
+case $OMR_ZOS_TARGET in #(
+  zOSV1R13) :
+     ;; #(
+  zOSV2R1) :
+     ;; #(
+  *) :
+    as_fn_error $? "An invalid value was provided for OMR_ZOS_TARGET: $OMR_ZOS_TARGET" "$LINENO" 5
+ ;;
+esac
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $OMR_ZOS_TARGET" >&5
+$as_echo "$OMR_ZOS_TARGET" >&6; }
 
 # Default OMRGLUE to example/glue if it was not specified
 OMRGLUE=${OMRGLUE:-"./example/glue"}

--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,7 @@ AC_ARG_VAR([OMR_HOST_OS], [The operating system where the package will run. One 
 AC_ARG_VAR([OMR_HOST_ARCH], [The architecture of the CPU where the package will run. One of: arm,ppc,s390,x86])
 AC_ARG_VAR([OMR_TARGET_DATASIZE], [Specifies whether the package will run in 32- or 64-bit mode. One of: 31,32,64])
 AC_ARG_VAR([OMR_TOOLCHAIN], [The toolchain used to build the package. One of: gcc,xlc,msvc])
+AC_ARG_VAR([OMR_ZOS_TARGET], [The zOS target used during compilation. One of: zOSV1R13,zOSV2R1])
 AC_ARG_VAR([OMR_CROSS_CONFIGURE],
 	[Indicates that configure is not being run on a system that is capable of building the package.
 	Compiler and feature detection tests will be invalid. All options must be configured manually.
@@ -187,6 +188,16 @@ AS_CASE([$OMR_TOOLCHAIN],
 	[AC_MSG_ERROR([An invalid value was provided for OMR_TOOLCHAIN: $OMR_TOOLCHAIN])]
 )
 AC_MSG_RESULT([$OMR_TOOLCHAIN])
+
+AC_MSG_CHECKING([OMR_ZOS_TARGET])
+AS_IF([test "x$OMR_ZOS_TARGET" = "x"],
+	[OMR_ZOS_TARGET=zOSV1R13])
+AS_CASE([$OMR_ZOS_TARGET],
+	[zOSV1R13],[],
+	[zOSV2R1],[],
+	[AC_MSG_ERROR([An invalid value was provided for OMR_ZOS_TARGET: $OMR_ZOS_TARGET])]
+)
+AC_MSG_RESULT([$OMR_ZOS_TARGET])
 
 # Default OMRGLUE to example/glue if it was not specified
 OMRGLUE=${OMRGLUE:-"./example/glue"}

--- a/omrmakefiles/configure.mk.in
+++ b/omrmakefiles/configure.mk.in
@@ -116,6 +116,7 @@ OMR_HOST_OS := @OMR_HOST_OS@
 OMR_HOST_ARCH := @OMR_HOST_ARCH@
 OMR_TARGET_DATASIZE := @OMR_TARGET_DATASIZE@
 OMR_TOOLCHAIN := @OMR_TOOLCHAIN@
+OMR_ZOS_TARGET := @OMR_ZOS_TARGET@
 
 lib_output_dir := @lib_output_dir@
 exe_output_dir := @exe_output_dir@

--- a/omrmakefiles/rules.zos.mk
+++ b/omrmakefiles/rules.zos.mk
@@ -39,14 +39,11 @@ endif
 ifeq ($(OMR_OPTIMIZE),1)
     COPTFLAGS=-O3 -Wc,TUNE\(10\) -Wc,inline\(auto,noreport,600,5000\)
 
-    # OMRTODO: The COMPAT=ZOSV1R13 option does not appear to be related to
-    # optimizations.  This linker option is supplied only on the compile line,
-    # and never when we link. It might be relevant to note that this was added
-    # at the same time as the compilation flag "-Wc,target=ZOSV1R10", which
-    # would give a performance boost.
-    # option means: "COMPAT=ZOSV1R13 is the minimum level that supports conditional sequential RLDs"
+    # -Wl,compat and -Wc,TARGET must agree with each other.
+    #
+    # Details for -Wl,compat can be found here: 
     # http://www-01.ibm.com/support/knowledgecenter/SSLTBW_2.1.0/com.ibm.zos.v2r1.ieab100/compat.htm
-    COPTFLAGS+=-Wl,compat=ZOSV1R13
+    COPTFLAGS+=-Wl,compat=$(OMR_ZOS_TARGET)
 endif
 ifneq ($(OMR_OPTIMIZE),1)
     COPTFLAGS=-0
@@ -68,7 +65,7 @@ GLOBAL_CPPFLAGS+=-DJ9ZOS390 -DLONGLONG -DJ9VM_TIERED_CODE_CACHE -D_ALL_SOURCE -D
 # TARGET   Generate code for the target operating system
 # list     Generate assembly listing
 # offset   In assembly listing, show addresses as offsets of function entry points
-GLOBAL_FLAGS+=-Wc,xplink,convlit\(ISO8859-1\),rostring,FLOAT\(IEEE,FOLD,AFP\),enum\(4\) -Wa,goff -Wc,NOANSIALIAS -Wc,TARGET\(zOSV1R13\) -W "c,list,offset"
+GLOBAL_FLAGS+=-Wc,xplink,convlit\(ISO8859-1\),rostring,FLOAT\(IEEE,FOLD,AFP\),enum\(4\) -Wa,goff -Wc,NOANSIALIAS -Wc,TARGET\($(OMR_ZOS_TARGET)\) -W "c,list,offset"
 
 ifeq (1,$(OMR_ENV_DATA64))
   GLOBAL_CPPFLAGS+=-DJ9ZOS39064


### PR DESCRIPTION
-Wc,TARGET and -Wl,compat are zOS compiler options. Both must agree with
each other. OMR_ZOS_TARGET will allow values for -Wc,TARGET and
-Wl,compat to be specified from outside.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>