### PR TITLE
Link and compile with -pthread

### DIFF
--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -77,8 +77,8 @@ endif()
 if(OMR_HOST_OS STREQUAL "linux")
 	add_definitions(
 		-DLINUX
-		-D_REENTRANT
 		-D_FILE_OFFSET_BITS=64
+		-pthread
 	)
 endif()
 
@@ -104,8 +104,8 @@ endif()
 if(OMR_HOST_OS STREQUAL "osx")
 	add_definitions(
 		-DOSX
-		-D_REENTRANT
 		-D_FILE_OFFSET_BITS=64
+		-pthread
 	)
 endif()
 

--- a/fvtest/omrGtestGlue/CMakeLists.txt
+++ b/fvtest/omrGtestGlue/CMakeLists.txt
@@ -39,10 +39,4 @@ target_sources(omrGtestGlue INTERFACE
 
 target_link_libraries(omrGtestGlue INTERFACE omrGtest)
 
-#TODO  system thread library should be linked in a more generic way.
-if(NOT OMR_HOST_OS STREQUAL "win")
-	if(NOT OMR_HOST_OS STREQUAL "zos")
-		target_link_libraries(omrGtest pthread)
-	endif()
-endif()
 #target_link_libraries(omrGtest INTERFACE omrGtestGlue)


### PR DESCRIPTION
We were previously consuming pthread in an ad-hoc way.
This now propagates -pthread through anything linking against
j9thrstatic (that's nearly everything).

`-pthread` has the same effect as `-lpthread` and `-D_REENTRANT`. Now,
we don't need to define `_REENTRANT` ourselves.

Signed-off-by: Robert Young <rwy0717@gmail.com>