### PR TITLE
JitBuilder small performance improvements

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -317,7 +317,7 @@ OMR::CodeGenerator::generateNop(TR::Node * node, TR::Instruction *instruction, T
    if (self()->comp()->getDebug())
       self()->comp()->getDebug()->resetDebugData();
 
-
+   self()->setIsLeafMethod();
    }
 
 TR_StackMemory

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -740,6 +740,10 @@ class OMR_EXTENSIBLE CodeGenerator
    TR_InterferenceGraph *getLocalsIG() {return _localsIG;}
    TR_InterferenceGraph *setLocalsIG(TR_InterferenceGraph *ig) {return (_localsIG = ig);}
 
+   bool isLeafMethod()      { return _flags1.testAny(IsLeafMethod); }
+   void setIsLeafMethod()   { _flags1.set(IsLeafMethod); }
+   void resetIsLeafMethod() { _flags1.reset(IsLeafMethod); }
+
    // --------------------------------------------------------------------------
    // Binary encoding code cache
    //
@@ -1701,7 +1705,7 @@ class OMR_EXTENSIBLE CodeGenerator
       UsesRegisterMaps                                   = 0x00000010,
       JNILinkageCalleeCleanup                            = 0x00000020,
       HasResumableTrapHandler                            = 0x00000040,
-      //                                                 = 0x00000080,   // Available
+      IsLeafMethod                                       = 0x00000080,
       SupportsPartialInlineOfMethodHooks                 = 0x00000100,
       SupportsReferenceArrayCopy                         = 0x00000200,
       SupportsJavaFloatSemantics                         = 0x00000400,

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -972,6 +972,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
         TR::Options::set32BitNumeric, offsetof(OMR::Options,_numRestrictedGPRs), 0, "F%d"},
    {"oldDataCacheImplementation",         "I\trevert to old data cache implementation.", SET_OPTION_BIT(TR_OldDataCacheImplementation),"F", NOT_IN_SUBSET},
    {"oldJVMPI",           "D\told way of determining which jit options to use with JVMPI",    SET_OPTION_BIT(TR_OldJVMPI), "P" },
+   {"omitFramePointer",         "I\tdo not dedicate a frame pointer register for X86 system linkage.", SET_OPTION_BIT(TR_OmitFramePointer),"F", NOT_IN_SUBSET},
    {"onlyInline=",                        "O{regex}\tlist of methods that can be inlined",
                                           TR::Options::setRegex, offsetof(OMR::Options, _onlyInline), 0, "P"},
    {"optDetails",         "L\tlog all optimizer transformations",

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -187,7 +187,7 @@ enum TR_CompilationOptions
    TR_DisableOnDemandLiteralPoolRegister  = 0x08000000 + 2,
    TR_DisableInternalPointers             = 0x10000000 + 2,
    TR_EnableNodeGC                        = 0x20000000 + 2,
-   // Available                           = 0x40000000 + 2,
+   TR_OmitFramePointer                    = 0x40000000 + 2,
    TR_ForceAOT                            = 0x80000000 + 2,
 
    // Option word 3

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -1556,7 +1556,10 @@ int32_t TR_HoistBlocks::process(TR::TreeTop *startTree, TR::TreeTop *endTree)
 
             if ((prevBlock->isCold()) || (prevBlock == cfgStart) || (prevBlock == block) ||
                 (exceptionEdgesMatter && cfg->compareExceptionSuccessors(block, prevBlock)))
+               {
+               nextEdge = next;
                continue;
+               };
 
             bool isLoopBackEdge = false;
             //
@@ -1576,7 +1579,10 @@ int32_t TR_HoistBlocks::process(TR::TreeTop *startTree, TR::TreeTop *endTree)
                }
 
             if (isLoopBackEdge)
+               {
+               nextEdge = next;
                continue;
+               }
 
 
             if (isLoopHdr)
@@ -1586,6 +1592,7 @@ int32_t TR_HoistBlocks::process(TR::TreeTop *startTree, TR::TreeTop *endTree)
                // peeled outside.  No convincing reason to keep hoisting out of
                // loops enabled.
                //
+               nextEdge = next;
                continue;
 
 
@@ -1616,7 +1623,10 @@ int32_t TR_HoistBlocks::process(TR::TreeTop *startTree, TR::TreeTop *endTree)
                   }
 
                if (successorsInMidLoop > 1)
+                  {
+                  nextEdge = next;
                   continue;
+                  }
                }
 
 
@@ -1628,7 +1638,10 @@ int32_t TR_HoistBlocks::process(TR::TreeTop *startTree, TR::TreeTop *endTree)
             // need for hoisting)
             //
             if (block->getPredecessors().size() == 1)
+               {
+               nextEdge = next;
                continue;
+               };
 
             TR::TreeTop *tt = prevBlock->getLastRealTreeTop();
 

--- a/compiler/x/amd64/codegen/AMD64SystemLinkage.cpp
+++ b/compiler/x/amd64/codegen/AMD64SystemLinkage.cpp
@@ -280,8 +280,10 @@ TR::AMD64ABILinkage::AMD64ABILinkage(TR::CodeGenerator *cg)
       IntegersInRegisters |
       LongsInRegisters    |
       FloatsInRegisters   |
-      ReservesOutgoingArgsInPrologue |
-      AlwaysDedicateFramePointerRegister;
+      ReservesOutgoingArgsInPrologue;
+
+   if (!cg->comp()->getOption(TR_OmitFramePointer))
+      _properties._properties |= AlwaysDedicateFramePointerRegister;
 
    // Integer arguments
    //

--- a/compiler/x/amd64/codegen/AMD64SystemLinkage.cpp
+++ b/compiler/x/amd64/codegen/AMD64SystemLinkage.cpp
@@ -766,6 +766,7 @@ TR::AMD64SystemLinkage::buildIndirectDispatch(TR::Node *callNode)
    // Dispatch
    //
    generateRegInstruction(CALLReg, callNode, vftRegister, callDeps, cg());
+   cg()->resetIsLeafMethod();
 
    // Build label post-conditions
    //
@@ -891,6 +892,8 @@ TR::Register *TR::AMD64SystemLinkage::buildDirectDispatch(
       {
       instr = generateImmSymInstruction(CALLImm4, callNode, (uintptrj_t)methodSymbol->getMethodAddress(), methodSymRef, preDeps, cg());
       }
+
+   cg()->resetIsLeafMethod();
 
    instr->setNeedsGCMap(getProperties().getPreservedRegisterMapForGC());
 

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -4806,6 +4806,7 @@ TR::X86ImmSymInstruction  *
 generateHelperCallInstruction(TR::Instruction * cursor, TR_RuntimeHelper index, TR::CodeGenerator *cg)
    {
    TR::SymbolReference * helperSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(index, false, false, false);
+   cg->resetIsLeafMethod();
    return new (cg->trHeapMemory()) TR::X86ImmSymInstruction(cursor, CALLImm4, (uintptrj_t)helperSymRef->getMethodAddress(), helperSymRef, cg);
    }
 
@@ -4813,6 +4814,7 @@ TR::X86ImmSymInstruction  *
 generateHelperCallInstruction(TR::Node * node, TR_RuntimeHelper index, TR::RegisterDependencyConditions  *dependencies, TR::CodeGenerator *cg)
    {
    TR::SymbolReference * helperSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(index, false, false, false);
+   cg->resetIsLeafMethod();
    return generateImmSymInstruction(
          CALLImm4,
          node,

--- a/compiler/x/codegen/X86SystemLinkage.cpp
+++ b/compiler/x/codegen/X86SystemLinkage.cpp
@@ -470,7 +470,7 @@ TR::X86SystemLinkage::createPrologue(TR::Instruction *cursor)
       + ( properties.getAlwaysDedicateFramePointerRegister() ? properties.getGPRWidth() : 0);
 
    uint32_t adjust = 0;
-   if (_properties.getOutgoingArgAlignment())
+   if (_properties.getOutgoingArgAlignment() && !cg()->isLeafMethod())
       {
       // AMD64 SysV spec requires: The end of the input argument area shall be aligned on a 16 (32, if __m256 is passed on stack) byte boundary. In other words, the value (%rsp + 8) is always a multiple of 16 (32) when control is transferred to the function entry point.
       TR_ASSERT(_properties.getOutgoingArgAlignment() == 16 || _properties.getOutgoingArgAlignment() == 4, "AMD64 SysV linkage require outgoingArgAlignment be 16/32 bytes aligned, while IA32 linkage require 4 bytes aligned.  We currently haven't support 32 bytes alignment for AMD64 SysV ABI yet.\n");

--- a/compiler/x/codegen/X86SystemLinkage.cpp
+++ b/compiler/x/codegen/X86SystemLinkage.cpp
@@ -516,9 +516,15 @@ TR::X86SystemLinkage::createPrologue(TR::Instruction *cursor)
 
    // Allocate the stack frame
    //
+   const int32_t singleWordSize = TR::Compiler->target.is32Bit() ? 4 : 8;
    if (allocSize == 0)
       {
       // No need to do anything
+      }
+   else if (allocSize == singleWordSize)
+      {
+      TR::RealRegister *ebxReal = machine()->getX86RealRegister(TR::RealRegister::ebx);
+      cursor = new (trHeapMemory()) TR::X86RegInstruction(cursor, PUSHReg, ebxReal, cg());
       }
    else
       {
@@ -704,6 +710,7 @@ TR::X86SystemLinkage::createEpilogue(TR::Instruction *cursor)
 
    // Deallocate the stack frame
    //
+   const int32_t singleWordSize = TR::Compiler->target.is32Bit() ? 4 : 8;
    if (_properties.getAlwaysDedicateFramePointerRegister())
       {
       // Restore stack pointer from frame pointer
@@ -714,6 +721,11 @@ TR::X86SystemLinkage::createEpilogue(TR::Instruction *cursor)
    else if (allocSize == 0)
       {
       // No need to do anything
+      }
+   else if (allocSize == singleWordSize)
+      {
+      TR::RealRegister *ebxReal = machine()->getX86RealRegister(TR::RealRegister::ebx);
+      cursor = new (trHeapMemory()) TR::X86RegInstruction(cursor, POPReg, ebxReal, cg());
       }
    else
       {

--- a/compiler/x/i386/codegen/IA32SystemLinkage.cpp
+++ b/compiler/x/i386/codegen/IA32SystemLinkage.cpp
@@ -362,6 +362,7 @@ TR::Register *TR::IA32SystemLinkage::buildDirectDispatch(TR::Node *callNode, boo
 
    // Call-out
    int32_t stackAdjustment = cg()->getProperties().getCallerCleanup() ? 0 : -argSize;
+   cg()->resetIsLeafMethod();
    TR::X86ImmInstruction* instr = generateImmSymInstruction(CALLImm4, callNode, (uintptr_t)methodSymbol->getMethodAddress(), methodSymRef, cg());
    instr->setAdjustsFramePointerBy(stackAdjustment);
 

--- a/compiler/x/i386/codegen/IA32SystemLinkage.cpp
+++ b/compiler/x/i386/codegen/IA32SystemLinkage.cpp
@@ -64,7 +64,12 @@ TR::IA32SystemLinkage::IA32SystemLinkage(
       TR::CodeGenerator *cg) :
    TR::X86SystemLinkage(cg)
    {
-   _properties._properties = CallerCleanup | AlwaysDedicateFramePointerRegister;
+   _properties._properties = CallerCleanup;
+
+   // if OmitFramePointer specified, don't use one
+   if (!cg->comp()->getOption(TR_OmitFramePointer))
+      _properties._properties |= AlwaysDedicateFramePointerRegister;
+
    // for shrinkwrapping, we cannot use pushes for the preserved regs. pushes/pops need to be in sequence and this is not compatible with shrinkwrapping as registers need not be saved/restored in sequenc
    if (cg->comp()->getOption(TR_DisableShrinkWrapping))
       _properties._properties |= UsesPushesForPreservedRegs;

--- a/jitbuilder/control/Jit.cpp
+++ b/jitbuilder/control/Jit.cpp
@@ -179,7 +179,7 @@ extern "C"
 bool
 initializeJit()
    {
-   return initializeJitBuilder(0, 0, 0, (char *)"-Xjit:acceptHugeMethods,enableBasicBlockHoisting");
+   return initializeJitBuilder(0, 0, 0, (char *)"-Xjit:acceptHugeMethods,enableBasicBlockHoisting,omitFramePointer");
    }
 
 extern "C"

--- a/jitbuilder/control/Jit.cpp
+++ b/jitbuilder/control/Jit.cpp
@@ -179,7 +179,7 @@ extern "C"
 bool
 initializeJit()
    {
-   return initializeJitBuilder(0, 0, 0, (char *)"-Xjit:acceptHugeMethods");
+   return initializeJitBuilder(0, 0, 0, (char *)"-Xjit:acceptHugeMethods,enableBasicBlockHoisting");
    }
 
 extern "C"

--- a/jitbuilder/optimizer/JBOptimizer.cpp
+++ b/jitbuilder/optimizer/JBOptimizer.cpp
@@ -89,23 +89,26 @@ static const OptimizationStrategy cheapTacticalGlobalRegisterAllocatorOpts[] =
    { OMR::endGroup                        }
    };
 
+static const OptimizationStrategy JBcoldStrategyOpts[] =
+   {
+   { OMR::deadTreesElimination                                                     },
+   { OMR::treeSimplification                                                       },
+   { OMR::localCSE                                                                 },
+   { OMR::basicBlockExtension                                                      },
+   { OMR::cheapTacticalGlobalRegisterAllocatorGroup                                },
+   };
+
 static const OptimizationStrategy JBwarmStrategyOpts[] =
    {
-   { OMR::treeSimplification                                                       }, // lots to simplify
-   { OMR::localCSE                                                                 }, // common as much as possible
-   { OMR::treeSimplification                                                       }, // simplify again
-   { OMR::localCSE                                                                 }, // and common
-   { OMR::basicBlockOrdering,                                                      }, // straighten goto's
-   { OMR::globalCopyPropagation,                                                   },
-   { OMR::globalDeadStoreElimination,                                              },
    { OMR::deadTreesElimination                                                     },
    { OMR::treeSimplification                                                       },
-   { OMR::deadTreesElimination                                                     },
-   { OMR::lastLoopVersionerGroup,                    OMR::IfLoops                  },
-   { OMR::globalDeadStoreElimination,                OMR::IfEnabledAndLoops        },
+   { OMR::localCSE                                                                 },
+   { OMR::basicBlockOrdering                                                       }, // straighten goto's
+   { OMR::globalCopyPropagation                                                    },
+   { OMR::globalDeadStoreElimination,                OMR::IfMoreThanOneBlock       },
    { OMR::deadTreesElimination                                                     },
    { OMR::treeSimplification                                                       },
-   { OMR::blockSplitter                                                            },
+   { OMR::basicBlockHoisting                                                       },
    { OMR::treeSimplification                                                       },
 
    { OMR::globalValuePropagation,                    OMR::IfMoreThanOneBlock       },
@@ -121,7 +124,7 @@ static const OptimizationStrategy JBwarmStrategyOpts[] =
    { OMR::localCSE                                                                 },
    { OMR::treeSimplification,                        OMR::IfEnabled                },
    { OMR::trivialDeadTreeRemoval,                    OMR::IfEnabled                },
-   { OMR::cheapTacticalGlobalRegisterAllocatorGroup, OMR::IfEnabled                },
+   { OMR::cheapTacticalGlobalRegisterAllocatorGroup                                },
    { OMR::globalDeadStoreGroup,                                                    },
    { OMR::rematerialization                                                        },
    { OMR::deadTreesElimination,                      OMR::IfEnabled                }, // remove dead anchors created by check/store removal


### PR DESCRIPTION
A sequence of small performance improvements for JitBuilder, mostly focused on prolog/epilog corner cases for small methods, but there is also a change to the JitBuilder optimization strategy now that the initial IL quality has been improved via #1110.