### PR TITLE
Begin to remove FrontEnd dependence on CCM

### DIFF
--- a/compiler/env/OMRCompilerEnv.hpp
+++ b/compiler/env/OMRCompilerEnv.hpp
@@ -38,6 +38,7 @@ namespace OMR { typedef OMR::CompilerEnv CompilerEnvConnector; }
 #include "env/ObjectModel.hpp"
 #include "env/ArithEnv.hpp"
 #include "env/VMEnv.hpp"
+#include "env/VMMethodEnv.hpp"
 
 namespace TR { class CompilerEnv; }
 
@@ -73,6 +74,10 @@ public:
    // Information about the VM environment.
    //
    TR::VMEnv vm;
+
+   // Information about methods in this compilation environment
+   //
+   TR::VMMethodEnv mth;
 
    // Object model in this compilation environment
    //

--- a/compiler/env/OMRVMMethodEnv.hpp
+++ b/compiler/env/OMRVMMethodEnv.hpp
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2000, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#ifndef OMR_VMMETHODENV_INCL
+#define OMR_VMMETHODENV_INCL
+
+/*
+ * The following #define and typedef must appear before any #includes in this file
+ */
+#ifndef OMR_VMMETHODENV_CONNECTOR
+#define OMR_VMMETHODENV_CONNECTOR
+namespace OMR { class VMMethodEnv; }
+namespace OMR { typedef OMR::VMMethodEnv VMMethodEnvConnector; }
+#endif
+
+#include <stdint.h>        // for int32_t, int64_t, uint32_t
+#include "infra/Annotations.hpp"
+#include "env/jittypes.h"
+
+
+namespace OMR
+{
+
+class OMR_EXTENSIBLE VMMethodEnv
+   {
+public:
+
+   /**
+    * \brief  Does this method contain any backward branches?
+    * \return true if there are backward branches, false if there aren't or unknown
+    */
+   bool hasBackwardBranches(TR_OpaqueMethodBlock *method) { return false; }
+
+   /**
+    * \brief  Is this method compiled?
+    * \return true if compiled, false if not or unknown
+    */ 
+   bool isCompiledMethod(TR_OpaqueMethodBlock *method) { return false; }
+
+   /**
+    * \brief  Ask for the start PC of the provided method
+    * \return the start PC, or 0 if unknown or not compiled
+    */
+   uintptr_t startPC(TR_OpaqueMethodBlock *method) { return 0; }
+   };
+
+}
+
+#endif

--- a/compiler/env/VMMethodEnv.hpp
+++ b/compiler/env/VMMethodEnv.hpp
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2000, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#ifndef TR_VMMETHODENV_INCL
+#define TR_VMMETHODENV_INCL
+
+#include "env/OMRVMMethodEnv.hpp"
+#include "infra/Annotations.hpp"
+
+namespace TR
+{
+
+class OMR_EXTENSIBLE VMMethodEnv : public OMR::VMMethodEnvConnector
+   {
+public:
+
+   VMMethodEnv() : OMR::VMMethodEnvConnector() {}
+
+   };
+
+}
+
+#endif

--- a/compiler/runtime/OMRCodeCache.cpp
+++ b/compiler/runtime/OMRCodeCache.cpp
@@ -221,7 +221,6 @@ OMR::CodeCache::resizeCodeMemory(void *memoryBlock, size_t newSize)
    uint8_t *expectedHeapAlloc = (uint8_t *) memoryBlock + oldSize;
    if (config.verboseReclamation())
       {
-      TR_FrontEnd *fe = _manager->fe();
       TR_VerboseLog::writeLineLocked(TR_Vlog_CODECACHE,"--resizeCodeMemory-- CC=%p cacheHeader=%p oldSize=%u newSize=%d shrinkage=%u", this, cacheHeader, oldSize, newSize, shrinkage);
       }
 
@@ -939,7 +938,6 @@ OMR::CodeCache::addFreeBlock2WithCallSite(uint8_t *start,
       {
       if (config.verboseReclamation())
          {
-         TR_FrontEnd *fe = _manager->fe();
          TR_VerboseLog::writeLineLocked(TR_Vlog_FAILURE,"addFreeBlock2[%s.%d]: failed to add free block. start = 0x%016x end = 0x%016x alignment = 0x%04x sizeof(CodeCacheFreeCacheBlock) = 0x%08x",
             file, lineNumber, start_o, end, config.codeCacheAlignment(), sizeof(CodeCacheFreeCacheBlock));
          }
@@ -1052,7 +1050,6 @@ OMR::CodeCache::addFreeBlock2WithCallSite(uint8_t *start,
 
    if (config.verboseReclamation())
       {
-      TR_FrontEnd *fe = _manager->fe();
       TR_VerboseLog::writeLineLocked(TR_Vlog_CODECACHE,"--ccr-- addFreeBlock2WithCallSite CC=%p start=%p end=%p mergedBlock=%p link=%p link->_size=%u, _sizeOfLargestFreeWarmBlock=%d _sizeOfLargestFreeColdBlock=%d warmCodeAlloc=%p coldBlockAlloc=%p",
          this,  (void*)start, (void*)end, mergedBlock, link, (uint32_t)link->_size, _sizeOfLargestFreeWarmBlock, _sizeOfLargestFreeColdBlock, _warmCodeAlloc, _coldCodeAlloc);
       }
@@ -1199,7 +1196,6 @@ OMR::CodeCache::findFreeBlock(size_t size, bool isCold, bool isMethodHeaderNeede
      //fprintf(stderr, "--ccr-- reallocate free'd block of size %d\n", size);
      if (config.verboseReclamation())
          {
-         TR_FrontEnd *fe = _manager->fe();
          TR_VerboseLog::writeLineLocked(TR_Vlog_CODECACHE,"--ccr- findFreeBlock: CodeCache=%p size=%u isCold=%d bestFitLink=%p bestFitLink->size=%u leftBlock=%p", this, size, isCold, bestFitLink, bestFitLink->_size, leftBlock);
          }
       }
@@ -1502,22 +1498,8 @@ OMR::CodeCache::allocateCodeMemory(size_t warmCodeSize,
    size_t coldSize = coldCodeSize;
    _manager->performSizeAdjustments(warmSize, coldSize, needsToBeContiguous, isMethodHeaderNeeded); // side effect on warmSize and coldSize
 
-#if 0
-   if (config.verboseReclamation())
-      {
-      TR_FrontEnd *fe = _manager->fe();
-      TR_VerboseLog::writeLineLocked(TR_Vlog_CODECACHE,"--ccr-- allocateCodeMemory CC=%p warmSize=%u, coldSize=%u headerNeeded=%d warmCodeAlloc=%p coldCodeAlloc=%p",
-         this, warmSize, coldSize, isMethodHeaderNeeded, _warmCodeAlloc, _coldCodeAlloc);
-      }
-#endif
-
    // Acquire mutex because we are walking the list of free blocks
    CacheCriticalSection walkingFreeList(self());
-
-#if 0
-   if (config.doSanityCheck())
-      checkForErrors();
-#endif
 
    // See if we can get a warm and/or cold block from the reclaimed method list
    if (!needsToBeContiguous)


### PR DESCRIPTION
Begin to eliminate `OMR::CodeCacheManager` dependence on deprecated FrontEnd functionality by either eliminating it outright or refactoring the FrontEnd functionality into it's own class.