### PR TITLE
Enforce singleton property in JitBuilder::CodeCacheManager

### DIFF
--- a/jitbuilder/runtime/JBCodeCacheManager.hpp
+++ b/jitbuilder/runtime/JBCodeCacheManager.hpp
@@ -58,7 +58,12 @@ public:
 
    void *operator new(size_t s, TR::CodeCacheManager *m) { return m; }
 
-   static TR::CodeCacheManager *instance()  { return _codeCacheManager; }
+   static TR::CodeCacheManager *instance()
+      {
+      TR_ASSERT_FATAL(_codeCacheManager, "CodeCacheManager not yet instantiated");
+      return _codeCacheManager;
+      }
+
    static JitConfig *jitConfig()            { return _jitConfig; }
    FrontEnd *pyfe()                         { return reinterpret_cast<FrontEnd *>(fe()); }
 

--- a/jitbuilder/runtime/JBCodeCacheManager.hpp
+++ b/jitbuilder/runtime/JBCodeCacheManager.hpp
@@ -50,6 +50,9 @@ class OMR_EXTENSIBLE CodeCacheManager : public OMR::CodeCacheManagerConnector
 public:
    CodeCacheManager(TR_FrontEnd *fe) : OMR::CodeCacheManagerConnector(fe)
       {
+      TR_ASSERT_FATAL(!_codeCacheManager, "CodeCacheManager already instantiated. "
+                                          "Cannot create multiple instances");
+
       _codeCacheManager = reinterpret_cast<TR::CodeCacheManager *>(this);
       }
 


### PR DESCRIPTION
- Fatal assertion to enforce singleton property in JitBuilder::CodeCacheManager
- Fatal assertion to ensure that JitBuilder::CodeCacheManager::instance() never returns a null pointer

Signed-off-by: Sajid Ahmed <Syed.Sajid.Ahmed23@ibm.com>