### PR TITLE
Disable PartialInlining under OSR

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -453,6 +453,9 @@ OMR::Compilation::Compilation(
 
    if (_options->getOption(TR_EnableOSR))
       {
+      // Current implementation of partial inlining will break OSR
+      self()->setOption(TR_DisablePartialInlining);
+
       //TODO: investigate the memory footprint of this allocation
       _osrCompilationData = new (self()->trHeapMemory()) TR_OSRCompilationData(self());
 


### PR DESCRIPTION
Partial inlining will copy the inlined call into the inlined body, to use
as the recovery in the event execution leaves the inlined portion of
the call. As this call is copied, it does not maintain the required
infrastructure for OSR.