### PR TITLE
Avoid heap resize in middle of concurrent sweep

### DIFF
--- a/gc/base/MemoryPoolLargeObjects.hpp
+++ b/gc/base/MemoryPoolLargeObjects.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2015
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -118,7 +118,7 @@ public:
 	virtual void unlock(MM_EnvironmentBase* env);
 
 	void preCollect(MM_EnvironmentBase* env, bool systemGC, bool aggressive, uintptr_t bytesRequested);
-	virtual void postCollect(MM_EnvironmentBase* env);
+	virtual void resizeLOA(MM_EnvironmentBase* env);
 	virtual bool completeFreelistRebuildRequired(MM_EnvironmentBase* env);
 
 	virtual MM_MemoryPool* getMemoryPool(void* addr);

--- a/gc/base/standard/ConcurrentSweepScheme.hpp
+++ b/gc/base/standard/ConcurrentSweepScheme.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2015
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -160,6 +160,11 @@ public:
 
 	virtual bool replenishPoolForAllocate(MM_EnvironmentBase *env, MM_MemoryPool *memoryPool, UDATA size);
 	void payAllocationTax(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace,  MM_AllocateDescription *allocDescriptionn);
+
+	/**
+	 * @return true if the concurrent sweep is not active.
+	 */
+	virtual bool isSweepCompleted(MM_EnvironmentBase* env) { return (!isConcurrentSweepActive()); }
 
 	MM_ConcurrentSweepScheme(MM_EnvironmentBase *env, MM_GlobalCollector *collector)
 		: MM_ParallelSweepScheme(env)

--- a/gc/base/standard/ParallelGlobalGC.hpp
+++ b/gc/base/standard/ParallelGlobalGC.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2015
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -178,6 +178,10 @@ private:
 	 */
 	void cleanupAfterGC(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription);
 
+	/**
+	 * redistribute free memory in tenure after global collection (move free memory from LOA to SOA)
+	 */
+	void tenureMemoryPoolPostCollect(MM_EnvironmentBase *env);
 protected:
 	bool initialize(MM_EnvironmentBase *env);
 	void tearDown(MM_EnvironmentBase *env);

--- a/gc/base/standard/ParallelSweepScheme.hpp
+++ b/gc/base/standard/ParallelSweepScheme.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2015
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -204,6 +204,8 @@ public:
 	 * @return the dark matter, measured in bytes, in the range
 	 */
 	uintptr_t performSamplingCalculations(MM_ParallelSweepChunk *sweepChunk, uintptr_t* markMapCurrent, uintptr_t* heapSlotFreeCurrent);
+
+	virtual bool isSweepCompleted(MM_EnvironmentBase* env) { return true; }
 
 	/**
 	 * Create a ParallelSweepScheme object.


### PR DESCRIPTION
  - Do not resize LOA if concurrent sweep is active(require complete stw
sweep for LOA resize to avoid potential concurrent sweep issue)
  - Move resizeLOA from GlobalGCComlete hook to postCollect
  - Remove GlobalGCComlete hook

Signed-off-by: Lin Hu <linhu@ca.ibm.com>