### PR TITLE
Cleanup and fix GC ExclusiveVMAccess APIs

### DIFF
--- a/example/glue/EnvironmentDelegate.hpp
+++ b/example/glue/EnvironmentDelegate.hpp
@@ -128,17 +128,13 @@ public:
 	 * This implementation is not pre-emptive. Threads that have obtained shared VM access must
 	 * check frequently whether any other thread is requesting exclusive VM access and release
 	 * shared VM access as quickly as possible in that event.
-	 *
-	 * The exclusiveAccessForGCObtainedAfterBeatenByOtherThread parameter may be required if a
-	 * concurrent GC strategy is employed. It must be set (true) when this method is called after
-	 * the stop-the-world GC completes and releases exclusive VM access if the calling thread
-	 * previously called releaseVMAccess(exclusiveAccessForGCBeatenByOtherThread = true).
-	 * Any resources temporarily released in that call can be recovered here before proceeding
-	 * with exclusive VM access.
-	 *
-	 * @param exclusiveAccessForGCObtainedAfterBeatenByOtherThread (optional, default = false)
 	 */
-	void acquireVMAccess(bool exclusiveAccessForGCObtainedAfterBeatenByOtherThread = false);
+	void acquireVMAccess();
+	
+	/**
+	 * Release shared VM acccess.
+	 */
+	void releaseVMAccess();
 
 	/**
 	 * Check whether another thread is requesting exclusive VM access. This method must be
@@ -151,34 +147,11 @@ public:
 	bool isExclusiveAccessRequestWaiting();
 
 	/**
-	 * Release shared VM acccess.
-	 *
-	 * The exclusiveAccessForGCBeatenByOtherThread parameter may be required if a concurrent
-	 * GC strategy is employed. It must be set (true) when this method is called by the concurrent
-	 * GC if it is unable to immediately obtain exclusive VM access (because a stop-the-world GC
-	 * is in progress). If the concurrent GC holds resources that must be temporarily relinquished
-	 * while waiting for exclusive VM access, this is the place to release them. They can be recovered
-	 * by calling acquireVMAccess(exclusiveAccessForGCObtainedAfterBeatenByOtherThread = true)
-	 * when the stop-the-world GC completes and releases exclusive VM access.
-	 *
-	 * @param exclusiveAccessForGCBeatenByOtherThread (optional, default = false)
-	 */
-	void releaseVMAccess(bool exclusiveAccessForGCBeatenByOtherThread = false);
-
-	/**
 	 * Acquire exclusive VM access. This method should only be called by the OMR runtime to
 	 * perform stop-the-world operations such as garbage collection. Calling thread will be
 	 * blocked until all other threads holding shared VM access have release VM access.
 	 */
 	void acquireExclusiveVMAccess();
-
-	/**
-	 * Attempt to acquire exclusive VM access. This method may fail and return false
-	 * if another thread is requesting or has obtained exclusive VM access.
-	 *
-	 * @return true if exclusive VM access has been obtained for the calling thread
-	 */
-	bool tryAcquireExclusiveVMAccess();
 
 	/**
 	 * Release exclusive VM acccess. If no other thread is waiting for exclusive VM access

--- a/gc/base/EnvironmentBase.cpp
+++ b/gc/base/EnvironmentBase.cpp
@@ -336,22 +336,6 @@ MM_EnvironmentBase::releaseVMAccess()
 	_delegate.releaseVMAccess();
 }
 
-bool
-MM_EnvironmentBase::tryAcquireExclusiveVMAccess()
-{
-	if (0 == _exclusiveCount) {
-		/* Check if we won the exclusive access race..return if we lost */
-		if (!_delegate.tryAcquireExclusiveVMAccess()) {
-			return false;
-		}
-		/* Report exclusive access time if we won race */
-		reportExclusiveAccessAcquire();
-	}
-	_exclusiveCount += 1;
-
-	return true;
-}
-
 void
 MM_EnvironmentBase::acquireExclusiveVMAccess()
 {
@@ -379,49 +363,77 @@ MM_EnvironmentBase::isExclusiveAccessRequestWaiting()
 }
 
 bool
-MM_EnvironmentBase::acquireExclusiveVMAccessForGC(MM_Collector *collector)
+MM_EnvironmentBase::acquireExclusiveVMAccessForGC(MM_Collector *collector, bool failIfNotFirst, bool flushCaches)
 {
 	MM_GCExtensionsBase *extensions = getExtensions();
 	uintptr_t collectorAccessCount = collector->getExclusiveAccessCount();
 
-	_exclusiveAccessBeatenByOtherThread = false;
-
-	while(_omrVMThread != extensions->gcExclusiveAccessThreadId) {
-		if(NULL == extensions->gcExclusiveAccessThreadId) {
-			/* there is a chance the thread can win the race to acquiring
-			 * exclusive for GC */
-			omrthread_monitor_enter(extensions->gcExclusiveAccessMutex);
-			if(NULL == extensions->gcExclusiveAccessThreadId) {
-				/* thread is the winner and will request the GC */
-				extensions->gcExclusiveAccessThreadId = _omrVMThread;
-			}
-			omrthread_monitor_exit(extensions->gcExclusiveAccessMutex);
-		}
-
-		if(_omrVMThread != extensions->gcExclusiveAccessThreadId) {
-			/* thread was not the winner for requesting a GC - allow the GC to
-			 * proceed and wait for it to complete */
-			Assert_MM_true(NULL != extensions->gcExclusiveAccessThreadId);
-
-			uintptr_t accessMask;
-			_delegate.releaseCriticalHeapAccess(&accessMask);
-
-			/* there is a chance the GC will already have executed at this
-			 * point or other threads will re-win and re-execute.  loop until
-			 * the thread sees that no more GCs are being requested.
+	/* Does the current thread have exclusive vm access? */
+	if (_omrVMThread->exclusiveCount > 0) {
+		/* Did the current thread get exclusive vm access via (or already come through this code) the
+		 * GC exclusive vm access APIs.
+		 */
+		if (_omrVMThread != extensions->gcExclusiveAccessThreadId) {
+			/* The current thread did not get exclusive vm access via the GC exclusive vm access API */
+			/* If another thread has started to get exclusive vm access for a GC cache that value so it
+			 * can be restored later. It is possible for a thread to win setting itself as the thread
+			 * requesting exclusive vm access for a GC but not actually be the next thread to perform
+			 * a GC.  It can happen if a system gc is requested while holding exclusive.
 			 */
-			omrthread_monitor_enter(extensions->gcExclusiveAccessMutex);
-			while(NULL != extensions->gcExclusiveAccessThreadId) {
-				omrthread_monitor_wait(extensions->gcExclusiveAccessMutex);
-			}
-			/* thread can now win and will request a GC */
+			_cachedGCExclusiveAccessThreadId = (OMR_VMThread *)extensions->gcExclusiveAccessThreadId;
+			/* Current thread has exclusive VM access so there is no reason to grab the mutex! */
 			extensions->gcExclusiveAccessThreadId = _omrVMThread;
+		}
+	} else {
+		while(_omrVMThread != extensions->gcExclusiveAccessThreadId) {
+			if(NULL == extensions->gcExclusiveAccessThreadId) {
+				/* there is a chance the thread can win the race to acquiring
+				 * exclusive for GC */
+				omrthread_monitor_enter(extensions->gcExclusiveAccessMutex);
+				if(NULL == extensions->gcExclusiveAccessThreadId) {
+					/* thread is the winner and will request the GC */
+					extensions->gcExclusiveAccessThreadId = _omrVMThread;
+				}
+				omrthread_monitor_exit(extensions->gcExclusiveAccessMutex);
+			}
 
-			omrthread_monitor_exit(extensions->gcExclusiveAccessMutex);
+			if(_omrVMThread != extensions->gcExclusiveAccessThreadId) {
+				/* thread was not the winner for requesting a GC - allow the GC to
+				 * proceed and wait for it to complete */
+				Assert_MM_true(NULL != extensions->gcExclusiveAccessThreadId);
 
-			_delegate.reacquireCriticalHeapAccess(accessMask);
+				uintptr_t accessMask;
+				_delegate.releaseCriticalHeapAccess(&accessMask);
+
+				/* there is a chance the GC will already have executed at this
+				 * point or other threads will re-win and re-execute.  loop until
+				 * the thread sees that no more GCs are being requested.
+				 */
+				omrthread_monitor_enter(extensions->gcExclusiveAccessMutex);
+				while(NULL != extensions->gcExclusiveAccessThreadId) {
+					omrthread_monitor_wait(extensions->gcExclusiveAccessMutex);
+				}
+
+				if (failIfNotFirst) {
+					if(collector->getExclusiveAccessCount() != collectorAccessCount) {
+						_exclusiveAccessBeatenByOtherThread = true;
+						omrthread_monitor_exit(extensions->gcExclusiveAccessMutex);
+						_delegate.reacquireCriticalHeapAccess(accessMask);
+						return false;
+					}
+				}
+
+				/* thread can now win and will request a GC */
+				extensions->gcExclusiveAccessThreadId = _omrVMThread;
+
+				omrthread_monitor_exit(extensions->gcExclusiveAccessMutex);
+
+				_delegate.reacquireCriticalHeapAccess(accessMask);
+			}
 		}
 	}
+
+	_exclusiveAccessBeatenByOtherThread = !(collector->getExclusiveAccessCount() == collectorAccessCount);
 
 	/* thread is the winner for requesting a GC (possibly through recursive
 	 * calls).  proceed with acquiring exclusive access. */
@@ -429,71 +441,14 @@ MM_EnvironmentBase::acquireExclusiveVMAccessForGC(MM_Collector *collector)
 
 	acquireExclusiveVMAccess();
 
-	_exclusiveAccessBeatenByOtherThread = !(collector->getExclusiveAccessCount() == collectorAccessCount);
 	collector->incrementExclusiveAccessCount();
 
-	GC_OMRVMInterface::flushCachesForGC(this);
+	if (flushCaches) {
+		GC_OMRVMInterface::flushCachesForGC(this);
+	}
 
 	return !_exclusiveAccessBeatenByOtherThread;
 
-}
-
-bool
-MM_EnvironmentBase::tryAcquireExclusiveVMAccessForGC(MM_Collector *collector)
-{
-	MM_GCExtensionsBase *extensions = getExtensions();
-	uintptr_t collectorAccessCount = collector->getExclusiveAccessCount();
-
-	_exclusiveAccessBeatenByOtherThread = false;
-
-	while(_omrVMThread != extensions->gcExclusiveAccessThreadId) {
-		if(NULL == extensions->gcExclusiveAccessThreadId) {
-			/* there is a chance the thread can win the race to acquiring exclusive for GC */
-			omrthread_monitor_enter(extensions->gcExclusiveAccessMutex);
-			if(NULL == extensions->gcExclusiveAccessThreadId) {
-				/* thread is the winner and will request the GC */
-				extensions->gcExclusiveAccessThreadId = _omrVMThread;
-			}
-			omrthread_monitor_exit(extensions->gcExclusiveAccessMutex);
-		}
-
-		if(_omrVMThread != extensions->gcExclusiveAccessThreadId) {
-			/* thread was not the winner for requesting a GC - allow the GC to proceed and wait for it to complete */
-			Assert_MM_true(NULL != extensions->gcExclusiveAccessThreadId);
-
-			uintptr_t accessMask;
-			_delegate.releaseCriticalHeapAccess(&accessMask);
-
-			/* there is a chance the GC will already have executed at this point or other threads will re-win and re-execute.  loop until the
-			 * thread sees that no more GCs are being requested.
-			 */
-			omrthread_monitor_enter(extensions->gcExclusiveAccessMutex);
-			while(NULL != extensions->gcExclusiveAccessThreadId) {
-				omrthread_monitor_wait(extensions->gcExclusiveAccessMutex);
-			}
-			omrthread_monitor_exit(extensions->gcExclusiveAccessMutex);
-
-			_delegate.reacquireCriticalHeapAccess(accessMask);
-
-			/* May have been beaten to a GC, but perhaps not the one we wanted.  Check and if in fact the collection we intended has been
-			 * completed, we will not acquire exclusive access.
-			 */
-			if(collector->getExclusiveAccessCount() != collectorAccessCount) {
-				return false;
-			}
-		}
-	}
-
-	/* thread is the winner for requesting a GC (possibly through recursive calls).  proceed with acquiring exclusive access. */
-	Assert_MM_true(_omrVMThread == extensions->gcExclusiveAccessThreadId);
-
-	acquireExclusiveVMAccess();
-
-	collector->incrementExclusiveAccessCount();
-
-	GC_OMRVMInterface::flushCachesForGC(this);
-
-	return true;
 }
 
 void
@@ -507,7 +462,8 @@ MM_EnvironmentBase::releaseExclusiveVMAccessForGC()
 	_exclusiveCount -= 1;
 	if (0 == _exclusiveCount) {
 		omrthread_monitor_enter(extensions->gcExclusiveAccessMutex);
-		extensions->gcExclusiveAccessThreadId = NULL;
+		extensions->gcExclusiveAccessThreadId = _cachedGCExclusiveAccessThreadId;
+		_cachedGCExclusiveAccessThreadId = NULL;
 		omrthread_monitor_notify_all(extensions->gcExclusiveAccessMutex);
 		omrthread_monitor_exit(extensions->gcExclusiveAccessMutex);
 		reportExclusiveAccessRelease();
@@ -526,7 +482,8 @@ MM_EnvironmentBase::unwindExclusiveVMAccessForGC()
 		_exclusiveCount = 0;
 
 		omrthread_monitor_enter(extensions->gcExclusiveAccessMutex);
-		extensions->gcExclusiveAccessThreadId = NULL;
+		extensions->gcExclusiveAccessThreadId = _cachedGCExclusiveAccessThreadId;
+		_cachedGCExclusiveAccessThreadId = NULL;
 		omrthread_monitor_notify_all(extensions->gcExclusiveAccessMutex);
 		omrthread_monitor_exit(extensions->gcExclusiveAccessMutex);
 		reportExclusiveAccessRelease();
@@ -534,81 +491,6 @@ MM_EnvironmentBase::unwindExclusiveVMAccessForGC()
 		_delegate.releaseExclusiveVMAccess();
 	}
 }
-
-#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
-bool
-MM_EnvironmentBase::tryAcquireExclusiveForConcurrentKickoff(MM_ConcurrentGCStats *stats)
-{
-	MM_GCExtensionsBase *extensions = MM_GCExtensionsBase::getExtensions(_omrVM);
-	uintptr_t gcCount = extensions->globalGCStats.gcCount;
-
-	while (_omrVMThread != extensions->gcExclusiveAccessThreadId) {
-		if (NULL == extensions->gcExclusiveAccessThreadId) {
-			/* there is a chance the thread can win the race to acquiring exclusive for GC */
-			omrthread_monitor_enter(extensions->gcExclusiveAccessMutex);
-			if (NULL == extensions->gcExclusiveAccessThreadId) {
-				/* thread is the winner and will request the GC */
-				extensions->gcExclusiveAccessThreadId =_omrVMThread ;
-			}
-			omrthread_monitor_exit(extensions->gcExclusiveAccessMutex);
-		}
-
-		if (_omrVMThread != extensions->gcExclusiveAccessThreadId) {
-			/* thread was not the winner for requesting a GC - allow the GC to proceed and wait for it to complete */
-			Assert_MM_true(NULL != extensions->gcExclusiveAccessThreadId);
-
-			uintptr_t accessMask = 0;
-
-			_delegate.releaseCriticalHeapAccess(&accessMask);
-
-			/* there is a chance the GC will already have executed at this point or other threads will re-win and re-execute.  loop until the
-			 * thread sees that no more GCs are being requested.
-			 */
-			omrthread_monitor_enter(extensions->gcExclusiveAccessMutex);
-			while (NULL != extensions->gcExclusiveAccessThreadId) {
-				omrthread_monitor_wait(extensions->gcExclusiveAccessMutex);
-			}
-			omrthread_monitor_exit(extensions->gcExclusiveAccessMutex);
-
-			_delegate.reacquireCriticalHeapAccess(accessMask);
-
-			/* May have been beaten to a GC, but perhaps not the one we wanted.  Check and if in fact the collection we intended has been
-			 * completed, we will not acquire exclusive access.
-			 */
-			if ((gcCount != extensions->globalGCStats.gcCount) || (CONCURRENT_INIT_COMPLETE != stats->getExecutionMode())) {
-				return false;
-			}
-		}
-	}
-
-	Assert_MM_true(_omrVMThread == extensions->gcExclusiveAccessThreadId);
-	Assert_MM_true(CONCURRENT_INIT_COMPLETE == stats->getExecutionMode());
-
-	/* thread is the winner for requesting a GC (possibly through recursive calls).  proceed with acquiring exclusive access. */
-	acquireExclusiveVMAccess();
-
-	return true;
-}
-
-void
-MM_EnvironmentBase::releaseExclusiveForConcurrentKickoff()
-{
-	MM_GCExtensionsBase *extensions = MM_GCExtensionsBase::getExtensions(_omrVM);
-
-	Assert_MM_true(extensions->gcExclusiveAccessThreadId ==_omrVMThread );
-	Assert_MM_true(0 != _exclusiveCount);
-
-	_exclusiveCount -= 1;
-	if (0 == _exclusiveCount) {
-		omrthread_monitor_enter(extensions->gcExclusiveAccessMutex);
-		extensions->gcExclusiveAccessThreadId = NULL;
-		omrthread_monitor_notify_all(extensions->gcExclusiveAccessMutex);
-		omrthread_monitor_exit(extensions->gcExclusiveAccessMutex);
-		reportExclusiveAccessRelease();
-		_delegate.releaseExclusiveVMAccess();
-	}
-}
-#endif /* defined(OMR_GC_MODRON_CONCURRENT_MARK) */
 
 uintptr_t
 MM_EnvironmentBase::relinquishExclusiveVMAccess()

--- a/gc/base/MemorySubSpaceFlat.cpp
+++ b/gc/base/MemorySubSpaceFlat.cpp
@@ -87,7 +87,7 @@ MM_MemorySubSpaceFlat::allocationRequestFailed(MM_EnvironmentBase* env, MM_Alloc
 	if (_collector) {
 		allocateDescription->saveObjects(env);
 		/* acquire exclusive access and, after we get it, see if we need to perform a collect or if someone else beat us to it */
-		if (!env->tryAcquireExclusiveVMAccessForGC(_collector)) {
+		if (!env->acquireExclusiveVMAccessForGC(_collector, true, true)) {
 			allocateDescription->restoreObjects(env);
 			/* Beaten to exclusive access for our collector by another thread - a GC must have occurred.  This thread
 			 * does NOT have exclusive access at this point.  Try and satisfy the allocate based on a GC having occurred.

--- a/gc/base/MemorySubSpaceGenerational.cpp
+++ b/gc/base/MemorySubSpaceGenerational.cpp
@@ -81,7 +81,7 @@ MM_MemorySubSpaceGenerational::allocationRequestFailed(MM_EnvironmentBase *env, 
 	}
 
 	allocateDescription->saveObjects(env);
-	if (!env->tryAcquireExclusiveVMAccessForGC(_collector)) {
+	if (!env->acquireExclusiveVMAccessForGC(_collector, true, true)) {
 		allocateDescription->restoreObjects(env);
 		addr = allocateGeneric(env, allocateDescription, allocationType, objectAllocationInterface, baseSubSpace);
 		if(NULL != addr) {

--- a/gc/base/MemorySubSpaceSemiSpace.cpp
+++ b/gc/base/MemorySubSpaceSemiSpace.cpp
@@ -77,7 +77,7 @@ MM_MemorySubSpaceSemiSpace::allocationRequestFailed(MM_EnvironmentBase *env, MM_
 	void *addr = NULL;
 
 	allocateDescription->saveObjects(env);
-	if (!env->tryAcquireExclusiveVMAccessForGC(_collector)) {
+	if (!env->acquireExclusiveVMAccessForGC(_collector, true, true)) {
 		allocateDescription->restoreObjects(env);
 		addr = allocateGeneric(env, allocateDescription, allocationType, objectAllocationInterface, _memorySubSpaceAllocate);
 		if(NULL != addr) {


### PR DESCRIPTION
There is a lot of duplicated code and makes modifications very
difficult. I am removing all of the APIs except 1 to keep things as
simple as possible.

The GC ExclusiveVMAccess APIs were not properly handling the case where
a system collect was called by a thread that already has
ExclusiveVMAccess outside of the GC. This could easily lead to a dead
lock because of the way the GC handles getting ExclusiveVMAccess. The
change also fixes the potential hang.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>