### PR TITLE
Adjust big callee threshold on z Systems

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -2478,6 +2478,8 @@ OMR::Options::jitPreProcess()
 
 #if defined(TR_HOST_POWER)
    _bigCalleeThreshold = 300;
+#elif defined(TR_HOST_S390)
+   _bigCalleeThreshold = 600;
 #else
    _bigCalleeThreshold = 400;
 #endif


### PR DESCRIPTION
It has been empirically tested that because z/Architecture lacks a call
return stack we tend to incur a higher penalty for calling methods. As
such inlining slightly more helps overall performance.

Increasing the big callee threshold has been found to causea marginal
increase in compile time at the benefit of very observable throughput on
the platform. As such making this increase the default.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>