### PR TITLE
Enforce reference arraycopy has type TR::Address

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -4597,39 +4597,35 @@ OMR::Node::freeExtensionIfExists()
       }
    }
 
-
-
 TR::DataType
 OMR::Node::getArrayCopyElementType()
    {
-   TR::Compilation * comp = TR::comp();
-   TR_ASSERT(self()->getOpCodeValue() == TR::arraycopy  || self()->getOpCodeValue() == TR::arrayset, "assertion failure");
+   TR_ASSERT(self()->getOpCodeValue() == TR::arraycopy || self()->getOpCodeValue() == TR::arrayset, "getArrayCopyElementType called on an invalid node");
 
-   if (_numChildren==3 || _numChildren==4 || _numChildren==6)
+   if (_numChildren == 3)
       {
-       return (TR::DataTypes)_unionBase._extension.getExtensionPtr()->getElem<uint32_t>(_numChildren);
+      return static_cast<TR::DataTypes>(_unionBase._extension.getExtensionPtr()->getElem<uint32_t>(_numChildren));
       }
+   else
+      {
+      TR_ASSERT(_numChildren == 5, "getArrayCopyElementType called on an arraycopy node with an invalid number of children");
 
-   TR_ASSERT(comp, "Query only valid during compilation\n");
-   if (TR::Compiler->target.is64Bit() && !comp->useCompressedPointers())
-      return TR::Int64;
-   return TR::Int32;
+      return TR::Address;
+      }
    }
 
 void
 OMR::Node::setArrayCopyElementType(TR::DataType type)
    {
-   TR_ASSERT(self()->getOpCodeValue() == TR::arraycopy || self()->getOpCodeValue() == TR::arrayset, "assertion failure");
+   TR_ASSERT(self()->getOpCodeValue() == TR::arraycopy || self()->getOpCodeValue() == TR::arrayset, "setArrayCopyElementType called on an invalid node");
 
-   if (_numChildren==3 || _numChildren==4 || _numChildren==6)
+   if (_numChildren == 3)
       {
-      uint16_t numExtensionElems = _unionBase._extension.getNumElems();
-      TR_ASSERT(numExtensionElems > _numChildren, "need an extra slot to set arrayCopyElementType\n");
+      TR_ASSERT(_unionBase._extension.getNumElems() > _numChildren, "Need an extra extension element slot in setArrayCopyElementType");
+
       _unionBase._extension.getExtensionPtr()->setElem<uint32_t>(_numChildren, type);
       }
    }
-
-
 
 TR_OpaqueClassBlock *
 OMR::Node::getArrayStoreClassInNode()

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -1274,6 +1274,20 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
             }
          }
 
+      if (isStringCompressedArrayCopy)
+         {
+         type = TR::Int8;
+
+         elementSize = TR::Symbol::convertTypeToSize(type);
+         }
+
+      if (isStringDecompressedArrayCopy)
+         {
+         type = TR::Int16;
+
+         elementSize = TR::Symbol::convertTypeToSize(type);
+         }
+
       if (primitiveArray1 || primitiveArray2)
          {
          type = primitiveArray1 ?
@@ -1283,6 +1297,12 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
          elementSize = TR::Symbol::convertTypeToSize(type);
          }
 
+      if (referenceArray1 || referenceArray2)
+         {
+         type = TR::Address;
+
+         elementSize = TR::Compiler->om.sizeofReferenceField();
+         }
 
       if (comp()->getOptions()->realTimeGC() &&
           comp()->requiresSpineChecks() &&
@@ -1299,12 +1319,6 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
             }
          else
             {
-            if (referenceArray1 || referenceArray2 )
-               {
-               type = TR::Address;
-               elementSize = TR::Compiler->om.sizeofReferenceField();
-               }
-
             //printf("primitiveArray1=%d, primitiveArray2=%d, referenceArray1=%d , referenceArray2=%d\n",primitiveArray1,primitiveArray2,referenceArray1,referenceArray2);
             arraySpineShift = fe()->getArraySpineShift(elementSize);
             bool sameLeafSrc = false;
@@ -1360,8 +1374,7 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
 
    if (transformTheCall && performTransformation(comp(), "%sChanging call %s [%p] to arraycopy\n", OPT_DETAILS, node->getOpCode().getName(), node))
       {
-
-      TR::ResolvedMethodSymbol *methodSymbol = comp()->getMethodSymbol();
+      TR::ResolvedMethodSymbol* methodSymbol = comp()->getMethodSymbol();
 
       bool canSkipAllChecksOnArrayCopy = methodSymbol->safeToSkipChecksOnArrayCopies() || isRecognizedMultiLeafArrayCopy || isStringCompressedArrayCopy || isStringDecompressedArrayCopy;
 
@@ -1528,56 +1541,30 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
             }
          }
 
-      // -------------------------------------------------------------------
-      // Determine element size and array stride
-      // -------------------------------------------------------------------
-      if (isStringCompressedArrayCopy)
+      if (srcArrayLength)
          {
-         type = TR::Int8;
+         int32_t stride = 0;
 
-         elementSize = TR::Symbol::convertTypeToSize(type);
-         }
-      else if (isStringDecompressedArrayCopy)
-         {
-         type = TR::Int16;
+         if (referenceArray1)
+            stride = TR::Compiler->om.sizeofReferenceField();
+         else if (srcArrayInfo)
+            stride = srcArrayInfo->elementSize();
 
-         elementSize = TR::Symbol::convertTypeToSize(type);
-         }
-      else
-         {
-         if (referenceArray1 || referenceArray2)
-            elementSize = TR::Compiler->om.sizeofReferenceField();
+         if (stride != 0)
+            srcArrayLength->setArrayStride(stride);
          }
 
-      if (!elementSize && srcArrayInfo)
-         elementSize = srcArrayInfo->elementSize();
-
-      if (elementSize)
+      if (dstArrayLength)
          {
-         int32_t stride;
-         if (srcArrayLength)
-            {
-            stride = 0;
-            if (referenceArray1)
-               stride = TR::Compiler->om.sizeofReferenceField();
-            else if (srcArrayInfo)
-               stride = srcArrayInfo->elementSize();
+         int32_t stride = 0;
 
-            if (stride)
-               srcArrayLength->setArrayStride(stride);
-            }
+         if (referenceArray2)
+            stride = TR::Compiler->om.sizeofReferenceField();
+         else if (dstArrayInfo)
+            stride = dstArrayInfo->elementSize();
 
-         if (dstArrayLength)
-            {
-            stride = 0;
-            if (referenceArray2)
-               stride = TR::Compiler->om.sizeofReferenceField();
-            else if (dstArrayInfo)
-               stride = dstArrayInfo->elementSize();
-
-            if (stride)
-               dstArrayLength->setArrayStride(stride);
-            }
+         if (stride != 0)
+            dstArrayLength->setArrayStride(stride);
          }
 
       // -------------------------------------------------------------------
@@ -1702,7 +1689,7 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
          // Calculate source address node
          // -------------------------------------------------------------------
 
-     src = generateArrayAddressTree(comp(), node, srcOffHigh, srcOffNode, srcObjNode, elementSize, stride, hdrSize);
+         src = generateArrayAddressTree(comp(), node, srcOffHigh, srcOffNode, srcObjNode, elementSize, stride, hdrSize);
 
          // -------------------------------------------------------------------
          // Calculate destination address node
@@ -1809,6 +1796,7 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
          node->setChild(3, dst);
          node->setChild(4, len);
          node->setNumChildren(5);
+         node->setArrayCopyElementType(type);
          }
 
       len->getByteCodeInfo().setDoNotProfile(0);

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -13576,8 +13576,7 @@ OMR::Z::TreeEvaluator::referenceArraycopyEvaluator(TR::Node* node, TR::CodeGener
       }
    else
       {
-      // TODO: There are cases under which the following assert will trigger. These need to be fixed and this assert needs to be re-enabled.
-      // TR_ASSERT(node->getArrayCopyElementType() == TR::Address, "Reference arraycopy element type should be a TR::Address but was '%s'", node->getArrayCopyElementType().toString());
+      TR_ASSERT_FATAL(node->getArrayCopyElementType() == TR::Address, "Reference arraycopy element type should be TR::Address but was '%s'", node->getArrayCopyElementType().toString());
 
       primitiveArraycopyEvaluator(node, cg, byteSrcNode, byteDstNode, byteLenNode);
 


### PR DESCRIPTION
Reference arraycopies are important when concurrent scavenge is enabled.
We need to determine at code generation time that a particular arraycopy
is indeed a reference arraycopy such that we can generate read barriers
for every array element access. As such it is important that all
arraycopy nodes that are in fact reference array copies specify the data
type of the array elements is a TR::Address.

We will use this fact in the code generator to determine whether we need
to generate read barriers for array reference loads.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>