### PR TITLE
ARM system linkage improvements

### DIFF
--- a/compiler/arm/codegen/ARMSystemLinkage.cpp
+++ b/compiler/arm/codegen/ARMSystemLinkage.cpp
@@ -36,6 +36,11 @@
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
 
+struct UnsupportedParameterType : public virtual TR::CompilationException
+   {
+   virtual const char* what() const throw() { return "Unsupported Parameter Type"; }
+   };
+
 TR::ARMLinkageProperties TR::ARMSystemLinkage::properties =
     {                           // TR_System
     IntegersInRegisters|        // linkage properties
@@ -217,122 +222,220 @@ uint32_t TR::ARMSystemLinkage::getRightToLeft()
    return getProperties().getRightToLeft();
    }
 
+static void mapSingleParameter(TR::ParameterSymbol *parameter, uint32_t &stackIndex)
+   {
+   auto size = parameter->getSize();
+   auto alignment = size <= 4 ? 4 : 8;
+   stackIndex = (stackIndex + alignment - 1)&(~(alignment - 1));
+   parameter->setParameterOffset(stackIndex);
+   stackIndex += size;
+   }
+
+/**
+ * @brief Maps symbols in the IL to locations on the stack
+ * @param method is the method for which symbols are being stack mapped
+ *
+ * In general, the shape of a stack frame is as follows:
+ *
+ * +-----------------------------+
+ * | caller frame                |
+ * +-----------------------------+
+ * | stack arguments             |
+ * +=============================+ <-+ (start of callee frame)
+ * | saved registers             |   |
+ * +-----------------------------+   | frame size
+ * | locals                      |   |
+ * +-----------------------------+ <-+- $sp
+ *
+ * A symbol is mapped onto the stack by assigning to it an offset from the stack
+ * pointer. All symbols representing stack allocated values must be mapped,
+ * including automatics (locals) on the callee frame and stack allocated
+ * arguments on the caller frame
+ *
+ * The algorithm used to map symbols iterates over each symbol in ascending
+ * address order. Using the frame shape depicted above as a general example:
+ * locals are mapped first, registers second. The algorithm is:
+ *
+ * 1. Set stackIndex to 0
+ * 2. For each symbol that must be mapped onto the **callee** stack frame,
+ *    starting at the lowest address:
+ *       a. set stackIndex as the symbol offset
+ *       b. increment stackIndex by the size of the symbol's type
+ *          plus alignment requirements
+ * 3. Increment stackIndex by the necessary amount to account for the stack
+ *    space required for saved registers
+ * 4. Save stackIndex as the size of the callee stack frame
+ * 5. For each symbol that must be mapped onto the **caller** stack frame,
+ *    starting at the lowest address:
+ *       a. set the symbol offset as the current stack index
+ *       b. increment the stack index by the size of the symbol's type,
+ *          plus alignment requirements
+ */
 void TR::ARMSystemLinkage::mapStack(TR::ResolvedMethodSymbol *method)
    {
-#if 0
-   ListIterator<TR::AutomaticSymbol>  automaticIterator(&method->getAutomaticList());
-   TR::AutomaticSymbol               *localCursor       = automaticIterator.getFirst();
-   const TR::ARMLinkageProperties&    linkage           = getProperties();
-   TR_ARMCodeGenerator              *codeGen           = cg();
-   TR_ARMMachine                    *machine           = codeGen->getARMMachine();
-   uint32_t                          stackIndex;
-   int32_t                           lowGCOffset;
-   TR::GCStackAtlas                  *atlas             = codeGen->getStackAtlas();
+   uint32_t stackIndex = 0;
+   ListIterator<TR::AutomaticSymbol> automaticIterator(&method->getAutomaticList());
+   TR::AutomaticSymbol *localCursor = automaticIterator.getFirst();
 
-   // map all garbage collected references together so can concisely represent
-   // stack maps. They must be mapped so that the GC map index in each local
-   // symbol is honoured.
+   // map non-double automatics
+   while (localCursor != NULL)
+      {
+      if (localCursor->getGCMapIndex() < 0 &&
+          localCursor->getDataType() != TR::Double)
+         {
+         localCursor->setOffset(stackIndex);
+         stackIndex += (localCursor->getSize()+3)&(~3);
+         }
+      localCursor = automaticIterator.getNext();
+      }
 
-   stackIndex = linkage.getOffsetToFirstLocal() +
-                codeGen->getLargestOutgoingArgSize();
-   lowGCOffset = stackIndex;
-   int32_t firstLocalGCIndex = atlas->getNumberOfParmSlotsMapped();
-
-   // Map local references to get the right amount of stack reserved
-   //
-   for (localCursor = automaticIterator.getFirst(); localCursor; localCursor = automaticIterator.getNext())
-      if (localCursor->getGCMapIndex() >= 0)
-         mapSingleAutomatic(localCursor,stackIndex);
-
-   // Map local references again to set the stack position correct according to
-   // the GC map index.
-   //
-   automaticIterator.reset();
-   for (localCursor = automaticIterator.getFirst(); localCursor; localCursor = automaticIterator.getNext())
-      if (localCursor->getGCMapIndex() >= 0)
-         localCursor->setOffset(stackIndex +4*(localCursor->getGCMapIndex()-firstLocalGCIndex));
-
-   method->setObjectTempSlots((lowGCOffset-stackIndex) >> 2);
-   atlas->setLocalBaseOffset(lowGCOffset);
-   lowGCOffset = stackIndex;
-
-   // Now map the rest of the locals
-   //
+   stackIndex += (stackIndex & 0x4) ? 4 : 0; // align to 8 bytes
    automaticIterator.reset();
    localCursor = automaticIterator.getFirst();
 
+   // map double automatics
    while (localCursor != NULL)
       {
-      if (localCursor->getGCMapIndex() < 0)
-         mapSingleAutomatic(localCursor, stackIndex);
+      if (localCursor->getDataType() == TR::Double)
+         {
+         localCursor->setOffset(stackIndex);
+         stackIndex += (localCursor->getSize()+7)&(~7);
+         }
       localCursor = automaticIterator.getNext();
       }
-   method->setScalarTempSlots((stackIndex-lowGCOffset) >> 2);
-
-   TR::RealRegister::RegNum regIndex = TR::RealRegister::gr13;
-   if (!method->isEHAware())
-      {
-      while (regIndex<=TR::RealRegister::LastGPR && !machine->getARMRealRegister(regIndex)->getHasBeenAssignedInMethod())
-         regIndex = (TR::RealRegister::RegNum)((uint32_t)regIndex+1);
-      }
-   stackIndex += (TR::RealRegister::LastGPR-regIndex+1)*4;
-   // Make the stack frame doubleword aligned.
-   stackIndex = ((stackIndex+7)>>3)<<3;
-
-   regIndex = TR::RealRegister::fp4;  // TODO - random fix
-   if (!method->isEHAware())
-      {
-      while (regIndex<=TR::RealRegister::LastFPR && !machine->getARMRealRegister(regIndex)->getHasBeenAssignedInMethod())
-         regIndex = (TR::RealRegister::RegNum)((uint32_t)regIndex+1);
-      }
-   stackIndex += (TR::RealRegister::LastFPR-regIndex+1)*8;
    method->setLocalMappingCursor(stackIndex);
 
+   // allocate space for preserved registers and link register (9 registers total)
+   stackIndex += 9*4;
+
+   /*
+    * Because the rest of the code generator currently expects **all** arguments
+    * to be passed on the stack, arguments passed in registers must be spilled
+    * in the callee frame. To map the arguments correctly, we use two loops. The
+    * first maps the arguments that will come in registers onto the callee stack.
+    * At the end of this loop, the `stackIndex` is the the size of the frame.
+    * The second loop then maps the remaining arguments onto the caller frame.
+    */
+
+   auto nextIntArgReg = 0;
+   auto nextFltArgReg = 0;
+
    ListIterator<TR::ParameterSymbol> parameterIterator(&method->getParameterList());
-   TR::ParameterSymbol              *parmCursor = parameterIterator.getFirst();
-   int32_t                          offsetToFirstParm = linkage.getOffsetToFirstParm();
-   if (linkage.getRightToLeft())
+   for (TR::ParameterSymbol *parameter = parameterIterator.getFirst();
+        parameter!=NULL && (nextIntArgReg < getProperties().getNumIntArgRegs() || nextFltArgReg < getProperties().getNumFloatArgRegs());
+        parameter=parameterIterator.getNext())
       {
-      while (parmCursor != NULL)
+      switch (parameter->getDataType())
          {
-         parmCursor->setParameterOffset(parmCursor->getParameterOffset() + offsetToFirstParm + stackIndex);
-         parmCursor = parameterIterator.getNext();
-         }
-      }
-   else
-      {
-      uint32_t sizeOfParameterArea = method->getNumParameterSlots() << 2;
-      while (parmCursor != NULL)
-         {
-         parmCursor->setParameterOffset(sizeOfParameterArea -
-                                        parmCursor->getParameterOffset() -
-                                        parmCursor->getSize() + stackIndex +
-                                        offsetToFirstParm);
-         parmCursor = parameterIterator.getNext();
+         case TR::Int8:
+         case TR::Int16:
+         case TR::Int32:
+         case TR::Address:
+            if (nextIntArgReg < getProperties().getNumIntArgRegs())
+               {
+               nextIntArgReg++;
+               mapSingleParameter(parameter, stackIndex);
+               }
+            else
+               {
+               nextIntArgReg = getProperties().getNumIntArgRegs() + 1;
+               }
+            break;
+         case TR::Int64:
+            nextIntArgReg += nextIntArgReg & 0x1; // round to next even number
+            if (nextIntArgReg + 1 < getProperties().getNumIntArgRegs())
+               {
+               nextIntArgReg += 2;
+               mapSingleParameter(parameter, stackIndex);
+               }
+            else
+               {
+               nextIntArgReg = getProperties().getNumIntArgRegs() + 1;
+               }
+            break;
+         case TR::Float:
+            comp()->failCompilation<UnsupportedParameterType>("Compiling methods with a single precision floating point parameter is not supported");
+            break;
+         case TR::Double:
+            if (nextFltArgReg < getProperties().getNumFloatArgRegs())
+               {
+               nextFltArgReg += 1;
+               mapSingleParameter(parameter, stackIndex);
+               }
+            else
+               {
+               nextFltArgReg = getProperties().getNumFloatArgRegs() + 1;
+               }
+            break;
+         case TR::Aggregate:
+            TR_ASSERT(false, "Function parameters of aggregate types are not currently supported on ARM.");
          }
       }
 
-   atlas->setParmBaseOffset(atlas->getParmBaseOffset() + offsetToFirstParm + stackIndex);
-#else
-   TR_ASSERT(0, "unimplemented");
-#endif
+   // save the stack frame size, aligned to 8 bytes
+   stackIndex = (stackIndex + 7)&(~7);
+   cg()->setFrameSizeInBytes(stackIndex);
+
+   nextIntArgReg = 0;
+   nextFltArgReg = 0;
+   parameterIterator.reset();
+
+   for (TR::ParameterSymbol *parameter = parameterIterator.getFirst();
+        parameter!=NULL && (nextIntArgReg < getProperties().getNumIntArgRegs() || nextFltArgReg < getProperties().getNumFloatArgRegs());
+        parameter=parameterIterator.getNext())
+      {
+      switch (parameter->getDataType())
+         {
+         case TR::Int8:
+         case TR::Int16:
+         case TR::Int32:
+         case TR::Address:
+            if (nextIntArgReg < getProperties().getNumIntArgRegs())
+               {
+               nextIntArgReg++;
+               }
+            else
+               {
+               mapSingleParameter(parameter, stackIndex);
+               }
+            break;
+         case TR::Int64:
+            nextIntArgReg += stackIndex & 0x1; // round to next even number
+            if (nextIntArgReg + 1 < getProperties().getNumIntArgRegs())
+               {
+               nextIntArgReg += 2;
+               }
+            else
+               {
+               mapSingleParameter(parameter, stackIndex);
+               }
+            break;
+         case TR::Float:
+            comp()->failCompilation<UnsupportedParameterType>("Compiling methods with a single precision floating point parameter is not supported");
+            break;
+         case TR::Double:
+            if (nextFltArgReg < getProperties().getNumFloatArgRegs())
+               {
+               nextFltArgReg += 1;
+               }
+            else
+               {
+               mapSingleParameter(parameter, stackIndex);
+               }
+            break;
+         case TR::Aggregate:
+            TR_ASSERT(false, "Function parameters of aggregate types are not currently supported on ARM.");
+         }
+      }
    }
 
 void TR::ARMSystemLinkage::mapSingleAutomatic(TR::AutomaticSymbol *p, uint32_t &stackIndex)
    {
-#if 0
-   p->setOffset(stackIndex);
-   if (p->getSize() <= 4)
-      {
-      stackIndex += 4;
-      }
-   else
-      {
-      stackIndex += 8;
-      }
-#else
-   TR_ASSERT(0, "unimplemented");
-#endif
+   int32_t roundedSize = (p->getSize()+3)&(~3);
+   if (roundedSize == 0)
+      roundedSize = 4;
+
+   p->setOffset(stackIndex -= roundedSize);
    }
 
 TR::ARMLinkageProperties& TR::ARMSystemLinkage::getProperties()

--- a/compiler/arm/codegen/ARMSystemLinkage.cpp
+++ b/compiler/arm/codegen/ARMSystemLinkage.cpp
@@ -167,33 +167,49 @@ TR::ARMLinkageProperties TR::ARMSystemLinkage::properties =
 
 void TR::ARMSystemLinkage::initARMRealRegisterLinkage()
    {
-#if 0
-   // Each real register's weight is set to match this linkage convention
-   TR_ARMMachine *machine = cg()->getARMMachine();
-   int icount;
+   TR::Machine *machine = cg()->machine();
 
-   icount = TR::RealRegister::gr1;
-   machine->getARMRealRegister((TR::RealRegister::RegNum)icount)->setState(TR::RealRegister::Locked);
-   machine->getARMRealRegister((TR::RealRegister::RegNum)icount)->setAssignedRegister(machine->getARMRealRegister((TR::RealRegister::RegNum)icount));
+   // make r15 (PC) unavailable for RA
+   TR::RealRegister *reg = machine->getARMRealRegister(TR::RealRegister::gr15);
+   reg->setState(TR::RealRegister::Locked);
+   reg->setAssignedRegister(reg);
 
-   icount = TR::RealRegister::gr2;
-   machine->getARMRealRegister((TR::RealRegister::RegNum)icount)->setState(TR::RealRegister::Locked);
-   machine->getARMRealRegister((TR::RealRegister::RegNum)icount)->setAssignedRegister(machine->getARMRealRegister((TR::RealRegister::RegNum)icount));
+   // make r14 (LR) unavailable for RA
+   reg = machine->getARMRealRegister(TR::RealRegister::gr14);
+   reg->setState(TR::RealRegister::Locked);
+   reg->setAssignedRegister(reg);
 
-   for (icount=TR::RealRegister::gr3; icount<=TR::RealRegister::gr12; icount++)
-      machine->getARMRealRegister((TR::RealRegister::RegNum)icount)->setWeight(icount);
+   // make r13 (SP) unavailable for RA
+   reg = machine->getARMRealRegister(TR::RealRegister::gr13);
+   reg->setState(TR::RealRegister::Locked);
+   reg->setAssignedRegister(reg);
 
-   for (icount=TR::RealRegister::LastGPR; icount>=TR::RealRegister::gr13; icount--)
-      machine->getARMRealRegister((TR::RealRegister::RegNum)icount)->setWeight(0xf000-icount);
+   // make r12 (IP) unavailable for RA
+   reg = machine->getARMRealRegister(TR::RealRegister::gr12);
+   reg->setState(TR::RealRegister::Locked);
+   reg->setAssignedRegister(reg);
 
-   for (icount=TR::RealRegister::FirstFPR;        icount<=TR::RealRegister::fp3; icount++)
-      machine->getARMRealRegister((TR::RealRegister::RegNum)icount)->setWeight(icount);
+   // make r9 unavailable for RA (just in case, because it's meaning is platform defined)
+   reg = machine->getARMRealRegister(TR::RealRegister::gr9);
+   reg->setState(TR::RealRegister::Locked);
+   reg->setAssignedRegister(reg);
 
-   for (icount=TR::RealRegister::LastFPR; icount>=TR::RealRegister::fp4; icount--)
-      machine->getARMRealRegister((TR::RealRegister::RegNum)icount)->setWeight(0xf000-icount);
-#else
-   TR_ASSERT(0, "unimplemented");
-#endif
+   /*
+    * Note: we can assign the same weight to all registers because loads/stores
+    * can be done on multiple registers simultaneously.
+    */
+
+   // assign "maximum" weight to registers r0-r8
+   for (int32_t r = TR::RealRegister::gr0; r <= TR::RealRegister::gr8; ++r)
+      {
+      machine->getARMRealRegister(static_cast<TR::RealRegister::RegNum>(r))->setWeight(0xf000);
+      }
+
+   // assign "maximum" weight to registers r10-r12
+   for (int32_t r = TR::RealRegister::gr10; r <= TR::RealRegister::gr12; ++r)
+      {
+      machine->getARMRealRegister(static_cast<TR::RealRegister::RegNum>(r))->setWeight(0xf000);
+      }
    }
 
 uint32_t TR::ARMSystemLinkage::getRightToLeft()

--- a/compiler/arm/codegen/BinaryEvaluator.cpp
+++ b/compiler/arm/codegen/BinaryEvaluator.cpp
@@ -1307,6 +1307,13 @@ static inline TR::Register *ibooleanTypeEvaluator(TR::Node *node,
    TR::Node     *secondChild    = node->getSecondChild();
    TR::Node     *firstChild     = node->getFirstChild();
 
+   auto comp = TR::comp();
+
+   if (comp->getOption(TR_TraceCG))
+      {
+      traceMsg(comp, "In ibooleanTypeEvaluator for n%dn (%p)\n", node->getGlobalIndex(), node);
+      }
+
    uint32_t base, rotate;
 
   if (secondChild->getOpCodeValue() == TR::iconst &&

--- a/compiler/arm/codegen/Instruction.hpp
+++ b/compiler/arm/codegen/Instruction.hpp
@@ -74,6 +74,7 @@ class OMR_EXTENSIBLE Instruction : public OMR::InstructionConnector
 
 }
 
+#include "codegen/OMRInstruction_inlines.hpp"
 
 //TODO: these downcasts everywhere need to be removed
 inline uint32_t        * toARMCursor(uint8_t *i) { return (uint32_t *)i; }

--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -619,7 +619,7 @@ int32_t OMR::ARM::CodeGenerator::setEstimatedLocationsForDataSnippetLabels(int32
    return estimatedSnippetStart+_constantData->getLength();
    }
 
-#if DEBUG
+#ifdef DEBUG
 void OMR::ARM::CodeGenerator::dumpDataSnippets(TR::FILE *outFile)
    {
    if (outFile == NULL)

--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -450,58 +450,10 @@ void OMR::ARM::CodeGenerator::doBinaryEncoding()
    {
    TR::Compilation *comp = TR::comp();
    int32_t estimate = 0;
-   TR::Recompilation *recomp = comp->getRecompilationInfo();
-   TR::Instruction *tempInstruction;
    TR::Instruction *cursorInstruction = comp->getFirstInstruction();
-   TR::Instruction *i2jEntryInstruction;
-   TR::Instruction *j2jEntryInstruction;
-   TR::ResolvedMethodSymbol *methodSymbol  = comp->getMethodSymbol();
-   bool  isPrivateLinkage = (methodSymbol->getLinkageConvention() == TR_Private);
 
-   if (methodSymbol->isJNI())
-      {
-      // leave space for the JNI target address
-      cursorInstruction = cursorInstruction->getNext();
-      }
+   self()->getLinkage()->createPrologue(cursorInstruction);
 
-   if (isPrivateLinkage)
-      {
-      j2jEntryInstruction = cursorInstruction->getNext();
-      self()->getLinkage()->loadUpArguments(cursorInstruction);
-      i2jEntryInstruction = cursorInstruction->getNext();
-      }
-   else
-      {
-      i2jEntryInstruction = j2jEntryInstruction = cursorInstruction;
-
-      // TODO: Probably bogus; what does loadUpArguments do when cursorInstruction == NULL?
-      cursorInstruction = NULL;
-      self()->getLinkage()->loadUpArguments(cursorInstruction);
-      }
-
-#ifdef J9_PROJECT_SPECIFIC
-   if (recomp != NULL)
-      {
-      recomp->generatePrePrologue();
-      }
-#endif
-   cursorInstruction = comp->getFirstInstruction();
-
-   while (cursorInstruction && cursorInstruction->getOpCodeValue() != ARMOp_proc)
-      {
-      estimate          = cursorInstruction->estimateBinaryLength(estimate);
-      cursorInstruction = cursorInstruction->getNext();
-      }
-   tempInstruction = cursorInstruction;
-
-#ifdef J9_PROJECT_SPECIFIC
-   if ((recomp != NULL) && (!recomp->useSampling()))
-      {
-      tempInstruction = recomp->generatePrologue(tempInstruction);
-      }
-#endif
-
-   self()->getLinkage()->createPrologue(tempInstruction);
    bool skipOneReturn = false;
    while (cursorInstruction)
       {
@@ -522,7 +474,9 @@ void OMR::ARM::CodeGenerator::doBinaryEncoding()
       estimate          = cursorInstruction->estimateBinaryLength(estimate);
       cursorInstruction = cursorInstruction->getNext();
       }
+
    estimate = self()->setEstimatedLocationsForSnippetLabels(estimate);
+
    if (estimate > 32768)
       {
       estimate = identifyFarConditionalBranches(estimate, self());
@@ -537,70 +491,12 @@ void OMR::ARM::CodeGenerator::doBinaryEncoding()
 
    self()->setBinaryBufferStart(temp);
    self()->setBinaryBufferCursor(temp);
+   self()->alignBinaryBufferCursor();
 
    while (cursorInstruction)
       {
-#ifdef DEBUG
-      uint32_t estLen = cursorInstruction->estimateBinaryLength((int32_t)0);
-#endif
       self()->setBinaryBufferCursor(cursorInstruction->generateBinaryEncoding());
-      self()->addToAtlas(cursorInstruction);
-      if (cursorInstruction->getNext() == i2jEntryInstruction)
-         {
-         self()->setPrePrologueSize(self()->getBinaryBufferCursor() - self()->getBinaryBufferStart());
-         comp->getSymRefTab()->findOrCreateStartPCSymbolRef()->getSymbol()->getStaticSymbol()->setStaticAddress(self()->getBinaryBufferCursor());
-         }
-#ifdef DEBUG
-      uint32_t binLen;
-      binLen = cursorInstruction->getBinaryLength();
-      if(binLen > estLen)
-         {
-         TR_ASSERT(0, "bin length estimated too small");
-         }
-#endif
-
       cursorInstruction = cursorInstruction->getNext();
-      if (isPrivateLinkage && cursorInstruction == j2jEntryInstruction)
-         {
-         uint32_t magicWord = ((self()->getBinaryBufferCursor()-self()->getCodeStart())<<16) | static_cast<uint32_t>(comp->getReturnInfo());
-         TR_ASSERT(_returnTypeInfoInstruction && _returnTypeInfoInstruction->getOpCodeValue() == ARMOp_dd, "assertion failure");
-         ((TR::ARMImmInstruction *)_returnTypeInfoInstruction)->setSourceImmediate(magicWord);
-         *(uint32_t *)(_returnTypeInfoInstruction->getBinaryEncoding()) = magicWord;
-
-#ifdef J9_PROJECT_SPECIFIC
-         if (recomp != NULL && recomp->couldBeCompiledAgain())
-            {
-            TR_LinkageInfo *lkInfo = TR_LinkageInfo::get(self()->getCodeStart());
-            if (recomp->useSampling())
-               lkInfo->setSamplingMethodBody();
-            else
-               lkInfo->setCountingMethodBody();
-            }
-#endif
-         }
-      }
-   // Create exception table entries for outlined instructions.
-   //
-   if (!comp->getOption(TR_DisableOOL))
-      {
-      ListIterator<TR_ARMOutOfLineCodeSection> oiIterator(&self()->getARMOutOfLineCodeSectionList());
-      TR_ARMOutOfLineCodeSection *oiCursor = oiIterator.getFirst();
-
-      while (oiCursor)
-         {
-         uint32_t startOffset = oiCursor->getFirstInstruction()->getBinaryEncoding() - self()->getCodeStart();
-         uint32_t endOffset   = oiCursor->getAppendInstruction()->getBinaryEncoding() - self()->getCodeStart();
-
-         TR::Block * block = oiCursor->getBlock();
-         bool needsETE = oiCursor->getFirstInstruction()->getNode()->getOpCode().hasSymbolReference() &&
-                         oiCursor->getFirstInstruction()->getNode()->getSymbolReference() &&
-                         oiCursor->getFirstInstruction()->getNode()->getSymbolReference()->canCauseGC();
-
-         if (needsETE && block && !block->getExceptionSuccessors().empty())
-            block->addExceptionRangeForSnippet(startOffset, endOffset);
-
-         oiCursor = oiIterator.getNext();
-         }
       }
    }
 

--- a/compiler/arm/codegen/OMRCodeGenerator.hpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.hpp
@@ -232,13 +232,16 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    uint32_t                         _numFPR;
    TR::RealRegister            *_frameRegister;
    TR::RealRegister            *_methodMetaDataRegister;
-   TR::ARMImmInstruction          *_returnTypeInfoInstruction;
    TR::ARMConstantDataSnippet       *_constantData;
    TR::ARMLinkageProperties   *_linkageProperties;
    List<TR_ARMOutOfLineCodeSection> _outOfLineCodeSectionList;
    // Internal Control Flow Depth Counters
    int32_t                          _internalControlFlowNestingDepth;
    int32_t                          _internalControlFlowSafeNestingDepth;
+
+   protected:
+
+   TR::ARMImmInstruction          *_returnTypeInfoInstruction;
 
    };
 

--- a/compiler/arm/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.cpp
@@ -93,6 +93,17 @@ TR::Instruction *armLoadConstant(TR::Node *node, int32_t value, TR::Register *tr
      uint32_t notBase     = notBits>>notTrailing;
      TR::Compilation *comp = TR::comp();
 
+     if (comp->getOption(TR_TraceCG))
+        {
+        traceMsg(comp, "In armLoadConstant with\n");
+        traceMsg(comp, "\tvalue = %d\n", value);
+        traceMsg(comp, "\tnotBits = %d\n", notBits);
+        traceMsg(comp, "\tbitTrailing = %d\n", bitTrailing);
+        traceMsg(comp, "\tnotTrailing = %d\n", notTrailing);
+        traceMsg(comp, "\tbase = %d\n", base);
+        traceMsg(comp, "\tnotBase = %d\n", notBase);
+        }
+
      TR::Instruction *insertingInstructions = cursor;
      if (cursor == NULL)
         cursor = comp->getAppendInstruction();

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -194,7 +194,12 @@ OMR::CodeGenPhase::performProcessRelocationsPhase(TR::CodeGenerator * cg, TR::Co
         comp->getMethodSymbol()->setMethodAddress(cg->getBinaryBufferStart());
         }
 
-     TR_ASSERT(cg->getWarmCodeLength() <= cg->getEstimatedWarmLength() && cg->getColdCodeLength() <= cg->getEstimatedColdLength(), "Method length estimate must be conservatively large");
+     TR_ASSERT(cg->getWarmCodeLength() <= cg->getEstimatedWarmLength() && cg->getColdCodeLength() <= cg->getEstimatedColdLength(),
+               "Method length estimate must be conservatively large\n"
+               "    warmCodeLength = %d, estimatedWarmLength = %d \n"
+               "    coldCodeLength = %d, estimatedColdLength = %d",
+               cg->getWarmCodeLength(), cg->getEstimatedWarmLength(),
+               cg->getColdCodeLength(),cg->getEstimatedColdLength());
 
      // also trace the interal stack atlas
      cg->getStackAtlas()->close(cg);

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -659,7 +659,7 @@ OMR::CodeGenerator::doInstructionSelection()
 
    // Set default value for pre-prologue size
    //
-   self()->setPrePrologueSize(4);
+   self()->setPrePrologueSize(0);
 
    if (comp->getOption(TR_TraceCG))
       {

--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -863,7 +863,16 @@ TR::IlValue *
 IlBuilder::StructFieldInstanceAddress(const char* structName, const char* fieldName, TR::IlValue* obj) {
    auto offset = typeDictionary()->OffsetOf(structName, fieldName);
    auto ptype = typeDictionary()->PointerTo(typeDictionary()->GetFieldType(structName, fieldName));
-   auto addr = Add(obj, ConstInt64(offset));
+   TR::IlValue* offsetValue = NULL;
+   if (TR::Compiler->target.is64Bit())
+      {
+      offsetValue = ConstInt64(offset);
+      }
+   else
+      {
+      offsetValue = ConstInt32(offset);
+      }
+   auto addr = Add(obj, offsetValue);
    return ConvertTo(ptype, addr);
 }
 

--- a/fvtest/jitbuildertest/Makefile
+++ b/fvtest/jitbuildertest/Makefile
@@ -29,6 +29,7 @@ OBJECTS := \
 	FieldAddressTest \
 	AnonymousTest \
 	ControlFlowTest \
+	SystemLinkageTest \
 	WorklistTest
 
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
@@ -46,6 +47,8 @@ MODULE_STATIC_LIBS += \
 
 MODULE_LIBPATH += \
   $(top_srcdir)/jitbuilder/release
+
+MODULE_CXXFLAGS += "-Wno-unused-variable"
 
 ifeq (linux,$(OMR_HOST_OS))
   MODULE_SHARED_LIBS += rt pthread

--- a/fvtest/jitbuildertest/SystemLinkageTest.cpp
+++ b/fvtest/jitbuildertest/SystemLinkageTest.cpp
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#include "JBTestUtil.hpp"
+
+#include <cmath>
+
+typedef int64_t (FooFunction)(int64_t, double, int32_t, double,
+                              int64_t, double, int32_t, double);
+
+DEFINE_BUILDER( FooBuilder,
+                Int64,
+                PARAM("arg0_int64", Int64),
+                PARAM("arg1_double", Double),
+                PARAM("arg2_int32", Int32 ),
+                PARAM("arg3_double", Double),
+                PARAM("arg4_int64", Int64),
+                PARAM("arg5_double", Double),
+                PARAM("arg6_int32", Int32),
+                PARAM("arg7_double", Double))
+   {
+   auto comp0 = EqualTo(Load("arg0_int64"), Load("arg4_int64"));
+   auto comp1 = EqualTo(Load("arg1_double"), Load("arg5_double"));
+   auto comp2 = EqualTo(Load("arg2_int32"), Load("arg6_int32"));
+   auto comp3 = EqualTo(Load("arg3_double"), Load("arg7_double"));
+   auto comp4 = And(comp0,
+                    And(comp1,
+                        And(comp2,comp3)));
+   Return(comp4);
+
+   return true;
+   }
+
+class SystemLinkageTest : public JitBuilderTest {};
+
+TEST_F(SystemLinkageTest, FooTest)
+   {
+   FooFunction *foo;
+   ASSERT_COMPILE(TR::TypeDictionary, FooBuilder, foo);
+
+   ASSERT_TRUE(foo(200, 3.14159, -10, 6.67300 * pow(10, -11),
+                   200, 3.14159, -10, 6.67300 * pow(10, -11)));
+   }

--- a/jitbuilder/release/Makefile
+++ b/jitbuilder/release/Makefile
@@ -18,6 +18,7 @@
 
 # Sample makefile using g++ may need additional compile options to work in any particular environment
 
+CXX?=g++
 CXXFLAGS=-g -std=c++0x -O2 -c -fno-rtti -fPIC -I./include/compiler -I./include
 
 .SUFFIXES: .cpp .o
@@ -104,194 +105,194 @@ testexperimental: experimental_goal all
 # Rules for individual examples
 
 atomicoperations : libjitbuilder.a AtomicOperations.o
-	g++ -g -fno-rtti -o $@ AtomicOperations.o -L. -ljitbuilder -ldl
+	$(CXX) -g -fno-rtti -o $@ AtomicOperations.o -L. -ljitbuilder -ldl
 
 AtomicOperations.o: src/AtomicOperations.cpp src/AtomicOperations.hpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 badtoiltype : libjitbuilder.a BadToIlType.o
-	g++ -g -fno-rtti -o $@ BadToIlType.o -L. -ljitbuilder -ldl
+	$(CXX) -g -fno-rtti -o $@ BadToIlType.o -L. -ljitbuilder -ldl
 
 BadToIlType.o: src/ToIlType.cpp
-	g++ -o $@ -DEXPECTED_FAIL $(CXXFLAGS) $<
+	$(CXX) -o $@ -DEXPECTED_FAIL $(CXXFLAGS) $<
 
 
 call : libjitbuilder.a Call.o
-	g++ -g -fno-rtti -o $@ Call.o -L. -ljitbuilder -ldl
+	$(CXX) -g -fno-rtti -o $@ Call.o -L. -ljitbuilder -ldl
 
 Call.o: src/Call.cpp src/Call.hpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 
 conditionals : libjitbuilder.a Conditionals.o	
-	g++ -g -fno-rtti -o $@ Conditionals.o -L. -ljitbuilder -ldl
+	$(CXX) -g -fno-rtti -o $@ Conditionals.o -L. -ljitbuilder -ldl
 
 Conditionals.o: src/Conditionals.cpp src/Conditionals.hpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 
 conststring : libjitbuilder.a ConstString.o	
-	g++ -g -fno-rtti -o $@ ConstString.o -L. -ljitbuilder -ldl
+	$(CXX) -g -fno-rtti -o $@ ConstString.o -L. -ljitbuilder -ldl
 
 ConstString.o: src/ConstString.cpp src/ConstString.hpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 
 dotproduct : libjitbuilder.a DotProduct.o
-	g++ -g -fno-rtti -o $@ DotProduct.o -L. -ljitbuilder -ldl
+	$(CXX) -g -fno-rtti -o $@ DotProduct.o -L. -ljitbuilder -ldl
 
 DotProduct.o: src/DotProduct.cpp src/DotProduct.hpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 
 fieldaddress : libjitbuilder.a FieldAddress.o
-	g++ -g -fno-rtti -o $@ FieldAddress.o -L. -ljitbuilder -ldl
+	$(CXX) -g -fno-rtti -o $@ FieldAddress.o -L. -ljitbuilder -ldl
 
 FieldAddress.o: src/FieldAddress.cpp src/FieldAddress.hpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 
 issupportedtype : libjitbuilder.a IsSupportedType.o
-	g++ -g -fno-rtti -o $@ IsSupportedType.o -L. -ljitbuilder -ldl
+	$(CXX) -g -fno-rtti -o $@ IsSupportedType.o -L. -ljitbuilder -ldl
 
 IsSupportedType.o: src/IsSupportedType.cpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 
 iterfib : libjitbuilder.a IterativeFib.o
-	g++ -g -fno-rtti -o $@ IterativeFib.o -L. -ljitbuilder -ldl
+	$(CXX) -g -fno-rtti -o $@ IterativeFib.o -L. -ljitbuilder -ldl
 
 IterativeFib.o: src/IterativeFib.cpp src/IterativeFib.hpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 
 linkedlist : libjitbuilder.a LinkedList.o
-	g++ -g -fno-rtti -o $@ LinkedList.o -L. -ljitbuilder -ldl
+	$(CXX) -g -fno-rtti -o $@ LinkedList.o -L. -ljitbuilder -ldl
 
 LinkedList.o: src/LinkedList.cpp src/LinkedList.hpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 
 localarray : libjitbuilder.a LocalArray.o
-	g++ -g -fno-rtti -o $@ LocalArray.o -L. -ljitbuilder -ldl
+	$(CXX) -g -fno-rtti -o $@ LocalArray.o -L. -ljitbuilder -ldl
 
 LocalArray.o: src/LocalArray.cpp src/LocalArray.hpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 
 mandelbrot : libjitbuilder.a Mandelbrot.o
-	g++ -g -fno-rtti -o $@ Mandelbrot.o -L. -ljitbuilder -ldl
+	$(CXX) -g -fno-rtti -o $@ Mandelbrot.o -L. -ljitbuilder -ldl
 
 Mandelbrot.o: src/Mandelbrot.cpp src/Mandelbrot.hpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 
 matmult : libjitbuilder.a MatMult.o
-	g++ -g -fno-rtti -o $@ MatMult.o -L. -ljitbuilder -ldl
+	$(CXX) -g -fno-rtti -o $@ MatMult.o -L. -ljitbuilder -ldl
 
 MatMult.o: src/MatMult.cpp src/MatMult.hpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 
 nestedloop : libjitbuilder.a NestedLoop.o
-	g++ -g -fno-rtti -o $@ NestedLoop.o -L. -ljitbuilder -ldl
+	$(CXX) -g -fno-rtti -o $@ NestedLoop.o -L. -ljitbuilder -ldl
 
 NestedLoop.o: src/NestedLoop.cpp src/NestedLoop.hpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 
 operandstacktests : libjitbuilder.a OperandStackTests.o
-	g++ -g -fno-rtti -o $@ OperandStackTests.o -L. -ljitbuilder -ldl
+	$(CXX) -g -fno-rtti -o $@ OperandStackTests.o -L. -ljitbuilder -ldl
 
 OperandStackTests.o: src/OperandStackTests.cpp src/OperandStackTests.hpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 
 pointer : libjitbuilder.a Pointer.o
-	g++ -g -fno-rtti -o $@ Pointer.o -L. -ljitbuilder -ldl
+	$(CXX) -g -fno-rtti -o $@ Pointer.o -L. -ljitbuilder -ldl
 
 Pointer.o: src/Pointer.cpp src/Pointer.hpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 
 pow2 : libjitbuilder.a Pow2.o
-	g++ -g -fno-rtti -o $@ Pow2.o -L. -ljitbuilder -ldl
+	$(CXX) -g -fno-rtti -o $@ Pow2.o -L. -ljitbuilder -ldl
 
 Pow2.o: src/Pow2.cpp src/Pow2.hpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 
 recfib : libjitbuilder.a RecursiveFib.o
-	g++ -g -fno-rtti -o $@ RecursiveFib.o -L. -ljitbuilder -ldl
+	$(CXX) -g -fno-rtti -o $@ RecursiveFib.o -L. -ljitbuilder -ldl
 
 RecursiveFib.o: src/RecursiveFib.cpp src/RecursiveFib.hpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 
 replay: libjitbuilder.a ReplayMethod.o ReplayMethodConstructor.o ReplayMethodBuildIL.o
-	g++ -g -fno-rtti -o $@ ReplayMethod.o ReplayMethodConstructor.o ReplayMethodBuilderIL.o -L. -ljitbuilder -ldl
+	$(CXX) -g -fno-rtti -o $@ ReplayMethod.o ReplayMethodConstructor.o ReplayMethodBuilderIL.o -L. -ljitbuilder -ldl
 
 ReplayMethod.o: ReplayMethod.cpp ReplayMethod.hpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 ReplayMethodConstructor.o: ReplayMethodConstructor.cpp ReplayMethod.hpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 ReplayMethodBuildIL.o: ReplayMethodBuildIL.cpp ReplayMethod.hpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 
 simple : libjitbuilder.a Simple.o
-	g++ -g -fno-rtti -o $@ Simple.o -L. -ljitbuilder -ldl
+	$(CXX) -g -fno-rtti -o $@ Simple.o -L. -ljitbuilder -ldl
 
 Simple.o: src/Simple.cpp src/Simple.hpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 
 structarray : libjitbuilder.a StructArray.o
-	g++ -g -fno-rtti -o $@ StructArray.o -L. -ljitbuilder -ldl
+	$(CXX) -g -fno-rtti -o $@ StructArray.o -L. -ljitbuilder -ldl
 
 StructArray.o: src/StructArray.cpp src/StructArray.hpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 
 switch : libjitbuilder.a Switch.o
-	g++ -g -fno-rtti -o $@ Switch.o -L. -ljitbuilder -ldl
+	$(CXX) -g -fno-rtti -o $@ Switch.o -L. -ljitbuilder -ldl
 
 Switch.o: src/Switch.cpp src/Switch.hpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 
 toiltype : libjitbuilder.a ToIlType.o
-	g++ -g -fno-rtti -o $@ ToIlType.o -L. -ljitbuilder -ldl
+	$(CXX) -g -fno-rtti -o $@ ToIlType.o -L. -ljitbuilder -ldl
 
 ToIlType.o: src/ToIlType.cpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 transactionaloperations : libjitbuilder.a TransactionalOperations.o
-	g++ -g -fno-rtti -o $@ TransactionalOperations.o -L. -ljitbuilder -ldl
+	$(CXX) -g -fno-rtti -o $@ TransactionalOperations.o -L. -ljitbuilder -ldl
 
 TransactionalOperations.o: src/TransactionalOperations.cpp src/TransactionalOperations.hpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 union : libjitbuilder.a Union.o
-	g++ -g -fno-rtti -o $@ Union.o -L. -ljitbuilder -ldl
+	$(CXX) -g -fno-rtti -o $@ Union.o -L. -ljitbuilder -ldl
 
 Union.o: src/Union.cpp src/Union.hpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 worklist : libjitbuilder.a Worklist.o
-	g++ -g -fno-rtti -o $@ Worklist.o -L. -ljitbuilder -ldl
+	$(CXX) -g -fno-rtti -o $@ Worklist.o -L. -ljitbuilder -ldl
 
 Worklist.o: src/Worklist.cpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 
 thunks : libjitbuilder.a Thunk.o
-	g++ -g -fno-rtti -o $@ Thunk.o -L. -ljitbuilder -ldl
+	$(CXX) -g -fno-rtti -o $@ Thunk.o -L. -ljitbuilder -ldl
 
 Thunk.o: src/Thunk.cpp
-	g++ -o $@ $(CXXFLAGS) $<
+	$(CXX) -o $@ $(CXXFLAGS) $<
 
 
 clean:


### PR DESCRIPTION
This series of commits improve/fix the ARM code generator in the OMR compiler. The main goal of this change is to complete the system linkage implementation. System linkage is the part of the code generator responsible for generating the instruction sequences at function call boundaries to satisfy the platform ABI.

These commits can be roughly grouped into 3 sections:

1. The first 6 commits do some necessary clean up to enable the other commits.
2. The next 4 commits constitute the main changes. These generalize parts of the ARM binary encoding and add missing functionality to the system linkage implementation.
3. The last 2 commits add a test case for the ARM system linkage and some trace in the code generator that was useful when debugging the previous changes. The test case is intended to exercises some edge cases in the system linkage implementation.

I am marking as WIP so that the changes can be reviewed while I run some more tests.

Issue #793