### PR TITLE
Remove optDetailString from OptimizationManager

### DIFF
--- a/compiler/optimizer/AsyncCheckInsertion.cpp
+++ b/compiler/optimizer/AsyncCheckInsertion.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -174,4 +174,10 @@ int32_t TR_AsyncCheckInsertion::perform()
       }
 
    return 0;
+   }
+
+const char *
+TR_AsyncCheckInsertion::optDetailString() const throw()
+   {
+   return "O^O ASYNC CHECK INSERTION: ";
    }

--- a/compiler/optimizer/AsyncCheckInsertion.hpp
+++ b/compiler/optimizer/AsyncCheckInsertion.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -45,6 +45,8 @@ class TR_AsyncCheckInsertion : public TR::Optimization
 
    virtual bool    shouldPerform();
    virtual int32_t perform();
+
+   virtual const char * optDetailString() const throw();
 
    private:
 

--- a/compiler/optimizer/CFGSimplifier.cpp
+++ b/compiler/optimizer/CFGSimplifier.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -841,4 +841,10 @@ bool TR_CFGSimplifier::simplifyCondCodeBooleanStore(TR::Block *joinBlock, TR::No
 bool TR_CFGSimplifier::canReverseBranchMask()
    {
    return false;
+   }
+
+const char *
+TR_CFGSimplifier::optDetailString() const throw()
+   {
+   return "O^O CFG SIMPLIFICATION: ";
    }

--- a/compiler/optimizer/CFGSimplifier.hpp
+++ b/compiler/optimizer/CFGSimplifier.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -44,6 +44,7 @@ class TR_CFGSimplifier : public TR::Optimization
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    private :
 

--- a/compiler/optimizer/CatchBlockRemover.cpp
+++ b/compiler/optimizer/CatchBlockRemover.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -161,4 +161,10 @@ int32_t TR_CatchBlockRemover::perform()
       traceMsg(comp(), "\nEnding Catch Block Removal\n");
 
    return 1; // actual cost
+   }
+
+const char *
+TR_CatchBlockRemover::optDetailString() const throw()
+   {
+   return "O^O CATCH BLOCK REMOVAL: ";
    }

--- a/compiler/optimizer/CatchBlockRemover.hpp
+++ b/compiler/optimizer/CatchBlockRemover.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -55,6 +55,7 @@ class TR_CatchBlockRemover : public TR::Optimization
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    private :
 

--- a/compiler/optimizer/CompactLocals.cpp
+++ b/compiler/optimizer/CompactLocals.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -591,4 +591,10 @@ TR_CompactLocals::doCompactLocals()
    //   cg()->setHasCompactedLocals();
 
    cg()->setLocalsIG(_localsIG);
+   }
+
+const char *
+TR_CompactLocals::optDetailString() const throw()
+   {
+   return "O^O COMPACT LOCALS: ";
    }

--- a/compiler/optimizer/CompactLocals.hpp
+++ b/compiler/optimizer/CompactLocals.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -72,6 +72,7 @@ public:
    void assignColorsToSymbols(TR_BitVector *bv);
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
    };
 
 #endif

--- a/compiler/optimizer/CopyPropagation.cpp
+++ b/compiler/optimizer/CopyPropagation.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -2531,4 +2531,10 @@ TR::Node *TR_CopyPropagation::isValidRegLoad(TR::Node *rhsOfStoreDefNode, TR::Tr
                   regNumber = -1;
 
    return (isRegLoad ? rhsOfStoreDefNode : NULL);
+   }
+
+const char *
+TR_CopyPropagation::optDetailString() const throw()
+   {
+   return "O^O COPY PROPAGATION: ";
    }

--- a/compiler/optimizer/CopyPropagation.hpp
+++ b/compiler/optimizer/CopyPropagation.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -61,6 +61,7 @@ class TR_CopyPropagation : public TR::Optimization
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    private :
    void replaceCopySymbolReferenceByOriginalIn(TR::SymbolReference * copySymRef, TR::Node * rhsOfStoreDefNode, TR::Node * useNode, TR::Node *defNode, TR::Node * baseAddrNode = NULL,bool baseAddrAvail = false);

--- a/compiler/optimizer/DeadStoreElimination.cpp
+++ b/compiler/optimizer/DeadStoreElimination.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -25,4 +25,10 @@ TR_DeadStoreElimination::TR_DeadStoreElimination(TR::OptimizationManager *manage
    : TR_IsolatedStoreElimination(manager)
    {
    _mustUseUseDefInfo = true;
+   }
+
+const char *
+TR_DeadStoreElimination::optDetailString() const throw()
+   {
+   return "O^O DEAD STORE ELIMINATION: ";
    }

--- a/compiler/optimizer/DeadStoreElimination.hpp
+++ b/compiler/optimizer/DeadStoreElimination.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -50,6 +50,8 @@ class TR_DeadStoreElimination : public TR_IsolatedStoreElimination
       {
       return new (manager->allocator()) TR_DeadStoreElimination(manager);
       }
+
+   virtual const char * optDetailString() const throw();
    };
 
 #endif

--- a/compiler/optimizer/DeadTreesElimination.cpp
+++ b/compiler/optimizer/DeadTreesElimination.cpp
@@ -900,4 +900,8 @@ TR::TreeTop *TR::DeadTreesElimination::findLastTreetop(TR::Block *block, TR::Tre
    return block->getLastRealTreeTop();
    }
 
-
+const char *
+TR::DeadTreesElimination::optDetailString() const throw()
+   {
+   return "O^O DEAD TREES ELIMINATION: ";
+   }

--- a/compiler/optimizer/DeadTreesElimination.hpp
+++ b/compiler/optimizer/DeadTreesElimination.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -83,6 +83,8 @@ class DeadTreesElimination : public TR::Optimization
    virtual int32_t perform();
    virtual int32_t performOnBlock(TR::Block *);
    virtual void prePerformOnBlocks();
+
+   virtual const char * optDetailString() const throw();
 
    protected:
 

--- a/compiler/optimizer/ExpressionsSimplification.cpp
+++ b/compiler/optimizer/ExpressionsSimplification.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -968,4 +968,10 @@ TR_ExpressionsSimplification::transformNode(TR::Node *srcNode, TR::Block *dstBlo
       lastTree->join(srcNodeTT);
       }
    return;
+   }
+
+const char *
+TR_ExpressionsSimplification::optDetailString() const throw()
+   {
+   return "O^O EXPRESSION SIMPLIFICATION: ";
    }

--- a/compiler/optimizer/ExpressionsSimplification.hpp
+++ b/compiler/optimizer/ExpressionsSimplification.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -130,7 +130,7 @@ class TR_ExpressionsSimplification : public TR::Optimization
       };
 
    virtual int32_t perform();
-
+   virtual const char * optDetailString() const throw();
 
    protected:
    vcount_t _visitCount;

--- a/compiler/optimizer/FieldPrivatizer.cpp
+++ b/compiler/optimizer/FieldPrivatizer.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -1632,4 +1632,10 @@ TR::Node * TR_FieldPrivatizer::walkTreeForLoadOrStoreNode(TR::Node *node)
       }
 
    return 0;
+   }
+
+const char *
+TR_FieldPrivatizer::optDetailString() const throw()
+   {
+   return "O^O FIELD PRIVATIZATION: ";
    }

--- a/compiler/optimizer/FieldPrivatizer.hpp
+++ b/compiler/optimizer/FieldPrivatizer.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -123,6 +123,7 @@ class TR_FieldPrivatizer : public TR_LoopTransformer
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    virtual int32_t detectCanonicalizedPredictableLoops(TR_Structure *, TR_BitVector **, int32_t);
    bool storesBackMustBePlacedInExitBlock(TR::Block *, TR::Block *, TR_BitVector *);

--- a/compiler/optimizer/GeneralLoopUnroller.cpp
+++ b/compiler/optimizer/GeneralLoopUnroller.cpp
@@ -4525,6 +4525,11 @@ bool TR_GeneralLoopUnroller::branchContainsInductionVariable(TR::Node *node,
    return false;
    }
 
+const char *
+TR_GeneralLoopUnroller::optDetailString() const throw()
+   {
+   return "O^O GENERAL LOOP UNROLLER: ";
+   }
 
 #undef GET_PREV_CLONE_BLOCK
 #undef GET_PREV_CLONE_NODE

--- a/compiler/optimizer/GeneralLoopUnroller.hpp
+++ b/compiler/optimizer/GeneralLoopUnroller.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -310,6 +310,7 @@ class TR_GeneralLoopUnroller : public TR_LoopTransformer
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    private:
    void collectNonColdInnerLoops(TR_RegionStructure *region, List<TR_RegionStructure> &innerLoops);

--- a/compiler/optimizer/GlobalRegisterAllocator.cpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.cpp
@@ -5010,6 +5010,11 @@ TR_GlobalRegisterAllocator::createStoresForSignExt(
       *currentArrayAccess = prevArrayAccess;
    }
 
+const char *
+TR_GlobalRegisterAllocator::optDetailString() const throw()
+   {
+   return "O^O GLOBAL REGISTER ASSIGNER: ";
+   }
 
 TR_LiveRangeSplitter::TR_LiveRangeSplitter(TR::OptimizationManager *manager)
    : TR::Optimization(manager), _splitBlocks(manager->trMemory()), _changedSomething(false), _origSymRefs(NULL)
@@ -5868,4 +5873,10 @@ TR_LiveRangeSplitter::placeStoresInLoopExits(TR::Node *node, TR_StructureSubGrap
          }
       }
    */
+   }
+
+const char *
+TR_LiveRangeSplitter::optDetailString() const throw()
+   {
+   return "O^O LIVE RANGE SPLITTER: ";
    }

--- a/compiler/optimizer/GlobalRegisterAllocator.hpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -95,6 +95,7 @@ class TR_LiveRangeSplitter : public TR::Optimization
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    void splitLiveRanges();
    void splitLiveRanges(TR_StructureSubGraphNode *structureNode);
@@ -135,6 +136,7 @@ public:
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    void walkTreesAndCollectSymbolDataTypes();
    void visitNodeForDataType(TR::Node*);

--- a/compiler/optimizer/GlobalValuePropagation.hpp
+++ b/compiler/optimizer/GlobalValuePropagation.hpp
@@ -50,6 +50,7 @@ class GlobalValuePropagation : public TR::ValuePropagation
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    private:
 

--- a/compiler/optimizer/InductionVariable.cpp
+++ b/compiler/optimizer/InductionVariable.cpp
@@ -5447,7 +5447,11 @@ bool TR_LoopStrider::isMulTermEquivalentTo(int32_t k, TR::Node * node)
    return false;
    }
 
-
+const char *
+TR_LoopStrider::optDetailString() const throw()
+   {
+   return "O^O LOOP STRIDER: ";
+   }
 
 // end sign-extension
 
@@ -7156,6 +7160,11 @@ TR_InductionVariableAnalysis::getEntryValue(TR::Block *block,
    return defValue;
    }
 
+const char *
+TR_InductionVariableAnalysis::optDetailString() const throw()
+   {
+   return "O^O INDUCTION VARIABLE ANALYSIS: ";
+   }
 
 ///////////////////////////////////////////
 void
@@ -7351,6 +7360,12 @@ int32_t TR_IVTypeTransformer::perform()
       }
 
    return 0;
+   }
+
+const char *
+TR_IVTypeTransformer::optDetailString() const throw()
+   {
+   return "O^O INDUCTION VARIABLE TYPE TRANSFORMER: ";
    }
 
 static bool isIdentityExpr(TR::Node *node, TR::SymbolReference *symref)

--- a/compiler/optimizer/InductionVariable.hpp
+++ b/compiler/optimizer/InductionVariable.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -136,6 +136,7 @@ class TR_LoopStrider : public TR_LoopTransformer
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    virtual int32_t detectCanonicalizedPredictableLoops(TR_Structure *, TR_BitVector **, int32_t);
 
@@ -453,6 +454,7 @@ class TR_InductionVariableAnalysis : public TR::Optimization
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    TR_Array<TR_BasicInductionVariable*> *getInductionVariables()
       {return _ivs; }
@@ -574,6 +576,7 @@ class TR_IVTypeTransformer : public TR_LoopTransformer
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    private:
    void changeIVTypeFromAddrToInt(TR_RegionStructure *natLoop);

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -219,6 +219,12 @@ int32_t TR_TrivialInliner::perform()
    return 1; // cost??
    }
 
+const char *
+TR_TrivialInliner::optDetailString() const throw()
+   {
+   return "O^O TRIVIAL INLINER: ";
+   }
+
 
 //---------------------------------------------------------------------
 // TR_InlinerBase

--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -173,6 +173,7 @@ class TR_Inliner : public TR::Optimization
          }
 
       virtual int32_t perform();
+      virtual const char * optDetailString() const throw();
    };
 
 class TR_TrivialInliner : public TR::Optimization
@@ -185,6 +186,7 @@ class TR_TrivialInliner : public TR::Optimization
          }
 
       virtual int32_t perform();
+      virtual const char * optDetailString() const throw();
    };
 
 class TR_InnerPreexistenceInfo

--- a/compiler/optimizer/IsolatedStoreElimination.cpp
+++ b/compiler/optimizer/IsolatedStoreElimination.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -1709,4 +1709,10 @@ TR_IsolatedStoreElimination::markNodesAndLocateSideEffectIn(TR::Node *node, vcou
       }
 
    return false;
+   }
+
+const char *
+TR_IsolatedStoreElimination::optDetailString() const throw()
+   {
+   return "O^O ISOLATED STORE ELIMINATION: ";
    }

--- a/compiler/optimizer/IsolatedStoreElimination.hpp
+++ b/compiler/optimizer/IsolatedStoreElimination.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -52,6 +52,7 @@ class TR_IsolatedStoreElimination : public TR::Optimization
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    protected:
 

--- a/compiler/optimizer/LoadExtensions.cpp
+++ b/compiler/optimizer/LoadExtensions.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -690,4 +690,10 @@ ncount_t TR_LoadExtensions::indexNodesForCodegen(TR::Node *parent, ncount_t node
       }
 
    return _nodeCount;
+   }
+
+const char *
+TR_LoadExtensions::optDetailString() const throw()
+   {
+   return "O^O LOAD EXTENSION: ";
    }

--- a/compiler/optimizer/LoadExtensions.hpp
+++ b/compiler/optimizer/LoadExtensions.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -59,6 +59,7 @@ public:
       }
 
    int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    inline TR_BitVector * getFlags() { return _signExtensionFlags; }
    static bool supportedConstLoad(TR::Node *load, TR::Compilation * c);

--- a/compiler/optimizer/LocalDeadStoreElimination.cpp
+++ b/compiler/optimizer/LocalDeadStoreElimination.cpp
@@ -1099,3 +1099,9 @@ void TR::LocalDeadStoreElimination::killStoreNodes(TR::Node *node)
          }
       }
    }
+
+const char *
+TR::LocalDeadStoreElimination::optDetailString() const throw()
+   {
+   return "O^O LOCAL DEAD STORE ELIMINATION: ";
+   }

--- a/compiler/optimizer/LocalDeadStoreElimination.hpp
+++ b/compiler/optimizer/LocalDeadStoreElimination.hpp
@@ -62,6 +62,7 @@ class LocalDeadStoreElimination : public TR::Optimization
    virtual int32_t performOnBlock(TR::Block *);
    virtual void prePerformOnBlocks();
    virtual void postPerformOnBlocks();
+   virtual const char * optDetailString() const throw();
 
    protected:
 

--- a/compiler/optimizer/LocalLiveRangeReducer.cpp
+++ b/compiler/optimizer/LocalLiveRangeReducer.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -1045,4 +1045,10 @@ void TR_LocalLiveRangeReduction::printOnVerifyError(TR_TreeRefInfo *optRefInfo,T
       comp()->dumpMethodTrees("For verifying\n");
       comp()->incVisitCount();
       }
+   }
+
+const char *
+TR_LocalLiveRangeReduction::optDetailString() const throw()
+   {
+   return "O^O LOCAL LIVE RANGE REDUCTION: ";
    }

--- a/compiler/optimizer/LocalLiveRangeReducer.hpp
+++ b/compiler/optimizer/LocalLiveRangeReducer.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -74,6 +74,7 @@ class TR_LocalLiveRangeReduction  : public TR::Optimization
    virtual int32_t perform();
    virtual void prePerformOnBlocks();
    virtual void postPerformOnBlocks();
+   virtual const char * optDetailString() const throw();
 
    private :
    bool transformExtendedBlock(TR::TreeTop *, TR::TreeTop *);

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -132,6 +132,11 @@ int32_t TR_PeepHoleBasicBlocks::perform()
    return rc;
    }
 
+const char *
+TR_PeepHoleBasicBlocks::optDetailString() const throw()
+   {
+   return "O^O BASIC BLOCK PEEPHOLE: ";
+   }
 
 // Extend basic blocks.
 // Return "true" if any basic block extension was done
@@ -786,6 +791,11 @@ int32_t TR_ExtendBasicBlocks::orderBlocksWithFrequencyInfo()
    return 1; // actual cost
    }
 
+const char *
+TR_ExtendBasicBlocks::optDetailString() const throw()
+   {
+   return "O^O BASIC BLOCK EXTENSION: ";
+   }
 
 // void TR_BlockManipulator::markColdBlocks()
 //    {
@@ -1391,7 +1401,11 @@ bool TR_HoistBlocks::hasSynergy(TR::Block *block, TR::Node *node1)
    return synergyExists;
    }
 
-
+const char *
+TR_HoistBlocks::optDetailString() const throw()
+   {
+   return "O^O BASIC BLOCK HOISTING: ";
+   }
 
 
 
@@ -2374,6 +2388,11 @@ bool TR_CompactNullChecks::replaceNullCheckIfPossible(TR::Node *cursorNode, TR::
    return true;
    }
 
+const char *
+TR_CompactNullChecks::optDetailString() const throw()
+   {
+   return "O^O COMPACT NULL CHECKS: ";
+   }
 
 static int32_t compareValues(TR::Node *node1, TR::Node *node2)
    {
@@ -2666,7 +2685,11 @@ bool TR_ArraysetStoreElimination::optimizeArraysetIfPossible(TR::Node *currentNo
    return false;
    }
 
-
+const char *
+TR_ArraysetStoreElimination::optDetailString() const throw()
+   {
+   return "O^O ARRAYSET STORE ELIMINATION: ";
+   }
 
 // Tries to simplify ands that are created by loop versioning;
 // basically tries avoid doing the same test twice within an and
@@ -3218,9 +3241,11 @@ int32_t TR_SimplifyAnds::process(TR::TreeTop *startTree, TR::TreeTop *endTree)
    return 1; // actual cost
    }
 
-
-
-
+const char *
+TR_SimplifyAnds::optDetailString() const throw()
+   {
+   return "O^O AND SIMPLIFICATION: ";
+   }
 
 
 // Basically if there is a branch that has a block B as its target; and block B
@@ -3676,6 +3701,12 @@ int32_t TR_EliminateRedundantGotos::process(TR::TreeTop *startTree, TR::TreeTop 
    return 0; // actual cost
    }
 
+const char *
+TR_EliminateRedundantGotos::optDetailString() const throw()
+   {
+   return "O^O GOTO ELIMINATION: ";
+   }
+
 // If there is a block B with a goto at the end of the block that goes to the
 // block C that follows it textually in the IL trees, eliminate the goto.
 //
@@ -3865,6 +3896,11 @@ int32_t TR_CleanseTrees::process(TR::TreeTop *startTree, TR::TreeTop *endTreeTop
    return 0; // actual cost
    }
 
+const char *
+TR_CleanseTrees::optDetailString() const throw()
+   {
+   return "O^O TREE CLEANSING: ";
+   }
 
 TR_ByteCodeInfo TR_ProfiledNodeVersioning::temporarilySetProfilingBcInfoOnNewArrayLengthChild(TR::Node *newArray, TR::Compilation *comp)
    {
@@ -4083,6 +4119,12 @@ int32_t TR_ProfiledNodeVersioning::perform()
 #endif
 
    return 123; // TODO: What to return here?
+   }
+
+const char *
+TR_ProfiledNodeVersioning::optDetailString() const throw()
+   {
+   return "O^O PROFILED NODE VERSIONING: ";
    }
 
 TR_Rematerialization::TR_Rematerialization(TR::OptimizationManager *manager, bool onlyLongReg)
@@ -5770,6 +5812,12 @@ int32_t TR_LongRegAllocation::getNumLongParms()
    return parms;
    }
 
+const char *
+TR_LongRegAllocation::optDetailString() const throw()
+   {
+   return "O^O LONG REG ALLOCATION: ";
+   }
+
 int8_t TR_Rematerialization::getLoopNestingLevel(int32_t weight)
    {
    if (weight == 1)
@@ -5823,6 +5871,11 @@ void TR_Rematerialization::initLongRegData()
    _numCallLiveLongs=0;
    }
 
+const char *
+TR_Rematerialization::optDetailString() const throw()
+   {
+   return "O^O REMATERIALIZATION: ";
+   }
 
 TR_BlockSplitter::TR_BlockSplitter(TR::OptimizationManager *manager)
    : TR::Optimization(manager)
@@ -6999,6 +7052,12 @@ TR::Block *TR_BlockSplitter::splitBlock(TR::Block *pred, TR_LinkHeadAndTail<Bloc
    return cloneStart;
    }
 
+const char *
+TR_BlockSplitter::optDetailString() const throw()
+   {
+   return "O^O BLOCK SPLITTER: ";
+   }
+
 #include "il/SymbolReference.hpp"
 
 void TR_InvariantArgumentPreexistence::ParmInfo::clear()
@@ -7958,6 +8017,12 @@ void TR_InvariantArgumentPreexistence::processIndirectLoad(TR::Node *node, TR::T
 
    }
 
+const char *
+TR_InvariantArgumentPreexistence::optDetailString() const throw()
+   {
+   return "O^O INVARIANT ARGUMENT PREEXISTENCE: ";
+   }
+
 int32_t TR_CheckcastAndProfiledGuardCoalescer::perform()
    {
    if (comp()->getOption(TR_DisableCheckcastAndProfiledGuardCoalescer))
@@ -8101,6 +8166,12 @@ void TR_CheckcastAndProfiledGuardCoalescer::doBasicCase(TR::TreeTop* checkcastTr
    // Lastly, remove the original checkcastTree.
    //
    checkcastTree->unlink(true);
+   }
+
+const char *
+TR_CheckcastAndProfiledGuardCoalescer::optDetailString() const throw()
+   {
+   return "O^O CHECKCAST AND PROFILED GUARD COALESCER: ";
    }
 
 TR_ColdBlockMarker::TR_ColdBlockMarker(TR::OptimizationManager *manager)
@@ -8327,6 +8398,12 @@ TR_ColdBlockMarker::hasNotYetRun(TR::Node *node)
    return false;
    }
 
+const char *
+TR_ColdBlockMarker::optDetailString() const throw()
+   {
+   return "O^O COLD BLOCK MARKER: ";
+   }
+
 TR_ColdBlockOutlining::TR_ColdBlockOutlining(TR::OptimizationManager *manager)
    : TR_ColdBlockMarker(manager)
    {}
@@ -8503,6 +8580,12 @@ TR_ColdBlockOutlining::reorderColdBlocks()
       }
    if (trace())
       traceMsg(comp(), "Cold Block Outlining: outlined %d cold blocks so far:\n", numBlocksSoFar);
+   }
+
+const char *
+TR_ColdBlockOutlining::optDetailString() const throw()
+   {
+   return "O^O COLD BLOCK OUTLINING: ";
    }
 
 TR::Block *
@@ -8769,6 +8852,12 @@ TR_TrivialDeadTreeRemoval::perform()
 //   return 1; // actual cost
    }
 
+const char *
+TR_TrivialDeadTreeRemoval::optDetailString() const throw()
+   {
+   return "O^O TRIVIAL DEAD TREE REMOVAL: ";
+   }
+
 int32_t TR_TrivialBlockExtension::perform()
    {
    int32_t cost = 0;
@@ -8818,4 +8907,10 @@ int32_t TR_TrivialBlockExtension::performOnBlock(TR::Block *block)
       }
 
    return 1;
+   }
+
+const char *
+TR_TrivialBlockExtension::optDetailString() const throw()
+   {
+   return "O^O TRIVIAL BLOCK EXTENSION: ";
    }

--- a/compiler/optimizer/LocalOpts.hpp
+++ b/compiler/optimizer/LocalOpts.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -78,6 +78,7 @@ public:
    virtual int32_t performOnBlock(TR::Block *);
    int32_t process(TR::TreeTop *, TR::TreeTop *);
    bool hasSynergy(TR::Block *, TR::Node *);
+   virtual const char * optDetailString() const throw();
    };
 
 class TR_BlockManipulator : public TR::Optimization
@@ -105,6 +106,7 @@ public:
       }
 
    virtual int32_t perform();
+   virtual const char *optDetailString() const throw();
 
 private:
    int32_t orderBlocksWithFrequencyInfo();
@@ -121,6 +123,7 @@ public:
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
    };
 
 
@@ -144,6 +147,7 @@ public:
 
    virtual int32_t perform();
    virtual int32_t performOnBlock(TR::Block *);
+   virtual const char * optDetailString() const throw();
    int32_t process(TR::TreeTop *, TR::TreeTop *);
 
 private:
@@ -173,6 +177,7 @@ public:
    virtual int32_t perform();
    virtual int32_t performOnBlock(TR::Block *);
    virtual void prePerformOnBlocks();
+   virtual const char * optDetailString() const throw();
    int32_t process(TR::TreeTop *, TR::TreeTop *);
    };
 
@@ -191,6 +196,7 @@ public:
    int32_t process(TR::TreeTop *, TR::TreeTop *);
    void reduceArraysetStores(TR::Block *, TR_BitVector *, TR_BitVector *, TR_BitVector *);
    bool optimizeArraysetIfPossible(TR::Node *, TR::Node *, TR::TreeTop *, TR::Node *, TR_BitVector *, TR_BitVector *, TR_BitVector *, vcount_t, TR::TreeTop *);
+   virtual const char * optDetailString() const throw();
    };
 
 /*
@@ -223,6 +229,8 @@ public:
    bool replacePassThroughIfPossible(TR::Node *, TR::Node *, TR::Node *, TR::Node *, bool *, TR_BitVector *, vcount_t, vcount_t, TR::TreeTop *);
 
    bool replaceNullCheckIfPossible(TR::Node *cursorNode, TR::Node *objectRef, TR::Node *prevNode, TR::Node *currentParent, TR_BitVector *writtenSymbols, vcount_t visitCount, vcount_t initialVisitCount, bool &compactionDone);
+
+   virtual const char * optDetailString() const throw();
 
    bool _isNextTree;
    };
@@ -312,6 +320,7 @@ public:
    virtual int32_t perform();
    virtual int32_t performOnBlock(TR::Block *);
    int32_t process(TR::TreeTop *, TR::TreeTop *);
+   virtual const char * optDetailString() const throw();
    };
 
 /*
@@ -381,6 +390,7 @@ public:
    virtual int32_t perform();
    virtual int32_t performOnBlock(TR::Block *);
    virtual void prePerformOnBlocks();
+   virtual const char * optDetailString() const throw();
    int32_t process(TR::TreeTop *, TR::TreeTop *);
 
    void addParentToList(TR::Node *, List<TR::Node> *, TR::Node *, List< List<TR::Node> > *);
@@ -460,6 +470,7 @@ class TR_LongRegAllocation : public TR_Rematerialization
       }
 
    virtual void postPerformOnBlocks();
+   virtual const char * optDetailString() const throw();
 
    private:
    void printStats();
@@ -478,6 +489,7 @@ public:
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
 private:
    double alpha;
@@ -718,6 +730,7 @@ class TR_InvariantArgumentPreexistence : public TR::Optimization
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    private:
 
@@ -785,6 +798,8 @@ class TR_CheckcastAndProfiledGuardCoalescer : public TR::Optimization
    virtual int32_t perform();
    void doBasicCase (TR::TreeTop* checkcastTree, TR::TreeTop* profiledGuardTree);
 
+   virtual const char * optDetailString() const throw();
+
    private:
       TR::Node* storeObjectInATemporary (TR::TreeTop* checkcastTree);
    };
@@ -799,6 +814,7 @@ class TR_ColdBlockMarker : public TR_BlockManipulator
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    protected:
    void initialize();
@@ -822,6 +838,7 @@ class TR_ColdBlockOutlining : public TR_ColdBlockMarker
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    private:
    void reorderColdBlocks();
@@ -839,6 +856,7 @@ class TR_ProfiledNodeVersioning : public TR::Optimization
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    // Use this as follows:
    //
@@ -865,6 +883,8 @@ class TR_TrivialDeadTreeRemoval : public TR::Optimization
 
    virtual int32_t perform();
    virtual int32_t performOnBlock(TR::Block *);
+   virtual const char * optDetailString() const throw();
+
    void transformBlock(TR::TreeTop * entryTree, TR::TreeTop * exitTree);
    void examineNode(TR::Node *node, vcount_t visitCount);
 
@@ -892,6 +912,7 @@ class TR_TrivialBlockExtension : public TR::Optimization
 
    virtual int32_t perform();
    virtual int32_t performOnBlock(TR::Block *);
+   virtual const char * optDetailString() const throw();
    };
 
 #endif

--- a/compiler/optimizer/LocalReordering.cpp
+++ b/compiler/optimizer/LocalReordering.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -746,4 +746,10 @@ bool TR_LocalReordering::isSubtreeCommoned(TR::Node *node)
       }
 
    return false;
+   }
+
+const char *
+TR_LocalReordering::optDetailString() const throw()
+   {
+   return "O^O LOCAL REORDERING: ";
    }

--- a/compiler/optimizer/LocalReordering.hpp
+++ b/compiler/optimizer/LocalReordering.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -69,6 +69,7 @@ class TR_LocalReordering  : public TR::Optimization
    virtual int32_t performOnBlock(TR::Block *);
    virtual void prePerformOnBlocks();
    virtual void postPerformOnBlocks();
+   virtual const char * optDetailString() const throw();
 
    private :
    bool transformBlock(TR::Block *);

--- a/compiler/optimizer/LocalValuePropagation.hpp
+++ b/compiler/optimizer/LocalValuePropagation.hpp
@@ -54,6 +54,7 @@ class LocalValuePropagation : public TR::ValuePropagation
    virtual int32_t performOnBlock(TR::Block *);
    virtual void prePerformOnBlocks();
    virtual void postPerformOnBlocks();
+   virtual const char * optDetailString() const throw();
 
    private:
 

--- a/compiler/optimizer/LoopCanonicalizer.cpp
+++ b/compiler/optimizer/LoopCanonicalizer.cpp
@@ -2996,6 +2996,12 @@ void TR_LoopCanonicalizer::rewritePostToPreIncrementTestInBlock(
    right->recursivelyDecReferenceCount();
    }
 
+const char *
+TR_LoopCanonicalizer::optDetailString() const throw()
+   {
+   return "O^O LOOP CANONICALIZER: ";
+   }
+
 bool TR_LoopTransformer::replaceAllInductionVariableComputations(TR::Block *loopInvariantBlock, TR_Structure *structure, TR::SymbolReference **newSymbolReference, TR::SymbolReference *inductionVarSymRef)
    {
    bool seenInductionVariableComputation = false;
@@ -4101,6 +4107,11 @@ int32_t TR_RedundantInductionVarElimination::perform()
    return true;
    }
 
+const char *
+TR_RedundantInductionVarElimination::optDetailString() const throw()
+   {
+   return "O^O REDUNDANT INDUCTION VAR ELIMINATION: ";
+   }
 
 /*******************************************/
 
@@ -4550,4 +4561,10 @@ bool TR_LoopInverter::checkIfSymbolIsReadInKnownTree(TR::Node *node, int32_t sym
       }
 
    return true;
+   }
+
+const char *
+TR_LoopInverter::optDetailString() const throw()
+   {
+   return "O^O LOOP INVERTER: ";
    }

--- a/compiler/optimizer/LoopCanonicalizer.hpp
+++ b/compiler/optimizer/LoopCanonicalizer.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -228,6 +228,7 @@ class TR_LoopCanonicalizer : public TR_LoopTransformer
 
    virtual int32_t perform();
    virtual TR_LoopCanonicalizer *asLoopCanonicalizer() {return this;}
+   virtual const char * optDetailString() const throw();
 
    protected:
    void eliminateRedundantInductionVariablesFromLoop(TR_RegionStructure *naturalLoop);
@@ -293,6 +294,7 @@ class TR_LoopInverter : public TR_LoopTransformer
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    virtual int32_t detectCanonicalizedPredictableLoops(TR_Structure *, TR_BitVector **, int32_t);
    bool isInvertibleLoop(int32_t, TR_Structure *);
@@ -313,6 +315,7 @@ class TR_RedundantInductionVarElimination : public TR_LoopCanonicalizer
 
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
    };
 
 #endif

--- a/compiler/optimizer/LoopReducer.cpp
+++ b/compiler/optimizer/LoopReducer.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -4519,4 +4519,10 @@ TR_LoopReducer::perform()
       }
 
    return 1; // actual cost
+   }
+
+const char *
+TR_LoopReducer::optDetailString() const throw()
+   {
+   return "O^O LOOP REDUCER: ";
    }

--- a/compiler/optimizer/LoopReducer.hpp
+++ b/compiler/optimizer/LoopReducer.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -349,6 +349,7 @@ public:
    virtual int32_t perform();
 
    virtual TR_LoopReducer * asLoopReducer() { return this; }
+   virtual const char * optDetailString() const throw();
 
 private:
    void reduceNaturalLoop(TR_RegionStructure * whileLoop);

--- a/compiler/optimizer/LoopReplicator.cpp
+++ b/compiler/optimizer/LoopReplicator.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -2367,6 +2367,12 @@ bool TR_LoopReplicator::heuristics(LoopInfo *lInfo, bool dumb)
       }
 
    return true;
+   }
+
+const char *
+TR_LoopReplicator::optDetailString() const throw()
+   {
+   return "O^O LOOP REPLICATOR: ";
    }
 
 #undef COLOR_BLACK

--- a/compiler/optimizer/LoopReplicator.hpp
+++ b/compiler/optimizer/LoopReplicator.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -66,6 +66,7 @@ class TR_LoopReplicator : public TR_LoopTransformer
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    // per loop structures
    struct BlockEntry : public TR_Link<BlockEntry>

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -136,6 +136,12 @@ TR_LoopSpecializer::TR_LoopSpecializer(TR::OptimizationManager *manager)
    : TR_LoopVersioner(manager, true)
    {}
 
+const char *
+TR_LoopSpecializer::optDetailString() const throw()
+   {
+   return "O^O LOOP SPECIALIZER: ";
+   }
+
 TR_LoopVersioner::TR_LoopVersioner(TR::OptimizationManager *manager, bool onlySpecialize, bool refineAliases)
    : TR_LoopTransformer(manager),
    _versionableInductionVariables(trMemory()), _specialVersionableInductionVariables(trMemory()),
@@ -8475,4 +8481,10 @@ bool TR_LoopVersioner::isInverseConversions(TR::Node* node)
          return true;
       }
    return false;
+   }
+
+const char *
+TR_LoopVersioner::optDetailString() const throw()
+   {
+   return "O^O LOOP VERSIONER: ";
    }

--- a/compiler/optimizer/LoopVersioner.hpp
+++ b/compiler/optimizer/LoopVersioner.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -167,6 +167,8 @@ class TR_LoopVersioner : public TR_LoopTransformer
    virtual int32_t detectCanonicalizedPredictableLoops(TR_Structure *, TR_BitVector **, int32_t);
    virtual bool isStoreInRequiredForm(int32_t, TR_Structure *);
 
+   virtual const char * optDetailString() const throw();
+
    protected:
 
    bool shouldOnlySpecializeLoops() { return _onlySpecializingLoops; }
@@ -300,6 +302,9 @@ class TR_LoopSpecializer : public TR_LoopVersioner
    public:
 
    TR_LoopSpecializer(TR::OptimizationManager *manager);
+
+   virtual const char * optDetailString() const throw();
+
    static TR::Optimization *create(TR::OptimizationManager *manager)
       {
       return new (manager->allocator()) TR_LoopSpecializer(manager);

--- a/compiler/optimizer/OMRLocalCSE.cpp
+++ b/compiler/optimizer/OMRLocalCSE.cpp
@@ -1849,3 +1849,10 @@ rcount_t OMR::LocalCSE::recursivelyIncReferenceCount(TR::Node *node)
       }
    return count;
    }
+
+const char *
+OMR::LocalCSE::optDetailString() const throw()
+   {
+   return "O^O LOCAL COMMON SUBEXPRESSION ELIMINATION: ";
+   }
+

--- a/compiler/optimizer/OMRLocalCSE.hpp
+++ b/compiler/optimizer/OMRLocalCSE.hpp
@@ -80,6 +80,7 @@ class LocalCSE : public TR::Optimization
    virtual int32_t performOnBlock(TR::Block *);
    virtual void prePerformOnBlocks();
    virtual void postPerformOnBlocks();
+   virtual const char * optDetailString() const throw();
 
    typedef TR::typed_allocator< std::pair< const int32_t, TR::Node* >, TR::Region & > HashTableAllocator;
    typedef std::multimap< int32_t, TR::Node*, std::less<int32_t>, HashTableAllocator > HashTable;

--- a/compiler/optimizer/OMROptimization.cpp
+++ b/compiler/optimizer/OMROptimization.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -125,12 +125,6 @@ const char *
 OMR::Optimization::name()
    {
    return self()->manager()->name();
-   }
-
-const char *
-OMR::Optimization::optDetailString()
-   {
-   return self()->manager()->optDetailString();
    }
 
 void

--- a/compiler/optimizer/OMROptimization.hpp
+++ b/compiler/optimizer/OMROptimization.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -106,7 +106,7 @@ public:
 
    OMR::Optimizations         id();
    const char *               name();
-   const char *               optDetailString();
+   virtual const char *       optDetailString() const throw() = 0;
 
    inline bool                trace();
    void                       setTrace(bool trace = true);

--- a/compiler/optimizer/OMROptimizationManager.cpp
+++ b/compiler/optimizer/OMROptimizationManager.cpp
@@ -42,7 +42,7 @@
 
 struct OptimizationStrategy;
 
-OMR::OptimizationManager::OptimizationManager(TR::Optimizer *o, OptimizationFactory factory, OMR::Optimizations optNum, const char *optDetailString, const OptimizationStrategy *groupOfOpts)
+OMR::OptimizationManager::OptimizationManager(TR::Optimizer *o, OptimizationFactory factory, OMR::Optimizations optNum, const OptimizationStrategy *groupOfOpts)
       : _optimizer(o),
         _factory(factory),
         _id(optNum),
@@ -57,7 +57,6 @@ OMR::OptimizationManager::OptimizationManager(TR::Optimizer *o, OptimizationFact
    {
    if (_id < OMR::Optimizations::numGroups)
       TR_ASSERT_SAFE_FATAL(_id < OMR::Optimizations::numGroups, "The optimization id requested (%d) is too high", _id);
-   _optDetailString = optDetailString;
 
    // set flags if necessary
    switch (self()->id())

--- a/compiler/optimizer/OMROptimizationManager.hpp
+++ b/compiler/optimizer/OMROptimizationManager.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -61,7 +61,7 @@ class OMR_EXTENSIBLE OptimizationManager : public TR::Allocatable<OptimizationMa
 
    TR::OptimizationManager *self();
 
-   OptimizationManager(TR::Optimizer *o, OptimizationFactory factory, OMR::Optimizations optNum, const char *optDetailString, const OptimizationStrategy *groupOfOpts = NULL);
+   OptimizationManager(TR::Optimizer *o, OptimizationFactory factory, OMR::Optimizations optNum, const OptimizationStrategy *groupOfOpts = NULL);
 
    TR::Optimizer *           optimizer()                     { return _optimizer; }
    TR::Compilation *         comp()                          { return _optimizer->comp(); }
@@ -81,7 +81,6 @@ class OMR_EXTENSIBLE OptimizationManager : public TR::Allocatable<OptimizationMa
    OptimizationFactory       factory()                       { return _factory; }
    OMR::Optimizations        id()                            { return _id; }
    const char *              name()                          { return OMR::Optimizer::getOptimizationName(_id); }
-   const char *              optDetailString()               { return _optDetailString; }
    const OptimizationStrategy *    groupOfOpts()                   { return _groupOfOpts; }
 
    int32_t                   numPassesCompleted()            { return _numPassesCompleted; }
@@ -202,7 +201,6 @@ class OMR_EXTENSIBLE OptimizationManager : public TR::Allocatable<OptimizationMa
    OptimizationFactory       _factory;
 
    OMR::Optimizations        _id;
-   const char *              _optDetailString;
    const OptimizationStrategy *    _groupOfOpts;
 
    int32_t                   _numPassesCompleted;

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -730,180 +730,180 @@ OMR::Optimizer::Optimizer(TR::Compilation *comp, TR::ResolvedMethodSymbol *metho
    // initialize OMR optimizations
 
    _opts[OMR::andSimplification] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_SimplifyAnds::create, OMR::andSimplification, "O^O AND SIMPLIFICATION");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_SimplifyAnds::create, OMR::andSimplification);
    _opts[OMR::arraysetStoreElimination] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_ArraysetStoreElimination::create, OMR::arraysetStoreElimination, "O^O ARRAYSET STORE ELIMINATION: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_ArraysetStoreElimination::create, OMR::arraysetStoreElimination);
    _opts[OMR::asyncCheckInsertion] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_AsyncCheckInsertion::create, OMR::asyncCheckInsertion, "O^O ASYNC CHECK INSERTION: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_AsyncCheckInsertion::create, OMR::asyncCheckInsertion);
    _opts[OMR::basicBlockExtension] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_ExtendBasicBlocks::create, OMR::basicBlockExtension, "O^O BASIC BLOCK EXTENSION: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_ExtendBasicBlocks::create, OMR::basicBlockExtension);
    _opts[OMR::basicBlockHoisting] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_HoistBlocks::create, OMR::basicBlockHoisting, "O^O BASIC BLOCK HOISTING: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_HoistBlocks::create, OMR::basicBlockHoisting);
    _opts[OMR::basicBlockOrdering] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_OrderBlocks::create, OMR::basicBlockOrdering, "O^O ORDER BLOCKS: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_OrderBlocks::create, OMR::basicBlockOrdering);
    _opts[OMR::basicBlockPeepHole] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_PeepHoleBasicBlocks::create, OMR::basicBlockPeepHole, "O^O BASIC BLOCK PEEPHOLE: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_PeepHoleBasicBlocks::create, OMR::basicBlockPeepHole);
    _opts[OMR::blockShuffling] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_BlockShuffling::create, OMR::blockShuffling, "O^O BLOCK SHUFFLING: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_BlockShuffling::create, OMR::blockShuffling);
    _opts[OMR::blockSplitter] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_BlockSplitter::create, OMR::blockSplitter, "O^O BLOCK SPLITTER: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_BlockSplitter::create, OMR::blockSplitter);
    _opts[OMR::catchBlockRemoval] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_CatchBlockRemover::create, OMR::catchBlockRemoval, "O^O CATCH BLOCK REMOVAL: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_CatchBlockRemover::create, OMR::catchBlockRemoval);
    _opts[OMR::CFGSimplification] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_CFGSimplifier::create, OMR::CFGSimplification, "O^O CFG SIMPLIFICATION: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_CFGSimplifier::create, OMR::CFGSimplification);
    _opts[OMR::checkcastAndProfiledGuardCoalescer] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_CheckcastAndProfiledGuardCoalescer::create, OMR::checkcastAndProfiledGuardCoalescer, "O^O CHECKCAST AND PROFILED GUARD COALESCER: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_CheckcastAndProfiledGuardCoalescer::create, OMR::checkcastAndProfiledGuardCoalescer);
    _opts[OMR::coldBlockMarker] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_ColdBlockMarker::create, OMR::coldBlockMarker, "O^O COLD BLOCK MARKER: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_ColdBlockMarker::create, OMR::coldBlockMarker);
    _opts[OMR::coldBlockOutlining] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_ColdBlockOutlining::create, OMR::coldBlockOutlining, "O^O COLD BLOCK OUTLINING: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_ColdBlockOutlining::create, OMR::coldBlockOutlining);
    _opts[OMR::compactLocals] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_CompactLocals::create, OMR::compactLocals, "O^O COMPACT LOCALS: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_CompactLocals::create, OMR::compactLocals);
    _opts[OMR::compactNullChecks] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_CompactNullChecks::create, OMR::compactNullChecks, "O^O COMPACT NULL CHECKS: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_CompactNullChecks::create, OMR::compactNullChecks);
    _opts[OMR::deadTreesElimination] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR::DeadTreesElimination::create, OMR::deadTreesElimination, "O^O DEAD TREES ELIMINATION: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR::DeadTreesElimination::create, OMR::deadTreesElimination);
    _opts[OMR::expressionsSimplification] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_ExpressionsSimplification::create, OMR::expressionsSimplification, "O^O EXPRESSION SIMPLIFICATION: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_ExpressionsSimplification::create, OMR::expressionsSimplification);
    _opts[OMR::generalLoopUnroller] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_GeneralLoopUnroller::create, OMR::generalLoopUnroller, "O^O GENERAL LOOP UNROLLER: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_GeneralLoopUnroller::create, OMR::generalLoopUnroller);
    _opts[OMR::globalCopyPropagation] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_CopyPropagation::create, OMR::globalCopyPropagation, "O^O COPY PROPAGATION: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_CopyPropagation::create, OMR::globalCopyPropagation);
    _opts[OMR::globalDeadStoreElimination] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_DeadStoreElimination::create, OMR::globalDeadStoreElimination, "O^O DEAD STORE ELIMINATION: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_DeadStoreElimination::create, OMR::globalDeadStoreElimination);
    _opts[OMR::innerPreexistence] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_InnerPreexistence::create, OMR::innerPreexistence, "O^O INNER PREEXISTENCE: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_InnerPreexistence::create, OMR::innerPreexistence);
    _opts[OMR::invariantArgumentPreexistence] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_InvariantArgumentPreexistence::create, OMR::invariantArgumentPreexistence, "O^O INVARIANT ARGUMENT PREEXISTENCE: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_InvariantArgumentPreexistence::create, OMR::invariantArgumentPreexistence);
    _opts[OMR::loadExtensions] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_LoadExtensions::create, OMR::loadExtensions, "O^O LOAD EXTENSION: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_LoadExtensions::create, OMR::loadExtensions);
    _opts[OMR::localCSE] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR::LocalCSE::create, OMR::localCSE, "O^O LOCAL COMMON SUBEXPRESSION ELIMINATION: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR::LocalCSE::create, OMR::localCSE);
    _opts[OMR::localDeadStoreElimination] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR::LocalDeadStoreElimination::create, OMR::localDeadStoreElimination, "O^O LOCAL DEAD STORE ELIMINATION: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR::LocalDeadStoreElimination::create, OMR::localDeadStoreElimination);
    _opts[OMR::localLiveRangeReduction] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_LocalLiveRangeReduction::create, OMR::localLiveRangeReduction, "O^O LOCAL LIVE RANGE REDUCTION: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_LocalLiveRangeReduction::create, OMR::localLiveRangeReduction);
    _opts[OMR::localReordering] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_LocalReordering::create, OMR::localReordering, "O^O LOCAL REORDERING: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_LocalReordering::create, OMR::localReordering);
    _opts[OMR::longRegAllocation] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_LongRegAllocation::create, OMR::longRegAllocation, "O^O LONG REG ALLOCATION: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_LongRegAllocation::create, OMR::longRegAllocation);
    _opts[OMR::loopCanonicalization] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_LoopCanonicalizer::create, OMR::loopCanonicalization, "O^O LOOP CANONICALIZER: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_LoopCanonicalizer::create, OMR::loopCanonicalization);
    _opts[OMR::loopVersioner] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_LoopVersioner::create, OMR::loopVersioner, "O^O LOOP VERSIONER: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_LoopVersioner::create, OMR::loopVersioner);
    _opts[OMR::loopReduction] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_LoopReducer::create, OMR::loopReduction, "O^O LOOP REDUCER: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_LoopReducer::create, OMR::loopReduction);
    _opts[OMR::loopReplicator] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_LoopReplicator::create, OMR::loopReplicator, "O^O LOOP REPLICATOR: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_LoopReplicator::create, OMR::loopReplicator);
    _opts[OMR::profiledNodeVersioning] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_ProfiledNodeVersioning::create, OMR::profiledNodeVersioning, "O^O PROFILED NODE VERSIONING: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_ProfiledNodeVersioning::create, OMR::profiledNodeVersioning);
    _opts[OMR::redundantAsyncCheckRemoval] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_RedundantAsyncCheckRemoval::create, OMR::redundantAsyncCheckRemoval, "O^O REDUNDANT ASYNC CHECK REMOVAL: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_RedundantAsyncCheckRemoval::create, OMR::redundantAsyncCheckRemoval);
    _opts[OMR::redundantGotoElimination] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_EliminateRedundantGotos::create, OMR::redundantGotoElimination, "O^O GOTO ELIMINATION: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_EliminateRedundantGotos::create, OMR::redundantGotoElimination);
    _opts[OMR::rematerialization] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_Rematerialization::create, OMR::rematerialization, "O^O REMATERIALIZATION");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_Rematerialization::create, OMR::rematerialization);
    _opts[OMR::shrinkWrapping] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_ShrinkWrap::create, OMR::shrinkWrapping, "O^O SHRINK WRAPPING: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_ShrinkWrap::create, OMR::shrinkWrapping);
    _opts[OMR::treesCleansing] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_CleanseTrees::create, OMR::treesCleansing, "O^O TREE CLEANSING: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_CleanseTrees::create, OMR::treesCleansing);
    _opts[OMR::treeSimplification] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR::Simplifier::create, OMR::treeSimplification, "O^O TREE SIMPLIFICATION: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR::Simplifier::create, OMR::treeSimplification);
    _opts[OMR::trivialBlockExtension] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_TrivialBlockExtension::create, OMR::trivialBlockExtension, "O^O TRIVIAL BLOCK EXTENSION: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_TrivialBlockExtension::create, OMR::trivialBlockExtension);
    _opts[OMR::trivialDeadTreeRemoval] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_TrivialDeadTreeRemoval::create, OMR::trivialDeadTreeRemoval, "O^O TRIVIAL DEAD TREE REMOVAL: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_TrivialDeadTreeRemoval::create, OMR::trivialDeadTreeRemoval);
    _opts[OMR::virtualGuardHeadMerger] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_VirtualGuardHeadMerger::create, OMR::virtualGuardHeadMerger, "O^O VIRTUAL GUARD HEAD MERGER: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_VirtualGuardHeadMerger::create, OMR::virtualGuardHeadMerger);
    _opts[OMR::virtualGuardTailSplitter] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_VirtualGuardTailSplitter::create, OMR::virtualGuardTailSplitter, "O^O VIRTUAL GUARD COALESCER: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_VirtualGuardTailSplitter::create, OMR::virtualGuardTailSplitter);
    _opts[OMR::generalStoreSinking] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_GeneralSinkStores::create, OMR::generalStoreSinking, "O^O GENERAL SINK STORES: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_GeneralSinkStores::create, OMR::generalStoreSinking);
    _opts[OMR::globalValuePropagation] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR::GlobalValuePropagation::create, OMR::globalValuePropagation, "O^O GLOBAL VALUE PROPAGATION: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR::GlobalValuePropagation::create, OMR::globalValuePropagation);
    _opts[OMR::localValuePropagation] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR::LocalValuePropagation::create, OMR::localValuePropagation, "O^O LOCAL VALUE PROPAGATION: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR::LocalValuePropagation::create, OMR::localValuePropagation);
    _opts[OMR::redundantInductionVarElimination] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_RedundantInductionVarElimination::create, OMR::redundantInductionVarElimination, "O^O REDUNDANT INDUCTION VAR ELIMINATION: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_RedundantInductionVarElimination::create, OMR::redundantInductionVarElimination);
    _opts[OMR::partialRedundancyElimination] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_PartialRedundancy::create, OMR::partialRedundancyElimination, "O^O PARTIAL REDUNDANCY ELIMINATION: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_PartialRedundancy::create, OMR::partialRedundancyElimination);
    _opts[OMR::loopInversion] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_LoopInverter::create, OMR::loopInversion, "O^O LOOP INVERTER: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_LoopInverter::create, OMR::loopInversion);
    _opts[OMR::inductionVariableAnalysis] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_InductionVariableAnalysis::create, OMR::inductionVariableAnalysis, "O^O INDUCTION VARIABLE ANALYSIS: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_InductionVariableAnalysis::create, OMR::inductionVariableAnalysis);
    _opts[OMR::osrExceptionEdgeRemoval] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_OSRExceptionEdgeRemoval::create, OMR::osrExceptionEdgeRemoval, "O^O OSR EXCEPTION EDGE REMOVAL: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_OSRExceptionEdgeRemoval::create, OMR::osrExceptionEdgeRemoval);
    _opts[OMR::regDepCopyRemoval] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR::RegDepCopyRemoval::create, OMR::regDepCopyRemoval, "O^O REGISTER DEPENDENCY COPY REMOVAL: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR::RegDepCopyRemoval::create, OMR::regDepCopyRemoval);
    _opts[OMR::prefetchInsertion] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_PrefetchInsertion::create, OMR::prefetchInsertion, "O^O PREFETCH INSERTION: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_PrefetchInsertion::create, OMR::prefetchInsertion);
    _opts[OMR::stripMining] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_StripMiner::create, OMR::stripMining, "O^O STRIP MINER: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_StripMiner::create, OMR::stripMining);
    _opts[OMR::fieldPrivatization] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_FieldPrivatizer::create, OMR::fieldPrivatization, "O^O FIELD PRIVATIZATION: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_FieldPrivatizer::create, OMR::fieldPrivatization);
    _opts[OMR::reorderArrayIndexExpr] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_IndexExprManipulator::create, OMR::reorderArrayIndexExpr, "O^O ARRAY INDEX EXPRESSION MANIPULATION: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_IndexExprManipulator::create, OMR::reorderArrayIndexExpr);
    _opts[OMR::loopStrider] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_LoopStrider::create, OMR::loopStrider, "O^O LOOP STRIDER: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_LoopStrider::create, OMR::loopStrider);
    _opts[OMR::osrDefAnalysis] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_OSRDefAnalysis::create, OMR::osrDefAnalysis, "O^O OSR DEF ANALYSIS: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_OSRDefAnalysis::create, OMR::osrDefAnalysis);
    _opts[OMR::osrLiveRangeAnalysis] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_OSRLiveRangeAnalysis::create, OMR::osrLiveRangeAnalysis, "O^O OSR LIVE RANGE ANALYSIS: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_OSRLiveRangeAnalysis::create, OMR::osrLiveRangeAnalysis);
    _opts[OMR::tacticalGlobalRegisterAllocator] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_GlobalRegisterAllocator::create, OMR::tacticalGlobalRegisterAllocator, "O^O GLOBAL REGISTER ASSIGNER: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_GlobalRegisterAllocator::create, OMR::tacticalGlobalRegisterAllocator);
    _opts[OMR::liveRangeSplitter] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_LiveRangeSplitter::create, OMR::liveRangeSplitter, "O^O LIVE RANGE SPLITTER: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_LiveRangeSplitter::create, OMR::liveRangeSplitter);
    _opts[OMR::loopSpecializer] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_LoopSpecializer::create, OMR::loopSpecializer, "O^O LOOP SPECIALIZER: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_LoopSpecializer::create, OMR::loopSpecializer);
 
    // NOTE: Please add new OMR optimizations here!
 
    // initialize OMR optimization groups
 
    _opts[OMR::globalDeadStoreGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::globalDeadStoreGroup, "", globalDeadStoreOpts);
+      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::globalDeadStoreGroup, globalDeadStoreOpts);
    _opts[OMR::loopCanonicalizationGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::loopCanonicalizationGroup, "", loopCanonicalizationOpts);
+      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::loopCanonicalizationGroup, loopCanonicalizationOpts);
    _opts[OMR::loopVersionerGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::loopVersionerGroup, "", loopVersionerOpts);
+      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::loopVersionerGroup, loopVersionerOpts);
    _opts[OMR::lastLoopVersionerGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::lastLoopVersionerGroup, "", lastLoopVersionerOpts);
+      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::lastLoopVersionerGroup, lastLoopVersionerOpts);
    _opts[OMR::methodHandleInvokeInliningGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::methodHandleInvokeInliningGroup, "", methodHandleInvokeInliningOpts);
+      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::methodHandleInvokeInliningGroup, methodHandleInvokeInliningOpts);
    _opts[OMR::earlyGlobalGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::earlyGlobalGroup, "", earlyGlobalOpts);
+      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::earlyGlobalGroup, earlyGlobalOpts);
    _opts[OMR::earlyLocalGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::earlyLocalGroup, "", earlyLocalOpts);
+      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::earlyLocalGroup, earlyLocalOpts);
    _opts[OMR::stripMiningGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::stripMiningGroup, "", stripMiningOpts);
+      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::stripMiningGroup, stripMiningOpts);
    _opts[OMR::arrayPrivatizationGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::arrayPrivatizationGroup, "", arrayPrivatizationOpts);
+      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::arrayPrivatizationGroup, arrayPrivatizationOpts);
    _opts[OMR::veryCheapGlobalValuePropagationGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::veryCheapGlobalValuePropagationGroup, "", veryCheapGlobalValuePropagationOpts);
+      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::veryCheapGlobalValuePropagationGroup, veryCheapGlobalValuePropagationOpts);
    _opts[OMR::eachExpensiveGlobalValuePropagationGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::eachExpensiveGlobalValuePropagationGroup, "", eachExpensiveGlobalValuePropagationOpts);
+      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::eachExpensiveGlobalValuePropagationGroup, eachExpensiveGlobalValuePropagationOpts);
    _opts[OMR::veryExpensiveGlobalValuePropagationGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::veryExpensiveGlobalValuePropagationGroup, "", veryExpensiveGlobalValuePropagationOpts);
+      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::veryExpensiveGlobalValuePropagationGroup, veryExpensiveGlobalValuePropagationOpts);
    _opts[OMR::loopSpecializerGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::loopSpecializerGroup, "", loopSpecializerOpts);
+      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::loopSpecializerGroup, loopSpecializerOpts);
    _opts[OMR::prefetchInsertionGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::prefetchInsertionGroup, "", prefetchInsertionOpts);
+      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::prefetchInsertionGroup, prefetchInsertionOpts);
    _opts[OMR::lateLocalGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::lateLocalGroup, "", lateLocalOpts);
+      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::lateLocalGroup, lateLocalOpts);
    _opts[OMR::eachLocalAnalysisPassGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::eachLocalAnalysisPassGroup, "", eachLocalAnalysisPassOpts);
+      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::eachLocalAnalysisPassGroup, eachLocalAnalysisPassOpts);
    _opts[OMR::tacticalGlobalRegisterAllocatorGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::tacticalGlobalRegisterAllocatorGroup, "", tacticalGlobalRegisterAllocatorOpts);
+      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::tacticalGlobalRegisterAllocatorGroup, tacticalGlobalRegisterAllocatorOpts);
    _opts[OMR::partialRedundancyEliminationGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::partialRedundancyEliminationGroup, "", partialRedundancyEliminationOpts);
+      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::partialRedundancyEliminationGroup, partialRedundancyEliminationOpts);
    _opts[OMR::reorderArrayExprGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::reorderArrayExprGroup, "", reorderArrayIndexOpts);
+      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::reorderArrayExprGroup, reorderArrayIndexOpts);
    _opts[OMR::blockManipulationGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::blockManipulationGroup, "", blockManipulationOpts);
+      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::blockManipulationGroup, blockManipulationOpts);
    _opts[OMR::localValuePropagationGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::localValuePropagationGroup, "", localValuePropagationOpts);
+      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::localValuePropagationGroup, localValuePropagationOpts);
    _opts[OMR::finalGlobalGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::finalGlobalGroup, "", finalGlobalOpts);
+      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::finalGlobalGroup, finalGlobalOpts);
 
    // NOTE: Please add new OMR optimization groups here!
 

--- a/compiler/optimizer/OMRSimplifier.cpp
+++ b/compiler/optimizer/OMRSimplifier.cpp
@@ -728,3 +728,8 @@ OMR::Simplifier::isBoundDefinitelyGELength(TR::Node *boundChild, TR::Node *lengt
    return false;
    }
 
+const char *
+OMR::Simplifier::optDetailString() const throw()
+   {
+   return "O^O TREE SIMPLIFICATION: ";
+   }

--- a/compiler/optimizer/OMRSimplifier.hpp
+++ b/compiler/optimizer/OMRSimplifier.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -81,6 +81,7 @@ class Simplifier : public TR::Optimization
    virtual int32_t performOnBlock(TR::Block *);
    virtual void prePerformOnBlocks();
    virtual void postPerformOnBlocks();
+   virtual const char * optDetailString() const throw();
 
    // Simplify a complete block.
    //

--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -4825,6 +4825,12 @@ void TR::GlobalValuePropagation::processBlock(TR_StructureSubGraphNode *node, bo
    propagateOutputConstraints(node, lastTimeThrough, false, List1, &List2);
    }
 
+const char *
+TR::GlobalValuePropagation::optDetailString() const throw()
+   {
+   return "O^O GLOBAL VALUE PROPAGATION: ";
+   }
+
 TR::CFGEdge *OMR::ValuePropagation::findOutEdge(TR::CFGEdgeList &edges, TR::CFGNode *target)
    {
    // Find the output edge in the list of edges to the given node
@@ -5730,6 +5736,11 @@ int32_t TR::ArraycopyTransformation::perform()
    return 1;
    }
 
+const char *
+TR::ArraycopyTransformation::optDetailString() const throw()
+   {
+   return "O^O ARRAY COPY TRANSFORMATION: ";
+   }
 
 void OMR::ValuePropagation::createNewBlockInfoForVersioning(TR::Block *block)
    {

--- a/compiler/optimizer/OMRValuePropagation.hpp
+++ b/compiler/optimizer/OMRValuePropagation.hpp
@@ -99,6 +99,7 @@ class ArraycopyTransformation : public TR::Optimization
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    private:
    TR::TreeTop* createArrayNode(TR::TreeTop* tree, TR::TreeTop* newTree, TR::SymbolReference* srcRef, TR::SymbolReference* dstRef, TR::SymbolReference* lenRef, TR::SymbolReference* srcObjRef, TR::SymbolReference* dstObjRef, bool isForward);

--- a/compiler/optimizer/OSRDefAnalysis.cpp
+++ b/compiler/optimizer/OSRDefAnalysis.cpp
@@ -648,6 +648,12 @@ bool TR_OSRDefAnalysis::requiresAnalysis()
    return methodSymbol->sharesStackSlots(comp());
    }
 
+const char *
+TR_OSRDefAnalysis::optDetailString() const throw()
+   {
+   return "O^O OSR DEF ANALYSIS: ";
+   }
+
 //Not needed anymore. I'll keep it commented out just in case it's needed in the future.
 //Check whether the first real non-profiling tree top in the block
 //is an OSR Helper call. If it is, return that treetop. Otherwise return null.
@@ -1299,6 +1305,12 @@ bool TR_OSRLiveRangeAnalysis::canAffordAnalysis()
    return true;
    }
 
+const char *
+TR_OSRLiveRangeAnalysis::optDetailString() const throw()
+   {
+   return "O^O OSR LIVE RANGE ANALYSIS: ";
+   }
+
 int32_t TR_OSRExceptionEdgeRemoval::perform()
    {
    if (comp()->getOption(TR_EnableOSR))
@@ -1366,4 +1378,10 @@ int32_t TR_OSRExceptionEdgeRemoval::perform()
    comp()->setOSRInfrastructureRemoved(true);
 
    return 1;
+   }
+
+const char *
+TR_OSRExceptionEdgeRemoval::optDetailString() const throw()
+   {
+   return "O^O OSR EXCEPTION EDGE REMOVAL: ";
    }

--- a/compiler/optimizer/OSRDefAnalysis.hpp
+++ b/compiler/optimizer/OSRDefAnalysis.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -60,6 +60,7 @@ class TR_OSRDefAnalysis : public TR::Optimization
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    private:
 
@@ -91,6 +92,7 @@ class TR_OSRLiveRangeAnalysis : public TR::Optimization
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    private:
 
@@ -123,6 +125,7 @@ class TR_OSRExceptionEdgeRemoval : public TR::Optimization
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
    };
 
 #endif

--- a/compiler/optimizer/OptimizationManager.hpp
+++ b/compiler/optimizer/OptimizationManager.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -34,8 +34,8 @@ class OMR_EXTENSIBLE OptimizationManager : public OMR::OptimizationManagerConnec
    {
    public:
 
-   OptimizationManager(TR::Optimizer *o, OptimizationFactory factory, OMR::Optimizations optNum, const char *optDetailString, const OptimizationStrategy *groupOfOpts = NULL) :
-      OMR::OptimizationManagerConnector(o, factory, optNum, optDetailString, groupOfOpts) {}
+   OptimizationManager(TR::Optimizer *o, OptimizationFactory factory, OMR::Optimizations optNum, const OptimizationStrategy *groupOfOpts = NULL) :
+      OMR::OptimizationManagerConnector(o, factory, optNum, groupOfOpts) {}
    };
 
 }

--- a/compiler/optimizer/OrderBlocks.cpp
+++ b/compiler/optimizer/OrderBlocks.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -2156,6 +2156,11 @@ int32_t TR_OrderBlocks::perform()
    return 1; // actual cost
    }
 
+const char *
+TR_OrderBlocks::optDetailString() const throw()
+   {
+   return "O^O ORDER BLOCKS: ";
+   }
 
 void checkOrderingConsistency(TR::Compilation *comp)
    {
@@ -2424,4 +2429,10 @@ void TR_BlockShuffling::reverse(TR::Block **blocks)
    for (upper=0, lower=_numBlocks-1; upper < lower; upper++, lower--)
       if (performTransformation(comp(), "O^O BLOCK SHUFFLING:   swap [%3d] and [%3d] (block_%d and block_%d)\n", upper, lower, blocks[upper]->getNumber(), blocks[lower]->getNumber()))
          swap(blocks, upper, lower);
+   }
+
+const char *
+TR_BlockShuffling::optDetailString() const throw()
+   {
+   return "O^O BLOCK SHUFFLING: ";
    }

--- a/compiler/optimizer/OrderBlocks.hpp
+++ b/compiler/optimizer/OrderBlocks.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -77,6 +77,7 @@ class TR_OrderBlocks : public TR_BlockOrderingOptimization
 
    virtual bool    shouldPerform();
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    void            doPeepHoleOptimizations(bool before, bool after)
                                              { if (before)
@@ -174,6 +175,7 @@ class TR_BlockShuffling : public TR_BlockOrderingOptimization
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    private:
 

--- a/compiler/optimizer/PartialRedundancy.cpp
+++ b/compiler/optimizer/PartialRedundancy.cpp
@@ -2242,6 +2242,11 @@ TR::TreeTop *TR_PartialRedundancy::replaceOptimalSubNodes(TR::TreeTop *curTree, 
    return curTree;
    }
 
+const char *
+TR_PartialRedundancy::optDetailString() const throw()
+   {
+   return "O^O PARTIAL REDUNDANCY ELIMINATION: ";
+   }
 
 
 // Analysis for adjusting the optimal info/redundant info sets for each block

--- a/compiler/optimizer/PartialRedundancy.hpp
+++ b/compiler/optimizer/PartialRedundancy.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -79,6 +79,7 @@ class TR_PartialRedundancy : public TR::Optimization
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    void printTrees();
    TR::TreeTop *placeComputationsOptimally(TR::Block *, TR::Node ***);

--- a/compiler/optimizer/PrefetchInsertion.cpp
+++ b/compiler/optimizer/PrefetchInsertion.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -485,4 +485,10 @@ bool TR_PrefetchInsertion::isBIV(TR::SymbolReference* symRef, TR::Block *block, 
       }
 
    return false;
+   }
+
+const char *
+TR_PrefetchInsertion::optDetailString() const throw()
+   {
+   return "O^O PREFETCH INSERTION: ";
    }

--- a/compiler/optimizer/PrefetchInsertion.hpp
+++ b/compiler/optimizer/PrefetchInsertion.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -43,6 +43,7 @@ class TR_PrefetchInsertion : public TR_LoopTransformer
       }
 
    virtual int32_t perform();
+   const char * optDetailString() const throw();
 
    private:
    struct ArrayAccessInfo

--- a/compiler/optimizer/RedundantAsyncCheckRemoval.cpp
+++ b/compiler/optimizer/RedundantAsyncCheckRemoval.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -1623,6 +1623,11 @@ void TR_RedundantAsyncCheckRemoval::solidifySoftAsyncChecks(TR_StructureSubGraph
 
    }
 
+const char *
+TR_RedundantAsyncCheckRemoval::optDetailString() const throw()
+   {
+   return "O^O REDUNDANT ASYNC CHECK REMOVAL: ";
+   }
 
 // --------------------------------------------------------
 // Loop Estimator

--- a/compiler/optimizer/RedundantAsyncCheckRemoval.hpp
+++ b/compiler/optimizer/RedundantAsyncCheckRemoval.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -187,6 +187,7 @@ class TR_RedundantAsyncCheckRemoval : public TR::Optimization
 
    virtual bool    shouldPerform();
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    enum YieldPointKind { NoYieldPoint, SoftYieldPoint, HardYieldPoint };
    enum CoverageKind { NotCovered, PartiallyCovered, FullyCovered };

--- a/compiler/optimizer/RegDepCopyRemoval.cpp
+++ b/compiler/optimizer/RegDepCopyRemoval.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -452,4 +452,10 @@ TR::RegDepCopyRemoval::generateRegcopyDebugCounter(const char *category)
       comp()->getHotnessName(comp()->getMethodHotness()),
       _treetop->getEnclosingBlock()->getNumber());
    TR::DebugCounter::prependDebugCounter(comp(), fullName, _treetop);
+   }
+
+const char *
+TR::RegDepCopyRemoval::optDetailString() const throw()
+   {
+   return "O^O REGISTER DEPENDENCY COPY REMOVAL: ";
    }

--- a/compiler/optimizer/RegDepCopyRemoval.hpp
+++ b/compiler/optimizer/RegDepCopyRemoval.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -63,6 +63,7 @@ class RegDepCopyRemoval : public TR::Optimization
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    private:
 

--- a/compiler/optimizer/ReorderIndexExpr.cpp
+++ b/compiler/optimizer/ReorderIndexExpr.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -190,4 +190,10 @@ TR_IndexExprManipulator::rewriteIndexExpression(TR_PrimaryInductionVariable *pri
             }
          }
       }
+   }
+
+const char *
+TR_IndexExprManipulator::optDetailString() const throw()
+   {
+   return "O^O ARRAY INDEX EXPRESSION MANIPULATION: ";
    }

--- a/compiler/optimizer/ReorderIndexExpr.hpp
+++ b/compiler/optimizer/ReorderIndexExpr.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -38,6 +38,8 @@ class TR_IndexExprManipulator: public TR::Optimization
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
+
    void rewriteIndexExpression(TR_Structure *);
 
    private:

--- a/compiler/optimizer/ShrinkWrapping.cpp
+++ b/compiler/optimizer/ShrinkWrapping.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -2600,4 +2600,10 @@ TR_YesNoMaybe TR_ShrinkWrap::blockEndsInReturn(int32_t blockNum, bool &hasExcept
       }
 
    return TR_no;
+   }
+
+const char *
+TR_ShrinkWrap::optDetailString() const throw()
+   {
+   return "O^O SHRINK WRAPPING: ";
    }

--- a/compiler/optimizer/ShrinkWrapping.hpp
+++ b/compiler/optimizer/ShrinkWrapping.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -72,6 +72,7 @@ class TR_ShrinkWrap : public TR::Optimization
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    void prePerformOnBlocks();
    void analyzeInstructions();

--- a/compiler/optimizer/SinkStores.cpp
+++ b/compiler/optimizer/SinkStores.cpp
@@ -2531,6 +2531,12 @@ bool TR_GeneralSinkStores::storeIsSinkingCandidate(TR::Block *block, TR::Node *n
            treeIsSinkableStore(node, sinkIndirectLoads, indirectLoadCount, depth, isLoadStatic, enablePreciseSymbolTracking() ? comp()->incVisitCount() : comp()->getVisitCount()));
    }
 
+const char *
+TR_GeneralSinkStores::optDetailString() const throw()
+   {
+   return "O^O GENERAL SINK STORES: ";
+   }
+
 // return true if it is safe to propagate the store thru the moved stores in the edge placement
 bool TR_SinkStores::isSafeToSinkThruEdgePlacement(int symIdx, TR::CFGNode *block, TR::CFGNode *succBlock, TR_BitVector *allEdgeInfoUsedOrKilledSymbols)
    {
@@ -3848,7 +3854,11 @@ bool TR_TrivialSinkStores::sinkStorePlacement(TR_MovableStore *store,
       return sunkStore;
    }
 
-
+const char *
+TR_TrivialSinkStores::optDetailString() const throw()
+   {
+   return "O^O TRIVIAL SINK STORES: ";
+   }
 
 
 bool TR_GeneralSinkStores::sinkStorePlacement(TR_MovableStore *movableStore,

--- a/compiler/optimizer/SinkStores.hpp
+++ b/compiler/optimizer/SinkStores.hpp
@@ -482,6 +482,7 @@ class TR_GeneralSinkStores : public TR_SinkStores
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    private:
    virtual bool storeIsSinkingCandidate(TR::Block *block,
@@ -509,6 +510,7 @@ class TR_TrivialSinkStores : public TR_SinkStores
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    private:
    TR::TreeTop *genSideExitTree(TR::TreeTop *store, TR::Block *exitBlock, bool isFirstGen);

--- a/compiler/optimizer/StripMiner.cpp
+++ b/compiler/optimizer/StripMiner.cpp
@@ -2133,3 +2133,9 @@ bool TR_StripMiner::findPivInSimpleForm(TR::Node *node, TR::SymbolReference *piv
 
    return false;
    }
+
+const char *
+TR_StripMiner::optDetailString() const throw()
+   {
+   return "O^O STRIP MINER: ";
+   }

--- a/compiler/optimizer/StripMiner.hpp
+++ b/compiler/optimizer/StripMiner.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -48,6 +48,7 @@ class TR_StripMiner : public TR_LoopTransformer
 
    virtual bool    shouldPerform();
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    private:
    /* types */

--- a/compiler/optimizer/TrivialDeadBlockRemover.cpp
+++ b/compiler/optimizer/TrivialDeadBlockRemover.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -146,4 +146,10 @@ int32_t TR_TrivialDeadBlockRemover::perform ()
       }
 
    return 1;
+   }
+
+const char *
+TR_TrivialDeadBlockRemover::optDetailString() const throw()
+   {
+   return "O^O TRIVIAL DEAD BLOCK REMOVAL: ";
    }

--- a/compiler/optimizer/TrivialDeadBlockRemover.hpp
+++ b/compiler/optimizer/TrivialDeadBlockRemover.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -28,6 +28,7 @@ class TR_TrivialDeadBlockRemover : public TR::Optimization {
 
    public:
       virtual int32_t perform();
+      virtual const char * optDetailString() const throw();
 
 
       TR_TrivialDeadBlockRemover(TR::OptimizationManager *manager):

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -4092,6 +4092,11 @@ TR::TreeTop *TR::LocalValuePropagation::processBlock(TR::TreeTop *startTree)
    return startTree;
    }
 
+const char *
+TR::LocalValuePropagation::optDetailString() const throw()
+   {
+   return "O^O LOCAL VALUE PROPAGATION: ";
+   }
 
 void OMR::ValuePropagation::launchNode(TR::Node *node, TR::Node *parent, int32_t whichChild)
    {

--- a/compiler/optimizer/VirtualGuardCoalescer.cpp
+++ b/compiler/optimizer/VirtualGuardCoalescer.cpp
@@ -1351,6 +1351,12 @@ TR::Node *TR_VirtualGuardTailSplitter::getFirstCallNode(TR::Block *block)
    return NULL;
    }
 
+const char *
+TR_VirtualGuardTailSplitter::optDetailString() const throw()
+   {
+   return "O^O VIRTUAL GUARD COALESCER: ";
+   }
+
 TR_InnerPreexistence::TR_InnerPreexistence(TR::OptimizationManager *manager)
    : TR::Optimization(manager)
    {}
@@ -1609,3 +1615,8 @@ TR_InnerPreexistence::devirtualize(GuardInfo *info)
    requestOpt(OMR::treeSimplification, true, guardBlock);
    }
 
+const char *
+TR_InnerPreexistence::optDetailString() const throw()
+   {
+   return "O^O INNER PREEXISTENCE: ";
+   }

--- a/compiler/optimizer/VirtualGuardCoalescer.hpp
+++ b/compiler/optimizer/VirtualGuardCoalescer.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -55,6 +55,7 @@ class TR_VirtualGuardTailSplitter : public TR::Optimization
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    private:
 
@@ -162,6 +163,7 @@ class TR_InnerPreexistence : public TR::Optimization
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
 
    class GuardInfo
       {

--- a/compiler/optimizer/VirtualGuardHeadMerger.cpp
+++ b/compiler/optimizer/VirtualGuardHeadMerger.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -430,4 +430,10 @@ void TR_VirtualGuardHeadMerger::tailSplitBlock(TR::Block * block, TR::Block * co
 
    optimizer()->setUseDefInfo(NULL);
    optimizer()->setValueNumberInfo(NULL);
+   }
+
+const char *
+TR_VirtualGuardHeadMerger::optDetailString() const throw()
+   {
+   return "O^O VIRTUAL GUARD HEAD MERGER: ";
    }

--- a/compiler/optimizer/VirtualGuardHeadMerger.hpp
+++ b/compiler/optimizer/VirtualGuardHeadMerger.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -37,6 +37,8 @@ class TR_VirtualGuardHeadMerger : public TR::Optimization
       }
 
    virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
+
    private:
    void tailSplitBlock(TR::Block * block, TR::Block * cold1);
    };

--- a/jitbuilder/optimizer/JBOptimizer.cpp
+++ b/jitbuilder/optimizer/JBOptimizer.cpp
@@ -143,56 +143,20 @@ Optimizer::Optimizer(TR::Compilation *comp, TR::ResolvedMethodSymbol *methodSymb
       const OptimizationStrategy *strategy, uint16_t VNType)
    : OMR::Optimizer(comp, methodSymbol, isIlGen, strategy, VNType)
    {
-   _opts[OMR::inductionVariableAnalysis] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_InductionVariableAnalysis::create, OMR::inductionVariableAnalysis, "O^O INDUCTION VARIABLE ANALYSIS: ");
-   _opts[OMR::partialRedundancyElimination] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_PartialRedundancy::create, OMR::partialRedundancyElimination, "O^O PARTIAL REDUNDANCY ELIMINATION: ");
    _opts[OMR::isolatedStoreElimination] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_IsolatedStoreElimination::create, OMR::isolatedStoreElimination, "O^O ISOLATED STORE ELIMINATION: ");
-   _opts[OMR::tacticalGlobalRegisterAllocator] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_GlobalRegisterAllocator::create, OMR::tacticalGlobalRegisterAllocator, "O^O GLOBAL REGISTER ASSIGNER: ");
-   _opts[OMR::loopInversion] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_LoopInverter::create, OMR::loopInversion, "O^O LOOP INVERTER: ");
-   _opts[OMR::loopSpecializer] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_LoopSpecializer::create, OMR::loopSpecializer, "O^O LOOP SPECIALIZER: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_IsolatedStoreElimination::create, OMR::isolatedStoreElimination);
    _opts[OMR::trivialStoreSinking] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_TrivialSinkStores::create, OMR::trivialStoreSinking, "O^O TRIVIAL SINK STORES: ");
-   _opts[OMR::generalStoreSinking] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_GeneralSinkStores::create, OMR::generalStoreSinking, "O^O GENERAL SINK STORES: ");
-   _opts[OMR::liveRangeSplitter] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_LiveRangeSplitter::create, OMR::liveRangeSplitter, "O^O LIVE RANGE SPLITTER: ");
-   _opts[OMR::redundantInductionVarElimination] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_RedundantInductionVarElimination::create, OMR::redundantInductionVarElimination, "O^O REDUNDANT INDUCTION VAR ELIMINATION: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_TrivialSinkStores::create, OMR::trivialStoreSinking);
    _opts[OMR::trivialDeadBlockRemover] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR_TrivialDeadBlockRemover::create, OMR::trivialDeadBlockRemover, "O^O TRIVIAL DEAD BLOCK REMOVAL ");
-   _opts[OMR::regDepCopyRemoval] =
-      new (comp->allocator()) TR::OptimizationManager(self(), TR::RegDepCopyRemoval::create, OMR::regDepCopyRemoval, "O^O REGISTER DEPENDENCY COPY REMOVAL: ");
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_TrivialDeadBlockRemover::create, OMR::trivialDeadBlockRemover);
    // NOTE: Please add new IBM optimizations here!
 
    // initialize additional IBM optimization groups
 
-   _opts[OMR::arrayPrivatizationGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::arrayPrivatizationGroup, "", arrayPrivatizationOpts);
-   _opts[OMR::reorderArrayExprGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::reorderArrayExprGroup, "", reorderArrayIndexOpts);
-   _opts[OMR::partialRedundancyEliminationGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::partialRedundancyEliminationGroup, "", partialRedundancyEliminationOpts);
    _opts[OMR::isolatedStoreGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::isolatedStoreGroup, "", isolatedStoreOpts);
+      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::isolatedStoreGroup, isolatedStoreOpts);
    _opts[OMR::cheapTacticalGlobalRegisterAllocatorGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::cheapTacticalGlobalRegisterAllocatorGroup, "", cheapTacticalGlobalRegisterAllocatorOpts);
-   _opts[OMR::tacticalGlobalRegisterAllocatorGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::tacticalGlobalRegisterAllocatorGroup, "", tacticalGlobalRegisterAllocatorOpts);
-   _opts[OMR::finalGlobalGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::finalGlobalGroup, "", finalGlobalOpts);
-   _opts[OMR::loopVersionerGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::loopVersionerGroup, "", loopVersionerOpts);
-   _opts[OMR::lastLoopVersionerGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::lastLoopVersionerGroup, "", lastLoopVersionerOpts);
-   _opts[OMR::blockManipulationGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::blockManipulationGroup, "", blockManipulationOpts);
-   _opts[OMR::eachLocalAnalysisPassGroup] =
-      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::eachLocalAnalysisPassGroup, "", eachLocalAnalysisPassOpts);
+      new (comp->allocator()) TR::OptimizationManager(self(), NULL, OMR::cheapTacticalGlobalRegisterAllocatorGroup, cheapTacticalGlobalRegisterAllocatorOpts);
 
    // NOTE: Please add new IBM optimization groups here!
 


### PR DESCRIPTION
Currently the optimization details string used during tracing is
initialized as part of the optimization manager construction. Because
OMR compiler consumers may initialize some optimizations themselves,
this opens us up to a scenario where these strings start to diverge
between the various consuming projects.

As developers rely on the consistency of those strings in order to aid
in cross-project debugging, this change modifies these optimization
string definitions such that they are an inherent part of the class
definition, and are accessed via a virtual function, for which each
implementation returns a statically defined string.

Signed-off-by: Luc des Trois Maisons <lmaisons@ca.ibm.com>