### PR TITLE
Improve alias info in FieldPrivatizer

### DIFF
--- a/compiler/optimizer/FieldPrivatizer.cpp
+++ b/compiler/optimizer/FieldPrivatizer.cpp
@@ -113,8 +113,18 @@ bool TR_FieldPrivatizer::isFieldAliasAccessed(TR::SymbolReference * symRef)
 
    if (symRef->getUseDefAliases().hasAliases())
       {
-      aliasAccessed = true;
+
+      TR_ASSERT(_allSymRefs[symRef->getReferenceNumber()] == true, "symRef should have been seen in the loop");
+      _allSymRefs[symRef->getReferenceNumber()] = false;
+
+      if (symRef->getUseDefAliases().containsAny(_allSymRefs, comp()))
+         {
+         aliasAccessed = true;
+         }
+      _allSymRefs[symRef->getReferenceNumber()] = true;
+
       }
+
    return aliasAccessed;
    }
 

--- a/compiler/optimizer/LoopCanonicalizer.cpp
+++ b/compiler/optimizer/LoopCanonicalizer.cpp
@@ -104,6 +104,7 @@ int32_t TR_LoopCanonicalizer::perform()
    _writtenExactlyOnce.Clear();
    _readExactlyOnce.Clear();
    _allKilledSymRefs.Clear();
+   _allSymRefs.Clear();
 
    _numberOfIterations = NULL;
    _constNode = NULL;
@@ -3442,6 +3443,7 @@ void TR_LoopTransformer::updateInfo(TR::Node *node, vcount_t visitCount, updateI
    if (node->getOpCode().hasSymbolReference())
       {
       refNo = node->getSymbolReference()->getReferenceNumber();
+      _allSymRefs[refNo] = true; 
       }
 
 //   traceMsg(comp(), "bf _allKilledSymRefs = ");

--- a/compiler/optimizer/LoopCanonicalizer.hpp
+++ b/compiler/optimizer/LoopCanonicalizer.hpp
@@ -72,6 +72,7 @@ class TR_LoopTransformer : public TR::Optimization
         _writtenExactlyOnce(comp()->allocator("LoopTransformer")),
         _readExactlyOnce(comp()->allocator("LoopTransformer")),
         _allKilledSymRefs(comp()->allocator("LoopTransformer")),
+        _allSymRefs(comp()->allocator("LoopTransformer")),
         _autosAccessed(NULL)
       {
       _doingVersioning = false;
@@ -98,6 +99,7 @@ class TR_LoopTransformer : public TR::Optimization
       _writtenExactlyOnce.Clear();
       _readExactlyOnce.Clear();
       _allKilledSymRefs.Clear();
+      _allSymRefs.Clear();
       }
 
    virtual int32_t perform(){return 0;}
@@ -176,6 +178,7 @@ class TR_LoopTransformer : public TR::Optimization
    TR::SparseBitVector _writtenExactlyOnce;
    TR::SparseBitVector _readExactlyOnce;
    TR::SparseBitVector _allKilledSymRefs;
+   TR::SparseBitVector _allSymRefs;
 
    TR::Node *_numberOfIterations, *_constNode, *_loadUsedInLoopIncrement;
 


### PR DESCRIPTION
FieldPrivatizer does not privatize fields that have any aliases.
Improve this by checking if any of the field's aliases are actually used inside the loop:

  - collect all symbol references used in the loop in _allSymRefs
  - AND getUseDefAliases with _allSymRefs when checking if field can be privatized

Signed-off-by: Gita Koblents <koblents@ca.ibm.com>