### PR TITLE
Add OSRInduceBlock flag and skip opts

### DIFF
--- a/compiler/il/OMRBlock.hpp
+++ b/compiler/il/OMRBlock.hpp
@@ -366,7 +366,7 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
    int32_t getNormalizedFrequency(TR::CFG *);
    int32_t getGlobalNormalizedFrequency(TR::CFG *);
 
-   bool isOSRInduceBlock(TR::Compilation *);
+   bool verifyOSRInduceBlock(TR::Compilation *);
 
    /**
     * Field functions end
@@ -411,6 +411,9 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
 
    void setIsAdded()                                  { _flags.set(_isAdded); }
    bool isAdded()                                     { return _flags.testAny(_isAdded); }
+
+   void setIsOSRInduceBlock()                         { _flags.set(_isOSRInduceBlock); }
+   bool isOSRInduceBlock()                            { return _flags.testAny(_isOSRInduceBlock); }
 
    void setIsOSRCodeBlock()                           { _flags.set(_isOSRCodeBlock); }
    bool isOSRCodeBlock()                              { return _flags.testAny(_isOSRCodeBlock); }
@@ -500,6 +503,7 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
       _hasBeenVisited                       = 0x00000400,
       _isPRECandidate                       = 0x00000800,
       _isAdded                              = 0x00001000,
+      _isOSRInduceBlock                     = 0x00002000,
       _isOSRCodeBlock                       = 0x00004000,
       _isOSRCatchBlock                      = 0x00008000,
       _createdAtCodeGen                     = 0x00080000,

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -527,6 +527,7 @@ OMR::ResolvedMethodSymbol::genInduceOSRCallNode(TR::TreeTop* insertionPoint,
    TR::Block * firstHalfBlock = insertionPoint->getEnclosingBlock();
    if (shouldSplitBlock)
        firstHalfBlock->split(insertionPoint, self()->comp()->getFlowGraph(), true);
+   firstHalfBlock->setIsOSRInduceBlock();
 
    int32_t firstArgIndex = 0;
    if ((refNode->getNumChildren() > 0) &&

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -2042,6 +2042,8 @@ void TR_CompactNullChecks::compactNullChecks(TR::Block *block, TR_BitVector *wri
          block = prevNode->getBlock();
               exitTree = block->getExit();
          }
+      if (block->isOSRInduceBlock() || block->isOSRCatchBlock() || block->isOSRCodeBlock())
+         return;
 
       //
       // Mark calls and stores that have already been evaluated with this

--- a/compiler/optimizer/OMRSimplifier.cpp
+++ b/compiler/optimizer/OMRSimplifier.cpp
@@ -337,6 +337,13 @@ OMR::Simplifier::simplifyExtendedBlock(TR::TreeTop * treeTop)
       if (block && !b->isExtensionOfPreviousBlock())
          break;
 
+      if (b->isOSRCodeBlock() || b->isOSRCatchBlock())
+         {
+         b->setHasBeenVisited();
+         treeTop = b->getExit();
+         continue;
+         }
+
 #ifdef DEBUG
       if (block != b)
          b->setHasBeenVisited();

--- a/compiler/optimizer/OSRDefAnalysis.cpp
+++ b/compiler/optimizer/OSRDefAnalysis.cpp
@@ -1269,35 +1269,17 @@ int32_t TR_OSRExceptionEdgeRemoval::perform()
    TR::CFGNode *cfgNode;
    for (cfgNode = cfg->getFirstNode(); cfgNode; cfgNode = cfgNode->getNext())
       {
-      if (cfgNode->getExceptionSuccessors().empty())
-         continue;
-
       TR::Block *block = toBlock(cfgNode);
-      bool seenInduceOSRCall = false;
-      TR::TreeTop *treeTop;
-      for (treeTop = block->getEntry(); treeTop != block->getExit(); treeTop = treeTop->getNextTreeTop())
-         {
-         if ((treeTop->getNode()->getNumChildren() > 0) &&
-             treeTop->getNode()->getFirstChild()->getOpCode().hasSymbolReference() &&
-             (comp()->getSymRefTab()->element(TR_induceOSRAtCurrentPC) == treeTop->getNode()->getFirstChild()->getSymbolReference()))
-	    {
-            seenInduceOSRCall = true;
-            break;
-	    }
-         }
-
-      if (seenInduceOSRCall)
+      TR_ASSERT(block->verifyOSRInduceBlock(comp()), "osr induce calls can only exist in osr induce blocks");
+      if (cfgNode->getExceptionSuccessors().empty() || block->isOSRInduceBlock())
          continue;
 
       for (auto edge = block->getExceptionSuccessors().begin(); edge != block->getExceptionSuccessors().end();)
          {
          TR::Block *catchBlock = toBlock((*edge++)->getTo());
-         if (catchBlock->isOSRCatchBlock())
-            {
-            if (!seenInduceOSRCall &&
-                performTransformation(comp(), "%s: Remove redundant exception edge from block_%d at [%p] to OSR catch block_%d at [%p]\n", OPT_DETAILS, block->getNumber(), block, catchBlock->getNumber(), catchBlock))
-                cfg->removeEdge(block, catchBlock);
-            }
+         if (catchBlock->isOSRCatchBlock()
+             && performTransformation(comp(), "%s: Remove redundant exception edge from block_%d at [%p] to OSR catch block_%d at [%p]\n", OPT_DETAILS, block->getNumber(), block, catchBlock->getNumber(), catchBlock))
+            cfg->removeEdge(block, catchBlock);
          }
       }
 

--- a/compiler/optimizer/RegisterCandidate.cpp
+++ b/compiler/optimizer/RegisterCandidate.cpp
@@ -1319,7 +1319,7 @@ TR_RegisterCandidate::processLiveOnEntryBlocks(TR::Block * * blocks, int32_t *bl
          blockWeight = blockStructureWeight[bnum];
          }
 
-      bool ignoreBlock = (dontAssignInColdBlocks(comp) && block->isCold()) || block->isOSRInduceBlock(comp);
+      bool ignoreBlock = (dontAssignInColdBlocks(comp) && block->isCold()) || block->isOSRInduceBlock();
       if (!ignoreBlock && (blockWeight >= maxFrequency*freqRatio))
          ++origNumberOfBlocks;
 
@@ -1352,7 +1352,7 @@ TR_RegisterCandidate::processLiveOnEntryBlocks(TR::Block * * blocks, int32_t *bl
          blockWeight = blockStructureWeight[block->getNumber()];
          }
 
-      bool ignoreBlock = (dontAssignInColdBlocks(comp) && block->isCold()) || block->isOSRInduceBlock(comp);
+      bool ignoreBlock = (dontAssignInColdBlocks(comp) && block->isCold()) || block->isOSRInduceBlock();
       if (!ignoreBlock && (blockWeight >= maxFrequency*freqRatio || useProfilingFrequencies))
          {
          ++numberOfBlocks;

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -4009,6 +4009,9 @@ TR::TreeTop *TR::LocalValuePropagation::processBlock(TR::TreeTop *startTree)
    TR::Node *node = startTree->getNode();
    _curBlock     = node->getBlock();
 
+   if (_curBlock->isOSRCodeBlock() || _curBlock->isOSRCatchBlock() || _curBlock->isOSRInduceBlock())
+      return _curBlock->getExit()->getNextTreeTop();
+
 #if DEBUG
    static int32_t stopAtBlock = -1;
    if (_curBlock->getNumber() == stopAtBlock)


### PR DESCRIPTION
OSRInduceBlocks will be filled with dead stores
and remat trees, resulting in a significant
compile time overhead if not ignored.

This change:
 - Adds a flag to identify OSRInduceBlocks
 - Check the flag in several opts
 - Remove the prior expensive version of the check