### PR TITLE
Disable/Sampling Hook trace for frequent events

### DIFF
--- a/gc/base/omrmmprivate.hdf
+++ b/gc/base/omrmmprivate.hdf
@@ -168,6 +168,7 @@
 			code which has hooked the J9HOOK_MM_WALK_HEAP_START hook, such as
 			GC_VMInterface::initializeExtensions.
 		</description>
+		<trace-sampling intervals="100" />
 		<struct>MM_WalkHeapStartEvent</struct>
 		<data type="struct OMR_VM*" name="omrVM" description="OMR vm instance" />
 	</event>
@@ -181,6 +182,7 @@
 			These actions are actually performed by code which has hooked the
 			J9HOOK_MM_WALK_HEAP_END hook, such as GC_VMInterface::initializeExtensions.
 		</description>
+		<trace-sampling intervals="100" />
 		<struct>MM_WalkHeapEndEvent</struct>
 		<data type="struct OMR_VM*" name="omrVM" description="OMR vm instance" />
 	</event>
@@ -729,6 +731,7 @@
 		<name>J9HOOK_MM_PRIVATE_OLD_TO_OLD_REFERENCE_CREATED</name>
 		<description>Triggered when old to old reference is created by GC (Scavenger) </description>
 		<condition>defined (__cplusplus)</condition>
+		<trace-sampling intervals="100" />
 		<struct>MM_OldToOldReferenceCreatedEvent</struct>
 		<data type="struct OMR_VMThread*" name="currentThread" description="the current thread" />
 		<data type="void *" name="objectPtr" description="pointer to the parent object" />

--- a/tools/hookgen/HookGen.hpp
+++ b/tools/hookgen/HookGen.hpp
@@ -69,7 +69,7 @@ private:
 	RCType startPrivateHeader();
 	RCType completePrivateHeader(const char *structName);
 	void writeEventToPublicHeader(const char *name, const char *description, const char *condition, const char *structName, const char *reverse, pugi::xml_node event);
-	void writeEventToPrivateHeader(const char *name, const char *condition, const char *once, const char *structName, pugi::xml_node event);
+	void writeEventToPrivateHeader(const char *name, const char *condition, const char *once, int sampling, const char *structName, pugi::xml_node event);
 	void writeEvent(pugi::xml_node event);
 
 	static void displayUsage();

--- a/util/hookable/hookable.cpp
+++ b/util/hookable/hookable.cpp
@@ -140,7 +140,6 @@ J9HookInitializeInterface(struct J9HookInterface **hookInterface, OMRPortLibrary
 	commonInterface->threshold4Trace = OMRHOOK_DEFAULT_THRESHOLD_IN_MILLISECONDS_WARNING_CALLBACK_ELAPSED_TIME;
 
 	commonInterface->eventSize = (interfaceSize - sizeof(J9CommonHookInterface)) / (sizeof(U_8) + sizeof(OMREventInfo4Dump) + sizeof(J9HookRecord*));
-
 	return 0;
 }
 
@@ -181,6 +180,9 @@ J9HookDispatch(struct J9HookInterface **hookInterface, uintptr_t taggedEventNum,
 	uintptr_t eventNum = taggedEventNum & J9HOOK_EVENT_NUM_MASK;
 	J9CommonHookInterface *commonInterface = (J9CommonHookInterface *)hookInterface;
 	J9HookRecord *record = HOOK_RECORD(commonInterface, eventNum);
+	OMREventInfo4Dump *eventDump = J9HOOK_DUMPINFO(commonInterface, eventNum);
+	uintptr_t samplingInterval = (taggedEventNum & J9HOOK_TAG_SAMPLING_MASK) >> 16;
+	bool sampling = false;
 
 	if (taggedEventNum & J9HOOK_TAG_ONCE) {
 		uint8_t oldFlags;
@@ -213,39 +215,49 @@ J9HookDispatch(struct J9HookInterface **hookInterface, uintptr_t taggedEventNum,
 			/* now read the id again to make sure that nothing has changed */
 			VM_AtomicSupport::readBarrier();
 			if (record->id == id) {
-				uint64_t timeDelta = 0;
+				uint64_t startTime = 0;
+				uintptr_t count = 0;
+				if (NULL != eventDump) {
+					count = VM_AtomicSupport::add((volatile uintptr_t *)&eventDump->count, 1);
+					sampling = (1 >= samplingInterval) || ((100 >= samplingInterval) && (0 == (count % samplingInterval)));
+				} else {
+					sampling =  false;
+				}
 				OMRPORT_ACCESS_FROM_OMRPORT(commonInterface->portLib);
-				uint64_t startTime = omrtime_current_time_millis();
-				function(hookInterface, eventNum, eventData, userData);
-				timeDelta = omrtime_current_time_millis() - startTime;
-
-				OMREventInfo4Dump *eventDump = J9HOOK_DUMPINFO(commonInterface, eventNum);
-
-				/* record hook info for dump if elapse time is longer than 1 millisecond */
-				if ((NULL != eventDump) && (0 != timeDelta)) {
-					eventDump->lastHook.callsite = record->callsite;
-					eventDump->lastHook.func_ptr = (void *)record->function;
-					eventDump->lastHook.startTime = startTime;
-					eventDump->lastHook.duration = timeDelta;
-					if (eventDump->longestHook.duration < eventDump->lastHook.duration) {
-						eventDump->longestHook.callsite = eventDump->lastHook.callsite;
-						eventDump->longestHook.startTime = eventDump->lastHook.startTime;
-						eventDump->longestHook.func_ptr = eventDump->lastHook.func_ptr;
-						eventDump->longestHook.duration = eventDump->lastHook.duration;
-					}
+				if (sampling) {
+					startTime = omrtime_current_time_millis();
 				}
 
-				if (commonInterface->threshold4Trace <= timeDelta) {
-					const char *callsite = "UNKNOWN";
-					char buffer[32];
-					if (NULL != record->callsite) {
-						callsite = record->callsite;
-					} else {
-						/* if the callsite info can not be retrieved, use callback function pointer instead  */
-						omrstr_printf(buffer, sizeof(buffer), "0x%p", record->function);
-						callsite = buffer;
+				function(hookInterface, eventNum, eventData, userData);
+
+				if (sampling) {
+					uint64_t timeDelta = omrtime_current_time_millis() - startTime;
+
+					eventDump->lastHook.startTime = startTime;
+					eventDump->lastHook.callsite = record->callsite;
+					eventDump->lastHook.func_ptr = (void *)record->function;
+					eventDump->lastHook.duration = timeDelta;
+
+					if ((eventDump->longestHook.duration < timeDelta) ||
+						(0 == eventDump->longestHook.startTime)) {
+							eventDump->longestHook.startTime = startTime;
+							eventDump->longestHook.callsite = record->callsite;
+							eventDump->longestHook.func_ptr = (void *)record->function;
+							eventDump->longestHook.duration = timeDelta;
 					}
-					Trc_Hook_Dispatch_Exceed_Threshold_Event(callsite, timeDelta);
+
+					if (commonInterface->threshold4Trace <= timeDelta) {
+						const char *callsite = "UNKNOWN";
+						char buffer[32];
+						if (NULL != record->callsite) {
+							callsite = record->callsite;
+						} else {
+							/* if the callsite info can not be retrieved, use callback function pointer instead  */
+							omrstr_printf(buffer, sizeof(buffer), "0x%p", record->function);
+							callsite = buffer;
+						}
+						Trc_Hook_Dispatch_Exceed_Threshold_Event(callsite, timeDelta);
+					}
 				}
 			} else {
 				/* this record has been updated while we were reading it. Skip it. */


### PR DESCRIPTION
 - disable/sampling hook tracepoint and hook dump via new tag
<trace-sampling intervals="N" /> in hdf for high-frequency events to
reduce performance impacts of tracking hooks
 - new invocation count in hook dump structure to trace event frequency

Signed-off-by: Lin Hu <linhu@ca.ibm.com>