### PR TITLE
Deprecate isConcurrentScavengeEnabled codegen query

### DIFF
--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -421,7 +421,7 @@ OMR::CodeGenPhase::performSetupForInstructionSelectionPhase(TR::CodeGenerator * 
    {
    TR::Compilation *comp = cg->comp();
 
-   if (cg->isConcurrentScavengeEnabled())
+   if (TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads())
       {
       // TODO (GuardedStorage): We need to come up with a better solution than anchoring aloadi's
       // to enforce certain evaluation order

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -496,18 +496,6 @@ class OMR_EXTENSIBLE CodeGenerator
    bool supportsMarshallingUnmarshallingIntrinsics() {return true;} // no virt, default
    bool supportsMergingGuards() {return false;} // no virt, default
 
-   /** \brief
-    *     Determines whether concurrent scavenge of objects during garbage collection is enabled.
-    *
-    *  \return
-    *     true if the code generator will emit read barriers for loads of object references from the heap in support
-    *     of concurrent scavenge; false otherwise.
-    */
-   bool isConcurrentScavengeEnabled()
-   {
-      return false;
-   }
-
    // --------------------------------------------------------------------------
    // Z only
    //

--- a/compiler/env/OMRObjectModel.hpp
+++ b/compiler/env/OMRObjectModel.hpp
@@ -97,6 +97,11 @@ class ObjectModel
    uintptrj_t objectHeaderSizeInBytes() { return 0; }
    uintptrj_t offsetOfIndexableSizeField() { return 0; }
 
+   /**
+   * @brief: Returns true if concurrent scavenging enabled in the VM's GC
+   */
+   bool shouldGenerateReadBarriersForFieldLoads() { return false; };
+
    };
 }
 

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -2861,7 +2861,7 @@ TR::Node *constrainWrtBar(OMR::ValuePropagation *vp, TR::Node *node)
 
    static bool doOpt = feGetEnv("TR_DisableWrtBarOpt") ? false : true;
 
-   if (vp->cg()->isConcurrentScavengeEnabled())
+   if (TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads())
       {
       // TODO (GuardedStorage): Why do we need this restriction?
       doOpt = false;

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -2962,7 +2962,7 @@ TR::Register *OMR::Z::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node
                
                // For concurrent scavenge the source is loaded and shifted by the guarded load, thus we need to use CG
                // here for a non-zero compressedrefs shift value
-               if (cg->isConcurrentScavengeEnabled())
+               if (TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads())
                   {
                   cmpOpCode = TR::InstOpCode::getCmpOpCode();
                   }

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -6113,7 +6113,7 @@ aloadHelper(TR::Node * node, TR::CodeGenerator * cg, TR::MemoryReference * tempM
                   {
                   auto loadMnemonic = TR::InstOpCode::BAD;
 
-                  if (cg->isConcurrentScavengeEnabled() &&
+                  if (TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads() &&
                       node->getOpCodeValue() == TR::aloadi &&
                       tempReg->containsCollectedReference())
                      {
@@ -13522,7 +13522,7 @@ OMR::Z::TreeEvaluator::primitiveArraycopyEvaluator(TR::Node* node, TR::CodeGener
 
 #ifdef J9_PROJECT_SPECIFIC
    TR::LabelSymbol* mergeLabel;
-   bool mustGenerateOOLGuardedLoadPath = cg->isConcurrentScavengeEnabled() &&
+   bool mustGenerateOOLGuardedLoadPath = TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads() &&
                                          node->getArrayCopyElementType() == TR::Address;
 
    if (mustGenerateOOLGuardedLoadPath)


### PR DESCRIPTION
Instead, expose a query on the Object Model class querying whether we
need read barriers for field loads. The compiler shouldn't technically
be querying the codegen to ask if concurrent scavenge is enabled, that
should be something that the Object Model should answer.
Issue: #1185

Signed-off-by: Alexey Zhikhartsev <alexey.zhikhartsev@ibm.com>