### PR TITLE
Aborted CS single allocate object handling

### DIFF
--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -378,7 +378,7 @@ MM_ParallelGlobalGC::shouldCompactThisCycle(MM_EnvironmentBase *env, MM_Allocate
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	/* Aborted CS need global GC with Nursery compaction */
-	if (ABORTED_SCAVENGE == _extensions->heap->getPercolateStats()->getLastPercolateReason()) {
+	if (_extensions->isScavengerBackOutFlagRaised()) {
 		Assert_MM_true(_extensions->concurrentScavenger);
 		compactReason = COMPACT_ABORTED_SCAVENGE;
 		goto compactionReqd;


### PR DESCRIPTION
More robust variant of https://github.com/eclipse/omr/pull/1169

This is supposed to cover (at least) one other even more rare case when
we abort in Concurrent Scavenger with single object allocation. Bottom
line, we will not rely on setting Percolate Reason on various allocation
paths (and possibly miss some) to let Global GC and SemiSpace know that
special treatment is needed for CS abort, but they will query Aborted
Flag directly. 

Aborted flag and its API is moved to GCExtensions. This is not
functional nor mandatory change. The motivation was simply: 1) minimize
#include dependency on Scavenger and 2) it's more consistent with RS
overflow flag/API which is already in the GCExtensions.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>