### PR TITLE
Corrects heap-resize tag conflict in idle case

### DIFF
--- a/gc/base/MemoryPoolAddressOrderedListBase.cpp
+++ b/gc/base/MemoryPoolAddressOrderedListBase.cpp
@@ -176,22 +176,25 @@ MM_MemoryPoolAddressOrderedListBase::releaseFreeEntryMemoryPages(MM_EnvironmentB
 	MM_HeapLinkedFreeHeader* currentFreeEntry = freeEntry;
 	uintptr_t pageSize = env->getExtensions()->heap->getPageSize();
 	while (NULL != currentFreeEntry) {
-		uintptr_t addressBase = MM_Math::roundToCeiling(pageSize, (uintptr_t)currentFreeEntry + sizeof(MM_HeapLinkedFreeHeader));
-		/* release/decommit memory after Header */
-		uintptr_t totalFreePagesCount = (currentFreeEntry->getSize() - (addressBase - (uintptr_t)currentFreeEntry)) / pageSize;
-		if (0 < totalFreePagesCount) {
-			uintptr_t commitPagesCount = 0;
-			uintptr_t decommitPagesCount = 0;
-			if (0 < _extensions->idleMinimumFree) {
-				commitPagesCount = totalFreePagesCount * _extensions->idleMinimumFree / 100;
-			}
-			decommitPagesCount = totalFreePagesCount - commitPagesCount;
-			/* leave commited pages of memory aside header */
-			addressBase += commitPagesCount * pageSize;
-			/* now decommit pages of memory */
-			if (0 < decommitPagesCount) {
-				if (_extensions->heap->decommitMemory((void*)addressBase, decommitPagesCount * pageSize, NULL, currentFreeEntry->afterEnd())) {
-					releasedMemory += decommitPagesCount * pageSize;
+		/* skip entry less than page size */
+		if (pageSize <= currentFreeEntry->getSize()) {
+			uintptr_t addressBase = MM_Math::roundToCeiling(pageSize, (uintptr_t)currentFreeEntry + sizeof(MM_HeapLinkedFreeHeader));
+			/* release/decommit memory after Header */
+			uintptr_t totalFreePagesCount = (currentFreeEntry->getSize() - (addressBase - (uintptr_t)currentFreeEntry)) / pageSize;
+			if (0 < totalFreePagesCount) {
+				uintptr_t commitPagesCount = 0;
+				uintptr_t decommitPagesCount = 0;
+				if (0 < _extensions->idleMinimumFree) {
+					commitPagesCount = totalFreePagesCount * _extensions->idleMinimumFree / 100;
+				}
+				decommitPagesCount = totalFreePagesCount - commitPagesCount;
+				/* leave commited pages of memory aside header */
+				addressBase += commitPagesCount * pageSize;
+				/* now decommit pages of memory */
+				if (0 < decommitPagesCount) {
+					if (_extensions->heap->decommitMemory((void*)addressBase, decommitPagesCount * pageSize, NULL, currentFreeEntry->afterEnd())) {
+						releasedMemory += decommitPagesCount * pageSize;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
While calculating the no. of pages to be released from a heap free
entry, it failed to recognize the entries which are lesser than page
size.  Variables used in the calculation is of type uintptr_t, while
subtraction the negative value treated as positive value because of
unsigned.

```
MM_MemoryPoolAddressOrderedListBase::releaseFreeEntryMemoryPages(...)
{
...
uintptr_t totalFreePagesCount = (currentFreeEntry->getSize() - (addressBase - (uintptr_t)currentFreeEntry)) / pageSize;
...
}
```

Issue: #1113

Signed-off-by: Parameswaran Selvam <parselva@in.ibm.com>