### PR TITLE
[Mem7] Remove Node lookup by index from NodePool

### DIFF
--- a/compiler/il/NodePool.cpp
+++ b/compiler/il/NodePool.cpp
@@ -51,13 +51,6 @@ TR::NodePool::removeNode(NodeIndex poolIdx)
    }
 
 TR::Node *
-TR::NodePool::getNodeAtPoolIndex(ncount_t poolIdx)
-   {
-   TR_ASSERT(_pool.Exists(poolIdx), "Node with Pool Index %d does not exist in the table", poolIdx);
-   return &_pool.ElementAt(poolIdx);
-   }
-
-TR::Node *
 TR::NodePool::allocate(ncount_t poolIndex)
    {
    if (!poolIndex)

--- a/compiler/il/NodePool.hpp
+++ b/compiler/il/NodePool.hpp
@@ -54,7 +54,6 @@ class NodePool
 
    TR::Node * allocate(ncount_t poolIndex = 0);
    bool      deallocate(TR::Node * node);
-   TR::Node * getNodeAtPoolIndex(ncount_t poolIdx);
    void      removeNodeAndReduceGlobalIndex(TR::Node * node);
    bool      removeDeadNodes();
    void      enableNodeGC()  { _disableGC = false; }

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -1950,37 +1950,6 @@ OMR::Node::containsNode(TR::Node *searchNode, vcount_t visitCount)
    return false;
    }
 
-bool
-OMR::Node::containsAnyNode(List<TR::Node *> &nodeList, vcount_t visitCount)
-   {
-   for (ListElement<TR::Node *> *el = nodeList.getListHead(); el; el = el->getNextElement())
-      {
-      if (self()->containsNode(*el->getData(), visitCount))
-         return true;
-      }
-   return false;
-   }
-
-/**
- * Calls containsNode on each node from bitvector. The bitvector is a Set of nodes which holds
- * NodePool indices which is accessible via TR::Node::getGlobalIndex.
- * The node is retrieved per index through the NodePool.
- */
-bool
-OMR::Node::containsAnyNode(TR::SparseBitVector &nodeSet, vcount_t visitCount, TR::Compilation *comp)
-   {
-   TR::SparseBitVector::Cursor bi(nodeSet);
-   for (bi.SetToFirstOne(); bi.Valid(); bi.SetToNextOne())
-      {
-      TR::Node *chk = comp->getNodePool().getNodeAtPoolIndex((ncount_t)bi);
-      if (self()->containsNode(chk, visitCount))
-         return true;
-      }
-   return false;
-   }
-
-
-
 /**
  * Does this node have an unresolved symbol reference?
  */

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -379,9 +379,6 @@ public:
    TR::Node *             uncommon();
 
    bool                   containsNode(TR::Node *searchNode, vcount_t visitCount); // Careful how you use this: it doesn't account for aliasing
-   // these call containsNode on each node found in the list or bitvector set of Nodes
-   bool                   containsAnyNode(List<TR::Node *> &nodeList, vcount_t visitCount);
-   bool                   containsAnyNode(TR::SparseBitVector &nodeSet, vcount_t visitCount, TR::Compilation *comp);
 
    /// Does this node have an unresolved symbol reference?
    bool                   hasUnresolvedSymbolReference();

--- a/compiler/optimizer/DeadTreesElimination.cpp
+++ b/compiler/optimizer/DeadTreesElimination.cpp
@@ -207,40 +207,39 @@ bool collectSymbolReferencesInNode(TR::Node *node,
 // TODO: Path retrieval is not implemented, but is trivial, making this O(N)
 static int32_t getLongestPathOfDAG(TR::Node *entry, TR::Compilation *cm)
    {
-   using namespace CS2;
    TR::StackMemoryRegion stackMemoryRegion(*cm->trMemory());
-
-   QueueOf<ncount_t, TR::Allocator> queue(cm->allocator());
-   HashTable<ncount_t, int32_t, TR::Allocator> longestPathLens(cm->allocator());
-   longestPathLens.Add(entry->getNodePoolIndex(), 0);
-   queue.Push(entry->getNodePoolIndex());
+   TR::deque<TR::Node *, TR::Region&> queue(stackMemoryRegion);
+   typedef TR::typed_allocator<std::pair<TR::Node *, int32_t>, TR::Region&> LongestPathAllocator;
+   typedef std::less<TR::Node *> LongestPathComparator;
+   typedef std::map<TR::Node *, int32_t, LongestPathComparator, LongestPathAllocator> LongestPathMap;
+   LongestPathMap longestPathLens((LongestPathComparator()), stackMemoryRegion);
+   longestPathLens[entry] = 0;
+   queue.push_back(entry);
    int32_t maxLen = 0;
-   while(!queue.IsEmpty())
+   while (!queue.empty())
       {
-      auto nodePoolIndex = queue.Pop();
-      auto node = cm->getNodePool().getNodeAtPoolIndex(nodePoolIndex);
-      auto prevLongestPathLen = longestPathLens.Get(nodePoolIndex);
+      TR::Node *node = queue.front();
+      queue.pop_front();
+      auto prevLongestPathLen = longestPathLens[node];
       if (node->getNumChildren() == 0)
          {
          if (prevLongestPathLen > maxLen)
             maxLen = prevLongestPathLen;
          }
-      for(int i=0; i<node->getNumChildren(); i++)
+      for (int i = 0; i < node->getNumChildren(); ++i)
          {
-         auto childPoolIndex = node->getChild(i)->getNodePoolIndex();
-         HashIndex hashIdx;
-         if (!longestPathLens.Locate(childPoolIndex, hashIdx))
-            longestPathLens.Add(childPoolIndex, 0, hashIdx);
-
+         TR::Node *child = node->getChild(i);
+         if (longestPathLens.find(child) == longestPathLens.end())
+            longestPathLens[child] = 0;
+         
          // if new longest path is found, update and push child
-         if (prevLongestPathLen + 1 > longestPathLens[hashIdx])
+         if (prevLongestPathLen + 1 > longestPathLens[child])
             {
-            longestPathLens[hashIdx] = prevLongestPathLen + 1;
-            queue.Push(childPoolIndex);
+            longestPathLens[child] = prevLongestPathLen + 1;
+            queue.push_back(child);
             }
          }
       }
-
    return maxLen;
    }
 


### PR DESCRIPTION
This change removes the node pool functionality to look up a node by its
pool index. This feature is rarely used in the compiler and not allowing
lookup by index allows for future changes to the node allocation
algorithms that do not permit such lookup.

Signed-off-by: Andrew Craik <ajcraik@ca.ibm.com>