### PR TITLE
Fix bug in masm2gas

### DIFF
--- a/tools/compiler/scripts/masm2gas.pl
+++ b/tools/compiler/scripts/masm2gas.pl
@@ -561,7 +561,7 @@ sub processFile
       # HACK: Pre-2.12.1 gas mixes up i386's CMPSD/MOVSD with SSE2's CMPSD/MOVSD; it also
       #       thinks that SSE2 instructions with QWORD PTR operands are reserved for x86-64
       # HACK: Unfortunately, post-2.15.90 gas on RHEL4 is broken again.
-      if (($gasVersion lt '2.12.1' or $gasVersion gt '2.12.90') and $llvmVersion gt '0')
+      if ($gasVersion lt '2.12.1' or $gasVersion gt '2.12.90')
          {
          # removing the modifier for SSE2 instructions seems to work
          $line =~ s/qword ptr//i


### PR DESCRIPTION
When LLVM assmbler support was added, an incorrect clause was added
on a path that wasn't being exercised.

This removes the new clause (which is superflous for LLVM anyhow, as
when $llvmVersion is > 0, $gasVersion is set to 3), restoring the old
behaviour.

Signed-off-by: Matthew Gaudet <magaudet@ca.ibm.com>