### PR TITLE
Improve insertPad to return the cursor position

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -1388,37 +1388,46 @@ OMR::Z::CodeGenerator::generateNop(TR::Node *n, TR::Instruction *preced, TR_NOPK
    return new (self()->trHeapMemory()) TR::S390NOPInstruction(TR::InstOpCode::NOP, 2, n, preced, self());
    }
 
-void
-OMR::Z::CodeGenerator::insertPad(TR::Node * theNode, TR::Instruction * insertionPoint, int32_t padSize, bool before)
+TR::Instruction*
+OMR::Z::CodeGenerator::insertPad(TR::Node* node, TR::Instruction* cursor, uint32_t size, bool prependCursor)
    {
-   if (0 == padSize)
+   if (size != 0)
       {
-      return;
-      }
+      if (prependCursor)
+         {
+         cursor = cursor->getPrev();
+         }
 
-   if (before)
-      {
-      insertionPoint = insertionPoint->getPrev();
-      }
-
-   switch (padSize)
-      {
-      case 4:
-         (void) new (self()->trHeapMemory()) TR::S390NOPInstruction(TR::InstOpCode::NOP, 4, theNode, insertionPoint, self());
+      switch (size)
+         {
+         case 2:
+            {
+            cursor = new (self()->trHeapMemory()) TR::S390NOPInstruction(TR::InstOpCode::NOP, 2, node, cursor, self());
+            }
          break;
 
-      case 6:
-         (void) new (self()->trHeapMemory()) TR::S390NOPInstruction(TR::InstOpCode::NOP, 4, theNode, insertionPoint, self());
-         (void) new (self()->trHeapMemory()) TR::S390NOPInstruction(TR::InstOpCode::NOP, 2, theNode, insertionPoint, self());
+         case 4:
+            {
+            cursor = new (self()->trHeapMemory()) TR::S390NOPInstruction(TR::InstOpCode::NOP, 4, node, cursor, self());
+            }
          break;
 
-      case 2:
-         (void) new (self()->trHeapMemory()) TR::S390NOPInstruction(TR::InstOpCode::NOP, 2, theNode, insertionPoint, self());
+         case 6:
+            {
+            cursor = new (self()->trHeapMemory()) TR::S390NOPInstruction(TR::InstOpCode::NOP, 4, node, cursor, self());
+            cursor = new (self()->trHeapMemory()) TR::S390NOPInstruction(TR::InstOpCode::NOP, 2, node, cursor, self());
+            }
          break;
 
-      default:
-         TR_ASSERT(false, "Unexpected pad size %d\n", padSize);
+         default:
+            {
+            TR_ASSERT(false, "Unexpected pad size %d\n", size);
+            }
+         break;
+         }
       }
+
+   return cursor;
    }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -810,7 +810,26 @@ public:
    TR_S390OutOfLineCodeSection *findS390OutOfLineCodeSectionFromLabel(TR::LabelSymbol *label);
 
    TR::Instruction *generateNop(TR::Node *node, TR::Instruction *preced=0, TR_NOPKind nopKind=TR_NOPStandard);
-   void insertPad(TR::Node *theNode,TR::Instruction *insertionPoint,int32_t padSize,bool);
+
+   /** \brief
+    *     Inserts padding (NOP) instructions in the instruction stream.
+    *
+    *  \param node
+    *     The node with which the generated instruction will be associated.
+    *
+    *  \param cursor
+    *     The instruction following which the padding instructions will be inserted.
+    *
+    *  \param size
+    *     The size in number of bytes of how much padding to insert. This value can be one of 0, 2, 4, or 6.
+    *
+    *  \param prependCursor
+    *     Determines whether the padding instructions will be inserted before or after \param cursor.
+    *
+    *  \return
+    *     The last padding instruction generated, or \param cursor if \param size is zero.
+    */
+   TR::Instruction* insertPad(TR::Node* node, TR::Instruction* cursor, uint32_t size, bool prependCursor);
 
    void setCurrentlyClobberedRestrictedRegister(int32_t regNum)
       {


### PR DESCRIPTION
Improve insertPad API to return the cursor position of the last inserted
padding instruction. We take this opportunity to fully document the API
as well.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>