### PR TITLE
Remove project-specific CodeCacheManager functions

### DIFF
--- a/compiler/runtime/OMRCodeCacheManager.cpp
+++ b/compiler/runtime/OMRCodeCacheManager.cpp
@@ -608,17 +608,6 @@ OMR::CodeCacheManager::replaceTrampoline(TR_OpaqueMethodBlock *method,
    }
 
 
-void
-OMR::CodeCacheManager::addFaintCacheBlock(FaintCacheBlock * & faintBlockList,
-                                        FaintCacheBlock *block,
-                                        uint8_t bytesToSaveAtStart)
-   {
-   block->_next = faintBlockList;
-   block->_bytesToSaveAtStart = bytesToSaveAtStart;
-   block->_isStillLive = false;
-   faintBlockList = block;
-   }
-
 // Is there space and are we allowed to allocate a new code cache?
 //
 bool
@@ -657,15 +646,6 @@ OMR::CodeCacheManager::addFreeBlock(void *metaData, uint8_t *startPC)
    {
    TR::CodeCache *owningCodeCache = self()->findCodeCacheFromPC(startPC);
    owningCodeCache->addFreeBlock(metaData);
-   }
-
-// May add the faint cache block to freeBlockList.
-// Caller should expect that block may sometimes not be added.
-void
-OMR::CodeCacheManager::freeFaintCacheBlock(FaintCacheBlock *block, uint8_t *startPC)
-   {
-   TR::CodeCache *owningCodeCache = self()->findCodeCacheFromPC(startPC);
-   owningCodeCache->addFreeBlock(block);
    }
 
 

--- a/compiler/runtime/OMRCodeCacheManager.hpp
+++ b/compiler/runtime/OMRCodeCacheManager.hpp
@@ -168,10 +168,6 @@ public:
    TR::CodeCache * getNewCodeCache(int32_t reservingCompThreadID);
 
    void addFreeBlock(void *metaData, uint8_t *startPC);
-   void freeFaintCacheBlock(FaintCacheBlock *block, uint8_t *startPC);
-   void addFaintCacheBlock(FaintCacheBlock * & blockList,
-                           FaintCacheBlock *block,
-                           uint8_t bytesToSaveAtStart);
 
    uint8_t * allocateCodeMemory(size_t warmCodeSize,
                                 size_t coldCodeSize,


### PR DESCRIPTION
These functions are J9 project specific:

* CodeCacheManager::addFaintCacheBlock
* CodeCacheManager::freeFaintCacheBlock

Signed-off-by: Daryl Maier <maier@ca.ibm.com>