### PR TITLE
Use consistent exclusive access backoff

### DIFF
--- a/gc/base/EnvironmentBase.cpp
+++ b/gc/base/EnvironmentBase.cpp
@@ -403,7 +403,8 @@ MM_EnvironmentBase::acquireExclusiveVMAccessForGC(MM_Collector *collector)
 			 * proceed and wait for it to complete */
 			Assert_MM_true(NULL != extensions->gcExclusiveAccessThreadId);
 
-			_delegate.releaseVMAccess(true);
+			uintptr_t accessMask;
+			_delegate.releaseCriticalHeapAccess(&accessMask);
 
 			/* there is a chance the GC will already have executed at this
 			 * point or other threads will re-win and re-execute.  loop until
@@ -418,7 +419,7 @@ MM_EnvironmentBase::acquireExclusiveVMAccessForGC(MM_Collector *collector)
 
 			omrthread_monitor_exit(extensions->gcExclusiveAccessMutex);
 
-			_delegate.acquireVMAccess(true);
+			_delegate.reacquireCriticalHeapAccess(accessMask);
 		}
 	}
 


### PR DESCRIPTION
The tryAcquireExclusiveVMAccess path in the GC will wait for another
thread if the other thread is already acquiring exclusive VM access.  It backs off
using releaseCriticalHeapAccess and reacquireCriticalHeapAccess.  The
acquireExclusiveVMAccess path uses releaseVMAccess(bool) and acquireVMAccess.
Change acquireExclusiveVMAccess to be consistent with
tryAcquireExclusiveVMAccess so the delegate may more easily detect the
exclusive backoff case.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>