### PR TITLE
Extract MM_MarkingDelegate from CLI

### DIFF
--- a/gc/base/ObjectScanner.hpp
+++ b/gc/base/ObjectScanner.hpp
@@ -291,7 +291,6 @@ public:
 				_scanPtr = NULL;
 				setNoMoreSlots();
 			}
-			startPtr = _scanPtr;
 		}
 
 		isLeafSlot = true;


### PR DESCRIPTION
Fix -Werror=unused-but-set-variable error in OpenJ9 compile.

There was a second reference to this unused-but-set-variable. Previous
commit only deleted declaration/initialization, assuming that this was
sole reference since unused. Search verified no more references in this
commit.

Signed-off-by: Kim Briggs <briggs@ca.ibm.com>