### PR TITLE
zTPF_OMR_Port_Pull2

### DIFF
--- a/gc/base/NonVirtualMemory.cpp
+++ b/gc/base/NonVirtualMemory.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2015
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -14,6 +14,7 @@
  *
  * Contributors:
  *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *    Multiple authors (IBM Corp.) - z/TPF platform initial port to OMR environment
  *******************************************************************************/
 
 
@@ -49,7 +50,7 @@ MM_NonVirtualMemory::newInstance(MM_EnvironmentBase* env, uintptr_t heapAlignmen
 	return vmem;
 }
 
-#if (defined(AIXPPC) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064)
+#if (defined(AIXPPC) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF)
 /**
  * Allocate a chunk of memory.
  * @param size The number of bytes to allocate.
@@ -110,4 +111,4 @@ MM_NonVirtualMemory::setNumaAffinity(uintptr_t numaNode, void* address, uintptr_
 	return true;
 }
 
-#endif /* (defined(AIXPPC) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) */
+#endif /* (defined(AIXPPC) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF) */

--- a/gc/base/NonVirtualMemory.hpp
+++ b/gc/base/NonVirtualMemory.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2016
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -14,6 +14,7 @@
  *
  * Contributors:
  *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *    Multiple authors (IBM Corp.) - z/TPF platform initial port to OMR environment
  *******************************************************************************/
 
 
@@ -60,16 +61,16 @@ protected:
 	{
 		_typeId = __FUNCTION__;
 	};
-#if (defined(AIXPPC) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064)
+#if (defined(AIXPPC) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF)
 	virtual void tearDown(MM_EnvironmentBase* env);
 	virtual void* reserveMemory(J9PortVmemParams* params);
-#endif /* (defined(AIXPPC) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) */
+#endif /* (defined(AIXPPC) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF) */
 public:
-#if (defined(AIXPPC) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064)
+#if (defined(AIXPPC) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF)
 	virtual bool commitMemory(void* address, uintptr_t size);
 	virtual bool decommitMemory(void* address, uintptr_t size, void* lowValidAddress, void* highValidAddress);
 	virtual bool setNumaAffinity(uintptr_t numaNode, void* address, uintptr_t byteAmount);
-#endif /* (defined(AIXPPC) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) */
+#endif /* (defined(AIXPPC) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF) */
 
 public:
 /*

--- a/include_core/omrcomp.h
+++ b/include_core/omrcomp.h
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2016
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -14,6 +14,7 @@
  *
  * Contributors:
  *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *    Multiple authors (IBM Corp.) - z/TPF platform initial port to OMR environment
  *******************************************************************************/
 
 #ifndef OMRCOMP_H
@@ -58,7 +59,7 @@ typedef int8_t					I_8;
 
 #if defined(MVS)
 typedef int32_t					BOOLEAN;
-#elif defined(LINUX) || defined(RS6000) || defined(J9ZOS390) || defined(OSX) /* MVS */
+#elif defined(LINUX) || defined(RS6000) || defined(J9ZOS390) || defined(OSX) || defined(OMRZTPF) /* MVS */
 typedef uint32_t					BOOLEAN;
 #else /* MVS */
 /* Don't typedef BOOLEAN since it's already defined on Windows */
@@ -108,7 +109,7 @@ EXE_EXTENSION_CHAR: the executable has a delimiter that we want to stop at as pa
 
 /* NOTE: Linux supports different processors -- do not assume 386 */
 
-#if defined(J9HAMMER) || defined(S39064) || defined(LINUXPPC64)
+#if defined(J9HAMMER) || defined(S39064) || defined(LINUXPPC64) || defined(OMRZTPF)
 
 /* LinuxPPC64 is like AIX64 so we need direct function pointers */
 #if defined(LINUXPPC64)
@@ -122,7 +123,7 @@ extern uintptr_t getTOC();
 #define TOC_STORE_TOC(dest,wrappedPointer) (dest = (((uintptr_t*)(wrappedPointer))[1]))
 #endif /* OMR_ENV_LITTLE_ENDIAN */
 #endif /* LINUXPPC64 */
-#endif /* J9HAMMER || S39064 || LINUXPPC64 */
+#endif /* J9HAMMER || S39064 || LINUXPPC64 || OMRZTPF */
 
 typedef double SYS_FLOAT;
 

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2016
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -14,6 +14,7 @@
  *
  * Contributors:
  *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *    Multiple authors (IBM Corp.) - z/TPF platform initial port to OMR environment
  *******************************************************************************/
 
 #if !defined(OMRPORT_H_)
@@ -197,12 +198,12 @@
  * Flags used to describe type of the page for the virtual memory
  * @{
  */
-#define OMRPORT_VMEM_PAGE_FLAG_NOT_USED 		0x1
-#define OMRPORT_VMEM_PAGE_FLAG_FIXED 		0x2
-#define OMRPORT_VMEM_PAGE_FLAG_PAGEABLE 		0x4
-#define OMRPORT_VMEM_PAGE_FLAG_SUPERPAGE_ANY	0x8
+#define OMRPORT_VMEM_PAGE_FLAG_NOT_USED 0x1
+#define OMRPORT_VMEM_PAGE_FLAG_FIXED 0x2
+#define OMRPORT_VMEM_PAGE_FLAG_PAGEABLE 0x4
+#define OMRPORT_VMEM_PAGE_FLAG_SUPERPAGE_ANY 0x8
 
-#define OMRPORT_VMEM_PAGE_FLAG_TYPE_MASK 		0xF
+#define OMRPORT_VMEM_PAGE_FLAG_TYPE_MASK 0xF
 /** @} */
 
 /**
@@ -231,7 +232,7 @@
 #define OMRPORT_TIME_DELTA_IN_NANOSECONDS ((uint64_t) 1000000000)
 /** @} */
 
-#if defined(LINUX)
+#if defined(LINUX) && !defined(OMRZTPF)
 #define OMR_CONFIGURABLE_SUSPEND_SIGNAL
 #endif /* defined(LINUX) */
 
@@ -366,6 +367,7 @@ typedef enum J9VMemMemoryQuery {
 #define OMRPORT_VMEM_STRICT_PAGE_SIZE	8
 #define OMRPORT_VMEM_ZOS_USE2TO32G_AREA 16
 #define OMRPORT_VMEM_ALLOC_QUICK 		32
+#define OMRPORT_VMEM_ZTPF_USE_31BIT_MALLOC 64
 
 /**
  * @name Virtual Memory Address
@@ -597,7 +599,11 @@ typedef struct J9ProcessorInfos {
 #define OMRPORT_SL_UNKNOWN 4					/* Unknown Shared Library related error. */
 
 #define OMRPORT_SLOPEN_DECORATE  1 			/* Note this value must remain 1, in order for legacy callers using TRUE and FALSE to control decoration */
+#if !defined(OMRZTPF)
 #define OMRPORT_SLOPEN_LAZY  2
+#else /* !defined(OMRZTPF) */
+#define J9PORT_SLOPEN_LAZY  0
+#endif /* defined(OMRZTPF) */
 #define OMRPORT_SLOPEN_NO_LOOKUP_MSG_FOR_NOT_FOUND  4
 #define OMRPORT_SLOPEN_OPEN_EXECUTABLE 8     /* Can be ORed without affecting existing flags. */
 

--- a/port/unix/omrfile.c
+++ b/port/unix/omrfile.c
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2016
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -14,6 +14,7 @@
  *
  * Contributors:
  *    Multiple authors (IBM Corp.) - initial API and implementation and/or initial documentation
+ *    Multiple authors (IBM Corp.) - z/TPF platform initial port to OMR environment
  *******************************************************************************/
 
 /**
@@ -27,13 +28,15 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/types.h>
-#if defined(LINUX)
+#if defined(LINUX) && !defined(OMRZTPF)
 #include <sys/vfs.h>
 #elif defined(OSX)
 #include <sys/param.h>
 #include <sys/mount.h>
-#endif /*  defined(LINUX) */
+#endif /*  defined(LINUX)  && !defined(OMRZTPF) */
+#if !defined(OMRZTPF)
 #include <sys/statvfs.h>
+#endif /* !defined(OMRZTPF) */
 #include <dirent.h>
 #include <fcntl.h>
 #include <time.h>
@@ -67,11 +70,11 @@ static const char *const fileFStatVFSErrorMsgPrefix = "fstatvfs : ";
 static int32_t EsTranslateOpenFlags(int32_t flags);
 static void setPortableError(OMRPortLibrary *portLibrary, const char *funcName, int32_t portlibErrno, int systemErrno);
 static int32_t findError(int32_t errorCode);
-#if defined(LINUX) || defined(OSX) || defined(AIXPPC) && !defined(J9OS_I5)
+#if (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || (defined(AIXPPC) && !defined(J9OS_I5))
 static void updateJ9FileStat(struct OMRPortLibrary *portLibrary, J9FileStat *j9statBuf, struct stat *statBuf, PlatformStatfs *statfsBuf);
-#else /* defined(LINUX) || defined(OSX) || defined(AIXPPC) && !defined(J9OS_I5) */
+#else /* (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || (defined(AIXPPC) && !defined(J9OS_I5)) */
 static void updateJ9FileStat(struct OMRPortLibrary *portLibrary, J9FileStat *j9statBuf, struct stat *statBuf);
-#endif /* defined(LINUX) || defined(OSX) || defined(AIXPPC) && !defined(J9OS_I5) */
+#endif /* (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || (defined(AIXPPC) && !defined(J9OS_I5)) */
 
 static int32_t
 EsTranslateOpenFlags(int32_t flags)
@@ -206,13 +209,13 @@ findError(int32_t errorCode)
  *
  * @return void
  */
-#if defined(LINUX) || defined(OSX) || defined(AIXPPC) && !defined(J9OS_I5)
+#if (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || (defined(AIXPPC) && !defined(J9OS_I5))
 static void
 updateJ9FileStat(struct OMRPortLibrary *portLibrary, J9FileStat *j9statBuf, struct stat *statBuf, PlatformStatfs *statfsBuf)
-#else /* defined(LINUX) || defined(OSX) || defined(AIXPPC) && !defined(J9OS_I5) */
+#else /* (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || (defined(AIXPPC) && !defined(J9OS_I5)) */
 static void
 updateJ9FileStat(struct OMRPortLibrary *portLibrary, J9FileStat *j9statBuf, struct stat *statBuf)
-#endif /* defined(LINUX) || defined(OSX) || defined(AIXPPC) && !defined(J9OS_I5) */
+#endif /* (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || (defined(AIXPPC) && !defined(J9OS_I5)) */
 {
 	if (S_ISDIR(statBuf->st_mode)) {
 		j9statBuf->isDir = 1;
@@ -242,7 +245,7 @@ updateJ9FileStat(struct OMRPortLibrary *portLibrary, J9FileStat *j9statBuf, stru
 	j9statBuf->ownerUid = statBuf->st_uid;
 	j9statBuf->ownerGid = statBuf->st_gid;
 
-#if defined(LINUX) || defined(OSX)
+#if (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX)
 	if (NULL != statfsBuf) {
 		switch (statfsBuf->f_type) {
 		/* Detect remote filesystem types */
@@ -783,7 +786,11 @@ omrfile_mkdir(struct OMRPortLibrary *portLibrary, const char *path)
 int32_t
 omrfile_move(struct OMRPortLibrary *portLibrary, const char *pathExist, const char *pathNew)
 {
+#ifndef OMRZTPF
 	return rename(pathExist, pathNew);
+#else
+	return rename(pathExist, (char *)pathNew);
+#endif
 }
 
 int32_t
@@ -793,8 +800,11 @@ omrfile_unlinkdir(struct OMRPortLibrary *portLibrary, const char *path)
 
 	/* QNX has modified the API for remove and rmdir.*/
 	/* Remove does not call rmdir automagically like every other Unix.*/
-
+#ifndef OMRZTPF
 	return remove(path);
+#else
+	return rmdir(path);
+#endif
 }
 
 
@@ -1133,9 +1143,9 @@ int32_t
 omrfile_fstat(struct OMRPortLibrary *portLibrary, intptr_t fd, struct J9FileStat *buf)
 {
 	struct stat statbuf;
-#if defined(LINUX) || defined(AIXPPC) || defined(OSX)
+#if (!defined(OMRZTPF) && defined(LINUX)) || defined(AIXPPC) || defined(OSX)
 	PlatformStatfs statfsbuf;
-#endif /* defined(LINUX) || defined(AIXPPC) || defined(OSX) */
+#endif /* (!defined(OMRZTPF) && defined(LINUX)) || defined(AIXPPC) || defined(OSX) */
 	int32_t rc = 0;
 	int localfd = (int)fd;
 
@@ -1153,7 +1163,7 @@ omrfile_fstat(struct OMRPortLibrary *portLibrary, intptr_t fd, struct J9FileStat
 		goto _end;
 	}
 
-#if defined(LINUX) || defined(OSX)
+#if (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX)
 	if (0 != fstatfs(localfd - FD_BIAS, &statfsbuf)) {
 		intptr_t myerror = errno;
 		Trc_PRT_file_fstat_fstatfsFailed(myerror);
@@ -1185,7 +1195,7 @@ int32_t
 omrfile_stat(struct OMRPortLibrary *portLibrary, const char *path, uint32_t flags, struct J9FileStat *buf)
 {
 	struct stat statbuf;
-#if defined(LINUX) || defined(AIXPPC) || defined(OSX)
+#if (defined(LINUX) && !defined(OMRZTPF)) || defined(AIXPPC) || defined(OSX)
 	PlatformStatfs statfsbuf;
 #endif /* defined(LINUX) || defined(AIXPPC) || defined(OSX) */
 
@@ -1196,7 +1206,7 @@ omrfile_stat(struct OMRPortLibrary *portLibrary, const char *path, uint32_t flag
 		return portLibrary->error_set_last_error(portLibrary, errno, findError(errno));
 	}
 
-#if defined(LINUX) || defined(OSX)
+#if (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX)
 	if (statfs(path, &statfsbuf)) {
 		return portLibrary->error_set_last_error(portLibrary, errno, findError(errno));
 	}
@@ -1217,6 +1227,7 @@ omrfile_stat(struct OMRPortLibrary *portLibrary, const char *path, uint32_t flag
 int32_t
 omrfile_stat_filesystem(struct OMRPortLibrary *portLibrary, const char *path, uint32_t flags, struct J9FileStatFilesystem *buf)
 {
+#ifndef OMRZTPF
 	struct statvfs statvfsbuf;
 
 	if (statvfs(path, &statvfsbuf)) {
@@ -1233,6 +1244,9 @@ omrfile_stat_filesystem(struct OMRPortLibrary *portLibrary, const char *path, ui
 	}
 
 	return 0;
+#else
+    return -4;
+#endif
 }
 
 intptr_t

--- a/port/unix/omrmem.c
+++ b/port/unix/omrmem.c
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2016
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -14,6 +14,7 @@
  *
  * Contributors:
  *    Multiple authors (IBM Corp.) - initial API and implementation and/or initial documentation
+ *    Multiple authors (IBM Corp.) - z/TPF platform initial port to OMR environment
  *******************************************************************************/
 
 /**
@@ -72,6 +73,8 @@ omrmem_allocate_memory_basic(struct OMRPortLibrary *portLibrary, uintptr_t byteA
 	retval = malloc(byteAmount);
 	Assert_AddressAbove4GBBar((NULL == retval) || (0x100000000 <= ((uintptr_t)retval)));
 	return retval;
+#elif defined(OMRZTPF)
+    return malloc64(byteAmount);
 #else
 	return malloc(byteAmount);
 #endif
@@ -125,7 +128,7 @@ omrmem_advise_and_free_memory_basic(struct OMRPortLibrary *portLibrary, void *me
 
 			Trc_PRT_mem_advise_and_free_memory_basic_oscall(memPtrPageRounded, memPtrSizePageRounded);
 
-#if defined(LINUX) || defined(OSX)
+#if (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX)
 			if (-1 == madvise((void *)memPtrPageRounded, memPtrSizePageRounded, MADV_DONTNEED)) {
 				Trc_PRT_mem_advise_and_free_memory_basic_madvise_failed((void *)memPtrPageRounded, memPtrSizePageRounded, errno);
 			}
@@ -160,6 +163,8 @@ omrmem_reallocate_memory_basic(struct OMRPortLibrary *portLibrary, void *memoryP
 {
 #if (defined(S390) || defined(J9ZOS390)) && !defined(OMR_ENV_DATA64)
 	return (void *)(((uintptr_t) realloc(memoryPointer, byteAmount)) & 0x7FFFFFFF);
+#elif defined(OMRZTPF)
+    return realloc64(memoryPointer, byteAmount);
 #else
 	return realloc(memoryPointer, byteAmount);
 #endif

--- a/port/unix/omrsl.c
+++ b/port/unix/omrsl.c
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2016
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -14,6 +14,7 @@
  *
  * Contributors:
  *    Multiple authors (IBM Corp.) - initial API and implementation and/or initial documentation
+ *    Multiple authors (IBM Corp.) - z/TPF platform initial port to OMR environment
  *******************************************************************************/
 
 /**
@@ -22,13 +23,13 @@
  * @brief shared library
  */
 
-#if defined(LINUX)
+#if defined(LINUX) && !defined(OMRZTPF)
 
 /* defining _GNU_SOURCE allows the use of dladdr() in dlfcn.h */
 #define _GNU_SOURCE
 #elif defined(OSX)
 #define _XOPEN_SOURCE
-#endif /* defined(LINUX) */
+#endif /* defined(LINUX)  && !defined(OMRZTPF) */
 
 /*
  *	Standard unix shared libraries

--- a/port/unix_include/omriconvhelpers.h
+++ b/port/unix_include/omriconvhelpers.h
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2016
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -14,6 +14,7 @@
  *
  * Contributors:
  *    Multiple authors (IBM Corp.) - initial API and implementation and/or initial documentation
+ *    Multiple authors (IBM Corp.) - z/TPF platform initial port to OMR environment
  *******************************************************************************/
 
 #ifndef omriconvhelpers_h_
@@ -25,7 +26,7 @@
 
 /* __STDC_ISO_10646__ indicates that the platform wchar_t encoding is Unicode */
 /* but older versions of libc fail to set the flag, even though they are Unicode */
-#if !defined(__STDC_ISO_10646__) && !defined(LINUX) && !defined(OSX)
+#if (!defined(__STDC_ISO_10646__) && !defined(LINUX) && !defined(OSX)) || defined(OMRZTPF)
 #define J9VM_USE_ICONV
 #endif /* !defined(__STDC_ISO_10646__) && !defined(LINUX) && !defined(OSX) */
 

--- a/port/ztpf/omrgetstfle.s
+++ b/port/ztpf/omrgetstfle.s
@@ -1,0 +1,41 @@
+###############################################################################
+#
+# (c) Copyright IBM Corp. 2013, 2017
+#
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License v1.0 and
+#  Apache License v2.0 which accompanies this distribution.
+#
+#      The Eclipse Public License is available at
+#      http://www.eclipse.org/legal/epl-v10.html
+#
+#      The Apache License v2.0 is available at
+#      http://www.opensource.org/licenses/apache2.0.php
+#
+# Contributors:
+#    Multiple authors (IBM Corp.) - initial API and implementation and/or initial documentation
+#    Multiple authors (IBM Corp.) - z/TPF platform initial port to OMR environment
+###############################################################################
+
+# This is a zLinux helper that stores the STFLE bits
+# into the passed memory reference.
+#
+# The helper returns the number of valid double-words in the STFLE
+# bits, minus 1.
+#
+# The stfle instruction is encoded as 0xb2b00000 in binary, leaving
+# it in as such so that we can compile on any platform.
+
+.file "j9getstfle.s"
+
+.text
+    .align  8
+.globl getstfle
+    .type   getstfle,@function
+getstfle:
+.text
+
+  lr   %r0,%r2
+.long 0xb2b03000
+  lr   %r2,%r0
+  br  %r14

--- a/port/ztpf/omrintrospect.c
+++ b/port/ztpf/omrintrospect.c
@@ -1,0 +1,1440 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 1991, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial API and implementation and/or initial documentation
+ *    Multiple authors (IBM Corp.) - z/TPF platform initial port to OMR environment
+ *******************************************************************************/
+
+/**
+ * @file
+ * @ingroup Port
+ * @brief process introspection support
+ */
+#include <pthread.h>
+#define J9ZTPF_introspect
+#include <sys/ucontext.h>
+#undef	J9ZTPF_introspect
+#include <sched.h>
+#include <string.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <errno.h>
+#include <stdio.h>
+#include <poll.h>
+#include <time.h>
+#include <fcntl.h>
+
+#include <dirent.h>
+#define __USE_GNU 1
+#include <dlfcn.h>
+#include <sys/utsname.h>
+
+#include <tpf/tpfapi.h>
+#include <tpf/c_thgl.h>
+#include <tpf/c_cinfc.h>
+#include "j9ztpf_time.h"
+#include "j9ztpf_kernel.h"
+
+/* z/TPF doesn't have a fdatasync(), it takes   */
+/*    one argument and returns void. Nullify it.*/
+#define fdatasync(x)    {}
+#include "omrport.h"
+#include "portpriv.h"
+#include "omrportpg.h"
+#include "omrsignal_context.h"
+#include "omrintrospect.h"
+#include "util_core_api.h"
+#include "ut_omrprt.h"
+
+extern void loadfpc();
+
+/*
+ * This is the signal that we use to suspend the various threads. This signal must be not be collapsable and
+ * must pass on values specified by sigqueue.
+ */
+
+#define SUSPEND_SIG SIGUSR1
+
+/*
+ * Internal semaphore retry timeouts. Some implementations of poll seem unreliable so we add a
+ * timeout to poll calls whether or not we have a deadline so we have a sample based scheduler visible
+ * spinlock.
+ */
+#define POLL_RETRY_INTERVAL -1
+
+typedef struct {
+	int descriptor_pair[2];
+	volatile uintptr_t in_count;
+	volatile uintptr_t out_count;
+	uintptr_t initial_value;
+	uintptr_t spinlock;
+	volatile uintptr_t released;
+} barrier_r;
+
+typedef struct {
+	int descriptor_pair[2];
+	volatile uintptr_t sem_value;
+	volatile uintptr_t initial_value;
+	uintptr_t spinlock;
+} sem_t_r;
+
+/*
+ * This structure contains platform specific information necessary to iterate over the threads
+ */
+struct PlatformWalkData {
+	/* thread to filter out of the platform iterator */
+	uintptr_t filterThread;
+	/* controller thread */
+	uintptr_t controllerThread;
+	/* volatile error flag for upcall handlers, shared across threads, non-zero means error */
+	volatile unsigned char error;
+	/* is the state currently consistent. False inside startDo/nextDo, must be true otherwise */
+	volatile unsigned char consistent;
+	/* old signal handler for the suspend signal */
+	struct sigaction oldHandler;
+	/* old mask */
+	sigset_t old_mask;
+	/* backpointer to encapsulating state */
+	J9ThreadWalkState *state;
+	/* total number of threads in the process, including calling thread */
+	long threadCount;
+	/* suspended threads unharvested */
+	int threadsOutstanding;
+	/* thread we're constructing */
+	J9PlatformThread *thread;
+	/* platform allocated context, or program allocated context */
+	unsigned char platformAllocatedContext;
+	/* records whether we need to clean up in resume */
+	unsigned char cleanupRequired;
+	/* the semaphore all suspended threads wait on */
+	sem_t_r client_sem;
+	/* the semaphore the controller thread waits on */
+	sem_t_r controller_sem;
+	/* barrier to prevent any threads exiting the introspect logic until all are ready */
+	barrier_r release_barrier;
+};
+
+/* Wrapper for the close function that retries on EINTR. */
+static int
+close_wrapper(int fd)
+{
+	int rc = 0;
+	if (fd != -1) {
+		do {
+			rc = close(fd);
+		} while ((0 != rc) && (EINTR == errno));
+	}
+
+	return rc;
+}
+
+/*
+ * This function constructs a barrier for use within signal handler contexts. It's a combination o
+ * spinlock techniques modified with blocking read/write/poll scheduler visible calls to avoid
+ * thread contention.
+ *
+ * @param barrier the barrier structure to initialize
+ * @param value the number of entrants to expect
+ *
+ * @return 0 on success, -1 otherwise
+ */
+static int
+barrier_init_r(barrier_r *barrier, int value)
+{
+	uintptr_t old_value;
+	memset(barrier, 0, sizeof(barrier_r));
+
+	if (pipe(barrier->descriptor_pair) != 0) {
+		return -1;
+	}
+
+	do {
+		old_value = barrier->initial_value;
+	} while (compareAndSwapuintptr_t((uintptr_t*)&barrier->initial_value, old_value, value, &barrier->spinlock) != old_value);
+	do {
+		old_value = barrier->in_count;
+	} while (compareAndSwapuintptr_t((uintptr_t*)&barrier->in_count, old_value, value, &barrier->spinlock) != old_value);
+	do {
+		old_value = barrier->released;
+	} while (compareAndSwapuintptr_t((uintptr_t*)&barrier->released, old_value, 0, &barrier->spinlock) != old_value);
+
+	return 0;
+}
+
+/*
+ * This function is a utility function used by the blocking barrier functions to wait in a polite, scheduler
+ * visible fashion until either prompted or the deadline has expired.
+ *
+ * @param barrier the barrier we're operating on
+ * @param deadline the system time in seconds after which we should return regardless of prompting
+ *
+ * @return 0 if cleanly prompted, -1 if timed out, other values are various errors
+ */
+static int
+barrier_block_until_poked(barrier_r *barrier, uintptr_t deadline)
+{
+	int ret = 0;
+	struct pollfd fds[1];
+	int interval = POLL_RETRY_INTERVAL;
+	struct timespec spec;
+
+	fds[0].fd = barrier->descriptor_pair[0];
+	fds[0].events = POLLHUP|POLLERR|POLLNVAL|POLLIN;
+	fds[0].revents = 0;
+
+	if (deadline == 0) {
+		/* block indefinitely */
+		interval = POLL_RETRY_INTERVAL;
+	} else {
+		/* calculate the interval */
+		if (clock_gettime(CLOCK_REALTIME, &spec) == -1) {
+			interval = 0;
+		} else {
+			interval = (deadline - spec.tv_sec) * 1000;
+
+			/* ensure that the poll timeout is set to the lesser of the retry interval or the deadline */
+			if (interval < 0) {
+				/* deadline has expired so run through once then bail at the end */
+				interval = 0;
+			} else if (interval > POLL_RETRY_INTERVAL && POLL_RETRY_INTERVAL != -1) {
+				interval = POLL_RETRY_INTERVAL;
+			}
+		}
+	}
+
+	/* wait for something to change */
+	ret = poll(fds, 1, interval);
+	if ((ret == -1 && errno != EINTR) || fds[0].revents & (POLLHUP|POLLERR|POLLNVAL)) {
+		return -2;
+	}
+
+	if (deadline != 0) {
+		/* check if we've timed out. Do this last as the other possibilities for return are of more interest */
+		if (clock_gettime(CLOCK_REALTIME, &spec) == -1) {
+			return -3;
+		}
+
+		if (spec.tv_sec >= deadline) {
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+/*
+ * This function is called by the conductor of the barrier. It will block until all entrants have entered
+ * the barrier via barrier_enter_r. If a maximum amount of time to block for is specified then this will
+ * time out once that deadline has expired.
+ *
+ * @param barrier the barrier to release
+ * @param seconds the maximum number of second for which to block. Indefinitely if 0 is specified.
+ *
+ * @return 0 on clean release, other values are various errors
+ */
+static int
+barrier_release_r(barrier_r *barrier, uintptr_t seconds)
+{
+	char byte = 0;
+	int result = 0;
+
+	int deadline = 0;
+	struct timespec spec;
+
+	if (clock_gettime(CLOCK_REALTIME, &spec) == -1) {
+		seconds = 0;
+	} else {
+		deadline = spec.tv_sec + seconds;
+	}
+
+	if ((compareAndSwapuintptr_t((uintptr_t*)&barrier->released, 0, 1, &barrier->spinlock)) != 0) {
+		/* barrier->released should have been 0, write something into the pipe so that poll doesn't block,
+		 * converts this to a busy wait
+		 */
+		barrier->released = 1;
+		write(barrier->descriptor_pair[1], &byte, 1);
+	}
+
+	/* wait until all entrants have arrived */
+	while ((compareAndSwapuintptr_t((uintptr_t*)&barrier->in_count, -1, -1, &barrier->spinlock)) > 0) {
+		if ((result = barrier_block_until_poked(barrier, deadline)) == -1) {
+			/* timeout or error */
+			break;
+		}
+	}
+
+	write(barrier->descriptor_pair[1], &byte, 1);
+	fdatasync(barrier->descriptor_pair[1]);
+	return result;
+}
+
+/*
+ * This function is called by entrants to the barrier. It will block until all expected entrants have called this
+ * function and barrier_release_r has been called, or the deadline has expired.
+ *
+ * @param barrier the barrier to enter
+ * @param deadline the system time in seconds after which we should unblock
+ *
+ * @return 0 on clean release, other values indicate errors
+ */
+static int
+barrier_enter_r(barrier_r *barrier, uintptr_t deadline)
+{
+	uintptr_t old_value = 0;
+	char byte = 1;
+	int result = 0;
+
+	/* decrement the wait count */
+	do {
+		old_value = barrier->in_count;
+	} while (compareAndSwapuintptr_t((uintptr_t*)&barrier->in_count, old_value, old_value - 1, &barrier->spinlock) != old_value);
+
+	if (old_value == 1 && (compareAndSwapuintptr_t((uintptr_t*)&barrier->released, 0, 0, &barrier->spinlock))) {
+		/* we're the last through the barrier so wake everyone up */
+		write(barrier->descriptor_pair[1], &byte, 1);
+	}
+
+	/* if we're entering a barrier with a negative count then count us out but we don't need to do anything */
+
+	/* wait until we are formally released */
+	while (compareAndSwapuintptr_t((uintptr_t*)&barrier->in_count, -1, -1, &barrier->spinlock) > 0 || !barrier->released) {
+		if ((result = barrier_block_until_poked(barrier, deadline)) < 0) {
+			/* timeout or error */
+			break;
+		}
+	}
+
+	/* increment the out count */
+	do {
+		old_value = barrier->out_count;
+	} while (compareAndSwapuintptr_t((uintptr_t*)&barrier->out_count, old_value, old_value + 1, &barrier->spinlock) != old_value);
+	return result;
+}
+
+/*
+ * This function updates the expected number of clients the barrier is waiting for. If all clients have already entered the barrier
+ * the the update will fail.
+ *
+ * @param barrier the barrier to update
+ * @param new_value the new number of entrants expected
+ *
+ * @return 0 on success, -1 on failure
+ */
+static int
+barrier_update_r(barrier_r *barrier, int new_value)
+{
+	/* we're altering the expected number of entries into the barrier */
+	uintptr_t old_value;
+	int difference = new_value - barrier->initial_value;
+
+	if (difference == 0) {
+		return 0;
+	}
+
+	do {
+		old_value = barrier->in_count;
+	} while (compareAndSwapuintptr_t((uintptr_t*)&barrier->in_count, old_value, old_value + difference, &barrier->spinlock) != old_value);
+
+	if (old_value < 0 || (old_value == 0 && barrier->initial_value != 0)) {
+		int restore_value = old_value;
+
+		/* barrier was already exited, so undo update and return error */
+		do {
+			old_value = barrier->in_count;
+		} while (compareAndSwapuintptr_t((uintptr_t*)&barrier->in_count, old_value, restore_value, &barrier->spinlock) != old_value);
+
+		return -1;
+	} else {
+		/* we've updated the in_count so update the initial_value */
+		do {
+			old_value = barrier->initial_value;
+		} while (compareAndSwapuintptr_t((uintptr_t*)&barrier->initial_value, old_value, new_value, &barrier->spinlock) != old_value);
+
+		/* don't need to notify anyone if updated_value is <= 0 as release will do it when called */
+
+		return 0;
+	}
+}
+
+/*
+ * This function destroys a barrier created by barrier_init_r. It first wakes up any waiters then waits for them
+ * to exit the barrier before returning if requested.
+ *
+ * @param barrier the barrier to destroy
+ * @int block if non-zero the barrier will block until waiters have exited
+ */
+static void
+barrier_destroy_r(barrier_r *barrier, int block)
+{
+	int current = 0;
+	int in = 0;
+	char byte = 1;
+
+	/* clean up and wait for all waiters to exit */
+	write(barrier->descriptor_pair[1], &byte, 1);
+	close_wrapper(barrier->descriptor_pair[1]);
+	close_wrapper(barrier->descriptor_pair[0]);
+
+	/* decrement the wait count */
+	if (block) {
+		do {
+			current = compareAndSwapuintptr_t((uintptr_t*)&barrier->out_count, -1, -1, &barrier->spinlock);
+			in = compareAndSwapuintptr_t((uintptr_t*)&barrier->in_count, -1, -1, &barrier->spinlock);
+		} while (current + in < barrier->initial_value);
+	}
+}
+
+/*
+ * Constructs a semaphore for use within signal handlers. The semaphore uses a combination of
+ * spinlock techniques to acquire the lock and blocking read/write/poll calls to prevent massive
+ * contention between threads.
+ *
+ * @param sem the semaphore to acquire
+ * @param value the initial count for the semaphore
+ *
+ * @return 0 on success, -1 otherwise
+ */
+static int
+sem_init_r(sem_t_r *sem, int value)
+{
+	if (pipe(sem->descriptor_pair) != 0) {
+		return -1;
+	}
+
+	sem->initial_value = value;
+	sem->sem_value = value;
+	sem->spinlock = 0;
+
+	return 0;
+}
+
+/*
+ * This function attempts to acquire the semaphore. It will block for, at most, the number of
+ * seconds specified.
+ *
+ * @param sem the semaphore to acquire
+ * @param seconds the maximum number of seconds the block for. Indefinitely if 0 is specified.
+ *
+ * @return 0 if semaphore is acquire, < 0 on error, -1 means timeout occured
+ */
+static int
+sem_timedwait_r(sem_t_r *sem, uintptr_t seconds)
+{
+	uintptr_t old_value = -1;
+	char byte = 0;
+	int ret = -1;
+	struct pollfd fds[1];
+	struct timespec spec;
+	int deadline = 0;
+	int interval = seconds;
+	fds[0].fd = sem->descriptor_pair[0];
+	fds[0].events = POLLHUP|POLLERR|POLLNVAL|POLLIN;
+	fds[0].revents = 0;
+
+	if (seconds == 0) {
+		/* block indefinitely */
+		interval = POLL_RETRY_INTERVAL;
+	} else {
+		/* calculate the deadline */
+		if (clock_gettime(CLOCK_REALTIME, &spec) == -1) {
+			interval = 0;
+		} else {
+			deadline = seconds + spec.tv_sec;
+
+			/* ensure that the poll timeout is set to the lesser of the retry interval or the deadline */
+			if ((seconds * 1000) < POLL_RETRY_INTERVAL || POLL_RETRY_INTERVAL == -1) {
+				/* poll timeout is specified in milliseconds */
+				interval = seconds * 1000;
+			} else {
+				interval = POLL_RETRY_INTERVAL;
+			}
+		}
+	}
+
+	while (1) {
+		old_value = compareAndSwapuintptr_t((uintptr_t*)&sem->sem_value, -1, -1, &sem->spinlock);
+		while (old_value > 0) {
+			if (compareAndSwapuintptr_t((uintptr_t*)&sem->sem_value, old_value, old_value - 1, &sem->spinlock) == old_value) {
+				/* successfully acquired lock */
+				return 0;
+			}
+
+			old_value = sem->sem_value;
+		}
+
+		/* wait for something to change */
+		ret = poll(fds, 1, interval);
+		if ((ret == -1 && errno != EINTR) || fds[0].revents & (POLLHUP|POLLERR|POLLNVAL)) {
+			return -2;
+		}
+
+		/* consume a byte off the pipe if it wasn't a timeout */
+		if (ret > 0) {
+			/* the pipe is configured as non-blocking, waiting is done on the poll call above*/
+			ret = read(fds[0].fd, &byte, 1);
+			if (ret == 0) {
+				/* EOF, pipe has become invalid */
+				return -4;
+			}
+		}
+
+		/* check if we've timed out. Do this last as the other possibilities for return are of more interest */
+		if (ret == 0 && seconds != 0) {
+			if (clock_gettime(CLOCK_REALTIME, &spec) == -1) {
+				return -3;
+			}
+
+			if (spec.tv_sec >= deadline) {
+				return -1;
+			}
+		}
+	}
+}
+
+/*
+ * This function attempts to acquire the semaphore. It will not block if the semaphore isn't available.
+ * @param sem the semaphore to acquire
+ *
+ * @return 0 if the semaphore was acquired, -1 otherwise.
+ */
+static int
+sem_trywait_r(sem_t_r *sem)
+{
+	uintptr_t old_value = 0;
+
+	/* try to get the lock */
+	old_value = compareAndSwapuintptr_t((uintptr_t*)&sem->sem_value, -1, -1, &sem->spinlock);
+	while (old_value > 0) {
+		int value = compareAndSwapuintptr_t((uintptr_t*)&sem->sem_value, old_value, old_value - 1, &sem->spinlock);
+		if (value == old_value) {
+			/* successfully acquired lock */
+			return 0;
+		}
+
+		/* retry if simply contending rather than failed */
+		old_value = value;
+	}
+
+	errno = EAGAIN;
+	return -1;
+}
+
+/*
+ * This function wakes a client or controller thread waiting on the semaphore if any. Otherwise it increments the
+ * semaphore count and will allow a single subsequent call to semget to succeed.
+ *
+ * @param sem the semaphore to post
+ *
+ * @return 0 on success, -1 on error
+ */
+static int
+sem_post_r(sem_t_r *sem)
+{
+	uintptr_t old_value;
+	char byte = 1;
+
+	/* release the lock */
+	do {
+		old_value = sem->sem_value;
+	} while (compareAndSwapuintptr_t((uintptr_t*)&sem->sem_value, old_value, old_value + 1, &sem->spinlock) != old_value);
+
+	/* wake up a waiter */
+	if (write(sem->descriptor_pair[1], &byte, 1) != 1) {
+		return -1;
+	}
+
+	return 0;
+}
+
+/*
+ * This function destroys a semaphore created with sem_init_r. It first reduces the semaphores capacity to 0 so that
+ * no more clients can acquire the lock. If something holds the lock then we undo the block and return an error,
+ * otherwise we close the file descriptors which should wake up any clients waiting on the lock.
+ *
+ * @param the semaphore to destroy
+ *
+ * @return 0 on success, -1 on error
+ */
+static int
+sem_destroy_r(sem_t_r *sem)
+{
+	uintptr_t old_value;
+
+	/* prevent the semaphore from being acquired by subtracting initial value*/
+	do {
+		old_value = sem->sem_value;
+	} while (compareAndSwapuintptr_t((uintptr_t*)&sem->sem_value, old_value, old_value - sem->initial_value, &sem->spinlock) != old_value);
+
+	if (old_value != sem->initial_value) {
+		/* undo the block and return error */
+		do {
+			old_value = sem->sem_value;
+		} while (compareAndSwapuintptr_t((uintptr_t*)&sem->sem_value, old_value, old_value + sem->initial_value, &sem->spinlock) != old_value);
+
+		/* semaphore is still in use */
+		return -1;
+	}
+
+	/* close the pipes */
+	close_wrapper(sem->descriptor_pair[0]);
+	close_wrapper(sem->descriptor_pair[1]);
+
+	return 0;
+}
+
+
+/*
+ * Utility function to check if we've timed out.
+ *
+ * @param deadline system time by which processing should have completed
+ *
+ * @return 1 if deadline expired, 0 otherwise
+ */
+static int
+timedOut(uintptr_t deadline)
+{
+	struct timespec spec;
+	if (clock_gettime(CLOCK_REALTIME, &spec) == -1) {
+		return 0;
+	}
+
+	return spec.tv_sec >= deadline;
+}
+
+/*
+ * Utility function to calculate remaining time before the deadline elapses.
+ *
+ * @param deadline system time by which processing should have completed
+ *
+ * @return number of seconds before timeout
+ */
+static int
+timeout(uintptr_t deadline)
+{
+	int secs = 0;
+
+	struct timespec spec;
+	if (clock_gettime(CLOCK_REALTIME, &spec) == -1) {
+		return 0;
+	}
+
+	secs = deadline - spec.tv_sec;
+
+	if (secs > 0) {
+		return secs;
+	}
+
+	return 0;
+}
+/*
+ * Signal handler used to provide preemptive up-call into native threads. We first check that
+ * the signal we're handling is one that's expected to give a degree of confidence that the
+ * value we're passed is a legitimate platform data pointer. After that the procedure is simple:
+ * 1. wait until posted
+ * 2. publish thread structure with the threads data to platform data.
+ * 3. generate backtraces (must be done here for linux if using 'backtrace' call, other platforms
+ *    could do this from another thread).
+ * 4. post the coordinating thread
+ * 5. wait for release
+ *
+ * The wait in step one is a cancellation point. If we wake from that semaphore and an error is noted
+ * then we skip stack production and wait for release. There's no timeout on the barrier enter as
+ * that logic should be dealt with by the coordinating thread.
+ *
+ * @param signal the number of the signal we receive. Should be SIGRTMIN or equivilent
+ * @param siginfo contains data about the signal including the platform data pointer provided when queued
+ * @param context_arg the context of the thread when the signal was dispatched
+ */
+static void
+upcall_handler(int signal, siginfo_t *siginfo, void *context_arg)
+{
+	thread_context *context = (thread_context*)context_arg;
+	J9ThreadWalkState *state;
+	struct PlatformWalkData *data = NULL;
+	int ret = 0;
+	pid_t pid = getpid();
+	unsigned long tid = j9thread_get_ras_tid();
+
+	/* check that this signal was queued by this process. */
+	if (siginfo->si_code != SI_QUEUE || siginfo->si_value.sival_ptr == NULL) {
+		/* these are not the signals you are looking for */
+		return;
+	}
+
+	data = (struct PlatformWalkData*)siginfo->si_value.sival_ptr;
+	state = data->state;
+
+	/* ignore the signal if we are the controller thread, or if an error/timeout has already occurred */
+	if (data->controllerThread == tid || data->error) {
+		return;
+	}
+
+	/* block until a context is requested, ignoring interrupts */
+	ret = sem_timedwait_r(&data->client_sem, timeout(data->state->deadline1));
+
+	if (ret != 0) {
+		/* error or timeout in sem_timedwait_r(), set shared error flag and don't do the backtrace */
+		data->error = ret;
+	} else if (data->error) {
+		/* error set by another thread while we were in sem_timedwait_r(), don't do the backtrace */
+	} else {
+		/* construct the thread to pass back */
+		data->thread = state->portLibrary->heap_allocate(state->portLibrary, state->heap, sizeof(J9PlatformThread));
+		if (data->thread == NULL) {
+			data->error = ALLOCATION_FAILURE;
+		} else {
+			memset(data->thread, 0, sizeof(J9PlatformThread));
+			data->thread->thread_id = tid;
+			data->platformAllocatedContext = 1;
+			data->thread->context = context;
+			state->portLibrary->introspect_backtrace_thread(state->portLibrary, data->thread, state->heap, NULL);
+			state->portLibrary->introspect_backtrace_symbols(state->portLibrary, data->thread, state->heap);
+		}
+	}
+
+	if (data->error) {
+		/* error or timeout, exit signal handler without waiting for the controller thread */
+		return;
+	}
+	/* release the controller */
+	sem_post_r(&data->controller_sem);
+
+	/* wait for the controller to close the pipe */
+	ret = barrier_enter_r(&data->release_barrier, data->state->deadline2);
+	if (ret != 0) {
+		/* timeout or error */
+		data->error = ret;
+	}
+}
+
+/* These functions count the number of threads in the process. This information is necessary so we can queue the
+ * correct number of signals to suspend all the threads (we might be able to simply call sigqueue until we get a
+ * queue full error, but then we can't queue additional signals to prompt thread scheduling. Also it may not be
+ * capped on all systems).
+ *
+ * @param data - the platform specific data, ignored 
+ * @return number of threads in the process
+ */
+static int
+count_threads( struct PlatformWalkData *data ) { 
+	struct iproc		*pProc;
+	struct ithgl		*pThgl;
+	if( is_threaded_ecb() ) {
+		pProc = iproc_process;
+		pThgl = pProc->iproc_thread_global_data;
+		return pThgl->active_cnt;
+	}
+	return 0;
+}
+
+
+/* This function installs a signal handler then generates signals until all threads in the process bar the calling
+ * thread are suspended. The signals have to be real-time signals (ie. >= SIGRTMIN) or it's not possible to pass
+ * a data via sigqueue. Also, non real-time signals of the same value can be collapsed and we require any threads
+ * scheduled during this suspension to immediately receive a signal, so we need at least one signal per unsuspended
+ * thread on the queue.
+ *
+ * @param data platform specific control data used during suspend/resume
+ * @return the number of threads suspended
+ */
+static int
+suspend_all_preemptive(struct PlatformWalkData *data)
+{
+#if defined(J9ZTPF)
+    errno = EBADF;
+    return -1;
+#endif
+	struct sigaction upcall_action;
+	pid_t pid = getpid();
+	int thread_count = 0;
+
+	struct OMRPortLibrary *portLibrary = data->state->portLibrary;
+	upcall_action.sa_sigaction = upcall_handler;
+	upcall_action.sa_flags = SA_SIGINFO | SA_RESTART;
+	sigemptyset(&upcall_action.sa_mask);
+	sigaddset(&upcall_action.sa_mask, SUSPEND_SIG);
+	Trc_PRT_introspect_suspendWithSignal(SUSPEND_SIG);
+
+	/* install the signal handler */
+	if (sigaction(SUSPEND_SIG, &upcall_action, &data->oldHandler) == -1) {
+		/* no solution but to bail if we can't install the handler */
+		RECORD_ERROR(data->state, SIGNAL_SETUP_ERROR, -1);
+		return -1;
+	}
+
+	if (data->oldHandler.sa_sigaction == upcall_handler) {
+		/* handler's already installed so we're screwed. We mustn't uninstall the handler
+		 * while cleaning as the thread that installed the initial handler will do so */
+		memset(&data->oldHandler, 0, sizeof(struct sigaction));
+		RECORD_ERROR(data->state, CONCURRENT_COLLECTION, -1);
+		return -1;
+	}
+
+	/* after this point it's safe to go through the full cleaup */
+	data->cleanupRequired = 1;
+
+	thread_count = count_threads(data);
+	if (thread_count < 1) {
+		RECORD_ERROR(data->state, THREAD_COUNT_FAILURE, -2);
+		return -2;
+	}
+
+	data->threadCount = 0;
+
+	/* our main suspend loop. We keep going round this until the number of suspended threads matches the number of
+	 * threads in the process
+	 */
+	do {
+		int i = 0;
+		sigval_t val;
+		val.sival_ptr = data;
+
+		/* fire off enough signals to pause all threads in the process barring us */
+		for (i = data->threadCount; i < thread_count -1; i++) {
+			int ret = sigqueue(pid, SUSPEND_SIG, val);
+
+			if (ret != 0) {
+				if (errno == EAGAIN) {
+					/* retry the queuing until we time out */
+					int j;
+					for (j = 0; ret != 0 && errno == EAGAIN && !timedOut(data->state->deadline1); j++) {
+						j9thread_yield();
+						ret = sigqueue(pid, SUSPEND_SIG, val);
+					}
+				}
+
+				if (ret != 0) {
+					/* failed to queue the signal, unrecoverable */
+					data->threadsOutstanding = i;
+					return -errno;
+				}
+			}
+
+			/* allow the signals time to be dispatched so we don't overflow the signal queue. 10 is an arbitrary
+			 * number to see if we can avoid the added complexity of coordination between the signal handler and
+			 * this suspend logic. Testing shows 48 threads suspended on AIX5.3 at the point where we get EAGAIN.
+			 */
+			if ((i % 10) == 0) {
+				j9thread_yield();
+			}
+		}
+
+		data->threadCount = thread_count;
+		thread_count = count_threads(data);
+		if (thread_count < 1) {
+			data->threadsOutstanding = data->threadCount - 1;
+			return -4;
+		}
+
+		if (data->threadCount == thread_count) {
+			/* nothing changed */
+			break;
+		} else if (data->threadCount > thread_count) {
+			/* threads exited in between us counting and generating signals, so swallow the surplus */
+			sigset_t set;
+			int sig;
+
+			for (i = 0; i < data->threadCount - thread_count; i++) {
+				/* sanity check that there is a signal on the queue for us */
+				sigpending(&set);
+				if (sigismember(&set, SUSPEND_SIG)) {
+					/* there is a suspend signal pending so swallow it */
+					sigemptyset(&set);
+					sigaddset(&set, SUSPEND_SIG);
+					sigwait(&set, &sig);
+				}
+			}
+
+			data->threadCount = thread_count;
+			break;
+		}
+	} while (!timedOut(data->state->deadline1));
+
+	if (timedOut(data->state->deadline1)) {
+		data->threadsOutstanding = data->threadCount - 1;
+		return -5;
+	}
+
+	return data->threadCount -1;
+}
+
+
+/*
+ * Frees anything and everything to do with the scope of the specified thread.
+ */
+static void
+freeThread(J9ThreadWalkState *state, J9PlatformThread *thread)
+{
+	J9PlatformStackFrame *frame;
+	struct PlatformWalkData *data = (struct PlatformWalkData*)state->platform_data;
+
+	if (thread == NULL) {
+		return;
+	}
+
+	frame = thread->callstack;
+	while (frame) {
+		J9PlatformStackFrame *tmp = frame;
+		frame = frame->parent_frame;
+
+		if (tmp->symbol) {
+			state->portLibrary->heap_free(state->portLibrary, state->heap, tmp->symbol);
+			tmp->symbol = NULL;
+		}
+
+		state->portLibrary->heap_free(state->portLibrary, state->heap, tmp);
+	}
+
+	if (!data->platformAllocatedContext && thread->context) {
+		state->portLibrary->heap_free(state->portLibrary, state->heap, thread->context);
+	}
+
+	state->portLibrary->heap_free(state->portLibrary, state->heap, thread);
+
+	if (state->current_thread == thread) {
+		state->current_thread = NULL;
+	}
+}
+
+
+/*
+ * This functions resumes all threads suspended by suspend_all_preemptive. The general behaviour
+ * is to swallow any spurious signals from the queue so they are not delivered after we remove our
+ * custom handler, the custom handler is removed, then we wake any threads blocking on the relase
+ * barrier. On AIX we set the signal handler to SIG_IGN before attempting to swallow signals off
+ * the queue because it seems to be possible for signals to be allocated to threads without yet
+ * being delivered, preventing that from working. Setting SIG_IGN seems to remove not yet delivered
+ * signals.
+ *
+ * @param data - platform specific control data used during suspend/resume
+ */
+static void
+resume_all_preempted(struct PlatformWalkData *data)
+{
+	sigset_t set;
+	int	clean_release = 0;
+	struct timespec	time_out;
+	J9ThreadWalkState *state = data->state;
+	struct OMRPortLibrary *portLibrary = state->portLibrary;
+	int	test_sig = SUSPEND_SIG;
+
+	/* 
+	 * We skip everything but the semaphores and the process mask if we didn't 
+	 * successfully install the signal handlers. Now there are no outstanding 
+	 * signals on the queue we can drop the handler 
+	 */
+	if (data->threadsOutstanding > 0) {
+		/* inhibit collection of contexts from any of the outstanding threads we release */
+		data->error = 1;
+	}
+
+	/* allow any outstanding threads to skip the handler. This will cause semwait to return with an error */
+	close_wrapper(data->client_sem.descriptor_pair[0]);
+	close_wrapper(data->client_sem.descriptor_pair[1]);
+
+	if (data->cleanupRequired) {
+		struct OMRPortLibrary *portLibrary = data->state->portLibrary;
+		/* clear out the signal queue so that any undispatched suspend signals are not left lying around */
+		while (sigpending(&set) == 0 && sigismember(&set, SUSPEND_SIG)) {
+			/* there is a suspend signal pending so swallow it. It is worth noting that sigwait isn't in the initial
+			 * set of posix signal safe functions, however the fact that it bypasses the installed signal handler is
+			 * too useful it ignore, so we risk it. It could be replaced with sigsuspend and some handler juggling if
+			 * need be but the added complexity isn't worth it until it's shown to be necessary
+			 */
+			sigemptyset(&set);
+			sigaddset(&set, SUSPEND_SIG);
+			sigwait(&set, &test_sig);
+		}
+
+		/* restore the old signal handler */
+		if ((data->oldHandler.sa_flags & SA_SIGINFO) == 0 && data->oldHandler.sa_handler == SIG_DFL ) {
+			/* if there wasn't an old signal handler the set this to ignore. There shouldn't be any suspend signals
+			 * left but better safe than sorry
+			 */
+			data->oldHandler.sa_handler = SIG_IGN;
+		}
+
+		sigaction(SUSPEND_SIG, &data->oldHandler, NULL);
+
+		/* release the threads from the upcall handler */
+		clean_release = barrier_release_r(&data->release_barrier, timeout(data->state->deadline2));
+		/* make sure they've all exited. 1 means we block until all threads that have entered the barrier leave */
+		barrier_destroy_r(&data->release_barrier, 1);
+	}
+
+	if (data->error) {
+		/* allow threads in upcall handler to run */
+		j9thread_yield();
+	}
+	/* clean up the semaphores */
+	sem_destroy_r(&data->client_sem);
+	sem_destroy_r(&data->controller_sem);
+
+	if (data->state->current_thread != NULL) {
+		freeThread(data->state, data->state->current_thread);
+	}
+
+	/* restore the mask for this thread */
+	sigprocmask(SIG_SETMASK, &data->old_mask, NULL);
+
+	/* clean up the heap */
+	data->state->portLibrary->heap_free(data->state->portLibrary, data->state->heap, data);
+	state->platform_data = NULL;
+}
+
+
+int  __attribute__((optimize(O0)))
+J9ZTPF_getcontext( void *region )
+{
+        register char *rgn asm("r2") = (char *)region;
+        /*
+         *      Because of the way the prologue works, registers 1, 11, and 15 are
+         *      clobbered; only 11 and 15 are recoverable ... 1 is lost forever.
+         *      (( SEE NOTE ABOVE, please. -O3 also clobbers R4 permanently. ))
+         *      This block needs to point at the *caller's* NSI, so R14's contents need
+         *      to replace bytes 8-15 of the PSW, we'll do that too.
+         */
+        asm volatile (
+                /*
+                 *              This section writes the primary ucontext_t block fields the
+                 *              user called for, using all 512 bytes of storage we were passed.
+                 *              First we set uc_flags & uc_link to zero, as well as the entire
+                 *              region occupied by uc_stack.
+                 */
+                "xc  0(40,%0),0(%0)\n\t"           /* Zeroize uc_flags & uc_link                        */
+                /*
+                 *              Next portion is the _sigregs (field: uc_mcontext) block
+                 *              It starts at offset 0x0028, where the PSW goes. But we need to
+                 *              save the caller's registers first thing, so do that first.
+                 */
+                "stmg %%r0,%%r10,56(%0)\n\t"   /* store grandes 0-10 at  +0x0038 for 0x58 bytes */
+                "mvc 144(48,%0),544(%%r11)\n\t" /*              grandes 11-15 at +0x0090 for 0x28 bytes */
+                "epsw %%r0,%%r1\n\t"               /* Get PSW into registers 0 & 1                                      */
+                "stg  %%r0,40(%0)\n\t"             /* Store PSW hi word at +0x0030 for 0x08 bytes       */
+                "lg   %%r0,168(%0)\n\t"            /* Pick up original R14, and                                         */
+                "stg  %%r0,48(%r0)\n\t"            /*  replace IC part of PSW with it.                          */
+                "stam %%a0,%%a15,184(%0)\n\t"  /* Store A0-15 at +0x00B8 for 0x40 bytes                 */
+                "stfpc 248(%0)\n\t"                        /* Store FPC register at +0x00F8 for 4 bytes         */
+                "xc  252(4,%0),252(%0)\n\t"    /* Zeroize 4 bytes' alignment padding (+0x0FC for 4)     */
+                "std %%f0,256(%0)\n\t"             /* Store FPR0 at +0x0100 for 8 bytes                         */
+                "std %%f1,264(%0)\n\t"             /* Store FPR1 at +0x0108 for 8 bytes                         */
+                "std %%f2,272(%0)\n\t"             /* Store FPR2 at +0x0110                                                     */
+                "std %%f3,280(%0)\n\t"             /* Store FPR3 at +0x0118                                                     */
+                "std %%f4,288(%0)\n\t"             /*           FPR4 at +0x0120                                                 */
+                "std %%f5,296(%0)\n\t"             /*           FPR5 at +0x0128                                                 */
+                "std %%f6,304(%0)\n\t"             /*           FPR6 at +0x0130                                                 */
+                "std %%f7,312(%0)\n\t"             /*           FPR7 at +0x0138                                                 */
+                "std %%f8,320(%0)\n\t"             /*           FPR8 at +0x0140                                                 */
+                "std %%f9,328(%0)\n\t"             /*           FPR9 at +0x0148                                                 */
+                "std %%f10,336(%0)\n\t"            /*      FPR10 at +0x0150                                                     */
+                "std %%f11,344(%0)\n\t"            /*      FPR11 at +0x0158                                                     */
+                "std %%f12,352(%0)\n\t"            /*      FPR12 at +0x0160                                                     */
+                "std %%f13,360(%0)\n\t"            /*      FPR13 at +0x0168                                                     */
+                "std %%f14,368(%0)\n\t"            /*      FPR14 at +0x0170                                                     */
+                "std %%f15,376(%0)\n\t"            /*      FPR15 at +0x0178                                                     */
+                /*
+                 *       Type sigset_t is next, field uc_sigmask at +0x0180 for 80,
+                 *       which will come from sigprocmask(), following.
+                 */
+                : /* no outputs */                        /* output constraints would go here                           */
+                : "a"(rgn)                                        /* input constraints go here                                          */
+                : "%r0", "%r1", "%r4", "memory");         /* clobber list goes here                                                     */
+        sigprocmask( SIG_BLOCK, NULL, &((ucontext_t *)region)->uc_sigmask );    /* Get sig masks        */
+        /*
+         *       Total lth = 0x200 (512) bytes. Send it back to the caller
+         *       in the address we were passed. We only need to return an
+         *       int for success (0) or non-zero for failure. The way this
+         *       routine is written, failure is not possible.
+         */
+        return 0;
+}
+
+
+
+/*
+ * Sets up the native thread structures including the backtrace. If a context is specified it is used instead of grabbing
+ * the context for the thread pointed to by state->current_thread.
+ *
+ * @param state - state variable for controlling the thread walk
+ * @param sigContext - context to use in place of live thread context
+ *
+ * @return - 0 on success, non-zero otherwise.
+ */
+static int
+setup_native_thread(J9ThreadWalkState *state, thread_context *sigContext, int heapAllocate)
+{
+	struct PlatformWalkData *data = (struct PlatformWalkData*)state->platform_data;
+	int size = sizeof(thread_context);
+
+	if (size < sizeof(ucontext_t)) {
+		size = sizeof(ucontext_t);
+	}
+
+	if (heapAllocate || sigContext) {
+		/* allocate the thread container*/
+		state->current_thread = (J9PlatformThread*)state->portLibrary->heap_allocate(state->portLibrary, state->heap, sizeof(J9PlatformThread));
+		if (state->current_thread == NULL) {
+			return -1;
+		}
+		memset(state->current_thread, 0, sizeof(J9PlatformThread));
+
+		/* allocate space for the copy of the context */
+		state->current_thread->context = (thread_context*)state->portLibrary->heap_allocate(state->portLibrary, state->heap, size);
+		if (state->current_thread->context == NULL) {
+			return -2;
+		}
+		memset(state->current_thread->context, 0, size);
+
+		/* copy the thread specifics */
+		state->current_thread->thread_id = data->thread->thread_id;
+		state->current_thread->process_id = data->thread->process_id;
+		state->current_thread->callstack = data->thread->callstack;
+
+		/* copy the context */
+		if (sigContext) {
+			/* we're using the provided context instead of generating it */
+			memcpy(state->current_thread->context, ((J9UnixSignalInfo*)sigContext)->platformSignalInfo.context, size);
+		} else if (state->current_thread->thread_id == j9thread_get_ras_tid()) {
+			/* return context for current thread */
+			J9ZTPF_getcontext((ucontext_t*)state->current_thread->context);
+		} else {
+			memcpy(state->current_thread->context, (void*)data->thread->context, size);
+		}
+	} else {
+		/* the data->thread object can be returned */
+		state->current_thread = data->thread;
+	}
+
+
+	/* populate backtraces if not present */
+	if (state->current_thread->callstack == NULL) {
+		/* don't pass sigContext in here as we should have fixed up the thread already. It confuses heap/not heap allocations if we
+		 * pass it here.
+		 */
+		SPECULATE_ERROR(state, FAULT_DURING_BACKTRACE, 2);
+		state->portLibrary->introspect_backtrace_thread(state->portLibrary, state->current_thread, state->heap, NULL);
+		CLEAR_ERROR(state);
+	}
+
+	if (state->current_thread->callstack && state->current_thread->callstack->symbol == NULL) {
+		SPECULATE_ERROR(state, FAULT_DURING_BACKTRACE, 3);
+		state->portLibrary->introspect_backtrace_symbols(state->portLibrary, state->current_thread, state->heap);
+		CLEAR_ERROR(state);
+	}
+
+	if (state->current_thread->error != 0) {
+		RECORD_ERROR(state, state->current_thread->error, 1);
+	}
+
+	return 0;
+}
+
+/*
+ * On some systems, sigqueue() doesn't reliably lead to receipt of the expected
+ * number of signals: On those platforms, the controller must not use sem_timedwait_r
+ * otherwise the process may hang waiting for threads which were assumed to have
+ * received the SUSPEND_SIG signal but did not. z/TPF doesn't have kernel-space
+ * signals and therefore there are _no_ reliable signals in the system at all:
+ * always return 0.
+ */
+static uintptr_t
+sigqueue_is_reliable(void)
+{
+	return 0;
+}
+
+/*
+ * Creates an iterator for the native threads present within the process, either all native threads
+ * or a subset depending on platform (see platform specific documentation for detail).
+ * This function will suspend all of the native threads that will be presented through the iterator
+ * and they will remain suspended until this function or nextDo return NULL. The context for the
+ * calling thread is always presented first.
+ *
+ * @param heap used to contain the thread context, the stack frame representations and symbol strings. No
+ * 			memory is allocated outside of the heap provided. Must not be NULL.
+ * @param state semi-opaque structure used as a cursor for iteration. Must not be NULL User visible fields
+ *			are:
+ * 			deadline - the system time in seconds at which to abort introspection and resume
+ * 			error - numeric error description, 0 on success
+ * 			error_detail - detail for the specific error
+ * 			error_string - string description of error
+ * @param signal_info a signal context to use. This will be used in place of the live context for the
+ * 			calling thread.
+ *
+ * @return NULL if there is a problem suspending threads, gathering thread contexts or if the heap
+ * is too small to contain even the context without stack trace. Errors are reported in the error,
+ * and error_detail fields of the state structure. A brief textual description is in error_string.
+ */
+J9PlatformThread*
+omrintrospect_threads_startDo_with_signal(struct OMRPortLibrary *portLibrary, J9Heap *heap, J9ThreadWalkState *state, void *signal_info)
+{
+	int result = 0;
+	struct PlatformWalkData *data;
+	J9PlatformThread thread;
+	sigset_t mask;
+	int suspend_result = 0;
+	int flag;
+
+/*
+ *	The following preprocessor guard will stop all attempts at attempting to walk the
+ *	native thread stacks, thus avoiding some pretty sticky code which may or may not 
+ *	work on z/TPF. We'll leave this gate open for now, with a pending decision to close
+ *	it or not.
+ */
+#ifdef ZOS64
+	RECORD_ERROR(state, UNSUPPORT_PLATFORM, 0);
+	return NULL;
+#endif
+
+	/* construct the walk state and thread structures */
+	state->heap = heap;
+	state->portLibrary = portLibrary;
+	data = (struct PlatformWalkData*)portLibrary->heap_allocate(portLibrary, heap, sizeof(struct PlatformWalkData));
+	state->platform_data = data;
+	state->current_thread = NULL;
+
+	if (!data) {
+		RECORD_ERROR(state, ALLOCATION_FAILURE, 0);
+		return NULL;
+	}
+
+	memset(data, 0, sizeof(struct PlatformWalkData));
+	data->state = state;
+	data->controllerThread = j9thread_get_ras_tid();
+
+	memset(&thread, 0, sizeof(J9PlatformThread));
+
+	/* prevent this thread from receiving the suspend signal */
+	sigemptyset(&mask);
+	sigaddset(&mask, SUSPEND_SIG);
+	if (sigprocmask(SIG_BLOCK, &mask, &data->old_mask) != 0) {
+		/* can't risk it if we can't filter the suspend signal from this thread */
+		RECORD_ERROR(state, SIGNAL_SETUP_ERROR, errno);
+		return NULL;
+	}
+
+	/* ensure that we can tell which file handles need closing if part of the semaphore initialization fails */
+	data->client_sem.descriptor_pair[0] = -1;
+	data->client_sem.descriptor_pair[1] = -1;
+	data->controller_sem.descriptor_pair[0] = -1;
+	data->controller_sem.descriptor_pair[1] = -1;
+	data->release_barrier.descriptor_pair[0] = -1;
+	data->release_barrier.descriptor_pair[1] = -1;
+
+	/* set up the semaphores */
+	if ((sem_init_r(&data->client_sem, 0)) != 0 || (sem_init_r(&data->controller_sem, 0)) != 0) {
+		RECORD_ERROR(state, INITIALIZATION_ERROR, errno);
+		goto cleanup;
+	}
+	/* initialise client semaphore pipe to be non-blocking */
+	flag = fcntl(data->client_sem.descriptor_pair[0],F_GETFL);
+	fcntl(data->client_sem.descriptor_pair[0],F_SETFL,flag | O_NONBLOCK);
+
+	barrier_init_r(&data->release_barrier, 0);
+
+	/* suspend all threads bar this one */
+	suspend_result = suspend_all_preemptive(state->platform_data);
+	if (suspend_result < 0) {
+		RECORD_ERROR(state, SUSPEND_FAILURE, suspend_result);
+		/* update the barrier for the number of signals we actually managed to queue */
+		barrier_update_r(&data->release_barrier, data->threadsOutstanding);
+		goto cleanup;
+	}
+
+	data->threadsOutstanding = suspend_result;
+	barrier_update_r(&data->release_barrier, data->threadsOutstanding);
+	/* we start at zero with no filter */
+	data->filterThread = 0;
+	data->thread = NULL;
+
+	/* pass back the current thread as we can be sure we won't hit a problem getting it */
+	thread.thread_id = j9thread_get_ras_tid();
+	thread.process_id = getpid();
+	data->thread = &thread;
+
+	data->consistent = 1;
+
+	result = setup_native_thread(state, signal_info, 1);
+	if (0 != result) {
+		RECORD_ERROR(state, ALLOCATION_FAILURE, result);
+		goto cleanup;
+	}
+
+	return state->current_thread;
+
+cleanup:
+	resume_all_preempted(data);
+	return NULL;
+}
+
+/* This function is identical to j9introspect_threads_startDo_with_signal but omits the signal argument
+ * and instead uses a live context for the calling thread.
+ */
+J9PlatformThread*
+omrintrospect_threads_startDo(struct OMRPortLibrary *portLibrary, J9Heap *heap, J9ThreadWalkState *state)
+{
+	return j9introspect_threads_startDo_with_signal(portLibrary, heap, state, NULL);
+}
+
+/* This function is called repeatedly to get subsequent threads in the iteration. The only way to
+ * resume suspended threads is to continue calling this function until it returns NULL.
+ *
+ * @param state state structure initialised by a call to one of the startDo functions.
+ *
+ * @return NULL if there is an error or if no more threads are available. Sets the error fields as
+ * listed detailed for j9introspect_threads_startDo_with_signal.
+ */
+J9PlatformThread*
+omrintrospect_threads_nextDo(J9ThreadWalkState *state)
+{
+	struct PlatformWalkData *data = (struct PlatformWalkData*)state->platform_data;
+	struct OMRPortLibrary *portLibrary = state->portLibrary;
+	J9PlatformThread *thread = NULL;
+	int result = 0;
+	sigset_t mask, old_mask;
+
+	if (data == NULL) {
+		/* state is invalid */
+		RECORD_ERROR(state, INVALID_STATE, 0);
+		return NULL;
+	}
+
+	if (!data->consistent) {
+		/* state is invalid */
+		RECORD_ERROR(state, INVALID_STATE, 1);
+		goto cleanup;
+	}
+
+	data->consistent = 0;
+
+	/* it's possible someone has played with the signal mask, most likely siglongjmp if there was a segfault or
+	 * similar, so ensure it matches our needs
+	 */
+	sigemptyset(&mask);
+	sigaddset(&mask, SUSPEND_SIG);
+	if (sigprocmask(SIG_BLOCK, &mask, &old_mask) != 0 && !sigismember(&old_mask, SUSPEND_SIG)) {
+		/* can't risk it if we can't filter the suspend signal from this thread */
+		RECORD_ERROR(state, SIGNAL_SETUP_ERROR, errno);
+		return NULL;
+	}
+
+	/* cleanup the previous threads */
+	freeThread(state, state->current_thread);
+
+	if (data->threadsOutstanding <= 0) {
+		/* we've finished processing threads */
+		goto cleanup;
+	}
+
+	/* record that we've processed one of the suspended threads */
+	data->threadsOutstanding--;
+
+	/* solicit the next thread context */
+	result = sem_post_r(&data->client_sem);
+
+	if (result == -1 || data->error) {
+		/* failed to solicit thread context */
+		RECORD_ERROR(state, COLLECTION_FAILURE, result==-1 ? -1:data->error);
+		goto cleanup;
+	}
+
+	if (sigqueue_is_reliable()) {
+		result = sem_timedwait_r(&data->controller_sem, timeout(data->state->deadline1));
+	} else {
+		for (;;) {
+			result = sem_trywait_r(&data->controller_sem);
+			if (0 == result) {
+				break;
+			} else if (timedOut(data->state->deadline1) || data->error) {
+				break;
+			} else {
+				sigval_t val;
+				val.sival_ptr = data;
+
+				/*
+				 * Because sigqueue is not reliable, we attempt to queue more signals in
+				 * the hopes that it will cause one of the remaining threads to respond.
+				 */
+				sigqueue(getpid(), SUSPEND_SIG, val);
+				j9thread_yield();
+			}
+		}
+	}
+
+	if (result != 0 || data->error) {
+		/* we've not received notification from a client thread */
+		if (data->error) {
+			RECORD_ERROR(state, COLLECTION_FAILURE, data->error);
+		} else {
+			RECORD_ERROR(state, TIMEOUT, result);
+		}
+		goto cleanup;
+	}
+
+	thread = data->thread;
+	thread->process_id = getpid();
+	data->consistent = 1;
+
+	result = setup_native_thread(state, NULL, 0);
+	if (0 != result) {
+		RECORD_ERROR(state, ALLOCATION_FAILURE, result);
+		goto cleanup;
+	}
+
+	return state->current_thread;
+
+cleanup:
+	resume_all_preempted(data);
+	return NULL;
+}
+
+int32_t
+omrintrospect_set_suspend_signal_offset(struct OMRPortLibrary *portLibrary, int32_t signalOffset)
+{
+	int32_t result = OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+#if defined(J9_CONFIGURABLE_SUSPEND_SIGNAL)
+	if ((signalOffset < 0)
+		|| (signalOffset > (SIGRTMAX - SIGRTMIN))
+#if defined(SIG_RI_INTERRUPT_INDEX)
+		|| (SIG_RI_INTERRUPT_INDEX == signalOffset)
+#endif  /* defined(SIG_RI_INTERRUPT_INDEX) */
+	) {
+		result = OMRPORT_ERROR_INVALID;
+	} else {
+		PPG_introspect_threadSuspendSignal = SIGRTMIN + signalOffset;
+		result = 0;
+	}
+#endif /* defined(J9_CONFIGURABLE_SUSPEND_SIGNAL) */
+	return result;
+
+}
+
+int32_t
+omrintrospect_startup(struct OMRPortLibrary *portLibrary)
+{
+        loadfpc();
+
+#if defined(J9_CONFIGURABLE_SUSPEND_SIGNAL)
+	PPG_introspect_threadSuspendSignal = SIGRTMIN;
+#endif /* defined(J9_CONFIGURABLE_SUSPEND_SIGNAL) */
+	return 0;
+}
+
+void
+omrintrospect_shutdown(struct OMRPortLibrary *portLibrary)
+{
+	return;
+}

--- a/port/ztpf/omrloadfpc.s
+++ b/port/ztpf/omrloadfpc.s
@@ -1,0 +1,47 @@
+###############################################################################
+#
+# (c) Copyright IBM Corp. 2013, 2017
+#
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License v1.0 and
+#  Apache License v2.0 which accompanies this distribution.
+#
+#      The Eclipse Public License is available at
+#      http://www.eclipse.org/legal/epl-v10.html
+#
+#      The Apache License v2.0 is available at
+#      http://www.opensource.org/licenses/apache2.0.php
+#
+# Contributors:
+#    Multiple authors (IBM Corp.) - initial API and implementation and/or initial documentation
+###############################################################################
+# This is a zLinux helper that stores the STFLE bits
+# into the passed memory reference.
+#
+# The helper returns the number of valid double-words in the STFLE
+# bits, minus 1.
+#
+# The stfle instruction is encoded as 0xb2b00000 in binary, leaving
+# it in as such so that we can compile on any platform.
+# ===================================================================
+
+.file "j9loadfpc.s"
+
+.text
+    .align  8
+.globl loadfpc
+    .type   loadfpc,@function
+loadfpc:
+.text
+	lgf %r2,1300
+	aghi %r2,8212
+    larl %r3,.LT0
+    mvc 0(4,%r2),.LC0-.LT0(%r3)
+    lfpc  .LC0-.LT0(%r3)
+    br  %r14
+
+    .align  8
+.LT0:
+.LC0:
+    .long   0x00400000
+ 

--- a/port/ztpf/omrmmap.c
+++ b/port/ztpf/omrmmap.c
@@ -1,0 +1,173 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 1991, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial API and implementation and/or initial documentation
+ *    Multiple authors (IBM Corp.) - z/TPF platform initial port to OMR environment
+ *******************************************************************************/
+
+/**
+ * @file
+ * @ingroup Port
+ * @brief Memory map
+ *
+ * This module provides memory mapping facilities that allow a user to map files
+ * into the virtual address space of the process.  There are various options that
+ * can be used when mapping a file into memory, such as copy on write.  Not all 
+ * of these options are available on all platforms, @ref omrmmap_capabilities
+ * provides the list of supported options.  Note also that on some platforms 
+ * memory mapping facilites do not exist at all. On these platforms the API will
+ * still be available, but will simply read the file into allocated memory.
+ */
+
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+
+#include "omrport.h"
+#include "portnls.h"
+#include "ut_omrprt.h"
+#include "protect_helpers.h"
+#include "portpriv.h"
+
+
+/**
+ * Map a part of file into memory. 
+ *
+ * @param [in]  portLibrary       The port library
+ * @param [in]  file                       The file descriptor/handle of the already open file to be mapped
+ * @param [in]  offset                  The file offset of the part to be mapped
+ * @param [in]  size                     The number of bytes to be mapped, if zero, the whole file is mapped
+ * @param [in]  mappingName      The name of the file mapping object to be created/opened.  This will be used as the basis of the name (invalid 
+ *                                                         characters being converted to '_') of the file mapping object on Windows
+ *                                                         so that it can be shared between processes.  If a named object is not required, this parameter can be
+ *                                                         specified as NULL
+ * @param [in]   flags                  Flags relating to the mapping:
+ * @args                                         OMRPORT_MMAP_FLAG_READ                     read only map
+ * @args                                         OMRPORT_MMAP_FLAG_WRITE                   read/write map
+ * @args                                         OMRPORT_MMAP_FLAG_COPYONWRITE copy on write map
+ * @args                                         OMRPORT_MMAP_FLAG_SHARED              share memory mapping with other processes
+ * @args                                         OMRPORT_MMAP_FLAG_PRIVATE              private memory mapping, do not share with other processes (implied by J9PORT_MMAP_FLAG_COPYONWRITE)
+ * @param [in]  categoryCode     Memory allocation category code
+ *
+ * @return                       A J9MmapHandle struct or NULL is an error has occurred
+ */
+J9MmapHandle *
+omrmmap_map_file(struct OMRPortLibrary *portLibrary, IDATA file, U_64 offset, UDATA size, const char *mappingName, U_32 flags, U_32 categoryCode)
+{
+  return NULL;
+}
+/**
+ * UnMap previously mapped memory.
+ *
+ * @param[in] portLibrary The port library
+ *
+ * @param[in] handle - A pointer to a J9MmapHandle structure returned by omrmmap_map_file.
+ */
+void
+omrmmap_unmap_file(struct OMRPortLibrary *portLibrary, J9MmapHandle *handle)
+{
+
+}
+/**
+ * Synchronise updates to memory mapped file region with file on disk.  The call may wait for the file write
+ * to complete or this may be scheduled for a later time and the function return immediately, depending on
+ * the flags setting
+ *
+ * @param [in]  portLibrary         The port library
+ * @param [in]  start                      Pointer to the start of the memory mapped area to be synchronised
+ * @param [in]  length                  Length of the memory mapped area to be synchronised
+ * @param [in]  flags                    Flags controlling the behaviour of the function:
+ * @args                                           J9PORT_MMAP_SYNC_WAIT   Synchronous update required, function will not
+ *                                                                     return until file updated.  Note that to achieve this on Windows requires the
+ *                                                                     file to be opened with the FILE_FLAG_WRITE_THROUGH flag
+ * @args                                           J9PORT_MMAP_SYNC_ASYNC Asynchronous update required, function returns
+ *                                                                    immediately, file will be updated later
+ * @args                                           J9PORT_MMAP_SYNC_INVALIDATE Requests that other mappings of the same
+ *                                                                    file be invalidated, so that they can be updated with the values just written
+ *
+* @return                                          0 on success, -1 on failure.  Errors will be reported using the usual port library mechanism
+ */
+IDATA
+omrmmap_msync(struct OMRPortLibrary *portLibrary, void *start, UDATA length, U_32 flags)
+{
+  return 0;
+}
+/**
+ * PortLibrary shutdown.
+ *
+ * @param[in] portLibrary The port library
+ *
+ * This function is called during shutdown of the portLibrary.  Any resources that were created by @ref omrmmap_startup
+ * should be destroyed here.
+ *
+ */
+void
+omrmmap_shutdown(struct OMRPortLibrary *portLibrary)
+{
+}
+/**
+ * PortLibrary startup.
+ *
+ * This function is called during startup of the portLibrary.  Any resources that are required for
+ * the memory mapping operations may be created here.  All resources created here should be destroyed
+ * in @ref omrmmap_shutdown.
+ *
+ * @param[in] portLibrary The port library
+ *
+ * @return 0 on success, negative error code on failure.  Error code values returned are
+ * \arg J9PORT_ERROR_STARTUP_MMAP
+ *
+ * @note Most implementations will simply return success.
+ */
+I_32
+omrmmap_startup(struct OMRPortLibrary *portLibrary)
+{
+	return 0;
+}
+/**
+ * Check the capabilities available for J9MMAP at runtime for the current platform.
+ *
+ *
+ * @param[in] portLibrary The port library
+ *
+ * @return a bit map containing the capabilites supported by the j9mmap sub component of the port library.
+ * Possible bit values:
+ *   J9PORT_MMAP_CAPABILITY_COPYONWRITE - if not present, platform is not capable of "copy on write" memory mapping.
+ *
+ */
+I_32
+omrmmap_capabilities(struct OMRPortLibrary *portLibrary)
+{
+  return 0;
+}
+
+IDATA
+omrmmap_protect(struct OMRPortLibrary *portLibrary, void* address, UDATA length, UDATA flags)
+{
+	return protect_memory(portLibrary, address, length, flags);
+}
+
+UDATA 
+omrmmap_get_region_granularity(struct OMRPortLibrary *portLibrary, void *address)
+{
+	return protect_region_granularity(portLibrary, address);
+}
+
+

--- a/port/ztpf/omrosbacktrace_impl.c
+++ b/port/ztpf/omrosbacktrace_impl.c
@@ -1,0 +1,326 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 1991, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial API and implementation and/or initial documentation
+ *    Multiple authors (IBM Corp.) - z/TPF platform initial port to OMR environment
+ *******************************************************************************/
+
+/**
+ * @file
+ * @ingroup Port
+ * @brief Stack backtracing support
+ */
+
+#include "omrport.h"
+#include "omrportpriv.h"
+#include "omrsignal_context.h"
+
+#include <execinfo.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include <dlfcn.h>
+
+#include "omrintrospect.h"
+
+uintptr_t protectedBacktrace(struct OMRPortLibrary *port, void *arg);
+uintptr_t backtrace_sigprotect(struct OMRPortLibrary *portLibrary,
+	J9PlatformThread *threadInfo, void **address_array, int capacity);
+
+struct frameData
+{
+	void **address_array;
+	unsigned int capacity;
+};
+
+/*
+ * NULL handler. We only care about preventing the signal from propagating up the call stack, no need to do
+ * anything in the handler.
+ */
+static uintptr_t
+handler(struct OMRPortLibrary *portLibrary, uintptr_t gpType, void* gpInfo, void* userData)
+{
+	return OMRPORT_SIG_EXCEPTION_RETURN;
+}
+
+/*
+ * Wrapped call to libc backtrace function
+ */
+uintptr_t
+protectedBacktrace(struct OMRPortLibrary *port, void *arg)
+{
+	struct frameData *addresses = (struct frameData *) arg;
+	return backtrace(addresses->address_array, addresses->capacity);
+}
+
+/*
+ * Provides signal protection for the libc backtrace call. If the stack walk causes a segfault then we check the output
+ * array to see if we got any frames as we may be able to provide a partial backtrace. We also record that the stack walk
+ * was incomplete so that information is available after the fuction returns.
+ */
+uintptr_t
+backtrace_sigprotect(struct OMRPortLibrary *portLibrary,
+	J9PlatformThread *threadInfo, void **address_array, int capacity)
+{
+	uintptr_t ret;
+	struct frameData args;
+	args.address_array = address_array;
+	args.capacity = capacity;
+
+	memset(address_array, 0, sizeof(void*) * capacity);
+
+	if (omrthread_self()) {
+		if (portLibrary->sig_protect(portLibrary, protectedBacktrace, &args,
+			handler, NULL,
+			OMRPORT_SIG_FLAG_SIGALLSYNC | OMRPORT_SIG_FLAG_MAY_RETURN, &ret)
+			!= 0) {
+			/* check to see if there were any addresses populated */
+			for (ret = 0; ret < args.capacity && address_array[ret] != NULL;
+				ret++)
+				;
+
+			threadInfo->error = FAULT_DURING_BACKTRACE;
+		}
+
+		return ret;
+	}
+	else {
+		return backtrace(address_array, capacity);
+	}
+}
+
+/* This function constructs a backtrace from a CPU context. Generally there are only one or two
+ * values in the context that are actually used to construct the stack but these vary by platform
+ * so arn't detailed here. If no heap is specified then this function will use malloc to allocate
+ * the memory necessary for the stack frame structures which must be freed by the caller.
+ *
+ * @param portLbirary a pointer to an initialized port library
+ * @param threadInfo the thread structure we want  to attach the backtrace to. Must not be NULL.
+ * @param heap a heap from which to allocate any necessary memory. If NULL malloc is used instead.
+ * @param signalInfo a platform signal context. If not null the context held in threadInfo is replaced
+ *  	  with the signal context before the backtrace is generated.
+ *
+ * @return the number of frames in the backtrace.
+ */
+uintptr_t
+omrintrospect_backtrace_thread_raw(struct OMRPortLibrary *portLibrary,
+	J9PlatformThread *threadInfo, J9Heap *heap, void *signalInfo)
+{
+	void *addresses[50];
+	J9PlatformStackFrame **nextFrame;
+	J9PlatformStackFrame *junkFrames = NULL;
+	J9PlatformStackFrame *prevFrame = NULL;
+	J9UnixSignalInfo *sigInfo = (J9UnixSignalInfo*) signalInfo;
+	int i;
+	int discard = 0;
+	int ret;
+	const char *regName = "";
+	void **faultingAddress = 0;
+
+	if (threadInfo == NULL
+		|| (threadInfo->context == NULL && sigInfo == NULL)) {
+		return 0;
+	}
+
+	/* if we've been passed a port library wrapped signal, then extract info from there */
+	if (sigInfo != NULL) {
+		threadInfo->context = sigInfo->platformSignalInfo.context;
+
+		/* get the faulting address so we can discard frames that are part of the signal handling */
+		infoForControl(portLibrary, sigInfo, 0, &regName,
+			(void**) &faultingAddress);
+	}
+
+	ret = backtrace_sigprotect(portLibrary, threadInfo, addresses,
+		sizeof(addresses) / sizeof(void*));
+
+	nextFrame = &threadInfo->callstack;
+	for (i = 0; i < ret; i++) {
+		if (heap != NULL) {
+			*nextFrame = portLibrary->heap_allocate(portLibrary, heap,
+				sizeof(J9PlatformStackFrame));
+		}
+		else {
+			*nextFrame = portLibrary->mem_allocate_memory(portLibrary,
+				sizeof(J9PlatformStackFrame), OMR_GET_CALLSITE(),
+				OMRMEM_CATEGORY_PORT_LIBRARY);
+		}
+
+		if (*nextFrame == NULL) {
+			if (!threadInfo->error) {
+				threadInfo->error = ALLOCATION_FAILURE;
+			}
+
+			break;
+		}
+
+		(*nextFrame)->parent_frame = NULL;
+		(*nextFrame)->symbol = NULL;
+		(*nextFrame)->instruction_pointer = (uintptr_t) addresses[i];
+		(*nextFrame)->stack_pointer = 0;
+		(*nextFrame)->base_pointer = 0;
+
+		nextFrame = &(*nextFrame)->parent_frame;
+
+		/* check to see if we should truncate the stack trace to omit handler frames */
+		if (prevFrame && faultingAddress && addresses[i] == *faultingAddress) {
+			/* discard all frames up to this point */
+			junkFrames = threadInfo->callstack;
+			threadInfo->callstack = prevFrame->parent_frame;
+
+			/* break the link so we can free the junk */
+			prevFrame->parent_frame = NULL;
+
+			/* correct the next frame */
+			nextFrame = &threadInfo->callstack->parent_frame;
+			/* record how many frames we discard */
+			discard = i + 1;
+		}
+
+		/* save the frame we've just set up so that we can blank it if necessary */
+		if (prevFrame == NULL) {
+			prevFrame = threadInfo->callstack;
+		}
+		else {
+			prevFrame = prevFrame->parent_frame;
+		}
+	}
+
+	/* if we discarded any frames then free them */
+	while (junkFrames != NULL) {
+		J9PlatformStackFrame *tmp = junkFrames;
+		junkFrames = tmp->parent_frame;
+
+		if (heap != NULL) {
+			portLibrary->heap_free(portLibrary, heap, tmp);
+		}
+		else {
+			portLibrary->mem_free_memory(portLibrary, tmp);
+		}
+	}
+
+	return i - discard;
+}
+
+/* This function takes a thread structure already populated with a backtrace by j9introspect_backtrace_thread
+ * and looks up the symbols for the frames. The format of the string generated is:
+ * 		symbol_name (statement_id instruction_pointer [module+offset])
+ * If it isn't possible to determine any of the items in the string then they are omitted. If no heap is specified
+ * then this function will use malloc to allocate the memory necessary for the symbols which must be freed by the caller.
+ *
+ * @param portLbirary a pointer to an initialized port library
+ * @param threadInfo a thread structure populated with a backtrace
+ * @param heap a heap from which to allocate any necessary memory. If NULL malloc is used instead.
+ *
+ * @return the number of frames for which a symbol was constructed.
+ */
+uintptr_t
+omrintrospect_backtrace_symbols_raw(struct OMRPortLibrary *portLibrary,
+	J9PlatformThread *threadInfo, J9Heap *heap)
+{
+	J9PlatformStackFrame *frame;
+	int i;
+
+	for (i = 0, frame = threadInfo->callstack; frame != NULL;
+		frame = frame->parent_frame, i++) {
+		char output_buf[512];
+		char *cursor = output_buf;
+		Dl_info dlInfo;
+		uintptr_t length;
+		uintptr_t iar = frame->instruction_pointer;
+		uintptr_t symbol_offset = 0;
+		uintptr_t module_offset = 0;
+		const char *symbol_name = "";
+		const char *module_name = "<unknown>";
+		short symbol_length = 0;
+
+		memset(&dlInfo, 0, sizeof(Dl_info));
+
+		/* do the symbol resolution while we're here */
+		if (dladdr((void*) iar, &dlInfo)) {
+			if (dlInfo.dli_sname != NULL) {
+				uintptr_t sym = (uintptr_t) dlInfo.dli_saddr;
+				symbol_name = dlInfo.dli_sname;
+				symbol_length = strlen(symbol_name);
+				symbol_offset = iar - (uintptr_t) sym;
+			}
+
+			if (dlInfo.dli_fname != NULL) {
+				/* strip off the full path if possible */
+				module_name = strrchr(dlInfo.dli_fname, '/');
+				if (module_name != NULL) {
+					module_name++;
+				}
+				else {
+					module_name = dlInfo.dli_fname;
+				}
+			}
+
+			if (dlInfo.dli_fbase != NULL) {
+				/* set the module offset */
+				module_offset = iar - (uintptr_t) dlInfo.dli_fbase;
+			}
+		}
+
+		/* sanity check */
+		if (symbol_name == NULL) {
+			symbol_name = "";
+			symbol_length = 0;
+		}
+
+		/* symbol_name+offset (id, instruction_pointer [module+offset]) */
+		if (symbol_length > 0) {
+			cursor += omrstr_printf(portLibrary, cursor,
+				sizeof(output_buf) - (cursor - output_buf), "%.*s",
+				symbol_length, symbol_name);
+			cursor += omrstr_printf(portLibrary, cursor,
+				sizeof(output_buf) - (cursor - output_buf), "+0x%x ",
+				symbol_offset);
+		}
+		cursor += omrstr_printf(portLibrary, cursor,
+			sizeof(output_buf) - (cursor - output_buf), "(0x%p",
+			frame->instruction_pointer);
+		if (module_name[0] != '\0') {
+			cursor += omrstr_printf(portLibrary, cursor,
+				sizeof(output_buf) - (cursor - output_buf), " [%s+0x%x]",
+				module_name, module_offset);
+		}
+		*(cursor++) = ')';
+		*cursor = 0;
+
+		length = (cursor - output_buf) + 1;
+		if (heap != NULL) {
+			frame->symbol = portLibrary->heap_allocate(portLibrary, heap,
+				length);
+		}
+		else {
+			frame->symbol = portLibrary->mem_allocate_memory(portLibrary,
+				length, OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
+		}
+
+		if (frame->symbol != NULL) {
+			strncpy(frame->symbol, output_buf, length);
+		}
+		else {
+			frame->symbol = NULL;
+			if (!threadInfo->error) {
+				threadInfo->error = ALLOCATION_FAILURE;
+			}
+			i--;
+		}
+	}
+
+	return i;
+}

--- a/port/ztpf/omrrttime.s
+++ b/port/ztpf/omrrttime.s
@@ -1,0 +1,42 @@
+###############################################################################
+#
+# (c) Copyright IBM Corp. 2017
+#
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License v1.0 and
+#  Apache License v2.0 which accompanies this distribution.
+#
+#      The Eclipse Public License is available at
+#      http://www.eclipse.org/legal/epl-v10.html
+#
+#      The Apache License v2.0 is available at
+#      http://www.opensource.org/licenses/apache2.0.php
+#
+# Contributors:
+#    Multiple authors (IBM Corp.) - initial API and implementation and/or initial documentation
+#    Multiple authors (IBM Corp.) - z/TPF platform initial port to OMR environment
+###############################################################################
+.file "j9rttime.s"
+.text
+    .align  8
+.globl maxprec
+    .type   maxprec,@function
+maxprec:
+.text
+    larl    %r3,.LT0
+    
+    stck 64(%r15)
+    lg  %r1,64(%r15)
+    sg %r1,.LC0-.LT0(%r3)
+    srlg %r1,%r1,9
+    lgr %r2,%r1
+    br  %r14
+
+    .align  8
+.LT0:
+.LC0:
+    .quad   0x7D91048BCA000000
+.Lfe1:
+    .size   maxprec,.Lfe1-maxprec
+    .ident  "maximum precision clock" 
+

--- a/port/ztpf/omrsignal.c
+++ b/port/ztpf/omrsignal.c
@@ -1,0 +1,1358 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 1991, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial API and implementation and/or initial documentation
+ *    Multiple authors (IBM Corp.) - z/TPF platform initial port to OMR environment
+ *******************************************************************************/
+
+/**
+ * @file omrsignal.c
+ * @ingroup Port
+ * @brief Signal handling details exclusive to z/TPF.&nbsp;&nbsp;  
+ *
+ * \details z/TPF does not have <i>reliable signals</i>, also known as <i>kernel-space</i> 
+ * signals in certain circles. Instead, all signals processing takes place in user space. Normally, the 
+ * act of delivering a signal (via <tt>kill()</tt>, <tt>pthread_kill()</tt>, <tt>raise()</tt>, et al) takes 
+ * place in user-space with no supervisory intervention; and once it's delivered, the process (or thread) must
+ * <i>declare itself ready to accept signals</i> via either a <tt>tpf_process_signals()</tt> or 
+ * <tt>tpf_thread_process_signals()</tt> call. That's going to sound weird to a modern UNIX 
+ * programmer, but that's the way it is, and it actually <i>works</i> for certain kinds
+ * of programs. Unfortunately, those programs which expect to be rerouted to a signal handler
+ * without warning (or consciously <i>"being ready" to process a signal</i>) aren't 
+ * among that set of code. In other words, there are no such things as 'synchronous signals'
+ * in z/TPF: all units of work (UOW) must declare themselves ready and willing to process any
+ * signals which may have been delivered to them since the last such declaration through the
+ * issuance of a <tt>tpf_process_signals()</tt> call.
+ *
+ * UNIX, on which most of this segment was originally founded, _does_ have reliable
+ * signals whereas z/TPF has none. Reliable signals is a way of saying that when a signal is 
+ * delivered and is NOT masked out, control is immediately transferred to the signal handler 
+ * registered for that particular signal -- it spends no time in a 'signal pending' state. 
+ * The way UNIX scheduling works, a <i>"context switch"</i> is performed when one 
+ * scheduleable unit of work (hereafter, UOW) has the CPU taken from it and assigned to the 
+ * next scheduleable UOW. To put it another way, the scheduler will change the now active UOW's <i>context</i>
+ * from "active, running" to "dormant, awaiting rescheduling" (or whichever event it's awaiting, which 
+ * could be an I/O completion, for example). 
+ *
+ * The dirty work of taking a CPU core away from a UOW is accomplished by stopping
+ * the current CPU, taking a copy of the machine state into what's called the <b><i>"machine
+ * state context"</i></b> (<tt>struct uc_mcontext</tt>) consisting of the PSW, registers, 
+ * etc, then setting its <b>"link state"</b> context (<tt>struct uc_link</tt>) to the next 
+ * executable instruction the outgoing UOW would have executed, putting this UOW at the 
+ * end of the queue; then selecting the next runnable UOW, restoring <i>its</i> <tt>uc_link</tt>
+ * data members to the proper places as dictated by hardware, then causing execution to resume at 
+ * the place <tt>uc_link</tt> says it should until the next timeslice expires. <i>Ad infinitum</i>.
+ *
+ * One of the descriptive statistics of how hard a UNIX-like machine is working is
+ * the <i>"context switch per second"</i> rate. A large *NIX server executes approximately
+ * twice as many context switches as it does interrupts over any small slice of time; some run 
+ * with over 10,000 (and more) context switches per second.
+ *
+ * z/TPF schedules very differently. For a timesliced process, which all JVM
+ * threads belong to, interrupts happen many, many times a second, and at each interrupt,
+ * the scheduler decides if the UOW has had its timeslice expire (or for more traditional TPF
+ * processes, which perform the equivalent of a <tt>yield()</tt> instruction for SCHED_FIFO
+ * scheduling, which is the original scheduling paradigm of the z/TPF system. If so, the machine
+ * state is stored in pages 2 and 3 of the Entry Control Block, and its scheduleable
+ * UOW address (the <i>Entry Control Block</i> or <b>ECB</b>) is queued on one of at least five 
+ * "CPU lists", depending on what its next expected state is. This data placement is the z/TPF
+ * equivalent of a UNIX context switch. But <b>the current machine state has nothing to do with 
+ * signal deliveries</b>, and that's what this segment is about: <i>the context switch that would have taken place if z/TPF supported 
+ * the delivery of reliable signals to the signal handler</i>.
+ *
+ * What we <em>do</em> have is the full machine state <b>when any dump is taken.</b> Whether
+ * the dump is the result of what we've been calling a "non-preemptible" event 
+ * (i.e. a <i>program check</i>, meaning that the process is going to exit shortly) 
+ * or a "hooked" event (meaning that the Java user
+ * has called for a dump on some otherwise normal event taking place, such as a 
+ * JVM start or stop, or perhaps a 'soft' Java exception having been thrown, where
+ * function <TT>j9dump_create()</TT> has to call for a dump from the z/TPF Control 
+ * Program), we still have the <b>extremely recent</b> machine state captured for
+ * us by the z/TPF SERRC processor, CCCPSE. Therefore, we <i>can</i> create a 'fake'
+ * ucontext structure <b>as long as the data the structure is to contain comes from
+ * a recent dump</b>. 
+ *
+ * In this segment, we labor under the presumption that the required dump has indeed been anticipated
+ * by the "kernel's" (we call the supervisor the "z/TPF Control Program") program check interrupt routine.
+ * If such a dump has been anticipated and the faulting UOW belongs to a process which is known to have 
+ * been bound to a JVM, CCCPSE (the Control Program's program check handler) has created what's called 
+ * a "Dump Interchange Record", out of which, in turn, is anchored a "Java Dump Buffer", or JDB.
+ *
+ * CCCPSE determines that eligible program checks fall into one of two categories. The first 
+ * category is called a "preemptible error", one which the Java language has specified as a 
+ * divide-by-zero or null-pointer exception (DBZ or NPE, respectively). In these situations,
+ * the Java interpreter routine receiving the signal is supposed to know what to do with it, 
+ * namely issue the 'soft' Java ArithmeticException("Divide-by-zero") or NullPointerException,
+ * depending upon the exact type of interrupt taken. The TPF-ish data is translated into its
+ * corresponding UNIX-information, such as "context blocks" required for each of these two
+ * situations. In these cases, no JDB is anchored in the DIB, as no system dump agent activity
+ * will take place.
+ *
+ * The second category is called a "non-preemptible error", one which CCCPSE cannot classify as
+ * preemptible and is associated with a Java program under interpretation or a byte interpreter
+ * malfunction. These kinds of program checks indicate something seriously wrong, such as a programming
+ * or data error, and infers that the JVM may not be in a condition to continue. In this kind of case,
+ * a JDB is anchored off the DIB in anticipation of the system dump agent being required to write
+ * an ELF core dump file.
+ *
+ * The JDB contains in-memory copies of all the native stack frames, an Error Information
+ * Record, and has made in-memory copies of every heap (malloc()'d heap nodes) in use by
+ * the faulting address space. We write our own ELF core dump file from this information 
+ * since the z/TPF kernel does not have this task as one of its duties like a UNIX kernel
+ * would.
+ *
+ * Regardless of the kind of error CCCPSE has determined we have, we always have a DIB, which 
+ * contains enough information to create the required context blocks associated with a 
+ * synchronous signal. If the error is not preemptible, we have also spawned a thread to write
+ * the ELF core dump file, in anticipation that it will be required by the system dump agent's
+ * execution, to follow.
+ */
+
+#include <jsig.h>
+
+#include "omrsignal_context.h"
+#include "omrcfg.h"
+#include "omrport.h"
+#include "portpriv.h"
+#include "ut_omrprt.h"
+#include "omrthread.h"
+#include <signal.h>
+#include <string.h>
+#include <unistd.h>
+#include <setjmp.h>
+#include <semaphore.h>
+
+/*
+ * get siginfo_t and SIGRTMIN definitions included
+ * Set up a thread to run a tpf_process_signals() loop,
+ * also defined here.
+*/
+#include <tpf/sysapi.h>
+#include <tpf/tpfapi.h>
+#include <signal.h>
+#include <tpf/i_jdib.h>
+#include <tpf/i_jdbf.h>
+
+#include "j9signal.h"		/* declare a couple of platform-unique structures */
+
+static uint32_t	ztpf_enableSignalHandlers(OMRPortLibrary *);
+static int J9THREAD_PROC ztpf_fireSignalHandlers(void *);
+
+static uint32_t	shutdown_ztpf_sigpush;
+static j9thread_monitor_t ztpfSigShutdownMonitor;
+
+static uint32_t
+ztpf_enableSignalHandlers(OMRPortLibrary *portLibrary)
+{ 
+	int	rc = J9THREAD_SUCCESS;
+	j9thread_t ztpf_signal_enabler_thd;
+
+	rc = j9thread_create(&ztpf_signal_enabler_thd, 512*256, J9THREAD_PRIORITY_NORMAL, 0, &ztpf_fireSignalHandlers, portLibrary, J9THREAD_CATEGORY_SYSTEM_THREAD);
+	if( J9THREAD_SUCCESS == rc ) { 
+		j9thread_set_name( omrthread_self(), "z/TPF Signal handler push loop" );
+	}
+	return rc;
+}
+
+#define WAIT_QUANTUM 50000				/* 50 ms in microsecond units			*/
+
+/*
+ * z/TPF does not have kernel threads. As such, signals are delivered reliably to 
+ * a process' or thread's pending signal queue; but the signal handler -- if any --
+ * for any signal does not receive control until a function called tpf_process_signals()
+ * is called. The usleep() function does this on its way into -- and back from -- 
+ * an EVNWC service whose timeout value we pass to it in microseconds; we've 
+ * #defined it as WAIT_QUANTUM above. Net-net, all we have to do is usleep, and
+ * we get any pending signals processed. This is a much lower-overhead operation than
+ * a pthread_cond_timedwait() operation or similar; even much lower than a tight DEFRC 
+ * loop.
+ *
+ * It continues to loop forever until the JVM controller thread tells it to kill
+ * itself via the <shutdown_ztpf_sigpush> monitor alarm.
+ */
+
+static int J9THREAD_PROC 
+ztpf_fireSignalHandlers(void *portlib)
+{
+	OMRPortLibrary *portLibrary = (OMRPortLibrary *)portlib;
+
+	j9thread_monitor_init_with_name(&ztpfSigShutdownMonitor, 0, "ztpf_thread_enabler_shutdown_monitor");
+
+	while(1) {										/* Never break this loop		*/
+		if( 0 == shutdown_ztpf_sigpush ) {
+			usleep(WAIT_QUANTUM);
+		} else { 
+			omrthread_monitor_enter(ztpfSigShutdownMonitor);
+			shutdown_ztpf_sigpush = 0;
+			j9thread_monitor_notify(ztpfSigShutdownMonitor);
+			j9thread_exit(ztpfSigShutdownMonitor);	/* This thread is gone.			*/
+		}
+	}
+	return 0;										/* UNREACHABLE					*/
+}
+
+
+#define MAX_PORTLIB_SIGNAL_TYPES 8
+
+typedef  void (*unix_sigaction) (int, siginfo_t *, void *, UDATA);
+
+/* CMVC 96193
+ * Prototyping here to avoid including j9protos.h
+ */
+extern J9_CFUNC void issueWriteBarrier(void);
+
+/* Store the previous signal handlers, we need to restore them when we're done */
+static struct {
+	struct sigaction action;
+	uint32_t restore;
+} oldActions[MAX_UNIX_SIGNAL_TYPES];
+
+/* Records the (port library defined) signals for which we have registered a master handler.
+ * Access to this must be protected by the masterHandlerMonitor */
+static uint32_t signalsWithMasterHandlers;
+
+#if defined(J9VM_PORT_ASYNC_HANDLER)
+static uint32_t	shutDownASynchReporter;
+#endif
+
+static uint32_t	attachedPortLibraries;
+
+typedef struct J9UnixAsyncHandlerRecord {
+	OMRPortLibrary* portLib;
+	j9sig_handler_fn handler;
+	void *handler_arg;
+	uint32_t flags;
+	struct J9UnixAsyncHandlerRecord	*next;
+} J9UnixAsyncHandlerRecord;
+
+/* holds the options set by j9sig_set_options */
+uint32_t signalOptionsGlobal;
+
+static J9UnixAsyncHandlerRecord	*asyncHandlerList = NULL;
+
+/* asyncSignalReporter synchronization	*/
+
+static sem_t wakeUpASyncReporter;
+static sem_t sigQuitPendingSem;
+static sem_t sigAbrtPendingSem;
+static sem_t sigTermPendingSem;
+static sem_t sigReconfigPendingSem;
+static sem_t sigXfszPendingSem;
+
+static j9thread_monitor_t asyncMonitor;
+static j9thread_monitor_t masterHandlerMonitor;
+static j9thread_monitor_t asyncReporterShutdownMonitor;
+static uint32_t	asyncThreadCount;
+static uint32_t	attachedPortLibraries;
+
+/* key to get the end of the synchronous handler records */
+j9thread_tls_key_t tlsKey;
+
+/* key to get the current synchronous signal */
+j9thread_tls_key_t tlsKeyCurrentSignal;
+
+struct {
+	uint32_t portLibSignalNo;
+	int	unixSignalNo;
+} signalMap[] =	{
+	{OMRPORT_SIG_FLAG_SIGSEGV, SIGSEGV},
+	{OMRPORT_SIG_FLAG_SIGILL,  SIGILL},
+	{OMRPORT_SIG_FLAG_SIGFPE,  SIGFPE},
+	{OMRPORT_SIG_FLAG_SIGQUIT, SIGIQUIT},
+	{OMRPORT_SIG_FLAG_SIGABRT, SIGABRT},
+	{OMRPORT_SIG_FLAG_SIGTERM, SIGTERM}
+};
+
+static j9thread_t asynchSignalReporterThread = NULL;
+static int32_t registerMasterHandlers(OMRPortLibrary *portLibrary, uint32_t flags, uint32_t allowedSubsetOfFlags);
+static void	removeAsyncHandlers(OMRPortLibrary* portLibrary);
+static uint32_t	mapUnixSignalToPortLib(uint32_t signalNo, siginfo_t *sigInfo);
+#if defined(J9VM_PORT_ASYNC_HANDLER)
+static int omrthread_t asynchSignalReporter(void *userData);
+#endif
+static uint32_t	registerSignalHandlerWithOS(OMRPortLibrary *portLibrary, uint32_t portLibrarySignalNo, unix_sigaction handler);
+static uint32_t	destroySignalTools(OMRPortLibrary *portLibrary);
+static int32_t	mapPortLibSignalToUnix(uint32_t portLibSignal);
+static uint32_t	countInfoInCategory(struct OMRPortLibrary *portLibrary, void *info, uint32_t category);
+static void	sig_full_shutdown(struct OMRPortLibrary *portLibrary);
+static int32_t	initializeSignalTools(OMRPortLibrary *portLibrary);
+
+void masterSynchSignalHandler(int signal, siginfo_t * sigInfo, void *contextInfo, UDATA breakingEventAddr);
+static void	masterASynchSignalHandler(int signal, siginfo_t * sigInfo, void *contextInfo, UDATA nullArg);
+
+int32_t
+omrsig_can_protect(struct OMRPortLibrary *portLibrary,  uint32_t flags)
+{
+	uint32_t supportedFlags = OMRPORT_SIG_FLAG_MAY_RETURN;
+
+	Trc_PRT_signal_omrsig_can_protect_entered(flags);
+
+	supportedFlags |= OMRPORT_SIG_FLAG_MAY_CONTINUE_EXECUTION;
+
+	if (J9_ARE_NO_BITS_SET(signalOptionsGlobal, OMRPORT_SIG_OPTIONS_REDUCED_SIGNALS_SYNCHRONOUS)) {
+		supportedFlags |= OMRPORT_SIG_FLAG_SIGALLSYNC;
+	}
+
+	if (J9_ARE_NO_BITS_SET(signalOptionsGlobal, OMRPORT_SIG_OPTIONS_REDUCED_SIGNALS_ASYNCHRONOUS)) {
+		supportedFlags |= OMRPORT_SIG_FLAG_SIGQUIT | OMRPORT_SIG_FLAG_SIGABRT | OMRPORT_SIG_FLAG_SIGTERM;
+	}
+
+	if (J9_ARE_ANY_BITS_SET(signalOptionsGlobal, OMRPORT_SIG_OPTIONS_SIGXFSZ)) {
+		supportedFlags |= OMRPORT_SIG_FLAG_SIGXFSZ;
+	}
+
+	if (J9_ARE_ALL_BITS_SET(supportedFlags, flags)) {
+		Trc_PRT_signal_omrsig_can_protect_exiting_is_able_to_protect(supportedFlags);
+		return 1;
+	} else {
+		Trc_PRT_signal_omrsig_can_protect_exiting_is_not_able_to_protect(supportedFlags);
+		return 0;
+	}
+}
+
+uint32_t
+j9sig_info(struct OMRPortLibrary *portLibrary, void *info, uint32_t category, int32_t index, const char **name, void **value)
+{
+	*name = "";
+
+	switch (category) {
+	case OMRPORT_SIG_SIGNAL:
+		return infoForSignal(portLibrary, info, index, name, value);
+	case OMRPORT_SIG_GPR:
+		return infoForGPR(portLibrary, info, index, name, value);
+	case OMRPORT_SIG_CONTROL:
+		return infoForControl(portLibrary, info, index, name, value);
+	case OMRPORT_SIG_MODULE:
+		return infoForModule(portLibrary, info, index, name, value);
+	case OMRPORT_SIG_FPR:
+		return infoForFPR(portLibrary, info, index, name, value);
+	case OMRPORT_SIG_OTHER:
+	default:
+		return OMRPORT_SIG_VALUE_UNDEFINED;
+	}
+}
+
+
+uint32_t
+j9sig_info_count(struct OMRPortLibrary *portLibrary, void *info, uint32_t category)
+{
+	return countInfoInCategory(portLibrary, info, category);
+}
+
+/**
+ * We register the master signal handlers here to deal with -Xrs
+ */
+int32_t
+j9sig_protect(struct OMRPortLibrary *portLibrary,  j9sig_protected_fn fn, void* fn_arg,
+					 j9sig_handler_fn handler, void* handler_arg, uint32_t flags, UDATA *result )
+{
+	struct J9SignalHandlerRecord thisRecord;
+	j9thread_t thisThread;
+	uint32_t rc = 0;
+	uint32_t flagsSignalsOnly;
+	uint32_t flagsWithoutMasterHandlers;
+	
+	Trc_PRT_signal_omrsig_protect_entered(fn, fn_arg, handler, handler_arg, flags);
+
+	if (J9_ARE_ANY_BITS_SET(signalOptionsGlobal, OMRPORT_SIG_OPTIONS_REDUCED_SIGNALS_SYNCHRONOUS)) {
+		/* -Xrs was set, we can't protect against any signals, do not install the master handler */
+		Trc_PRT_signal_omrsig_protect_cannot_protect_dueto_Xrs(fn, fn_arg, flags);
+		*result = fn(portLibrary, fn_arg);		
+		Trc_PRT_signal_omrsig_protect_exiting_did_not_protect_due_to_Xrs(fn, fn_arg, handler, handler_arg, flags);
+		return 0;
+	} 
+
+	/*
+	 * Check to see if we have already installed a masterHandler for these signal(s).
+	 * We will need to aquire the masterHandlerMonitor if flagsWithoutMasterHandlers is not 0
+	 * in order to install the handlers (and to check if another thread had "just" taken care of it).
+	 *
+	 * If we do have masterHandlers installed already then OMRPORT_SIG_OPTIONS_REDUCED_SIGNALS_SYNCHRONOUS
+	 * has not been set.
+	 */
+	flagsSignalsOnly = flags & OMRPORT_SIG_FLAG_SIGALLSYNC;
+	flagsWithoutMasterHandlers = flagsSignalsOnly & (~signalsWithMasterHandlers);
+
+	if (0 != flagsWithoutMasterHandlers) {
+		/*
+		 * We have not installed handlers for all the signals, so acquire the masterHandlerMonitor,
+		 * check again, then install handlers as required: all done in registerMasterHandlers
+		 */
+		omrthread_monitor_enter(masterHandlerMonitor);
+		rc = registerMasterHandlers(portLibrary, flags, OMRPORT_SIG_FLAG_SIGALLSYNC);
+		omrthread_monitor_exit(masterHandlerMonitor);
+
+		if (0 != rc) {
+			return OMRPORT_SIG_ERROR;
+		}
+	}
+	
+	thisThread = omrthread_self();
+	thisRecord.previous = omrthread_tls_get(thisThread, tlsKey);
+	thisRecord.portLibrary = portLibrary;
+	thisRecord.handler = handler;
+	thisRecord.handler_arg = handler_arg;
+	thisRecord.flags = flags;
+
+	if (J9_ARE_ANY_BITS_SET(flags, OMRPORT_SIG_FLAG_MAY_RETURN)) {
+		J9CurrentSignal *currentSignal;
+		/* 
+		 * Record the current signal. We need to store this value back into tls if we
+		 * jump back into this function because any signals that may have occurred 
+		 * within the scope of this layer of protection would have been handled by that point.
+		 * 
+		 * The only scenario where this is of real concern, is if more than one signal was 
+		 * handled per call to j9sig_protect. In this case, the current signal in tls will 
+		 * be pointing at a stale stack frame and signal: CMVC 126838 
+		 */
+		currentSignal = omrthread_tls_get(thisThread, tlsKeyCurrentSignal);
+		/*
+		 * setjmp/longjmp does not clear the mask setup by the OS when it delivers the signal. Use
+		 * sigsetjmp/siglongjmp(buf, 1) instead
+		 */
+		if (0 != setjmp(thisRecord.mark)) {
+			/*
+			 * The handler has long jumped back here -- reset the 
+			 * signal handler stack, and CurrentSignal, then return 
+			 */
+			j9thread_tls_set(thisThread, tlsKey, thisRecord.previous);
+			j9thread_tls_set(thisThread, tlsKeyCurrentSignal, currentSignal);
+			*result = 0;
+			Trc_PRT_signal_omrsignal_sig_protect_Exit_long_jumped_back_to_omrsig_protect(fn, fn_arg, handler,
+																					   handler_arg, flags); 
+			return OMRPORT_SIG_EXCEPTION_OCCURRED;
+		}
+	}
+
+	if (0 != j9thread_tls_set(thisThread, tlsKey, &thisRecord)) {
+		Trc_PRT_signal_omrsignal_sig_protect_Exit_ERROR_accessing_tls(fn, fn_arg, handler, handler_arg, flags);
+		return OMRPORT_SIG_ERROR;
+	}
+
+	*result = fn(portLibrary, fn_arg);
+	/*
+	 * if the first j9thread_tls_set succeeded, then this one will always succeed
+	 */
+	j9thread_tls_set(thisThread, tlsKey, thisRecord.previous);
+
+	Trc_PRT_signal_omrsignal_sig_protect_Exit_after_returning_from_fn(fn, fn_arg, handler, handler_arg, flags, *result);
+	return 0;
+}
+
+
+uint32_t
+omrsig_set_async_signal_handler(struct OMRPortLibrary* portLibrary, j9sig_handler_fn handler,
+							   void* handler_arg, uint32_t flags)
+{
+	uint32_t rc = 0;
+	J9UnixAsyncHandlerRecord *cursor;
+	J9UnixAsyncHandlerRecord **previousLink;
+
+	Trc_PRT_signal_omrsig_set_async_signal_handler_entered(handler, handler_arg, flags);
+	
+	omrthread_monitor_enter(masterHandlerMonitor);
+
+	if (J9_ARE_ANY_BITS_SET(signalOptionsGlobal, OMRPORT_SIG_OPTIONS_REDUCED_SIGNALS_ASYNCHRONOUS)) {
+		/*
+		 * -Xrs was set, we can't protect against any signals,
+		 *  do not install any handlers except SIGXFSZ.
+		 */
+		if (J9_ARE_ANY_BITS_SET(flags, OMRPORT_SIG_FLAG_SIGXFSZ)
+			&& J9_ARE_ANY_BITS_SET(signalOptionsGlobal, OMRPORT_SIG_OPTIONS_SIGXFSZ)) {
+			rc = registerMasterHandlers(portLibrary, OMRPORT_SIG_FLAG_SIGXFSZ, OMRPORT_SIG_FLAG_SIGALLASYNC);
+		} else {
+			Trc_PRT_signal_omrsig_set_async_signal_handler_will_not_set_handler_due_to_Xrs(handler, handler_arg, flags);
+			rc = -1;
+		}
+	} else {
+		rc = registerMasterHandlers(portLibrary, flags, OMRPORT_SIG_FLAG_SIGALLASYNC);
+	}
+	omrthread_monitor_exit(masterHandlerMonitor);
+
+	if (0 != rc) {
+		Trc_PRT_signal_omrsig_set_async_signal_handler_exiting_did_nothing_possible_error(handler, handler_arg, flags);
+		return OMRPORT_SIG_ERROR;
+	}
+	
+	omrthread_monitor_enter(asyncMonitor);
+	/*
+	 * wait until no signals are being reported
+	 */
+	while(asyncThreadCount > 0) {
+		j9thread_monitor_wait(asyncMonitor);
+	}
+	/*
+	 * is this handler already registered? 
+	 */
+	previousLink = &asyncHandlerList;
+	cursor = asyncHandlerList;
+
+	while (NULL != cursor) {
+		if ( (cursor->portLib == portLibrary) && (cursor->handler == handler) && (cursor->handler_arg == handler_arg) ) {
+			if (0 == flags) {	/* Remove the listener, but not masterHandlers, which get removed at j9signal shutdown */
+				*previousLink = cursor->next;						/* remove this handler record */
+				portLibrary->mem_free_memory(portLibrary, cursor);
+				Trc_PRT_signal_omrsig_set_async_signal_handler_user_handler_removed(handler, handler_arg, flags);
+			} else {
+				/*
+				 * update the listener with the new flags 
+				 */
+				Trc_PRT_signal_omrsig_set_async_signal_handler_user_handler_added_1(handler, handler_arg, flags);
+				cursor->flags |= flags;
+			}
+			break;
+		}
+		previousLink = &cursor->next;
+		cursor = cursor->next;
+	}
+
+	if (NULL == cursor) {							/* cursor will only be NULL if we failed to find it in the list */
+		if (0 != flags) {
+			J9UnixAsyncHandlerRecord *record = portLibrary->mem_allocate_memory(portLibrary, sizeof(*record),
+																				OMR_GET_CALLSITE(),
+																				OMRMEM_CATEGORY_PORT_LIBRARY);
+			if (NULL == record) {
+				rc = 1;
+			} else {
+				record->portLib = portLibrary;
+				record->handler = handler;
+				record->handler_arg = handler_arg;
+				record->flags = flags;
+				record->next = NULL;
+				/*
+				 * add the new record to the end of the list
+				 */
+				Trc_PRT_signal_omrsig_set_async_signal_handler_user_handler_added_2(handler, handler_arg, flags);
+				*previousLink = record;
+			}
+		}
+	}
+
+	omrthread_monitor_exit(asyncMonitor);
+
+	Trc_PRT_signal_omrsig_set_async_signal_handler_exiting(handler, handler_arg, flags);
+	return rc;
+}
+
+/*
+ * The full shutdown routine "sig_full_shutdown" overrides this once we've completed startup 
+ */
+void
+omrsig_shutdown(struct OMRPortLibrary *portLibrary)
+{
+
+	Trc_PRT_signal_omrsig_shutdown_empty_routine(portLibrary);
+	return;
+}
+
+/**
+ * Start up the signal handling component of the port library
+ *
+ * Note: none of the master handlers are registered with the OS until the first call to either
+ *		 j9sig_protect or j9sig_set_async_signal_handler.
+ */
+int32_t
+j9sig_startup(struct OMRPortLibrary *portLibrary)
+{
+	int32_t result = 0;
+	j9thread_monitor_t globalMonitor;
+	uint32_t index;
+	
+	Trc_PRT_signal_omrsig_startup_entered(portLibrary);
+
+	globalMonitor = j9thread_global_monitor();
+
+	omrthread_monitor_enter(globalMonitor);
+	if (attachedPortLibraries++ == 0) {				/* Restore the old signal actions	*/
+		for (index = 0; index < MAX_UNIX_SIGNAL_TYPES ;index++) {
+			oldActions[index].restore = 0;
+		}
+		result = initializeSignalTools(portLibrary);
+	}
+	omrthread_monitor_exit(globalMonitor);
+
+	/*
+	 * z/TPF needs a thread calling tpf_process_signals() every 50 ms or so.
+	 * This thread gets launched here.
+	 */
+	if( J9THREAD_SUCCESS != ztpf_enableSignalHandlers(portLibrary) ) { 
+		portLibrary->tty_err_printf( portLibrary, "JVMZTPF01E Cannot enable tpf_process_signals()" );
+	}
+	/*
+	 *	If we have successfully started up the signal portion, 
+	 *	then install the full shutdown routine.
+	 */
+	if(result == 0) {
+		portLibrary->sig_shutdown = sig_full_shutdown;
+	}
+	Trc_PRT_signal_omrsig_startup_exiting(portLibrary, result);
+	return result;
+}
+
+static uint32_t
+countInfoInCategory(struct OMRPortLibrary *portLibrary, void *info, uint32_t category) {
+
+	void* value;
+	const char* name;
+	uint32_t count = 0;
+
+	while (portLibrary->sig_info(portLibrary, info, category, count, &name, &value) != OMRPORT_SIG_VALUE_UNDEFINED) {
+		count++;
+	}
+	return count;
+}
+
+/**
+ * Reports the asynchronous signal to all listeners.
+ */
+static int32_t J9THREAD_PROC
+asynchSignalReporter(void *userData) {
+
+	J9UnixAsyncHandlerRecord* cursor;
+	uint32_t asyncSignalFlag = 0;
+	int result = 0;
+	j9thread_set_name(omrthread_self(), "Signal Reporter");
+
+	for(;;) {
+
+		Trc_PRT_signal_omrsig_asynchSignalReporterThread_going_to_sleep();
+		/* CMVC  119663 sem_wait can return -1/EINTR on signal in NPTL */
+		while (0 != sem_wait(&wakeUpASyncReporter));
+		Trc_PRT_signal_omrsig_asynchSignalReporter_woken_up();
+		/* we get woken up if there is a signal pending or it is time to shutdown */
+		if(0 != shutDownASynchReporter) {
+			Trc_PRT_signal_omrsig_asynchSignalReporter_woken_up_for_shutdown();
+			break;
+		}
+		/*
+		 * determine which signal we've being woken up for 
+		 */
+		if (0 == sem_trywait(&sigQuitPendingSem)) {
+			Trc_PRT_signal_omrsig_asynchSignalReporter_woken_up_for_SIGQUIT();
+			asyncSignalFlag = OMRPORT_SIG_FLAG_SIGQUIT;
+		} 
+		else if (0 == sem_trywait(&sigAbrtPendingSem)) {
+			Trc_PRT_signal_omrsig_asynchSignalReporter_woken_up_for_SIGABRT();
+			asyncSignalFlag = OMRPORT_SIG_FLAG_SIGABRT;
+		} 
+		else if (0 == sem_trywait(&sigTermPendingSem)) {
+			Trc_PRT_signal_omrsig_asynchSignalReporter_woken_up_for_SIGTERM();
+			asyncSignalFlag = OMRPORT_SIG_FLAG_SIGTERM;
+		} 
+		else if (0 == sem_trywait(&sigXfszPendingSem)) {
+			Trc_PRT_signal_omrsig_asynchSignalReporter_woken_up_for_SIGXFSZ();
+			asyncSignalFlag = OMRPORT_SIG_FLAG_SIGXFSZ;
+		}
+		/*
+		 * report the signal recorded in signalType to all registered listeners (for this signal)
+		 * incrementing the asyncThreadCount will prevent the list from being modified while we use it	
+		 */
+		omrthread_monitor_enter(asyncMonitor);
+		asyncThreadCount++;
+		omrthread_monitor_exit(asyncMonitor);
+
+		cursor = asyncHandlerList;
+		while (NULL != cursor) {
+			if (J9_ARE_ANY_BITS_SET(cursor->flags, asyncSignalFlag)) {
+				Trc_PRT_signal_omrsig_asynchSignalReporter_calling_handler(cursor->portLib,
+																		  asyncSignalFlag, cursor->handler_arg); 
+				cursor->handler(cursor->portLib, asyncSignalFlag, NULL, cursor->handler_arg);
+			}
+			cursor = cursor->next;
+		}
+		omrthread_monitor_enter(asyncMonitor);
+		if (--asyncThreadCount == 0) {
+			j9thread_monitor_notify_all(asyncMonitor);
+		}
+		omrthread_monitor_exit(asyncMonitor);
+#ifdef OMRPORT_JSIG_SUPPORT
+		if (J9_ARE_NO_BITS_SET(signalOptionsGlobal, OMRPORT_SIG_OPTIONS_JSIG_NO_CHAIN)) {
+			int unixSignal = mapPortLibSignalToUnix(asyncSignalFlag);	 /* mapPortLibSignalToUnix returns */
+																		 /* -1 on an unknown mapping	   */
+			if (-1 != unixSignal) {
+				jsig_handler(unixSignal, NULL, NULL);
+			}
+		}
+#endif
+		asyncSignalFlag = 0;								/* reset the signal store */
+	}
+	
+	omrthread_monitor_enter(asyncReporterShutdownMonitor);
+	shutDownASynchReporter = 0;
+	j9thread_monitor_notify(asyncReporterShutdownMonitor);
+	j9thread_exit(asyncReporterShutdownMonitor);
+
+	/* unreachable */
+	return 0;
+}
+
+/**
+ * This signal handler is specific to synchronous signals.
+ * It will call all of the user's handlers that were registered with the 
+ * vm using j9sig_protect upon receiving a signal one listens for.
+ *
+ */ 
+void
+masterSynchSignalHandler(int signal, siginfo_t * sigInfo, void *contextInfo, UDATA breakingEventAddr)
+{ 
+	j9thread_t thisThread = omrthread_self();
+	uint32_t result = uint32_t_MAX;
+
+	if (NULL != thisThread) {
+		uint32_t portLibType;
+		struct J9SignalHandlerRecord* thisRecord;
+		struct J9CurrentSignal currentSignal; 
+		struct J9CurrentSignal *previousSignal;
+		
+		/* Trc_PRT_signal_masterSynchSignalHandler_entered(signal, sigInfo, contextInfo); */
+
+		thisRecord = NULL;
+		
+		portLibType = mapUnixSignalToPortLib(signal, sigInfo);
+	
+		/* record this signal in tls so that jsig_handler can be called if any of the handlers decide we should be shutting down */
+		currentSignal.signal = signal;
+		currentSignal.sigInfo = sigInfo;
+		currentSignal.contextInfo = contextInfo;
+		currentSignal.portLibSignalType = portLibType;
+#ifndef J9ZTPF
+		currentSignal.breakingEventAddr = breakingEventAddr;
+#endif
+	
+		previousSignal =  omrthread_tls_get(thisThread, tlsKeyCurrentSignal);
+
+		j9thread_tls_set(thisThread, tlsKeyCurrentSignal, &currentSignal);
+		/*
+		 * walk the stack of registered handlers from top to bottom searching for one which handles this type of exception 
+		 */
+		thisRecord = omrthread_tls_get(thisThread, tlsKey);
+
+		while (NULL != thisRecord) {
+
+			if (J9_ARE_ANY_BITS_SET(thisRecord->flags,portLibType)) {
+				struct J9UnixSignalInfo j9Info;
+				struct J9PlatformSignalInfo platformSignalInfo;
+
+				/*
+				 * the equivalent of these memsets were here before, but were they needed? 
+				 */
+				memset(&j9Info, 0, sizeof(j9Info));
+				memset(&platformSignalInfo, 0, sizeof(platformSignalInfo));
+
+				j9Info.portLibrarySignalType = portLibType;
+				j9Info.handlerAddress = (void*)thisRecord->handler;
+				j9Info.handlerAddress2 = (void*)masterSynchSignalHandler;
+				j9Info.sigInfo = sigInfo;
+				j9Info.platformSignalInfo = platformSignalInfo;
+				/*
+				 * Found a suitable handler - what signal type do we want to pass 
+				 * on here? port or platform based ?
+				 */
+				fillInUnixSignalInfo(thisRecord->portLibrary, contextInfo, &j9Info);
+				j9Info.platformSignalInfo.breakingEventAddr = breakingEventAddr;
+				/*
+				 * remove the handler we are about to invoke, now, in case the handler crashes
+				 */
+				j9thread_tls_set(thisThread, tlsKey, thisRecord->previous);
+#if 0
+				Trc_PRT_signal_masterSynchSignalHandler_calling_handler
+				   (signal, sigInfo, contextInfo, thisRecord->handler, thisRecord->portLibrary);
+#endif
+				result = thisRecord->handler(thisRecord->portLibrary, portLibType, &j9Info, thisRecord->handler_arg);
+#if 0
+				Trc_PRT_signal_masterSynchSignalHandler_called_handler
+				   (signal, sigInfo, contextInfo, thisRecord->handler, thisRecord->portLibrary, result);
+#endif
+				/* 
+				 * The only case in which we don't want the previous handler back on top is if 
+				 * it just returned OMRPORT_SIG_EXCEPTION_RETURN. In this case we will remove it
+				 * from the top after executing the siglongjmp 
+				 */
+				j9thread_tls_set(thisThread, tlsKey, thisRecord);
+
+				if (result == OMRPORT_SIG_EXCEPTION_CONTINUE_SEARCH) {
+					/* continue looping */
+				} 
+				else if (result == OMRPORT_SIG_EXCEPTION_CONTINUE_EXECUTION) {
+					j9thread_tls_set(thisThread, tlsKeyCurrentSignal, previousSignal);
+#if 0
+					Trc_PRT_signal_masterSynchSignalHandler_exiting_continuing_execution
+					   (signal, sigInfo, contextInfo, thisRecord->handler, thisRecord->portLibrary);
+#endif
+					return;
+				} 
+				else /* if (result == OMRPORT_SIG_EXCEPTION_RETURN) */ {
+					j9thread_tls_set(thisThread, tlsKeyCurrentSignal, previousSignal);
+#if 0
+					Trc_PRT_signal_masterSynchSignalHandler_exiting_siglongjumping
+					   (signal, sigInfo, contextInfo, thisRecord->handler, thisRecord->portLibrary);
+#endif
+					longjmp(thisRecord->mark, 0);
+					/* unreachable */
+				}
+			}
+			thisRecord = thisRecord->previous;
+		}
+		j9thread_tls_set(thisThread, tlsKeyCurrentSignal, previousSignal);
+
+	} /* if (thisThread != NULL) */
+
+	/* The only ways to get here are: (1) if this thread was not attached to the thread library or 
+	 * (2) the thread hasn't registered any signal handlers with the port library that could handle the signal
+	 */
+	if (J9_ARE_NO_BITS_SET(signalOptionsGlobal, OMRPORT_SIG_OPTIONS_JSIG_NO_CHAIN)) {
+#if 0
+		Trc_PRT_signal_masterSynchSignalHandler_calling_jsig_handler(signal, sigInfo, contextInfo);
+#endif
+		int rc	= jsig_handler(signal, (void *)sigInfo, contextInfo);
+		if ((JSIG_RC_DEFAULT_ACTION_REQUIRED == rc) && (SI_USER != sigInfo->si_code) ) {
+#if 0
+			Trc_PRT_signal_masterSynchSignalHandler_aborting_after_jsig_handler(signal, sigInfo, contextInfo);
+#endif
+			abort();
+		}
+
+	}
+	/*
+	 * If we got this far there weren't any handlers on the stack that knew what to with this signal,
+	 * so the default action is to abort 
+	 */
+#if 0
+	Trc_PRT_signal_masterSynchSignalHandler_no_handlers_so_aborting(signal, sigInfo, contextInfo);
+#endif
+	abort();
+
+}
+
+
+/** 
+ * Determines the signal received and notifies the asynch signal reporter
+ *
+ * One semaphore is used to notify the asynchronous signal reporter that it is time to act.
+ * Each expected aynch signal type has an associated semaphore which is used to count the number of "pending" signals.
+ *
+ */
+static void
+masterASynchSignalHandler(int signal, siginfo_t * sigInfo, void *contextInfo, UDATA nullArg)
+{ 
+	uint32_t portLibSignalType;
+	portLibSignalType = mapUnixSignalToPortLib(signal, sigInfo);
+
+	/* Todo: default? */
+	switch (portLibSignalType) {
+	case OMRPORT_SIG_FLAG_SIGQUIT:
+		sem_post(&sigQuitPendingSem);
+		break;
+	case OMRPORT_SIG_FLAG_SIGABRT:
+		sem_post(&sigAbrtPendingSem);
+		break;
+	case OMRPORT_SIG_FLAG_SIGTERM:
+		sem_post(&sigTermPendingSem);
+		break;
+	case OMRPORT_SIG_FLAG_SIGRECONFIG:
+		sem_post(&sigReconfigPendingSem);
+		break;
+	case OMRPORT_SIG_FLAG_SIGXFSZ:
+		sem_post(&sigXfszPendingSem);
+		break;
+	}
+#if 0
+	Trc_PRT_signal_omrsignal_AsynchSignalHandler_Entry(signal, sigInfo, contextInfo);
+#endif
+	sem_post(&wakeUpASyncReporter);
+	return;
+}
+
+/**
+ * Register the signal handler with the OS, generally used to register the master signal handlers 
+ * Not to be confused with j9sig_protect, which registers the user's handler with the port library.
+ * 
+ * Calls to this function must be synchronized using "masterHandlerMonitor".
+ * 
+ * The use of this function forces the flags SA_RESTART | SA_SIGINFO | SA_NODEFER to be set for the new signal action
+ * 
+ * The old action for the signal handler is stored in oldActions. These must be restored before the portlibrary is shut down.
+ *
+ * @return 0 upon success, non-zero otherwise.
+ */
+static uint32_t
+registerSignalHandlerWithOS(OMRPortLibrary *portLibrary, uint32_t portLibrarySignalNo,  unix_sigaction handler)
+{
+	struct sigaction newAction;
+	int	unixSignalNo = mapPortLibSignalToUnix(portLibrarySignalNo);
+
+	if( unixSignalNo == -1 )	/* if the signal is undefined to TPF,	*/
+		return 0;				/*	 skip the rest of this function.	*/
+	/*
+	 * do not block any signals
+	 */
+	if (0 != sigemptyset(&newAction.sa_mask)) {
+		return -1;
+	}
+	/*
+	 * Automatically restart system calls that get interrupted by any signal
+	 * Neutrino V6.3 does not support this 
+	 */
+	newAction.sa_flags = SA_RESTART;
+	/*
+	 * Setting to SA_SIGINFO will result in "void (*sa_sigaction) (int, siginfo_t *, void *)" 
+	 * to be used, and not "__sighandler_t sa_handler". Both are members of struct sigaction,
+	 * using the former allows us to access much more information than just the signal number 
+	 */
+	newAction.sa_flags |= SA_SIGINFO;
+
+	/* 
+	 * SA_NODEFER prevents the current signal from being masked by default in the handler. 
+	 * However, it can still be masked if one explicitly requests so in sa_mask field, 
+	 * as is done on z/OS 
+	 */
+	newAction.sa_flags |= SA_NODEFER;
+
+	/*
+	 * The master exception handler:
+	 *		The (void *) casting only applies to zLinux because a new parameter "UDATA breakingEventAddr" 
+	 *		has been introduced in masterSynchSignalHandler() to obtain BEA on zLinux but not for other platforms.
+	 *		As a result, the total number of parameters in masterSynchSignalHandler() on zLinux & z/TPF
+	 *		is 4 while the number is 3 on other platforms, because there is no need to change the signature of 
+	 *		masterSynchSignalHandler in there. Since the code is shared on all platforms, the change here is used 
+	 *		to split them up to avoid any compiling error.
+	 */
+	newAction.sa_sigaction = (void *)handler;
+
+	/* now that we've set up the sigaction struct the way we want it, register the handler with the OS */
+	if (J9JSIG_SIGACTION(unixSignalNo, &newAction, &oldActions[unixSignalNo].action)) {
+		Trc_PRT_signal_registerSignalHandlerWithOS_failed_to_registerHandler(portLibrarySignalNo, unixSignalNo, handler);
+		return -1;
+	} 
+	else {
+		Trc_PRT_signal_registerSignalHandlerWithOS_registeredHandler(portLibrarySignalNo, unixSignalNo, handler);	
+		oldActions[unixSignalNo].restore = 1;
+	}
+
+	/* CMVC 96193 signalsWithMasterHandlers is checked without acquiring the masterHandlerMonitor */ 
+	issueWriteBarrier();
+	/*
+	 * we've successfully registered the master handler for this, record it!
+	 */
+	signalsWithMasterHandlers |= portLibrarySignalNo;
+
+	return 0;
+}
+
+ /**
+ * \fn	The unix signal number is converted to the corresponding port library 
+ *		signal number.
+ *
+ *	We do this by going in and matching the Program Interrupt Code, which we
+ *	have if and only if we have an associated Java Dump Buffer. If we don't
+ *	have one, then we can't map it, so just return zero.
+ *
+ *	There are multiple functions which call this routine. Test to see if the
+ *	siginfo_t passed by reference is already built. If so, do not rebuild it.
+ *
+ *	Some signals have subtypes which are detailed in the siginfo_t structure.
+ *	That's fine for other platforms, but not too likely on z/TPF; and even if
+ *	so, probably doesn't distinguish between floating point, integer, and 
+ *	packed decimal datatype errors (for example). So go ahead and do it 
+ *	ourselves -- that way, we're sure.
+ *
+ *	The only signal value we do this for is SIGFPE; all the others just return
+ *	what they're passed.
+ *
+ *	\param[in]	signalNo	The signal number as passed back to the signal handler.
+ *	\param[in]	sigInfo		The <tt>siginfo_t</tt> structure as passed back to the
+ *							upper-layer signal handler.
+ *
+ *	\note	Make sure to test the sigInfo pointer, treat it as non-extant if zero.
+ *			Go ahead and write on it if it's there. If we have one, we'll store
+ *			the signal value and the translated PIC into it.
+ */
+uint32_t
+mapUnixSignalToPortLib(uint32_t signalNo, siginfo_t *sigInfo)
+{
+	uint32_t index;
+	struct ijdib *dibPtr = (struct ijdib *)(ecbp2()->ce2dib);
+	struct ijavdbf *dbfPtr = (struct ijavdbf *)(dibPtr->dibjdb);
+
+	for (index = 0 ; index < sizeof(signalMap)/sizeof(signalMap[0]); index++) {
+		if (signalMap[index].unixSignalNo == signalNo) {									
+			if( !sigInfo )							/* If we don't have a siginfo_t pointer,*/
+				return signalNo;					/*	then just return what we got passed */
+
+			/*	Otherwise, do translation from the JDB if there's one of those as long		*/
+			/*	as we have a DIB pointer belonging to this thread from which to build it.	*/
+			/*	If these conditions aren't met, then just return it to the caller verbatim. */
+
+			if( (0 != sigInfo->si_signo || 0 != sigInfo->si_code) && dbfPtr ) {
+				ztpfDeriveSiginfo( sigInfo );		/* Build a new siginfo_t				*/
+				signalNo = sigInfo->si_signo;		/* Set return value.					*/
+			}
+			if (SIGFPE == signalNo) {
+				if (0 != sigInfo) {
+					/* If we are not looking up the mapping in response to a signal
+					 * we will not have a siginfo_t structure */
+					/* Linux 2.4 kernel bug: 64-bit platforms or in 0x30000 into si_code */
+					switch (sigInfo->si_code & 0xff) {
+					case FPE_FLTDIV:
+						return OMRPORT_SIG_FLAG_SIGFPE_DIV_BY_ZERO;
+					case FPE_INTDIV:
+						return OMRPORT_SIG_FLAG_SIGFPE_INT_DIV_BY_ZERO;
+					case FPE_INTOVF:
+						return OMRPORT_SIG_FLAG_SIGFPE_INT_OVERFLOW;
+					default:
+						return OMRPORT_SIG_FLAG_SIGFPE;
+					}
+				return OMRPORT_SIG_FLAG_SIGFPE;
+				}
+			}
+			return signalMap[index].portLibSignalNo;
+		}
+	}
+	return 0;
+}
+
+/**
+ * \fn The defined port library signal is converted to the corresponding unix 
+ * signal number.
+ *
+ * Note that FPE signal codes (subtypes) all map to the same signal number and are not included 
+ * 
+ * \param[in] portLibSignal The internal J9 Port Library signal number
+ * \return The corresponding Unix signal number or -1 if the portLibSignal could not be mapped
+ */
+static int
+mapPortLibSignalToUnix(uint32_t portLibSignal)
+{
+	uint32_t index;
+
+	/* mask out subtypes */
+	portLibSignal &= OMRPORT_SIG_FLAG_SIGALLSYNC | OMRPORT_SIG_FLAG_SIGQUIT | OMRPORT_SIG_FLAG_SIGABRT | OMRPORT_SIG_FLAG_SIGTERM | OMRPORT_SIG_FLAG_SIGXFSZ;
+	for (index = 0; index < sizeof(signalMap)/sizeof(signalMap[0]); index++) {
+
+		if (signalMap[index].portLibSignalNo == portLibSignal) {
+			return signalMap[index].unixSignalNo;
+		}
+	}
+	return -1;
+}
+
+
+/**
+ * \fn Registers the master handler for the signals in flags that don't have one.
+ * 
+ * Calls to this function must be synchronized using masterHandlerMonitor.
+ *
+ * @param[in] portLibrary			Address of this JVM's OMRPortLibrary
+ * @param[in] flags					The flags that we want signals for
+ * @param[in] allowedSubsetOfFlags	Must be either OMRPORT_SIG_FLAG_SIGALLSYNC or OMRPORT_SIG_FLAG_SIGALLASYNC
+ * 
+ * @return	0 upon success; OMRPORT_SIG_ERROR otherwise.
+ *			Possible failure scenarios include attempting to register a handler for
+ *			a signal that is not included in the allowedSubsetOfFlags
+*/
+static int32_t
+registerMasterHandlers(OMRPortLibrary *portLibrary, uint32_t flags, uint32_t allowedSubsetOfFlags)
+{
+	uint32_t flagsSignalsOnly = 0;
+	uint32_t flagsWithoutHandlers = 0;
+	unix_sigaction handler;
+
+	if (OMRPORT_SIG_FLAG_SIGALLSYNC == allowedSubsetOfFlags) {
+		handler = masterSynchSignalHandler;
+	} 
+	else if (OMRPORT_SIG_FLAG_SIGALLASYNC == allowedSubsetOfFlags) {
+		handler = masterASynchSignalHandler;
+	} 
+	else {
+		return OMRPORT_SIG_ERROR;
+	}
+	flagsSignalsOnly = flags & allowedSubsetOfFlags;
+	flagsWithoutHandlers = flagsSignalsOnly & (~signalsWithMasterHandlers);
+
+	if (0 != flagsWithoutHandlers) {		/* we be registerin' some handlers */
+		uint32_t portSignalType = 0;
+		/*
+		 * portSignalType starts off at 0 as it is the smallest synch signal. 
+		 * In the case that we are registering an asynch signal, flagsWithoutHandlers has already
+		 * masked off the synchronous signals (eg. "0") so we are not at risk of registering a 
+		 * handler for an incorrect signal	
+		*/
+		for (portSignalType = 4; portSignalType < allowedSubsetOfFlags; portSignalType = portSignalType << 1) {
+			/*
+			 * Iterate through all the signals and register the master handler
+			 * for those that don't have one yet
+			 */
+			if (J9_ARE_ANY_BITS_SET(flagsWithoutHandlers, portSignalType)) {
+				/*
+				 * we need a master handler for this (portSignalType's) signal
+				 */
+				if (0 != registerSignalHandlerWithOS(portLibrary, portSignalType, handler)) {
+					return OMRPORT_SIG_ERROR;
+				}
+			}
+		}
+	}
+	return 0;
+}
+
+
+static int32_t
+initializeSignalTools(OMRPortLibrary *portLibrary)
+{
+
+	/* use this to record the end of the list of signal infos */
+	if(j9thread_tls_alloc(&tlsKey))		{
+		return -1;
+	}
+
+	/* use this to record the last signal that occured such that we can call jsig_handler in j9exit_shutdown_and_exit */
+	if(j9thread_tls_alloc(&tlsKeyCurrentSignal)) {
+		return -1;
+	}
+
+	if(j9thread_monitor_init_with_name( &masterHandlerMonitor, 0, "portLibrary_omrsig_masterHandler_monitor" ) ) {
+		return -1;
+	}
+
+	if(j9thread_monitor_init_with_name( &asyncReporterShutdownMonitor, 0, "portLibrary_omrsig_asynch_reporter_shutdown_monitor" ) ) {
+		return -1;
+	}
+
+	if(j9thread_monitor_init_with_name( &asyncMonitor, 0, "portLibrary_omrsig_async_monitor" ) ) {
+		return -1;
+	}
+
+	/* The asynchronous signal reporter will wait on this semaphore  */
+	if(0 != sem_init(&wakeUpASyncReporter, 0, 0))	 {
+		return -1;
+	}
+
+	/* The asynchronous signal reporter keeps track of the number of pending singals with these... */  
+	if(0 != sem_init(&sigQuitPendingSem, 0, 0))		{
+		return -1;
+	}
+	if(0 != sem_init(&sigAbrtPendingSem, 0, 0))		{
+		return -1;
+	}
+	if(0 != sem_init(&sigTermPendingSem, 0, 0))		{
+		return -1;
+	}
+	if(0 != sem_init(&sigReconfigPendingSem, 0, 0))	{
+		return -1;
+	}
+	if(0 != sem_init(&sigXfszPendingSem, 0, 0))		{
+		return -1;
+	}
+	if(J9THREAD_SUCCESS != j9thread_create(&asynchSignalReporterThread, 256 * 1024, J9THREAD_PRIORITY_MAX, 0, &asynchSignalReporter, NULL, J9THREAD_CATEGORY_SYSTEM_THREAD)) {
+		return -1;
+	}
+	return 0;
+}
+
+static int32_t
+setReporterPriority(OMRPortLibrary *portLibrary, UDATA priority)
+{
+	
+	Trc_PRT_signal_setReporterPriority(portLibrary, priority);
+	
+	if(asynchSignalReporterThread == NULL) {
+		return -1;
+	}
+	
+	return j9thread_set_priority(asynchSignalReporterThread, priority);
+}
+
+/**
+ * sets the priority of the the async reporting thread
+*/
+int32_t
+omrsig_set_reporter_priority(struct OMRPortLibrary *portLibrary, UDATA priority)
+{
+
+	int32_t result = 0;
+
+	j9thread_monitor_t globalMonitor = j9thread_global_monitor();
+	
+	omrthread_monitor_enter(globalMonitor);
+	if (attachedPortLibraries > 0) {
+		result = setReporterPriority(portLibrary, priority);
+	}
+	omrthread_monitor_exit(globalMonitor);
+
+	return result;
+}
+
+static uint32_t
+destroySignalTools(OMRPortLibrary *portLibrary)
+{
+	j9thread_tls_free(tlsKey);
+	j9thread_tls_free(tlsKeyCurrentSignal);
+	j9thread_monitor_destroy(masterHandlerMonitor);
+	j9thread_monitor_destroy(asyncReporterShutdownMonitor);
+	j9thread_monitor_destroy( asyncMonitor);
+	j9thread_monitor_destroy(ztpfSigShutdownMonitor);
+	sem_destroy(&wakeUpASyncReporter);
+	sem_destroy(&sigQuitPendingSem);
+	sem_destroy(&sigAbrtPendingSem);
+	sem_destroy(&sigTermPendingSem);
+	sem_destroy(&sigReconfigPendingSem);
+	sem_destroy(&sigXfszPendingSem);
+	return 0;
+}
+
+int32_t
+omrsig_set_options(struct OMRPortLibrary *portLibrary, uint32_t options)
+{
+	Trc_PRT_signal_omrsig_set_options(options);
+	
+	if ( (OMRPORT_SIG_OPTIONS_REDUCED_SIGNALS_SYNCHRONOUS | OMRPORT_SIG_OPTIONS_REDUCED_SIGNALS_ASYNCHRONOUS)  & options)  {
+		/* check that we haven't already set any master handlers */
+		
+		uint32_t anyHandlersInstalled = 0;
+		
+		omrthread_monitor_enter(masterHandlerMonitor);
+		if (0 != signalsWithMasterHandlers) {
+			anyHandlersInstalled = 1;
+		}
+		omrthread_monitor_exit(masterHandlerMonitor);
+		
+		if (anyHandlersInstalled) {
+			Trc_PRT_signal_omrsig_set_options_too_late_handlers_installed(options);
+			return -1;
+		}
+	}
+	signalOptionsGlobal |= options;
+	return 0;
+}
+
+uint32_t
+omrsig_get_options(struct OMRPortLibrary *portLibrary)
+{
+	return signalOptionsGlobal;
+}
+
+
+intptr_t
+omrsig_get_current_signal(struct OMRPortLibrary *portLibrary)
+{
+	J9CurrentSignal * currentSignal = omrthread_tls_get(omrthread_self(), tlsKeyCurrentSignal);
+	if (currentSignal == NULL) {
+		return 0;
+	}
+	return currentSignal->portLibSignalType;
+}
+
+static void
+sig_full_shutdown(struct OMRPortLibrary *portLibrary)
+{
+	j9thread_monitor_t globalMonitor;
+	uint32_t index;
+	
+	Trc_PRT_signal_sig_full_shutdown_enter(portLibrary);
+
+	globalMonitor =j9thread_global_monitor();
+	omrthread_monitor_enter(globalMonitor);
+	if (--attachedPortLibraries == 0) {		/* register the old actions we overwrote with our own */
+		for ( index = 0; index < MAX_UNIX_SIGNAL_TYPES; index++) {
+			if (oldActions[index].restore) {
+				J9JSIG_SIGACTION(index, &oldActions[index].action, NULL);
+				/* record that we no longer have a handler installed with the OS for this signal */
+				Trc_PRT_signal_sig_full_shutdown_deregistered_handler_with_OS(portLibrary, index);
+				signalsWithMasterHandlers &= ~mapUnixSignalToPortLib(index, 0);				
+			}
+		}
+		removeAsyncHandlers(portLibrary);
+#if defined(J9VM_PORT_ASYNC_HANDLER)
+		/* shut down the asynch reporter thread */
+		omrthread_monitor_enter(asyncReporterShutdownMonitor);
+		shutDownASynchReporter = 1;
+		sem_post(&wakeUpASyncReporter);
+		while (shutDownASynchReporter) {
+			j9thread_monitor_wait(asyncReporterShutdownMonitor);	
+		}
+		omrthread_monitor_exit(asyncReporterShutdownMonitor);
+#endif	/* defined(J9VM_PORT_ASYNC_HANDLER) */
+		omrthread_monitor_enter(ztpfSigShutdownMonitor);
+		shutdown_ztpf_sigpush = 1;
+		while (shutdown_ztpf_sigpush) {
+			j9thread_monitor_wait(ztpfSigShutdownMonitor);	
+		}
+		omrthread_monitor_exit(ztpfSigShutdownMonitor);
+		/* destroy all of the remaining monitors */
+		destroySignalTools(portLibrary);
+	}
+	omrthread_monitor_exit(globalMonitor);
+	Trc_PRT_signal_sig_full_shutdown_exiting(portLibrary);
+}
+
+static void
+removeAsyncHandlers(OMRPortLibrary* portLibrary)
+{
+	/* clean up the list of async handlers */
+	J9UnixAsyncHandlerRecord* cursor;
+	J9UnixAsyncHandlerRecord** previousLink;
+
+	omrthread_monitor_enter(asyncMonitor);
+
+	/* wait until no signals are being reported */
+	while(asyncThreadCount > 0) {
+		j9thread_monitor_wait(asyncMonitor);
+	}
+
+	previousLink = &asyncHandlerList;
+	cursor = asyncHandlerList;
+	while (cursor) {
+		if ( cursor->portLib == portLibrary ) {
+			*previousLink = cursor->next;
+			portLibrary->mem_free_memory(portLibrary, cursor);
+			cursor = *previousLink;
+		} else {
+			previousLink = &cursor->next;
+			cursor = cursor->next;
+		}
+	}
+
+	omrthread_monitor_exit(asyncMonitor);
+}
+
+#if defined(OMRPORT_JSIG_SUPPORT)
+
+/*	@internal 
+ *
+ * j9exit_shutdown_and_exit needs to call this to ensure the signal is chained to jsig (the application
+ *	handler in the case when the shutdown is due to a fatal signal.
+ * 
+ * @return	
+*/
+void
+omrsig_chain_at_shutdown_and_exit(struct OMRPortLibrary *portLibrary)
+{
+
+	J9CurrentSignal *currentSignal = omrthread_tls_get(omrthread_self(), tlsKeyCurrentSignal);
+
+	Trc_PRT_signal_omrsig_chain_at_shutdown_and_exit_enter(portLibrary);
+
+	if (currentSignal != NULL) {
+		/* we are shutting down due to a signal, forward it to the application handlers */
+		if (!(signalOptionsGlobal & OMRPORT_SIG_OPTIONS_JSIG_NO_CHAIN)) {
+			Trc_PRT_signal_omrsig_chain_at_shutdown_and_exit_forwarding_to_jsigHandler(portLibrary, currentSignal->signal);
+			jsig_handler(currentSignal->signal, currentSignal->sigInfo, currentSignal->contextInfo);
+		}	
+	}
+	Trc_PRT_signal_omrsig_chain_at_shutdown_and_exit_exiting(portLibrary);
+
+}
+#endif /* OMRPORT_JSIG_SUPPORT */
+

--- a/port/ztpf/omrsignal.h
+++ b/port/ztpf/omrsignal.h
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 1991, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial API and implementation and/or initial documentation
+ *    Multiple authors (IBM Corp.) - z/TPF platform initial port to OMR environment
+ *******************************************************************************/
+#ifndef _ZTPF_OMRSIGNAL_H_INCLUDED
+#define _ZTPF_OMRSIGNAL_H_INCLUDED
+#include <setjmp.h>
+#include <tpf/i_jdib.h>
+
+/*
+ *	The following structure and user-defined type originally came from
+ *	omrsignal.c; apparently custom-implemented for each different kind of
+ *	platform. We have moved these here because these are custom for and	
+ *	possibly unique to z/TPF at some later time.
+ */
+
+struct J9SignalHandlerRecord {
+	struct J9SignalHandlerRecord *previous;
+	struct OMRPortLibrary *portLibrary;
+	j9sig_handler_fn handler;
+	void *handler_arg;
+	jmp_buf	mark;			
+	uint32_t flags;
+};
+
+typedef struct J9CurrentSignal {
+	int	signal;
+	siginfo_t *sigInfo;
+	void *contextInfo;
+	uintptr_t breakingEventAddr;
+	uint32_t portLibSignalType;
+	DIB	*ptrDIB;
+} J9CurrentSignal;
+
+void masterSynchSignalHandler(int signal, siginfo_t * sigInfo, void *contextInfo, uintptr_t breakingEventAddr);
+
+#endif

--- a/port/ztpf/omrsignal_context.c
+++ b/port/ztpf/omrsignal_context.c
@@ -1,0 +1,680 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 1991, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial API and implementation and/or initial documentation
+ *    Multiple authors (IBM Corp.) - z/TPF platform initial port to OMR environment
+ *******************************************************************************/
+
+/**
+ * \file
+ * \ingroup Port
+ * \brief Saves and returns information about signals
+ */
+
+#define ZTPF_NEEDS_GETCONTEXT
+
+#include <errno.h>
+#include <string.h>
+#include <sys/ucontext.h>
+#include "sys/sigcontext.h"
+#include <tpf/c_proc.h>
+#include "omrport.h"
+#include "omrsignal_context.h"
+
+/**
+ * The number of registers in the hardware implementation.
+ */
+#define NUM_REGS 16
+
+/**
+ * The number of elements in our PIC-to-si_signo,si_code table
+ */
+#define PIC_TABLE_MAX  60 
+
+/*
+ *	What follows is a set of signal number & signal code values to which a s390
+ *	PIC should translate. For multiply-assignable high-level PICs, leave the 
+ *	si_code field zero; we can try to clear it up after PIC translation. This 
+ *	table was pretty well matched up with how CPSE treats PICs, apart from 
+ *	having to deal with PER and/or transactional considerations.
+ *
+ *	In terms of virtual memory management, we work in a primary-space mode. 
+ *	Exceptions associated with the all the others: secondary-space mode,
+ *	access-register mode, and home mode. Virtual address mapping is the same
+ *	for all CPUs (I-streams) except for page 0 (addresses 0-0400 hex).
+ */
+static const sigvpair_t	pic2pair[] = {	IMPOSSIBLE, /*	0: Not assigned						*/
+	{ SIGILL,	ILL_ILLOPC },	/* PIC 1, Operation exc */
+	{ SIGILL,	ILL_PRVOPC },	/* PIC 2, Priv Oper'n	*/
+	{ SIGILL,	ILL_ILLADR },	/* PIC 3, Execute exc.	*/
+	{ SIGSEGV,	SEGV_ACCERR },	/* PIC 4: Protection exc*/
+	{ SIGSEGV,	SEGV_ACCERR },	/* PIC 5: Addressing	*/
+	{ SIGILL,	ILL_ILLOPN },	/* PIC 6, Spec exc		*/
+	{ SIGFPE,	0 },			/* PIC 7: Data. All math*/
+	{ SIGFPE,	FPE_INTOVF },	/* PIC 8: Int overflow	*/
+	{ SIGFPE,	FPE_INTDIV },	/* PIC 9: Int divide	*/
+	{ SIGFPE,	FPE_INTOVF },	/* PIC A: Dec overflow	*/
+	{ SIGFPE,	FPE_INTDIV },	/* PIC B: Dec divide	*/
+	IMPOSSIBLE, /*	c: HFP Exponent O'flow. Impossible	*/
+	IMPOSSIBLE, /*	d: HFP Exponent U'flow. Impossible	*/
+	IMPOSSIBLE, /*	e: HFP Significance. Impossible.	*/
+	IMPOSSIBLE, /*	f: HFP Divide Exception. Impossible */
+	{ SIGSEGV,	SEGV_MAPERR },	/* PIC 10: PST exc(seg) */
+	{ SIGSEGV,	SEGV_MAPERR },	/* PIC 11: PST exc(tbl) */
+	{ SIGSEGV,	SEGV_MAPERR },	/* PIC 12: Translation	*/
+	{ SIGILL,	ILL_PRVOPC },	/* PIC 13: Spcl Oper	*/
+	IMPOSSIBLE, /* 14:									*/
+	{ SIGSEGV,	SEGV_ACCERR },	/* PIC 15: Operand excp */
+	IMPOSSIBLE, /* 16: Trace table. Impossible.			*/
+	IMPOSSIBLE, /* 17:									*/
+	IMPOSSIBLE, /* 18:									*/
+	IMPOSSIBLE, /* 19:									*/
+	IMPOSSIBLE, /* 1a: Block-Volatility. Impossible.	*/
+	IMPOSSIBLE, /* 1b:									*/ 
+	IMPOSSIBLE, /* 1c: Space switch. Impossible.		*/
+	IMPOSSIBLE, /* 1d: HFP Square Root. Impossible.		*/
+	IMPOSSIBLE, /* 1e:									*/
+	IMPOSSIBLE, /* 1f: PC Translation-Spec. Impossible. */
+	IMPOSSIBLE, /* 20: AFX-Translation. Impossible		*/
+	IMPOSSIBLE, /* 21: ASX Translation. Impossible		*/
+	IMPOSSIBLE, /* 22: LX Translation. Impossible.		*/
+	IMPOSSIBLE, /* 23: EX-Translation. Impossible.		*/
+	IMPOSSIBLE, /* 24: Primary Authority. Impossible.	*/
+	IMPOSSIBLE, /* 25: Secondary Authority. Impossible. */
+	IMPOSSIBLE, /* 26: LFX Translation. Impossible.		*/
+	IMPOSSIBLE, /* 27: LSX Translation. Impossible.		*/
+	IMPOSSIBLE, /* 28: ALET Specification. Impossible.	*/
+	IMPOSSIBLE, /* 29: ALEN Xlation. Impossible.		*/
+	IMPOSSIBLE, /* 2a: ALET Sequence. Impossible.		*/
+	IMPOSSIBLE, /* 2b: ASTE Validity. Impossible.		*/
+	IMPOSSIBLE, /* 2c: ASTE Sequence. Impossible.		*/
+	IMPOSSIBLE, /* 2d: Extended Authority. Impossible.	*/
+	IMPOSSIBLE, /* 2e: LSTE Sequence. Impossible.		*/
+	IMPOSSIBLE, /* 2f: ASTE Instance. Impossible.		*/
+	IMPOSSIBLE, /* 30: Stack full. Impossible.			*/
+	IMPOSSIBLE, /* 31:									*/
+	IMPOSSIBLE, /* 32: Stack specification. Impossible. */
+	IMPOSSIBLE, /* 33: Stack type. Impossible.			*/
+	IMPOSSIBLE, /* 34: Stack operation. Impossible.		*/
+	IMPOSSIBLE, /* 35:									*/
+	IMPOSSIBLE, /* 36:									*/
+	IMPOSSIBLE, /* 37:									*/
+	{ SIGSEGV,	SEGV_MAPERR },	/* PIC 38: ASCE Excep.	*/
+	{ SIGSEGV,	SEGV_MAPERR },	/* PIC 39: Reg 1st Xlt	*/
+	{ SIGSEGV,	SEGV_MAPERR },	/* PIC 3a: Reg 2nd Xlt	*/
+	{ SIGSEGV,	SEGV_MAPERR }	/* PIC 3b: Reg 3rd Xlt	*/
+}; 
+typedef	struct iproc IPROC;
+
+#define	J9SIGNAL_CONTEXT
+#define OSDUMP_SYMBOLS_ONLY
+#include "safe_storage.h"
+
+static void	ztpfDeriveSigcontext( struct sigcontext *uscPtr, ucontext_t *uctPtr );
+static void	ztpfDeriveUcontext( ucontext_t *uscPtr );
+safeStorage *allocateDurableStorage( void );
+
+#define MAX_CSTG_BLOCKS	16
+#define _RGN_SIZE (sizeof(safeStorage))
+/*
+ * TOD_16_SECONDS is really 16.777216 seconds, but who's splitting hairs?
+ * See Principles Of Operation, page 4-61 ... we're masking out up to bit 28.
+ * If we cycle through all these blocks in 16 wall-clock seconds, allocate
+ * twice as many and try again. Likewise if we find the 16-second cycle time
+ * too short.
+ */
+#define TOD_16_SECONDS (UINT_MAX & 0x0000000fffffffff)
+
+typedef struct _unixcontext_block {
+	uint64_t tod;
+	safeStorage region;
+} ustgndx;
+
+/*
+ * These two short lines define a whole slew of space.
+ */
+static ustgndx regions[MAX_CSTG_BLOCKS];
+static uint32_t	regions_used;
+
+/**
+ * \function allocateDurableStorage()
+ *
+ * Prior to some testing, we discovered that allocating UNIX-formatted signal-related
+ * context blocks on the stack wasn't such a wise idea once the original faulting thread
+ * had gone back to the thread pool and its stack got tromped all over. This fact was
+ * completely unknown until late in development.
+ *
+ * The solution was to grab some storage that wouldn't be subject to such problems. The
+ * memory into which the .bss segment is assigned is a (set of) master page(s) of hex 
+ * zeros, and once written upon, is copied-on-write and become the property of the 
+ * PROCESS (don't want to raise any confusion here) which did the writing. Therefore,
+ * this storage appears zero to each new process which calls this module. NO SMP-
+ * RELATED CONCURRENCY CONCERNS EXIST; one of the attractive features which forced
+ * us into this storage class. The biggest users, by far, of this space are threads
+ * which have called the system dump agent, whether they've taken an actual fault or
+ * not. We labor under the presumption that the lifetime of these context blocks is
+ * well under 16 seconds, and TOD-stamp test the time of each block's allocation 
+ * before reusing it.
+ *
+ * This E/P must be exported! File module.xml is therefore modified conditionally to 
+ * export this label, and it will appear in j9prt.exp when it is created for z/TPF, 
+ * when the buildtools are built. z/TPF is the only known system which needs this 
+ * kind of allocation. It is used exclusively for the translation of z/TPF-ish data 
+ * into UNIX-ish context & signal blocks.
+ *
+ * 
+ * \returns		A uint8_t pointer sufficiently large to house all three required UNIX-
+ *				style context & signal information blocks. IT IS UP TO THE CALLER
+ *				TO PARTITION THIS BLOCK.
+ */
+
+safeStorage *
+allocateDurableStorage( void )
+{ 
+	uint8_t	i = 0;
+	safeStorage *rtnv;
+	uint64_t todNow;
+	tpf_TOD_type tod;
+	uint64_t elapsed;
+
+reenter:
+	tpf_STCK( &tod );
+	todNow = tod.stck_hex;
+	if( regions_used ) {
+		for( i = 0; i < MAX_CSTG_BLOCKS; i++ ) {
+			elapsed = todNow - regions[i].tod;
+			if (elapsed > TOD_16_SECONDS ) {
+				break;
+			}
+		}
+		if( i == MAX_CSTG_BLOCKS ) {
+			usleep(50000);
+			goto reenter;
+		}
+	}
+	/*
+	 * We've made our selection. Reserve it and clear it out.
+	 */
+	regions[i].tod = todNow;
+	regions_used += 1;
+	rtnv = &(regions[i].region);
+	memset( rtnv, 0, sizeof(safeStorage) );
+	rtnv->pPROC = iproc_process;
+	rtnv->argv.sii = &(rtnv->siginfo);
+	rtnv->argv.uct = &(rtnv->ucontext);
+	rtnv->argv.sct = &(rtnv->sigcontext);
+	rtnv->argv.wkspcSize = PATH_MAX;
+	rtnv->argv.wkSpace = &(rtnv->workbuffer[0]);
+	rtnv->argv.OSFilename = &(rtnv->filename[0]);
+	return rtnv;
+}
+
+void
+ztpfDeriveSiginfo( siginfo_t *build ) {
+   uint16_t	pic;
+   uint16_t	ilc;
+   uint8_t dxc;
+   sigvpair_t *translated = NULL;
+   char *lowcore = NULL;
+   DIB *pDib = ecbp2()->ce2dib;
+   DBFHDR *pDbf = (DBFHDR *)(pDib->dibjdb);
+   DBFITEM *pDbi;
+   struct cderi *pEri = NULL;
+   struct iproc *procPtr = iproc_process;
+
+   /*
+	*	 If we have a java dump buffer (ijavdbf) which belongs to this
+	*	 thread AND that buffer is not locked, then use it. We prefer
+	*	 the low core image in the java dump buffer to the copy in the
+	*	 DIB; but use the DIB's copy if there's no buffer.
+	*/
+   if( pDbf && pDbf->ijavcnt ) {	/* We have the full Error Recording Info, use it.	*/
+	  pDbi = (DBFITEM *)pDbf+1;					/* We have a bunch of void ptrs			*/
+	  pEri = (struct cderi *)(pDbi->ijavsbuf);	/*	to cast through ... ugh...			*/
+	  lowcore = (uint8_t *)pEri;					/* And struct cderi is incomplete ...	*/
+	  lowcore += 0x310;							/*	ai yi yi Lucy.						*/
+   }
+   else {							/* All we have is the DIB, so use it instead.		*/
+	  lowcore = pDib->dilow;					/* Fixup low core pointer				*/
+	  pEri = NULL;								/* And indicate there's no full ERI.	*/
+   }
+   pic = s390FetchPIC( lowcore );		/* Translate the PIC into si_signo & si_code	*/
+   translated = (sigvpair_t *)&pic2pair[pic];
+   build->si_signo = translated->si_signo;
+   build->si_code = translated->si_code;
+   /*
+	* This could just as well have been an "if-then-else" construct, but
+	* it was felt wise to leave it in case testing revealed something else
+	* that requires analysis.
+	*/
+   switch( build->si_signo ) { 
+   case SIGFPE:
+	  if( 0 == build->si_code ) {		   /* If we need to interpret DXC bits,   */
+		 /*
+		 * Returning a good si_code value means we have to interrogate the
+		 * DXC value, so go get a normalized version of it.
+		 */
+		 dxc = s390FetchDXC( lowcore );
+		 /*
+		  * "Sluice" through the acceptable values of the DXC for known si_code
+		  * values. If we don't find one, call it SI_KERNEL for lack of any 
+		  * better idea.
+		  */
+		 if( 0x09 == dxc )
+			build->si_code = FPE_INTDIV;
+		 else if( 0x08 == dxc )
+			build->si_code = FPE_INTOVF;
+		 else if( 0x40 == dxc )
+			build->si_code = FPE_FLTDIV;
+		 else if( 0x20 == dxc )
+			build->si_code = FPE_FLTOVF;
+		 else if( 0x10 == dxc )
+			build->si_code = FPE_FLTUND;
+		 else if( 0x08 == dxc )
+			build->si_code = FPE_FLTRES;
+		 else if( 0x80 == dxc )
+			build->si_code = FPE_FLTINV;
+		 else
+			build->si_code = SI_KERNEL;    /* Unknown synchronous signal	  */
+	  }
+	  break;
+	/*
+	 * SIGSEGV signals need si_addr set to the addr that failed translation
+	 * It's in the ERI, but not in the DIB. So if we have an ERI, use it.
+	 */
+   case SIGSEGV:
+	  if( build->si_code == SEGV_MAPERR && pEri ) { 
+		 uint64_t *address;
+		 lowcore = (char *)pEri;		/* The failing vaddr is at ISVTRXAD */
+		 address = (uint64_t *)lowcore+0x1b8;	/*	at offset 0x1B8 into the ERI*/
+		 build->si_addr = (void *)*address; /* Move the failed address.		*/
+	  }									/* Otherwise leave it zero.			*/
+	  break;
+   case SIGILL:
+	  build->si_addr = (char *)pDib->dispw[1];	/*	Failing PSW $IP			*/
+	  break;
+   default:
+	  break;
+   }										
+   build->si_pid = procPtr->iproc_pid;	/* All of them need PID and			 */
+   build->si_uid = procPtr->iproc_uid;	/*	UID values, with TID & errno	 */
+   build->si_ztpf_tid = ecbp2()->ce2thnum; /* values, too.					 */
+   build->si_errno = errno;
+   return;
+}
+
+/*
+ * This routine completes the blank uscPtr-based memory area
+ * into which the sigcontext structure is supposed to go.
+ *
+ * It cannot be called until the ucontext block has been filled
+ * in so we have a place to conveniently ripoff information from.
+ */
+
+static void
+ztpfDeriveSigcontext( struct sigcontext *uscPtr, ucontext_t *uctPtr ) {
+	memset( uscPtr, 0, sizeof(*uscPtr) );		/* Set it all to zeros, then */
+	uscPtr->sregs = &(uctPtr->uc_mcontext);		/*	fill it all in.			 */
+	uscPtr->oldmask[0] = uctPtr->uc_sigmask;
+	return;
+}
+
+
+static void
+ztpfDeriveUcontext( ucontext_t *uscPtr ) { 
+   DIB *pDib = ecbp2()->ce2dib;	 
+   DBFHDR *pJdb = (DBFHDR *)(pDib->dibjdb);
+   DBFITEM *pDbi = NULL;
+   uint8_t*	lowcore = NULL;
+
+   memset( uscPtr, 0, sizeof(*uscPtr) );	/* Zeroize everything		*/
+   if( pJdb ) {					 /* If JDB contents are for this thread */
+	  if( pJdb->ijavcnt ) {		 /*  and the JDB is unlocked			*/
+		 pDbi = (DBFITEM *)(pJdb+1);		 /* Point at the JDB base	*/
+		 lowcore = (uint8_t *)(pDbi->ijavsbuf);  /*  and its low core copy. */
+	  }
+	  else {					 /* Otherwise use what's in the DIB		*/
+		 lowcore = pDib->dilow;  /* Use the low core pointer from DIB	*/
+	  }
+   }
+	/*
+     *	 Fill in the uc_mcontext, uc_flags and uc_sigmask fields. 
+	 *	 Leave uc_link alone, it has no meaning in or for z/TPF.
+     */
+	uscPtr->uc_mcontext.regs.psw.mask = pDib->dispw[0];	/* PSW lo half */
+	uscPtr->uc_mcontext.regs.psw.addr = pDib->dispw[1];	/* PSW hi half */
+	memcpy( uscPtr->uc_mcontext.regs.gprs, 
+		  pDib->direg, sizeof(pDib->direg) );		/*GPRs*/
+	memcpy( uscPtr->uc_mcontext.fpregs.fprs, 
+		  pDib->dfreg, sizeof(pDib->dfreg) );		/*FPRs*/
+	uscPtr->uc_flags = ecbp2()->ce2thnum;			/* Put the TID in ucontext->uc_flags  */
+	sigprocmask( SIG_SETMASK, NULL, &(uscPtr->uc_sigmask) ); /* Our mask is the old mask  */
+	return;
+}
+
+
+/**
+ * \brief Translate z/TPF-ish data into UNIX-ish context data
+ *
+ * This routine sets up all three failure context records needed
+ * by UNIX-ish 3-argument signal handlers: the sigcontext, the
+ * ucontext_t, and siginfo_t structures, one at a time.
+ *
+ * \param[in][out] si	Address of a blank siginfo_t buffer.
+ * \param[in][out] uc	Address of a blank ucontext_t buffer.
+ * \param[in][out] sc	Address of a blank struct sigcontext buffer.
+ *
+ * \returns void		All blank buffer regions filled in.
+ */
+void
+translateInterruptContexts( args *argv ) { 
+
+   ztpfDeriveSiginfo( dumpSiginfo(argv) );
+   ztpfDeriveUcontext( dumpUcontext(argv) );
+   ztpfDeriveSigcontext( dumpSigcontext(argv), dumpUcontext(argv) );
+   return;
+}
+
+
+/**
+ * \brief Store signal information in the J9UnixSignalInfo struct.
+ *
+ * This routine is <em>supposed</em> to store the context information provided
+ * to it by its caller in a J9UnixSignalInfo structure. We have no idea where 
+ * that struct is stored, the caller must provide it.
+ *
+ * \param[in]	portLibrary		Pointer to the OMRPortLibrary in use
+ * \param[in]	contextInfo		Pointer to context information
+ * \param[out]	j9info			Pointer to a J9UnixSignalInfo structure
+ *
+ * \returns		Not a thing.
+ */
+void
+fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct J9UnixSignalInfo *j9Info)
+{
+	j9Info->platformSignalInfo.context = (ucontext_t *)contextInfo;		/* module info is filled on demand */
+}
+
+
+/**
+ * \brief Return specific signal information to the caller.
+ *
+ * This routine stores the name and value attributes of a given signal 
+ * described in a J9UnixSignalInfo structure whose address is passed 
+ * by the caller. The <TT>index</TT> parameter is the artificial J9
+ * signal value (or 'class type'?) associated with the kind of signal.
+ *
+ * \param[in]	portLibrary		The OMRPortLibrary in use
+ * \param[in]	info			A pointer to the J9UnixSignalInfo from which the information
+ *								is taken
+ * \param[in]	index			The J9 signal value assigned to the 'signal type'
+ * \param[out]	name			The name of the signal type class, double pointer to type char
+ * \param[out]	value			The real (raw) signal number
+ *
+ * \returns		Unsigned 32-bit integer describing what the \ref value return is, an address, or
+ *				an address. Also can return an error indicator.
+ */
+U_32
+infoForSignal(struct OMRPortLibrary *portLibrary, struct J9UnixSignalInfo *info, int32_t index, const char **name, void **value)
+{
+	*name = "";
+
+	switch (index) {
+	case OMRPORT_SIG_SIGNAL_TYPE:
+	case 0:
+		*name = "J9Generic_Signal_Number";
+		*value = &info->portLibrarySignalType;
+		return OMRPORT_SIG_VALUE_32;
+	case OMRPORT_SIG_SIGNAL_PLATFORM_SIGNAL_TYPE:
+	case 1:
+		*name = "Signal_Number";
+		*value = &info->sigInfo->si_signo;
+		return OMRPORT_SIG_VALUE_32;
+
+	case OMRPORT_SIG_SIGNAL_ERROR_VALUE:
+	case 2:
+		*name = "Error_Value";
+		*value = &info->sigInfo->si_errno;
+		return OMRPORT_SIG_VALUE_32;
+
+	case OMRPORT_SIG_SIGNAL_CODE:
+	case 3:
+		*name = "Signal_Code";
+		*value = &info->sigInfo->si_code;
+		return OMRPORT_SIG_VALUE_32;
+
+	case OMRPORT_SIG_SIGNAL_HANDLER:
+	case 4:
+		*name = "Handler1";
+		*value = &info->handlerAddress;
+		return OMRPORT_SIG_VALUE_ADDRESS;
+	case 5:
+		*name = "Handler2";
+		*value = &info->handlerAddress2;
+		return OMRPORT_SIG_VALUE_ADDRESS;
+
+	case OMRPORT_SIG_SIGNAL_INACCESSIBLE_ADDRESS:
+	case 6:
+		/*
+		 * si_code > 0 indicates that the signal was generated by the kernel
+		 */
+		if ( info->sigInfo->si_code > 0 ) {
+			if ( ( info->sigInfo->si_signo == SIGSEGV ) ) {
+				*name = "InaccessibleAddress";
+				*value = &info->sigInfo->si_addr;	/* This will be wrong for z/TPF until I figure
+														out where to get the failing address.		*/
+				return OMRPORT_SIG_VALUE_ADDRESS;
+			}
+		}
+		return OMRPORT_SIG_VALUE_UNDEFINED;
+	default:
+		return OMRPORT_SIG_VALUE_UNDEFINED;
+	}
+}
+	
+/**
+ * \brief	Return a floating point register name
+ *
+ * This routine is passed an index value, and returns the name of the register at that
+ * index location as the <TT>name</TT>. The <TT>value</TT> parameter appears to receive
+ * the register * content from context information.
+ *
+ * \param[in]	portLibrary		Pointer to the OMRPortLibrary in use
+ * \param[in]	info			Pointer to applicable J9UnixSignalInfo structure.
+ * \param[in]	index			Number of the floating point register sought.
+ * \param[out]	name			Double pointer to type char, name of the register
+ * \param[out]	value			Double pointer to type void, likely to be last known
+ *								content of the register, so it'd be a pointer to a 
+ *								pointer of type <TT>double</TT>.
+ */
+uint32_t
+infoForFPR(struct OMRPortLibrary *portLibrary, struct J9UnixSignalInfo *info, int32_t index, const char **name, void **value)
+{
+	const char *n_fpr[NUM_REGS] = {
+									"fpr0", 
+									"fpr1",  
+									"fpr2",  
+									"fpr3",  
+									"fpr4",  
+									"fpr5",  
+									"fpr6",  
+									"fpr7",  
+									"fpr8",  
+									"fpr9",  
+									"fpr10",  
+									"fpr11",  
+									"fpr12",  
+									"fpr13",  
+									"fpr14",  
+									"fpr15"}; 
+	*name = "";
+	if ( (index >=0) && (index < NUM_REGS)) {
+		*name = n_fpr[index];
+		*value = &(info->platformSignalInfo.context->uc_mcontext.fpregs.fprs[index]);
+		return OMRPORT_SIG_VALUE_FLOAT_64;
+	}
+	return OMRPORT_SIG_VALUE_UNDEFINED;
+}
+
+/**
+ * \brief	Return a general register name and content
+ *
+ * See the documentation for <TT>infoForFPR()</TT>, above; applicable to 
+ * general registers instead of FPRs.
+ *
+ * \param[in]	portLibrary		Pointer to the OMRPortLibrary in use
+ * \param[in]	info			Pointer to applicable J9UnixSignalInfo structure.
+ * \param[in]	index			Number of the general register sought.
+ * \param[out]	name			Double pointer to type char, name of the register
+ * \param[out]	value			Double pointer to type void, last known value
+ *								stored in the register.
+ *
+ * \note	Original z/TPF POC had this routine guarded out and returning a value of 
+ *			OMRPORT_SIG_VALUE_UNDEFINED, so it appeared that the signal was not supported
+ *			in z/TPF, no matter what it was. 
+ * \note	This routine was unguarded as part of making the CP emulate kernel-space, UNIX-
+ *			style implementations of reactions to program interrupts.
+ * \note	There were guard macros here based on #ifndef J9VM_ENV_DATA64 which I've simply
+ *			removed. If the guard value were true, there were 16 more definition slots for
+ *			the high parts of the general registers. All gone; we don't support 32-bit 
+ *			hardware (even if we do grudgingly support AMODE=31).
+ */
+U_32
+infoForGPR(struct OMRPortLibrary *portLibrary, struct J9UnixSignalInfo *info, int32_t index, const char **name, void **value)
+{
+	const char *n_gpr[NUM_REGS] = {
+									"gpr0", 
+									"gpr1",  
+									"gpr2",  
+									"gpr3",  
+									"gpr4",  
+									"gpr5",  
+									"gpr6",  
+									"gpr7",  
+									"gpr8",  
+									"gpr9",  
+									"gpr10",  
+									"gpr11",  
+									"gpr12",  
+									"gpr13",  
+									"gpr14",  
+									"gpr15"
+	};
+
+	*name = "";
+	if ( (index >=0) && (index < NUM_REGS)) {
+		*name = n_gpr[index];
+		*value = &(info->platformSignalInfo.context->uc_mcontext.regs.gprs[index]);
+		return OMRPORT_SIG_VALUE_ADDRESS;
+	}
+	return OMRPORT_SIG_VALUE_UNDEFINED;
+}
+
+/**
+ * \fn	Return miscellaneous h/w control words from signal/dump contexts.
+ *
+ * \param[in]	portLibrary		Pointer to the portability library in use
+ * \param[in]	info			Pointer to J9UnixSignalInfo block
+ * \param[in]	index			The J9 'type class' of the signal associated with this dump
+ * \param[out]	name			Dbl pointer to a buffer large enough to hold an object name
+ * \param[out]	value			Dbl pointer to a buffer large enough to hold an object value
+ *
+ * \note	We have to trust that the pointers to <tt>name</tt> and <tt>value</tt> are properly
+ *			sized and permissioned.
+ *
+ */
+U_32
+infoForControl(struct OMRPortLibrary *portLibrary, struct J9UnixSignalInfo *info, int32_t index, const char **name, void **value)
+{
+	uint8_t *eip;
+	mcontext_t *mcontext = (mcontext_t *)&info->platformSignalInfo.context->uc_mcontext;
+	*name = "";
+	
+	switch (index) {
+	case OMRPORT_SIG_CONTROL_PC:
+	case 0:
+		*name = "psw";
+		*value = &(mcontext->regs.psw.addr);
+		return OMRPORT_SIG_VALUE_ADDRESS;
+	case 1:
+		*name = "mask";
+		*value = &(mcontext->regs.psw.mask);
+		return OMRPORT_SIG_VALUE_ADDRESS;
+	case OMRPORT_SIG_CONTROL_S390_FPC:
+	case 2:
+		*name = "fpc";
+		*value = &(mcontext->fpregs.fpc);
+		return OMRPORT_SIG_VALUE_ADDRESS;
+	case OMRPORT_SIG_CONTROL_S390_BEA:
+	case 3:
+		*name = "bea";
+		*value = &(info->platformSignalInfo.breakingEventAddr);
+		return OMRPORT_SIG_VALUE_ADDRESS;
+	default:
+		return OMRPORT_SIG_VALUE_UNDEFINED;
+	}
+	/* UNREACHABLE */
+}
+
+U_32
+infoForModule(struct OMRPortLibrary *portLibrary, struct J9UnixSignalInfo *info, int32_t index, const char **name, void **value)
+{
+	Dl_info		*dl_info = &(info->platformSignalInfo.dl_info);
+	void*		address;
+	int32_t		dl_result;
+	mcontext_t *mcontext = (mcontext_t *)&info->platformSignalInfo.context->uc_mcontext;
+	*name = "";
+
+	address = (void *)mcontext->regs.psw.addr;
+	dl_result = dladdr(address, dl_info);
+	switch (index) {
+	case OMRPORT_SIG_MODULE_NAME:
+	case 0:
+		*name = "Module";
+		if (dl_result) {
+			*value = (void *)(dl_info->dli_fname);
+		return OMRPORT_SIG_VALUE_STRING;
+		}
+	return OMRPORT_SIG_VALUE_UNDEFINED;
+	case 1:
+		*name = "Module_base_address";
+		if (dl_result) {
+			*value = (void *)&(dl_info->dli_fbase);
+		return OMRPORT_SIG_VALUE_ADDRESS;
+		}
+		return OMRPORT_SIG_VALUE_UNDEFINED;
+	case 2:
+		*name = "Symbol";
+		if (dl_result) {
+			if (dl_info->dli_sname != NULL) {
+				*value = (void *)(dl_info->dli_sname);
+				return OMRPORT_SIG_VALUE_STRING;
+			}
+		}
+		return OMRPORT_SIG_VALUE_UNDEFINED;
+		case 3:
+			*name = "Symbol_address";
+			if (dl_result) {
+				*value = (void *)&(dl_info->dli_saddr);
+				return OMRPORT_SIG_VALUE_ADDRESS;
+			}
+			return OMRPORT_SIG_VALUE_UNDEFINED;
+	default:
+		return OMRPORT_SIG_VALUE_UNDEFINED;
+	}
+	/*	UNREACHABLE  */
+	return OMRPORT_SIG_VALUE_UNDEFINED;
+}
+

--- a/port/ztpf/omrsignal_context.h
+++ b/port/ztpf/omrsignal_context.h
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 1991, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial API and implementation and/or initial documentation
+ *    Multiple authors (IBM Corp.) - z/TPF platform initial port to OMR environment
+ *******************************************************************************/
+#ifndef _OMR_SIGNAL_CONTEXT_H_INCLUDED
+#define _OMR_SIGNAL_CONTEXT_H_INCLUDED
+
+#include "omrport.h"
+#include <errno.h>
+#include "omrosdump_helpers.h"
+#include <sys/sigcontext.h>
+
+#include <unistd.h>
+#include <sys/ucontext.h>
+
+#define MAX_UNIX_SIGNAL_TYPES  32
+
+#define __USE_GNU 1
+#include <dlfcn.h>
+#undef __USE_GNU
+
+
+/*
+ * This structure declaration came in this file in this format from J9
+ */
+typedef struct J9PlatformSignalInfo {
+	ucontext_t *context;
+	uintptr_t breakingEventAddr;
+	Dl_info	dl_info;
+} J9PlatformSignalInfo;
+
+/*
+ * This structure declaration came in this file in this format from J9
+ */
+typedef struct J9UnixSignalInfo {
+	struct J9PlatformSignalInfo	platformSignalInfo;
+	uint32_t portLibrarySignalType;
+	void* handlerAddress;
+	void* handlerAddress2;
+	siginfo_t *sigInfo;
+} J9UnixSignalInfo;
+
+
+/*
+ * The following structure is the element represented in our table
+ * of PIC-to-si_signo/si_code values.
+ */
+typedef struct {
+	int	si_signo;
+	int	si_code;
+} sigvpair_t;
+
+/*
+ *	By "impossible", what is meant is that either (a) the exception pertains
+ *	to vmm modes that z/TPF doesn't support (any except primary-space), (b)
+ *	the exception pertains to an unused floating point format, such as HFP,
+ *	(c) some other circumstance which is not possible in TPF user-space,
+ *	or (d) an unassigned PIC value. The signal number was chosen to be 
+ *	SIGABND just because it's so unusual, and the SI_KERNEL code means that
+ *	this signal was emitted by the (impostor) kernel. That's us!!
+ */
+#define IMPOSSIBLE { SIGABND, SI_KERNEL }
+
+/* 
+ * We use only the two defined ILC bits, which are already set in the 
+ * correct positions to indicate their possible domain of values, 
+ * the numbers 2, 4, or 6. We ensure this through masking out all other
+ * bits, just in case. The 2-byte ILC for program interrupts resides at
+ * address 00000008C. The 2-byte PIC follows at address 0000008E.
+ */
+/**
+ * This 'macro' picks up the ILC from its location in an array
+ * of characters meant to represent offset zero in low memory
+ * and normalizes it to only its meaningful bits.
+ */
+static const inline uint16_t s390FetchILC(uint8_t* b) { uint16_t* q=(uint16_t*)(b+0x8c);
+												return (*q & 0x06); }
+/**
+ * This 'macro' picks up the PIC from its location in an array
+ * of characters meant to represent offset zero in low memory,
+ * and normalizes it to only its meaningful bits. We don't care
+ * if the interrupt was concurrent with a PER event or a trans-
+ * action context.
+ */
+static const inline uint16_t s390FetchPIC(uint8_t* b) { uint16_t* q=(uint16_t*)(b+0x8e);
+												 return (*q & 0x13f); }
+
+/**
+ * This 'macro' picks up the DXC from its location in an array
+ * of characters meant to represent offset zero in low memory.
+ */
+static const inline uint8_t  s390FetchDXC(uint8_t* b) { return *(b+0x93); }
+
+/*
+ * Decls for externally-exported entry points
+ */
+#ifndef J9SIGNAL_CONTEXT
+void translateInterruptContexts( args *argv ) __attribute__((nonnull));
+void ztpfDeriveSiginfo( siginfo_t *build ) __attribute__((nonnull));
+#endif
+uint32_t infoForFPR(struct OMRPortLibrary *portLibrary, struct J9UnixSignalInfo* info, int32_t index, const char **name, void **value)
+ __attribute__((nonnull(1,2,4,5)));
+
+uint32_t infoForGPR(struct OMRPortLibrary *portLibrary, struct J9UnixSignalInfo* info, int32_t index, const char **name, void **value) __attribute__((nonnull(1,2,4,5)));
+
+uint32_t infoForModule(struct OMRPortLibrary *portLibrary, struct J9UnixSignalInfo* info, int32_t index, const char **name, void **value) __attribute__((nonnull(1,2,4,5)));
+
+uint32_t infoForControl(struct OMRPortLibrary *portLibrary, struct J9UnixSignalInfo* info, int32_t index, const char **name, void **value) __attribute__((nonnull(1,2,4,5)));
+
+uint32_t infoForSignal(struct OMRPortLibrary *portLibrary, struct J9UnixSignalInfo* info, int32_t index, const char **name, void **value) __attribute__((nonnull(1,2,4,5)));
+
+void fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct J9UnixSignalInfo *j9Info)  __attribute__((nonnull));
+#endif

--- a/util/omrutil/unix/linux/s390/archinfo.c
+++ b/util/omrutil/unix/linux/s390/archinfo.c
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2001, 2015
+ * (c) Copyright IBM Corp. 2001, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -14,12 +14,17 @@
  *
  * Contributors:
  *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *    Multiple authors (IBM Corp.) - z/TPF Port updates
  ******************************************************************************/
 
 /* _GNU_SOURCE forces GLIBC_2.0 sscanf/vsscanf/fscanf for RHEL5 compatability */
-#if defined(LINUX)
+#if defined(LINUX) && !defined(OMRZTPF)
 #define _GNU_SOURCE
-#endif /* defined(LINUX) */
+#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#if defined(OMRZTPF)
+#include <tpf/c_cinfc.h>   /* for access to cinfc */
+#include <tpf/c_pi1dt.h>   /* for access to machine type. */
+#endif /* defined(OMRZTPF) */
 
 #include <string.h>
 #include <stdio.h>
@@ -60,7 +65,7 @@ int32_t
 get390zLinuxMachineType(void)
 {
 	int machine = -1;
-#if (defined (LINUX) && defined(S390))
+#if (defined (LINUX) && defined(S390) && !defined(OMRZTPF))
 	int i;
 	char line[80];
 	const int LINE_SIZE = sizeof(line) - 1;
@@ -93,6 +98,11 @@ get390zLinuxMachineType(void)
 			machine = -1; /* unsupported platform */
 		}
 	}
+#elif defined(OMRZTPF)
+        struct pi1dt *pid;
+        /* machine hardware name */
+        pid = (struct pi1dt *)cinfc_fast(CINFC_CMMPID);
+        machine = (int)(pid->pi1pids.pi1mslr.pi1mod);
 #endif
 	return machine;
 }


### PR DESCRIPTION
Description:
This pull request is the second in a series of committing omr changes
for the z/TPF platform. This pull request is a follow-on to PR #1147.
A successful personal build was done in the IBM environment
(build_id=351866), there were two or three compilation failures that
were fixed.  Unlike PR #1147 there are a small amount of platform
common files which were updated.

It's expected there will be two more pull requests after this one of
smaller sizes then followed by pull requests for specific fixes as part
of z/TPF builds and runtime fixes.

The current z/TPF build procedures are still a work-in-progress.

Most of the formatting was pre-existing.  Some of the files maybe
removed once our build is finalized.  So no need to overly analyze this
pull requests as we still have passes coming as we work out our build
and runtime bugs.

Signed-off-by: jjohnst-us <jjohnst@us.ibm.com>