### PR TITLE
Code cleanup related to pseudo instruction on X86

### DIFF
--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -487,7 +487,7 @@ OMR::X86::CodeGenerator::CodeGenerator() :
    _deferredSplits(getTypedAllocator<TR::X86LabelInstruction*>(TR::comp()->allocator())),
    _flags(0)
    {
-	_clobIterator = _clobberingInstructions.begin();
+   _clobIterator = _clobberingInstructions.begin();
    }
 
 TR::Linkage *
@@ -690,7 +690,6 @@ int32_t OMR::X86::CodeGenerator::getMaximumNumbersOfAssignableFPRs()
 // this method is placed here as a dummy until platform specific code is removed from LocalOpt
 int32_t OMR::X86::CodeGenerator::getMaximumNumbersOfAssignableVRs()
    {
-   //TR_ASSERT(false,"getMaximumNumbersOfAssignableVRs should never be called.");
    return INT_MAX;
    }
 
@@ -731,8 +730,8 @@ void OMR::X86::CodeGenerator::clobberLiveDiscardableRegisters(
       // we have assigned registers for this instruction.
       auto  iterator = self()->getLiveDiscardableRegisters().begin();
       while (iterator != self()->getLiveDiscardableRegisters().end())
-      	 {
-    	 TR::Register *registerCursor = *iterator;
+         {
+         TR::Register *registerCursor = *iterator;
          if (registerCursor->getRematerializationInfo()->isRematerializableFromMemory())
             {
             TR::SymbolReference * rmSymRef = registerCursor->getRematerializationInfo()->getSymbolReference();
@@ -786,13 +785,13 @@ void OMR::X86::CodeGenerator::clobberLiveDiscardableRegisters(
                      }
                   }
                else
-            	   ++iterator;
+                  ++iterator;
                }
             else
-            	++iterator;
+               ++iterator;
             }
          else
-        	 ++iterator;
+            ++iterator;
          }
 
       // If a register-dependent discardable register depends on any of the deactivated
@@ -826,7 +825,7 @@ void OMR::X86::CodeGenerator::clobberLiveDependentDiscardableRegisters(TR::Clobb
 
       for (auto iterator = self()->getLiveDiscardableRegisters().begin(); iterator != self()->getLiveDiscardableRegisters().end();)
          {
-    	 TR::Register * candidate = *iterator;
+         TR::Register * candidate = *iterator;
          TR_RematerializationInfo * info = candidate->getRematerializationInfo();
 
          if (info->isIndirect() && info->getBaseRegister() == baseReg)
@@ -844,7 +843,7 @@ void OMR::X86::CodeGenerator::clobberLiveDependentDiscardableRegisters(TR::Clobb
                }
             }
          else
-        	 ++iterator;
+             ++iterator;
          }
       }
    }
@@ -1382,7 +1381,7 @@ void OMR::X86::CodeGenerator::processClobberingInstructions(TR::ClobberingInstru
    while (clobInstructionCursor &&
     (clobInstructionCursor->getInstruction() == instructionCursor) && self()->enableRematerialisation())
       {
-	  auto regIterator = clobInstructionCursor->getClobberedRegisters().begin();
+      auto regIterator = clobInstructionCursor->getClobberedRegisters().begin();
       while (regIterator != clobInstructionCursor->getClobberedRegisters().end())
          {
          (*regIterator)->setIsDiscardable();
@@ -1408,13 +1407,14 @@ void OMR::X86::CodeGenerator::processClobberingInstructions(TR::ClobberingInstru
          regIterator++;
          }
       if(_clobIterator == --(_clobberingInstructions.end()))
-    	  clobInstructionCursor = 0;
+         clobInstructionCursor = 0;
       else if(_clobIterator == _clobberingInstructions.end())
-    	  clobInstructionCursor = 0;
-      else {
-    	  ++_clobIterator;
-    	  clobInstructionCursor = *_clobIterator;
-      }
+         clobInstructionCursor = 0;
+      else
+         {
+         ++_clobIterator;
+         clobInstructionCursor = *_clobIterator;
+         }
       }
    }
 
@@ -1501,11 +1501,9 @@ void OMR::X86::CodeGenerator::doBackwardsRegisterAssignment(
       self()->tracePostRAInstruction(instructionCursor);
       TR::ClobberingInstruction * clobInst;
       if(_clobIterator == self()->getClobberingInstructions().end())
-    	  clobInst = 0;
+         clobInst = 0;
       else
-      {
-    	  clobInst = *_clobIterator;
-      }
+         clobInst = *_clobIterator;
       self()->processClobberingInstructions(clobInst, instructionCursor);
 
       // Skip over any instructions that may have been inserted prior to the
@@ -2398,9 +2396,6 @@ bool OMR::X86::CodeGenerator::processInstruction(TR::Instruction *instr, TR_BitV
                                              bool traceIt)
    {
    TR::Instruction *x86Instr = instr;
-
-   if (x86Instr->getOpCode().cannotBeAssembled())
-      return false;
 
    if (x86Instr->getOpCode().isCallOp())
       {
@@ -3706,7 +3701,7 @@ void OMR::X86::CodeGenerator::removeUnavailableRegisters(TR_RegisterCandidate * 
             break;
             }
          default:
-         	break;
+            break;
          }
       }
    }

--- a/compiler/x/codegen/X86Debug.cpp
+++ b/compiler/x/codegen/X86Debug.cpp
@@ -67,9 +67,6 @@ TR_Debug::printx(TR::FILE *pOutFile, TR::Instruction  * instr)
    //print all the X86 instructions here.
    if (pOutFile == NULL)
       return;
-   // Do not print pseudo-instructions in post-binary encoding dumps.
-   if (instr->getBinaryEncoding() && (instr->getOpCode().isPseudoOp() != 0))
-      return;
    switch (instr->getKind())
       {
       case TR::Instruction::IsLabel:
@@ -317,27 +314,27 @@ TR_Debug::dumpDependencyGroup(TR::FILE *                         pOutFile,
       r = (group->getRegisterDependency(i))->getRealRegister();
 
       if (omitNullDependencies)
-	 if (!virtReg && r != TR::RealRegister::AllFPRegisters)
-	    continue;
+        if (!virtReg && r != TR::RealRegister::AllFPRegisters)
+           continue;
 
       if  (r == TR::RealRegister::AllFPRegisters)
-	 {
-	 trfprintf(pOutFile, " [All FPRs]");
-	 }
+        {
+        trfprintf(pOutFile, " [All FPRs]");
+        }
       else
-	 {
-	 trfprintf(pOutFile, " [%s : ", getName(virtReg));
-	 if (r == TR::RealRegister::NoReg)
-	    trfprintf(pOutFile, "NoReg]");
-	 else if (r == TR::RealRegister::ByteReg)
-	    trfprintf(pOutFile, "ByteReg]");
-	 else if (r == TR::RealRegister::BestFreeReg)
-	    trfprintf(pOutFile, "BestFreeReg]");
-	 else if (r == TR::RealRegister::SpilledReg)
-	    trfprintf(pOutFile, "SpilledReg]");
-	 else
-	    trfprintf(pOutFile, "%s]", getName(_cg->machine()->getX86RealRegister(r)));
-	 }
+        {
+        trfprintf(pOutFile, " [%s : ", getName(virtReg));
+        if (r == TR::RealRegister::NoReg)
+           trfprintf(pOutFile, "NoReg]");
+        else if (r == TR::RealRegister::ByteReg)
+           trfprintf(pOutFile, "ByteReg]");
+        else if (r == TR::RealRegister::BestFreeReg)
+           trfprintf(pOutFile, "BestFreeReg]");
+        else if (r == TR::RealRegister::SpilledReg)
+           trfprintf(pOutFile, "SpilledReg]");
+        else
+           trfprintf(pOutFile, "%s]", getName(_cg->machine()->getX86RealRegister(r)));
+        }
 
       foundDep = true;
       }
@@ -403,9 +400,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86PaddingInstruction  * instr)
    if (pOutFile == NULL)
       return;
 
-   if (instr->getOpCode().cannotBeAssembled())
-      return;
-
    printPrefix(pOutFile, instr);
    if (instr->getBinaryEncoding())
       trfprintf(pOutFile, "nop (%d byte%s)\t\t%s Padding (%d byte%s)",
@@ -432,9 +426,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86AlignmentInstruction  * instr)
    uint8_t length = instr->getBinaryLength();
    uint8_t margin = instr->getMargin();
 
-   if (instr->getOpCode().cannotBeAssembled())
-      return;
-
    printPrefix(pOutFile, instr);
    if (instr->getBinaryEncoding())
       trfprintf(pOutFile, "nop (%d byte%s)\t\t%s ",
@@ -457,9 +448,6 @@ void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86RestoreVMThreadInstruction  * instr)
    {
    if (pOutFile == NULL)
-      return;
-
-   if (instr->getOpCode().cannotBeAssembled())
       return;
 
    printPrefix(pOutFile, instr);
@@ -511,9 +499,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86BoundaryAvoidanceInstruction  * instr
    if (pOutFile == NULL)
       return;
 
-   if (instr->getOpCode().cannotBeAssembled())
-      return;
-
    printPrefix(pOutFile, instr);
    if (instr->getBinaryEncoding())
       trfprintf(pOutFile, "nop (%d byte%s)\t\t%s ",
@@ -534,9 +519,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86PatchableCodeAlignmentInstruction  * 
    if (pOutFile == NULL)
       return;
 
-   if (instr->getOpCode().cannotBeAssembled())
-      return;
-
    printPrefix(pOutFile, instr);
    if (instr->getBinaryEncoding())
       trfprintf(pOutFile, "nop (%d byte%s)\t\t%s ",
@@ -555,9 +537,6 @@ void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86LabelInstruction  * instr)
    {
    if (pOutFile == NULL)
-      return;
-
-   if (instr->getOpCode().cannotBeAssembled())
       return;
 
    printPrefix(pOutFile, instr);
@@ -610,9 +589,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86FenceInstruction  * instr)
        instr->getNode()->getOpCodeValue() != TR::BBEnd)
       return;
 
-   if (instr->getOpCode().cannotBeAssembled())
-      return;
-
    TR::Node *node = instr->getNode();
    if (node && node->getOpCodeValue() == TR::BBStart)
       {
@@ -662,9 +638,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86VirtualGuardNOPInstruction  * instr)
    if (pOutFile == NULL)
       return;
 
-   if (instr->getOpCode().cannotBeAssembled())
-      return;
-
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s Site:" POINTER_PRINTF_FORMAT ", ", getMnemonicName(&instr->getOpCode()), instr->getSite());
    print(pOutFile, instr->getLabelSymbol());
@@ -678,9 +651,6 @@ void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86ImmInstruction  * instr)
    {
    if (pOutFile == NULL)
-      return;
-
-   if (instr->getOpCode().cannotBeAssembled())
       return;
 
    printPrefix(pOutFile, instr);
@@ -714,9 +684,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::AMD64Imm64Instruction * instr)
    if (pOutFile == NULL)
       return;
 
-   if (instr->getOpCode().cannotBeAssembled())
-      return;
-
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s\t", getMnemonicName(&instr->getOpCode()));
 
@@ -746,9 +713,6 @@ void
 TR_Debug::print(TR::FILE *pOutFile, TR::AMD64Imm64SymInstruction * instr)
    {
    if (pOutFile == NULL)
-      return;
-
-   if (instr->getOpCode().cannotBeAssembled())
       return;
 
    printPrefix(pOutFile, instr);
@@ -795,9 +759,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::AMD64RegImm64Instruction * instr)
    if (pOutFile == NULL)
       return;
 
-   if (instr->getOpCode().cannotBeAssembled())
-      return;
-
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s\t", getMnemonicName(&instr->getOpCode()));
    if (!(instr->getOpCode().targetRegIsImplicit() != 0))
@@ -817,10 +778,6 @@ void TR_Debug::print(TR::FILE *pOutFile, TR::X86VFPSaveInstruction  *instr)
    if (pOutFile == NULL)
       return;
 
-   // vfpSave is a compile-time accounting pseudo instruction
-   if (instr->getOpCode().cannotBeAssembled())
-      return;
-
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "vfpSave", getMnemonicName(&instr->getOpCode()));
 
@@ -833,10 +790,6 @@ void TR_Debug::print(TR::FILE *pOutFile, TR::X86VFPSaveInstruction  *instr)
 void TR_Debug::print(TR::FILE *pOutFile, TR::X86VFPRestoreInstruction  *instr)
    {
    if (pOutFile == NULL)
-      return;
-
-   // vfpRestore is a compile-time accounting pseudo instruction
-   if (instr->getOpCode().cannotBeAssembled())
       return;
 
    printPrefix(pOutFile, instr);
@@ -866,9 +819,6 @@ void TR_Debug::print(TR::FILE *pOutFile, TR::X86VFPReleaseInstruction  *instr)
    if (pOutFile == NULL)
       return;
 
-   if (instr->getOpCode().cannotBeAssembled())
-      return;
-
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "vfpRelease [%s]", getName(instr->getDedicateInstruction()));
 
@@ -881,10 +831,6 @@ void TR_Debug::print(TR::FILE *pOutFile, TR::X86VFPReleaseInstruction  *instr)
 void TR_Debug::print(TR::FILE *pOutFile, TR::X86VFPCallCleanupInstruction  *instr)
    {
    if (pOutFile == NULL)
-      return;
-
-   // vfpCallCleanup is a compile-time accounting pseudo instruction
-   if (instr->getOpCode().cannotBeAssembled())
       return;
 
    printPrefix(pOutFile, instr);
@@ -903,9 +849,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86ImmSnippetInstruction  * instr)
    if (pOutFile == NULL)
       return;
 
-   if (instr->getOpCode().cannotBeAssembled())
-      return;
-
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s\t", getMnemonicName(&instr->getOpCode()));
    printIntConstant(pOutFile, instr->getSourceImmediate(), 16, getImmediateSizeFromInstruction(instr), true);
@@ -921,10 +864,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86ImmSymInstruction  * instr)
    if (pOutFile == NULL)
       return;
 
-   if (instr->getOpCode().cannotBeAssembled())
-      return;
-
-   TR::Symbol       *sym   = instr->getSymbolReference()->getSymbol();
+   TR::Symbol     *sym   = instr->getSymbolReference()->getSymbol();
    const char     *name  = getName(instr->getSymbolReference());
 
    printPrefix(pOutFile, instr);
@@ -986,9 +926,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86RegInstruction  * instr)
    if (pOutFile == NULL)
       return;
 
-   if (instr->getOpCode().cannotBeAssembled())
-      return;
-
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s\t", getMnemonicName(&instr->getOpCode()));
    if (!(instr->getOpCode().targetRegIsImplicit() != 0))
@@ -1020,9 +957,6 @@ void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86RegRegInstruction  * instr)
    {
    if (pOutFile == NULL)
-      return;
-
-   if (instr->getOpCode().cannotBeAssembled())
       return;
 
    printPrefix(pOutFile, instr);
@@ -1064,9 +998,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86RegImmInstruction  * instr)
    if (pOutFile == NULL)
       return;
 
-   if (instr->getOpCode().cannotBeAssembled())
-      return;
-
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s\t", getMnemonicName(&instr->getOpCode()));
    if (!(instr->getOpCode().targetRegIsImplicit() != 0))
@@ -1084,9 +1015,6 @@ void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86RegRegImmInstruction  * instr)
    {
    if (pOutFile == NULL)
-      return;
-
-   if (instr->getOpCode().cannotBeAssembled())
       return;
 
    printPrefix(pOutFile, instr);
@@ -1113,9 +1041,6 @@ void
 TR_Debug::print(TR::FILE *pOutFile, TR::X86RegRegRegInstruction  * instr)
    {
    if (pOutFile == NULL)
-      return;
-
-   if (instr->getOpCode().cannotBeAssembled())
       return;
 
    printPrefix(pOutFile, instr);
@@ -1881,7 +1806,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::RealRegister * reg, TR_RegisterSizes siz
          trfprintf(pOutFile, "%s", getName(reg, size));
          break;
       default:
-      	break;
+         break;
       }
    }
 
@@ -2414,7 +2339,7 @@ TR_Debug::printArgumentFlush(TR::FILE *              pOutFile,
             numFPArgs++;
             break;
          default:
-         	break;
+            break;
          }
 
       if (opCodeName)

--- a/compiler/x/codegen/X86Ops.ins
+++ b/compiler/x/codegen/X86Ops.ins
@@ -24,7 +24,7 @@
 INSTRUCTION(BADIA32Op, int3,
             BINARY(VEX_L___, VEX_vNONE, PREFIX___, REX__, ESCAPE_____, 0xcc, 0, ModRM_NONE, Immediate_0),
             PROPERTY0(0),
-            PROPERTY1(IA32OpProp1_CannotBeAssembled)),
+            PROPERTY1(0)),
 INSTRUCTION(ADC1AccImm1, adc,
             BINARY(VEX_L___, VEX_vNONE, PREFIX___, REX__, ESCAPE_____, 0x14, 0, ModRM_NONE, Immediate_1),
             PROPERTY0(IA32OpProp_ModifiesTarget | IA32OpProp_TargetRegisterIgnored | IA32OpProp_ByteTarget | IA32OpProp_ByteImmediate | IA32OpProp_ModifiesOverflowFlag | IA32OpProp_ModifiesSignFlag | IA32OpProp_ModifiesZeroFlag | IA32OpProp_ModifiesParityFlag | IA32OpProp_ModifiesCarryFlag | IA32OpProp_TestsCarryFlag | IA32OpProp_UsesTarget),
@@ -3528,77 +3528,76 @@ INSTRUCTION(PSRLQRegImm1, psrlq,
             PROPERTY0(IA32OpProp_ModifiesTarget | IA32OpProp_ByteImmediate | IA32OpProp_DoubleFP | IA32OpProp_TargetRegisterInModRM | IA32OpProp_UsesTarget),
             PROPERTY1(IA32OpProp1_XMMSource | IA32OpProp1_XMMTarget)),
 
-// OpCodes beyond this point are dummy ops
-// Dummy ops are not Intel X86 instructions; they are for OMR internal usage only.
+// OpCodes beyond this point are pseudo instructions; they are for OMR internal usage only.
 INSTRUCTION(FENCE, Fence, // Address of binary is to be written to specified data address, SymbolReference controls code motion across fence
             BINARY(VEX_L___, VEX_vNONE, PREFIX___, REX__, ESCAPE_____, 0x00, 0, ModRM_NONE, Immediate_0),
             PROPERTY0(0),
-            PROPERTY1(IA32OpProp1_CannotBeAssembled)),
+            PROPERTY1(IA32OpProp1_PseudoOp)),
 INSTRUCTION(VGFENCE, VGFence, // Special Fence used for patching virtual guards
             BINARY(VEX_L___, VEX_vNONE, PREFIX___, REX__, ESCAPE_____, 0x00, 0, ModRM_NONE, Immediate_0),
             PROPERTY0(0),
-            PROPERTY1(IA32OpProp1_CannotBeAssembled)),
+            PROPERTY1(IA32OpProp1_PseudoOp)),
 INSTRUCTION(PROCENTRY, ProcEntry, // Entry to the method
             BINARY(VEX_L___, VEX_vNONE, PREFIX___, REX__, ESCAPE_____, 0x00, 0, ModRM_NONE, Immediate_0),
             PROPERTY0(0),
-            PROPERTY1(IA32OpProp1_CannotBeAssembled)),
+            PROPERTY1(IA32OpProp1_PseudoOp)),
 INSTRUCTION(DQImm64, dq, // Define 8 bytes
             BINARY(VEX_L___, VEX_vNONE, PREFIX___, REX__, ESCAPE_____, 0x00, 0, ModRM_NONE, Immediate_8),
             PROPERTY0(0),
-            PROPERTY1(IA32OpProp1_LongImmediate)),
+            PROPERTY1(IA32OpProp1_PseudoOp | IA32OpProp1_LongImmediate)),
 INSTRUCTION(DDImm4, dd, // Define 4 bytes
             BINARY(VEX_L___, VEX_vNONE, PREFIX___, REX__, ESCAPE_____, 0x00, 0, ModRM_NONE, Immediate_4),
             PROPERTY0(IA32OpProp_IntImmediate),
-            PROPERTY1(0)),
+            PROPERTY1(IA32OpProp1_PseudoOp)),
 INSTRUCTION(DWImm2, dw, // Define 2 bytes
             BINARY(VEX_L___, VEX_vNONE, PREFIX___, REX__, ESCAPE_____, 0x00, 0, ModRM_NONE, Immediate_2),
             PROPERTY0(IA32OpProp_ShortImmediate),
-            PROPERTY1(0)),
+            PROPERTY1(IA32OpProp1_PseudoOp)),
 INSTRUCTION(DBImm1, db, // Define 1 byte
             BINARY(VEX_L___, VEX_vNONE, PREFIX___, REX__, ESCAPE_____, 0x00, 0, ModRM_NONE, Immediate_1),
             PROPERTY0(IA32OpProp_ByteImmediate),
-            PROPERTY1(0)),
+            PROPERTY1(IA32OpProp1_PseudoOp)),
 INSTRUCTION(WRTBAR, wrtbar, // Write barrier directive/macro for GCs that need them
             BINARY(VEX_L___, VEX_vNONE, PREFIX___, REX__, ESCAPE_____, 0x00, 0, ModRM_NONE, Immediate_0),
             PROPERTY0(IA32OpProp_UsesTarget | IA32OpProp_ModifiesTarget | IA32OpProp_IntSource | IA32OpProp_IntTarget | IA32OpProp_ByteTarget),
-            PROPERTY1(IA32OpProp1_PseudoOp | IA32OpProp1_CannotBeAssembled)),
+            PROPERTY1(IA32OpProp1_PseudoOp)),
 INSTRUCTION(ASSOCREGS, assocRegs, // Directive to change register associations
             BINARY(VEX_L___, VEX_vNONE, PREFIX___, REX__, ESCAPE_____, 0x00, 0, ModRM_NONE, Immediate_0),
             PROPERTY0(0),
-            PROPERTY1(IA32OpProp1_PseudoOp | IA32OpProp1_CannotBeAssembled)),
+            PROPERTY1(IA32OpProp1_PseudoOp)),
 INSTRUCTION(FPREGSPILL, fpRegSpill, // Directive to force the FP stack to be spilled
             BINARY(VEX_L___, VEX_vNONE, PREFIX___, REX__, ESCAPE_____, 0x00, 0, ModRM_NONE, Immediate_0),
             PROPERTY0(0),
-            PROPERTY1(IA32OpProp1_PseudoOp | IA32OpProp1_CannotBeAssembled)),
+            PROPERTY1(IA32OpProp1_PseudoOp)),
 INSTRUCTION(VirtualGuardNOP, vgnop, // A virtual guard encoded as a NOP instruction
             BINARY(VEX_L___, VEX_vNONE, PREFIX___, REX__, ESCAPE_____, 0x00, 0, ModRM_NONE, Immediate_0),
             PROPERTY0(IA32OpProp_BranchOp | IA32OpProp_TestsZeroFlag),
-            PROPERTY1(IA32OpProp1_CannotBeAssembled)),
+            PROPERTY1(IA32OpProp1_PseudoOp)),
 INSTRUCTION(LABEL, Label, // Destination of a jump
             BINARY(VEX_L___, VEX_vNONE, PREFIX___, REX__, ESCAPE_____, 0x00, 0, ModRM_NONE, Immediate_0),
             PROPERTY0(0),
-            PROPERTY1(0)),
+            PROPERTY1(IA32OpProp1_PseudoOp)),
 INSTRUCTION(FCMPEVAL, fcmpEval, // Instruction selection of FP comparisons at register assignment time
             BINARY(VEX_L___, VEX_vNONE, PREFIX___, REX__, ESCAPE_____, 0x00, 0, ModRM_NONE, Immediate_0),
             PROPERTY0(0),
-            PROPERTY1(IA32OpProp1_PseudoOp | IA32OpProp1_CannotBeAssembled)),
+            PROPERTY1(IA32OpProp1_PseudoOp)),
 INSTRUCTION(RestoreVMThread, RestoreVMThread, // restore VM thread register from fs:[0]
             BINARY(VEX_L___, VEX_vNONE, PREFIX___, REX__, ESCAPE_____, 0x00, 0, ModRM_NONE, Immediate_0),
             PROPERTY0(0),
-            PROPERTY1(IA32OpProp1_CannotBeAssembled)),
+            PROPERTY1(IA32OpProp1_PseudoOp)),
 INSTRUCTION(PPS_OPCount, PPS_OPCount, // Phase profiling site (object access counting)
             BINARY(VEX_L___, VEX_vNONE, PREFIX___, REX__, ESCAPE_____, 0x00, 0, ModRM_NONE, Immediate_0),
             PROPERTY0(IA32OpProp_UsesTarget | IA32OpProp_ModifiesOverflowFlag | IA32OpProp_ModifiesSignFlag | IA32OpProp_ModifiesZeroFlag | IA32OpProp_ModifiesParityFlag | IA32OpProp_ModifiesCarryFlag),
-            PROPERTY1(IA32OpProp1_CannotBeAssembled)),
+            PROPERTY1(IA32OpProp1_PseudoOp)),
 INSTRUCTION(PPS_OPField, PPS_OPField, // Phase profiling site (object field counting)
             BINARY(VEX_L___, VEX_vNONE, PREFIX___, REX__, ESCAPE_____, 0x00, 0, ModRM_NONE, Immediate_0),
             PROPERTY0(IA32OpProp_ModifiesOverflowFlag | IA32OpProp_ModifiesSignFlag | IA32OpProp_ModifiesZeroFlag | IA32OpProp_ModifiesParityFlag | IA32OpProp_ModifiesCarryFlag),
-            PROPERTY1(IA32OpProp1_CannotBeAssembled)),
+            PROPERTY1(IA32OpProp1_PseudoOp)),
 INSTRUCTION(AdjustFramePtr, AdjustFramePtr, // Adjust frame pointer
             BINARY(VEX_L___, VEX_vNONE, PREFIX___, REX__, ESCAPE_____, 0x00, 0, ModRM_NONE, Immediate_0),
             PROPERTY0(0),
-            PROPERTY1(IA32OpProp1_CannotBeAssembled)),
+            PROPERTY1(IA32OpProp1_PseudoOp)),
 INSTRUCTION(ReturnMarker, ReturnMarker, // Return Marker for linkages that do not end with a RET instruction
             BINARY(VEX_L___, VEX_vNONE, PREFIX___, REX__, ESCAPE_____, 0x00, 0, ModRM_NONE, Immediate_0),
             PROPERTY0(0),
-            PROPERTY1(IA32OpProp1_PseudoOp | IA32OpProp1_CannotBeAssembled)),
+            PROPERTY1(IA32OpProp1_PseudoOp)),

--- a/compiler/x/codegen/X86Ops_inlines.hpp
+++ b/compiler/x/codegen/X86Ops_inlines.hpp
@@ -84,12 +84,12 @@ template <typename TBuffer> inline typename TBuffer::cursor_t TR_X86OpCode::OpCo
    return buffer;
    }
 
-inline void TR_X86OpCode::CheckAndFinishGroup07(TR_X86OpCodes op, uint8_t* cursor)
+inline void TR_X86OpCode::CheckAndFinishGroup07(uint8_t* cursor)
    {
-   if(_binaries[op].isGroup07())
+   if(info().isGroup07())
       {
       auto pModRM = (TR::Instruction::ModRM*)(cursor-1);
-      switch(op)
+      switch(_opCode)
          {
          case XEND:
             pModRM->rm = 0x05; // 0b101


### PR DESCRIPTION
1. Remove unused property - CannotBeAssembled
2. Repurpose little-used property - PseudoOp - for all dummy/pseudo instructions

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>