### PR TITLE
Fix for unsafe generation of VFMA and VFMS on z

### DIFF
--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -18264,7 +18264,8 @@ generateFusedMultiplyAddIfPossible(TR::CodeGenerator *cg, TR::Node *addNode, TR:
       }
 
    // if the FloatMAF option is not set and the node is not FP strict, we can't generate FMA operations
-   if (addNode->getType().isFloatingPoint() && !comp->getOption(TR_FloatMAF) && !mulNode->isFPStrictCompliant())
+   if ((addNode->getType().isFloatingPoint() || TR::VectorFloat == addNode->getType() || TR::VectorDouble == addNode->getType())
+       && !comp->getOption(TR_FloatMAF) && !mulNode->isFPStrictCompliant())
       return false;
 
    if (!performTransformation(comp, "O^O Changing [%p] to fused multiply and add (FMA) operation\n", addNode))


### PR DESCRIPTION
generateFusedMultiplyAddIfPossible tries to check if it is working on
floating point data before generating fused instructions. The problem is
caused by the fact that a call to isFloatingPoint on a type returns false
for VectorDouble and VectorFloat types. To address this issue, a specific
check for VectorDouble and VectorFloat was added to the function
generateFusedMultiplyAddIfPossible.

Issue: #1160
Signed-off-by: jimmyk <jimmyk@ca.ibm.com>