### PR TITLE
CS background thread count

### DIFF
--- a/gc/base/Dispatcher.cpp
+++ b/gc/base/Dispatcher.cpp
@@ -83,8 +83,14 @@ MM_Dispatcher::cleanupAfterTask(MM_EnvironmentBase *env)
 }
 
 void
-MM_Dispatcher::run(MM_EnvironmentBase *env, MM_Task *task)
+MM_Dispatcher::run(MM_EnvironmentBase *env, MM_Task *task, uintptr_t newThreadCount)
 {
+	uintptr_t defaultThreadCount = threadCount();
+	if (UDATA_MAX != newThreadCount) {
+		/* Let tasks run with different (typically reduced) thread count. */
+		setThreadCount(newThreadCount);
+	}
+
 	task->masterSetup(env);
 	prepareThreadsForTask(env, task);
 	acceptTask(env);
@@ -92,6 +98,9 @@ MM_Dispatcher::run(MM_EnvironmentBase *env, MM_Task *task)
 	completeTask(env);
 	cleanupAfterTask(env);
 	task->masterCleanup(env);
+
+	/* restore the default thread count */
+	setThreadCount(defaultThreadCount);
 }
 
 bool 

--- a/gc/base/Dispatcher.hpp
+++ b/gc/base/Dispatcher.hpp
@@ -67,8 +67,9 @@ public:
 	MMINLINE virtual uintptr_t threadCount() { return 1; }
 	MMINLINE virtual uintptr_t threadCountMaximum() { return 1; }
 	MMINLINE virtual uintptr_t activeThreadCount() { return 1; }
+	MMINLINE virtual void setThreadCount(uintptr_t threadCount) {}
 
-	void run(MM_EnvironmentBase *env, MM_Task *task);
+	void run(MM_EnvironmentBase *env, MM_Task *task, uintptr_t threadCount = UDATA_MAX);
 	virtual void reinitAfterFork(MM_EnvironmentBase *env, uintptr_t newThreadCount) {}
 
 	/**

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -412,6 +412,7 @@ public:
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	bool concurrentScavenger; /**< CS enabled/disabled flag */
 	bool concurrentScavengerRequested; /**< set to true if CS is requested (by cmdline option), but there are more checks to do before deciding whether the request is to be obeyed */
+	uintptr_t concurrentScavengerBackgroundThreads; /**< number of background GC threads during concurrent phase of Scavenge */
 #endif	/* OMR_GC_CONCURRENT_SCAVENGER */
 	uintptr_t scavengerFailedTenureThreshold;
 	uintptr_t maxScavengeBeforeGlobal;
@@ -1321,6 +1322,7 @@ public:
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 		, concurrentScavenger(false)
 		, concurrentScavengerRequested(false)
+		, concurrentScavengerBackgroundThreads(0)
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 		, scavengerFailedTenureThreshold(0)
 		, maxScavengeBeforeGlobal(0)

--- a/gc/base/ParallelDispatcher.cpp
+++ b/gc/base/ParallelDispatcher.cpp
@@ -389,6 +389,19 @@ MM_ParallelDispatcher::wakeUpThreads(uintptr_t count)
 }
 
 /**
+ * Let tasks run with reduced thread count.
+ * After the task is complete the thread count should be restored.
+ * Dispatcher may additionally adjust (reduce) the count.
+ */
+void
+MM_ParallelDispatcher::setThreadCount(uintptr_t threadCount)
+{
+	Assert_MM_true(threadCount <= _threadCountMaximum);
+	Assert_MM_true(0 < threadCount);
+ 	_threadCount = threadCount;
+}
+
+/**
  * Decide how many threads should be active for a given task.
  */
 void

--- a/gc/base/ParallelDispatcher.hpp
+++ b/gc/base/ParallelDispatcher.hpp
@@ -118,6 +118,7 @@ public:
 	MMINLINE virtual uintptr_t threadCountMaximum() { return _threadCountMaximum; }
 	MMINLINE omrthread_t* getThreadTable() { return _threadTable; }
 	MMINLINE virtual uintptr_t activeThreadCount() { return _activeThreadCount; }
+	virtual void setThreadCount(uintptr_t threadCount);
 
 	MMINLINE omrsig_handler_fn getSignalHandler() {return _handler;}
 	MMINLINE void * getSignalHandlerArg() {return _handler_arg;}

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -4710,7 +4710,8 @@ MM_Scavenger::scavengeConcurrent(MM_EnvironmentBase *env, UDATA totalBytesToScav
 	Assert_MM_true(concurrent_state_scan == _concurrentState);
 
 	MM_ConcurrentScavengeTask scavengeTask(env, _dispatcher, this, MM_ConcurrentScavengeTask::SCAVENGE_SCAN, totalBytesToScavenge, forceExit, env->_cycleState);
-	_dispatcher->run(env, &scavengeTask);
+	/* Concurrent background task will run with different (typically lower) number of threads. */
+	_dispatcher->run(env, &scavengeTask, _extensions->concurrentScavengerBackgroundThreads);
 
 	uintptr_t bytesScanned = scavengeTask.getBytesScanned();
 	/* we can't assert the work queue is empty. some mutator threads could have just flushed their copy caches, after the task terminated */


### PR DESCRIPTION
Concurrent phase of Concurrent Scavenger has its own (background) thread
count. Typically reduced, relative to STW operation. A reasonable
default is 1/2 of STW thread count. However, the default and an option
to override it, will be in language dependent part.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>