### PR TITLE
Fix compile err in MSSS::getActiveMemorySize

### DIFF
--- a/gc/base/MemorySubSpaceSemiSpace.cpp
+++ b/gc/base/MemorySubSpaceSemiSpace.cpp
@@ -278,9 +278,8 @@ MM_MemorySubSpaceSemiSpace::getActiveMemorySize(uintptr_t includeMemoryType)
 		} else {
 			Assert_MM_unreachable();
 		}
-	} else {
-		return 0;
-	}		
+	}
+	return 0;
 }
 
 /**


### PR DESCRIPTION
Some compilers enforce return even in the 'unreachable' path.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>