### PR TITLE
Add dead stores to OSR code block

### DIFF
--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -1174,6 +1174,12 @@ OMR::ResolvedMethodSymbol::genOSRHelperCall(int32_t currentInlinedSiteIndex, TR:
       }
    else
       {
+      // Add the dead stores for this call site
+      TR_OSRMethodData* callerOSRData = self()->comp()->getOSRCompilationData()->findCallerOSRMethodData(osrMethodData);
+      TR_InlinedCallSite &callSiteInfo = self()->comp()->getInlinedCallSite(currentInlinedSiteIndex);
+      callerOSRData->getMethodSymbol()->insertStoresForDeadStackSlots(self()->comp(), callSiteInfo._byteCodeInfo,
+         OSRCodeBlock->getExit(), false);
+
       //create an appropritely-typed return node and append it to the OSR code block and add
       //the corresponding cfg edge
       bool voidReturn = self()->getResolvedMethod()->returnOpCode() == TR::Return;
@@ -1798,6 +1804,113 @@ OMR::ResolvedMethodSymbol::getOSRTransitionTreeTop(TR::TreeTop *tt)
    return tt;
    }
 
+/**
+ * Inserts irrelevant stores before the provided tree to limit symrefs that appear live at an OSR transition.
+ * This is based on the results from OSRLiveRangeAnalysis. It is assumed that the byteCodeInfo's call site is a call
+ * to this resolved method symbol.
+ *
+ * \param byteCodeInfo BCI the OSR transition targets, used to look up dead symrefs in OSRLiveRangeAnalysis results.
+ * \param insertTree Tree to prepend dead stores to.
+ * \param keepStashedArgsLive Flag to toggle how symrefs used as arguments to this BCI are treated. If transitioning directly to this
+ *  BCI, it should be true. If transitioning within a deeper frame to the current, it should be false. Defaults true.
+ */
+void
+OMR::ResolvedMethodSymbol::insertStoresForDeadStackSlots(TR::Compilation *comp, TR_ByteCodeInfo &byteCodeInfo, TR::TreeTop *insertTree, bool keepStashedArgsLive)
+   {
+   TR::SymbolReferenceTable *symRefTab = comp->getSymRefTab();
+   int32_t callSite = byteCodeInfo.getCallerIndex();
+   int32_t byteCodeIndex = byteCodeInfo.getByteCodeIndex();
+   TR_OSRMethodData *osrMethodData = comp->getOSRCompilationData()->findOrCreateOSRMethodData(callSite, self());
+
+   TR_BitVector *deadSymRefs = osrMethodData->getLiveRangeInfo(byteCodeIndex);
+   if (deadSymRefs == NULL)
+      return;
+
+   // The arguments to the induce OSR call may be stashed against its bytecode index.
+   // If so, dead stores must not be generated for these symrefs.
+   if (keepStashedArgsLive)
+      {
+      TR_Array<int32_t> *args = osrMethodData->getArgInfo(byteCodeIndex);
+      for (int32_t i = 0; args && i < args->size(); ++i)
+         deadSymRefs->reset((*args)[i]);
+      }
+
+   TR::TreeTop *prev = insertTree->getPrevTreeTop();
+   TR::TreeTop *next = insertTree;
+
+   if (comp->getOption(TR_TraceOSR))
+      traceMsg(comp, "Inserting stores for dead stack slots in method at caller index %d and bytecode index %d for induceOSR call %p\n", callSite, byteCodeIndex, insertTree->getNode());
+
+   TR_BitVectorIterator bvi(*deadSymRefs);
+   while (bvi.hasMoreElements())
+      {
+      int32_t nextDeadVar = bvi.getNextElement();
+      TR::SymbolReference *nextSymRef = symRefTab->getSymRef(nextDeadVar);
+
+      if (!nextSymRef->getSymbol()->isParm()
+          && performTransformation(comp, "OSR LIVE RANGE ANALYSIS : Local %d is reset before tree [%p] (caller index %d bytecode index %d)\n", nextSymRef->getReferenceNumber(), insertTree->getNode(), callSite, byteCodeIndex))
+         {
+         TR::Node *storeNode = TR::Node::createWithSymRef(comp->il.opCodeForDirectStore(nextSymRef->getSymbol()->getDataType()), 1, 1,
+                                              TR::Node::createConstDead(insertTree->getNode(), nextSymRef->getSymbol()->getDataType()), nextSymRef);
+         storeNode->setStoredValueIsIrrelevant(true);
+         TR::TreeTop *storeTree = TR::TreeTop::create(comp, storeNode);
+         prev->join(storeTree);
+         storeTree->join(next);
+         prev = storeTree;
+         }
+      }
+   }
+
+/**
+ * \verbatim
+ * OSR dead stores for a transition at BCI 1:N
+ *
+ * CalleeIndex CallerIndex ByteCodeIndex
+ *     0         -1           P
+ *     1         0            M
+ *
+ *        |
+ *        |
+ *   -------------    ---------------------------
+ *   | MAINLINE  |    | OSR INDUCE BLOCK        |
+ *   -------------    ---------------------------
+ *   | OSR Guard |--->| Dead stores for 1:N     |
+ *   -------------    ---------------------------
+ *        |                        |
+ *        |                        |
+ *        V           ---------------------------
+ *                    | OSR CATCH + CODE BLOCKS |
+ *                    ---------------------------
+ *                    | Callee 1 prepareForOSR  |
+ *                    | Dead stores for 0:M     |
+ *                    ---------------------------
+ *                                 |
+ *                                 |
+ *                    ---------------------------
+ *                    | OSR CATCH + CODE BLOCKS |
+ *                    ---------------------------
+ *                    | Callee 0 prepareForOSR  |
+ *                    | Dead stores for -1:P    |
+ *                    ---------------------------
+ *                                 |
+ *                                 |
+ *                    ---------------------------
+ *                    | OSR CATCH + CODE BLOCKS |
+ *                    ---------------------------
+ *                    | Callee -1 prepareForOSR |
+ *                    ---------------------------
+ *                                 |
+ *                                 V
+ * \endverbatim
+ * This function adds the dead stores for the current BCI.
+ * It does not have to concern itself with dead stores for any outer call sites, as they are located in the OSRCodeBlocks for
+ * each frame, as demonstrated in the above example. This is safe as all OSR transitions in a callee will have the same liveness 
+ * in the caller's frame.
+ *
+ * \param byteCodeInfo BCI the OSR transition targets, used to look up dead symrefs in OSRLiveRangeAnalysis results.
+ * \param induceOSRTree Tree to prepend dead stores to.
+ * \param callSymbolForDeadSlots If the BCI's call site does not match the this ResolvedMethodSymbol, allow the correct one to be specified.
+ */
 void
 OMR::ResolvedMethodSymbol::insertStoresForDeadStackSlotsBeforeInducingOSR(TR::Compilation *comp, int32_t inlinedSiteIndex, TR_ByteCodeInfo &byteCodeInfo, TR::TreeTop *induceOSRTree, TR::ResolvedMethodSymbol *callSymbolForDeadSlots)
    {
@@ -1807,72 +1920,11 @@ OMR::ResolvedMethodSymbol::insertStoresForDeadStackSlotsBeforeInducingOSR(TR::Co
       return;
       }
 
-   TR::SymbolReferenceTable *symRefTab = comp->getSymRefTab();
-   int32_t callSite = byteCodeInfo.getCallerIndex();
-   int32_t byteCodeIndex = byteCodeInfo.getByteCodeIndex();
-   TR_OSRMethodData *osrMethodData;
-   if (callSymbolForDeadSlots)
-      osrMethodData = comp->getOSRCompilationData()->findCallerOSRMethodData(comp->getOSRCompilationData()->findOrCreateOSRMethodData(inlinedSiteIndex, callSymbolForDeadSlots));
-   else
-      osrMethodData = comp->getOSRCompilationData()->findOrCreateOSRMethodData(callSite, self());
+   if (!callSymbolForDeadSlots)
+      callSymbolForDeadSlots = self(); 
 
-   traceMsg(comp, "About to do dead store insertion using osrMethodData %p - %d:%d\n", osrMethodData, callSite, byteCodeIndex);
-
-   TR::TreeTop *prev = induceOSRTree->getPrevTreeTop();
-   TR::TreeTop *next = induceOSRTree;
-
-   // The arguments to the induce OSR call may be stashed against its bytecode index.
-   // If so, dead stores must not be generated for these symrefs.
-   TR_BitVector *deadSymRefs = osrMethodData->getLiveRangeInfo(byteCodeIndex);
-   TR_Array<int32_t> *args = osrMethodData->getArgInfo(byteCodeIndex);
-   if (deadSymRefs && args)
-      {
-      for (int32_t i = 0; i < args->size(); ++i)
-         deadSymRefs->reset((*args)[i]);
-      }
-
-   while (osrMethodData)
-      {
-      if (comp->getOption(TR_TraceOSR))
-         traceMsg(comp, "Inserting stores for dead stack slots in method at caller index %d and bytecode index %d for induceOSR call %p\n", callSite, byteCodeIndex, induceOSRTree->getNode());
-
-      if (deadSymRefs)
-         {
-         TR_BitVectorIterator bvi(*deadSymRefs);
-         while (bvi.hasMoreElements())
-            {
-            int32_t nextDeadVar = bvi.getNextElement();
-            TR::SymbolReference *nextSymRef = symRefTab->getSymRef(nextDeadVar);
-
-            if (!nextSymRef->getSymbol()->isParm()
-                && performTransformation(comp, "OSR LIVE RANGE ANALYSIS : Local %d is reset before induceOSR call tree %p (caller index %d bytecode index %d)\n", nextSymRef->getReferenceNumber(), induceOSRTree->getNode(), callSite, byteCodeIndex))
-               {
-               TR::Node *storeNode = TR::Node::createWithSymRef(comp->il.opCodeForDirectStore(nextSymRef->getSymbol()->getDataType()), 1, 1,
-                                                    TR::Node::createConstDead(induceOSRTree->getNode(), nextSymRef->getSymbol()->getDataType()), nextSymRef);
-               storeNode->setStoredValueIsIrrelevant(true);
-               TR::TreeTop *storeTree = TR::TreeTop::create(comp, storeNode);
-               prev->join(storeTree);
-               storeTree->join(next);
-               prev = storeTree;
-               }
-            }
-         }
-
-      TR_ASSERT((callSite == osrMethodData->getInlinedSiteIndex()), "OSR method data and inlined call sites array being walked out of sync\n");
-      if (osrMethodData->getInlinedSiteIndex() > -1)
-         {
-         TR_InlinedCallSite &callSiteInfo = comp->getInlinedCallSite(callSite);
-         callSite = callSiteInfo._byteCodeInfo.getCallerIndex();
-         osrMethodData = comp->getOSRCompilationData()->findCallerOSRMethodData(osrMethodData);
-         byteCodeIndex = callSiteInfo._byteCodeInfo.getByteCodeIndex();
-         deadSymRefs = osrMethodData->getLiveRangeInfo(byteCodeIndex);
-         }
-      else
-         osrMethodData = NULL;
-      }
+   callSymbolForDeadSlots->insertStoresForDeadStackSlots(comp, byteCodeInfo, induceOSRTree);
    }
-
-
 
 TR_OSRPoint *
 OMR::ResolvedMethodSymbol::findOSRPoint(TR_ByteCodeInfo &bcInfo)

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
@@ -146,6 +146,7 @@ public:
    void cleanupUnreachableOSRBlocks(int32_t inlinedSiteIndex, TR::Compilation *comp);
    void insertRematableStoresFromCallSites(TR::Compilation *comp, int32_t siteIndex, TR::TreeTop *induceOSRTree);
    void insertStoresForDeadStackSlotsBeforeInducingOSR(TR::Compilation *comp, int32_t inlinedSiteIndex, TR_ByteCodeInfo &byteCodeInfo, TR::TreeTop *induceOSRTree, TR::ResolvedMethodSymbol *callSymbolForDeadSlots);
+   void insertStoresForDeadStackSlots(TR::Compilation *comp, TR_ByteCodeInfo &byteCodeInfo, TR::TreeTop *insertTree, bool keepStashedArgsLive=true);
    bool sharesStackSlots(TR::Compilation *comp);
    void resetLiveLocalIndices();
 


### PR DESCRIPTION
To reduce OSR overhead, the dead stores for an entire call
site can be placed in its OSR code block, rather than
every OSR induce block. This is done during IlGen for the
callee, as OSR live range analysis would have already been
performed for the caller.