### PR TITLE
Add new Xjit option enableAggressiveLoopVersioning

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -615,6 +615,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"dynamicThreadPriority",              "M\tenable dynamic changing of compilation thread priority", SET_OPTION_BIT(TR_DynamicThreadPriority), "F", NOT_IN_SUBSET},
    {"earlyLPQ",                           "M\tAllow compilations from low priority queue to happen early, during startup", SET_OPTION_BIT(TR_EarlyLPQ), "F", NOT_IN_SUBSET },
    {"enableAggressiveLiveness",           "I\tenable globalLiveVariablesForGC below warm", SET_OPTION_BIT(TR_EnableAggressiveLiveness), "F"},
+   {"enableAggressiveLoopVersioning", "O\tOptions and thresholds that result in loop versioning occurring in more cases", SET_OPTION_BIT(TR_EnableAggressiveLoopVersioning), "F" },
    {"enableAllocationOfScratchBTL",       "M\tAllow the allocation scratch memory below the line (zOS 31-bit)", RESET_OPTION_BIT(TR_DontAllocateScratchBTL), "F", NOT_IN_SUBSET },
    {"enableAllocationSinking",            "O\tdelay object allocations until immediately before the corresponding constructor calls", TR::Options::enableOptimization, allocationSinking, 0, "P"},
    {EnableAnnotations,                    "O\tenable annotation support",                      SET_OPTION_BIT(TR_EnableAnnotations), "F"},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -281,7 +281,7 @@ enum TR_CompilationOptions
 
    // Option word 6
    //
-   // Available                           = 0x00000020 + 6,
+   TR_EnableAggressiveLoopVersioning      = 0x00000020 + 6,
    TR_EnableElementPrivatization          = 0x00000040 + 6,
    TR_CompileBit                          = 0x00000080 + 6,
    TR_WaitBit                             = 0x00000100 + 6,


### PR DESCRIPTION
enableAggressiveLoopVersioning is a new jit option that will be used to
guard a number of changes to the behaviour of LoopVersioner.

Signed-off-by: JamesKingdon <jkingdon@ca.ibm.com>