### PR TITLE
WIP: Add copyright information to omrsig.dll in J9 on Windows

### DIFF
--- a/configure
+++ b/configure
@@ -7189,7 +7189,7 @@ fi
 # Restore the value of $cross_compiling.
 cross_compiling=$save_cross_compiling
 
-ac_config_files="$ac_config_files include_core/omrversionstrings.h:include_core/omrversionstrings.h.in omrmakefiles/configure.mk:omrmakefiles/configure.mk.in"
+ac_config_files="$ac_config_files include_core/omrversionstrings.h:include_core/omrversionstrings.h.in omrmakefiles/configure.mk:omrmakefiles/configure.mk.in ./omr.rc:./omr.rc.in"
 
 
 ac_config_headers="$ac_config_headers include_core/omrcfg.h:include_core/omrcfg.h.in"
@@ -7908,6 +7908,7 @@ do
   case $ac_config_target in
     "include_core/omrversionstrings.h") CONFIG_FILES="$CONFIG_FILES include_core/omrversionstrings.h:include_core/omrversionstrings.h.in" ;;
     "omrmakefiles/configure.mk") CONFIG_FILES="$CONFIG_FILES omrmakefiles/configure.mk:omrmakefiles/configure.mk.in" ;;
+    "./omr.rc") CONFIG_FILES="$CONFIG_FILES ./omr.rc:./omr.rc.in" ;;
     "include_core/omrcfg.h") CONFIG_HEADERS="$CONFIG_HEADERS include_core/omrcfg.h:include_core/omrcfg.h.in" ;;
     "toolconfigure") CONFIG_COMMANDS="$CONFIG_COMMANDS toolconfigure" ;;
 
@@ -8537,4 +8538,3 @@ if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: unrecognized options: $ac_unrecognized_opts" >&5
 $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
 fi
-

--- a/configure.ac
+++ b/configure.ac
@@ -49,6 +49,14 @@ AC_ARG_VAR([OMR_CROSS_CONFIGURE],
 	Compiler and feature detection tests will be invalid. All options must be configured manually.
 	One of: yes,no. (Default: no)])
 
+AC_ARG_VAR([OMR_PRODUCT_DESCRIPTION], [The description of product integerating OMR. (Default: J9 Virtual Machine Runtime\0)])
+AC_ARG_VAR([OMR_PRODUCT_NAME], [The name of product integerating OMR. (Default: IBM SDK, Java(tm) 2 Technology Edition\0)])
+AC_ARG_VAR([OMR_PRODUCT_VERSION], [The version of product integerating OMR. (Default: R2.9\0)])
+
+OMR_PRODUCT_DESCRIPTION=${OMR_PRODUCT_DESCRIPTION:-"AC_PACKAGE_STRING AC_PACKAGE_URL"}
+OMR_PRODUCT_NAME=${OMR_PRODUCT_NAME:-"AC_PACKAGE_NAME"}
+OMR_PRODUCT_VERSION=${OMR_PRODUCT_VERSION:-"AC_PACKAGE_VERSION"}
+
 AC_ARG_ENABLE([optimized],
 	AS_HELP_STRING([--enable-optimized], [Create an optimized build. (Default: yes)]),
 	[],
@@ -606,6 +614,7 @@ cross_compiling=$save_cross_compiling
 AC_CONFIG_FILES([
 	include_core/omrversionstrings.h:include_core/omrversionstrings.h.in
 	omrmakefiles/configure.mk:omrmakefiles/configure.mk.in
+	omr.rc
 ])
 
 AC_CONFIG_HEADERS([include_core/omrcfg.h:include_core/omrcfg.h.in])
@@ -624,3 +633,4 @@ AC_CONFIG_COMMANDS([toolconfigure],
 		[OMR_HOSTCONFIG_ENV="CC= CXX="])])
 
 AC_OUTPUT
+

--- a/omr.rc.in
+++ b/omr.rc.in
@@ -1,0 +1,29 @@
+
+#include <windows.h>
+#include <winver.h>
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION 2,9,5,19691
+ PRODUCTVERSION 2,9,5,19691
+ FILEFLAGSMASK 0x3fL
+ FILEFLAGS 0x0L
+ FILEOS VOS_NT_WINDOWS32
+ FILETYPE VFT_DLL
+ FILESUBTYPE 0x0L
+BEGIN
+	BLOCK "StringFileInfo"
+	BEGIN
+		BLOCK "040904b0"
+		BEGIN
+			VALUE "CompanyName", "International Business Machines Corporation\0"
+			VALUE "LegalCopyright", "Copyright IBM Corp. 1991, 2017\0"
+			VALUE "FileDescription", "@OMR_PRODUCT_DESCRIPTION@\0"
+			VALUE "ProductName", "@OMR_PRODUCT_NAME@\0"
+			VALUE "ProductVersion", "@OMR_PRODUCT_VERSION@\0"
+		END
+	END
+	BLOCK "VarFileInfo"
+	BEGIN
+		VALUE "Translation", 0x0409, 1200
+	END
+END

--- a/omrmakefiles/configure.mk.in
+++ b/omrmakefiles/configure.mk.in
@@ -102,6 +102,14 @@ OMRTHREAD_LIB_WIN32 := @OMRTHREAD_LIB_WIN32@
 OMRTHREAD_LIB_ZOS := @OMRTHREAD_LIB_ZOS@
 
 ###
+### Version information used to generate .rc file on Windows
+###
+
+OMR_PRODUCT_DESCRIPTION := @OMR_PRODUCT_DESCRIPTION@
+OMR_PRODUCT_NAME := @OMR_PRODUCT_NAME@
+OMR_PRODUCT_VERSION := @OMR_PRODUCT_VERSION@
+
+###
 ### Global Autoconfigure Flags
 ###
 

--- a/omrmakefiles/rules.win.mk
+++ b/omrmakefiles/rules.win.mk
@@ -181,6 +181,10 @@ endef
 
 RC_INCLUDES=$(call buildCPPIncludeFlags,$(MODULE_INCLUDES) $(GLOBAL_INCLUDES))
 
+# compilation rule for text resource files
+%.res: %.rc
+    $(RC) $(RC_INCLUDES) $<
+
 # compilation rule for message text files
 %.res: %.mc
 	mc $<

--- a/omrsigcompat/makefile
+++ b/omrsigcompat/makefile
@@ -25,6 +25,14 @@ OBJECTS := omrsig
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
 EXPORT_FUNCTIONS_FILE := omrsig.exportlist
 
+ifeq (win,$(OMR_HOST_OS))
+OMR_RES_FILE := $(top_srcdir)/omr.res
+ifneq ("$(wildcard $(COPYRIGHT_RC_FILE))","")
+OBJECTS += $(OMR_RES_FILE)
+omrsig.dll: $(OMR_RES_FILE)
+endif
+endif
+
 ## Create platform specific exports
 
 $(EXPORT_FUNCTIONS_FILE):

--- a/run_configure.mk
+++ b/run_configure.mk
@@ -124,8 +124,8 @@ touch $(CONFIGURE_OUTPUT_FILES)
 endef
 
 CONFIGURE_DEPENDENCIES := SPEC config.guess config.sub configure tools/configure
-CONFIGURE_OUTPUT_FILES := include_core/omrcfg.h include_core/omrversionstrings.h omrmakefiles/configure.mk tools/toolconfigure.mk CONFIGURE_SENTINEL_FILE
-CONFIGURE_INPUT_FILES := include_core/omrcfg.h.in include_core/omrversionstrings.h.in omrmakefiles/configure.mk.in tools/toolconfigure.mk.in
+CONFIGURE_OUTPUT_FILES := include_core/omrcfg.h include_core/omrversionstrings.h omrmakefiles/configure.mk ./omr.rc tools/toolconfigure.mk CONFIGURE_SENTINEL_FILE
+CONFIGURE_INPUT_FILES := include_core/omrcfg.h.in include_core/omrversionstrings.h.in omrmakefiles/configure.mk.in ./omr.rc.in tools/toolconfigure.mk.in
 CONFIGURE_BYPRODUCTS := config.cache config.status config.log autom4te.cache tools/config.cache tools/config.status toolconfig/config.log tools/autom4te.cache
 
 all: check-environment-variables CONFIGURE_SENTINEL_FILE


### PR DESCRIPTION
This is required by Miscrosoft as any dll/exe file must
come with copyright information.

Signed-off-by: CHENGJin <jincheng@ca.ibm.com>