### PR TITLE
CMake: Change glue to be interface library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,13 +32,13 @@ set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules" ${CMAKE_MODULE_PATH})
 
 
 ###
-### Getting the glue directory
+### Getting the glue target
 ###
-
-if (NOT DEFINED OMR_GLUE)
-    set(OMR_GLUE "./example/glue" CACHE PATH "The glue directory")
+if (NOT DEFINED OMR_GLUE_TARGET)
+	set(OMR_GLUE_TARGET "omr_example_glue" CACHE STRING "The glue target, must be an interface library")
     message(STATUS "Glue not set, defaulting to example glue")
 endif()
+add_subdirectory(example/glue)
 
 # TODO: OMR_EXAMPLE flag
 # TODO: OMR_RTTI flag
@@ -84,6 +84,17 @@ endif()
 configure_file(./omrcfg.CMakeTemplate.h omrcfg.h)
 configure_file(./omrversionstrings.CMakeTemplate.h omrversionstrings.h)
 
+add_library(omrglue STATIC)
+# lInk as private since we dont want the interface sources to propogate
+target_link_libraries(omrglue
+	PUBLIC
+	omrgc
+	PRIVATE
+	${OMR_GLUE_TARGET}
+)
+#but we need to propogate the include paths
+target_include_directories(omrglue INTERFACE $<TARGET_PROPERTY:${OMR_GLUE_TARGET},INTERFACE_INCLUDE_DIRECTORIES>)
+
 add_subdirectory(tools)
 # Yeah, its dumb doing this here. Read note in tools/CMakeLists.txt
 if(CMAKE_CROSSCOMPILING)
@@ -103,7 +114,8 @@ add_subdirectory(fvtest)
 
 if(OMR_GC)
   add_subdirectory(gc)
-  add_subdirectory("${OMR_GLUE}")
+  # if we are building the gc, add gc headers to omrglue
+  target_include_directories(omrglue PRIVATE $<TARGET_PROPERTY:omrgc,INCLUDE_DIRECTORIES>)
 endif(OMR_GC)
 
 if(OMR_JITBUILDER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,14 +85,14 @@ configure_file(./omrcfg.CMakeTemplate.h omrcfg.h)
 configure_file(./omrversionstrings.CMakeTemplate.h omrversionstrings.h)
 
 add_library(omrglue STATIC)
-# lInk as private since we dont want the interface sources to propogate
+# Link as private since we dont want the interface sources to propagate
 target_link_libraries(omrglue
 	PUBLIC
 	omrgc
 	PRIVATE
 	${OMR_GLUE_TARGET}
 )
-#but we need to propogate the include paths
+#but we need to propagate the include paths
 target_include_directories(omrglue INTERFACE $<TARGET_PROPERTY:${OMR_GLUE_TARGET},INTERFACE_INCLUDE_DIRECTORIES>)
 
 add_subdirectory(tools)

--- a/example/glue/CMakeLists.txt
+++ b/example/glue/CMakeLists.txt
@@ -16,27 +16,30 @@
 #    Multiple authors (IBM Corp.) - initial implementation and documentation
 ###############################################################################
 
-add_library(omrglue STATIC
-	CollectorLanguageInterfaceImpl.cpp
-	CompactSchemeFixupObject.cpp
-	EnvironmentDelegate.cpp
-	FrequentObjectsStats.cpp
-	GlobalCollectorDelegate.cpp
-	LanguageVMGlue.c
-	MarkingDelegate.cpp
-	ObjectIterator.cpp
-	ObjectModelDelegate.cpp
-	omrExampleVM.cpp
-	Profiling.c
-	StartupManagerImpl.cpp
-	UtilGlue.c
-	VerboseManagerImpl.cpp
-	omrExampleVM.cpp
+add_library(omr_example_glue INTERFACE)
+target_sources(omr_example_glue INTERFACE
+	${CMAKE_CURRENT_SOURCE_DIR}/CollectorLanguageInterfaceImpl.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/CompactSchemeFixupObject.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/EnvironmentDelegate.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/FrequentObjectsStats.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/GlobalCollectorDelegate.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/LanguageVMGlue.c
+	${CMAKE_CURRENT_SOURCE_DIR}/MarkingDelegate.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/ObjectIterator.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/ObjectModelDelegate.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/omrExampleVM.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/Profiling.c
+	${CMAKE_CURRENT_SOURCE_DIR}/StartupManagerImpl.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/UtilGlue.c
+	${CMAKE_CURRENT_SOURCE_DIR}/VerboseManagerImpl.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/omrExampleVM.cpp
 )
 
-target_include_directories(omrglue PUBLIC . ..)
+target_include_directories(omr_example_glue INTERFACE
+	${CMAKE_CURRENT_SOURCE_DIR}
+	${CMAKE_CURRENT_SOURCE_DIR}/..
+)
 
-target_link_libraries(omrglue PUBLIC
-	omrgc
+target_link_libraries(omr_example_glue INTERFACE
 	j9thrstatic
 )


### PR DESCRIPTION
Instead of taking cache variable OMR_GLUE which points to directory
with glue, now take OMR_GLUE_TARGET which contains name of glue target

Old system was limited to having glue reside in a subdirectory of
omr, which is not particularily useful.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>