### PR TITLE
Extract MM_MarkingDelegate from CLI

### DIFF
--- a/gc/base/ObjectScanner.hpp
+++ b/gc/base/ObjectScanner.hpp
@@ -263,8 +263,6 @@ public:
 	MMINLINE GC_SlotObject *
 	getNextSlot(bool &isLeafSlot)
 	{
-		fomrobject_t *startPtr = _scanPtr;
-
 		while (NULL != _scanPtr) {
 			/* while there is at least one bit-mapped slot, advance scan ptr to a non-NULL slot or end of map */
 			while ((0 != _scanMap) && ((0 == (1 & _scanMap)) || (0 == *_scanPtr))) {


### PR DESCRIPTION
Fix -Werror=unused-but-set-variable error in OpenJ9 compile.

Signed-off-by: Kim Briggs <briggs@ca.ibm.com>