### PR TITLE
First zTPF Pull to OMR

### DIFF
--- a/port/ztpf/omrosdump.c
+++ b/port/ztpf/omrosdump.c
@@ -1,0 +1,362 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 1991, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial API and implementation and/or initial documentation
+ *    Multiple authors (IBM Corp.) - refactoring and modifications for z/TPF platform
+ *******************************************************************************/
+
+/**
+ * \file
+ * \ingroup Port
+ * \brief Dump formatting externals referenced from portLibrary
+ */
+
+#define ZTPF_NEEDS_GETCONTEXT
+
+#include <signal.h>
+#include <tpf/c_proc.h>
+#include <tpf/c_cinfc.h>
+#include <tpf/tpfapi.h>
+#include <tpf/sysapi.h>
+#include <tpf/c_idsprg.h>
+#include <tpf/c_stck.h>
+#include <sys/ucontext.h>
+#include <pthread.h>
+#define OSDUMP_SYMBOLS_ONLY
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <errno.h>
+#include <tpf/c_eb0eb.h>
+#include <tpf/c_proc.h>
+#include "omrport.h"
+#include "portpriv.h"
+#include "omrosdump_helpers.h"
+#include "omrsignal.h"
+#include <signal.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <libgen.h>
+
+typedef struct iproc IPROC;
+#include "safe_storage.h"
+
+/**
+ * \fn Callback from CCCPSE: preemptible error.
+ *
+ * The z/TPF kernel will call us back at this function when it (the z/TPF
+ * program interrupt handler) determines that the error is 'preemptible'
+ * (i.e. is a 'soft' interrupt which is caused by division by zero or a
+ * null-pointer reference).
+ *
+ */
+static void __attribute__((used))
+ztpf_preemptible_err_ep(void)
+{
+	// let the port library do the work.
+	ztpf_preemptible_helper();
+}
+
+/**
+ * \fn Callback from CCCPSE: non-preemptible error.
+ *
+ * The z/TPF kernel will call us back at this function when it (the z/TPF
+ * program interrupt handler) determines that the error is 'non-preemptible'
+ * (i.e. is a 'hard' interrupt) caused by any number of programming errors
+ * considered serious enough to question the state of the JVM.
+ */
+static void
+__attribute__((used))
+ztpf_nonpreemptible_err_ep(void)
+{
+	// let the port library do the work.
+	ztpf_nonpreemptible_helper();
+}
+
+/**
+ * \fn  Create an ELF core dump file of the user space
+ *
+ *
+ *        This function determines if there is a Java Dump Buffer available pertinent to this
+ *        thread/process. If one is not, we know we were called from the system dump agent's
+ *        executing a hook (such as -Xdump:system:events=vmstop) and arrange for one to be
+ *        created right now. If a dump pertinent to us is available, we use it. We then call
+ *        ztpfBuildCoreDump() in order to build an ELF core dump from its contents, then
+ *        write it to file.
+ *
+ *        After we're done writing the file, zeroize the Java Dump Buffer pointer in the
+ *        DIB block.
+ *
+ * \param[in] portLibrary       The port library.
+ * \param[in,out] filename      Buffer for filename. On input, describes a requested filename.
+ * \param[in] dumpType          Type of dump to perform. Ignored for z/TPF.
+ * \param[in] userData          Implementation specific data. Ignored for z/TPF.
+ * \return 0 on success, non-zero otherwise.
+ *
+ * \note <TT>filename</TT> buffer can not be NULL.
+ * \note User must allocate and free <TT>filename</TT> buffer.
+ * \note <TT>filename</TT> buffer length is platform dependent, assumed to be <TT>EsMaxPath</TT> or <TT>MAX_PATH</TT>
+ * \note If <TT>filename</TT> buffer is empty, an error will be returned. Should it
+ *        contain only a filename (no path), one will be chosen for it.
+ */
+uintptr_t
+omrdump_create(struct OMRPortLibrary *portLibrary, char *filename, char *dumpType, void *userData)
+{
+	uint8_t workspace[PATH_MAX];
+	uint8_t *errMsg = "";
+	uint8_t *JVMfn = NULL;
+	uint8_t holdkey = 0;
+
+	DIB *pDIB = NULL;
+	DBFHDR *pDBF = NULL;
+	safeStorage *s = NULL;
+	uintptr_t ptr;
+	char *targetDirectory;
+	void *oldPath;
+
+	s = allocateDurableStorage();
+	if (s == NULL)  {
+		portLibrary->tty_err_printf(portLibrary, "Unable to to allocateDurableStorage().\n");
+		return 1; /* Return Failure. */
+	}
+	s->argv.portLibrary = portLibrary;
+	s->argv.OSFilename = filename;
+
+	/*
+	 * First, figure out whether or not we have to generate the dump buffer contents.
+	 * If this routine was called as a result of a hooked event being hit; not a
+	 * program check, then there is not a Java dump buffer (JDB) provided by the
+	 * z/TPF Control Program (supervisor, kernel, whatever you want to call the
+	 * permanently-memory-resident part of the system loaded by IPL).
+	 *
+	 * If we knew that this thread were the same thread which faulted, we could simply
+	 * check ce2dib->dibjdb for non-zero content. Unfortunately, we don't have that
+	 * assurance. Instead, the ce2dib address was stored by the synchronous master
+	 * signal callback routine in the process block. Fetch it and see if it's non-zero.
+	 * If so, a thread (the system dump agent) was dispatched here to create the dump
+	 * file due to a synchronous signal (like SIGSEGV). If not, there was no signal
+	 * and thus no existing data from which to write the core file.
+	 *
+	 * If there was no signal involved, we know that this call to omrdump_create()
+	 * was issued by the system dump agent which fired because of a hooked event. In
+	 * these cases, we presume that the user has a reason for wanting to see a system
+	 * snapshot at the event, and we have to issue a SERRC 4006 in order to get the
+	 * dump buffer created, even if it is quite a few microseconds after the call to
+	 * the dump agents from the Dump() java class or a hooked event. We'll have to do
+	 * this -- it's as close in time as we can get. Once the 4006 comes back, we can
+	 * dispatch a thread to write the dump core file and wait on it. From that point, we
+	 * will follow a very simple common process regardless of how the "OS core dump" file
+	 * was created: we will rename it to whatever the system dump agent specified in the
+	 * call and then we're done.
+	 *
+	 * It is crucial that the "OS core file" be written to the same path as the dump
+	 * agent specified for the final filename. When we rename it, we will invoke no
+	 * I/O overhead -- rename() simply alters the name field in the directory entry.
+	 *
+	 * A MFS (memory file system) output destination is recommended for speed's sake.
+	 */
+	/*
+	 * ------------------------------------------------------------------------------
+	 *  FUNCTION MAINLINE BEGINS
+	 * ------------------------------------------------------------------------------
+	 */
+	/*
+	 *        Go see if there's a current signal we're working now. If there is one,
+	 *        we stuffed its DIB in the process block at a reserved location.
+	 *        If it's not zero, that's where the faulting DIB is. If it is zero, we
+	 *        aren't working a synchronous signal.
+	 */
+	if (s->pPROC->iproc_tdibptr) { /* If there's a DIB ptr stashed,  */
+		pDIB = (DIB *) (s->pPROC->iproc_tdibptr); /* use it, then free the stash    */
+		PROC_LOCK(&(s->pPROC->iproc_JVMLock), holdkey);
+		s->pPROC->iproc_tdibptr = 0L; /* location ...                   */
+		PROC_UNLOCK(&(s->pPROC->iproc_JVMLock), holdkey);
+		pDBF = pDIB->dibjdb; /* and set our JDB pointer. */
+	}
+
+	/*
+	 * If we have been entered from a non-interrupt generated event, go get the current
+	 * system state parts that an ELF core file cares about, and base the core file
+	 * on them.
+	 */
+	if (!(pDBF)) { /* Is there a JDB?              */
+		serrc_op_ext(SERRC_RETURN, 0x4006, NULL, '\xc9', NULL); /* No, go create one.   */
+		s->pDIB = ecbp2()->ce2dib; /* We now have a DIB pointer.   */
+		pDIB = s->pDIB; /* Prep it, to pass along to coreBuilder Thread. JJ_UT*/
+		translateInterruptContexts(&(s->argv)); /* Go build UNIX context blks.  */
+	}
+
+	s->argv.dibPtr = pDIB; /* Pass the DIB to the file writer      */
+
+	/*
+	 * Build the ELF core file. Wait on it to come back.
+	 */
+	JVMfn = ztpfBuildCoreFile(&(s->argv));
+
+	/*
+	 * Unless ztpfBuildCoreFile() spit up on us, we should have an absolute pathname to the file. Let's
+	 * see what we got. If we took an error, the flags bits will generally
+	 * tell us what the broader error was, and if a runtime service failed,
+	 * errno will have been placed in argv.rc.
+	 */
+	if (!JVMfn) { /* Uh oh. There was an error. What to say?      */
+		if (s->argv.flags & J9TPF_ERRMSG_IN_WKSPC) {
+			errMsg = s->argv.wkSpace; /* The thread told us what to say ...           */
+		} else { /* How do we come up with a message?            */
+			switch (s->argv.flags & J9TPF_FLAGS_ERR_MASK) {
+			case (J9TPF_JDUMPBUFFER_LOCKED + J9TPF_NO_JAVA_DUMPBUFFER):
+			case J9TPF_JDUMPBUFFER_LOCKED:
+				errMsg = "Java dump buffer is locked";
+				break;
+			case J9TPF_NO_JAVA_DUMPBUFFER:
+				errMsg = "Java dump buffer is likely not for this process";
+				break;
+			case J9TPF_FILE_SYSTEM_ERROR:
+				if (s->argv.rc) { /* If the thread left us an errno,      */
+					errMsg = strerror(s->argv.rc); /*see if we can get a decent   */
+				} /* reason out of strerror().    */
+				else if (strlen(s->argv.wkSpace)) { /* Otherwise, see if there's     */
+					errMsg = s->argv.wkSpace; /*	 a message left by the dump writer	*/
+				} /* If there is, use it.                 */
+				break;
+			case J9TPF_OUT_OF_BUFFERSPACE:
+				errMsg =
+						"insufficient free buffer space to write the core file";
+				break;
+			default:
+				sprintf(workspace,
+						"unantipated err flag value (0x%X). errno=%x.",
+						s->argv.flags, s->argv.rc);
+				errMsg = workspace;
+				strcat(errMsg, "\nThere is no system dump to work with.");
+				break;
+			}
+		}
+		portLibrary->tty_err_printf(portLibrary,
+				"unable to write ELF core dump: %s\n", errMsg);
+		return 1; /* Report failure, get outta here.      */
+	} else {
+		s->argv.rc = rename(s->argv.wkSpace, JVMfn); /* Success. Return.                     */
+		if ((s->argv.rc < 0) && (errno == ENOENT)) {
+			//Current working directory may be different from target Dump Directory.
+			//In this scenario the dump is already in the target directory.
+			//Therefore re-issue the command using an absolute path name for old
+			//name.
+			targetDirectory = dirname(JVMfn);
+			if (targetDirectory == NULL) {
+				portLibrary->tty_err_printf(portLibrary,
+						"Problem determining directory for %s\n", JVMfn);
+			}
+			// +2 for terminating Null and joining path seperator
+			oldPath = alloca(
+					strlen(targetDirectory) + strlen(s->argv.wkSpace) + 2);
+			strcpy(oldPath, targetDirectory);
+			strcat(oldPath, "/");
+			strcat(oldPath, s->argv.wkSpace);
+			s->argv.rc = rename(oldPath, JVMfn); /* Success. Return. */
+			if (s->argv.rc < 0) {
+				portLibrary->tty_err_printf(portLibrary,
+						"Failed to rename: %s\n", oldPath);
+			}
+			//free response from dirname (using atoe wrapper library) because
+			//untranslated dirname is static storage and atoe_dirname needs
+			//to use malloc for response.
+			free(targetDirectory);
+		}
+
+	}
+	return 0;
+}
+
+/**
+ *       \deprecated Still referenced from portLibrary, must be kept as is.
+ */
+int32_t
+omrdump_startup(struct OMRPortLibrary *portLibrary)
+{
+
+	char prevSPK;
+	IPROC *pPROC = (IPROC *) iproc_process;
+	struct ifetch *fblk;
+	int rc;
+	PROC_LOCK(&(pPROC->iprocloc), prevSPK);
+	memset(pPROC->iproc_nppsw, 0,
+			(sizeof(pPROC->iproc_nppsw) + sizeof(pPROC->iproc_pepsw)
+					+ sizeof(pPROC->iproc_byteinterp)
+					+ sizeof(pPROC->iproc_tdibptr)
+					+ sizeof(pPROC->iproc_JVMLock)));
+	pPROC->iproc_flags |= IPROC_JVMPROCESS;
+	PROC_UNLOCK(&(pPROC->iprocloc), prevSPK);
+
+	/*  The byte interpreter is _this_ module, DJPR. Its name needs to be passed in EBCDIC.
+	 *  The #define following is that constant in EBCDIC.
+	 */
+#define OMRZTPF_BYTE_INTERP "\xC4\xF9\xE5\xD4"
+	/*              J9ZTPF_BYTE_INTERP "D9VM" */
+	/*
+	 *      z/TPF handles JVM-associated processes a little differently than all
+	 *      others. We need to mark the process block to inform the kernel that
+	 *      this is such a process so h/w-detected errors can come back to us instead
+	 *      of going to exit. There are no such things as kernel-space signals.
+	 */
+
+	/*
+	 *      First, get the address range of the byte interpreter module.
+	 *      The kernel needs this to detect what's faulting: native or Java code
+	 */
+	rc = getpc( OMRZTPF_BYTE_INTERP, GETPC_LOCK, NO_LVL, &fblk, GETPC_NODUMP,
+			GETPC_PBI, NULL);
+	/*
+	 *      Next, get a lock on the JVM's sub-area of the process block
+	 *      with the PROC_LOCK() macro, which also puts us in KEY 0 so
+	 *      we can write on it.
+	 */
+	PROC_LOCK(&(pPROC->iproc_JVMLock), prevSPK);
+	/*
+	 * Calculate & store the address range of the byte interpreter module
+	 */
+	pPROC->iproc_byteinterp[0] = fblk->_iftch_entry + fblk->_iftch_txt_off;
+	pPROC->iproc_byteinterp[1] = pPROC->iproc_byteinterp[0]
+			+ fblk->_iftch_txt_size - 1;
+	/*
+	 * Give CCCPSE a pair of callback addresses. These are in PSW format.
+	 */
+	pPROC->iproc_nppsw[0] = 0;
+	pPROC->iproc_pepsw[0] = 0;
+	pPROC->iproc_nppsw[1] = (unsigned long int) &ztpf_nonpreemptible_err_ep;
+	pPROC->iproc_pepsw[1] = (unsigned long int) &ztpf_preemptible_err_ep;
+	/*
+	 * Unlock the process block and put us back in the normal problem
+	 * state key.
+	 */
+	PROC_UNLOCK(&(pPROC->iproc_JVMLock), prevSPK);
+
+	return 0;
+}
+
+/**
+ *              \deprecated Still referenced from portLibrary, must be kept as is.
+ */
+void
+omrdump_shutdown(struct OMRPortLibrary *portLibrary)
+{
+	/* noop */
+}

--- a/port/ztpf/omrosdump_helpers.c
+++ b/port/ztpf/omrosdump_helpers.c
@@ -1,0 +1,1020 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 1991, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial API and implementation and/or initial documentation
+ *    Multiple authors (IBM Corp.) - refactoring and modifications for z/TPF platform
+ *******************************************************************************/
+
+/**
+ * \file
+ * \ingroup Port
+ * \brief Dump formatting support internals unique to z/TPF
+ */
+
+#define ZTPF_NEEDS_GETCONTEXT
+
+#include <tpf/tpf_limits.h>                /* For PATH_MAX            */
+#include <tpf/i_ecb3.h>                    /* Page 3, ECB            */
+#include <tpf/c_deri.h>                    /* SERRC info record    */
+#include <sys/stat.h>                      /* For chmod().            */
+#include <elf.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <errno.h>
+#include <unistd.h>
+#include <string.h>
+#include <ctype.h>
+#include <tpf/c_cinfc.h>
+#include <tpf/c_idsprg.h>
+#include <tpf/tpfapi.h>
+#include <atoe.h>
+
+#include "portnls.h"
+#include "omrosdump_helpers.h"
+#include "safe_storage.h"
+
+extern void translateInterruptContexts(args *argv) __attribute__((nonnull));
+extern void masterSynchSignalHandler(int nbr, siginfo_t *siginfo,
+		void *ucontext, uintptr_t bear);
+
+#define    KEY0(a)    do { cinfc(CINFC_WRITE, CINFC_CMMJDB); } while(0)
+#define    UNKEY(a) do { keyrc(); } while(0)
+
+char javaPgmsToDump[][5] = { "DJBV", "DJHK", "DJNC", "DJVB", "DJCK", "DJHS",
+		"DJPR", "DJVM", "DJDD", "DJHT", "DJRD", "DJZL", "DJDP", "DJHV", "DJSG",
+		"D9VM", "DJDY", "DJHY", "DJSH", "DJ7B", "DJGC", "DJIT", "DJTH", "DJAR",
+		"DJGK", "DJMT", "DJTR" };
+
+/**
+ * The ELF program header permission bits for read, write, and execute combined
+ */
+#define PT_RWX 7
+
+/**
+ * Size, in bytes, of the ELF NOTE region for z/Architecture machines
+ */
+#define NOTE_TABLE_SIZE 1020L
+
+/*
+ *      Non-exportable function prototypes
+ */
+static uint8_t* splitPathName(char *finalname, char *pathname);
+static void buildELFHeader(Elf64_Ehdr *buffer);
+static uint16_t buildELFPheaderBlk(Elf64_Phdr *buffer, DBFHDR *dbfHdr, uintptr_t phnum,
+		uint64_t * numBytes);
+static uintptr_t buildELFNoteArea(Elf64_Nhdr *buffer, DIB *dibPtr);
+static void errMsg(args *argv, uint8_t *message, ...) __attribute__((nonnull(1,2)));
+static uint64_t writeDumpFile(int32_t fd, uint8_t *buffer, uint64_t bytes);
+
+/*
+ * This function does the output to file, and returns the total count
+ * of bytes written. It should be equal to the <bytes> argument.
+ *
+ * In the event of error, it will return ULONG_MAX.
+ */
+static uint64_t
+writeDumpFile(int32_t fd, uint8_t *buffer, uint64_t bytes)
+{
+	int64_t bytesWrittenOnce = 0;
+	uint64_t bytesWrittenTotal = 0;
+	uint64_t bytesLeft = bytes;
+	uint8_t *next = buffer;
+	uint64_t chunkSize = PAGE_SIZE;
+
+	while (bytesLeft) {
+		if (bytesLeft < chunkSize) {
+			chunkSize = bytesLeft;
+		}
+		bytesWrittenOnce = write(fd, next, chunkSize);
+		if (-1 == bytesWrittenOnce) {
+			return -1L;
+		}
+		next += bytesWrittenOnce;
+		bytesWrittenTotal += (uint64_t) bytesWrittenOnce;
+		bytesLeft -= (uint64_t) bytesWrittenOnce;
+	}
+	return bytesWrittenTotal;
+}
+
+static void
+errMsg(args *argv, uint8_t *message, ...)
+{
+	va_list plist;
+
+	va_start(plist, message);
+	vsprintf(workSpace(argv), message, plist);
+	va_end(plist);
+	dumpFlags(argv) |= J9TPF_ERRMSG_IN_WKSPC;
+	return;
+}
+
+/**
+ * \internal Calculate the distance between adjacent memory segments.
+ *
+ * \retval 0    These items are adjacent
+ * \retval nz    These items are not adjacent, the distance in bytes between them.
+ */
+static void
+calcGap(DBFITEM *curr, DBFITEM *next, uint64_t *gap)
+{
+	uint64_t distance = next->ijavsad - curr->ijavsad;
+	*gap = distance - curr->ijavsiz;
+	return;
+}
+
+/**
+ * \internal Make sure the DBF table, which points to all the memory regions collected
+ * by CCCPSE, is as compact as possible. The goal is to cut the number of ELF
+ * Phdrs down as much as possible by merging adjoining memory regions. In order to do
+ * this, it needs to mark each DBFITEM, which is in protected memory, SPK=0. This 
+ * function is therefore in SPK=0 for its duration, and restores SPK1 prior to return.
+ *
+ * \param[in] dbfHdr Address of the Java dump buffer as returned from CCCPSE.
+ *
+ * \return
+ *      The number of program headers after merge
+ */
+static uintptr_t
+adjustDBFTable(DBFHDR *dbfHdr)
+{
+	DBFITEM *dbfTbl = (DBFITEM *) dbfHdr + 1; /* DBTI[0] starts right after dbfHdr    */
+	DBFITEM *pred = dbfTbl; /* Predecessor DBTI                        */
+	/*
+	 * For first pass only, set pred = curr. We never want to address zero.
+	 * We'll use it only to test bitfields which aren't possible to be set
+	 * for the very first item.
+	 */
+	DBFITEM *curr = dbfTbl; /* Current DBTI under examination        */
+	DBFITEM *succ = pred + 1; /* Successor DBTI                        */
+	DBFITEM *limit = dbfTbl + (dbfHdr->ijavcnt); /* DBTI[n+1] address                */
+	uintptr_t phnum = 0; /* Number of expected Elf64_Phdrs        */
+	uintptr_t wGap; /* ACCUMULATOR: total ibc gap            */
+	void *wVstart; /* WORK: new p_vaddr                    */
+	IDATA chunkSize = 0L; /* Semi-permanent per set ... size        */
+	IDATA totalIBCSize = 0L; /* Total sizes of all writeable sets    */
+
+	KEY0(); /* JDB's in SPK=0, get auth to write it.*/
+	while (curr < limit) {
+		memset(DBTITYPE, 0, sizeof(char) + (sizeof(DBTIGAP)));/* Clear DBTI tail            */
+		calcGap(curr, succ, &wGap); /* Get GAP size.                        */
+
+		if (0 == wGap) {
+			/*
+			 *    This pair qualifies to be combined
+			 */
+			if (PSETSTRT || PSETMIDL) {
+				CSETMIDL = TRUE; /* It is either mid-set ...                    */
+			} else { /*  ... or starts a new set.                */
+				CSETSTRT = TRUE;
+				wVstart = DBTIVADDR; /* If it's a start, hold the start vaddr.   */
+				chunkSize += DBTISIZ;
+				DBTIGAP = wGap;
+			}
+		} else {
+			/*
+			 *    This pair does not qualify to be combined. Is it last in set, or is its
+			 *    predecessor not part of this one?
+			 */
+			if (PSETMIDL || PSETSTRT) { /*    It's the end of a set, so summarize        */
+				CSETLAST = TRUE; /*     the set's start adrs & size in this    */
+				chunkSize += DBTISIZ; /*     JDB index item, it's the one we'll        */
+				DBTISIZ += chunkSize; /*     be building the Elf64_Phdr from.        */
+				chunkSize = 0L;
+				DBTIVADDR = wVstart; /*    Reset starting address & size            */
+				wVstart = 0L; /*     accumulators.                            */
+			} else {
+				CSETSOLO = TRUE; /*    This one is a standalone item.            */
+			}
+			/*
+			 * We will only write Elf64_Phdr items for those DBF items marked CSETLAST
+			 * or CSETSOLO.
+			 */
+			if (CSETLAST || CSETSOLO) {
+				phnum += 1; /* We will write a Phdr because of this item*/
+			}
+		}
+		DBTIGAP = wGap; /* Save the gap for later analysis            */
+		pred = curr; /* Advance our pair pointers                */
+		curr = succ;
+		succ += 1;
+	}
+	UNKEY(); /* Restore SPK=1                            */
+	return phnum; /* Return revised count to caller.            */
+}
+
+/*
+ * \internal   Calculate the path to where the dump should be written, 
+ *               isolating it into the <TT>fullpath</TT> parameter, and
+ *               placing the filename portion of the path string into the
+ *               <TT>filename</TT> argument.
+ *
+ * \param[in]  finalname    Buffer containing full path of the final filename. (const)
+ * \param[out] pathname        Ptr to user-acquired buffer of length PATH_MAX for the path.
+ *
+ * \retval        Address of full path, also copied into <TT>pathname</TT>.
+ *                This value ends in a path separator.
+ */
+static uint8_t *
+splitPathName(char *finalname, char *pathname)
+{
+	char tempPath[PATH_MAX];
+	char *lastSep = finalname ? strrchr(finalname, DIR_SEPARATOR) : NULL;
+
+	/*
+	 *    The <fullpath> parameter is the final filename the JVM has selected
+	 *    from the filled-out templated name that the user gave us. It also
+	 *    has a path preceding the basename; which was selected from the search
+	 *    hierarchy picked out by the dump agent according to its rules. Use
+	 *    this path for the OS dump filename. Eventually, it will be renamed
+	 *    to the final JVM-created name; but the idea is not to change paths -
+	 *    this way, we are reassured that we never have to copy the file's
+	 *    data between paths; we only change the directory entry's name.
+	 */
+	if (NULL != lastSep) {
+		/*
+		 * fullpath starts with a pathname: split it down to the directory name
+		 * and the filename, making sure to preserve the trailing front slash.
+		 * DO NOT WRITE ON THE PASSED ARGUMENT!
+		 */
+		size_t charsToCopy = lastSep - finalname + 1;
+		strncpy(tempPath, finalname, charsToCopy);
+		tempPath[charsToCopy] = '\0';
+	} else {
+		strcpy(&tempPath[0], "/tmp/");
+	}
+	strcpy(pathname, &tempPath[0]);
+	return pathname;
+}
+
+/**
+ * \internal Build the z/TPF ELF-format core dump from the JDB built by CCCPSE.
+ *
+ * First figure out the absolute file path (starts with a '/' and
+ * ends with a file suffix) we are to write the dump to, then ensure we
+ * have enough room left over in the Java dump buffer left for us by 
+ * CCCPSE. If we do not, return an error. Otherwise, section the buffer
+ * space off, building in order:
+ *    - The ELF64 header
+ *    - The ELF64 Program Header section
+ *    - The ELF64 NOTE section
+ *      
+ * Finally, write all the above to the indicated filename, and follow it
+ * with a copy of storage contents from the Java dump buffer, which is
+ * laid out in ascending address order, with the ELF64_Phdrs created to
+ * match the dump buffer. Expect a final file size measured in tens
+ * of megabytes.
+ *
+ * As a matter of protocol, set the first 8 bytes of the Java Dump
+ * Buffer (struct ijavdbf) to zeros so CCCPSE knows it's okay to 
+ * write over its contents once we're done working with it.
+ *
+ * The arg block is used for the bi-directional passing of data. Those of its
+ * members which are pointers (most of them, in fact) are used mainly for 
+ * output or at least have an output role. The fields of <arg> which are
+ * required are shown as input parameters below. The fields of <arg> which
+ * are used for output are detailed as return values.
+ *
+ * Since the pthread_create() calls limits us to one pointer to type void as the
+ * function's input, and the function is required to return a void pointer, this
+ * function will take the address of the <arg> block as the input parameter, and
+ * will return a pointer to type char which represents the file name which now
+ * contains the full path name of the ELF-format core dump file. There are also 
+ * fields in <arg> that will be updated as described below.
+ *
+ * \param[in][out]     arg   pointer to a user-created datatype 'args', declared
+ *                           in header file j9osdump_helpers.h
+ * \param[in]        arg->OSFilename        Pointer to scratch storage for a path +
+ *                                        file name string. It will be presumed 
+ *                                        to be at least PATH_MAX+1 in size.
+ * \param[in]        arg->wkspcSize        32-bit quantity representing the size in
+ *                                        bytes of the wkSpace field, following.
+ * \param[in]        arg->wkSpace        64-bit pointer to scratch workspace for
+ *                                        use by this function. It is recommended
+ *                                        to make it equal to PATH_MAX, since file &
+ *                                        path names will be built in this space.
+ * \param[in][out]    arg->flags            Indicators as to what is present and what
+ *                                        is not.
+ * \param[in]        arg->sii            Pointer to scratch storage to be used 
+ *                                        forever more as a siginfo_t block
+ * \param[in]        arg->uct            Pointer to scratch storage to be used 
+ *                                        forever more as a ucontext_t block
+ * \param[in]        arg->sct            Pointer to scratch storage to be used 
+ *                                        forever more as a sigcontext block
+ * \param[in]        arg->portLibrary    Pointer to an initialized OMRPortLibrary
+ *                                        block. If there isn't one at call time,
+ *                                        leave this value NULL and set flag
+ *                                        J9ZTPF_NO_PORT_LIBRARY
+ * \param[in]        arg->dibPtr            Address of the DIB attached to the faulting
+ *                                        UOW at post-interrupt time.
+ * 
+ * \returns    Pointer to a hz-terminated string representing the absolute path
+ *               name at which the core dump file was written.
+ *            
+ * \returns    arg->sii                   Filled in.
+ * \returns    arg->uct                   Filled in.
+ * \returns    arg->sct                   Filled in.
+ * \returns    arg->rc                   Final return code. Zero if successful
+ *                                       (core file built), non-zero if not.
+ * \returns    arg->OSFilename           Same as the function return value.
+ */
+void *
+ztpfBuildCoreFile(void *argv_block)
+{
+#define  MOUNT_TFS    4  /* TPF Filesystem equate from imount.h */
+
+	args *arg = (args *) argv_block;
+	uint8_t *buffer, *endBuffer;
+	DBFHDR *dbfptr; /* Ptr to JDB's index header                */
+	DIB *dibPtr = dibAddr(arg); /* Ptr to the Dump I'chg Block    */
+	Elf64_Ehdr *ehdrp; /* Pointer to Elf64 file header                */
+	Elf64_Phdr *phdrp; /* Pointer to Elf64_Phdr block                */
+	Elf64_Nhdr *narea; /* Pointer to the ELF NOTE data                */
+	char pathName[PATH_MAX]; /* Working buffer for core.* fname.*/
+	char *ofn = dumpFilename(arg); /* Output dump file path    */
+	uint32_t ofd; /* File descriptor for output dump            */
+	uintptr_t rc; /* Working return code d.o.                    */
+	uintptr_t wPtr; /* Working byte-sized pointer d.o.            */
+	uint64_t phCount; /* Counter of Elf64_Phdrs required            */
+	uint8_t *imageBuffer; /* Start of the JDB's ICB            */
+	uint64_t imageBufferSize; /* Size of data in the ICB            */
+	uint64_t octetsToWrite = 0UL; /* Count of bytes to write        */
+	uint64_t octetsWritten = 0UL; /* Count of bytes written        */
+	uint64_t spcAvailable;
+
+	/*
+	 *    If there is a Java dump buffer belonging to this process, then
+	 *    convert its contents into an Elf64 core dump file; otherwise
+	 *    return failure.
+	 */
+	if (!(dibPtr->dibjdb)) { /* No dump buffer? Not possible.*/
+		dumpFlags(arg) |= J9TPF_NO_JAVA_DUMPBUFFER;
+		returnCode (arg) = -1; /* Set error flags & bad RC ...    */
+		return NULL; /* 'Bye.                        */
+	}
+	dbfptr = dibPtr->dibjdb; /* Pick up the dump buffer ptr    */
+	if (0L == dbfptr->ijavcnt) { /* Did CCCPSE write us one?        */
+		returnCode (arg) = -1; /* Nope. JDB is locked...        */
+		dumpFlags(arg) |= J9TPF_JDUMPBUFFER_LOCKED;
+		return NULL; /* See ya next time.            */
+	}
+	/*
+	 *     Calculate the start, end, and net length of the output buffer we'll
+	 *     use for the ELF-dictated start of the file content. The start address
+	 *     should, as a matter of good practice, start on a paragraph boundary.
+	 */
+	buffer = (uint8_t *) (dbfptr->ijavbfp); /* Get buffer start as uint8_t ptr    */
+	buffer = (uint8_t *) NEXT_PARA(buffer); /* Start it on next paragraph    */
+	/*    boundary.                    */
+	endBuffer = buffer + dbfptr->ijavbfl; /* Get bytes left in buffer        */
+	spcAvailable = endBuffer - buffer; /* Get corrected count of bytes    */
+
+	phCount = dbfptr->ijavcnt;
+
+	int numJavaPgms = sizeof(javaPgmsToDump) / 5;
+	octetsToWrite = sizeof(Elf64_Ehdr)
+			+ ((phCount + 1 + numJavaPgms) * sizeof(Elf64_Phdr)) +
+			NOTE_TABLE_SIZE;
+	/*
+	 *     Uh oh. Not enough free space remaining in the dump buffer. Now
+	 *     we've gotta go to the heap and see if there's enough there. Not
+	 *     much hope; but we have to try it.
+	 */
+	if (octetsToWrite > spcAvailable) { /* Check for available memory,    */
+		buffer = malloc64(octetsToWrite); /*  anywhere. We're desperate.    */
+		if (!buffer) { /* If we can't buffer our I/Os,    */
+			returnCode (arg) = -1; /*  we are done. Indicate error */
+			errMsg(arg, "Cannot buffer dump file, out of memory");
+			dumpFlags(arg) |= J9TPF_OUT_OF_BUFFERSPACE;
+			KEY0();
+			dbfptr->ijavcnt = 0L; /* Unlock the JDB so CCCPSE can reuse it*/
+			UNKEY();
+			return NULL; /* See ya 'round.                */
+		}
+	}
+	/*
+	 *    We're ready to write the file. First, we need a full path + filename
+	 *    to represent the "OS filename" we're going to write. Get that path
+	 *    from the final file name passed in the <tt>args</tt> block, then
+	 *    follow that with "core.%X.%d" with the TOD in the second node and
+	 *    the PID number in the third. In this way, we can identify the OS
+	 *    filename later.
+	 *
+	 *    Next, we'll try to open it in CREATE+WRITE_ONLY mode. If it fails,
+	 *    halt; else write away!
+	 */
+	splitPathName(ofn, pathName);
+	/*
+	 *    The "OS filename" will look like ${path}/core.${TOD_in_hex}.${pid}
+	 */
+	sprintf(workSpace(arg), "core.%lX.%d", dibPtr->dstckf,
+			dumpSiginfo(arg)->si_pid);
+	{
+		int pathLen = strlen(pathName);
+		char ebcdicPath[pathLen + 1];
+		a2e_len(pathName, ebcdicPath, strlen(pathName));
+		int fsystype = pathconf(ebcdicPath, _TPF_PC_FS_TYPE);
+		if (fsystype == MOUNT_TFS) {
+			errMsg(arg, "Cannot use the tfs for java dumps: path used='%s'\n",
+					pathName);
+			returnCode (arg) = -1;
+			KEY0();
+			dbfptr->ijavcnt = 0L; /* Unlock the JDB so CCCPSE can reuse it*/
+			UNKEY();
+			return NULL;
+			//dir_path_name is within the TFS
+		}
+	}
+	strcat(pathName, workSpace(arg));
+	ofd = open(pathName, O_WRONLY | O_CREAT | O_EXCL);
+
+	if (-1 == ofd) {
+		errMsg(arg, "Cannot open() filename %s: %s\n", strerror(errno));
+		returnCode (arg) = -1;
+		KEY0();
+		dbfptr->ijavcnt = 0L; /* Unlock the JDB so CCCPSE can reuse it*/
+		UNKEY();
+		return NULL;
+	}
+	/*
+	 *    The file is named and opened. Now we have to go build its ELF-dictated
+	 *    parts. Set up pointers to the start of each sub-section, and then go
+	 *    build them. When that's complete, write the file in two parts: first,
+	 *    the ELF-dictated start, and then follow that with the data in the
+	 *    ICB.
+	 */
+	wPtr = (uintptr_t) buffer; /*    Calc section addresses with single    */
+	                           /*     byte arithmetic                    */
+	ehdrp = (Elf64_Ehdr *) wPtr; /*    Elf64_Ehdr pointer                    */
+	phdrp = (Elf64_Phdr *) (ehdrp + 1); /*    Elf64_Phdr pointer                    */
+	buildELFHeader(ehdrp);
+	uint64_t numBytes = 0;
+	uint64_t pCount = buildELFPheaderBlk(phdrp, dbfptr, phCount, &numBytes);
+	KEY0(); /* Get into SPK 0, then write the        */
+	ehdrp->e_phnum = pCount; /*  absolutely final Phdr count and     */
+	ehdrp->e_phoff = 0x40; /*    offset of its table into place in    */
+	UNKEY(); /*  the Ehdr, then get back to SPK 1.    */
+	wPtr = (uintptr_t) phdrp; /* Calculate the end address        */
+	wPtr += ((phCount + 1 + numJavaPgms) * sizeof(Elf64_Phdr)); /*    of the Elf64_Phdr section        */
+	narea = (Elf64_Nhdr *) wPtr; /* Calculate the address of NOTE sec,    */
+	buildELFNoteArea(narea, dibPtr); /*    and go write it there.                */
+	/*
+	 *    Write the ELF-dictated portion of the file first.
+	 */
+	octetsWritten = writeDumpFile(ofd, buffer, octetsToWrite);
+	if (-1 == octetsWritten) {
+		errMsg(arg, "Error writing dump file %s: %s", ofn, strerror(errno));
+		dumpFlags(arg) |= J9TPF_FILE_SYSTEM_ERROR;
+		KEY0();
+		dbfptr->ijavcnt = 0L; /* Unlock the JDB so CCCPSE can reuse it*/
+		UNKEY();
+		return NULL;
+	}
+	/*
+	 *    Finish the output with the ICB portion of the Java Dump Buffer
+	 */
+	imageBuffer = (uint8_t *) cinfc_fast(CINFC_CMMJDB);
+	octetsWritten = writeDumpFile(ofd, imageBuffer, numBytes);
+	if (-1 == octetsWritten) {
+		errMsg(arg, "Error writing dump file %s: %s", ofn, strerror(errno));
+		dumpFlags(arg) |= J9TPF_FILE_SYSTEM_ERROR;
+		KEY0();
+		dbfptr->ijavcnt = 0L; /* Unlock the JDB so CCCPSE can reuse it*/
+		UNKEY();
+		return NULL;
+	}
+	int i = 0;
+	for (i = 0; i < numJavaPgms; i++) {
+		struct pat * pgmpat = progc(javaPgmsToDump[i], PROGC_PBI);
+		struct ifetch *pgmbase = pgmpat->patgca;
+		if (pgmbase != NULL) {
+			int offset = pgmbase->_iftch_txt_off + pgmbase->_iftch_txt_size
+					+ 0x1000;
+			char * text = ((char*) pgmbase) + offset;
+			uint64_t size = pgmpat->patpsize - offset;
+			octetsWritten = writeDumpFile(ofd, text, size);
+			if (-1 == octetsWritten) {
+				errMsg(arg, "Error writing dump file %s: %s", ofn,
+						strerror(errno));
+				dumpFlags(arg) |= J9TPF_FILE_SYSTEM_ERROR;
+				KEY0();
+				dbfptr->ijavcnt = 0L; /* Unlock the JDB so CCCPSE can reuse it*/
+				UNKEY();
+				return NULL;
+			}
+		}
+	}
+	/*
+	 *    That's all folks. Close the file and return the so-called "OS Filename"
+	 *    to the caller as if the OS had written it.
+	 */
+	rc = close(ofd); /* Only try to close() the file once    */
+	if (-1 == rc) {
+		errMsg(arg, "I/O error attempting to close %s:%s\n", ofn,
+				strerror(errno));
+		KEY0();
+		dbfptr->ijavcnt = 0L; /* Unlock the JDB so CCCPSE can reuse it*/
+		UNKEY();
+		return NULL;
+	}
+	/*
+	 * Make sure we have a recognizable IPC permission on the OS filename,
+	 *  then make sure the JDB buffer is unlocked in case CPSE needs it again.
+	 */
+	rc = chmod(workSpace(arg), S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
+	KEY0();
+	dbfptr->ijavcnt = 0L; /* Unlock the JDB so CCCPSE can reuse it*/
+	UNKEY();
+	/*
+	 * Return the filename to the caller. Remember that the buffer containing
+	 * it is non-JVM-managed heap space and should be free()d back to it to
+	 * avoid a mem leak.
+	 */
+	strcpy(dumpFilename(arg), ofn); /* Store it in the args block so the */
+	return (void *) ofn; /*  caller always has it, and goback.*/
+}
+
+static char *elf64header_constant =
+		"\x7f\x45\x4c\x46\x02\x02\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+				"\x00\x04\x00\x16\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00"
+				"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+				"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+
+/**
+ * \internal Build the ELF64 header. This is really simple, just overlay the input buffer
+ * region with a set of constants. We will worry about the number of Program Headers
+ * later.
+ *
+ * \param[in]  buffer    Address of writeable memory large enough to hold the ELF64_Ehdr structure.
+ * \param[out] buffer    As above, filled in for the sizeof(Elf64_Ehdr).
+ *
+ * \return
+ *      Address of <TT>buffer</TT> as given.
+ */
+static void
+buildELFHeader(Elf64_Ehdr *buffer)
+{
+	Elf64_Ehdr *ePtr = buffer;
+	KEY0();
+	memcpy(buffer, elf64header_constant, sizeof(*buffer));
+	ePtr->e_type = ET_CORE;
+	ePtr->e_ehsize = sizeof(*ePtr);
+	ePtr->e_phentsize = sizeof(Elf64_Phdr);
+	UNKEY();
+}
+
+/**
+ * \internal
+ *
+ * Build the ELF64 program header block in memory.
+ *
+ * The Elf64_Phdr looks like this:<b><tt> 
+ * 0000 0004    p_type        Type of memory this Phdr represents.<b>
+ * 0004 0004    p_flags        Phdr flags (permissions +OS_specific bits)<b>
+ * 0008 0008    p_offset    Offset in file (0-relative) of memory image<b>
+ * 0010 0008    p_vaddr        Virtual address of memory image @ run time<b>
+ * 0018 0008    p_addr        Physical adress of memory image @ run time<b>
+ * 0020 0008    p_filesz    Size of memory image in file<b>
+ * 0028 0008    p_memsz        Size of memory image in memory<b>
+ * 0030    0008    p_align        Boundary to align to when loaded<b>
+ * ---- ----<b>
+ * 0038 0038    Total length (56 decimal), natural alignment/size.<b></tt>
+ *
+ *    p_type should be obvious. Unlike relocatable/absolute ELF forms, the 
+ *    The 0th element does not have to be a PT_NULL. In fact, observed core
+ *    files often are of type PT_NOTE; we'll follow that pattern. The 2nd
+ *    through last elements are PT_LOAD.
+ *
+ *    p_flags are just the permissions. For PT_NULL, they're zero. For PT_NOTE,
+ *    they're zero (not loaded to memory), and the PT_LOADs are rwx (7).
+ *
+ *    p_offset is the offset from zero in the file at which the image starts.
+ *    Each file-resident image runs continuously & sequentially for p_filesz. 
+ *    We'll have to calculate the offset value and keep a running total, starting
+ *    from p_offset for the PT_NOTE segment, then incrementing it by each
+ *    p_filesz value.
+ *    
+ *    p_vaddr is the virtual address at which the segment resides. It's truly 
+ *    meant more for executables & shared objects, its content of of little 
+ *    consequence; but we'll take a policy of making it the physical address. 
+ *    Same for p_addr, which is meant to describe the physical address. App-
+ *    ropriate for a core file, not so much for a typical executable/DSO.
+ *
+ *    p_memsz is the image's size when loaded to memory. For a core file, 
+ *    p_filesz = p_memsz. This would make a difference for an executable or
+ *    DSO (this is how the .bss segment, for example, is described: memsz as
+ *    required, 0 filesz.
+ *
+ *    p_align is the required alignment, if any, for the memory image described
+ *    by this phdr. A value of 0 or 1 means no alignment required. Otherwise,
+ *    the value should be modulo of a page size. For a core file, just use 1.
+ *
+ * 
+ * \param[in]  buffer    Address of writeable memory large enough to house all 
+ *                        required Phdr elements (phnum * sizeof(Elf64_Phdr)).
+ * \param[in]  dbfHdr    Address of the Java dump buffer given to us by CCCPSE
+ * \param[in]  phnum    The number of program headers to write
+ *
+ * \returns
+ *      Count of program headers written.
+ */
+static uint16_t
+buildELFPheaderBlk(Elf64_Phdr *buffer, DBFHDR *dbfHdr,
+		uint64_t phnum, uint64_t * numBytes)
+{
+	Elf64_Phdr *phdrPtr = buffer;
+	DBFITEM *curr = (DBFITEM *) (dbfHdr + 1);
+	uint64_t dbfiCount = dbfHdr->ijavcnt;
+	uint16_t newPhdrCount = 0;
+	int numJavaPgms = sizeof(javaPgmsToDump) / 5;
+	uint64_t netOffset = sizeof(Elf64_Ehdr)
+			+ ((phnum + 1 + numJavaPgms) * sizeof(Elf64_Phdr));
+
+	/*
+	 * First we set up one constant Phdr ... a PT_NOTE. The rest come from DBF
+	 * table items as adjusted.
+	 */
+	KEY0();
+	memset(phdrPtr, 0, sizeof(Elf64_Phdr)); /* Set up 1 zero Phdr        */
+	phdrPtr->p_type = PT_NOTE; /* Type = NOTE.                */
+	phdrPtr->p_offset = netOffset; /* NOTE segment offset        */
+	phdrPtr->p_filesz = NOTE_TABLE_SIZE; /* Size is a known constant    */
+	/*
+	 * Now write a Phdr for every useable DBF table item
+	 */
+	netOffset += NOTE_TABLE_SIZE; /* First value of p_offset    */
+	phdrPtr += 1; /* Start with next phdr    slot*/
+
+	while (dbfiCount > 0) {
+		memset(phdrPtr, 0, sizeof(Elf64_Phdr)); /* Zeroize all 56 bytes.        */
+		phdrPtr->p_type = PT_LOAD; /* Normal virtual memory content, loadable*/
+		phdrPtr->p_flags = PT_RWX; /* Flags = rwx                            */
+		phdrPtr->p_offset = netOffset; /* Fill in offset into file ...            */
+		phdrPtr->p_vaddr = (uintptr_t) DBTIVADDR; /*  ... the virtual memory address        */
+		phdrPtr->p_filesz = phdrPtr->p_memsz = DBTISIZ; /*  ... and memory sizes.        */
+		phdrPtr->p_align = 1; /* Align all images to 1                */
+		/*
+		 *    Set up for next write.
+		 */
+		netOffset += DBTISIZ; /* Set next offset and                    */
+		phdrPtr += 1; /*    next phdr pointer.                    */
+		newPhdrCount += 1; /* Increment actual phnum                */
+		/*
+		 * Set up for next read
+		 */
+		curr += 1; /* Set next DBF table item ptr              */
+		dbfiCount -= 1; /* One less DBF table item to work ....   */
+	}
+	// return number of bytes to write from the dump buffer
+	*numBytes = netOffset
+			- (sizeof(Elf64_Ehdr)
+					+ ((phnum + 1 + numJavaPgms) * sizeof(Elf64_Phdr))
+					+ NOTE_TABLE_SIZE);
+	int i = 0;
+	for (i = 0; i < numJavaPgms; i++) {
+		struct pat * pgmpat = progc(javaPgmsToDump[i], PROGC_PBI);
+		if (pgmpat != NULL) {
+			struct ifetch *pgmbase = pgmpat->patgca;
+			if (pgmbase != NULL) {
+				int offset = pgmbase->_iftch_txt_off + pgmbase->_iftch_txt_size
+						+ 0x1000;
+				char * text = ((char*) pgmbase) + offset;
+				uint64_t size = pgmpat->patpsize - offset;
+				memset(phdrPtr, 0, sizeof(Elf64_Phdr)); /* Zeroize all 56 bytes.        */
+				phdrPtr->p_type = PT_LOAD; /* Normal virtual memory content, loadable*/
+				phdrPtr->p_flags = PT_RWX; /* Flags = rwx                            */
+				phdrPtr->p_offset = netOffset; /* Fill in offset into file ...            */
+				phdrPtr->p_vaddr = (uintptr_t) text;
+				phdrPtr->p_filesz = phdrPtr->p_memsz = size;
+				phdrPtr->p_align = 1; /* Align all images to 1                */
+				netOffset += size; /* Set next offset and                    */
+				phdrPtr += 1; /*    next phdr pointer.                    */
+				newPhdrCount += 1; /* Increment actual phnum                */
+			}
+		}
+	}
+	UNKEY();
+	return newPhdrCount; /* We're done                              */
+}
+
+#define    NOTE_DATA_OFFSET(p)    ((uintptr_t)p+0x14)
+
+/**
+ * \internal
+ *      
+ * \details Build the data (in the user-passed <TT>buffer</TT> address)
+ * block to which an Elf64_Phdr will point. Its role is to extract 
+ * information passed to it in CE2DIB and IJAVDBF and put them in the
+ * proper places. Sometimes these values require translation to put 
+ * them into proper contextual meaning, for example, a hardware PIC code
+ * can infer a signal value. As long as we get close enough, it's good.
+ * The contents of the NOTE section are very poorly documented.
+ *
+ * \note The final sub-section, tagged <i><tt>NT_ZTPF_SERRC</tt></i>, is invented 
+ * for this routine's purposes: its role is to express the SE number associated 
+ * with the already-written traditional SERRC dump as requested during design. Its 
+ * existence may require addition of a method to the Java class which processes 
+ * ELF NOTEs in <b><tt>jdmpview</tt></b> - there is no ELF NOTE tag otherwise 
+ * suited for this purpose. Otherwise, this information stays buried.
+ *
+ * This function returns the total size of the buffer as its Elf64_Phdr
+ * must report it.
+ *
+ * \param[in]  buffer    Writeable memory large enough to house the NOTE
+ *                        section (see \ref NOTE_TABLE_SIZE, above).
+ * \param[in]  dibPtr    Address of the CPSE<->JVM Dump Interchange Block
+ *                        belonging to the faulting or requesting Unit Of Work.
+ * \returns
+ *         Size, in bytes, of the NOTE table section as written.
+ */
+static uintptr_t
+buildELFNoteArea(Elf64_Nhdr *buffer, DIB *dibPtr)
+{
+	uintptr_t tableSize = NOTE_TABLE_SIZE; /* Return value                    */
+
+	/* Pointers to the different required NOTE subsections, in sequential
+	 * order of appearance: PRSTATUS, PRPSINFO, AUXV, FPREGSET, and
+	 * S390_LAST_BREAK. The NOTE subsections are a little bizarre: each has a
+	 * header of 0x0c bytes in length, followed by a displayable label of
+	 * what it is. In general, these headers end up being 0x14 bytes in length
+	 * because their data needs to be fullword-aligned. So, in general, the ptr
+	 * prefixed with "nsh_" is the lower of the two addresses, being the
+	 * Elf64_Nhdr pointer, and the un-prefixed pointer is where the data goes.
+	 * Kinda screwy, but so is the NOTE section itself when there are a number
+	 * of subsections in sequence.
+	 */
+	Elf64_Nhdr *nsh_prstat; /* NT_PRSTATUS NOTE header        */
+	prstatus_t *prstat; /* PRSTATUS NOTE data ptr        */
+	Elf64_Nhdr *nsh_prpsin; /* NT_PRPSINFO NOTE header        */
+	prpsinfo_t *prinfo; /* PRPSINFO NOTE data ptr        */
+	Elf64_Nhdr *nsh_auxvxx; /* NT_AUXV NOTE header            */
+	AUXV *auxv; /* NT_AUXV NOTE data ptr        */
+	Elf64_Nhdr *nsh_fpregs; /* NT_FPREGSET NOTE header        */
+	fpregset_t *fpregs; /* NT_FPREGSET data ptr            */
+	Elf64_Nhdr *nsh_lastbr; /* NT_S390_LAST_BREAK NOTE hdr    */
+	uint16_t signalNumber;
+	siginfo_t wSiginfo;
+
+	DIB *holdDibPtr;
+	DBFHDR *dbfPtr = dibPtr->dibjdb;
+	/*
+	 *    The ERI sits as the first JDB index item. We have to bump its pointer
+	 *    past the DBFHDR, which just so happens to be the same length as a DBFITEM
+	 *    itself.
+	 */
+	DBFITEM *eriRef = (DBFITEM *) dbfPtr + 1;
+	struct cderi *eriPtr = (struct cderi *) (eriRef->ijavsbuf);
+	/*
+	 * z/TPF keeps its process information in a unique IPROC block, address it.
+	 */
+	struct iproc *pIPROC = iproc_process; /* Ptr to this PID's IPROC block */
+	struct iproc *pPIPROC; /* Ptr to mom's PID IPROC block    */
+	/*
+	 *     The datatypes inside each NOTE section and subsection are so diverse
+	 *     as to make the commonly-used typecasting approach cumbersome and difficult
+	 *     to understand. Often working pointer fields which have a length of 1 for
+	 *     address arithmetic uses are the easiest or best way to do this yet still
+	 *     have legible code. We use all three of the following data objects in that
+	 *     vein.
+	 */
+	uint8_t *wSrc; /* General uint8_t address pointer    */
+	uint8_t *wDest; /* General uint8_t address pointer    */
+	uint8_t *wPtr; /* General uint8_t address pointer    */
+
+	/*
+	 *     Build the NT_PRSTATUS subsection first
+	 */
+	KEY0();
+	memset(buffer, 0, tableSize); /* Clear the entire buffer        */
+	nsh_prstat = buffer; /* Start the data sec hdr ptr.    */
+	prstat = (prstatus_t *) NOTE_DATA_OFFSET(nsh_prstat); /* Point at its data*/
+	nsh_prstat->n_namesz = 5; /* Size of "CORE" = 5            */
+	nsh_prstat->n_descsz = sizeof(prstatus_t);
+	nsh_prstat->n_type = NT_PRSTATUS; /* Type = 1                        */
+	memcpy(nsh_prstat + 1, "CORE", 5); /* Label this one "CORE".        */
+	/*
+	 *    The "current signal" value is inferred from the h/w PIC value lookup.
+	 *    Unfortunately, ztpfDeriveSiginfo() is coded to use the DIB hung off
+	 *    page 2 of the ECB, not the passed DIB. So hold on to the real
+	 *    DIB address for this ECB in a safe place, and stuff the passed dibPtr
+	 *    into page 2 of the ECB before the call, then replace it after the
+	 *    call.
+	 */
+	holdDibPtr = ecbp2()->ce2dib; /* Substitute the passed DIB    */
+	ecbp2()->ce2dib = dibPtr; /*  for the real one, then ...    */
+	UNKEY(); /*  reset the SPK to prob state */
+	ztpfDeriveSiginfo(&wSiginfo); /* While we go build a long        */
+	KEY0(); /*  siginfo_t from which to        */
+	prstat->info.si_signo = wSiginfo.si_signo; /*  feed the short one. After    */
+	prstat->info.si_code = wSiginfo.si_code; /*  we've returned, get back    */
+	prstat->info.si_errno = wSiginfo.si_errno; /*  into supv state prot key.    */
+	prstat->cursig = wSiginfo.si_errno;
+	ecbp2()->ce2dib = holdDibPtr; /* Replace the real DIB pointer    */
+	/*
+	 *    The relative PID values come from the process block .... Just read
+	 *  them dirty; don't bother with a lock at first, see if it works before
+	 *  we take a chance on losing ctl with a lock
+	 */
+	prstat->pid = pIPROC->iproc_pid; /* My PID                    */
+	prstat->pgid = pIPROC->iproc_pgid; /* My PGID                    */
+	prstat->ppid = pIPROC->iproc_pptr->iproc_pid; /* Mom's PID                */
+	/* No concept of a session ID    */
+	/*
+	 * The System z TOD clock ticks once every 244 picoseconds. To get to accurate
+	 * nanoseconds, we'd need to divide its value by 4.09836. Since we can't
+	 * divide by a fractional quantity without going to floating point (and
+	 * thereby introducing approximation error & burning more cycles), we
+	 * usually trade precision for speed by shifting right 2 bits (dividing by 4)
+	 * to yield nanoseconds from a little less than a quarter of a ns. That's
+	 * considered close enough. But now that we need _micro_second (ns * 1000)
+	 * precision, we'd be amplifying the error. And since we have to divide by 1000
+	 * anyway, we might as well divide by 4098 (would shifting right 12 bits, for
+	 * 4096, be close enough? No. That would cause us to lose a full millisecond in
+	 * precision error!) to be accurate. So that's what we're doing below, since
+	 * we have to eat the cycles in the division operation anyway -- might as well
+	 * use the right divisor. Never mind rounding up with the remainder; we're
+	 * already generating a larger result than reality because we can't go
+	 * fractional. Does it really matter? Nah. But if you're gonna do it, you might
+	 * as well do it right ....
+	 */
+	prstat->stime.tv_usec = ecbptr()->ce1istim / 4098; /* Used CPU time    */
+	wDest = (char *) &(prstat->reg); /* Point at offset +0 of reg fld    */
+	/*
+	 *     The PGM/O PSW is followed by a 16-wide array of ULONGs which
+	 *     represent the values of all 16 general registers, 0 through 15,
+	 *     as they were at the time the PGM/N PSW fired. Prepare to copy
+	 *     them into the NT_PRSTATUS section, lth=128+16 (144).
+	 */
+	wSrc = (char *) (dibPtr->dispw); /* Point @ PSW & general regs        */
+	memcpy(wDest, wSrc, 144); /* Preserve all that data.            */
+	prstat->fpvalid = TRUE; /* Yes, we have floating point        */
+	/*
+	 * NT_PRPSINFO is next
+	 */
+	nsh_prpsin = (Elf64_Nhdr *) (prstat + 1); /* Point to next NOTE hdr    */
+	prinfo = (prpsinfo_t *) NOTE_DATA_OFFSET(nsh_prpsin);
+	nsh_prpsin->n_namesz = 5; /* Size of "CORE" = 5        */
+	nsh_prpsin->n_descsz = sizeof(prpsinfo_t);
+	nsh_prpsin->n_type = NT_PRPSINFO; /* Type = 3                    */
+	memcpy(nsh_prpsin + 1, "CORE", 5); /* Set "CORE" name ...        */
+	prinfo->char_state = 'R'; /* We were 'R'unning.        */
+	prinfo->flag = 0x00400440L; /* Flags are constant        */
+	prinfo->uid = pIPROC->iproc_uid; /* User id &                */
+	prinfo->gid = pIPROC->iproc_gid; /*  group id.                */
+	memcpy(&prinfo->pid, &prstat->pid, 16); /* Process ID set again        */
+	strcpy(prinfo->fname, "main"); /* Just like Linux does it    */
+	wSrc = getenv("IBM_JAVA_COMMAND_LINE");
+	if (wSrc) {
+		strncpy(prinfo->psargs, wSrc, PRARGSZ);
+		prinfo->psargs[PRARGSZ - 1] = '\0';
+	}
+	/*
+	 * NT_AUXV after that ... we fake it (we have no ELF protocols involved
+	 * in task switching and thus have no AUXV structure or meaning).
+	 */
+	nsh_auxvxx = (Elf64_Nhdr *) (prinfo + 1); /* Next NOTE header            */
+	auxv = (AUXV *) NOTE_DATA_OFFSET(nsh_auxvxx); /* and data region ptr.    */
+	nsh_auxvxx->n_namesz = 5; /* Size of "CORE" = 5        */
+	nsh_auxvxx->n_descsz = sizeof(AUXV);
+	nsh_auxvxx->n_type = NT_AUXV; /* Type = 6                    */
+	memcpy(nsh_auxvxx + 1, "CORE", 5); /* Set "CORE" name ...        */
+	memset(auxv, 0, sizeof(AUXV)); /* Fill it out.                */
+	/*
+	 * ... then NT_FPREGSET
+	 */
+	nsh_fpregs = (Elf64_Nhdr *) (auxv + 1); /* Next NOTE header            */
+	fpregs = (fpregset_t *) NOTE_DATA_OFFSET(nsh_fpregs); /* and data ptr    */
+	nsh_fpregs->n_namesz = 5; /* Size of "CORE" = 5        */
+	nsh_fpregs->n_descsz = sizeof(fpregset_t);
+	nsh_fpregs->n_type = NT_FPREGSET; /* Type = 2                    */
+	memcpy(nsh_fpregs + 1, "CORE", 5); /* Set "CORE" name ...        */
+	/*
+	 * We don't care what the real FPCR contained. We're setting the mask
+	 * only to state that 16 fprs exist. The real FPCR is too hard to get,
+	 * anyway.
+	 */
+	fpregs->fpcr = 0x00800000;
+	wSrc = (uint8_t *) &(dibPtr->dfreg); /* Get the adrs of the fp    */
+	wDest = (uint8_t *) &(fpregs->fpreg); /*  regs, then copy them    */
+	memcpy(wDest, wSrc, sizeof(fpregs->fpreg)); /*  into the note area.    */
+	/*
+	 * ... then NT_S390_LAST_BREAK
+	 */
+	nsh_lastbr = (Elf64_Nhdr *) (fpregs + 1);
+	nsh_lastbr->n_namesz = 6; /* Size of "LINUX" = 6        */
+	nsh_lastbr->n_descsz = 8; /* Always 0x008 bytes.        */
+	nsh_lastbr->n_type = 0x306; /* Type = NT_S390_LAST_BR    */
+	wDest = (uint8_t *) NOTE_DATA_OFFSET(nsh_lastbr);
+	memcpy(nsh_lastbr + 1, "LINUX", 6); /* Set "LINUX" name            */
+	wSrc = (char *) (dibPtr->dbrevn); /* Get NOTE data source ptr */
+	memcpy(wDest, wSrc, 8); /*  and move it in.            */
+	UNKEY();
+	return tableSize; /* We're done.                */
+	/*
+	 * ... and finally, NT_ZTPF_SERRC (made up; we'll need to add the Java
+	 * class code to display this)
+	 */
+	wPtr += 8;
+	nsh_lastbr = (Elf64_Nhdr *) (wDest + 8);
+	nsh_lastbr->n_namesz = 5; /* Size of "ZTPF" = 5        */
+	nsh_lastbr->n_descsz = 68; /* Always 0x044 bytes.        */
+	nsh_lastbr->n_type = 0x500; /* Type = 500                */
+	memcpy(nsh_lastbr + 1, "ZTPF", 5); /* Set "ZTPF" name ...        */
+	wDest += 0x14; /*  and point at data        */
+	sprintf(wDest, "SE-%4.4d OPR-%c%6.6X PGM-%4.4s %5.5c %8.8s", eriPtr->eriseq,
+			eriPtr->eridpfx, eriPtr->eridnum, eriPtr->eridate, eriPtr->eritime);
+	UNKEY();
+	return tableSize; /* We're done.                */
+}
+
+void
+ztpf_preemptible_helper(void)
+{
+	safeStorage *s = allocateDurableStorage();
+	translateInterruptContexts(&(s->argv));
+
+	s->argv.flags = J9TPF_NO_PORT_LIBRARY;
+	s->pDIB = ecbp2()->ce2dib;
+	s->argv.dibPtr = s->pDIB;
+	masterSynchSignalHandler(s->siginfo.si_signo, &(s->siginfo), &(s->ucontext),
+			s->pDIB->dbrevn);
+	/*
+	 * Like its "harder" cousin, below, if the signal handler returns here, it is
+	 * acknowledging that it wants to exit. Otherwise, don't expect a return. In
+	 * the normal case, the faulting thread gets returned to the J9 thread pool
+	 * so there's no chance of an accidental return here.
+	 */
+	exit(0);
+	/* UNREACHABLE */
+}
+
+void
+ztpf_nonpreemptible_helper(void)
+{
+	safeStorage *s = allocateDurableStorage();
+	uint8_t holdkey;
+	sigset_t newmask;
+	sigset_t oldmask;
+
+	/*
+	 *    Go translate the TPF-ish data available at interrupt time into UNIX-ish
+	 *    formatted blocks in preparation to call the master synchronous signal
+	 *    handler for the JVM's structured signal handling architecture. This
+	 *    storage comes from a static storage segment in DJPR.
+	 */
+	s->pDIB = (DIB *) (ecbp2()->ce2dib);
+	s->argv.dibPtr = s->pDIB;
+	translateInterruptContexts(&(s->argv));
+
+	/*
+	 *    Only proceed if (1) the signal is currently NOT blocked, and (2)
+	 *    if no other interrupt has queued itself. In the interim, if
+	 *    applicable, sleep for 50 ms. IOW, serialize all synchronous
+	 *    signals -- we have to, we only have one JDB.
+	 */
+	sigemptyset(&newmask); /* Ensure our 'constant' mask word is zeros    */
+	sigaddset(&newmask, s->siginfo.si_signo); /* Build a constant signal mask word        */
+
+	do {
+		PROC_LOCK(&(s->pPROC->iproc_JVMLock), holdkey);
+		if (s->pPROC->iproc_tdibptr) { /* Are we blocked because we're already    working    */
+			PROC_UNLOCK(&(s->pPROC->iproc_JVMLock), holdkey); /* another signal? If so,unlock    */
+			usleep(50000); /* and sleep for 50 ms.            */
+		}
+		pthread_sigmask(SIG_BLOCK, NULL, &oldmask); /* Test the signal mask again.    */
+	} while ((newmask & oldmask) || (s->pPROC->iproc_tdibptr));
+	/*
+	 *    We are released to go process this signal. Do it. The lock we also hold
+	 *    on our little subsection of the PROC block is also still in effect.
+	 *    But first, stash the DIB pointer in the IPROC block, then unlock it.
+	 */
+	s->pPROC->iproc_tdibptr = (uint64_t) s->pDIB; /*    Stash the faulting DIB pointer            */
+	PROC_UNLOCK(&(s->pPROC->iproc_JVMLock), holdkey);
+	/*
+	 * Call the master structured signal handler for synchronous signals.
+	 * It's not possible that an async signal can get here. The signal handler will
+	 * either hand off execution to the JIT, or will run the dump agents. Do not
+	 * expect a return; else the normal SIG_DFL (bye, bye) rule applies.
+	 */
+	masterSynchSignalHandler(s->siginfo.si_signo, &(s->siginfo), &(s->ucontext),
+			s->pDIB->dbrevn);
+	/*
+	 * If execution returns to this point, the signal handler returned
+	 * here. This means that the thread accepts the consequences of a
+	 * return from the SIG_DFL treatment of a fatal signal, which means
+	 * an end to the process.
+	 */
+	exit(0);
+	/* UNREACHABLE */
+}

--- a/port/ztpf/omrosdump_helpers.h
+++ b/port/ztpf/omrosdump_helpers.h
@@ -1,0 +1,284 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 1991, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial API and implementation and/or initial documentation
+ *    Multiple authors (IBM Corp.) - refactoring and modifications for z/TPF platform
+ *******************************************************************************/
+
+/**
+ * @file
+ * @ingroup Port
+ * @brief z/TPF-specific Dump formatting declarations
+ */
+
+#ifndef _ZTPF_J9OSDUMP_HELPERS_H_INCLUDED
+#define _ZTPF_J9OSDUMP_HELPERS_H_INCLUDED
+
+#include <tpf/i_jdib.h>
+#include <tpf/i_jdbf.h>
+#include <tpf/c_deri.h>
+#include <elf.h>
+#include <errno.h>
+#include <tpf/tpfapi.h>
+
+#ifndef OSDUMP_SYMBOLS_ONLY
+#include "omrport.h"
+#include "portpriv.h" 
+#endif
+
+/*
+ * Get process lock
+ */
+#define PROC_LOCK(proc_lock_ptr, old_key)       \
+    do{                                         \
+        cinfc(CINFC_WRITE, CINFC_CMMFS1);       \
+        old_key = ecbp2()->ce2okey;             \
+        if (is_threaded_ecb()) {                \
+            lockc(proc_lock_ptr,LOCK_O_SPIN); } \
+    } while(0)
+/*
+ * Release process lock
+ */
+#define PROC_UNLOCK(proc_lock_ptr, old_key)     \
+    do{                                         \
+        if (is_threaded_ecb()) {                \
+            unlkc(proc_lock_ptr); }             \
+        ecbp2()->ce2okey = old_key;             \
+        keyrc_okey();                           \
+    } while(0)
+
+/* This data structure is the argument block whose address we need to pass to
+ * ztpfBuildCoreFile() as its one and only parameter. Function
+ * translateInterruptContexts() also uses it since it requires so much of the
+ * same data.
+ *
+ * There are ten (10) data members in this block, it is 0x50 bytes long.
+ */
+typedef struct {
+   siginfo_t *sii; /* argv[0] = ptr to siginfo_t */
+   ucontext_t *uct;	/* argv[1] = ptr to ucontext_t */
+   struct sigcontext *sct; /* argv[2] = ptr to struct sigcontext */
+   uint8_t *OSFilename; /* argv[4] = ptr to dump OS filename */
+   int32_t rc; /* argv[3] = return code area */
+   uint32_t flags; /* argv[5] = 32 bits of output flags	*/
+   uint32_t	wkspcSize; /* argv[6] = How big is argv[7]?	*/
+   uint8_t *wkSpace; /* argv[7] = ptr to workspace */
+   struct J9PortLibrary	*portLibrary;   /* argv[8] = ptr to J9PortLibrary */
+   DIB *dibPtr;		  /* argv[9] = ptr to Dump Interchange Blk.	*/
+} args;
+
+/* Argument pointer Accessors */
+#define dumpSiginfo(p) (p->sii)
+#define dumpUcontext(p) (p->uct)
+#define dumpSigcontext(p) (p->sct)
+#define returnCode(p) (p->rc)
+#define dumpFilename(p) (p->OSFilename)
+#define dumpFlags(p) (p->flags)
+#define workSpcSize(p) (p->wkspcSize)
+#define workSpace(p) (p->wkSpace)
+#define portLib(p) (p->portLibrary)
+#define dibAddr(p) (p->dibPtr)
+/* Values for args.flags follow  */
+#define  J9TPF_NO_PORT_LIBRARY		0x01	 /* No port library available		*/
+#define  J9TPF_SLAVE_OUTSTANDING	0x02	 /* The pthread spawned to			*/
+											 /* ztpfBuildCoreFile() was launched*/
+											 /* and we don't know if it's yet	*/
+											 /* completed.						*/
+#define  J9TPF_FILE_SYSTEM_ERROR	0x04	 /* File could not be written: media*/
+#define  J9TPF_NO_JAVA_DUMPBUFFER	0x08	 /* There was a DIB but no JDB		*/
+											 /*  anchored to it.				*/
+#define  J9TPF_JDUMPBUFFER_LOCKED	0x10	 /* JDB in use or no JDB exists		*/
+#define  J9TPF_OUT_OF_BUFFERSPACE	0x20	 /* Insufficient memory for I/O buf */
+#define	 J9TPF_ERRMSG_IN_WKSPC		0x40	 /* Useable error msg in workSpace(p)	*/
+#define  J9TPF_FLAGS_ERR_MASK \
+(J9TPF_OUT_OF_BUFFERSPACE|J9TPF_JDUMPBUFFER_LOCKED|J9TPF_NO_JAVA_DUMPBUFFER|J9TPF_FILE_SYSTEM_ERROR)
+
+
+		/*
+		 *    Exportable entry point declarations. This must be referenced in a 
+		 *    'version script' with which this module is linked. Conditionally,
+		 *    when the build target is z/TPF, include it in "module.xml" so it
+		 *    will come out in a file called "j9prt.exp".
+		 */
+void *			ztpfBuildCoreFile( void *argv ); /* This decl is set up to take a
+					void pointer as its argument because of the constraints of
+					pthread_create(), and we really mean to use a thread to 
+					execute this function. It will cast the pointer back into 
+					an (args *) because of this ugliness.						*/
+
+		/*
+		 *    External entry point declarations WRT this T.U.
+		 */
+#ifndef J9SIGNAL_CONTEXT
+extern void		ztpfDeriveSiginfo( siginfo_t *build ) __attribute__((nonnull));
+extern void		translateInterruptContexts( args *argv ) __attribute__((nonnull));
+extern uint8_t *allocateContextStorage( void );
+extern void     ztpf_preemptible_helper(void);
+extern void     ztpf_nonpreemptible_helper(void);
+#endif
+
+			/*********************************************************/
+			/*	  Programming convenience definitions/declarations	 */
+			/*********************************************************/
+#ifndef  PAGE_SIZE
+#define  PAGE_SIZE	 4096			   /* The size of one page (for vmm purposes)	*/
+#undef	 HOLD_PAGE_SIZE
+#else 
+#define  HOLD_PAGE_SIZE PAGE_SIZE
+#undef	 PAGE_SIZE
+#define  PAGE_SIZE	 4096
+#endif
+
+#ifndef  TRUE
+#define  TRUE  1
+#endif
+#ifndef	 FALSE
+#define  FALSE 0
+#endif
+
+/**
+ * \internal This macro pushes an address up to the nearest higher
+ *	  paragraph (0x10) boundary.
+ *
+ * \param[in]  a	 Any address/pointer value
+ *
+ * \returns			 The address of the next higher paragraph.
+ */
+#define NEXT_PARA(a) (((((UDATA)(a))+15) >> 4) << 4 )
+
+/**
+ * \internal DBFINULL is a typecast-qualified equivalent of NULL
+ */
+#define DBFINULL	((DBFITEM *)0)
+#define DBTIVADDR	(curr->ijavsad)			/** The starting EVA of the data region.			*/
+#define DBTIOFFS	(curr->ijavsbuf)		/** The starting address in our local copy buffer.	*/
+#define DBTISIZ		(curr->ijavsiz)			/** The size of the memory region					*/
+#define DBTIGAP		(curr->ijavgap)			/** The gap field									*/
+/*
+ * DBITYPE is one byte of bitfields; if you write one zero there, you'll
+ * have turned all its flags off. These bit indicators are symbolized 
+ * for two pointer combinations; the DBITYPE bit addressed by the 
+ * <tt>curr</tt> pointer and that addressed by the <tt>pred</tt> pointer. 
+ * Values starting with 'C' are addressed off the <tt>curr</tt> pointer,
+ * and values starting with 'P' are addressed off the <tt>pred</tt> pointer.
+ *	nSETSTRT is the starting item for a contiguous set
+ *	nSETMIDL is in a set, not the starter, not the ender
+ *	nSETLAST is the last (ender) of a contiguous set
+ *	nSETNONE means this item can be ignored
+ */
+#define DBTITYPE	(curr->ijavdesc+35)	/** A byte of bitfields, as follows:	*/
+#define CSETSTRT	(curr->ijavsset)		/** Starts a set	*/
+#define CSETMIDL	(curr->ijavmset)		/** Middle of a set	*/
+#define CSETLAST	(curr->ijavlset)		/** End of a set	*/
+#define CSETSOLO	(curr->ijavnone)		/** A set of one	*/
+#define PSETSTRT	(pred->ijavsset)		/** Starts a set	*/ 
+#define PSETMIDL	(pred->ijavmset)		/** Middle of a set	*/
+#define PSETLAST	(pred->ijavlset)		/** End of a set	*/
+#define PSETSOLO	(pred->ijavnone)		/** A set of one	*/
+
+#ifdef	 HOLD_PAGE_SIZE
+#undef	 PAGE_SIZE
+#define  PAGE_SIZE	 HOLD_PAGE_SIZE
+#undef	 HOLD_PAGE_SIZE
+#endif
+
+/*
+ *	  Aggregate data type declarations of importance to the ELF core file.
+ *	  Most of these aggregates appear somewhere in the .NOTE section.
+ */
+//avoid: error: conflicting types for greg_t, etc... sys/ucontext.h already has them
+//typedef uint64_t	greg_t;			/* Datatype for a general register			*/
+//typedef SYS_FLOAT	fpreg_t;		/* Datatype for a floating point reg		*/
+					 
+/*					 
+ *	The NT_AUXV segment means something to a UNIX or Linux system. It means
+ *	nothing to z/TPF; we don't turn over control to the system interpreter (we
+ *	don't even HAVE one) like *ix systems do. So instead, we're going to
+ *	fulfill the requirement for an NT_AUXV segment with a fake one of 304 zeros.
+ */
+typedef struct fake_auxv {
+   uint8_t fake_data[304];		/* Gotta go with 304 zeros here.			*/
+} AUXV;
+
+typedef struct { 
+   uint64_t	hi_word;
+   uint64_t	lo_word;
+} psw_t;
+
+typedef struct {
+   long double	fpxreg[16];
+} fpxregset_t;
+
+/*
+ * Here, in UNIX sequence, are the s390x general registers. We aren't honoring
+ * any other hardware architecture, so this is it.
+ */
+typedef struct {
+   psw_t		psw;				/* Program status word						*/
+   uint64_t		gprs[16];			/* General purpose registers				*/
+   uint32_t		acrs[16];			/* Access registers (no value in z/TPF)		*/
+   uint64_t		orig_gpr2;			/* Original R2, held by interpreter.		*/
+} s390_regs;
+
+//
+//avoid: error: conflicting types for ‘gregset_t’ sys/ucontext.h has the definition already.
+//
+//typedef struct {					/* Datatype for a full set of ...			*/
+//	uint64_t		gprs[16];			/* ... sixteen 64-bit general registers.	*/
+//} gregset_t;
+
+typedef struct shortsiginfo_t {		/* This is the leading struct in ELF		*/
+	uint32_t		si_signo;		/*	PRSTATUS.								*/
+	uint32_t		si_code;
+	uint32_t		si_errno;
+} ziginfo_t;
+
+typedef struct {					/* Process status block						*/
+	ziginfo_t		info;			/* Info associated with signal				*/
+	int16_t			cursig;			/* Current signal							*/
+	uint64_t		sigpend;		/* Set of pending signals					*/
+	uint64_t		sighold;		/* Set of held signals						*/
+	pid_t			pid;			/* Process id number						*/
+	pid_t			ppid;			/* Parent process id number					*/
+	pid_t			pgid;			/* Process group id (irrelevant in z/TPF)	*/
+	pid_t			sid;			/* Session id (irrelevant in z/TPF)			*/
+	struct timeval	utime;			/* User CPU time							*/
+	struct timeval	stime;			/* System CPU time							*/
+	struct timeval	cutime;			/* Cumulative user time						*/
+	struct timeval	cstime;			/* Cumulative system time					*/
+	s390_regs		reg;			/* General purpose registers				*/
+	int32_t			fpvalid;		/* True if math co-processor being used.	*/
+} prstatus_t;						/* Datatype for process status				*/
+
+#define PRARGSZ	(80)				/* Number of chars for args */
+
+typedef struct {					/* Process state information block			*/
+   uint8_t		char_state;			/* numeric process state					*/
+   uint8_t		sname;				/* char process state 'name'				*/
+   uint8_t		zomb;				/* zombie: yes or no?						*/
+   uint8_t		nice;				/* nice val									*/
+   uint64_t		flag;				/* flags									*/
+   uid_t		uid;				/* userid									*/
+   gid_t		gid;				/* group id									*/
+   pid_t		pid;				/* process id								*/
+   pid_t		ppid;				/* parent process id						*/
+   pid_t		pgrp;				/* process group (irrelevant in z/TPF)		*/
+   pid_t		sid;				/* session id (irrelevant in z/TPF)			*/
+   uint8_t		fname[16];			/* filename of executable/entry point		*/
+   uint8_t		psargs[PRARGSZ];	/* initial part of arg list					*/
+} prpsinfo_t;						/* Datatype for process state info			*/
+
+#endif
+

--- a/port/ztpf/omrvmem.c
+++ b/port/ztpf/omrvmem.c
@@ -1,0 +1,1842 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 1991, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial API and implementation and/or initial documentation
+ *    Multiple authors (IBM Corp.) - refactoring and modifications for z/TPF platform
+ *******************************************************************************/
+
+/**
+ * @file
+ * @ingroup Port
+ * @brief Virtual memory
+ */
+
+/* for syscall */
+
+#define _GNU_SOURCE
+
+
+#include "omrport.h"
+#include "portpriv.h"
+#include "omrportpg.h"
+#include "ut_omrprt.h"
+#include "omrportasserts.h"
+#include "omrvmem.h"
+
+#include <dirent.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+
+#include <tpf/tpfapi.h>
+#include <tpf/i_shm.h>
+#include <tpf/c_cinfc.h>
+#include <tpf/c_eb0eb.h>
+
+#include <sys/types.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <limits.h>
+
+#if defined(OMR_PORT_NUMA_SUPPORT)
+#include <numaif.h>
+#endif /* OMR_PORT_NUMA_SUPPORT */
+
+#if !defined(MPOL_F_MEMS_ALLOWED)
+#define MPOL_F_MEMS_ALLOWED 4
+#endif
+
+#include <sys/shm.h>
+
+#if !defined(MAP_FAILED)
+#define MAP_FAILED -1
+#endif
+
+#define INVALID_KEY -1
+
+#if 0
+#define J9VMEM_DEBUG
+#endif
+
+#define VMEM_MEMINFO_SIZE_MAX	2048
+#define VMEM_PROC_MEMINFO_FNAME	"/proc/meminfo"
+#define VMEM_PROC_MAPS_FNAME	"/proc/self/maps"
+
+#define FOUR_K_MINUS_1 (4*1024-1)
+#define GET_4K_ALIGNED_PTR(alignedPtr, ptr) do { \
+	alignedPtr = ( ((uintptr_t)ptr) + FOUR_K_MINUS_1 + sizeof(uintptr_t) ) & ~0xfff; \
+	*(uintptr_t *)(alignedPtr-sizeof(uintptr_t)) = (uintptr_t)ptr; \
+} while(0);
+#define GET_BASE_PTR_FROM_ALIGNED_PTR(alignedPtr) ( *(void **)((uintptr_t)alignedPtr - sizeof(uintptr_t)) )
+#define GET_4K_ALIGNED_ALLOCATION_SIZE(byteAmount) (byteAmount + FOUR_K_MINUS_1 + sizeof(uintptr_t))
+
+typedef struct vmem_hugepage_info_t {
+	uintptr_t enabled; /*!< boolean enabling j9 large page support */
+	uintptr_t pages_total; /*!< total number of pages maintained by the kernel */
+	uintptr_t pages_free; /*!< number of free pages that may be allocated by us */
+	uintptr_t page_size; /*!< page size in bytes */
+} vmem_hugepage_info_t;
+
+typedef void* ADDRESS;
+
+typedef struct AddressRange {
+	ADDRESS start;
+	ADDRESS end;
+} AddressRange;
+
+void addressRange_Init(AddressRange* range, ADDRESS start, ADDRESS end);
+BOOLEAN addressRange_Intersect(AddressRange* a, AddressRange* b,
+		AddressRange* result);
+BOOLEAN addressRange_IsValid(AddressRange* range);
+uintptr_t addressRange_Width(AddressRange* range);
+ADDRESS findAvailableMemoryBlockNoMalloc(struct OMRPortLibrary *portLibrary,
+		ADDRESS start, ADDRESS end, uintptr_t byteAmount, BOOLEAN reverse);
+
+static void * getMemoryInRangeForLargePages(struct OMRPortLibrary *portLibrary,
+		struct J9PortVmemIdentifier *identifier, key_t addressKey,
+		OMRMemCategory * category, uintptr_t byteAmount, void *startAddress,
+		void *endAddress, uintptr_t alignmentInBytes, uintptr_t vmemOptions,
+		uintptr_t pageSize, uintptr_t mode);
+static void * getMemoryInRangeForDefaultPages(struct OMRPortLibrary *portLibrary,
+		struct J9PortVmemIdentifier *identifier, OMRMemCategory * category,
+		uintptr_t byteAmount, void *startAddress, void *endAddress,
+		uintptr_t alignmentInBytes, uintptr_t vmemOptions, uintptr_t mode);
+static void * allocateMemoryForLargePages(struct OMRPortLibrary *portLibrary,
+		struct J9PortVmemIdentifier *identifier, void *currentAddress,
+		key_t addressKey, OMRMemCategory* category, uintptr_t byteAmount,
+		uintptr_t pageSize, uintptr_t mode);
+static BOOLEAN isStrictAndOutOfRange(void *memoryPointer, void *startAddress,
+		void *endAddress, uintptr_t vmemOptions);
+static BOOLEAN rangeIsValid(struct J9PortVmemIdentifier *identifier,
+		void *address, uintptr_t byteAmount);
+static void *reserveLargePages(struct OMRPortLibrary *portLibrary,
+		struct J9PortVmemIdentifier *identifier, OMRMemCategory * category,
+		uintptr_t byteAmount, void *startAddress, void *endAddress, uintptr_t pageSize,
+		uintptr_t alignmentInBytes, uintptr_t vmemOptions, uintptr_t mode);
+
+void *default_pageSize_reserve_memory(struct OMRPortLibrary *portLibrary,
+		void *address, uintptr_t byteAmount,
+		struct J9PortVmemIdentifier *identifier, uintptr_t mode, uintptr_t pageSize,
+		OMRMemCategory * category);
+static void port_numa_interleave_memory(struct OMRPortLibrary *portLibrary,
+		void *start, uintptr_t size);
+void update_vmemIdentifier(J9PortVmemIdentifier *identifier, void *address,
+		void *handle, uintptr_t byteAmount, uintptr_t mode, uintptr_t pageSize,
+		uintptr_t pageFlags, uintptr_t allocator, OMRMemCategory * category);
+static uintptr_t get_hugepages_info(struct OMRPortLibrary *portLibrary,
+		vmem_hugepage_info_t *page_info);
+int get_protectionBits(uintptr_t mode);
+
+#if defined(OMR_PORT_NUMA_SUPPORT)
+/*
+ * glibc doesn't include mbind yet. It is in libnuma, but we can't rely on that being available on all systems.
+ * We define our own helper to make the syscall so that we can use it without relying on external libraries.
+ */
+static long
+do_mbind(void *start, unsigned long len, int policy, const unsigned long *nodemask, unsigned long maxnode, unsigned flags)
+{
+	return (long)syscall(SYS_mbind, start, len, policy, nodemask, maxnode, flags);
+}
+
+/**
+ * glibc doesn't include get_mempolicy. It is in libnuma, but we can't rely on that being available on all systems.
+ * We define our own helper to make the syscall so that we can use it without relying on external libraries.
+ *
+ * For details, see the man page for get_mempolicy(2).
+ * Below is an incomplete summary.
+ *
+ * do_get_mempolicy()
+ *
+ *     gets the NUMA policy of the calling process or virtual memory address
+ *
+ * @param int           *policy  [out] returns the policy, or next interleave node
+ * @param unsigned long *nmask   [out] the node bit mask associated with the policy
+ * @param unsigned long  maxnode [in]  length of nmask array
+ * @param unsigned long  addr    [in]  virtual memory address of requested policy info
+ * @param unsigned long  flags   [in]  controls get_mempolicy behaviour
+ *
+ * @return 0 on success, -1 on error returned via errno.
+ * errno==EFAULT: Part of all of memory specified by nmask inaccessible
+ * errno==EINVAL: Invalid arguments (many invalid combinations).
+ */
+static long
+do_get_mempolicy(int *policy, unsigned long *nmask, unsigned long maxnode, unsigned long addr, unsigned long flags)
+{
+	return (long)syscall(SYS_get_mempolicy, policy, nmask, maxnode, addr, flags);
+}
+
+/*
+ * Read the /sys/devices/system/node/ directory, if it exists, to find out the indices of
+ * all NUMA nodes on this system. Store them into a bitmask in the port platform globals.
+ */
+static intptr_t
+initializeNumaGlobals(struct OMRPortLibrary *portLibrary)
+{
+	uintptr_t result = 0;
+	uintptr_t maxNodes = sizeof(J9PortNodeMask) * 8;
+	uintptr_t nodeCount = 0;
+	int schedReturnCode = 0;
+	int mempolicyReturnCode = 0;
+	int useAllNodes = 0;
+
+	memset(&PPG_numa_available_node_mask, 0, sizeof(J9PortNodeMask));
+	PPG_numa_max_node_bits = 0;
+
+	/* populate the processAffinity with the process's incoming affinity - this will allow us to honour options like "numactl --cpubind=" */
+	CPU_ZERO(&PPG_process_affinity);
+	schedReturnCode = sched_getaffinity(0, sizeof(PPG_process_affinity), &PPG_process_affinity);
+
+	/* look-up the process's default NUMA policy as applied to the set of nodes (the policy is usually "0" and applies to no nodes) */
+	PPG_numa_policy_mode = -1;
+	memset(&PPG_numa_mempolicy_node_mask, 0, sizeof(J9PortNodeMask));
+	mempolicyReturnCode = do_get_mempolicy(&PPG_numa_policy_mode, PPG_numa_mempolicy_node_mask.mask, maxNodes, (unsigned long)NULL, 0);
+
+	if (0 == mempolicyReturnCode) {
+
+		long anySet = 0;
+		int arrayLen = sizeof(PPG_numa_mempolicy_node_mask.mask) / sizeof(PPG_numa_mempolicy_node_mask.mask[0]);
+		int i = 0;
+
+		/* Check if any bits are set in PPG_numa_mempolicy_node_mask. If no nodes are specified in either the system default or process default
+		 * policies then the mask will be all 0's which (if used later) would indicate no nodes are available for virtual memory allocation. */
+		for (i = 0; ((0 == anySet) && (i < arrayLen)); i++) {
+			anySet |= PPG_numa_mempolicy_node_mask.mask[i];
+		}
+		if (0 == anySet) {
+			/* If an empty set is returned, e.g. if numactl is not used, ask again with MPOL_F_MEMS_ALLOWED to get the correct node mask. */
+			mempolicyReturnCode = do_get_mempolicy((int *) NULL, PPG_numa_mempolicy_node_mask.mask, maxNodes, (unsigned long)NULL, MPOL_F_MEMS_ALLOWED);
+
+			/* MPOL_F_MEMS_ALLOWED is unavailable on older systems. If it fails, we use PPG_numa_available_node_mask instead. */
+			if (0 != mempolicyReturnCode) {
+				Trc_PRT_vmem_omrvmem_initializeNumaGlobals_get_allowed_mems_failure(errno);
+				mempolicyReturnCode = 0;
+				useAllNodes = 1;
+			}
+		}
+	} else {
+		Trc_PRT_vmem_omrvmem_initializeNumaGlobals_get_mempolicy_failure(errno);
+	}
+
+	/* only proceed if we could successfully look up the memory policy and default affinity */
+	if ((0 == schedReturnCode) && (0 == mempolicyReturnCode)) {
+		DIR* nodes = opendir("/sys/devices/system/node/");
+		if (NULL != nodes) {
+			struct dirent *node = readdir(nodes);
+			while (NULL != node) {
+				unsigned long nodeIndex = 0;
+				if (1 == sscanf(node->d_name, "node%lu", &nodeIndex)) {
+					if (nodeIndex < maxNodes) {
+						unsigned long wordIndex = nodeIndex / sizeof(PPG_numa_available_node_mask.mask[0]);
+						unsigned long bit = 1 << (nodeIndex % sizeof(PPG_numa_available_node_mask.mask[0]));
+						PPG_numa_available_node_mask.mask[wordIndex] |= bit;
+						/**
+						 * PPG_numa_max_node_bits represents the maximum number of nodes.
+						 * Node indexes start from 0, therefore PPG_numa_max_node_bits is max node index number plus 1.
+						 * For instance, if there are following nodes:node0, node5, node8,
+						 * then PPG_numa_max_node_bits is equal to 8 + 1 = 9
+						 */
+						if (nodeIndex >= PPG_numa_max_node_bits) {
+							PPG_numa_max_node_bits = nodeIndex + 1;
+						}
+
+						nodeCount += 1;
+					}
+				}
+				node = readdir(nodes);
+			}
+			closedir(nodes);
+		}
+	}
+
+	/* if there aren't at least two nodes then there's nothing we can do with NUMA */
+	if (nodeCount < 2) {
+		result = -1;
+	} else if (1 == useAllNodes) {
+		/* Failed to get memory policy allowed nodes, use all available nodes instead. */
+		memcpy(PPG_numa_mempolicy_node_mask.mask, PPG_numa_available_node_mask.mask, sizeof(PPG_numa_available_node_mask.mask));
+	}
+
+	return result;
+}
+#endif /* defined(OMR_PORT_NUMA_SUPPORT) */
+
+/*
+ * Init the range with values
+ *
+ * @param AddressRange* range	[out]	Returns the range object
+ * @param void* 		start	[in] 	The start address of the range
+ * @param void*  		end		[in]	The end address of the range
+ */
+void
+addressRange_Init(AddressRange* range, ADDRESS start, ADDRESS end)
+{
+	range->start = start;
+	range->end = end;
+}
+
+/*
+ * Calculate out the intersection of 2 ranges
+ *
+ * @param AddressRange* a		[in] 	a range object
+ * @param AddressRange* b		[in] 	another range object
+ * @param AddressRange* result 	[out]	the intersection of the above 2 ranges
+ *
+ * Returns TRUE if they have intersection.
+ */
+BOOLEAN
+addressRange_Intersect(AddressRange* a, AddressRange* b, AddressRange* result)
+{
+	result->start = a->start > b->start ? a->start : b->start;
+	result->end = a->end < b->end ? a->end : b->end;
+
+	return addressRange_IsValid(result);
+}
+
+/*
+ * Calculate if a range is valid.
+ * A valid range should have start < its end
+ *
+ * @param AddressRange* range	[in] 	a range object
+ *
+ * Returns TRUE if range's start < end.
+ */
+BOOLEAN
+addressRange_IsValid(AddressRange* range)
+{
+	return (range->end > range->start) ? TRUE : FALSE;
+}
+
+/*
+ * Calculate out the with of a range
+ *
+ * @param AddressRange* range 	[in]	a range object
+ *
+ * Returns the width of the range.
+ * Caller should make sure the input parameter 'range' is valid,
+ * otherwise, unexpected value may be returned.
+ */
+uintptr_t
+addressRange_Width(AddressRange* range)
+{
+	Assert_PRT_true(TRUE == addressRange_IsValid(range));
+	return range->end - range->start;
+}
+
+/*
+ * Find a memory block using maps information from file /proc/self/maps
+ * In order to avoid file context corruption, this method implemented without memory operation such as malloc/free
+ *
+ *
+ * @param OMRPortLibrary *portLibrary	[in] The portLibrary object
+ * @param ADDRESS 		start			[in] The start address allowed, see also @param end
+ * @param ADDRESS 		end				[in] The end address allowed, see also @param start.
+ * 											 The returned memory address should be within the range defined by the @param start and the @param end.
+ * @param uintptr_t 		byteAmount		[in] The block size required.
+ * @param BOOLEAN 		reverse			[in] Returns the first available memory block when this param equals FALSE, returns the last available memory block when this param equals TRUE
+ *
+ * returns the address available.
+ */
+ADDRESS
+findAvailableMemoryBlockNoMalloc(struct OMRPortLibrary *portLibrary,
+		ADDRESS start, ADDRESS end, uintptr_t byteAmount, BOOLEAN reverse)
+{
+	BOOLEAN dataCorrupt = FALSE;
+	BOOLEAN matchFound = FALSE;
+
+	AddressRange allowedRange;
+	addressRange_Init(&allowedRange, start, end);
+
+	AddressRange lastAvailableRange;
+	addressRange_Init(&lastAvailableRange, NULL, NULL);
+
+	int fd = -1;
+	if ((fd = omrfile_open(portLibrary, VMEM_PROC_MAPS_FNAME, EsOpenRead, 0))
+			!= -1) {
+		char readBuf[1024];
+		intptr_t bytesRead = 0;
+		/*
+		 * Please refer to the file format of /proc/self/maps.
+		 * 'lineBuf' represent for a line in the file.
+		 *
+		 * Don't change the length of 'lineBuf' easily.
+		 * The minimal length should be 34 on 64bit machine,
+		 * as 34 is the minimal safe length to represent for a 64bit address range.
+		 * For example: "1234567890120000-1234567890123000" (NOTE: there is a '\0' in the end)
+		 */
+		char lineBuf[100];
+		intptr_t lineCursor = 0;
+		AddressRange lastMmapRange;
+		addressRange_Init(&lastMmapRange, NULL, NULL);
+
+		while (TRUE) { /* read-file-loop */
+			BOOLEAN lineEnd = FALSE;
+			BOOLEAN gotEOF = FALSE;
+			bytesRead = omrfile_read(portLibrary, fd, readBuf, sizeof(readBuf));
+			if (-1 == bytesRead) {
+				dataCorrupt = TRUE;
+				break;
+			}
+
+			intptr_t readCursor = 0;
+			do { /* proc-chars-loop */
+				char ch = '\0';
+				/*
+				 * Scan out a line from 'readBuf', and save the line data to 'lineBuf'.
+				 * 1. End the line with '\0'.
+				 * 2. Set lineEnd = TRUE when '\n' found.
+				 */
+				if (0 == bytesRead) {
+					gotEOF = TRUE;
+					ch = '\n';
+				} else {
+					ch = readBuf[readCursor];
+					readCursor++;
+				}
+				/*
+				 * We only save the beginning chars for each line, because:
+				 * 1. we only need the memory range data, it always at the beginning of the lines.
+				 * 2. the size of the 'lineBuf' is fixed, we skip the extra chars in order to avoid out-of-bound-writting
+				 */
+				if (lineCursor < sizeof(lineBuf)) {
+					lineBuf[lineCursor] = ch;
+					lineCursor++;
+				}
+
+				if ('\n' == ch) {
+					lineEnd = TRUE;
+					lineBuf[lineCursor - 1] = '\0';
+				}
+
+				if (TRUE == lineEnd) { /* proc-line-data */
+					AddressRange currentMmapRange;
+					addressRange_Init(&currentMmapRange, NULL, NULL);
+					Assert_PRT_true(lineBuf[lineCursor - 1] == '\0');
+
+					if (TRUE == gotEOF) {
+						/* We reach the end of the file. */
+						addressRange_Init(&currentMmapRange,
+								(ADDRESS) (uintptr_t) (-1), (ADDRESS) (uintptr_t) (-1));
+					} else {
+						char* next = NULL;
+						uintptr_t start = 0;
+						uintptr_t end = 0;
+						start = (uintptr_t) strtoull(lineBuf, &next, 16);
+						if ((ULLONG_MAX == start) && (ERANGE == errno)) {
+							dataCorrupt = TRUE;
+							break;
+						}
+						/* skip the '-' */
+						next++;
+						if (next >= (lineBuf + lineCursor - 1)) {
+							dataCorrupt = TRUE;
+							break;
+						}
+						end = (uintptr_t) strtoull(next, &next, 16);
+						if ((ULLONG_MAX == end) && (ERANGE == errno)) {
+							dataCorrupt = TRUE;
+							break;
+						}
+
+						currentMmapRange.start = (ADDRESS) start;
+						currentMmapRange.end = (ADDRESS) end;
+						lineCursor = 0;
+
+						if ((currentMmapRange.start >= currentMmapRange.end)
+								|| (currentMmapRange.start < lastMmapRange.end)) {
+							dataCorrupt = TRUE;
+							break;
+						}
+					}
+
+					if (currentMmapRange.start == lastMmapRange.end) {
+						lastMmapRange.end = currentMmapRange.end;
+					} else {
+						/* free block found */
+						AddressRange freeRange;
+						AddressRange intersectAvailable;
+						BOOLEAN haveIntersect = FALSE;
+
+						addressRange_Init(&freeRange, lastMmapRange.end,
+								currentMmapRange.start);
+						memcpy(&lastMmapRange, &currentMmapRange,
+								sizeof(AddressRange));
+
+						/* check if the free block has intersection with the allowed range */
+						haveIntersect = addressRange_Intersect(&allowedRange,
+								&freeRange, &intersectAvailable);
+						if (TRUE == haveIntersect) {
+							uintptr_t intersectSize = addressRange_Width(
+									&intersectAvailable);
+							if (intersectSize >= byteAmount) {
+								memcpy(&lastAvailableRange, &intersectAvailable,
+										sizeof(AddressRange));
+								matchFound = TRUE;
+								if (FALSE == reverse) {
+									break;
+								}
+							}
+						}
+					}
+					lineEnd = FALSE;
+				} /* end proc-line-data */
+			} while (readCursor < bytesRead); /* end proc-chars-loop */
+
+			if ((FALSE == reverse) && (TRUE == matchFound)) {
+				break;
+			}
+
+			if (TRUE == (gotEOF | dataCorrupt)) {
+				break;
+			}
+		} /* end read-file-loop */
+		omrfile_close(portLibrary, fd);
+	} else {
+		dataCorrupt = TRUE;
+	}
+
+	if (TRUE == dataCorrupt) {
+		return NULL;
+	}
+
+	if (TRUE == matchFound) {
+		if (FALSE == reverse) {
+			return lastAvailableRange.start;
+		} else {
+			return (lastAvailableRange.end - byteAmount);
+		}
+	} else {
+		return NULL;
+	}
+}
+
+void
+omrvmem_shutdown(struct OMRPortLibrary *portLibrary)
+{
+#if defined(OMR_PORT_NUMA_SUPPORT)
+	if (NULL != portLibrary->portGlobals) {
+		PPG_numa_platform_supports_numa = 0;
+	}
+#endif
+}
+
+int32_t
+omrvmem_startup(struct OMRPortLibrary *portLibrary)
+{
+	vmem_hugepage_info_t vmem_page_info;
+
+	/* clear page info data, this has the effect of starting off in a standard state */
+	memset(&vmem_page_info, 0x00, sizeof(vmem_hugepage_info_t));
+	get_hugepages_info(portLibrary, &vmem_page_info);
+
+	/* 0 terminate the table */
+	memset(PPG_vmem_pageSize, 0, OMRPORT_VMEM_PAGESIZE_COUNT * sizeof(uintptr_t));
+	memset(PPG_vmem_pageFlags, 0, OMRPORT_VMEM_PAGESIZE_COUNT * sizeof(uintptr_t));
+
+	/* First the default page size */
+	PPG_vmem_pageSize[0] = 4096;
+	PPG_vmem_pageFlags[0] = OMRPORT_VMEM_PAGE_FLAG_NOT_USED;
+
+	/* Now the large pages */
+	if (vmem_page_info.enabled) {
+		PPG_vmem_pageSize[1] = vmem_page_info.page_size;
+		PPG_vmem_pageFlags[1] = OMRPORT_VMEM_PAGE_FLAG_NOT_USED;
+	}
+
+#if defined(OMR_PORT_NUMA_SUPPORT)
+	if (0 == initializeNumaGlobals(portLibrary)) {
+		PPG_numa_platform_supports_numa = 1;
+	} else {
+		PPG_numa_platform_supports_numa = 0;
+	}
+#endif
+
+	/* set default value to advise OS about vmem that is no longer needed */
+	portLibrary->portGlobals->vmemAdviseOSonFree = 1;
+
+	return 0;
+}
+
+void *
+omrvmem_commit_memory(struct OMRPortLibrary *portLibrary, void *address,
+		uintptr_t byteAmount, struct J9PortVmemIdentifier *identifier)
+{
+	void *rc = NULL;
+	Trc_PRT_vmem_omrvmem_commit_memory_Entry(address, byteAmount);
+
+	if (rangeIsValid(identifier, address, byteAmount)) {
+				ASSERT_VALUE_IS_PAGE_SIZE_ALIGNED(address, identifier->pageSize);ASSERT_VALUE_IS_PAGE_SIZE_ALIGNED(
+				byteAmount, identifier->pageSize);
+
+		/* Default page size */
+		if (PPG_vmem_pageSize[0] == identifier->pageSize
+				|| 0 != (identifier->mode & OMRPORT_VMEM_MEMORY_MODE_EXECUTE)) {
+			rc = address;
+		}
+	} else {
+		Trc_PRT_vmem_omrvmem_commit_memory_invalidRange(identifier->address,
+				identifier->size, address, byteAmount);
+		portLibrary->error_set_last_error(portLibrary, -1,
+				OMRPORT_ERROR_VMEM_INVALID_PARAMS);
+	}
+
+#if defined(J9VMEM_DEBUG)
+	printf("\t\t omrvmem_commit_memory returning 0x%x\n",rc);fflush(stdout);
+#endif
+	Trc_PRT_vmem_omrvmem_commit_memory_Exit(rc);
+	return rc;
+}
+
+intptr_t
+omrvmem_decommit_memory(struct OMRPortLibrary *portLibrary, void *address,
+		uintptr_t byteAmount, struct J9PortVmemIdentifier *identifier)
+{
+	intptr_t result = 0;
+
+	Trc_PRT_vmem_omrvmem_decommit_memory_Entry(address, byteAmount);
+
+	/* JVM is not allowed to decommit, just return success */
+	Trc_PRT_vmem_decommit_memory_not_allowed(
+			portLibrary->portGlobals->vmemAdviseOSonFree);
+
+	Trc_PRT_vmem_omrvmem_decommit_memory_Exit(result);
+
+	return result;
+}
+
+int32_t
+omrvmem_free_memory(struct OMRPortLibrary *portLibrary, void *address,
+		uintptr_t byteAmount, struct J9PortVmemIdentifier *identifier)
+{
+
+	void *freeAddress;
+
+	int32_t ret = -1;
+	OMRMemCategory * category = identifier->category;
+	/* CMVC 180372 - Some users store the identifier in the allocated memory.
+	 * We therefore store the allocator in a temp, clear the identifier then
+	 * free the memory
+	 */
+	uintptr_t allocator = identifier->allocator;
+	Trc_PRT_vmem_omrvmem_free_memory_Entry(address, byteAmount);
+
+	/* CMVC 180372 - Identifier must be cleared before memory is freed, see comment above */
+	update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, 0, NULL);
+
+	/* Default page Size */
+	if (OMRPORT_VMEM_RESERVE_USED_SHM != allocator) {
+		freeAddress = GET_BASE_PTR_FROM_ALIGNED_PTR(address);
+		free(freeAddress);
+	} else {
+		ret = (int32_t) shmdt(address);
+	}
+
+	omrmem_categories_decrement_counters(category, byteAmount);
+
+	Trc_PRT_vmem_omrvmem_free_memory_Exit(ret);
+	return ret;
+}
+
+int32_t
+omrvmem_vmem_params_init(struct OMRPortLibrary *portLibrary,
+		struct J9PortVmemParams *params)
+{
+	memset(params, 0, sizeof(struct J9PortVmemParams));
+	params->startAddress = NULL;
+	params->endAddress = OMRPORT_VMEM_MAX_ADDRESS;
+	params->byteAmount = 0;
+	params->pageSize = PPG_vmem_pageSize[0];
+	params->pageFlags = PPG_vmem_pageFlags[0];
+	params->mode = OMRPORT_VMEM_MEMORY_MODE_READ | OMRPORT_VMEM_MEMORY_MODE_WRITE;
+	params->options = 0;
+	params->category = OMRMEM_CATEGORY_UNKNOWN;
+	params->alignmentInBytes = 0;
+	return 0;
+}
+
+void *
+omrvmem_reserve_memory(struct OMRPortLibrary *portLibrary, void *address,
+		uintptr_t byteAmount, struct J9PortVmemIdentifier *identifier, uintptr_t mode,
+		uintptr_t pageSize, uint32_t category)
+{
+	struct J9PortVmemParams params;
+	omrvmem_vmem_params_init(portLibrary, &params);
+	if (NULL != address) {
+		params.startAddress = address;
+		params.endAddress = address;
+	}
+	params.byteAmount = byteAmount;
+	params.mode = mode;
+	params.pageSize = pageSize;
+	params.pageFlags = OMRPORT_VMEM_PAGE_FLAG_NOT_USED;
+	params.options = 0;
+	params.category = category;
+	return portLibrary->vmem_reserve_memory_ex(portLibrary, identifier, &params);
+}
+
+void *
+omrvmem_reserve_memory_ex(struct OMRPortLibrary *portLibrary,
+		struct J9PortVmemIdentifier *identifier,
+		struct J9PortVmemParams *params)
+{
+	void *memoryPointer = NULL;
+	OMRMemCategory * category = omrmem_get_category(portLibrary,
+			params->category);
+
+	Trc_PRT_vmem_omrvmem_reserve_memory_Entry_replacement(params->startAddress,
+			params->byteAmount, params->pageSize);
+
+	Assert_PRT_true(params->startAddress <= params->endAddress);
+	ASSERT_VALUE_IS_PAGE_SIZE_ALIGNED(params->byteAmount, params->pageSize);
+
+	/* Invalid input */
+	if (0 == params->pageSize) {
+		update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, 0, NULL);
+		Trc_PRT_vmem_omrvmem_reserve_memory_invalid_input();
+	} else if (PPG_vmem_pageSize[0] == params->pageSize) {
+		uintptr_t alignmentInBytes = max(params->pageSize,
+				params->alignmentInBytes);
+		uintptr_t minimumGranule = min(params->pageSize, params->alignmentInBytes);
+
+		/* Make sure that the alignment is a multiple of both requested alignment and page size (enforces that arguments are powers of two and, thus, their max is their lowest common multiple) */
+		if ((0 == minimumGranule)
+				|| (0 == (alignmentInBytes % minimumGranule))) {
+			memoryPointer = getMemoryInRangeForDefaultPages(portLibrary,
+					identifier, category, params->byteAmount,
+					params->startAddress, params->endAddress, alignmentInBytes,
+					params->options, params->mode);
+		}
+	} else if (PPG_vmem_pageSize[1] == params->pageSize) {
+		uintptr_t largePageAlignmentInBytes = max(params->pageSize,
+				params->alignmentInBytes);
+		uintptr_t largePageMinimumGranule = min(params->pageSize,
+				params->alignmentInBytes);
+
+		/* Make sure that the alignment is a multiple of both requested alignment and page size (enforces that arguments are powers of two and, thus, their max is their lowest common multiple) */
+		if ((0 == largePageMinimumGranule)
+				|| (0 == (largePageAlignmentInBytes % largePageMinimumGranule))) {
+			memoryPointer = reserveLargePages(portLibrary, identifier, category,
+					params->byteAmount, params->startAddress,
+					params->endAddress, params->pageSize,
+					largePageAlignmentInBytes, params->options, params->mode);
+		}
+		if (NULL == memoryPointer) {
+			/* If strict page size flag is not set try again with default page size */
+			if (0 == (OMRPORT_VMEM_STRICT_PAGE_SIZE & params->options)) {
+#if defined(J9VMEM_DEBUG)
+				printf("\t\t\t NULL == memoryPointer, reverting to default pages\n");fflush(stdout);
+#endif
+				uintptr_t defaultPageSize = PPG_vmem_pageSize[0];
+				uintptr_t alignmentInBytes = max(defaultPageSize,
+						params->alignmentInBytes);
+				uintptr_t minimumGranule = min(defaultPageSize,
+						params->alignmentInBytes);
+
+				/* Make sure that the alignment is a multiple of both requested alignment and page size (enforces that arguments are powers of two and, thus, their max is their lowest common multiple) */
+				if ((0 == minimumGranule)
+						|| (0 == (alignmentInBytes % minimumGranule))) {
+					memoryPointer = getMemoryInRangeForDefaultPages(portLibrary,
+							identifier, category, params->byteAmount,
+							params->startAddress, params->endAddress,
+							alignmentInBytes, params->options, params->mode);
+				}
+			} else {
+				update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, 0,
+				NULL);
+			}
+		}
+	} else {
+		/* If the pageSize is not one of the supported page sizes, error */
+		update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, 0, NULL);
+		Trc_PRT_vmem_omrvmem_reserve_memory_unsupported_page_size(
+				params->pageSize);
+	}
+#if defined(OMR_PORT_NUMA_SUPPORT)
+	if (NULL != memoryPointer) {
+		port_numa_interleave_memory(portLibrary, memoryPointer, params->byteAmount);
+	}
+#endif
+
+#if defined(J9VMEM_DEBUG)
+	printf("\tomrvmem_reserve_memory_ex returning %p\n", memoryPointer);fflush(stdout);
+#endif
+
+	Trc_PRT_vmem_omrvmem_reserve_memory_Exit_replacement(memoryPointer,
+			params->startAddress);
+	return memoryPointer;
+}
+
+static void *
+reserveLargePages(struct OMRPortLibrary *portLibrary,
+		struct J9PortVmemIdentifier *identifier, OMRMemCategory * category,
+		uintptr_t byteAmount, void *startAddress, void *endAddress, uintptr_t pageSize,
+		uintptr_t alignmentInBytes, uintptr_t vmemOptions, uintptr_t mode)
+{
+	/* The address should usually be passed in as NULL in order to let the kernel find and assign a
+	 * large enough window of virtual memory
+	 *
+	 * Requesting HUGETLB pages via shmget has the effect of "reserving" them. They have to be attached to become allocated for use
+	 * The execute flags are ignored by shmget
+	 */
+	key_t addressKey;
+
+	int shmgetFlags = SHM_HUGETLB | IPC_CREAT | TPF_IPC64;
+
+	void *memoryPointer = NULL;
+
+	if (0 != (OMRPORT_VMEM_MEMORY_MODE_READ & mode)) {
+		shmgetFlags |= SHM_R;
+	}
+	if (0 != (OMRPORT_VMEM_MEMORY_MODE_WRITE & mode)) {
+		shmgetFlags |= SHM_W;
+	}
+
+	addressKey = shmget(IPC_PRIVATE, (size_t) byteAmount, shmgetFlags);
+	if (-1 == addressKey) {
+		Trc_PRT_vmem_omrvmem_reserve_memory_shmget_failed(byteAmount,
+				shmgetFlags);
+	} else {
+		memoryPointer = getMemoryInRangeForLargePages(portLibrary, identifier,
+				addressKey, category, byteAmount, startAddress, endAddress,
+				alignmentInBytes, vmemOptions, pageSize, mode);
+
+		/* release when complete, protect from ^C or crash */
+		if (0 != shmctl(addressKey, IPC_RMID, NULL)) {
+			/* if releasing addressKey fails detach memory to avoid leaks and fail */
+			if (NULL != memoryPointer) {
+				if (0 != shmdt(memoryPointer)) {
+					Trc_PRT_vmem_omrvmem_reserve_memory_shmdt_failed(
+							memoryPointer);
+				}
+			}
+			Trc_PRT_vmem_omrvmem_reserve_memory_failure();
+			memoryPointer = NULL;
+		}
+
+		if (NULL != memoryPointer) {
+			/* Commit memory if required, else return reserved memory */
+			if (0 != (OMRPORT_VMEM_MEMORY_MODE_COMMIT & mode)) {
+				if (NULL
+						== omrvmem_commit_memory(portLibrary, memoryPointer,
+								byteAmount, identifier)) {
+					/* If the commit fails free the memory */
+					omrvmem_free_memory(portLibrary, memoryPointer, byteAmount,
+							identifier);
+					memoryPointer = NULL;
+				}
+			}
+		}
+	}
+
+	if (NULL == memoryPointer) {
+		update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, 0, NULL);
+	}
+
+#if defined(J9VMEM_DEBUG)
+	printf("\treserveLargePages returning 0x%zx\n", memoryPointer);fflush(stdout);
+#endif
+	return memoryPointer;
+}
+
+uintptr_t
+omrvmem_get_page_size(struct OMRPortLibrary *portLibrary,
+		struct J9PortVmemIdentifier *identifier)
+{
+	return identifier->pageSize;
+}
+
+uintptr_t
+omrvmem_get_page_flags(struct OMRPortLibrary *portLibrary,
+		struct J9PortVmemIdentifier *identifier)
+{
+	return identifier->pageFlags;
+}
+
+uintptr_t*
+omrvmem_supported_page_sizes(struct OMRPortLibrary *portLibrary)
+{
+	return PPG_vmem_pageSize;
+}
+
+uintptr_t*
+omrvmem_supported_page_flags(struct OMRPortLibrary *portLibrary)
+{
+	return PPG_vmem_pageFlags;
+}
+
+static uintptr_t
+get_hugepages_info(struct OMRPortLibrary *portLibrary,
+		vmem_hugepage_info_t *page_info)
+{
+	int fd;
+	int bytes_read;
+	char *line_ptr, read_buf[VMEM_MEMINFO_SIZE_MAX];
+	char token_name[128];
+	int tokens_assigned;
+	uintptr_t token_value;
+
+	fd = omrfile_open(portLibrary, VMEM_PROC_MEMINFO_FNAME, EsOpenRead, 0);
+	if (fd < 0) {
+		return 0;
+	}
+
+	bytes_read = omrfile_read(portLibrary, fd, read_buf,
+	VMEM_MEMINFO_SIZE_MAX - 1);
+	if (bytes_read <= 0) {
+		omrfile_close(portLibrary, fd);
+		return 0;
+	}
+
+	/* make sure its null terminated */
+	read_buf[bytes_read] = 0;
+
+	/** Why this is data is not available via a well defined system call remains a mystery. Meanwhile
+	 *  we have to parse /proc/meminfo to figure out how many pages are available/free as well as
+	 *  their size
+	 */
+	line_ptr = read_buf;
+	while (line_ptr && *line_ptr) {
+
+		tokens_assigned = sscanf(line_ptr, "%127s %zu %*s", token_name,
+				&token_value);
+
+#ifdef LPDEBUG
+		portLibrary->tty_printf(portLibrary, "/proc/meminfo => %s [%zu] %d\n", token_name, token_value, tokens_assigned);
+#endif
+
+		if (tokens_assigned) {
+			if (!strcmp(token_name, "HugePages_Total:")) {
+				page_info->pages_total = token_value;
+			} else if (!strcmp(token_name, "HugePages_Free:")) {
+				page_info->pages_free = token_value;
+			} else if (!strcmp(token_name, "Hugepagesize:")) {
+				page_info->page_size = token_value * 1024; /* value is in KB, convert to bytes */
+			}
+		}
+
+		line_ptr = strpbrk(line_ptr, "\n");
+		if (line_ptr && *line_ptr) {
+			line_ptr++; /* skip the \n if we are not done yet */
+		}
+	}
+
+	omrfile_close(portLibrary, fd);
+
+	/* "Enable" large page support if the system has been found to be initialized */
+	if (page_info->pages_total) {
+		page_info->enabled = 1;
+	}
+
+	return 1;
+}
+
+void *
+default_pageSize_reserve_memory(struct OMRPortLibrary *portLibrary,
+		void *address, uintptr_t byteAmount,
+		struct J9PortVmemIdentifier *identifier, uintptr_t mode, uintptr_t pageSize,
+		OMRMemCategory * category)
+{
+	/* This function is cloned in J9SourceUnixJ9VMem (omrvmem_reserve_memory).
+	 * Any changes made here may need to be reflected in that version .
+	 */
+	int fd = -1;
+	int flags = MAP_PRIVATE;
+	void *result = NULL;
+	int protectionFlags = PROT_NONE;
+
+	Trc_PRT_vmem_default_reserve_entry(address, byteAmount);
+
+#if defined(MAP_ANONYMOUS)
+	flags |= MAP_ANONYMOUS;
+#elif defined(MAP_ANON)
+	flags |= MAP_ANON;
+#else
+	fd = portLibrary->file_open(portLibrary, "/dev/zero",
+	EsOpenRead | EsOpenWrite, 0);
+	if (-1 != fd)
+#endif
+			{
+		if (0 != (OMRPORT_VMEM_MEMORY_MODE_COMMIT & mode)) {
+			protectionFlags = get_protectionBits(mode);
+		} else {
+			flags |= MAP_NORESERVE;
+		}
+
+		{
+			uintptr_t alignedPtr = 0;
+			uintptr_t allocSize = (uintptr_t)GET_4K_ALIGNED_ALLOCATION_SIZE(byteAmount);
+			result = malloc64(allocSize);
+			if (result != NULL) {
+				GET_4K_ALIGNED_PTR(alignedPtr, result);
+				result = (void *)alignedPtr;
+			} else {
+				result = (void *)MAP_FAILED;
+			}
+		}
+
+#if !defined(MAP_ANONYMOUS) && !defined(MAP_ANON)
+		portLibrary->file_close(portLibrary, fd);
+#endif
+
+		if (MAP_FAILED == result) {
+			result = NULL;
+		} else {
+			/* Update identifier and commit memory if required, else return reserved memory */
+			update_vmemIdentifier(identifier, result, result, byteAmount, mode,
+					pageSize, OMRPORT_VMEM_PAGE_FLAG_NOT_USED,
+					OMRPORT_VMEM_RESERVE_USED_MMAP, category);
+
+			omrmem_categories_increment_counters(category, byteAmount);
+			if (0 != (OMRPORT_VMEM_MEMORY_MODE_COMMIT & mode)) {
+				if (NULL
+						== omrvmem_commit_memory(portLibrary, result, byteAmount,
+								identifier)) {
+					/* If the commit fails free the memory */
+					omrvmem_free_memory(portLibrary, result, byteAmount,
+							identifier);
+					result = NULL;
+				}
+			}
+		}
+	}
+
+	if (NULL == result) {
+		Trc_PRT_vmem_default_reserve_failed(address, byteAmount);
+		update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, 0, NULL);
+	}
+
+	Trc_PRT_vmem_default_reserve_exit(result, address, byteAmount);
+	return result;
+}
+
+void *
+default_pageSize_reserve_memory_32bit(struct OMRPortLibrary *portLibrary,
+		void *address, uintptr_t byteAmount,
+		struct J9PortVmemIdentifier *identifier, uintptr_t mode, uintptr_t pageSize,
+		OMRMemCategory * category)
+{
+	/* This function is cloned in J9SourceUnixJ9VMem (omrvmem_reserve_memory).
+	 * Any changes made here may need to be reflected in that version .
+	 */
+	int fd = -1;
+	int flags = MAP_PRIVATE;
+	void *result = NULL;
+	int protectionFlags = PROT_NONE;
+
+	Trc_PRT_vmem_default_reserve_entry(address, byteAmount);
+
+#if defined(MAP_ANONYMOUS)
+	flags |= MAP_ANONYMOUS;
+#elif defined(MAP_ANON)
+	flags |= MAP_ANON;
+#else
+	fd = portLibrary->file_open(portLibrary, "/dev/zero",
+	EsOpenRead | EsOpenWrite, 0);
+	if (-1 != fd)
+#endif
+			{
+		if (0 != (OMRPORT_VMEM_MEMORY_MODE_COMMIT & mode)) {
+			protectionFlags = get_protectionBits(mode);
+		} else {
+			flags |= MAP_NORESERVE;
+		}
+
+		/* do NOT use the MAP_FIXED flag on Linux. With this flag, Linux may return
+		 * an address that has already been reserved.
+		 */
+
+		{
+			uintptr_t alignedPtr = 0;
+			uintptr_t allocSize = (uintptr_t)GET_4K_ALIGNED_ALLOCATION_SIZE(byteAmount);
+			result = malloc(allocSize);
+			if (result != NULL)
+			{
+				GET_4K_ALIGNED_PTR(alignedPtr, result);
+				result = (void *)alignedPtr;
+			}
+			else
+			{
+				result = (void *)MAP_FAILED;
+			}
+		}
+
+#if !defined(MAP_ANONYMOUS) && !defined(MAP_ANON)
+		portLibrary->file_close(portLibrary, fd);
+#endif
+
+		if (MAP_FAILED == result) {
+			result = NULL;
+		} else {
+			/* Update identifier and commit memory if required, else return reserved memory */
+			update_vmemIdentifier(identifier, result, result, byteAmount, mode,
+					pageSize, OMRPORT_VMEM_PAGE_FLAG_NOT_USED,
+					OMRPORT_VMEM_RESERVE_USED_MMAP, category);
+
+			omrmem_categories_increment_counters(category, byteAmount);
+			if (0 != (OMRPORT_VMEM_MEMORY_MODE_COMMIT & mode)) {
+				if (NULL
+						== omrvmem_commit_memory(portLibrary, result, byteAmount,
+								identifier)) {
+					/* If the commit fails free the memory */
+					omrvmem_free_memory(portLibrary, result, byteAmount,
+							identifier);
+					result = NULL;
+				}
+			}
+		}
+	}
+
+	if (NULL == result) {
+		Trc_PRT_vmem_default_reserve_failed(address, byteAmount);
+		update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, 0, NULL);
+	}
+
+	Trc_PRT_vmem_default_reserve_exit(result, address, byteAmount);
+	return result;
+}
+
+/**
+ * @internal
+ * Update J9PortVmIdentifier structure
+ *
+ * @param[in] identifier The structure to be updated
+ * @param[in] address Base address
+ * @param[in] handle Platform specific handle for reserved memory
+ * @param[in] byteAmount Size of allocated area
+ * @param[in] mode Access Mode
+ * @param[in] pageSize Constant describing pageSize
+ * @param[in] pageFlags flags for describing page type
+ * @param[in] allocator Constant describing how the virtual memory was allocated.
+ * @param[in] category Memory allocation category
+ */
+void
+update_vmemIdentifier(J9PortVmemIdentifier *identifier, void *address,
+		void *handle, uintptr_t byteAmount, uintptr_t mode, uintptr_t pageSize,
+		uintptr_t pageFlags, uintptr_t allocator, OMRMemCategory * category)
+{
+	identifier->address = address;
+	identifier->handle = handle;
+	identifier->size = byteAmount;
+	identifier->pageSize = pageSize;
+	identifier->pageFlags = pageFlags;
+	identifier->mode = mode;
+	identifier->allocator = allocator;
+	identifier->category = category;
+}
+
+int
+get_protectionBits(uintptr_t mode)
+{
+	int protectionFlags = 0;
+
+	if (0 != (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode)) {
+		protectionFlags |= PROT_EXEC;
+	}
+	if (0 != (OMRPORT_VMEM_MEMORY_MODE_READ & mode)) {
+		protectionFlags |= PROT_READ;
+	}
+	if (0 != (OMRPORT_VMEM_MEMORY_MODE_WRITE & mode)) {
+		protectionFlags |= PROT_WRITE;
+	}
+	if (0 == protectionFlags) {
+		protectionFlags = PROT_NONE;
+	}
+
+	return protectionFlags;
+}
+
+void
+port_numa_interleave_memory(struct OMRPortLibrary *portLibrary, void *start,
+		uintptr_t size)
+{
+#if defined(OMR_PORT_NUMA_SUPPORT)
+	Trc_PRT_vmem_port_numa_interleave_memory_enter();
+
+	if (1 == PPG_numa_platform_supports_numa) {
+		/* There seem to be variations in different kernel levels regarding how they treat the maxnode argument.
+		 * Depending on the system we're running on, it may fail if we specify a mask that is greater than the number of nodes.
+		 *
+		 * To support both configs, we first try to pass in the count of all bits in the mask, regardless of
+		 * how many we're using (the unused ones are zero and will simply be ignored). If that fails, we try
+		 * again, this time passing in the actual number of nodes.
+		 */
+		unsigned long maxnode = sizeof(J9PortNodeMask) * 8;
+
+		if (0 != do_mbind(start, size, MPOL_INTERLEAVE, PPG_numa_mempolicy_node_mask.mask, maxnode, 0)) {
+			if (0 != do_mbind(start, size, MPOL_INTERLEAVE, PPG_numa_mempolicy_node_mask.mask, PPG_numa_max_node_bits, 0)) {
+				/* record the error in the trace buffer and assert */
+				Trc_PRT_vmem_port_numa_interleave_memory_mbind_failed(errno, strerror(errno));
+
+				/* There are cases where mbind() can fail that we are currently not handling. Instead of
+				 * asserting, and thereby bringing down the VM in such cases, simply record the above
+				 * tracepoint and continue execution, since this isn't a fatal error.
+				 *
+				 * In one instance on RHEL6, it was observed that the /sys/devices/system/node/ filesystem
+				 * had entries for node0 and node4, but setting node0 in the mask would cause the mbind()
+				 * call to fail. On this sytem, there was a file /sys/devices/system/node/has_normal_memory
+				 * which only listed node 4. It might make sense to parse that file, if it exists, and to
+				 * only set the bits for nodes that are listed in that file. Alternatively we could test
+				 * each node using mbind() with only the node's bit set, to determine if we should set
+				 * that bit in PPG_numa_available_node_mask.mask.
+				 */
+#if 0
+				Assert_PRT_true(FALSE);
+#endif
+			}
+		}
+	} else {
+		/* numa could not be configured at startup */
+		Trc_PRT_vmem_port_numa_numa_support_could_not_be_configured_at_startup();
+	}
+
+	Trc_PRT_vmem_port_numa_interleave_memory_exit();
+#endif /* defined(OMR_PORT_NUMA_SUPPORT) */
+}
+
+void
+omrvmem_default_large_page_size_ex(struct OMRPortLibrary *portLibrary,
+		uintptr_t mode, uintptr_t *pageSize, uintptr_t *pageFlags)
+{
+#if defined(LINUXPPC)
+	if (OMRPORT_VMEM_MEMORY_MODE_EXECUTE != (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode))
+#endif /* defined(LINUXPPC) */
+	{
+		/* Note that the PPG_vmem_pageSize is a null-terminated list of page sizes.
+		 * There will always be the 0 element (default page size),
+		 * so the 1 element will be zero or the default large size where only 2 are supported
+		 * (platforms with more complicated logic will use their own special process to determine the best response
+		 */
+		if (NULL != pageSize) {
+			*pageSize = PPG_vmem_pageSize[1];
+		}
+		if (NULL != pageFlags) {
+			*pageFlags = PPG_vmem_pageFlags[1];
+		}
+	}
+#if defined(LINUXPPC)
+	else {
+		if (NULL != pageSize) {
+			/* Return the same page size as used by JIT code cache */
+			uintptr_t defaultPageSize = (uintptr_t)sysconf(_SC_PAGESIZE);
+			*pageSize = (FOUR_K == defaultPageSize) ? 0 : defaultPageSize;
+			if (NULL != pageFlags) {
+				*pageFlags = (0 == *pageSize) ? 0 : OMRPORT_VMEM_PAGE_FLAG_NOT_USED;
+			}
+		} else {
+			if (NULL != pageFlags) {
+				*pageFlags = OMRPORT_VMEM_PAGE_FLAG_NOT_USED;
+			}
+		}
+	}
+#endif /* defined(LINUXPPC) */
+
+	return;
+}
+
+intptr_t
+omrvmem_find_valid_page_size(struct OMRPortLibrary *portLibrary, uintptr_t mode,
+		uintptr_t *pageSize, uintptr_t *pageFlags, BOOLEAN *isSizeSupported)
+{
+	uintptr_t validPageSize = *pageSize;
+	uintptr_t validPageFlags = *pageFlags;
+	uintptr_t defaultLargePageSize = 0;
+	uintptr_t defaultLargePageFlags = OMRPORT_VMEM_PAGE_FLAG_NOT_USED;
+
+	Assert_PRT_true_wrapper(OMRPORT_VMEM_PAGE_FLAG_NOT_USED == validPageFlags);
+
+	if (0 != validPageSize) {
+#if defined(LINUXPPC)
+		/* On Linux PPC, for executable pages, search through the list of supported page sizes only if
+		 * - request is for 16M pages, and
+		 * - 64 bit system OR (32 bit system AND CodeCacheConsolidation is enabled)
+		 */
+#if defined(J9VM_ENV_DATA64)
+		if ((OMRPORT_VMEM_MEMORY_MODE_EXECUTE != (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode)) ||
+				(SIXTEEN_M == validPageSize))
+#else
+		/* Check if the TR_ppcCodeCacheConsolidationEnabled env variable is set.
+		 * TR_ppcCodeCacheConsolidationEnabled is a manually set env variable used to indicate
+		 * that Code Cache Consolidation is enabled in the JIT.
+		 */
+		BOOLEAN codeCacheConsolidationEnabled = FALSE;
+
+		if (OMRPORT_VMEM_MEMORY_MODE_EXECUTE == (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode)) {
+			if (portLibrary->sysinfo_get_env(portLibrary, "TR_ppcCodeCacheConsolidationEnabled", NULL, 0) != -1) {
+				codeCacheConsolidationEnabled = TRUE;
+			}
+		}
+		if ((OMRPORT_VMEM_MEMORY_MODE_EXECUTE != (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode)) ||
+				((TRUE == codeCacheConsolidationEnabled) && (SIXTEEN_M == validPageSize)))
+#endif /* defined(J9VM_ENV_DATA64) */
+#endif /* defined(LINUXPPC) */
+		{
+			uintptr_t pageIndex = 0;
+			uintptr_t *supportedPageSizes = portLibrary->vmem_supported_page_sizes(
+					portLibrary);
+			uintptr_t *supportedPageFlags = portLibrary->vmem_supported_page_flags(
+					portLibrary);
+
+			for (pageIndex = 0; 0 != supportedPageSizes[pageIndex];
+					pageIndex++) {
+				if ((supportedPageSizes[pageIndex] == validPageSize)
+						&& (supportedPageFlags[pageIndex] == validPageFlags)) {
+					goto _end;
+				}
+			}
+		}
+	}
+
+	portLibrary->vmem_default_large_page_size_ex(portLibrary, mode,
+			&defaultLargePageSize, &defaultLargePageFlags);
+	if (0 != defaultLargePageSize) {
+		validPageSize = defaultLargePageSize;
+		validPageFlags = defaultLargePageFlags;
+	} else {
+#if defined(LINUXPPC)
+		if (OMRPORT_VMEM_MEMORY_MODE_EXECUTE == (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode)) {
+			validPageSize = (uintptr_t)sysconf(_SC_PAGESIZE);
+			validPageFlags = OMRPORT_VMEM_PAGE_FLAG_NOT_USED;
+		} else
+#endif /* defined(LINUXPPC) */
+		{
+			validPageSize = PPG_vmem_pageSize[0];
+			validPageFlags = PPG_vmem_pageFlags[0];
+		}
+	}
+
+	_end:
+	/* Since page type is not used, ignore pageFlags when setting isSizeSupported. */
+	*isSizeSupported = (*pageSize == validPageSize);
+	*pageSize = validPageSize;
+	*pageFlags = validPageFlags;
+
+	return 0;
+}
+
+/**
+ * Allocates memory in specified range using a best effort approach
+ * (unless OMRPORT_VMEM_STRICT_ADDRESS flag is used) and returns a pointer
+ * to the newly allocated memory. Returns NULL on failure.
+ */
+static void *
+getMemoryInRangeForDefaultPages(struct OMRPortLibrary *portLibrary,
+		struct J9PortVmemIdentifier *identifier, OMRMemCategory * category,
+		uintptr_t byteAmount, void *startAddress, void *endAddress,
+		uintptr_t alignmentInBytes, uintptr_t vmemOptions, uintptr_t mode)
+{
+	intptr_t direction = 1;
+	void *currentAddress = startAddress;
+	void *oldAddress = NULL;
+	void *memoryPointer = NULL;
+
+	/* check allocation direction */
+	if (0 != (vmemOptions & OMRPORT_VMEM_ALLOC_DIR_TOP_DOWN)) {
+		direction = -1;
+		currentAddress = endAddress;
+	} else if (0 != (vmemOptions & OMRPORT_VMEM_ALLOC_DIR_BOTTOM_UP)) {
+		if (startAddress == NULL) {
+			currentAddress += direction * alignmentInBytes;
+		}
+	} else if (NULL == startAddress) {
+		if (OMRPORT_VMEM_MAX_ADDRESS == endAddress) {
+			/* if caller specified the entire address range and does not care about the direction
+			 * save time by letting OS choose where to allocate the memory
+			 */
+			goto allocAnywhere;
+		} else {
+			/* if the startAddress is NULL but the endAddress is not we
+			 * need to change the startAddress so that we have a better chance
+			 * of getting memory within the range because NULL means don't care
+			 */
+			currentAddress = (void *) alignmentInBytes;
+		}
+	}
+
+	/* check if we should use quick search for fast performance */
+	if (J9_ARE_ANY_BITS_SET(vmemOptions, OMRPORT_VMEM_ALLOC_QUICK)) {
+
+		void *smartAddress = NULL;
+		void *allocatedAddress = NULL;
+
+		if (1 == direction) {
+			smartAddress = findAvailableMemoryBlockNoMalloc(portLibrary,
+					currentAddress, endAddress, byteAmount, FALSE);
+		} else {
+			smartAddress = findAvailableMemoryBlockNoMalloc(portLibrary,
+					startAddress, currentAddress, byteAmount, TRUE);
+		}
+
+		allocatedAddress = default_pageSize_reserve_memory(portLibrary,
+				smartAddress, byteAmount, identifier, mode,
+				PPG_vmem_pageSize[0], category);
+
+		if (NULL != allocatedAddress) {
+			/* If the memoryPointer located outside of the range, free it and set the pointer to NULL */
+			if ((startAddress <= allocatedAddress)
+					&& (endAddress >= allocatedAddress)) {
+				memoryPointer = allocatedAddress;
+			} else if (0
+					!= omrvmem_free_memory(portLibrary, allocatedAddress,
+							byteAmount, identifier)) {
+				return NULL;
+			}
+		}
+		/*
+		 * memoryPointer != NULL means that available address was found.
+		 * Otherwise, in case NULL == memoryPointer
+		 * the below logic will continue trying.
+		 */
+	}
+
+	if (NULL == memoryPointer) {
+
+		/* Let's check for a 32bit or under request first. */
+		if (0 != (vmemOptions & OMRPORT_VMEM_ZTPF_USE_31BIT_MALLOC)) {
+			memoryPointer = default_pageSize_reserve_memory_32bit(portLibrary,
+					currentAddress, byteAmount, identifier, mode,
+					PPG_vmem_pageSize[0], category);
+		}
+
+		if (NULL == memoryPointer) {
+			/* try all addresses within range */
+			while ((startAddress <= currentAddress)
+					&& (endAddress >= currentAddress)) {
+				memoryPointer = default_pageSize_reserve_memory(portLibrary,
+						currentAddress, byteAmount, identifier, mode,
+						PPG_vmem_pageSize[0], category);
+
+				if (NULL != memoryPointer) {
+					/* stop if returned pointer is within range */
+					if ((startAddress <= memoryPointer)
+							&& (endAddress >= memoryPointer)) {
+						break;
+					}
+					if (0
+							!= omrvmem_free_memory(portLibrary, memoryPointer,
+									byteAmount, identifier)) {
+						return NULL;
+					}
+					memoryPointer = NULL;
+				}
+
+				oldAddress = currentAddress;
+
+				currentAddress += direction * alignmentInBytes;
+
+				/* protect against loop around */
+				if (((1 == direction)
+						&& ((uintptr_t) oldAddress > (uintptr_t) currentAddress))
+						|| ((-1 == direction)
+								&& ((uintptr_t) oldAddress < (uintptr_t) currentAddress))) {
+					break;
+				}
+			}
+		}
+	}
+	/* if strict flag is not set and we did not get any memory, attempt to get memory at any address */
+	if (0 == (OMRPORT_VMEM_STRICT_ADDRESS & vmemOptions)
+			&& (NULL == memoryPointer)) {
+		allocAnywhere: memoryPointer = default_pageSize_reserve_memory(
+				portLibrary, NULL, byteAmount, identifier, mode,
+				PPG_vmem_pageSize[0], category);
+	}
+
+	if (NULL == memoryPointer) {
+		memoryPointer = NULL;
+	} else if (isStrictAndOutOfRange(memoryPointer, startAddress, endAddress,
+			vmemOptions)) {
+		/* if strict flag is set and returned pointer is not within range then fail */
+		omrvmem_free_memory(portLibrary, memoryPointer, byteAmount, identifier);
+
+		Trc_PRT_vmem_omrvmem_reserve_memory_ex_UnableToAllocateWithinSpecifiedRange(
+				byteAmount, startAddress, endAddress);
+
+		memoryPointer = NULL;
+	}
+
+	return memoryPointer;
+}
+
+/**
+ * Allocates memory in specified range using a best effort approach
+ * (unless OMRPORT_VMEM_STRICT_ADDRESS flag is used) and returns a pointer
+ * to the newly allocated memory. Returns NULL on failure.
+ */
+static void *
+getMemoryInRangeForLargePages(struct OMRPortLibrary *portLibrary,
+		struct J9PortVmemIdentifier *identifier, key_t addressKey,
+		OMRMemCategory * category, uintptr_t byteAmount, void *startAddress,
+		void *endAddress, uintptr_t alignmentInBytes, uintptr_t vmemOptions,
+		uintptr_t pageSize, uintptr_t mode)
+{
+	intptr_t direction = 1;
+	void *currentAddress = startAddress;
+	void *oldAddress = NULL;
+	void *memoryPointer = NULL;
+
+	/* check allocation direction */
+	if (0 != (vmemOptions & OMRPORT_VMEM_ALLOC_DIR_TOP_DOWN)) {
+		direction = -1;
+		currentAddress = endAddress;
+	} else if (0 != (vmemOptions & OMRPORT_VMEM_ALLOC_DIR_BOTTOM_UP)) {
+		if (startAddress == NULL) {
+			currentAddress += direction * alignmentInBytes;
+		}
+	} else if (NULL == startAddress) {
+		if (OMRPORT_VMEM_MAX_ADDRESS == endAddress) {
+			/* if caller specified the entire address range and does not care about the direction
+			 * save time by letting OS choose where to allocate the memory
+			 */
+			goto allocAnywhere;
+		} else {
+			/* if the startAddress is NULL but the endAddress is not we
+			 * need to change the startAddress so that we have a better chance
+			 * of getting memory within the range because NULL means don't care
+			 */
+			currentAddress = (void *) alignmentInBytes;
+		}
+	}
+
+	/* prevent while loop from attempting to free memory on first entry */
+	memoryPointer = MAP_FAILED;
+
+	/* try all addresses within range */
+	while ((startAddress <= currentAddress) && (endAddress >= currentAddress)) {
+		/* free previously attached memory and attempt to get new memory */
+		if (memoryPointer != MAP_FAILED) {
+			if (0
+					!= omrvmem_free_memory(portLibrary, memoryPointer,
+							byteAmount, identifier)) {
+				return NULL;
+			}
+		}
+
+		memoryPointer = allocateMemoryForLargePages(portLibrary, identifier,
+				currentAddress, addressKey, category, byteAmount, pageSize,
+				mode);
+
+		/* stop if returned pointer is within range */
+		if ((MAP_FAILED != memoryPointer) && (startAddress <= memoryPointer)
+				&& (endAddress >= memoryPointer)) {
+			break;
+		}
+
+		oldAddress = currentAddress;
+
+		currentAddress += direction * alignmentInBytes;
+
+		/* protect against loop around */
+		if (((1 == direction) && ((uintptr_t) oldAddress > (uintptr_t) currentAddress))
+				|| ((-1 == direction)
+						&& ((uintptr_t) oldAddress < (uintptr_t) currentAddress))) {
+			break;
+		}
+	}
+
+	/* if strict flag is not set and we did not get any memory, attempt to get memory at any address */
+	if (0 == (OMRPORT_VMEM_STRICT_ADDRESS & vmemOptions)
+			&& (MAP_FAILED == memoryPointer)) {
+		allocAnywhere: memoryPointer = allocateMemoryForLargePages(portLibrary,
+				identifier, NULL, addressKey, category, byteAmount, pageSize,
+				mode);
+	}
+
+	if (MAP_FAILED == memoryPointer) {
+		Trc_PRT_vmem_omrvmem_reserve_memory_shmat_failed2(byteAmount,
+				startAddress, endAddress);
+		memoryPointer = NULL;
+	} else if (isStrictAndOutOfRange(memoryPointer, startAddress, endAddress,
+			vmemOptions)) {
+		/* if strict flag is set and returned pointer is not within range then fail */
+		omrvmem_free_memory(portLibrary, memoryPointer, byteAmount, identifier);
+
+		Trc_PRT_vmem_omrvmem_reserve_memory_ex_UnableToAllocateWithinSpecifiedRange(
+				byteAmount, startAddress, endAddress);
+
+		memoryPointer = NULL;
+	}
+
+	return memoryPointer;
+}
+
+/**
+ * Attempts to allocate memory at currentAddress by delegating to the appropriate
+ * function depending on whether or not the default page size is being used.
+ * Returns pointer to newly allocated memory upon success and if default page size
+ * is being used NULL upon failure else -1 upon failure.
+ */
+static void *
+allocateMemoryForLargePages(struct OMRPortLibrary *portLibrary,
+		struct J9PortVmemIdentifier *identifier, void *currentAddress,
+		key_t addressKey, OMRMemCategory* category, uintptr_t byteAmount,
+		uintptr_t pageSize, uintptr_t mode)
+{
+	void *memoryPointer = shmat(addressKey, currentAddress, 0);
+
+	if (MAP_FAILED != memoryPointer) {
+		update_vmemIdentifier(identifier, memoryPointer,
+				(void *) (uintptr_t) addressKey, byteAmount, mode, pageSize,
+				OMRPORT_VMEM_PAGE_FLAG_NOT_USED, OMRPORT_VMEM_RESERVE_USED_SHM,
+				category);
+		omrmem_categories_increment_counters(category, byteAmount);
+	}
+
+	return memoryPointer;
+}
+
+/**
+ * Returns TRUE if OMRPORT_VMEM_STRICT_ADDRESS flag is set and memoryPointer
+ * is outside of range, else returns FALSE
+ */
+static BOOLEAN
+isStrictAndOutOfRange(void *memoryPointer, void *startAddress,
+		void *endAddress, uintptr_t vmemOptions)
+{
+	if ((0 != (OMRPORT_VMEM_STRICT_ADDRESS & vmemOptions))
+			&& ((memoryPointer > endAddress) || (memoryPointer < startAddress))) {
+		return TRUE;
+	} else {
+		return FALSE;
+	}
+}
+
+/**
+ * Ensures that the requested address and (address + byteAmount) fall
+ * within the reserved identifier->address and (identifier->address + identifier->size)
+ * @returns TRUE if the range is valid, FALSE otherwise
+ */
+static BOOLEAN
+rangeIsValid(struct J9PortVmemIdentifier *identifier,
+		void *address, uintptr_t byteAmount)
+{
+	BOOLEAN isValid = FALSE;
+	uintptr_t requestedUpperLimit = (uintptr_t) address + byteAmount - 1;
+
+	if (requestedUpperLimit + 1 >= byteAmount) {
+		/* Requested range does not wrap around */
+		uintptr_t realUpperLimit = (uintptr_t) identifier->address + identifier->size
+				- 1;
+
+		if (((uintptr_t) address >= (uintptr_t) identifier->address)
+				&& (requestedUpperLimit <= realUpperLimit)) {
+			isValid = TRUE;
+		}
+	}
+
+	return isValid;
+}
+
+intptr_t
+omrvmem_numa_set_affinity(struct OMRPortLibrary *portLibrary,
+		uintptr_t numaNode, void *address, uintptr_t byteAmount,
+		struct J9PortVmemIdentifier *identifier)
+{
+	intptr_t result = OMRPORT_ERROR_VMEM_OPFAILED;
+
+	Trc_PRT_vmem_port_numa_set_affinity_enter(numaNode, address, byteAmount);
+
+#if defined(OMR_PORT_NUMA_SUPPORT)
+	if (1 == PPG_numa_platform_supports_numa) {
+		unsigned long maxnode = sizeof(J9PortNodeMask) * 8;
+
+		if ( (numaNode > 0) && (numaNode <= PPG_numa_max_node_bits) && (numaNode <= maxnode)) {
+			J9PortNodeMask nodeMask;
+			/* The Linux NUMA node indices start at 0 while ours start at 1 */
+			unsigned long nodeIndex = numaNode - 1;
+			unsigned long wordIndex = nodeIndex / sizeof(nodeMask.mask[0]);
+			unsigned long bit = 1 << (nodeIndex % sizeof(nodeMask.mask[0]));
+
+			/* Check if this node actually exists. (The PPG_numa_available_node_mask has all valid nodes set.) */
+			if (bit == (PPG_numa_available_node_mask.mask[wordIndex] & bit)) {
+				memset(&nodeMask, 0, sizeof(nodeMask));
+				nodeMask.mask[wordIndex] |= bit;
+
+				/**
+				 *	mbind returns 0 in the case of success, otherwise -1.
+				 *
+				 */
+				if (0 != do_mbind(address, byteAmount, MPOL_PREFERRED, nodeMask.mask, PPG_numa_max_node_bits, 0)) {
+					/* record the error in the trace buffer and assert */
+					Trc_PRT_vmem_numa_set_affinity_mbind_failed(errno, strerror(errno));
+					/**
+					 * In the case of an error, assert the failure and exit the VM.
+					 * This might not be a fatal error and we could ignore it and continue running just like in port_numa_interleave_memory.
+					 * This assert is useful to determine any problems calling mbind and improve the performance by succeeding mbind call.
+					 *
+					 */
+					Assert_PRT_true(FALSE);
+				} else {
+					result = 0;
+				}
+			} else {
+				result = OMRPORT_ERROR_VMEM_OPFAILED;
+				Trc_PRT_vmem_port_numa_set_affinity_node_not_present(numaNode);
+			}
+		} else {
+			result = OMRPORT_ERROR_VMEM_OPFAILED;
+			Trc_PRT_vmem_port_numa_set_affinity_node_out_of_range(numaNode);
+		}
+	} else {
+		result = OMRPORT_ERROR_VMEM_OPFAILED;
+		Trc_PRT_vmem_port_numa_set_affinity_no_NUMA();
+	}
+#endif /* OMR_PORT_NUMA_SUPPORT */
+
+	Trc_PRT_vmem_port_numa_set_affinity_exit(result);
+
+	return result;
+}
+
+intptr_t
+omrvmem_numa_get_node_details(struct OMRPortLibrary *portLibrary,
+		J9MemoryNodeDetail *numaNodes, uintptr_t *nodeCount)
+{
+	intptr_t result = OMRPORT_ERROR_VMEM_OPFAILED;
+
+#if defined(OMR_PORT_NUMA_SUPPORT)
+	/* only try to look-up node details if NUMA is supported */
+	if (PPG_numa_platform_supports_numa) {
+		DIR *nodes = opendir("/sys/devices/system/node/");
+		if (NULL == nodes) {
+			/* couldn't find the directory - this would be inconsistent since PPG_numa_platform_supports_numa requires seeing this directory, in the current implementation */
+			result = OMRPORT_ERROR_VMEM_OPFAILED;
+		} else {
+			uintptr_t arraySize = *nodeCount;
+			uintptr_t populatedNodeCount = 0;
+			struct dirent nodeStorage;
+			struct dirent *node = NULL;
+
+			/* by default, set the SET and CLEAR states to the same value since "default" NUMA mode has all nodes cleared */
+			J9MemoryState nodeSetState = J9NUMA_PREFERRED;
+			J9MemoryState nodeClearState = nodeSetState;
+			switch (PPG_numa_policy_mode) {
+				case MPOL_BIND:
+				/* BIND is not supposed to permit allocation elsewhere */
+				nodeSetState = J9NUMA_ALLOWED;
+				nodeClearState = J9NUMA_DENIED;
+				break;
+				case MPOL_INTERLEAVE:
+				/* interleave is allowed to fall back to other nodes */
+				case MPOL_PREFERRED:
+				/* preferred merely states the intent to favour the given node(s) */
+				nodeSetState = J9NUMA_PREFERRED;
+				nodeClearState = J9NUMA_ALLOWED;
+				break;
+				default:
+				/* do nothing */
+				break;
+			}
+
+			/* walk through the /sys/devices/system/node/ directory to find each individual node */
+			while ((0 == readdir_r(nodes, &nodeStorage, &node)) && (NULL != node)) {
+				unsigned long nodeIndex = 0;
+				if (1 == sscanf(node->d_name, "node%lu", &nodeIndex)) {
+					if (nodeIndex < PPG_numa_max_node_bits) {
+						DIR* oneNode = NULL;
+						char nodeName[sizeof("/sys/devices/system/node/") + NAME_MAX + 1] = "/sys/devices/system/node/";
+
+						strncat(nodeName, node->d_name, NAME_MAX);
+						/* walk the directory for this specific node to find its CPUs */
+						oneNode = opendir(nodeName);
+						if (NULL != oneNode) {
+							/* as long as we haven't yet filled the user-provided buffer, populate the entry with the node details */
+							if (populatedNodeCount < arraySize) {
+								J9MemoryState memoryState = nodeClearState;
+
+								/* find each CPU and check to see if it is part of our global mask */
+								uintptr_t allowedCPUCount = 0;
+								struct dirent cpuStorage;
+								struct dirent *fileEntry = NULL;
+								uint64_t memoryOnNodeInKibiBytes = 0;
+								while ((0 == readdir_r(oneNode, &cpuStorage, &fileEntry)) && (NULL != fileEntry)) {
+									unsigned long cpuIndex = 0;
+									const char *fileName = fileEntry->d_name;
+									if ((1 == sscanf(fileName, "cpu%lu", &cpuIndex)) && (CPU_ISSET(cpuIndex, &PPG_process_affinity))) {
+										/* the CPU exists and is in our process-wide affinity so we know that we can use it */
+										allowedCPUCount += 1;
+									} else if (0 == strcmp(fileName, "meminfo")) {
+										/* parse out the memory quantity of this node since a 0-byte node will need to be reported as "J9NUMA_DENIED" to ensure that the mbind won't fail with EINVAL */
+										char memInfoFileName[sizeof(nodeName) + NAME_MAX + 1];
+										FILE *memInfoStream = 0;
+
+										memset(memInfoFileName, 0x0, sizeof(memInfoFileName));
+										strncpy(memInfoFileName, nodeName, sizeof(memInfoFileName));
+										strncat(memInfoFileName, "/meminfo", NAME_MAX);
+										memInfoStream = fopen(memInfoFileName, "r");
+										if (NULL != memInfoStream) {
+											if (1 != fscanf(memInfoStream, " Node %*u MemTotal: %llu kB", &memoryOnNodeInKibiBytes)) {
+												/* failed to find string */
+												memoryOnNodeInKibiBytes = 0;
+											}
+											fclose(memInfoStream);
+										}
+									}
+								}
+								closedir(oneNode);
+
+								/* check to see if this node was described in the default policy for the process */
+								if (0 != (PPG_numa_mempolicy_node_mask.mask[nodeIndex / 8] & (1 << nodeIndex % 8))) {
+									memoryState = nodeSetState;
+								}
+								/* if we didn't find any memory on this node, don't let us use it */
+								if (0 == memoryOnNodeInKibiBytes) {
+									memoryState = J9NUMA_DENIED;
+								}
+								numaNodes[populatedNodeCount].j9NodeNumber = nodeIndex + 1;
+								numaNodes[populatedNodeCount].memoryPolicy = memoryState;
+								numaNodes[populatedNodeCount].computationalResourcesAvailable = allowedCPUCount;
+							}
+							populatedNodeCount += 1;
+						}
+					}
+				}
+			}
+			/* save back how many entries we saw (the caller knows that the number of entries we populated is the minimum of how many we were given and how many we found) */
+			*nodeCount = populatedNodeCount;
+			result = 0;
+			closedir(nodes);
+		}
+	}
+#endif /* OMR_PORT_NUMA_SUPPORT */
+
+	return result;
+}
+
+int32_t
+omrvmem_get_available_physical_memory(struct OMRPortLibrary *portLibrary,
+		uint64_t *freePhysicalMemorySize)
+{
+
+	uint16_t physMemory = *(uint16_t*)(cinfc_fast(CINFC_CMMMMES) + 8);
+	physMemory -= ecbp2()->ce2retfrm;
+	uint64_t result = (uint64_t)physMemory << 20;
+	*freePhysicalMemorySize = result;
+	Trc_PRT_vmem_get_available_physical_memory_result(result);
+
+	return 0;
+}
+
+int32_t
+omrvmem_get_process_memory_size(struct OMRPortLibrary *portLibrary,
+		J9VMemMemoryQuery queryType, uint64_t *memorySize)
+{
+
+	int32_t result = ecbp2()->ce2retfrm;
+	result = result << 20;
+	*memorySize = (uint64_t) result;
+	Trc_PRT_vmem_get_process_memory_exit(result, *memorySize);
+
+	return result;
+}


### PR DESCRIPTION
Description:
This pull represents a learning effort of committing omr changes for the z/TPF platform.   These four files are new copies (based on the other platforms) and reside in the new port/ztpf folder and will not affect any other platforms.  A successful personal build was done in the IBM environment (build_id=348248), as would be expected because only the z/TPF platform has the capability of building its unique environment.

The files were randomly chosen and deal with dump processing and virtual memory.  A larger pull request is in the works for a later date.
