### PR TITLE
Calculate OSRDef during OSRLiveRangeAnalysis

### DIFF
--- a/compiler/compile/OSRData.cpp
+++ b/compiler/compile/OSRData.cpp
@@ -793,6 +793,12 @@ TR_OSRMethodData::ensureSlotSharingInfoAt(int32_t byteCodeIndex)
       }
    }
 
+bool
+TR_OSRMethodData::hasSlotSharingInfo()
+   {
+   return !bcInfoHashTab.IsEmpty();
+   }
+
 void
 TR_OSRMethodData::addScratchBufferOffset(int32_t slotIndex, int32_t symRefOrder, int32_t scratchBufferOffset)
    {

--- a/compiler/compile/OSRData.hpp
+++ b/compiler/compile/OSRData.hpp
@@ -274,6 +274,7 @@ class TR_OSRMethodData
    void addSlotSharingInfo(int32_t byteCodeIndex,
                            int32_t slot, int32_t symRefNum, int32_t symRefOrder, int32_t symSize, bool takesTwoSlots);
    void ensureSlotSharingInfoAt(int32_t byteCodeIndex);
+   bool hasSlotSharingInfo();
    void addInstruction(int32_t instructionPC, int32_t byteCodeIndex);
 
    int32_t getHeaderSize() const;

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -1844,7 +1844,8 @@ OMR::ResolvedMethodSymbol::insertStoresForDeadStackSlotsBeforeInducingOSR(TR::Co
             int32_t nextDeadVar = bvi.getNextElement();
             TR::SymbolReference *nextSymRef = symRefTab->getSymRef(nextDeadVar);
 
-            if (performTransformation(comp, "OSR LIVE RANGE ANALYSIS : Local %d is reset before induceOSR call tree %p (caller index %d bytecode index %d)\n", nextSymRef->getReferenceNumber(), induceOSRTree->getNode(), callSite, byteCodeIndex))
+            if (!nextSymRef->getSymbol()->isParm()
+                && performTransformation(comp, "OSR LIVE RANGE ANALYSIS : Local %d is reset before induceOSR call tree %p (caller index %d bytecode index %d)\n", nextSymRef->getReferenceNumber(), induceOSRTree->getNode(), callSite, byteCodeIndex))
                {
                TR::Node *storeNode = TR::Node::createWithSymRef(comp->il.opCodeForDirectStore(nextSymRef->getSymbol()->getDataType()), 1, 1,
                                                     TR::Node::createConstDead(induceOSRTree->getNode(), nextSymRef->getSymbol()->getDataType()), nextSymRef);

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -537,8 +537,8 @@ static const OptimizationStrategy ilgenStrategyOpts[] =
    { coldBlockMarker                               },
    { allocationSinking,             IfNews         },
    { invariantArgumentPreexistence, IfNotClassLoadPhaseAndNotProfiling },
-   { osrDefAnalysis                                },
    { osrLiveRangeAnalysis                          },
+   { osrDefAnalysis                                },
 #endif
    { endOpts },
    };

--- a/compiler/optimizer/OSRDefAnalysis.hpp
+++ b/compiler/optimizer/OSRDefAnalysis.hpp
@@ -98,6 +98,8 @@ class TR_OSRLiveRangeAnalysis : public TR::Optimization
    void buildOSRLiveRangeInfo(TR::Node *node, TR_BitVector *liveVars, TR_OSRPoint *osrPoint,
       int32_t *liveLocalIndexToSymRefNumberMap, int32_t maxSymRefNumber, int32_t numBits,
       TR_OSRMethodData *osrMethodData);
+   void buildOSRSlotSharingInfo(TR::Node *node, TR_BitVector *liveVars, TR_OSRPoint *osrPoint,
+      int32_t *liveLocalIndexToSymRefNumberMap, TR_BitVector *slotSharingVars);
    void maintainLiveness(TR::Node *node, TR::Node *parent, int32_t childNum, vcount_t  visitCount,
        TR_Liveness *liveLocals, TR_BitVector *liveVars, TR::Block *block);
    TR::TreeTop *collectPendingPush(TR_ByteCodeInfo bci, TR::TreeTop *pps, TR_BitVector *liveVars);


### PR DESCRIPTION
To reduce the compile time overhead of OSR, it is possible
to calculate which slots are being used at an OSR
point based on the set of live symrefs during
OSRLiveRangeAnalysis, rather than having to perform both
it and OSRDefAnalysis.