### PR TITLE
Add missing licence headers to makefiles

### DIFF
--- a/fvtest/compilertest/Makefile
+++ b/fvtest/compilertest/Makefile
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 .PHONY: all clean cleanobjs cleandeps cleandll
 all:
 clean:

--- a/fvtest/compilertest/build/IWYU_Mappings.imp
+++ b/fvtest/compilertest/build/IWYU_Mappings.imp
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 
 [
 

--- a/fvtest/compilertest/build/files/common.mk
+++ b/fvtest/compilertest/build/files/common.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/compile/OSRData.cpp \
     $(JIT_OMR_DIRTY_DIR)/compile/Method.cpp \

--- a/fvtest/compilertest/build/files/host/arm.mk
+++ b/fvtest/compilertest/build/files/host/arm.mk
@@ -1,1 +1,20 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 JIT_PRODUCT_SOURCE_FILES+=

--- a/fvtest/compilertest/build/files/host/p.mk
+++ b/fvtest/compilertest/build/files/host/p.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 JIT_PRODUCT_SOURCE_FILES+=\
     $(JIT_PRODUCT_DIR)/p/runtime/AsmUtil.spp \
     $(JIT_PRODUCT_DIR)/p/runtime/CodeDispatch.spp \

--- a/fvtest/compilertest/build/files/host/x.mk
+++ b/fvtest/compilertest/build/files/host/x.mk
@@ -1,2 +1,21 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 JIT_PRODUCT_SOURCE_FILES+=\
     $(JIT_PRODUCT_DIR)/x/runtime/AsmUtil64.asm

--- a/fvtest/compilertest/build/files/host/z.mk
+++ b/fvtest/compilertest/build/files/host/z.mk
@@ -1,1 +1,20 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 JIT_PRODUCT_SOURCE_FILES+=

--- a/fvtest/compilertest/build/files/target/amd64.mk
+++ b/fvtest/compilertest/build/files/target/amd64.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/x/amd64/codegen/OMRCodeGenerator.cpp \
     $(JIT_OMR_DIRTY_DIR)/x/amd64/codegen/OMRMachine.cpp \

--- a/fvtest/compilertest/build/files/target/arm.mk
+++ b/fvtest/compilertest/build/files/target/arm.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/arm/codegen/ARMBinaryEncoding.cpp \
     $(JIT_OMR_DIRTY_DIR)/arm/codegen/OMRCodeGenerator.cpp \

--- a/fvtest/compilertest/build/files/target/i386.mk
+++ b/fvtest/compilertest/build/files/target/i386.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/x/i386/codegen/OMRCodeGenerator.cpp \
     $(JIT_OMR_DIRTY_DIR)/x/i386/codegen/OMRMachine.cpp \

--- a/fvtest/compilertest/build/files/target/p.mk
+++ b/fvtest/compilertest/build/files/target/p.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/p/codegen/BinaryEvaluator.cpp \
     $(JIT_OMR_DIRTY_DIR)/p/codegen/ControlFlowEvaluator.cpp \

--- a/fvtest/compilertest/build/files/target/x.mk
+++ b/fvtest/compilertest/build/files/target/x.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/x/codegen/BinaryCommutativeAnalyser.cpp \
     $(JIT_OMR_DIRTY_DIR)/x/codegen/BinaryEvaluator.cpp \

--- a/fvtest/compilertest/build/files/target/z.mk
+++ b/fvtest/compilertest/build/files/target/z.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/z/codegen/BinaryAnalyser.cpp \
     $(JIT_OMR_DIRTY_DIR)/z/codegen/BinaryCommutativeAnalyser.cpp \

--- a/fvtest/compilertest/build/platform/common.mk
+++ b/fvtest/compilertest/build/platform/common.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 #
 # Common file for setting platform tokens
 # Mostly just guesses the platform and includes the relevant

--- a/fvtest/compilertest/build/platform/host/amd64-linux-gcc.mk
+++ b/fvtest/compilertest/build/platform/host/amd64-linux-gcc.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 HOST_ARCH=x
 HOST_SUBARCH=i386
 HOST_BITS=32

--- a/fvtest/compilertest/build/platform/host/amd64-linux64-clang.mk
+++ b/fvtest/compilertest/build/platform/host/amd64-linux64-clang.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 HOST_ARCH=x
 HOST_SUBARCH=amd64
 HOST_BITS=64

--- a/fvtest/compilertest/build/platform/host/amd64-linux64-gcc.mk
+++ b/fvtest/compilertest/build/platform/host/amd64-linux64-gcc.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 HOST_ARCH=x
 HOST_SUBARCH=amd64
 HOST_BITS=64

--- a/fvtest/compilertest/build/platform/host/amd64-osx-clang.mk
+++ b/fvtest/compilertest/build/platform/host/amd64-osx-clang.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 HOST_ARCH=x
 HOST_SUBARCH=amd64
 HOST_BITS=64

--- a/fvtest/compilertest/build/platform/host/ppc64-linux64-gcc.mk
+++ b/fvtest/compilertest/build/platform/host/ppc64-linux64-gcc.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 HOST_ARCH=p
 HOST_SUBARCH=
 HOST_BITS=64

--- a/fvtest/compilertest/build/platform/host/ppc64le-linux64-gcc.mk
+++ b/fvtest/compilertest/build/platform/host/ppc64le-linux64-gcc.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 HOST_ARCH=p
 HOST_SUBARCH=
 HOST_BITS=64

--- a/fvtest/compilertest/build/platform/host/s390-linux-clang.mk
+++ b/fvtest/compilertest/build/platform/host/s390-linux-clang.mk
@@ -1,3 +1,21 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
 HOST_ARCH=z
 HOST_SUBARCH=
 HOST_BITS=32

--- a/fvtest/compilertest/build/platform/host/s390-linux-gcc.mk
+++ b/fvtest/compilertest/build/platform/host/s390-linux-gcc.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 HOST_ARCH=z
 HOST_SUBARCH=
 HOST_BITS=32

--- a/fvtest/compilertest/build/platform/host/s390-linux64-clang.mk
+++ b/fvtest/compilertest/build/platform/host/s390-linux64-clang.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 HOST_ARCH=z
 HOST_SUBARCH=
 HOST_BITS=64

--- a/fvtest/compilertest/build/platform/host/s390-linux64-gcc.mk
+++ b/fvtest/compilertest/build/platform/host/s390-linux64-gcc.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 HOST_ARCH=z
 HOST_SUBARCH=
 HOST_BITS=64

--- a/fvtest/compilertest/build/platform/target/all.mk
+++ b/fvtest/compilertest/build/platform/target/all.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 #
 # If user didn't pass a target arch, assume same as host
 #

--- a/fvtest/compilertest/build/rules/common.mk
+++ b/fvtest/compilertest/build/rules/common.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 # Add our targets to the global targets
 all: jit
 clean: jit_cleanobjs jit_cleandeps jit_cleandll

--- a/fvtest/compilertest/build/rules/gnu/common.mk
+++ b/fvtest/compilertest/build/rules/gnu/common.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 #
 # Defines rules for compiling source files into object files
 #

--- a/fvtest/compilertest/build/rules/gnu/filetypes.mk
+++ b/fvtest/compilertest/build/rules/gnu/filetypes.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 #
 # These are the rules to compile files of type ".x" into object files
 # as well as to generate clean and cleandeps rules

--- a/fvtest/compilertest/build/toolcfg/common.mk
+++ b/fvtest/compilertest/build/toolcfg/common.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 J9_VERSION?=29
 
 ifdef J9SRC

--- a/fvtest/compilertest/build/toolcfg/gnu/common.mk
+++ b/fvtest/compilertest/build/toolcfg/gnu/common.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 #
 # Explicitly set shell
 #

--- a/fvtest/compilertest/build/toolcfg/host/32.mk
+++ b/fvtest/compilertest/build/toolcfg/host/32.mk
@@ -1,1 +1,20 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 HOST_DEFINES+=TR_HOST_32BIT

--- a/fvtest/compilertest/build/toolcfg/host/64.mk
+++ b/fvtest/compilertest/build/toolcfg/host/64.mk
@@ -1,1 +1,20 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 HOST_DEFINES+=TR_HOST_64BIT BITVECTOR_64BIT

--- a/fvtest/compilertest/build/toolcfg/host/aix.mk
+++ b/fvtest/compilertest/build/toolcfg/host/aix.mk
@@ -1,1 +1,20 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 HOST_DEFINES+=AIX

--- a/fvtest/compilertest/build/toolcfg/host/arm.mk
+++ b/fvtest/compilertest/build/toolcfg/host/arm.mk
@@ -1,1 +1,20 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 HOST_DEFINES+=TR_HOST_ARM

--- a/fvtest/compilertest/build/toolcfg/host/linux.mk
+++ b/fvtest/compilertest/build/toolcfg/host/linux.mk
@@ -1,1 +1,20 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 HOST_DEFINES+=LINUX

--- a/fvtest/compilertest/build/toolcfg/host/osx.mk
+++ b/fvtest/compilertest/build/toolcfg/host/osx.mk
@@ -1,1 +1,20 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 HOST_DEFINES+=OSX

--- a/fvtest/compilertest/build/toolcfg/host/p.mk
+++ b/fvtest/compilertest/build/toolcfg/host/p.mk
@@ -1,1 +1,20 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 HOST_DEFINES+=TR_HOST_POWER

--- a/fvtest/compilertest/build/toolcfg/host/win.mk
+++ b/fvtest/compilertest/build/toolcfg/host/win.mk
@@ -1,1 +1,20 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 HOST_DEFINES+=WINDOWS

--- a/fvtest/compilertest/build/toolcfg/host/x.mk
+++ b/fvtest/compilertest/build/toolcfg/host/x.mk
@@ -1,1 +1,20 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 HOST_DEFINES+=TR_HOST_X86

--- a/fvtest/compilertest/build/toolcfg/host/z.mk
+++ b/fvtest/compilertest/build/toolcfg/host/z.mk
@@ -1,1 +1,20 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 HOST_DEFINES+=TR_HOST_S390

--- a/fvtest/compilertest/build/toolcfg/host/zos.mk
+++ b/fvtest/compilertest/build/toolcfg/host/zos.mk
@@ -1,1 +1,20 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 HOST_DEFINES+=ZOS

--- a/fvtest/compilertest/build/toolcfg/target/32.mk
+++ b/fvtest/compilertest/build/toolcfg/target/32.mk
@@ -1,1 +1,20 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 TARGET_DEFINES+=TR_TARGET_32BIT

--- a/fvtest/compilertest/build/toolcfg/target/64.mk
+++ b/fvtest/compilertest/build/toolcfg/target/64.mk
@@ -1,1 +1,20 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 TARGET_DEFINES+=TR_TARGET_64BIT

--- a/fvtest/compilertest/build/toolcfg/target/arm.mk
+++ b/fvtest/compilertest/build/toolcfg/target/arm.mk
@@ -1,1 +1,20 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 TARGET_DEFINES+=TR_TARGET_ARM

--- a/fvtest/compilertest/build/toolcfg/target/p.mk
+++ b/fvtest/compilertest/build/toolcfg/target/p.mk
@@ -1,1 +1,20 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 TARGET_DEFINES+=TR_TARGET_POWER

--- a/fvtest/compilertest/build/toolcfg/target/x.mk
+++ b/fvtest/compilertest/build/toolcfg/target/x.mk
@@ -1,1 +1,20 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 TARGET_DEFINES+=TR_TARGET_X86

--- a/fvtest/compilertest/build/toolcfg/target/z.mk
+++ b/fvtest/compilertest/build/toolcfg/target/z.mk
@@ -1,1 +1,20 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 TARGET_DEFINES+=TR_TARGET_S390

--- a/fvtest/compilertest/iwyu.mk
+++ b/fvtest/compilertest/iwyu.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 # include-what-you-use, or iwyu, is a open source tool based on clang
 # that is used to analyse C++ source paths. It will check files that it's
 # given for uses of objects, and suggest including the necessary

--- a/fvtest/compilertest/linter.mk
+++ b/fvtest/compilertest/linter.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 # To lint: 
 #
 # PLATFORM=foo-bar-clang make -f linter.mk 

--- a/fvtest/compilertest/testjit.mk
+++ b/fvtest/compilertest/testjit.mk
@@ -1,3 +1,22 @@
+################################################################################
+##
+## (c) Copyright IBM Corp. 2016, 2017
+##
+##  This program and the accompanying materials are made available
+##  under the terms of the Eclipse Public License v1.0 and
+##  Apache License v2.0 which accompanies this distribution.
+##
+##      The Eclipse Public License is available at
+##      http://www.eclipse.org/legal/epl-v10.html
+##
+##      The Apache License v2.0 is available at
+##      http://www.opensource.org/licenses/apache2.0.php
+##
+## Contributors:
+##    Multiple authors (IBM Corp.) - initial implementation and documentation
+################################################################################
+
+
 #
 # "all" should be the first target to appear so it's the default
 #


### PR DESCRIPTION
Somehow the compiler test build system missed the licence headers, so
this adds them.

Signed-off-by: Matthew Gaudet <magaudet@ca.ibm.com>