### PR TITLE
Ignore generated file omr.rc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ config.cache
 config.log
 config.status
 SPEC
+omr.rc
 
 OMR_VERSION_STRING
 OMR_JIT_VERSION_STRING


### PR DESCRIPTION
omr.rc is a generated file introduced by commit 8ce8861 / a40dfc7.  Add
it to .gitignore to stop it from showing up in untracked changes.

Signed-off-by: Luc des Trois Maisons <lmaisons@ca.ibm.com>