### PR TITLE
WIP: Replace SparseBitVector with dense in dominators

### DIFF
--- a/compiler/optimizer/Dominators.hpp
+++ b/compiler/optimizer/Dominators.hpp
@@ -63,7 +63,7 @@ class TR_Dominators
 
    protected:
 
-   typedef TR::SparseBitVector SparseBitVector;
+   typedef TR::BitVector SparseBitVector;
 
    private:
 


### PR DESCRIPTION
The dominators analysis used a SparseBitVector
to represent semidominant nodes. Due to the
heap allocation overhead of the CS2 SparseBitVector
and the density of CFG node numbers, this has
been replaced with a dense bit vector.