### PR TITLE
Add int overload for DefineLine

### DIFF
--- a/compiler/ilgen/MethodBuilder.cpp
+++ b/compiler/ilgen/MethodBuilder.cpp
@@ -86,7 +86,6 @@ MethodBuilder::MethodBuilder(TR::TypeDictionary *types, OMR::VirtualMachineState
    _cachedParameterTypes(0),
    _cachedSignature(0),
    _definingFile(""),
-   _definingLine(""),
    _symbols(0),
    _newSymbolsAreTemps(false),
    _useBytecodeBuilders(false),
@@ -97,6 +96,9 @@ MethodBuilder::MethodBuilder(TR::TypeDictionary *types, OMR::VirtualMachineState
    _bytecodeWorklist(NULL),
    _bytecodeHasBeenInWorklist(NULL)
    {
+
+   _definingLine[0] = '\0';
+
    REPLAY({
       std::fstream rpHpp("ReplayMethod.hpp",std::fstream::out);
       rpHpp << "#include \"ilgen/MethodBuilder.hpp\"" << std::endl;

--- a/compiler/ilgen/MethodBuilder.hpp
+++ b/compiler/ilgen/MethodBuilder.hpp
@@ -100,9 +100,14 @@ class MethodBuilder : public TR::IlBuilder
    void AppendBuilder(TR::IlBuilder *b)    { this->OMR::IlBuilder::AppendBuilder(b); }
 
    void DefineFile(const char *file)                         { _definingFile = file; }
+
    void DefineLine(const char *line)
       {
       snprintf(_definingLine, MAX_LINE_NUM_LEN * sizeof(char), "%s", line);
+      }
+   void DefineLine(int line)
+      {
+      snprintf(_definingLine, MAX_LINE_NUM_LEN * sizeof(char), "%d", line);
       }
 
    void DefineName(const char *name);

--- a/compiler/ilgen/MethodBuilder.hpp
+++ b/compiler/ilgen/MethodBuilder.hpp
@@ -30,6 +30,9 @@
 #include <fstream>
 #include "ilgen/IlBuilder.hpp"
 
+// Maximum length of _definingLine string (including null terminator)
+#define MAX_LINE_NUM_LEN 7
+
 class TR_HashTabInt;
 class TR_HashTabString;
 class TR_BitVector;
@@ -97,7 +100,10 @@ class MethodBuilder : public TR::IlBuilder
    void AppendBuilder(TR::IlBuilder *b)    { this->OMR::IlBuilder::AppendBuilder(b); }
 
    void DefineFile(const char *file)                         { _definingFile = file; }
-   void DefineLine(const char *line)                         { _definingLine = line; }
+   void DefineLine(const char *line)
+      {
+      snprintf(_definingLine, MAX_LINE_NUM_LEN * sizeof(char), "%s", line);
+      }
 
    void DefineName(const char *name);
    void DefineParameter(const char *name, TR::IlType *type);
@@ -173,7 +179,7 @@ class MethodBuilder : public TR::IlBuilder
    TR::IlType               ** _cachedParameterTypes;
    char                      * _cachedSignature;
    const char                * _definingFile;
-   const char                * _definingLine;
+   char                        _definingLine[MAX_LINE_NUM_LEN];
    TR::IlType                * _cachedParameterTypesArray[10];
    char                        _cachedSignatureArray[100];
 


### PR DESCRIPTION
Contains the following:

- An int overload, `DefineLine(int)`, for `OMR::MethodBuilder::DefineLine`
- Minor changes (in order to accommodate the above) to the `DefineLine(const char *)` method, and the way defining line number is stored inside MethodBuilder object

Signed-off-by: Sajid Ahmed <Syed.Sajid.Ahmed23@ibm.com>