### PR TITLE
Add public API to get OS kernel info

### DIFF
--- a/fvtest/porttest/si.cpp
+++ b/fvtest/porttest/si.cpp
@@ -2048,7 +2048,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_os_description)
 	intptr_t rc = 0;
 	reportTestEntry(OMRPORTLIB, testName);
 
-	OMROSDesc desc;
+	struct OMROSDesc desc;
 	rc =  omrsysinfo_get_os_description(&desc);
 
 	for (int i = 0; i < OMRPORT_SYSINFO_OS_FEATURES_SIZE * 32; i++) {
@@ -2056,6 +2056,47 @@ TEST(PortSysinfoTest, sysinfo_test_get_os_description)
 		portTestEnv->log(LEVEL_VERBOSE, "omrsysinfo_test_get_os_description() feature %d: value=%d, rc=%zi\n", i, feature, rc);
 	}
 
+	reportTestExit(OMRPORTLIB, testName);
+	return;
+}
+
+/**
+ * Test omrsysinfo_test_os_kernel_info.
+ */
+TEST(PortSysinfoTest, sysinfo_test_os_kernel_info)
+{
+	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
+	const char *testName = "omrsysinfo_test_os_kernel_info";
+
+	BOOLEAN rc = 0;
+	struct OMROSKernelInfo kernelInfo = {0};
+
+	reportTestEntry(OMRPORTLIB, testName);
+
+	rc = omrsysinfo_os_kernel_info(&kernelInfo);
+
+#if defined(LINUX)
+	/* Throw an error if failure happens on Linux */
+	if (FALSE == rc) {
+		outputErrorMessage(PORTTEST_ERROR_ARGS,
+				"omrsysinfo_os_kernel_info failed on Linux: kernelVersion=%zu, majorRevision=%zu, minorRevision=%zu\n", kernelInfo.kernelVersion, kernelInfo.majorRevision, kernelInfo.minorRevision);
+		goto exit;
+	} else {
+		/* Throw an error if kernel version is 0 */
+		if (0 == kernelInfo.kernelVersion) {
+			outputErrorMessage(PORTTEST_ERROR_ARGS, "omrsysinfo_os_kernel_info failed on Linux - kernel version can't be 0 (unsupported)\n");
+			goto exit;
+		}
+	}
+#else /* defined(LINUX) */
+	if (TRUE == rc) {
+		/* Throw an error if omrsysinfo_os_kernel_info passes on an unsupported platform */
+		outputErrorMessage(PORTTEST_ERROR_ARGS,	"omrsysinfo_os_kernel_info passed on an unsupported platform\n");
+		goto exit;
+	}
+#endif /* defined(LINUX) */
+
+exit:
 	reportTestExit(OMRPORTLIB, testName);
 	return;
 }

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -961,6 +961,12 @@ typedef struct OMROSDesc {
 /* zOS features */
 #define OMRPORT_ZOS_FEATURE_RMODE64 31 /* RMODE64. */
 
+typedef struct OMROSKernelInfo {
+	uint32_t kernelVersion;
+	uint32_t majorRevision;
+	uint32_t minorRevision;
+} OMROSKernelInfo;
+
 struct OMRPortLibrary;
 typedef struct J9Heap J9Heap;
 
@@ -1391,9 +1397,11 @@ typedef struct OMRPortLibrary {
 	/** see @ref omrsysinfo.c::omrsysinfo_get_open_file_count "omrsysinfo_get_open_file_count"*/
 	int32_t (*sysinfo_get_open_file_count)(struct OMRPortLibrary *portLibrary, uint64_t *count) ;
 	/** see @ref omrsysinfo.c::omrsysinfo_get_os_description "omrsysinfo_get_os_description"*/
-	intptr_t  ( *sysinfo_get_os_description)(struct OMRPortLibrary *portLibrary, OMROSDesc *desc) ;
+	intptr_t  ( *sysinfo_get_os_description)(struct OMRPortLibrary *portLibrary, struct OMROSDesc *desc) ;
 	/** see @ref omrsysinfo.c::omrsysinfo_os_has_feature "omrsysinfo_os_has_feature"*/
-	BOOLEAN  ( *sysinfo_os_has_feature)(struct OMRPortLibrary *portLibrary, OMROSDesc *desc, uint32_t feature) ;
+	BOOLEAN  ( *sysinfo_os_has_feature)(struct OMRPortLibrary *portLibrary, struct OMROSDesc *desc, uint32_t feature) ;
+	/** see @ref omrsysinfo.c::omrsysinfo_os_kernel_info "omrsysinfo_os_kernel_info"*/
+	BOOLEAN  ( *sysinfo_os_kernel_info)(struct OMRPortLibrary *portLibrary, struct OMROSKernelInfo *kernelInfo) ;
 	/** see @ref omrport.c::omrport_init_library "omrport_init_library"*/
 	int32_t (*port_init_library)(struct OMRPortLibrary *portLibrary, uintptr_t size) ;
 	/** see @ref omrport.c::omrport_startup_library "omrport_startup_library"*/
@@ -1832,6 +1840,7 @@ extern J9_CFUNC int32_t omrport_getVersion(struct OMRPortLibrary *portLibrary);
 #define omrsysinfo_get_open_file_count(param1) privateOmrPortLibrary->sysinfo_get_open_file_count(privateOmrPortLibrary, (param1))
 #define omrsysinfo_get_os_description(param1) privateOmrPortLibrary->sysinfo_get_os_description(privateOmrPortLibrary, (param1))
 #define omrsysinfo_os_has_feature(param1,param2) privateOmrPortLibrary->sysinfo_os_has_feature(privateOmrPortLibrary, (param1), (param2))
+#define omrsysinfo_os_kernel_info(param1) privateOmrPortLibrary->sysinfo_os_kernel_info(privateOmrPortLibrary, (param1))
 #define omrintrospect_startup() privateOmrPortLibrary->introspect_startup(privateOmrPortLibrary)
 #define omrintrospect_shutdown() privateOmrPortLibrary->introspect_shutdown(privateOmrPortLibrary)
 #define omrintrospect_set_suspend_signal_offset(param1) privateOmrPortLibrary->introspect_set_suspend_signal_offset(privateOmrPortLibrary, param1)

--- a/port/common/omrport.c
+++ b/port/common/omrport.c
@@ -249,6 +249,7 @@ static OMRPortLibrary MasterPortLibraryTable = {
 	omrsysinfo_get_open_file_count, /* sysinfo_get_open_file_count */
 	omrsysinfo_get_os_description, /* sysinfo_get_os_description */
 	omrsysinfo_os_has_feature, /* sysinfo_os_has_feature */
+	omrsysinfo_os_kernel_info, /* sysinfo_os_kernel_info */
 	omrport_init_library, /* port_init_library */
 	omrport_startup_library, /* port_startup_library */
 	omrport_create_library, /* port_create_library */

--- a/port/common/omrsysinfo.c
+++ b/port/common/omrsysinfo.c
@@ -748,7 +748,7 @@ omrsysinfo_get_open_file_count(struct OMRPortLibrary *portLibrary, uint64_t *cou
  * @return 0 on success, -1 on failure
  */
 intptr_t
-omrsysinfo_get_os_description(struct OMRPortLibrary *portLibrary, OMROSDesc *desc)
+omrsysinfo_get_os_description(struct OMRPortLibrary *portLibrary, struct OMROSDesc *desc)
 {
 	intptr_t rc = -1;
 	Trc_PRT_sysinfo_get_os_description_Entered(desc);
@@ -771,7 +771,7 @@ omrsysinfo_get_os_description(struct OMRPortLibrary *portLibrary, OMROSDesc *des
  * @return TRUE if feature is present, FALSE otherwise.
  */
 BOOLEAN
-omrsysinfo_os_has_feature(struct OMRPortLibrary *portLibrary, OMROSDesc *desc, uint32_t feature)
+omrsysinfo_os_has_feature(struct OMRPortLibrary *portLibrary, struct OMROSDesc *desc, uint32_t feature)
 {
 	BOOLEAN rc = FALSE;
 	Trc_PRT_sysinfo_os_has_feature_Entered(desc, feature);
@@ -785,4 +785,21 @@ omrsysinfo_os_has_feature(struct OMRPortLibrary *portLibrary, OMROSDesc *desc, u
 
 	Trc_PRT_sysinfo_os_has_feature_Exit((uintptr_t)rc);
 	return rc;
+}
+
+/**
+ * Retrieves information about OS kernel. Only Linux kernel is supported at this point.
+ *
+ * For Linux kernel, version info is retrieved. For example, if the version is 2.6.32, it
+ * will set kernelVersion to 2, majorRevision to 6 and minorRevision to 32.
+ *
+ * @param[in] portLibrary instance of port library
+ * @param[in/out] kernelInfo contains information about the kernel
+ *
+ * @return TRUE on success, FALSE on unsupported platforms and on failure.
+ */
+BOOLEAN
+omrsysinfo_os_kernel_info(struct OMRPortLibrary *portLibrary, struct OMROSKernelInfo *kernelInfo)
+{
+	return FALSE;
 }

--- a/port/linuxppc64/omrtime.c
+++ b/port/linuxppc64/omrtime.c
@@ -238,33 +238,6 @@ omrtime_shutdown(struct OMRPortLibrary *portLibrary)
 }
 
 /**
- * Retrieves the Linux Kernel version.
- *
- * Returns the Linux Kernel version. For example, if the version is 2.6.32, it
- * will set kernelVersion to 2, majorRevision to 6 and minorRevision to 32.
- *
- * @param[out] kernelVersion
- * @param[out] majorVersion
- * @param[out] minorVersion
- *
- * @return TRUE on success, FALSE otherwise.
- */
-static BOOLEAN
-getLinuxKernelVersion(uint32_t *kernelVersion, uint32_t *majorRevision, uint32_t *minorRevision)
-{
-	BOOLEAN success = FALSE;
-	struct utsname name;
-
-	if (0 == uname(&name)) {
-		if (3 == sscanf(name.release, "%u.%u.%u", kernelVersion, majorRevision, minorRevision)) {
-			success = TRUE;
-		}
-	}
-
-	return success;
-}
-
-/**
  * PortLibrary startup.
  *
  * This function is called during startup of the portLibrary.  Any resources that are required for
@@ -320,10 +293,10 @@ omrtime_startup(struct OMRPortLibrary *portLibrary)
 	 */
 	systemcfgP_nanos = NULL;
 	if (NULL != systemcfgP_millis) {
-		uint32_t kernelVersion, majorRevision, minorRevision;
+		struct OMROSKernelInfo kernelInfo = {0};
 
-		if (getLinuxKernelVersion(&kernelVersion, &majorRevision, &minorRevision)) {
-			if ((2 == kernelVersion) && (6 == majorRevision) && (18 >= minorRevision)) {
+		if (omrsysinfo_os_kernel_info(portLibrary, &kernelInfo)) {
+			if ((2 == kernelInfo.kernelVersion) && (6 == kernelInfo.majorRevision) && (18 >= kernelInfo.minorRevision)) {
 				systemcfgP_nanos = systemcfgP_millis;
 			}
 		}

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -504,9 +504,11 @@ omrsysinfo_get_tmp(struct OMRPortLibrary *portLibrary, char *buf, uintptr_t bufL
 extern J9_CFUNC int32_t 
 omrsysinfo_get_open_file_count(struct OMRPortLibrary *portLibrary, uint64_t *count);
 extern J9_CFUNC intptr_t
-omrsysinfo_get_os_description(struct OMRPortLibrary *portLibrary, OMROSDesc *desc);
+omrsysinfo_get_os_description(struct OMRPortLibrary *portLibrary, struct OMROSDesc *desc);
 extern J9_CFUNC BOOLEAN
-omrsysinfo_os_has_feature(struct OMRPortLibrary *portLibrary, OMROSDesc *desc, uint32_t feature);
+omrsysinfo_os_has_feature(struct OMRPortLibrary *portLibrary, struct OMROSDesc *desc, uint32_t feature);
+extern J9_CFUNC BOOLEAN
+omrsysinfo_os_kernel_info(struct OMRPortLibrary *portLibrary, struct OMROSKernelInfo *kernelInfo);
 
 /* J9SourceJ9Signal*/
 extern J9_CFUNC int32_t

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -247,8 +247,8 @@ static intptr_t searchSystemPath(struct OMRPortLibrary *portLibrary, char *filen
 #endif /* defined(AIXPPC) || defined(J9ZOS390) */
 
 #if defined(J9ZOS390)
-static void setOSFeature(OMROSDesc *desc, uint32_t feature);
-static intptr_t getZOSDescription(struct OMRPortLibrary *portLibrary, OMROSDesc *desc);
+static void setOSFeature(struct OMROSDesc *desc, uint32_t feature);
+static intptr_t getZOSDescription(struct OMRPortLibrary *portLibrary, struct OMROSDesc *desc);
 #endif /* defined(J9ZOS390) */
 
 /**
@@ -2984,7 +2984,7 @@ leave_routine:
  *
  */
 static void
-setOSFeature(OMROSDesc *desc, uint32_t feature)
+setOSFeature(struct OMROSDesc *desc, uint32_t feature)
 {
 	if ((NULL != desc) && (feature < (OMRPORT_SYSINFO_OS_FEATURES_SIZE * 32))) {
 		uint32_t featureIndex = feature / 32;
@@ -3003,7 +3003,7 @@ setOSFeature(OMROSDesc *desc, uint32_t feature)
  * @return 0 on success, -1 on failure
  */
 static intptr_t
-getZOSDescription(struct OMRPortLibrary *portLibrary, OMROSDesc *desc)
+getZOSDescription(struct OMRPortLibrary *portLibrary, struct OMROSDesc *desc)
 {
 	intptr_t rc = 0;
 
@@ -3020,7 +3020,7 @@ getZOSDescription(struct OMRPortLibrary *portLibrary, OMROSDesc *desc)
 #endif /* defined(J9ZOS390) */
 
 intptr_t
-omrsysinfo_get_os_description(struct OMRPortLibrary *portLibrary, OMROSDesc *desc)
+omrsysinfo_get_os_description(struct OMRPortLibrary *portLibrary, struct OMROSDesc *desc)
 {
 	intptr_t rc = -1;
 	Trc_PRT_sysinfo_get_os_description_Entered(desc);
@@ -3038,7 +3038,7 @@ omrsysinfo_get_os_description(struct OMRPortLibrary *portLibrary, OMROSDesc *des
 }
 
 BOOLEAN
-omrsysinfo_os_has_feature(struct OMRPortLibrary *portLibrary, OMROSDesc *desc, uint32_t feature)
+omrsysinfo_os_has_feature(struct OMRPortLibrary *portLibrary, struct OMROSDesc *desc, uint32_t feature)
 {
 	BOOLEAN rc = FALSE;
 	Trc_PRT_sysinfo_os_has_feature_Entered(desc, feature);
@@ -3052,4 +3052,22 @@ omrsysinfo_os_has_feature(struct OMRPortLibrary *portLibrary, OMROSDesc *desc, u
 
 	Trc_PRT_sysinfo_os_has_feature_Exit((uintptr_t)rc);
 	return rc;
+}
+
+BOOLEAN
+omrsysinfo_os_kernel_info(struct OMRPortLibrary *portLibrary, struct OMROSKernelInfo *kernelInfo)
+{
+	BOOLEAN success = FALSE;
+
+#if defined(LINUX)
+	struct utsname name = {0};
+
+	if (0 == uname(&name)) {
+		if (3 == sscanf(name.release, "%u.%u.%u", &kernelInfo->kernelVersion, &kernelInfo->majorRevision, &kernelInfo->minorRevision)) {
+			success = TRUE;
+		}
+	}
+#endif /* defined(LINUX) */
+
+	return success;
 }

--- a/port/win32/omrsysinfo.c
+++ b/port/win32/omrsysinfo.c
@@ -1577,7 +1577,7 @@ omrsysinfo_get_open_file_count(struct OMRPortLibrary *portLibrary, uint64_t *cou
 }
 
 intptr_t
-omrsysinfo_get_os_description(struct OMRPortLibrary *portLibrary, OMROSDesc *desc)
+omrsysinfo_get_os_description(struct OMRPortLibrary *portLibrary, struct OMROSDesc *desc)
 {
 	intptr_t rc = -1;
 	Trc_PRT_sysinfo_get_os_description_Entered(desc);
@@ -1591,7 +1591,7 @@ omrsysinfo_get_os_description(struct OMRPortLibrary *portLibrary, OMROSDesc *des
 }
 
 BOOLEAN
-omrsysinfo_os_has_feature(struct OMRPortLibrary *portLibrary, OMROSDesc *desc, uint32_t feature)
+omrsysinfo_os_has_feature(struct OMRPortLibrary *portLibrary, struct OMROSDesc *desc, uint32_t feature)
 {
 	BOOLEAN rc = FALSE;
 	Trc_PRT_sysinfo_os_has_feature_Entered(desc, feature);
@@ -1605,4 +1605,10 @@ omrsysinfo_os_has_feature(struct OMRPortLibrary *portLibrary, OMROSDesc *desc, u
 
 	Trc_PRT_sysinfo_os_has_feature_Exit((uintptr_t)rc);
 	return rc;
+}
+
+BOOLEAN
+omrsysinfo_os_kernel_info(struct OMRPortLibrary *portLibrary, struct OMROSKernelInfo *kernelInfo)
+{
+	return FALSE;
 }


### PR DESCRIPTION
omrsysinfo_os_kernel_info has been added to the port library in
order to retrieve kernel information. Only Linux kernel is supported at
this point; Linux kernel version is retrieved.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>