### PR TITLE
Add API to check OS features

### DIFF
--- a/fvtest/porttest/si.cpp
+++ b/fvtest/porttest/si.cpp
@@ -2036,3 +2036,26 @@ TEST(PortSysinfoTest, sysinfo_test_get_open_file_count)
 }
 #endif /* defined(LINUX) || defined(AIXPPC) */
 #endif /* !(defined(WIN32) || defined(WIN64)) */
+
+/**
+ * Test omrsysinfo_test_get_os_description.
+ */
+TEST(PortSysinfoTest, sysinfo_test_get_os_description)
+{
+	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
+	const char *testName = "omrsysinfo_test_get_os_description";
+
+	intptr_t rc = 0;
+	reportTestEntry(OMRPORTLIB, testName);
+
+	OMROSDesc desc;
+	rc =  omrsysinfo_get_os_description(&desc);
+
+	for (int i = 0; i < OMRPORT_SYSINFO_OS_FEATURES_SIZE * 32; i++) {
+		BOOLEAN feature = omrsysinfo_os_has_feature(&desc, i);
+		portTestEnv->log(LEVEL_VERBOSE, "omrsysinfo_test_get_os_description() feature %d: value=%d, rc=%zi\n", i, feature, rc);
+	}
+
+	reportTestExit(OMRPORTLIB, testName);
+	return;
+}

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -952,6 +952,15 @@ typedef struct J9StringTokens {
 	void *table;
 } J9StringTokens;
 
+/* Holds OS features used with omrsysinfo_get_os_description and omrsysinfo_os_has_feature */
+#define OMRPORT_SYSINFO_OS_FEATURES_SIZE 1
+typedef struct OMROSDesc {
+	uint32_t features[OMRPORT_SYSINFO_OS_FEATURES_SIZE];
+} OMROSDesc;
+
+/* zOS features */
+#define OMRPORT_ZOS_FEATURE_RMODE64 31 /* RMODE64. */
+
 struct OMRPortLibrary;
 typedef struct J9Heap J9Heap;
 
@@ -1381,6 +1390,10 @@ typedef struct OMRPortLibrary {
 	void (*sysinfo_set_number_entitled_CPUs)(struct OMRPortLibrary *portLibrary, uintptr_t number) ;
 	/** see @ref omrsysinfo.c::omrsysinfo_get_open_file_count "omrsysinfo_get_open_file_count"*/
 	int32_t (*sysinfo_get_open_file_count)(struct OMRPortLibrary *portLibrary, uint64_t *count) ;
+	/** see @ref omrsysinfo.c::omrsysinfo_get_os_description "omrsysinfo_get_os_description"*/
+	intptr_t  ( *sysinfo_get_os_description)(struct OMRPortLibrary *portLibrary, OMROSDesc *desc) ;
+	/** see @ref omrsysinfo.c::omrsysinfo_os_has_feature "omrsysinfo_os_has_feature"*/
+	BOOLEAN  ( *sysinfo_os_has_feature)(struct OMRPortLibrary *portLibrary, OMROSDesc *desc, uint32_t feature) ;
 	/** see @ref omrport.c::omrport_init_library "omrport_init_library"*/
 	int32_t (*port_init_library)(struct OMRPortLibrary *portLibrary, uintptr_t size) ;
 	/** see @ref omrport.c::omrport_startup_library "omrport_startup_library"*/
@@ -1817,6 +1830,8 @@ extern J9_CFUNC int32_t omrport_getVersion(struct OMRPortLibrary *portLibrary);
 #define omrsysinfo_get_cwd(param1,param2) privateOmrPortLibrary->sysinfo_get_cwd(privateOmrPortLibrary, (param1), (param2))
 #define omrsysinfo_get_tmp(param1,param2,param3) privateOmrPortLibrary->sysinfo_get_tmp(privateOmrPortLibrary, (param1), (param2), (param3))
 #define omrsysinfo_get_open_file_count(param1) privateOmrPortLibrary->sysinfo_get_open_file_count(privateOmrPortLibrary, (param1))
+#define omrsysinfo_get_os_description(param1) privateOmrPortLibrary->sysinfo_get_os_description(privateOmrPortLibrary, (param1))
+#define omrsysinfo_os_has_feature(param1,param2) privateOmrPortLibrary->sysinfo_os_has_feature(privateOmrPortLibrary, (param1), (param2))
 #define omrintrospect_startup() privateOmrPortLibrary->introspect_startup(privateOmrPortLibrary)
 #define omrintrospect_shutdown() privateOmrPortLibrary->introspect_shutdown(privateOmrPortLibrary)
 #define omrintrospect_set_suspend_signal_offset(param1) privateOmrPortLibrary->introspect_set_suspend_signal_offset(privateOmrPortLibrary, param1)

--- a/port/common/omrport.c
+++ b/port/common/omrport.c
@@ -247,6 +247,8 @@ static OMRPortLibrary MasterPortLibraryTable = {
 	omrsysinfo_get_tmp, /* sysinfo_get_tmp */
 	omrsysinfo_set_number_entitled_CPUs, /* sysinfo_set_number_entitled_CPUs */
 	omrsysinfo_get_open_file_count, /* sysinfo_get_open_file_count */
+	omrsysinfo_get_os_description, /* sysinfo_get_os_description */
+	omrsysinfo_os_has_feature, /* sysinfo_os_has_feature */
 	omrport_init_library, /* port_init_library */
 	omrport_startup_library, /* port_startup_library */
 	omrport_create_library, /* port_create_library */

--- a/port/common/omrport.tdf
+++ b/port/common/omrport.tdf
@@ -1003,3 +1003,9 @@ TraceExit=Trc_PRT_vmem_reserve_using_moservices_exit Group=mem Overhead=1 Level=
 TraceException=Trc_PRT_vmem_omrvmem_decommit_nonpageable_memory Group=mem Overhead=1 Level=1 NoEnv Template="omrvmem_decommit_memory attemp to decommit non-pageable memory at address=%p byteAmount=%u"
 
 TraceExit=Trc_PRT_mmap_map_seek_failed Group=mmap Overhead=1 Level=1 NoEnv Template="omrmmap_map_file: Failed to seek to offset = %lld"
+
+TraceEntry=Trc_PRT_sysinfo_get_os_description_Entered Group=sysinfo Overhead=1 Level=5 NoEnv Template="sysinfo_get_os_description: desc = %p"
+TraceExit=Trc_PRT_sysinfo_get_os_description_Exit Group=sysinfo Overhead=1 Level=5 NoEnv Template="sysinfo_get_os_description: returning with %zd"
+
+TraceEntry=Trc_PRT_sysinfo_os_has_feature_Entered Group=sysinfo Overhead=1 Level=5 NoEnv Template="sysinfo_os_has_feature: desc = %p, feature = %d"
+TraceExit=Trc_PRT_sysinfo_os_has_feature_Exit Group=sysinfo Overhead=1 Level=5 NoEnv Template="sysinfo_os_has_feature: returning with %zu."

--- a/port/common/omrsysinfo.c
+++ b/port/common/omrsysinfo.c
@@ -738,3 +738,51 @@ omrsysinfo_get_open_file_count(struct OMRPortLibrary *portLibrary, uint64_t *cou
 	return OMRPORT_ERROR_SYSINFO_GET_OPEN_FILES_NOT_SUPPORTED;
 }
 
+/**
+ * Determine OS features.
+ *
+ * @param[in] portLibrary instance of port library
+ * @param[out] desc pointer to the struct that will contain the OS features.
+ * desc will still be initialized if there is a failure.
+ *
+ * @return 0 on success, -1 on failure
+ */
+intptr_t
+omrsysinfo_get_os_description(struct OMRPortLibrary *portLibrary, OMROSDesc *desc)
+{
+	intptr_t rc = -1;
+	Trc_PRT_sysinfo_get_os_description_Entered(desc);
+
+	if (NULL != desc) {
+		memset(desc, 0, sizeof(OMROSDesc));
+	}
+
+	Trc_PRT_sysinfo_get_os_description_Exit(rc);
+	return rc;
+}
+
+/**
+ * Determine OS has a feature enabled.
+ *
+ * @param[in] portLibrary instance of port library
+ * @param[in] desc The struct that will contain the OS features
+ * @param[in] feature The feature to check (see omrport.h for list of OS features)
+ *
+ * @return TRUE if feature is present, FALSE otherwise.
+ */
+BOOLEAN
+omrsysinfo_os_has_feature(struct OMRPortLibrary *portLibrary, OMROSDesc *desc, uint32_t feature)
+{
+	BOOLEAN rc = FALSE;
+	Trc_PRT_sysinfo_os_has_feature_Entered(desc, feature);
+
+	if ((NULL != desc) && (feature < (OMRPORT_SYSINFO_OS_FEATURES_SIZE * 32))) {
+		uint32_t featureIndex = feature / 32;
+		uint32_t featureShift = feature % 32;
+
+		rc = J9_ARE_ALL_BITS_SET(desc->features[featureIndex], 1 << featureShift);
+	}
+
+	Trc_PRT_sysinfo_os_has_feature_Exit((uintptr_t)rc);
+	return rc;
+}

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -503,6 +503,10 @@ extern J9_CFUNC intptr_t
 omrsysinfo_get_tmp(struct OMRPortLibrary *portLibrary, char *buf, uintptr_t bufLen, BOOLEAN ignoreEnvVariable);
 extern J9_CFUNC int32_t 
 omrsysinfo_get_open_file_count(struct OMRPortLibrary *portLibrary, uint64_t *count);
+extern J9_CFUNC intptr_t
+omrsysinfo_get_os_description(struct OMRPortLibrary *portLibrary, OMROSDesc *desc);
+extern J9_CFUNC BOOLEAN
+omrsysinfo_os_has_feature(struct OMRPortLibrary *portLibrary, OMROSDesc *desc, uint32_t feature);
 
 /* J9SourceJ9Signal*/
 extern J9_CFUNC int32_t

--- a/port/win32/omrsysinfo.c
+++ b/port/win32/omrsysinfo.c
@@ -1576,3 +1576,33 @@ omrsysinfo_get_open_file_count(struct OMRPortLibrary *portLibrary, uint64_t *cou
 	return OMRPORT_ERROR_SYSINFO_GET_OPEN_FILES_NOT_SUPPORTED;
 }
 
+intptr_t
+omrsysinfo_get_os_description(struct OMRPortLibrary *portLibrary, OMROSDesc *desc)
+{
+	intptr_t rc = -1;
+	Trc_PRT_sysinfo_get_os_description_Entered(desc);
+
+	if (NULL != desc) {
+		memset(desc, 0, sizeof(OMROSDesc));
+	}
+
+	Trc_PRT_sysinfo_get_os_description_Exit(rc);
+	return rc;
+}
+
+BOOLEAN
+omrsysinfo_os_has_feature(struct OMRPortLibrary *portLibrary, OMROSDesc *desc, uint32_t feature)
+{
+	BOOLEAN rc = FALSE;
+	Trc_PRT_sysinfo_os_has_feature_Entered(desc, feature);
+
+	if ((NULL != desc) && (feature < (OMRPORT_SYSINFO_OS_FEATURES_SIZE * 32))) {
+		uint32_t featureIndex = feature / 32;
+		uint32_t featureShift = feature % 32;
+
+		rc = J9_ARE_ALL_BITS_SET(desc->features[featureIndex], 1 << featureShift);
+	}
+
+	Trc_PRT_sysinfo_os_has_feature_Exit((uintptr_t)rc);
+	return rc;
+}


### PR DESCRIPTION
A new struct, OMROSDesc, added to hold operating system (OS)
features.

omrsysinfo_get_os_description function determines OS features and 
holds this information in the new struct, OMROSDesc.

omrsysinfo_os_has_feature function queries the new struct, OMROSDesc,
to determine if a OS feature is available.

At this point, only one feature has been added -
OMRPORT_ZOS_FEATURE_RMODE64.

OMRPORT_ZOS_FEATURE_RMODE64 - detects whether OS supports RMODE64
feature on zOS. Detection of RMODE64 feature is crucial for 
determining what size of code cache to allocate on zOS.

omrsysinfo_get_os_description function only works for zOS at this 
point i.e. it will return 0. For other operating systems, it will 
return -1. Minimal templates have been added to support other 
operating systems.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>