### PR TITLE
Aborted CS heap fixup in percolate global

### DIFF
--- a/gc/base/MarkingScheme.cpp
+++ b/gc/base/MarkingScheme.cpp
@@ -279,6 +279,8 @@ MM_MarkingScheme::scanObject(MM_EnvironmentBase *env, omrobjectptr_t objectPtr)
 #else /* OMR_GC_LEAF_BITS */
 		while (NULL != (slotObject = objectScanner->getNextSlot())) {
 #endif /* OMR_GC_LEAF_BITS */
+			fixupForwardedSlot(slotObject);
+
 			inlineMarkObjectNoCheck(env, slotObject->readReferenceFromSlot(), isLeafSlot);
 		}
 	}


### PR DESCRIPTION
Concurrent Scavenger. Abort scenario. 

Fixup of Nursery references used to be done by walking Nursery during
abort handling within Scavenger. It was not safe in general case - for
example if Aborted Scvenger was preceded by sweep. 
Now Nursery fixup is done during marking within Percolate Global GC 
Nursery is made walkable after the sweep (for now in Language specific
code), iterating via Marked Object Iterator.

Fixup of the roots still done inside Scavenger abort handling.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>