### PR TITLE
Add two new generateInstruction APIs

### DIFF
--- a/compiler/z/codegen/S390GenerateInstructions.cpp
+++ b/compiler/z/codegen/S390GenerateInstructions.cpp
@@ -134,6 +134,16 @@ generateS390BranchInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic o
    return cursor;
    }
 
+TR::Instruction* generateS390BranchInstruction(TR::CodeGenerator* cg, TR::InstOpCode::Mnemonic op, TR::Node* node, TR::InstOpCode::S390BranchCondition compareOpCode, TR::Register* targetReg, TR::Instruction* preced)
+   {
+   TR::Instruction* returnInstruction = generateS390RegInstruction(cg, op, node, targetReg, preced);
+
+   // RR type branch instructions use the first operand register field as a mask value
+   static_cast<TR::S390RegInstruction*>(returnInstruction)->setBranchCondition(compareOpCode);
+
+   return returnInstruction;
+   }
+
 TR::Instruction *
 generateS390BranchInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * targetReg,
                               TR::LabelSymbol * sym, TR::Instruction * preced)
@@ -2354,6 +2364,18 @@ generateDirectCall(TR::CodeGenerator * cg, TR::Node * callNode, bool myself, TR:
 #endif
 
       }  
+   }
+
+TR::Instruction* generateDataConstantInstruction(TR::CodeGenerator* cg, TR::InstOpCode::Mnemonic op, TR::Node* node, uint32_t data, TR::Instruction* preced)
+   {
+   if (preced != NULL)
+      {
+      return new (INSN_HEAP) TR::S390ImmInstruction(op, node, data, preced, cg);
+      }
+   else
+      {
+      return new (INSN_HEAP) TR::S390ImmInstruction(op, node, data, cg);
+      }
    }
 
 /**

--- a/compiler/z/codegen/S390GenerateInstructions.hpp
+++ b/compiler/z/codegen/S390GenerateInstructions.hpp
@@ -88,6 +88,32 @@ TR::Instruction *generateS390BranchInstruction(
                    TR::LabelSymbol *sym,
                    TR::Instruction *preced = 0);
 
+/** \brief
+ *     Generates a branch instruction accepting a branch condition and a target register.
+ *
+ *  \param cg
+ *     The code generator used to generate the instructions.
+ *
+ *  \param op
+ *     The mnemonic of the branch instruction.
+ *
+ *  \param node
+ *     The node to which the generated instruction will be associated with.
+ *
+ *  \param compareOpCode
+ *     The branch condition code.
+ *
+ *  \param targetReg
+ *     The data to inline in the instruction stream.
+ *
+ *  \param preced
+ *     The preceeding instruction to link the generated branch instruction with.
+ *
+ *  \return
+ *     The generated instruction.
+ */
+TR::Instruction* generateS390BranchInstruction(TR::CodeGenerator* cg, TR::InstOpCode::Mnemonic op, TR::Node* node, TR::InstOpCode::S390BranchCondition compareOpCode, TR::Register* targetReg, TR::Instruction* preced = NULL);
+
 TR::Instruction *generateS390BranchInstruction(
                    TR::CodeGenerator *cg,
                    TR::InstOpCode::Mnemonic                       op,
@@ -1299,6 +1325,29 @@ TR::Instruction *generateDirectCall(
                    TR::SymbolReference                  *callSymRef,
                    TR::RegisterDependencyConditions *cond,
                    TR::Instruction                      *preced = 0);
+
+/** \brief
+ *     Generates a data constant in the instruction stream.
+ *
+ *  \param cg
+ *     The code generator used to generate the instructions.
+ *
+ *  \param op
+ *     The mnemonic of the data constant pseudo instruction.
+ *
+ *  \param node
+ *     The node with which the generated instruction will be associated.
+ *
+ *  \param data
+ *     The data constant to inline in the instruction stream.
+ *
+ *  \param preced
+ *     The preceeding instruction to link the generated data constant instruction with.
+ *
+ *  \return
+ *     The generated instruction.
+ */
+TR::Instruction* generateDataConstantInstruction(TR::CodeGenerator* cg, TR::InstOpCode::Mnemonic op, TR::Node* node, uint32_t data, TR::Instruction* preced = NULL);
 
 TR::Instruction *generateRegUnresolvedSym(
                    TR::CodeGenerator *cg,


### PR DESCRIPTION
Add two new APIs:

- generateS390BranchInstruction overload targeting RR instructions
- generateDataConstantInstruction

The former is an overload to generate RR instruction formats such as
BCR, and the latter is a new API to generate data constant
pseudo-instructions in the instruction stream.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>