### PR TITLE
Fold enableZOSTrampolines into enableRMODE64

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -749,7 +749,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"enableZAccessRegs",                "O\tenable use of access regs as spill area on 390.", SET_OPTION_BIT(TR_Enable390AccessRegs), "F"},
    {"enableZEpilogue",                  "O\tenable 64-bit 390 load-multiple breakdown.", SET_OPTION_BIT(TR_Enable39064Epilogue), "F"},
    {"enableZFreeVMThreadReg",           "O\tenable use of vm thread reg as assignable reg on 390.", SET_OPTION_BIT(TR_Enable390FreeVMThreadReg), "F"},
-   {"enablezOSTrampolines",                  "O\tenable generation of trampolines for method dispatch on zOS64", SET_OPTION_BIT(TR_EnableZOSTrampolines), "F"},
    {"enumerateAddresses=", "D\tselect kinds of addresses to be replaced by unique identifiers in trace file", TR::Options::setAddressEnumerationBits, offsetof(OMR::Options, _addressToEnumerate), 0, "F"},
    {"estimateRegisterPressure",           "O\tdeprecated; equivalent to enableRegisterPressureSimulation", RESET_OPTION_BIT(TR_DisableRegisterPressureSimulation), "F"},
    {"experimentalClassLoadPhase",         "O\tenable the experimental class load phase algorithm", SET_OPTION_BIT(TR_ExperimentalClassLoadPhase), "F"},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -898,7 +898,7 @@ enum TR_CompilationOptions
    TR_DisableSIMDStringCaseConv                       = 0x00040000 + 27,
    TR_DisableSIMDUTF16BEEncoder                       = 0x00080000 + 27,
    TR_DisableSIMDArrayCopy                            = 0x00100000 + 27,
-   TR_EnableZOSTrampolines                            = 0x00200000 + 27,
+   // Available                                       = 0x00200000 + 27,
    TR_EnableRMODE64                                   = 0x00400000 + 27,
    TR_EnableLocalVPSkipLowFreqBlock                   = 0x00800000 + 27,
    TR_DisableLastITableCache                          = 0x01000000 + 27,

--- a/compiler/z/codegen/OMRSnippet.cpp
+++ b/compiler/z/codegen/OMRSnippet.cpp
@@ -133,7 +133,7 @@ OMR::Z::Snippet::generatePICBinary(TR::CodeGenerator * cg, uint8_t * cursor, TR:
 
 #if defined(TR_TARGET_64BIT) 
 #if defined(J9ZOS390)
-      if (cg->comp()->getOption(TR_EnableZOSTrampolines))
+      if (cg->comp()->getOption(TR_EnableRMODE64))
 #endif
          {
          if (NEEDS_TRAMPOLINE(destAddr, cursor, cg))

--- a/compiler/z/codegen/S390GenerateInstructions.cpp
+++ b/compiler/z/codegen/S390GenerateInstructions.cpp
@@ -2255,15 +2255,14 @@ generateDirectCall(TR::CodeGenerator * cg, TR::Node * callNode, bool myself, TR:
 
    bool isHelper = callSymRef->getSymbol()->castToMethodSymbol()->isHelper();
 
-   // Direct Call on zlinux64 and zOS64 can require a trampoline. As the trampoline will kill EPReg
-   // we should always see EPReg defined in the post-deps of such calls.
+   // Direct calls on 64-bit systems may require a trampoline. As the trampoline will kill the EP register we should
+   // always see the EP register defined in the post-dependencies of such calls.
 #if defined(TR_TARGET_64BIT) 
 #if defined(J9ZOS390)
-   if (comp->getOption(TR_EnableZOSTrampolines))
+   if (comp->getOption(TR_EnableRMODE64))
 #endif
       {
-      TR_ASSERT(RegEP != NULL,
-         "generateDirectCall: zLinux64 and zOS require EPReg be defined on directCalls to correctly handle trampolines.\n");
+      TR_ASSERT(RegEP != NULL, "Trampoline support on 64-bit systems requires EP register to be defined.\n");
       }
 #endif
 
@@ -2302,7 +2301,7 @@ generateDirectCall(TR::CodeGenerator * cg, TR::Node * callNode, bool myself, TR:
    else // address known
       {
 #if !defined(TR_TARGET_64BIT) || (defined(TR_TARGET_64BIT) && defined(J9ZOS390))
-      if (cg->canUseRelativeLongInstructions(imm) || isHelper || comp->getOption(TR_EnableZOSTrampolines))
+      if (cg->canUseRelativeLongInstructions(imm) || isHelper || comp->getOption(TR_EnableRMODE64))
 #endif
          {
          if (!isHelper && cg->supportsBranchPreloadForCalls())
@@ -2322,7 +2321,7 @@ generateDirectCall(TR::CodeGenerator * cg, TR::Node * callNode, bool myself, TR:
          TR::S390RILInstruction *tempInst;
 #if defined(TR_TARGET_64BIT)
 #if defined (J9ZOS390)
-         if (comp->getOption(TR_EnableZOSTrampolines))
+         if (comp->getOption(TR_EnableRMODE64))
 #endif
             {
             tempInst = (new (INSN_HEAP) TR::S390RILInstruction(TR::InstOpCode::BRASL, callNode, RegRA, imm, callSymRef, cg));
@@ -2330,7 +2329,7 @@ generateDirectCall(TR::CodeGenerator * cg, TR::Node * callNode, bool myself, TR:
 #endif
 #if !defined(TR_TARGET_64BIT) || (defined(TR_TARGET_64BIT) && defined(J9ZOS390))
 #if (defined(TR_TARGET_64BIT) && defined(J9ZOS390))
-         if (!comp->getOption(TR_EnableZOSTrampolines))
+         if (!comp->getOption(TR_EnableRMODE64))
 #endif
 
             {

--- a/compiler/z/codegen/S390HelperCallSnippet.cpp
+++ b/compiler/z/codegen/S390HelperCallSnippet.cpp
@@ -104,7 +104,7 @@ TR::S390HelperCallSnippet::emitSnippetBody()
 
 #if defined(TR_TARGET_64BIT)
 #if defined(J9ZOS390)
-   if (cg()->comp()->getOption(TR_EnableZOSTrampolines))
+   if (cg()->comp()->getOption(TR_EnableRMODE64))
 #endif
       {
       if (NEEDS_TRAMPOLINE(destAddr, cursor, cg()))

--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -2408,7 +2408,7 @@ TR::S390RILInstruction::generateBinaryEncoding()
 
 #if defined(TR_TARGET_64BIT)
 #if defined(J9ZOS390)
-        if (comp->getOption(TR_EnableZOSTrampolines))
+        if (comp->getOption(TR_EnableRMODE64))
 #endif
             {
             // get the correct target addr for helpers
@@ -2446,7 +2446,7 @@ TR::S390RILInstruction::generateBinaryEncoding()
          }
 #if defined(TR_TARGET_64BIT)
 #if defined(J9ZOS390)
-      if (comp->getOption(TR_EnableZOSTrampolines)) 
+      if (comp->getOption(TR_EnableRMODE64))
 #endif
          {
          if (comp->getCodeCacheSwitched())
@@ -2515,7 +2515,7 @@ TR::S390RILInstruction::generateBinaryEncoding()
                }
 #if defined(TR_TARGET_64BIT) 
 #if defined(J9ZOS390)
-            if (comp->getOption(TR_EnableZOSTrampolines))
+            if (comp->getOption(TR_EnableRMODE64))
 #endif
                {
                i2 = adjustCallOffsetWithTrampoline(i2, cursor);


### PR DESCRIPTION
Because of the nature of executable memory allocation on z/OS, unless
RMODE64 is enabled we can only allocate executable memory below the 2GB
bar. The relative immediate instructions used for linkage dispatch can
address 32-bits worth of half-words in a signed format, meaning we can
branch -4GB to +4GB from the branch instruction. This region exceeds the
2GB limit and hence when RMODE64 is disabled we never need to generate
trampolines on z/OS.

When RMODE64 is enabled however, the executable memory may be allocated
anywhere within the 64-bit virtual address space, and hence we may
exceed the reachable addressability of the linkage branch instructions.
In such cases we always need to generate trampolines which makes the
enableZOSTrampolines synonymous with enableRMODE64.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>