### PR TITLE
 Disable/Sampling Hook trace for frequent events

### DIFF
--- a/gc/base/omrmmprivate.hdf
+++ b/gc/base/omrmmprivate.hdf
@@ -168,6 +168,7 @@
 			code which has hooked the J9HOOK_MM_WALK_HEAP_START hook, such as
 			GC_VMInterface::initializeExtensions.
 		</description>
+		<trace-sampling intervals="100" />
 		<struct>MM_WalkHeapStartEvent</struct>
 		<data type="struct OMR_VM*" name="omrVM" description="OMR vm instance" />
 	</event>
@@ -181,6 +182,7 @@
 			These actions are actually performed by code which has hooked the
 			J9HOOK_MM_WALK_HEAP_END hook, such as GC_VMInterface::initializeExtensions.
 		</description>
+		<trace-sampling intervals="100" />
 		<struct>MM_WalkHeapEndEvent</struct>
 		<data type="struct OMR_VM*" name="omrVM" description="OMR vm instance" />
 	</event>
@@ -729,6 +731,7 @@
 		<name>J9HOOK_MM_PRIVATE_OLD_TO_OLD_REFERENCE_CREATED</name>
 		<description>Triggered when old to old reference is created by GC (Scavenger) </description>
 		<condition>defined (__cplusplus)</condition>
+		<trace-sampling intervals="100" />
 		<struct>MM_OldToOldReferenceCreatedEvent</struct>
 		<data type="struct OMR_VMThread*" name="currentThread" description="the current thread" />
 		<data type="void *" name="objectPtr" description="pointer to the parent object" />

--- a/include_core/omrhookable.h
+++ b/include_core/omrhookable.h
@@ -66,6 +66,7 @@ typedef struct J9HookInterface {
 #define J9HOOK_TAG_AGENT_ID  0x20000000
 #define J9HOOK_TAG_COUNTED  0x40000000
 #define J9HOOK_TAG_ONCE  0x80000000
+#define J9HOOK_TAG_SAMPLING_MASK	0x00ff0000
 #define J9HOOK_AGENTID_FIRST  ((uintptr_t)0)
 #define J9HOOK_AGENTID_DEFAULT  ((uintptr_t)1)
 #define J9HOOK_AGENTID_LAST  ((uintptr_t)-1)
@@ -87,6 +88,7 @@ typedef struct OMRHookInfo4Dump {
 typedef struct OMREventInfo4Dump {
 	struct OMRHookInfo4Dump longestHook;
 	struct OMRHookInfo4Dump lastHook;
+	uint64_t count;
 }OMREventInfo4Dump;
 
 typedef struct J9CommonHookInterface {

--- a/tools/hookgen/HookGen.cpp
+++ b/tools/hookgen/HookGen.cpp
@@ -220,7 +220,7 @@ HookGen::writeEventToPublicHeader(const char *name, const char *description, con
  * Write an event to the private header
  */
 void
-HookGen::writeEventToPrivateHeader(const char *name, const char *condition, const char *once, const char *structName, pugi::xml_node event)
+HookGen::writeEventToPrivateHeader(const char *name, const char *condition, const char *once, int sampling, const char *structName, pugi::xml_node event)
 {
 	if (NULL != condition) {
 		fprintf(_privateFile, "#if %s\n", condition);
@@ -236,7 +236,7 @@ HookGen::writeEventToPrivateHeader(const char *name, const char *condition, cons
 	for (pugi::xml_node data = event.child("data"); data; data = data.next_sibling("data")) {
 		fprintf(_privateFile, "\t\teventData.%s = (arg_%s); \\\n", data.attribute("name").as_string(), data.attribute("name").as_string());
 	}
-	fprintf(_privateFile, "\t\t(*J9_HOOK_INTERFACE(hookInterface))->J9HookDispatch(J9_HOOK_INTERFACE(hookInterface), %s%s, &eventData); \\\n", name, once == NULL ? "" : " | J9HOOK_TAG_ONCE");
+	fprintf(_privateFile, "\t\t(*J9_HOOK_INTERFACE(hookInterface))->J9HookDispatch(J9_HOOK_INTERFACE(hookInterface), %s%s%s%d, &eventData); \\\n", name, once == NULL ? "" : " | J9HOOK_TAG_ONCE", " | ", sampling<<16);
 	for (pugi::xml_node data = event.child("data"); data; data = data.next_sibling("data")) {
 		if (data.attribute("return").as_bool()) {
 			fprintf(_privateFile, "\t\t(arg_%s) = eventData.%s; /* return argument */ \\\n", data.attribute("name").as_string(), data.attribute("name").as_string());
@@ -290,6 +290,8 @@ HookGen::writeEvent(pugi::xml_node event)
 	const char *structName = event.child("struct").text().as_string();
 	const char *once = event.child("once").text().as_string();
 	const char *reverse = event.child("reverse").text().as_string();
+	pugi::xml_node sampling_node = event.child("trace-sampling");
+	int sampling = 0;
 
 	if (event.child("condition").empty()) {
 		condition = NULL;
@@ -297,12 +299,22 @@ HookGen::writeEvent(pugi::xml_node event)
 	if (event.child("once").empty()) {
 		once = NULL;
 	}
+	if (sampling_node) {
+		sampling = sampling_node.attribute("intervals").as_int(0);
+		if (sampling < 0) {
+			sampling = 0;
+		}
+		if (sampling > 100) {
+			sampling = 0xff;
+		}
+	}
+
 	if (event.child("reverse").empty()) {
 		reverse = NULL;
 	}
 
 	writeEventToPublicHeader(name, description, condition, structName, reverse, event);
-	writeEventToPrivateHeader(name, condition, once, structName, event);
+	writeEventToPrivateHeader(name, condition, once, sampling, structName, event);
 }
 
 /**

--- a/tools/hookgen/HookGen.hpp
+++ b/tools/hookgen/HookGen.hpp
@@ -69,7 +69,7 @@ private:
 	RCType startPrivateHeader();
 	RCType completePrivateHeader(const char *structName);
 	void writeEventToPublicHeader(const char *name, const char *description, const char *condition, const char *structName, const char *reverse, pugi::xml_node event);
-	void writeEventToPrivateHeader(const char *name, const char *condition, const char *once, const char *structName, pugi::xml_node event);
+	void writeEventToPrivateHeader(const char *name, const char *condition, const char *once, int sampling, const char *structName, pugi::xml_node event);
 	void writeEvent(pugi::xml_node event);
 
 	static void displayUsage();

--- a/util/hookable/hookable.cpp
+++ b/util/hookable/hookable.cpp
@@ -181,6 +181,9 @@ J9HookDispatch(struct J9HookInterface **hookInterface, uintptr_t taggedEventNum,
 	uintptr_t eventNum = taggedEventNum & J9HOOK_EVENT_NUM_MASK;
 	J9CommonHookInterface *commonInterface = (J9CommonHookInterface *)hookInterface;
 	J9HookRecord *record = HOOK_RECORD(commonInterface, eventNum);
+	OMREventInfo4Dump *eventDump = J9HOOK_DUMPINFO(commonInterface, eventNum);
+	uintptr_t samplingInterval = (taggedEventNum & J9HOOK_TAG_SAMPLING_MASK) >> 16;
+	bool sampling = false;
 
 	if (taggedEventNum & J9HOOK_TAG_ONCE) {
 		uint8_t oldFlags;
@@ -213,39 +216,49 @@ J9HookDispatch(struct J9HookInterface **hookInterface, uintptr_t taggedEventNum,
 			/* now read the id again to make sure that nothing has changed */
 			VM_AtomicSupport::readBarrier();
 			if (record->id == id) {
-				uint64_t timeDelta = 0;
+				uint64_t startTime = 0;
+				uint64_t count = 0;
+				if (NULL != eventDump) {
+					count = VM_AtomicSupport::addU64(&eventDump->count,1);
+					sampling = (1 >= samplingInterval) || ((100 >= samplingInterval) && (0 == (count % samplingInterval)));
+				} else {
+					sampling =  false;
+				}
 				OMRPORT_ACCESS_FROM_OMRPORT(commonInterface->portLib);
-				uint64_t startTime = omrtime_current_time_millis();
-				function(hookInterface, eventNum, eventData, userData);
-				timeDelta = omrtime_current_time_millis() - startTime;
-
-				OMREventInfo4Dump *eventDump = J9HOOK_DUMPINFO(commonInterface, eventNum);
-
-				/* record hook info for dump if elapse time is longer than 1 millisecond */
-				if ((NULL != eventDump) && (0 != timeDelta)) {
-					eventDump->lastHook.callsite = record->callsite;
-					eventDump->lastHook.func_ptr = (void *)record->function;
-					eventDump->lastHook.startTime = startTime;
-					eventDump->lastHook.duration = timeDelta;
-					if (eventDump->longestHook.duration < eventDump->lastHook.duration) {
-						eventDump->longestHook.callsite = eventDump->lastHook.callsite;
-						eventDump->longestHook.startTime = eventDump->lastHook.startTime;
-						eventDump->longestHook.func_ptr = eventDump->lastHook.func_ptr;
-						eventDump->longestHook.duration = eventDump->lastHook.duration;
-					}
+				if (sampling) {
+					startTime = omrtime_current_time_millis();
 				}
 
-				if (commonInterface->threshold4Trace <= timeDelta) {
-					const char *callsite = "UNKNOWN";
-					char buffer[32];
-					if (NULL != record->callsite) {
-						callsite = record->callsite;
-					} else {
-						/* if the callsite info can not be retrieved, use callback function pointer instead  */
-						omrstr_printf(buffer, sizeof(buffer), "0x%p", record->function);
-						callsite = buffer;
+				function(hookInterface, eventNum, eventData, userData);
+
+				if (sampling) {
+					uint64_t timeDelta = omrtime_current_time_millis() - startTime;
+
+					eventDump->lastHook.startTime = startTime;
+					eventDump->lastHook.callsite = record->callsite;
+					eventDump->lastHook.func_ptr = (void *)record->function;
+					eventDump->lastHook.duration = timeDelta;
+
+					if ((eventDump->longestHook.duration < timeDelta) ||
+						(0 == eventDump->longestHook.startTime)) {
+							eventDump->longestHook.startTime = startTime;
+							eventDump->longestHook.callsite = record->callsite;
+							eventDump->longestHook.func_ptr = (void *)record->function;
+							eventDump->longestHook.duration = timeDelta;
 					}
-					Trc_Hook_Dispatch_Exceed_Threshold_Event(callsite, timeDelta);
+
+					if (commonInterface->threshold4Trace <= timeDelta) {
+						const char *callsite = "UNKNOWN";
+						char buffer[32];
+						if (NULL != record->callsite) {
+							callsite = record->callsite;
+						} else {
+							/* if the callsite info can not be retrieved, use callback function pointer instead  */
+							omrstr_printf(buffer, sizeof(buffer), "0x%p", record->function);
+							callsite = buffer;
+						}
+						Trc_Hook_Dispatch_Exceed_Threshold_Event(callsite, timeDelta);
+					}
 				}
 			} else {
 				/* this record has been updated while we were reading it. Skip it. */


### PR DESCRIPTION
 Disable/Sampling Hook trace for frequent events

 - disable/sampling hook tracepoint and hook dump via new tag <trace-sampling intervals="N" /> in hdf for high-frequency events to reduce performance impacts of tracking hooks
 - new invocation count in hook dump structure to trace event frequency
 - atomic operation for updating hook dump information to keep data
consistent in race condition

Signed-off-by: Lin Hu <linhu@ca.ibm.com>