### PR TITLE
Rename guard merging checks to not specify HCR

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -494,7 +494,7 @@ class OMR_EXTENSIBLE CodeGenerator
    //
    bool supports32bitAiadd() {return true;}  // no virt, default
    bool supportsMarshallingUnmarshallingIntrinsics() {return true;} // no virt, default
-   bool supportsMergingOfHCRGuards() {return false;} // no virt, default
+   bool supportsMergingGuards() {return false;} // no virt, default
 
    /** \brief
     *     Determines whether concurrent scavenge of objects during garbage collection is enabled.

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -1796,7 +1796,7 @@ TR_InlinerBase::addGuardForVirtual(
       // will undergo special processing later in the compilation
       if (virtualGuard &&
           comp()->getHCRMode() != TR::osr &&
-          comp()->cg()->supportsMergingOfHCRGuards())
+          comp()->cg()->supportsMergingGuards())
          {
          TR::Node *guardNode = virtualGuard->getNode();
          if (guardNode)

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1027,11 +1027,11 @@ OMR::X86::CodeGenerator::getSupportsIbyteswap()
    }
 
 bool
-OMR::X86::CodeGenerator::supportsMergingOfHCRGuards()
+OMR::X86::CodeGenerator::supportsMergingGuards()
    {
    return self()->getSupportsVirtualGuardNOPing() &&
           self()->comp()->performVirtualGuardNOPing() &&
-          self()->allowHCRGuardMerging();
+          self()->allowGuardMerging();
    }
 
 TR::RealRegister *

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -295,7 +295,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    virtual bool getSupportsIbyteswap();
 
-   bool supportsMergingOfHCRGuards();
+   bool supportsMergingGuards();
 
    bool supportsAtomicAdd()                {return true;}
    bool hasTMEvaluator()                       {return true;}
@@ -658,7 +658,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    public:
 
-   bool allowHCRGuardMerging() { return false; }
+   bool allowGuardMerging() { return false; }
 
    bool enableBetterSpillPlacements()
       {

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -6088,7 +6088,7 @@ OMR::Z::CodeGenerator::StopUsingEscapedMemRefsRegisters(int32_t topOfMemRefStack
    }
 
 bool
-OMR::Z::CodeGenerator::supportsMergingOfHCRGuards()
+OMR::Z::CodeGenerator::supportsMergingGuards()
    {
    return self()->getSupportsVirtualGuardNOPing() &&
           self()->comp()->performVirtualGuardNOPing() &&

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -431,7 +431,7 @@ public:
    void RemoveMemRefFromStack(TR::MemoryReference * mr);
    void StopUsingEscapedMemRefsRegisters(int32_t topOfMemRefStackBeforeEvaluation);
 
-   bool supportsMergingOfHCRGuards();
+   bool supportsMergingGuards();
 
    bool supportsDirectJNICallsForAOT() { return true;}
 


### PR DESCRIPTION
OSR guards now support guard merging, under the same conditions
as HCR guards. This renames checks required to merge these
guards to not specify HCR.