### PR TITLE
Do not generate decompression sequence under CS

### DIFF
--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -423,9 +423,8 @@ OMR::CodeGenPhase::performSetupForInstructionSelectionPhase(TR::CodeGenerator * 
 
    if (cg->isConcurrentScavengeEnabled())
       {
-      // TODO (GuardedStorage): We need to come up with a better solution than anchoring tree tops of compressedrefs
-      // sequences to enforce certain evaluation order. Perhaps not lowering compressedrefs in the first place when
-      // concurrent scavenge is supported is the correct solution here.
+      // TODO (GuardedStorage): We need to come up with a better solution than anchoring aloadi's
+      // to enforce certain evaluation order
       traceMsg(comp, "GuardedStorage: in performSetupForInstructionSelectionPhase\n");
 
       auto mapAllocator = getTypedAllocator<std::pair<TR::TreeTop*, TR::TreeTop*> >(comp->allocator());
@@ -439,7 +438,7 @@ OMR::CodeGenPhase::performSetupForInstructionSelectionPhase(TR::CodeGenerator * 
 
          traceMsg(comp, "GuardedStorage: Examining node = %p\n", node);
 
-         if ((comp->useCompressedPointers() && node->getOpCodeValue() == TR::l2a) || (!comp->useCompressedPointers() && node->getOpCodeValue() == TR::aloadi))
+         if (node->getOpCodeValue() == TR::aloadi)
             {
             TR::TreeTop* anchorTreeTop = TR::TreeTop::create(comp, TR::Node::create(TR::treetop, 1, node));
             TR::TreeTop* appendTreeTop = iter.currentTree();
@@ -449,7 +448,7 @@ OMR::CodeGenPhase::performSetupForInstructionSelectionPhase(TR::CodeGenerator * 
                appendTreeTop = currentTreeTopToappendTreeTop[appendTreeTop];
                }
 
-            // Anchor the l2a before the current treetop
+            // Anchor the aloadi before the current treetop
             appendTreeTop->insertBefore(anchorTreeTop);
             currentTreeTopToappendTreeTop[iter.currentTree()] = anchorTreeTop;
 

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -432,13 +432,66 @@ OMR::CodeGenPhase::performSetupForInstructionSelectionPhase(TR::CodeGenerator * 
       std::map<TR::TreeTop*, TR::TreeTop*, std::less<TR::TreeTop*>, TR::typed_allocator<std::pair<TR::TreeTop*, TR::TreeTop*>, TR::Allocator> >
          currentTreeTopToappendTreeTop(std::less<TR::TreeTop*> (), mapAllocator);
 
+      TR_BitVector *unAnchorableAloadiNodes = comp->getBitVectorPool().get();
+
       for (TR::PreorderNodeIterator iter(comp->getStartTree(), comp); iter != NULL; ++iter)
          {
          TR::Node *node = iter.currentNode();
 
          traceMsg(comp, "GuardedStorage: Examining node = %p\n", node);
 
-         if (node->getOpCodeValue() == TR::aloadi)
+         // isNullCheck handles both TR::NULLCHK and TR::ResolveAndNULLCHK
+         // both of which do not operate on their child but their
+         // grandchild (or greatgrandchild).
+         if (node->getOpCode().isNullCheck())
+            {
+            // An aloadi cannot be anchored if there is a Null Check on
+            // its child. There are two situations where this occurs.
+            // The first is when doing an aloadi off some node that is
+            // being NULLCHK'd (see Ex1). The second is when doing an
+            // icalli in which case the aloadi loads the VFT of an
+            // object that must be NULLCHK'd (see Ex2).
+            //
+            // Ex1:
+            //    n1n NULLCHK on n3n
+            //    n2n    aloadi f    <-- First Child And Parent of Null Chk'd Node
+            //    n3n       aload O
+            //
+            // Ex2:
+            //    n1n NULLCHK on n4n
+            //    n2n    icall foo        <-- First Child
+            //    n3n       aloadi <vft>  <-- Parent of Null Chk'd Node
+            //    n4n          aload O
+            //    n4n       ==> aload O
+
+            TR::Node *nodeBeingNullChkd = node->getNullCheckReference();
+            if (nodeBeingNullChkd)
+               {
+               TR::Node *firstChild = node->getFirstChild();
+               TR::Node *parentOfNullChkdNode = NULL;
+
+               if (firstChild->getOpCode().isCall() &&
+                   firstChild->getOpCode().isIndirect())
+                  {
+                  parentOfNullChkdNode = firstChild->getFirstChild();
+                  }
+               else
+                  {
+                  parentOfNullChkdNode = firstChild;
+                  }
+
+               if (parentOfNullChkdNode &&
+                   parentOfNullChkdNode->getOpCodeValue() == TR::aloadi &&
+                   parentOfNullChkdNode->getNumChildren() > 0 &&
+                   parentOfNullChkdNode->getFirstChild() == nodeBeingNullChkd)
+                  {
+                  unAnchorableAloadiNodes->set(parentOfNullChkdNode->getGlobalIndex());
+                  traceMsg(comp, "GuardedStorage: Cannot anchor  %p\n", firstChild);
+                  }
+               }
+            }
+         else if (node->getOpCodeValue() == TR::aloadi &&
+                  !unAnchorableAloadiNodes->isSet(node->getGlobalIndex()))
             {
             TR::TreeTop* anchorTreeTop = TR::TreeTop::create(comp, TR::Node::create(TR::treetop, 1, node));
             TR::TreeTop* appendTreeTop = iter.currentTree();
@@ -455,6 +508,8 @@ OMR::CodeGenPhase::performSetupForInstructionSelectionPhase(TR::CodeGenerator * 
             traceMsg(comp, "GuardedStorage: Anchored  %p to treetop = %p\n", node, anchorTreeTop);
             }
          }
+
+      comp->getBitVectorPool().release(unAnchorableAloadiNodes);
       }
 
    if (cg->shouldBuildStructure() &&

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -532,8 +532,7 @@ OMR::Z::CodeGenerator::CodeGenerator()
      _previouslyAssignedTo(self()->comp()->allocator("LocalRA")),
      _bucketPlusIndexRegisters(self()->comp()->allocator()),
      _currentDEPEND(NULL),
-     _outgoingArgLevelDuringTreeEvaluation(0),
-     _evaluatingCompressionSequenceCounter(0)
+     _outgoingArgLevelDuringTreeEvaluation(0)
    {
    TR::Compilation *comp = self()->comp();
    _cgFlags = 0;
@@ -6223,29 +6222,6 @@ TR_S390ScratchRegisterManager*
 OMR::Z::CodeGenerator::generateScratchRegisterManager(int32_t capacity)
    {
    return new (self()->trHeapMemory()) TR_S390ScratchRegisterManager(capacity, self());
-   }
-
-// TODO (GuardedStorage)
-void
-OMR::Z::CodeGenerator::incEvaluatingCompressionSequence()
-   {
-   TR_ASSERT(_evaluatingCompressionSequenceCounter != 0x7FFFFFFF, "_evaluatingCompressionSequenceCounter overflow");
-
-   ++_evaluatingCompressionSequenceCounter;
-   }
-
-void
-OMR::Z::CodeGenerator::decEvaluatingCompressionSequence()
-   {
-   TR_ASSERT(_evaluatingCompressionSequenceCounter != 0x00000000, "_evaluatingCompressionSequenceCounter overflow");
-
-   --_evaluatingCompressionSequenceCounter;
-   }
-
-bool
-OMR::Z::CodeGenerator::isEvaluatingCompressionSequence()
-   {
-   return _evaluatingCompressionSequenceCounter != 0;
    }
 
 void

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -329,13 +329,6 @@ public:
    TR_BranchPreloadCallData _outlineCall;
    TR_BranchPreloadCallData _outlineArrayCall;
 
-   // TODO (GuardedStorage): This needs to be revisited. We need to avoid lowering compressedrefs trees if concurrent
-   // scavenge is enabled, rather than trying to pattern match and avoid evaluating them
-   int32_t _evaluatingCompressionSequenceCounter;
-   void incEvaluatingCompressionSequence();
-   void decEvaluatingCompressionSequence();
-   bool isEvaluatingCompressionSequence();
-
    TR::list<TR_BranchPreloadCallData*> *_callsForPreloadList;
 
    TR::list<TR_BranchPreloadCallData*> * getCallsForPreloadList() { return _callsForPreloadList; }

--- a/compiler/z/codegen/UnaryEvaluator.cpp
+++ b/compiler/z/codegen/UnaryEvaluator.cpp
@@ -485,30 +485,7 @@ OMR::Z::TreeEvaluator::l2aEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR_ASSERT(hasCompPtrs, "no compression sequence found under l2a node [%p]\n", node);
    */
 
-   TR::Register* source = NULL;
-   
-   // TODO (GuardedStorage): Why is isl2aForCompressedArrayletLeafLoad check necessary?
-   const bool shouldGenerateGuardedLoadsForCompressedLoad = cg->isConcurrentScavengeEnabled() && comp->useCompressedPointers() && (TR::Compiler->om.compressedReferenceShift() == 0 || firstChild->containsCompressionSequence()) && !node->isl2aForCompressedArrayletLeafLoad();
-
-   if (shouldGenerateGuardedLoadsForCompressedLoad)
-      {
-      cg->incEvaluatingCompressionSequence();
-      
-      if (firstChild->containsCompressionSequence())
-         {
-         source = cg->evaluate(firstChild->getFirstChild());
-         }
-      else
-         {
-         source = cg->evaluate(firstChild);
-         }
-         
-      cg->decEvaluatingCompressionSequence();
-      }
-   else
-      {
-      source = cg->evaluate(firstChild);
-      }
+   TR::Register* source = cg->evaluate(firstChild);
 
    // first child is either iu2l (when shift==0) or
    // the first child is a compression sequence. in the
@@ -520,7 +497,7 @@ OMR::Z::TreeEvaluator::l2aEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    node->setRegister(source);
 
 
-   if (shouldGenerateGuardedLoadsForCompressedLoad && firstChild->containsCompressionSequence())
+   if (firstChild->containsCompressionSequence())
       {
       cg->decReferenceCount(firstChild->getFirstChild());
       }


### PR DESCRIPTION
These commits remove the need for the compiler to generate the decompression sequence trees. 