### PR TITLE
z/TPF omr dump updates

### DIFF
--- a/compiler/env/defines.h
+++ b/compiler/env/defines.h
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -14,6 +14,7 @@
  *
  * Contributors:
  *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *    Multiple authors (IBM Corp.) - z/TPF platform initial port to OMR environment
  ******************************************************************************/
 
 
@@ -82,11 +83,13 @@
 #endif
 
 /*
-  Standarize the OS macros Use HOST_OS instead of various different
+  Standardize the OS macros Use HOST_OS instead of various different
   ways of checking for a particular host os.  As a reference, see
   http://sourceforge.net/p/predef/wiki/OperatingSystems/
 */
 #if defined(__linux__)
+#  define HOST_OS OMR_LINUX
+#elif defined(_TPF_SOURCE)
 #  define HOST_OS OMR_LINUX
 #elif defined(_AIX)
 #  define HOST_OS OMR_AIX

--- a/compiler/infra/ThreadLocal.h
+++ b/compiler/infra/ThreadLocal.h
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -14,14 +14,25 @@
  *
  * Contributors:
  *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *    Multiple authors (IBM Corp.) - z/TPF platform initial port to OMR environment
  ******************************************************************************/
 
 #ifndef THREADLOCAL_INCL
 #define THREADLOCAL_INCL
 
+#if defined(OMRZTPF) && !defined(SUPPORTS_THREAD_LOCAL)
+/*
+ * For this include file, ThreadLocal.h, and the z/TPF OS platform,
+ * say that tls is supported. The z/TPF platform should use
+ * pthread _key_t variables and pthread functions for
+ * the tls* functions that are defined here.
+ */
+#define SUPPORTS_THREAD_LOCAL
+#endif
+
 #if defined(SUPPORTS_THREAD_LOCAL)
 
-#if defined(WINDOWS) || defined(LINUX) || defined(OSX) || defined(AIXPPC)
+#if defined(WINDOWS) || (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || defined(AIXPPC)
  #if defined(WINDOWS)
   #include "windows.h"
   #define tlsDeclare(type, variable) extern DWORD variable
@@ -38,7 +49,7 @@
   #define tlsSet(variable, value) variable = value
   #define tlsGet(variable, type) (variable)
  #endif
-#else /* !(defined(WINDOWS) || defined(LINUX) || defined(OSX) || defined(AIXPPC)) */  /* mainly defined(J9ZOS390) */
+#else /* !(defined(WINDOWS) || (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || defined(AIXPPC)) */  /* Mainly for defined(OMRZTPF) or defined(J9ZOS390) */
  #include <pthread.h>
 
  #define tlsDeclare(type, variable) extern pthread_key_t variable

--- a/compiler/z/codegen/SystemLinkage.cpp
+++ b/compiler/z/codegen/SystemLinkage.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -14,6 +14,7 @@
  *
  * Contributors:
  *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *    Multiple authors (IBM Corp.) - z/TPF platform initial port to OMR environment
  *******************************************************************************/
 
 // See also S390Linkage.cpp which contains more S390 Linkage
@@ -931,10 +932,21 @@ TR::S390zLinuxSystemLinkage::S390zLinuxSystemLinkage(TR::CodeGenerator * codeGen
    setReturnAddressRegister (TR::RealRegister::GPR14 );
 
    setGOTPointerRegister   (TR::RealRegister::GPR12  );
+
+#if defined(OMRZTPF)
+/*
+ * z/TPF os is a 64 bit target
+ */
+   setOffsetToRegSaveArea     (16);    // z/TPF is a 64 bit target only
+   setGPRSaveAreaBeginOffset  (16);    //x'10'  see ICST_R2 in tpf/icstk.h
+   setGPRSaveAreaEndOffset    (160);   //x'a0'  see ICST_PAT in tpf/icstk.h
+   setOffsetToFirstParm       (448);   //x'1c0' see ICST_PAR in tpf/icstk.h
+#else
    setOffsetToRegSaveArea   ((TR::Compiler->target.is64Bit()) ? 16 : 8);
    setGPRSaveAreaBeginOffset  ((TR::Compiler->target.is64Bit()) ? 48 : 24);
    setGPRSaveAreaEndOffset  ((TR::Compiler->target.is64Bit()) ? 128 : 64 );
    setOffsetToFirstParm   ((TR::Compiler->target.is64Bit()) ? 160 : 96);
+#endif /* defined(OMRZTPF) */
    setOffsetToFirstLocal  (0);
    setOffsetToLongDispSlot(TR::Compiler->target.is64Bit() ? 8 : 4);
    setOutgoingParmAreaBeginOffset(getOffsetToFirstParm());

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -602,7 +602,7 @@ typedef struct J9ProcessorInfos {
 #if !defined(OMRZTPF)
 #define OMRPORT_SLOPEN_LAZY  2
 #else /* !defined(OMRZTPF) */
-#define J9PORT_SLOPEN_LAZY  0
+#define OMRPORT_SLOPEN_LAZY  0
 #endif /* defined(OMRZTPF) */
 #define OMRPORT_SLOPEN_NO_LOOKUP_MSG_FOR_NOT_FOUND  4
 #define OMRPORT_SLOPEN_OPEN_EXECUTABLE 8     /* Can be ORed without affecting existing flags. */

--- a/port/ztpf/omrosdump_helpers.c
+++ b/port/ztpf/omrosdump_helpers.c
@@ -900,14 +900,14 @@ buildELFNoteArea(Elf64_Nhdr *buffer, DIB *dibPtr)
 	nsh_fpregs->n_type = NT_FPREGSET; /* Type = 2                    */
 	memcpy(nsh_fpregs + 1, "CORE", 5); /* Set "CORE" name ...        */
 	/*
-	 * We don't care what the real FPCR contained. We're setting the mask
+	 * We don't care what the real FPCR (fpc) contained. We're setting the mask
 	 * only to state that 16 fprs exist. The real FPCR is too hard to get,
 	 * anyway.
 	 */
-	fpregs->fpcr = 0x00800000;
+	fpregs->fpc = 0x00800000;
 	wSrc = (uint8_t *) &(dibPtr->dfreg); /* Get the adrs of the fp    */
-	wDest = (uint8_t *) &(fpregs->fpreg); /*  regs, then copy them    */
-	memcpy(wDest, wSrc, sizeof(fpregs->fpreg)); /*  into the note area.    */
+	wDest = (U_8 *)&(fpregs->fprs);                /*  regs, then copy them     */
+	memcpy( wDest, wSrc, sizeof(fpregs->fprs) );   /*  into the note area.      */
 	/*
 	 * ... then NT_S390_LAST_BREAK
 	 */

--- a/port/ztpf/omrosdump_helpers.h
+++ b/port/ztpf/omrosdump_helpers.h
@@ -75,7 +75,7 @@ typedef struct {
    uint32_t flags; /* argv[5] = 32 bits of output flags	*/
    uint32_t	wkspcSize; /* argv[6] = How big is argv[7]?	*/
    uint8_t *wkSpace; /* argv[7] = ptr to workspace */
-   struct J9PortLibrary	*portLibrary;   /* argv[8] = ptr to J9PortLibrary */
+   struct OMRPortLibrary	*portLibrary;   /* argv[8] = ptr to OMRPortLibrary */
    DIB *dibPtr;		  /* argv[9] = ptr to Dump Interchange Blk.	*/
 } args;
 
@@ -121,13 +121,11 @@ void *			ztpfBuildCoreFile( void *argv ); /* This decl is set up to take a
 		/*
 		 *    External entry point declarations WRT this T.U.
 		 */
-#ifndef J9SIGNAL_CONTEXT
 extern void		ztpfDeriveSiginfo( siginfo_t *build ) __attribute__((nonnull));
 extern void		translateInterruptContexts( args *argv ) __attribute__((nonnull));
 extern uint8_t *allocateContextStorage( void );
 extern void     ztpf_preemptible_helper(void);
 extern void     ztpf_nonpreemptible_helper(void);
-#endif
 
 			/*********************************************************/
 			/*	  Programming convenience definitions/declarations	 */
@@ -198,9 +196,6 @@ extern void     ztpf_nonpreemptible_helper(void);
  *	  Aggregate data type declarations of importance to the ELF core file.
  *	  Most of these aggregates appear somewhere in the .NOTE section.
  */
-//avoid: error: conflicting types for greg_t, etc... sys/ucontext.h already has them
-//typedef uint64_t	greg_t;			/* Datatype for a general register			*/
-//typedef SYS_FLOAT	fpreg_t;		/* Datatype for a floating point reg		*/
 					 
 /*					 
  *	The NT_AUXV segment means something to a UNIX or Linux system. It means
@@ -231,13 +226,6 @@ typedef struct {
    uint32_t		acrs[16];			/* Access registers (no value in z/TPF)		*/
    uint64_t		orig_gpr2;			/* Original R2, held by interpreter.		*/
 } s390_regs;
-
-//
-//avoid: error: conflicting types for ‘gregset_t’ sys/ucontext.h has the definition already.
-//
-//typedef struct {					/* Datatype for a full set of ...			*/
-//	uint64_t		gprs[16];			/* ... sixteen 64-bit general registers.	*/
-//} gregset_t;
 
 typedef struct shortsiginfo_t {		/* This is the leading struct in ELF		*/
 	uint32_t		si_signo;		/*	PRSTATUS.								*/

--- a/port/ztpf/safe_storage.h
+++ b/port/ztpf/safe_storage.h
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 1991, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *    Multiple authors (IBM Corp.) - z/TPF platform initial port to OMR environment
+ *******************************************************************************/
+
+#ifndef _SAFE_STORAGE_H_INCLUDED
+#define _SAFE_STORAGE_H_INCLUDED
+
+#include <tpf/c_proc.h>
+#include <sys/sigcontext.h>
+#include "omrosdump_helpers.h"
+
+/*
+ * The only fields in safeStorage.argv that require setting by
+ * the caller are dibPtr and portLibrary. argv.rc & argv.flags
+ * are pre-cleared to zero. Function allocateDurableStorage()
+ * has initialized all the pointers to point back into the
+ * same static storage block. By passing &(safeStorage.argv)
+ * to our thread-based functions (such as ztpfBuildCoreFile()
+ * and translateInterruptContexts(), you've fulfilled the
+ * very purpose of this block.
+ *
+ * All fields in "safeStorage" are cleared; callers are
+ * responsible for completing them, if desired.
+ */
+typedef struct _durable_storage {
+	U_8	workbuffer[PATH_MAX];
+	U_8	filename[PATH_MAX];
+	siginfo_t	siginfo;
+	ucontext_t ucontext;
+	struct sigcontext sigcontext;
+	DIB	*pDIB;
+	struct iproc *pPROC;
+	args argv;
+} safeStorage;
+
+extern safeStorage *allocateDurableStorage( void );
+
+#endif

--- a/thread/common/omrthread.c
+++ b/thread/common/omrthread.c
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2016
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -14,6 +14,7 @@
  *
  * Contributors:
  *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *    Multiple authors (IBM Corp.) - z/TPF platform initial port to OMR environment
  *******************************************************************************/
 
 /**
@@ -1578,7 +1579,7 @@ thread_wrapper(WRAPPER_ARG arg)
 
 	threadEnableCpuMonitor(thread);
 
-#if defined(LINUX)
+#if defined(LINUX)  && !defined(OMRZTPF)
 	/* Workaround for NPTL bug on Linux. See omrthread_exit() */
 	{
 		jmp_buf jumpBuffer;
@@ -1589,9 +1590,9 @@ thread_wrapper(WRAPPER_ARG arg)
 		}
 		thread->jumpBuffer = NULL;
 	}
-#else /* defined(LINUX) */
+#else /* defined(LINUX) && !defined(OMRZTPF) */
 	thread->entrypoint(thread->entryarg);
-#endif /* defined(LINUX) */
+#endif /* defined(LINUX) && !defined(OMRZTPF) */
 
 	threadInternalExit();
 	/* UNREACHABLE */

--- a/thread/common/omrthreadinspect.c
+++ b/thread/common/omrthreadinspect.c
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 1991, 2016
+ * (c) Copyright IBM Corp. 1991, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -14,6 +14,7 @@
  *
  * Contributors:
  *    Multiple authors (IBM Corp.) - initial implementation and documentation
+      Multiple authors (IBM Corp.) - z/TPF platform initial port to OMR environment
  *******************************************************************************/
 
 /**
@@ -29,7 +30,9 @@
 
 #if defined(LINUX)
 /* Allowing the use of pthread_attr_getstack in omrthread_get_stack_range */
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include <features.h>
 #elif defined(OSX)
 #include <pthread.h>


### PR DESCRIPTION
Cleaned up our opensource version of sys/ucontext.h to use unmodified
definitions. The omr/port/ztpf file updates support this change.

Signed-off-by: pelemie <lemie@us.ibm.com>