### PR TITLE
Fix usage of rbx to allocate a stack frame

### DIFF
--- a/compiler/x/amd64/codegen/AMD64SystemLinkage.hpp
+++ b/compiler/x/amd64/codegen/AMD64SystemLinkage.hpp
@@ -53,6 +53,9 @@ class AMD64SystemLinkage : public TR::X86SystemLinkage
    virtual TR::Register *buildDirectDispatch(TR::Node *callNode, bool spillFPRegs);
 
    TR::Register *buildVolatileAndReturnDependencies(TR::Node *callNode, TR::RegisterDependencyConditions *deps);
+
+   virtual TR::RealRegister* getSingleWordFrameAllocationRegister() { return machine()->getX86RealRegister(TR::RealRegister::r11); }
+
    private:
    bool layoutTypeInRegs(TR::DataType type, uint16_t &intReg, uint16_t &floatReg, TR::parmLayoutResult&);
 

--- a/compiler/x/codegen/X86SystemLinkage.cpp
+++ b/compiler/x/codegen/X86SystemLinkage.cpp
@@ -523,8 +523,8 @@ TR::X86SystemLinkage::createPrologue(TR::Instruction *cursor)
       }
    else if (allocSize == singleWordSize)
       {
-      TR::RealRegister *ebxReal = machine()->getX86RealRegister(TR::RealRegister::ebx);
-      cursor = new (trHeapMemory()) TR::X86RegInstruction(cursor, PUSHReg, ebxReal, cg());
+      TR::RealRegister *realReg = getSingleWordFrameAllocationRegister();
+      cursor = new (trHeapMemory()) TR::X86RegInstruction(cursor, PUSHReg, realReg, cg());
       }
    else
       {
@@ -724,8 +724,8 @@ TR::X86SystemLinkage::createEpilogue(TR::Instruction *cursor)
       }
    else if (allocSize == singleWordSize)
       {
-      TR::RealRegister *ebxReal = machine()->getX86RealRegister(TR::RealRegister::ebx);
-      cursor = new (trHeapMemory()) TR::X86RegInstruction(cursor, POPReg, ebxReal, cg());
+      TR::RealRegister *realReg = getSingleWordFrameAllocationRegister();
+      cursor = new (trHeapMemory()) TR::X86RegInstruction(cursor, POPReg, realReg, cg());
       }
    else
       {

--- a/compiler/x/codegen/X86SystemLinkage.hpp
+++ b/compiler/x/codegen/X86SystemLinkage.hpp
@@ -82,6 +82,17 @@ class X86SystemLinkage : public TR::Linkage
    virtual int32_t layoutParm(TR::ParameterSymbol *paramSymbol, int32_t &dataCursor, uint16_t &intReg, uint16_t &floatRrgs, TR::parmLayoutResult&) = 0;
 
    virtual TR::Register* buildVolatileAndReturnDependencies(TR::Node*, TR::RegisterDependencyConditions*) = 0;
+
+   /**
+    * @brief Returns a register appropriate for allocating/de-allocating small stack frames
+    *
+    * When the size of a new stack frame that is the same size as a word on the
+    * platform, the frame can be simply allocated/de-allocated by pushing/popping
+    * a volatile, non-return register. This function returns a register that
+    * is guarenteed to be safe for such uses.
+    */
+   virtual TR::RealRegister* getSingleWordFrameAllocationRegister() = 0;
+
    public:
 
    const TR::X86LinkageProperties& getProperties();

--- a/compiler/x/i386/codegen/IA32SystemLinkage.hpp
+++ b/compiler/x/i386/codegen/IA32SystemLinkage.hpp
@@ -45,6 +45,7 @@ class IA32SystemLinkage : public TR::X86SystemLinkage
    int32_t layoutParm(TR::Node*, int32_t&, uint16_t&, uint16_t&, TR::parmLayoutResult&);
    int32_t layoutParm(TR::ParameterSymbol*, int32_t&, uint16_t&, uint16_t&, TR::parmLayoutResult&);
    virtual TR::Register *buildVolatileAndReturnDependencies(TR::Node *callNode, TR::RegisterDependencyConditions *deps);
+   virtual TR::RealRegister* getSingleWordFrameAllocationRegister() { return machine()->getX86RealRegister(TR::RealRegister::ecx); }
    private:
    virtual uint32_t getAlignment(TR::DataType);
    };


### PR DESCRIPTION
This change introduces the helper function `getSingleWordFrameAllocationRegister()` that returns an appropriate register for allocating/deallocating the stack on a given platform. Now, instead of pushing/popping rbx on x86, r11 is used on x86-64 and ecx is used on x86-32.

Fixes #1243

Signed-off-by: Leonardo Banderali <leob@linux.vnet.ibm.com>