### PR TITLE
Fix casting error on windows

### DIFF
--- a/tools/tracegen/TDFParser.cpp
+++ b/tools/tracegen/TDFParser.cpp
@@ -340,7 +340,7 @@ TDFParser::getTemplate(const char *line, const char *key)
 	char *format = NULL;
 	size_t len = 0;
 	/*
-	 * Number of quotes in the string. Must be 2 when the string is fully parsed to ensure there is an opening and closing quote.
+	 * Number of quotes in the string. Must be even when the string is fully parsed to ensure there is an opening and closing quote.
 	 */
 	int count = 0;
 
@@ -365,15 +365,15 @@ TDFParser::getTemplate(const char *line, const char *key)
 	}
 
 	len = (pos - vpos);
-	for (int i = strlen(line); i >= 0; i--){
-		if (line[i] == ' '){
-			continue;
-		}
-		else if (line[i] == '\"'){
+	for (size_t i = 0; i < strlen(line); i++) {
+		if (line[i] == '\"') {
 			count++;
 		}
 	}
-	if (!(count % 2 == 0)){
+	/*
+	 * If number of quotes is not even, then there must have been an opening quote without a closing quote
+	 */
+	if (count % 2 != 0) {
 		goto failed;
 	}
 


### PR DESCRIPTION
casting strlen in forloop to be an int to fix
possible loss of data error on windows plateform

Signed-off-by: LinaSerry <linaserry@cmail.carleton.ca>