### PR TITLE
Reduce the minimum CPU interval

### DIFF
--- a/omr/OMR_TI.cpp
+++ b/omr/OMR_TI.cpp
@@ -27,7 +27,7 @@
 #include "OMR_MethodDictionary.hpp"
 #include "OMR_VM.hpp"
 
-#define MINIMUM_CPU_LOAD_INTERVAL J9CONST_I64(10000000)
+#define MINIMUM_CPU_LOAD_INTERVAL J9CONST_I64(1000000)
 #define MAXIMUM_NEGATIVE_ELAPSED_TIME_COUNT 3
 #define UTSINTERFACE_FROM_OMRVMTHREAD(vmThread) ((vmThread)->_vm->_trcEngine? &(vmThread)->_vm->_trcEngine->omrTraceIntfS : NULL)
 


### PR DESCRIPTION
On some newer HW the current value is too high. This ends up causing
test failures. In the future the code should be investigated to see if
we could remove this value altogether but for now I am just trying to
stabilize testing.

In the future this code should also be investigated to remove the
NO_HISTORY option. This could likely be removed by caching the CPU times
on startup of the library.

Fixes #852

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>