### PR TITLE
Fix integer cast in omrerror.c

### DIFF
--- a/port/common/omrfilestreamtext.c
+++ b/port/common/omrfilestreamtext.c
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2015, 2016
+ * (c) Copyright IBM Corp. 2015, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -112,7 +112,7 @@ omrfilestream_vprintf(struct OMRPortLibrary *portLibrary, OMRFileStream *fileStr
 	COPY_VA_LIST(copyOfArgs, args);
 
 	/* What is size of buffer required ? Does not include the \0 */
-	numberWritten = portLibrary->str_vprintf(portLibrary, NULL, (U_32)(-1), format, copyOfArgs);
+	numberWritten = portLibrary->str_vprintf(portLibrary, NULL, 0, format, copyOfArgs);
 	numberWritten += 1;
 
 	Trc_PRT_filestream_vprintf_stackBufferNotBigEnough(fileStream, format, numberWritten);

--- a/port/common/omrstr.c
+++ b/port/common/omrstr.c
@@ -2037,7 +2037,7 @@ omrstr_set_token(struct OMRPortLibrary *portLibrary, struct J9StringTokens *toke
 
 	va_start(args, format);
 	/* find out how large a buffer we need to format the strings */
-	tokenBufLen = portLibrary->str_vprintf(portLibrary, NULL, (unsigned int)-1, format, args);
+	tokenBufLen = portLibrary->str_vprintf(portLibrary, NULL, 0, format, args);
 	va_end(args);
 
 	/* stack allocate the necessary storage */

--- a/port/include/omrportptb.h
+++ b/port/include/omrportptb.h
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2015
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -39,6 +39,7 @@
 #include "omrport.h"
 
 #define J9ERROR_DEFAULT_BUFFER_SIZE 256 /**< default customized error message size if we need to create one */
+#define J9ERROR_MAXIMUM_BUFFER_SIZE 0xFFFFFFFF /**< maximum customized error message size if we need to create one */
 
 /**
  * @typedef
@@ -52,11 +53,11 @@ typedef struct PortlibPTBuffers_struct {
 	int32_t platformErrorCode; /**< error code as reported by the OS */
 	int32_t portableErrorCode; /**< error code translated to portable format by application */
 	char *errorMessageBuffer; /**< last saved error message, either customized or from OS */
-	uint32_t errorMessageBufferSize; /**< error message buffer size */
+	uintptr_t errorMessageBufferSize; /**< error message buffer size */
 
 	int32_t reportedErrorCode; /**< last reported error code */
 	char *reportedMessageBuffer; /**< last reported error message, either customized or from OS */
-	uint32_t reportedMessageBufferSize; /**< reported message buffer size */
+	uintptr_t reportedMessageBufferSize; /**< reported message buffer size */
 } PortlibPTBuffers_struct;
 
 /**

--- a/port/unix/omrfile.c
+++ b/port/unix/omrfile.c
@@ -918,7 +918,7 @@ omrfile_vprintf(struct OMRPortLibrary *portLibrary, intptr_t fd, const char *for
 {
 	char outputBuffer[256];
 	char *allocatedBuffer;
-	uint32_t numberWritten;
+	uintptr_t numberWritten;
 	va_list copyOfArgs;
 
 	/* Attempt to write output to stack buffer */
@@ -939,7 +939,7 @@ omrfile_vprintf(struct OMRPortLibrary *portLibrary, intptr_t fd, const char *for
 	COPY_VA_LIST(copyOfArgs, args);
 
 	/* What is size of buffer required ? Does not include the \0 */
-	numberWritten = portLibrary->str_vprintf(portLibrary, NULL, (uint32_t)(-1), format, copyOfArgs);
+	numberWritten = portLibrary->str_vprintf(portLibrary, NULL, 0, format, copyOfArgs);
 	numberWritten += 1;
 
 	allocatedBuffer = portLibrary->mem_allocate_memory(portLibrary, numberWritten, OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);

--- a/port/unix_include/omrportptb.h
+++ b/port/unix_include/omrportptb.h
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2015
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -41,6 +41,7 @@
 #include "omriconvhelpers.h"
 
 #define J9ERROR_DEFAULT_BUFFER_SIZE 256 /**< default customized error message size if we need to create one */
+#define J9ERROR_MAXIMUM_BUFFER_SIZE 0xFFFFFFFF /**< maximum customized error message size if we need to create one */
 
 /**
  * @typedef
@@ -54,11 +55,11 @@ typedef struct PortlibPTBuffers_struct {
 	int32_t platformErrorCode; /**< error code as reported by the OS */
 	int32_t portableErrorCode; /**< error code translated to portable format by application */
 	char *errorMessageBuffer; /**< last saved error message, either customized or from OS */
-	uint32_t errorMessageBufferSize; /**< error message buffer size */
+	uintptr_t errorMessageBufferSize; /**< error message buffer size */
 
 	int32_t reportedErrorCode; /**< last reported error code */
 	char *reportedMessageBuffer; /**< last reported error message, either customized or from OS */
-	uint32_t reportedMessageBufferSize; /**< reported message buffer size */
+	uintptr_t reportedMessageBufferSize; /**< reported message buffer size */
 
 #if defined(J9VM_PROVIDE_ICONV)
 	iconv_t converterCache[UNCACHED_ICONV_DESCRIPTOR]; /**< Everything in J9IconvName before UNCACHED_ICONV_DESCRIPTOR is cached */

--- a/port/win32/omrfile.c
+++ b/port/win32/omrfile.c
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2015
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -856,7 +856,7 @@ omrfile_vprintf(struct OMRPortLibrary *portLibrary, intptr_t fd, const char *for
 	COPY_VA_LIST(copyOfArgs, args);
 
 	/* What is size of buffer required ? Does not include the \0 */
-	numberWritten = portLibrary->str_vprintf(portLibrary, NULL, (uint32_t)(-1), format, copyOfArgs);
+	numberWritten = portLibrary->str_vprintf(portLibrary, NULL, 0, format, copyOfArgs);
 	numberWritten += 1;
 
 	allocatedBuffer = portLibrary->mem_allocate_memory(portLibrary, numberWritten, OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);

--- a/port/win32_include/omrportptb.h
+++ b/port/win32_include/omrportptb.h
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2015
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -39,6 +39,7 @@
 #include "omrport.h"
 
 #define J9ERROR_DEFAULT_BUFFER_SIZE 256 /**< default customized error message size if we need to create one */
+#define J9ERROR_MAXIMUM_BUFFER_SIZE 0xFFFFFFFF /**< maximum customized error message size if we need to create one */
 
 /**
  * @typedef
@@ -52,11 +53,11 @@ typedef struct PortlibPTBuffers_struct {
 	int32_t platformErrorCode; /**< error code as reported by the OS */
 	int32_t portableErrorCode; /**< error code translated to portable format by application */
 	char *errorMessageBuffer; /**< last saved error message, either customized or from OS */
-	uint32_t errorMessageBufferSize; /**< error message buffer size */
+	uintptr_t errorMessageBufferSize; /**< error message buffer size */
 
 	int32_t reportedErrorCode; /**< last reported error code */
 	char *reportedMessageBuffer; /**< last reported error message, either customized or from OS */
-	uint32_t reportedMessageBufferSize; /**< reported message buffer size */
+	uintptr_t reportedMessageBufferSize; /**< reported message buffer size */
 } PortlibPTBuffers_struct;
 
 /**


### PR DESCRIPTION
Port library method str_vprintf() requires a uintptr_t value for buffer
length and returns uintptr_t, return value was being assigned to
uint32_t value that is later assigned to a uint32_t-valued
field. 

Buffer length arg for str_vprintf() is not used when buffer pointer is
NULL. Replaced value for buffer length arg with 0 (was (unit32_t)-1).

Method will now reuse existing buffer if reallocation fails or
allocation size is >= 2^32. Error message will be truncated and null
terminated if too long to fit in current buffer.

Additional related fixes to use uintptr_t consistently for buffer sizes
and to fix inconsistent use of str_vprintf() args and return value.

Unexpected problem found in Port.cpp. OSX needs sys/statfs.h. I don't
know how it ever got into master without including it. 

Signed-off-by: Kim Briggs <briggs@ca.ibm.com>