### PR TITLE
Revert "Disable/Sampling Hook trace for frequent events"

### DIFF
--- a/gc/base/omrmmprivate.hdf
+++ b/gc/base/omrmmprivate.hdf
@@ -168,7 +168,6 @@
 			code which has hooked the J9HOOK_MM_WALK_HEAP_START hook, such as
 			GC_VMInterface::initializeExtensions.
 		</description>
-		<trace-sampling intervals="100" />
 		<struct>MM_WalkHeapStartEvent</struct>
 		<data type="struct OMR_VM*" name="omrVM" description="OMR vm instance" />
 	</event>
@@ -182,7 +181,6 @@
 			These actions are actually performed by code which has hooked the
 			J9HOOK_MM_WALK_HEAP_END hook, such as GC_VMInterface::initializeExtensions.
 		</description>
-		<trace-sampling intervals="100" />
 		<struct>MM_WalkHeapEndEvent</struct>
 		<data type="struct OMR_VM*" name="omrVM" description="OMR vm instance" />
 	</event>
@@ -731,7 +729,6 @@
 		<name>J9HOOK_MM_PRIVATE_OLD_TO_OLD_REFERENCE_CREATED</name>
 		<description>Triggered when old to old reference is created by GC (Scavenger) </description>
 		<condition>defined (__cplusplus)</condition>
-		<trace-sampling intervals="100" />
 		<struct>MM_OldToOldReferenceCreatedEvent</struct>
 		<data type="struct OMR_VMThread*" name="currentThread" description="the current thread" />
 		<data type="void *" name="objectPtr" description="pointer to the parent object" />

--- a/include_core/omrhookable.h
+++ b/include_core/omrhookable.h
@@ -66,7 +66,6 @@ typedef struct J9HookInterface {
 #define J9HOOK_TAG_AGENT_ID  0x20000000
 #define J9HOOK_TAG_COUNTED  0x40000000
 #define J9HOOK_TAG_ONCE  0x80000000
-#define J9HOOK_TAG_SAMPLING_MASK	0x00ff0000
 #define J9HOOK_AGENTID_FIRST  ((uintptr_t)0)
 #define J9HOOK_AGENTID_DEFAULT  ((uintptr_t)1)
 #define J9HOOK_AGENTID_LAST  ((uintptr_t)-1)
@@ -88,7 +87,6 @@ typedef struct OMRHookInfo4Dump {
 typedef struct OMREventInfo4Dump {
 	struct OMRHookInfo4Dump longestHook;
 	struct OMRHookInfo4Dump lastHook;
-	uint64_t count;
 }OMREventInfo4Dump;
 
 typedef struct J9CommonHookInterface {

--- a/tools/hookgen/HookGen.cpp
+++ b/tools/hookgen/HookGen.cpp
@@ -220,7 +220,7 @@ HookGen::writeEventToPublicHeader(const char *name, const char *description, con
  * Write an event to the private header
  */
 void
-HookGen::writeEventToPrivateHeader(const char *name, const char *condition, const char *once, int sampling, const char *structName, pugi::xml_node event)
+HookGen::writeEventToPrivateHeader(const char *name, const char *condition, const char *once, const char *structName, pugi::xml_node event)
 {
 	if (NULL != condition) {
 		fprintf(_privateFile, "#if %s\n", condition);
@@ -236,7 +236,7 @@ HookGen::writeEventToPrivateHeader(const char *name, const char *condition, cons
 	for (pugi::xml_node data = event.child("data"); data; data = data.next_sibling("data")) {
 		fprintf(_privateFile, "\t\teventData.%s = (arg_%s); \\\n", data.attribute("name").as_string(), data.attribute("name").as_string());
 	}
-	fprintf(_privateFile, "\t\t(*J9_HOOK_INTERFACE(hookInterface))->J9HookDispatch(J9_HOOK_INTERFACE(hookInterface), %s%s%s%d, &eventData); \\\n", name, once == NULL ? "" : " | J9HOOK_TAG_ONCE", " | ", sampling<<16);
+	fprintf(_privateFile, "\t\t(*J9_HOOK_INTERFACE(hookInterface))->J9HookDispatch(J9_HOOK_INTERFACE(hookInterface), %s%s, &eventData); \\\n", name, once == NULL ? "" : " | J9HOOK_TAG_ONCE");
 	for (pugi::xml_node data = event.child("data"); data; data = data.next_sibling("data")) {
 		if (data.attribute("return").as_bool()) {
 			fprintf(_privateFile, "\t\t(arg_%s) = eventData.%s; /* return argument */ \\\n", data.attribute("name").as_string(), data.attribute("name").as_string());
@@ -290,8 +290,6 @@ HookGen::writeEvent(pugi::xml_node event)
 	const char *structName = event.child("struct").text().as_string();
 	const char *once = event.child("once").text().as_string();
 	const char *reverse = event.child("reverse").text().as_string();
-	pugi::xml_node sampling_node = event.child("trace-sampling");
-	int sampling = 0;
 
 	if (event.child("condition").empty()) {
 		condition = NULL;
@@ -299,22 +297,12 @@ HookGen::writeEvent(pugi::xml_node event)
 	if (event.child("once").empty()) {
 		once = NULL;
 	}
-	if (sampling_node) {
-		sampling = sampling_node.attribute("intervals").as_int(0);
-		if (sampling < 0) {
-			sampling = 0;
-		}
-		if (sampling > 100) {
-			sampling = 0xff;
-		}
-	}
-
 	if (event.child("reverse").empty()) {
 		reverse = NULL;
 	}
 
 	writeEventToPublicHeader(name, description, condition, structName, reverse, event);
-	writeEventToPrivateHeader(name, condition, once, sampling, structName, event);
+	writeEventToPrivateHeader(name, condition, once, structName, event);
 }
 
 /**

--- a/tools/hookgen/HookGen.hpp
+++ b/tools/hookgen/HookGen.hpp
@@ -69,7 +69,7 @@ private:
 	RCType startPrivateHeader();
 	RCType completePrivateHeader(const char *structName);
 	void writeEventToPublicHeader(const char *name, const char *description, const char *condition, const char *structName, const char *reverse, pugi::xml_node event);
-	void writeEventToPrivateHeader(const char *name, const char *condition, const char *once, int sampling, const char *structName, pugi::xml_node event);
+	void writeEventToPrivateHeader(const char *name, const char *condition, const char *once, const char *structName, pugi::xml_node event);
 	void writeEvent(pugi::xml_node event);
 
 	static void displayUsage();


### PR DESCRIPTION
This reverts commit 463227e01189b482e5fc3763103041ff1e0246e1 to avoid z390 and ppc crush.