### PR TITLE
Split block containing the call under OSR

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -5058,11 +5058,11 @@ bool TR_InlinerBase::inlineCallTarget2(TR_CallStack * callStack, TR_CallTarget *
             _disableTailRecursion = true;
          }
       }
-   else if (comp()->getOSRMode() == TR::involuntaryOSR && tif->crossedBasicBlock())
+   else if (comp()->getOption(TR_EnableOSR) && tif->crossedBasicBlock() && !comp()->osrInfrastructureRemoved())
       {
       /**
-       * In involuntary OSR mode, we need to split block even for cases without virtual guard. This is 
-       * because in involuntary OSR a block with OSR point must have an exception edge to the osrCatchBlock
+       * In OSR, we need to split block even for cases without virtual guard. This is 
+       * because in OSR a block with OSR point must have an exception edge to the osrCatchBlock
        * of correct callerIndex. Split the block here so that the OSR points from callee
        * and from caller are separated.
        */


### PR DESCRIPTION
In any OSR mode, blocks containing OSR points should have exception
edges to the method's OSRCatchBlock. However, when inlining and
splitting a block in the caller, the callee's final block
and the second half of the split block may be merged, preventing
the addition of an edge to the OSRCatchBlock. This was fixed
under FSD by always splitting the block, however, it should also
be applied to other OSR modes as long as OSR exception edges
are expected to be found.