### PR TITLE
Deprecate unused bcdCheckSymbol

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -116,7 +116,6 @@ class SymbolReferenceTable
       isClassAndDepthFlagsSymbol,
       isClassFlagsSymbol,
       vftSymbol,
-      bcdCheckSymbol,
       currentThreadSymbol,
       recompilationCounterSymbol,
       excpSymbol,

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -2085,7 +2085,6 @@ static const char *commonNonhelperSymbolNames[] =
    "<isClassAndDepthFlags>",
    "<isClassFlags>",
    "<vft>",
-   "<bcdCheckSymbol>",
    "<currentThread>",
    "<recompilationCounter>",
    "<excp>",


### PR DESCRIPTION
bcdCheckSymbol is no longer used either in OMR or in any upstream
projects. It is slated to be deprecated.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>