### PR TITLE
Change assignment operator in GNUmakefile

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -65,8 +65,8 @@ endif
 
 tool_targets += tools/hookgen
 
-HOOK_DEFINITION_FILES := $(abspath ./gc/base/omrmmprivate.hdf ./gc/include/omrmm.hdf ./fvtest/algotest/hooksample.hdf)
-HOOK_DEFINITION_SENTINEL := $(patsubst %.hdf,%.sentinel, $(HOOK_DEFINITION_FILES))
+HOOK_DEFINITION_FILES = $(abspath ./gc/base/omrmmprivate.hdf ./gc/include/omrmm.hdf ./fvtest/algotest/hooksample.hdf)
+HOOK_DEFINITION_SENTINEL = $(patsubst %.hdf,%.sentinel, $(HOOK_DEFINITION_FILES))
 define HOOKGEN_COMMAND
 cd $(exe_output_dir) && ./hookgen $<
 endef


### PR DESCRIPTION
Updated the GNUmakefile

Changes are:
-Changed operator assignment for HOOK_DEFINITION_SENTINEL and HOOK_DEFINITION_FILE in GNUmakefile from := to =, for expansion of the variable only during usage

Task #1172
Signed-off-by: Jingxian Liu jingxliu0814@gmail.com