### PR TITLE
Use dense BitVectors in region analysis

### DIFF
--- a/compiler/optimizer/StructuralAnalysis.cpp
+++ b/compiler/optimizer/StructuralAnalysis.cpp
@@ -43,15 +43,15 @@
 #include "ras/Debug.hpp"                              // for TR_DebugBase
 
 void TR_RegionAnalysis::simpleIterator (TR_Stack<int32_t>& workStack,
-                                        SparseBitVector& vector,
+                                        StructureBitVector& vector,
                                         WorkBitVector &regionNodes,
                                         WorkBitVector &nodesInPath,
                                         bool &cyclesFound,
                                         TR::Block *hdrBlock,
                                         bool doThisCheck)
    {
-   SparseBitVector::Cursor cursor(vector);
-   for (cursor.SetToLastOne(); cursor.Valid(); cursor.SetToPreviousOne())
+   StructureBitVector::Cursor cursor(vector);
+   for (cursor.SetToFirstOne(); cursor.Valid(); cursor.SetToNextOne())
       {
       StructInfo &next = getInfo(cursor);
 
@@ -345,7 +345,7 @@ TR_RegionStructure *TR_RegionAnalysis::findNaturalLoop(StructInfo &node,
 
    int32_t numBackEdges = 0;
 
-   SparseBitVector::Cursor cursor(node._pred);
+   StructureBitVector::Cursor cursor(node._pred);
    for (cursor.SetToFirstOne(); cursor.Valid(); cursor.SetToNextOne())
       {
       StructInfo &backEdgeNode = getInfo(cursor);
@@ -472,14 +472,14 @@ void TR_RegionAnalysis::addNaturalLoopNodes(StructInfo &node, WorkBitVector &reg
    regionNodes[index] = true;
    nodesInPath[index] = true;
 
-   SparseBitVector::Cursor cursor(node._pred);
+   StructureBitVector::Cursor cursor(node._pred);
    for (cursor.SetToFirstOne(); cursor.Valid(); cursor.SetToNextOne())
       {
       StructInfo &next = getInfo(cursor);
       if (_dominators.dominates(hdrBlock, next._originalBlock))
          addNaturalLoopNodes(next, regionNodes, nodesInPath, cyclesFound, hdrBlock);
       }
-   SparseBitVector::Cursor eCursor(node._exceptionPred);
+   StructureBitVector::Cursor eCursor(node._exceptionPred);
    for (eCursor.SetToFirstOne(); eCursor.Valid(); eCursor.SetToNextOne())
       {
       StructInfo &next = getInfo(eCursor);
@@ -604,7 +604,7 @@ void TR_RegionAnalysis::addRegionNodes(StructInfo &node, WorkBitVector &regionNo
    regionNodes[index] = true;
    nodesInPath[index] = true;
 
-   SparseBitVector::Cursor cursor(node._succ);
+   StructureBitVector::Cursor cursor(node._succ);
    for (cursor.SetToFirstOne(); cursor.Valid(); cursor.SetToNextOne())
       {
       StructInfo &next = getInfo(cursor);
@@ -622,7 +622,7 @@ void TR_RegionAnalysis::addRegionNodes(StructInfo &node, WorkBitVector &regionNo
          addRegionNodes(next, regionNodes, nodesInPath, cyclesFound, hdrBlock);
 
       }
-   SparseBitVector::Cursor eCursor(node._exceptionSucc);
+   StructureBitVector::Cursor eCursor(node._exceptionSucc);
    for (eCursor.SetToFirstOne(); eCursor.Valid(); eCursor.SetToNextOne())
       {
       StructInfo &next = getInfo(eCursor);
@@ -658,7 +658,7 @@ void TR_RegionAnalysis::buildRegionSubGraph(TR_RegionStructure *region,
 
    // Bits cannot be turned off while iterating over a CS2 sparse bit vector,
    // so they are accumulated in a separate vector and turned off after iteration
-   SparseBitVector bitsToBeRemoved(_compilation->allocator());
+   StructureBitVector bitsToBeRemoved(_compilation->allocator());
 
    WorkBitVector::Cursor rCursor(regionNodes);
    for (rCursor.SetToFirstOne(); rCursor.Valid(); rCursor.SetToNextOne())
@@ -671,7 +671,7 @@ void TR_RegionAnalysis::buildRegionSubGraph(TR_RegionStructure *region,
       from = cfgNodes[fromIndex];
       region->addSubNode(from);
 
-      SparseBitVector::Cursor cursor(fromNode._succ);
+      StructureBitVector::Cursor cursor(fromNode._succ);
       for (cursor.SetToFirstOne(); cursor.Valid(); cursor.SetToNextOne())
          {
          toIndex = cursor;
@@ -706,7 +706,7 @@ void TR_RegionAnalysis::buildRegionSubGraph(TR_RegionStructure *region,
       fromNode._succ -= bitsToBeRemoved;
 
       bitsToBeRemoved.Clear();
-      SparseBitVector::Cursor eCursor(fromNode._exceptionSucc);
+      StructureBitVector::Cursor eCursor(fromNode._exceptionSucc);
       for (eCursor.SetToFirstOne(); eCursor.Valid(); eCursor.SetToNextOne())
          {
          toIndex = eCursor;

--- a/compiler/optimizer/StructuralAnalysis.hpp
+++ b/compiler/optimizer/StructuralAnalysis.hpp
@@ -58,12 +58,12 @@ class TR_RegionAnalysis
 
    class StructInfo;
    typedef CS2::TableOf<StructInfo, TR::Allocator> InfoTable;
-   typedef TR::SparseBitVector SparseBitVector;
+   typedef TR::BitVector StructureBitVector;
    typedef TR::BitVector WorkBitVector;
    typedef TR::deque<TR_StructureSubGraphNode*> SubGraphNodes;
 
    void simpleIterator(TR_Stack<int32_t>& workStack,
-                       SparseBitVector& vector,
+                       StructureBitVector& vector,
                        WorkBitVector &regionNodes,
                        WorkBitVector &nodesInPath,
                        bool &cyclesFound,
@@ -77,10 +77,10 @@ class TR_RegionAnalysis
          : _pred(allocator), _succ(allocator), _exceptionPred(allocator), _exceptionSucc(allocator)
          {
          }
-      SparseBitVector     _pred;
-      SparseBitVector     _succ;
-      SparseBitVector     _exceptionPred;
-      SparseBitVector     _exceptionSucc;
+      StructureBitVector     _pred;
+      StructureBitVector     _succ;
+      StructureBitVector     _exceptionPred;
+      StructureBitVector     _exceptionSucc;
       TR_Structure       *_structure;
       TR::Block           *_originalBlock;
       int32_t             _nodeIndex;

--- a/compiler/optimizer/Structure.cpp
+++ b/compiler/optimizer/Structure.cpp
@@ -363,8 +363,7 @@ void TR_RegionStructure::addGlobalRegisterCandidateToExits(TR_RegisterCandidate 
    }
 
 
-
-static bool findCycle(TR_StructureSubGraphNode *node, TR::SparseBitVector &regionNodes, TR_BitVector &nodesSeenOnPath, TR_BitVector &nodesCleared, int32_t entryNode)
+static bool findCycle(TR_StructureSubGraphNode *node, TR::BitVector &regionNodes, TR_BitVector &nodesSeenOnPath, TR_BitVector &nodesCleared, int32_t entryNode)
    {
    if (nodesSeenOnPath.get(node->getNumber()))
       return true;             // An internal cycle found

--- a/compiler/optimizer/Structure.hpp
+++ b/compiler/optimizer/Structure.hpp
@@ -626,8 +626,8 @@ class TR_RegionStructure : public TR_Structure
         void reset() {_iter.SetToFirstOne();}
 
         private:
-          TR::SparseBitVector _nodes;
-          TR::SparseBitVector::Cursor _iter;
+          TR::BitVector _nodes;
+          TR::BitVector::Cursor _iter;
           TR::CFG * _cfg;
        };
 
@@ -646,7 +646,7 @@ class TR_RegionStructure : public TR_Structure
 
    void checkForInternalCycles();
    void removeEdge(TR::CFGEdge *edge, bool isExitEdge);
-   typedef TR::SparseBitVector SubNodeIndices;
+   typedef TR::BitVector SubNodeIndices;
 
    TR_StructureSubGraphNode         *_entryNode;
    TR_BitVector                     *_invariantSymbols;

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -373,7 +373,7 @@ TR_Debug::print(TR::FILE *outFile, TR_RegionAnalysis * regionAnalysis, uint32_t 
               indentation+11,
               " ");
       int num = 0;
-      TR_RegionAnalysis::SparseBitVector::Cursor cursor(node._succ);
+      TR_RegionAnalysis::StructureBitVector::Cursor cursor(node._succ);
       for (cursor.SetToFirstOne(); cursor.Valid(); cursor.SetToNextOne())
          {
         TR_RegionAnalysis::StructInfo &succ = regionAnalysis->getInfo(cursor);
@@ -395,7 +395,7 @@ TR_Debug::print(TR::FILE *outFile, TR_RegionAnalysis * regionAnalysis, uint32_t 
               indentation+11,
               " ");
       num = 0;
-      TR_RegionAnalysis::SparseBitVector::Cursor eCursor(node._exceptionSucc);
+      TR_RegionAnalysis::StructureBitVector::Cursor eCursor(node._exceptionSucc);
       for (eCursor.SetToFirstOne(); eCursor.Valid(); eCursor.SetToNextOne())
          {
          TR_RegionAnalysis::StructInfo &succ = regionAnalysis->getInfo(eCursor);


### PR DESCRIPTION
Use dense BitVectors, rather than sparse, to
implement region analysis. This reduces the
compile overhead, as allocations for the sparse
BitVectors are costly.