### PR TITLE
Add flag to skip setting frequency

### DIFF
--- a/compiler/optimizer/OMROptimizationManager.hpp
+++ b/compiler/optimizer/OMROptimizationManager.hpp
@@ -139,6 +139,7 @@ class OMR_EXTENSIBLE OptimizationManager : public TR::Allocatable<OptimizationMa
       cannotOmitTrivialDefs                = 0x00200000,
       maintainsUseDefInfo                  = 0x00400000,
       requiresAccurateNodeCount            = 0x00800000,
+      doNotSetFrequencies                  = 0x01000000,
       dummyLastEnum
       };
 
@@ -168,6 +169,7 @@ class OMR_EXTENSIBLE OptimizationManager : public TR::Allocatable<OptimizationMa
    bool getLastRun()                     { return _flags.testAny(lastRun); }
    bool getCannotOmitTrivialDefs()       { return _flags.testAny(cannotOmitTrivialDefs); }
    bool getMaintainsUseDefInfo()         { return _flags.testAny(maintainsUseDefInfo); }
+   bool getDoNotSetFrequencies()         { return _flags.testAny(doNotSetFrequencies); }
 
    void setRequiresStructure(bool b)           { _flags.set(requiresStructure, b); }
    void setRequiresGlobalsUseDefInfo(bool b)   { _flags.set(requiresGlobalsUseDefInfo, b); }
@@ -192,6 +194,7 @@ class OMR_EXTENSIBLE OptimizationManager : public TR::Allocatable<OptimizationMa
    void setLastRun(bool b)                     { _flags.set(lastRun,b); }
    void setCannotOmitTrivialDefs(bool b)       { _flags.set(cannotOmitTrivialDefs, b); }
    void setMaintainsUseDefInfo(bool b)         { _flags.set(maintainsUseDefInfo, b); }
+   void setDoNotSetFrequencies(bool b)         { _flags.set(doNotSetFrequencies, b); }
 
    protected:
 

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -1942,7 +1942,7 @@ int32_t OMR::Optimizer::performOptimization(const OptimizationStrategy *optimiza
       int32_t origCfgNodeCount = comp()->getFlowGraph()->getNextNodeNumber();
       int32_t origOptMsgIndex = self()->getOptMessageIndex();
 
-      if (comp()->isOutermostMethod() && (comp()->getFlowGraph()->getMaxFrequency() < 0))
+      if (comp()->isOutermostMethod() && (comp()->getFlowGraph()->getMaxFrequency() < 0) && !manager->getDoNotSetFrequencies())
          {
          TR::Compilation::CompilationPhaseScope buildingFrequencies(comp());
          comp()->reportAnalysisPhase(BUILDING_FREQUENCIES);


### PR DESCRIPTION
Currently, frequencies will be calculated and set before an
optimization when all necessary information is present. It is then
maintained across modifications to the CFG. This necessary information
includes structure analysis.

This change allows an optimization to explicitly prevent frequencies
from being set before itself. This is useful for early opts that require
structure, but not frequency, and may significantly alter the structure
to the point where the frequency data would not have been adequately
maintained.