### PR TITLE
Point out case sensitivity in IP Validation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,6 +148,11 @@ Here is the checklist for contributions to be _acceptable_:
 5. Ensure that you use the _same_ email address as your Eclipse account in commits.
 6. Include the appropriate copyright notice and license at the top of each file.
 
+Your signing of the ECA will be verified by a webservice called 'ip-validation'
+that checks the email address that signed-off on your commits has signed the
+ECA. **Note**: This service is case-sensitive, so ensure the email that signed
+the ECA and that signed-off on your commits is the same, down to the case. 
+
 ### Copyright Notice and Licensing Requirements
 
 **It is the responsibility of each contributor to obtain legal advice, and


### PR DESCRIPTION
Some contributors have run into issues where a seemingly correct signoff
line gets rejected. It has since been discovered that the
'ip-validation' check is case sensitive on the email address.

This calls that behaviour out in CONTRIBUTING.md to try to minimize the
pain.

[ci skip] as documentation only change.

Signed-off-by: Matthew Gaudet <magaudet@ca.ibm.com>