### PR TITLE
Check runtime flag if CS code should be run

### DIFF
--- a/gc/base/Collector.cpp
+++ b/gc/base/Collector.cpp
@@ -195,7 +195,7 @@ MM_Collector::preCollect(MM_EnvironmentBase* env, MM_MemorySubSpace* subSpace, M
 	/* There might be a colliding concurrent cycle in progress, that must be completed before we start this one.
 	 * Specific Collector subclass will have exact knowledge if that is the case.
 	 */
-	completeConcurrentCycle(env);
+	completeExternalConcurrentCycle(env);
 
 	/* Record the master GC thread CPU time at the start to diff later */
 	_masterThreadCpuTimeStart = omrthread_get_self_cpu_time(env->getOmrVMThread()->_os_thread);

--- a/gc/base/Collector.hpp
+++ b/gc/base/Collector.hpp
@@ -278,7 +278,7 @@ public:
 	virtual uintptr_t masterThreadConcurrentCollect(MM_EnvironmentBase *env) { return 0; }
 	virtual	void postConcurrentUpdateStatsAndReport(MM_EnvironmentBase *env, MM_ConcurrentGMPStats *stats, UDATA bytesConcurrentlyScanned) {}
 	virtual void forceConcurrentFinish() {}
-	virtual void completeConcurrentCycle(MM_EnvironmentBase *env) {}
+	virtual void completeExternalConcurrentCycle(MM_EnvironmentBase *env) {}
 	
 	MM_Collector(MM_CollectorLanguageInterface *cli)
 		: MM_BaseVirtual()

--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -1180,12 +1180,14 @@ MM_ParallelGlobalGC::isMarked(void *objectPtr)
 }
 
 void
-MM_ParallelGlobalGC::completeConcurrentCycle(MM_EnvironmentBase *env)
+MM_ParallelGlobalGC::completeExternalConcurrentCycle(MM_EnvironmentBase *env)
 {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
-	/* ParallelGlobalGC or ConcurrentGC (STW phase) cannot start before Concurrent Scavenger cycle is in progress */
-	_extensions->scavenger->completeConcurrentScavenger(env);
-#endif
+	if (_extensions->isConcurrentScavengerEnabled()) {
+		/* ParallelGlobalGC or ConcurrentGC (STW phase) cannot start before Concurrent Scavenger cycle is in progress */
+		_extensions->scavenger->completeConcurrentCycle(env);
+	}
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
 }
 
 void

--- a/gc/base/standard/ParallelGlobalGC.hpp
+++ b/gc/base/standard/ParallelGlobalGC.hpp
@@ -299,7 +299,7 @@ public:
 	}
 #endif /* OMR_GC_MODRON_COMPACTION */
 
-	virtual void completeConcurrentCycle(MM_EnvironmentBase *env);
+	virtual void completeExternalConcurrentCycle(MM_EnvironmentBase *env);
 
 	MM_ParallelGlobalGC(MM_EnvironmentBase *env, MM_CollectorLanguageInterface *cli)
 		: MM_GlobalCollector(env, cli)

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -4874,7 +4874,7 @@ MM_Scavenger::triggerConcurrentScavengerTransition(MM_EnvironmentBase *env, MM_A
 }
 
 void
-MM_Scavenger::completeConcurrentScavenger(MM_EnvironmentBase *env)
+MM_Scavenger::completeConcurrentCycle(MM_EnvironmentBase *env)
 {
 	/* this is supposed to be called by an external cycle (for example ConcurrentGC, STW phase)
 	 * that is just to be started, but cannot before Scavenger is complete */

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -542,7 +542,7 @@ public:
 	/**
 	 * complete (trigger end) of a Concurrent Scavenger Cycle
 	 */
-	void completeConcurrentScavenger(MM_EnvironmentBase *envBase);
+	void completeConcurrentCycle(MM_EnvironmentBase *envBase);
 
 	/* worker thread */
 	void workThreadProcessRoots(MM_EnvironmentStandard *env);


### PR DESCRIPTION
In configuration, where Concurrent Scavenger is compile time enabled,
but run time disabled, we have to check run time flag before accessing
any CS functionality.

Fixing a specific spot in Global GC, that calls Scavenger to complete
any active concurrent cycle.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>