### PR TITLE
WIP: Insert a GC Map for Unsafe Shadow Symbol [X86]

### DIFF
--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -1075,6 +1075,12 @@ TR::Register *OMR::X86::TreeEvaluator::integerStoreEvaluator(TR::Node *node, TR:
    if (instr && node->getOpCode().isIndirect())
       cg->setImplicitExceptionPoint(instr);
 
+   if (node->getSymbol()->isUnsafeShadowSymbol())
+      {
+      instr->setNeedsGCMap(0xFF00FFFF);
+      instr->setNode(node);
+      }
+
    if (usingCompressedPointers)
       cg->decReferenceCount(node->getSecondChild());
 


### PR DESCRIPTION
An exception may occur on a node with Unsafe Shadow Symbol,
and hence a GC Map is needed.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>