### PR TITLE
Separate out compactonidle from gconidle

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -719,6 +719,7 @@ public:
 	uintptr_t idleMinimumFree;   /** < percentage of free heap to be retained as committed, default=0 for gencon, complete tenture free memory will be decommitted */
 	uintptr_t lastGCFreeBytes;  /** < records the free memory size from last Global GC cycle */
 	uintptr_t gcOnIdleRatio; /**< the percentage of allocation since the last GC allocation determines the invocation of global GC, default global GC is invoked if allocation is > 20% */
+	bool gcOnIdle; /**< Enables releasing free heap pages if true while systemGarbageCollect invoked with IDLE GC code, default is false */
 	bool compactOnIdle; /**< Forces compaction if global GC executed while VM Runtime State set to IDLE, default is false */
 #endif
 
@@ -1498,6 +1499,7 @@ public:
 		, idleMinimumFree(0)
 		, lastGCFreeBytes(0)
 		, gcOnIdleRatio(20)
+		, gcOnIdle(false)
 		, compactOnIdle(false)
 #endif
 	{

--- a/gc/base/MemorySubSpace.cpp
+++ b/gc/base/MemorySubSpace.cpp
@@ -921,7 +921,7 @@ MM_MemorySubSpace::systemGarbageCollect(MM_EnvironmentBase* env, uint32_t gcCode
 	if (_collector && _usesGlobalCollector) {
 		bool invokeGC = true;
 #if defined(OMR_GC_IDLE_HEAP_MANAGER)
-		if (J9MMCONSTANT_EXPLICIT_GC_IDLE_GC == gcCode ) {
+		if ((J9MMCONSTANT_EXPLICIT_GC_IDLE_GC == gcCode) && (_extensions->gcOnIdle || _extensions->compactOnIdle)) {
 			MM_MemorySpace* defaultMemorySpace = _extensions->heap->getDefaultMemorySpace();
 			uintptr_t freeMemorySize = defaultMemorySpace->getApproximateActiveFreeMemorySize(MEMORY_TYPE_OLD);
 			uintptr_t actvMemorySize = defaultMemorySpace->getActiveMemorySize(MEMORY_TYPE_OLD);
@@ -950,7 +950,7 @@ MM_MemorySubSpace::systemGarbageCollect(MM_EnvironmentBase* env, uint32_t gcCode
 			env->releaseExclusiveVMAccessForGC();
 		}
 #if defined(OMR_GC_IDLE_HEAP_MANAGER)
-		if (J9MMCONSTANT_EXPLICIT_GC_IDLE_GC == gcCode ) {
+		if ((J9MMCONSTANT_EXPLICIT_GC_IDLE_GC == gcCode) && (_extensions->gcOnIdle)) {
 			OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
 			uint64_t startTime = omrtime_hires_clock();
 			uintptr_t releasedBytes = _extensions->heap->getDefaultMemorySpace()->releaseFreeMemoryPages(env);


### PR DESCRIPTION
Modifies code to perform global GC with assured compaction if systemGarbageCollect is called with GC code "EXPLICIT_GC_IDLE_GC" and compactOnIdle is set to true.  If gcOnIdle is set along with
compactOnIdle then "releases free heap pages" too.  

For example, if the runtime wants to use the idle CPU cycles to clean up the managed heap and make heap ready for the next active period. In such cases, the runtime wants to execute "systemGarbageCollect" with "J9MMCONSTANT_EXPLICIT_GC_IDLE_GC" and invoke compaction only. 

This PR modifies the code to separate out gcOnIdle and compactOnIdle as two independent actions and can be set & invoked separately.

Issue: #1213 
Signed-off-by: Parameswaran Selvam <parselva@in.ibm.com>