### PR TITLE
Revert x86 arraytranslate register dependencies

### DIFF
--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -4275,12 +4275,13 @@ TR::Register *OMR::X86::TreeEvaluator::arraytranslateEvaluator(TR::Node *node, T
    TR::Register *dummy1 = cg->allocateRegister();
    TR::Register *dummy2 = cg->allocateRegister(TR_FPR);
    TR::Register *dummy3 = cg->allocateRegister(TR_FPR);
+   TR::Register *dummy4 = cg->allocateRegister(TR_FPR);
 
    bool arraytranslateOT = false;
    if  (sourceByte && (node->getChild(3)->getOpCodeValue() == TR::iconst) && (node->getChild(3)->getInt() == 0))
 	arraytranslateOT = true;
 
-   int noOfDependencies = (sourceByte && !arraytranslateOT) ? 7 : 8;
+   int noOfDependencies = (sourceByte && !arraytranslateOT) ? 8 : 9;
 
 
    TR::RegisterDependencyConditions  *dependencies =
@@ -4294,6 +4295,7 @@ TR::Register *OMR::X86::TreeEvaluator::arraytranslateEvaluator(TR::Node *node, T
    dependencies->addPostCondition(dummy1, TR::RealRegister::ebx, cg);
    dependencies->addPostCondition(dummy2, TR::RealRegister::xmm1, cg);
    dependencies->addPostCondition(dummy3, TR::RealRegister::xmm2, cg);
+   dependencies->addPostCondition(dummy4, TR::RealRegister::xmm3, cg);
 
 
    TR_RuntimeHelper helper ;
@@ -4320,6 +4322,7 @@ TR::Register *OMR::X86::TreeEvaluator::arraytranslateEvaluator(TR::Node *node, T
    cg->stopUsingRegister(dummy1);
    cg->stopUsingRegister(dummy2);
    cg->stopUsingRegister(dummy3);
+   cg->stopUsingRegister(dummy4);
 
    for (uint16_t i = 0; i < node->getNumChildren(); i++)
       cg->decReferenceCount(node->getChild(i));

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -4256,10 +4256,10 @@ TR::Register *OMR::X86::TreeEvaluator::arraytranslateEvaluator(TR::Node *node, T
    // arraytranslate
    //    input ptr
    //    output ptr
-   //    translation table (not used)
-   //    terminal character (not used when src is byte and dest is word, otherwise, it's a mask)
+   //    translation table (dummy)
+   //    terminal character (dummy when src is byte and dest is word, otherwise, it's a mask)
    //    input length (in elements)
-   //    stopping char (not used for X)
+   //    stopping char (dummy for X)
    // Number of elements translated is returned
    //
 
@@ -4269,24 +4269,19 @@ TR::Register *OMR::X86::TreeEvaluator::arraytranslateEvaluator(TR::Node *node, T
    TR::Register *srcPtrReg, *dstPtrReg, *transTableReg, *termCharReg, *lengthReg;
    bool stopUsingCopyReg1 = TR::TreeEvaluator::stopUsingCopyRegAddr(node->getChild(0), srcPtrReg, cg);
    bool stopUsingCopyReg2 = TR::TreeEvaluator::stopUsingCopyRegAddr(node->getChild(1), dstPtrReg, cg);
-   bool stopUsingCopyReg4 = false;
-   if (!sourceByte)
-      {
-      stopUsingCopyReg4 = TR::TreeEvaluator::stopUsingCopyRegInteger(node->getChild(3), termCharReg, cg);
-      }
-   
+   bool stopUsingCopyReg4 = TR::TreeEvaluator::stopUsingCopyRegInteger(node->getChild(3), termCharReg, cg);
    bool stopUsingCopyReg5 = TR::TreeEvaluator::stopUsingCopyRegInteger(node->getChild(4), lengthReg, cg);
    TR::Register *resultReg = cg->allocateRegister();
    TR::Register *dummy1 = cg->allocateRegister();
    TR::Register *dummy2 = cg->allocateRegister(TR_FPR);
    TR::Register *dummy3 = cg->allocateRegister(TR_FPR);
-   TR::Register *dummy4 = cg->allocateRegister(TR_FPR);
 
    bool arraytranslateOT = false;
-   if (sourceByte && (node->getChild(3)->getOpCodeValue() == TR::iconst) && (node->getChild(3)->getInt() == 0))
-      arraytranslateOT = true;
+   if  (sourceByte && (node->getChild(3)->getOpCodeValue() == TR::iconst) && (node->getChild(3)->getInt() == 0))
+	arraytranslateOT = true;
 
-   int noOfDependencies = (sourceByte)? 8 : 9;
+   int noOfDependencies = (sourceByte && !arraytranslateOT) ? 7 : 8;
+
 
    TR::RegisterDependencyConditions  *dependencies =
       generateRegisterDependencyConditions((uint8_t)0, noOfDependencies, cg);
@@ -4295,18 +4290,22 @@ TR::Register *OMR::X86::TreeEvaluator::arraytranslateEvaluator(TR::Node *node, T
    dependencies->addPostCondition(lengthReg, TR::RealRegister::ecx, cg);
    dependencies->addPostCondition(resultReg, TR::RealRegister::eax, cg);
 
+
    dependencies->addPostCondition(dummy1, TR::RealRegister::ebx, cg);
    dependencies->addPostCondition(dummy2, TR::RealRegister::xmm1, cg);
    dependencies->addPostCondition(dummy3, TR::RealRegister::xmm2, cg);
-   dependencies->addPostCondition(dummy4, TR::RealRegister::xmm3, cg);
 
 
    TR_RuntimeHelper helper ;
    if (sourceByte)
       {
+      
       TR_ASSERT(!node->isTargetByteArrayTranslate(), "Both source and target are byte for array translate");
       if (arraytranslateOT)
+      {
          helper = TR::Compiler->target.is64Bit() ? TR_AMD64arrayTranslateTROT : TR_IA32arrayTranslateTROT;
+         dependencies->addPostCondition(termCharReg, TR::RealRegister::edx, cg);
+      }
       else
          helper = TR::Compiler->target.is64Bit() ? TR_AMD64arrayTranslateTROTNoBreak : TR_IA32arrayTranslateTROTNoBreak;
       }
@@ -4321,17 +4320,9 @@ TR::Register *OMR::X86::TreeEvaluator::arraytranslateEvaluator(TR::Node *node, T
    cg->stopUsingRegister(dummy1);
    cg->stopUsingRegister(dummy2);
    cg->stopUsingRegister(dummy3);
-   cg->stopUsingRegister(dummy4);
 
-   cg->decReferenceCount(node->getChild(0));               // Input
-   cg->decReferenceCount(node->getChild(1));               // Output
-   cg->recursivelyDecReferenceCount(node->getChild(2));    // Translate table (not used)
-   if (sourceByte)
-      cg->recursivelyDecReferenceCount(node->getChild(3)); // Terminal char (not used)
-   else
-      cg->decReferenceCount(node->getChild(3));            // Terminal char (used)
-   cg->decReferenceCount(node->getChild(4));               // Length
-   cg->recursivelyDecReferenceCount(node->getChild(5));    // Stopping char (not used)
+   for (uint16_t i = 0; i < node->getNumChildren(); i++)
+      cg->decReferenceCount(node->getChild(i));
 
    if (stopUsingCopyReg1)
       cg->getLiveRegisters(TR_GPR)->registerIsDead(srcPtrReg);


### PR DESCRIPTION
Recent changes to the register dependencies for `arraytranslate` on x86 rely on the new helpers. These changes are reverted in order to allow the previous helpers to run again. However, the addition of `xmm3` is retained because it is a necessary fix.