### PR TITLE
WIP: Separate cannot OSR at and during BCI

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -666,7 +666,7 @@ bool OMR::Compilation::isPotentialOSRPoint(TR::Node *node, TR::Node **osrPointNo
    static char *disableMonentOSR = feGetEnv("TR_disableMonentOSR");
 
    bool potentialOSRPoint = false;
-   if (self()->getOSRTransitionTarget() == TR::postExecutionOSR)
+   if (self()->getOSRTransitionTarget() & TR::postExecutionOSR)
       {
       if (node->getOpCodeValue() == TR::treetop || node->getOpCode().isCheck())
          node = node->getFirstChild(); 
@@ -706,7 +706,7 @@ bool OMR::Compilation::isPotentialOSRPointWithSupport(TR::TreeTop *tt)
 
    if (potentialOSRPoint && self()->getOSRMode() == TR::voluntaryOSR)
       {
-      if (self()->getOSRTransitionTarget() == TR::postExecutionOSR && tt->getNode() != osrNode)
+      if (self()->getOSRTransitionTarget() & TR::postExecutionOSR && tt->getNode() != osrNode)
          {
          // The OSR point applies where the node is anchored, rather than where it may
          // be commoned. Therefore, it is necessary to check if the node is anchored under
@@ -735,7 +735,7 @@ bool OMR::Compilation::isPotentialOSRPointWithSupport(TR::TreeTop *tt)
          TR_ByteCodeInfo &bci = osrNode->getByteCodeInfo();
          TR::ResolvedMethodSymbol *method = bci.getCallerIndex() == -1 ?
             self()->getMethodSymbol() : self()->getInlinedResolvedMethodSymbol(bci.getCallerIndex());
-         potentialOSRPoint = method->supportsInduceOSR(bci, tt->getEnclosingBlock(), NULL, self(), false);
+         potentialOSRPoint = method->supportsInduceOSR(bci, tt->getEnclosingBlock(), self(), false);
          }
       }
 
@@ -768,9 +768,21 @@ OMR::Compilation::getOSRMode()
 TR::OSRTransitionTarget
 OMR::Compilation::getOSRTransitionTarget()
    {
+   TR::OSRTransitionTarget target = TR::disableOSR;
+
+   // Under NextGenHCR, transitions will occur after the OSR points
+   // Otherwise, the default is before
    if (self()->getHCRMode() == TR::osr)
-      return TR::postExecutionOSR;
-   return TR::preExecutionOSR;
+      {
+      target = TR::postExecutionOSR;
+      // If OSROnGuardFailure is enabled, transitions will also occur before
+      if (self()->getOption(TR_EnableOSROnGuardFailure))
+         target = TR::preAndPostExecutionOSR;
+      }
+   else if (self()->getOption(TR_EnableOSR))
+      target = TR::preExecutionOSR;
+
+   return target;
    }
 
 /*
@@ -782,7 +794,7 @@ int32_t
 OMR::Compilation::getOSRInductionOffset(TR::Node *node)
    {
    // If no induction after the OSR point, offset must be 0
-   if (self()->getOSRTransitionTarget() != TR::postExecutionOSR)
+   if (!(self()->getOSRTransitionTarget() & TR::postExecutionOSR))
       return 0;
    
    TR::Node *osrNode;
@@ -818,7 +830,7 @@ bool
 OMR::Compilation::requiresAnalysisOSRPoint(TR::Node *node)
    {
    // If no induction after the OSR point, cannot use analysis point
-   if (self()->getOSRTransitionTarget() != TR::postExecutionOSR)
+   if (!(self()->getOSRTransitionTarget() & TR::postExecutionOSR))
       return false;
 
    TR::Node *osrNode;
@@ -831,7 +843,7 @@ OMR::Compilation::requiresAnalysisOSRPoint(TR::Node *node)
    if (osrNode->getOpCode().isCall())
       return true;
 
-   switch (node->getOpCodeValue())
+   switch (osrNode->getOpCodeValue())
       {
       // Monents only require a trailing OSR point as they will perform OSR when executing the
       // monitor and there is no change in liveness due to the monent
@@ -2333,6 +2345,26 @@ OMR::Compilation::setOSRCallSiteRemat(uint32_t callSiteIndex, TR::SymbolReferenc
 
    table[slot * 2] = ppSymRef->getReferenceNumber();
    table[slot * 2 + 1] = loadSymRef ? loadSymRef->getReferenceNumber() : 0;
+   }
+
+/*
+ * Check if it is not possible to perform an OSR transition during this call site.
+ * A true result means transitioning within this method is definitely not possible, however,
+ * a false result does not ensure OSR is possible.
+ */
+bool
+OMR::Compilation::cannotAttemptOSRDuring(uint32_t index)
+   {
+   return _inlinedCallSites[index].cannotAttemptOSRDuring();
+   }
+
+/*
+ * Store a known cannotAttemptOSRDuring result against this call site.
+ */
+void
+OMR::Compilation::setCannotAttemptOSRDuring(uint32_t index, bool cannotOSR)
+   {
+   _inlinedCallSites[index].setCannotAttemptOSRDuring(cannotOSR);
    }
 
 TR_InlinedCallSite *

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -591,6 +591,7 @@ public:
       TR::SymbolReference *_callSymRef;
       int32_t *_osrCallSiteRematTable;
       bool _directCall;
+      bool _cannotAttemptOSRDuring;
 
       public:
 
@@ -599,7 +600,7 @@ public:
                              TR::ResolvedMethodSymbol *resolvedMethod,
                              TR::SymbolReference *callSymRef,
                              bool directCall):
-         _resolvedMethod(resolvedMethod), _callSymRef(callSymRef), _directCall(directCall), _osrCallSiteRematTable(0)
+         _resolvedMethod(resolvedMethod), _callSymRef(callSymRef), _directCall(directCall), _osrCallSiteRematTable(0), _cannotAttemptOSRDuring(false)
          {
          _site._methodInfo = methodInfo;
          _site._byteCodeInfo = bcInfo;
@@ -612,6 +613,8 @@ public:
       int32_t *osrCallSiteRematTable() { return _osrCallSiteRematTable; }
       void setOSRCallSiteRematTable(int32_t *array) { _osrCallSiteRematTable = array; }
       bool directCall() { return _directCall; }
+      bool cannotAttemptOSRDuring() { return _cannotAttemptOSRDuring; }
+      void setCannotAttemptOSRDuring(bool cannotOSR) { _cannotAttemptOSRDuring = cannotOSR; }
       };
 
    uint32_t getNumInlinedCallSites();
@@ -624,6 +627,8 @@ public:
    void getOSRCallSiteRemat(uint32_t callSiteIndex, uint32_t slot, TR::SymbolReference *&ppSymRef, TR::SymbolReference *&loadSymRef);
    void setOSRCallSiteRemat(uint32_t callSiteIndex, TR::SymbolReference *ppSymRef, TR::SymbolReference *loadSymRef);
    bool isInlinedDirectCall(uint32_t index);
+   bool cannotAttemptOSRDuring(uint32_t index);
+   void setCannotAttemptOSRDuring(uint32_t index, bool cannot);
 
    TR_InlinedCallSite *getCurrentInlinedCallSite();
    int32_t getCurrentInlinedSiteIndex();

--- a/compiler/compile/OSRData.cpp
+++ b/compiler/compile/OSRData.cpp
@@ -686,9 +686,11 @@ TR_OSRMethodData::inlinesAnyMethod() const
    }
 
 void
-TR_OSRMethodData::addLiveRangeInfo(int32_t byteCodeIndex, TR::OSRPointType osrPoint, TR_BitVector *liveRangeInfo)
+TR_OSRMethodData::addLiveRangeInfo(int32_t byteCodeIndex, TR::OSRTransitionTarget target, TR_BitVector *liveRangeInfo)
    {
-   TR_BCLiveRangeInfoHashKey key(byteCodeIndex, osrPoint);
+   TR_ASSERT(target == TR::postExecutionOSR || target == TR::preExecutionOSR, "can only add live range info for pre or post transition target");
+
+   TR_BCLiveRangeInfoHashKey key(byteCodeIndex, target);
    bcLiveRangeInfoHashTab.Add(key, liveRangeInfo);
    }
 
@@ -711,21 +713,23 @@ TR_BitVector *
 TR_OSRMethodData::getLiveRangeInfo(int32_t byteCodeIndex)
    {
    TR_BitVector* liveRangeInfo = NULL;
-   if (getMethodSymbol()->comp()->getOSRTransitionTarget() == TR::postExecutionOSR)
+   if (getMethodSymbol()->comp()->getOSRTransitionTarget() & TR::postExecutionOSR)
       {
-      liveRangeInfo = getLiveRangeInfo(byteCodeIndex, TR::inductionOSR);
+      liveRangeInfo = getLiveRangeInfo(byteCodeIndex, TR::postExecutionOSR);
       if (!liveRangeInfo)
-         liveRangeInfo = getLiveRangeInfo(byteCodeIndex, TR::analysisOSR);
+         liveRangeInfo = getLiveRangeInfo(byteCodeIndex, TR::preExecutionOSR);
       }
    else
-      liveRangeInfo = getLiveRangeInfo(byteCodeIndex, TR::inductionOSR);
+      liveRangeInfo = getLiveRangeInfo(byteCodeIndex, TR::preExecutionOSR);
    return liveRangeInfo;
    }
 
 TR_BitVector *
-TR_OSRMethodData::getLiveRangeInfo(int32_t byteCodeIndex, TR::OSRPointType osrPoint)
+TR_OSRMethodData::getLiveRangeInfo(int32_t byteCodeIndex, TR::OSRTransitionTarget target)
    {
-   TR_BCLiveRangeInfoHashKey key(byteCodeIndex, osrPoint);
+   TR_ASSERT(target == TR::postExecutionOSR || target == TR::preExecutionOSR, "can only get live range info for pre or post transition target");
+
+   TR_BCLiveRangeInfoHashKey key(byteCodeIndex, target);
    CS2::HashIndex hashIndex;
    TR_BitVector* liveRangeInfo = NULL;
    if (bcLiveRangeInfoHashTab.Locate(key, hashIndex))

--- a/compiler/compile/OSRData.hpp
+++ b/compiler/compile/OSRData.hpp
@@ -59,8 +59,10 @@ namespace TR
  */
    enum OSRTransitionTarget
       {
-      preExecutionOSR,
-      postExecutionOSR
+      disableOSR = 0,
+      preExecutionOSR = 1,
+      postExecutionOSR = 2,
+      preAndPostExecutionOSR = 3
       };
 
 /*
@@ -76,21 +78,6 @@ namespace TR
       {
       voluntaryOSR,
       involuntaryOSR
-      };
-
-/*
- * There are two types of OSR points, induction and analysis.
- *
- * An induction point is a normal OSR point, which undergoes the
- * OSR analysis and may have a transition for it, based on the mode.
- *
- * An analysis point is used only for the OSR analysis will not have
- * a transition point for it.
- */
-   enum OSRPointType
-      {
-      inductionOSR,
-      analysisOSR 
       };
    }
 
@@ -298,8 +285,8 @@ class TR_OSRMethodData
    void setNumSymRefs(int32_t numBits) {_numSymRefs = numBits; }
    int32_t getNumSymRefs() { return _numSymRefs; }
 
-   void addLiveRangeInfo(int32_t byteCodeIndex, TR::OSRPointType osrPoint, TR_BitVector *liveRangeInfo);
-   TR_BitVector *getLiveRangeInfo(int32_t byteCodeIndex, TR::OSRPointType osrPoint);
+   void addLiveRangeInfo(int32_t byteCodeIndex, TR::OSRTransitionTarget target, TR_BitVector *liveRangeInfo);
+   TR_BitVector *getLiveRangeInfo(int32_t byteCodeIndex, TR::OSRTransitionTarget target);
    TR_BitVector *getLiveRangeInfo(int32_t byteCodeIndex);
 
    bool linkedToCaller() { return _linkedToCaller; }
@@ -310,7 +297,7 @@ class TR_OSRMethodData
    private:
    void createOSRBlocks(TR::Node* n);
 
-   typedef CS2::CompoundHashKey<int32_t, TR::OSRPointType> TR_BCLiveRangeInfoHashKey;
+   typedef CS2::CompoundHashKey<int32_t, TR::OSRTransitionTarget> TR_BCLiveRangeInfoHashKey;
    typedef CS2::HashTable<TR_BCLiveRangeInfoHashKey, TR_BitVector *, TR::Allocator> TR_BCLiveRangeInfoHashTable;
    typedef CS2::HashTable<int32_t, TR_OSRSlotSharingInfo*, TR::Allocator> TR_BCInfoHashTable;
    typedef CS2::HashTable<int32_t, TR_Array<int32_t>, TR::Allocator> TR_Slot2ScratchBufferOffset;

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -127,7 +127,6 @@ OMR::ResolvedMethodSymbol::ResolvedMethodSymbol(TR_ResolvedMethod * method, TR::
      _comp(comp),
      _firstJitTempIndex(-1),
      _cannotAttemptOSR(NULL),
-     _shouldNotAttemptOSR(NULL),
      _pythonConstsSymRef(NULL),
      _pythonNumLocalVars(0),
      _pythonLocalVarSymRefs(NULL),
@@ -565,11 +564,11 @@ OMR::ResolvedMethodSymbol::genInduceOSRCallNode(TR::TreeTop* insertionPoint,
 
 
 bool
-OMR::ResolvedMethodSymbol::induceOSRAfter(TR::TreeTop *insertionPoint, TR_ByteCodeInfo induceBCI, TR::TreeTop* branch, bool extendRemainder)
+OMR::ResolvedMethodSymbol::induceOSRAfter(TR::TreeTop *insertionPoint, TR_ByteCodeInfo induceBCI, TR::TreeTop* branch, bool extendRemainder, int32_t offset)
    {
    TR::Block *block = insertionPoint->getEnclosingBlock();
 
-   if (self()->supportsInduceOSR(induceBCI, block, NULL, self()->comp()))
+   if (self()->supportsInduceOSR(induceBCI, block, self()->comp(), TR::postExecutionOSR))
       {
       TR::CFG *cfg = self()->comp()->getFlowGraph();
       cfg->setStructure(NULL);
@@ -590,6 +589,8 @@ OMR::ResolvedMethodSymbol::induceOSRAfter(TR::TreeTop *insertionPoint, TR_ByteCo
                traceMsg(self()->comp(), "  Split of block_%d at n%dn produced block_%d\n", block->getNumber(), remainderTree->getNode()->getGlobalIndex(), remainderBlock->getNumber());
             }
          }
+
+      induceBCI.setByteCodeIndex(induceBCI.getByteCodeIndex() + offset);
 
       // create a block that will be the target of the branch with BCI for the induceOSR
       TR::Block *osrBlock = TR::Block::createEmptyBlock(self()->comp(), MAX_COLD_BLOCK_COUNT);
@@ -618,7 +619,7 @@ OMR::ResolvedMethodSymbol::induceOSRAfter(TR::TreeTop *insertionPoint, TR_ByteCo
 TR::TreeTop *
 OMR::ResolvedMethodSymbol::induceImmediateOSRWithoutChecksBefore(TR::TreeTop *insertionPoint)
    {
-   if (self()->supportsInduceOSR(insertionPoint->getNode()->getByteCodeInfo(), insertionPoint->getEnclosingBlock(), NULL, self()->comp()))
+   if (self()->supportsInduceOSR(insertionPoint->getNode()->getByteCodeInfo(), insertionPoint->getEnclosingBlock(), self()->comp()))
       return self()->genInduceOSRCallAndCleanUpFollowingTreesImmediately(insertionPoint, insertionPoint->getNode()->getByteCodeInfo(), false, false, self()->comp());
    if (self()->comp()->getOption(TR_TraceOSR))
       traceMsg(self()->comp(), "induceImmediateOSRWithoutChecksBefore n%dn failed - supportsInduceOSR returned false\n", insertionPoint->getNode()->getGlobalIndex());
@@ -891,24 +892,25 @@ OMR::ResolvedMethodSymbol::genAndAttachOSRCodeBlocks(int32_t currentInlinedSiteI
          TR::Block * OSRCatchBlock = osrMethodData->findOrCreateOSRCatchBlock(ttnode);
          TR_OSRPoint *osrPoint = NULL;
 
-         // Generate an OSR point for the induction point, ignoring whether it is after or not
-         TR_ByteCodeInfo offsetBCI = ttnode->getByteCodeInfo();
-         offsetBCI.setByteCodeIndex(offsetBCI.getByteCodeIndex() + self()->comp()->getOSRInductionOffset(ttnode));
-         osrPoint = new (self()->comp()->trHeapMemory()) TR_OSRPoint(offsetBCI, osrMethodData, self()->comp()->trMemory());
-         osrPoint->setOSRIndex(self()->addOSRPoint(osrPoint));
-         if (self()->comp()->getOption(TR_TraceOSR))
-            traceMsg(self()->comp(), "offset osr point added for [%p] at offset bci %d:%d\n",
-               ttnode, offsetBCI.getCallerIndex(), offsetBCI.getByteCodeIndex());
-
-         // Generate an OSR point for the analysis point, if needed
-         if (self()->comp()->requiresAnalysisOSRPoint(ttnode))
+         if (comp()->getOSRTransitionTarget() & TR::preExecutionOSR || self()->comp()->requiresAnalysisOSRPoint(ttnode))
             {
             osrPoint = new (self()->comp()->trHeapMemory()) TR_OSRPoint(ttnode->getByteCodeInfo(), osrMethodData, self()->comp()->trMemory());
             osrPoint->setOSRIndex(self()->addOSRPoint(osrPoint));
             if (self()->comp()->getOption(TR_TraceOSR))
-               traceMsg(self()->comp(), "osr point added for [%p] at %d:%d\n",
+               traceMsg(self()->comp(), "pre osr point added for [%p] for bci %d:%d\n",
                   ttnode, ttnode->getByteCodeInfo().getCallerIndex(),
                   ttnode->getByteCodeInfo().getByteCodeIndex());
+            }
+
+         if (comp()->getOSRTransitionTarget() & TR::postExecutionOSR)
+            {
+            TR_ByteCodeInfo offsetBCI = ttnode->getByteCodeInfo();
+            offsetBCI.setByteCodeIndex(offsetBCI.getByteCodeIndex() + self()->comp()->getOSRInductionOffset(ttnode));
+            osrPoint = new (self()->comp()->trHeapMemory()) TR_OSRPoint(offsetBCI, osrMethodData, self()->comp()->trMemory());
+            osrPoint->setOSRIndex(self()->addOSRPoint(osrPoint));
+            if (self()->comp()->getOption(TR_TraceOSR))
+               traceMsg(self()->comp(), "post osr point added for [%p] for bci %d:%d\n",
+                  ttnode, offsetBCI.getCallerIndex(), offsetBCI.getByteCodeIndex());
             }
 
          // Add an exception edge from the current block to the OSR catch block if there isn't already one
@@ -1222,7 +1224,6 @@ OMR::ResolvedMethodSymbol::genIL(TR_FrontEnd * fe, TR::Compilation * comp, TR::S
          if (comp->getOption(TR_EnableOSR) && !comp->isPeekingMethod())
             {
             _cannotAttemptOSR = new (comp->trHeapMemory()) TR_BitVector(1, comp->trMemory(), heapAlloc, growable);
-            _shouldNotAttemptOSR = new (comp->trHeapMemory()) TR_BitVector(1, comp->trMemory(), heapAlloc, growable);
             }
 
          if (_tempIndex == -1)
@@ -1250,9 +1251,11 @@ OMR::ResolvedMethodSymbol::genIL(TR_FrontEnd * fe, TR::Compilation * comp, TR::S
             // parms, and locals alive. Only do this in non HCR mode since under HCR we will be more selective about where to
             // add OSR points.
             //
-            bool doOSR =
-               comp->getOption(TR_EnableOSR) && comp->supportsInduceOSR() &&
-               !comp->isPeekingMethod()  && (comp->getOption(TR_EnableNextGenHCR) || !comp->getOption(TR_EnableHCR)) ;
+            bool doOSR = comp->getOption(TR_EnableOSR)
+               && !comp->isPeekingMethod()
+               && (comp->getOption(TR_EnableNextGenHCR) || !comp->getOption(TR_EnableHCR))
+               && comp->supportsInduceOSR()
+               && !self()->cannotAttemptOSRDuring(comp->getCurrentInlinedSiteIndex(), comp);
 
             optimizer = TR::Optimizer::createOptimizer(comp, self(), true);
             previousOptimizer = comp->getOptimizer();
@@ -1436,142 +1439,179 @@ OMR::ResolvedMethodSymbol::resetLiveLocalIndices()
    }
 
 bool
-OMR::ResolvedMethodSymbol::supportsInduceOSR(TR_ByteCodeInfo bci,
+OMR::ResolvedMethodSymbol::supportsInduceOSR(TR_ByteCodeInfo &bci,
                                            TR::Block *blockToOSRAt,
-                                           TR::ResolvedMethodSymbol *calleeSymbolIfCallNode,
                                            TR::Compilation *comp,
                                            bool runCleanup)
    {
    if (!comp->supportsInduceOSR())
       return false;
 
-   if (self()->cannotAttemptOSR(bci, blockToOSRAt, calleeSymbolIfCallNode, comp, runCleanup))
+   // Check it is possible to transition within this call site
+   if (self()->cannotAttemptOSRDuring(bci.getCallerIndex(), comp, runCleanup))
+      return false;
+
+   // Check it is possible to transition at this BCI
+   if (self()->cannotAttemptOSRAt(bci, blockToOSRAt, comp))
       return false;
 
    return true;
    }
 
-
+/*
+ * Prevent OSR transitions to the specified bytecode index.
+ * Will only prevent those directed immediately to this index,
+ * not those from a deeper frame.
+ * See setCannotAttemptOSRDuring to prevent these cases.
+ */
 void
 OMR::ResolvedMethodSymbol::setCannotAttemptOSR(int32_t n)
    {
    _cannotAttemptOSR->set(n);
    }
 
-
-void
-OMR::ResolvedMethodSymbol::setShouldNotAttemptOSR(int32_t n)
-   {
-   _shouldNotAttemptOSR->set(n);
-   }
-
-
+/*
+ * Check if OSR can be attempted within the specified call site index.
+ * Will check OSR infrastructure, such as code and catch blocks, is still present.
+ *
+ * If it is not possible to transition, this will be stored in TR_InlinedCallSiteInfo, as it is
+ * assumed that once a transition is not possible, it will not become possible later.
+ *
+ * runCleanup: If there are missing OSR blocks detected, runnning cleanup will remove those that are no longer needed.
+ */
 bool
-OMR::ResolvedMethodSymbol::cannotAttemptOSR(TR_ByteCodeInfo bci,
-                                          TR::Block *blockToOSRAt,
-                                          TR::ResolvedMethodSymbol *calleeSymbolIfCallNode,
-                                          TR::Compilation *comp,
-                                          bool runCleanup)
+OMR::ResolvedMethodSymbol::cannotAttemptOSRDuring(int32_t callSite, TR::Compilation *comp, bool runCleanup)
    {
    if (comp->getOption(TR_TraceOSR))
-      traceMsg(comp, "Checking if OSR can be attempted at bytecode index %d\n", bci.getByteCodeIndex());
+      traceMsg(comp, "Checking if OSR can be attempted during call site %d\n", callSite);
 
-   if (!comp->canAffordOSRControlFlow())
-      {
-      if (comp->getOption(TR_TraceOSR))
-         traceMsg(comp, "Cannot afford OSR control flow\n");
-      return true;
-      }
-
-   if (_shouldNotAttemptOSR->get(bci.getByteCodeIndex()))
-      {
-      if (comp->getOption(TR_TraceOSR))
-         traceMsg(comp, "Should not attempt OSR at this bytecode\n");
-      return true;
-      }
-
-   if (bci.doNotProfile())
-     {
-     if (comp->getOption(TR_TraceOSR))
-        traceMsg(comp, "Node was not present at IL gen time\n");
-
-     return true; // if this is a call node created by the optimizer (string peepholes) it may not exist in the bytecodes
-     }
-
-   TR::SymbolReferenceTable *symRefTab = comp->getSymRefTab();
-   int32_t callSite = bci.getCallerIndex();
-   int32_t byteCodeIndex = bci.getByteCodeIndex();
-
+   int32_t origCallSite = callSite;
    TR_OSRMethodData *osrMethodData = comp->getOSRCompilationData()->findOrCreateOSRMethodData(callSite, self());
-   TR::Block * OSRCatchBlock = osrMethodData->getOSRCatchBlock();
+   bool cannotAttemptOSR = false;
+   int32_t byteCodeIndex;
 
-   // Walk up the inlined call stack and safety check every call to see if OSR is safe - note that we only check
-   // cannotOSR in this case as we only abort the OSR if correctness is in jeopardy
-   while (osrMethodData)
+   // Walk up the inlined call stack and safety check every call to see if OSR is safe - note that we check
+   // cannotAttemptOSRDuring, not cannotAttemptOSRAt
+   while (osrMethodData->getInlinedSiteIndex() > -1)
       {
-      if (comp->getOption(TR_TraceOSR))
-         traceMsg(comp, "Checking if OSR can be attempted at caller index %d and bytecode index %d\n", callSite, byteCodeIndex);
+      TR_ASSERT(callSite == osrMethodData->getInlinedSiteIndex(), "OSR method data and inlined call sites array being walked out of sync\n");
 
-      auto *callerSymbol = osrMethodData->getMethodSymbol();
-
-      if (callerSymbol->_cannotAttemptOSR->get(byteCodeIndex))
-        {
-        if (comp->getOption(TR_TraceOSR))
-           traceMsg(comp, "Cannot attempt OSR at this bytecode in caller\n");
-        return true;
-        }
-
-      TR_ASSERT((callSite == osrMethodData->getInlinedSiteIndex()), "OSR method data and inlined call sites array being walked out of sync\n");
-      if (osrMethodData->getInlinedSiteIndex() > -1)
+      TR_InlinedCallSite &callSiteInfo = comp->getInlinedCallSite(callSite);
+      cannotAttemptOSR = comp->cannotAttemptOSRDuring(callSite);
+      if (!cannotAttemptOSR)
          {
-         TR_InlinedCallSite &callSiteInfo = comp->getInlinedCallSite(callSite);
          callSite = callSiteInfo._byteCodeInfo.getCallerIndex();
-         if (callSiteInfo._byteCodeInfo.doNotProfile())
-            {
-            if (comp->getOption(TR_TraceOSR))
-               traceMsg(comp, "Node in caller was not present at IL gen time\n");
+         byteCodeIndex = callSiteInfo._byteCodeInfo.getByteCodeIndex();
+         if (comp->getOption(TR_TraceOSR))
+            traceMsg(comp, "Checking if OSR can be attempted at caller bytecode index %d:%d\n", callSite, byteCodeIndex);
 
-            return true;
-            }
-
+         // Check OSR method data has been generated for the caller
          osrMethodData = comp->getOSRCompilationData()->findCallerOSRMethodData(osrMethodData);
          if (!osrMethodData)
             {
             if (comp->getOption(TR_TraceOSR))
-               traceMsg(comp, "OSR method data is NULL\n");
-
-            return true;
+               traceMsg(comp, "Cannot attempt OSR as OSR method data for caller of callee %d is NULL\n", callSite);
+            cannotAttemptOSR = true;
+            break;
             }
 
-         byteCodeIndex = callSiteInfo._byteCodeInfo.getByteCodeIndex();
+         // Check the OSR catch/code blocks exist
+         TR::Block * osrCodeBlock = osrMethodData->getOSRCodeBlock();
+         if (!osrCodeBlock || osrCodeBlock->isUnreachable())
+            {
+            if (comp->getOption(TR_TraceOSR))
+               traceMsg(comp, "Cannot attempt OSR as OSR code block for site index %d is absent\n",
+                  osrMethodData->getInlinedSiteIndex());
+            if (runCleanup)
+               self()->cleanupUnreachableOSRBlocks(origCallSite, comp);
+            cannotAttemptOSR = true;
+            break;
+            }
+
+         // Check it is possible to transition during the caller
+         auto *callerSymbol = osrMethodData->getMethodSymbol();
+         if (callerSymbol->_cannotAttemptOSR->get(byteCodeIndex))
+            {
+            if (comp->getOption(TR_TraceOSR))
+               traceMsg(comp, "Cannot attempt OSR during caller bytecode index %d:%d\n", callSite, byteCodeIndex);
+            cannotAttemptOSR = true;
+            break;
+            }
+
+         // Check the caller existed during ILGen
+         if (callSiteInfo._byteCodeInfo.doNotProfile())
+            {
+            if (comp->getOption(TR_TraceOSR))
+               traceMsg(comp, "Cannot attempt OSR during caller bytecode index %d:%d as it did not exist at ilgen\n", callSite, byteCodeIndex);
+            cannotAttemptOSR = true;
+            break;
+            }
          }
       else
-         {
-         osrMethodData = NULL;
-         }
+         break;
       }
 
-   auto *symToCheckOSRBlocksReachability = self();
-   if (calleeSymbolIfCallNode)
-      symToCheckOSRBlocksReachability = calleeSymbolIfCallNode;
+   // Store the result against the call site now that it is known 
+   //
+   if (origCallSite > -1 && !comp->cannotAttemptOSRDuring(origCallSite) && cannotAttemptOSR)
+      comp->setCannotAttemptOSRDuring(origCallSite, cannotAttemptOSR);
+   return cannotAttemptOSR; 
+   }
 
-   if (comp->getMethodSymbol() != symToCheckOSRBlocksReachability
-       && !symToCheckOSRBlocksReachability->allCallerOSRBlocksArePresent(callSite, comp))
+/*
+ * Check whether OSR can be attempted at the specified bytecode index.
+ * This will check transition is possible in the context of this call site, ignoring those higher in the call stack.
+ *
+ * TODO: Return enum encoding the failure case, so that OSR modes can manage the different failures.
+ *
+ * bci: Bytecode info to perform the transition at
+ * blockToOSRAt: Block containing the transition, to verify the exception edge is present.
+ * comp: Compilation object.
+ */
+bool
+OMR::ResolvedMethodSymbol::cannotAttemptOSRAt(TR_ByteCodeInfo &bci,
+                                          TR::Block *blockToOSRAt,
+                                          TR::Compilation *comp)
+   {
+   int32_t callSite = bci.getCallerIndex();
+   int32_t byteCodeIndex = bci.getByteCodeIndex();
+   if (comp->getOption(TR_TraceOSR))
+      traceMsg(comp, "Checking if OSR can be attempted at bytecode index %d:%d\n",
+         callSite, byteCodeIndex);
+
+   // Check it is possible to transition at this index
+   if (self()->_cannotAttemptOSR->get(byteCodeIndex))
       {
-      if (runCleanup)
-         symToCheckOSRBlocksReachability->cleanupUnreachableOSRBlocks(callSite, comp);
       if (comp->getOption(TR_TraceOSR))
-         traceMsg(comp, "Some caller OSR blocks are not present\n");
-
+         traceMsg(comp, "Cannot attempt OSR at bytecode index %d:%d\n",
+            callSite, byteCodeIndex);
       return true;
       }
 
-   if (blockToOSRAt && (!OSRCatchBlock || !blockToOSRAt->hasExceptionSuccessor(OSRCatchBlock)))
+   // Check the BCI existed at ilgen
+   if (bci.doNotProfile())
       {
-      if (comp->getOption(TR_TraceOSR) && OSRCatchBlock)
-         traceMsg(comp, "Missing OSR exception successor block_%d for block_%d - cannot OSR\n", OSRCatchBlock->getNumber(), blockToOSRAt->getNumber());
-      if (comp->getOption(TR_TraceOSR) && !OSRCatchBlock)
-         traceMsg(comp, "Missing OSR exception successor for block_%d - cannot OSR\n", blockToOSRAt->getNumber());
+      if (comp->getOption(TR_TraceOSR))
+         traceMsg(comp, "Cannot attempt OSR at bytecode index %d:%d as it did not exist at ilgen\n",
+            callSite, byteCodeIndex);
+      return true;
+      }
+
+   TR_OSRMethodData *osrMethodData = comp->getOSRCompilationData()->findOrCreateOSRMethodData(callSite, self());
+   TR::Block * osrCatchBlock = osrMethodData->getOSRCatchBlock();
+
+   // If a block is specified, check the osrCatchBlock exists and there is an exception edge to it
+   if (blockToOSRAt && (!osrCatchBlock || !blockToOSRAt->hasExceptionSuccessor(osrCatchBlock)))
+      {
+      if (comp->getOption(TR_TraceOSR))
+         {
+         if (osrCatchBlock)
+            traceMsg(comp, "Cannot attempt OSR as block_%d is missing an edge to OSR catch block: block_%d\n",
+               blockToOSRAt->getNumber(), osrCatchBlock->getNumber());
+         else
+            traceMsg(comp, "Cannot attempt OSR as call site index %d lacks an OSR catch block for block_%d\n",
+               callSite, blockToOSRAt->getNumber());
+         }
       return true;
       }
 
@@ -1579,35 +1619,6 @@ OMR::ResolvedMethodSymbol::cannotAttemptOSR(TR_ByteCodeInfo bci,
      traceMsg(comp, "OSR can be attempted\n");
 
    return false;
-   }
-
-bool
-OMR::ResolvedMethodSymbol::allCallerOSRBlocksArePresent(int32_t inlinedSiteIndex, TR::Compilation *comp)
-   {
-   TR_OSRMethodData *osrMethodData = inlinedSiteIndex > -1 ? comp->getOSRCompilationData()->findCallerOSRMethodData(comp->getOSRCompilationData()->findOrCreateOSRMethodData(inlinedSiteIndex, self())) : NULL;
-   TR::Block * OSRCatchBlock = osrMethodData ? osrMethodData->getOSRCatchBlock() : NULL;
-
-   bool allCallersOSRCodeBlocksAreStillInCFG = true;
-   while (osrMethodData)
-      {
-      TR::Block * CallerOSRCodeBlock = osrMethodData->getOSRCodeBlock();
-      if (!CallerOSRCodeBlock ||
-          CallerOSRCodeBlock->isUnreachable())
-         {
-         if (comp->getOption(TR_TraceOSR))
-            traceMsg(comp, "Osr catch block at inlined site index %d is absent\n", osrMethodData->getInlinedSiteIndex());
-
-         return false;
-         }
-      else if (comp->getOption(TR_TraceOSR))
-         traceMsg(comp, "Osr catch block at inlined site index %d is present\n", osrMethodData->getInlinedSiteIndex());
-
-      if (osrMethodData->getInlinedSiteIndex() > -1)
-         osrMethodData = comp->getOSRCompilationData()->findCallerOSRMethodData(osrMethodData);
-      else
-         osrMethodData = NULL;
-      }
-   return true;
    }
 
 void
@@ -1752,7 +1763,7 @@ OMR::ResolvedMethodSymbol::isOSRRelatedNode(TR::Node *node, TR_ByteCodeInfo &osr
 TR::TreeTop *
 OMR::ResolvedMethodSymbol::getOSRTransitionTreeTop(TR::TreeTop *tt)
    {
-   if (self()->comp()->getOSRTransitionTarget() == TR::postExecutionOSR)
+   if (self()->comp()->getOSRTransitionTarget() & TR::postExecutionOSR)
       {
       TR_ByteCodeInfo bci = self()->getOSRByteCodeInfo(tt->getNode());
       TR::TreeTop *cursor = tt->getNextTreeTop();
@@ -1789,14 +1800,14 @@ OMR::ResolvedMethodSymbol::insertStoresForDeadStackSlotsBeforeInducingOSR(TR::Co
    TR::TreeTop *prev = induceOSRTree->getPrevTreeTop();
    TR::TreeTop *next = induceOSRTree;
 
-   TR::OSRPointType pointType = TR::inductionOSR;
+   TR::OSRTransitionTarget pointType = TR::preAndPostExecutionOSR;
 
    while (osrMethodData)
       {
       if (comp->getOption(TR_TraceOSR))
          traceMsg(comp, "Inserting stores for dead stack slots in method at caller index %d and bytecode index %d for induceOSR call %p\n", callSite, byteCodeIndex, induceOSRTree->getNode());
 
-      TR_BitVector *deadSymRefs = osrMethodData->getLiveRangeInfo(byteCodeIndex, pointType);
+      TR_BitVector *deadSymRefs = pointType == TR::preAndPostExecutionOSR ? osrMethodData->getLiveRangeInfo(byteCodeIndex) : osrMethodData->getLiveRangeInfo(byteCodeIndex, pointType);
       if (deadSymRefs)
          {
          TR_BitVectorIterator bvi(*deadSymRefs);
@@ -1825,7 +1836,7 @@ OMR::ResolvedMethodSymbol::insertStoresForDeadStackSlotsBeforeInducingOSR(TR::Co
          callSite = callSiteInfo._byteCodeInfo.getCallerIndex();
          osrMethodData = comp->getOSRCompilationData()->findCallerOSRMethodData(osrMethodData);
          byteCodeIndex = callSiteInfo._byteCodeInfo.getByteCodeIndex();
-         pointType = comp->getOSRTransitionTarget() == TR::postExecutionOSR ? TR::analysisOSR : TR::inductionOSR;
+         pointType = TR::preExecutionOSR;
          }
       else
          osrMethodData = NULL;

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -1889,7 +1889,7 @@ TR_InlinerBase::addGuardForVirtual(
    // this is necessary to ensure the stack has the correct contents when it transitions, therefore, it
    // is necessary to add the store here as well
    //
-   if (comp()->getOSRTransitionTarget() == TR::postExecutionOSR)
+   if (comp()->getOSRTransitionTarget() & TR::postExecutionOSR)
       {
       TR::TreeTop *cursor = callNodeTreeTop->getNextTreeTop();
       TR_ByteCodeInfo bci = callNode->getByteCodeInfo();
@@ -1977,7 +1977,7 @@ TR_InlinerBase::addGuardForVirtual(
    // compilation and those later processes will handle them using OSR so we don't want to complicate
    // that with additional OSR at this point
    if ((comp()->getHCRMode() != TR::osr || guard->_kind != TR_HCRGuard)
-       && callNode->getSymbolReference()->getOwningMethodSymbol(comp())->supportsInduceOSR(callNode->getByteCodeInfo(), block1, calleeSymbol, comp(), false))
+       && callNode->getSymbolReference()->getOwningMethodSymbol(comp())->supportsInduceOSR(callNode->getByteCodeInfo(), block1, comp(), false))
       {
       bool shouldUseOSR = heuristicForUsingOSR(callNode, calleeSymbol, callerSymbol, createdHCRAndVirtualGuard);
 
@@ -2069,8 +2069,7 @@ bool TR_InlinerBase::heuristicForUsingOSR(TR::Node *callNode, TR::ResolvedMethod
       int32_t osrCallerNumLiveStackSlots = 0;
       totalOSRCallersStackSlots = totalOSRCallersStackSlots + osrCallerNumStackSlots;
 
-      TR_BitVector *deadSymRefs = osrMethodData->getLiveRangeInfo(byteCodeIndex,
-         comp()->getOSRTransitionTarget() == TR::postExecutionOSR ? TR::analysisOSR : TR::inductionOSR);
+      TR_BitVector *deadSymRefs = osrMethodData->getLiveRangeInfo(byteCodeIndex, TR::preExecutionOSR);
       if (deadSymRefs)
          {
          osrCallerNumLiveStackSlots = osrMethodData->getNumSymRefs() - deadSymRefs->elementCount();

--- a/compiler/optimizer/OSRDefAnalysis.cpp
+++ b/compiler/optimizer/OSRDefAnalysis.cpp
@@ -387,17 +387,17 @@ void TR_OSRDefInfo::buildOSRDefs(void *vblockInfo, AuxiliaryData &aux)
 
       // If we reach an OSR point and we require a transition point at it,
       // build the defs immediately
-      if (isPotentialOSRPoint && (comp()->getOSRTransitionTarget() == TR::preExecutionOSR
+      if (isPotentialOSRPoint && (comp()->getOSRTransitionTarget() & TR::preExecutionOSR
           || comp()->requiresAnalysisOSRPoint(node)))
          {
          osrPoint = _methodSymbol->findOSRPoint(node->getByteCodeInfo());
-         TR_ASSERT(osrPoint != NULL, "Cannot find an OSR point for node %p", node);
+         TR_ASSERT(osrPoint != NULL, "Cannot find a pre OSR point for node %p", node);
          }
  
       buildOSRDefs(node, analysisInfo, osrPoint, nextOsrPoint, NULL, aux);
       nextOsrPoint = NULL;
  
-      if (isPotentialOSRPoint && comp()->getOSRTransitionTarget() == TR::postExecutionOSR)
+      if (isPotentialOSRPoint && comp()->getOSRTransitionTarget() & TR::postExecutionOSR)
          {
          // Skip to the end of the OSR region, processing all treetops along the way
          TR::TreeTop *pps = treeTop->getNextTreeTop(); 
@@ -413,7 +413,7 @@ void TR_OSRDefInfo::buildOSRDefs(void *vblockInfo, AuxiliaryData &aux)
          // to be processed on the next call to buildOSRDefs
          bci.setByteCodeIndex(bci.getByteCodeIndex() + comp()->getOSRInductionOffset(node));
          nextOsrPoint = _methodSymbol->findOSRPoint(bci);
-         TR_ASSERT(nextOsrPoint != NULL, "Cannot find an offset OSR point for node %p", node);
+         TR_ASSERT(nextOsrPoint != NULL, "Cannot find a post OSR point for node %p", node);
          }
       }
 
@@ -853,7 +853,7 @@ int32_t TR_OSRLiveRangeAnalysis::perform()
          // cursor to before the PPs. The cursor will either point at the first PP or the treetop
          // before it, depending on whether it could be the OSR point for these PP.
          TR::TreeTop *offsetOSRTreeTop = NULL;
-         if (comp()->getOSRTransitionTarget() == TR::postExecutionOSR &&
+         if (comp()->getOSRTransitionTarget() & TR::postExecutionOSR &&
              comp()->getMethodSymbol()->isOSRRelatedNode(tt->getNode()))
             {
             offsetOSRTreeTop = tt;   
@@ -872,14 +872,14 @@ int32_t TR_OSRLiveRangeAnalysis::perform()
 
          // If the transition point is after the OSR point, build the OSR live info before
          // any PPS are processed.
-         if (isPotentialOSRPoint && comp()->getOSRTransitionTarget() == TR::postExecutionOSR)
+         if (isPotentialOSRPoint && comp()->getOSRTransitionTarget() & TR::postExecutionOSR)
             {
             TR_ByteCodeInfo bcInfo = node->getByteCodeInfo();
             bcInfo.setByteCodeIndex(bcInfo.getByteCodeIndex() + comp()->getOSRInductionOffset(node));
             TR_OSRPoint *offsetOSRPoint = comp()->getMethodSymbol()->findOSRPoint(bcInfo);
-            TR_ASSERT(offsetOSRPoint != NULL, "Cannot find an offset OSR point for node %p", node);
+            TR_ASSERT(offsetOSRPoint != NULL, "Cannot find a post OSR point for node %p", node);
             buildOSRLiveRangeInfo(node, _liveVars, offsetOSRPoint, liveLocalIndexToSymRefNumberMap,
-               maxSymRefNumber, numBits, osrMethodData, TR::inductionOSR);
+               maxSymRefNumber, numBits, osrMethodData, TR::postExecutionOSR);
             }
 
          // Maintain liveness across post pending pushes and the OSR point itself
@@ -892,14 +892,13 @@ int32_t TR_OSRLiveRangeAnalysis::perform()
 
          // If the transition point is before the OSR point, build the OSR live info after
          // the post PPS and the OSR point are processed.
-         if (isPotentialOSRPoint && (comp()->getOSRTransitionTarget() == TR::preExecutionOSR ||
+         if (isPotentialOSRPoint && (comp()->getOSRTransitionTarget() & TR::preExecutionOSR ||
              comp()->requiresAnalysisOSRPoint(node)))
             {
             TR_OSRPoint *osrPoint = comp()->getMethodSymbol()->findOSRPoint(bci);
-            TR_ASSERT(osrPoint != NULL, "Cannot find an OSR point for node %p", node);
+            TR_ASSERT(osrPoint != NULL, "Cannot find a pre OSR point for node %p", node);
             buildOSRLiveRangeInfo(node, _liveVars, osrPoint, liveLocalIndexToSymRefNumberMap,
-               maxSymRefNumber, numBits, osrMethodData,
-               comp()->getOSRTransitionTarget() == TR::postExecutionOSR ? TR::analysisOSR : TR::inductionOSR);
+               maxSymRefNumber, numBits, osrMethodData, TR::preExecutionOSR);
             }
          }
 
@@ -1123,9 +1122,10 @@ void TR_OSRLiveRangeAnalysis::maintainLiveness(TR::Node *node,
 
 void TR_OSRLiveRangeAnalysis::buildOSRLiveRangeInfo(TR::Node *node, TR_BitVector *liveVars, TR_OSRPoint *osrPoint,
    int32_t *liveLocalIndexToSymRefNumberMap, int32_t maxSymRefNumber, int32_t numBits,
-   TR_OSRMethodData *osrMethodData, TR::OSRPointType osrPointType)
+   TR_OSRMethodData *osrMethodData, TR::OSRTransitionTarget target)
    {
    TR_ASSERT(liveVars, "live variable info must be available for a block\n");
+   TR_ASSERT(target == TR::postExecutionOSR || target == TR::preExecutionOSR, "can only add live range info for pre or post transition target");
    _deadVars->setAll(numBits);
    *_deadVars -= *liveVars;
 
@@ -1145,7 +1145,7 @@ void TR_OSRLiveRangeAnalysis::buildOSRLiveRangeInfo(TR::Node *node, TR_BitVector
       }
 
    osrMethodData->setNumSymRefs(numBits);
-   osrMethodData->addLiveRangeInfo(osrPoint->getByteCodeInfo().getByteCodeIndex(), osrPointType, deadSymRefs);
+   osrMethodData->addLiveRangeInfo(osrPoint->getByteCodeInfo().getByteCodeIndex(), target, deadSymRefs);
 
    if (comp()->getOption(TR_TraceOSR))
       {

--- a/compiler/optimizer/OSRDefAnalysis.hpp
+++ b/compiler/optimizer/OSRDefAnalysis.hpp
@@ -97,7 +97,7 @@ class TR_OSRLiveRangeAnalysis : public TR::Optimization
    bool canAffordAnalysis();
    void buildOSRLiveRangeInfo(TR::Node *node, TR_BitVector *liveVars, TR_OSRPoint *osrPoint,
       int32_t *liveLocalIndexToSymRefNumberMap, int32_t maxSymRefNumber, int32_t numBits,
-      TR_OSRMethodData *osrMethodData, TR::OSRPointType osrPointType);
+      TR_OSRMethodData *osrMethodData, TR::OSRTransitionTarget target);
    void maintainLiveness(TR::Node *node, TR::Node *parent, int32_t childNum, vcount_t  visitCount,
        TR_Liveness *liveLocals, TR_BitVector *liveVars, TR::Block *block);
    TR::TreeTop *collectPendingPush(TR_ByteCodeInfo bci, TR::TreeTop *pps, TR_BitVector *liveVars);


### PR DESCRIPTION
This change modifies the implementation and use of the resolved
method symbol's API to determine if a BCI cannot OSR. It will now
consider the transition BCI, rather than the OSR node's BCI and
can distinguish between cases where it is not possible to
transition at a bytecode index and transition during an index,
eg. an inlined call.

This change includes:
 - Separate API into cannotAttemptOSRAt and cannotAttemptOSRDuring
 - Store cannotAttemptOSRDuring result against call site info
 - Fix check to verify OSR blocks for all callers exist and
   perform unreachable block cleanup
 - Don't generate OSR infrastructure if this call site cannot
   transition
 - Remove unused shouldNotOSR bitvector