### PR TITLE
Set OSR block freq during ColdBlockMarker

### DIFF
--- a/compiler/compile/OSRData.cpp
+++ b/compiler/compile/OSRData.cpp
@@ -626,14 +626,16 @@ void
 TR_OSRMethodData::createOSRBlocks(TR::Node* n)
    {
    if (getOSRCodeBlock() != NULL) return;
+   bool duringIlgen = comp()->getCurrentIlGenerator() != NULL;
+
    // Create one if there is no match
    TR_ASSERT(n, "reference node must be provided");
-   osrCodeBlock = TR::Block::createEmptyBlock(n, comp(), 0);
+   osrCodeBlock = TR::Block::createEmptyBlock(n, comp(), duringIlgen ? -1 : 0);
    osrCodeBlock->setIsCold();
    osrCodeBlock->setIsOSRCodeBlock();
    osrCodeBlock->setDoNotProfile();
 
-   osrCatchBlock = TR::Block::createEmptyBlock(n, comp(), 0);
+   osrCatchBlock = TR::Block::createEmptyBlock(n, comp(), duringIlgen ? -1 : 0);
    osrCatchBlock->setIsCold();
    osrCatchBlock->setDoNotProfile();
    osrCatchBlock->setIsOSRCatchBlock();

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -8166,8 +8166,15 @@ TR_ColdBlockMarker::identifyColdBlocks()
    for (TR::AllBlockIterator iter(optimizer()->getMethodSymbol()->getFlowGraph(), comp()); iter.currentBlock(); ++iter)
       {
       TR::Block *block = iter.currentBlock();
+
       if (block->isCold())
+         {
+         // OSR blocks may not have had a chance to set their frequencies yet
+         if (block->isOSRCodeBlock() || block->isOSRCatchBlock())
+            block->setFrequency(UNKNOWN_COLD_BLOCK_COUNT);
+
          foundColdBlocks = true;
+         }
       else
          {
          int32_t coldness = isBlockCold(block);


### PR DESCRIPTION
Setting the frequencies on blocks during IlGen
can prevent the JitProfiler from properly applying
its raw frequencies. OSR blocks, which can be created
during IlGen, have always received a frequency of 0.
This modifies them to receive a frequency of -1, 
which is later set to 0 during ColdBlockMarker.