### PR TITLE
Increase the default pseudo-TOC size

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1571,7 +1571,7 @@ int32_t       OMR::Options::_sampleInterval = 30;
 int32_t       OMR::Options::_sampleThreshold = 3000;
 int32_t       OMR::Options::_startupMethodDontDowngradeThreshold = -1;
 
-int32_t       OMR::Options::_tocSizeInKB = 64;
+int32_t       OMR::Options::_tocSizeInKB = 256;
 
 int32_t       OMR::Options::_aggressiveRecompilationChances = 4;
 


### PR DESCRIPTION
We found 256KB to be the right size for most of the workloads we looked at,
including Liberty/Hadoop/Spark. We have seen significant performance benefit
from this change.

Signed-off-by: Julian Wang <zlwang@ca.ibm.com>