### PR TITLE
Remove unnecessary uses of TR::comp()

### DIFF
--- a/compiler/arm/codegen/ARMBinaryEncoding.cpp
+++ b/compiler/arm/codegen/ARMBinaryEncoding.cpp
@@ -246,7 +246,7 @@ uint8_t *TR::ARMImmInstruction::generateBinaryEncoding()
 
 uint8_t *TR::ARMImmSymInstruction::generateBinaryEncoding()
    {
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = cg()->comp();
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
    cursor = getOpCode().copyBinaryToBuffer(instructionStart);

--- a/compiler/arm/codegen/BinaryEvaluator.cpp
+++ b/compiler/arm/codegen/BinaryEvaluator.cpp
@@ -1307,7 +1307,7 @@ static inline TR::Register *ibooleanTypeEvaluator(TR::Node *node,
    TR::Node     *secondChild    = node->getSecondChild();
    TR::Node     *firstChild     = node->getFirstChild();
 
-   auto comp = TR::comp();
+   auto comp = cg->comp();
 
    if (comp->getOption(TR_TraceCG))
       {

--- a/compiler/arm/codegen/ConstantDataSnippet.cpp
+++ b/compiler/arm/codegen/ConstantDataSnippet.cpp
@@ -44,7 +44,7 @@ int32_t TR::ARMConstantDataSnippet::addConstantRequest(void              *v,
                                                   TR::Node *node,
                                                   bool isUnloadablePicSite)
    {
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = cg()->comp();
 
    intptrj_t   ain, aex;
 
@@ -300,7 +300,7 @@ uint8_t *TR::ARMConstantDataSnippet::emitSnippetBody()
    float      fconv;
    uint32_t   i32;
 
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = cg()->comp();
    setSnippetBinaryStart(codeCursor);
    count = 4;
 
@@ -557,7 +557,7 @@ void TR::ARMConstantDataSnippet::print(TR::FILE *outFile)
    if (outFile == NULL)
       return;
 
-   TR_FrontEnd *fe = TR::comp()->fe();
+   TR_FrontEnd *fe = cg()->comp()->fe();
 
    uint8_t   *codeCursor = getSnippetBinaryStart();
    uint8_t   *codeStart  = cg()->getBinaryBufferStart();

--- a/compiler/arm/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/arm/codegen/ControlFlowEvaluator.cpp
@@ -78,7 +78,7 @@ TR::Register *OMR::ARM::TreeEvaluator::ireturnEvaluator(TR::Node *node, TR::Code
    addDependency(deps, returnRegister, cg->getProperties().getIntegerReturnRegister(), TR_GPR, cg);
 
    generateAdminInstruction(cg, ARMOp_ret, node, deps);
-   TR::comp()->setReturnInfo(TR_IntReturn);
+   cg->comp()->setReturnInfo(TR_IntReturn);
    return NULL;
    }
 
@@ -93,7 +93,7 @@ TR::Register *OMR::ARM::TreeEvaluator::lreturnEvaluator(TR::Node *node, TR::Code
    addDependency(deps, highReg, cg->getProperties().getLongHighReturnRegister(), TR_GPR, cg);
 
    generateAdminInstruction(cg, ARMOp_ret, node, deps);
-   TR::comp()->setReturnInfo(TR_LongReturn);
+   cg->comp()->setReturnInfo(TR_LongReturn);
    return NULL;
    }
 
@@ -102,7 +102,7 @@ TR::Register *OMR::ARM::TreeEvaluator::lreturnEvaluator(TR::Node *node, TR::Code
 TR::Register *OMR::ARM::TreeEvaluator::returnEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    generateAdminInstruction(cg, ARMOp_ret, node);
-   TR::comp()->setReturnInfo(TR_VoidReturn);
+   cg->comp()->setReturnInfo(TR_VoidReturn);
    return NULL;
    }
 
@@ -122,7 +122,7 @@ static TR::Instruction *compareIntsForOrder(TR_ARMConditionCode  branchType,
    bool            cannotInline = false;
 
    // For TR::instanceof, the opcode must be ificmpeq/ne.
-   if (!TR::comp()->getOption(TR_OptimizeForSpace) &&
+   if (!cg->comp()->getOption(TR_OptimizeForSpace) &&
         firstChild->getOpCodeValue() == TR::instanceof &&
         firstChild->getRegister() == NULL &&
         node->getReferenceCount() <=1 &&
@@ -204,7 +204,7 @@ TR::Instruction *OMR::ARM::TreeEvaluator::compareIntsForEquality(TR_ARMCondition
    if (virtualGuardHelper(node, cg))
       return NULL;
 
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = cg->comp();
    TR::Node        *secondChild = node->getSecondChild();
    TR::Node        *firstChild = node->getFirstChild();
 
@@ -230,7 +230,7 @@ TR::Instruction *OMR::ARM::TreeEvaluator::compareIntsForEquality(TR_ARMCondition
    bool            cannotInline = false;
 
    // For TR::instanceof, the opcode must be ificmpeq/ne.
-   if (!TR::comp()->getOption(TR_OptimizeForSpace) &&
+   if (!cg->comp()->getOption(TR_OptimizeForSpace) &&
         firstChild->getOpCodeValue() == TR::instanceof &&
         firstChild->getRegister() == NULL &&
         node->getReferenceCount() <=1 &&
@@ -549,7 +549,7 @@ static TR::Register *compareLongsForOrder(TR_ARMConditionCode branchOp, TR::Node
    // For now we just generate pessimistic code.
    static bool disableOOLForLongCompares = (feGetEnv("TR_DisableOOLForLongCompares") != NULL);
    TR::Register *src2Reg = cg->evaluate(secondChild);
-   if (/* isSmall() || */ TR::comp()->getOption(TR_DisableOOL) || disableOOLForLongCompares)
+   if (cg->comp()->getOption(TR_DisableOOL) || disableOOLForLongCompares)
       {
       TR::ARMControlFlowInstruction *cfop = generateControlFlowInstruction(cg, ARMOp_iflong, node, deps);
       cfop->addSourceRegister(src1Reg->getHighOrder());
@@ -1239,7 +1239,7 @@ static void lookupScheme3(TR::CodeGenerator *cg, TR::Node *node, bool unbalanced
       }
 
    /* TODO: AOT fixup */
-   if (!TR::comp()->getOption(TR_AOT))
+   if (!cg->comp()->getOption(TR_AOT))
       {
       armLoadConstant(node, address, addrRegister, cg, NULL);
       }
@@ -1301,7 +1301,7 @@ static void lookupScheme3(TR::CodeGenerator *cg, TR::Node *node, bool unbalanced
 // Called by switchDispatch().
 static void lookupScheme4(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::comp()->failCompilation<TR::CompilationException>("Automatically failing on lookup scheme 4");
+   cg->comp()->failCompilation<TR::CompilationException>("Automatically failing on lookup scheme 4");
 
 /*  TODO implement lookups
    int32_t  total = node->getNumChildren();

--- a/compiler/arm/codegen/FPTreeEvaluator.cpp
+++ b/compiler/arm/codegen/FPTreeEvaluator.cpp
@@ -141,7 +141,7 @@ static TR::Register *singlePrecisionEvaluator(TR::Node *node, TR_ARMOpCodes opCo
       {
       if (resultCanStayInFloatRegister(cg->getCurrentEvaluationTreeTop()->getNode(), node))
          {
-         traceMsg(TR::comp(), "Result of node %p can stay in FP reg.\n", node);
+         traceMsg(cg->comp(), "Result of node %p can stay in FP reg.\n", node);
          trgReg = floatTrgReg;
          }
       else
@@ -188,7 +188,7 @@ static TR::Register *doublePrecisionEvaluator(TR::Node *node, TR_ARMOpCodes opCo
       {
       if (resultCanStayInFloatRegister(cg->getCurrentEvaluationTreeTop()->getNode(), node))
          {
-         traceMsg(TR::comp(), "Result of node %p can stay in FP reg.\n", node);
+         traceMsg(cg->comp(), "Result of node %p can stay in FP reg.\n", node);
          trgReg = doubleTrgReg;
          }
       else
@@ -274,7 +274,7 @@ static TR::Register *callLong2DoubleHelper(TR::Node *node, TR::CodeGenerator *cg
 #if defined(__ARM_PCS_VFP)
       if (resultCanStayInFloatRegister(cg->getCurrentEvaluationTreeTop()->getNode(), node))
          {
-         traceMsg(TR::comp(), "Result of node %p can stay in FP reg.\n", node);
+         traceMsg(cg->comp(), "Result of node %p can stay in FP reg.\n", node);
          doubleTrgReg = trgReg;
          }
       else
@@ -361,7 +361,7 @@ static TR::Register *callLong2FloatHelper(TR::Node *node, TR::CodeGenerator *cg)
 #if defined(__ARM_PCS_VFP)
       if (resultCanStayInFloatRegister(cg->getCurrentEvaluationTreeTop()->getNode(), node))
          {
-         traceMsg(TR::comp(), "Result of node %p can stay in FP reg.\n", node);
+         traceMsg(cg->comp(), "Result of node %p can stay in FP reg.\n", node);
          floatTrgReg = trgReg;
          }
       else
@@ -681,7 +681,7 @@ static TR::Register *callDoubleRemainderHelper(TR::Node *node, TR::CodeGenerator
 #if defined(__ARM_PCS_VFP)
       if (resultCanStayInFloatRegister(cg->getCurrentEvaluationTreeTop()->getNode(), node))
          {
-         traceMsg(TR::comp(), "Result of node %p can stay in FP reg.\n", node);
+         traceMsg(cg->comp(), "Result of node %p can stay in FP reg.\n", node);
          doubleTrgReg = trgReg;
          }
       else
@@ -784,7 +784,7 @@ static TR::Register *callFloatRemainderHelper(TR::Node *node, TR::CodeGenerator 
 #if defined(__ARM_PCS_VFP)
       if (resultCanStayInFloatRegister(cg->getCurrentEvaluationTreeTop()->getNode(), node))
          {
-         traceMsg(TR::comp(), "Result of node %p can stay in FP reg.\n", node);
+         traceMsg(cg->comp(), "Result of node %p can stay in FP reg.\n", node);
          floatTrgReg = trgReg;
          }
       else
@@ -819,7 +819,7 @@ TR::Register *OMR::ARM::TreeEvaluator::ibits2fEvaluator(TR::Node *node, TR::Code
       	 {
 
          if (resultCanStayInFloatRegister(cg->getCurrentEvaluationTreeTop()->getNode(), node))
-            traceMsg(TR::comp(), "Result of node %p can stay in FP reg (not exec.).\n", node);
+            traceMsg(cg->comp(), "Result of node %p can stay in FP reg (not exec.).\n", node);
 
          target = cg->allocateRegister();
          generateTrg1MemInstruction(cg, ARMOp_ldr, node, target, tempMR);
@@ -899,7 +899,7 @@ TR::Register *OMR::ARM::TreeEvaluator::lbits2dEvaluator(TR::Node *node, TR::Code
    TR::Register            *target = NULL;
    TR::Register            *lowReg  = NULL;
    TR::Register            *highReg = NULL;
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = cg->comp();
 
    if (child->getRegister() == NULL && child->getReferenceCount() == 1 &&
        child->getOpCode().isLoadVar())
@@ -968,7 +968,7 @@ TR::Register *OMR::ARM::TreeEvaluator::dbits2lEvaluator(TR::Node *node, TR::Code
    TR::Register            *srcReg = NULL;
    TR::Register            *lowReg  = NULL;
    TR::Register            *highReg = NULL;
-   TR::Compilation         *comp = TR::comp();
+   TR::Compilation         *comp = cg->comp();
 
    TR_ASSERT(!node->normalizeNanValues(), "Check NAN\n");
    if (child->getRegister() == NULL && child->getReferenceCount() == 1 &&
@@ -1021,7 +1021,7 @@ TR::Register *OMR::ARM::TreeEvaluator::fconstEvaluator(TR::Node *node, TR::CodeG
    TR::Register *floatTrgReg = cg->allocateSinglePrecisionRegister();
    float value = node->getFloat();
    uint32_t i32 = *(int32_t *)(&value);
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = cg->comp();
    TR::RealRegister *machineIPReg = cg->machine()->getARMRealRegister(TR::RealRegister::gr15);
    TR::RegisterDependencyConditions *deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(2, 2, cg->trMemory());
 
@@ -1047,7 +1047,7 @@ TR::Register *OMR::ARM::TreeEvaluator::fconstEvaluator(TR::Node *node, TR::CodeG
       {
       if (resultCanStayInFloatRegister(cg->getCurrentEvaluationTreeTop()->getNode(), node))
          {
-         traceMsg(TR::comp(), "Result of node %p can stay in FP reg.\n", node);
+         traceMsg(cg->comp(), "Result of node %p can stay in FP reg.\n", node);
          trgReg = floatTrgReg;
          }
       else
@@ -1081,7 +1081,7 @@ TR::Register *OMR::ARM::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::CodeG
    TR::Register *doubleTrgReg = cg->allocateRegister(TR_FPR);
    double value = node->getDouble();
    uint64_t i64 = (*(int64_t *)&value);
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = cg->comp();
    TR::RealRegister *machineIPReg = cg->machine()->getARMRealRegister(TR::RealRegister::gr15);
    TR::RegisterDependencyConditions *deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(2, 2, cg->trMemory());
 
@@ -1163,7 +1163,7 @@ TR::Register *OMR::ARM::TreeEvaluator::floadEvaluator(TR::Node *node, TR::CodeGe
       {
       if (resultCanStayInFloatRegister(cg->getCurrentEvaluationTreeTop()->getNode(), node))
          {
-         traceMsg(TR::comp(), "Result of node %p can stay in FP reg in fload.\n", node);
+         traceMsg(cg->comp(), "Result of node %p can stay in FP reg in fload.\n", node);
          // This seem to break things.. trgReg = floatTrgReg;
 #ifdef STAYINFP
          trgReg = floatTrgReg;
@@ -1231,7 +1231,7 @@ TR::Register *OMR::ARM::TreeEvaluator::dloadEvaluator(TR::Node *node, TR::CodeGe
       {
       if (resultCanStayInFloatRegister(cg->getCurrentEvaluationTreeTop()->getNode(), node))
          {
-         traceMsg(TR::comp(), "Result of node %p can stay in FP reg in dload.\n", node);
+         traceMsg(cg->comp(), "Result of node %p can stay in FP reg in dload.\n", node);
          trgReg = doubleTrgReg;
          }
       else
@@ -1523,7 +1523,7 @@ TR::Register *OMR::ARM::TreeEvaluator::freturnEvaluator(TR::Node *node, TR::Code
    else
       TR_ASSERT(0, "Unknown register type\n");
    generateAdminInstruction(cg, ARMOp_ret, node, deps);
-   TR::comp()->setReturnInfo(TR_FloatReturn);
+   cg->comp()->setReturnInfo(TR_FloatReturn);
    return NULL;
    }
 
@@ -1546,7 +1546,7 @@ TR::Register *OMR::ARM::TreeEvaluator::dreturnEvaluator(TR::Node *node, TR::Code
    else
       TR_ASSERT(0, "Unknown register type\n");
    generateAdminInstruction(cg, ARMOp_ret, node, deps);
-   TR::comp()->setReturnInfo(TR_DoubleReturn);
+   cg->comp()->setReturnInfo(TR_DoubleReturn);
    return NULL;
    }
 
@@ -1572,7 +1572,7 @@ static TR::Register *generateFusedMultiplyAdd(TR::Node *addNode, TR_ARMOpCodes O
    TR::Node     *mulNode = addNode->getFirstChild();
    TR::Node     *addChild    = addNode->getSecondChild();
 
-   if (!isFPStrictMul(mulNode, TR::comp()))
+   if (!isFPStrictMul(mulNode, cg->comp()))
       {
       addChild = addNode->getFirstChild();
       mulNode  = addNode->getSecondChild();
@@ -1628,7 +1628,7 @@ static TR::Register *generateFusedMultiplyAdd(TR::Node *addNode, TR_ARMOpCodes O
 TR::Register *OMR::ARM::TreeEvaluator::faddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    // TODO: Check conditions to use fmacs if possible
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = cg->comp();
    TR::Register *result = NULL;
    if (((isFPStrictMul(node->getFirstChild(), comp) && (node->getSecondChild()->getReferenceCount() == 1)) ||
         (isFPStrictMul(node->getSecondChild(), comp) && (node->getFirstChild()->getReferenceCount() == 1))) &&
@@ -1647,7 +1647,7 @@ TR::Register *OMR::ARM::TreeEvaluator::daddEvaluator(TR::Node *node, TR::CodeGen
    {
    // TODO: Check conditions to use fmacd if possible
    TR::Register *result = NULL;
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = cg->comp();
    if (((isFPStrictMul(node->getFirstChild(), comp) && (node->getSecondChild()->getReferenceCount() == 1)) ||
         (isFPStrictMul(node->getSecondChild(), comp) && (node->getFirstChild()->getReferenceCount() == 1))) &&
          performTransformation(comp, "O^O Changing [%p] to fmacd\n", node))
@@ -1664,7 +1664,7 @@ TR::Register *OMR::ARM::TreeEvaluator::daddEvaluator(TR::Node *node, TR::CodeGen
 TR::Register *OMR::ARM::TreeEvaluator::dsubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    // TODO: Check conditions to use fmscd if possible
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = cg->comp();
    TR::Register *result = NULL;
    if (isFPStrictMul(node->getFirstChild(), comp) &&
       (node->getSecondChild()->getReferenceCount() == 1) &&
@@ -1688,7 +1688,7 @@ TR::Register *OMR::ARM::TreeEvaluator::dsubEvaluator(TR::Node *node, TR::CodeGen
 TR::Register *OMR::ARM::TreeEvaluator::fsubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    // TODO: Check conditions to use fmscs if possible
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = cg->comp();
    TR::Register *result = NULL;
    if (isFPStrictMul(node->getFirstChild(), comp) &&
       (node->getSecondChild()->getReferenceCount() == 1) &&
@@ -1759,7 +1759,7 @@ TR::Register *OMR::ARM::TreeEvaluator::fnegEvaluator(TR::Node *node, TR::CodeGen
    TR::Register *result = NULL;
    TR::Node *firstChild = node->getFirstChild();
    bool isAdd = firstChild->getOpCode().isAdd();
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = cg->comp();
 
    if (firstChild->getReferenceCount() < 2 &&
       !firstChild->getRegister() && isAdd)
@@ -1815,7 +1815,7 @@ TR::Register *OMR::ARM::TreeEvaluator::dnegEvaluator(TR::Node *node, TR::CodeGen
    TR::Register *result = NULL;
    TR::Node *firstChild = node->getFirstChild();
    bool isAdd = firstChild->getOpCode().isAdd();
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = cg->comp();
 
    if (firstChild->getReferenceCount() < 2 &&
       !firstChild->getRegister() && isAdd)
@@ -1892,7 +1892,7 @@ TR::Register *OMR::ARM::TreeEvaluator::i2fEvaluator(TR::Node *node, TR::CodeGene
          {
          if (resultCanStayInFloatRegister(cg->getCurrentEvaluationTreeTop()->getNode(), node))
             {
-            traceMsg(TR::comp(), "Result of node %p can stay in FP reg.\n", node);
+            traceMsg(cg->comp(), "Result of node %p can stay in FP reg.\n", node);
             trgReg = floatTrgReg;
             }
          else
@@ -1954,7 +1954,7 @@ TR::Register *OMR::ARM::TreeEvaluator::i2dEvaluator(TR::Node *node, TR::CodeGene
       {
       if (resultCanStayInFloatRegister(cg->getCurrentEvaluationTreeTop()->getNode(), node))
          {
-         traceMsg(TR::comp(), "Result of node %p can stay in FP reg.\n", node);
+         traceMsg(cg->comp(), "Result of node %p can stay in FP reg.\n", node);
          trgReg = doubleTrgReg;
          }
       else
@@ -2026,7 +2026,7 @@ TR::Register *OMR::ARM::TreeEvaluator::f2dEvaluator(TR::Node *node, TR::CodeGene
       {
       if (resultCanStayInFloatRegister(cg->getCurrentEvaluationTreeTop()->getNode(), node))
          {
-         traceMsg(TR::comp(), "Result of node %p can stay in FP reg.\n", node);
+         traceMsg(cg->comp(), "Result of node %p can stay in FP reg.\n", node);
          trgReg = doubleTrgReg;
          }
       else
@@ -2192,7 +2192,7 @@ TR::Register *OMR::ARM::TreeEvaluator::d2fEvaluator(TR::Node *node, TR::CodeGene
       {
       if (resultCanStayInFloatRegister(cg->getCurrentEvaluationTreeTop()->getNode(), node))
          {
-         traceMsg(TR::comp(), "Result of node %p can stay in FP reg.\n", node);
+         traceMsg(cg->comp(), "Result of node %p can stay in FP reg.\n", node);
          trgReg = floatTrgReg;
          }
       else
@@ -2709,7 +2709,7 @@ TR::Register *OMR::ARM::TreeEvaluator::lbits2dEvaluator(TR::Node *node, TR::Code
    TR::Register            *target = NULL;
    TR::Register            *lowReg  = NULL;
    TR::Register            *highReg = NULL;
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = cg->comp();
 
    if (child->getRegister() == NULL && child->getReferenceCount() == 1 &&
        child->getOpCode().isLoadVar())
@@ -2745,7 +2745,7 @@ TR::Register *OMR::ARM::TreeEvaluator::dbits2lEvaluator(TR::Node *node, TR::Code
    TR::Register            *target = NULL;
    TR::Register            *lowReg  = NULL;
    TR::Register            *highReg = NULL;
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = cg->comp();
 
    TR_ASSERT(!node->normalizeNanValues(), "Check NAN\n");
    if (child->getRegister() == NULL && child->getReferenceCount() == 1 &&

--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -273,7 +273,7 @@ directToInterpreterHelper(TR::ResolvedMethodSymbol *methodSymbol, TR::CodeGenera
 
 TR::Instruction *OMR::ARM::CodeGenerator::generateSwitchToInterpreterPrePrologue(TR::Instruction *cursor, TR::Node *node)
    {
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = self()->comp();
    TR::Register   *gr4 = self()->machine()->getARMRealRegister(TR::RealRegister::gr4);
    TR::Register   *lr = self()->machine()->getARMRealRegister(TR::RealRegister::gr14); // link register
    TR::ResolvedMethodSymbol *methodSymbol = comp->getJittedMethodSymbol();
@@ -343,7 +343,7 @@ static void removeGhostRegistersFromGCMaps(TR::CodeGenerator *cg, TR::Instructio
 
 void OMR::ARM::CodeGenerator::beginInstructionSelection()
    {
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = self()->comp();
    TR::Node *startNode = comp->getStartTree()->getNode();
    if (comp->getMethodSymbol()->getLinkageConvention() == TR_Private)
       {
@@ -371,13 +371,13 @@ void OMR::ARM::CodeGenerator::endInstructionSelection()
    {
    if (_returnTypeInfoInstruction != NULL)
       {
-      _returnTypeInfoInstruction->setSourceImmediate(static_cast<uint32_t>(TR::comp()->getReturnInfo()));
+      _returnTypeInfoInstruction->setSourceImmediate(static_cast<uint32_t>(self()->comp()->getReturnInfo()));
       }
    }
 
 void OMR::ARM::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
    {
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = self()->comp();
 
    if (comp->getOption(TR_TraceCG))
       diagnostic("\nPerforming Register Assignment:\n");
@@ -448,7 +448,7 @@ void OMR::ARM::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssig
 
 void OMR::ARM::CodeGenerator::doBinaryEncoding()
    {
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = self()->comp();
    int32_t estimate = 0;
    TR::Instruction *cursorInstruction = comp->getFirstInstruction();
 
@@ -569,7 +569,7 @@ TR::Register *OMR::ARM::CodeGenerator::gprClobberEvaluate(TR::Node *node)
 static int32_t identifyFarConditionalBranches(int32_t estimate, TR::CodeGenerator *cg)
    {
    TR_Array<TR::ARMConditionalBranchInstruction *> candidateBranches(cg->trMemory(), 256);
-   TR::Instruction *cursorInstruction = TR::comp()->getFirstInstruction();
+   TR::Instruction *cursorInstruction = cg->comp()->getFirstInstruction();
 
    while (cursorInstruction)
       {
@@ -652,7 +652,7 @@ void OMR::ARM::CodeGenerator::buildRegisterMapForInstruction(TR_GCStackMap *map)
 /* @@
 bool OMR::ARM::CodeGenerator::canNullChkBeImplicit(TR::Node *node)
    {
-   return TR::comp()->cg()->canNullChkBeImplicit(node, true);
+   return self()->canNullChkBeImplicit(node, true);
    }
 */
 

--- a/compiler/arm/codegen/OMRLinkage.cpp
+++ b/compiler/arm/codegen/OMRLinkage.cpp
@@ -487,7 +487,7 @@ int32_t OMR::ARM::Linkage::buildARMLinkageArgs(TR::Node                         
                                            bool                                isVirtualOrJNI)
    {
    const TR::ARMLinkageProperties &properties = self()->getProperties();
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = self()->comp();
    TR::CodeGenerator  *codeGen      = self()->cg();
    TR::ARMMemoryArgument *pushToMemory = NULL;
    void                 *stackMark;

--- a/compiler/arm/codegen/OMRLinkage.hpp
+++ b/compiler/arm/codegen/OMRLinkage.hpp
@@ -329,7 +329,7 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
 
    TR_Debug        *getDebug()         {return _cg->getDebug();}
    TR::CodeGenerator *cg()               {return _cg;}
-   TR::Compilation      *comp()             {return TR::comp();}
+   TR::Compilation      *comp()             {return _cg->comp();}
    TR_FrontEnd         *fe()               {return _cg->fe();}
    TR_Memory *          trMemory()         {return _cg->trMemory(); }
    TR_HeapMemory        trHeapMemory();

--- a/compiler/arm/codegen/OMRMachine.cpp
+++ b/compiler/arm/codegen/OMRMachine.cpp
@@ -104,7 +104,7 @@ TR::RealRegister *OMR::ARM::Machine::freeBestRegister(TR::Instruction     *curre
                         							bool isSinglePrecision)
    {
    TR::Register           *candidates[NUM_ARM_MAXR];
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = self()->cg()->comp();
    TR::MemoryReference *tmemref;
    TR_BackingStore       *location;
    TR::RealRegister    *best, *crtemp=NULL;
@@ -204,7 +204,7 @@ TR::RealRegister *OMR::ARM::Machine::freeBestRegister(TR::Instruction     *curre
          //!(cursor->refsRegister(candidates[0])))
          //  cursor = cursor->getPrev();
          //if (!cursor->getOpCode().doubleFPOp())
-         //  location = cg()->getFreeLocalFloatSpill();
+         //  location = self()->cg()->getFreeLocalFloatSpill();
          //else
          if (candidates[0]->getBackingStorage())
             {
@@ -1013,7 +1013,7 @@ void
 OMR::ARM::Machine::takeRegisterStateSnapShot()
    {
    int32_t i;
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = self()->cg()->comp();
    for (i = TR::RealRegister::FirstGPR; i < TR::RealRegister::gr12; i++) // Skipping the special/reserved register.  Add FPR later
       {
       //_registerAssociationsSnapShot[i] = _registerAssociations[i];
@@ -1040,7 +1040,7 @@ void
 OMR::ARM::Machine::restoreRegisterStateFromSnapShot()
    {
    int32_t i;
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = self()->cg()->comp();
    for (i = TR::RealRegister::FirstGPR; i < TR::RealRegister::gr12; i++) // Skipping SpilledReg
       {
       _registerFile[i]->setFlags(_registerFlagsSnapShot[i]);

--- a/compiler/arm/codegen/OMRMemoryReference.cpp
+++ b/compiler/arm/codegen/OMRMemoryReference.cpp
@@ -55,7 +55,7 @@ OMR::ARM::MemoryReference::MemoryReference(TR::Register *br, TR::Register *ir, T
    _indexNode(NULL),
    _modBase(NULL),
    _unresolvedSnippet(NULL),
-   _symbolReference(TR::comp()->getSymRefTab()),
+   _symbolReference(cg->comp()->getSymRefTab()),
    _flag(0),
    _scale(0)
    {
@@ -68,7 +68,7 @@ OMR::ARM::MemoryReference::MemoryReference(TR::Register *br, TR::Register *ir, u
    _indexNode(NULL),
    _modBase(NULL),
    _unresolvedSnippet(NULL),
-   _symbolReference(TR::comp()->getSymRefTab()),
+   _symbolReference(cg->comp()->getSymRefTab()),
    _flag(0),
    _scale(scale)
    {
@@ -81,7 +81,7 @@ OMR::ARM::MemoryReference::MemoryReference(TR::Register *br, int32_t disp, TR::C
    _indexNode(NULL),
    _modBase(NULL),
    _unresolvedSnippet(NULL),
-   _symbolReference(TR::comp()->getSymRefTab()),
+   _symbolReference(cg->comp()->getSymRefTab()),
    _flag(0),
    _scale(0)
    {
@@ -99,13 +99,13 @@ OMR::ARM::MemoryReference::MemoryReference(TR::Node          *rootLoadOrStore,
      _indexRegister(NULL),
      _indexNode(NULL),
      _unresolvedSnippet(NULL),
-     _symbolReference(TR::comp()->getSymRefTab()),
+     _symbolReference(cg->comp()->getSymRefTab()),
      _modBase(NULL),
      _length(len),
      _scale(0),
      _flag(0)
    {
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = cg->comp();
    TR::SymbolReference *ref    = rootLoadOrStore->getSymbolReference();
    TR::Symbol           *symbol = ref->getSymbol();
    bool               isStore = rootLoadOrStore->getOpCode().isStore();
@@ -167,7 +167,7 @@ OMR::ARM::MemoryReference::MemoryReference(TR::Node *node, TR::SymbolReference *
      _indexRegister(NULL),
      _indexNode(NULL),
      _unresolvedSnippet(NULL),
-     _symbolReference(TR::comp()->getSymRefTab()),
+     _symbolReference(cg->comp()->getSymRefTab()),
      _modBase(NULL),
      _length(len),
      _scale(0),
@@ -202,7 +202,7 @@ OMR::ARM::MemoryReference::MemoryReference(TR::Node *node, TR::SymbolReference *
 
    self()->setSymbol(symbol, cg);
    _symbolReference.copyFlags(symRef);
-   _symbolReference.copyRefNumIfPossible(symRef, TR::comp()->getSymRefTab());
+   _symbolReference.copyRefNumIfPossible(symRef, cg->comp()->getSymRefTab());
    self()->addToOffset(0, symRef->getOffset(), cg);
    if (self()->getUnresolvedSnippet() != NULL)
       self()->adjustForResolution(cg);
@@ -213,7 +213,7 @@ OMR::ARM::MemoryReference::MemoryReference(TR::MemoryReference &mr,
                                              int32_t                displacement,
                                              uint32_t               len,
                                              TR::CodeGenerator      *cg)
-   : _symbolReference(TR::comp()->getSymRefTab())
+   : _symbolReference(cg->comp()->getSymRefTab())
    {
    _baseRegister    = mr._baseRegister;
    _baseNode        = NULL;
@@ -1333,7 +1333,7 @@ static void loadRelocatableConstant(TR::Node               *node,
    TR::Symbol                        *symbol;
    int32_t                          addr, offset, highAddr;
    TR::Instruction                  *instr;
-   TR::Compilation * comp = TR::comp();
+   TR::Compilation * comp = cg->comp();
    symbol = ref->getSymbol();
    /* This method is called only if symbol->isStatic() && !ref->isUnresolved(). */
    TR_ASSERT(symbol->isStatic() || symbol->isMethod(), "loadRelocatableConstant, problem with new symbol hierarchy");

--- a/compiler/arm/codegen/OMRRegisterDependency.cpp
+++ b/compiler/arm/codegen/OMRRegisterDependency.cpp
@@ -320,7 +320,7 @@ void TR_ARMRegisterDependencyGroup::assignRegisters(TR::Instruction  *currentIns
                                                     uint32_t         numberOfRegisters,
                                                     TR::CodeGenerator *cg)
    {
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = cg->comp();
    TR::Machine *machine = cg->machine();
    TR::Register  *virtReg;
    TR::RealRegister::RegNum dependentRegNum;

--- a/compiler/arm/codegen/OMRRegisterDependency.hpp
+++ b/compiler/arm/codegen/OMRRegisterDependency.hpp
@@ -82,7 +82,7 @@ struct TR_ARMRegisterDependency
 void print(TR::FILE *pOutFile, TR::CodeGenerator *cg)
    {
    TR_ARMMachine *machine = getARMMachine(cg);
-   TR_FrontEnd *fe = TR::comp()->fe();
+   TR_FrontEnd *fe = cg->comp()->fe();
    trfprintf(pOutFile,"\nVirtual: ");
    (void)trfflush(pOutFile);
    _virtualRegister->print(pOutFile, TR_WordReg);

--- a/compiler/arm/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.cpp
@@ -91,7 +91,7 @@ TR::Instruction *armLoadConstant(TR::Node *node, int32_t value, TR::Register *tr
      uint32_t notTrailing = trailingZeroes(notBits) & ~1;
      uint32_t base        = bitValue>>bitTrailing;
      uint32_t notBase     = notBits>>notTrailing;
-     TR::Compilation *comp = TR::comp();
+     TR::Compilation *comp = cg->comp();
 
      if (comp->getOption(TR_TraceCG))
         {
@@ -469,7 +469,7 @@ TR::Register *OMR::ARM::TreeEvaluator::lloadEvaluator(TR::Node *node, TR::CodeGe
    TR::Register           *lowReg  = cg->allocateRegister();
    TR::Register           *highReg = cg->allocateRegister();
    TR::RegisterPair       *trgReg = cg->allocateRegisterPair(lowReg, highReg);
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = cg->comp();
    bool bigEndian = TR::Compiler->target.cpu.isBigEndian();
    bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP());
 
@@ -638,7 +638,7 @@ TR::Register *OMR::ARM::TreeEvaluator::iwrtbarEvaluator(TR::Node *node, TR::Code
 TR::Register *OMR::ARM::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node *valueChild;
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = cg->comp();
    if (node->getOpCode().isIndirect())
       {
       valueChild = node->getSecondChild();
@@ -1074,7 +1074,7 @@ TR::Register *OMR::ARM::TreeEvaluator::newObjectEvaluator(TR::Node *node, TR::Co
 
 TR::Register *OMR::ARM::TreeEvaluator::newArrayEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::comp()->suppressAllocationInlining())
+   if (cg->comp()->suppressAllocationInlining())
       {
       TR::ILOpCodes opCode = node->getOpCodeValue();
       TR::Node::recreate(node, TR::acall);
@@ -1090,7 +1090,7 @@ TR::Register *OMR::ARM::TreeEvaluator::newArrayEvaluator(TR::Node *node, TR::Cod
 
 TR::Register *OMR::ARM::TreeEvaluator::anewArrayEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::comp()->suppressAllocationInlining())
+   if (cg->comp()->suppressAllocationInlining())
       {
       TR::ILOpCodes opCode = node->getOpCodeValue();
       TR::Node::recreate(node, TR::acall);
@@ -1176,7 +1176,7 @@ TR::Register *OMR::ARM::TreeEvaluator::loadaddrEvaluator(TR::Node *node, TR::Cod
       resultReg = sym->isLocalObject() ?  cg->allocateCollectedReferenceRegister() : cg->allocateRegister();
       if (mref->useIndexedForm())
          {
-         TR::comp()->failCompilation<TR::CompilationException>("implement unresolved loadAddr indexed");
+         cg->comp()->failCompilation<TR::CompilationException>("implement unresolved loadAddr indexed");
          generateTrg1MemInstruction(cg, ARMOp_add, node, resultReg, mref);
          }
       else
@@ -1324,7 +1324,7 @@ TR::Register *OMR::ARM::TreeEvaluator::passThroughEvaluator(TR::Node *node, TR::
 
 TR::Register *OMR::ARM::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = cg->comp();
    TR::Block *block = node->getBlock();
    TR::RegisterDependencyConditions *deps = NULL;
 

--- a/compiler/codegen/CodeGenGC.cpp
+++ b/compiler/codegen/CodeGenGC.cpp
@@ -459,7 +459,7 @@ TR_GCStackMap::addToAtlas(TR::Instruction * instruction, TR::CodeGenerator *code
    uint8_t * codeStart = codeGen->getCodeStart();
    setLowestCodeOffset(instruction->getBinaryEncoding() - codeStart);
    codeGen->getStackAtlas()->addStackMap(this);
-   bool osrEnabled = TR::comp()->getOption(TR_EnableOSR);
+   bool osrEnabled = codeGen->comp()->getOption(TR_EnableOSR);
    if (osrEnabled)
       codeGen->addToOSRTable(instruction);
    }
@@ -472,7 +472,7 @@ TR_GCStackMap::addToAtlas(uint8_t * callSiteAddress, TR::CodeGenerator *codeGen)
    uint32_t callSiteOffset = callSiteAddress - codeGen->getCodeStart();
    setLowestCodeOffset(callSiteOffset - 1);
    codeGen->getStackAtlas()->addStackMap(this);
-   bool osrEnabled = TR::comp()->getOption(TR_EnableOSR);
+   bool osrEnabled = codeGen->comp()->getOption(TR_EnableOSR);
    if (osrEnabled)
       codeGen->addToOSRTable(callSiteOffset, getByteCodeInfo());
    }

--- a/compiler/codegen/NodeEvaluation.cpp
+++ b/compiler/codegen/NodeEvaluation.cpp
@@ -466,7 +466,7 @@ OMR::CodeGenerator::evaluateChildrenWithMultipleRefCount(TR::Node * node)
 	     (child->getOpCode().hasSymbolReference() ||
 	      (child->getOpCodeValue() == TR::l2a && child->getChild(0)->containsCompressionSequence())))
             {
-            TR::SymbolReference *vftPointerSymRef = TR::comp()->getSymRefTab()->element(TR::SymbolReferenceTable::vftSymbol);
+            TR::SymbolReference *vftPointerSymRef = self()->comp()->getSymRefTab()->element(TR::SymbolReferenceTable::vftSymbol);
             if (node->isNopableInlineGuard()
                 && self()->getSupportsVirtualGuardNOPing()
                 && child->getOpCodeValue() == TR::aloadi

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -407,7 +407,7 @@ OMR::CodeGenPhase::performInstructionSelectionPhase(TR::CodeGenerator * cg, TR::
          {
          if (TO_KIND_MASK(r) & cg->getSupportedLiveRegisterKinds())
             {
-            TR::CodeGenerator::checkForLiveRegisters(cg->getLiveRegisters((TR_RegisterKinds)r));
+            cg->checkForLiveRegisters(cg->getLiveRegisters((TR_RegisterKinds)r));
             }
          }
 #endif
@@ -622,7 +622,7 @@ OMR::CodeGenPhase::performCleanUpFlagsPhase(TR::CodeGenerator * cg, TR::CodeGenP
 void
 OMR::CodeGenPhase::performFindAndFixCommonedReferencesPhase(TR::CodeGenerator * cg, TR::CodeGenPhase * phase)
    {
-   if (!TR::comp()->useRegisterMaps())
+   if (!cg->comp()->useRegisterMaps())
       cg->findAndFixCommonedReferences();
    }
 

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -186,7 +186,9 @@ TR::Node* generatePoisonNode(TR::Compilation *comp, TR::Block *currentBlock, TR:
 
 TR::Instruction *
 OMR::CodeGenerator::generateNop(TR::Node * node, TR::Instruction *instruction, TR_NOPKind nopKind)
-    { TR_ASSERT(0, "shouldn't get here"); return NULL;}OMR::CodeGenerator::CodeGenerator() :
+    { TR_ASSERT(0, "shouldn't get here"); return NULL;}
+
+OMR::CodeGenerator::CodeGenerator() :
       _compilation(TR::comp()),
       _trMemory(TR::comp()->trMemory()),
       _liveLocals(0),
@@ -3791,7 +3793,7 @@ void OMR::CodeGenerator::recordSingleRegisterUse(TR::Register *reg)
 
 void OMR::CodeGenerator::startRecordingRegisterUsage()
    {
-   self()->setReferencedRegisterList(new (self()->trHeapMemory()) TR::list<OMR::RegisterUsage*>(getTypedAllocator<OMR::RegisterUsage*>(TR::comp()->allocator())));
+   self()->setReferencedRegisterList(new (self()->trHeapMemory()) TR::list<OMR::RegisterUsage*>(getTypedAllocator<OMR::RegisterUsage*>(self()->comp()->allocator())));
    self()->setEnableRegisterUsageTracking();
    }
 

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -799,7 +799,7 @@ class OMR_EXTENSIBLE CodeGenerator
    // --------------------------------------------------------------------------
    // Live registers
    //
-   static void checkForLiveRegisters(TR_LiveRegisters *);
+   void checkForLiveRegisters(TR_LiveRegisters *);
    TR_LiveRegisters *getLiveRegisters(TR_RegisterKinds rk) {return _liveRegisters[rk];}
    TR_LiveRegisters *setLiveRegisters(TR_LiveRegisters *p, TR_RegisterKinds rk) {return (_liveRegisters[rk] = p);}
 

--- a/compiler/codegen/OMRInstruction.cpp
+++ b/compiler/codegen/OMRInstruction.cpp
@@ -36,7 +36,7 @@ Instruction::Instruction(
       TR::Node *node) :
    _opcode(op),
    _next(0),
-   _prev(TR::comp()->getAppendInstruction()),
+   _prev(cg->comp()->getAppendInstruction()),
    _node(node),
    _binaryEncodingBuffer(0),
    _binaryLength(0),

--- a/compiler/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/codegen/OMRTreeEvaluator.cpp
@@ -141,7 +141,7 @@ bool OMR::TreeEvaluator::instanceOfOrCheckCastNeedSuperTest(TR::Node * node, TR:
           !TR::Compiler->cls.isInterfaceClass(cg->comp(), clazz) &&
           !TR::Compiler->cls.isClassFinal(cg->comp(), clazz) &&
            helperSym->preservesAllRegisters() &&
-          !TR::comp()->getOption(TR_OptimizeForSpace))
+          !cg->comp()->getOption(TR_OptimizeForSpace))
          return true;
       }
    return false;

--- a/compiler/codegen/OutOfLineCodeSection.cpp
+++ b/compiler/codegen/OutOfLineCodeSection.cpp
@@ -85,7 +85,7 @@ TR_OutOfLineCodeSection::TR_OutOfLineCodeSection(TR::LabelSymbol *entryLabel, TR
 void TR_OutOfLineCodeSection::swapInstructionListsWithCompilation()
    {
    TR::Instruction *temp;
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = _cg->comp();
 
    temp = comp->getFirstInstruction();
    comp->setFirstInstruction(_firstInstruction);
@@ -107,7 +107,7 @@ void TR_OutOfLineCodeSection::swapInstructionListsWithCompilation()
 void TR_OutOfLineCodeSection::preEvaluatePersistentHelperArguments()
    {
    TR_ASSERT(_callNode, "preEvaluatePersistentHelperArguments can only be called for TR_OutOfLineCodeSection which are helper calls");
-   TR::TreeEvaluator::initializeStrictlyFutureUseCounts(_callNode, TR::comp()->incVisitCount(), _cg);
+   TR::TreeEvaluator::initializeStrictlyFutureUseCounts(_callNode, _cg->comp()->incVisitCount(), _cg);
    evaluateNodesWithFutureUses(_callNode);
    }
 
@@ -138,7 +138,7 @@ void TR_OutOfLineCodeSection::evaluateNodesWithFutureUses(TR::Node *node)
 TR::Node *TR_OutOfLineCodeSection::createOutOfLineCallNode(TR::Node *callNode, TR::ILOpCodes callOp)
    {
    int32_t   i;
-   vcount_t  visitCount = TR::comp()->incVisitCount();
+   vcount_t  visitCount = _cg->comp()->incVisitCount();
    TR::Node  *child;
 
    for (i=0; i<callNode->getNumChildren(); i++)

--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -250,9 +250,6 @@ bool skipCompare (TR::Node *node)
    {
    TR::Node     *firstChild  = node->getFirstChild();
    TR::Node     *secondChild = node->getSecondChild();
-   TR::Compilation *comp = TR::comp();
-
-
    return false;
    }
 

--- a/compiler/p/codegen/OMRConstantDataSnippet.cpp
+++ b/compiler/p/codegen/OMRConstantDataSnippet.cpp
@@ -43,7 +43,7 @@ int32_t OMR::ConstantDataSnippet::addConstantRequest(void              *v,
                                                   TR::Node *node,
                                                   bool isUnloadablePicSite)
    {
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = cg()->comp();
    union {
       float       fvalue;
       int32_t     ivalue;
@@ -537,7 +537,7 @@ void OMR::ConstantDataSnippet::print(TR::FILE *outFile)
    if (outFile == NULL)
       return;
 
-   TR_FrontEnd *fe = TR::comp()->fe();
+   TR_FrontEnd *fe = cg()->comp()->fe();
 
    uint8_t   *codeCursor = getSnippetBinaryStart();
    uint8_t   *codeStart  = cg()->getBinaryBufferStart();

--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -1412,7 +1412,7 @@ static TR::RealRegister::RegNum choose_rX(TR::Instruction *currentInstruction, T
 
 uint32_t OMR::Power::MemoryReference::estimateBinaryLength(TR::CodeGenerator& codeGen)
    {
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = codeGen.comp();
    if (self()->isTOCAccess())
       {
       int32_t tocOffset = self()->getTOCOffset();

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -4359,7 +4359,7 @@ OMR::Power::TreeEvaluator::generateHelperBranchAndLinkInstruction(
 
 TR::Register *OMR::Power::TreeEvaluator::setmemoryEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = cg->comp();
    TR::Node             *dstAddrNode, *lengthNode, *valueNode;
    dstAddrNode = node->getChild(0);
    lengthNode = node->getChild(1);

--- a/compiler/p/codegen/PPCHelperCallSnippet.cpp
+++ b/compiler/p/codegen/PPCHelperCallSnippet.cpp
@@ -100,7 +100,7 @@ uint8_t *TR::PPCHelperCallSnippet::genHelperCall(uint8_t *buffer)
 
    if (!(distance>=BRANCH_BACKWARD_LIMIT && distance<=BRANCH_FORWARD_LIMIT))
       {
-      distance = TR::comp()->fe()->indexedTrampolineLookup(getDestination()->getReferenceNumber(), (void *)buffer) - (intptrj_t)buffer;
+      distance = cg()->comp()->fe()->indexedTrampolineLookup(getDestination()->getReferenceNumber(), (void *)buffer) - (intptrj_t)buffer;
       TR_ASSERT(distance>=BRANCH_BACKWARD_LIMIT && distance<=BRANCH_FORWARD_LIMIT,
              "CodeCache is more than 32MB.\n");
       }

--- a/compiler/x/codegen/BinaryCommutativeAnalyser.cpp
+++ b/compiler/x/codegen/BinaryCommutativeAnalyser.cpp
@@ -764,7 +764,7 @@ TR::Register *TR_X86BinaryCommutativeAnalyser::integerAddAnalyserImpl(TR::Node  
                                                                       TR::Node      *carry)
    {
    TR::Register *targetRegister;
-   TR::Compilation* comp = TR::comp();
+   TR::Compilation* comp = _cg->comp();
    TR::Register *firstRegister  = firstChild->getRegister();
    TR::Register *secondRegister = secondChild->getRegister();
 

--- a/compiler/x/codegen/FPBinaryArithmeticAnalyser.cpp
+++ b/compiler/x/codegen/FPBinaryArithmeticAnalyser.cpp
@@ -170,7 +170,7 @@ void TR_X86FPBinaryArithmeticAnalyser::genericFPAnalyser(TR::Node *root)
    TR::Node             *targetChild        = NULL,
                         *sourceChild        = NULL,
                         *opChild[2]         = {NULL, NULL};
-   TR::Compilation      *comp               = TR::comp();
+   TR::Compilation      *comp               = _cg->comp();
    TR::MemoryReference  *constMR            = NULL;
    bool                 operandNeedsScaling = false;
    TR::Register         *scalingRegister    = NULL;

--- a/compiler/x/codegen/IntegerMultiplyDecomposer.cpp
+++ b/compiler/x/codegen/IntegerMultiplyDecomposer.cpp
@@ -47,7 +47,7 @@ inline bool getNodeIs64Bit(TR::Node *node, TR::CodeGenerator *cg)
 // decomposeIntegerMultiplier needs to update this array if it allocates new temporary registers inside
 TR::Register *TR_X86IntegerMultiplyDecomposer::decomposeIntegerMultiplier(int32_t &tempRegArraySize, TR::Register **tempRegArray)
    {
-   TR::Compilation* comp = TR::comp();
+   TR::Compilation* comp = _cg->comp();
    bool nodeIs64Bit = getNodeIs64Bit(_node, _cg);
    int64_t absMultiplier = _multiplier;
    if (_multiplier < 0)

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -2902,7 +2902,7 @@ bool OMR::X86::CodeGenerator::allowGlobalRegisterAcrossBranch(TR_RegisterCandida
 bool OMR::X86::CodeGenerator::supportsInliningOfIsInstance()
    {
    static const char *envp = feGetEnv("TR_NINLINEISINSTANCE");
-   return !envp && !TR::comp()->getOption(TR_DisableInlineIsInstance);
+   return !envp && !self()->comp()->getOption(TR_DisableInlineIsInstance);
    }
 
 uint8_t OMR::X86::CodeGenerator::getSizeOfCombinedBuffer()

--- a/compiler/x/codegen/OMRMachine.cpp
+++ b/compiler/x/codegen/OMRMachine.cpp
@@ -2080,7 +2080,7 @@ TR_RegisterAssignerState::createDependenciesFromRegisterState(TR_OutlinedInstruc
    {
    // Calculate the required number of dependencies.
    //
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = _machine->cg()->comp();
    int32_t numDeps = 0;
    int32_t i;
    int32_t endReg = TR::RealRegister::LastXMMR;
@@ -2251,7 +2251,7 @@ bool TR_RegisterAssignerState::isLive(TR::Register *virtReg)
 
 void TR_RegisterAssignerState::dump()
    {
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = _machine->cg()->comp();
 
    if (comp->getOptions()->getOption(TR_TraceNonLinearRegisterAssigner))
       {

--- a/compiler/z/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/z/codegen/OMRCodeGenPhase.cpp
@@ -40,7 +40,7 @@ OMR::Z::CodeGenPhase::performMarkLoadAsZeroOrSignExtensionPhase(TR::CodeGenerato
    {
    if (TR::Compiler->target.cpu.isZ() && cg->getOptimizationPhaseIsComplete())
       {
-      TR::Compilation* comp = TR::comp();
+      TR::Compilation* comp = cg->comp();
       TR::OptimizationManager *manager = comp->getOptimizer()->getOptimization(OMR::loadExtensions);
       TR_ASSERT(manager, "Load extensions optimization should be initialized.");
       TR_LoadExtensions *loadExtensions = (TR_LoadExtensions *) manager->factory()(manager);

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -377,7 +377,7 @@ OMR::Z::CodeGenerator::lowerTreeIfNeeded(
 
 bool OMR::Z::CodeGenerator::supportsInliningOfIsInstance()
    {
-   return !TR::comp()->getOption(TR_DisableInlineIsInstance);
+   return !self()->comp()->getOption(TR_DisableInlineIsInstance);
    }
 
 bool OMR::Z::CodeGenerator::canTransformUnsafeCopyToArrayCopy()
@@ -6903,8 +6903,8 @@ OMR::Z::CodeGenerator::getLinkageGlobalRegisterNumber(int8_t linkageRegisterInde
 
    else
       {
-//      traceMsg(TR::comp(), "lastLinkageGPR = %d linkaeRegisterIndex = %d  getGlobalRegisterNumber(getS390Linkage()->getIntegerArgumentRegister(linkageRegisterIndex)-1) = %d\n",machine()->getLastLinkageGPR(),linkageRegisterIndex, self()->getGlobalRegisterNumber(getS390Linkage()->getIntegerArgumentRegister(linkageRegisterIndex)-1));
-//      traceMsg(TR::comp(), "getS390Linkage()->getIntegerArgumentRegister(linkageRegisterIndex) = %d\n",getS390Linkage()->getIntegerArgumentRegister(linkageRegisterIndex));
+//      traceMsg(self()->comp(), "lastLinkageGPR = %d linkaeRegisterIndex = %d  getGlobalRegisterNumber(getS390Linkage()->getIntegerArgumentRegister(linkageRegisterIndex)-1) = %d\n",machine()->getLastLinkageGPR(),linkageRegisterIndex, self()->getGlobalRegisterNumber(getS390Linkage()->getIntegerArgumentRegister(linkageRegisterIndex)-1));
+//      traceMsg(self()->comp(), "getS390Linkage()->getIntegerArgumentRegister(linkageRegisterIndex) = %d\n",getS390Linkage()->getIntegerArgumentRegister(linkageRegisterIndex));
 
       result = self()->getGlobalRegisterNumber(self()->getS390Linkage()->getIntegerArgumentRegister(linkageRegisterIndex)-1);
       }

--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -1326,7 +1326,7 @@ OMR::Z::Machine::assignBestRegisterSingle(TR::Register    *targetRegister,
    {
    TR_RegisterKinds kindOfRegister = targetRegister->getKind();
    TR::RealRegister * assignedRegister = targetRegister->getAssignedRealRegister();
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = _cg->comp();
 
    bool reverseSpilled = false;
 
@@ -1698,7 +1698,7 @@ OMR::Z::Machine::assignBestRegisterPair(TR::Register    *regPair,
 
    TR::Register * firstVirtualBaseAR = NULL;
    TR::Register * lastVirtualBaseAR = NULL;
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = _cg->comp();
 
    if (regPair->isArGprPair())
       {
@@ -2199,7 +2199,7 @@ OMR::Z::Machine::findBestFreeRegisterPair(TR::RealRegister ** firstRegister, TR:
    uint32_t interference = 0;
    int32_t first, maskI;
    int32_t last;
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = _cg->comp();
 
    TR::RealRegister * freeRegisterLow = NULL;
    TR::RealRegister * freeRegisterHigh = NULL;
@@ -2338,7 +2338,7 @@ OMR::Z::Machine::freeBestFPRegisterPair(TR::RealRegister ** firstReg, TR::RealRe
    uint64_t          availRegMask)
    {
    TR::Node * currentNode = currInst->getNode();
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = self()->cg()->comp();
    int32_t first, maskI;
    int32_t last;
    TR::Instruction * cursor = NULL;
@@ -2542,7 +2542,7 @@ OMR::Z::Machine::freeBestRegisterPair(TR::RealRegister ** firstReg, TR::RealRegi
    int32_t first, maskI;
    int32_t last;
    TR::Instruction * cursor = NULL;
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = _cg->comp();
    TR::Machine *machine = self()->cg()->machine();
 
    TR_BackingStore * locationLow;
@@ -2980,7 +2980,7 @@ OMR::Z::Machine::findBestFreeRegister(TR::Instruction   *currentInstruction,
    uint32_t randomInterference;
    int32_t randomWeight;
    uint32_t randomPreference;
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = _cg->comp();
 
    uint32_t preference = 0;
    if(virtualReg != NULL)
@@ -3844,7 +3844,7 @@ OMR::Z::Machine::freeBestRegister(TR::Instruction * currentInstruction, TR::Regi
                                  uint64_t availRegMask, bool allowNullReturn, bool doNotSpillToSiblingHPR)
    {
    _cg->traceRegisterAssignment("FREE BEST REGISTER FOR %R", virtReg);
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = _cg->comp();
 
    if (virtReg->containsCollectedReference())
       _cg->traceRegisterAssignment("%R contains collected", virtReg);
@@ -4170,7 +4170,7 @@ OMR::Z::Machine::freeBestRegister(TR::Instruction * currentInstruction, TR::Regi
  */
 void OMR::Z::Machine::freeRealRegister(TR::Instruction *currentInstruction, TR::RealRegister *targetReal, bool is64BitReg)
   {
-  TR::Compilation *comp = TR::comp();
+  TR::Compilation *comp = _cg->comp();
   TR::Register *virtReg=targetReal->getAssignedRegister();
   bool enableHighWordRA = _cg->supportsHighWordFacility() && !comp->getOption(TR_DisableHighWordRA) &&
                           targetReal->getKind() != TR_FPR && targetReal->getKind() != TR_VRF;
@@ -4283,7 +4283,7 @@ OMR::Z::Machine::freeHighWordRegister(TR::Instruction *currentInstruction, TR::R
 void
 OMR::Z::Machine::spillRegister(TR::Instruction * currentInstruction, TR::Register* virtReg, uint32_t availHighWordRegMap)
    {
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = _cg->comp();
    TR::InstOpCode::Mnemonic opCode;
    bool containsInternalPointer = false;
    bool containsCollectedReg    = false;
@@ -4694,7 +4694,7 @@ OMR::Z::Machine::reverseSpillState(TR::Instruction      *currentInstruction,
    TR::Instruction * cursor = NULL;
    TR::RealRegister * freeHighWordReg = NULL;
    TR_Debug * debugObj = self()->cg()->getDebug();
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = self()->cg()->comp();
    //This may not actually need to be reversed if
    //this is a dummy register used for OOL dependencies
 
@@ -5030,7 +5030,7 @@ OMR::Z::Machine::isAssignable(TR::Register * virtReg, TR::RealRegister * realReg
       }
    else
       {
-      if (_cg->supportsHighWordFacility() && !TR::comp()->getOption(TR_DisableHighWordRA) &&
+      if (_cg->supportsHighWordFacility() && !_cg->comp()->getOption(TR_DisableHighWordRA) &&
           virtReg->getKind() != TR_FPR && virtReg->getKind() != TR_VRF)
          {
          if ((virtReg->is64BitReg() && realReg->getLowWordRegister()->getAssignedRegister() == realReg->getHighWordRegister()->getAssignedRegister()) ||
@@ -5073,7 +5073,7 @@ OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction                       
    TR::Instruction * cursor = NULL;
    TR::Node * currentNode = currentInstruction->getNode();
    bool doNotRegCopy = false;
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = _cg->comp();
 
    if(virtualRegister->isArGprPair())
      virtualRegister->getGPRofArGprPair()->setIsLive();
@@ -6102,7 +6102,7 @@ uint64_t OMR::Z::Machine::filterColouredRegisterConflicts(TR::Register *targetRe
                                                              TR::Instruction *currInst)
   {
   uint64_t mask=0xffffffff;
-  TR::Compilation *comp = TR::comp();
+  TR::Compilation *comp = _cg->comp();
   TR::list<TR::Register *> conflictRegs(getTypedAllocator<TR::Register*>(comp->allocator()));
 
   if(currInst->defsAnyRegister(targetRegister))
@@ -6552,7 +6552,7 @@ OMR::Z::Machine::initializeFPRegPairTable()
 uint32_t *
 OMR::Z::Machine::initializeGlobalRegisterTable()
    {
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = _cg->comp();
 
    if (!comp->getOption(TR_DisableRegisterPressureSimulation))
       {
@@ -7047,7 +7047,7 @@ OMR::Z::Machine::initializeGlobalRegisterTable()
 uint32_t
 OMR::Z::Machine::initGlobalVectorRegisterMap(uint32_t vectorOffset)
    {
-   if (!_cg->getSupportsVectorRegisters() && !TR::comp()->getOption(TR_DisableVectorRegGRA))
+   if (!_cg->getSupportsVectorRegisters() && !_cg->comp()->getOption(TR_DisableVectorRegGRA))
       {
       self()->setFirstGlobalVRFRegisterNumber(-1);
       self()->setLastGlobalVRFRegisterNumber(-1);
@@ -7133,7 +7133,7 @@ OMR::Z::Machine::initGlobalVectorRegisterMap(uint32_t vectorOffset)
 
    if (traceVectorGRN)
       {
-      printf("Java func: %s func: %s\n", TR::comp()->getCurrentMethod()->nameChars(), __FUNCTION__);
+      printf("Java func: %s func: %s\n", _cg->comp()->getCurrentMethod()->nameChars(), __FUNCTION__);
       printf("ff %d\t", self()->getFirstGlobalFPRRegisterNumber());
       printf("lf %d\t", self()->getLastGlobalFPRRegisterNumber());
       printf("fof %d\t", self()->getFirstOverlappedGlobalFPRRegisterNumber());
@@ -7153,7 +7153,7 @@ OMR::Z::Machine::initGlobalVectorRegisterMap(uint32_t vectorOffset)
 void
 OMR::Z::Machine::lockGlobalRegister(int32_t globalRegisterTableIndex)
    {
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = _cg->comp();
    if (comp->getOption(TR_DisableRegisterPressureSimulation))
       {
       _globalRegisterNumberToRealRegisterMap[globalRegisterTableIndex] = (uint32_t) (-1);
@@ -7191,7 +7191,7 @@ OMR::Z::Machine::findGlobalRegisterIndex(TR::RealRegister::RegNum gReg)
 void
 OMR::Z::Machine::releaseLiteralPoolRegister()
    {
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = _cg->comp();
    if (comp->getOption(TR_DisableRegisterPressureSimulation))
       {
       _globalRegisterNumberToRealRegisterMap[GLOBAL_REG_FOR_LITPOOL] = TR::RealRegister::GPR6;
@@ -7328,7 +7328,7 @@ OMR::Z::Machine::setRegisterWeightsFromAssociations()
    {
    TR::Linkage * linkage = _cg->getS390Linkage();
    int32_t first = TR::RealRegister::FirstGPR;
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = _cg->comp();
    int32_t last = TR::RealRegister::LastAssignableVRF;
    if (_cg->supportsHighWordFacility() && !comp->getOption(TR_DisableHighWordRA))
       last = TR::RealRegister::LastHPR;
@@ -7373,7 +7373,7 @@ OMR::Z::Machine::setRegisterWeightsFromAssociations()
 void
 OMR::Z::Machine::createRegisterAssociationDirective(TR::Instruction * cursor)
    {
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = _cg->comp();
    int32_t last = TR::RealRegister::LastAssignableVRF;
    TR::RegisterDependencyConditions * associations;
 
@@ -7457,7 +7457,7 @@ OMR::Z::Machine::isRestrictedReg(TR::RealRegister::RegNum reg)
       TR::RealRegister::GPR11,
       TR::RealRegister::GPR12,
       };
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = _cg->comp();
    static const int32_t regListSize = (sizeof(regList) / sizeof(TR::RealRegister::RegNum));
 
    int32_t numRestrictedRegs = comp->getOptions()->getNumRestrictedGPRs();
@@ -7616,7 +7616,7 @@ TR::RegisterDependencyConditions * OMR::Z::Machine::createDepCondForLiveGPRs(TR:
    // Calculate number of register dependencies required. This step is not really necessary, but
    // it is space conscious
    //
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = _cg->comp();
    for (i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastVRF; i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstVRF : i+1) )
       {
       TR::RealRegister *realReg = self()->getS390RealRegister(i);

--- a/compiler/z/codegen/OMRSnippet.cpp
+++ b/compiler/z/codegen/OMRSnippet.cpp
@@ -150,7 +150,7 @@ OMR::Z::Snippet::generatePICBinary(TR::CodeGenerator * cg, uint8_t * cursor, TR:
       self()->setSnippetDestAddr(destAddr);
 
       *(int32_t *) cursor = (int32_t)((destAddr - (intptrj_t)(cursor - 2)) / 2);
-      AOTcgDiag1(TR::comp(), "add TR_AbsoluteHelperAddress cursor=%x\n", cursor);
+      AOTcgDiag1(cg->comp(), "add TR_AbsoluteHelperAddress cursor=%x\n", cursor);
       cg->addProjectSpecializedRelocation(cursor, (uint8_t*) glueRef, NULL, TR_HelperAddress,
                                       __FILE__, __LINE__, self()->getNode());
       cursor += sizeof(int32_t);

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -2877,7 +2877,7 @@ tryGenerateConversionRXComparison(TR::Node *node, TR::CodeGenerator *cg, bool *i
          case TR::ifacmpge:
          case TR::ifacmpgt:
             isUnsignedCmp = true;
-//            traceMsg(TR::comp(), "Setting isUnsignedCmp to true for address compare\n");
+//            traceMsg(cg->comp(), "Setting isUnsignedCmp to true for address compare\n");
             break;
          default:
             break;
@@ -9529,7 +9529,7 @@ TR::Register * inlineVMSL256Multiply(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 inlineP256Multiply(TR::Node * node, TR::CodeGenerator * cg)
    {
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = cg->comp();
    static const char * disableECCSIMD = feGetEnv("TR_disableECCSIMD");
    static const char * disableECCMLGR = feGetEnv("TR_disableECCMLGR");
    static const char * disableECCKarat = feGetEnv("TR_disableECCKarat");
@@ -17810,7 +17810,7 @@ inlineUTF16BEEncodeSIMD(TR::Node *node, TR::CodeGenerator *cg)
 TR::Register*
 inlineUTF16BEEncode(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::Compilation* comp = TR::comp();
+   TR::Compilation* comp = cg->comp();
 
    // Create the necessary registers
    TR::Register* output    = cg->gprClobberEvaluate(node->getChild(1));
@@ -18348,8 +18348,8 @@ OMR::Z::TreeEvaluator::vaddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       (canUseNodeForFusedMultiply(node->getFirstChild()) || canUseNodeForFusedMultiply(node->getSecondChild())) &&
       generateFusedMultiplyAddIfPossible(cg, node, TR::InstOpCode::VFMA))
       {
-      if (TR::comp()->getOption(TR_TraceCG))
-         traceMsg(TR::comp(), "Successfully changed vadd with vmul child to fused multiply and add operation\n");
+      if (cg->comp()->getOption(TR_TraceCG))
+         traceMsg(cg->comp(), "Successfully changed vadd with vmul child to fused multiply and add operation\n");
 
       return node->getRegister();
       }
@@ -18383,8 +18383,8 @@ OMR::Z::TreeEvaluator::vsubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       canUseNodeForFusedMultiply(node->getFirstChild()) &&
       generateFusedMultiplyAddIfPossible(cg, node, TR::InstOpCode::VFMS))
       {
-      if (TR::comp()->getOption(TR_TraceCG))
-         traceMsg(TR::comp(), "Successfully changed vsub with vmul child to fused multiply and sub operation\n");
+      if (cg->comp()->getOption(TR_TraceCG))
+         traceMsg(cg->comp(), "Successfully changed vsub with vmul child to fused multiply and sub operation\n");
 
       return node->getRegister();
       }


### PR DESCRIPTION
`TR::comp()` is primarily useful in contexts where the Compilation
object isn't already cached somewhere.  While retrieving the
current compilation's Compilation object is always legal using
`TR::comp()` it does incur a performance penalty because the data
is retrieved from thread local storage (TLS).

In places where the Compilation object is already cached, retrieve
it from there rather than TLS.  This change should only be a
compile-time performance win.

This PR is split into commits from each major subdirectory under
`compile`.