### PR TITLE
Do not decrease the ref count of compress sequence of l2aEvaluator

### DIFF
--- a/compiler/z/codegen/UnaryEvaluator.cpp
+++ b/compiler/z/codegen/UnaryEvaluator.cpp
@@ -496,11 +496,6 @@ OMR::Z::TreeEvaluator::l2aEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
    node->setRegister(source);
 
-
-   if (firstChild->containsCompressionSequence())
-      {
-      cg->decReferenceCount(firstChild->getFirstChild());
-      }
    cg->decReferenceCount(firstChild);
 
    return source;


### PR DESCRIPTION
Previously we used to evaluate the shift left child when
l2a node contains compression sequence under Concurrent
Scavenge mode. As this part of code was refactored, we
do not need to decrement reference count of the shift left
child of the tree as we don't evaluate it in this function.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>