### PR TITLE
Add const to const-returning function

### DIFF
--- a/compiler/cs2/timer.h
+++ b/compiler/cs2/timer.h
@@ -211,7 +211,7 @@ public:
     return PlatformTimer::Read();
   }
 
-  static char* Name(bool csv = false) {
+  static const char* Name(bool csv = false) {
     if (csv)
       return "Timing";
     else
@@ -219,7 +219,7 @@ public:
   }
 
   // must be 13 chars or less, alternativeFormat is in seconds/millisecs
-  static char *UnitsText(bool alternativeFormat = false) {
+  static const char *UnitsText(bool alternativeFormat = false) {
     if (alternativeFormat)
       return "  ssssss.msec (% total)";
     else


### PR DESCRIPTION
Otherwise you're returning a pointer to a string constant which may
abort at runtime should you write to it.

Signed-off-by: Matthew Gaudet <magaudet@ca.ibm.com>