### PR TITLE
Fold memory reference to SS format for MVC instr

### DIFF
--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -6412,8 +6412,15 @@ bool directMemoryStoreHelper(TR::CodeGenerator* cg, TR::Node* storeNode)
                TR::DebugCounter::incStaticDebugCounter(cg->comp(), "z/optimization/directMemoryStore/indirect");
 
                // Force the memory references to not use an index register because MVC is an SS instruction
+               // After generating a memory reference, Enforce it to generate LA instruction.
+               // This will avoid scenarios when we have common base/index between destination and source
+               // And when generating the source memory reference, it clobber evaluates one of the node shared between 
+               // target memory reference as well.
                TR::MemoryReference* targetMemRef = generateS390MemoryReference(storeNode, cg, false);
+               targetMemRef->enforceSSFormatLimits(storeNode, cg, NULL);
+
                TR::MemoryReference* sourceMemRef = generateS390MemoryReference(valueNode, cg, false);
+               sourceMemRef->enforceSSFormatLimits(storeNode, cg, NULL);
 
                generateSS1Instruction(cg, TR::InstOpCode::MVC, storeNode, storeNode->getSize() - 1, targetMemRef, sourceMemRef);
 


### PR DESCRIPTION
Force memory reference to use SS format limits right after
they are generated when we get success to reduce store node
to direct memory-memory copy and use MVC instruction to perform
operation. This avoids scenario when index child of source and
target memory reference shares common nodes and we clobber evaluate
that node before it is used.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>