### PR TITLE
Avoid adding tabort to OSR guards

### DIFF
--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -1133,7 +1133,8 @@ OMR::ResolvedMethodSymbol::genOSRHelperCall(int32_t currentInlinedSiteIndex, TR:
    OSRCodeBlock->append(osrTT);
 
    bool disableOSRwithTM = feGetEnv("TR_disableOSRwithTM") ? true: false;
-   if (self()->comp()->cg()->getSupportsTM() && !self()->comp()->getOption(TR_DisableTLE) && !disableOSRwithTM)
+   if (self()->comp()->cg()->getSupportsTM() && !self()->comp()->getOption(TR_DisableTLE) && !disableOSRwithTM
+       && self()->comp()->getHCRMode() != TR::osr)
       {
       TR::Node *tabortNode = TR::Node::create(osrNode, TR::tabort, 0, 0);
       TR::TreeTop *tabortTT = TR::TreeTop::create(self()->comp(),tabortNode, NULL,NULL);


### PR DESCRIPTION
Currently, a tabort to end a transaction will be placed before
any prepareForOSR. This is desirable as it prevents repeated
failures when performing an OSR transition. However, when using
OSR guards, it is more suitable to place the abort on the
taken side of the guard, as this will abort before any remat or
an OSR induce occurs.