### PR TITLE
Cut down on bogus warnings in appveyor build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,6 +26,7 @@ environment:
   GTEST_COLOR: '1'
 
 before_build:
+  - del "C:\Program Files (x86)\MSBuild\14.0\Microsoft.Common.targets\ImportAfter\Xamarin.Common.targets"
   - cmd: cmake -Wdev -G "Visual Studio 14 2015 Win64" .
 
 build:


### PR DESCRIPTION
Xaramin MSBuild configuration files are corrupted in VS2015.
This results in MSBuild spamming various warning messages.
Solution is to simply delete the files as we don't need xaramin

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>