### PR TITLE
Add breakpoint guard to support inlining in FSD

### DIFF
--- a/compiler/arm/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/arm/codegen/ControlFlowEvaluator.cpp
@@ -308,7 +308,7 @@ static bool virtualGuardHelper(TR::Node *node, TR::CodeGenerator *cg)
    {
 #ifdef J9_PROJECT_SPECIFIC
    TR::Compilation *comp = cg->comp();
-   if ((!node->isNopableInlineGuard() && !node->isHCRGuard()) ||
+   if ((!node->isNopableInlineGuard() && !node->isHCRGuard() && !node->isBreakpointGuard()) ||
        !cg->getSupportsVirtualGuardNOPing())
       return false;
 

--- a/compiler/codegen/OMRAheadOfTimeCompile.cpp
+++ b/compiler/codegen/OMRAheadOfTimeCompile.cpp
@@ -173,7 +173,14 @@ void createGuardSiteForRemovedGuard(TR::Compilation *comp, TR::Node *ifNode)
       if (virtualGuard->getKind() == TR_HCRGuard)
          {
          if (comp->getOption(TR_TraceReloCG))
-                     traceMsg(comp, "createGuardSiteForRemovedGuard: removing HCRGuard, no need to add AOTNOPsite, node %p\n", ifNode);
+            traceMsg(comp, "createGuardSiteForRemovedGuard: removing HCRGuard, no need to add AOTNOPsite, node %p\n", ifNode);
+         return;
+         }
+
+      if (virtualGuard->getKind() == TR_BreakpointGuard)
+         {
+         if (comp->getOption(TR_TraceReloCG))
+            traceMsg(comp, "createGuardSiteForRemovedGuard: removing BreakpointGuard, no need to add AOTNOPsite, node %p\n", ifNode);
          return;
          }
 

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -1537,7 +1537,7 @@ OMR::Compilation::addVirtualGuard(TR_VirtualGuard *guard)
 TR_VirtualGuard *
 OMR::Compilation::findVirtualGuardInfo(TR::Node*guardNode)
    {
-   TR_ASSERT(guardNode->isTheVirtualGuardForAGuardedInlinedCall() || guardNode->isOSRGuard() || guardNode->isHCRGuard() || guardNode->isProfiledGuard() || guardNode->isMethodEnterExitGuard(), "@node %p\n", guardNode);
+   TR_ASSERT(guardNode->isTheVirtualGuardForAGuardedInlinedCall() || guardNode->isOSRGuard() || guardNode->isHCRGuard() || guardNode->isProfiledGuard() || guardNode->isMethodEnterExitGuard() || guardNode->isBreakpointGuard(), "@node %p\n", guardNode);
 
    TR_VirtualGuardKind guardKind = TR_NoGuard;
    if (guardNode->isSideEffectGuard())
@@ -1550,6 +1550,8 @@ OMR::Compilation::findVirtualGuardInfo(TR::Node*guardNode)
       guardKind = TR_MethodEnterExitGuard;
    else if (guardNode->isMutableCallSiteTargetGuard())
       guardKind = TR_MutableCallSiteTargetGuard;
+   else if (guardNode->isBreakpointGuard())
+      guardKind = TR_BreakpointGuard;
 
    TR_VirtualGuard *guard = NULL;
 
@@ -1583,7 +1585,8 @@ OMR::Compilation::findVirtualGuardInfo(TR::Node*guardNode)
              (*current)->getKind() != TR_HCRGuard &&
              (*current)->getKind() != TR_OSRGuard &&
              (*current)->getKind() != TR_MethodEnterExitGuard &&
-             (*current)->getKind() != TR_MutableCallSiteTargetGuard)
+             (*current)->getKind() != TR_MutableCallSiteTargetGuard &&
+             (*current)->getKind() != TR_BreakpointGuard)
             {
             guard = *current;
             if (self()->getOption(TR_TraceRelocatableDataDetailsCG))

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -159,6 +159,7 @@ class SymbolReferenceTable
       heapBaseSymbol,
       heapTopSymbol,
       j9methodExtraFieldSymbol,
+      j9methodConstantPoolSymbol,
       startPCLinkageInfoSymbol,
       instanceShapeFromROMClassSymbol,
 

--- a/compiler/compile/VirtualGuard.cpp
+++ b/compiler/compile/VirtualGuard.cpp
@@ -213,6 +213,71 @@ TR_VirtualGuard::createMethodGuard
    return createMethodGuardWithReceiver (kind, comp, calleeIndex, callNode, destination, calleeSymbol, thisClass, callNode->getSecondChild());
    }
 
+/*
+ * generating the actual test node for breakpoint guard
+ */
+TR::Node*
+TR_VirtualGuard::createBreakpointGuardNode
+(TR::Compilation * comp, int16_t calleeIndex,
+ TR::Node* callNode, TR::TreeTop * destination, TR::ResolvedMethodSymbol * calleeSymbol)
+   {
+#ifdef J9_PROJECT_SPECIFIC
+/*
+ * Shape of a breakpoint guard:
+ * iflcmpeq/ificmpeq
+ *    land/iand
+ *       lloadi/iloadi <ConstantPool shadow>
+ *          aconst J9Method
+ *       isBreakpointedBit 
+ *    isBreakpointedBit 
+ */
+   bool is64Bit = TR::Compiler->target.is64Bit();
+   TR::SymbolReferenceTable * symRefTab = comp->getSymRefTab();
+   TR::SymbolReference * fieldSymRef = symRefTab->findOrCreateJ9MethodConstantPoolFieldSymbolRef(offsetof(struct J9Method, constantPool));
+   TR::Node * aconstNode = TR::Node::aconst(callNode, (uintptrj_t)calleeSymbol->getResolvedMethod()->getPersistentIdentifier());
+   TR::Node * constantPool = TR::Node::createWithSymRef(is64Bit? TR::lloadi: TR::iloadi, 1, 1, aconstNode, fieldSymRef);
+   aconstNode->setIsMethodPointerConstant(true);
+   aconstNode->setInlinedSiteIndex(calleeIndex);
+   aconstNode->setByteCodeIndex(0);
+   TR::Node * flagBit = NULL;
+   TR::Node *guard = NULL;
+   if (TR::Compiler->target.is64Bit())
+      {
+      flagBit = TR::Node::create(callNode, TR::lconst, 0, 0);
+      flagBit->setLongInt(comp->fej9()->offsetOfMethodIsBreakpointedBit());
+
+      }
+   else
+      {
+      flagBit = TR::Node::create(callNode, TR::iconst, 0, comp->fej9()->offsetOfMethodIsBreakpointedBit());
+      }
+
+   guard =  TR::Node::createif(is64Bit? TR::iflcmpeq: TR::ificmpeq,
+            TR::Node::create(is64Bit? TR::land: TR::iand, 2, constantPool, flagBit),
+            flagBit,
+            destination);
+   return guard;
+#else
+   TR_ASSERT(false, "need project specific implementation to generate the breakpoint guard node");
+#endif
+   }
+ 
+/*
+ * a breakpoint guard jumps to the slow path if a breakpoint is set for the inlined callee
+ */
+TR::Node*
+TR_VirtualGuard::createBreakpointGuard
+(TR::Compilation * comp, int16_t calleeIndex,
+ TR::Node* callNode, TR::TreeTop * destination, TR::ResolvedMethodSymbol * calleeSymbol)
+   {
+   TR::Node *guard = createBreakpointGuardNode(comp, calleeIndex, callNode, destination, calleeSymbol);
+   TR_VirtualGuard *vg = new (comp->trHeapMemory()) TR_VirtualGuard(TR_FSDTest, TR_BreakpointGuard, comp, callNode, guard, calleeIndex, comp->getCurrentInlinedSiteIndex());
+   setGuardKind(guard, TR_BreakpointGuard, comp);
+
+   traceMsg(comp ,"create breakpoint guard: callNode %p guardNode %p isBreakpointGuard %d\n", callNode, guard, guard->isBreakpointGuard());
+   return guard;
+   }
+
 TR::Node*
 TR_VirtualGuard::createMethodGuardWithReceiver
 (TR_VirtualGuardKind kind, TR::Compilation * comp, int16_t calleeIndex,
@@ -492,6 +557,9 @@ TR_VirtualGuard::setGuardKind(TR::Node * node, TR_VirtualGuardKind kind, TR::Com
          break;
       case TR_OSRGuard:
          node->setIsOSRGuard();
+         break;
+      case TR_BreakpointGuard:
+         node->setIsBreakpointGuard();
          break;
       default:
          TR_ASSERT(kind == TR_NonoverriddenGuard, "Expected TR_NonoverriddenGuard(%d); found %d", (int)TR_NonoverriddenGuard, kind);

--- a/compiler/compile/VirtualGuard.hpp
+++ b/compiler/compile/VirtualGuard.hpp
@@ -56,6 +56,7 @@ enum TR_VirtualGuardKind
    TR_InnerGuard,
    TR_ArrayStoreCheckGuard,
    TR_OSRGuard,
+   TR_BreakpointGuard
    };
 
 enum TR_VirtualGuardTestType
@@ -64,7 +65,8 @@ enum TR_VirtualGuardTestType
    TR_VftTest,
    TR_MethodTest,
    TR_NonoverriddenTest,
-   TR_RubyInlineTest
+   TR_RubyInlineTest,
+   TR_FSDTest /**< used in debugging mode to test if a breakpoint is set for the inlined callee */
    };
 
 
@@ -169,6 +171,9 @@ class TR_VirtualGuard
          TR::TreeTop *destination,
          TR::ResolvedMethodSymbol * symbol,
          TR_OpaqueClassBlock *thisClass);
+
+   static TR::Node *createBreakpointGuard(TR::Compilation * comp, int16_t calleeIndex, TR::Node* callNode, TR::TreeTop * destination, TR::ResolvedMethodSymbol * calleeSymbol);
+   static TR::Node *createBreakpointGuardNode(TR::Compilation * comp, int16_t calleeIndex, TR::Node* callNode, TR::TreeTop * destination, TR::ResolvedMethodSymbol * calleeSymbol);
 
    static void setGuardKind(TR::Node *guard, TR_VirtualGuardKind kind, TR::Compilation * comp);
 

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -7440,7 +7440,7 @@ OMR::Node::resetIsTheVirtualGuardForAGuardedInlinedCall()
 bool
 OMR::Node::isNopableInlineGuard()
    {
-   return self()->isTheVirtualGuardForAGuardedInlinedCall() && !self()->isProfiledGuard();
+   return self()->isTheVirtualGuardForAGuardedInlinedCall() && !self()->isProfiledGuard() && !self()->isBreakpointGuard();
    }
 
 
@@ -7529,13 +7529,32 @@ OMR::Node::setIsOSRGuard()
       _flags.set(osrGuard);
    }
 
+void
+OMR::Node::setIsBreakpointGuard()
+   {
+   TR::Compilation *c = TR::comp();
+   TR_ASSERT(self()->getOpCode().isIf(), "assertion failure");
+   if (performNodeTransformation1(c, "O^O NODE FLAGS: Setting breakpoint guard flag on node %p\n", self()))
+      _flags.set(breakpointGuard);
+   }
+
+bool
+OMR::Node::isBreakpointGuard()
+   {
+   return _flags.testValue(inlineGuardMask, breakpointGuard) && self()->getOpCode().isIf();
+   }
+
+const char *
+OMR::Node::printIsBreakpointGuard()
+   {
+   return self()->isBreakpointGuard() ? "breakpointGuard " : "";
+   }
+
 const char *
 OMR::Node::printIsOSRGuard()
    {
    return self()->isOSRGuard() ? "osrGuard " : "";
    }
-
-
 
 bool
 OMR::Node::childrenWereSwapped()

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -1296,6 +1296,10 @@ public:
    void setIsOSRGuard();
    const char * printIsOSRGuard();
 
+   bool isBreakpointGuard();
+   void setIsBreakpointGuard();
+   const char * printIsBreakpointGuard();
+
    bool childrenWereSwapped();
    void setSwappedChildren(bool v);
 
@@ -1889,6 +1893,7 @@ protected:
       methodEnterExitGuard                  = 0x0000A000,
       directMethodGuard                     = 0x0000B000,
       osrGuard                              = 0x0000C000,
+      breakpointGuard                       = 0x0000D000,
       swappedChildren                       = 0x00020000,
       versionIfWithMaxExpr                  = 0x00010000,
       versionIfWithMinExpr                  = 0x00040000,

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -1530,6 +1530,11 @@ TR_InlinerBase::createVirtualGuard(
    else if (guard->_type == TR_MethodTest)
       return TR_VirtualGuard::createMethodGuard(guard->_kind, comp(), calleeIndex, callNode,
              destination, calleeSymbol, thisClass);
+   else if (guard->_kind == TR_BreakpointGuard)
+      {
+      return TR_VirtualGuard::createBreakpointGuard(comp(), calleeIndex, callNode,
+             destination, calleeSymbol);
+      }
    else
       {
       TR_ASSERT(guard->_type == TR_NonoverriddenTest, "assertion failure");
@@ -1699,6 +1704,26 @@ void TR_InlinerBase::rematerializeCallArguments(TR_TransformInlinedFunction & ti
       }
    }
 
+void
+TR_InlinerBase::addAdditionalGuard(TR::Node *callNode, TR::ResolvedMethodSymbol * calleeSymbol, TR_OpaqueClassBlock * thisClass, TR::Block *prevBlock, TR::Block *inlinedBody, TR::Block *slowPath, TR_VirtualGuardKind kind, TR_VirtualGuardTestType type, bool favourVFTCompare, TR::CFG *callerCFG)
+   {
+   TR::Block *guardBlock = TR::Block::createEmptyBlock(callNode, comp(), prevBlock->getFrequency());
+      callerCFG->addNode(guardBlock);
+      callerCFG->addEdge(prevBlock, guardBlock);
+      callerCFG->addEdge(guardBlock, inlinedBody);
+      callerCFG->addEdge(guardBlock, slowPath);
+      callerCFG->copyExceptionSuccessors(prevBlock, guardBlock);
+      callerCFG->removeEdge(prevBlock, inlinedBody);
+
+      TR_VirtualGuardSelection *guard = new (trStackMemory()) TR_VirtualGuardSelection(kind, type);
+      TR::TreeTop *tt = guardBlock->append(TR::TreeTop::create(comp(),
+                                    createVirtualGuard(callNode, calleeSymbol, slowPath->getEntry(),
+                                       calleeSymbol->getFirstTreeTop()->getNode()->getInlinedSiteIndex(),
+                                       thisClass, favourVFTCompare, guard)));
+      guardBlock->setDoNotProfile();
+      prevBlock->getExit()->join(guardBlock->getEntry());
+      guardBlock->getExit()->join(inlinedBody->getEntry());
+   }
 
 TR::TreeTop *
 TR_InlinerBase::addGuardForVirtual(
@@ -1832,6 +1857,11 @@ TR_InlinerBase::addGuardForVirtual(
       }
    else if (!disableHCRGuards && comp()->getHCRMode() != TR::none)
       createdHCRGuard = true;
+
+   if (comp()->getOption(TR_FullSpeedDebug) && guard->_kind != TR_BreakpointGuard)
+      {
+      addAdditionalGuard(callNode, calleeSymbol, thisClass, block1, block2, block4, TR_BreakpointGuard, TR_FSDTest, false /*favourVftCompare*/,callerCFG);
+      }
 
    bool appendTestToBlock1 = false;
    if (guard->_kind == TR_InnerGuard)
@@ -3875,6 +3905,11 @@ bool TR_DirectCallSite::findCallSiteTarget (TR_CallStack* callStack, TR_InlinerB
       {
       tempreceiverClass = _initialCalleeMethod->classOfMethod();
       guard = new (comp()->trHeapMemory()) TR_VirtualGuardSelection(TR_HCRGuard, TR_NonoverriddenTest);
+      }
+   else if (comp()->getOption(TR_FullSpeedDebug))
+      {
+      tempreceiverClass = _receiverClass;
+      guard = new (comp()->trHeapMemory()) TR_VirtualGuardSelection(TR_BreakpointGuard, TR_FSDTest);
       }
    else
       {

--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -356,6 +356,8 @@ class TR_InlinerBase: public TR_HasRandomGenerator
       TR::TreeTop * addGuardForVirtual(TR::ResolvedMethodSymbol *, TR::ResolvedMethodSymbol *, TR::TreeTop *, TR::Node *,
                                       TR_OpaqueClassBlock *, TR::TreeTop *, TR::TreeTop *, TR::TreeTop *, TR_TransformInlinedFunction&,
                                       List<TR::SymbolReference> &, TR_VirtualGuardSelection *, TR::TreeTop **, TR_CallTarget *calltarget=0);
+
+      void addAdditionalGuard(TR::Node *callNode, TR::ResolvedMethodSymbol * calleeSymbol, TR_OpaqueClassBlock *thisClass, TR::Block *prevBlock, TR::Block *inlinedBody, TR::Block *slowPath, TR_VirtualGuardKind kind, TR_VirtualGuardTestType type, bool favourVftCompare, TR::CFG *callerCFG);
       void rematerializeCallArguments(TR_TransformInlinedFunction & tif,
    TR_VirtualGuardSelection *guard, TR::Node *callNode, TR::Block *block1, TR::TreeTop *rematPoint);
       void replaceCallNode(TR::ResolvedMethodSymbol *, TR::Node *, rcount_t, TR::TreeTop *, TR::Node *, TR::Node *);

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -5564,7 +5564,7 @@ void TR_LoopVersioner::buildConditionalTree(List<TR::TreeTop> *nullCheckTrees, L
       TR::Node *dupThisChild = NULL;
 
       if (conditionalNode->isTheVirtualGuardForAGuardedInlinedCall() &&
-          !conditionalNode->isNonoverriddenGuard()  && !conditionalNode->isHCRGuard())
+          !conditionalNode->isNonoverriddenGuard()  && !conditionalNode->isHCRGuard() && !conditionalNode->isBreakpointGuard())
          {
          bool searchReqd = true;
          TR::Node *nextRealNode = NULL;

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1046,6 +1046,7 @@ TR_Debug::nodePrintAllFlags(TR::Node *node, TR_PrettyPrinterString &output)
    output.append(format, node->printIsDummyGuard()        );
    output.append(format, node->printIsHCRGuard()          );
    output.append(format, node->printIsOSRGuard()          );
+   output.append(format, node->printIsBreakpointGuard()          );
    output.append(format, node->printIsMutableCallSiteTargetGuard() );
    output.append(format, node->printIsByteToByteTranslate());
    output.append(format, node->printIsByteToCharTranslate());
@@ -2127,6 +2128,7 @@ static const char *commonNonhelperSymbolNames[] =
    "<heapBase>",
    "<heapTop>",
    "<j9methodExtraField>",
+   "<j9methodConstantPoolField>",
    "<startPCLinkageInfo>",
    "<instanceShapeFromROMClass>",
    "<synchronizedFieldLoad>",
@@ -4544,6 +4546,8 @@ TR_Debug::getVirtualGuardKindName(TR_VirtualGuardKind kind)
          return "ArrayStoreCheckGuard";
       case TR_OSRGuard:
          return "OSRGuard";
+      case TR_BreakpointGuard:
+         return "BreakpointGuard";
       default:
          break;
       }
@@ -4566,6 +4570,8 @@ TR_Debug::getVirtualGuardTestTypeName(TR_VirtualGuardTestType testType)
          return "NonoverriddenTest";
       case TR_RubyInlineTest:
          return "RubyInlineTest";
+      case TR_FSDTest:
+         return "FSDTest";
       }
    TR_ASSERT(0, "Unknown virtual guard test type");
    return "(unknown virtual guard test type)";


### PR DESCRIPTION
This changeset is part of the code to add breakpoint guards to support
inlining in FSD mode.The breakpoint guard reads a bit from
a field of the callee method which is set when any breakpoints
are set for that particular method.

This changeset create the actual breakpoint guard and add it to each
callee under FSD mode.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>