### PR TITLE
Allow late decision whether to obey CS request

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -397,7 +397,8 @@ public:
 	bool scavengerEnabled;
 	bool scavengerRsoScanUnsafe;
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
-	bool concurrentScavenger;
+	bool concurrentScavenger; /**< CS enabled/disabled flag */
+	bool concurrentScavengerRequested; /**< set to true if CS is requested (by cmdline option), but there are more checks to do before deciding whether the request is to be obeyed */
 #endif	/* OMR_GC_CONCURRENT_SCAVENGER */
 	uintptr_t scavengerFailedTenureThreshold;
 	uintptr_t maxScavengeBeforeGlobal;
@@ -1145,6 +1146,7 @@ public:
 		, scavengerEnabled(false)
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 		, concurrentScavenger(false)
+		, concurrentScavengerRequested(false)
 #endif		
 		, scavengerFailedTenureThreshold(0)
 		, scvArraySplitMaximumAmount(DEFAULT_ARRAY_SPLIT_MAXIMUM_SIZE)

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -268,14 +268,6 @@ MM_Scavenger::initialize(MM_EnvironmentBase *env)
 
 	_cacheLineAlignment = CACHE_LINE_SIZE;
 
-#if defined(OMR_GC_CONCURRENT_SCAVENGER)
-	if (_extensions->concurrentScavenger) {
-		if (!_masterGCThread.initialize(this)) {
-			return false;
-		}
-	}
-#endif /* OMR_GC_CONCURRENT_SCAVENGER */
-
 	return true;
 }
 
@@ -309,6 +301,9 @@ MM_Scavenger::collectorStartup(MM_GCExtensionsBase* extensions)
 {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	if (_extensions->concurrentScavenger) {
+		if (!_masterGCThread.initialize(this)) {
+			return false;
+		}
 		if (!_masterGCThread.startup()) {
 			return false;
 		}

--- a/gc/include/omrmm.hdf
+++ b/gc/include/omrmm.hdf
@@ -199,6 +199,7 @@ typedef uintptr_t (*condYieldFromGCFunctionPtr) (OMR_VMThread *omrVMThread, uint
 		<data type="struct OMR_VMThread*" name="currentThread" description="current thread" />
 		<data type="uint64_t" name="timestamp" description="time of event" />		
 		<data type="const char*" name="gcPolicy" description="-Xgcpolicy value" />
+		<data type="uintptr_t" name="concurrentScavenger" description="Scavenger running Concurrently flag" />
 		<data type="uintptr_t" name="maxHeapSize" description="-Xmx value" />
 		<data type="uintptr_t" name="initialHeapSize" description="-Xms value" />
 		<data type="uint64_t" name="physicalMemory" description="the total amount of physical memory" />

--- a/gc/verbose/VerboseHandlerOutput.cpp
+++ b/gc/verbose/VerboseHandlerOutput.cpp
@@ -245,6 +245,9 @@ MM_VerboseHandlerOutput::handleInitialized(J9HookInterface** hook, uintptr_t eve
 	enterAtomicReportingBlock();
 	writer->formatAndOutput(env, 0, "<initialized %s>", tagTemplate);
 	writer->formatAndOutput(env, 1, "<attribute name=\"gcPolicy\" value=\"%s\" />", event->gcPolicy);
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	writer->formatAndOutput(env, 1, "<attribute name=\"concurrentScavenger\" value=\"%s\" />", event->concurrentScavenger ? "true" : "false");
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
 	writer->formatAndOutput(env, 1, "<attribute name=\"maxHeapSize\" value=\"0x%zx\" />", event->maxHeapSize);
 	writer->formatAndOutput(env, 1, "<attribute name=\"initialHeapSize\" value=\"0x%zx\" />", event->initialHeapSize);
 #if defined(OMR_GC_COMPRESSED_POINTERS)


### PR DESCRIPTION
Concurrent Scavenger: Introduce an additional 'requested' flag that will be set during parsing
of the CS command line option. There might be platform/language specific
requirements after we parsing is done that will dictate whether the
request is obeyed or not.

Add a line in 'initialized' verbose GC stanza to report if we actually
run CS or not.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>