### PR TITLE
Set array copy flags in VP for recognized methods

### DIFF
--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -1295,6 +1295,13 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
          type = TR::Int8;
 
          elementSize = TR::Symbol::convertTypeToSize(type);
+
+         // VP may not know anything about the types of the objects we are copying, hence primitiveArray1 and
+         // and primitiveArray2 would both return false. However because we are dealing with a recognized method we
+         // know that the types must be primitive. As such we we can safely set the following two variables without
+         // repercussions.
+         primitiveArray1 = true;
+         primitiveArray2 = true;
          }
 
       if (isStringDecompressedArrayCopy)
@@ -1302,6 +1309,13 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
          type = TR::Int16;
 
          elementSize = TR::Symbol::convertTypeToSize(type);
+
+         // VP may not know anything about the types of the objects we are copying, hence primitiveArray1 and
+         // and primitiveArray2 would both return false. However because we are dealing with a recognized method we
+         // know that the types must be primitive. As such we we can safely set the following two variables without
+         // repercussions.
+         primitiveArray1 = true;
+         primitiveArray2 = true;
          }
 
       if (comp()->getOptions()->realTimeGC() &&


### PR DESCRIPTION
VP may not have the type information of the source or destination arrays
we are copying. However for the specialized String compression array
copies we can be certain that both the source and destination arrays are
primitive arrays. As such it is always safe to set the primitive array
copy flags in VP for such recognized methods.

Failure to set these flags can get us in an invalid state in which we
fail to properly generate array store checks or misinterpret the special
String compression array copies as reference array copies, both of which
are incorrect.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>