### PR TITLE
Replace FE functions with VMMethodEnv equivalents

### DIFF
--- a/compiler/env/OMRCompilerEnv.hpp
+++ b/compiler/env/OMRCompilerEnv.hpp
@@ -77,7 +77,7 @@ public:
 
    // Information about methods in this compilation environment
    //
-   TR::VMMethodEnv mth;
+   TR::VMMethodEnv mtd;
 
    // Object model in this compilation environment
    //

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -2344,9 +2344,9 @@ TR_Hotness OMR::Optimizer::checkMaxHotnessOfInlinedMethods( TR::Compilation *com
          {
          TR_InlinedCallSite & ics = comp->getInlinedCallSite(i);
          TR_OpaqueMethodBlock *method = comp->fe()->getInlinedCallSiteMethod(&ics);
-         if (comp->fe()->isCompiledMethod(method))
+         if (TR::Compiler->mtd.isCompiledMethod(method))
             {
-            TR_PersistentJittedBodyInfo * bodyInfo = TR::Recompilation::getJittedBodyInfoFromPC(comp->fe()->getMethodStartPC(method));
+            TR_PersistentJittedBodyInfo * bodyInfo = TR::Recompilation::getJittedBodyInfoFromPC((void *)TR::Compiler->mtd.startPC(method));
             if (bodyInfo &&
                 bodyInfo->getHotness() > strategy)
                {

--- a/compiler/optimizer/RedundantAsyncCheckRemoval.cpp
+++ b/compiler/optimizer/RedundantAsyncCheckRemoval.cpp
@@ -31,6 +31,7 @@
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
 #include "control/Recompilation.hpp"           // for TR_Recompilation
+#include "env/CompilerEnv.hpp"
 #include "env/StackMemoryRegion.hpp"
 #include "env/jittypes.h"                      // for TR_ByteCodeInfo, etc
 #include "il/Block.hpp"                        // for Block, toBlock
@@ -889,7 +890,7 @@ bool TR_RedundantAsyncCheckRemoval::originatesFromShortRunningMethod(TR_RegionSt
 	    }
 	 TR_InlinedCallSite &ics = comp()->getInlinedCallSite(callerIndex);
 	 if (!comp()->isShortRunningMethod(callerIndex) &&
-	     comp()->fe()->hasBackwardBranches((TR_OpaqueMethodBlock*)ics._vmMethodInfo))
+	     TR::Compiler->mtd.hasBackwardBranches((TR_OpaqueMethodBlock*)ics._vmMethodInfo))
 	    break;
 	 //set callerIndex to its caller
 	 callerIndex = comp()->getInlinedCallSite(callerIndex)._byteCodeInfo.getCallerIndex();

--- a/compiler/runtime/OMRCodeCache.cpp
+++ b/compiler/runtime/OMRCodeCache.cpp
@@ -26,6 +26,7 @@
 #include "codegen/FrontEnd.hpp"         // for TR_VerboseLog, etc
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"  // for TR::Options, etc
+#include "env/CompilerEnv.hpp"
 #include "env/IO.hpp"                   // for POINTER_PRINTF_FORMAT
 #include "env/defines.h"                // for HOST_OS, OMR_LINUX
 #include "env/jittypes.h"               // for FLUSH_MEMORY
@@ -541,7 +542,7 @@ OMR::CodeCache::findTrampoline(TR_OpaqueMethodBlock * method)
       trampoline = entry->_info._resolved._currentTrampoline;
       if (!trampoline)
          {
-         void *newPC = _manager->fe()->getMethodStartPC(method);
+         void *newPC = (void *) TR::Compiler->mtd.startPC(method);
 
          trampoline = self()->allocateTrampoline();
 
@@ -648,7 +649,7 @@ OMR::CodeCache::syncTempTrampolines()
          {
          for (CodeCacheHashEntry *entry = _resolvedMethodHT->_buckets[entryIdx]; entry; entry = entry->_next)
             {
-            void *newPC = (void *) _manager->fe()->getMethodStartPC(entry->_info._resolved._method);
+            void *newPC = (void *) TR::Compiler->mtd.startPC(entry->_info._resolved._method);
             void *trampoline = entry->_info._resolved._currentTrampoline;
             if (trampoline && entry->_info._resolved._currentStartPC != newPC)
                {
@@ -676,7 +677,7 @@ OMR::CodeCache::syncTempTrampolines()
          for (uint32_t entryIdx = 0; entryIdx < syncBlock->_entryCount; entryIdx++)
             {
             CodeCacheHashEntry *entry = syncBlock->_hashEntryArray[entryIdx];
-            void *newPC = (void *) _manager->fe()->getMethodStartPC(entry->_info._resolved._method);
+            void *newPC = (void *) TR::Compiler->mtd.startPC(entry->_info._resolved._method);
 
             // call the codegen to perform the trampoline code modification
             self()->createTrampoline(entry->_info._resolved._currentTrampoline,


### PR DESCRIPTION
* Start using the VMMethodEnv equivalents
* Rename the `CompilerEnv` field `mth` to the more appropriate
abbreviation `mtd`

Signed-off-by: Daryl Maier <maier@ca.ibm.com>