### PR TITLE
Remove the use of colons in feGetEnv

### DIFF
--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -401,7 +401,7 @@ TR::VPConstraint *OMR::ValuePropagation::addConstraintToList(TR::Node *node, int
       // If the relationship does not exist, we must have traversed the whole list
       // Make sure that our lists are not getting too long -
       //
-      static const char *p = feGetEnv("TR::VPMaxRelDepth");
+      static const char *p = feGetEnv("TR_VPMaxRelDepth");
       static const int32_t maxRelDepth = p ? atoi(p) : 64;
       if (!rel && numRelatives > maxRelDepth)
          {
@@ -616,7 +616,7 @@ TR::VPConstraint *OMR::ValuePropagation::addGlobalConstraint(TR::Node *node, int
 
    bool newOrChanged = false;
 
-   static const char *p = feGetEnv("TR::VPMaxRelDepth");
+   static const char *p = feGetEnv("TR_VPMaxRelDepth");
    static const int32_t maxRelDepth = p ? atoi(p) : 64;
    if (!rel && numRelatives > maxRelDepth)
       {

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -288,7 +288,7 @@ void OMR::ValuePropagation::initialize()
 
    _reachedMaxRelationDepth = false;
    _propagationDepth = 0;
-   static const char *pEnv = feGetEnv("TR::VPMaxRelDepth");
+   static const char *pEnv = feGetEnv("TR_VPMaxRelDepth");
    _maxPropagationDepth = pEnv ? atoi(pEnv) : MAX_RELATION_DEPTH;
    if (comp()->getMethodHotness() > warm)
       _maxPropagationDepth = _maxPropagationDepth * 3;

--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -6557,7 +6557,7 @@ OMR::Z::Machine::initializeGlobalRegisterTable()
    if (!comp->getOption(TR_DisableRegisterPressureSimulation))
       {
       int32_t p = 0;
-      static char *dontInitializeGlobalRegisterTableFromLinkage = feGetEnv("TR::dontInitializeGlobalRegisterTableFromLinkage");
+      static char *dontInitializeGlobalRegisterTableFromLinkage = feGetEnv("TR_dontInitializeGlobalRegisterTableFromLinkage");
       bool enableHighWordGRA = _cg->supportsHighWordFacility() && !comp->getOption(TR_DisableHighWordRA);
       if (dontInitializeGlobalRegisterTableFromLinkage)
          {


### PR DESCRIPTION
The colon character cannot be used as part of a name in an export due to
its special treatment to separate exported directories. We must revert
back to using underscores.

Signed-off-by: Irwin D'Souza <dsouzai@ca.ibm.com>