### PR TITLE
Harmonize OMR JIT verbose logs

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -4734,7 +4734,6 @@ char *OMR::Options::_verboseOptionNames[TR_NumVerboseOptions] =
    "compileEnd",
    "compileRequest",
    "gc",
-   "compileTime",
    "recompile",
    "compilePerformance",
    "filters",
@@ -5216,6 +5215,10 @@ bool  OMR::Options::fePostProcessJIT(void *base)
       char tmp[1025];
       fileName = _fe->getFormattedName(tmp, 1025, jitConfig->options.vLogFileName, NULL, TR::Options::getCmdLineOptions()->getOption(TR_EnablePIDExtension));
       jitConfig->options.vLogFile = trfopen(fileName, "w", false);
+      }
+   else
+      {
+      jitConfig->options.vLogFile = OMR::IO::Stderr;
       }
    self()->setVerboseOptions(jitConfig->options.verboseFlags);
 #endif

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1105,7 +1105,6 @@ enum TR_VerboseFlags
 
    TR_VerboseCompileRequest,
    TR_VerboseGc,
-   TR_VerboseCompileTime, // Not used in j9. TR_VerbosePerformance will do it
    TR_VerboseRecompile,   // this adds jit profiling information
    TR_VerbosePerformance, // Print options, compilation start/end/failure/time/memory
    TR_VerboseFilters,

--- a/compiler/env/FEBase.cpp
+++ b/compiler/env/FEBase.cpp
@@ -86,7 +86,7 @@ portLib_get390zLinuxMachineType()
    ::FILE * fp = fopen("/proc/cpuinfo", "r");
    if (fp)
       {
-      while (fgets(line, LINE_SIZE, fp) > 0)
+      while (fgets(line, LINE_SIZE, fp) != NULL)
          {
          int len = strlen(line);
          if (len > PROC_HEADER_SIZE && !memcmp(line, procHeader, PROC_HEADER_SIZE))

--- a/compiler/env/SystemSegmentProvider.hpp
+++ b/compiler/env/SystemSegmentProvider.hpp
@@ -51,7 +51,8 @@ public:
 
 private:
    TR::RawAllocator _rawAllocator;
-   size_t _bytesAllocated;
+   size_t _currentBytesAllocated;
+   size_t _highWaterMark;
    typedef TR::typed_allocator<
       TR::MemorySegment,
       TR::RawAllocator

--- a/compiler/ras/LimitFile.cpp
+++ b/compiler/ras/LimitFile.cpp
@@ -1022,6 +1022,11 @@ TR_Debug::scanFilterName(char *string, TR_FilterBST *filter)
                seenLineNumber = true;
                }
             }
+         else if (seenLineNumber && *string == ' ')
+            {
+            break;
+            }
+
          else
             signatureLen++;
          }

--- a/fvtest/compilertest/tests/OptionSetTest.cpp
+++ b/fvtest/compilertest/tests/OptionSetTest.cpp
@@ -34,9 +34,10 @@ std::string
 TestCompiler::OptionSetTest::getMethodFromLine(const std::string &line)
    {
    size_t sep = line.find_last_of(':');
+   size_t end = line.find_first_of(' ', sep);
    if(sep == std::string::npos)
       return "";
-   return line.substr(sep + 1);
+   return line.substr(sep + 1, end - (sep + 1));
    }
 
 /**


### PR DESCRIPTION
Standardize the format of verbose log messages indicating that a
compilation was successful. For the compileEnd verbose option, provide
a log entry in the format "([hotness]) [method name] @ [start address]-
[end address]". For the compilePerformance verbose option, extend the
prior format to also include " time=[time elapsed compiling] mem=[memory
allocated for scratch usage in KiB]"

Signed-off-by: Luc des Trois Maisons <lmaisons@ca.ibm.com>