### PR TITLE
Allow preemption of optimization initialization

### DIFF
--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -732,6 +732,13 @@ OMR::Optimizer::Optimizer(TR::Compilation *comp, TR::ResolvedMethodSymbol *metho
    // zero opts table
    memset(_opts, 0, sizeof(_opts));
 
+/*
+ * Allow downstream projects to disable the default initializaiton of optimizations
+ * and allow them to take full control over this process.  This can be an advantage
+ * if they don't use all of the optimizations initialized here as they can avoid
+ * getting linked in to the binary in their entirety.
+ */
+#if !defined(TR_OVERRIDE_OPTIMIZATION_INITIALIZATION)
    // initialize OMR optimizations
 
    _opts[OMR::andSimplification] =
@@ -915,6 +922,7 @@ OMR::Optimizer::Optimizer(TR::Compilation *comp, TR::ResolvedMethodSymbol *metho
       new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::finalGlobalGroup, finalGlobalOpts);
 
    // NOTE: Please add new OMR optimization groups here!
+#endif
 
 }
 
@@ -2815,7 +2823,8 @@ void OMR::Optimizer::doStructureChecks()
 
 bool OMR::Optimizer::getLastRun(OMR::Optimizations opt)
    {
-   TR_ASSERT(_opts[opt], "Optimization manager for %d should be initialized first", opt);
+   if (!_opts[opt])
+      return false;
    return _opts[opt]->getLastRun();
    }
 

--- a/jitbuilder/optimizer/JBOptimizer.hpp
+++ b/jitbuilder/optimizer/JBOptimizer.hpp
@@ -32,6 +32,8 @@ namespace JitBuilder { class Optimizer; }
 namespace JitBuilder { typedef JitBuilder::Optimizer OptimizerConnector; }
 #endif
 
+#define TR_OVERRIDE_OPTIMIZATION_INITIALIZATION 1
+
 #include "optimizer/OMROptimizer.hpp"
 
 #include <stddef.h>                    // for NULL


### PR DESCRIPTION
Allow language runtimes consuming the OMR compiler to preempt the
default initialization of OptimizationManager objects, providing instead
a complete alternative that initializes OptimizationManagers only for
the optimizations and optimization groups needed by the consuming
project.

Signed-off-by: Luc des Trois Maisons <lmaisons@ca.ibm.com>