### PR TITLE
Don't convert intptr_t to int

### DIFF
--- a/fvtest/threadtest/abortTest.cpp
+++ b/fvtest/threadtest/abortTest.cpp
@@ -167,7 +167,7 @@ sleepingMain(void *arg)
 
 	EXPECT_EQ(rc, J9THREAD_PRIORITY_INTERRUPTED);
 
-	return rc;
+	return 0;
 }
 
 typedef struct wait_testdata_t {


### PR DESCRIPTION
Just return 0, the RC is unused.

Cc: @ktbriggs
Signed-off-by: Robert Young <rwy0717@gmail.com>