### PR TITLE
Fix test for `str_ftime()` in Singapore time zone

### DIFF
--- a/fvtest/porttest/omrstrTest.cpp
+++ b/fvtest/porttest/omrstrTest.cpp
@@ -520,8 +520,8 @@ TEST(PortStrTest, str_test3)
 	/* First test: The epoch */
 	portTestEnv->log("\t This test could fail if you abut the international dateline (westside of dateline)\n");
 	timeMillis = 0;
-	strncpy(expected, "1970 01 Jan 01 XX:00:00", J9STR_BUFFER_SIZE);
-	test_omrstr_ftime(OMRPORTLIB, testName, buf, J9STR_BUFFER_SIZE, "%Y %m %b %d XX:%M:%S", timeMillis, expected);
+	strncpy(expected, "1970 01 Jan 01 XX:YY:00", J9STR_BUFFER_SIZE);
+	test_omrstr_ftime(OMRPORTLIB, testName, buf, J9STR_BUFFER_SIZE, "%Y %m %b %d XX:YY:%S", timeMillis, expected);
 
 
 


### PR DESCRIPTION
Test for `str_ftime()` fails when run in Singapore time zone.

The test expects all time zone offsets to UTC at Unix timestamp `0` to
be full hours. In Singapore at Unix timestamp `0` the offset was 7
hours and 30 minutes.

The change simply makes it so the test ignores differences in minutes
between UTC and local time in addition to ignoring differences in
hours.

Signed-off-by: Paavo Parkkinen <pparkkin@gmail.com>