### PR TITLE
Improve JitBuilder's initial IL quality

### DIFF
--- a/compiler/ilgen/IlValue.cpp
+++ b/compiler/ilgen/IlValue.cpp
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+
+
+#include "compile/Compilation.hpp"
+#include "il/Block.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/Symbol.hpp"
+#include "il/symbol/AutomaticSymbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "ilgen/IlValue.hpp" // must follow include for compile/Compilation.hpp for TR_Memory
+#include "ilgen/MethodBuilder.hpp"
+
+
+OMR::IlValue::IlValue(TR::Node *node, TR::TreeTop *treeTop, TR::Block *block, TR::MethodBuilder *methodBuilder)
+   : _id(methodBuilder->getNextValueID()),
+     _nodeThatComputesValue(node),
+     _treeTopThatAnchorsValue(treeTop),
+     _blockThatComputesValue(block),
+     _methodBuilder(methodBuilder),
+     _symRefThatCanBeUsedInOtherBlocks(0)
+   {
+   }
+
+TR::DataType
+OMR::IlValue::getDataType()
+   {
+   return _nodeThatComputesValue->getDataType();
+   }
+
+void
+OMR::IlValue::storeToAuto()
+   {
+   if (_symRefThatCanBeUsedInOtherBlocks == NULL)
+      {
+      TR::Compilation *comp = TR::comp();
+
+      // first use from another block, need to create symref and insert store tree where node  was computed
+      TR::SymbolReference *symRef = comp->getSymRefTab()->createTemporary(_methodBuilder->methodSymbol(), _nodeThatComputesValue->getDataType());
+      symRef->getSymbol()->setNotCollected();
+      char *name = (char *) comp->trMemory()->allocateHeapMemory(8 * sizeof(char));
+      sprintf(name, "_T%-5d", symRef->getCPIndex());
+      symRef->getSymbol()->getAutoSymbol()->setName(name);
+
+      // create store and its treetop
+      TR::Node *storeNode = TR::Node::createStore(symRef, _nodeThatComputesValue);
+      TR::TreeTop *prevTreeTop = _treeTopThatAnchorsValue->getPrevTreeTop();
+      TR::TreeTop *newTree = TR::TreeTop::create(comp, storeNode);
+      newTree->insertNewTreeTop(prevTreeTop, _treeTopThatAnchorsValue);
+
+      _treeTopThatAnchorsValue->unlink(true);
+
+      _treeTopThatAnchorsValue = newTree;
+      _symRefThatCanBeUsedInOtherBlocks = symRef;
+      }
+   }
+
+TR::Node *
+OMR::IlValue::load(TR::Block *block)
+   {
+   if (_blockThatComputesValue == block)
+      return _nodeThatComputesValue;
+
+   storeToAuto();
+   return TR::Node::createLoad(_symRefThatCanBeUsedInOtherBlocks);
+   }
+
+void
+OMR::IlValue::storeOver(TR::IlValue *value, TR::Block *block)
+   {
+   if (value->_blockThatComputesValue == block && _blockThatComputesValue == block)
+      {
+      // probably not very common scenario, but if both values are in the same block as current
+      // then storeOver just needs to update node pointer
+      _nodeThatComputesValue = value->_nodeThatComputesValue;
+      }
+   else
+      {
+      // more commonly, if any value is in another block or this use will be in a different block, first ensure this value is
+      // stored to an auto symbol
+      // NOTE this may mean nodes may be stored to more than one auto, but that's ok
+      storeToAuto();
+
+      // then make sure value has been stored to the same auto
+      TR::Node *store = TR::Node::createStore(_symRefThatCanBeUsedInOtherBlocks, value->_nodeThatComputesValue);
+      TR::TreeTop *tt = TR::TreeTop::create(TR::comp(), store);
+      block->append(tt);
+
+      // finally, subsequent uses of this value should load the auto, so update the node pointer
+      _nodeThatComputesValue = TR::Node::createLoad(_symRefThatCanBeUsedInOtherBlocks);
+      }
+   }

--- a/compiler/ilgen/IlValue.cpp
+++ b/compiler/ilgen/IlValue.cpp
@@ -55,8 +55,8 @@ OMR::IlValue::storeToAuto()
       // first use from another block, need to create symref and insert store tree where node  was computed
       TR::SymbolReference *symRef = comp->getSymRefTab()->createTemporary(_methodBuilder->methodSymbol(), _nodeThatComputesValue->getDataType());
       symRef->getSymbol()->setNotCollected();
-      char *name = (char *) comp->trMemory()->allocateHeapMemory(8 * sizeof(char));
-      sprintf(name, "_T%-5d", symRef->getCPIndex());
+      char *name = (char *) comp->trMemory()->allocateHeapMemory((2+10+1) * sizeof(char)); // 2 ("_T") + max 10 digits + trailing zero
+      sprintf(name, "_T%u", symRef->getCPIndex());
       symRef->getSymbol()->getAutoSymbol()->setName(name);
 
       // create store and its treetop

--- a/compiler/ilgen/IlValue.hpp
+++ b/compiler/ilgen/IlValue.hpp
@@ -1,0 +1,147 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+
+#ifndef OMR_ILVALUE_INCL
+#define OMR_ILVALUE_INCL
+
+#ifndef TR_ILVALUE_DEFINED
+#define TR_ILVALUE_DEFINED
+#define PUT_OMR_ILVALUE_INTO_TR
+#endif // !defined(TR_ILVALUE_DEFINED)
+
+#include "il/DataTypes.hpp" // for TR::DataType
+
+namespace TR { class Node; }
+namespace TR { class TreeTop; }
+namespace TR { class Block; }
+namespace TR { class Symbol; }
+namespace TR { class SymbolReference; }
+namespace TR { class MethodBuilder; }
+namespace TR { class IlValue; }
+
+namespace OMR
+{
+
+class IlValue
+   {
+public:
+   TR_ALLOC(TR_Memory::IlGenerator)
+
+   /**
+    * @brief initial state assumes value will only be used locally
+    */
+   IlValue(TR::Node *node, TR::TreeTop *treeTop, TR::Block *block, TR::MethodBuilder *methodBuilder);
+
+   /**
+    * @brief return a TR::Node that computes this value, either directly if in same block or by loading a local variable if not
+    * @param block TR::Block for the load point so it can be compared to the TR::Block where value is computed
+    */
+   TR::Node *load(TR::Block *block);
+
+   /**
+    * @brief ensures that the provided value replaces the current value, but only affects subsequent loads
+    * @param value the new value that should be returned whenever the current value is loaded
+    * @param block TR::Block for the replacement point, so that either the node pointer is changed or what's stored in the symbol reference
+    */
+   void storeOver(TR::IlValue *value, TR::Block *block);
+
+   /**
+    * @brief return the data type of this value
+    */
+   TR::DataType getDataType();
+
+   /**
+    * @brief returns the TR::SymbolReference holding the value, or NULL if willBeUsedInAnotherBlock() has not yet been called
+    * Caller should ensure the current block is different than the block that computes the value; if the current block is the
+    * same then it is better to use the value as a node pointer via GetNodePointerIfLegal().
+    */
+   TR::SymbolReference *getSymbolReference()
+      {
+      return _symRefThatCanBeUsedInOtherBlocks;
+      }
+
+   /**
+    * @brief returns a unique identifier for this IlValue object within its MethodBuilder
+    * Note that IlValues from different MethodBuilders can have the same ID.
+    */
+   int32_t getID()
+      {
+      return _id;
+      }
+
+protected:
+   /**
+    * @brief ensures this value is accessible via an auto symbol, but only generates store if hasn't already been stored
+    */
+   void storeToAuto();
+
+private:
+
+   /**
+    * @brief identifying number for values guaranteed to be unique per MethodBuilder
+    */
+   int32_t               _id;
+
+   /**
+    * @brief TR::Node pointer that computes the actual value
+    */
+   TR::Node            * _nodeThatComputesValue;
+
+   /**
+    * @brief TR::TreeTop that anchors this node (though not necessarily directly)
+    */
+   TR::TreeTop         * _treeTopThatAnchorsValue;
+
+   /**
+    * @brief TR::Block where the value is computed
+    */
+   TR::Block           * _blockThatComputesValue;
+
+   /**
+    * @brief Method builder object where value is computed
+    */
+   TR::MethodBuilder   * _methodBuilder;
+
+   /**
+    * @brief TR::SymbolReference for temp holding value if it needs to be used outside basic block that computes it
+    */
+   TR::SymbolReference * _symRefThatCanBeUsedInOtherBlocks;
+   };
+
+} // namespace OMR
+
+
+
+#if defined(PUT_OMR_ILVALUE_INTO_TR)
+
+namespace TR
+{
+   class IlValue : public OMR::IlValue
+      {
+      public:
+         IlValue(TR::Node *node, TR::TreeTop *treeTop, TR::Block *block, TR::MethodBuilder *methodBuilder)
+            : OMR::IlValue(node, treeTop, block, methodBuilder)
+            { }
+      };
+
+} // namespace TR
+
+#endif // defined(PUT_OMR_ILVALUE_INTO_TR)
+
+#endif // !defined(OMR_ILVALUE_INCL)

--- a/compiler/ilgen/MethodBuilder.cpp
+++ b/compiler/ilgen/MethodBuilder.cpp
@@ -89,6 +89,7 @@ MethodBuilder::MethodBuilder(TR::TypeDictionary *types, OMR::VirtualMachineState
    _definingLine(""),
    _symbols(0),
    _newSymbolsAreTemps(false),
+   _nextValueID(0),
    _useBytecodeBuilders(false),
    _countBlocksWorklist(0),
    _connectTreesWorklist(0),
@@ -329,24 +330,24 @@ MethodBuilder::symbolDefined(const char *name)
    }
 
 void
-MethodBuilder::defineSymbol(const char *name, TR::IlValue *v)
+MethodBuilder::defineSymbol(const char *name, TR::SymbolReference *symRef)
    {
    TR_HashId id1=0, id2=0, id3;
 
-   _symbols->add(name, id1, (void *)v);
-   _symbolNameFromSlot->add(v->getCPIndex(), id2, (void *)name);
-   _symbolTypes->add(name, id3, (void *)(uintptr_t) v->getSymbol()->getDataType());
+   _symbols->add(name, id1, (void *)symRef);
+   _symbolNameFromSlot->add(symRef->getCPIndex(), id2, (void *)name);
+   _symbolTypes->add(name, id3, (void *)(uintptr_t) symRef->getSymbol()->getDataType());
    if (!_newSymbolsAreTemps)
       _methodSymbol->setFirstJitTempIndex(_methodSymbol->getTempIndex());
    }
 
-TR::IlValue *
+TR::SymbolReference *
 MethodBuilder::lookupSymbol(const char *name)
    {
    TR_HashId symbolsID=0;
    bool present = _symbols->locate(name, symbolsID);
    if (present)
-      return (TR::IlValue *)_symbols->getData(symbolsID);
+      return (TR::SymbolReference *)_symbols->getData(symbolsID);
 
    TR::SymbolReference *symRef;
    TR_HashId typesID;
@@ -370,7 +371,9 @@ MethodBuilder::lookupSymbol(const char *name)
       _symbolNameFromSlot->add(symRef->getCPIndex(), nameFromSlotID, (void *)name);
       }
    symRef->getSymbol()->setNotCollected();
+
    _symbols->add(name, symbolsID, (void *)symRef);
+
    return symRef;
    }
 

--- a/compiler/ilgen/MethodBuilder.hpp
+++ b/compiler/ilgen/MethodBuilder.hpp
@@ -35,6 +35,7 @@ class TR_HashTabString;
 class TR_BitVector;
 namespace TR { class BytecodeBuilder; }
 namespace TR { class ResolvedMethod; }
+namespace TR { class SymbolReference; }
 namespace OMR { class VirtualMachineState; }
 
 namespace OMR
@@ -51,6 +52,8 @@ class MethodBuilder : public TR::IlBuilder
    virtual void setupForBuildIL();
 
    virtual bool injectIL();
+
+   int32_t getNextValueID()                                  { return _nextValueID++; }
 
    bool usesBytecodeBuilders()                               { return _useBytecodeBuilders; }
    void setUseBytecodeBuilders()                             { _useBytecodeBuilders = true; }
@@ -84,8 +87,8 @@ class MethodBuilder : public TR::IlBuilder
       return getSignature(_numParameters, paramTypeArray);
       }
 
-   TR::IlValue *lookupSymbol(const char *name);
-   void defineSymbol(const char *name, TR::IlValue *v);
+   TR::SymbolReference *lookupSymbol(const char *name);
+   void defineSymbol(const char *name, TR::SymbolReference *v);
    bool symbolDefined(const char *name);
    bool isSymbolAnArray(const char * name);
 
@@ -180,6 +183,8 @@ class MethodBuilder : public TR::IlBuilder
    // This map should only be accessed inside a compilation via lookupSymbol
    TR_HashTabString          * _symbols;
    bool                        _newSymbolsAreTemps;
+
+   int32_t                     _nextValueID;
 
    bool                        _useBytecodeBuilders;
    uint32_t                    _numBlocksBeforeWorklist;

--- a/compiler/ilgen/VirtualMachineOperandStack.cpp
+++ b/compiler/ilgen/VirtualMachineOperandStack.cpp
@@ -118,14 +118,14 @@ VirtualMachineOperandStack::MergeInto(OMR::VirtualMachineOperandStack* other, TR
    for (int32_t i=_stackTop;i >= 0;i--)
       {
       // only need to do something if the two entries aren't already the same
-      if (other->_stack[i]->getCPIndex() != _stack[i]->getCPIndex())
+      if (other->_stack[i]->getID() != _stack[i]->getID())
          {
          // what if types don't match? could use ConvertTo, but seems...arbitrary
          // nobody *should* design bytecode set where corresponding elements of stacks from
          // two incoming control flow edges can have different primitive types. objects, sure
          // but not primitive types (even different types of objects should have same primitive
          // type: Address. Expecting to be disappointed here some day...
-         TR_ASSERT(_stack[i]->getSymbol()->getDataType() == other->_stack[i]->getSymbol()->getDataType(), "invalid stack merge: primitive type mismatch at same depth stack elements");
+         TR_ASSERT(_stack[i]->getDataType() == other->_stack[i]->getDataType(), "invalid stack merge: primitive type mismatch at same depth stack elements");
          b->StoreOver(other->_stack[i], _stack[i]);
          }
       }

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -254,6 +254,7 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
       self()->setUseSSEForSinglePrecision();
       self()->setUseSSEForDoublePrecision();
       self()->setSupportsAutoSIMD();
+      self()->setSupportsJavaFloatSemantics();
       }
 
    // Choose the best XMM double precision load instruction for the target architecture.

--- a/fvtest/compilertest/build/files/common.mk
+++ b/fvtest/compilertest/build/files/common.mk
@@ -223,6 +223,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     $(JIT_OMR_DIRTY_DIR)/env/OMRCompilerEnv.cpp \
     $(JIT_OMR_DIRTY_DIR)/env/PersistentAllocator.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/IlBuilder.cpp \
+    $(JIT_OMR_DIRTY_DIR)/ilgen/IlValue.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/IlInjector.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/MethodBuilder.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/BytecodeBuilder.cpp \

--- a/jitbuilder/build/files/common.mk
+++ b/jitbuilder/build/files/common.mk
@@ -210,6 +210,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/env/OMRIO.cpp \
     $(JIT_OMR_DIRTY_DIR)/env/OMRKnownObjectTable.cpp \
     $(JIT_OMR_DIRTY_DIR)/env/Globals.cpp \
+    $(JIT_OMR_DIRTY_DIR)/ilgen/IlValue.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/IlInjector.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/IlBuilder.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/MethodBuilder.cpp \

--- a/jitbuilder/build/rules/common.mk
+++ b/jitbuilder/build/rules/common.mk
@@ -78,6 +78,9 @@ $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/il/OMRILOpCodesEnum.hpp: $(FIXED_SRCBASE
 $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/il/ILHelpers.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/il/ILHelpers.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/il
 	cp $< $@ || cp $< $@
 
+$(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/IlValue.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/IlValue.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
+	cp $< $@ || cp $< $@
+
 $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/IlInjector.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/IlInjector.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
 	cp $< $@ || cp $< $@
 
@@ -121,6 +124,7 @@ JITBUILDER_FILES=$(RELEASE_DIR)/Makefile \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/il/ILOpCodesEnum.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/il/OMRDataTypes.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/il/OMRILOpCodesEnum.hpp \
+             $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/IlValue.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/IlInjector.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/IlBuilder.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/MethodBuilder.hpp \


### PR DESCRIPTION
enable Java "float" semantics for X86 code generator if using SSE for floats
Fix for #834 : first stage more efficient IL generation for JitBuilder
Added descriptions for fields of IlBuilder class