### PR TITLE
Enable Array Copy under Concurrent Scavenge

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -808,15 +808,7 @@ OMR::Z::CodeGenerator::CodeGenerator()
    self()->setLiveRegisters(new (self()->trHeapMemory()) TR_LiveRegisters(comp), TR_VRF);
 
    self()->setSupportsPrimitiveArrayCopy();
-
-   // TODO (GuardedStorage): Currently we cannot support reference array copy if concurrent scavenge is enabled. The
-   // reason behind this restriction is that during a concurrent scavenge cycle the references read from the source
-   // array need to have issued read barriers and the code generators may not be aware or even support this in the
-   // high-performance memory copy instructions that may be generated.
-   if (!self()->isConcurrentScavengeEnabled())
-      {
-      self()->setSupportsReferenceArrayCopy();
-      }
+   self()->setSupportsReferenceArrayCopy();
 
    self()->setSupportsPartialInlineOfMethodHooks();
 

--- a/compiler/z/codegen/OpMemToMem.hpp
+++ b/compiler/z/codegen/OpMemToMem.hpp
@@ -525,13 +525,6 @@ class MemToMemTypedMacroOp
          _startReg = dstReg;
          _strideReg = strideReg;
          _applyDepLocally = applyDepLocally;
-         if (_destType == TR::Address)
-            {
-            if (TR::Compiler->target.is64Bit() && !_cg->comp()->useCompressedPointers())
-                _destType = TR::Int64;
-            else
-                _destType = TR::Int32;
-            }
 
          _endReg   = _cg->allocateRegister();
          _bxhReg   = _cg->allocateConsecutiveRegisterPair(_startReg, _strideReg);
@@ -640,8 +633,9 @@ class MemInitVarLenTypedMacroOp : public MemToMemTypedVarLenMacroOp
 class MemCpyVarLenTypedMacroOp : public MemToMemTypedVarLenMacroOp
    {
    public:
-      MemCpyVarLenTypedMacroOp(TR::Node* rootNode, TR::Node* dstNode, TR::Node* srcNode, TR::CodeGenerator * cg, TR::DataType destType, TR::Register* lenReg, TR::Node * lenNode, bool isForward = false)
-         : MemToMemTypedVarLenMacroOp(rootNode, dstNode, srcNode, cg, destType, lenReg, lenNode, isForward)
+      MemCpyVarLenTypedMacroOp(TR::Node* rootNode, TR::Node* dstNode, TR::Node* srcNode, TR::CodeGenerator * cg, TR::DataType destType, TR::Register* lenReg, TR::Node * lenNode, bool needsGuardedLoad, bool isForward = false)
+         : _needsGuardedLoad(needsGuardedLoad),
+           MemToMemTypedVarLenMacroOp(rootNode, dstNode, srcNode, cg, destType, lenReg, lenNode, isForward)
          {
          allocWorkReg();
          }
@@ -658,6 +652,7 @@ class MemCpyVarLenTypedMacroOp : public MemToMemTypedVarLenMacroOp
    private:
       void allocWorkReg();
       TR::Register* _workReg;
+      bool          _needsGuardedLoad;
    };
 
 class MemCpyAtomicMacroOp: public MemToMemTypedVarLenMacroOp


### PR DESCRIPTION
This commit enables the previously disabled (under concurrent scavenge)
transformation of the array copy call into the arraycopy node.

In order to handle a current scavenge cycle, the compiler generates code
to check a runtime flag. Execution conditionally branches to an Out Of Line
sequence which contains the necessary guarded load, shift, and store
instructions. This code is only active under `#ifdef J9_PROJECT_SPECIFIC`.