### PR TITLE
Check the number of pending pushes on a method

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -1759,6 +1759,8 @@ OMR::SymbolReferenceTable::findOrCreatePendingPushTemporary(
    {
 #ifdef J9_PROJECT_SPECIFIC
    TR_ASSERT(!type.isBCD() || size,"binary coded decimal types must provide a size\n");
+   TR_ASSERT_FATAL(!owningMethodSymbol->comp()->getOption(TR_EnableOSR) || (slot + TR::Symbol::convertTypeToNumberOfSlots(type) - 1) < owningMethodSymbol->getNumPPSlots(),
+      "cannot create a pending push temporary that exceeds the number of slots for this method\n");
 #endif
    TR::SymbolReference *tempSymRef = findOrCreateAutoSymbol(owningMethodSymbol, -(slot + 1), type, true, false, false, false, size);
    tempSymRef->getSymbol()->setIsPendingPush();

--- a/compiler/ilgen/ByteCodeIteratorWithState.hpp
+++ b/compiler/ilgen/ByteCodeIteratorWithState.hpp
@@ -54,6 +54,7 @@ template<typename ByteCode,
         _tryCatchInfo(comp->allocator("IlGen"))
       {
       _printByteCodes = (comp->getOutFile() != NULL && comp->getOption(TR_TraceBC) && (comp->isOutermostMethod() || comp->getOption(TR_DebugInliner) || comp->trace(OMR::inlining)));
+      _cannotAttemptOSR = comp->getOption(TR_EnableOSR) && !comp->isPeekingMethod() && methodSym->cannotAttemptOSRDuring(comp->getCurrentInlinedSiteIndex(), comp);
       }
 
    void printByteCodes()
@@ -421,6 +422,7 @@ protected:
    TR_LinkHead<IndexPair>                         _backwardBranches;
    bool                                           _inExceptionHandler;
    bool                                           _printByteCodes;
+   bool                                           _cannotAttemptOSR;
 
    flags8_t *                                     _flags;
 


### PR DESCRIPTION
Under OSR, it will not be possible to transition correctly
if we allocate more pending push slots than the VM expects. To ensure
this never occurs, the JIT will perform a fatal assertion if it
detects a requested slot beyond the limit.