### PR TITLE
Reduce the default lvBlockFreqCutoff value

### DIFF
--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -208,8 +208,26 @@ bool TR_LoopVersioner::loopIsWorthVersioning(TR_RegionStructure *naturalLoop)
             }
          }
 
+      bool aggressive = TR::Options::getCmdLineOptions()->getOption(TR_EnableAggressiveLoopVersioning);
+
+      int32_t lvBlockFreqCutoff;
       static const char * b = feGetEnv("TR_LoopVersionerFreqCutoff");
-      int32_t lvBlockFreqCutoff = b ? atoi(b) : 5000;
+      if (b) 
+         {
+         lvBlockFreqCutoff = atoi(b);
+         }
+      else if (aggressive)
+         {
+         lvBlockFreqCutoff = 500;
+         }
+      else
+         {
+         lvBlockFreqCutoff = 5000;
+         }
+
+      if (trace()) traceMsg(comp(), "lvBlockFreqCutoff=%d\n", lvBlockFreqCutoff);
+         
+
       if (entryBlock->getFrequency() < lvBlockFreqCutoff)
          return false;
       }


### PR DESCRIPTION
The current default threshold of 5000 for lvBlockFreqCutoff was
found to be too high for some use-cases. A lower threshold of
500 was introduced, currently subject to
-Xjit:enableAggressiveLoopVersioning
being set until the change is tested across more
applications. The env var TR_LoopVersionerFreqCutoff remains
available to over-ride the default setting.

Signed-off-by: JamesKingdon <jkingdon@ca.ibm.com>