### PR TITLE
Fix properties of VLGV instruction on Z architecture

### DIFF
--- a/compiler/z/codegen/ArchInstOpCodeProperties.hpp
+++ b/compiler/z/codegen/ArchInstOpCodeProperties.hpp
@@ -6028,7 +6028,8 @@
    S390OpProp_SetsOperand1,
 
       // VLGV
-   S390OpProp_SetsOperand1,
+   S390OpProp_SetsOperand1 |
+   S390OpProp_Is64Bit,
 
       // VLLEZ
    S390OpProp_IsLoad |


### PR DESCRIPTION
“VECTOR LOAD GR FROM VR ELEMENT” (VLGV instruction) loads an element of a vector register in a scalar register.
However, regardless of the element size, the remaining of 64-bit output GR fills with zeros.
This indicates that the instruction clobbers all 64 bits of its output register and has to be marked as a 64bit instruction.

Signed-off-by: Hadi Jooybar <hjooybar@ca.ibm.com>