### PR TITLE
Fix processing of verbose options

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -4774,9 +4774,8 @@ OMR::Options::setVerboseBitsInJitPrivateConfig(char *option, void *base, TR::Opt
 #ifdef J9_PROJECT_SPECIFIC
    TR_JitPrivateConfig *privateConfig = *(TR_JitPrivateConfig**)((char*)_feBase+entry->parm1);
    TR_ASSERT(sizeof(VerboseOptionFlagArray) <= sizeof(privateConfig->verboseFlags), "TR_JitPrivateConfig::verboseFlags field is too small");
-   TR::OptionTable privatizedEntry = *entry;
-   privatizedEntry.parm1 = offsetof(TR_JitPrivateConfig, verboseFlags);
-   return TR::Options::setVerboseBits(option, privateConfig, &privatizedEntry);
+   VerboseOptionFlagArray *verboseOptionFlags = (VerboseOptionFlagArray*)((char*)privateConfig + offsetof(TR_JitPrivateConfig, verboseFlags));
+   return TR::Options::setVerboseBitsHelper(option, verboseOptionFlags, entry->parm2);
 #else
    return NULL;
 #endif
@@ -4787,11 +4786,17 @@ char *
 OMR::Options::setVerboseBits(char *option, void *base, TR::OptionTable *entry)
    {
    VerboseOptionFlagArray *verboseOptionFlags = (VerboseOptionFlagArray*)((char*)_feBase+entry->parm1);
-   if (entry->parm2 != 0) // This is used for -Xjit:verbose without any options
+   return TR::Options::setVerboseBitsHelper(option, verboseOptionFlags, entry->parm2);
+   }
+
+
+char *
+OMR::Options::setVerboseBitsHelper(char *option, VerboseOptionFlagArray *verboseOptionFlags, uintptrj_t defaultVerboseFlags)
+   {
+   if (defaultVerboseFlags != 0) // This is used for -Xjit:verbose without any options
       {
-      // Since no verbose options are specified, add the default options,
-      // specified in parm2 of the options table
-      verboseOptionFlags->maskWord(0, entry->parm2);
+      // Since no verbose options are specified, add the default options
+      verboseOptionFlags->maskWord(0, defaultVerboseFlags);
       }
    else // This is used for -Xjit:verbose={}  construct
       {

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1989,6 +1989,7 @@ private:
       void maskWord(int wordIndex, uint64_t mask){ _words[wordIndex] |= mask; }
       void replaceWord(int wordIndex, uint64_t newValue){ _words[wordIndex] = newValue; }
       };
+   typedef OptionFlagArray<TR_VerboseFlags, TR_NumVerboseOptions> VerboseOptionFlagArray;
 
    static bool validateOptionsTables(void *feBase, TR_FrontEnd *fe);
 
@@ -2026,6 +2027,8 @@ private:
    //
    static char *setVerboseBits(char *option, void *base, TR::OptionTable *entry);
    static char *setVerboseBitsInJitPrivateConfig(char *option, void *base, TR::OptionTable *entry);
+   // Helper method used by the two methods above
+   static char *setVerboseBitsHelper(char *option, VerboseOptionFlagArray *verboseOptionFlags, uintptrj_t defaultVerboseFlags);
 
    // Set samplingjprofiling bits
    //
@@ -2312,7 +2315,6 @@ private:
    static TR_YesNoMaybe        _startupTimeMatters; // set very late in setCounts()
    // If countsAreProvidedByUser, then this flag is undefined
 
-   typedef OptionFlagArray<TR_VerboseFlags, TR_NumVerboseOptions> VerboseOptionFlagArray;
    static VerboseOptionFlagArray  _verboseOptionFlags;
    static char                   *_verboseOptionNames[TR_NumVerboseOptions];
    static bool                 _quickstartDetected; // set when Quickstart was specified on the command line


### PR DESCRIPTION
This commit fixes a bug introduced by PR #1007.
The new implementation of setVerboseBitsInJitPrivateConfig() is able to find
the JitConfig without looking at the value of parameter 'base'. However,
when trying to set the verbose flags in PrivateJitConfig for the trj9
subproject it uses setVerboseBits() which, similarly, was changed to
ignore the parameter 'base' and retrieve the OMR JitConfig from _feBase.
This is wrong.
The solution is to factor out the commong code that sets verbose bits
and call it from two different places:
1) setVerboseBitsInJitPrivateConfig() used by trj9 subproject
2) setVerboseBits() used by OMR generic code

Issue: #1085
Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>