### PR TITLE
Aborted CS: Handle indirect refs

### DIFF
--- a/gc/base/CollectorLanguageInterface.hpp
+++ b/gc/base/CollectorLanguageInterface.hpp
@@ -305,6 +305,11 @@ public:
 	 * @param[in] env The environment for the calling thread.
 	 */	 
 	virtual void scavenger_switchConcurrentForThread(MM_EnvironmentBase *env) = 0;
+	/**
+	 * After aborted Concurrent Scavenger, handle indirect object references (off heap structures associated with object with refs to Nursery). 
+	 * Fixup should update slots to point to the forwarded version of the object and/or remove self forwarded bit in the object itself.
+	 */
+	virtual void scavenger_fixupIndirectObjectSlots(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr) = 0;
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 #endif /* OMR_GC_MODRON_SCAVENGER */
 

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -3228,7 +3228,9 @@ MM_Scavenger::fixupObjectScan(MM_EnvironmentStandard *env, omrobjectptr_t object
 		}
 	}
 
-	// todo: check if need to do anything about indirect references
+	if (_extensions->objectModel.hasIndirectObjectReferents((CLI_THREAD_TYPE*)env->getLanguageVMThread(), objectPtr)) {
+		_cli->scavenger_fixupIndirectObjectSlots(env, objectPtr);
+	}
 }
 
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */


### PR DESCRIPTION
When fixing up references in root/RS scanning in Aborted Concurrent
Scavenger, also handle indirect references (references to Nursery from
off heap structures associated with the object). Language specific code
will actually do the fixup (for example, in Java it will fixup class
structure)

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>