### PR TITLE
[CMAKE] Use -fno-strict-aliasing for GC

### DIFF
--- a/gc/CMakeLists.txt
+++ b/gc/CMakeLists.txt
@@ -266,6 +266,12 @@ add_library(omrgc
 )
 add_dependencies(omrgc omrgc_hookgen)
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
+    target_compile_options(omrgc PRIVATE -fno-strict-aliasing)
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "XL|VisualAge")
+    target_compile_options(omrgc PRIVATE -qalias=noansi)
+endif()
+
 target_include_directories(omrgc
 	PUBLIC
 		.


### PR DESCRIPTION
This matches the behaviour in the makefiles, and allows more modern
versions of GCC and clang to pass the GC tests.

Signed-off-by: Matthew Gaudet <magaudet@ca.ibm.com>