### PR TITLE
Tell VP that tstart has no fallthrough

### DIFF
--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -3317,6 +3317,7 @@ TR::Node *constrainTstart(OMR::ValuePropagation *vp, TR::Node *node)
    {
    //TR_ASSERT(0, "Not implemented!");
    constrainChildren(vp,node);
+   vp->setUnreachablePath(); // no fallthrough
    return node;
    }
 


### PR DESCRIPTION
Without this, global VP (value propagation) would look for a fallthrough edge from a block ending with `tstart` to the textually following block, which may not be a branch target of the `tstart` node. Failure to find the edge results in dereferencing a past-the-end iterator.