### PR TITLE
Safely dup trees for loop versioning tests

### DIFF
--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -4817,13 +4817,13 @@ void TR_LoopVersioner::buildNullCheckComparisonsTree(List<TR::Node> *nullChecked
                TR::Node *dupInvariantNullCheckReference;
                if(nullCheckReferenceisField)
                   {
-                  dupInvariantNullCheckReference=nextNode->getData()->duplicateTree();
-                  dupInvariantNullCheckReference->setAndIncChild(0,invariantNullCheckReference->duplicateTree());
+                  dupInvariantNullCheckReference=nextNode->getData()->duplicateTreeForCodeMotion();
+                  dupInvariantNullCheckReference->setAndIncChild(0,invariantNullCheckReference->duplicateTreeForCodeMotion());
                   nodeToBeNullChkd = dupInvariantNullCheckReference;
                   }
                else
                   {
-                  dupInvariantNullCheckReference= invariantNullCheckReference->duplicateTree();
+                  dupInvariantNullCheckReference= invariantNullCheckReference->duplicateTreeForCodeMotion();
                   TR::Node *oldInvariantNullCheckReference = nextNode->getData();
                   nextTree->getData()->getNode()->setNullCheckReference(dupInvariantNullCheckReference);
                   oldInvariantNullCheckReference->recursivelyDecReferenceCount();
@@ -4854,17 +4854,11 @@ void TR_LoopVersioner::buildNullCheckComparisonsTree(List<TR::Node> *nullChecked
             if(nullCheckReferenceisField)
                duplicateNullCheckReference = nodeToBeNullChkd;
             else
-               duplicateNullCheckReference = nodeToBeNullChkd->duplicateTree();
+               duplicateNullCheckReference = nodeToBeNullChkd->duplicateTreeForCodeMotion();
             }
          else
-            duplicateNullCheckReference = nextNode->getData()->duplicateTree();
+            duplicateNullCheckReference = nextNode->getData()->duplicateTreeForCodeMotion();
 
-         // nothing is known anymore about the null-ness of the object
-         if (duplicateNullCheckReference->getOpCodeValue() != TR::loadaddr)
-            {
-            duplicateNullCheckReference->setIsNonNull(false);
-            duplicateNullCheckReference->setIsNull(false);
-            }
          //TR::Node *nextComparisonNode = TR::Node::createif(TR::ifacmpeq, duplicateNullCheckReference, TR::Node::create(duplicateNullCheckReference, TR::aconst, 0, 0), exitGotoBlock->getEntry());
          TR::Node *nextComparisonNode = TR::Node::createif(TR::ifacmpeq, duplicateNullCheckReference, TR::Node::aconst(duplicateNullCheckReference, 0), exitGotoBlock->getEntry());
          comparisonTrees->add(nextComparisonNode);
@@ -4906,9 +4900,7 @@ void TR_LoopVersioner::buildIwrtbarComparisonsTree(List<TR::TreeTop> *iwrtbarTre
 
       if (performTransformation(comp(), "%s Creating test outside loop for checking if %p is iwrtbar is required\n", OPT_DETAILS_LOOP_VERSIONER, iwrtbarNode))
          {
-         TR::Node *duplicateBase = iwrtbarNode->getLastChild()->duplicateTree();
-         duplicateBase->setIsNull(false);
-         duplicateBase->setIsNonNull(false);
+         TR::Node *duplicateBase = iwrtbarNode->getLastChild()->duplicateTreeForCodeMotion();
          TR::Node *ifNode, *ifNode1, *ifNode2;
 
          bool isX86 = false;
@@ -4945,11 +4937,7 @@ void TR_LoopVersioner::buildIwrtbarComparisonsTree(List<TR::TreeTop> *iwrtbarTre
 
          dumpOptDetails(comp(), "1 The node %p has been created for testing if iwrtbar is required\n", ifNode1);
 
-         duplicateBase = iwrtbarNode->getLastChild()->duplicateTree();
-         duplicateBase->setIsNull(false);
-         duplicateBase->setIsNonNull(false);
-
-         //printf(" stack compare value %p\n", stackCompareValue);
+         duplicateBase = iwrtbarNode->getLastChild()->duplicateTreeForCodeMotion();
 
          if (!isX86 && (isVariableHeapBase || isVariableHeapSize))
             {
@@ -4999,7 +4987,7 @@ void TR_LoopVersioner::buildDivCheckComparisonsTree(List<TR::TreeTop> *nullCheck
 
       if (performTransformation(comp(), "%s Creating test outside loop for checking if %p is divide by zero\n", OPT_DETAILS_LOOP_VERSIONER, divCheckNode))
          {
-         TR::Node *duplicateDivisor = divCheckNode->getFirstChild()->getSecondChild()->duplicateTree();
+         TR::Node *duplicateDivisor = divCheckNode->getFirstChild()->getSecondChild()->duplicateTreeForCodeMotion();
          TR::Node *ifNode;
          if (duplicateDivisor->getType().isInt64())
             ifNode =  TR::Node::createif(TR::iflcmpeq, duplicateDivisor, TR::Node::create(duplicateDivisor, TR::lconst, 0, 0), exitGotoBlock->getEntry());
@@ -5073,17 +5061,12 @@ void TR_LoopVersioner::buildArrayStoreCheckComparisonsTree(List<TR::TreeTop> *nu
       //collectAllExpressionsToBeChecked(nullCheckTrees, divCheckTrees, checkCastTrees, arrayStoreCheckTrees, arrayNode, comparisonTrees, exitGotoBlock, visitCount);
 
 
-      TR::Node *duplicateSrcArray = arrayNode->duplicateTree();
+      TR::Node *duplicateSrcArray = arrayNode->duplicateTreeForCodeMotion();
       TR::Node *duplicateClassPtr = TR::Node::createWithSymRef(TR::aloadi, 1, 1, duplicateSrcArray, comp()->getSymRefTab()->findOrCreateVftSymbolRef());
 
       collectAllExpressionsToBeChecked(nullCheckTrees, divCheckTrees, checkCastTrees, arrayStoreCheckTrees, duplicateClassPtr, comparisonTrees, exitGotoBlock, visitCount);
 
-      TR::Node *duplicateCheckedValue = childOfAddressNode->duplicateTree();
-      if (duplicateCheckedValue->getOpCodeValue() != TR::loadaddr)
-         {
-         duplicateCheckedValue->setIsNonNull(false);
-         duplicateCheckedValue->setIsNull(false);
-         }
+      TR::Node *duplicateCheckedValue = childOfAddressNode->duplicateTreeForCodeMotion();
 
      TR::Node *instanceofNode = TR::Node::createWithSymRef(TR::instanceof, 2, 2, duplicateCheckedValue,  duplicateClassPtr, comp()->getSymRefTab()->findOrCreateInstanceOfSymbolRef(comp()->getMethodSymbol()));
      TR::Node *ificmpeqNode =  TR::Node::createif(TR::ificmpeq, instanceofNode, TR::Node::create(arrayStoreCheckNode, TR::iconst, 0, 0), exitGotoBlock->getEntry());
@@ -5390,7 +5373,7 @@ bool TR_LoopVersioner::buildSpecializationTree(List<TR::TreeTop> *nullCheckTrees
             {
             TR::Node *invariantSpecializedNode = isDependentOnInvariant(specializedNode);
             if (invariantSpecializedNode)
-               dupSpecializedNode = invariantSpecializedNode->duplicateTree();
+               dupSpecializedNode = invariantSpecializedNode->duplicateTreeForCodeMotion();
             else
                TR_ASSERT(0, "Should not be considering profiled expr for versioning\n");
             }
@@ -5410,7 +5393,7 @@ bool TR_LoopVersioner::buildSpecializationTree(List<TR::TreeTop> *nullCheckTrees
          {
          TR::Node *duplicateNode = dupSpecializedNode;
          if (!duplicateNode)
-            duplicateNode = specializedNode->duplicateTree();
+            duplicateNode = specializedNode->duplicateTreeForCodeMotion();
 
          TR_ValueInfo *valueInfo = (TR_ValueInfo *)TR_ValueProfiler::getProfiledValueInfo(specializedNode, comp());
          int32_t value = valueInfo->getTopValue();
@@ -5997,7 +5980,7 @@ void TR_LoopVersioner::buildSpineCheckComparisonsTree(List<TR::TreeTop> *nullChe
       if (performTransformation(comp(), "%s Creating test outside loop for checking if %p has spine\n", OPT_DETAILS_LOOP_VERSIONER, spineCheckNode))
          {
          performSpineCheck = true;
-         TR::Node *contigArrayLength = TR::Node::create(TR::contigarraylength, 1, arrayBase->duplicateTree());
+         TR::Node *contigArrayLength = TR::Node::create(TR::contigarraylength, 1, arrayBase->duplicateTreeForCodeMotion());
          TR::Node *nextComparisonNode = TR::Node::createif(TR::ificmpne, contigArrayLength, TR::Node::create(spineCheckNode, TR::iconst, 0, 0), exitGotoBlock->getEntry());
 
          comparisonTrees->add(nextComparisonNode);
@@ -6244,7 +6227,7 @@ void TR_LoopVersioner::buildBoundCheckComparisonsTree(List<TR::TreeTop> *nullChe
          if (performTransformation(comp(), "%s Creating test outside loop for checking if %p exceeds bounds\n", OPT_DETAILS_LOOP_VERSIONER, boundCheckNode))
             {
             performFirstBoundCheck = true;
-            nextComparisonNode = TR::Node::createif(TR::ificmplt, indexNode->duplicateTree(), TR::Node::create(boundCheckNode, TR::iconst, 0, 0), exitGotoBlock->getEntry());
+            nextComparisonNode = TR::Node::createif(TR::ificmplt, indexNode->duplicateTreeForCodeMotion(), TR::Node::create(boundCheckNode, TR::iconst, 0, 0), exitGotoBlock->getEntry());
 
             if (trace())
                traceMsg(comp(), "Index invariant in each iter -> Creating %p (%s)\n", nextComparisonNode, nextComparisonNode->getOpCode().getName());
@@ -6261,9 +6244,9 @@ void TR_LoopVersioner::buildBoundCheckComparisonsTree(List<TR::TreeTop> *nullChe
             {
             performSecondBoundCheck = true;
             if (boundCheckNode->getOpCodeValue() == TR::BNDCHK || boundCheckNode->getOpCodeValue() == TR::BNDCHKwithSpineCHK)
-               nextComparisonNode = TR::Node::createif(TR::ificmpge, indexNode->duplicateTree(), arrayLengthNode->duplicateTree(), exitGotoBlock->getEntry());
+               nextComparisonNode = TR::Node::createif(TR::ificmpge, indexNode->duplicateTreeForCodeMotion(), arrayLengthNode->duplicateTreeForCodeMotion(), exitGotoBlock->getEntry());
             else
-               nextComparisonNode = TR::Node::createif(TR::ificmpgt, indexNode->duplicateTree(), arrayLengthNode->duplicateTree(), exitGotoBlock->getEntry());
+               nextComparisonNode = TR::Node::createif(TR::ificmpgt, indexNode->duplicateTreeForCodeMotion(), arrayLengthNode->duplicateTreeForCodeMotion(), exitGotoBlock->getEntry());
 
             if (trace())
                traceMsg(comp(), "Index invariant in each iter -> Creating %p (%s)\n", nextComparisonNode, nextComparisonNode->getOpCode().getName());
@@ -6640,13 +6623,13 @@ void TR_LoopVersioner::buildBoundCheckComparisonsTree(List<TR::TreeTop> *nullChe
             if (isSpecialInductionVariable)
                {
                //printf("Found an opportunity for special versioning in method %s\n", comp()->signature());
-               nextComparisonNode = TR::Node::createif(TR::ificmplt, boundCheckNode->getChild(indexChildIndex)->duplicateTree(), TR::Node::create(boundCheckNode, TR::iconst, 0, 0), exitGotoBlock->getEntry());
+               nextComparisonNode = TR::Node::createif(TR::ificmplt, boundCheckNode->getChild(indexChildIndex)->duplicateTreeForCodeMotion(), TR::Node::create(boundCheckNode, TR::iconst, 0, 0), exitGotoBlock->getEntry());
                if (trace())
                   traceMsg(comp(), "Induction variable added in each iter -> Creating %p (%s)\n", nextComparisonNode, nextComparisonNode->getOpCode().getName());
                }
             else
                {
-               TR::Node *duplicateIndex = boundCheckNode->getChild(indexChildIndex)->duplicateTree();
+               TR::Node *duplicateIndex = boundCheckNode->getChild(indexChildIndex)->duplicateTreeForCodeMotion();
 
                if ( changedIndexSymRefAtSomePoint || !_unchangedValueUsedInBndCheck->get(boundCheckNode->getGlobalIndex()))
                   {
@@ -6686,7 +6669,7 @@ void TR_LoopVersioner::buildBoundCheckComparisonsTree(List<TR::TreeTop> *nullChe
                else
                   {
                   int32_t boundChildIndex = (boundCheckNode->getOpCodeValue() == TR::BNDCHKwithSpineCHK) ? 2 : 0;
-                  nextComparisonNode = TR::Node::createif(TR::ificmpge, duplicateIndex, boundCheckNode->getChild(boundChildIndex)->duplicateTree(), exitGotoBlock->getEntry());
+                  nextComparisonNode = TR::Node::createif(TR::ificmpge, duplicateIndex, boundCheckNode->getChild(boundChildIndex)->duplicateTreeForCodeMotion(), exitGotoBlock->getEntry());
                   nextComparisonNode->setIsVersionableIfWithMaxExpr(comp());
                   if (trace())
                      traceMsg(comp(), "Induction variable subed in each iter -> Creating %p (%s)\n", nextComparisonNode, nextComparisonNode->getOpCode().getName());
@@ -7313,13 +7296,7 @@ void TR_LoopVersioner::collectAllExpressionsToBeChecked(List<TR::TreeTop> *nullC
             }
 
 
-         TR::Node *duplicateNullCheckReference = node->getFirstChild()->duplicateTree();
-         // nothing is known anymore about the null-ness of the object
-         if (duplicateNullCheckReference->getOpCodeValue() != TR::loadaddr)
-            {
-            duplicateNullCheckReference->setIsNonNull(false);
-            duplicateNullCheckReference->setIsNull(false);
-            }
+         TR::Node *duplicateNullCheckReference = node->getFirstChild()->duplicateTreeForCodeMotion();
          TR::Node *ifacmpeqNode =  TR::Node::createif(TR::ifacmpeq, duplicateNullCheckReference, TR::Node::aconst(node, 0),  exitGotoBlock->getEntry());
          comparisonTrees->add(ifacmpeqNode);
          dumpOptDetails(comp(), "The node %p has been created for testing if null check is required\n", ifacmpeqNode);
@@ -7378,12 +7355,7 @@ void TR_LoopVersioner::collectAllExpressionsToBeChecked(List<TR::TreeTop> *nullC
             {
             if (performTransformation(comp(), "%s Creating test outside loop for checking if %p is of the correct type\n", OPT_DETAILS_LOOP_VERSIONER, node->getFirstChild()))
                {
-               TR::Node *duplicateCheckedValue = node->getFirstChild()->duplicateTree();
-               if (duplicateCheckedValue->getOpCodeValue() != TR::loadaddr)
-                  {
-                  duplicateCheckedValue->setIsNonNull(false);
-                  duplicateCheckedValue->setIsNull(false);
-                  }
+               TR::Node *duplicateCheckedValue = node->getFirstChild()->duplicateTreeForCodeMotion();
                TR::Node *instanceofNode = TR::Node::createWithSymRef(TR::instanceof, 2, 2, duplicateCheckedValue,  duplicateClassPtr, comp()->getSymRefTab()->findOrCreateInstanceOfSymbolRef(comp()->getMethodSymbol()));
                TR::Node *ificmpeqNode =  TR::Node::createif(TR::ificmpeq, instanceofNode, TR::Node::create(node, TR::iconst, 0, 0), exitGotoBlock->getEntry());
                comparisonTrees->add(ificmpeqNode);
@@ -7397,12 +7369,7 @@ void TR_LoopVersioner::collectAllExpressionsToBeChecked(List<TR::TreeTop> *nullC
 #ifdef J9_PROJECT_SPECIFIC
             if (performTransformation(comp(), "%s Creating test outside loop for checking if %p is of array type\n", OPT_DETAILS_LOOP_VERSIONER, node->getFirstChild()))
                {
-               TR::Node *duplicateCheckedValue = node->getFirstChild()->duplicateTree();
-               if (duplicateCheckedValue->getOpCodeValue() != TR::loadaddr)
-                  {
-                  duplicateCheckedValue->setIsNonNull(false);
-                  duplicateCheckedValue->setIsNull(false);
-                  }
+               TR::Node *duplicateCheckedValue = node->getFirstChild()->duplicateTreeForCodeMotion();
                TR::Node *vftLoad = TR::Node::createWithSymRef(TR::aloadi, 1, 1, duplicateCheckedValue, comp()->getSymRefTab()->findOrCreateVftSymbolRef());
                //TR::Node *componentTypeLoad = TR::Node::create(TR::aloadi, 1, vftLoad, comp()->getSymRefTab()->findOrCreateArrayComponentTypeSymbolRef());
                TR::Node *romClassLoad = TR::Node::createWithSymRef(TR::aloadi, 1, 1, vftLoad, comp()->getSymRefTab()->findOrCreateClassRomPtrSymbolRef());
@@ -7475,13 +7442,13 @@ void TR_LoopVersioner::collectAllExpressionsToBeChecked(List<TR::TreeTop> *nullC
             {
             if (childInRequiredForm->getSecondChild()->getOpCode().isLoadConst() &&
                (childInRequiredForm->getSecondChild()->getInt() == shiftWidth))
-               duplicateIndex = childInRequiredForm->getFirstChild()->duplicateTree();
+               duplicateIndex = childInRequiredForm->getFirstChild()->duplicateTreeForCodeMotion();
             }
          else if (childInRequiredForm->getOpCodeValue() == TR::imul || childInRequiredForm->getOpCodeValue() == TR::lmul)
             {
             if (childInRequiredForm->getSecondChild()->getOpCode().isLoadConst() &&
                (childInRequiredForm->getSecondChild()->getInt() == dataWidth))
-               duplicateIndex = childInRequiredForm->getFirstChild()->duplicateTree();
+               duplicateIndex = childInRequiredForm->getFirstChild()->duplicateTreeForCodeMotion();
             }
          }
 
@@ -7491,35 +7458,35 @@ void TR_LoopVersioner::collectAllExpressionsToBeChecked(List<TR::TreeTop> *nullC
          if (!childInRequiredForm)
             {
             TR::Node *constNode = TR::Node::create(node, type.isInt32() ? TR::iconst : TR::lconst, 0, 0);
-            duplicateIndex = TR::Node::create(type.isInt32() ? TR::isub : TR::lsub, 2, offset->duplicateTree(), constNode);
+            duplicateIndex = TR::Node::create(type.isInt32() ? TR::isub : TR::lsub, 2, offset->duplicateTreeForCodeMotion(), constNode);
             if (type.isInt64())
                constNode->setLongInt((int64_t)headerSize);
             else
                constNode->setInt((int64_t)headerSize);
             }
          else
-            duplicateIndex = childInRequiredForm->duplicateTree();
+            duplicateIndex = childInRequiredForm->duplicateTreeForCodeMotion();
 
 
          duplicateIndex = TR::Node::create(type.isInt32() ? TR::iushr : TR::lushr, 2, duplicateIndex,
                                           TR::Node::create(node, TR::iconst, 0, shiftWidth));
          }
 
-      TR::Node *duplicateBase = node->getFirstChild()->getFirstChild()->duplicateTree();
+      TR::Node *duplicateBase = node->getFirstChild()->getFirstChild()->duplicateTreeForCodeMotion();
       TR::Node *arrayLengthNode = TR::Node::create(TR::arraylength, 1, duplicateBase);
 
       arrayLengthNode->setArrayStride(dataWidth);
       if (type.isInt64())
          arrayLengthNode = TR::Node::create(TR::i2l, 1, arrayLengthNode);
 
-      TR::Node *ificmpgeNode = TR::Node::createif(
-                                                type.isInt32() ? TR::ificmpge : TR::iflcmpge, duplicateIndex, arrayLengthNode, exitGotoBlock->getEntry());
+      TR::Node *ificmpgeNode = TR::Node::createif(type.isInt32() ? TR::ificmpge : TR::iflcmpge, duplicateIndex, arrayLengthNode, exitGotoBlock->getEntry());
       comparisonTrees->add(ificmpgeNode);
       TR::Node *constNode = 0;
       if(type.isInt32())
          constNode = TR::Node::create(arrayLengthNode, TR::iconst , 0, 0);
       else
          constNode = TR::Node::create(arrayLengthNode, TR::lconst, 0, 0);
+      // Note: duplicateIndex was already duplicated for code motion, we don't need to duplicate the duplicate for code motion
       TR::Node *ificmpltNode = TR::Node::createif(type.isInt32() ? TR::ificmplt : TR::iflcmplt, duplicateIndex->duplicateTree(), constNode, exitGotoBlock->getEntry());
       if (type.isInt64())
          ificmpltNode->getSecondChild()->setLongInt(0);
@@ -7572,7 +7539,7 @@ void TR_LoopVersioner::collectAllExpressionsToBeChecked(List<TR::TreeTop> *nullC
    }
 
 
-      TR::Node *duplicateDivisor = node->getSecondChild()->duplicateTree();
+      TR::Node *duplicateDivisor = node->getSecondChild()->duplicateTreeForCodeMotion();
       TR::Node *ifNode;
       if (duplicateDivisor->getType().isInt64())
          ifNode =  TR::Node::createif(TR::iflcmpeq, duplicateDivisor, TR::Node::create(node, TR::lconst, 0, 0), exitGotoBlock->getEntry());
@@ -7594,21 +7561,11 @@ void TR_LoopVersioner::collectAllExpressionsToBeChecked(List<TR::TreeTop> *nullC
             {
             if ((checkCastNode == node) && performTransformation(comp(), "%s Creating test outside loop for checking if %p is casted\n", OPT_DETAILS_LOOP_VERSIONER, node))
                {
-               TR::Node *duplicateClassPtr = node->getSecondChild()->duplicateTree();
-               TR::Node *duplicateCheckedValue = node->getFirstChild()->duplicateTree();
-               if (duplicateCheckedValue->getOpCodeValue() != TR::loadaddr)
-                  {
-                  duplicateCheckedValue->setIsNonNull(false);
-                  duplicateCheckedValue->setIsNull(false);
-                  }
+               TR::Node *duplicateClassPtr = node->getSecondChild()->duplicateTreeForCodeMotion();
+               TR::Node *duplicateCheckedValue = node->getFirstChild()->duplicateTreeForCodeMotion();
                if (node->getOpCodeValue() == TR::checkcastAndNULLCHK)
                   {
-                  TR::Node *duplicateNullCheckReference = node->getFirstChild()->duplicateTree();
-                  if (duplicateNullCheckReference->getOpCodeValue() != TR::loadaddr)
-                     {
-                     duplicateNullCheckReference->setIsNonNull(false);
-                     duplicateNullCheckReference->setIsNull(false);
-                     }
+                  TR::Node *duplicateNullCheckReference = node->getFirstChild()->duplicateTreeForCodeMotion();
                   TR::Node *ifacmpeqNode =  TR::Node::createif(TR::ifacmpeq, duplicateNullCheckReference, TR::Node::aconst(node, 0),  exitGotoBlock->getEntry());
                   comparisonTrees->add(ifacmpeqNode);
                   dumpOptDetails(comp(), "The node %p has been created for testing if null check is required\n", ifacmpeqNode);


### PR DESCRIPTION
Insure that all loop versioning tests that use duplicated nodes from inside the loop do so safely by making sure that the duplicated nodes' flags are cleared, since the flags may no longer be accurate outside the loop.

This is a follow up fix to 72f1d48904936cc352e52516e81ea7bb5353a8e5, which addressed one guard test that was known to be the cause of a downstream bug. This patch addresses all the remaining guard tests, including another test (that checks the induction variable against the loop lower bound) that is causing another bug for downstream.

The tests modified by this patch were identified by looking for

* nodes being duplicated via `duplicateTree()` and
* being consumed directly or indirectly by `if*cmp*` nodes that are
* inserted prior to the loop, and guarded with a `performTransformation()`

and replacing `duplicateTree()` calls with `duplicateTreeForCodeMotion()`. In some cases the duplicated nodes had their flags manually cleared because the author was aware of the need to do so; such code was removed because it is now redundant. The many other calls to `duplicateTree()` were left intact because it was not clear what the intention of the auther was or whether or not node flags should be cleared.