### PR TITLE
typed_allocator should take references to Regions

### DIFF
--- a/compiler/optimizer/OMRLocalCSE.cpp
+++ b/compiler/optimizer/OMRLocalCSE.cpp
@@ -319,11 +319,10 @@ void OMR::LocalCSE::transformBlock(TR::TreeTop * entryTree, TR::TreeTop * exitTr
    memset(_replacedNodesAsArray, 0, _numNodes*sizeof(TR::Node*));
    memset(_replacedNodesByAsArray, 0, _numNodes*sizeof(TR::Node*));
 
-   TR::typed_allocator<void*, TR::Region> alloc(stackMemoryRegion);
-   _hashTable = new (stackMemoryRegion) HashTable(std::less<int32_t>(), alloc);
-   _hashTableWithSyms = new (stackMemoryRegion) HashTable(std::less<int32_t>(), alloc);
-   _hashTableWithCalls = new (stackMemoryRegion) HashTable(std::less<int32_t>(), alloc);
-   _hashTableWithConsts = new (stackMemoryRegion) HashTable(std::less<int32_t>(), alloc);
+   _hashTable = new (stackMemoryRegion) HashTable(std::less<int32_t>(), stackMemoryRegion);
+   _hashTableWithSyms = new (stackMemoryRegion) HashTable(std::less<int32_t>(), stackMemoryRegion);
+   _hashTableWithCalls = new (stackMemoryRegion) HashTable(std::less<int32_t>(), stackMemoryRegion);
+   _hashTableWithConsts = new (stackMemoryRegion) HashTable(std::less<int32_t>(), stackMemoryRegion);
 
    _nextReplacedNode = 0;
    SharedSparseBitVector seenAvailableLoadedSymbolReferences(comp()->allocator());

--- a/compiler/optimizer/OMRLocalCSE.hpp
+++ b/compiler/optimizer/OMRLocalCSE.hpp
@@ -147,7 +147,8 @@ class LocalCSE : public TR::Optimization
    virtual void prePerformOnBlocks();
    virtual void postPerformOnBlocks();
 
-   typedef std::multimap<int32_t, TR::Node*, std::less<int32_t>, TR::typed_allocator<void*, TR::Region>> HashTable;
+   typedef TR::typed_allocator< std::pair< const int32_t, TR::Node* >, TR::Region & > HashTableAllocator;
+   typedef std::multimap< int32_t, TR::Node*, std::less<int32_t>, HashTableAllocator > HashTable;
 
    protected:
 


### PR DESCRIPTION
C++ standard library containers will frequently create ephemeral
instances of type coercions of the the containers allocator type,
expecting any allocator instantiation within the same container instance
to be equivalent for allocations and deallocations, with one instance
being able to deallocate memory provided by another instance. Implied by
this requirement is that memory allocations must be able to outlive the
allocator instances from which they were allocated.

Given the above, when using TR::Regions and TR::typed_allocator as the
allocator for C++ containers, one needs to ensure that the instances of
typed_allocator use references to an externally defined Region. A Region
whose lifetime is under explicit control of its user.

This change corrects region use in LocalCSE's uses of std::multimap to
enforce these requirements.

Signed-off-by: Luc des Trois Maisons <lmaisons@ca.ibm.com>