### PR TITLE
Add option disableProfilingDataReclamation

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -471,6 +471,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableProfileGenerator",            "O\tdisable profile generator",                      TR::Options::disableOptimization, profileGenerator, 0, "P"},
 #endif
    {"disableProfiling",                   "O\tdisable profiling",                              SET_OPTION_BIT(TR_DisableProfiling), "P"},
+   {"disableProfilingDataReclamation",    "O\tdisable reclamation for profiling data",         SET_OPTION_BIT(TR_DisableProfilingDataReclamation), "F", NOT_IN_SUBSET},
    {"disableProloguePushes",              "O\tuse stores instead of pushes in x86 prologues",  SET_OPTION_BIT(TR_DisableProloguePushes), "P"},
    {"disableRampupImprovements",          "M\tDisable various changes that improve rampup",    SET_OPTION_BIT(TR_DisableRampupImprovements), "F", NOT_IN_SUBSET},
    {"disableReadMonitors",                 "O\tdisable read monitors",                         SET_OPTION_BIT(TR_DisableReadMonitors), "F"},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -918,7 +918,7 @@ enum TR_CompilationOptions
    // Available                                       = 0x00000400 + 28,
    TR_InlinerFanInUseCalculatedSize                   = 0x00000800 + 28,
    // Available                                       = 0x00001000 + 28,
-   // Availabe                                        = 0x00002000 + 28,
+   TR_DisableProfilingDataReclamation                 = 0x00002000 + 28,
    TR_DisableTrivialDeadBlockRemover                  = 0x00004000 + 28,
    TR_DisableInvariantCodeMotion                      = 0x00008000 + 28,
    TR_EnableSelfTuningScratchMemoryUsageBeforeCompile = 0x00010000 + 28,


### PR DESCRIPTION
Add an option that should to disable the cleanup of memory allocated for profile information, in case an issue arises with profile data cleanup