### PR TITLE
JProfiling bug fix

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -2639,7 +2639,7 @@ TR_TransformInlinedFunction::transform()
    // If the first block has exception predecessors or multiply predecessors then we can't merge
    // the first block with the caller's block
    //
-   if (comp()->isJProfilingCompilation() ||
+   if (comp()->getOption(TR_EnableJProfiling) ||
        (firstBlock->getPredecessors().size() > 1) ||
        firstBlock->hasExceptionSuccessors() ||
        comp()->fe()->isMethodEnterTracingEnabled(calleeResolvedMethod->getPersistentIdentifier()) ||


### PR DESCRIPTION
comp->isJProfilingCompilation() was recently changed to always return false
on the account that there is a similar query in CompilationInfo.
However, comp->isJProfilingCompilation() is used in the inliner.
This query will be replaced by  comp->getOption(TR_EnableJProfiling) which is
correct as long as the JIT doesn't change its mind while optimizing the
method in hand. Currently the JIT never changes its mind once it decided it
is going to generate a JProfiling body. Even if the JIT will turn off
JProfiling midway while optimizing a method, the resulting code is still
correct with no runtime performance penalty. The only downside is a small
compilation time increase.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>