### PR TITLE
[Mem1] Allocate using regions in TR_List and TR_BitVector

### DIFF
--- a/compiler/codegen/GCStackMap.hpp
+++ b/compiler/codegen/GCStackMap.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -79,6 +79,7 @@ public :
 
 class TR_InternalPointerMap
    {
+   TR_Memory *_trMemory;
    List<TR_InternalPointerPair> _internalPtrPairs;
    int32_t _numDistinctPinningArrays;
    int32_t _size;
@@ -89,12 +90,13 @@ public:
    TR_ALLOC(TR_Memory::InternalPointerMap)
 
    TR_InternalPointerMap(TR_Memory * m)
-      : _numInternalPtrs(0),
+      : _trMemory(m),
+        _numInternalPtrs(0),
         _numDistinctPinningArrays(0),
         _internalPtrPairs(m),
         _size(0) {}
 
-   TR_Memory *   trMemory()     { return _internalPtrPairs.trMemory(); }
+   TR_Memory *   trMemory()     { return _trMemory; }
    TR_HeapMemory trHeapMemory() { return trMemory(); }
 
    TR_InternalPointerMap *clone()

--- a/compiler/compile/VirtualGuard.cpp
+++ b/compiler/compile/VirtualGuard.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -122,7 +122,7 @@ TR_VirtualGuard::addNOPSite()
    {
    TR_ASSERT(isNopable() || mergedWithHCRGuard(), "assertion failure");
 
-   TR_VirtualGuardSite *site = new (trHeapMemory()) TR_VirtualGuardSite;
+   TR_VirtualGuardSite *site = new (_sites.getRegion()) TR_VirtualGuardSite;
 
    _sites.add(site);
    return site;

--- a/compiler/compile/VirtualGuard.hpp
+++ b/compiler/compile/VirtualGuard.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -241,9 +241,6 @@ class TR_VirtualGuard
    bool                    canBeRemoved()   { return !_cannotBeRemoved; }
 
 #ifdef J9_PROJECT_SPECIFIC
-   TR_Memory *             trMemory()       { return _sites.trMemory(); }
-   TR_HeapMemory           trHeapMemory()   { return trMemory(); }
-
    TR_VirtualGuardSite *addNOPSite();
    List<TR_VirtualGuardSite> &getNOPSites()   { return _sites; }
 #endif

--- a/compiler/env/ExceptionTable.cpp
+++ b/compiler/env/ExceptionTable.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -58,7 +58,7 @@ TR_ExceptionTableEntryIterator::TR_ExceptionTableEntryIterator(TR::Compilation *
          List<TR_ExceptionTableEntry> & tableEntries =
             _tableEntries[catchBlock->getInlineDepth()][catchBlock->getHandlerIndex()];
 
-         tableEntries._trMemory = comp->trMemory();
+         tableEntries.setRegion(comp->trMemory()->heapMemoryRegion());
 
          uint32_t catchType = catchBlock->getCatchType();
          TR_ResolvedMethod * method = catchBlock->getOwningMethod();

--- a/compiler/env/TRMemory.hpp
+++ b/compiler/env/TRMemory.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -719,6 +719,11 @@ TR_HeapMemory::allocate(size_t size, TR_MemoryBase::ObjectType ot)
    void * operator new[] (size_t s, TR_Memory * m, TR_AllocationKind k) \
       {void *alloc = m->allocateMemory(s, k, a); return alloc; } \
    void operator delete[] (void *p, TR_Memory * m, TR_AllocationKind k) { m->freeMemory(p, k, a); } \
+   void * operator new(size_t size, TR::Region &region) { return region.allocate(size); } \
+   void operator delete(void * p, TR::Region &region) { region.deallocate(p); } \
+   void * operator new[](size_t size, TR::Region &region) { return region.allocate(size); } \
+   void operator delete[](void * p, TR::Region &region) { region.deallocate(p); } \
+
 
 class TRPersistentMemoryAllocator
    {

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -96,11 +96,12 @@ TR::TreeTop *findEndTreeTop(TR::ResolvedMethodSymbol *rms)
 void
 OMR::ResolvedMethodSymbol::initForCompilation(TR::Compilation *comp)
    {
-   self()->getParameterList()._trMemory = comp->trMemory();
-   self()->getAutomaticList()._trMemory = comp->trMemory();
+   TR::Region &heapRegion = comp->trMemory()->heapMemoryRegion();
+   self()->getParameterList().setRegion(heapRegion);
+   self()->getAutomaticList().setRegion(heapRegion);
 
-   self()->getVariableSizeSymbolList()._trMemory = comp->trMemory();
-   self()->getTrivialDeadTreeBlocksList()._trMemory = comp->trMemory();
+   self()->getVariableSizeSymbolList().setRegion(heapRegion);
+   self()->getTrivialDeadTreeBlocksList().setRegion(heapRegion);
    }
 
 
@@ -2015,7 +2016,7 @@ OMR::ResolvedMethodSymbol::getAutoSymRefs(int32_t slot)
          _autoSymRefs = new (m->trHeapMemory()) TR_Array<List<TR::SymbolReference> >(m, _resolvedMethod->numberOfParameterSlots() + _resolvedMethod->numberOfTemps() + 5, true);
       }
 
-   (*_autoSymRefs)[slot]._trMemory = m;
+   (*_autoSymRefs)[slot].setRegion(m->heapMemoryRegion());
 
    return (*_autoSymRefs)[slot];
    }
@@ -2044,7 +2045,7 @@ OMR::ResolvedMethodSymbol::getPendingPushSymRefs(int32_t slot)
       _pendingPushSymRefs = new (m->trHeapMemory()) TR_Array<List<TR::SymbolReference> >(m, 10, true);
       }
 
-   (*_pendingPushSymRefs)[slot]._trMemory = m;
+   (*_pendingPushSymRefs)[slot].setRegion(m->heapMemoryRegion());
 
    return (*_pendingPushSymRefs)[slot];
    }

--- a/compiler/optimizer/SinkStores.cpp
+++ b/compiler/optimizer/SinkStores.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -267,7 +267,7 @@ ListElement<TR_BlockListEntry> *TR_OrderedBlockList::addInTraversalOrder(TR::Blo
       ptr = ptr->getNextElement();
       }
 
-   return addAfter((new (trStackMemory()) TR_BlockListEntry(block, edge, trMemory())), prevPtr);
+   return addAfter((new (getRegion()) TR_BlockListEntry(block, edge, getRegion())), prevPtr);
    }
 
 

--- a/compiler/optimizer/SinkStores.hpp
+++ b/compiler/optimizer/SinkStores.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -289,8 +289,8 @@ class TR_BlockListEntry
    public:
    TR_ALLOC(TR_Memory::DataFlowAnalysis)
 
-   TR_BlockListEntry(TR::Block *block, TR::CFGEdge *pred, TR_Memory * m)
-      : _preds(m)
+   TR_BlockListEntry(TR::Block *block, TR::CFGEdge *pred, TR::Region &region)
+      : _preds(region)
       { _block = block; if (pred != 0) _preds.add(pred); _count = 1; }
 
    TR::Block       * _block;   // block

--- a/compiler/optimizer/StripMiner.cpp
+++ b/compiler/optimizer/StripMiner.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -272,15 +272,16 @@ void TR_StripMiner::collectLoops(TR_Structure *str)
       li->_loopTest = loopTest;
       li->_piv = piv;
       li->_asyncTree = NULL;
-      li->_mainParentsOfLoads._trMemory = trMemory();
+      TR::Region &scratchRegion = trMemory()->currentStackRegion();
+      li->_mainParentsOfLoads.setRegion(scratchRegion);
       li->_mainParentsOfLoads.init();
-      li->_mainParentsOfStores._trMemory = trMemory();
+      li->_mainParentsOfStores.setRegion(scratchRegion);
       li->_mainParentsOfStores.init();
-      li->_residualParentsOfLoads._trMemory = trMemory();
+      li->_residualParentsOfLoads.setRegion(scratchRegion);
       li->_residualParentsOfLoads.init();
-      li->_residualParentsOfStores._trMemory = trMemory();
+      li->_residualParentsOfStores.setRegion(scratchRegion);
       li->_residualParentsOfStores.init();
-      li->_edgesToRemove._trMemory = trMemory();
+      li->_edgesToRemove.setRegion(scratchRegion);
       li->_edgesToRemove.init();
 
       examineLoop(li, mainLoop, false);


### PR DESCRIPTION
The current implementations of TR_BitVector and TR_List allocate memory
using trMemory(). This is problematic for growable data structures using
stack memory since new stack marks may cause the lifetime of internal
data structures to be inconsistent. In addition, the lack of a
TR::Region based API prohibits modelling memory lifetimes which do not
follow the existing stack mark or heap.

This change modifies the data structures to store a region to do their
memory management and to always use the same region for their
allocation. The trMemory based APIs derrive the appropriate default
region to minimize impact on the code.

To facilitate allocation from region overrides of the pacement new and
delete operators taking TR:Region are supplied to mirror those for
trMemory and friends.

Signed-off-by: Andrew Craik <ajcraik@ca.ibm.com>