### PR TITLE
Ignore OSR blocks in optimizations

### DIFF
--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -5979,16 +5979,23 @@ int32_t TR_BlockSplitter::perform()
          children->push(unvisitedEdge->getTo());
          continue;
          }
+      mergeNode = toBlock(children->top());
       if (
-            (toBlock(children->top())->hasExceptionPredecessors() == true) ||
-            (children->top()->getPredecessors().size() == 1) ||
-            children->top()->getPredecessors().empty()
+            (mergeNode->hasExceptionPredecessors() == true) ||
+            (mergeNode->getPredecessors().size() == 1) ||
+            mergeNode->getPredecessors().empty()
          )
          {
          children->pop();
          continue;
          }
-      mergeNode = toBlock(children->top());
+      if (mergeNode->isOSRCodeBlock() || mergeNode->isOSRInduceBlock())
+         {
+         if (trace())
+            traceMsg(comp(), "    rejecting osr block_%d\n", mergeNode->getNumber());
+         children->pop();
+         continue;
+         }
       if (!mergeNode->getEntry())
          {
          if (trace())

--- a/compiler/optimizer/VirtualGuardCoalescer.cpp
+++ b/compiler/optimizer/VirtualGuardCoalescer.cpp
@@ -291,7 +291,9 @@ void TR_VirtualGuardTailSplitter::initializeDataStructures()
       TR_SuccessorIterator it(block);
       for (TR::CFGEdge *edge = it.getFirst(); edge; edge = it.getNext())
          {
-         dfsList.add(toBlock(edge->getTo()));
+         TR::Block *to = toBlock(edge->getTo());
+         if (!to->isOSRInduceBlock() && !to->isOSRCatchBlock() && !to->isOSRCodeBlock())
+            dfsList.add(toBlock(edge->getTo()));
          }
       }
 


### PR DESCRIPTION
OSRCode and OSRInduce blocks should not be
candidates for BlockSplitter, as they are
specialized blocks for OSR transitions.