### PR TITLE
Make the travis builds faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ addons:
       - llvm-3.4
       - gcc-multilib
       - g++-multilib
+      - ninja-build
 env:
   matrix:
     - BUILD_WITH_CMAKE=yes

--- a/scripts/build-on-travis.sh
+++ b/scripts/build-on-travis.sh
@@ -19,28 +19,30 @@
 
 set -evx
 
+export JOBS=4
+
 if test "x$BUILD_WITH_CMAKE" = "xyes"; then
   mkdir build
   cd build
-  cmake -Wdev -C../cmake/caches/Travis.cmake ..
+  time cmake -Wdev -GNinja -C../cmake/caches/Travis.cmake ..
   if test "x$RUN_BUILD" != "xno"; then
-    cmake --build .
+    time cmake --build .
     if test "x$RUN_TESTS" != "xno"; then
-      ctest -V
+      time ctest -V --parallel $JOBS
     fi
   fi
 else
-  make -f run_configure.mk OMRGLUE=./example/glue SPEC="$SPEC" PLATFORM="$PLATFORM"
+  time make -f run_configure.mk OMRGLUE=./example/glue SPEC="$SPEC" PLATFORM="$PLATFORM"
   if test "x$RUN_BUILD" != "xno"; then
     # Normal build system
-    make -j4
+    time make --jobs $JOBS
     if test "x$RUN_TESTS" != "xno"; then
-      make test
+      time make --jobs $JOBS test
     fi
   fi
   if test "x$RUN_LINT" = "xyes"; then
     llvm-config --version
     clang++ --version
-    make lint
+    time make --jobs $JOBS lint
   fi
 fi


### PR DESCRIPTION
- Shallow git clone
- Make --job parallelism
- CMake: Use the Ninja generator

It's difficult to time, when caching behaviour seems to be a little
unpredictable, but these changes seems to help.

A one-off measurement (with ccache populated):
- Make:  17m -> 15m
- CMake: 17m -> 09m
- Lint:  06m -> 02m

I've also started timing major build steps, to help evaluate build
system changes.

Signed-off-by: Robert Young <rwy0717@gmail.com>