### PR TITLE
Ensure JitBuilder creates calls under treetops

### DIFF
--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -1758,14 +1758,14 @@ IlBuilder::genCall(TR::SymbolReference *methodSymRef, int32_t numArgs, TR::IlVal
       callNode->setAndIncChild(childIndex++, loadValue(arg));
       }
 
+   // callNode must be anchored by itself
+   genTreeTop(callNode);
+
    if (returnType != TR::NoType)
       {
       TR::IlValue *returnValue = newValue(callNode->getDataType(), callNode);
       return returnValue;
       }
-
-   // callNode must still be anchored in this case
-   genTreeTop(callNode);
 
    return NULL;
    }


### PR DESCRIPTION
IlBuilder::genCall() was only generating call nodes under their
own treetop if the call node did not return a value. Unfortunately,
the way IlValue works, it could cause the call node to swing down
to places it should never go. Resolve that by anchoring the call
node under its own treetop explicitly in genCall().

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>