### PR TITLE
Include f/w-ed obj. when iterating Evac in backout

### DIFF
--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -3444,6 +3444,9 @@ MM_Scavenger::completeBackOut(MM_EnvironmentStandard *env)
 				if (isObjectInEvacuateMemory((omrobjectptr_t)rootRegion->getLowAddress())) {
 					/* tell the object iterator to work on the given region */
 					GC_ObjectHeapIteratorAddressOrderedList evacuateHeapIterator(_extensions, rootRegion, false);
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+					evacuateHeapIterator.includeForwardedObjects();
+#endif
 					omrobjectptr_t objectPtr = NULL;
 					omrobjectptr_t fwdObjectPtr = NULL;
 					while((objectPtr = evacuateHeapIterator.nextObjectNoAdvance()) != NULL) {


### PR DESCRIPTION
On platforms where Concurrent Scavenger (CS) is compile-time enabled,
but CS not running, during backout, explicitly request inclusion of
forwarded objects when iterating Evacuate space to find
tenured-remembered objects (to un-remember them).

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>