### PR TITLE
Aborted CS overlapping with CM

### DIFF
--- a/gc/base/EnvironmentBase.hpp
+++ b/gc/base/EnvironmentBase.hpp
@@ -45,9 +45,6 @@
 class MM_AllocationContext;
 class MM_AllocateDescription;
 class MM_Collector;
-#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
-class MM_ConcurrentGCStats;
-#endif /* defined(OMR_GC_MODRON_CONCURRENT_MARK) */
 class MM_HeapRegionQueue;
 class MM_MemorySpace;
 class MM_ObjectAllocationInterface;

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -4444,17 +4444,19 @@ MM_Scavenger::mutatorSetupForGC(MM_EnvironmentBase *envBase)
 {
 	MM_EnvironmentStandard *env = MM_EnvironmentStandard::getEnvironment(envBase);
 
-	/* caches should all be reset */
-	Assert_MM_true(NULL == env->_survivorCopyScanCache);
-	Assert_MM_true(NULL == env->_tenureCopyScanCache);
-	Assert_MM_true(NULL == env->_scanCache);
-	Assert_MM_true(NULL == env->_deferredScanCache);
-	Assert_MM_true(NULL == env->_deferredCopyCache);
-	Assert_MM_true(NULL == env->_tenureTLHRemainderBase);
-	Assert_MM_true(NULL == env->_tenureTLHRemainderTop);
-	Assert_MM_false(env->_loaAllocation);
-	Assert_MM_true(NULL == env->_survivorTLHRemainderBase);
-	Assert_MM_true(NULL == env->_survivorTLHRemainderTop);
+	if (isConcurrentInProgress()) {
+		/* caches should all be reset */
+		Assert_MM_true(NULL == env->_survivorCopyScanCache);
+		Assert_MM_true(NULL == env->_tenureCopyScanCache);
+		Assert_MM_true(NULL == env->_scanCache);
+		Assert_MM_true(NULL == env->_deferredScanCache);
+		Assert_MM_true(NULL == env->_deferredCopyCache);
+		Assert_MM_true(NULL == env->_tenureTLHRemainderBase);
+		Assert_MM_true(NULL == env->_tenureTLHRemainderTop);
+		Assert_MM_false(env->_loaAllocation);
+		Assert_MM_true(NULL == env->_survivorTLHRemainderBase);
+		Assert_MM_true(NULL == env->_survivorTLHRemainderTop);
+	}
 }
 
 void
@@ -4463,7 +4465,7 @@ MM_Scavenger::mutatorFinalReleaseCopyCaches(MM_EnvironmentBase *envBase, MM_Envi
 	MM_EnvironmentStandard *env = MM_EnvironmentStandard::getEnvironment(envBase);
 	MM_EnvironmentStandard *threadEnvironment = MM_EnvironmentStandard::getEnvironment(threadEnvironmentBase);
 
-	if (MUTATOR_THREAD == threadEnvironment->getThreadType()) {
+	if (isConcurrentInProgress() && (MUTATOR_THREAD == threadEnvironment->getThreadType())) {
 		/* in case of scavenge complete phase, master thread will act on behalf (use its own environment) of mutator threads
 		 * in case of thread teardown, caller ensures that own environment is used
 		 */


### PR DESCRIPTION
During Concurrent Mark (CM) and overlapping Aborted Concurrent Scavenger
(CS) it is ok to encounter a self-forwarded object, but we must not fix
it up at that point, yet. We have to complete CS Cycle first (during
which self-forwarded pointers serve important role of preventing
duplicate objects). Only during the final (STW) phase of CM the fixup
work will be done, while scanning Nursery.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>