### PR TITLE
Remove enableAESInHardwareTransformations()

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1377,7 +1377,6 @@ class OMR_EXTENSIBLE CodeGenerator
    int32_t arrayInitMinimumNumberOfBytes() {return 8;} // no virt
 
    int32_t getMaxPatchableInstructionLength() { return 0; } // no virt
-   bool enableAESInHardwareTransformations() {return false;}
 
    TR::Instruction *saveOrRestoreRegisters(TR_BitVector *regs, TR::Instruction *cursor, bool doSaves);
 

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1926,15 +1926,6 @@ OMR::Power::CodeGenerator::isTargetSnippetOrOutOfLine(TR::Instruction *instr, TR
       return false;
    }
 
-bool OMR::Power::CodeGenerator::enableAESInHardwareTransformations()
-   {
-   if (  (TR::Compiler->target.cpu.getPPCSupportsAES() || (TR::Compiler->target.cpu.getPPCSupportsVMX() && TR::Compiler->target.cpu.getPPCSupportsVSX())) &&
-         !self()->comp()->getOptions()->getOption(TR_DisableAESInHardware))
-      return true;
-   else
-      return false;
-   }
-
 bool OMR::Power::CodeGenerator::supportsAESInstructions()
    {
     if ( TR::Compiler->target.cpu.getPPCSupportsAES() && !self()->comp()->getOptions()->getOption(TR_DisableAESInHardware))

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -263,7 +263,6 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    void processIncomingParameterUsage(TR_BitVector **registerUsageInfo, int32_t blockNum);
    void updateSnippetMapWithRSD(TR::Instruction *cur, int32_t rsd);
    bool isTargetSnippetOrOutOfLine(TR::Instruction *instr, TR::Instruction **start, TR::Instruction **end);
-   bool enableAESInHardwareTransformations();
    virtual bool supportsAESInstructions();
 
    virtual bool getSupportsTLE()

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -960,15 +960,6 @@ bool OMR::X86::CodeGenerator::supportsFS0VMThreadRematerialization()
 #endif
    }
 
-bool OMR::X86::CodeGenerator::enableAESInHardwareTransformations()
-   {
-   if (TR::CodeGenerator::getX86ProcessorInfo().supportsAESNI() && !self()->comp()->getOptions()->getOption(TR_DisableAESInHardware) && !self()->comp()->getCurrentMethod()->isJNINative())
-      return true;
-   else
-      return false;
-   }
-
-
 #undef ALLOWED_TO_REMATERIALIZE
 #undef CAN_REMATERIALIZE
 

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -349,7 +349,6 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    void processIncomingParameterUsage(TR_BitVector **registerUsageInfo, int32_t blockNum);
    void updateSnippetMapWithRSD(TR::Instruction *cur, int32_t rsd);
    bool isTargetSnippetOrOutOfLine(TR::Instruction *instr, TR::Instruction **start, TR::Instruction **end);
-   bool enableAESInHardwareTransformations();
 
    TR::SymbolReference *getWordConversionTemp();
    TR::SymbolReference *getDoubleWordConversionTemp();


### PR DESCRIPTION
This codegen query is not used in OMR.  It will be moved to
its downstream project.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>