### PR TITLE
Add some compiler tests using Tril

### DIFF
--- a/fvtest/compilertriltest/.gitignore
+++ b/fvtest/compilertriltest/.gitignore
@@ -1,0 +1,2 @@
+build*/
+CMakeLists.txt.user

--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -33,6 +33,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fdiagnostics-color=always -fno-rtti 
 add_executable(comptest
    main.cpp
    TreeVerifierTest.cpp
+   OpCodeTest.cpp
 )
 
 target_link_libraries(comptest

--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -1,0 +1,46 @@
+###############################################################################
+#
+# (c) Copyright IBM Corp. 2017, 2017
+#
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License v1.0 and
+#  Apache License v2.0 which accompanies this distribution.
+#
+#      The Eclipse Public License is available at
+#      http://www.eclipse.org/legal/epl-v10.html
+#
+#      The Apache License v2.0 is available at
+#      http://www.opensource.org/licenses/apache2.0.php
+#
+# Contributors:
+#    Multiple authors (IBM Corp.) - initial implementation and documentation
+###############################################################################
+
+cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+
+project(comptest LANGUAGES C CXX)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+set(CXX_EXTENSIONS OFF)
+
+enable_testing()
+find_package(GTest REQUIRED)
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../tril/tril ${CMAKE_CURRENT_BINARY_DIR}/tril)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fdiagnostics-color=always -fno-rtti -fno-threadsafe-statics -Wno-deprecated -Wno-enum-compare -Wno-invalid-offsetof -Wno-write-strings -O3 -pthread -fomit-frame-pointer -fasynchronous-unwind-tables -Wreturn-type -fno-dollars-in-identifiers -m64 -fno-strict-aliasing")
+
+add_executable(comptest
+   main.cpp
+)
+
+target_link_libraries(comptest
+   ${GTEST_BOTH_LIBRARIES} 
+   ${tril_LIBRAREIS}
+   tril
+)
+
+add_test(
+    NAME comptest
+    COMMAND comptest --gtest_color=yes
+)

--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -32,11 +32,11 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fdiagnostics-color=always -fno-rtti 
 
 add_executable(comptest
    main.cpp
+   TreeVerifierTest.cpp
 )
 
 target_link_libraries(comptest
-   ${GTEST_BOTH_LIBRARIES} 
-   ${tril_LIBRAREIS}
+   ${GTEST_BOTH_LIBRARIES}
    tril
 )
 

--- a/fvtest/compilertriltest/JitTest.hpp
+++ b/fvtest/compilertriltest/JitTest.hpp
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#ifndef JITTEST_HPP
+#define JITTEST_HPP
+
+#include <gtest/gtest.h>
+#include "Jit.hpp"
+
+#define ASSERT_NULL(pointer) ASSERT_EQ(nullptr, (pointer))
+#define ASSERT_NOTNULL(pointer) ASSERT_TRUE(nullptr != (pointer))
+
+/**
+ * @brief The JitBuilderTest class is a basic test fixture for JitBuilder test cases.
+ *
+ * Most JitBuilder test case fixtures should publically inherit from this class.
+ *
+ * Example use:
+ *
+ *    class MyTestCase : public JitBuilderTest {};
+ */
+class JitTest : public ::testing::Test
+   {
+   public:
+
+   static void SetUpTestCase()
+      {
+      ASSERT_TRUE(initializeJit()) << "Failed to initialize the JIT.";
+      }
+
+   static void TearDownTestCase()
+      {
+      shutdownJit();
+      }
+   };
+
+#endif // JITTEST_HPP

--- a/fvtest/compilertriltest/OpCodeTest.cpp
+++ b/fvtest/compilertriltest/OpCodeTest.cpp
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#include "OpCodeTest.hpp"
+#include "jitbuilder_compiler.hpp"
+
+#include <limits>
+
+#define INT32_POS 3
+#define INT32_NEG -2
+#define INT32_ZERO 0
+
+class Int32Arithmetic : public BinaryOpTest<int32_t> {};
+
+TEST_P(Int32Arithmetic, ConstArithmetic) {
+    auto param = to_struct(GetParam());
+
+    char inputTrees[120] = {0};
+    std::snprintf(inputTrees, 120, "(method \"Int32\" (block (ireturn (i%s (iconst %d) (iconst %d)) )))", param.opcode.c_str(), param.lhs, param.rhs);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::JitBuilderCompiler compiler{trees};
+
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(void)>();
+    ASSERT_EQ(param.oracle(param.lhs, param.rhs), entry_point());
+}
+
+TEST_P(Int32Arithmetic, LoadParamArithmetic) {
+    auto param = to_struct(GetParam());
+
+    char inputTrees[120] = {0};
+    std::snprintf(inputTrees, 120, "(method \"Int32\" \"Int32\" \"Int32\" (block (ireturn (i%s (iload parm=0) (iload parm=1)) )))", param.opcode.c_str());
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::JitBuilderCompiler compiler{trees};
+
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(int32_t, int32_t)>();
+    ASSERT_EQ(param.oracle(param.lhs, param.rhs), entry_point(param.lhs, param.rhs));
+}
+
+INSTANTIATE_TEST_CASE_P(ArithmeticTest, Int32Arithmetic, ::testing::Combine(
+    ::testing::ValuesIn(
+        make_value_pairs<int32_t>(INT32_ZERO, INT32_POS, INT32_NEG, INT32_MIN, INT32_MAX)),
+    ::testing::Values(
+        std::make_tuple("add", [](int32_t l, int32_t r){return l+r;}),
+        std::make_tuple("sub", [](int32_t l, int32_t r){return l-r;}),
+        std::make_tuple("mul", [](int32_t l, int32_t r){return l*r;}) )));
+
+INSTANTIATE_TEST_CASE_P(DivArithmeticTest, Int32Arithmetic, ::testing::Combine(
+    ::testing::ValuesIn(
+        filter(make_value_pairs<int32_t>(INT32_ZERO, INT32_POS, INT32_NEG, INT32_MIN, INT32_MAX),
+               [](std::tuple<int32_t, int32_t> a){ return std::get<1>(a) == 0;} )),
+    ::testing::Values(
+        std::make_tuple("div", [](int32_t l, int32_t r){return l/r;}),
+        std::make_tuple("rem", [](int32_t l, int32_t r){return l%r;}) )));

--- a/fvtest/compilertriltest/OpCodeTest.hpp
+++ b/fvtest/compilertriltest/OpCodeTest.hpp
@@ -1,0 +1,146 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#ifndef OPCODETEST_HPP
+#define OPCODETEST_HPP
+
+#include "JitTest.hpp"
+
+#include <string>
+#include <tuple>
+#include <iterator>
+
+/**
+ * @brief Type for holding argument to parameterized opcode tests
+ * @tparam Ret the type returned by the opcode
+ * @tparam Args the types of the arguments to the opcode
+ *
+ * This type is just a tuple that packages the different parts of a argument for
+ * an opcode test. The first field is another tuple holding the input values to
+ * be given to the opcode for testing. The second field is a two-tuple containing
+ * the opcode's name as a string, and a pointer to an oracle function that
+ * returns the expected return value of the opcode test when given the input
+ * values from the first part of the outer tuple.
+ */
+template <typename Ret, typename... Args>
+using ParamType = std::tuple<std::tuple<Args...>, std::tuple<std::string, Ret (*)(Args...)> >;
+
+/**
+ * @brief Type for holding argument to parameterized binary opcode tests
+ */
+template <typename Ret, typename Left, typename Right>
+using BinaryOpParamType = ParamType<Ret, Left, Right>;
+
+/**
+ * @brief Struct equivalent to the BinaryOpParamType tuple
+ *
+ * Used for easier unpacking of test argument.
+ */
+template <typename Ret, typename Left, typename Right>
+struct BinaryOpParamStruct {
+        Left lhs;
+        Right rhs;
+        std::string opcode;
+        Ret (*oracle)(Left, Right);
+};
+
+/**
+ * @brief Given an instance of BinaryOpParamType, returns an equivalent instance
+ *    of BinaryOpParamStruct
+ */
+template <typename Ret, typename Left, typename Right>
+BinaryOpParamStruct<Ret, Left, Right> to_struct(BinaryOpParamType<Ret, Left, Right> param) {
+    BinaryOpParamStruct<Ret, Left, Right> s;
+    s.lhs = std::get<0>(std::get<0>(param));
+    s.rhs = std::get<1>(std::get<0>(param));
+    s.opcode = std::get<0>(std::get<1>(param));
+    s.oracle = std::get<1>(std::get<1>(param));
+    return s;
+}
+
+/**
+ * @brief Given two lists input values, returns their cartesain product
+ *
+ * The values are specified as argument. The first five are treated as the first
+ * set and the remaining five as the second set. The returned value is a vector
+ * of two-tuples containing the cartesian product of the two sets. The intention
+ * is to use this function to generate all possible combinations of input to a
+ * function. There is convention that for each set: the first value is the
+ * "zero" value, the second is some positive value, the third is some negative
+ * value, the fourth is the minimum value, and the last is the maximum value.
+ * Following this convention is neither required nor enforced.
+ */
+template <typename L, typename R>
+std::vector<std::tuple<L, R>> make_value_pairs(L lzero, L lpos, L lneg, L lmin, L lmax,
+                                               R rzero, R rpos, R rneg, R rmin, R rmax) {
+    return std::vector<std::tuple<L, R>>{{
+        std::make_tuple(lzero, rzero),
+        std::make_tuple(lzero, rpos),
+        std::make_tuple(lpos, rzero),
+        std::make_tuple(lpos, rpos),
+        std::make_tuple(lzero, rneg),
+        std::make_tuple(lneg, rzero),
+        std::make_tuple(lneg, rneg),
+        std::make_tuple(lneg, rpos),
+        std::make_tuple(lpos, rneg),
+        std::make_tuple(lmax, rzero),
+        std::make_tuple(lzero, rmax),
+        std::make_tuple(lmin, rzero),
+        std::make_tuple(lzero, rmin),
+        std::make_tuple(lmax, rpos),
+        std::make_tuple(lpos, rmax),
+        std::make_tuple(lmin, rpos),
+        std::make_tuple(lpos, rmin),
+        std::make_tuple(lmax, rneg),
+        std::make_tuple(lneg, rmax),
+        std::make_tuple(lmin, rneg),
+        std::make_tuple(lneg, rmin),
+        std::make_tuple(lmax, rmax),
+        std::make_tuple(lmin, rmin),
+        std::make_tuple(lmax, rmin),
+        std::make_tuple(lmin, rmax) }};
+}
+
+/**
+ * @brief Given a set of input values, returns the cartesian product of the set with itself
+ */
+template <typename T>
+std::vector<std::tuple<T, T>> make_value_pairs(T zero, T pos, T neg, T min, T max) {
+    return make_value_pairs<T, T>(zero, pos, neg, min, max, zero, pos, neg, min, max);
+}
+
+/**
+ * @brief Given a vector and a predicate, returns a copy of the vector with the
+ *    elements matching the predicate removed
+ */
+template <typename T, typename Predicate>
+std::vector<T> filter(std::vector<T> range, Predicate pred) {
+    auto end = std::remove_if(std::begin(range), std::end(range), pred);
+    range.erase(end, std::end(range));
+    return range;
+}
+
+//~ Opcode test fixtures ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+template <typename Ret, typename... Args>
+class OpCodeTest : public JitTest, public ::testing::WithParamInterface<ParamType<Ret, Args...>> {};
+
+template <typename T>
+class BinaryOpTest : public JitTest, public ::testing::WithParamInterface<BinaryOpParamType<T,T,T>> {};
+
+#endif // OPCODETEST_HPP

--- a/fvtest/compilertriltest/TreeVerifierTest.cpp
+++ b/fvtest/compilertriltest/TreeVerifierTest.cpp
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#include "JitTest.hpp"
+#include "jitbuilder_compiler.hpp"
+
+#include <string>
+
+class IllformedTrees : public JitTest, public ::testing::WithParamInterface<std::string> {};
+
+TEST_P(IllformedTrees, FailCompilation) {
+    auto inputTrees = GetParam();
+    auto trees = parseString(inputTrees.c_str());
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::JitBuilderCompiler compiler{trees};
+
+    ASSERT_DEATH(compiler.compile(), "Tree verification error")
+            << "Compilation did not fail due to ill-formed input trees";
+}
+
+INSTANTIATE_TEST_CASE_P(TreeVerifierTest, IllformedTrees, ::testing::Values(
+    "(method \"Int32\" (block (ireturn (sconst 3))))",
+    "(method \"Int32\" (block (ireturn (iadd (iconst 1) (sconst 3)))))",
+    "(method \"Int32\" (block (ireturn (sadd (iconst 1) (iconst 3)))))",
+    "(method \"Address\" (block (areturn (aiadd (aconst 4) (iconst 1)))))",
+    "(method \"Address\" (block (areturn (aladd (aconst 4) (lconst 1)))))",
+    "(method \"Address\" (block (areturn (aiadd (iconst 1) (aconst 4)))))",
+    "(method \"Address\" (block (areturn (aladd (lconst 1) (aconst 4)))))",
+    "(method \"Int32\" (block (ireturn (acmpeq (iconst 4) (aconst 4)))))",
+    "(method \"Int32\" (block (ireturn (acmpge (lconst 4) (aconst 4)))))",
+    "(method \"Int16\" (block (ireturn (scmpeq (sconst 1) (sconst 3)))))",
+    "(method \"Int32\" (block (ireturn (lcmpeq (lconst 1) (lconst 3)))))"
+    ));
+
+class WellformedTrees : public JitTest, public ::testing::WithParamInterface<std::string> {};
+
+TEST_P(WellformedTrees, CompileOnly) {
+    auto inputTrees = GetParam();
+    auto trees = parseString(inputTrees.c_str());
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::JitBuilderCompiler compiler{trees};
+
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly";
+}
+
+INSTANTIATE_TEST_CASE_P(TreeVerifierTest, WellformedTrees, ::testing::Values(
+    "(method \"Int32\" (block (ireturn (iconst 3))))",
+    "(method \"Int32\" (block (ireturn (iadd (iconst 1) (iconst 3)))))",
+    "(method \"Address\" (block (areturn (aladd (aconst 4) (lconst 1)))))",
+    "(method \"Int32\" (block (ireturn (acmpge (aconst 4) (aconst 4)))))"
+    ));

--- a/fvtest/compilertriltest/main.cpp
+++ b/fvtest/compilertriltest/main.cpp
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#include "gtest/gtest.h"
+
+int main(int argc, char** argv) {
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
These changes add some compiler tests that use Tril to generate input IL. These include Tree Verifier tests and some initial opcode tests. The opcode tests are intended to show how tests that could eventually replace the existing opcode tests (in the test compiler) can be written.

It should be noted that some of the Tree Verifier tests currently fail because the Tree verifier has historically been poorly maintained and is not behaving as expected.

[ci skip] because Tril is not part of continuous integration