### PR TITLE
Compress OSR infra after all OSR points are added

### DIFF
--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -235,6 +235,12 @@ OMR::CodeGenPhase::performEmitSnippetsPhase(TR::CodeGenerator * cg, TR::CodeGenP
 
    cg->emitSnippets();
 
+   if (comp->getOption(TR_EnableOSR))
+      {
+      comp->getOSRCompilationData()->checkOSRLimits();
+      comp->getOSRCompilationData()->compressInstruction2SharedSlotMap();
+      }
+
    if (comp->getOption(TR_TraceCG) || comp->getOptions()->getTraceCGOption(TR_TraceCGPostBinaryEncoding))
       {
       diagnostic("\nbuffer start = %8x, code start = %8x, buffer length = %d", cg->getBinaryBufferStart(), cg->getCodeStart(), cg->getEstimatedWarmLength());
@@ -288,11 +294,6 @@ OMR::CodeGenPhase::performBinaryEncodingPhase(TR::CodeGenerator * cg, TR::CodeGe
       {
       if (cg->getDebug())
          cg->getDebug()->verifyFinalNodeReferenceCounts(comp->getMethodSymbol());
-      }
-   if (comp->getOption(TR_EnableOSR))
-      {
-      comp->getOSRCompilationData()->checkOSRLimits();
-      comp->getOSRCompilationData()->compressInstruction2SharedSlotMap();
       }
    }
 


### PR DESCRIPTION
OSR slot sharing information is intended to be
compressed after the map from instruction to slot
information has been generated. However, it is
being compressed before the slot sharing information
for snippets has been added. This can result in
a transition failing if a snippet's instruction PC
is within a range of compressed PCs and has different
slot sharing information.