### PR TITLE
Add exception points as potential OSR point in involuntaryOSR

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -688,6 +688,8 @@ bool OMR::Compilation::isPotentialOSRPoint(TR::Node *node)
       }
    else if (node->canGCandReturn())
       potentialOSRPoint = true;
+   else if (self()->getOSRMode() == TR::involuntaryOSR && node->canGCandExcept())
+      potentialOSRPoint = true;
 
    return potentialOSRPoint;
    }


### PR DESCRIPTION
In involuntaryOSR, exception points could yield to VM and should
be treated as potential OSR points.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>