### PR TITLE
Fix bogus check in port library

### DIFF
--- a/port/win32/omrintrospect.c
+++ b/port/win32/omrintrospect.c
@@ -241,7 +241,7 @@ cleanup(J9ThreadWalkState *state)
 					result = -1;
 				}
 
-				if (result != -1 || (HANDLE) GetLastError() != INVALID_HANDLE_VALUE) {
+				if (result != -1 || GetLastError() != ERROR_INVALID_HANDLE) {
 					/* it seems this can raise an exception if the handle has become invalid */
 					CloseHandle(data->snapshot);
 				}


### PR DESCRIPTION
Code checked GetLastError() against a handle value instead of
an error code value

Fixes #1029

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>