### PR TITLE
Correctly block/unblock even/odd register pairs

### DIFF
--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -1822,8 +1822,13 @@ OMR::Z::Machine::assignBestRegisterPair(TR::Register    *regPair,
          {
          freeRegisterHigh->block();
          }
+
       freeRegisterLow = self()->reverseSpillState(currInst, lastReg);
-      freeRegisterLow->block();
+
+      if (freeRegisterHigh)
+         {
+         freeRegisterHigh->unblock();
+         }
       }
 
    // TotalUse & FutureUse are only equal upon the first assignment.  Hence, if they arn't
@@ -1837,8 +1842,13 @@ OMR::Z::Machine::assignBestRegisterPair(TR::Register    *regPair,
          {
          freeRegisterLow->block();
          }
+
       freeRegisterHigh = self()->reverseSpillState(currInst, firstReg);
-      freeRegisterHigh->block();
+
+      if (freeRegisterLow)
+         {
+         freeRegisterLow->unblock();
+         }
       }
 
    // Propose coloured registers

--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -4744,18 +4744,25 @@ OMR::Z::Machine::reverseSpillState(TR::Instruction      *currentInstruction,
       // in this case, assign a new register and return
       if (!freeHighWordReg)
          {
-      if (!location)
-         {
-         if (debugObj)
-            self()->cg()->traceRegisterAssignment("OOL: Not generating reverse spill for (%s)\n",
-                                          debugObj->getName(spilledRegister));
-         if (enableHighWordRA && spilledRegister->is64BitReg())
+         if (location == NULL)
             {
-            targetRegister->getHighWordRegister()->setState(TR::RealRegister::Assigned);
-            targetRegister->getHighWordRegister()->setAssignedRegister(spilledRegister);
+            if (debugObj)
+               {
+               self()->cg()->traceRegisterAssignment("OOL: Not generating reverse spill for (%s)\n", debugObj->getName(spilledRegister));
+               }
+
+            targetRegister->setState(TR::RealRegister::Assigned);
+            targetRegister->setAssignedRegister(spilledRegister);
+            spilledRegister->setAssignedRegister(targetRegister);
+
+            if (enableHighWordRA && spilledRegister->is64BitReg())
+               {
+               targetRegister->getHighWordRegister()->setState(TR::RealRegister::Assigned);
+               targetRegister->getHighWordRegister()->setAssignedRegister(spilledRegister);
+               }
+
+            return targetRegister;
             }
-         return targetRegister;
-         }
          }
       }
 


### PR DESCRIPTION
When assigning register pairs we need to consider two cases of either
the even or odd register in the register pair being spilled. In such a
case we must reverse the spill state of the respective register, however
we must be careful here not to cause changes to the register state of
the other register in the register pair.

For example if we are attempting to assign a pair of registers (A,B)
where A has been spilled onto the stack and B is currently in a register
we must be careful to not evict B from the register state when reversing
the spill state of A.

To avoid such issues we block register B until the spill state of
register A has been reversed. We must also unblock register B following
this action.

This commit addresses a problem in which we do not correctly unblock
register B, and thus the register stays blocked for the remainder of the
register assignment.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>