### PR TITLE
Enable NextGenHCR by default

### DIFF
--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -946,7 +946,7 @@ enum TR_CompilationOptions
    // Available                                       = 0x00001000 + 29,
    TR_UseHigherCountsForNonSCCMethods                 = 0x00002000 + 29,
    TR_UseHigherMethodCountsAfterStartup               = 0x00004000 + 29,
-   TR_EnableNextGenHCR                                = 0x00008000 + 29,
+   TR_DisableNextGenHCR                               = 0x00008000 + 29,
    TR_DisableMetadataReclamation                      = 0x00010000 + 29,
    TR_DisableInlineIsInstance                         = 0x00020000 + 29,
    TR_DisableSIMDStringHashCode                       = 0x00040000 + 29,

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -1275,7 +1275,7 @@ OMR::ResolvedMethodSymbol::genIL(TR_FrontEnd * fe, TR::Compilation * comp, TR::S
             //
             bool doOSR = comp->getOption(TR_EnableOSR)
                && !comp->isPeekingMethod()
-               && (comp->getOption(TR_EnableNextGenHCR) || !comp->getOption(TR_EnableHCR))
+               && !(comp->getOption(TR_DisableNextGenHCR) && comp->getOption(TR_EnableHCR))
                && comp->supportsInduceOSR()
                && !self()->cannotAttemptOSRDuring(comp->getCurrentInlinedSiteIndex(), comp);
 


### PR DESCRIPTION
Enable NextGenHCR, HCR implemented with on-stack replacement, by
default. This will result in OSR and HCR being enabled by default,
as this feature requires them.

These defaults are performed after OSR may be disabled in
`OMR::Compilation`, as defaulting before this point could result
in situations that do not require HCR having the older implementation
enabled instead.