### PR TITLE
Missing explicit type conversion

### DIFF
--- a/port/common/omrerror.c
+++ b/port/common/omrerror.c
@@ -333,7 +333,7 @@ omrerror_set_last_error_with_message_format(struct OMRPortLibrary *portLibrary, 
 	ptBuffers->portableErrorCode = portableCode;
 
 	va_start(args, format);
-	requiredSize = portLibrary->str_vprintf(portLibrary, NULL, (uint32_t)-1, format, args);
+	requiredSize = (uint32_t)portLibrary->str_vprintf(portLibrary, NULL, (uint32_t)-1, format, args);
 	va_end(args);
 
 	/* Store the message, allocate a bigger buffer if required.  Keep the old buffer around


### PR DESCRIPTION
omrstr_vprintf() returns uintptr_t, but in
omrerror_set_last_error_with_message_format(), it is being
assigned to a variable of type uint32_t without explicit
conversion.

Signed-off-by: Ashutosh Mehra <asmehra1@in.ibm.com>