### PR TITLE
Dynamic Nursery tilting in CS

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -413,6 +413,7 @@ public:
 	bool concurrentScavenger; /**< CS enabled/disabled flag */
 	bool concurrentScavengerRequested; /**< set to true if CS is requested (by cmdline option), but there are more checks to do before deciding whether the request is to be obeyed */
 	uintptr_t concurrentScavengerBackgroundThreads; /**< number of background GC threads during concurrent phase of Scavenge */
+	uintptr_t concurrentScavengerSlack; /**< amount of bytes added on top of avearge allocated bytes during concurrent cycle, in calcualtion for survivor size */
 #endif	/* OMR_GC_CONCURRENT_SCAVENGER */
 	uintptr_t scavengerFailedTenureThreshold;
 	uintptr_t maxScavengeBeforeGlobal;
@@ -1323,6 +1324,7 @@ public:
 		, concurrentScavenger(false)
 		, concurrentScavengerRequested(false)
 		, concurrentScavengerBackgroundThreads(0)
+		, concurrentScavengerSlack(0)
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 		, scavengerFailedTenureThreshold(0)
 		, maxScavengeBeforeGlobal(0)

--- a/gc/base/MarkingScheme.cpp
+++ b/gc/base/MarkingScheme.cpp
@@ -28,6 +28,9 @@
 #include "MarkMap.hpp"
 #include "MarkingScheme.hpp"
 #include "Task.hpp"
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+#include "Scavenger.hpp"
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
 #if defined(OMR_GC_MODRON_CONCURRENT_MARK)
 #include "WorkPacketsConcurrent.hpp"
 #else
@@ -376,4 +379,13 @@ MM_MarkingScheme::createWorkPackets(MM_EnvironmentBase *env) {
 
 	return workPackets;
 }
+
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+bool
+MM_MarkingScheme::isConcurrentScavengeInProgress()
+{
+	return _extensions->scavenger->isConcurrentInProgress();
+}
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
+
 

--- a/gc/base/MemorySubSpaceSemiSpace.cpp
+++ b/gc/base/MemorySubSpaceSemiSpace.cpp
@@ -136,13 +136,6 @@ MM_MemorySubSpaceSemiSpace::allocationRequestFailed(MM_EnvironmentBase *env, MM_
 	return addr;
 }
 
-#if defined(OMR_GC_CONCURRENT_SCAVENGER)
-void
-MM_MemorySubSpaceSemiSpace::payAllocationTax(MM_EnvironmentBase *env, MM_MemorySubSpace *baseSubSpace, MM_AllocateDescription *allocDescription)
-{
-}
-#endif /* OMR_GC_CONCURRENT_SCAVENGER */
-
 #if defined(OMR_GC_ARRAYLETS)
 void *
 MM_MemorySubSpaceSemiSpace::allocateArrayletLeaf(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, MM_MemorySubSpace *baseSubSpace, MM_MemorySubSpace *previousSubSpace, bool shouldCollectOnFailure)
@@ -441,7 +434,6 @@ MM_MemorySubSpaceSemiSpace::flip(MM_EnvironmentBase *env, Flip_step step)
 	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
 	bool debug = _extensions->debugTiltedScavenge;
 #endif
-
 	switch (step) {
 	case set_evacuate:
 		_memorySubSpaceEvacuate = _memorySubSpaceAllocate;
@@ -452,6 +444,9 @@ MM_MemorySubSpaceSemiSpace::flip(MM_EnvironmentBase *env, Flip_step step)
 		_memorySubSpaceAllocate->isAllocatable(true);
 		/* Let know MemorySpace about new default MemorySubSpace */
 		getMemorySpace()->setDefaultMemorySubSpace(getDefaultMemorySubSpace());
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+		_bytesAllocatedAtConcurrentStart = _extensions->allocationStats.bytesAllocated();
+#endif
 		break;
 	case disable_allocation:
 		_memorySubSpaceAllocate->isAllocatable(false);
@@ -459,6 +454,12 @@ MM_MemorySubSpaceSemiSpace::flip(MM_EnvironmentBase *env, Flip_step step)
 	case restore_allocation_and_set_survivor:
 		_memorySubSpaceAllocate->isAllocatable(true);
 		_memorySubSpaceSurvivor = _memorySubSpaceEvacuate;
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+		_bytesAllocatedAtConcurrentEnd = _extensions->allocationStats.bytesAllocated();
+		Assert_MM_true(_bytesAllocatedAtConcurrentStart <= _bytesAllocatedAtConcurrentEnd);
+		_avgBytesAllocatedDuringConcurrent = (uintptr_t)MM_Math::weightedAverage((float)_avgBytesAllocatedDuringConcurrent,
+											 (float)(_bytesAllocatedAtConcurrentEnd - _bytesAllocatedAtConcurrentStart), 0.5);
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
 		break;
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	case backout:
@@ -636,124 +637,125 @@ MM_MemorySubSpaceSemiSpace::checkSubSpaceMemoryPostCollectTilt(MM_EnvironmentBas
 	MM_GCExtensionsBase *extensions = MM_GCExtensionsBase::getExtensions(env->getOmrVM());
 
 	if(extensions->tiltedScavenge) {
-		if (_extensions->isConcurrentScavengerEnabled()) {
-			/* for now, support static tilting only */
-			_desiredSurvivorSpaceRatio = extensions->survivorSpaceMinimumSizeRatio;
+		uintptr_t flipBytes;
+		uintptr_t flipBytesDelta;
+		bool debug = extensions->debugTiltedScavenge;
+		OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
+
+		uintptr_t currentSize = getTopLevelMemorySubSpace(MEMORY_TYPE_NEW)->getCurrentSize();
+
+		if(debug) {
+			omrtty_printf("\nTilt check:\n");
+		}
+
+		flipBytes = extensions->scavengerStats._flipBytes + extensions->scavengerStats._failedFlipBytes;
+
+		if(debug) {
+			omrtty_printf("\tBytes flip:%zu fail:%zu total:%zu\n",
+				extensions->scavengerStats._flipBytes,
+				extensions->scavengerStats._failedFlipBytes,
+				flipBytes);
+		}
+
+		/* Determine the absolute value of the change in bytes flipped since the last scavenge */
+		if(flipBytes > _previousBytesFlipped) {
+			flipBytesDelta = flipBytes - _previousBytesFlipped;
 		} else {
-			uintptr_t flipBytes;
-			uintptr_t flipBytesDelta;
-			bool debug = extensions->debugTiltedScavenge;
-			OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
+			flipBytesDelta = _previousBytesFlipped - flipBytes;
+		}
 
-			/* OMRTODO consider maintaining _flipBytes separately for each NUMA SemiSpace.
-			 * Currently, _flipBytes is cumulative for all SemiSpaces. To compensate, current size is obtained
-			 * for all of SemiSpaces too (from top level New SubSpace). This will result in blended tilt ratio,
-			 * set equally for all of SemiSpaces.
-			 */
-			uintptr_t currentSize = getTopLevelMemorySubSpace(MEMORY_TYPE_NEW)->getCurrentSize();
+		if(debug) {
+			omrtty_printf("\tflip delta from last (%zu):%zu\n", _previousBytesFlipped, flipBytesDelta);
+		}
 
+		/* Current flip count becomes previous */
+		_previousBytesFlipped = flipBytes;
+
+		/* The average bytes flipped weighted average is more heavily affected if the current size is
+		 * greater than the current average
+		 */
+		if(debug) {
+			omrtty_printf("\tcurrent average bytes flipped: %zu (avg delta %zu)\n",
+				_tiltedAverageBytesFlipped,
+				_tiltedAverageBytesFlippedDelta);
+		}
+
+		/* Check if there was any failed to flip objects - which puts us into a bit of a panic mode */
+		if(0 != extensions->scavengerStats._failedFlipCount) {
+			/* Panic mode - the current numbers should heavily influence the averages */
 			if(debug) {
-				omrtty_printf("\nTilt check:\n");
+				omrtty_printf("\tfailed flip weight\n");
 			}
-
-			flipBytes = extensions->scavengerStats._flipBytes + extensions->scavengerStats._failedFlipBytes;
-
-			if(debug) {
-				omrtty_printf("\tBytes flip:%zu fail:%zu total:%zu\n",
-					extensions->scavengerStats._flipBytes,
-					extensions->scavengerStats._failedFlipBytes,
-					flipBytes);
-			}
-
-			/* Determine the absolute value of the change in bytes flipped since the last scavenge */
-			if(flipBytes > _previousBytesFlipped) {
-				flipBytesDelta = flipBytes - _previousBytesFlipped;
-			} else {
-				flipBytesDelta = _previousBytesFlipped - flipBytes;
-			}
-
-			if(debug) {
-				omrtty_printf("\tflip delta from last (%zu):%zu\n", _previousBytesFlipped, flipBytesDelta);
-			}
-
-			/* Current flip count becomes previous */
-			_previousBytesFlipped = flipBytes;
-
-			/* The average bytes flipped weighted average is more heavily affected if the current size is
-			 * greater than the current average
-			 */
-			if(debug) {
-				omrtty_printf("\tcurrent average bytes flipped: %zu (avg delta %zu)\n",
-					_tiltedAverageBytesFlipped,
-					_tiltedAverageBytesFlippedDelta);
-			}
-
-			/* Check if there was any failed to flip objects - which puts us into a bit of a panic mode */
-			if(0 != extensions->scavengerStats._failedFlipCount) {
-				/* Panic mode - the current numbers should heavily influence the averages */
+			_tiltedAverageBytesFlipped = (uintptr_t)MM_Math::weightedAverage((float)_tiltedAverageBytesFlipped, (float)flipBytes, 0.0f);
+			_tiltedAverageBytesFlippedDelta = (uintptr_t)MM_Math::weightedAverage((float)_tiltedAverageBytesFlippedDelta, (float)flipBytesDelta, 0.0f);
+		} else {
+			/* No panic situation - determine the new tilt ratio through normal means */
+			if(flipBytes > _tiltedAverageBytesFlipped) {
 				if(debug) {
-					omrtty_printf("\tfailed flip weight\n");
+					omrtty_printf("\tincrease flip weight\n");
 				}
-				_tiltedAverageBytesFlipped = (uintptr_t)MM_Math::weightedAverage((float)_tiltedAverageBytesFlipped, (float)flipBytes, 0.0f);
-				_tiltedAverageBytesFlippedDelta = (uintptr_t)MM_Math::weightedAverage((float)_tiltedAverageBytesFlippedDelta, (float)flipBytesDelta, 0.0f);
+				_tiltedAverageBytesFlipped = (uintptr_t)MM_Math::weightedAverage((float)_tiltedAverageBytesFlipped, (float)flipBytes, 0.2f);
+				_tiltedAverageBytesFlippedDelta = (uintptr_t)MM_Math::weightedAverage((float)_tiltedAverageBytesFlippedDelta, (float)flipBytesDelta, 0.2f);
 			} else {
-				/* No panic situation - determine the new tilt ratio through normal means */
-				if(flipBytes > _tiltedAverageBytesFlipped) {
-					if(debug) {
-						omrtty_printf("\tincrease flip weight\n");
-					}
-					_tiltedAverageBytesFlipped = (uintptr_t)MM_Math::weightedAverage((float)_tiltedAverageBytesFlipped, (float)flipBytes, 0.2f);
-					_tiltedAverageBytesFlippedDelta = (uintptr_t)MM_Math::weightedAverage((float)_tiltedAverageBytesFlippedDelta, (float)flipBytesDelta, 0.2f);
-				} else {
-					if(debug) {
-						omrtty_printf("\tdecrease flip weight\n");
-					}
-					_tiltedAverageBytesFlipped = (uintptr_t)MM_Math::weightedAverage((float)_tiltedAverageBytesFlipped, (float)flipBytes, 0.8f);
-					_tiltedAverageBytesFlippedDelta = (uintptr_t)MM_Math::weightedAverage((float)_tiltedAverageBytesFlippedDelta, (float)flipBytesDelta, 0.8f);
+				if(debug) {
+					omrtty_printf("\tdecrease flip weight\n");
 				}
+				_tiltedAverageBytesFlipped = (uintptr_t)MM_Math::weightedAverage((float)_tiltedAverageBytesFlipped, (float)flipBytes, 0.8f);
+				_tiltedAverageBytesFlippedDelta = (uintptr_t)MM_Math::weightedAverage((float)_tiltedAverageBytesFlippedDelta, (float)flipBytesDelta, 0.8f);
 			}
+		}
 
-			if(debug) {
-				omrtty_printf("\tnew average bytes flipped: %zu (avg delta %zu)\n",
-					_tiltedAverageBytesFlipped,
-					_tiltedAverageBytesFlippedDelta);
+		if(debug) {
+			omrtty_printf("\tnew average bytes flipped: %zu (avg delta %zu)\n",
+				_tiltedAverageBytesFlipped,
+				_tiltedAverageBytesFlippedDelta);
+		}
+
+		/* Calculate the desired survivor space ratio */
+		double survivorSizeAmplification = 1.04 + extensions->dispatcher->threadCount() / 100.0;
+		double desiredSurvivorSize = (_tiltedAverageBytesFlipped + _tiltedAverageBytesFlippedDelta) * survivorSizeAmplification;
+
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+		if (_extensions->isConcurrentScavengerEnabled()) {
+			/* Account for mutator allocated objects in hybrid survivor/allocated during concurrent phase of Concurrent Scavenger */
+			desiredSurvivorSize += _avgBytesAllocatedDuringConcurrent * 1.2 + extensions->concurrentScavengerSlack;
+			if (debug) {
+				omrtty_printf("\tmutator bytesAllocated current %zu average %zu\n", _bytesAllocatedAtConcurrentEnd - _bytesAllocatedAtConcurrentStart,
+																					_avgBytesAllocatedDuringConcurrent);
 			}
+		}
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
-			/* Calculate the desired survivor space ratio */
+		_desiredSurvivorSpaceRatio = desiredSurvivorSize / currentSize;
 
-			double survivorSizeAmplification = 1.04 + extensions->dispatcher->threadCount() / 100.0;
-			_desiredSurvivorSpaceRatio = (_tiltedAverageBytesFlipped + _tiltedAverageBytesFlippedDelta)
-											* survivorSizeAmplification	/ currentSize;
+		if(debug) {
+			omrtty_printf("\tDesired survivor size: %zu  ratio: %zu\n",
+				(uintptr_t)(currentSize * _desiredSurvivorSpaceRatio),	(uintptr_t) (_desiredSurvivorSpaceRatio * 100));
+		}
 
-			if(debug) {
-				omrtty_printf("\tDesired survivor size: %zu  ratio: %zu\n",
-					(uintptr_t)(currentSize * _desiredSurvivorSpaceRatio),	(uintptr_t) (_desiredSurvivorSpaceRatio * 100));
-			}
+		/* Sanity check for lowest possible ratio */
+		if (_desiredSurvivorSpaceRatio <  extensions->survivorSpaceMinimumSizeRatio) {
+			_desiredSurvivorSpaceRatio =  extensions->survivorSpaceMinimumSizeRatio;
+		}
 
-			/* Sanity check for lowest possible ratio */
-			if (_desiredSurvivorSpaceRatio <  extensions->survivorSpaceMinimumSizeRatio) {
-				_desiredSurvivorSpaceRatio =  extensions->survivorSpaceMinimumSizeRatio;
-			}
+		/* Never hand out more than 50% to the survivor */
+		if (_desiredSurvivorSpaceRatio > extensions->survivorSpaceMaximumSizeRatio) {
+			_desiredSurvivorSpaceRatio = extensions->survivorSpaceMaximumSizeRatio;
+		}
 
-			/* Never hand out more than 50% to the survivor */
-			if (_desiredSurvivorSpaceRatio > extensions->survivorSpaceMaximumSizeRatio) {
-				_desiredSurvivorSpaceRatio = extensions->survivorSpaceMaximumSizeRatio;
-			}
+		/* we have flipped already, so to get old survivor space ratio we fetch allocate size */
+		double previousSurvivorSpaceRatio = (double) _memorySubSpaceAllocate->getActiveMemorySize() / currentSize;
 
-			/* we have flipped already, so to get old survivor space ratio we fetch allocate size */
-			double previousSurvivorSpaceRatio = (double) _memorySubSpaceAllocate->getActiveMemorySize() / currentSize;
+		/* Do not let survivor space shrink by more than the maximum tilt increase */
+		assume0(previousSurvivorSpaceRatio >= extensions->tiltedScavengeMaximumIncrease);
+		if (_desiredSurvivorSpaceRatio < (previousSurvivorSpaceRatio - extensions->tiltedScavengeMaximumIncrease)) {
+			_desiredSurvivorSpaceRatio = previousSurvivorSpaceRatio -  extensions->tiltedScavengeMaximumIncrease;
+		}
 
-			/* Do not let survivor space shrink by more than the maximum tilt increase */
-			assume0(previousSurvivorSpaceRatio >= extensions->tiltedScavengeMaximumIncrease);
-			if (_desiredSurvivorSpaceRatio < (previousSurvivorSpaceRatio - extensions->tiltedScavengeMaximumIncrease)) {
-				_desiredSurvivorSpaceRatio = previousSurvivorSpaceRatio -  extensions->tiltedScavengeMaximumIncrease;
-			}
-
-			if(debug) {
-				omrtty_printf("\tPrevious survivor ratio: %zu\n", (uintptr_t) (previousSurvivorSpaceRatio * 100));
-				omrtty_printf("\tAdjusted survivor size: %zu  ratio: %zu\n",(uintptr_t)(currentSize * _desiredSurvivorSpaceRatio),
-					(uintptr_t) (_desiredSurvivorSpaceRatio * 100));
-			}
+		if(debug) {
+			omrtty_printf("\tPrevious survivor ratio: %zu\n", (uintptr_t) (previousSurvivorSpaceRatio * 100));
+			omrtty_printf("\tAdjusted survivor size: %zu  ratio: %zu\n",(uintptr_t)(currentSize * _desiredSurvivorSpaceRatio),
+				(uintptr_t) (_desiredSurvivorSpaceRatio * 100));
 		}
 	}
 }

--- a/gc/base/MemorySubSpaceSemiSpace.hpp
+++ b/gc/base/MemorySubSpaceSemiSpace.hpp
@@ -73,6 +73,11 @@ private:
 	uint64_t _lastScavengeEndTime;
 
 	double _desiredSurvivorSpaceRatio;
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	uintptr_t _bytesAllocatedAtConcurrentStart;
+	uintptr_t _bytesAllocatedAtConcurrentEnd;
+	uintptr_t _avgBytesAllocatedDuringConcurrent;
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
 	MM_LargeObjectAllocateStats *_largeObjectAllocateStats; /**< Approximate allocation profile for large objects. Struct to keep merged stats from two allocate pools */
 
@@ -123,10 +128,6 @@ public:
 	void poisonEvacuateSpace();
 
 	void cacheRanges(MM_MemorySubSpace *subSpace, void **base, void **top);
-
-#if defined(OMR_GC_CONCURRENT_SCAVENGER)
-	virtual void payAllocationTax(MM_EnvironmentBase *env, MM_MemorySubSpace *baseSubSpace, MM_AllocateDescription *allocDescription);
-#endif
 
 	MM_MemorySubSpace *getTenureMemorySubSpace() { 	return _parent->getTenureMemorySubSpace(); }
 	MM_MemorySubSpace *getMemorySubSpaceAllocate() { return _memorySubSpaceAllocate; };
@@ -185,6 +186,11 @@ public:
 		,_averageScavengeTimeRatio(0.0)
 		,_lastScavengeEndTime(0)
 		,_desiredSurvivorSpaceRatio(0.0)
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)		
+		,_bytesAllocatedAtConcurrentStart(0)
+		,_bytesAllocatedAtConcurrentEnd(0)
+		,_avgBytesAllocatedDuringConcurrent(0)
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */ 		
 	{
 		_typeId = __FUNCTION__;
 	}


### PR DESCRIPTION
In Concurrent Scavenger, in calculation for Survivor size, account of
bytes allocated by mutator during the concurrent cycle.

Also re-enabling paying alloc taxes for SemiSpace. This is just a
forgotten todo - it was disabled in the early CS development to avoid
interaction with Concurrent Marking.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>