### PR TITLE
Fix properties of VLVG instruction (z Systems)

### DIFF
--- a/compiler/z/codegen/ArchInstOpCodeProperties.hpp
+++ b/compiler/z/codegen/ArchInstOpCodeProperties.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -6049,10 +6049,12 @@
       // VLVG
    S390OpProp_IsLoad |
    S390OpProp_UsesTarget |
-   S390OpProp_SetsOperand1,
+   S390OpProp_SetsOperand1 |
+   S390OpProp_Is64Bit,
 
       // VLVGP
-   S390OpProp_SetsOperand1,
+   S390OpProp_SetsOperand1 |
+   S390OpProp_Is64Bit,
 
       // VLL
    S390OpProp_IsLoad |


### PR DESCRIPTION
“VECTOR LOAD VR ELEMENT FROM GR” (VLVG instruction) stores a general register in a vector register.
For double-word element size (mask = 3) this instruction uses all 64 bits of its source register. Therefore, it has to be marked as a 64bit instruction.
The same logic applies to VLVGP instruction as well.

Signed-off-by: Hadi Jooybar <hjooybar@ca.ibm.com>