### PR TITLE
Support for GRA for vector registers on x

### DIFF
--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -394,7 +394,7 @@ TR::Register *OMR::X86::TreeEvaluator::lookupEvaluator(TR::Node *node, TR::CodeG
                   depsRegisterIndex = (TR::RealRegister::RegNum) cg->getGlobalRegister(globalRegNum);
                   selectorRegInGlRegDeps = true;
                   }
-               else if (globalReg->getKind() == TR_GPR || globalReg->getKind() == TR_FPR)
+               else if (globalReg->getKind() == TR_GPR || globalReg->getKind() == TR_FPR || globalReg->getKind() == TR_VRF)
                   {
                   TR::RegisterPair *globalRegPair = globalReg->getRegisterPair();
                   TR::RealRegister::RegNum registerIndex = (TR::RealRegister::RegNum) cg->getGlobalRegister(globalRegNum);

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -297,6 +297,8 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
    self()->setLastGlobalGPR(self()->machine()->getLastGlobalGPRRegisterNumber());
    self()->setLast8BitGlobalGPR(self()->machine()->getLast8BitGlobalGPRRegisterNumber());
    self()->setLastGlobalFPR(self()->machine()->getLastGlobalFPRRegisterNumber());
+   self()->setFirstGlobalVRF(self()->getFirstGlobalFPR());
+   self()->setLastGlobalVRF(self()->getLastGlobalFPR());
 
    // Initialize Linkage for Code Generator
    self()->initializeLinkage();
@@ -350,6 +352,8 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
    self()->setLiveRegisters(new (self()->trHeapMemory()) TR_LiveRegisters(comp), TR_GPR);
    self()->addSupportedLiveRegisterKind(TR_FPR);
    self()->setLiveRegisters(new (self()->trHeapMemory()) TR_LiveRegisters(comp), TR_FPR);
+   self()->addSupportedLiveRegisterKind(TR_VRF);
+   self()->setLiveRegisters(new (self()->trHeapMemory()) TR_LiveRegisters(comp), TR_VRF);
 
    self()->setSupportsArrayCmp();
    self()->setSupportsPrimitiveArrayCopy();

--- a/compiler/x/codegen/OMRRegisterIterator.cpp
+++ b/compiler/x/codegen/OMRRegisterIterator.cpp
@@ -32,7 +32,7 @@ OMR::X86::RegisterIterator::RegisterIterator(TR::Machine *machine, TR_RegisterKi
       _firstRegIndex = TR::RealRegister::eax;
       _lastRegIndex = TR::RealRegister::LastAssignableGPR;
       }
-   else if (kind == TR_FPR)
+   else if (kind == TR_FPR || kind == TR_VRF)
       {
       _firstRegIndex = TR::RealRegister::xmm0;
       _lastRegIndex = TR::RealRegister::LastXMMR;

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -1862,7 +1862,7 @@ void TR::X86MemInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
       }
 
 #ifdef J9_PROJECT_SPECIFIC
-   if (kindsToBeAssigned & (TR_X87_Mask | TR_FPR_Mask))
+   if (kindsToBeAssigned & (TR_X87_Mask | TR_FPR_Mask | TR_VRF_Mask))
       {
       TR::UnresolvedDataSnippet *snippet = getMemoryReference()->getUnresolvedDataSnippet();
       if (snippet)
@@ -1870,7 +1870,7 @@ void TR::X86MemInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
          if (kindsToBeAssigned & TR_X87_Mask)
             snippet->setNumLiveX87Registers(cg()->machine()->fpGetNumberOfLiveFPRs());
 
-         if (kindsToBeAssigned & TR_FPR_Mask)
+         if (kindsToBeAssigned & (TR_FPR_Mask | TR_VRF_Mask))
             snippet->setHasLiveXMMRegisters((cg()->machine()->fpGetNumberOfLiveXMMRs() > 0) ? true : false);
          }
       }
@@ -2212,7 +2212,7 @@ void TR::X86MemRegInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigne
          TR::UnresolvedDataSnippet *snippet = getMemoryReference()->getUnresolvedDataSnippet();
          if (snippet)
             {
-            if (kindsToBeAssigned & TR_FPR_Mask)
+            if (kindsToBeAssigned & (TR_FPR_Mask | TR_VRF_Mask))
                snippet->setHasLiveXMMRegisters((cg()->machine()->fpGetNumberOfLiveXMMRs() > 0) ? true : false);
             }
 #endif
@@ -2420,7 +2420,7 @@ void TR::X86MemRegRegInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssi
          {
 #ifdef J9_PROJECT_SPECIFIC
          TR::UnresolvedDataSnippet *snippet = getMemoryReference()->getUnresolvedDataSnippet();
-         if (snippet && (kindsToBeAssigned & TR_FPR_Mask))
+         if (snippet && (kindsToBeAssigned & (TR_FPR_Mask | TR_VRF_Mask)))
             snippet->setHasLiveXMMRegisters((cg()->machine()->fpGetNumberOfLiveXMMRs() > 0) ? true : false);
 #endif
 
@@ -2713,7 +2713,7 @@ void TR::X86RegMemInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigne
       }
 
 #ifdef J9_PROJECT_SPECIFIC
-   if (kindsToBeAssigned & (TR_X87_Mask | TR_FPR_Mask))
+   if (kindsToBeAssigned & (TR_X87_Mask | TR_FPR_Mask | TR_VRF_Mask))
       {
       TR::UnresolvedDataSnippet *snippet = getMemoryReference()->getUnresolvedDataSnippet();
       if (snippet)
@@ -2721,7 +2721,7 @@ void TR::X86RegMemInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigne
          if (kindsToBeAssigned & TR_X87_Mask)
             snippet->setNumLiveX87Registers(cg()->machine()->fpGetNumberOfLiveFPRs());
 
-         if (kindsToBeAssigned & TR_FPR_Mask)
+         if (kindsToBeAssigned & (TR_FPR_Mask | TR_VRF_Mask))
             snippet->setHasLiveXMMRegisters((cg()->machine()->fpGetNumberOfLiveXMMRs() > 0) ? true : false);
          }
       }
@@ -3924,7 +3924,7 @@ void TR::X86FPMemRegInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssig
       }
 
 #ifdef J9_PROJECT_SPECIFIC
-   if (kindsToBeAssigned & TR_FPR_Mask)
+   if (kindsToBeAssigned & (TR_FPR_Mask | TR_VRF_Mask))
       {
       TR::UnresolvedDataSnippet *snippet = getMemoryReference()->getUnresolvedDataSnippet();
       if (snippet)
@@ -3964,7 +3964,7 @@ void TR::X86FPRegMemInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssig
       }
 
 #ifdef J9_PROJECT_SPECIFIC
-   if (kindsToBeAssigned & TR_FPR_Mask)
+   if (kindsToBeAssigned & (TR_FPR_Mask | TR_VRF_Mask))
       {
       TR::UnresolvedDataSnippet *snippet = getMemoryReference()->getUnresolvedDataSnippet();
       if (snippet)

--- a/compiler/x/codegen/X86Debug.cpp
+++ b/compiler/x/codegen/X86Debug.cpp
@@ -2004,7 +2004,7 @@ TR_Debug::getName(TR::RealRegister * reg, TR_RegisterSizes size)
          }
       }
 
-   if (reg->getKind() == TR_FPR)
+   if (reg->getKind() == TR_FPR || reg->getKind() == TR_VRF)
       size = TR_QuadWordReg;
 
    return getName(reg->getRegisterNumber(), size);


### PR DESCRIPTION
Modified initialize inside OMRCodeGenerator.cpp to indicate the first and
last real registers that can hold vector values. This information is used
by GRA to perform GRA.

GRA can lead to the creation of register dependencies so the register
dependency code inside OMRRegisterDependency.cpp was updated to handle
TR_VRF registers. This change also updates several other register related
functions to handle TR_VRF registers. In most cases, this results in
perform actions similar to the TR_FPR case but slightly modified for the
TR_VRF case.

Issue: #1126
Signed-off-by: jimmyk <jimmyk@ca.ibm.com>