### PR TITLE
Add helper method to check all points can OSR

### DIFF
--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -1479,6 +1479,12 @@ OMR::ResolvedMethodSymbol::supportsInduceOSR(TR_ByteCodeInfo &bci,
    return true;
    }
 
+bool
+OMR::ResolvedMethodSymbol::hasOSRProhibitions()
+   {
+   return _cannotAttemptOSR != NULL && !_cannotAttemptOSR->isEmpty();
+   }
+
 /*
  * Prevent OSR transitions to the specified bytecode index.
  * Will only prevent those directed immediately to this index,

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
@@ -276,6 +276,7 @@ public:
    bool cannotAttemptOSRAt(TR_ByteCodeInfo &bci, TR::Block *blockToOSRAt, TR::Compilation *comp);
    bool cannotAttemptOSRDuring(int32_t callSite, TR::Compilation *comp, bool runCleanup = true);
    bool supportsInduceOSR(TR_ByteCodeInfo &bci, TR::Block *blockToOSRAt, TR::Compilation *comp, bool runCleanup = true);
+   bool hasOSRProhibitions();
 
    typedef enum
       {


### PR DESCRIPTION
To simplify analysis, optimizations may ask if
there are any OSR points that cannot transition.
This adds a helper to determine if OSR is always
safe, excluding checks to the OSR infrastructure.