### PR TITLE
Add support for VirtualMachineOperandArray

### DIFF
--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -275,6 +275,22 @@ IlBuilder::NewValue(TR::IlType *dt)
    TR_ASSERT_FATAL(0, "should not create a value without a TR::Node");
    }
 
+TR::IlValue *
+IlBuilder::Copy(TR::IlValue *value)
+   {
+   TR::DataType dt = value->getDataType();
+   TR::SymbolReference *newSymRef = symRefTab()->createTemporary(_methodSymbol, dt);
+   newSymRef->getSymbol()->setNotCollected();
+
+   storeToTemp(newSymRef, loadValue(value));
+
+   TR::IlValue *newVal = newValue(newSymRef->getSymbol()->getDataType(), loadTemp(newSymRef));
+
+   TraceIL("IlBuilder[ %p ]::Copy value (%d) dataType (%d) to newVal (%d) at cpIndex (%d)\n", this, value->getID(), dt, newVal->getID(), newSymRef->getCPIndex());
+
+   return newVal;
+   }
+
 TR::TreeTop *
 IlBuilder::getFirstTree()
    {

--- a/compiler/ilgen/IlBuilder.hpp
+++ b/compiler/ilgen/IlBuilder.hpp
@@ -142,6 +142,8 @@ public:
    // create a new local value (temporary variable)
    TR::IlValue *NewValue(TR::IlType *dt);
 
+   TR::IlValue *Copy(TR::IlValue *value);
+
    // constants
    TR::IlValue *NullAddress();
    TR::IlValue *ConstInt8(int8_t value);

--- a/compiler/ilgen/VirtualMachineOperandArray.cpp
+++ b/compiler/ilgen/VirtualMachineOperandArray.cpp
@@ -1,0 +1,181 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017,2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+
+#include "ilgen/VirtualMachineOperandArray.hpp"
+#include "compile/Compilation.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/symbol/AutomaticSymbol.hpp"
+#include "ilgen/BytecodeBuilder.hpp"
+#include "ilgen/MethodBuilder.hpp"
+#include "ilgen/TypeDictionary.hpp"
+
+#define TraceEnabled    (TR::comp()->getOption(TR_TraceILGen))
+#define TraceIL(m, ...) {if (TraceEnabled) {traceMsg(TR::comp(), m, ##__VA_ARGS__);}}
+
+namespace OMR
+{
+VirtualMachineOperandArray::VirtualMachineOperandArray(TR::MethodBuilder *mb, int32_t numOfElements, TR::IlType *elementType, VirtualMachineRegister *arrayBaseRegister)
+   : VirtualMachineState(),
+   _mb(mb),
+   _numberOfElements(numOfElements),
+   _elementType(elementType),
+   _arrayBaseRegister(arrayBaseRegister)
+   {
+   int32_t numBytes = _numberOfElements * sizeof(TR::IlValue *);
+   _values = (TR::IlValue **) TR::comp()->trMemory()->allocateHeapMemory(numBytes);
+   memset(_values, 0, numBytes);
+
+   // store current operand stack pointer base address so we can use it whenever we need
+   // to recreate the stack as the interpreter would have
+   mb->Store("OperandArray_base", arrayBaseRegister->Load(mb));
+   }
+
+VirtualMachineOperandArray::VirtualMachineOperandArray(OMR::VirtualMachineOperandArray *other)
+   : VirtualMachineState(),
+   _mb(other->_mb),
+   _numberOfElements(other->_numberOfElements),
+   _elementType(other->_elementType),
+   _arrayBaseRegister(other->_arrayBaseRegister)
+   {
+   int32_t numBytes = _numberOfElements * sizeof(TR::IlValue *);
+   _values = (TR::IlValue **) TR::comp()->trMemory()->allocateHeapMemory(numBytes);
+   memcpy(_values, other->_values, numBytes);
+   }
+
+
+// commits the simulated operand array of values to the virtual machine state
+// the given builder object is where the operations to commit the state will be inserted
+// into the array which is assumed to be managed independently, most likely
+void
+VirtualMachineOperandArray::Commit(TR::IlBuilder *b)
+   {
+   TR::IlType *Element = _elementType;
+   TR::IlType *pElement = _mb->typeDictionary()->PointerTo(Element);
+
+   TR::IlValue *arrayBase = b->Load("OperandArray_base");
+
+   for (int32_t i = 0;i < _numberOfElements;i++)
+      {
+      TR::IlValue *element = _values[i];
+      if (element != NULL)
+         {
+         b->StoreAt(
+         b->   IndexAt(pElement,
+                  arrayBase,
+         b->      ConstInt32(i)),
+               element);
+         }
+      }
+   }
+
+void
+VirtualMachineOperandArray::Reload(TR::IlBuilder* b)
+   {
+   TR::IlType* Element = _elementType;
+   TR::IlType* pElement = _mb->typeDictionary()->PointerTo(Element);
+   // reload the elements back into the simulated operand array
+   TR::IlValue* array = b->Load("OperandArray_base");
+   for (int32_t i = 0; i < _numberOfElements; i++)
+      {
+      _values[i] = b->LoadAt(pElement,
+                   b->   IndexAt(pElement,
+                            array,
+                   b->      ConstInt32(i)));
+       }
+   }
+
+void
+VirtualMachineOperandArray::MergeInto(OMR::VirtualMachineState *o, TR::IlBuilder *b)
+   {
+   VirtualMachineOperandArray *other = (VirtualMachineOperandArray *)o;
+   TR_ASSERT(_numberOfElements == other->_numberOfElements, "array are not same size");
+   for (int32_t i=0;i < _numberOfElements;i++)
+      {
+      if (NULL == other->_values[i])
+         {
+         TR_ASSERT(_values[i] == NULL, "if an element in the dest array at index is NULL it has to be NULL in the src array");
+         }
+      else if (other->_values[i]->getID() != _values[i]->getID())
+         {
+         // Types have to match!!!
+         TR_ASSERT(_values[i]->getDataType() == other->_values[i]->getDataType(), "invalid array merge: primitive type mismatch at same index");
+         TraceIL("VirtualMachineOperandArray[ %p ]::MergeInto builder %p index %d storeOver %p(%d) with %p(%d)\n", this, b, i, other->_values[i], other->_values[i]->getID(), _values[i], _values[i]->getID());
+         b->StoreOver(other->_values[i], _values[i]);
+         }
+      }
+   }
+
+// Update the OperandArray_base after the Virtual Machine moves the array.
+// This call will normally be followed by a call to Reload if any of the array values changed in the move
+void
+VirtualMachineOperandArray::UpdateArray(TR::IlBuilder *b, TR::IlValue *array)
+   {
+   b->Store("OperandArray_base", array);
+   }
+
+// Allocate a new operand array and copy everything in this state
+// If VirtualMachineOperandArray is subclassed, this function *must* also be implemented in the subclass!
+VirtualMachineState *
+VirtualMachineOperandArray::MakeCopy()
+   {
+   VirtualMachineOperandArray *copy = (VirtualMachineOperandArray *) TR::comp()->trMemory()->allocateHeapMemory(sizeof(VirtualMachineOperandArray));
+   new (copy) VirtualMachineOperandArray(this);
+
+   return copy;
+   }
+
+TR::IlValue *
+VirtualMachineOperandArray::Get(int32_t index)
+   {
+   TR_ASSERT(index < _numberOfElements, "index has to be less than the number of elements");
+   TR_ASSERT(index >= 0, "index can not be negative");
+   return _values[index];
+   }
+
+void
+VirtualMachineOperandArray::Set(int32_t index, TR::IlValue *value)
+   {
+   TR_ASSERT(index < _numberOfElements, "index has to be less than the number of elements");
+   TR_ASSERT(index >= 0, "index can not be negative");
+
+   if (NULL != _values[index])
+      {
+      TraceIL("VirtualMachineOperandArray[ %p ]::Set index %d to %p(%d) old value was %p(%d)\n", this, index, value, value->getID(), _values[index], _values[index]->getID());
+      }
+   else
+      {
+      TraceIL("VirtualMachineOperandArray[ %p ]::Set index %d to %p(%d)\n", this, index, value, value->getID());
+      }
+
+   _values[index] = value;
+   }
+
+
+void
+VirtualMachineOperandArray::Move(TR::IlBuilder *b, int32_t dstIndex, int32_t srcIndex)
+   {
+   TR_ASSERT(dstIndex < _numberOfElements, "dstIndex has to be less than the number of elements");
+   TR_ASSERT(dstIndex >= 0, "dstIndex can not be negative");
+   TR_ASSERT(srcIndex < _numberOfElements, "srcIndex has to be less than the number of elements");
+   TR_ASSERT(srcIndex >= 0, "srcIndex can not be negative");
+
+   _values[dstIndex] = b->Copy(_values[srcIndex]);
+   TraceIL("VirtualMachineOperandArray[ %p ]::Move builder %p move srcIndex %d %p(%d) to dstIndex %d %p(%d)\n", this, b, srcIndex, _values[srcIndex], _values[srcIndex]->getID(), dstIndex, _values[dstIndex], _values[dstIndex]->getID());
+   }
+
+} // namespace OMR

--- a/compiler/ilgen/VirtualMachineOperandArray.hpp
+++ b/compiler/ilgen/VirtualMachineOperandArray.hpp
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+
+#ifndef OMR_VIRTUALMACHINEOPERANDARRAY_INCL
+#define OMR_VIRTUALMACHINEOPERANDARRAY_INCL
+
+#include <stdint.h>
+#include "ilgen/VirtualMachineRegister.hpp"
+#include "ilgen/IlBuilder.hpp"
+
+namespace TR { class MethodBuilder; }
+
+namespace OMR
+{
+
+/**
+ * @brief simulates an operand array used by many bytecode based virtual machines
+ * In such virtual machines, the operand array holds the intermediate expression values
+ * computed by the bytecodes. The compiler simulates this operand array as well, but
+ * what is modified from the simulated operand array are expression nodes
+ * that represent the value computed by the bytecodes.
+ *
+ * The array is represented as an array of pointers to TR::IlValue's, making it
+ * easy to use IlBuilder services to consume and compute new values. 
+ *
+ * The current implementation does not share anything among different
+ * VirtualMachineOperandArray objects. Possibly, some of the state could be
+ * shared to save some memory. For now, simplicity is the goal.
+ *
+ * VirtualMachineOperandArray implements VirtualMachineState:
+ * Commit() simply iterates over the simulated operand array and stores each
+ *   value onto the virtual machine's operand array (more details at definition).
+ * Reload() read the virtual machine array back into the simulated operand array
+ * MakeCopy() copies the state of the operand array
+ * MergeInto() is slightly subtle. Operations may have been already created
+ *   below the merge point, and those operations will have assumed the
+ *   expressions are stored in the TR::IlValue's for the state being merged
+ *   *to*. So the purpose of MergeInto() is to store the values of the current
+ *   state into the same variables as in the "other" state.
+ * UpdateArray() update OperandArray_base so Reload/Commit will use the right
+ *    if the array moves in memory
+ *
+ */
+
+class VirtualMachineOperandArray : public VirtualMachineState
+   {
+   public:
+   /**
+    * @brief public constructor, must be instantiated inside a compilation because uses heap memory
+    * @param mb TR::MethodBuilder object of the method currently being compiled
+    * @param numOfElements the number of elements in the array
+    */
+   VirtualMachineOperandArray(TR::MethodBuilder *mb, int32_t numOfElements, TR::IlType *elementType, VirtualMachineRegister *arrayBase);
+   /**
+    * @brief constructor used to copy the array from another state
+    * @param other the operand array whose values should be used to initialize this object
+    */
+   VirtualMachineOperandArray(VirtualMachineOperandArray *other);
+
+   /**
+    * @brief write the simulated operand array to the virtual machine
+    * @param b the builder where the operations will be placed to recreate the virtual machine operand array
+    */
+   virtual void Commit(TR::IlBuilder *b);
+   
+   /**
+    * @brief read the virtual machine array back into the simulated operand array
+    * @param b the builder where the operations will be placed to recreate the simulated operand array
+    * stack accounts for new or dropped virtual machine stack elements. 
+    */
+   virtual void Reload(TR::IlBuilder *b);
+
+   /**
+    * @brief create an identical copy of the current object.
+    * @returns the copy of the current object
+    */
+   virtual VirtualMachineState *MakeCopy();
+
+   /**
+    * @brief emit operands to store current operand array values into same variables as used in another operand array
+    * @param other operand array for the builder object control is merging into
+    * @param b builder object where the operations will be added to make the current operand array the same as the other
+    */
+   virtual void MergeInto(OMR::VirtualMachineState *other, TR::IlBuilder *b);
+   
+   /**
+    * @brief update the values used to read and write the virtual machine array
+    * @param b the builder where the values will be placed
+    * @param array the new array base address.
+    */
+   virtual void UpdateArray(TR::IlBuilder *b, TR::IlValue *array);
+
+   /**
+    * @brief Returns the expression at the given index of the simulated operand array
+    * @param index the location of the expression to return
+    * @returns the expression at the given index
+    */
+   virtual TR::IlValue *Get(int32_t index);
+   
+   /**
+    * @brief Set the expression into the simulated operand array at the given index
+    * @param index the location to store the expression
+    * @param value expression to store into the simulated operand array
+    */
+   virtual void Set(int32_t index, TR::IlValue *value);
+  
+   /**
+    * @brief Move the expression from one index to another index in the simulated operand array
+    * @param dstIndex the location to store the expression
+    * @param srcIndex the location to copy the expression from
+    */ 
+   virtual void Move(TR::IlBuilder *b, int32_t dstIndex, int32_t srcIndex);
+
+   private:
+   TR::MethodBuilder *_mb;
+   int32_t _numberOfElements;
+   OMR::VirtualMachineRegister *_arrayBaseRegister;
+   TR::IlType *_elementType;
+   TR::IlValue **_values;
+   };
+}
+
+#endif // !defined(OMR_VIRTUALMACHINEOPERANDARRAY_INCL)

--- a/jitbuilder/build/files/common.mk
+++ b/jitbuilder/build/files/common.mk
@@ -219,6 +219,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/ilgen/ThunkBuilder.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/BytecodeBuilder.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/TypeDictionary.cpp \
+    $(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineOperandArray.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineOperandStack.cpp \
     $(JIT_OMR_DIRTY_DIR)/runtime/Alignment.cpp \
     $(JIT_OMR_DIRTY_DIR)/runtime/CodeCacheTypes.cpp \

--- a/jitbuilder/build/rules/common.mk
+++ b/jitbuilder/build/rules/common.mk
@@ -1,6 +1,6 @@
 ################################################################################
 ##
-## (c) Copyright IBM Corp. 2016, 2016
+## (c) Copyright IBM Corp. 2016, 2017
 ##
 ##  This program and the accompanying materials are made available
 ##  under the terms of the Eclipse Public License v1.0 and
@@ -108,6 +108,9 @@ $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineRegister.hpp: $(FIXE
 $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineRegisterInStruct.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineRegisterInStruct.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
 	cp $< $@ || cp $< $@
 
+$(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineOperandArray.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineOperandArray.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
+	cp -u $< $@ || cp $< $@
+
 $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineOperandStack.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineOperandStack.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
 	cp $< $@ || cp $< $@
 
@@ -134,6 +137,7 @@ JITBUILDER_FILES=$(RELEASE_DIR)/Makefile \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineState.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineRegister.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineRegisterInStruct.hpp \
+             $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineOperandArray.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineOperandStack.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/IlGen.hpp \
              $(RELEASE_SRC)/Call.hpp \

--- a/jitbuilder/release/Makefile
+++ b/jitbuilder/release/Makefile
@@ -38,6 +38,7 @@ ALL_TESTS = \
             linkedlist \
             localarray \
             nestedloop \
+            operandarraytests \
             operandstacktests \
             pointer \
             pow2 \
@@ -75,6 +76,7 @@ all_goal: common_goal
 	./fieldaddress
 	./linkedlist
 	./localarray
+	./operandarraytests
 	./operandstacktests
 	./pointer
 	./recfib
@@ -199,6 +201,13 @@ nestedloop : libjitbuilder.a NestedLoop.o
 
 NestedLoop.o: src/NestedLoop.cpp src/NestedLoop.hpp
 	$(CXX) -o $@ $(CXXFLAGS) $<
+
+
+operandarraytests : libjitbuilder.a OperandArrayTests.o
+	g++ -g -fno-rtti -o $@ OperandArrayTests.o -L. -ljitbuilder -ldl
+
+OperandArrayTests.o: src/OperandArrayTests.cpp src/OperandArrayTests.hpp
+	g++ -o $@ $(CXXFLAGS) $<
 
 
 operandstacktests : libjitbuilder.a OperandStackTests.o

--- a/jitbuilder/release/src/OperandArrayTests.cpp
+++ b/jitbuilder/release/src/OperandArrayTests.cpp
@@ -1,0 +1,551 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+
+#include <iostream>
+#include <stdlib.h>
+#include <stdint.h>
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdarg.h>
+
+#include "Jit.hpp"
+#include "ilgen/TypeDictionary.hpp"
+#include "ilgen/MethodBuilder.hpp"
+#include "ilgen/BytecodeBuilder.hpp"
+#include "ilgen/VirtualMachineOperandArray.hpp"
+#include "ilgen/VirtualMachineRegister.hpp"
+#include "ilgen/VirtualMachineRegisterInStruct.hpp"
+#include "OperandArrayTests.hpp"
+
+using std::cout;
+using std::cerr;
+
+static bool verbose = false;
+static int32_t numFailingTests = 0;
+static int32_t numPassingTests = 0;
+static ARRAYVALUETYPE **verifyArray = NULL;
+static ARRAYVALUETYPE expectedResult8 = -1;
+static char * result8Operator;
+
+static void
+setupResult8Equals()
+   {
+   expectedResult8 = 9;
+   result8Operator = (char *)"==";
+   }
+
+static void
+setupResult8NotEquals()
+   {
+   expectedResult8 = 11;
+   result8Operator = (char *)"!=";
+   }
+
+int
+main(int argc, char *argv[])
+   {
+   if (argc == 2 && strcmp(argv[1], "--verbose") == 0)
+      verbose = true;
+
+   cout << "Step 1: initialize JIT\n";
+   bool initialized = initializeJit();
+   if (!initialized)
+      {
+      cerr << "FAIL: could not initialize JIT\n";
+      exit(-1);
+      }
+
+   cout << "Step 2: compile operand array tests set up for equals\n";
+   TR::TypeDictionary types2;
+   OperandArrayTestMethod pointerMethod(&types2);
+   uint8_t *entry2 = 0;
+   int32_t rc2 = compileMethodBuilder(&pointerMethod, &entry2);
+   if (rc2 != 0)
+      {
+      cerr << "FAIL: compilation error " << rc2 << "\n";
+      exit(-2);
+      }
+
+   cout << "Step 3: invoke compiled code and print results\n";
+   typedef void (OperandArrayTestMethodFunction)();
+   OperandArrayTestMethodFunction *ptrTest = (OperandArrayTestMethodFunction *) entry2;
+   verifyArray = pointerMethod.getArrayPtr();
+   setupResult8Equals();
+   ptrTest();
+
+   cout << "Step 4: compile operand array tests set up for notequals\n";
+   TR::TypeDictionary types4;
+   OperandArrayTestUsingFalseMethod pointerMethodFalse(&types4);
+   uint8_t *entry4 = 0;
+   int32_t rc4 = compileMethodBuilder(&pointerMethodFalse, &entry4);
+   if (rc4 != 0)
+      {
+      cerr << "FAIL: compilation error " << rc4 << "\n";
+      exit(-4);
+      }
+
+   cout << "Step 5: invoke compiled code and print results\n";
+   typedef void (OperandArrayTestUsingFalseMethodFunction)();
+   OperandArrayTestUsingFalseMethodFunction *ptrTestFalse = (OperandArrayTestUsingFalseMethodFunction *) entry4;
+   verifyArray = pointerMethodFalse.getArrayPtr();
+   setupResult8NotEquals();
+   ptrTestFalse();
+
+   cout << "Step 6: shutdown JIT\n";
+   shutdownJit();
+
+   cout << "Number passing tests: " << numPassingTests << "\n";
+   cout << "Number failing tests: " << numFailingTests << "\n";
+
+   if (numFailingTests == 0)
+      cout << "ALL PASS\n";
+   else
+      cout << "SOME FAILURES\n";
+   }
+
+
+ARRAYVALUETYPE *OperandArrayTestMethod::_realArray = NULL;
+int32_t OperandArrayTestMethod::_realArrayLength = 0;
+
+void
+OperandArrayTestMethod::createArray()
+   {
+   int32_t arraySizeInBytes = _realArrayLength * sizeof(ARRAYVALUETYPE);
+   _realArray = (ARRAYVALUETYPE *) malloc(arraySizeInBytes);
+   memset(_realArray, 0, arraySizeInBytes);
+   }
+
+ARRAYVALUETYPE *
+OperandArrayTestMethod::moveArray()
+   {
+   int32_t stackSizeInBytes = _realArrayLength * sizeof(ARRAYVALUETYPE);
+   ARRAYVALUETYPE *newArray = (ARRAYVALUETYPE *) malloc(stackSizeInBytes);
+   memcpy(newArray, _realArray, stackSizeInBytes);
+   memset(_realArray, 0xFF, stackSizeInBytes);
+   free(_realArray);
+   _realArray = newArray;
+
+   return _realArray;
+   }
+
+void
+OperandArrayTestMethod::freeArray()
+   {
+   memset(_realArray, 0xFF, _realArrayLength * sizeof(ARRAYVALUETYPE));
+   free(_realArray);
+   _realArray = NULL;
+   }
+
+static void Fail()
+   {
+   numFailingTests++;
+   }
+
+static void Pass()
+   {
+   numPassingTests++;
+   }
+
+#define REPORT1(c,n,v)         { if (c) { Pass(); if (verbose) cout << "Pass\n"; } else { Fail(); if (verbose) cout << "Fail: " << (n) << " is " << (v) << "\n"; } }
+#define REPORT2(c,n1,v1,n2,v2) { if (c) { Pass(); if (verbose) cout << "Pass\n"; } else { Fail(); if (verbose) cout << "Fail: " << (n1) << " is " << (v1) << ", " << (n2) << " is " << (v2) << "\n"; } }
+
+void
+verifyResult0()
+   {
+   //VMOA      [0   ,null,null,...,null]
+   //_realArray[null,null,null,...,null]
+   if (verbose) cout << "Set(0, 0); [ no commit ]\n";
+   OperandArrayTestMethod::verify("0", 0, 0);
+   }
+
+void
+verifyResult1()
+   {
+   //VMOA      [0,null,null,...,null]
+   //_realArray[0,null,null,...,null]
+   if (verbose) cout << "Commit();\n";
+   OperandArrayTestMethod::verify("1", 1, 1, 0);
+   }
+
+void
+verifyResult2(ARRAYVALUETYPE last)
+   {
+   //VMOA      [0,1   ,2   ,null,...,null]
+   //_realArray[0,null,null,null,...,null]
+   if (verbose) cout << "Set(1, 1); Set(2, 2); Get(2)   [ no commit]\n";
+   if (verbose) cout << "\tResult 2: last value == 2: ";
+   REPORT1(last == 2, "last", last);
+
+   OperandArrayTestMethod::verify("2", 1, 1, 0);
+   }
+
+void
+verifyResult3(ARRAYVALUETYPE last)
+   {
+   //VMOA      [0,1,2,null,...,null]
+   //_realArray[0,1,2,null,...,null]
+   if (verbose) cout << "Commit(); Get(2)\n";
+   if (verbose) cout << "\tResult 2: last value == 2: ";
+   REPORT1(last == 2, "last", last);
+
+   OperandArrayTestMethod::verify("3", 3, 3, 0, 1, 2);
+   }
+
+void
+verifyResult4(ARRAYVALUETYPE last)
+   {
+   //VMOA      [0,1,2,2   ,null,...,null]
+   //_realArray[0,1,2,null,null,...,null]
+   if (verbose) cout << "Move(3, 2)    [ no commit]\n";
+   if (verbose) cout << "\tResult 4: last value == 2: ";
+   REPORT1(last == 2, "last", last);
+
+   OperandArrayTestMethod::verify("4", 3, 3, 0, 1, 2);
+   }
+
+void
+verifyResult5(ARRAYVALUETYPE last)
+   {
+   //VMOA      [0,1,2,2,null,...,null]
+   //_realArray[0,1,2,2,null,...,null]
+   if (verbose) cout << "Commit(); Get(3)\n";
+   if (verbose) cout << "\tResult 5: last value == 2: ";
+   REPORT1(last == 2, "last", last);
+
+   OperandArrayTestMethod::verify("5", 4, 4, 0, 1, 2, 2);
+   }
+
+void
+verifyResult6(ARRAYVALUETYPE last)
+   {
+   //VMOA      [0,1,2,2,4,null,...,null]
+   //_realArray[0,1,2,2,4,null,...,null]
+   if (verbose) cout << "Set(4, Add(GET(2), Get(3))); Commit(); Get(4)\n";
+   if (verbose) cout << "\tResult 6: last == 4: ";
+   REPORT1(last == 4, "last", last);
+
+   OperandArrayTestMethod::verify("6", 5, 5, 0, 1, 2, 2, 4);
+   }
+
+void
+verifyResult7()
+   {
+   //VMOA      [0,1,2,2,4,5,5,null]
+   //_realArray[0,1,2,2,4,5,5,null]
+   if (verbose) cout << "Set(5,5); Set(6,5); Commit();\n";
+   OperandArrayTestMethod::verify("7", 7, 7, 0, 1, 2, 2, 4, 5, 5);
+   }
+
+void
+verifyResult8(ARRAYVALUETYPE last)
+   {
+   //VMOA      [0,1,2,{9,11},4,5,5,null]
+   //_realArray[0,1,2,{9,11},4,5,5,null]
+   if (verbose) cout << "if (5 " << result8Operator << " 5) { SET(3,9); } else { Set(3,11); } Commit(); Get(3);\n";
+   if (verbose) cout << "\tResult 8: last == " << expectedResult8 << ": ";
+   REPORT1(last == expectedResult8, "last", last);
+   OperandArrayTestMethod::verify("8", 7, 7, 0, 1, 2, expectedResult8, 4, 5, 5);
+   }
+
+void
+verifyResult9(ARRAYVALUETYPE six, ARRAYVALUETYPE seven)
+   {
+   //VMOA      [0,1,2,{9,11},4,5,22,22]
+   //_realArray[0,1,2,{9,11},4,5,5 ,5]
+   if (verbose) cout << "Set(7,GET(6)); Commit();\n";
+   if (verbose) cout << "Set(7,22); ";
+   if (verbose) cout << "Commit();\n";
+   if (verbose) cout << "\tResult 9: six == 22: ";
+   REPORT1(six == 22, "six", six);
+   if (verbose) cout << "\tResult 9: seven == 22: ";
+   REPORT1(seven == 22, "seven", seven);
+   OperandArrayTestMethod::verify("9", 8, 8, 0, 1, 2, expectedResult8, 4, 5, 22, 22);
+   }
+
+void
+verifyResult10(ARRAYVALUETYPE one, ARRAYVALUETYPE two)
+   {
+   //VMOA      [0,7,19,{9,11},4,5,22,22]
+   //_realArray[0,7,19,{9,11},4,5,5 ,5]
+   if (verbose) cout << "update the real array at index 2 and 3; ";
+   if (verbose) cout << "Reload();\n";
+   if (verbose) cout << "\tResult 10: one == 7: ";
+   REPORT1(one == 7, "one", one);
+   if (verbose) cout << "\tResult 10: two == 19: ";
+   REPORT1(two == 19, "two", two);
+   OperandArrayTestMethod::verify("10", 8, 8, 0, 7, 19, expectedResult8, 4, 5, 22, 22);
+   }
+
+void
+modifyIndex1And2(ARRAYVALUETYPE one, ARRAYVALUETYPE two)
+   {
+   //VMOA      [0,1,2,{9,11},4,5,22,22]
+   //_realArray[0,1,2,{9,11},4,5,5 ,5]
+   if (verbose) cout << "modify elements at index 1 and 2 and return";
+   ARRAYVALUETYPE *realArray = *verifyArray;
+   REPORT1(realArray[1]== 1, "modifyTop3Elements realArray[1]", realArray[1]);
+   REPORT1(realArray[2]== 2, "modifyTop3Elements realArray[2]", realArray[2]);
+   realArray[1] = one;
+   realArray[2] = two;
+   //VMOA      [0,1,2 ,{9,11},4,5,22,22]
+   //_realArray[0,7,19,{9,11},4,5,5 ,5]
+   }
+
+bool
+OperandArrayTestMethod::verifyUntouched(int32_t maxTouched)
+   {
+   for (int32_t i=maxTouched;i<_realArrayLength;i++)
+      if (_realArray[i] != 0)
+         return false;
+   return true;
+   }
+
+void
+OperandArrayTestMethod::verify(const char *step, int32_t max, int32_t num, ...)
+   {
+   va_list args;
+   va_start(args, num);
+   for (int32_t a=0;a < num;a++)
+      {
+      ARRAYVALUETYPE val = va_arg(args, ARRAYVALUETYPE);
+      if (verbose) cout << "\tResult " << step << ": _realArray[" << a << "] == " << val << ": ";
+      REPORT2(_realArray[a] == val, "_realArray[a]", _realArray[a], "val", val);
+      }
+
+   if (verbose) cout << "\tResult " << step << ": upper stack untouched: ";
+   REPORT1(verifyUntouched(max), "max", max);
+   }
+
+
+OperandArrayTestMethod::OperandArrayTestMethod(TR::TypeDictionary *d)
+   : MethodBuilder(d)
+   {
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   DefineName("test");
+   DefineReturnType(NoType);
+
+   _realArrayLength = 8;
+   _realArray = (ARRAYVALUETYPE *) malloc (_realArrayLength * sizeof(ARRAYVALUETYPE));
+   memset(_realArray, 0, _realArrayLength*sizeof(ARRAYVALUETYPE));
+
+   _valueType = ARRAYVALUEILTYPE;
+   TR::IlType *pValueType = d->PointerTo(_valueType);
+
+   DefineFunction("createArray", "0", "0", (void *)&OperandArrayTestMethod::createArray, NoType, 0);
+   DefineFunction("moveArray", "0", "0", (void *)&OperandArrayTestMethod::moveArray, pValueType, 0);
+   DefineFunction("freeArray", "0", "0", (void *)&OperandArrayTestMethod::freeArray, NoType, 0);
+   DefineFunction("verifyResult0", "0", "0", (void *)&verifyResult0, NoType, 0);
+   DefineFunction("verifyResult1", "0", "0", (void *)&verifyResult1, NoType, 0);
+   DefineFunction("verifyResult2", "0", "0", (void *)&verifyResult2, NoType, 1, _valueType);
+   DefineFunction("verifyResult3", "0", "0", (void *)&verifyResult3, NoType, 1, _valueType);
+   DefineFunction("verifyResult4", "0", "0", (void *)&verifyResult4, NoType, 1, _valueType);
+   DefineFunction("verifyResult5", "0", "0", (void *)&verifyResult5, NoType, 1, _valueType);
+   DefineFunction("verifyResult6", "0", "0", (void *)&verifyResult6, NoType, 1, _valueType);
+   DefineFunction("verifyResult7", "0", "0", (void *)&verifyResult7, NoType, 0);
+   DefineFunction("verifyResult8", "0", "0", (void *)&verifyResult8, NoType, 1, _valueType);
+   DefineFunction("verifyResult9", "0", "0", (void *)&verifyResult9, NoType, 2, _valueType, _valueType);
+   DefineFunction("verifyResult10", "0", "0", (void *)&verifyResult10, NoType, 2, _valueType, _valueType);
+   DefineFunction("modifyIndex1And2", "0", "0", (void *)&modifyIndex1And2, NoType, 2, _valueType, _valueType);
+   }
+
+// convenience macros
+#define STACK(b)         ((OMR::VirtualMachineOperandArray *)(b)->vmState())
+#define UPDATEARRAY(b,s) (STACK(b)->UpdateArray(b, s))
+#define COMMIT(b)        (STACK(b)->Commit(b))
+#define RELOAD(b)        (STACK(b)->Reload(b))
+#define SET(b,i,v)       (STACK(b)->Set((i),(v)))
+#define GET(b,i)         (STACK(b)->Get((i)))
+#define MOVE(b, d, s)    (STACK(b)->Move(b, d, s))
+
+bool
+OperandArrayTestMethod::testArray(TR::BytecodeBuilder *builder, bool useEqual)
+   {
+   //VMOA      [null,null,null,...,null]
+   //_realArray[null,null,null,...,null]
+
+   SET(builder, 0, builder->ConstInteger(_valueType, 0));
+   //VMOA      [0   ,null,null,...,null]
+   //_realArray[null,null,null,...,null]
+   builder->Call("verifyResult0", 0);
+
+   COMMIT(builder);
+   //VMOA      [0,null,null,...,null]
+   //_realArray[0,null,null,...,null]
+   builder->Call("verifyResult1", 0);
+
+   SET(builder, 1, builder->ConstInteger(_valueType, 1));
+   SET(builder, 2, builder->ConstInteger(_valueType, 2));
+   //VMOA      [0,1   ,2   ,null,...,null]
+   //_realArray[0,null,null,null,...,null]
+   builder->Call("verifyResult2", 1, GET(builder, 2));
+
+   COMMIT(builder);
+   TR::IlValue *newArray = builder->Call("moveArray", 0);
+   UPDATEARRAY(builder, newArray);
+   //VMOA      [0,1,2,null,...,null]
+   //_realArray[0,1,2,null,...,null]
+   builder->Call("verifyResult3", 1, GET(builder, 2));
+
+   MOVE(builder, 3, 2);
+   //VMOA      [0,1,2,2   ,null,...,null]
+   //_realArray[0,1,2,null,null,...,null]
+   builder->Call("verifyResult4", 1, GET(builder, 3));
+
+   COMMIT(builder);
+   //VMOA      [0,1,2,2,null,...,null]
+   //_realArray[0,1,2,2,null,...,null]
+   builder->Call("verifyResult5", 1, GET(builder, 3));
+
+   TR::IlValue *sum = builder->Add(GET(builder, 2), GET(builder, 3));
+   SET(builder, 4, sum);
+   COMMIT(builder);
+   //VMOA      [0,1,2,2,4,null,...,null]
+   //_realArray[0,1,2,2,4,null,...,null]
+   builder->Call("verifyResult6", 1, GET(builder, 4));
+
+   SET(builder, 5, builder->ConstInteger(_valueType, 5));
+   SET(builder, 6, builder->ConstInteger(_valueType, 5));
+   COMMIT(builder);
+   //VMOA      [0,1,2,2,4,5,5,null]
+   //_realArray[0,1,2,2,4,5,5,null]
+   builder->Call("verifyResult7", 0);
+
+   TR::BytecodeBuilder *thenBB = OrphanBytecodeBuilder(0, (char*)"BCI_then");
+   TR::BytecodeBuilder *elseBB = OrphanBytecodeBuilder(1, (char*)"BCI_else");
+   TR::BytecodeBuilder *mergeBB = OrphanBytecodeBuilder(2, (char*)"BCI_merge");
+
+   TR::IlValue *v1 = GET(builder, 5);
+   TR::IlValue *v2 = GET(builder, 6);
+
+   if (useEqual)
+      builder->IfCmpEqual(thenBB, v1, v2);
+   else
+      builder->IfCmpNotEqual(thenBB, v1, v2);
+
+   builder->AddFallThroughBuilder(elseBB);
+
+   SET(thenBB, 3, thenBB->ConstInteger(_valueType, 9));
+   //VMOA      [0,1,2,9,4,5,5,null]
+   //_realArray[0,1,2,2,4,5,5,null]
+   thenBB->Goto(mergeBB);
+
+   SET(elseBB, 3, elseBB->ConstInteger(_valueType, 11));
+   //VMOA      [0,1,2,11,4,5,5,null]
+   //_realArray[0,1,2,2, 4,5,5,null]
+   elseBB->AddFallThroughBuilder(mergeBB);
+
+   COMMIT(mergeBB);
+   //VMOA      [0,1,2,{9,11},4,5,5,null]
+   //_realArray[0,1,2,{9,11},4,5,5,null]
+   // Since I used MOVE to set index 3 to the value of index 2 only index 3 changed
+   mergeBB->Call("verifyResult8", 1, GET(mergeBB, 3));
+
+   SET(mergeBB, 7, GET(mergeBB, 6));
+   COMMIT(mergeBB);
+   //VMOA      [0,1,2,{9,11},4,5,5,5]
+   //_realArray[0,1,2,{9,11},4,5,5,5]
+
+   TR::BytecodeBuilder *change7 = OrphanBytecodeBuilder(3, (char*)"BCI_change7");
+   TR::BytecodeBuilder *nextMerge = OrphanBytecodeBuilder(4, (char*)"nextMerge");
+   TR::BytecodeBuilder *view6and7 = OrphanBytecodeBuilder(5, (char*)"BCI_view6and7");
+
+   mergeBB->IfCmpEqual(change7, GET(mergeBB, 5), GET(mergeBB, 6));
+   mergeBB->AddFallThroughBuilder(nextMerge);
+
+   nextMerge->AddFallThroughBuilder(view6and7);
+
+   SET(change7, 7, change7->ConstInteger(_valueType, 22));
+   //VMOA      [0,1,2,{9,11},4,5,5,22]
+   //_realArray[0,1,2,{9,11},4,5,5,5]
+   change7->Goto(view6and7);
+   //Since the TR::IlValue at index 6 and 7 was the same value the merge will cause both to be updated
+   //VMOA      [0,1,2,{9,11},4,5,22,22]
+   //_realArray[0,1,2,{9,11},4,5,5 ,5]
+   COMMIT(view6and7);
+   //VMOA      [0,1,2,{9,11},4,5,22,22]
+   //_realArray[0,1,2,{9,11},4,5,22,22]
+   view6and7->Call("verifyResult9", 2, GET(view6and7, 6), GET(view6and7, 7));
+
+   TR::IlValue *one = view6and7->ConstInteger(_valueType, 7);
+   TR::IlValue *two = view6and7->ConstInteger(_valueType, 19);
+   view6and7->Call("modifyIndex1And2", 2, one, two);
+   //VMOA      [0,1,2 ,{9,11},4,5,22,22]
+   //_realArray[0,7,19,{9,11},4,5,22,22]
+   RELOAD(view6and7);
+   //VMOA      [0,7,19,{9,11},4,5,22,22]
+   //_realArray[0,7,19,{9,11},4,5,22,22]
+   view6and7->Call("verifyResult10", 2, GET(view6and7, 1), GET(view6and7, 2));
+
+   view6and7->Return();
+
+   return true;
+   }
+
+bool
+OperandArrayTestMethod::buildIL()
+   {
+   TR::IlType *pElementType = _types->PointerTo(Word);
+
+   Call("createArray", 0);
+
+   TR::IlValue *arrayBaseAddress = ConstAddress(&_realArray);
+   OMR::VirtualMachineRegister *arrayBase = new OMR::VirtualMachineRegister(this, "ARRAY", pElementType, sizeof(ARRAYVALUETYPE), arrayBaseAddress);
+   OMR::VirtualMachineOperandArray *array = new OMR::VirtualMachineOperandArray(this, _realArrayLength, _valueType, arrayBase);
+
+   setVMState(array);
+
+   TR::BytecodeBuilder *bb = OrphanBytecodeBuilder(0, (char *) "entry");
+   AppendBuilder(bb);
+
+   testArray(bb, true);
+
+   Call("freeArray", 0);
+
+   return true;
+   }
+
+OperandArrayTestUsingFalseMethod::OperandArrayTestUsingFalseMethod(TR::TypeDictionary *d)
+   : OperandArrayTestMethod(d)
+   {
+   }
+
+bool
+OperandArrayTestUsingFalseMethod::buildIL()
+   {
+   TR::IlType *pElementType = _types->PointerTo(Word);
+
+   Call("createArray", 0);
+
+   TR::IlValue *arrayBaseAddress = ConstAddress(&_realArray);
+   OMR::VirtualMachineRegister *arrayBase = new OMR::VirtualMachineRegister(this, "ARRAY", pElementType, sizeof(ARRAYVALUETYPE), arrayBaseAddress);
+   OMR::VirtualMachineOperandArray *array = new OMR::VirtualMachineOperandArray(this, _realArrayLength, _valueType, arrayBase);
+
+   setVMState(array);
+
+   TR::BytecodeBuilder *bb = OrphanBytecodeBuilder(0, (char *) "entry");
+   AppendBuilder(bb);
+
+   testArray(bb, false);
+
+   Call("freeArray", 0);
+
+   return true;
+   }

--- a/jitbuilder/release/src/OperandArrayTests.hpp
+++ b/jitbuilder/release/src/OperandArrayTests.hpp
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2016, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+
+#ifndef OPERANDARRAYTESTS_INCL
+#define OPERANDARRAYTESTS_INCL
+
+#include "ilgen/MethodBuilder.hpp"
+
+#define ARRAYVALUEILTYPE Int32
+#define ARRAYVALUETYPE   int32_t
+
+namespace TR { class BytecodeBuilder; }
+
+class OperandArrayTestMethod : public TR::MethodBuilder
+   {
+   public:
+   OperandArrayTestMethod(TR::TypeDictionary *);
+   virtual bool buildIL();
+
+   static void verify(const char *step, int32_t max, int32_t num, ...);
+   static bool verifyUntouched(int32_t maxTouched);
+
+   ARRAYVALUETYPE **getArrayPtr() { return &_realArray; }
+
+   protected:
+   bool testArray(TR::BytecodeBuilder *b, bool useEqual);
+
+   TR::IlType                      *_valueType;
+
+   static ARRAYVALUETYPE           *_realArray;
+   static int32_t                   _realArrayLength;
+   
+   static void createArray();
+   static ARRAYVALUETYPE *moveArray();
+   static void freeArray();
+   };
+   
+class OperandArrayTestUsingFalseMethod : public OperandArrayTestMethod
+   {
+   public:
+   OperandArrayTestUsingFalseMethod(TR::TypeDictionary *);
+   virtual bool buildIL();
+   };
+
+#endif // !defined(OPERANDARRAYTESTS_INCL)


### PR DESCRIPTION
Not all Virtual Machines have an Operand Stack. Another common construct
is to have a fixed sized array of "registers". The new
VirtualMachineOperandArray is very similar to the VMOS but it does not
allow for growth and it has to deal with NULL entries as not all entries
may have a value.

The VirtualMachineOperandArray::Move API requires that a copy of the
IlValue stored at srcIndex be stored at dstIndex. To accomplish this I
added a new API to IlBuilder call CopyValue.

I have added tests to verify the all of the functionality.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>