### PR TITLE
Fix optimization manager enabled field

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -198,7 +198,7 @@ int32_t TR_TrivialInliner::perform()
    comp()->generateAccurateNodeCount();
 
    TR::ResolvedMethodSymbol * sym = comp()->getMethodSymbol();
-   if (sym->mayHaveInlineableCall() && !comp()->isDisabled(OMR::inlining))
+   if (sym->mayHaveInlineableCall() && optimizer()->isEnabled(OMR::inlining))
       {
       uint32_t initialSize = comp()->getOptions()->getTrivialInlinerMaxSize();;
       if (comp()->getOption(TR_Randomize) || comp()->getOption(TR_VerbosePseudoRandom))
@@ -245,7 +245,7 @@ TR_InlinerBase::TR_InlinerBase(TR::Optimizer * optimizer, TR::Optimization *opti
    _util = optimizer->getInlinerUtil();
    _policy->setInliner(this);
    _util->setInliner(this);
-   if (comp()->getOptions()->isDisabled(OMR::innerPreexistence))
+   if (!optimizer->isEnabled(OMR::innerPreexistence))
       _disableInnerPrex = true;
 
    setInlineVirtuals(true);
@@ -1058,7 +1058,7 @@ bool
 TR_InlineCall::inlineCall(TR::TreeTop * callNodeTreeTop, TR_OpaqueClassBlock * thisClass, bool recursiveInlining, TR_PrexArgInfo *argInfo, int32_t initialMaxSize)
    {
    TR_InlinerDelimiter delimiter(tracer(),"TR_InlineCall::inlineCall");
-   if (comp()->isDisabled(OMR::inlining))
+   if (!getOptimizer()->isEnabled(OMR::inlining))
       return false;
 
    TR::Node * parent = callNodeTreeTop->getNode();

--- a/compiler/optimizer/LoopReducer.cpp
+++ b/compiler/optimizer/LoopReducer.cpp
@@ -4438,7 +4438,7 @@ TR_LoopReducer::perform()
    // enable only if the new loop reduction framework is
    // disabled
    //
-   if (!comp()->getOptions()->isDisabled(OMR::idiomRecognition))
+   if (optimizer()->isEnabled(OMR::idiomRecognition))
       {
       dumpOptDetails(comp(), "idiom recognition is enabled, skipping loopReducer\n");
       return 0;

--- a/compiler/optimizer/OMROptimizationManager.cpp
+++ b/compiler/optimizer/OMROptimizationManager.cpp
@@ -49,7 +49,7 @@ OMR::OptimizationManager::OptimizationManager(TR::Optimizer *o, OptimizationFact
         _numPassesCompleted(0),
         _optData(NULL),
         _optPolicy(NULL),
-        _enabled(false),
+        _enabled(!o->comp()->isDisabled(optNum)),
         _requested(false),
         _requestedBlocks(o->trMemory()),
         _trace(o->comp()->getOptions()->trace(optNum))

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -925,6 +925,14 @@ OMR::Optimizer::getOptimizationName(OMR::Optimizations opt)
    return ::optimizer_name[opt];
    }
 
+bool
+OMR::Optimizer::isEnabled(OMR::Optimizations i)
+   {
+   if (_opts[i] != NULL)
+      return _opts[i]->enabled();
+   return false;
+   }
+
 TR_Debug *OMR::Optimizer::getDebug()
    {
    return _compilation->getDebug();
@@ -1621,7 +1629,7 @@ int32_t OMR::Optimizer::performOptimization(const OptimizationStrategy *optimiza
       bool needTreeDump = false;
       bool needStructureDump = false;
 
-      if (comp()->getOptions()->isDisabled(optNum))
+      if (!isEnabled(optNum))
          return 0;
 
       TR::SimpleRegex * regex = comp()->getOptions()->getDisabledOpts();

--- a/compiler/optimizer/OMROptimizer.hpp
+++ b/compiler/optimizer/OMROptimizer.hpp
@@ -273,6 +273,8 @@ class Optimizer
       return _opts[i];
       }
 
+   bool isEnabled(OMR::Optimizations i);
+
    enum // RAS
       {
       // Analyses start with "A", but not "A0" because that's "After Optimization"


### PR DESCRIPTION
Initialize optimization manager enabled field based on its related
options flag and start using the manager field to query from then on.

Signed-off-by: Xiaoli Liang <xsliang@ca.ibm.com>