### PR TITLE
Add option to force induceOSRAfter always

### DIFF
--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -564,11 +564,11 @@ OMR::ResolvedMethodSymbol::genInduceOSRCallNode(TR::TreeTop* insertionPoint,
 
 
 bool
-OMR::ResolvedMethodSymbol::induceOSRAfter(TR::TreeTop *insertionPoint, TR_ByteCodeInfo induceBCI, TR::TreeTop* branch, bool extendRemainder, int32_t offset)
+OMR::ResolvedMethodSymbol::induceOSRAfter(TR::TreeTop *insertionPoint, TR_ByteCodeInfo induceBCI, TR::TreeTop* branch, bool extendRemainder, int32_t offset, bool force)
    {
    TR::Block *block = insertionPoint->getEnclosingBlock();
 
-   if (self()->supportsInduceOSR(induceBCI, block, self()->comp()))
+   if (force || self()->supportsInduceOSR(induceBCI, block, self()->comp()))
       {
       TR::CFG *cfg = self()->comp()->getFlowGraph();
       cfg->setStructure(NULL);

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
@@ -166,7 +166,12 @@ public:
 
    bool canInjectInduceOSR(TR::Node* node);
 
-   bool induceOSRAfter(TR::TreeTop *insertionPoint, TR_ByteCodeInfo induceBCI, TR::TreeTop* branch, bool extendRemainder, int32_t offset);
+   /*
+    * Insert an OSR guard after the insertionPoint using induceBCI. Checks will be performed with induceBCI, but the transition destination will
+    * have the offset applied. Branch will be the destination treetop of the OSR guard.
+    * forceInduce can be used if it is well known a transition should be supported, such as at the start of the method.
+    */
+   bool induceOSRAfter(TR::TreeTop *insertionPoint, TR_ByteCodeInfo induceBCI, TR::TreeTop* branch, bool extendRemainder, int32_t offset, bool forceInduce=false);
    TR::TreeTop *induceImmediateOSRWithoutChecksBefore(TR::TreeTop *insertionPoint);
 
    int32_t incTempIndex(TR_FrontEnd * fe);


### PR DESCRIPTION
induceOSRAfter will check if the provided bytecode index
supports induce OSR before inserting the OSR infrastructure.
However, there are times where it is known to the caller that
a transition must be possible, for example, at the start of
the method. This adds an option forcing the method to skip
its safety check.