### PR TITLE
Appveyor: Disable TestOtherThreadCputime

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,7 +22,7 @@ shallow_clone: true
 clone_depth: 1
 
 environment:
-  GTEST_FILTER: '-*dump_test_create_dump_*:*NumaSetAffinity:*NumaSetAffinitySuspended:PortSysinfoTest.sysinfo_test0'
+  GTEST_FILTER: '-*dump_test_create_dump_*:*NumaSetAffinity:*NumaSetAffinitySuspended:PortSysinfoTest.sysinfo_test0:ThreadExtendedTest.TestOtherThreadCputime'
   GTEST_COLOR: '1'
   TEST_RESULT_DIR: '%APPVEYOR_BUILD_FOLDER%\test_results'
   GTEST_OUTPUT: 'xml:%TEST_RESULT_DIR%\'


### PR DESCRIPTION
This test is not testing anything particularily useful, and takes up
a significant ammount of time in the appveyor builds (~20 min)

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>