### PR TITLE
Z nanotime precision

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -646,12 +646,6 @@ class OMR_EXTENSIBLE CodeGenerator
 
    uint32_t getMaxObjectSizeGuaranteedNotToOverflow() { return _maxObjectSizeGuaranteedNotToOverflow; }
 
-   // high precision timer can be converted into millisecond timer or nanosecond timer through appropriate
-   // division or multiplication (respectively). For example, 390 high precision timer provides accuracy to
-   // 1/8 of a microsecond so converters are 8000 and 125 respectively (multiplying the two should give you 1000000)
-   int64_t getCurrentTimeMillisDivisor() { return 0; } // no virt
-   int64_t getNanoTimeMultiplier() { return 0; } // no virt
-
    // --------------------------------------------------------------------------
    // OSR, not code generator
    //

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -1115,9 +1115,6 @@ public:
       return 7;
       }
 
-   int64_t getCurrentTimeMillisDivisor() { return 8000; }
-   int64_t getNanoTimeMultiplier() { return 125; }
-
    // LL: move to .cpp
    bool arithmeticNeedsLiteralFromPool(TR::Node *node);
 

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -232,6 +232,34 @@
 #define OMRPORT_TIME_DELTA_IN_NANOSECONDS ((uint64_t) 1000000000)
 /** @} */
 
+#if defined(S390) || defined(J9ZOS390)
+/**
+ * @name Constants to calculate time from high-resolution timer
+ * @anchor hiresConstants
+ * High-resolution timer can be converted into millisecond timer or nanosecond timer through appropriate
+ * division or multiplication (respectively). For example, 390 high-resolution timer provides accuracy to
+ * 1/2048 of a microsecond so, to convert hires timer to
+ * - nanoseconds, multiply it by 125/256
+ * - microseconds, divide it by 2,048
+ * - milliseconds, divide it by 2,048,000
+ * @{
+ */
+#define OMRPORT_TIME_HIRES_NANOTIME_NUMERATOR ((uint64_t) 125)
+#define OMRPORT_TIME_HIRES_NANOTIME_DENOMINATOR ((uint64_t) 256)
+#define OMRPORT_TIME_HIRES_MICROTIME_DIVISOR ((uint64_t) 2048)
+#define OMRPORT_TIME_HIRES_MILLITIME_DIVISOR ((uint64_t) 2048000)
+#define OMRTIME_HIRES_CLOCK_FREQUENCY ((uint64_t) 2048000000) /* Frequency is microseconds / second */
+
+#else
+
+#define OMRPORT_TIME_HIRES_NANOTIME_NUMERATOR ((uint64_t) 0)
+#define OMRPORT_TIME_HIRES_NANOTIME_DENOMINATOR ((uint64_t) 0)
+#define OMRPORT_TIME_HIRES_MICROTIME_DIVISOR ((uint64_t) 0)
+#define OMRPORT_TIME_HIRES_MILLITIME_DIVISOR ((uint64_t) 0)
+
+#endif /* defined(S390) || defined(J9ZOS390) */
+/** @} */
+
 #if defined(LINUX) && !defined(OMRZTPF)
 #define OMR_CONFIGURABLE_SUSPEND_SIGNAL
 #endif /* defined(LINUX) */

--- a/port/linuxs390/omrrttime.s
+++ b/port/linuxs390/omrrttime.s
@@ -33,7 +33,7 @@ maxprec:
     ahi %r2,-1
 .LCarry:
     s   %r2,.LC0-.LT0(%r1)
-    srdl %r2,9
+    srdl %r2,1
     br  %r14
 
     .align  8

--- a/port/linuxs390/omrtime.c
+++ b/port/linuxs390/omrtime.c
@@ -30,7 +30,6 @@
 #include "omrportpg.h"
 #include "omrport.h"
 
-#define OMRTIME_HIRES_CLOCK_FREQUENCY J9CONST_U64(8000000)
 #define OMRTIME_CLOCK_DELTA_ADJUSTMENT_INTERVAL_USEC J9CONST_I64(60 * 1000 * 1000)
 
 #define OMRTIME_NANOSECONDS_PER_SECOND J9CONST_I64(1000000000)
@@ -40,7 +39,23 @@ extern int64_t maxprec();
 
 static void omrtime_calculate_hw_time_delta(struct OMRPortLibrary *portLibrary);
 
-
+/**
+ * Multiply a number by a fraction
+ *
+ * @param[in] num The number to be multiplied by the fraction
+ * @param[in] numerator The numerator of the fraction
+ * @param[in] denominator The denominator of the fraction
+ *
+ * @return The result of the multiplication
+ */
+static int64_t
+muldiv64(const int64_t num, const int64_t numerator, const int64_t denominator)
+{
+	const int64_t quotient = num / denominator;
+	const int64_t remainder = num - quotient * denominator;
+	const int64_t res = quotient * numerator + ((remainder * numerator) / denominator);
+	return res;
+}
 
 /**
  * Query OS for timestamp.
@@ -55,7 +70,7 @@ uintptr_t
 omrtime_msec_clock(struct OMRPortLibrary *portLibrary)
 {
 	int64_t msec;
-	int64_t usec = maxprec() / 8;
+	int64_t usec = maxprec() / OMRPORT_TIME_HIRES_MICROTIME_DIVISOR;
 
 	msec = usec / 1000;
 
@@ -82,7 +97,7 @@ omrtime_msec_clock(struct OMRPortLibrary *portLibrary)
 uintptr_t
 omrtime_usec_clock(struct OMRPortLibrary *portLibrary)
 {
-	int64_t usec = maxprec() / 8;
+	int64_t usec = maxprec() / OMRPORT_TIME_HIRES_MICROTIME_DIVISOR;
 
 	if ((usec - PPG_last_clock_delta_update > OMRTIME_CLOCK_DELTA_ADJUSTMENT_INTERVAL_USEC)
 	 || (usec < PPG_last_clock_delta_update)
@@ -121,7 +136,7 @@ int64_t
 omrtime_current_time_millis(struct OMRPortLibrary *portLibrary)
 {
 	int64_t msec;
-	int64_t usec = maxprec() / 8;
+	int64_t usec = maxprec() / OMRPORT_TIME_HIRES_MICROTIME_DIVISOR;
 
 	/*
 	 * Note that this function is called by JIT inlined code to not only
@@ -253,7 +268,7 @@ omrtime_calculate_hw_time_delta(struct OMRPortLibrary *portLibrary)
 	struct timeval tp;
 
 	/* Get hardware microsecond UTC clock */
-	currentHWTime = maxprec() / 8;
+	currentHWTime = maxprec() / OMRPORT_TIME_HIRES_MICROTIME_DIVISOR;
 
 	/* Get OS microsecond UTC clock */
 	gettimeofday(&tp, NULL);

--- a/port/linuxs390/omrtime.c
+++ b/port/linuxs390/omrtime.c
@@ -245,9 +245,10 @@ omrtime_hires_delta(struct OMRPortLibrary *portLibrary, uint64_t startTime, uint
 	if (OMRTIME_HIRES_CLOCK_FREQUENCY == requiredResolution) {
 		/* no conversion necessary */
 	} else if (OMRTIME_HIRES_CLOCK_FREQUENCY < requiredResolution) {
-		ticks = (uint64_t)((double)ticks * ((double)requiredResolution / (double)OMRTIME_HIRES_CLOCK_FREQUENCY));
+		ticks = muldiv64(ticks, requiredResolution, OMRTIME_HIRES_CLOCK_FREQUENCY);
 	} else {
-		ticks = (uint64_t)((double)ticks / ((double)OMRTIME_HIRES_CLOCK_FREQUENCY / (double)requiredResolution));
+		/*equivalent to ticks / (OMRTIME_HIRES_CLOCK_FREQUENCY / requiredResolution)*/
+		ticks = muldiv64(ticks, requiredResolution, OMRTIME_HIRES_CLOCK_FREQUENCY);
 	}
 	return ticks;
 }

--- a/port/linuxs39064/omrrttime.s
+++ b/port/linuxs39064/omrrttime.s
@@ -28,7 +28,7 @@ maxprec:
     stckf 64(%r15)
     lg  %r1,64(%r15)
     sg %r1,.LC0-.LT0(%r3)
-    srlg %r1,%r1,9
+    srlg %r1,%r1,1
     lgr %r2,%r1
     br  %r14
 

--- a/port/zos390/omrrttime.s
+++ b/port/zos390/omrrttime.s
@@ -47,7 +47,7 @@ LCarry0  s   r2,LC0
          ahi r2,-1
 LCarry1  s   r2,CVTLSO
          drop r0,r1
-         srdl r2,9
+         srdl r2,1
          EDCXEPLG
          AGO .JMP2
 
@@ -63,7 +63,7 @@ maxprec  CELQPRLG BASEREG=8
          using CVTXTNT2,r1
          slg r3,CVTLSO
          drop r0,r1
-         srlg r3,r3,9
+         srlg r3,r3,1
          CELQEPLG
 
 .JMP2    ANOP

--- a/port/zos390/omrtime.c
+++ b/port/zos390/omrtime.c
@@ -30,10 +30,25 @@
 #include "omrportpriv.h"
 #include "omrportpg.h"
 
-/* Frequency is microseconds / second */
-#define OMRTIME_HIRES_CLOCK_FREQUENCY J9CONST_U64(8000000)
-
 extern int64_t MAXPREC();
+
+/**
+ * Multiply a number by a fraction
+ *
+ * @param[in] num The number to be multiplied by the fraction
+ * @param[in] numerator The numerator of the fraction
+ * @param[in] denominator The denominator of the fraction
+ *
+ * @return The result of the multiplication
+ */
+static int64_t
+muldiv64(const int64_t num, const int64_t numerator, const int64_t denominator)
+{
+	const int64_t quotient = num / denominator;
+	const int64_t remainder = num - quotient * denominator;
+	const int64_t res = quotient * numerator + ((remainder * numerator) / denominator);
+	return res;
+}
 
 /**
  * Query OS for timestamp.
@@ -48,7 +63,7 @@ extern int64_t MAXPREC();
 uintptr_t
 omrtime_msec_clock(struct OMRPortLibrary *portLibrary)
 {
-	int64_t millisec = MAXPREC() / 8000;
+	int64_t millisec = MAXPREC() / OMRPORT_TIME_HIRES_MILLITIME_DIVISOR;
 	return millisec;
 }
 /**
@@ -63,7 +78,7 @@ omrtime_msec_clock(struct OMRPortLibrary *portLibrary)
 uintptr_t
 omrtime_usec_clock(struct OMRPortLibrary *portLibrary)
 {
-	int64_t microsec = MAXPREC() / 8;
+	int64_t microsec = MAXPREC() / OMRPORT_TIME_HIRES_MICROTIME_DIVISOR;
 	return microsec;
 }
 
@@ -71,8 +86,14 @@ uint64_t
 omrtime_current_time_nanos(struct OMRPortLibrary *portLibrary, uintptr_t *success)
 {
 	*success = 1;
-	uint64_t nanos = MAXPREC() * 125;
-	return nanos;
+
+	const int64_t subnanosec = MAXPREC();
+
+	// calculate nanosec = subnanosec * NUMERATOR / DENOMINATOR via integer arithmetics
+	const int64_t nanosec = muldiv64(subnanosec,
+			OMRPORT_TIME_HIRES_NANOTIME_NUMERATOR, OMRPORT_TIME_HIRES_NANOTIME_DENOMINATOR);
+
+	return nanosec;
 }
 
 /**
@@ -87,15 +108,20 @@ omrtime_current_time_nanos(struct OMRPortLibrary *portLibrary, uintptr_t *succes
 int64_t
 omrtime_current_time_millis(struct OMRPortLibrary *portLibrary)
 {
-	int64_t millisec = MAXPREC() / 8000;
+	int64_t millisec = MAXPREC() / OMRPORT_TIME_HIRES_MILLITIME_DIVISOR;
 	return millisec;
 }
 
 int64_t
 omrtime_nano_time(struct OMRPortLibrary *portLibrary)
 {
-	int64_t nanos = MAXPREC() * 125;
-	return nanos;
+	const int64_t subnanosec = MAXPREC();
+
+	// calculate nanosec = subnanosec * NUMERATOR / DENOMINATOR via integer arithmetics
+	const int64_t nanosec = muldiv64(subnanosec,
+			OMRPORT_TIME_HIRES_NANOTIME_NUMERATOR, OMRPORT_TIME_HIRES_NANOTIME_DENOMINATOR);
+
+	return nanosec;
 }
 
 /**

--- a/port/zos390/omrtime.c
+++ b/port/zos390/omrtime.c
@@ -184,9 +184,10 @@ omrtime_hires_delta(struct OMRPortLibrary *portLibrary, uint64_t startTime, uint
 	if (OMRTIME_HIRES_CLOCK_FREQUENCY == requiredResolution) {
 		/* no conversion necessary */
 	} else if (OMRTIME_HIRES_CLOCK_FREQUENCY < requiredResolution) {
-		ticks = (uint64_t)((double)ticks * ((double)requiredResolution / (double)OMRTIME_HIRES_CLOCK_FREQUENCY));
+		ticks = muldiv64(ticks, requiredResolution, OMRTIME_HIRES_CLOCK_FREQUENCY);
 	} else {
-		ticks = (uint64_t)((double)ticks / ((double)OMRTIME_HIRES_CLOCK_FREQUENCY / (double)requiredResolution));
+		/*equivalent to ticks / (OMRTIME_HIRES_CLOCK_FREQUENCY / requiredResolution)*/
+		ticks = muldiv64(ticks, requiredResolution, OMRTIME_HIRES_CLOCK_FREQUENCY);
 	}
 	return ticks;
 }


### PR DESCRIPTION
Previously, the high-resolution timer was truncated to 1/8 of a microsec and then multiplied by a constant to e.g. obtain the current time in nanoseconds.

Now, we obtain high-resolution timer that has the precision of approximately 0.5 of a nanosecond and adjusts it to produce e.g. the current time in nanoseconds without losing precision.