### PR TITLE
Fix compiler CPU usage regression

### DIFF
--- a/compiler/env/ExceptionTable.cpp
+++ b/compiler/env/ExceptionTable.cpp
@@ -83,9 +83,17 @@ TR_ExceptionTableEntryIterator::TR_ExceptionTableEntryIterator(TR::Compilation *
                bool found = false;
                TR_ASSERT(tt->getNode(), "a treetop doesn't have a node ????");
                TR::Block * prevBlock = tt->getNode()->getBlock();
-               for (auto e = exceptionPredecessors.begin(); e != exceptionPredecessors.end(); ++e)
-                  if (toBlock((*e)->getFrom()) == prevBlock)
-                     { exceptionPredecessors.erase(e); found = true; break; }
+               for (auto previousEdge = exceptionPredecessors.before_begin(), currentEdge = exceptionPredecessors.begin();
+                    currentEdge != exceptionPredecessors.end();
+                    ++previousEdge, ++currentEdge)
+                  {
+                  if (toBlock((*currentEdge)->getFrom()) == prevBlock)
+                     {
+                     currentEdge = exceptionPredecessors.erase_after(previousEdge);
+                     found = true;
+                     break;
+                     }
+                  }
                if (!found) break;
                first = prevBlock;
                addSnippetRanges(tableEntries, prevBlock, catchBlock, catchType, method, comp);
@@ -99,9 +107,17 @@ TR_ExceptionTableEntryIterator::TR_ExceptionTableEntryIterator(TR::Compilation *
                if (!tt) break;
                bool found = false;
                TR::Block * nextBlock = tt->getNode()->getBlock();
-               for (auto e = exceptionPredecessors.begin(); e != exceptionPredecessors.end(); ++e)
-                  if (toBlock((*e)->getFrom()) == nextBlock)
-                     { exceptionPredecessors.erase(e); found = true; break; }
+               for (auto previousEdge = exceptionPredecessors.before_begin(), currentEdge = exceptionPredecessors.begin();
+                    currentEdge != exceptionPredecessors.end();
+                    ++previousEdge, ++currentEdge)
+                  {
+                  if (toBlock((*currentEdge)->getFrom()) == nextBlock)
+                     {
+                     exceptionPredecessors.erase_after(previousEdge);
+                     found = true;
+                     break;
+                     }
+                  }
                if (!found) break;
                last = nextBlock;
                addSnippetRanges(tableEntries, nextBlock, catchBlock, catchType, method, comp);

--- a/compiler/env/TRMemory.hpp
+++ b/compiler/env/TRMemory.hpp
@@ -557,6 +557,7 @@ public:
    void freeMemory(void *p, TR_AllocationKind kind, ObjectType ot = UnknownType);
    TR::PersistentInfo * getPersistentInfo() { return _trPersistentMemory->getPersistentInfo(); }
    TR::Region& currentStackRegion();
+   TR::Region& heapMemoryRegion() { return _heapMemoryRegion; }
 
 private:
 
@@ -907,8 +908,7 @@ typedef TRMemoryAllocator<heapAlloc, 12, 28> TRCS2MemoryAllocator;
 
 namespace TR
    {
-   typedef CS2::stat_allocator < CS2::heap_allocator<65536, 12,
-                                   TRCS2MemoryAllocator > >  ThreadLocalAllocator;
+   typedef CS2::heap_allocator< 65536, 12, TRCS2MemoryAllocator > ThreadLocalAllocator;
    typedef CS2::shared_allocator < ThreadLocalAllocator > Allocator;
 
    typedef TRPersistentMemoryAllocator CS2PersistentAllocator;

--- a/compiler/il/OMRBlock.hpp
+++ b/compiler/il/OMRBlock.hpp
@@ -604,7 +604,7 @@ private:
    TR::Block * _firstBlock;
    TR::Block * _nextBlockInExtendedBlock;
    TR::CFG   * _cfg;
-   std::list<TR::CFGEdge*, TR::typed_allocator<TR::CFGEdge*, TR::Allocator> >::iterator _iterator;
+   TR::CFGEdgeList::iterator _iterator;
    TR::CFGEdgeList* _list;
    };
 

--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -536,10 +536,10 @@ TR::CFGNode::CFGNode(TR_Memory * m)
      _forwardTraversalIndex(-1),
      _backwardTraversalIndex(-1),
      _m(m),
-     _successors(getTypedAllocator<TR::CFGEdge*>(TR::comp()->allocator())),
-     _predecessors(getTypedAllocator<TR::CFGEdge*>(TR::comp()->allocator())),
-     _exceptionSuccessors(getTypedAllocator<TR::CFGEdge*>(TR::comp()->allocator())),
-     _exceptionPredecessors(getTypedAllocator<TR::CFGEdge*>(TR::comp()->allocator()))
+     _successors(m->heapMemoryRegion()),
+     _predecessors(m->heapMemoryRegion()),
+     _exceptionSuccessors(m->heapMemoryRegion()),
+     _exceptionPredecessors(m->heapMemoryRegion())
    {
    }
 TR::CFGNode::CFGNode(int32_t n, TR_Memory * m)
@@ -549,10 +549,10 @@ TR::CFGNode::CFGNode(int32_t n, TR_Memory * m)
      _forwardTraversalIndex(-1),
      _backwardTraversalIndex(-1),
      _m(m),
-     _successors(getTypedAllocator<TR::CFGEdge*>(TR::comp()->allocator())),
-     _predecessors(getTypedAllocator<TR::CFGEdge*>(TR::comp()->allocator())),
-     _exceptionSuccessors(getTypedAllocator<TR::CFGEdge*>(TR::comp()->allocator())),
-     _exceptionPredecessors(getTypedAllocator<TR::CFGEdge*>(TR::comp()->allocator()))
+     _successors(m->heapMemoryRegion()),
+     _predecessors(m->heapMemoryRegion()),
+     _exceptionSuccessors(m->heapMemoryRegion()),
+     _exceptionPredecessors(m->heapMemoryRegion())
    {
    }
 

--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -1070,25 +1070,8 @@ bool OMR::CFG::removeEdge(TR::CFGNode *from, TR::CFGNode *to)
    return false;
    }
 
-
-void OMR::CFG::removeSelfEdge(List<TR::CFGEdge> succList, int32_t selfNumber)
-   {
-   ListIterator<TR::CFGEdge> succIt(&succList);
-   TR::CFGEdge * edge;
-
-   for (edge = succIt.getCurrent(); edge != NULL; edge = succIt.getNext())
-      {
-      TR::Block * dest = toBlock(edge->getTo());
-      TR::Block * src  = toBlock(edge->getFrom());
-      if (src->getNumber() == selfNumber && dest->getNumber() == selfNumber)
-         {
-         removeEdge(edge);
-         }
-      }
-   return;
-   }
-
-void OMR::CFG::removeEdge(TR::CFGEdgeList succList, int32_t selfNumber, int32_t destNumber)
+void
+OMR::CFG::removeEdge(TR::CFGEdgeList &succList, int32_t selfNumber, int32_t destNumber)
    {
 
    for (auto edge = succList.begin(); edge != succList.end();)

--- a/compiler/infra/OMRCfg.hpp
+++ b/compiler/infra/OMRCfg.hpp
@@ -30,6 +30,7 @@ namespace OMR { typedef OMR::CFG CFGConnector; }
 
 #include <stddef.h>                 // for NULL
 #include <stdint.h>                 // for uint32_t
+#include <vector>
 #include "compile/Compilation.hpp"  // for Compilation
 #include "cs2/tableof.h"            // for TableOf
 #include "cs2/listof.h"             // for ListOf
@@ -366,10 +367,12 @@ public: //FIXME: These public members should eventually be wrtapped in an interf
 class TR_CFGIterator
    {
 public:
-   TR_CFGIterator(TR::CFGEdgeList& l1, TR::CFGEdgeList& l2) : combinedList(l1)
+   TR_CFGIterator(TR::CFGEdgeList& regularEdges, TR::CFGEdgeList& exceptionEdges) :
+      _regularEdges(regularEdges),
+      _exceptionEdges(exceptionEdges),
+      _regularEdgeIterator(_regularEdges.begin()),
+      _exceptionEdgeIterator(_exceptionEdges.begin())
       {
-      combinedList.insert(combinedList.end(), l2.begin(), l2.end());
-      currentIterator = combinedList.begin();
       }
 
    /**
@@ -377,8 +380,9 @@ public:
     */
    TR::CFGEdge* getFirst()
       {
-      currentIterator = combinedList.begin();
-      return (combinedList.empty()) ? NULL : *currentIterator ;
+      _regularEdgeIterator = _regularEdges.begin();
+      _exceptionEdgeIterator = _exceptionEdges.begin();
+      return getCurrent();
       }
 
    /**
@@ -386,7 +390,7 @@ public:
     */
    TR::CFGEdge* getCurrent()
       {
-      return (currentIterator == combinedList.end()) ? NULL : *currentIterator;
+      return _regularEdgeIterator == _regularEdges.end() ? ( _exceptionEdgeIterator == _exceptionEdges.end() ? NULL : *_exceptionEdgeIterator ) : *_regularEdgeIterator;
       }
 
    /**
@@ -394,12 +398,22 @@ public:
     */
    TR::CFGEdge* getNext()
       {
-      return (++currentIterator == combinedList.end()) ? NULL : *currentIterator;
+      if (_regularEdgeIterator != _regularEdges.end())
+         {
+         ++_regularEdgeIterator;
+         }
+      else if (_exceptionEdgeIterator != _exceptionEdges.end())
+         {
+         ++_exceptionEdgeIterator;
+         }
+      return getCurrent();
       }
 
 private:
-   TR::CFGEdgeList combinedList;
-   TR::CFGEdgeList::iterator currentIterator;
+   TR::CFGEdgeList &_regularEdges;
+   TR::CFGEdgeList &_exceptionEdges;
+   TR::CFGEdgeList::iterator _regularEdgeIterator;
+   TR::CFGEdgeList::iterator _exceptionEdgeIterator;
    };
 
 class TR_SuccessorIterator : public TR_CFGIterator

--- a/compiler/infra/OMRCfg.hpp
+++ b/compiler/infra/OMRCfg.hpp
@@ -199,8 +199,7 @@ class CFG
    bool removeEdge(TR::CFGEdge *e);
    bool removeEdge(TR::CFGNode *from, TR::CFGNode *to);
    bool removeEdge(TR::CFGEdge *e, bool recursiveImpl);
-   void removeSelfEdge(List<TR::CFGEdge> succList, int32_t selfNumber);
-   void removeEdge(TR::CFGEdgeList succList, int32_t selfNumber, int32_t destNumber);
+   void removeEdge(TR::CFGEdgeList &succList, int32_t selfNumber, int32_t destNumber);
 
    void removeBlock(TR::Block *);
 
@@ -400,11 +399,7 @@ public:
 
 private:
    TR::CFGEdgeList combinedList;
-
-   std::list<TR::CFGEdge*,
-             TR::typed_allocator<TR::CFGEdge*,
-             TR::Allocator>
-            >::iterator currentIterator;
+   TR::CFGEdgeList::iterator currentIterator;
    };
 
 class TR_SuccessorIterator : public TR_CFGIterator

--- a/compiler/infra/TRCfgNode.hpp
+++ b/compiler/infra/TRCfgNode.hpp
@@ -27,14 +27,15 @@
 #include "infra/Link.hpp"       // for TR_Link1
 #include "infra/List.hpp"       // for List
 #include "infra/TRCfgEdge.hpp"  // for CFGEdge
-#include "infra/TRlist.hpp"
+#include "infra/forward_list.hpp"
 class TR_StructureSubGraphNode;
 namespace TR { class Block; }
 namespace TR { class Compilation; }
 
 namespace TR
 {
-typedef TR::list<CFGEdge*> CFGEdgeList;
+typedef TR::typed_allocator< CFGEdge*, TR::Region& > CFGEdgeListAllocator;
+typedef TR::forward_list< CFGEdge*, CFGEdgeListAllocator > CFGEdgeList;
 
 class CFGNode : public ::TR_Link1<CFGNode>
    {

--- a/compiler/infra/TRCfgNode.hpp
+++ b/compiler/infra/TRCfgNode.hpp
@@ -57,7 +57,7 @@ class CFGNode : public ::TR_Link1<CFGNode>
    TR::CFGEdgeList& getSuccessors()            {return _successors;}
    TR::CFGEdgeList& getPredecessors()          {return _predecessors;}
    TR::CFGEdgeList& getExceptionSuccessors()   {return _exceptionSuccessors;}
-   TR::CFGEdgeList & getExceptionPredecessors() {return _exceptionPredecessors;}
+   TR::CFGEdgeList& getExceptionPredecessors() {return _exceptionPredecessors;}
 
    //getEdge looks in both getSuccessors() and getExceptionSuccessors()
    //use getSuccessorEdge or getExceptionEdge if a search in a particular list is required

--- a/compiler/infra/forward_list.hpp
+++ b/compiler/infra/forward_list.hpp
@@ -1,0 +1,737 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#ifndef FORWARD_LIST_HPP
+#define FORWARD_LIST_HPP
+
+#pragma once
+
+#if 0
+#include <memory>
+#include <forward_list>
+
+namespace TR {
+
+/**
+ * @class TR::forward_list
+ *
+ * @brief An extension of std::forward_list providing a linear-time size method.
+ *
+ * std::forward_list is a container for which the objective is to provide performance equal manually maintained
+ * singly-linked list. A result of this  is that std::forward_list does not provide a size method, as it cannot
+ * provide one that operates in O(1) time. However, there are a number of places in our code base that depend on
+ * being able to request the size of a container, where the container is one targetted for re-implementation as
+ * a forward_list. To reconcile these requirements, we provide an extension to std::forward_list that provides a
+ * size() operation that runs in time linear to the number of objects stored in the container.
+ *
+ */
+
+template < typename T, typename Alloc = std::allocator<T> >
+class forward_list : public std::forward_list<T, Alloc>
+   {
+public:
+   using typename std::forward_list<T, Alloc>::allocator_type;
+   using typename std::forward_list<T, Alloc>::size_type;
+   using typename std::forward_list<T, Alloc>::iterator;
+   using typename std::forward_list<T, Alloc>::const_iterator;
+   forward_list(const allocator_type &allocator) : std::forward_list<T, Alloc>(allocator) {}
+   size_type size() const;
+   };
+
+}
+
+template < typename T, typename Alloc >
+auto TR::forward_list< T, Alloc >::size() const -> size_type
+   {
+   size_type size(0);
+   for (auto it = this->begin(); it != this->end(); ++it)
+      {
+      ++size;
+      }
+   return size;
+   }
+
+#else
+#include <list>
+#include <iterator>
+
+namespace TR {
+
+namespace forward_list_private {
+
+struct Link
+   {
+   explicit Link(Link *next) : _next(next) {}
+   Link *_next;
+   };
+
+template <typename T>
+struct ListElement : public Link
+   {
+   typedef T value_type;
+   ListElement(Link *tail, const value_type &value) : Link(tail), _value(value) {}
+   value_type _value;
+   };
+
+}
+
+/**
+ * @class TR::forward_list
+ *
+ * @brief A partial re-implementation of std::forward_list for C++03 supplemented by a linear-time size method.
+ *
+ * std::forward_list is a container introduced in the 2011 revision of the C++ standard for which
+ * the objective is to provide the performance of a singly-linked list. Because the continer is singly-linked,
+ * the interfaces common to other containers, where manipulations are performed on the half-closed interval
+ * [begin, end), are problematic. To provide a work-around, std::forward_list provides similar operations that
+ * operate on the open interval (before_begin, end), and provide [operation]_after variants that perform the
+ * requested operation on the position immediately following the provided iterator.
+ *
+ * A further result of the strict requirement of being equally performant to a manually maintained singly-linked
+ * list, is that std::forward_list does not provide a size method, as it cannot provide one that operates in O(1)
+ * time. However, there are a number of places in our code base that depend on being able to request the size of
+ * a container, where the container is one targetted for re-implementation as a forward_list. To reconcile these
+ * requirements, we provide an extension to std::forward_list that provides a size() operation that runs in time
+ * linear to the number of objects stored in the container.
+ *
+ */
+
+template < typename T, typename Alloc >
+class forward_list
+   {
+public:
+   typedef Alloc allocator_type;
+   typedef typename allocator_type::value_type value_type;
+   typedef typename allocator_type::reference reference;
+   typedef typename allocator_type::const_reference const_reference;
+   typedef typename allocator_type::pointer pointer;
+   typedef typename allocator_type::const_pointer const_pointer;
+   typedef typename allocator_type::difference_type difference_type;
+   typedef typename allocator_type::size_type size_type;
+
+private:
+   typedef forward_list_private::Link Link;
+
+public:
+
+   class iterator;
+   class const_iterator
+      {
+   public:
+      typedef forward_list container_type;
+      typedef typename container_type::value_type value_type;
+      typedef typename container_type::const_reference reference;
+      typedef typename container_type::const_reference const_reference;
+      typedef typename container_type::const_pointer pointer;
+      typedef typename container_type::const_pointer const_pointer;
+      typedef typename container_type::difference_type difference_type;
+      typedef typename std::forward_iterator_tag iterator_category;
+
+      const_iterator();
+      const_iterator(const const_iterator &other);
+      const_iterator &operator =(const const_iterator &other);
+      const_iterator &operator ++();
+      const_iterator operator ++(int);
+      const_reference operator *() throw();
+      const_pointer operator ->() throw();
+      friend bool operator ==(const const_iterator &left, const const_iterator &right) { return left._element == right._element; }
+      friend bool operator !=(const const_iterator &left, const const_iterator &right) { return !(left == right); }
+
+   private:
+      friend class forward_list;
+      friend class container_type::iterator;
+
+      static Link * degenerate();
+
+      const_iterator(const Link *element);
+
+      const Link * _element;
+      };
+
+   class iterator
+      {
+   public:
+      typedef forward_list container_type;
+      typedef typename container_type::value_type value_type;
+      typedef typename container_type::reference reference;
+      typedef typename container_type::const_reference const_reference;
+      typedef typename container_type::pointer pointer;
+      typedef typename container_type::const_pointer const_pointer;
+      typedef typename container_type::difference_type difference_type;
+      typedef typename std::forward_iterator_tag iterator_category;
+
+      iterator();
+      iterator(const iterator &other);
+      iterator &operator =(const iterator &other);
+      iterator &operator ++();
+      iterator operator ++(int);
+      reference operator *() throw();
+      pointer operator ->() throw();
+      friend bool operator ==(const iterator &left, const iterator &right) { return left._element == right._element; }
+      friend bool operator !=(const iterator &left, const iterator &right) { return !(left == right); }
+      operator const_iterator() { return const_iterator(_element); }
+
+   private:
+      friend class forward_list;
+
+      static Link *degenerate();
+
+      iterator(Link *element);
+      Link *_element;
+      };
+
+   explicit forward_list(const allocator_type &allocator = allocator_type());
+//   explicit forward_list(size_type size, const allocator_type &allocator = allocator_type());
+//   forward_list(size_type size, const value_type& initialValue, const allocator_type &allocator = allocator_type());
+   template < typename InputIterator > forward_list(InputIterator first, InputIterator last, const allocator_type &allocator = allocator_type());
+   forward_list(const forward_list &prototype);
+   forward_list(const forward_list &prototype, const allocator_type &allocator);
+   ~forward_list();
+   forward_list &operator =(const forward_list &prototype);
+
+//   template < typename InputIterator > void assign(InputIterator first, InputIterator last);
+//   void assign(size_type n, const value_type &value);
+
+   allocator_type get_allocator() const throw();
+
+   iterator before_begin();
+   const_iterator before_begin() const;
+   inline const_iterator cbefore_begin() const;
+
+   iterator begin();
+   const_iterator begin() const;
+   inline const_iterator cbegin() const;
+
+   iterator end();
+   const_iterator end() const;
+   inline const_iterator cend() const;
+
+   bool empty() const throw();
+   size_type size() const throw();
+   size_type max_size() const throw();
+
+   reference front();
+   const_reference front() const;
+
+   void push_front(const value_type &value);
+   void pop_front();
+
+   iterator insert_after(iterator position, const value_type& value);
+//   iterator insert_after(const_iterator position, size_type count, const value_type& value);
+   template < typename InputIterator > iterator insert_after(iterator position, InputIterator first, InputIterator last);
+
+   iterator erase_after(iterator position);
+//   iterator erase_after(const_iterator position, iterator last);
+
+//   void resize(size_type newSize);
+//   void resize(size_type newSize, const value_type &value);
+   void clear() throw();
+
+//   void splice_after(const_iterator position, forward_list &donor);
+//   void splice_after(const_iterator position, forward_list &donor, const_iterator breakPoint);
+//   void splice_after(const_iterator position, forward_list &donor, const_iterator nearBound, const_iterator farBound);
+
+   void remove(const value_type &value);
+
+//   void unique();
+
+//   void merge(forward_list &donor);
+
+private:
+
+   typedef forward_list_private::ListElement<T> ListElement;
+   typedef typename allocator_type::template rebind<ListElement>::other ListElementAllocator;
+
+   Link _head;
+   ListElementAllocator _allocator;
+   };
+
+}
+
+
+template < typename T, typename Alloc >
+TR::forward_list< T, Alloc >::forward_list(const allocator_type &allocator) :
+   _head(NULL),
+   _allocator(allocator)
+   {
+   }
+
+//template < typename T, typename Alloc >
+//TR::forward_list< T, Alloc >::forward_list(size_type size, const allocator_type &allocator) :
+//   _head(NULL),
+//   _allocator(allocator)
+//   {
+//   }
+
+//template < typename T, typename Alloc >
+//TR::forward_list< T, Alloc >::forward_list(size_type size, const value_type &initialValue, const allocator_type &allocator) :
+//   _head(NULL),
+//   _allocator(allocator)
+//   {
+//   }
+
+//template < typename T, typename Alloc >
+//template < typename InputIterator >
+//TR::forward_list< T, Alloc >::forward_list(InputIterator first, InputIterator last, const allocator_type &allocator) :
+//   _head(NULL),
+//   _allocator(allocator)
+//   {
+//   }
+
+template < typename T, typename Alloc >
+TR::forward_list< T, Alloc >::forward_list(const forward_list &prototype) :
+   _head(NULL),
+   _allocator(prototype._allocator)
+   {
+   insert_after(before_begin(), prototype.begin(), prototype.end());
+   }
+
+template < typename T, typename Alloc >
+TR::forward_list< T, Alloc >::forward_list(const forward_list &prototype, const allocator_type &allocator):
+   _head(NULL),
+   _allocator(allocator)
+   {
+   insert_after(before_begin(), prototype.begin(), prototype.end());
+   }
+
+template < typename T, typename Alloc >
+TR::forward_list< T, Alloc >::~forward_list()
+   {
+   clear();
+   }
+
+//template < typename T, typename Alloc >
+//TR::forward_list< T, Alloc > &
+//TR::forward_list< T, Alloc >::operator =(const forward_list &other)
+//   {
+//   }
+
+//template < typename T, typename Alloc >
+//template < typename InputIterator >
+//void
+//TR::forward_list< T, Alloc >::assign(InputIterator first, InputIterator last)
+//   {
+//   }
+
+//template < typename T, typename Alloc >
+//void
+//TR::forward_list< T, Alloc >::assign(size_type n, const value_type &value)
+//   {
+//   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::allocator_type
+TR::forward_list< T, Alloc >::get_allocator() const throw()
+   {
+   return _allocator;
+   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::iterator
+TR::forward_list< T, Alloc >::before_begin()
+   {
+   return iterator(&_head);
+   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::const_iterator
+TR::forward_list< T, Alloc >::before_begin() const
+   {
+   return const_iterator(&_head);
+   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::const_iterator
+TR::forward_list< T, Alloc >::cbefore_begin() const
+   {
+   return const_cast<const forward_list &>(*this).before_begin();
+   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::iterator
+TR::forward_list< T, Alloc >::begin()
+   {
+   return iterator(_head._next);
+   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::const_iterator
+TR::forward_list< T, Alloc >::begin() const
+   {
+   return const_iterator(_head._next);
+   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::const_iterator
+TR::forward_list< T, Alloc >::cbegin() const
+   {
+   return const_cast<const forward_list &>(*this).begin();
+   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::iterator
+TR::forward_list< T, Alloc >::end()
+   {
+   return iterator(NULL);
+   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::const_iterator
+TR::forward_list< T, Alloc >::end() const
+   {
+   return const_iterator(NULL);
+   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::const_iterator
+TR::forward_list< T, Alloc >::cend() const
+   {
+   return const_cast<const forward_list &>(*this).end();
+   }
+
+template < typename T, typename Alloc >
+bool
+TR::forward_list< T, Alloc >::empty() const throw()
+   {
+   return _head._next == NULL;
+   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::size_type
+TR::forward_list< T, Alloc >::size() const throw()
+   {
+   size_type size(0);
+   for (auto it = this->begin(); it != this->end(); ++it)
+      {
+      ++size;
+      }
+   return size;
+   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::size_type
+TR::forward_list< T, Alloc >::max_size() const throw()
+   {
+   return _allocator.max_size();
+   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::reference
+TR::forward_list< T, Alloc >::front()
+   {
+   return static_cast<ListElement &>(*_head._next)._value;
+   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::const_reference
+TR::forward_list< T, Alloc >::front() const
+   {
+   return static_cast<const ListElement &>(*_head._next)._value;
+   }
+
+template < typename T, typename Alloc >
+void
+TR::forward_list< T, Alloc >::push_front(const value_type &value)
+   {
+   ListElement *newElement = _allocator.allocate(1);
+   _allocator.construct(newElement, ListElement(_head._next, value));
+   _head._next = newElement;
+   }
+
+template < typename T, typename Alloc >
+void
+TR::forward_list< T, Alloc >::pop_front()
+   {
+   Link *deadElement(_head._next);
+   _head._next = deadElement->_next;
+   _allocator.destroy(static_cast<ListElement *>(deadElement));
+   _allocator.deallocate(static_cast<ListElement *>(deadElement), 1);
+   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::iterator
+TR::forward_list< T, Alloc >::insert_after(iterator position, const value_type &value)
+   {
+   ListElement *newElement = _allocator.allocate(1);
+   _allocator.construct(newElement, ListElement(position._element->_next, value));
+   position.element->_next = newElement;
+   }
+
+//template < typename T, typename Alloc >
+//typename TR::forward_list< T, Alloc >::iterator
+//TR::forward_list< T, Alloc >::insert_after(const_iterator position, size_type count, const value_type &value)
+//   {
+//   }
+
+template < typename T, typename Alloc >
+template < typename InputIterator >
+typename TR::forward_list< T, Alloc >::iterator
+TR::forward_list< T, Alloc >::insert_after(iterator position, InputIterator first, InputIterator last)
+   {
+   Link * const farBound = position._element->_next;
+
+   try
+      {
+      Link * prev = position._element;
+      for (auto currentPosition = first; currentPosition != last; ++currentPosition)
+         {
+         ListElement *newElement = _allocator.allocate(1);
+         try
+            {
+            _allocator.construct(newElement, ListElement(farBound, *currentPosition));
+            }
+         catch (...)
+            {
+            _allocator.deallocate(newElement, 1);
+            throw;
+            }
+         prev->_next = newElement;
+         prev = newElement;
+         }
+      return iterator(prev);
+      }
+   catch (...)
+      {
+      while (position._element->_next != farBound)
+         {
+         erase_after(position);
+         }
+      throw;
+      }
+   return position;
+   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::iterator
+TR::forward_list< T, Alloc >::erase_after(iterator position)
+   {
+   Link *deadElement(position._element->_next);
+   position._element->_next = deadElement->_next;
+   _allocator.destroy(static_cast<ListElement *>(deadElement));
+   _allocator.deallocate(static_cast<ListElement *>(deadElement), 1);
+   return iterator(position._element->_next);
+   }
+
+//template < typename T, typename Alloc >
+//typename TR::forward_list< T, Alloc >::iterator
+//TR::forward_list< T, Alloc >::erase_after(const_iterator position, iterator last)
+//   {
+//   }
+
+//template < typename T, typename Alloc >
+//void
+//TR::forward_list< T, Alloc >::resize(size_type newSize)
+//   {
+//   }
+
+//template < typename T, typename Alloc >
+//void
+//TR::forward_list< T, Alloc >::resize(size_type newSize, const value_type &value)
+//   {
+//   }
+
+template < typename T, typename Alloc >
+void
+TR::forward_list< T, Alloc >::clear() throw()
+   {
+   while (_head._next != NULL)
+      {
+      ListElement *deadElement = static_cast<ListElement *>(_head._next);
+      _head._next = _head._next->_next;
+      _allocator.destroy(deadElement);
+      _allocator.deallocate(deadElement, 1);
+      }
+   }
+
+//template < typename T, typename Alloc >
+//void
+//TR::forward_list< T, Alloc >::splice_after(const_iterator position, forward_list &donor)
+//   {
+//   }
+
+//template < typename T, typename Alloc >
+//void
+//TR::forward_list< T, Alloc >::splice_after(const_iterator position, forward_list &donor, const_iterator breakPoint)
+//   {
+//   }
+
+//template < typename T, typename Alloc >
+//void
+//TR::forward_list< T, Alloc >::splice_after(const_iterator position, forward_list &donor, const_iterator nearBound, const_iterator farBound)
+//   {
+//   }
+
+template < typename T, typename Alloc >
+void
+TR::forward_list< T, Alloc >::remove(const value_type &value)
+   {
+   for (auto preceding = before_begin(), current = begin(); current != end(); ++preceding, ++current)
+      {
+      while (*current == value)
+         {
+         current = erase_after(preceding);
+         if (current == end())
+            {
+            return;
+            }
+         }
+      }
+   }
+
+//template < typename T, typename Alloc >
+//void
+//TR::forward_list< T, Alloc >::unique()
+//   {
+//   }
+
+//template < typename T, typename Alloc >
+//void
+//TR::forward_list< T, Alloc >::merge(forward_list &donor)
+//   {
+//   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::Link *
+TR::forward_list< T, Alloc >::const_iterator::degenerate()
+   {
+   return reinterpret_cast<Link *>(static_cast<uintptr_t>(-1));
+   }
+
+template < typename T, typename Alloc >
+TR::forward_list< T, Alloc >::const_iterator::const_iterator() :
+   _element(degenerate())
+   {
+   }
+
+template < typename T, typename Alloc >
+TR::forward_list< T, Alloc >::const_iterator::const_iterator(const const_iterator &other) :
+   _element(other._element)
+   {
+   }
+
+template < typename T, typename Alloc >
+TR::forward_list< T, Alloc >::const_iterator::const_iterator(const Link *element) :
+   _element(element)
+   {
+   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::const_iterator &
+TR::forward_list< T, Alloc >::const_iterator::operator =(const const_iterator &other)
+   {
+   _element = other._element;
+   return *this;
+   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::const_iterator &
+TR::forward_list< T, Alloc >::const_iterator::operator ++()
+   {
+   _element = _element->_next;
+   return *this;
+   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::const_iterator
+TR::forward_list< T, Alloc >::const_iterator::operator ++(int)
+   {
+   const_iterator current(*this);
+   _element = _element->_next;
+   return current;
+   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::const_reference
+TR::forward_list< T, Alloc >::const_iterator::operator *() throw()
+   {
+   return static_cast<const ListElement &>(*_element)._value;
+   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::const_pointer
+TR::forward_list< T, Alloc >::const_iterator::operator ->() throw()
+   {
+   return &static_cast<const ListElement &>(*_element)._value;
+   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::Link *
+TR::forward_list< T, Alloc >::iterator::degenerate()
+   {
+   return reinterpret_cast<Link *>(static_cast<uintptr_t>(-1));
+   }
+
+template < typename T, typename Alloc >
+TR::forward_list< T, Alloc >::iterator::iterator() :
+   _element(degenerate())
+   {
+   }
+
+template < typename T, typename Alloc >
+TR::forward_list< T, Alloc >::iterator::iterator(const iterator &other) :
+   _element(other._element)
+   {
+   }
+
+template < typename T, typename Alloc >
+TR::forward_list< T, Alloc >::iterator::iterator(Link *element) :
+   _element(element)
+   {
+   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::iterator &
+TR::forward_list< T, Alloc >::iterator::operator =(const iterator &other)
+   {
+   _element = other._element;
+   return *this;
+   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::iterator &
+TR::forward_list< T, Alloc >::iterator::operator ++()
+   {
+   _element = _element->_next;
+   return *this;
+   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::iterator
+TR::forward_list< T, Alloc >::iterator::operator ++(int)
+   {
+   iterator current(*this);
+   _element = _element->_next;
+   return current;
+   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::reference
+TR::forward_list< T, Alloc >::iterator::operator *() throw()
+   {
+   return static_cast<ListElement &>(*_element)._value;
+   }
+
+template < typename T, typename Alloc >
+typename TR::forward_list< T, Alloc >::pointer
+TR::forward_list< T, Alloc >::iterator::operator ->() throw()
+   {
+   return &static_cast<ListElement &>(*_element)._value;
+   }
+
+#endif
+#endif // FORWARD_LIST_HPP

--- a/compiler/optimizer/CopyPropagation.cpp
+++ b/compiler/optimizer/CopyPropagation.cpp
@@ -2053,11 +2053,10 @@ bool TR_CopyPropagation::isRedefinedBetweenStoreTreeAnd(TR::list< TR::Node *> & 
          vcount_t visitCount = comp()->getVisitCount();
          block->setVisitCount(visitCount);
 
-         TR::CFGEdgeList predList(block->getPredecessors());
-         predList.insert(predList.end(), block->getExceptionPredecessors().begin(), block->getExceptionPredecessors().end());
-         for (auto nextEdge = predList.begin(); nextEdge != predList.end(); ++nextEdge)
+         TR_PredecessorIterator precedingEdges(block);
+         for (auto precedingEdge = precedingEdges.getFirst(); precedingEdge; precedingEdge = precedingEdges.getNext())
             {
-            TR::Block *next = toBlock((*nextEdge)->getFrom());
+            TR::Block *next = toBlock(precedingEdge->getFrom());
             if ((next->getVisitCount() != visitCount) && (next != cfg->getStart()) &&
                 ((regNumber == -1) || (next->startOfExtendedBlock() != _storeBlock)))
                {

--- a/compiler/optimizer/Dominators.cpp
+++ b/compiler/optimizer/Dominators.cpp
@@ -253,7 +253,7 @@ void TR_Dominators::initialize(TR::Block *start, BBInfo *nullParent) {
     * Seed an initial list of successors using a dummy loop edge connecting the start to itself.
     */
    TR::CFGEdge dummyEdge;
-   TR::CFGEdgeList startList(getTypedAllocator<TR::CFGEdge*>(comp()->allocator()));
+   TR::CFGEdgeList startList(comp()->region());
    startList.push_front(&dummyEdge);
 
    StackInfo seed(startList, startList.begin(), -1);

--- a/compiler/optimizer/Dominators.hpp
+++ b/compiler/optimizer/Dominators.hpp
@@ -95,7 +95,7 @@ class TR_Dominators
    struct StackInfo
       {
       typedef TR::CFGEdgeList list_type;
-      typedef std::list<TR::CFGEdge*, TR::typed_allocator<TR::CFGEdge*, TR::Allocator> >::iterator iterator_type;
+      typedef TR::CFGEdgeList::iterator iterator_type;
       StackInfo(list_type &list, iterator_type position, int32_t parent) :
          list(list),
          listPosition(position),

--- a/compiler/optimizer/DominatorsChk.cpp
+++ b/compiler/optimizer/DominatorsChk.cpp
@@ -168,7 +168,7 @@ void TR_DominatorsChk::initialize(TR::Block *start, TR::Block *nullParent)
    // Set up to start at the start block
    //
    TR::CFGEdge dummyEdge;
-   TR::CFGEdgeList dummyList(getTypedAllocator<TR::CFGEdge*>(comp()->allocator()));
+   TR::CFGEdgeList dummyList(comp()->region());
    dummyList.push_front(&dummyEdge);
    (*stack)[0].curIterator = dummyList.begin();
    (*stack)[0].list = &dummyList;

--- a/compiler/optimizer/DominatorsChk.hpp
+++ b/compiler/optimizer/DominatorsChk.hpp
@@ -88,7 +88,7 @@ class TR_DominatorsChk
    class StackInfo
       {
       public:
-      std::list<TR::CFGEdge*, TR::typed_allocator<TR::CFGEdge*, TR::Allocator> >::iterator curIterator;
+      TR::CFGEdgeList::iterator curIterator;
       TR::CFGEdgeList * list;
       int32_t                  parent;
       };

--- a/compiler/optimizer/GlobalRegisterAllocator.cpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.cpp
@@ -168,7 +168,7 @@ class multipleJumpSuccessorIterator : public SuccessorIterator
       else
          return (*_iterator)->getTo()->asBlock();
       }
-   std::list<TR::CFGEdge*, TR::typed_allocator<TR::CFGEdge*, TR::Allocator> >::iterator _iterator;
+   TR::CFGEdgeList::iterator _iterator;
    TR::CFGEdgeList* _list;
    };
 

--- a/compiler/optimizer/InductionVariable.hpp
+++ b/compiler/optimizer/InductionVariable.hpp
@@ -21,6 +21,7 @@
 
 #include <stddef.h>                              // for NULL
 #include <stdint.h>                              // for int32_t, int64_t
+#include <deque>                                 // for std::deque
 #include <map>                                   // for std::map
 #include <utility>                               // for std::pair
 #include "codegen/FrontEnd.hpp"                  // for TR_FrontEnd
@@ -458,6 +459,9 @@ class TR_InductionVariableAnalysis : public TR::Optimization
 
    private:
 
+   typedef TR::typed_allocator< TR::CFGEdge *, TR::Allocator > WorkQueueAllocator;
+   typedef std::deque< TR::CFGEdge *, WorkQueueAllocator > WorkQueue;
+
    class DeltaInfo
       {
       public:
@@ -496,6 +500,7 @@ class TR_InductionVariableAnalysis : public TR::Optimization
       TR_BitVector *_allDefs;
       };
 
+   static void appendPredecessors(WorkQueue &workList, TR::Block *block);
 
    void gatherCandidates(TR_Structure *s, TR_BitVector *b, TR_BitVector*);
 

--- a/compiler/optimizer/LoopCanonicalizer.cpp
+++ b/compiler/optimizer/LoopCanonicalizer.cpp
@@ -410,11 +410,10 @@ void TR_LoopTransformer::detectWhileLoopsInSubnodesInOrder(ListAppender<TR_Struc
          _nodesInCycle->set(rootNode->getNumber());
 
          bool stopAnalyzingThisNode = false;
-         TR::CFGEdgeList predList(rootNode->getPredecessors());
-         predList.insert(predList.end(), rootNode->getExceptionPredecessors().begin(), rootNode->getExceptionPredecessors().end());
-         for (auto pred = predList.begin(); pred != predList.end(); ++pred)
+         TR_PredecessorIterator precedingEdges(rootNode);
+         for (auto precedingEdge = precedingEdges.getFirst(); precedingEdge; precedingEdge = precedingEdges.getNext())
             {
-            TR_StructureSubGraphNode *predNode = (TR_StructureSubGraphNode *) (*pred)->getFrom();
+            TR_StructureSubGraphNode *predNode = (TR_StructureSubGraphNode *) precedingEdge->getFrom();
             TR_Structure *predStructure = predNode->getStructure();
             if (pendingList->get(predStructure->getNumber()))
                {
@@ -434,18 +433,17 @@ void TR_LoopTransformer::detectWhileLoopsInSubnodesInOrder(ListAppender<TR_Struc
       pendingList->reset(root->getNumber());
       _analysisStack.pop();
 
-      TR::CFGEdgeList succList(rootNode->getSuccessors());
-      succList.insert(succList.end(), rootNode->getExceptionSuccessors().begin(), rootNode->getExceptionSuccessors().end());
-      for (auto succ = succList.begin(); succ != succList.end(); ++succ)
+      TR_SuccessorIterator succeedingEdges(rootNode);
+      for (auto succeedingEdge = succeedingEdges.getFirst(); succeedingEdge; succeedingEdge = succeedingEdges.getNext())
          {
-         TR_StructureSubGraphNode *succNode = (TR_StructureSubGraphNode *) (*succ)->getTo();
+         TR_StructureSubGraphNode *succNode = (TR_StructureSubGraphNode *) succeedingEdge->getTo();
          TR_Structure *succStructure = succNode->getStructure();
          bool isExitEdge = false;
          ListIterator<TR::CFGEdge> ei(&region->getExitEdges());
          TR::CFGEdge *edge;
          for (edge = ei.getCurrent(); edge != NULL; edge = ei.getNext())
             {
-            if (edge == *succ)
+            if (edge == succeedingEdge)
                {
                isExitEdge = true;
                break;

--- a/compiler/optimizer/LoopCanonicalizer.cpp
+++ b/compiler/optimizer/LoopCanonicalizer.cpp
@@ -588,8 +588,10 @@ void TR_LoopTransformer::detectWhileLoops(ListAppender<TR_Structure> &whileLoops
             //
             if (entryNode->getSuccessors().size() == 2)
                {
-               TR::CFGEdge* succ1 = entryNode->getSuccessors().front();
-               TR::CFGEdge* succ2 = entryNode->getSuccessors().back(); //Get the 2nd successor
+               auto it = entryNode->getSuccessors().begin();
+               TR::CFGEdge* succ1 = *it;
+               ++it;
+               TR::CFGEdge* succ2 = *it;
                bool succ1Internal = region->contains(toStructureSubGraphNode(succ1->getTo())->getStructure(), region->getParent());
                bool succ2Internal = region->contains(toStructureSubGraphNode(succ2->getTo())->getStructure(), region->getParent());
                if (succ1Internal ^ succ2Internal)
@@ -624,8 +626,10 @@ void TR_LoopTransformer::detectWhileLoops(ListAppender<TR_Structure> &whileLoops
                                  {
                                  if (exitBlock->getSuccessors().size() == 2)
                                     {
-                                    TR::CFGEdge* exitSucc1 = exitBlock->getSuccessors().front();
-                                    TR::CFGEdge* exitSucc2 = exitBlock->getSuccessors().back(); // Get the 2nd Successor
+                                    auto it = exitBlock->getSuccessors().begin();
+                                    TR::CFGEdge* exitSucc1 = *it;
+                                    ++it;
+                                    TR::CFGEdge* exitSucc2 = *it;
                                     bool successor1Internal = region->contains(toBlock(exitSucc1->getTo())->getStructureOf(), region->getParent());
                                     bool successor2Internal = region->contains(toBlock(exitSucc2->getTo())->getStructureOf(), region->getParent());
                                     if (successor1Internal ^ successor2Internal)

--- a/compiler/optimizer/LoopReducer.cpp
+++ b/compiler/optimizer/LoopReducer.cpp
@@ -2197,8 +2197,7 @@ TR_LoopReducer::generateArraycmp(TR_RegionStructure * whileLoop, TR_InductionVar
 
    // update the CFG
    _cfg->setStructure(NULL);
-   TR::CFGEdgeList iSuccList = incrementBlock->getSuccessors();
-   removeEdge(iSuccList, incrementBlock->getNumber(), branchBlock->getNumber());
+   _cfg->removeEdge(incrementBlock->getSuccessors(), incrementBlock->getNumber(), branchBlock->getNumber());
 
    return true;
    }
@@ -3390,35 +3389,34 @@ TR_LoopReducer::generateArraytranslate(TR_RegionStructure * whileLoop, TR_Induct
          }
       }
 
+   TR::CFGEdgeList &loadSuccList = loadBlock->getSuccessors();
+   TR::CFGEdgeList &storeSuccList = storeBlock->getSuccessors();
+   TR::CFGEdgeList &cmpSuccList = cmpBlock->getSuccessors();
    if (hasBranch)
       {
-	  TR::CFGEdgeList loadSuccList = loadBlock->getSuccessors();
-	  TR::CFGEdgeList storeSuccList = storeBlock->getSuccessors();
 
-      removeEdge(loadSuccList, loadBlock->getNumber(), storeBlock->getNumber());
+      _cfg->removeEdge(loadSuccList, loadBlock->getNumber(), storeBlock->getNumber());
 
       if (hasBreak)
          {
-         removeEdge(loadSuccList, loadBlock->getNumber(), breakExitBlock->getNumber());
+         _cfg->removeEdge(loadSuccList, loadBlock->getNumber(), breakExitBlock->getNumber());
          }
       else
          {
-         removeEdge(loadSuccList, loadBlock->getNumber(), otherStoreBlock->getNumber());
-         removeEdge(loadSuccList, loadBlock->getNumber(), storeBlock->getNumber());
-         removeEdge(storeSuccList, storeBlock->getNumber(), loadBlock->getNumber());
+         _cfg->removeEdge(loadSuccList, loadBlock->getNumber(), otherStoreBlock->getNumber());
+         _cfg->removeEdge(loadSuccList, loadBlock->getNumber(), storeBlock->getNumber());
+         _cfg->removeEdge(storeSuccList, storeBlock->getNumber(), loadBlock->getNumber());
 
-         TR::CFGEdgeList cmpSuccList = cmpBlock->getSuccessors();
-         removeEdge(cmpSuccList, cmpBlock->getNumber(), loadBlock->getNumber());
+         _cfg->removeEdge(cmpSuccList, cmpBlock->getNumber(), loadBlock->getNumber());
          }
 
-      removeEdge(storeSuccList, storeBlock->getNumber(), loadBlock->getNumber());
+      _cfg->removeEdge(storeSuccList, storeBlock->getNumber(), loadBlock->getNumber());
 
       return false; // do not remove self edge
       }
    else
       {
-	  TR::CFGEdgeList loadSuccList = loadBlock->getSuccessors();
-      removeEdge(loadSuccList, loadBlock->getNumber(), nextBlock->getNumber());
+      _cfg->removeEdge(loadSuccList, loadBlock->getNumber(), nextBlock->getNumber());
       return true;
       }
    }
@@ -3692,11 +3690,8 @@ TR_LoopReducer::generateArraytranslateAndTest(TR_RegionStructure * whileLoop, TR
       }
    _cfg->setStructure(NULL);
 
-   TR::CFGEdgeList loadSuccList = loadBlock->getSuccessors();
-   TR::CFGEdgeList cmpSuccList = cmpBlock->getSuccessors();
-
-   removeEdge(loadSuccList, loadBlock->getNumber(), cmpBlock->getNumber());
-   removeEdge(cmpSuccList, cmpBlock->getNumber(), nextBlock->getNumber());
+   _cfg->removeEdge(loadBlock->getSuccessors(), loadBlock->getNumber(), cmpBlock->getNumber());
+   _cfg->removeEdge(cmpBlock->getSuccessors(), cmpBlock->getNumber(), nextBlock->getNumber());
    return true;
    }
 
@@ -4233,37 +4228,9 @@ TR_LoopReducer::constrainedIndVar(TR_InductionVariable * indVar)
    }
 
 void
-TR_LoopReducer::removeSelfEdge(TR::CFGEdgeList succList, int32_t selfNumber)
+TR_LoopReducer::removeSelfEdge(TR::CFGEdgeList &succList, int32_t selfNumber)
    {
-   for (auto edge = succList.begin(); edge != succList.end();)
-      {
-      TR::Block * dest = toBlock((*edge)->getTo());
-      TR::Block * src = toBlock((*edge)->getFrom());
-      if (src->getNumber() == selfNumber && dest->getNumber() == selfNumber)
-         {
-         _cfg->removeEdge(*(edge++));
-         }
-      else
-    	 ++edge;
-      }
-   return;
-   }
-
-void
-TR_LoopReducer::removeEdge(TR::CFGEdgeList succList, int32_t selfNumber, int32_t destNumber)
-   {
-   for (auto edge = succList.begin(); edge != succList.end();)
-      {
-      TR::Block * dest = toBlock((*edge)->getTo());
-      TR::Block * src = toBlock((*edge)->getFrom());
-      if (src->getNumber() == selfNumber && dest->getNumber() == destNumber)
-         {
-         _cfg->removeEdge(*(edge++));
-         }
-      else
-         ++edge;
-      }
-   return;
+   _cfg->removeEdge(succList, selfNumber, selfNumber);
    }
 
 int

--- a/compiler/optimizer/LoopReducer.hpp
+++ b/compiler/optimizer/LoopReducer.hpp
@@ -352,10 +352,9 @@ public:
 
 private:
    void reduceNaturalLoop(TR_RegionStructure * whileLoop);
-   void removeSelfEdge(TR::CFGEdgeList succList, int32_t selfNumber);
+   void removeSelfEdge(TR::CFGEdgeList &succList, int32_t selfNumber);
    int addBlock(TR::Block * newBlock, TR::Block ** blocks, int numBlock, const int maxNumBlock);
    int addRegionBlocks(TR_RegionStructure * region, TR::Block ** blocks, int numBlock, const int maxNumBlock);
-   void removeEdge(TR::CFGEdgeList succList, int32_t selfNumber, int32_t destNumber);
    bool constrainedIndVar(TR_InductionVariable * indVar);
 
    TR::ILOpCodes convertIf(TR::ILOpCodes ifCmp);

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -4456,11 +4456,12 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
    // so that they now branch to the first block containing the
    // (first) versioning test.
    //
-   for (auto nextPred = invariantBlock->getPredecessors().begin(); nextPred != invariantBlock->getPredecessors().end();)
+   while (!invariantBlock->getPredecessors().empty())
       {
-	  (*nextPred)->setTo(chooserBlock);
-	  TR::Block *nextPredBlock = toBlock((*nextPred)->getFrom());
-      nextPred = invariantBlock->getPredecessors().erase(nextPred);
+      TR::CFGEdge * const nextPred = invariantBlock->getPredecessors().front();
+      invariantBlock->getPredecessors().pop_front();
+      nextPred->setTo(chooserBlock);
+      TR::Block * const nextPredBlock = toBlock(nextPred->getFrom());
       if (nextPredBlock != _cfg->getStart())
          {
          TR::TreeTop *lastTreeInPred = nextPredBlock->getLastRealTreeTop();

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -3517,7 +3517,7 @@ static bool isLegalToMerge(TR::Node * node, TR::Block * block, TR::Block * nextB
 // Changes branch destinations for merge blocks.
 //
 static void changeBranchDestinationsForMergeBlocks(TR::Block * block, TR::Block * nextBlock,
-                    TR::Node    * bbStartNode, TR::CFGEdgeList &inEdge, std::list<TR::CFGEdge*, TR::typed_allocator<TR::CFGEdge*, TR::Allocator> >::iterator &inEdgeIter, TR::Simplifier * s)
+                    TR::Node    * bbStartNode, TR::CFGEdgeList &inEdge, TR::CFGEdgeList::iterator &inEdgeIter, TR::Simplifier * s)
    {
    TR::CFGEdgeList &successors     = block->getSuccessors();
    TR::CFGEdge* outEdge = successors.front();
@@ -14890,7 +14890,7 @@ TR::Node *endBlockSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
 
    TR::Block * nextBlock                     = bbStartNode->getBlock();
    TR::CFGEdgeList   &inEdge        = nextBlock->getPredecessors();
-   std::list<TR::CFGEdge*, TR::typed_allocator<TR::CFGEdge*, TR::Allocator> >::iterator inEdgeIter = inEdge.begin();
+   TR::CFGEdgeList::iterator inEdgeIter = inEdge.begin();
    TR::CFGEdgeList        &nextExcpOut     = nextBlock->getExceptionSuccessors();
    bool                     moreThanOnePred = (!(nextBlock->getPredecessors().empty()) && (nextBlock->getPredecessors().size() > 1));
 

--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -5611,10 +5611,8 @@ TR::TreeTop* TR::ArraycopyTransformation::createMultipleArrayNodes(TR::TreeTop* 
       cfg->addEdge(TR::CFGEdge::createEdge(forwardArrayCopyBlock,  followOnBlock, trMemory()));
       cfg->copyExceptionSuccessors(ifBlock, forwardArrayCopyBlock);
 
-      TR::CFGEdgeList elseSuccList = outerElseBlock->getSuccessors();
-      cfg->removeEdge(elseSuccList, outerElseBlock->getNumber(), followOnBlock->getNumber());
-      TR::CFGEdgeList condSuccList = arraycopyBlock->getSuccessors();
-      cfg->removeEdge(condSuccList, arraycopyBlock->getNumber(), ifBlock->getNumber());
+      cfg->removeEdge(outerElseBlock->getSuccessors(), outerElseBlock->getNumber(), followOnBlock->getNumber());
+      cfg->removeEdge(arraycopyBlock->getSuccessors(), arraycopyBlock->getNumber(), ifBlock->getNumber());
 
       outerArraycopyTree = arraycopyForward;
       }

--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -6058,11 +6058,12 @@ void OMR::ValuePropagation::versionBlocks()
       // so that they now branch to the first block containing the
       // (first) versioning test.
       //
-      for (auto nextPred = block->getPredecessors().begin(); nextPred != block->getPredecessors().end();)
+      while (!block->getPredecessors().empty())
          {
-         (*nextPred)->setTo(chooserBlock);
-         TR::Block *nextPredBlock = toBlock((*nextPred)->getFrom());
-         nextPred = block->getPredecessors().erase(nextPred);
+         TR::CFGEdge * const nextPred = block->getPredecessors().front();
+         block->getPredecessors().pop_front();
+         nextPred->setTo(chooserBlock);
+         TR::Block * const nextPredBlock = toBlock(nextPred->getFrom());
 
          if (nextPredBlock != _cfg->getStart())
             {

--- a/compiler/optimizer/OrderBlocks.cpp
+++ b/compiler/optimizer/OrderBlocks.cpp
@@ -1506,10 +1506,9 @@ bool TR_OrderBlocks::doPeepHoleBlockCorrections(TR::Block *block, char *title)
       if (performTransformation(comp(), "%s block_%d has no predecessors so removing it and its out edges from the flow graph\n", title, block->getNumber()))
          {
          // disconnect any out edges
-         TR::CFGEdgeList succList(block->getSuccessors());
-         succList.insert(succList.end(), block->getExceptionSuccessors().begin(), block->getExceptionSuccessors().end());
-         for (auto edge=succList.begin(); edge != succList.end(); ++edge)
-            cfg->removeEdge((*edge)->getFrom(), (*edge)->getTo());
+         TR_SuccessorIterator outEdges(block);
+         for (auto succeedingEdge = outEdges.getFirst(); succeedingEdge; succeedingEdge = outEdges.getNext())
+            cfg->removeEdge(succeedingEdge->getFrom(), succeedingEdge->getTo());
 
          removeEmptyBlock(cfg, block, title);
          return false;

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -2293,7 +2293,7 @@ TR::Block *OMR::X86::TreeEvaluator::getOverflowCatchBlock(TR::Node *node, TR::Co
    {
    //make sure the overflowCHK has a catch block first
    TR::Block *overflowCatchBlock = NULL;
-   TR::CFGEdgeList excepSucc =cg->getCurrentEvaluationTreeTop()->getEnclosingBlock()->getExceptionSuccessors();
+   TR::CFGEdgeList &excepSucc = cg->getCurrentEvaluationTreeTop()->getEnclosingBlock()->getExceptionSuccessors();
    for (auto e = excepSucc.begin(); e != excepSucc.end(); ++e) 
       {    
       TR::Block *dest = toBlock((*e)->getTo());


### PR DESCRIPTION
Restore compiler CPU usage that was regressed when changing the implementation of the container used by CFG nodes to keep track of incoming and outgoing edges.