### PR TITLE
[Mem4] Clean RegisterCandidates memory management

### DIFF
--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -42,6 +42,7 @@ namespace OMR { typedef OMR::Node NodeConnector; }
 #include "infra/Annotations.hpp"          // for OMR_EXTENSIBLE
 #include "infra/Assert.hpp"               // for TR_ASSERT
 #include "infra/Flags.hpp"                // for flags32_t
+#include "infra/TRlist.hpp"               // for TR::list
 
 class TR_BitVector;
 class TR_Debug;
@@ -63,7 +64,6 @@ namespace TR { class Symbol; }
 namespace TR { class SymbolReference; }
 namespace TR { class TreeTop; }
 namespace TR { class NodeExtension; }
-namespace TR { template <class T> class list; }
 template <class T> class List;
 
 #define NUM_DEFAULT_CHILDREN    2

--- a/compiler/infra/TRlist.hpp
+++ b/compiler/infra/TRlist.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -26,11 +26,11 @@
 #include "env/TRMemory.hpp"  // for TR_Memory, etc
 namespace TR
    {
-   template <class T> class list : public std::list<T, TR::typed_allocator<T, TR::Allocator> >
+   template <class T, class Alloc = TR::Allocator> class list : public std::list<T, TR::typed_allocator<T, Alloc> >
       {
       public:
-      list(TR::typed_allocator<T, TR::Allocator> ta) :
-         std::list<T, TR::typed_allocator<T, TR::Allocator> > (ta)
+      list(TR::typed_allocator<T, Alloc> ta) :
+         std::list<T, TR::typed_allocator<T, Alloc> > (ta)
          {
          }
 

--- a/compiler/infra/deque.hpp
+++ b/compiler/infra/deque.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2016, 2016
+ * (c) Copyright IBM Corp. 2016, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -27,12 +27,12 @@
 
 namespace TR {
 
-template <typename T>
-class deque : public std::deque<T, typed_allocator<T, Allocator> >
+template <typename T, class Alloc = TR::Allocator>
+class deque : public std::deque<T, typed_allocator<T, Alloc> >
    {
 public:
-   typedef typed_allocator<T, Allocator> allocator_type;
-   typedef std::deque<T, typed_allocator<T, Allocator> > container_type;
+   typedef typed_allocator<T, Alloc> allocator_type;
+   typedef std::deque<T, typed_allocator<T, Alloc> > container_type;
    typedef typename allocator_type::value_type value_type;
    typedef typename allocator_type::reference reference;
    typedef typename allocator_type::const_reference const_reference;
@@ -42,11 +42,11 @@ public:
     */
    typedef std::size_t size_type;
 
-   explicit deque(const Allocator &allocator);
-   explicit deque(size_type size, const Allocator &allocator);
-   explicit deque(size_type size, const T& initialValue, const Allocator &allocator);
-   template <typename InputIterator> deque(InputIterator first, InputIterator last, const Allocator &allocator);
-   deque(const deque<T> &x);
+   explicit deque(const allocator_type &allocator);
+   explicit deque(size_type size, const allocator_type &allocator);
+   explicit deque(size_type size, const T& initialValue, const allocator_type &allocator);
+   template <typename InputIterator> deque(InputIterator first, InputIterator last, const allocator_type &allocator);
+   deque(const deque<T, Alloc> &x);
    ~deque();
 
    reference operator[](size_type index);
@@ -55,45 +55,45 @@ public:
 
 }
 
-template <typename T>
-TR::deque<T>::deque(const Allocator &allocator) :
-   container_type(allocator_type(allocator))
+template <typename T, class Alloc>
+TR::deque<T, Alloc>::deque(const allocator_type &allocator) :
+   container_type(allocator)
    {
    }
 
-template <typename T>
-TR::deque<T>::deque(size_type size, const Allocator &allocator) :
-   container_type(size, T(), allocator_type(allocator))
+template <typename T, class Alloc>
+TR::deque<T, Alloc>::deque(size_type size, const allocator_type &allocator) :
+   container_type(size, T(), allocator)
    {
    }
 
-template <typename T>
-TR::deque<T>::deque(size_type size, const T& initialValue, const Allocator &allocator) :
-   container_type(size, initialValue, allocator_type(allocator))
+template <typename T, class Alloc>
+TR::deque<T, Alloc>::deque(size_type size, const T& initialValue, const allocator_type &allocator) :
+   container_type(size, initialValue, allocator)
    {
    }
 
-template <typename T>
+template <typename T, class Alloc>
 template <typename InputIterator>
-TR::deque<T>::deque(InputIterator first, InputIterator last, const Allocator &allocator) :
-   container_type(first, last, allocator_type(allocator))
+TR::deque<T, Alloc>::deque(InputIterator first, InputIterator last, const allocator_type &allocator) :
+   container_type(first, last, allocator)
    {
    }
 
-template <typename T>
-TR::deque<T>::deque(const deque<T> &other) :
+template <typename T, class Alloc>
+TR::deque<T, Alloc>::deque(const deque<T, Alloc> &other) :
    container_type(other)
    {
    }
 
-template <typename T>
-TR::deque<T>::~deque()
+template <typename T, class Alloc>
+TR::deque<T, Alloc>::~deque()
    {
    }
 
-template <typename T>
-typename TR::deque<T>::reference
-TR::deque<T>::operator [](size_type index)
+template <typename T, class Alloc>
+typename TR::deque<T, Alloc>::reference
+TR::deque<T, Alloc>::operator [](size_type index)
    {
 // In DEBUG, at() is used for correctness due to its bound checking
 // whilst [] is used in PROD for performance
@@ -104,9 +104,9 @@ TR::deque<T>::operator [](size_type index)
 #endif // defined(DEBUG) || defined(PROD_WITH_ASSUMES)
    }
 
-template <typename T>
-typename TR::deque<T>::const_reference
-TR::deque<T>::operator [](size_type index) const
+template <typename T, class Alloc>
+typename TR::deque<T, Alloc>::const_reference
+TR::deque<T, Alloc>::operator [](size_type index) const
    {
 // In DEBUG, at() is used for correctness due to its bound checking
 // whilst [] is used in PROD for performance

--- a/compiler/infra/vector.hpp
+++ b/compiler/infra/vector.hpp
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#ifndef VECTOR_HPP
+#define VECTOR_HPP
+
+#pragma once
+
+#include <vector>
+#include "env/TypedAllocator.hpp"
+#include "env/TRMemory.hpp"
+
+namespace TR {
+
+template <typename T, class Alloc = TR::Allocator>
+class vector : public std::vector<T, typed_allocator<T, Alloc> >
+   {
+public:
+   typedef typed_allocator<T, Alloc> allocator_type;
+   typedef std::vector<T, typed_allocator<T, Alloc> > container_type;
+   typedef typename allocator_type::value_type value_type;
+   typedef typename allocator_type::reference reference;
+   typedef typename allocator_type::const_reference const_reference;
+   /*
+    * This would ideally use the parent vector's size_type.  However, such usage
+    * runs into two-phase lookup problems when compiling with MSVC++ 2010.
+    */
+   typedef std::size_t size_type;
+
+   explicit vector(const allocator_type &allocator);
+   explicit vector(size_type size, const allocator_type &allocator);
+   explicit vector(size_type size, const T& initialValue, const allocator_type &allocator);
+   template <typename InputIterator> vector(InputIterator first, InputIterator last, const allocator_type &allocator);
+   vector(const vector<T, Alloc> &x);
+   ~vector();
+
+   reference operator[](size_type index);
+   const_reference operator[](size_type index) const;
+   };
+
+}
+
+template <typename T, class Alloc>
+TR::vector<T, Alloc>::vector(const allocator_type &allocator) :
+   container_type(allocator)
+   {
+   }
+
+template <typename T, class Alloc>
+TR::vector<T, Alloc>::vector(size_type size, const allocator_type &allocator) :
+   container_type(size, T(), allocator)
+   {
+   }
+
+template <typename T, class Alloc>
+TR::vector<T, Alloc>::vector(size_type size, const T& initialValue, const allocator_type &allocator) :
+   container_type(size, initialValue, allocator)
+   {
+   }
+
+template <typename T, class Alloc>
+template <typename InputIterator>
+TR::vector<T, Alloc>::vector(InputIterator first, InputIterator last, const allocator_type &allocator) :
+   container_type(first, last, allocator)
+   {
+   }
+
+template <typename T, class Alloc>
+TR::vector<T, Alloc>::vector(const vector<T, Alloc> &other) :
+   container_type(other)
+   {
+   }
+
+template <typename T, class Alloc>
+TR::vector<T, Alloc>::~vector()
+   {
+   }
+
+template <typename T, class Alloc>
+typename TR::vector<T, Alloc>::reference
+TR::vector<T, Alloc>::operator [](size_type index)
+   {
+// In DEBUG, at() is used for correctness due to its bound checking
+// whilst [] is used in PROD for performance
+#if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
+   return this->at(index);
+#else
+   return container_type::operator[](index);
+#endif // defined(DEBUG) || defined(PROD_WITH_ASSUMES)
+   }
+
+template <typename T, class Alloc>
+typename TR::vector<T, Alloc>::const_reference
+TR::vector<T, Alloc>::operator [](size_type index) const
+   {
+// In DEBUG, at() is used for correctness due to its bound checking
+// whilst [] is used in PROD for performance
+#if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
+   return this->at(index);
+#else
+   return container_type::operator[](index);
+#endif // defined(DEBUG) || defined(PROD_WITH_ASSUMES)  
+   }
+
+#endif // VECTOR_HPP

--- a/compiler/optimizer/DataFlowAnalysis.hpp
+++ b/compiler/optimizer/DataFlowAnalysis.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -24,9 +24,6 @@
 #include "compile/Compilation.hpp"               // for Compilation
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
-#include "cs2/arrayof.h"                         // for ArrayOf
-#include "cs2/hashtab.h"                         // for HashTable
-#include "cs2/tableof.h"                         // for TableOf
 #include "env/TRMemory.hpp"                      // for TR_Memory, etc
 #include "il/Node.hpp"                           // for Node, vcount_t
 #include "infra/Array.hpp"                       // for TR_Array
@@ -325,7 +322,6 @@ template<class Container>class TR_BasicDFSetAnalysis<Container *> :
    virtual void allocateBlockInfoContainer(Container **result, bool isSparse = true, bool lock = false);
    virtual void allocateBlockInfoContainer(Container **result, Container *other);
    virtual void allocateTempContainer(Container **result, Container *other);
-   TR::BitVector *allocateBitVector();
 
    Container *_regularInfo;
    Container *_exceptionInfo;
@@ -335,7 +331,7 @@ template<class Container>class TR_BasicDFSetAnalysis<Container *> :
    Container **_exceptionGenSetInfo;
    Container **_exceptionKillSetInfo;
    Container *_temp, *_temp2;
-   TR::BitVector *_nodesInCycle;
+   TR_BitVector *_nodesInCycle;
    bool _containsExceptionTreeTop;
    bool _firstIteration;
    bool _traceBVA;
@@ -344,7 +340,6 @@ template<class Container>class TR_BasicDFSetAnalysis<Container *> :
    int32_t _numberOfNodes;
    int32_t _maxReferenceNumber;
    TR::Node **_supportedNodesAsArray;
-   CS2::TableOf<TR::BitVector, TR::Allocator> *_bitVectorTable;
    bool _hasImproperRegion;
    };
 
@@ -387,9 +382,9 @@ template<class Container>class TR_ForwardDFSetAnalysis<Container *> :
    virtual void analyzeTreeTopsInBlockStructure(TR_BlockStructure *);
    virtual void analyzeNode(TR::Node *, vcount_t, TR_BlockStructure *, Container *);
 
-   bool analyzeNodeIfPredecessorsAnalyzed(TR_RegionStructure *, TR::BitVector &);
+   bool analyzeNodeIfPredecessorsAnalyzed(TR_RegionStructure *, TR_BitVector &);
 
-   virtual void initializeGenAndKillSetInfo(TR_RegionStructure *, TR::BitVector &);
+   virtual void initializeGenAndKillSetInfo(TR_RegionStructure *, TR_BitVector &);
    virtual void initializeGenAndKillSetInfoForRegion(TR_RegionStructure *);
    virtual void initializeGenAndKillSetInfoForBlock(TR_BlockStructure *);
    virtual bool canGenAndKillForStructure(TR_Structure *);
@@ -547,9 +542,9 @@ template<class Container>class TR_BackwardDFSetAnalysis<Container *> :
    virtual void analyzeTreeTopsInBlockStructure(TR_BlockStructure *);
    virtual void analyzeNode(TR::Node *, vcount_t, TR_BlockStructure *, Container *);
 
-   bool analyzeNodeIfSuccessorsAnalyzed(TR_RegionStructure *, TR::BitVector &, TR::BitVector &);
+   bool analyzeNodeIfSuccessorsAnalyzed(TR_RegionStructure *, TR_BitVector &, TR_BitVector &);
 
-   virtual void initializeGenAndKillSetInfo(TR_RegionStructure *, TR::BitVector &, TR::BitVector &, bool);
+   virtual void initializeGenAndKillSetInfo(TR_RegionStructure *, TR_BitVector &, TR_BitVector &, bool);
    virtual void initializeGenAndKillSetInfoForRegion(TR_RegionStructure *);
    virtual void initializeGenAndKillSetInfoForBlock(TR_BlockStructure *);
    virtual bool canGenAndKillForStructure(TR_Structure *);

--- a/compiler/optimizer/GlobalRegisterAllocator.cpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -3516,10 +3516,9 @@ void TR_GlobalRegisterAllocator::offerAllAutosAndRegisterParmAsCandidates(TR::Bl
          int32_t symRefNumber = symRef->getReferenceNumber();
          if (rc)
             {
-            TR_RegisterCandidate::BlockInfo::Cursor bc(rc->_blocks.all());
-            while (bc.hasMoreElements())
+            for (auto itr = rc->_blocks.begin(), end = rc->_blocks.end(); itr != end; ++itr)
                {
-               int32_t block_num = bc.getNextElement();
+               int32_t block_num = itr->first;
                TR_ASSERT(block_num < numberOfNodes, "Overflow on candidate BB numbers");
                block = cfgBlocks[block_num];
                if (!block) continue;
@@ -3643,10 +3642,9 @@ void TR_GlobalRegisterAllocator::offerAllAutosAndRegisterParmAsCandidates(TR::Bl
                // If it is new then set the count to zero or one based on use in the block
                if (rc)
                   {
-                  TR_RegisterCandidate::BlockInfo::Cursor bc(rc->_blocks.all());
-                  while (bc.hasMoreElements())
+                  for (auto itr = rc->_blocks.begin(), end = rc->_blocks.end(); itr != end; ++itr)
                      {
-                     int32_t block_num = bc.getNextElement();
+                     int32_t block_num = itr->first;
                      TR_ASSERT(block_num < numberOfNodes, "Overflow on candidate BB numbers");
                      block = cfgBlocks[block_num];
                      if (!block) continue;
@@ -3791,10 +3789,10 @@ void TR_GlobalRegisterAllocator::offerAllFPAutosAndParmsAsCandidates(TR::Block *
                  (sym->isParm() && methodSymbol->getParameterList().find(sym->castToParmSymbol()) && sym->isReferencedParameter())))
                {
                TR_RegisterCandidate *rc = comp()->getGlobalRegisterCandidates()->findOrCreate(symRef);
-
-         TR_RegisterCandidate::BlockInfo::Cursor bc(rc->_blocks.all());
-               while (bc.hasMoreElements()) {
-                  int32_t block_num = bc.getNextElement();
+               
+               for (auto itr = rc->_blocks.begin(), end = rc->_blocks.end(); itr != end; ++itr)
+                  {
+                  int32_t block_num = itr->first;
                   TR_ASSERT(block_num < numberOfNodes, "Overflow on candidate BB numbers");
       block = cfgBlocks[block_num];
                   if (!block) continue;

--- a/compiler/optimizer/OSRDefAnalysis.cpp
+++ b/compiler/optimizer/OSRDefAnalysis.cpp
@@ -361,7 +361,7 @@ void TR_OSRDefInfo::buildOSRDefs(void *vblockInfo, AuxiliaryData &aux)
    // Allocate the array of bit vectors that will represent live definitions at OSR points
    //
    int32_t numOSRPoints = _methodSymbol->getNumOSRPoints();
-   aux._defsForOSR.GrowTo(numOSRPoints);
+   aux._defsForOSR.resize(numOSRPoints, TR_UseDefInfo::BitVector(comp()->allocator()));
 
    TR::Block *block;
    TR::TreeTop *treeTop;

--- a/compiler/optimizer/UseDefInfo.hpp
+++ b/compiler/optimizer/UseDefInfo.hpp
@@ -22,10 +22,7 @@
 #include <stddef.h>                 // for NULL
 #include <stdint.h>                 // for int32_t, uint32_t, intptr_t
 #include "compile/Compilation.hpp"  // for Compilation
-#include "cs2/arrayof.h"            // for ArrayOf
 #include "cs2/bitvectr.h"           // for ABitVector
-#include "cs2/cs2.h"                // for Pair
-#include "cs2/llistof.h"            // for LinkedListOf
 #include "cs2/sparsrbit.h"          // for ASparseBitVector
 #include "env/TRMemory.hpp"         // for Allocator, SparseBitVector, etc
 #include "il/Node.hpp"              // for Node, scount_t
@@ -61,6 +58,7 @@ namespace TR { class TreeTop; }
  */
 class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
    {
+   TR::Region _region;
    public:
 
    // Construct use def info for the current method's trees. This also assigns
@@ -186,7 +184,7 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
    public:
 
    TR::Node      *getSingleDefiningLoad(TR::Node *node);
-   void          resetDefUseInfo() {_defUseInfo.MakeEmpty();}
+   void          resetDefUseInfo() {_defUseInfo.clear();}
 
    bool          skipAnalyzingForCompileTime(TR::Node *node, TR::Block *block, TR::Compilation *comp, AuxiliaryData &aux);
 
@@ -295,7 +293,7 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
       TR::Node *parent,
       TR::TreeTop *treeTop,
       AuxiliaryData &aux,
-      TR::deque<uint32_t> &symRefToLocalIndexMap,
+      TR::deque<uint32_t, TR::Region&> &symRefToLocalIndexMap,
       bool considerImplicitStores = false
       );
    bool assignAdjustedNodeIndex(TR::Block *, TR::Node *node, TR::Node *parent, TR::TreeTop *treeTop, AuxiliaryData &aux, bool considerImplicitStores = false);
@@ -312,18 +310,18 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
 
    private:
 
-   CS2::ArrayOf<CS2::Pair<TR::Node *, TR::TreeTop *>, TR::Allocator> _atoms;                          //TR::Node            **_nodes;
+   TR::vector<std::pair<TR::Node *, TR::TreeTop *>, TR::Region&> _atoms;
 
    private:
-   CS2::ArrayOf<BitVector,TR::Allocator> _useDefInfo;
+   TR::vector<BitVector, TR::Region&> _useDefInfo;
    bool _isUseDefInfoValid;
 
-   TR::list<BitVector> _infoCache;                                 ///< initially empty bit vectors that are used for caching
+   TR::list<BitVector, TR::Region&> _infoCache;                    ///< initially empty bit vectors that are used for caching
    const BitVector _EMPTY;                                         ///< the empty bit vector
-   CS2::ArrayOf<const BitVector *,TR::Allocator> _useDerefDefInfo; ///< all load defs are dereferenced
-   CS2::ArrayOf<BitVector,TR::Allocator> _defUseInfo;
-   CS2::ArrayOf<BitVector,TR::Allocator> _loadDefUseInfo;
-   CS2::ArrayOf<int32_t, TR::Allocator> _sideTableToSymRefNumMap;
+   TR::vector<const BitVector *,TR::Region&> _useDerefDefInfo; ///< all load defs are dereferenced
+   TR::vector<BitVector, TR::Region&> _defUseInfo;
+   TR::vector<BitVector, TR::Region&> _loadDefUseInfo;
+   TR::vector<int32_t, TR::Region&> _sideTableToSymRefNumMap;
 
    int32_t             _numDefOnlyNodes;
    int32_t             _numDefUseNodes;
@@ -364,7 +362,7 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
       };
 
 
-   CS2::ArrayOf<TR_UseDef,TR::Allocator> _useDefs;
+   TR::vector<TR_UseDef, TR::Region &> _useDefs;
 
    class MemorySymbol
       {
@@ -376,10 +374,10 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
 
       friend class TR_UseDefInfo;
       };
-   typedef CS2::LinkedListOf<MemorySymbol,TR::Allocator> MemorySymbolList;
+   typedef TR::list<MemorySymbol, TR::Region&> MemorySymbolList;
 
    int32_t                 _numMemorySymbols;
-   CS2::ArrayOf<MemorySymbolList, TR::Allocator> _valueNumbersToMemorySymbolsMap;
+   TR::vector<MemorySymbolList *, TR::Region&> _valueNumbersToMemorySymbolsMap;
    TR_ValueNumberInfo *_valueNumberInfo;
    TR::CFG                   *_cfg;
    };

--- a/compiler/optimizer/UseDefInfo.hpp
+++ b/compiler/optimizer/UseDefInfo.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -78,44 +78,46 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
    class AuxiliaryData
       {
       private:
-         AuxiliaryData(int32_t numSymRefs, ncount_t nodeCount, TR::Allocator allocator) :
-             _onceReadSymbols(numSymRefs, BitVector(allocator), allocator),
-             _onceWrittenSymbols(numSymRefs, BitVector(allocator), allocator),
+         AuxiliaryData(int32_t numSymRefs, ncount_t nodeCount, TR::Region &region, TR::Allocator allocator) :
+             _region(region),
+             _onceReadSymbols(numSymRefs, _region),
+             _onceWrittenSymbols(numSymRefs, _region),
              _defsForSymbol(allocator, BitVector(allocator)),
-             _neverReadSymbols(allocator),
-             _neverReferencedSymbols(allocator),
-             _neverWrittenSymbols(allocator),
-             _volatileOrAliasedToVolatileSymbols(allocator),
-             _onceWrittenSymbolsIndices(numSymRefs, TR::SparseBitVector(allocator), allocator),
-             _onceReadSymbolsIndices(numSymRefs, TR::SparseBitVector(allocator), allocator),
+             _neverReadSymbols(numSymRefs, _region),
+             _neverReferencedSymbols(numSymRefs, _region),
+             _neverWrittenSymbols(numSymRefs, _region),
+             _volatileOrAliasedToVolatileSymbols(numSymRefs, _region),
+             _onceWrittenSymbolsIndices(numSymRefs, TR::SparseBitVector(allocator), _region),
+             _onceReadSymbolsIndices(numSymRefs, TR::SparseBitVector(allocator), _region),
              _expandedAtoms(allocator, CS2::Pair<TR::Node *, TR::TreeTop *>(NULL, NULL)),
-             _sideTableToUseDefMap(allocator),
-             _numAliases(numSymRefs, allocator),
-             _nodesByGlobalIndex(nodeCount, allocator),
-             _loadsBySymRefNum(numSymRefs, allocator),
+             _sideTableToUseDefMap(_region),
+             _numAliases(numSymRefs, _region),
+             _nodesByGlobalIndex(nodeCount, _region),
+             _loadsBySymRefNum(numSymRefs, _region),
              _defsForOSR(allocator, TR_UseDefInfo::BitVector(allocator))
             {}
+      TR::Region _region;
 
-      TR::deque<BitVector> _onceReadSymbols;
-      TR::deque<BitVector> _onceWrittenSymbols;
+      TR::deque<TR_BitVector *, TR::Region&> _onceReadSymbols;
+      TR::deque<TR_BitVector *, TR::Region&> _onceWrittenSymbols;
       // defsForSymbol are known definitions of the symbol
       CS2::ArrayOf<BitVector, TR::Allocator> _defsForSymbol;
-      TR::BitVector _neverReadSymbols;
-      TR::BitVector _neverReferencedSymbols;
-      TR::BitVector _neverWrittenSymbols;
-      TR::BitVector _volatileOrAliasedToVolatileSymbols;
-      TR::deque<TR::SparseBitVector> _onceWrittenSymbolsIndices;
-      TR::deque<TR::SparseBitVector> _onceReadSymbolsIndices;
+      TR_BitVector _neverReadSymbols;
+      TR_BitVector _neverReferencedSymbols;
+      TR_BitVector _neverWrittenSymbols;
+      TR_BitVector _volatileOrAliasedToVolatileSymbols;
+      TR::deque<TR::SparseBitVector, TR::Region&> _onceWrittenSymbolsIndices;
+      TR::deque<TR::SparseBitVector, TR::Region&> _onceReadSymbolsIndices;
 
       CS2::ArrayOf<CS2::Pair<TR::Node *, TR::TreeTop *>, TR::Allocator> _expandedAtoms;    //TR::Node            **_expandedNodes;
 
 
       protected:
-      CS2::ArrayOf<uint32_t, TR::Allocator> _sideTableToUseDefMap;
+      TR::deque<uint32_t, TR::Region&> _sideTableToUseDefMap;
       private:
-      TR::deque<uint32_t> _numAliases;
-      TR::deque<TR::Node *> _nodesByGlobalIndex;
-      TR::deque<TR::Node *> _loadsBySymRefNum;
+      TR::deque<uint32_t, TR::Region&> _numAliases;
+      TR::deque<TR::Node *, TR::Region&> _nodesByGlobalIndex;
+      TR::deque<TR::Node *, TR::Region&> _loadsBySymRefNum;
 
       protected:
       // used only in TR_OSRDefInfo - should extend AuxiliaryData really:

--- a/compiler/optimizer/UseDefInfo.hpp
+++ b/compiler/optimizer/UseDefInfo.hpp
@@ -33,6 +33,7 @@
 #include "il/SymbolReference.hpp"   // for SymbolReference
 #include "infra/Assert.hpp"         // for TR_ASSERT
 #include "infra/deque.hpp"          // for TR::deque
+#include "infra/vector.hpp"         // for TR::vector
 #include "infra/TRlist.hpp"         // for TR::list
 
 class TR_ReachingDefinitions;
@@ -80,36 +81,36 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
       private:
          AuxiliaryData(int32_t numSymRefs, ncount_t nodeCount, TR::Region &region, TR::Allocator allocator) :
              _region(region),
-             _onceReadSymbols(numSymRefs, _region),
-             _onceWrittenSymbols(numSymRefs, _region),
-             _defsForSymbol(allocator, BitVector(allocator)),
+             _onceReadSymbols(numSymRefs, static_cast<TR_BitVector*>(NULL), _region),
+             _onceWrittenSymbols(numSymRefs, static_cast<TR_BitVector*>(NULL), _region),
+             _defsForSymbol(0, BitVector(allocator), _region),
              _neverReadSymbols(numSymRefs, _region),
              _neverReferencedSymbols(numSymRefs, _region),
              _neverWrittenSymbols(numSymRefs, _region),
              _volatileOrAliasedToVolatileSymbols(numSymRefs, _region),
              _onceWrittenSymbolsIndices(numSymRefs, TR::SparseBitVector(allocator), _region),
              _onceReadSymbolsIndices(numSymRefs, TR::SparseBitVector(allocator), _region),
-             _expandedAtoms(allocator, CS2::Pair<TR::Node *, TR::TreeTop *>(NULL, NULL)),
+             _expandedAtoms(0, std::make_pair<TR::Node *, TR::TreeTop *>(NULL, NULL), _region),
              _sideTableToUseDefMap(_region),
              _numAliases(numSymRefs, _region),
              _nodesByGlobalIndex(nodeCount, _region),
              _loadsBySymRefNum(numSymRefs, _region),
-             _defsForOSR(allocator, TR_UseDefInfo::BitVector(allocator))
+             _defsForOSR(0, TR_UseDefInfo::BitVector(allocator), _region)
             {}
       TR::Region _region;
 
-      TR::deque<TR_BitVector *, TR::Region&> _onceReadSymbols;
-      TR::deque<TR_BitVector *, TR::Region&> _onceWrittenSymbols;
+      TR::vector<TR_BitVector *, TR::Region&> _onceReadSymbols;
+      TR::vector<TR_BitVector *, TR::Region&> _onceWrittenSymbols;
       // defsForSymbol are known definitions of the symbol
-      CS2::ArrayOf<BitVector, TR::Allocator> _defsForSymbol;
+      TR::vector<BitVector, TR::Region&> _defsForSymbol;
       TR_BitVector _neverReadSymbols;
       TR_BitVector _neverReferencedSymbols;
       TR_BitVector _neverWrittenSymbols;
       TR_BitVector _volatileOrAliasedToVolatileSymbols;
-      TR::deque<TR::SparseBitVector, TR::Region&> _onceWrittenSymbolsIndices;
-      TR::deque<TR::SparseBitVector, TR::Region&> _onceReadSymbolsIndices;
+      TR::vector<TR::SparseBitVector, TR::Region&> _onceWrittenSymbolsIndices;
+      TR::vector<TR::SparseBitVector, TR::Region&> _onceReadSymbolsIndices;
 
-      CS2::ArrayOf<CS2::Pair<TR::Node *, TR::TreeTop *>, TR::Allocator> _expandedAtoms;    //TR::Node            **_expandedNodes;
+      TR::vector<std::pair<TR::Node *, TR::TreeTop *>, TR::Region&> _expandedAtoms;
 
 
       protected:
@@ -121,7 +122,7 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
 
       protected:
       // used only in TR_OSRDefInfo - should extend AuxiliaryData really:
-      CS2::ArrayOf<BitVector, TR::Allocator> _defsForOSR;
+      TR::vector<BitVector, TR::Region&> _defsForOSR;
 
       friend class TR_UseDefInfo;
       friend class TR_ReachingDefinitions;


### PR DESCRIPTION
The RegisterCandidates data structure has several CS2::TableOf data structures which are leaking a  lot of memory. This change removes the TableOf structures, introduces a memory allocation region, allocates the candidates from the region, and efficiently cleans up candidates when freed. The top two commits are in this pull request - Mem1 - Mem3 are the base.