### PR TITLE
 Fix an "undefined symbol" runtime error on zLinux

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -11705,14 +11705,6 @@ bool OMR::Z::CodeGenerator::loadAndStoreMayOverlap(TR::Node *store, size_t store
    }
 
 
-template <class TR_AliasSetInterface>
-bool OMR::Z::CodeGenerator::loadAndStoreMayOverlap(TR::Node *store, size_t storeSize, TR::Node *load, size_t loadSize, TR_AliasSetInterface &storeAliases)
-   {
-   return storeAliases.contains(load->getSymbolReference(), self()->comp());
-   }
-
-
-
 bool
 OMR::Z::CodeGenerator::checkIfcmpxx(TR::Node *node)
    {

--- a/compiler/z/codegen/OMRCodeGenerator_inlines.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator_inlines.hpp
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2000, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#ifndef OMR_Z_CODEGENERATOR_INLINES_INCL
+#define OMR_Z_CODEGENERATOR_INLINES_INCL
+
+#include "compiler/codegen/OMRCodeGenerator_inlines.hpp"
+#include "codegen/OMRCodeGenerator.hpp"
+
+template <class TR_AliasSetInterface>
+bool OMR::Z::CodeGenerator::loadAndStoreMayOverlap(::TR::Node *store, size_t storeSize, ::TR::Node *load, size_t loadSize, TR_AliasSetInterface &storeAliases)
+   {
+   return storeAliases.contains(load->getSymbolReference(), self()->comp());
+   }
+
+#endif // OMR_Z_CODEGENERATOR_INLINES_INCL


### PR DESCRIPTION
Fix an "undefined symbol" runtime error on zLinux

The template method `loadAndStoreMayOverlap` in `OMR::Z::CodeGenerator`
was implemented in the implementation file rather than the header file,
and, hence, was violating the C++ standard. GCC 4.8.5 is inlining the
template straight into the overload candidate and not emitting the
template instantiation. The result was an "undefined symbol" error
during runtime on zLinux.
Issue: #1183

Signed-off-by: Alexey Zhikhartsev <alexey.zhikhartsev@ibm.com>