### PR TITLE
Remove macro definition 'null'

### DIFF
--- a/compiler/il/OMRDataTypes.hpp
+++ b/compiler/il/OMRDataTypes.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -38,10 +38,6 @@ namespace OMR { typedef OMR::DataType DataTypeConnector; }
 #endif
 
 namespace TR { class DataType; }
-
-/* undefine null in case the platform already has a declaration */
-#undef null
-#define null {0}
 
 typedef int32_t CASECONST_TYPE;
 

--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -7047,7 +7047,7 @@ void OMR::ValuePropagation::transformStringConcats(VPStringCached *stringCached)
         }
      }
 
-  TR::Node *stringNode = null;
+  TR::Node *stringNode = NULL;
   TR::Node *indexNode = TR::Node::iconst(appendedString[0], 0); // Length of string 1
 
 
@@ -7089,7 +7089,7 @@ TR::SymbolReference * OMR::ValuePropagation::getStringCacheRef()
   TR_ScratchList<TR_ResolvedMethod> stringMethods(comp()->trMemory());
   comp()->fej9()->getResolvedMethods(comp()->trMemory(), stringClass, &stringMethods);
   ListIterator<TR_ResolvedMethod> it(&stringMethods);
-  TR::SymbolReference * callsymreference=null;
+  TR::SymbolReference * callsymreference=NULL;
 
   for (TR_ResolvedMethod *method = it.getCurrent(); method; method = it.getNext())
       {
@@ -7879,8 +7879,8 @@ void OMR::ValuePropagation::doDelayedTransformations()
       comp()->fej9()->getResolvedMethods(comp()->trMemory(), optClnClass, &clnMethods);
       ListIterator<TR_ResolvedMethod> clnit(&clnMethods);
 
-      TR_ResolvedMethod *method = null;
-      TR::SymbolReference *optClnClassSymRef = null;
+      TR_ResolvedMethod *method = NULL;
+      TR::SymbolReference *optClnClassSymRef = NULL;
       bool clnFound = false;
       for (method = clnit.getCurrent(); method; method = clnit.getNext())
          {

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -4568,7 +4568,7 @@ TR_S390Peephole::trueCompEliminationForLoadComp()
    prev = realInstruction(prev, false);
 
    TR::Register * srcReg = ((TR::S390RRInstruction *) curr)->getRegisterOperand(2);
-   TR::RealRegister *tempReg = null;
+   TR::RealRegister *tempReg = NULL;
    if((toRealRegister(srcReg))->getRegisterNumber() == TR::RealRegister::GPR1)
       {
       tempReg = _cg->machine()->getS390RealRegister(TR::RealRegister::GPR2);

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -8040,7 +8040,7 @@ inlineHighestOneBit(
     **/
 
    // need to clobber evaluate all cases except when in 64-bit long
-   TR::Register * srcReg = null;
+   TR::Register * srcReg = NULL;
    bool srcClobbered = false;
    if ((TR::Compiler->target.is64Bit() || cg->use64BitRegsOn32Bit()) && isLong)
       srcReg = cg->evaluate(firstChild);


### PR DESCRIPTION
The macro 'null' was defined to be '{0}' a zeroed struct. It was only
used to initialize pointer variables, in which case it is no different
from 0 or NULL. Removing the definition and usage of 'null' makes it
easier to use omr alongside code that defines or uses 'null' in a
different manner.