### PR TITLE
Fix for bad register dependency creation on Power

### DIFF
--- a/compiler/p/codegen/OMRMachine.cpp
+++ b/compiler/p/codegen/OMRMachine.cpp
@@ -1864,12 +1864,7 @@ OMR::Power::Machine::createCondForLiveAndSpilledGPRs(bool cleanRegState, TR::lis
    // it is space conscious.
    //
    int32_t c = 0;
-   int32_t endReg = TR::RealRegister::LastCCR;
-
-   // As the real registers order between VR and CR are exchanged, LastCCR will cover all VRFs
-   TR_LiveRegisters *liveVRFs = self()->cg()->getLiveRegisters(TR_VRF);
-   if (liveVRFs && liveVRFs->getNumberOfLiveRegisters() > 0)
-      endReg = TR::RealRegister::LastVRF;
+   int32_t endReg = TR::RealRegister::LastCCR; // As the real registers order between VR and CR are exchanged, LastCCR will cover all VRFs
 
    for (int32_t i = TR::RealRegister::FirstGPR; i <= endReg; i++)
       {


### PR DESCRIPTION
The register enums in p/codegen/RealRegisterEnum.hpp are listed in this
order: GPR, FPR, VRF, CCR. createCondForLiveAndSpilledGPRs in
p/codegen/OMRMachine.cpp tries to iterate over those four types of
registers by setting a loop range to go from FirstGPR to LastCCR. It does
this to generate a register dependency. This logic is correct so there are
no problems so far.

createCondForLiveAndSpilledGPRs then checks to see if there are any live
VRF registers. If so, it changes the end of the loop range to LastVRF.
This is a problem. The range from FirstGPR to LastVRF only covers GPR, FPR
and VRF registers. The existence of a live VRF register causes CCR
registers to be excluded from consideration to be added to the register
dependency.

This fix removes the check for live VRF registers. It is unnecessary since
the default range of FirstGPR to LastCCR already includes vector
registers.

Issue: #1203
Signed-off-by: jimmyk <jimmyk@ca.ibm.com>