### PR TITLE
Fix bcInfo of asyncCHK node

### DIFF
--- a/compiler/optimizer/LoopReplicator.cpp
+++ b/compiler/optimizer/LoopReplicator.cpp
@@ -2030,14 +2030,14 @@ void TR_LoopReplicator::fixUpLoopEntry(LoopInfo *lInfo, TR::Block *loopHeader)
          }
       }
 
-   TR::Node *firstNode = loopHeader->getEntry()->getNextTreeTop()->getNode();
+   TR::Node *bbstartNode = loopHeader->getEntry()->getNode();
 
    // rip out the trees from the original loop header
    loopHeader->getEntry()->join(loopHeader->getExit());
 
    // add the async tree into the loopheader
    //
-   TR::TreeTop *asyncTT = TR::TreeTop::create(comp(), TR::Node::createWithSymRef(firstNode, TR::asynccheck, 0, comp()->getSymRefTab()->findOrCreateAsyncCheckSymbolRef(comp()->getMethodSymbol())));
+   TR::TreeTop *asyncTT = TR::TreeTop::create(comp(), TR::Node::createWithSymRef(bbstartNode, TR::asynccheck, 0, comp()->getSymRefTab()->findOrCreateAsyncCheckSymbolRef(comp()->getMethodSymbol())));
    loopHeader->getEntry()->join(asyncTT);
    asyncTT->join(loopHeader->getExit());
    }


### PR DESCRIPTION
AsyncCHKs are OSR points and VM relies on correct bytecode info
to transfer to the next bytecode execution. When inserting an
asyncCHK node, we need to make sure it has the same bytecode info
as the node right before or after. The original code makes the
inserted AsynChk have bytecode info of the next **treetop** which is
incorrect beause it might skip children of the node hanging under
that treetop and make VM believe the bytecode represented by the
children have already been executed and resume execution from the
wrong place.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>