### PR TITLE
Skip OSR related trees when splitting block

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -3087,6 +3087,11 @@ TR_HandleInjectedBasicBlock::createTemps(bool replaceAllReferences)
             if (tt->getNode()->getOpCode().isBranch() || tt->getNode()->getOpCode().isSwitch())
                tt = tt->getPrevTreeTop();
 
+            // If this treetop is an OSR point, a store cannot be placed between it and the 
+            // transition treetop in postExecutionOSR
+            if (comp()->isPotentialOSRPoint(tt->getNode()))
+               tt = comp()->getMethodSymbol()->getOSRTransitionTreeTop(tt);
+
             TR::Node *value = ref->_node;
             // Convert the node being stored to the type required by the FE
             if (comp()->fe()->dataTypeForLoadOrStore(nodeDataType) != nodeDataType)


### PR DESCRIPTION
An OSR point may have related trees, such as
pending push stores, immediately after it.
It is not acceptable to insert other trees in
this region. As block splitter may try to
uncommon, it must skip the entire OSR region
when creating the store.