### PR TITLE
Remove liveness diff between post and pre OSR

### DIFF
--- a/compiler/compile/OSRData.cpp
+++ b/compiler/compile/OSRData.cpp
@@ -686,53 +686,17 @@ TR_OSRMethodData::inlinesAnyMethod() const
    }
 
 void
-TR_OSRMethodData::addLiveRangeInfo(int32_t byteCodeIndex, TR::OSRTransitionTarget target, TR_BitVector *liveRangeInfo)
+TR_OSRMethodData::addLiveRangeInfo(int32_t byteCodeIndex, TR_BitVector *liveRangeInfo)
    {
-   TR_ASSERT(target == TR::postExecutionOSR || target == TR::preExecutionOSR, "can only add live range info for pre or post transition target");
-
-   TR_BCLiveRangeInfoHashKey key(byteCodeIndex, target);
-   bcLiveRangeInfoHashTab.Add(key, liveRangeInfo);
+   bcLiveRangeInfoHashTab.Add(byteCodeIndex, liveRangeInfo);
    }
 
-/*
- * Get the live range info for a bytecode index
- * In postExecution OSR, it is possible for the same bytecode index to have different
- * liveness information, based on whether it was generated for a induction or
- * an analysis point.
- *
- * For example, consider two calls, where the result of one feeds into the other.
- * For a transition point after the first call, its result is on the stack, whilst,
- * for an analysis point before the second call, the result has been taken as an
- * argument and is no longer on the stack.
- *
- * This method will default to using the postExecutionOSR point, as it will always
- * contain the live values at the preExecutionOSR point. However, a more exact
- * result can be achieve by specifing the point type.
- */
 TR_BitVector *
 TR_OSRMethodData::getLiveRangeInfo(int32_t byteCodeIndex)
    {
-   TR_BitVector* liveRangeInfo = NULL;
-   if (getMethodSymbol()->comp()->isOSRTransitionTarget(TR::postExecutionOSR))
-      {
-      liveRangeInfo = getLiveRangeInfo(byteCodeIndex, TR::postExecutionOSR);
-      if (!liveRangeInfo)
-         liveRangeInfo = getLiveRangeInfo(byteCodeIndex, TR::preExecutionOSR);
-      }
-   else
-      liveRangeInfo = getLiveRangeInfo(byteCodeIndex, TR::preExecutionOSR);
-   return liveRangeInfo;
-   }
-
-TR_BitVector *
-TR_OSRMethodData::getLiveRangeInfo(int32_t byteCodeIndex, TR::OSRTransitionTarget target)
-   {
-   TR_ASSERT(target == TR::postExecutionOSR || target == TR::preExecutionOSR, "can only get live range info for pre or post transition target");
-
-   TR_BCLiveRangeInfoHashKey key(byteCodeIndex, target);
    CS2::HashIndex hashIndex;
    TR_BitVector* liveRangeInfo = NULL;
-   if (bcLiveRangeInfoHashTab.Locate(key, hashIndex))
+   if (bcLiveRangeInfoHashTab.Locate(byteCodeIndex, hashIndex))
       {
       liveRangeInfo = bcLiveRangeInfoHashTab.DataAt(hashIndex);
       }
@@ -787,7 +751,7 @@ TR_OSRMethodData::addArgInfo(int32_t byteCodeIndex, int32_t argIndex, int32_t ar
 /*
  * Get the list of symbol reference numbers for a bytecode index
  * to be used as arguments to the induce call targeting it
- */ 
+ */
 TR_Array<int32_t>*
 TR_OSRMethodData::getArgInfo(int32_t byteCodeIndex)
    {

--- a/compiler/compile/OSRData.hpp
+++ b/compiler/compile/OSRData.hpp
@@ -287,8 +287,7 @@ class TR_OSRMethodData
    void setNumSymRefs(int32_t numBits) {_numSymRefs = numBits; }
    int32_t getNumSymRefs() { return _numSymRefs; }
 
-   void addLiveRangeInfo(int32_t byteCodeIndex, TR::OSRTransitionTarget target, TR_BitVector *liveRangeInfo);
-   TR_BitVector *getLiveRangeInfo(int32_t byteCodeIndex, TR::OSRTransitionTarget target);
+   void addLiveRangeInfo(int32_t byteCodeIndex, TR_BitVector *liveRangeInfo);
    TR_BitVector *getLiveRangeInfo(int32_t byteCodeIndex);
 
    void ensureArgInfoAt(int32_t byteCodeIndex, int32_t argNum);
@@ -303,8 +302,7 @@ class TR_OSRMethodData
    private:
    void createOSRBlocks(TR::Node* n);
 
-   typedef CS2::CompoundHashKey<int32_t, TR::OSRTransitionTarget> TR_BCLiveRangeInfoHashKey;
-   typedef CS2::HashTable<TR_BCLiveRangeInfoHashKey, TR_BitVector *, TR::Allocator> TR_BCLiveRangeInfoHashTable;
+   typedef CS2::HashTable<int32_t, TR_BitVector *, TR::Allocator> TR_BCLiveRangeInfoHashTable;
    typedef CS2::HashTable<int32_t, TR_OSRSlotSharingInfo*, TR::Allocator> TR_BCInfoHashTable;
    typedef CS2::HashTable<int32_t, TR_Array<int32_t>*, TR::Allocator> TR_ArgInfoHashTable;
    typedef CS2::HashTable<int32_t, TR_Array<int32_t>, TR::Allocator> TR_Slot2ScratchBufferOffset;

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -528,8 +528,15 @@ OMR::ResolvedMethodSymbol::genInduceOSRCallNode(TR::TreeTop* insertionPoint,
    if (shouldSplitBlock)
        firstHalfBlock->split(insertionPoint, self()->comp()->getFlowGraph(), true);
 
+   // The arguments for a transition to this bytecode index may have already been stashed.
+   // If they have, use these directly rather than copying the reference node.
+   TR_OSRMethodData *osrMethodData = self()->comp()->getOSRCompilationData()->findOrCreateOSRMethodData(
+      refNode->getByteCodeInfo().getCallerIndex(), self());
+   TR_Array<int32_t> *stashedArgs = osrMethodData->getArgInfo(refNode->getByteCodeIndex());
    int32_t firstArgIndex = 0;
-   if ((refNode->getNumChildren() > 0) &&
+   if (stashedArgs)
+      numChildren = stashedArgs->size(); 
+   else if ((refNode->getNumChildren() > 0) &&
        refNode->getFirstChild()->getOpCode().isCall())
       {
       refNode = refNode->getFirstChild();
@@ -544,7 +551,14 @@ OMR::ResolvedMethodSymbol::genInduceOSRCallNode(TR::TreeTop* insertionPoint,
    TR_OSRPoint *point = self()->findOSRPoint(refNode->getByteCodeInfo());
    TR_ASSERT(point, "Could not find osr point for bytecode %d:%d!", refNode->getByteCodeInfo().getCallerIndex(), refNode->getByteCodeInfo().getByteCodeIndex());
 
-   if (copyChildren)
+   // If arguments have been stashed against this BCI, copy them now, ignoring the copyChildren flag
+   if (stashedArgs)
+      {
+      for (int32_t i = 0; i < numChildren; ++i)
+         induceOSRCallNode->setAndIncChild(i,
+            TR::Node::createLoad(induceOSRCallNode, self()->comp()->getSymRefTab()->getSymRef((*stashedArgs)[i])));
+      }
+   else if (copyChildren)
       {
       for (int i = firstArgIndex; i < numChildren; i++)
          induceOSRCallNode->setAndIncChild(i-firstArgIndex, refNode->getChild(i));
@@ -629,30 +643,11 @@ OMR::ResolvedMethodSymbol::induceImmediateOSRWithoutChecksBefore(TR::TreeTop *in
 TR::TreeTop *
 OMR::ResolvedMethodSymbol::genInduceOSRCallAndCleanUpFollowingTreesImmediately(TR::TreeTop *insertionPoint, TR_ByteCodeInfo induceBCI, bool shouldSplitBlock, TR::Compilation *comp)
    {
-   // Add children to the induce node if they have been registered for this bytecode index
-   // TODO: Eventually all implementations of OSR should place call arguments in pending push slots
-   // and either transition with them in the OSR buffer or as arguments to the induce here
-   TR_OSRMethodData *osrMethodData = self()->comp()->getOSRCompilationData()->findOrCreateOSRMethodData(induceBCI.getCallerIndex(), self());
-   TR_Array<int32_t> *args = osrMethodData->getArgInfo(induceBCI.getByteCodeIndex());
-   int32_t children = args == NULL ? 0 : args->size();
-
-   TR::TreeTop *induceOSRCallTree = self()->genInduceOSRCall(insertionPoint, induceBCI.getCallerIndex(), children, false, shouldSplitBlock);
+   TR::TreeTop *induceOSRCallTree = self()->genInduceOSRCall(insertionPoint, induceBCI.getCallerIndex(), 0, false, shouldSplitBlock);
 
    if (induceOSRCallTree)
       {
       TR::TreeTop *treeAfterInduceOSRCall = induceOSRCallTree->getNextTreeTop();
-   
-      // Add loads of the required symrefs to the induce call
-      TR::Node *induceOSRCall = induceOSRCallTree->getNode()->getFirstChild();
-      if (args)
-         {
-         induceOSRCall->setNumChildren(children);
-         for (int32_t i = 0; i < children; ++i)
-            {
-            induceOSRCall->setAndIncChild(i,
-               TR::Node::createLoad(induceOSRCall, self()->comp()->getSymRefTab()->getSymRef((*args)[i])));
-            }
-         }
 
       while (treeAfterInduceOSRCall)
          {
@@ -669,7 +664,6 @@ OMR::ResolvedMethodSymbol::genInduceOSRCallAndCleanUpFollowingTreesImmediately(T
 
    return induceOSRCallTree;
    }
-
 
 TR::TreeTop *
 OMR::ResolvedMethodSymbol::genInduceOSRCallForGuardedCallee(TR::TreeTop* insertionPoint,
@@ -697,7 +691,6 @@ OMR::ResolvedMethodSymbol::genInduceOSRCall(TR::TreeTop* insertionPoint, int32_t
    TR_OSRMethodData *osrMethodData = self()->comp()->getOSRCompilationData()->findOrCreateOSRMethodData(inlinedSiteIndex, self());
    return self()->genInduceOSRCall(insertionPoint, inlinedSiteIndex, osrMethodData, NULL, numChildren, copyChildren, shouldSplitBlock);
    }
-
 
 TR::TreeTop *
 OMR::ResolvedMethodSymbol::genInduceOSRCall(TR::TreeTop* insertionPoint,
@@ -1821,14 +1814,21 @@ OMR::ResolvedMethodSymbol::insertStoresForDeadStackSlotsBeforeInducingOSR(TR::Co
    TR::TreeTop *prev = induceOSRTree->getPrevTreeTop();
    TR::TreeTop *next = induceOSRTree;
 
-   TR::OSRTransitionTarget pointType = TR::preAndPostExecutionOSR;
+   // The arguments to the induce OSR call may be stashed against its bytecode index.
+   // If so, dead stores must not be generated for these symrefs.
+   TR_BitVector *deadSymRefs = osrMethodData->getLiveRangeInfo(byteCodeIndex);
+   TR_Array<int32_t> *args = osrMethodData->getArgInfo(byteCodeIndex);
+   if (deadSymRefs && args)
+      {
+      for (int32_t i = 0; i < args->size(); ++i)
+         deadSymRefs->reset((*args)[i]);
+      }
 
    while (osrMethodData)
       {
       if (comp->getOption(TR_TraceOSR))
          traceMsg(comp, "Inserting stores for dead stack slots in method at caller index %d and bytecode index %d for induceOSR call %p\n", callSite, byteCodeIndex, induceOSRTree->getNode());
 
-      TR_BitVector *deadSymRefs = pointType == TR::preAndPostExecutionOSR ? osrMethodData->getLiveRangeInfo(byteCodeIndex) : osrMethodData->getLiveRangeInfo(byteCodeIndex, pointType);
       if (deadSymRefs)
          {
          TR_BitVectorIterator bvi(*deadSymRefs);
@@ -1857,7 +1857,7 @@ OMR::ResolvedMethodSymbol::insertStoresForDeadStackSlotsBeforeInducingOSR(TR::Co
          callSite = callSiteInfo._byteCodeInfo.getCallerIndex();
          osrMethodData = comp->getOSRCompilationData()->findCallerOSRMethodData(osrMethodData);
          byteCodeIndex = callSiteInfo._byteCodeInfo.getByteCodeIndex();
-         pointType = TR::preExecutionOSR;
+         deadSymRefs = osrMethodData->getLiveRangeInfo(byteCodeIndex);
          }
       else
          osrMethodData = NULL;

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -2069,7 +2069,7 @@ bool TR_InlinerBase::heuristicForUsingOSR(TR::Node *callNode, TR::ResolvedMethod
       int32_t osrCallerNumLiveStackSlots = 0;
       totalOSRCallersStackSlots = totalOSRCallersStackSlots + osrCallerNumStackSlots;
 
-      TR_BitVector *deadSymRefs = osrMethodData->getLiveRangeInfo(byteCodeIndex, TR::preExecutionOSR);
+      TR_BitVector *deadSymRefs = osrMethodData->getLiveRangeInfo(byteCodeIndex);
       if (deadSymRefs)
          {
          osrCallerNumLiveStackSlots = osrMethodData->getNumSymRefs() - deadSymRefs->elementCount();

--- a/compiler/optimizer/OSRDefAnalysis.cpp
+++ b/compiler/optimizer/OSRDefAnalysis.cpp
@@ -913,7 +913,7 @@ int32_t TR_OSRLiveRangeAnalysis::perform()
             TR_OSRPoint *offsetOSRPoint = comp()->getMethodSymbol()->findOSRPoint(bcInfo);
             TR_ASSERT(offsetOSRPoint != NULL, "Cannot find a post OSR point for node %p", node);
             buildOSRLiveRangeInfo(node, _liveVars, offsetOSRPoint, liveLocalIndexToSymRefNumberMap,
-               maxSymRefNumber, numBits, osrMethodData, TR::postExecutionOSR);
+               maxSymRefNumber, numBits, osrMethodData);
             }
 
          // Maintain liveness across post pending pushes and the OSR point itself
@@ -932,7 +932,7 @@ int32_t TR_OSRLiveRangeAnalysis::perform()
             TR_OSRPoint *osrPoint = comp()->getMethodSymbol()->findOSRPoint(bci);
             TR_ASSERT(osrPoint != NULL, "Cannot find a pre OSR point for node %p", node);
             buildOSRLiveRangeInfo(node, _liveVars, osrPoint, liveLocalIndexToSymRefNumberMap,
-               maxSymRefNumber, numBits, osrMethodData, TR::preExecutionOSR);
+               maxSymRefNumber, numBits, osrMethodData);
             }
          }
 
@@ -946,7 +946,7 @@ int32_t TR_OSRLiveRangeAnalysis::perform()
          TR_OSRPoint *osrPoint = comp()->getMethodSymbol()->findOSRPoint(bci);
          TR_ASSERT(osrPoint != NULL, "Cannot find a OSR point for method entry");
          buildOSRLiveRangeInfo(comp()->getStartTree()->getNode(), _liveVars, osrPoint, liveLocalIndexToSymRefNumberMap,
-            maxSymRefNumber, numBits, osrMethodData, TR::postExecutionOSR);
+            maxSymRefNumber, numBits, osrMethodData);
          }
 
       block = block->getNextBlock();
@@ -1169,10 +1169,9 @@ void TR_OSRLiveRangeAnalysis::maintainLiveness(TR::Node *node,
 
 void TR_OSRLiveRangeAnalysis::buildOSRLiveRangeInfo(TR::Node *node, TR_BitVector *liveVars, TR_OSRPoint *osrPoint,
    int32_t *liveLocalIndexToSymRefNumberMap, int32_t maxSymRefNumber, int32_t numBits,
-   TR_OSRMethodData *osrMethodData, TR::OSRTransitionTarget target)
+   TR_OSRMethodData *osrMethodData)
    {
    TR_ASSERT(liveVars, "live variable info must be available for a block\n");
-   TR_ASSERT(target == TR::postExecutionOSR || target == TR::preExecutionOSR, "can only add live range info for pre or post transition target");
    _deadVars->setAll(numBits);
    *_deadVars -= *liveVars;
 
@@ -1192,7 +1191,7 @@ void TR_OSRLiveRangeAnalysis::buildOSRLiveRangeInfo(TR::Node *node, TR_BitVector
       }
 
    osrMethodData->setNumSymRefs(numBits);
-   osrMethodData->addLiveRangeInfo(osrPoint->getByteCodeInfo().getByteCodeIndex(), target, deadSymRefs);
+   osrMethodData->addLiveRangeInfo(osrPoint->getByteCodeInfo().getByteCodeIndex(), deadSymRefs);
 
    if (comp()->getOption(TR_TraceOSR))
       {

--- a/compiler/optimizer/OSRDefAnalysis.hpp
+++ b/compiler/optimizer/OSRDefAnalysis.hpp
@@ -97,7 +97,7 @@ class TR_OSRLiveRangeAnalysis : public TR::Optimization
    bool canAffordAnalysis();
    void buildOSRLiveRangeInfo(TR::Node *node, TR_BitVector *liveVars, TR_OSRPoint *osrPoint,
       int32_t *liveLocalIndexToSymRefNumberMap, int32_t maxSymRefNumber, int32_t numBits,
-      TR_OSRMethodData *osrMethodData, TR::OSRTransitionTarget target);
+      TR_OSRMethodData *osrMethodData);
    void maintainLiveness(TR::Node *node, TR::Node *parent, int32_t childNum, vcount_t  visitCount,
        TR_Liveness *liveLocals, TR_BitVector *liveVars, TR::Block *block);
    TR::TreeTop *collectPendingPush(TR_ByteCodeInfo bci, TR::TreeTop *pps, TR_BitVector *liveVars);


### PR DESCRIPTION
With the addition of argument stashing for OSR
infrastructure, pre and post OSR points no longer
require a distinction between their dead stores.