### PR TITLE
Enable AutoSIMD support on x86

### DIFF
--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -409,15 +409,6 @@ OMR::CodeGenerator::prepareRegistersForAssignment()
          registerCursor->setFutureUseCount(registerCursor->getTotalUseCount());
       km = registerCursor->getKindAsMask();
 
-      /*
-       * Sometimes TR_VRF virtual registers need to be assigned even when there are no TR_VRF real registers
-       * This can occur when there is a full overlap between TR_VRF and TR_FPR real registers and they are all marked as TR_FPR
-       * isFPRUsedAsVRF is used to indicate if assignment is necessary
-       * if true, RA is told it may need to assign TR_VRF as well as TR_FPR registers if a TR_FPR real register is seen
-       */
-      if (registerCursor->getKind() == TR_FPR && self()->isFPRUsedAsVRF())
-         km |= TO_KIND_MASK(TR_VRF);
-
       if (!(foundKindsMask & km))
          foundKindsMask |= km;
       }

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1184,11 +1184,6 @@ class OMR_EXTENSIBLE CodeGenerator
    void addToUnlatchedRegisterList(TR::RealRegister *reg);
    void freeUnlatchedRegisters();
 
-   //This indicates if TR_VRF virtual registers may need to be assigned even if the system only has TR_FPR real registers
-   //This is set to true when there is a full overlap between TR_FPR and TR_VRF registers and all of the TR_FPR/TR_VRF
-   //registers are marked as TR_FPR
-   bool isFPRUsedAsVRF() { return false; }
-
    // --------------------------------------------------------------------------
    // Listing
    //

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -259,6 +259,7 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
       {
       self()->setUseSSEForSinglePrecision();
       self()->setUseSSEForDoublePrecision();
+      self()->setSupportsAutoSIMD();
       }
 
    // Choose the best XMM double precision load instruction for the target architecture.
@@ -976,27 +977,34 @@ bool
 OMR::X86::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR::DataType dt)
    {
    /*
-    * This is a place holder function. It currently always returns false because none of the SIMD evaluators for OpCodes used
-    * in AutoSIMD have been implemented.
-    * This should be filled in (and this comment updated) as support for SIMD evaluators is implemented.
+    * Only a few of the vector evaluators for opcodes used in AutoSIMD have been implemented.
+    * The cases that return false are placeholders that should be updated as support for more vector evaluators is added.
     */
    // implemented vector opcodes
    switch (opcode.getOpCodeValue())
       {
       case TR::vadd:
-      case TR::vsub:
       case TR::vmul:
-      case TR::vdiv:
-      case TR::vrem:
-      case TR::vneg:
+         if (dt == TR::Double)
+            return true;
+         else
+            return false;
       case TR::vload:
       case TR::vloadi:
       case TR::vstore:
       case TR::vstorei:
+      case TR::vsplats:
+         if (dt == TR::Int32 || dt == TR::Int64 || dt == TR::Float || dt == TR::Double)
+            return true;
+         else
+            return false;
+      case TR::vsub:
+      case TR::vdiv:
+      case TR::vrem:
+      case TR::vneg:
       case TR::vxor:
       case TR::vor:
       case TR::vand:
-      case TR::vsplats:
       case TR::getvelem:
       default:
          return false;

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -564,8 +564,6 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    virtual void simulateNodeEvaluation (TR::Node *node, TR_RegisterPressureState *state, TR_RegisterPressureSummary *summary);
 
-   bool isFPRUsedAsVRF() { return _targetProcessorInfo.supportsSSE2(); }
-
    protected:
 
    CodeGenerator();


### PR DESCRIPTION
Updated getSupportsOpCodeForAutoSIMD in x/codegen/OMRCodeGenerator.cpp to
reflect the recently implemented vector evaluators. Instead of returning
false in all cases, getSupportsOpCodeForAutoSIMD will now return true for
loads, stores and vector splats for int32, int64, float and double data
and also double type add and multiply. All of these operations are
supported in the new vector evaluators.

A call to setSupportsAutoSIMD is now made inside initialize in
OMRCodeGenerator.cpp to indicate that autoSIMD is now supported. This call
is behind a check for SSE2 support.

The function isFPRUsedAsVRF and any references to it were removed. It was
added to prepareRegistersForAssignment in error. It is not needed for
AutoSIMD and sometimes caused registers to not be assigned properly. It
was only used in one place, so the entire fuction is just being removed.

Issue: #1066
Signed-off-by: jimmyk <jimmyk@ca.ibm.com>