### PR TITLE
Add version information to .dll files on Windows

### DIFF
--- a/configure
+++ b/configure
@@ -659,6 +659,7 @@ CCLINKEXE
 CCLINKSHARED
 CCLINK
 OMR_CROSS_COMPILE
+OMR_GC_IDLE_HEAP_MANAGER
 OMRTHREAD_LIB_UNIX
 OMRTHREAD_LIB_ZOS
 OMRTHREAD_LIB_WIN32
@@ -740,6 +741,9 @@ CPPFLAGS
 LDFLAGS
 CFLAGS
 CC
+OMR_PRODUCT_VERSION
+OMR_PRODUCT_NAME
+OMR_PRODUCT_DESCRIPTION
 OMR_CROSS_CONFIGURE
 OMR_TOOLCHAIN
 OMR_TARGET_DATASIZE
@@ -798,8 +802,7 @@ PACKAGE_VERSION
 PACKAGE_TARNAME
 PACKAGE_NAME
 PATH_SEPARATOR
-SHELL
-OMR_GC_IDLE_HEAP_MANAGER'
+SHELL'
 ac_subst_files='OMR_VERSION_STRING
 OMR_JIT_VERSION_STRING'
 ac_user_opts='
@@ -899,6 +902,9 @@ OMR_HOST_ARCH
 OMR_TARGET_DATASIZE
 OMR_TOOLCHAIN
 OMR_CROSS_CONFIGURE
+OMR_PRODUCT_DESCRIPTION
+OMR_PRODUCT_NAME
+OMR_PRODUCT_VERSION
 CC
 CFLAGS
 LDFLAGS
@@ -1699,6 +1705,14 @@ Some influential environment variables:
               capable of building the package. Compiler and feature detection
               tests will be invalid. All options must be configured manually.
               One of: yes,no. (Default: no)
+  OMR_PRODUCT_DESCRIPTION
+              The description of product integerating OMR. (Default: J9
+              Virtual Machine Runtime\0)
+  OMR_PRODUCT_NAME
+              The name of product integerating OMR. (Default: IBM SDK,
+              Java(tm) 2 Technology Edition\0)
+  OMR_PRODUCT_VERSION
+              The version of product integerating OMR. (Default: R2.9\0)
   CC          C compiler command
   CFLAGS      C compiler flags
   LDFLAGS     linker flags, e.g. -L<lib dir> if you have libraries in a
@@ -2752,6 +2766,14 @@ case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
 
 
 
+
+
+
+
+
+OMR_PRODUCT_DESCRIPTION=${OMR_PRODUCT_DESCRIPTION:-"OMR 1.0 "}
+OMR_PRODUCT_NAME=${OMR_PRODUCT_NAME:-"OMR"}
+OMR_PRODUCT_VERSION=${OMR_PRODUCT_VERSION:-"1.0"}
 
 # Check whether --enable-optimized was given.
 if test "${enable_optimized+set}" = set; then :
@@ -7034,6 +7056,26 @@ fi
 
 fi
 
+# Check whether --enable-OMR_GC_IDLE_HEAP_MANAGER was given.
+if test "${enable_OMR_GC_IDLE_HEAP_MANAGER+set}" = set; then :
+  enableval=$enable_OMR_GC_IDLE_HEAP_MANAGER; if test "x${enableval}" = xyes; then :
+  OMR_GC_IDLE_HEAP_MANAGER=1
+
+   $as_echo "#define OMR_GC_IDLE_HEAP_MANAGER 1" >>confdefs.h
+
+else
+  OMR_GC_IDLE_HEAP_MANAGER=0
+
+
+fi
+else
+  OMR_GC_IDLE_HEAP_MANAGER=0
+
+
+fi
+
+
+
 ###
 ### Variable Substitution
 ###
@@ -7048,16 +7090,7 @@ fi
 
 CC=$BUILD_CC
 
-if test "${enable_OMR_GC_IDLE_HEAP_MANAGER+set}" = set; then :
-  enableval=$enable_OMR_GC_IDLE_HEAP_MANAGER; if test "x${enableval}" = xyes; then :
-  OMR_GC_IDLE_HEAP_MANAGER=1
-   $as_echo "#define OMR_GC_IDLE_HEAP_MANAGER 1" >>confdefs.h
-else
-  OMR_GC_IDLE_HEAP_MANAGER=0
-fi
-else
-  OMR_GC_IDLE_HEAP_MANAGER=0
-fi
+
 
 
 
@@ -7189,7 +7222,7 @@ fi
 # Restore the value of $cross_compiling.
 cross_compiling=$save_cross_compiling
 
-ac_config_files="$ac_config_files include_core/omrversionstrings.h:include_core/omrversionstrings.h.in omrmakefiles/configure.mk:omrmakefiles/configure.mk.in"
+ac_config_files="$ac_config_files include_core/omrversionstrings.h:include_core/omrversionstrings.h.in omrmakefiles/configure.mk:omrmakefiles/configure.mk.in omr.rc"
 
 
 ac_config_headers="$ac_config_headers include_core/omrcfg.h:include_core/omrcfg.h.in"
@@ -7908,6 +7941,7 @@ do
   case $ac_config_target in
     "include_core/omrversionstrings.h") CONFIG_FILES="$CONFIG_FILES include_core/omrversionstrings.h:include_core/omrversionstrings.h.in" ;;
     "omrmakefiles/configure.mk") CONFIG_FILES="$CONFIG_FILES omrmakefiles/configure.mk:omrmakefiles/configure.mk.in" ;;
+    "omr.rc") CONFIG_FILES="$CONFIG_FILES omr.rc" ;;
     "include_core/omrcfg.h") CONFIG_HEADERS="$CONFIG_HEADERS include_core/omrcfg.h:include_core/omrcfg.h.in" ;;
     "toolconfigure") CONFIG_COMMANDS="$CONFIG_COMMANDS toolconfigure" ;;
 
@@ -8537,4 +8571,5 @@ if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: unrecognized options: $ac_unrecognized_opts" >&5
 $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
 fi
+
 

--- a/configure.ac
+++ b/configure.ac
@@ -49,6 +49,14 @@ AC_ARG_VAR([OMR_CROSS_CONFIGURE],
 	Compiler and feature detection tests will be invalid. All options must be configured manually.
 	One of: yes,no. (Default: no)])
 
+AC_ARG_VAR([OMR_PRODUCT_DESCRIPTION], [The description of product integerating OMR. (Default: OMR 1.0)])
+AC_ARG_VAR([OMR_PRODUCT_NAME], [The name of product integerating OMR. (Default: OMR)])
+AC_ARG_VAR([OMR_PRODUCT_VERSION], [The version of product integerating OMR. (Default: 1.0)])
+
+OMR_PRODUCT_DESCRIPTION=${OMR_PRODUCT_DESCRIPTION:-"AC_PACKAGE_STRING AC_PACKAGE_URL"}
+OMR_PRODUCT_NAME=${OMR_PRODUCT_NAME:-"AC_PACKAGE_NAME"}
+OMR_PRODUCT_VERSION=${OMR_PRODUCT_VERSION:-"AC_PACKAGE_VERSION"}
+
 AC_ARG_ENABLE([optimized],
 	AS_HELP_STRING([--enable-optimized], [Create an optimized build. (Default: yes)]),
 	[],
@@ -606,6 +614,7 @@ cross_compiling=$save_cross_compiling
 AC_CONFIG_FILES([
 	include_core/omrversionstrings.h:include_core/omrversionstrings.h.in
 	omrmakefiles/configure.mk:omrmakefiles/configure.mk.in
+	omr.rc
 ])
 
 AC_CONFIG_HEADERS([include_core/omrcfg.h:include_core/omrcfg.h.in])
@@ -624,3 +633,4 @@ AC_CONFIG_COMMANDS([toolconfigure],
 		[OMR_HOSTCONFIG_ENV="CC= CXX="])])
 
 AC_OUTPUT
+

--- a/fvtest/porttest/sltestlib/makefile
+++ b/fvtest/porttest/sltestlib/makefile
@@ -23,6 +23,9 @@ MODULE_NAME := sltestlib
 ARTIFACT_TYPE := c_shared
 OBJECTS := sltest
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
+ifeq (win,$(OMR_HOST_OS))
+	OBJECTS += $(top_srcdir)/omr.res
+endif
 EXPORT_FUNCTIONS_FILE := sltestlib.exportlist
 
 include $(top_srcdir)/omrmakefiles/rules.mk

--- a/fvtest/rastest/bindthreadagent.mk
+++ b/fvtest/rastest/bindthreadagent.mk
@@ -24,6 +24,9 @@ ARTIFACT_TYPE := c_shared
 
 OBJECTS := bindthreadagent
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
+ifeq (win,$(OMR_HOST_OS))
+	OBJECTS += $(top_srcdir)/omr.res
+endif
 
 MODULE_INCLUDES += ../util
 EXPORT_FUNCTIONS_FILE := omragent.exportlist

--- a/fvtest/rastest/cpuLoadAgent.mk
+++ b/fvtest/rastest/cpuLoadAgent.mk
@@ -24,7 +24,9 @@ ARTIFACT_TYPE := c_shared
 
 OBJECTS := cpuLoadAgent
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
-
+ifeq (win,$(OMR_HOST_OS))
+	OBJECTS += $(top_srcdir)/omr.res
+endif
 MODULE_INCLUDES += ../util
 EXPORT_FUNCTIONS_FILE := omragent.exportlist
 MODULE_STATIC_LIBS += testutil

--- a/fvtest/rastest/invalidAgentMissingOnLoad.mk
+++ b/fvtest/rastest/invalidAgentMissingOnLoad.mk
@@ -24,7 +24,9 @@ ARTIFACT_TYPE := c_shared
 
 OBJECTS := invalidAgentMissingOnLoad
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
-
+ifeq (win,$(OMR_HOST_OS))
+	OBJECTS += $(top_srcdir)/omr.res
+endif
 EXPORT_FUNCTIONS_FILE := invalidAgentMissingOnLoad.exportlist
 
 include $(top_srcdir)/omrmakefiles/rules.mk

--- a/fvtest/rastest/invalidAgentMissingOnUnload.mk
+++ b/fvtest/rastest/invalidAgentMissingOnUnload.mk
@@ -24,7 +24,9 @@ ARTIFACT_TYPE := c_shared
 
 OBJECTS := invalidAgentMissingOnUnload
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
-
+ifeq (win,$(OMR_HOST_OS))
+	OBJECTS += $(top_srcdir)/omr.res
+endif
 EXPORT_FUNCTIONS_FILE := invalidAgentMissingOnUnload.exportlist
 
 include $(top_srcdir)/omrmakefiles/rules.mk

--- a/fvtest/rastest/invalidAgentReturnError.mk
+++ b/fvtest/rastest/invalidAgentReturnError.mk
@@ -24,7 +24,9 @@ ARTIFACT_TYPE := c_shared
 
 OBJECTS := invalidAgentReturnError
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
-
+ifeq (win,$(OMR_HOST_OS))
+	OBJECTS += $(top_srcdir)/omr.res
+endif
 EXPORT_FUNCTIONS_FILE := omragent.exportlist
 
 include $(top_srcdir)/omrmakefiles/rules.mk

--- a/fvtest/rastest/memorycategoriesagent.mk
+++ b/fvtest/rastest/memorycategoriesagent.mk
@@ -24,7 +24,9 @@ ARTIFACT_TYPE := c_shared
 
 OBJECTS := memorycategoriesagent
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
-
+ifeq (win,$(OMR_HOST_OS))
+	OBJECTS += $(top_srcdir)/omr.res
+endif
 MODULE_INCLUDES += ../util
 EXPORT_FUNCTIONS_FILE := omragent.exportlist
 MODULE_STATIC_LIBS += testutil

--- a/fvtest/rastest/sampleSubscriber.mk
+++ b/fvtest/rastest/sampleSubscriber.mk
@@ -24,7 +24,9 @@ ARTIFACT_TYPE := c_shared
 
 OBJECTS := sampleSubscriber
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
-
+ifeq (win,$(OMR_HOST_OS))
+	OBJECTS += $(top_srcdir)/omr.res
+endif
 MODULE_INCLUDES += ../util
 EXPORT_FUNCTIONS_FILE := omragent.exportlist
 MODULE_STATIC_LIBS += testutil

--- a/fvtest/rastest/subscriberAgent.mk
+++ b/fvtest/rastest/subscriberAgent.mk
@@ -24,7 +24,9 @@ ARTIFACT_TYPE := c_shared
 
 OBJECTS := subscriberAgent
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
-
+ifeq (win,$(OMR_HOST_OS))
+	OBJECTS += $(top_srcdir)/omr.res
+endif
 MODULE_INCLUDES += ../util
 EXPORT_FUNCTIONS_FILE := omragent.exportlist
 MODULE_STATIC_LIBS += testutil

--- a/fvtest/rastest/subscriberAgentWithJ9thread.mk
+++ b/fvtest/rastest/subscriberAgentWithJ9thread.mk
@@ -24,7 +24,9 @@ ARTIFACT_TYPE := c_shared
 
 OBJECTS := subscriberAgentWithJ9thread
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
-
+ifeq (win,$(OMR_HOST_OS))
+	OBJECTS += $(top_srcdir)/omr.res
+endif
 MODULE_INCLUDES += ../util
 EXPORT_FUNCTIONS_FILE := omragent.exportlist
 MODULE_STATIC_LIBS += testutil

--- a/fvtest/rastest/traceNotStartedAgent.mk
+++ b/fvtest/rastest/traceNotStartedAgent.mk
@@ -24,7 +24,9 @@ ARTIFACT_TYPE := c_shared
 
 OBJECTS := traceNotStartedAgent
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
-
+ifeq (win,$(OMR_HOST_OS))
+	OBJECTS += $(top_srcdir)/omr.res
+endif
 EXPORT_FUNCTIONS_FILE := omragent.exportlist
 
 include $(top_srcdir)/omrmakefiles/rules.mk

--- a/fvtest/rastest/traceOptionAgent.mk
+++ b/fvtest/rastest/traceOptionAgent.mk
@@ -24,7 +24,9 @@ ARTIFACT_TYPE := c_shared
 
 OBJECTS := traceOptionAgent
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
-
+ifeq (win,$(OMR_HOST_OS))
+	OBJECTS += $(top_srcdir)/omr.res
+endif
 EXPORT_FUNCTIONS_FILE := omragent.exportlist
 
 include $(top_srcdir)/omrmakefiles/rules.mk

--- a/fvtest/rastest/traceagent.mk
+++ b/fvtest/rastest/traceagent.mk
@@ -24,7 +24,9 @@ ARTIFACT_TYPE := c_shared
 
 OBJECTS := traceagent
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
-
+ifeq (win,$(OMR_HOST_OS))
+	OBJECTS += $(top_srcdir)/omr.res
+endif
 MODULE_INCLUDES += ../util
 EXPORT_FUNCTIONS_FILE := omragent.exportlist
 MODULE_STATIC_LIBS += testutil

--- a/omr.rc.in
+++ b/omr.rc.in
@@ -1,0 +1,29 @@
+
+#include <windows.h>
+#include <winver.h>
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION 2,9,5,19691
+ PRODUCTVERSION 2,9,5,19691
+ FILEFLAGSMASK 0x3fL
+ FILEFLAGS 0x0L
+ FILEOS VOS_NT_WINDOWS32
+ FILETYPE VFT_DLL
+ FILESUBTYPE 0x0L
+BEGIN
+	BLOCK "StringFileInfo"
+	BEGIN
+		BLOCK "040904b0"
+		BEGIN
+			VALUE "CompanyName", "International Business Machines Corporation\0"
+			VALUE "LegalCopyright", "Copyright IBM Corp. 1991, 2017\0"
+			VALUE "FileDescription", "@OMR_PRODUCT_DESCRIPTION@\0"
+			VALUE "ProductName", "@OMR_PRODUCT_NAME@\0"
+			VALUE "ProductVersion", "@OMR_PRODUCT_VERSION@\0"
+		END
+	END
+	BLOCK "VarFileInfo"
+	BEGIN
+		VALUE "Translation", 0x0409, 1200
+	END
+END

--- a/omrmakefiles/configure.mk.in
+++ b/omrmakefiles/configure.mk.in
@@ -102,6 +102,14 @@ OMRTHREAD_LIB_WIN32 := @OMRTHREAD_LIB_WIN32@
 OMRTHREAD_LIB_ZOS := @OMRTHREAD_LIB_ZOS@
 
 ###
+### Version information used to generate .rc file on Windows
+###
+
+OMR_PRODUCT_DESCRIPTION := @OMR_PRODUCT_DESCRIPTION@
+OMR_PRODUCT_NAME := @OMR_PRODUCT_NAME@
+OMR_PRODUCT_VERSION := @OMR_PRODUCT_VERSION@
+
+###
 ### Global Autoconfigure Flags
 ###
 

--- a/omrmakefiles/rules.win.mk
+++ b/omrmakefiles/rules.win.mk
@@ -182,10 +182,12 @@ endef
 RC_INCLUDES=$(call buildCPPIncludeFlags,$(MODULE_INCLUDES) $(GLOBAL_INCLUDES))
 
 # compilation rule for message text files
-%.res: %.mc
+%.rc: %.mc
 	mc $<
-	$(RC) $(RC_INCLUDES) $*.rc
-	$(RM) $*.rc
+
+# compilation rule for text resource files on Windows
+%.res: %.rc
+	$(RC) $(RC_INCLUDES) $<
 
 define AR_COMMAND
 $(AR) -out:$@ $(OBJECTS)

--- a/omrsigcompat/makefile
+++ b/omrsigcompat/makefile
@@ -23,6 +23,9 @@ MODULE_NAME := omrsig
 ARTIFACT_TYPE := c_shared
 OBJECTS := omrsig
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
+ifeq (win,$(OMR_HOST_OS))
+	OBJECTS += $(top_srcdir)/omr.res
+endif
 EXPORT_FUNCTIONS_FILE := omrsig.exportlist
 
 ## Create platform specific exports

--- a/run_configure.mk
+++ b/run_configure.mk
@@ -124,8 +124,8 @@ touch $(CONFIGURE_OUTPUT_FILES)
 endef
 
 CONFIGURE_DEPENDENCIES := SPEC config.guess config.sub configure tools/configure
-CONFIGURE_OUTPUT_FILES := include_core/omrcfg.h include_core/omrversionstrings.h omrmakefiles/configure.mk tools/toolconfigure.mk CONFIGURE_SENTINEL_FILE
-CONFIGURE_INPUT_FILES := include_core/omrcfg.h.in include_core/omrversionstrings.h.in omrmakefiles/configure.mk.in tools/toolconfigure.mk.in
+CONFIGURE_OUTPUT_FILES := include_core/omrcfg.h include_core/omrversionstrings.h omrmakefiles/configure.mk ./omr.rc tools/toolconfigure.mk CONFIGURE_SENTINEL_FILE
+CONFIGURE_INPUT_FILES := include_core/omrcfg.h.in include_core/omrversionstrings.h.in omrmakefiles/configure.mk.in ./omr.rc.in tools/toolconfigure.mk.in
 CONFIGURE_BYPRODUCTS := config.cache config.status config.log autom4te.cache tools/config.cache tools/config.status toolconfig/config.log tools/autom4te.cache
 
 all: check-environment-variables CONFIGURE_SENTINEL_FILE


### PR DESCRIPTION
This is required by Miscrosoft as any executable
binary file (e.g. dll, exe, ocx) belonging to a 
product must come with version information on 
Windows platform.

The idea is to generate a binary resource file
(omr.res) from a text resource template file
(omr.rc.in) and link it to all requested .dll files.

Signed-off-by: CHENGJin <jincheng@ca.ibm.com>