### PR TITLE
Increase the limit of constant data snippet

### DIFF
--- a/compiler/z/codegen/ConstantDataSnippet.hpp
+++ b/compiler/z/codegen/ConstantDataSnippet.hpp
@@ -26,6 +26,7 @@
 #include "compile/Compilation.hpp"  // for comp, Compilation (ptr only)
 #include "env/jittypes.h"           // for uintptrj_t
 #include "infra/Assert.hpp"         // for TR_ASSERT
+#include "OMRCodeGenerator.hpp"
 
 class TR_Debug;
 namespace TR { class CodeGenerator; }
@@ -47,7 +48,7 @@ class S390ConstantDataSnippet : public TR::Snippet
    protected:
    union
       {
-      uint8_t                       _value[16];
+      uint8_t                       _value[1<<TR_DEFAULT_DATA_SNIPPET_EXPONENT];
       char *                        _string;
       };
 

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -1143,8 +1143,8 @@ public:
    TR::Instruction* ccInstruction() { return _ccInstruction; }
    void setCCInstruction(TR::Instruction* cc) { _ccInstruction = cc; }
 
-   #define TR_DEFAULT_DATA_SNIPPET_EXPONENT 4
-   int32_t constantDataSnippetExponent() { return TR_DEFAULT_DATA_SNIPPET_EXPONENT; } // 1 << 4 = 16 byte max size for each constantDataSnippet
+   #define TR_DEFAULT_DATA_SNIPPET_EXPONENT 6
+   int32_t constantDataSnippetExponent() { return TR_DEFAULT_DATA_SNIPPET_EXPONENT; } // 1 << 6 = 64 byte max size for each constantDataSnippet
 
 
  private:


### PR DESCRIPTION
On z Systems, constant data snippet size was limited to
16 bytes. This commit increases that to 64 bytes.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>