### PR TITLE
Refactor x86 assembly code

### DIFF
--- a/compiler/x/amd64/runtime/AMD64AsmUtil.inc
+++ b/compiler/x/amd64/runtime/AMD64AsmUtil.inc
@@ -23,9 +23,6 @@ public compareAndExchange2
 public compareAndExchange4
 public compareAndExchange8
 public _patchingFence16
-public _patchingFence24
-public _patchingFenceCPUID
-public atomicIncrement4
 
 Align16 macro
 ; TODO:AMD64: Find a way not to get 16 bytes of padding when we are already aligned!
@@ -102,45 +99,5 @@ ENDIF
         mfence
         ret
 _patchingFence16 ENDP
-
-        Align16
-_patchingFence24 PROC
-        mfence
-IFDEF WINDOWS
-        clflush [rcx]
-        clflush [rcx+8]
-        clflush [rcx+16]
-ELSE
-        clflush [rdi]
-        clflush [rdi+8]
-        clflush [rdi+16]
-ENDIF
-        mfence
-        ret
-_patchingFence24 ENDP
-
-
-; void _patchingFenceCPUID();
-
-_patchingFenceCPUID PROC
-         pushfq
-         push       rbx
-         cpuid
-         pop        rbx
-         popfq
-         ret
-_patchingFenceCPUID ENDP
-
-; prototype: int32_t atomicIncrement4(int32_t *value)
-atomicIncrement4 PROC
-   mov   eax, [rdi]        ; load original value
-LtryNextValue:
-   mov   ecx, eax
-   add   ecx, 1
-   lock cmpxchg dword ptr [rdi], ecx
-   jnz   LtryNextValue
-   mov   eax, ecx
-   ret
-atomicIncrement4 ENDP
 
 _TEXT   ends

--- a/compiler/x/i386/runtime/IA32AsmUtil.inc
+++ b/compiler/x/i386/runtime/IA32AsmUtil.inc
@@ -1,0 +1,97 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; (c) Copyright IBM Corp. 2000, 2017
+;;
+;;  This program and the accompanying materials are made available
+;;  under the terms of the Eclipse Public License v1.0 and
+;;  Apache License v2.0 which accompanies this distribution.
+;;
+;;      The Eclipse Public License is available at
+;;      http://www.eclipse.org/legal/epl-v10.html
+;;
+;;      The Apache License v2.0 is available at
+;;      http://www.opensource.org/licenses/apache2.0.php
+;;
+;; Contributors:
+;;    Multiple authors (IBM Corp.) - initial implementation and documentation
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+   _TEXT SEGMENT PARA USE32 PUBLIC 'CODE'
+
+   public compareAndExchange1
+   public compareAndExchange2
+   public compareAndExchange4
+   public compareAndExchange8b
+   public _patchingFence16
+
+; Atomically Compare And Exchange the value contained data pointed to by ptr
+; with oldValue, and if equal, replace by newValue
+; Return zero on failure. Nonzero otherwise.
+;
+; prototype: int32_t compareAndExchange1(uint8_t *ptr, uint8_t oldValue, uint8_t newValue)
+
+compareAndExchange1 PROC NEAR
+                mov        ecx, [esp + 04h]		; fetch ptr
+        	mov        eax, [esp + 08h]		; fetch oldValue
+        	mov        edx, [esp + 0ch]		; fetch newValue
+        	lock cmpxchg byte ptr [ecx], dl
+        	jnz        LfailedCMPXCHG
+LpassedCMPXCHG:
+        	or         eax, 1		; return nozero
+        	ret
+compareAndExchange1 ENDP
+
+compareAndExchange2 PROC NEAR
+        	mov        ecx, [esp + 04h]		; fetch ptr
+        	mov        eax, [esp + 08h]		; fetch oldValue
+        	mov        edx, [esp + 0ch]		; fetch newValue
+        	lock cmpxchg word ptr [ecx], dx
+        	jnz        LfailedCMPXCHG
+        	jmp        LpassedCMPXCHG
+compareAndExchange2 ENDP
+
+compareAndExchange4 PROC NEAR
+        	mov        ecx, [esp + 04h]		; fetch ptr
+        	mov        eax, [esp + 08h]		; fetch oldValue
+        	mov        edx, [esp + 0ch]		; fetch newValue
+        	lock cmpxchg dword ptr [ecx], edx
+        	jz         LpassedCMPXCHG
+LfailedCMPXCHG:
+        	xor        eax, eax
+        	ret
+compareAndExchange4 ENDP
+
+; int32_t compareAndExchange8b(uint64_t *ptr, uint64_t oldValue, uint64_t newValue);
+
+compareAndExchange8b PROC NEAR
+        	push       ebx           		
+        	push       esi
+        	mov        esi, [esp + 0ch]		; fetch ptr
+        	mov        eax, [esp + 010h]		; fetch oldValue lo
+        	mov        edx, [esp + 014h]		; fetch oldValue hi
+        	mov        ebx, [esp + 018h]		; fetch newValue lo
+        	mov        ecx, [esp + 01ch]		; fetch newValue hi
+   ifdef WINDOWS
+        	lock cmpxchg8b qword ptr [esi]
+   else
+        	lock cmpxchg8b [esi]
+   endif
+        	pop        esi
+        	pop        ebx
+        	jz         LpassedCMPXCHG
+        	xor        eax, eax
+        	ret
+compareAndExchange8b ENDP
+
+; Execute the fence required to ensure patching operations are strongly ordered
+; so that another processor executing the same code does not see inconsistent
+; results.
+;
+; prototype: void _patchingFence16(void *startAddress)
+;
+
+        align   16
+_patchingFence16:             ; Entry point for C code
+        ret
+
+   _TEXT ends


### PR DESCRIPTION
1. Created IA32AsmUtil.inc file to hold assembly routines for x86-32 platform.
2. Removed assembly routines _patchingFence24, _patchingFenceCPUID, and atomicIncrement4 on x86 platforms since they are not used anymore.
3. Removed deprecated macros tr_mfence, tr_clflush, tr_clflush16, tr_clflush24, and clearFPStack on x86-32 platform.

Signed-off-by: Xiaoli Liang <xsliang@ca.ibm.com>