### PR TITLE
Improve some compiler messages, logs, warnings

### DIFF
--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -2888,7 +2888,7 @@ OMR::CodeGenerator::simulateTreeEvaluation(TR::Node *node, TR_RegisterPressureSt
             {
             self()->getNumberOfTemporaryRegistersUsedByCall(node, state, numGPRTemporaries, numFPRTemporaries, numVRFTemporaries);
             if ((numGPRTemporaries >= 1 || numFPRTemporaries >= 1 || numVRFTemporaries >= 1)
-               && (self()->comp()->getOption(TR_TraceRegisterPressureDetails) && !performTransformation(self()->comp(), "O^O GLOBAL REGISTER ALLOCATION: Call %p has %d GPR and %d FPR and VRF % dummy registers\n", node, numGPRTemporaries, numFPRTemporaries, numVRFTemporaries)))
+               && (self()->comp()->getOption(TR_TraceRegisterPressureDetails) && !performTransformation(self()->comp(), "O^O GLOBAL REGISTER ALLOCATION: Call %p has %d GPR and %d FPR and VRF %d dummy registers\n", node, numGPRTemporaries, numFPRTemporaries, numVRFTemporaries)))
                {
                numGPRTemporaries = 0;
                numFPRTemporaries = 0;
@@ -3121,7 +3121,7 @@ OMR::CodeGenerator::simulateNodeEvaluation(TR::Node *node, TR_RegisterPressureSt
          self()->simulateMemoryReference(&memref, node->getChild(0), state, summary);
       }
 
-//   traceMsg(TR::comp(), "state->_gprPressure = %d summary->_gprPressure = %d summary->PRESSURE_LIMIT = %d\n",state->_gprPressure,summary->_gprPressure,summary->PRESSURE_LIMIT);
+   traceMsg(TR::comp(), "state->_gprPressure = %d summary->_gprPressure = %d summary->PRESSURE_LIMIT = %d\n",state->_gprPressure,summary->_gprPressure,summary->PRESSURE_LIMIT);
 
    if (summary->_gprPressure < summary->PRESSURE_LIMIT)
       TR_ASSERT(state->_gprPressure <= summary->_gprPressure, "Children of %s must record max register gprPressure in summary; %d > %d", self()->getDebug()->getName(node), state->_gprPressure, summary->_gprPressure);

--- a/compiler/env/OMRIO.hpp
+++ b/compiler/env/OMRIO.hpp
@@ -49,7 +49,7 @@ namespace OMR { typedef OMR::IO IOConnector; }
 #ifdef _MSC_VER
    #define POINTER_PRINTF_FORMAT "0x%p"
 #else
-   #ifdef LINUX
+   #if defined(LINUX) || defined(OSX)
       #ifdef TR_HOST_64BIT
          #ifdef TR_TARGET_X86
             #define POINTER_PRINTF_FORMAT "%012p"

--- a/compiler/il/NodeExtension.hpp
+++ b/compiler/il/NodeExtension.hpp
@@ -58,8 +58,7 @@ public:
     template <class T>
     T  setElem(uint16_t index, T elem)
        {
-       (T)(_data[index] = (uintptr_t)elem);
-       return (T)_data[index];
+       return (T)(_data[index] = (uintptr_t)elem);
        }
 
     template <class T>

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -171,7 +171,7 @@ OMR::Node::Node(TR::Node *originatingByteCodeNode, TR::ILOpCodes op, uint16_t nu
 
       if (_byteCodeInfo.getCallerIndex() < 0)
          _byteCodeInfo.setCallerIndex(ilGen->currentCallSiteIndex());
-      TR_ASSERT(_byteCodeInfo.getCallerIndex() < (INT_MAX/4), "Caller index too high; cannot set high order bit\n");
+      TR_ASSERT(_byteCodeInfo.getCallerIndex() < (SHRT_MAX/4), "Caller index too high; cannot set high order bit\n");
       _byteCodeInfo.setDoNotProfile(0);
       }
    else if (originatingByteCodeNode)

--- a/compiler/optimizer/GeneralLoopUnroller.cpp
+++ b/compiler/optimizer/GeneralLoopUnroller.cpp
@@ -3903,7 +3903,7 @@ TR_GeneralLoopUnroller::countNodesAndSubscripts(TR::Node *node, int32_t &numNode
          // TODO: leaf routine?
 
          // Is it always inlined BIF?
-         if (methodSym->getRecognizedMethod() != -1)
+         if (methodSym->getRecognizedMethod() != TR::unknownMethod)
             lwp._numBIFs++;
          }
       }

--- a/compiler/ras/CallStack.cpp
+++ b/compiler/ras/CallStack.cpp
@@ -30,9 +30,9 @@ void TR_CallStackIterator::printStackBacktrace(TR::Compilation *comp)
    while (!isDone())
       {
       if (comp)
-         traceMsg(comp, "%s+0x%x\n", getProcedureName(), getOffsetInProcedure());
+         traceMsg(comp, "%s+0x%lx\n", getProcedureName(), getOffsetInProcedure());
       else
-         fprintf(stderr, "%s+0x%x\n", getProcedureName(), getOffsetInProcedure());
+         fprintf(stderr, "%s+0x%lx\n", getProcedureName(), getOffsetInProcedure());
       getNext();
       }
    }

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1795,9 +1795,9 @@ TR_Debug::getAutoName(TR::SymbolReference * symRef)
       {
       char * symName = (char *)_comp->trMemory()->allocateHeapMemory(20);
       if (symRef->getSymbol()->getDataType() == TR::Float || symRef->getSymbol()->getDataType() == TR::Double)
-         sprintf(symName, "#FPSPILL%d_%d", symRef->getSymbol()->getSize(), symRef->getReferenceNumber());
+         sprintf(symName, "#FPSPILL%zu_%d", symRef->getSymbol()->getSize(), symRef->getReferenceNumber());
       else
-         sprintf(symName, "#SPILL%d_%d", symRef->getSymbol()->getSize(), symRef->getReferenceNumber());
+         sprintf(symName, "#SPILL%zu_%d", symRef->getSymbol()->getSize(), symRef->getReferenceNumber());
 
       if (_comp->getOption(TR_MaskAddresses))
          sprintf(name, "<%s *Masked*>", symName);

--- a/compiler/x/codegen/X86Ops.hpp
+++ b/compiler/x/codegen/X86Ops.hpp
@@ -354,10 +354,8 @@ class TR_X86OpCode
                return 4;
             case Immediate_8:
                return 8;
-            default:
-               TR_ASSERT(false, "IMPOSSIBLE TO REACH HERE.");
-               break;
             }
+            TR_ASSERT_FATAL(false, "IMPOSSIBLE TO REACH HERE.");
          }
       // check if the instruction can be encoded as AVX
       inline bool supportsAVX() const


### PR DESCRIPTION
Sundry small improvements to messages, log files, and compiler warnings. Only 2 could be considered functional issues: 1) an assertion testing the size of something assuming it was a 32-bit integer when it was, in fact, a 16-bit integer, and 2) a "unrecognized" method test using -1 when TR::unknownMethod exists and is zero, not -1.