### PR TITLE
Extend OSR Induce API to accept optional CFG

### DIFF
--- a/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
@@ -152,16 +152,16 @@ public:
 
    bool genPartialIL(TR_FrontEnd *, TR::Compilation *, TR::SymbolReferenceTable *, bool forceClassLookahead = false, TR_InlineBlocks *blocksToInline = 0);
 
-   void genOSRHelperCall(int32_t inlinedSiteIndex, TR::SymbolReferenceTable* symRefTab);
+   void genOSRHelperCall(int32_t inlinedSiteIndex, TR::SymbolReferenceTable* symRefTab, TR::CFG *cfg = NULL);
    void genAndAttachOSRCodeBlocks(int32_t inlinedSiteIndex) ;
    int  matchInduceOSRCall(TR::TreeTop* insertionPoint,
                                int16_t callerIndex,
                                int16_t byteCodeIndex,
                                const char* childPath);
 
-   TR::TreeTop *genInduceOSRCallNode(TR::TreeTop* insertionPoint, int32_t numChildren, bool copyChildren, bool shouldSplitBlock = true);
-   TR::TreeTop *genInduceOSRCall(TR::TreeTop* insertionPoint, int32_t inlinedSiteIndex, int32_t numChildren, bool copyChildren, bool shouldSplitBlock);
-   TR::TreeTop *genInduceOSRCall(TR::TreeTop* insertionPoint, int32_t inlinedSiteIndex, TR_OSRMethodData *osrMethodData, int32_t numChildren, bool copyChildren, bool shouldSplitBlock);
+   TR::TreeTop *genInduceOSRCallNode(TR::TreeTop* insertionPoint, int32_t numChildren, bool copyChildren, bool shouldSplitBlock = true, TR::CFG *cfg = NULL);
+   TR::TreeTop *genInduceOSRCall(TR::TreeTop* insertionPoint, int32_t inlinedSiteIndex, int32_t numChildren, bool copyChildren, bool shouldSplitBlock, TR::CFG *cfg = NULL);
+   TR::TreeTop *genInduceOSRCall(TR::TreeTop* insertionPoint, int32_t inlinedSiteIndex, TR_OSRMethodData *osrMethodData, int32_t numChildren, bool copyChildren, bool shouldSplitBlock, TR::CFG *cfg = NULL);
    TR::TreeTop *genInduceOSRCallAndCleanUpFollowingTreesImmediately(TR::TreeTop *insertionPoint, TR_ByteCodeInfo induceBCI, bool shouldSplitBlock, TR::Compilation *comp);
 
    bool canInjectInduceOSR(TR::Node* node);

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -2019,7 +2019,7 @@ TR_InlinerBase::addGuardForVirtual(
            createdHCRGuard ||
            (osrForNonHCRGuards && shouldAttemptOSR)))
          {
-         TR::TreeTop *induceTree = callerSymbol->genInduceOSRCall(guardedCallNodeTreeTop, callNode->getByteCodeInfo().getCallerIndex(), (callNode->getNumChildren() - callNode->getFirstArgumentIndex()), false, false);
+         TR::TreeTop *induceTree = callerSymbol->genInduceOSRCall(guardedCallNodeTreeTop, callNode->getByteCodeInfo().getCallerIndex(), (callNode->getNumChildren() - callNode->getFirstArgumentIndex()), false, false, callerSymbol->getFlowGraph());
          if (induceOSRCallTree)
             *induceOSRCallTree = induceTree;
          }


### PR DESCRIPTION
OSR induce calls are added during inlining for
OSROnGuardFailure. The OSR Induce API currently
assumes that the outermost CFG should be used
when manipulating blocks to add an induce call.
This is not valid when inlining a call whose
caller is not the outermost method. To correct
this, the API has been extended with an optional
CFG argument that defaults to the outermost.