### PR TITLE
Default isConcurrentScavengeEnabled to false

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -6095,16 +6095,6 @@ OMR::Z::CodeGenerator::supportsMergingOfHCRGuards()
           !self()->comp()->compileRelocatableCode();
    }
 
-bool
-OMR::Z::CodeGenerator::isConcurrentScavengeEnabled()
-   {
-#if defined(OMR_GC_CONCURRENT_SCAVENGER)
-   return TR::Compiler->target.cpu.getS390SupportsGuardedStorageFacility();
-#else
-   return false;
-#endif
-   }
-
 // Helpers for profiled interface slots
 void
 OMR::Z::CodeGenerator::addPICsListForInterfaceSnippet(TR::S390ConstantDataSnippet * ifcSnippet, TR::list<TR_OpaqueClassBlock*> * PICSlist)

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -433,15 +433,6 @@ public:
 
    bool supportsMergingOfHCRGuards();
 
-   /** \brief
-    *     Determines whether concurrent scavenge of objects during garbage collection is enabled.
-    *
-    *  \return
-    *     true if the code generator will emit read barriers for loads of object references from the heap in support
-    *     of concurrent scavenge; false otherwise.
-    */
-   bool isConcurrentScavengeEnabled();
-
    bool supportsDirectJNICallsForAOT() { return true;}
 
    bool shouldYankCompressedRefs() { return true; }


### PR DESCRIPTION
Concurrent scavenge requires GC support, hardware checks, OS level
checks, and guarded storage block initialization to be properly done.
The infrastructure for such plumbing work should be done at a downstream
OMR project level. As such we are defaulting concurrent scavenge to be
disabled by default unless a downstream project extends the
CodeGenerator class and overrides the value.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>