### PR TITLE
Merge OptAttributes into Node

### DIFF
--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -104,12 +104,9 @@ OMR::CodeGenerator::checkForLiveRegisters(TR_LiveRegisters *liveRegisters)
       traceMsg(self()->comp(), "\n\n");
       for (TR_LiveRegisterInfo *p = liveRegisters->getFirstLiveRegister(); p; p = p->getNext())
          {
-         if (p->getNode() && p->getNode()->hasOptAttributes())
+         if (p->getNode())
             traceMsg(self()->comp(), "Virtual register %s (for node [%s], ref count=%d) is live at end of method\n",
                         debug->getName(p->getRegister()), debug->getName(p->getNode()), p->getNode()->getReferenceCount());
-         else if (p->getNode())
-                     traceMsg(self()->comp(), "Virtual register %s (for node [%s]) is live at end of method\n",
-                                 debug->getName(p->getRegister()), debug->getName(p->getNode()));
          else
             traceMsg(self()->comp(), "Virtual register %s %p is live at end of method with node count %d\n", debug->getName(p->getRegister()), p->getRegister(), p->getNodeCount());
          regsAreLive = true;

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -849,17 +849,6 @@ OMR::CodeGenerator::doInstructionSelection()
          }
       }
 
-   // Free opt attributes
-   //
-   if (!comp->getOption(TR_DisableOptAttributesMemoryFree))
-      {
-      if (!TR::Compiler->target.cpu.isX86())
-         {
-         // x86 code uses getRegister post instruction selection, prevents FreeOptAttributes() from being called
-         comp->getNodePool().FreeOptAttributes();
-         }
-      }
-
 #if defined(TR_TARGET_S390)
    // Virtual function insertInstructionPrefetches is implemented only for s390 platform,
    // for all other platforms the function is empty

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -446,7 +446,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableNoVMAccess",                  "O\tdisable compilation without holding VM access",  SET_OPTION_BIT(TR_DisableNoVMAccess), "F"},
    {"disableOnDemandLiteralPoolRegister", "O\tdisable on demand literal pool register",        SET_OPTION_BIT(TR_DisableOnDemandLiteralPoolRegister), "F"},
    {"disableOOL",                         "O\tdisable out of line instruction selection",      SET_OPTION_BIT(TR_DisableOOL), "F"},
-   {"disableOptAttributesMemoryFree",     "O\tdisable freeing Node::OptAttributes",            SET_OPTION_BIT(TR_DisableOptAttributesMemoryFree), "F"},
    {"disableOpts=",                       "O{regex}\tlist of optimizations to disable",
                                           TR::Options::setRegex, offsetof(OMR::Options, _disabledOpts), 0, "P"},
    {"disableOptTransformations=",         "O{regex}\tlist of optimizer transformations to disable",

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -883,7 +883,7 @@ enum TR_CompilationOptions
 
    // Option word 27
    TR_ForceIEEEDivideByZeroException                  = 0x00000020 + 27,
-   TR_DisableOptAttributesMemoryFree                  = 0x00000040 + 27,
+   // Available                                       = 0x00000040 + 27,
    TR_DisableDirectStaticAccessOnZ                    = 0x00000080 + 27,
    TR_EnableRubyTieredCompilation                     = 0x00000100 + 27,
    TR_EnableRIEMIT                                    = 0x00000200 + 27,

--- a/compiler/il/Node.hpp
+++ b/compiler/il/Node.hpp
@@ -37,8 +37,8 @@ public:
    Node() : OMR::NodeConnector() {}
 
    Node(TR::Node *originatingByteCodeNode, TR::ILOpCodes op,
-        uint16_t numChildren, OptAttributes * oa = NULL)
-      : OMR::NodeConnector(originatingByteCodeNode, op, numChildren, oa)
+        uint16_t numChildren)
+      : OMR::NodeConnector(originatingByteCodeNode, op, numChildren)
       {}
 
    Node(Node *from, uint16_t numChildren = 0)

--- a/compiler/il/NodePool.hpp
+++ b/compiler/il/NodePool.hpp
@@ -46,9 +46,7 @@ class NodePool
       _pool(allocator),
       _globalIndex(0),
       _poolIndex(0),
-      _disableGC(true),
-      _optAttribGlobalIndex(0),
-      _optAttribPool(allocator)
+      _disableGC(true)
       {
       }
 
@@ -63,9 +61,6 @@ class NodePool
    ncount_t  getMaxIndex()           { return _globalIndex; }
    TR::Compilation * comp() { return _comp; }
 
-   OMR::Node::OptAttributes * allocateOptAttributes();
-   void FreeOptAttributes();
-
    void cleanUp();
 
    private:
@@ -75,11 +70,8 @@ class NodePool
    bool                  _disableGC;
    ncount_t              _globalIndex;
    ncount_t              _poolIndex;
-   ncount_t              _optAttribGlobalIndex;
 
    Pool_t                _pool;
-
-   CS2::TableOf<OMR::Node::OptAttributes,TR::Allocator, 8, CS2::ABitVector> _optAttribPool;
    };
 
 }

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -94,8 +94,10 @@ OMR::Node::Node()
      _numChildren(0),
      _globalIndex(0),
      _flags(0),
+     _visitCount(0),
+     _localIndex(0),
+     _referenceCount(0),
      _byteCodeInfo(),
-     _optAttributes(NULL),
      _unionBase(),
      _unionPropertyA()
    {
@@ -108,13 +110,15 @@ OMR::Node::~Node()
    self()->freeExtensionIfExists();
    }
 
-OMR::Node::Node(TR::Node *originatingByteCodeNode, TR::ILOpCodes op, uint16_t numChildren, OptAttributes * optAttributes)
+OMR::Node::Node(TR::Node *originatingByteCodeNode, TR::ILOpCodes op, uint16_t numChildren)
    : _opCode(op),
      _numChildren(numChildren),
      _globalIndex(0),
      _flags(0),
+     _visitCount(0),
+     _localIndex(0),
+     _referenceCount(0),
      _byteCodeInfo(),
-     _optAttributes(NULL),
      _unionBase(),
      _unionPropertyA()
    {
@@ -140,24 +144,16 @@ OMR::Node::Node(TR::Node *originatingByteCodeNode, TR::ILOpCodes op, uint16_t nu
       self()->setChild(1, NULL);
       }
 
-   if (optAttributes != NULL)
+   self()->setGlobalIndex(comp->getNodePool().getLastGlobalIndex());
+   self()->setNodePoolIndex(comp->getNodePool().getLastPoolIndex());
+   self()->setReferenceCount(0);
+   self()->setVisitCount(0);
+   self()->setLocalIndex(0);
+   memset( &(_unionA), 0, sizeof( _unionA ) );
+   if (self()->getGlobalIndex() == MAX_NODE_COUNT)
       {
-      self()->setOptAttributes(optAttributes);
-      }
-   else
-      {
-      self()->setOptAttributes(new (comp->getNodePool()) OMR::Node::OptAttributes());
-      self()->setGlobalIndex(comp->getNodePool().getLastGlobalIndex());
-      self()->setNodePoolIndex(comp->getNodePool().getLastPoolIndex());
-      self()->setReferenceCount(0);
-      self()->setVisitCount(0);
-      self()->setLocalIndex(0);
-      memset( &(self()->getOptAttributes()->_unionA), 0, sizeof( self()->getOptAttributes()->_unionA ) );
-      if (self()->getGlobalIndex() == MAX_NODE_COUNT)
-         {
-         TR_ASSERT(0, "getGlobalIndex() == MAX_NODE_COUNT");
-         comp->failCompilation<TR::ExcessiveComplexity>("Global index equal to max node count");
-         }
+      TR_ASSERT(0, "getGlobalIndex() == MAX_NODE_COUNT");
+      comp->failCompilation<TR::ExcessiveComplexity>("Global index equal to max node count");
       }
 
    _byteCodeInfo.setInvalidCallerIndex();
@@ -218,8 +214,10 @@ OMR::Node::Node(TR::Node * from, uint16_t numChildren)
      _numChildren(0),
      _globalIndex(0),
      _flags(0),
+     _visitCount(0),
+     _localIndex(0),
+     _referenceCount(0),
      _byteCodeInfo(),
-     _optAttributes(NULL),
      _unionBase(),
      _unionPropertyA()
    {
@@ -233,7 +231,6 @@ OMR::Node::Node(TR::Node * from, uint16_t numChildren)
    if (from->getOpCode().getOpCodeValue() == TR::allocationFence)
       self()->setAllocation(NULL);
 
-   self()->setOptAttributes(new (comp->getNodePool()) OMR::Node::OptAttributes());
    self()->setGlobalIndex(comp->getNodePool().getLastGlobalIndex());
    self()->setNodePoolIndex(comp->getNodePool().getLastPoolIndex());
    // a memcpy is used above to copy fields from the argument "node" to "this", but
@@ -241,7 +238,7 @@ OMR::Node::Node(TR::Node * from, uint16_t numChildren)
    self()->setReferenceCount(from->getReferenceCount());
    self()->setVisitCount(from->getVisitCount());
    self()->setLocalIndex(from->getLocalIndex());
-   self()->getOptAttributes()->_unionA = from->getOptAttributes()->_unionA;
+   _unionA = from->_unionA;
 
    if (self()->getGlobalIndex() == MAX_NODE_COUNT)
       {
@@ -577,11 +574,21 @@ OMR::Node::createInternal(TR::Node *originatingByteCodeNode, TR::ILOpCodes op, u
       // Recreate node from originalNode, ignore originatingByteCodeNode
       ncount_t poolIndex = originalNode->getNodePoolIndex();
       ncount_t globalIndex = originalNode->getGlobalIndex();
-      OptAttributes *optAttributes = originalNode->getOptAttributes();
+      vcount_t visitCount = originalNode->getVisitCount();
+      scount_t localIndex = originalNode->getLocalIndex();
+      rcount_t referenceCount = originalNode->getReferenceCount();
+      UnionA unionA = originalNode->_unionA;
       const TR_ByteCodeInfo byteCodeInfo = originalNode->getByteCodeInfo();  // copy bytecode info into temporary variable
-      TR::Node * node = new (TR::comp()->getNodePool(), poolIndex) TR::Node(0, op, numChildren, optAttributes);
+      TR::Node * node = new (TR::comp()->getNodePool(), poolIndex) TR::Node(0, op, numChildren);
       node->setGlobalIndex(globalIndex);
       node->setByteCodeInfo(byteCodeInfo);
+
+      node->setNodePoolIndex(poolIndex);
+      node->setVisitCount(visitCount);
+      node->setLocalIndex(localIndex);
+      node->setReferenceCount(referenceCount);
+      node->_unionA = unionA;
+
       return node;
       }
    }
@@ -4136,19 +4143,6 @@ OMR::Node::countChildren(TR::ILOpCodes opcode)
  * OptAttributes functions
  */
 
-OMR::Node::OptAttributes::OptAttributes() :
-   _visitCount(0),
-   _localIndex(0),
-   _referenceCount(0)
-   {
-   }
-
-void *
-OMR::Node::OptAttributes::operator new (size_t s, TR::NodePool & nodes)
-   {
-   return (void *)nodes.allocateOptAttributes();
-   }
-
 void
 OMR::Node::resetVisitCounts(vcount_t count)
    {
@@ -4215,13 +4209,13 @@ OMR::Node::setIsNotRematerializeable()
    {
    TR::Compilation * c = TR::comp();
    if (performNodeTransformation1(c, "Setting notRematerializeable flag on node %p\n", self()))
-      self()->getOptAttributes()->_localIndex = (self()->getOptAttributes()->_localIndex | SCOUNT_HIGH_BIT);
+      _localIndex = (_localIndex | SCOUNT_HIGH_BIT);
    }
 
 bool
 OMR::Node::isRematerializeable()
    {
-   if (self()->getOptAttributes()->_localIndex & SCOUNT_HIGH_BIT)
+   if (_localIndex & SCOUNT_HIGH_BIT)
       return false;
    return true;
    }
@@ -4230,8 +4224,8 @@ TR::Register*
 OMR::Node::getRegister()
    {
    TR_ASSERT(self()->getOpCodeValue() != TR::BBStart, "don't call getRegister for a BBStart");
-   if ((uintptr_t)self()->getOptAttributes()->_unionA._register & 1) return 0; // tagged pointer means the field is actually an evaluation priority
-   return self()->getOptAttributes()->_unionA._register;
+   if ((uintptr_t)_unionA._register & 1) return 0; // tagged pointer means the field is actually an evaluation priority
+   return _unionA._register;
    }
 
 TR::Register *
@@ -4272,7 +4266,7 @@ OMR::Node::setRegister(TR::Register *reg)
 #endif
       }
 
-   return (self()->getOptAttributes()->_unionA._register = reg);
+   return (_unionA._register = reg);
    }
 
 void *
@@ -4297,7 +4291,7 @@ OMR::Node::unsetRegister()
       reg->getLiveRegisterInfo()->setNode(NULL);
       }
 
-   self()->getOptAttributes()->_unionA._register = NULL;
+   _unionA._register = NULL;
    return NULL;
    }
 
@@ -4306,7 +4300,7 @@ OMR::Node::unsetRegister()
 int32_t
 OMR::Node::getEvaluationPriority(TR::CodeGenerator * codeGen)
    {
-   if (self()->getOptAttributes()->_unionA._register == 0) // not evaluated into register & priority unknown
+   if (_unionA._register == 0) // not evaluated into register & priority unknown
       {
       // Hack: our trees can have cycles (lmul/lumulh). To avoid infinite
       // recursion, initialize this node's priority to zero
@@ -4315,8 +4309,8 @@ OMR::Node::getEvaluationPriority(TR::CodeGenerator * codeGen)
       // dealt with the issue of cycles in nodes
       return self()->setEvaluationPriority(codeGen->getEvaluationPriority(self()));
       }
-   if ((uintptr_t)(self()->getOptAttributes()->_unionA._register) & 1) // evaluation priority
-      return (uintptr_t)(self()->getOptAttributes()->_unionA._register) >> 1;
+   if ((uintptr_t)(_unionA._register) & 1) // evaluation priority
+      return (uintptr_t)(_unionA._register) >> 1;
    else // already evaluated to a register - nonsensical question
       return 0;
    }
@@ -4324,10 +4318,10 @@ OMR::Node::getEvaluationPriority(TR::CodeGenerator * codeGen)
 int32_t
 OMR::Node::setEvaluationPriority(int32_t p)
    {
-   if (self()->getOptAttributes()->_unionA._register == 0 ||            // not evaluated, priority unknown
-       ((uintptr_t)(self()->getOptAttributes()->_unionA._register) & 1))  // not evaluated, priority known
+   if (_unionA._register == 0 ||            // not evaluated, priority unknown
+       ((uintptr_t)(_unionA._register) & 1))  // not evaluated, priority known
       {
-      self()->getOptAttributes()->_unionA._register = (TR::Register*)(uintptr_t)((p << 1) | 1);
+      _unionA._register = (TR::Register*)(uintptr_t)((p << 1) | 1);
       }
    else // evaluated into a register
       {

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -124,8 +124,6 @@ class OMR_EXTENSIBLE Node
 // Forward declarations
 public:
    class ChildIterator;
-protected:
-   struct OptAttributes;
 
 private:
 
@@ -139,7 +137,7 @@ private:
  */
 protected:
 
-   Node(TR::Node *originatingByteCodeNode, TR::ILOpCodes op, uint16_t numChildren, OptAttributes * optAttributes = NULL);
+   Node(TR::Node *originatingByteCodeNode, TR::ILOpCodes op, uint16_t numChildren);
 
    Node(TR::Node *from, uint16_t numChildren = 0);
 
@@ -656,8 +654,6 @@ public:
    /**
     * OptAttributes functions
     */
-
-   bool            hasOptAttributes()  { return _optAttributes != NULL; }
 
    inline vcount_t getVisitCount();
    inline vcount_t setVisitCount(vcount_t vc);
@@ -1553,10 +1549,6 @@ protected:
 
    bool collectSymbolReferencesInNode(TR_BitVector &symbolReferencesInNode, vcount_t visitCount);
 
-   // For OptAttributes
-   void setOptAttributes(OptAttributes * oa) { _optAttributes = oa; }
-   OptAttributes * getOptAttributes() { TR_ASSERT(_optAttributes != NULL, "_optAttributes is NULL!"); return _optAttributes; }
-
    // For NodeExtension
    inline bool  hasNodeExtension();
    inline void  setHasNodeExtension(bool v);
@@ -1577,45 +1569,6 @@ protected:
 
 // Protected inner classes and structs.
 protected:
-
-   /**
-    * Discarding optimization phase specific TR::Node data after node evaluation
-    *
-    * The OptAttribute class is meant contain fields of TR::Node which are relevant
-    * only before instruction selection has ended.
-    *
-    * A side table of OptAttributes is kept in TR::NodePool and will be freed
-    * when instruction selection is complete.  A Node's pointer to its
-    * OptAttributes will be NULLed as well, triggering an assertion on any
-    * attempt to access these fields post-instruction selection.
-    */
-   struct OptAttributes {
-      friend class TR::NodePool;
-
-      OptAttributes();
-      void * operator new (size_t s, TR::NodePool & nodes);
-
-      vcount_t _visitCount;
-      rcount_t _referenceCount;
-      scount_t _localIndex;        ///< general index that has the lifetime of a single optimization pass
-
-      union
-         {
-         uint16_t _useDefIndex;    ///< used by optimizations
-
-         /**
-          * The _register field is only used during codegen. It is a
-          * tagged pointer though. The low bit set means that the field
-          * is actually an evaluation priority.
-          * 0   - not evaluated, priority unknown
-          * odd - not evaluated, rest of the fields is evaluationPriority
-          * even- evaluated into a register
-          */
-         TR::Register * _register;
-         } _unionA;
-
-      ncount_t _poolIndex;         ///< index to retrieve node from nodepool, this can be shared amongst nodes with non-intersecting lifetimes
-   };
 
    struct NodeExtensionStore
       {
@@ -1673,6 +1626,21 @@ protected:
          }
       };
 
+   union UnionA
+      {
+      uint16_t _useDefIndex;    ///< used by optimizations
+
+      /**
+       * The _register field is only used during codegen. It is a
+       * tagged pointer though. The low bit set means that the field
+       * is actually an evaluation priority.
+       * 0   - not evaluated, priority unknown
+       * odd - not evaluated, rest of the fields is evaluationPriority
+       * even- evaluated into a register
+       */
+      TR::Register * _register;
+      };
+
    // Union Property verification helpers
    enum UnionPropertyA_Type
       {
@@ -1688,7 +1656,6 @@ protected:
 
    UnionPropertyA_Type getUnionPropertyA_Type();
 
-
 // Protected fields
 protected:
 
@@ -1701,6 +1668,9 @@ protected:
    /// Number of children this node has.
    uint16_t               _numChildren;
 
+   /// Visits to this node, used throughout optimizations.
+   vcount_t               _visitCount;
+
    /// Unique index for every single node created - no other node
    /// will have the same index within a compilation.
    ncount_t               _globalIndex;
@@ -1708,12 +1678,19 @@ protected:
    /// Flags for the node.
    flags32_t              _flags;
 
+   /// Index for this node, used throughout optimizations.
+   scount_t               _localIndex;
+
    /// Info about the byte code associated with this node.
    TR_ByteCodeInfo        _byteCodeInfo;
 
-   /// Contains fields of TR::Node which are relevant
-   /// only before instruction selection has ended.
-   OptAttributes *        _optAttributes;
+   ///< index to retrieve node from nodepool, this can be shared amongst nodes with non-intersecting lifetimes
+   ncount_t _poolIndex;
+
+   /// References to this node.
+   rcount_t _referenceCount;
+
+   UnionA                 _unionA;
 
    /// Elements unioned with children.
    UnionBase              _unionBase;

--- a/compiler/il/OMRNode_inlines.hpp
+++ b/compiler/il/OMRNode_inlines.hpp
@@ -265,122 +265,122 @@ OMR::Node::ChildIterator::stepForward()
 vcount_t
 OMR::Node::getVisitCount()
    {
-   return self()->getOptAttributes()->_visitCount;
+   return _visitCount;
    }
 
 vcount_t
 OMR::Node::setVisitCount(vcount_t vc)
    {
-   return (self()->getOptAttributes()->_visitCount = vc);
+   return (_visitCount = vc);
    }
 
 vcount_t
 OMR::Node::incVisitCount()
    {
-   ++self()->getOptAttributes()->_visitCount;
-   TR_ASSERT(self()->getOptAttributes()->_visitCount > 0, "Assertion failure : %s (0x%p)", self()->getOpCode().getName(), this);
-   return self()->getOptAttributes()->_visitCount;
+   ++_visitCount;
+   TR_ASSERT(_visitCount > 0, "Assertion failure : %s (0x%p)", self()->getOpCode().getName(), this);
+   return _visitCount;
    }
 
 rcount_t
 OMR::Node::getReferenceCount()
    {
-   return self()->getOptAttributes()->_referenceCount;
+   return _referenceCount;
    }
 
 rcount_t
 OMR::Node::setReferenceCount(rcount_t rc)
    {
-   return (self()->getOptAttributes()->_referenceCount = rc);
+   return (_referenceCount = rc);
    }
 
 rcount_t
 OMR::Node::incReferenceCount()
    {
-   ++(self()->getOptAttributes()->_referenceCount);
-   TR_ASSERT(self()->getOptAttributes()->_referenceCount > 0, "Assertion failure : %s (0x%p)", self()->getOpCode().getName(), this);
-   return self()->getOptAttributes()->_referenceCount;
+   ++(_referenceCount);
+   TR_ASSERT(_referenceCount > 0, "Assertion failure : %s (0x%p)", self()->getOpCode().getName(), this);
+   return _referenceCount;
    }
 
 rcount_t
 OMR::Node::decReferenceCount()
    {
-   TR_ASSERT(self()->getOptAttributes()->_referenceCount > 0 || self()->getOpCode().isTreeTop(), "Assertion failure : %s (0x%p)", self()->getOpCode().getName(), this);
-   return --(self()->getOptAttributes()->_referenceCount);
+   TR_ASSERT(_referenceCount > 0 || self()->getOpCode().isTreeTop(), "Assertion failure : %s (0x%p)", self()->getOpCode().getName(), this);
+   return --(_referenceCount);
    }
 
 scount_t
 OMR::Node::getLocalIndex()
    {
-   return self()->getOptAttributes()->_localIndex;
+   return _localIndex;
    }
 
 scount_t
 OMR::Node::setLocalIndex(scount_t li)
    {
-   return (self()->getOptAttributes()->_localIndex = li);
+   return (_localIndex = li);
    }
 
 scount_t
 OMR::Node::incLocalIndex()
    {
-   ++self()->getOptAttributes()->_localIndex;
-   TR_ASSERT(self()->getOptAttributes()->_localIndex>0, "assertion failure"); return self()->getOptAttributes()->_localIndex;
+   ++_localIndex;
+   TR_ASSERT(_localIndex>0, "assertion failure"); return _localIndex;
    }
 
 scount_t
 OMR::Node::decLocalIndex()
    {
-   TR_ASSERT(self()->getOptAttributes()->_localIndex > 0, "assertion failure"); return --self()->getOptAttributes()->_localIndex;
+   TR_ASSERT(_localIndex > 0, "assertion failure"); return --_localIndex;
    }
 
 scount_t
 OMR::Node::getFutureUseCount()
    {
-   return self()->getOptAttributes()->_localIndex;
+   return _localIndex;
    }
 
 scount_t
 OMR::Node::setFutureUseCount(scount_t li)
    {
-   return (self()->getOptAttributes()->_localIndex = (scount_t)li);
+   return (_localIndex = (scount_t)li);
    }
 
 scount_t
 OMR::Node::incFutureUseCount()
    {
-   ++self()->getOptAttributes()->_localIndex;
-   return self()->getOptAttributes()->_localIndex;
+   ++_localIndex;
+   return _localIndex;
    }
 
 scount_t
 OMR::Node::decFutureUseCount()
    {
-   return --self()->getOptAttributes()->_localIndex;
+   return --_localIndex;
    }
 
 uint16_t
 OMR::Node::getUseDefIndex()
    {
-   return self()->getOptAttributes()->_unionA._useDefIndex;
+   return _unionA._useDefIndex;
    }
 
 uint16_t
 OMR::Node::setUseDefIndex(uint16_t udi)
    {
-   return (self()->getOptAttributes()->_unionA._useDefIndex = udi);
+   return (_unionA._useDefIndex = udi);
    }
 
 ncount_t
 OMR::Node::getNodePoolIndex()
    {
-   return self()->getOptAttributes()->_poolIndex;
+   return _poolIndex;
    }
 
 void
 OMR::Node::setNodePoolIndex(ncount_t i)
    {
-   self()->getOptAttributes()->_poolIndex = i;
+   _poolIndex = i;
    }
 
 /**

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -1512,14 +1512,7 @@ TR_Debug::printBasicPostNodeInfo(TR::FILE *pOutFile, TR::Node * node, uint32_t i
          "%s=[%d,%d,-] rc=", bciOrLoc,
          node->getByteCodeInfo().getCallerIndex(),
          node->getByteCodeInfo().getByteCodeIndex());
-      if (node->hasOptAttributes())
-         {
-         output.append("%d", node->getReferenceCount());
-         }
-      else
-         {
-         output.append("-");
-         }
+      output.append("%d", node->getReferenceCount());
       }
    else
       {
@@ -1528,20 +1521,10 @@ TR_Debug::printBasicPostNodeInfo(TR::FILE *pOutFile, TR::Node * node, uint32_t i
          node->getByteCodeInfo().getCallerIndex(),
          node->getByteCodeInfo().getByteCodeIndex(),
          lineNumber);
-      if (node->hasOptAttributes())
-         {
-         output.append("%d", node->getReferenceCount());
-         }
-      else
-         {
-         output.append("-");
-         }
+      output.append("%d", node->getReferenceCount());
       }
 
-   if (node->hasOptAttributes())
-      {
-      output.append(" vc=%d", node->getVisitCount());
-      }
+   output.append(" vc=%d", node->getVisitCount());
 
    if (!inDebugExtension() &&
          _comp->getOptimizer() &&
@@ -1550,12 +1533,12 @@ TR_Debug::printBasicPostNodeInfo(TR::FILE *pOutFile, TR::Node * node, uint32_t i
    else
       output.append(" vn=-");
 
-   if ((node->hasOptAttributes()) && (node->getLocalIndex()))
+   if (node->getLocalIndex())
       output.append(" li=%d", node->getLocalIndex());
    else
       output.append(" li=-");
 
-   if (node->hasOptAttributes() && node->getUseDefIndex())
+   if (node->getUseDefIndex())
       output.append(" udi=%d", node->getUseDefIndex());
    else
       output.append(" udi=-");


### PR DESCRIPTION
OptAttributes hold information about a Node, such
as its reference count and local index. They are held separate
so that the OptAttributes can be freed when no longer needed.
Currently this is limited to before codegen on certain platforms.

However, they are already allocated into the heap region
using a CS2 TableOf and only have a limited chance of their memory
being reused by another CS2 data structure.

Moving these fields into the Node itself with proper ordering
results in only an 8 byte increase to its size and improves
locality, as they are frequently accessed.