### PR TITLE
Add ILTraverser and TrilDumper to compiler

### DIFF
--- a/compiler/infra/ILTraverser.cpp
+++ b/compiler/infra/ILTraverser.cpp
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#include "infra/ILTraverser.hpp"
+
+#include "il/symbol/ResolvedMethodSymbol.hpp"
+#include "il/Block.hpp"
+#include "il/Block_inlines.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+
+TR::ILTraverser::ILTraverser(TR::Compilation * comp) : _observers(comp->allocator()), _visitedNodes(comp), _comp(comp)
+   {
+   }
+
+void TR::ILTraverser::traverse(TR::ResolvedMethodSymbol* method)
+   {
+   for (auto o : _observers) o->visitingMethod(method);
+   traverse(method->getFirstTreeTop(), method->getLastTreeTop());
+   for (auto o : _observers) o->returnedToMethod(method);
+   }
+
+void TR::ILTraverser::traverse(TR::Block* block)
+   {
+   for (auto o : _observers) o->visitingBlock(block);
+   traverse(block->getEntry(), block->getExit());
+   for (auto o : _observers) o->returnedToBlock(block);
+   }
+
+void TR::ILTraverser::traverse(TR::TreeTop* start, TR::TreeTop* stop)
+   {
+   for (auto currentTree = start; currentTree != stop; currentTree = currentTree->getNextTreeTop())
+      {
+      for (auto o : _observers) o->visitingTreeTop(currentTree);
+      traverse(currentTree->getNode());
+      for (auto o : _observers) o->returnedToTreeTop(currentTree);
+      }
+
+   // visit last treetop
+   for (auto o : _observers) o->visitingTreeTop(stop);
+   traverse(stop->getNode());
+   for (auto o : _observers) o->returnedToTreeTop(stop);
+   }
+
+void TR::ILTraverser::traverse(TR::Node* node)
+   {
+   for (auto o : _observers) o->visitingNode(node);
+
+   // add node to the visited list so we don't visit its children again
+   // if the node is commoned
+   _visitedNodes.add(node);
+
+   // visit all the children
+   for (auto childIndex = 0; childIndex < node->getNumChildren(); ++childIndex)
+      {
+      auto child = node->getChild(childIndex);
+
+      if (!_visitedNodes.contains(child))
+         {
+         traverse(child);
+         }
+      else
+         {
+         for (auto o : _observers) o->visitingCommonedChildNode(child);
+         }
+
+      for (auto o : _observers) o->returnedToNode(node);
+      }
+
+   for (auto o : _observers) o->visitedAllChildrenOfNode(node);
+   }

--- a/compiler/infra/ILTraverser.hpp
+++ b/compiler/infra/ILTraverser.hpp
@@ -1,0 +1,166 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#ifndef TR_ILTRAVERSER_HPP
+#define TR_ILTRAVERSER_HPP
+
+#include "infra/Checklist.hpp"
+#include "env/TRMemory.hpp"
+#include "compile/Compilation.hpp"
+
+#include <vector>
+#include <algorithm>
+
+namespace TR {
+
+// forward declaration of "imported" classes
+class ResolvedMethodSymbol;
+class Block;
+class TreeTop;
+class Node;
+
+/**
+ * @brief A class that abstracts aways the details of traversing Testarossa IL.
+ *
+ * This class uses the Observer pattern to separate the actual traversal mechanism
+ * from the code that needs to do the traversal. An observer can register itself
+ * with an instance of this class to be notified of the various transitions during
+ * the traversal.
+ *
+ * This class expects the input IL to be "sound"; properly structured for traversal.
+ */
+class ILTraverser
+   {
+   public:
+   explicit ILTraverser(TR::Compilation* comp);
+
+   /**
+    * @brief The base class for observers of an instance of ILTraverser
+    *
+    * Objects inheriting from this class can be registered with an instance of
+    * ILTraverser to be notified of the various transitions done during traversal.
+    *
+    * All signals have an empty body by default so that derived classes need
+    * only implement the signals they are interested in.
+    *
+    * All the events that can be listened to have the same general interface.
+    * They all take as argument a pointer to the object being visited. For each
+    * type of object that can be visited, there is one signal for when the object
+    * is entered, and one signal for when traversal returns to the object after
+    * having visited the object's children.
+    *
+    * Some specialized versions of these signals are also provided to accommodate
+    * the traversal requirements of certain object types (e.g. there is a
+    * special signal for when a commoned node is being re-visited).
+    */
+   struct Observer
+      {
+      virtual ~Observer() = default;
+
+      // emitted when visiting methods
+      virtual void visitingMethod(TR::ResolvedMethodSymbol* method) {}
+      virtual void returnedToMethod(TR::ResolvedMethodSymbol* method) {}
+
+      // emitted when visiting blocks
+      virtual void visitingBlock(TR::Block* block) {}
+      virtual void returnedToBlock(TR::Block* block) {}
+
+      // emitted when visiting TreeTops
+      virtual void visitingTreeTop(TR::TreeTop* treeTop) {}
+      virtual void returnedToTreeTop(TR::TreeTop* treeTop) {}
+
+      // emitted when visiting IL nodes
+      virtual void visitingNode(TR::Node* node) {}
+      virtual void visitingCommonedChildNode(TR::Node* node) {}
+      virtual void returnedToNode(TR::Node* node) {}
+      virtual void visitedAllChildrenOfNode(TR::Node* node) {}
+      };
+
+   /**
+    * @brief Registers an observer object with this class instance
+    * @param o is a pointer to the observer object being registered
+    */
+   void registerObserver(Observer* o) { _observers.push_back(o); }
+
+   /**
+    * @brief Deregisters an observer object from this class instance
+    * @param o is a pointer to the observer object being deregistered
+    */
+   void removeObserver(Observer* o)
+      {
+      auto i = std::find(_observers.cbegin(), _observers.cend(), o);
+      if (i != _observers.cend())
+         {
+         _observers.erase(i);
+         }
+      }
+
+   /**
+    * @brief Traverses the IL of a method
+    * @param method is the method containing the IL to be traversed
+    *
+    * Will visit the method itself and then visit each TreeTop of the method.
+    * Note that it will not visit actual blocks.
+    */
+   void traverse(TR::ResolvedMethodSymbol* method);
+
+   /**
+    * @brief Traverses the IL in a (basic) block
+    * @param block is the TR:Block instance containing the IL to be traversed
+    *
+    * Will visit the block itself and then visit each TreeTop in the block.
+    */
+   void traverse(TR::Block* block);
+
+   /**
+    * @brief Traverses the IL between two TreeTops inclusive
+    * @param start points to the TreeTop where traversal will begin (inclusive)
+    * @param stop points to the Treetop where the traversal will end (inclusive)
+    *
+    * Will iterate over each TreeTop in the specified range inclusively, visiting
+    * the nodes contained by each TreeTop in the process. It should be noted that
+    * this function *will not* traverse the blocks in an extended basic block.
+    */
+   void traverse(TR::TreeTop* start, TR::TreeTop* stop);
+
+   /**
+    * @brief Traverses an IL node and its children
+    * @param node is the node to be traversed
+    *
+    * Will visit the specified node, and then visit the node's children in order.
+    * The signal `Observer::returnedToNode(node)` is emitted after each child
+    * is visited. The signal `Observer::visitedAllChildrenOfNode(node)` is
+    * emitted after all children of the node have been visited. If the node is
+    * not being visited for the first time (i.e. it is a commoned node), then
+    * the signal `Observer::visitingCommonedChildNode(node)` is emitted, instead
+    * of the regular `Observer::visitingNode(node)`, and its children are not
+    * be re-visited.
+    */
+   void traverse(TR::Node* node);
+
+   TR::Compilation* comp() { return _comp; }
+
+   private:
+   std::vector<Observer*, TR::typed_allocator<Observer*, TR::Allocator>> _observers;
+   TR::NodeChecklist _visitedNodes;
+   TR::Compilation* _comp;
+   };
+
+} // namespace TR
+
+#endif // TR_ILTRAVERSER_HPP

--- a/compiler/infra/TrilDumper.cpp
+++ b/compiler/infra/TrilDumper.cpp
@@ -1,0 +1,182 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#include "infra/TrilDumper.hpp"
+
+#include "infra/List.hpp"
+#include "il/symbol/AutomaticSymbol.hpp"
+#include "il/symbol/ParameterSymbol.hpp"
+#include "il/Block.hpp"
+#include "il/Block_inlines.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/ILOps.hpp"
+#include "il/Symbol.hpp"
+#include "compile/ResolvedMethod.hpp"
+
+#include "stdio.h"
+
+TR::TrilDumper::TrilDumper(FILE * file) : _outputFile(file)
+   {
+   }
+
+void TR::TrilDumper::visitingMethod(TR::ResolvedMethodSymbol* method)
+   {
+   TR_ResolvedMethod * resolvedMethod = method->getResolvedMethod();
+
+   // all methods must have a return type, so just print it
+   fprintf(_outputFile, "(method return=%s ", TR::DataType::getName(resolvedMethod->returnType()));
+
+   // print the method's name if it has one
+   if (method->getName()) { fprintf(_outputFile, "name=%s ", method->getName()); }
+
+   // print the argument types, skipping the `arg` field entirely if there are none
+   auto paramList = method->getParameterList();
+   auto paramIter = ListIterator<TR::ParameterSymbol>(&paramList);
+   if (!paramIter.atEnd())
+      {
+      TR::ParameterSymbol* param = paramIter.getFirst();
+      fprintf(_outputFile, "args=[%s", TR::DataType::getName(param->getDataType()));
+      param = paramIter.getNext();
+      for (; !paramIter.atEnd(); param = paramIter.getNext())
+         {
+         fprintf(_outputFile, ", %s", TR::DataType::getName(param->getDataType()));
+         }
+      fprintf(_outputFile, "] ");
+      }
+   }
+
+void TR::TrilDumper::returnedToMethod(TR::ResolvedMethodSymbol* method)
+   {
+   fprintf(_outputFile, ") ");
+   }
+
+void TR::TrilDumper::visitingNode(TR::Node* node)
+   {
+   auto opcode = node->getOpCode();
+   auto opcodeValue = opcode.getOpCodeValue();
+
+   /*
+    * Because Tril does not explicitly represent BBStart and BBEnd nodes (they
+    * are implicitly part of a Block), we use them to define where a block has
+    * to be printed. This is also required because we cannot rely on
+    * `visitingBlock()` being emitted when traversing the IL of a method (see
+    * TR::ILTraverser API documentation).
+    */
+
+   if (opcodeValue == TR::BBStart)
+      {
+      // a BBStart means we are entering a new block, so we "open" a new
+      // block and print its name
+      auto block = node->getBlock();
+      fprintf(_outputFile, "(block name=\"block_%d\" ", block->getNumber());
+      }
+   else if (opcodeValue == TR::BBEnd)
+      {
+      // a BBEnd means we are exiting a block and need to "close" it
+      fprintf(_outputFile, ") ");
+      }
+   else
+      {
+
+      // print the node's name
+      fprintf(_outputFile, "(%s ", node->getOpCode().getName());
+
+      if (opcode.isLoadConst())
+          {
+          // if the node is a `*const`, print the constant value
+          if (opcode.isInteger())
+              {
+              fprintf(_outputFile, "%ld ", node->get64bitIntegralValue());
+              }
+          else if (opcode.isIntegerOrAddress()) // since there is no `isAddress()`
+              {
+              // it should be noted that although a correct address will be printed,
+              // the address may not be valid if recompiling the output Tril code
+              fprintf(_outputFile, "%ld ", node->getAddress());
+              }
+          else if (opcode.isDouble())
+              {
+              fprintf(_outputFile, "%f ", node->getDouble());
+              }
+          else if (opcode.isFloat())
+              {
+              fprintf(_outputFile, "%f ", static_cast<double>(node->getFloat()));
+              }
+          }
+      else if (opcode.isLoadDirect() || opcode.isStoreDirect())
+          {
+          // if the node is a direct load/store, print an argument appropriate
+          // for the contained symref
+          auto sym = node->getSymbol();
+          if (sym->isParm())
+              {
+              fprintf(_outputFile, "parm=%d ", sym->getParmSymbol()->getSlot());
+              }
+          else if (sym->isAuto())
+              {
+              fprintf(_outputFile, "temp=\"symref_%d\" ", node->getSymbolReference()->getCPIndex());
+              }
+          else
+              {
+              fprintf(_outputFile, "\n\n**** Unrecognized symref type **** \n\n");
+              }
+          }
+      else if (opcode.isIndirect())
+          {
+          // if the node is an indirect load/store, print the offset on the symref
+          fprintf(_outputFile, "offset=%ld ", node->getSymbolReference()->getOffset());
+          }
+      else if (opcode.isBranch())
+          {
+          // if the node is a branch, print the name of the target block
+          auto target = node->getBranchDestination()->getEnclosingBlock(true)->getNumber();
+          if (target == 1)
+              {
+              fprintf(_outputFile, "target=@exit ");
+              }
+          else
+              {
+              fprintf(_outputFile, "target=\"block_%d\" ", target);
+              }
+          }
+
+      // use the node index as its id (used for commoning)
+      fprintf(_outputFile, "id=\"n%dn\" ", node->getGlobalIndex());
+      }
+   }
+
+void TR::TrilDumper::visitingCommonedChildNode(TR::Node* node)
+   {
+   // for commoned nodes, we can "close" the node right away since the children
+   // are not re-visited
+   fprintf(_outputFile, "(@common id=\"n%dn\") ", node->getGlobalIndex());
+   }
+
+void TR::TrilDumper::visitedAllChildrenOfNode(TR::Node* node)
+   {
+   auto opcode = node->getOpCode();
+   auto opcodeValue = opcode.getOpCodeValue();
+
+   // we must only "close" nodes that are neither BBStart nor BBEnd, since these
+   // are used to delimit the start and end of `block` nodes
+   if (opcodeValue != TR::BBStart && opcodeValue != TR::BBEnd)
+      {
+      fprintf(_outputFile, ") ");
+      }
+   }

--- a/compiler/infra/TrilDumper.hpp
+++ b/compiler/infra/TrilDumper.hpp
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#ifndef TR_TRILDUMPER_HPP
+#define TR_TRILDUMPER_HPP
+
+#include "infra/ILTraverser.hpp"
+
+namespace TR {
+
+/**
+ * @brief A class for dumping Testarossa IL as Tril
+ *
+ * This class is implemented as an observer of TR::ILTraverser. To print Tril,
+ * an instance of this class must first be registered as an observer of an
+ * instance of TR::ILTraverser. The Tril code will be printed when one of the
+ * `traverse()` methods is called on the ILTraverser.
+ *
+ * Example usage:
+ *      // dump Tril code for a method
+ *      TR::TrilDumper dumper{stderr};
+ *      TR::ILTraverser traverser(comp);
+ *      traverser.registerObserver(&dumper);
+ *      traverser.traverse(comp()->getJittedMethodSymbol());
+ *      fprintf(stderr, "\n");
+ *
+ * Using this pattern allows the printing logic to be isolated from the IL
+ * traversal logic.
+ *
+ * The output Tril code will all appear on a single line, with exactly one ' '
+ * (space) separating each element (node, node argument, etc.).
+ */
+class TrilDumper : public TR::ILTraverser::Observer
+   {
+   public:
+
+    /**
+    * @brief Constructs an instance of TR::TrilDumper.
+    * @param file is the file object to which the Tril code will be printed
+    */
+   explicit TrilDumper(FILE* file);
+
+   void visitingMethod(TR::ResolvedMethodSymbol* method) override;
+   void returnedToMethod(TR::ResolvedMethodSymbol* method) override;
+   void visitingNode(TR::Node* node) override;
+   void visitingCommonedChildNode(TR::Node* node) override;
+   void visitedAllChildrenOfNode(TR::Node* node) override;
+
+   private:
+   FILE* _outputFile;
+   };
+
+} // namespace TR
+
+#endif // TR_TRILDUMPER_HPP


### PR DESCRIPTION
These commits add two new convenience classes to the OMR compiler:

* `TR::ILTraverser`: abstracts away traversing Testarossa IL using the Observer pattern
* `TR::TrilDumper`: a class for printint Testarossa IL as Tril code

Currently, neither of these classes are actually being used. This pull requests simply contributes them so they can be used in later work. I have tested the changes locally by "artificially" connecting the new classes to a downstream project and ensuring that the printed Tril code reproduces the behavior of the original source code when compiled and executed.

[ci skip] because these classes are not being used by anything and can't be tested directly