### PR TITLE
Add warning for CMake builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,7 +26,7 @@ environment:
   GTEST_COLOR: '1'
 
 before_build:
-  - ps: cmake -Wdev -G "Visual Studio 14 2015 Win64" .
+  - cmd: cmake -Wdev -G "Visual Studio 14 2015 Win64" .
 
 build:
   project: omr.sln

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,11 @@
 
 cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
 
+# Warn user that CMake support is currently experimental
+message(WARNING
+"CMake support is currently experimental.\n\
+Various components may fail to compile with default configuration options, and some are not even attempted.")
+
 #TODO figure out method of sharing version info with makefile build
 set(OMR_VERSION_MAJOR 0)
 set(OMR_VERSION_MINOR 0)


### PR DESCRIPTION
Warn user that CMake support is currently experimental.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>