### PR TITLE
Remove allocator pointer in CfgNode

### DIFF
--- a/compiler/env/TRMemory.hpp
+++ b/compiler/env/TRMemory.hpp
@@ -719,6 +719,11 @@ TR_HeapMemory::allocate(size_t size, TR_MemoryBase::ObjectType ot)
    void * operator new[] (size_t s, TR_Memory * m, TR_AllocationKind k) \
       {void *alloc = m->allocateMemory(s, k, a); return alloc; } \
    void operator delete[] (void *p, TR_Memory * m, TR_AllocationKind k) { m->freeMemory(p, k, a); } \
+   void * operator new(size_t size, TR::Region &region) { return region.allocate(size); } \
+   void operator delete(void * p, TR::Region &region) { region.deallocate(p); } \
+   void * operator new[](size_t size, TR::Region &region) { return region.allocate(size); } \
+   void operator delete[](void * p, TR::Region &region) { region.deallocate(p); } \
+
 
 class TRPersistentMemoryAllocator
    {

--- a/compiler/env/TypedAllocator.hpp
+++ b/compiler/env/TypedAllocator.hpp
@@ -63,6 +63,7 @@ public:
       return !(left == right);
       }
 
+   untyped_allocator backingAllocator() { return _backingAllocator; }
 protected:
    explicit typed_allocator( untyped_allocator backingAllocator ) throw() : _backingAllocator(backingAllocator) {}
 

--- a/compiler/il/OMRBlock.hpp
+++ b/compiler/il/OMRBlock.hpp
@@ -289,7 +289,7 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
    void setInstructionBoundaries(uint32_t startPC, uint32_t endPC);
    InstructionBoundaries & getInstructionBoundaries()  { return _instructionBoundaries; }
 
-   void addExceptionRangeForSnippet(uint32_t startPC, uint32_t endPC);
+   void addExceptionRangeForSnippet(OMR::Compilation *comp, uint32_t startPC, uint32_t endPC);
    InstructionBoundaries * getFirstSnippetBoundaries() { return _snippetBoundaries.getFirst(); }
 
    TR::Instruction *getFirstInstruction()                         { return _firstInstruction; }

--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -425,16 +425,21 @@ TR_OrderedExceptionHandlerIterator::getCurrent()
    }
 
 
-TR::CFGEdge::CFGEdge(TR::CFGNode *pF, TR::CFGNode *pT, TR_AllocationKind allocKind)
+TR::CFGEdge::CFGEdge(TR::CFGNode *pF, TR::CFGNode *pT)
    : _pFrom(pF), _pTo(pT), _visitCount(0), _frequency(0), _id(-1)
    {}
 
 TR::CFGEdge * TR::CFGEdge::createEdge (TR::CFGNode *pF, TR::CFGNode *pT, TR_Memory* trMemory, TR_AllocationKind allocKind)
    {
-   TR::CFGEdge * newEdge =  new (trMemory, allocKind) TR::CFGEdge(pF, pT, allocKind);
+   return TR::CFGEdge::createEdge(pF, pT, allocKind == heapAlloc ? trMemory->heapMemoryRegion() : trMemory->currentStackRegion());
+   }
 
-   pF->addSuccessor(newEdge, allocKind);
-   pT->addPredecessor(newEdge, allocKind);
+TR::CFGEdge * TR::CFGEdge::createEdge (TR::CFGNode *pF, TR::CFGNode *pT, TR::Region &region)
+   {
+   TR::CFGEdge * newEdge =  new (region) TR::CFGEdge(pF, pT);
+
+   pF->addSuccessor(newEdge);
+   pT->addPredecessor(newEdge);
    if (pT->getFrequency() >= 0)
       newEdge->setFrequency(pT->getFrequency());
    if ((pF->getFrequency() >= 0) && (pF->getFrequency() < newEdge->getFrequency()))
@@ -445,10 +450,15 @@ TR::CFGEdge * TR::CFGEdge::createEdge (TR::CFGNode *pF, TR::CFGNode *pT, TR_Memo
 
 TR::CFGEdge * TR::CFGEdge::createExceptionEdge (TR::CFGNode *pF, TR::CFGNode *pT, TR_Memory* trMemory, TR_AllocationKind allocKind)
    {
-   TR::CFGEdge * newEdge =  new (trMemory, allocKind) TR::CFGEdge(pF, pT, allocKind);
+   return TR::CFGEdge::createExceptionEdge(pF, pT, allocKind == heapAlloc ? trMemory->heapMemoryRegion() : trMemory->currentStackRegion());
+   }
 
-   pF->addExceptionSuccessor(newEdge, allocKind);
-   pT->addExceptionPredecessor(newEdge, allocKind);
+TR::CFGEdge * TR::CFGEdge::createExceptionEdge (TR::CFGNode *pF, TR::CFGNode *pT, TR::Region &region)
+   {
+   TR::CFGEdge * newEdge =  new (region) TR::CFGEdge(pF, pT);
+
+   pF->addExceptionSuccessor(newEdge);
+   pT->addExceptionPredecessor(newEdge);
 
    return newEdge;
    }

--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -370,7 +370,7 @@ bool OMR::alwaysTrue(TR::CFGEdge * e)
    }
 
 
-TR_OrderedExceptionHandlerIterator::TR_OrderedExceptionHandlerIterator(TR::Block * tryBlock)
+TR_OrderedExceptionHandlerIterator::TR_OrderedExceptionHandlerIterator(TR::Block * tryBlock, TR::Region &region)
    {
    if (tryBlock->getExceptionSuccessors().empty())
       _dim = 0;
@@ -387,7 +387,7 @@ TR_OrderedExceptionHandlerIterator::TR_OrderedExceptionHandlerIterator(TR::Block
          }
 
       _dim = handlerDim * inlineDim;
-      _handlers = (TR::Block **)tryBlock->trMemory()->allocateStackMemory(_dim*sizeof(TR::Block *));
+      _handlers = (TR::Block **)region.allocate(_dim*sizeof(TR::Block *));
       memset(_handlers, 0, _dim*sizeof(TR::Block *));
 
       for (auto e = tryBlock->getExceptionSuccessors().begin(); e != tryBlock->getExceptionSuccessors().end(); ++e)
@@ -535,7 +535,6 @@ TR::CFGNode::CFGNode(TR_Memory * m)
      _frequency(-1),
      _forwardTraversalIndex(-1),
      _backwardTraversalIndex(-1),
-     _m(m),
      _successors(m->heapMemoryRegion()),
      _predecessors(m->heapMemoryRegion()),
      _exceptionSuccessors(m->heapMemoryRegion()),
@@ -548,11 +547,34 @@ TR::CFGNode::CFGNode(int32_t n, TR_Memory * m)
      _frequency(-1),
      _forwardTraversalIndex(-1),
      _backwardTraversalIndex(-1),
-     _m(m),
      _successors(m->heapMemoryRegion()),
      _predecessors(m->heapMemoryRegion()),
      _exceptionSuccessors(m->heapMemoryRegion()),
      _exceptionPredecessors(m->heapMemoryRegion())
+   {
+   }
+TR::CFGNode::CFGNode(TR::Region &region)
+   : _nodeNumber(-1),
+     _visitCount(0),
+     _frequency(-1),
+     _forwardTraversalIndex(-1),
+     _backwardTraversalIndex(-1),
+     _successors(region),
+     _predecessors(region),
+     _exceptionSuccessors(region),
+     _exceptionPredecessors(region)
+   {
+   }
+TR::CFGNode::CFGNode(int32_t n, TR::Region &region)
+   : _nodeNumber(n),
+     _visitCount(0),
+     _frequency(-1),
+     _forwardTraversalIndex(-1),
+     _backwardTraversalIndex(-1),
+     _successors(region),
+     _predecessors(region),
+     _exceptionSuccessors(region),
+     _exceptionPredecessors(region)
    {
    }
 

--- a/compiler/infra/OMRCfg.hpp
+++ b/compiler/infra/OMRCfg.hpp
@@ -440,7 +440,7 @@ class TR_OrderedExceptionHandlerIterator
 public:
    TR_ALLOC(TR_Memory::OrderedExceptionHandlerIterator)
 
-   TR_OrderedExceptionHandlerIterator(TR::Block * tryBlock);
+   TR_OrderedExceptionHandlerIterator(TR::Block * tryBlock, TR::Region &region);
 
    TR::Block * getFirst();
 

--- a/compiler/infra/TRCfgEdge.hpp
+++ b/compiler/infra/TRCfgEdge.hpp
@@ -45,7 +45,9 @@ class CFGEdge : public TR_Link<CFGEdge>
    //
 
    static CFGEdge * createEdge (CFGNode *pF, CFGNode *pT, TR_Memory* trMemory, TR_AllocationKind allocKind = heapAlloc);
+   static CFGEdge * createEdge (CFGNode *pF, CFGNode *pT, TR::Region &region);
    static CFGEdge * createExceptionEdge (CFGNode *pF, CFGNode *pT, TR_Memory* trMemory, TR_AllocationKind allocKind = heapAlloc);
+   static CFGEdge * createExceptionEdge (CFGNode *pF, CFGNode *pT, TR::Region &region);
 
    CFGNode *getFrom() {return _pFrom;}
    CFGNode *getTo()   {return _pTo;}
@@ -89,7 +91,7 @@ class CFGEdge : public TR_Link<CFGEdge>
    private:
 
    //keeping this c-tor private since there is no real need to make it public right now
-   CFGEdge(CFGNode *pF, CFGNode *pT, TR_AllocationKind allocKind = heapAlloc);
+   CFGEdge(CFGNode *pF, CFGNode *pT);
 
    enum  // flags
       {

--- a/compiler/infra/TRCfgNode.hpp
+++ b/compiler/infra/TRCfgNode.hpp
@@ -50,10 +50,8 @@ class CFGNode : public ::TR_Link1<CFGNode>
 
    CFGNode(TR_Memory * m);
    CFGNode(int32_t n, TR_Memory * m);
-
-   TR_Memory *        trMemory()  { return _m; }
-   TR_HeapMemory   trHeapMemory() { return trMemory(); }
-   TR_StackMemory trStackMemory() { return trMemory(); }
+   CFGNode(TR::Region &region);
+   CFGNode(int32_t n, TR::Region &region);
 
    TR::CFGEdgeList& getSuccessors()            {return _successors;}
    TR::CFGEdgeList& getPredecessors()          {return _predecessors;}
@@ -141,7 +139,6 @@ class CFGNode : public ::TR_Link1<CFGNode>
    virtual TR_StructureSubGraphNode *asStructureSubGraphNode() {return NULL;}
 
    private:
-   TR_Memory * _m;
    template <typename FUNC>
    CFGEdge * getEdgeMatchingNodeInAList (CFGNode * n, TR::CFGEdgeList& list, FUNC blockGetter);
    static CFGNode * fromBlockGetter (CFGEdge * e) {return e->getFrom();};

--- a/compiler/optimizer/Structure.hpp
+++ b/compiler/optimizer/Structure.hpp
@@ -26,6 +26,7 @@
 #include "compile/Compilation.hpp"  // for Compilation
 #include "cs2/sparsrbit.h"          // for ASparseBitVector<>::Cursor
 #include "env/TRMemory.hpp"         // for TR_Memory, etc
+#include "env/Region.hpp"         // for TR_Memory, etc
 #include "il/Block.hpp"             // for Block
 #include "il/DataTypes.hpp"         // for TR_YesNoMaybe
 #include "il/Node.hpp"              // for Node, vcount_t
@@ -278,8 +279,14 @@ class TR_StructureSubGraphNode : public TR::CFGNode
    TR_StructureSubGraphNode(TR_Structure *s)
       : TR::CFGNode(s->getNumber(), s->trMemory()), _structure(s), _index(0) {s->setSubGraphNode(this);}
 
+   TR_StructureSubGraphNode(TR_Structure *s, TR::Region &region)
+      : TR::CFGNode(s->getNumber(), region), _structure(s), _index(0) {s->setSubGraphNode(this);}
+
    TR_StructureSubGraphNode(int32_t n, TR_Memory * m)
       : TR::CFGNode(n, m), _structure(0), _index (0) {}
+
+   TR_StructureSubGraphNode(int32_t n, TR::Region &r)
+      : TR::CFGNode(n, r), _structure(0), _index (0) {}
 
    static TR_StructureSubGraphNode *create(int32_t num, TR_RegionStructure *region);
 

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -3361,7 +3361,7 @@ TR::Node *constrainThrow(OMR::ValuePropagation *vp, TR::Node *node)
       printf("\n\n throw type %.*s\n", len, sig);
       }
 
-   TR_OrderedExceptionHandlerIterator oehi(vp->_curBlock);
+   TR_OrderedExceptionHandlerIterator oehi(vp->_curBlock, vp->comp()->trMemory()->currentStackRegion());
    for (TR::Block *catchBlock = oehi.getFirst(); catchBlock; catchBlock = oehi.getNext())
       {
       if (catchBlock->isOSRCatchBlock())

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -2184,7 +2184,7 @@ void OMR::Power::CodeGenerator::doBinaryEncoding()
                          (*oiIterator)->getFirstInstruction()->getNode()->getSymbolReference()->canCauseGC();
 
          if (needsETE && block && !block->getExceptionSuccessors().empty())
-            block->addExceptionRangeForSnippet(startOffset, endOffset);
+            block->addExceptionRangeForSnippet(self()->comp(), startOffset, endOffset);
 
          ++oiIterator;
          }

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -2003,7 +2003,7 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
       bool      needsETE = (*oiIterator)->getCallNode() && (*oiIterator)->getCallNode()->getSymbolReference()->canCauseGC();
 
       if (needsETE && block && !block->getExceptionSuccessors().empty())
-         block->addExceptionRangeForSnippet(startOffset, endOffset);
+         block->addExceptionRangeForSnippet(self()->comp(), startOffset, endOffset);
 
       ++oiIterator;
       }

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -6566,7 +6566,7 @@ OMR::Z::CodeGenerator::doBinaryEncoding()
             uint32_t startOffset = (*oiIterator)->getFirstInstruction()->getBinaryEncoding() - self()->getCodeStart();
             uint32_t endOffset   = (*oiIterator)->getAppendInstruction()->getBinaryEncoding() - self()->getCodeStart();
 
-            block->addExceptionRangeForSnippet(startOffset, endOffset);
+            block->addExceptionRangeForSnippet(self()->comp(), startOffset, endOffset);
             }
 
          ++oiIterator;


### PR DESCRIPTION
To simplify memory management, CfgNodes should
not have a pointer to the allocator. Instead,
the allocator can be accessed from the CFG
or compilation object. Furthermore, a region
can be specified when creating a CfgNode.