### PR TITLE
Fix str_vprintf() usage in port library

### DIFF
--- a/fvtest/porttest/omrstrTest.cpp
+++ b/fvtest/porttest/omrstrTest.cpp
@@ -179,46 +179,33 @@ test_omrstr_vprintf(struct OMRPortLibrary *portLibrary, const char *testName, co
 	/* Buffer larger than required */
 	va_start(args, expectedResult);
 	validate_omrstr_vprintf(OMRPORTLIB, testName, actualResult, sizeof(actualResult), expectedResult, format, args);
-	va_end(args);
 
 	/* Exact size buffer (+1 for NUL)*/
-	va_start(args, expectedResult);
 	validate_omrstr_vprintf(OMRPORTLIB, testName, actualResult, strlen(expectedResult) + 1, expectedResult, format, args);
-	va_end(args);
 
 	/* Truncated buffer - use strlen(expectedResult) as length of buffer thus reducing the size by 1*/
 	if (strlen(expectedResult) > 1) {
 		strcpy(truncatedExpectedResult, expectedResult);
 		truncatedExpectedResult[strlen(expectedResult) - 1] = '\0';
 
-		va_start(args, expectedResult);
 		validate_omrstr_vprintf(OMRPORTLIB, testName, actualResult, strlen(expectedResult), truncatedExpectedResult, format, args);
-		va_end(args);
-
 
 		/* Truncated buffer - use strlen(expectedResult)-1 as length of buffer thus reducing the size by 2*/
 		if (strlen(expectedResult) > 2) {
 			truncatedExpectedResult[strlen(expectedResult) - 2] = '\0';
 
-			va_start(args, expectedResult);
 			validate_omrstr_vprintf(OMRPORTLIB, testName, actualResult, strlen(expectedResult) - 1, truncatedExpectedResult, format, args);
-			va_end(args);
 		}
 	}
 
 	/* Some NULL test, size of buffer does not matter */
 	/* NULL, 0, expect size of buffer required */
-	va_start(args, expectedResult);
 	validate_omrstr_vprintf_with_NULL(OMRPORTLIB, testName, 0, (uint32_t)strlen(expectedResult) + 1, format, args);
-	va_end(args);
 
 	/* NULL, -1, expect size of buffer required */
-	va_start(args, expectedResult);
 	validate_omrstr_vprintf_with_NULL(OMRPORTLIB, testName, (uint32_t)-1, (uint32_t)strlen(expectedResult) + 1, format, args);
-	va_end(args);
 
 	/* NULL, truncated buffer, use strlen(expectedResult) as length of buffer thus reducing the size by 1 */
-	va_start(args, expectedResult);
 	validate_omrstr_vprintf_with_NULL(OMRPORTLIB, testName, (uint32_t)strlen(expectedResult), (uint32_t)strlen(expectedResult) + 1, format, args);
 	va_end(args);
 }

--- a/fvtest/porttest/testHelpers.cpp
+++ b/fvtest/porttest/testHelpers.cpp
@@ -240,18 +240,16 @@ outputErrorMessage(struct OMRPortLibrary *portLibrary, const char *fileName, int
 	va_start(args, format);
 	/* get the size needed to hold the error message that was passed in */
 	sizeBuf = omrstr_vprintf(NULL, 0, format, args);
-	va_end(args);
 
 	buf = (char *)omrmem_allocate_memory(sizeBuf, OMRMEM_CATEGORY_PORT_LIBRARY);
 	if (NULL != buf) {
-		va_start(args, format);
 		omrstr_vprintf(buf, sizeBuf, format, args);
-		va_end(args);
 	} else {
 		portTestEnv->log(LEVEL_ERROR, "\n\n******* omrmem_allocate_memory failed to allocate %i bytes, exiting.\n\n", sizeBuf);
 		exit(EXIT_OUT_OF_MEMORY);
 
 	}
+	va_end(args);
 
 	portTestEnv->log(LEVEL_ERROR, "%s line %4zi: %s ", fileName, lineNumber, testName);
 	portTestEnv->log(LEVEL_ERROR, "%s\n", buf);

--- a/jitbuilder/release/src/OperandStackTests.cpp
+++ b/jitbuilder/release/src/OperandStackTests.cpp
@@ -402,6 +402,7 @@ OperandStackTestMethod::verifyStack(const char *step, int32_t max, int32_t num, 
       if (verbose) cout << "\tResult " << step << ": _realStack[" << a << "] == " << val << ": ";
       REPORT2(_realStack[a] == val, "_realStack[a]", _realStack[a], "val", val);
       }
+   va_end(args);
 
    if (verbose) cout << "\tResult " << step << ": upper stack untouched: ";
    REPORT1(verifyUntouched(max), "max", max);

--- a/port/common/omrerror.c
+++ b/port/common/omrerror.c
@@ -334,7 +334,6 @@ omrerror_set_last_error_with_message_format(struct OMRPortLibrary *portLibrary, 
 
 	va_start(args, format);
 	requiredSize = portLibrary->str_vprintf(portLibrary, NULL, 0, format, args);
-	va_end(args);
 
 	/* Store the message, allocate a bigger buffer if required.  Keep the old buffer around
 	 * just in case memory can not be allocated
@@ -354,14 +353,13 @@ omrerror_set_last_error_with_message_format(struct OMRPortLibrary *portLibrary, 
 	/* Save the message -- if we failed allocate an appropriate size buffer above it may be truncated into preexisting buffer*/
 	if ((NULL != ptBuffers->errorMessageBuffer) && (ptBuffers->errorMessageBufferSize > 0)) {
 		uintptr_t sizeWritten = 0;
-		va_start(args, format);
 		sizeWritten = portLibrary->str_vprintf(portLibrary, ptBuffers->errorMessageBuffer, ptBuffers->errorMessageBufferSize, format, args);
 		/* Check for truncation and add null byte at end if necessary */
 		if (sizeWritten == ptBuffers->errorMessageBufferSize) {
 			ptBuffers->errorMessageBuffer[sizeWritten - 1] = 0;
 		}
-		va_end(args);
 	}
+	va_end(args);
 
 	return portableCode;
 }

--- a/port/unix/omrfile.c
+++ b/port/unix/omrfile.c
@@ -916,41 +916,34 @@ omrfile_startup(struct OMRPortLibrary *portLibrary)
 void
 omrfile_vprintf(struct OMRPortLibrary *portLibrary, intptr_t fd, const char *format, va_list args)
 {
-	char outputBuffer[256];
-	char *allocatedBuffer;
-	uintptr_t numberWritten;
-	va_list copyOfArgs;
+	char localBuffer[256];
+	char *writeBuffer = NULL;
+	uintptr_t bufferSize = 0;
+	uintptr_t stringSize = 0;
 
-	/* Attempt to write output to stack buffer */
-	COPY_VA_LIST(copyOfArgs, args);
-	numberWritten = portLibrary->str_vprintf(portLibrary, outputBuffer, sizeof(outputBuffer), format, copyOfArgs);
+	/* str_vprintf(.., NULL, ..) result is size of buffer required including the null terminator */
+	bufferSize = portLibrary->str_vprintf(portLibrary, NULL, 0, format, args);
 
-	/* str_vprintf always null terminates, returns number characters written excluding the null terminator */
-	if (sizeof(outputBuffer)  > (numberWritten + 1)) {
-		/* write out the buffer */
-		portLibrary->file_write_text(portLibrary, fd, outputBuffer, numberWritten);
-		return;
+	/* use local buffer if possible, allocate a buffer from system memory if local buffer not large enough */
+	if (sizeof(localBuffer) >= bufferSize) {
+		writeBuffer = localBuffer;
+	} else {
+		writeBuffer = portLibrary->mem_allocate_memory(portLibrary, bufferSize, OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
 	}
 
-	/* Either the buffer was too small, or it was the exact size.  Unfortunately can't tell the difference,
-	 * need to determine the size of the buffer (another call to str_vprintf) then print to the buffer,
-	 * a third call to str_vprintf
-	 */
-	COPY_VA_LIST(copyOfArgs, args);
-
-	/* What is size of buffer required ? Does not include the \0 */
-	numberWritten = portLibrary->str_vprintf(portLibrary, NULL, 0, format, copyOfArgs);
-	numberWritten += 1;
-
-	allocatedBuffer = portLibrary->mem_allocate_memory(portLibrary, numberWritten, OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
-	if (NULL == allocatedBuffer) {
+	/* format and write out the buffer (truncate into local buffer as last resort) without null terminator */
+	if (NULL != writeBuffer) {
+		stringSize = portLibrary->str_vprintf(portLibrary, writeBuffer, bufferSize, format, args);
+		portLibrary->file_write_text(portLibrary, fd, writeBuffer, stringSize);
+		/* dispose of buffer if not on local */
+		if (writeBuffer != localBuffer) {
+			portLibrary->mem_free_memory(portLibrary, writeBuffer);
+		}
+	} else {
 		portLibrary->nls_printf(portLibrary, J9NLS_ERROR, J9NLS_PORT_FILE_MEMORY_ALLOCATE_FAILURE);
-		return;
+		stringSize = portLibrary->str_vprintf(portLibrary, localBuffer, sizeof(localBuffer), format, args);
+		portLibrary->file_write_text(portLibrary, fd, localBuffer, stringSize);
 	}
-
-	numberWritten = portLibrary->str_vprintf(portLibrary, allocatedBuffer, numberWritten, format, args);
-	portLibrary->file_write_text(portLibrary, fd, allocatedBuffer, numberWritten);
-	portLibrary->mem_free_memory(portLibrary, allocatedBuffer);
 }
 
 /**

--- a/port/win32/omrfile.c
+++ b/port/win32/omrfile.c
@@ -833,41 +833,34 @@ omrfile_unlinkdir(struct OMRPortLibrary *portLibrary, const char *path)
 void
 omrfile_vprintf(struct OMRPortLibrary *portLibrary, intptr_t fd, const char *format, va_list args)
 {
-	char outputBuffer[256];
-	char *allocatedBuffer;
-	uintptr_t numberWritten;
-	va_list copyOfArgs;
+	char localBuffer[256];
+	char *writeBuffer = NULL;
+	uintptr_t bufferSize = 0;
+	uintptr_t stringSize = 0;
 
-	/* Attempt to write output to stack buffer */
-	COPY_VA_LIST(copyOfArgs, args);
-	numberWritten = portLibrary->str_vprintf(portLibrary, outputBuffer, sizeof(outputBuffer), format, copyOfArgs);
+	/* str_vprintf(.., NULL, ..) result is size of buffer required including the null terminator */
+	bufferSize = portLibrary->str_vprintf(portLibrary, NULL, 0, format, args);
 
-	/* str_vprintf always null terminates, returns number characters written excluding the null terminator */
-	if (sizeof(outputBuffer) > (numberWritten + 1)) {
-		/* write out the buffer */
-		portLibrary->file_write_text(portLibrary, fd, outputBuffer, numberWritten);
-		return;
+	/* use local buffer if possible, allocate a buffer from system memory if local buffer not large enough */
+	if (sizeof(localBuffer) >= bufferSize) {
+		writeBuffer = localBuffer;
+	} else {
+		writeBuffer = portLibrary->mem_allocate_memory(portLibrary, bufferSize, OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
 	}
 
-	/* Either the buffer was too small, or it was the exact size.  Unfortunately can't tell the difference,
-	 * need to determine the size of the buffer (another call to str_vprintf) then print to the buffer,
-	 * a third call to str_vprintf
-	 */
-	COPY_VA_LIST(copyOfArgs, args);
-
-	/* What is size of buffer required ? Does not include the \0 */
-	numberWritten = portLibrary->str_vprintf(portLibrary, NULL, 0, format, copyOfArgs);
-	numberWritten += 1;
-
-	allocatedBuffer = portLibrary->mem_allocate_memory(portLibrary, numberWritten, OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
-	if (NULL == allocatedBuffer) {
+	/* format and write out the buffer (truncate into local buffer as last resort) without null terminator */
+	if (NULL != writeBuffer) {
+		stringSize = portLibrary->str_vprintf(portLibrary, writeBuffer, bufferSize, format, args);
+		portLibrary->file_write_text(portLibrary, fd, writeBuffer, stringSize);
+		/* dispose of buffer if not on local */
+		if (writeBuffer != localBuffer) {
+			portLibrary->mem_free_memory(portLibrary, writeBuffer);
+		}
+	} else {
 		portLibrary->nls_printf(portLibrary, J9NLS_ERROR, J9NLS_PORT_FILE_MEMORY_ALLOCATE_FAILURE);
-		return;
+		stringSize = portLibrary->str_vprintf(portLibrary, localBuffer, sizeof(localBuffer), format, args);
+		portLibrary->file_write_text(portLibrary, fd, localBuffer, stringSize);
 	}
-
-	numberWritten = portLibrary->str_vprintf(portLibrary, allocatedBuffer, numberWritten, format, args);
-	portLibrary->file_write_text(portLibrary, fd, allocatedBuffer, numberWritten);
-	portLibrary->mem_free_memory(portLibrary, allocatedBuffer);
 }
 
 intptr_t


### PR DESCRIPTION
Usage of this method is incorrect in several port methods. This commit
fixes usage and simplifies affected methods somewhat.

Signed-off-by: Kim Briggs <briggs@ca.ibm.com>