### PR TITLE
Set arraycopy type in correct order

### DIFF
--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -1274,20 +1274,6 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
             }
          }
 
-      if (isStringCompressedArrayCopy)
-         {
-         type = TR::Int8;
-
-         elementSize = TR::Symbol::convertTypeToSize(type);
-         }
-
-      if (isStringDecompressedArrayCopy)
-         {
-         type = TR::Int16;
-
-         elementSize = TR::Symbol::convertTypeToSize(type);
-         }
-
       if (primitiveArray1 || primitiveArray2)
          {
          type = primitiveArray1 ?
@@ -1302,6 +1288,20 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
          type = TR::Address;
 
          elementSize = TR::Compiler->om.sizeofReferenceField();
+         }
+
+      if (isStringCompressedArrayCopy)
+         {
+         type = TR::Int8;
+
+         elementSize = TR::Symbol::convertTypeToSize(type);
+         }
+
+      if (isStringDecompressedArrayCopy)
+         {
+         type = TR::Int16;
+
+         elementSize = TR::Symbol::convertTypeToSize(type);
          }
 
       if (comp()->getOptions()->realTimeGC() &&


### PR DESCRIPTION
Compressed and decompressed array copies are also primitive array copies
and as such we must set the type and element size of these special array
copies after setting the type and element size as derived from the fact
that they are primitive array copies as well.

This is done to enforce the fact that for the specially recognized
decompressed array copies we have type set to TR::Int16 and element size
derived from the respective type.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>