### PR TITLE
Fix live monitor meta data to detect invalid cases

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -251,6 +251,7 @@ public:
 
 private:
    int32_t addSuccessors(TR::CFGNode * cfgNode, TR_Stack<TR::SymbolReference *> *, bool traceIt, bool dontPropagateMonitor = false, MonitorInBlock monitorType = NoMonitor, int32_t callerIndex = -1, bool walkOnlyExceptionSuccs = false);
+   bool isMonitorStateConsistentForBlock(TR::Block *block, TR_Stack<TR::SymbolReference *> *newMonitorStack, bool popMonitor);
 
    TR_Memory *        trMemory()  { return comp()->trMemory(); }
    TR_HeapMemory   trHeapMemory() { return trMemory(); }
@@ -1677,6 +1678,8 @@ class OMR_EXTENSIBLE CodeGenerator
    bool trackingInMemoryKilledLoads() {return _flags4.testAny(TrackingInMemoryKilledLoads);}
    void setTrackingInMemoryKilledLoads() {_flags4.set(TrackingInMemoryKilledLoads);}
    void resetTrackingInMemoryKilledLoads() {_flags4.reset(TrackingInMemoryKilledLoads);}
+
+   void setLmmdFailed() { _lmmdFailed = true;}
 
    protected:
 


### PR DESCRIPTION
In original lmmd code, when propagating monitor state from one block
to its sucessors the blocks that are already visited are skipped
and it's assumed that the monitor state for one block should be the
same no matter which predecessor it's propagated from.
This code detect the cases where the monitor state for one block can vary
when propagating from different predecessor blocks. In those cases,
lmmd should resort to the most conservative solution.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>