### PR TITLE
Create PatchNOPedGuardSite class in OMR

### DIFF
--- a/compiler/arm/runtime/VirtualGuardRuntime.cpp
+++ b/compiler/arm/runtime/VirtualGuardRuntime.cpp
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2000, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+
+#include "codegen/ARMInstruction.hpp"
+
+extern uint32_t encodeBranchDistance(uint32_t from, uint32_t to);
+extern void armCodeSync(uint8_t *, uint32_t);
+
+extern "C" void _patchVirtualGuard(uint8_t *locationAddr, uint8_t *destinationAddr, int32_t smpFlag)
+   {
+   int32_t newInstr;
+   int32_t distance = (int32_t)destinationAddr - (int32_t)locationAddr;
+   TR_ASSERT(distance <= BRANCH_FORWARD_LIMIT && distance >= BRANCH_BACKWARD_LIMIT, "_patchVirtualGuard: Destination too far.\n");
+   newInstr = 0xEA000000 | encodeBranchDistance((uint32_t)locationAddr, (uint32_t)destinationAddr);
+   *(int32_t *)locationAddr = newInstr;
+   armCodeSync((uint8_t *)locationAddr, ARM_INSTRUCTION_LENGTH);
+   }

--- a/compiler/env/FEBase.cpp
+++ b/compiler/env/FEBase.cpp
@@ -279,7 +279,7 @@ extern "C" bool jitTestOSForSSESupport(void) { return false; } // TODO there are
 #ifdef J9_PROJECT_SPECIFIC
 // FIXME:
 #include "runtime/RuntimeAssumptions.hpp"
-void TR_PatchNOPedGuardSite::compensate(TR_FrontEnd *fe, bool isSMP, uint8_t *location, uint8_t *destination) { notImplemented("TR_PatchNOPedGuardSite::compensate"); }
+void TR::PatchNOPedGuardSite::compensate(TR_FrontEnd *fe, bool isSMP, uint8_t *location, uint8_t *destination) { notImplemented("TR::PatchNOPedGuardSite::compensate"); }
 void TR_PersistentClassInfo::removeASubClass(TR_PersistentClassInfo *) { notImplemented("TR_PersistentClassInfo::removeASubClass"); }
 bool isOrderedPair(uint8_t recordType) { notImplemented("isOrderedPair"); return false; }
 void OMR::RuntimeAssumption::addToRAT(TR_PersistentMemory * persistentMemory, TR_RuntimeAssumptionKind kind, TR_FrontEnd *fe, OMR::RuntimeAssumption** sentinel) { notImplemented("addToRAT"); }

--- a/compiler/p/runtime/VirtualGuardRuntime.spp
+++ b/compiler/p/runtime/VirtualGuardRuntime.spp
@@ -1,0 +1,101 @@
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!
+!! (c) Copyright IBM Corp. 2000, 2017
+!!
+!!  This program and the accompanying materials are made available
+!!  under the terms of the Eclipse Public License v1.0 and
+!!  Apache License v2.0 which accompanies this distribution.
+!!
+!!      The Eclipse Public License is available at
+!!      http://www.eclipse.org/legal/epl-v10.html
+!!
+!!      The Apache License v2.0 is available at
+!!      http://www.opensource.org/licenses/apache2.0.php
+!!
+!! Contributors:
+!!    Multiple authors (IBM Corp.) - initial implementation and documentation
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+#include "p/runtime/ppcasmdefines.inc"
+	.file "VirtualGuard.s"
+
+#ifdef AIXPPC
+	.globl	._patchVirtualGuard
+	.globl	_patchVirtualGuard
+
+#elif defined(LINUXPPC64)
+	.globl	FUNC_LABEL(_patchVirtualGuard)
+	.type	FUNC_LABEL(_patchVirtualGuard), @function
+
+#elif defined(LINUX)
+	.globl	_patchVirtualGuard
+#endif
+
+
+#ifdef AIXPPC
+! .text section
+	.csect    VGuard_TEXT{PR}
+#elif defined(LINUXPPC64)
+	.section  ".text"
+	.align    2
+#endif
+
+
+
+
+#ifdef AIXPPC
+._patchVirtualGuard:
+	.function ._patchVirtualGuard,startproc._patchVirtualGuard,16,0,(endproc._patchVirtualGuard-startproc._patchVirtualGuard)
+#elif defined(LINUXPPC64)
+FUNC_LABEL(_patchVirtualGuard):
+#else
+_patchVirtualGuard:
+#endif
+!       parameters
+!           r3 - location of nop
+!           r4 - address of jump destination / offset?
+!           r5 - TR_VM struct
+!           r6 - smpflag
+	startproc._patchVirtualGuard:
+        sub     r4,r4,r3
+        lis     r6,0x4800
+        rlwimi  r6,r4,0,6,31
+        stw     r6,0(r3)
+        dcbst   0,r3
+        sync
+        icbi    0,r3
+	sync
+        isync
+        blr
+	endproc._patchVirtualGuard:
+
+! .data section
+#ifdef AIXPPC
+	.toc
+TOC_patchVirtualGuard:
+	.tc	_patchVirtualGuard[TC],_patchVirtualGuard
+
+	.csect    _patchVirtualGuard{DS}
+	ADDR      ._patchVirtualGuard
+	ADDR      TOC{TC0}
+	ADDR      0x00000000
+! End   csect     _patchVirtualGuard{DS}
+#elif defined(LINUXPPC64)
+	.section  ".toc"
+TOC_patchVirtualGuard:
+	.tc	_patchVirtualGuard[TC],_patchVirtualGuard
+
+#if !defined(__LITTLE_ENDIAN__)
+	.section  ".opd","aw"
+	.align    3
+	.globl    _patchVirtualGuard
+	.size     _patchVirtualGuard,24
+_patchVirtualGuard:
+	.quad     ._patchVirtualGuard
+	.quad     .TOC.@tocbase
+	.long     0x00000000
+	.long     0x00000000
+#endif
+
+#endif
+

--- a/compiler/runtime/OMRRuntimeAssumptions.cpp
+++ b/compiler/runtime/OMRRuntimeAssumptions.cpp
@@ -1,0 +1,41 @@
+/******************************************************************************* 
+ *
+ * (c) Copyright IBM Corp. 2000, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+
+#include "runtime/OMRRuntimeAssumptions.hpp"
+#include "env/jittypes.h"
+
+#if defined(__IBMCPP__) && !defined(AIXPPC) && !defined(LINUXPPC)
+#define ASM_CALL __cdecl
+#else
+#define ASM_CALL
+#endif
+
+#if defined(TR_HOST_S390) || defined(TR_HOST_X86) || defined(TR_HOST_ARM)
+// on these platforms, _patchVirtualGuard is written in C++
+extern "C" void _patchVirtualGuard(uint8_t *locationAddr, uint8_t *destinationAddr, int32_t smpFlag);
+#else
+extern "C" void ASM_CALL _patchVirtualGuard(uint8_t*, uint8_t*, uint32_t);
+#endif
+
+
+void TR::PatchNOPedGuardSite::compensate(bool isSMP, uint8_t *location, uint8_t *destination)
+   {
+   _patchVirtualGuard(location, destination, isSMP);
+   }
+
+

--- a/compiler/x/runtime/VirtualGuardRuntime.cpp
+++ b/compiler/x/runtime/VirtualGuardRuntime.cpp
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2000, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+
+#include <stdint.h>
+#include "infra/Assert.hpp"
+
+#define IS_32BIT_SIGNED(x)   ((x) == ( int32_t)(x))
+
+extern "C" void _patchingFence16(void *startAddr);
+
+extern "C" void _patchVirtualGuard(uint8_t *locationAddr, uint8_t *destinationAddr, int32_t smpFlag)
+   {
+   intptr_t destinationDistance = destinationAddr - locationAddr;
+   TR_ASSERT(IS_32BIT_SIGNED(destinationDistance), "Destination address must be in range of 5-byte jmp instruction");
+
+   if (-126 <= destinationDistance && destinationDistance <= 129)
+      {
+      // Two-byte jmp instruction
+      //
+      intptr_t displacement = destinationDistance-2;
+      *(uint16_t*)locationAddr = 0xeb + (displacement << 8);
+      }
+   else
+      {
+      // Five-byte jmp instruction
+      //
+      intptr_t displacement = destinationDistance-5;
+
+      // Self-loop
+      *(uint16_t*)locationAddr = 0xfeeb;
+
+      _patchingFence16(locationAddr);
+
+      // Bytes 2-4
+      locationAddr[2] = (displacement >> 8);
+      locationAddr[3] = (displacement >> 16);
+      locationAddr[4] = (displacement >> 24);
+
+      // Bytes 0-1; unlock the self-loop/JMP+3
+      _patchingFence16(locationAddr);
+      *(uint16_t*)locationAddr = 0xe9 + ((displacement & 0xff) << 8);
+      }
+   }

--- a/compiler/z/runtime/VirtualGuardRuntime.cpp
+++ b/compiler/z/runtime/VirtualGuardRuntime.cpp
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2000, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+
+#include <stdio.h>
+#include <stdint.h>
+#include "codegen/FrontEnd.hpp"
+#include "compile/Compilation.hpp"
+#include "env/jittypes.h"
+#include "infra/Assert.hpp"
+
+// Patch instruction at location.  It should be either a BRC or BRCL, and the offset field should
+// already be set--just need to toggle bits 12 to 16 from 0x0 to 0xf to turn the BRC[L] from
+// a nop to an unconditional branch.
+// Since we're modifying 4 bits in the 2nd byte, it will not stradle a double word boundary and
+// so the instruction should move from nop->branch atomically.
+extern "C" void _patchVirtualGuard(uint8_t *locationAddr, uint8_t *destinationAddr, int32_t smpFlag){
+
+   int64_t offset;
+   static bool doTrace = (debug("traceVGNOP") != 0);
+
+   if(doTrace)
+      printf("####> patching VGNOP at %p (%x) destAddr: %p (%x), flag:%d\n",
+              locationAddr,*(int32_t*)locationAddr,
+              destinationAddr,*(int32_t*)destinationAddr,smpFlag);
+
+   intptrj_t distance = destinationAddr - locationAddr;
+   offset = destinationAddr - locationAddr;
+   offset = offset / 2;
+
+   if (distance >= -32768 && distance <= 32767)
+      {
+      locationAddr[0] = 0xa7;
+      locationAddr[1] = 0xf4;
+      locationAddr[2] = (offset >> 8)  & 0x00ff;
+      locationAddr[3] = offset         & 0x00ff;
+      }
+   else
+      {
+      locationAddr[0] = 0xc0;
+      locationAddr[1] = 0xf4;
+      locationAddr[2] = (offset >> 24) & 0x000000ff;
+      locationAddr[3] = (offset >> 16) & 0x000000ff;
+      locationAddr[4] = (offset >> 8)  & 0x000000ff;
+      locationAddr[5] = offset         & 0x000000ff;
+      }
+
+   TR_ASSERT(destinationAddr == (distance + locationAddr),
+          "%p != %p(2*%ld+%p)\n",destinationAddr,distance+locationAddr,offset,locationAddr);
+}


### PR DESCRIPTION
PatchNOPedGuardSite is a location redirection runtime assumption. It can
patch at a particular location to unconditionally jump to a destination. Provided 
interface and implementation for patching virtual guards in OMR.


Signed-off-by: Xiaoli Liang <xsliang@ca.ibm.com>