### PR TITLE
Tracegen tool fixes

### DIFF
--- a/tools/tracegen/TraceHeaderWriter.cpp
+++ b/tools/tracegen/TraceHeaderWriter.cpp
@@ -390,7 +390,8 @@ TraceHeaderWriter::tpAssert(FILE *fd, unsigned int overhead, unsigned int test, 
 	if (0 <= fprintf(fd, TP_ASSERT_TEMPLATE
 			, overhead
 			, testmacro
-			, name, parmStringNoLeadingComma
+			, name
+			, envParam ? "thr" : parmStringNoLeadingComma
 			, module
 			, id
 			, module
@@ -410,7 +411,7 @@ TraceHeaderWriter::tpAssert(FILE *fd, unsigned int overhead, unsigned int test, 
 			, conditionStr
 			, testnop
 			, name
-			, parmStringNoLeadingComma
+			, envParam ? "thr" : parmStringNoLeadingComma
 			, module
 			, id)) {
 		rc = RC_OK;


### PR DESCRIPTION
Tracepoints/TraceAssert normally have a default parameter which is
the current thread.  There is an option NoEnv to remove the default
current thread parameter.  The template for generating the TraceAssert
was not taking the envParam into consideration.  This means that
TraceAsserts which did not use NoEnv were generating incorrect data.
The fix is to take it into consideration and generate the correct code
for these asserts.

Header file creation now throws an error if the Trace point is not
properly formatted rather than being generated and then later causing
a compilation error.

Signed-off-by: LinaSerry <linaserry@cmail.carleton.ca>