### PR TITLE
Detect new Intel X86 microarchitecture

### DIFF
--- a/compiler/env/ProcessorInfo.hpp
+++ b/compiler/env/ProcessorInfo.hpp
@@ -213,6 +213,7 @@ enum TR_ProcessorDescription
    TR_ProcessorIntelIvyBridge   = 0x0000000e,
    TR_ProcessorIntelHaswell     = 0x0000000f,
    TR_ProcessorIntelBroadwell   = 0x00000010,
+   TR_ProcessorIntelSkylake     = 0x00000011,
    };
 
 #endif

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -106,14 +106,6 @@ extern "C" bool jitTestOSForSSESupport(void);
 
 TR_X86ProcessorInfo OMR::X86::CodeGenerator::_targetProcessorInfo;
 
-bool TR_X86ProcessorInfo::isIntelOldMachine()
-   {
-   if(isIntelPentium() || isIntelP6() ||  isIntelPentium4() || isIntelCore2() ||  isIntelTulsa() || isIntelNehalem())
-      return true;
-
-   return false;
-   }
-
 void TR_X86ProcessorInfo::initialize(TR::Compilation *comp)
    {
    // For now, we only convert the feature bits into a flags32_t, for easier querying.
@@ -154,6 +146,8 @@ void TR_X86ProcessorInfo::initialize(TR::Compilation *comp)
             uint32_t extended_model = getCPUModel(_processorSignature) + (getCPUExtendedModel(_processorSignature) << 4);
             switch (extended_model)
                {
+               case 0x55:
+                  _processorDescription |= TR_ProcessorIntelSkylake; break;
                case 0x4f:
                   _processorDescription |= TR_ProcessorIntelBroadwell; break;
                case 0x3f:

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -191,7 +191,9 @@ struct TR_X86ProcessorInfo
    bool isIntelIvyBridge()    { return (_processorDescription & 0x000000ff) == TR_ProcessorIntelIvyBridge; }
    bool isIntelHaswell()      { return (_processorDescription & 0x000000ff) == TR_ProcessorIntelHaswell; }
    bool isIntelBroadwell()    { return (_processorDescription & 0x000000ff) == TR_ProcessorIntelBroadwell; }
-   bool isIntelOldMachine() ;
+   bool isIntelSkylake()      { return (_processorDescription & 0x000000ff) == TR_ProcessorIntelSkylake; }
+
+   bool isIntelOldMachine()   { return (isIntelPentium() || isIntelP6() || isIntelPentium4() || isIntelCore2() || isIntelTulsa() || isIntelNehalem()); }
 
    bool isAMDK6()             { return (_processorDescription & 0x000000fe) == TR_ProcessorAMDK5; } // accept either K5 or K6
    bool isAMDAthlonDuron()    { return (_processorDescription & 0x000000ff) == TR_ProcessorAMDAthlonDuron; }


### PR DESCRIPTION
1. Detect Skylake based Intel X86 CPU;
2. Inline logic querying old Intel CPUs.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>