### PR TITLE
Flush verbose GC every-time heap-resize executed

### DIFF
--- a/gc/verbose/VerboseHandlerOutput.cpp
+++ b/gc/verbose/VerboseHandlerOutput.cpp
@@ -866,6 +866,7 @@ MM_VerboseHandlerOutput::outputHeapResizeInfo(MM_EnvironmentBase *env, uintptr_t
 	getTagTemplate(tagTemplate, sizeof(tagTemplate), omrtime_current_time_millis());
 
 	writer->formatAndOutput(env, indent, "<heap-resize id=\"%zu\" type=\"%s\" space=\"%s\" amount=\"%zu\" count=\"%zu\" timems=\"%llu.%03llu\" reason=\"%s\" %s />", id, resizeTypeName, getSubSpaceType(subSpaceType), resizeAmount, resizeCount, timeInMicroSeconds / 1000, timeInMicroSeconds % 1000, reasonString, tagTemplate);
+	writer->flush(env);
 }
 
 void


### PR DESCRIPTION
Previously, heap-resize operation is subtask of gc-cycle. So, it was
not required to flush verbose GC buffer immediately. But, as part of
the EXPLICIT_GC_IDLE_GC, heap-resize type="release free pages" may be
executed outside the gc-cycle. For those cases, the immediate buffer
flush required for the tag appear in the verbose output.

Issue: #1233 

Signed-off-by: Parameswaran Selvam <parselva@in.ibm.com>