### PR TITLE
Revert "correct concurrent sweepStates after heap resize"

### DIFF
--- a/gc/base/MemoryPool.hpp
+++ b/gc/base/MemoryPool.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2017
+ * (c) Copyright IBM Corp. 1991, 2015
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -330,12 +330,6 @@ public:
 	MMINLINE void incrementDarkMatterSamples(uintptr_t samples) { _darkMatterSamples += samples; }
 
 	MMINLINE virtual uintptr_t getDarkMatterSamples() { return _darkMatterSamples; }
-
-	/**
-	 * @return HeapResizeType, can be HEAP_NO_RESIZE(default), HEAP_LOA_CONTRACT
-	 */
-	virtual uintptr_t postCollect(MM_EnvironmentBase* env) {return HEAP_NO_RESIZE;}
-
 	/**
 	 * Create a MemoryPool object.
 	 */

--- a/gc/base/MemoryPoolLargeObjects.cpp
+++ b/gc/base/MemoryPoolLargeObjects.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2017
+ * (c) Copyright IBM Corp. 1991, 2016
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -62,7 +62,10 @@ reportGlobalGCIncrementStart(J9HookInterface** hook, uintptr_t eventNum, void* e
 void
 reportGlobalGCComplete(J9HookInterface** hook, uintptr_t eventNum, void* eventData, void* userData)
 {
-	/* Empty, move heapResize from here to postCollect (heapResize should be finished before GlobalGCComplete hook) */
+	MM_GlobalGCEndEvent* event = (MM_GlobalGCEndEvent*)eventData;
+	MM_EnvironmentBase* env = MM_EnvironmentBase::getEnvironment(event->currentThread);
+
+	((MM_MemoryPoolLargeObjects*)userData)->postCollect(env);
 }
 
 /**
@@ -206,10 +209,9 @@ MM_MemoryPoolLargeObjects::preCollect(MM_EnvironmentBase* env, bool systemGC, bo
 /**
  * Perform any post-collection work on pool.
  */
-uintptr_t
+void
 MM_MemoryPoolLargeObjects::postCollect(MM_EnvironmentBase* env)
 {
-	uintptr_t ret = HEAP_NO_RESIZE;
 	bool debug = _extensions->debugLOAResize;
 
 	_soaBytesAfterLastGC = _memoryPoolSmallObjects->getApproximateFreeMemorySize();
@@ -257,7 +259,7 @@ MM_MemoryPoolLargeObjects::postCollect(MM_EnvironmentBase* env)
 
 		/* If minimum required now zero then there is no storage available for transfer */
 		if (0 == minimumLOAContractRequired) {
-			return ret;
+			return;
 		}
 
 		/* LOA base may land in a middle of a live object, but it should be fine */
@@ -306,7 +308,6 @@ MM_MemoryPoolLargeObjects::postCollect(MM_EnvironmentBase* env)
 
 		_extensions->heap->getResizeStats()->setLastLoaResizeReason(LOA_CONTRACT_MIN_SOA);
 		_memorySubSpace->reportHeapResizeAttempt(env, spaceDelta , HEAP_LOA_CONTRACT);
-		ret = HEAP_LOA_CONTRACT;
 
 		/* Verify all pools in valid state after we are done */
 		assume0(_memoryPoolSmallObjects->isMemoryPoolValid(env, true));
@@ -314,7 +315,6 @@ MM_MemoryPoolLargeObjects::postCollect(MM_EnvironmentBase* env)
 		assume0(_memoryPoolSmallObjects->isValidListOrdering());
 		assume0(_memoryPoolLargeObjects->isValidListOrdering());
 	}
-	return ret;
 }
 
 

--- a/gc/base/MemoryPoolLargeObjects.hpp
+++ b/gc/base/MemoryPoolLargeObjects.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2017
+ * (c) Copyright IBM Corp. 1991, 2015
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -118,7 +118,7 @@ public:
 	virtual void unlock(MM_EnvironmentBase* env);
 
 	void preCollect(MM_EnvironmentBase* env, bool systemGC, bool aggressive, uintptr_t bytesRequested);
-	virtual uintptr_t postCollect(MM_EnvironmentBase* env);
+	virtual void postCollect(MM_EnvironmentBase* env);
 	virtual bool completeFreelistRebuildRequired(MM_EnvironmentBase* env);
 
 	virtual MM_MemoryPool* getMemoryPool(void* addr);

--- a/gc/base/standard/ConcurrentSweepScheme.hpp
+++ b/gc/base/standard/ConcurrentSweepScheme.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2017
+ * (c) Copyright IBM Corp. 1991, 2015
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -131,8 +131,6 @@ private:
 
 	void calculateApproximateFree(MM_EnvironmentBase* env, MM_MemoryPool *memoryPool, MM_ConcurrentSweepPoolState *sweepState);
 
-	void updateSweepStates(MM_EnvironmentBase* env, uintptr_t resizeType);
-
 protected:
 	virtual bool initialize(MM_EnvironmentBase *env);
 	virtual void tearDown(MM_EnvironmentBase *env);
@@ -162,8 +160,6 @@ public:
 
 	virtual bool replenishPoolForAllocate(MM_EnvironmentBase *env, MM_MemoryPool *memoryPool, UDATA size);
 	void payAllocationTax(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace,  MM_AllocateDescription *allocDescriptionn);
-
-	virtual void postCollect(MM_EnvironmentBase* env, uintptr_t resizeType);
 
 	MM_ConcurrentSweepScheme(MM_EnvironmentBase *env, MM_GlobalCollector *collector)
 		: MM_ParallelSweepScheme(env)

--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2017
+ * (c) Copyright IBM Corp. 1991, 2016
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -793,25 +793,9 @@ MM_ParallelGlobalGC::internalPreCollect(MM_EnvironmentBase *env, MM_MemorySubSpa
 }
 
 void
-MM_ParallelGlobalGC::tenureMemoryPoolPostCollect(MM_EnvironmentBase *env)
-{
-	MM_MemorySpace *defaultMemorySpace = _extensions->heap->getDefaultMemorySpace();
-	MM_MemorySubSpace *tenureMemorySubspace = defaultMemorySpace->getTenureMemorySubSpace();
-	MM_MemoryPool *memoryPool = tenureMemorySubspace->getMemoryPool();
-	uintptr_t resizeType = memoryPool->postCollect(env);
-
-	if (HEAP_NO_RESIZE != resizeType) {
-		/* update sweepStates after heap resize (for concurrentSweep only) */
-		_sweepScheme->postCollect(env, resizeType);
-	}
-}
-
-void
 MM_ParallelGlobalGC::internalPostCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *subSpace)
 {
 	MM_GlobalCollector::internalPostCollect(env, subSpace);
-
-	tenureMemoryPoolPostCollect(env);
 
 	reportGCCycleFinalIncrementEnding(env);
 	reportGlobalGCIncrementEnd(env);

--- a/gc/base/standard/ParallelGlobalGC.hpp
+++ b/gc/base/standard/ParallelGlobalGC.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2017
+ * (c) Copyright IBM Corp. 1991, 2015
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -178,10 +178,6 @@ private:
 	 */
 	void cleanupAfterGC(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription);
 
-	/**
-	 * redistribute free memory in tenure after global collection (move free memory from LOA to SOA)
-	 */
-	void tenureMemoryPoolPostCollect(MM_EnvironmentBase *env);
 protected:
 	bool initialize(MM_EnvironmentBase *env);
 	void tearDown(MM_EnvironmentBase *env);

--- a/gc/base/standard/ParallelSweepScheme.hpp
+++ b/gc/base/standard/ParallelSweepScheme.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2017
+ * (c) Copyright IBM Corp. 1991, 2015
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -204,8 +204,6 @@ public:
 	 * @return the dark matter, measured in bytes, in the range
 	 */
 	uintptr_t performSamplingCalculations(MM_ParallelSweepChunk *sweepChunk, uintptr_t* markMapCurrent, uintptr_t* heapSlotFreeCurrent);
-
-	virtual void postCollect(MM_EnvironmentBase* env, uintptr_t resizeType) {}
 
 	/**
 	 * Create a ParallelSweepScheme object.

--- a/gc/stats/CollectionStatisticsVLHGC.hpp
+++ b/gc/stats/CollectionStatisticsVLHGC.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2017
+ * (c) Copyright IBM Corp. 1991, 2016
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -42,7 +42,6 @@ public:
 
 	uintptr_t _edenFreeHeapSize; /**< Eden free heap size in bytes */
 	uintptr_t _edenHeapSize;	/**< Eden heap size in bytes */
-	uintptr_t _scheduledEdenHeapSize;	/**< Scheduled Eden heap size in bytes */
 
 	uintptr_t _arrayletReferenceObjects; /**< Count of non-contiguous reference arraylets */
 	uintptr_t _arrayletReferenceLeaves;	/**< Count (total) of reference arraylet leaves */
@@ -96,7 +95,6 @@ public:
 		,_incrementCount(0)
 		,_edenFreeHeapSize(0)
 		,_edenHeapSize(0)
-		,_scheduledEdenHeapSize(0)
 		,_arrayletReferenceObjects(0)
 		,_arrayletReferenceLeaves(0)
 		,_largestReferenceArraylet(0)

--- a/gc/verbose/schema.xsd
+++ b/gc/verbose/schema.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-(c) Copyright IBM Corp. 2010, 2017
+(c) Copyright IBM Corp. 2010, 2016
 
  This program and the accompanying materials are made available
  under the terms of the Eclipse Public License v1.0 and
@@ -167,7 +167,6 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 			<element ref="vgc:numa" maxOccurs="1" minOccurs="0" />
 			<element ref="vgc:pending-finalizers" maxOccurs="1" minOccurs="0" />
 			<element ref="vgc:remembered-set" maxOccurs="1" minOccurs="0" />
-			<element ref="vgc:warning" maxOccurs="1" minOccurs="0" />
 		</sequence>
 		<attribute name="id" type="integer" use="required" />
 		<attributeGroup ref="vgc:mem"/>


### PR DESCRIPTION
Reverts eclipse/omr#1019

This change is causing issues when concurrent sweep is happening.  I am reverting the PR until the concurrent sweep issues can be resolved