### PR TITLE
Fix link order

### DIFF
--- a/omrmakefiles/rules.mk
+++ b/omrmakefiles/rules.mk
@@ -132,7 +132,8 @@ MODULE_LDFLAGS += $(call buildLibPathFlags,$(MODULE_LIBPATH))
 GLOBAL_LDFLAGS += $(call buildLibPathFlags,$(GLOBAL_LIBPATH))
 
 # Static Libraries
-GLOBAL_LDFLAGS += $(call buildLinkGroup,$(call buildStaticLibLinkFlags,$(MODULE_STATIC_LIBS) $(GLOBAL_STATIC_LIBS)))
+MODULE_LDFLAGS += $(call buildLinkGroup,$(call buildStaticLibLinkFlags,$(MODULE_STATIC_LIBS)))
+GLOBAL_LDFLAGS += $(call buildLinkGroup,$(call buildStaticLibLinkFlags,$(GLOBAL_STATIC_LIBS)))
 
 # Shared Libraries. Must be after static libraries.
 MODULE_LDFLAGS += $(call buildSharedLibLinkFlags,$(MODULE_SHARED_LIBS))


### PR DESCRIPTION
Shared libraries must come after static libraries on the link command.
This is to satisfy missing symbols in static libraries. The old code
actually documented this requirement, but did not implement it.

This patch fixes a link error in ddrgen.

Signed-off-by: Robert Young <rwy0717@gmail.com>