### PR TITLE
Support long/double auto-SIMD operations on Z

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -11321,6 +11321,8 @@ bool OMR::Z::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR
             return true;
          else
             return false;
+      case TR::vl2vd:
+         return true;
       default:
         return false;
       }

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -16279,6 +16279,9 @@ OMR::Z::TreeEvaluator::inlineVectorUnaryOp(TR::Node * node,
 
    switch (op)
       {
+      case TR::InstOpCode::VCDG:
+         generateVRRaInstruction(cg, op, node, returnReg, sourceReg1, 0, 0, 3);
+         break;
       case TR::InstOpCode::VLC:
          generateVRRaInstruction(cg, op, node, returnReg, sourceReg1, 0, 0, getVectorElementSizeMask(node));
          break;
@@ -18241,6 +18244,12 @@ OMR::Z::TreeEvaluator::vnegEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       }
 
    return TR::TreeEvaluator::inlineVectorUnaryOp(node, cg, opCode);
+   }
+
+TR::Register *
+OMR::Z::TreeEvaluator::vl2vdEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return TR::TreeEvaluator::inlineVectorUnaryOp(node, cg, TR::InstOpCode::VCDG);
    }
 
 TR::Register *

--- a/compiler/z/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.hpp
@@ -393,6 +393,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *vincEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vdecEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vnegEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *vl2vdEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vcomEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vaddEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vsubEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/z/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/z/codegen/TreeEvaluatorTable.hpp
@@ -520,7 +520,7 @@
    TR::TreeEvaluator::indirectCallEvaluator,// TR::vcalli
    TR::TreeEvaluator::ternaryEvaluator,     // TR::vternary
    TR::TreeEvaluator::passThroughEvaluator, // TR::v2v
-   TR::TreeEvaluator::unImpOpEvaluator,     // TR::vl2vd 
+   TR::TreeEvaluator::vl2vdEvaluator,       // TR::vl2vd 
    TR::TreeEvaluator::vconstEvaluator,      // TR::vconst
    TR::TreeEvaluator::getvelemEvaluator,    // TR::getvelem
    TR::TreeEvaluator::vsetelemEvaluator,    // TR::vsetelem


### PR DESCRIPTION

  - add vl2vdEvaluator that uses VCDG instruction
  - enable vl2vd opcode in OMR::Z::CodeGenerator::getSupportsOpCodeForAutoSIMD

Signed-off-by: Gita Koblents <koblents@ca.ibm.com>