### PR TITLE
[Mem10] Reduce memory leakage from LocalCSE

### DIFF
--- a/compiler/il/OMRBlock.cpp
+++ b/compiler/il/OMRBlock.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -125,7 +125,7 @@ OMR::Block::Block(TR::TreeTop *entry, TR::TreeTop *exit, TR_Memory * m) :
 
 /// Copy constructor
 OMR::Block::Block(TR::Block &other, TR::TreeTop *entry, TR::TreeTop *exit) :
-   TR::CFGNode(other.trMemory()),
+   TR::CFGNode(other._region),
    _pEntry(entry),
    _pExit(exit),
    _pStructureOf(NULL),
@@ -141,18 +141,18 @@ OMR::Block::Block(TR::Block &other, TR::TreeTop *entry, TR::TreeTop *exit) :
    if (exit && exit->getNode())   exit->getNode()->setBlock(self());
 
    if (other._liveLocals)
-      _liveLocals = new (other.trHeapMemory()) TR_BitVector(*other._liveLocals);
+      _liveLocals = new (other._region) TR_BitVector(*other._liveLocals);
 
    if (other._catchBlockExtension)
       {
-      _catchBlockExtension = new (other.trHeapMemory())
+      _catchBlockExtension = new (other._region)
          TR_CatchBlockExtension(*other._catchBlockExtension);
       }
 
    self()->setFrequency(other.getFrequency());
 
    if (other._globalRegisters)
-      _globalRegisters = new (other.trHeapMemory()) TR_Array<TR_GlobalRegister>(*other._globalRegisters);
+      _globalRegisters = new (other._region) TR_Array<TR_GlobalRegister>(*other._globalRegisters);
 
    _flags.set(other._flags.getValue());
    _moreflags.set(other._moreflags.getValue());
@@ -427,8 +427,8 @@ OMR::Block::breakFallThrough(TR::Compilation *comp, TR::Block *faller, TR::Block
          comp->getFlowGraph()->addNode(gotoBlock, faller->getCommonParentStructureIfExists(fallee, comp->getFlowGraph()));
       else
          comp->getFlowGraph()->addNode(gotoBlock);
-      comp->getFlowGraph()->addEdge(TR::CFGEdge::createEdge(faller,  gotoBlock, self()->trMemory()));
-      comp->getFlowGraph()->addEdge(TR::CFGEdge::createEdge(gotoBlock,  fallee, self()->trMemory()));
+      comp->getFlowGraph()->addEdge(TR::CFGEdge::createEdge(faller,  gotoBlock, comp->trMemory()));
+      comp->getFlowGraph()->addEdge(TR::CFGEdge::createEdge(gotoBlock,  fallee, comp->trMemory()));
       // remove the edge only if the branch target is not pointing to the next block
       if (lastNode->getBranchDestination() != fallee->getEntry())
          comp->getFlowGraph()->removeEdge(faller, fallee);
@@ -752,9 +752,9 @@ OMR::Block::changeBranchDestination(TR::TreeTop * newDestination, TR::CFG *cfg)
 void
 OMR::Block::uncommonNodesBetweenBlocks(TR::Compilation *comp, TR::Block *newBlock, TR::ResolvedMethodSymbol *methodSymbol)
    {
-   TR_ScratchList<TR::SymbolReference> symbolReferenceTempsA(self()->trMemory());
-   TR_ScratchList<TR::SymbolReference> injectedBasicBlockTemps(self()->trMemory());
-   TR_ScratchList<TR::SymbolReference> symbolReferenceTempsC(self()->trMemory());
+   TR_ScratchList<TR::SymbolReference> symbolReferenceTempsA(comp->trMemory());
+   TR_ScratchList<TR::SymbolReference> injectedBasicBlockTemps(comp->trMemory());
+   TR_ScratchList<TR::SymbolReference> symbolReferenceTempsC(comp->trMemory());
 
    TR_HandleInjectedBasicBlock ibb(comp, NULL, methodSymbol? methodSymbol: comp->getMethodSymbol(),
                                    symbolReferenceTempsA,
@@ -805,7 +805,7 @@ OMR::Block::split(TR::TreeTop * startOfNewBlock, TR::CFG * cfg, bool fixupCommon
    TR::Compilation * comp = cfg->comp();
    comp->setCurrentBlock(self());
    TR::Node * startNode = startOfNewBlock->getNode();
-   TR::Block * block2 = new (self()->trHeapMemory()) TR::Block(TR::TreeTop::create(comp, TR::Node::create(startNode, TR::BBStart)), self()->getExit(), self()->trMemory());
+   TR::Block * block2 = new (comp->trHeapMemory()) TR::Block(TR::TreeTop::create(comp, TR::Node::create(startNode, TR::BBStart)), self()->getExit(), comp->trMemory());
    block2->inheritBlockInfo(self());
 
    cfg->addNode(block2);
@@ -832,9 +832,9 @@ OMR::Block::split(TR::TreeTop * startOfNewBlock, TR::CFG * cfg, bool fixupCommon
       TR_BlockStructure *thisBlockStructure = self()->getStructureOf();
       if (thisBlockStructure)
          {
-         TR_BlockStructure *blockStructure2 = new (self()->trHeapMemory()) TR_BlockStructure(comp, block2->getNumber(), block2);
+         TR_BlockStructure *blockStructure2 = new (cfg->structureRegion()) TR_BlockStructure(comp, block2->getNumber(), block2);
          TR_RegionStructure *parentStructure = thisBlockStructure->getParent()->asRegion();
-         TR_StructureSubGraphNode *blockStructureNode2 = new (self()->trHeapMemory()) TR_StructureSubGraphNode(blockStructure2);
+         TR_StructureSubGraphNode *blockStructureNode2 = new (cfg->structureRegion()) TR_StructureSubGraphNode(blockStructure2);
          TR_StructureSubGraphNode *subNode;
          TR_RegionStructure::Cursor si(*parentStructure);
          for (subNode = si.getCurrent(); subNode != NULL; subNode = si.getNext())
@@ -849,7 +849,7 @@ OMR::Block::split(TR::TreeTop * startOfNewBlock, TR::CFG * cfg, bool fixupCommon
           (*nextSucc)->setFrom(blockStructureNode2);
 
          subNode->getSuccessors().clear();
-         TR::CFGEdge::createEdge(subNode,  blockStructureNode2, self()->trMemory());
+         TR::CFGEdge::createEdge(subNode,  blockStructureNode2, comp->trMemory());
 
          for (auto nextSucc = subNode->getExceptionSuccessors().begin(); nextSucc != subNode->getExceptionSuccessors().end(); ++nextSucc)
           {
@@ -873,7 +873,7 @@ OMR::Block::split(TR::TreeTop * startOfNewBlock, TR::CFG * cfg, bool fixupCommon
           if (excSuccWasAdded)
              {
              if (toStructureSubGraphNode((*nextSucc)->getTo())->getStructure())
-                 TR::CFGEdge::createExceptionEdge(blockStructureNode2, (*nextSucc)->getTo(), self()->trMemory());
+                 TR::CFGEdge::createExceptionEdge(blockStructureNode2, (*nextSucc)->getTo(), comp->trMemory());
              else
                 parentStructure->addExitEdge(blockStructureNode2, (*nextSucc)->getTo()->getNumber(), true);
              }
@@ -993,12 +993,12 @@ OMR::Block::createConditionalSideExitBeforeTree(TR::TreeTop *tree,
    exitBlock->append(returnTree);
    compareTree->getNode()->setBranchDestination(exitBlock->getEntry());
 
-   cfg->addEdge(TR::CFGEdge::createEdge(self(),  exitBlock, self()->trMemory()));
+   cfg->addEdge(TR::CFGEdge::createEdge(self(),  exitBlock, comp->trMemory()));
 
    TR::CFGNode *afterExitBlock = cfg->getEnd(); // typically is a return which goes to EXIT
    if (returnTree->getNode()->getOpCode().isBranch())
       afterExitBlock = returnTree->getNode()->getBranchDestination()->getNode()->getBlock();
-   cfg->addEdge(TR::CFGEdge::createEdge(exitBlock,  afterExitBlock, self()->trMemory()));
+   cfg->addEdge(TR::CFGEdge::createEdge(exitBlock,  afterExitBlock, comp->trMemory()));
 
    cfg->copyExceptionSuccessors(self(), exitBlock);
 
@@ -1104,8 +1104,8 @@ OMR::Block::createConditionalBlocksBeforeTree(TR::TreeTop * tree,
    ifBlock->append(TR::TreeTop::create(comp, TR::Node::create(node, TR::Goto, 0, remainderBlock->getEntry())));
    compareTree->getNode()->setBranchDestination(ifBlock->getEntry());
 
-   cfg->addEdge(TR::CFGEdge::createEdge(self(),  ifBlock, self()->trMemory()));
-   cfg->addEdge(TR::CFGEdge::createEdge(ifBlock,    remainderBlock, self()->trMemory()));
+   cfg->addEdge(TR::CFGEdge::createEdge(self(),  ifBlock, comp->trMemory()));
+   cfg->addEdge(TR::CFGEdge::createEdge(ifBlock,    remainderBlock, comp->trMemory()));
 
    cfg->copyExceptionSuccessors(self(), ifBlock);
 
@@ -1123,8 +1123,8 @@ OMR::Block::createConditionalBlocksBeforeTree(TR::TreeTop * tree,
          elseBlock->setIsExtensionOfPreviousBlock(true);       // fall-through block is an extension
 
       cfg->addNode(elseBlock);
-      cfg->addEdge(TR::CFGEdge::createEdge(self(),  elseBlock, self()->trMemory()));
-      cfg->addEdge(TR::CFGEdge::createEdge(elseBlock,  remainderBlock, self()->trMemory()));
+      cfg->addEdge(TR::CFGEdge::createEdge(self(),  elseBlock, comp->trMemory()));
+      cfg->addEdge(TR::CFGEdge::createEdge(elseBlock,  remainderBlock, comp->trMemory()));
       cfg->copyExceptionSuccessors(self(), elseBlock);
       cfg->removeEdge(self(), remainderBlock);
       }
@@ -1547,7 +1547,7 @@ OMR::Block::setInstructionBoundaries(uint32_t startPC, uint32_t endPC)
 void
 OMR::Block::addExceptionRangeForSnippet(uint32_t startPC, uint32_t endPC)
    {
-   _snippetBoundaries.add(new (self()->trHeapMemory()) InstructionBoundaries(startPC, endPC));
+   _snippetBoundaries.add(new (TR::comp()->trHeapMemory()) InstructionBoundaries(startPC, endPC));
    }
 
 void
@@ -1822,7 +1822,7 @@ TR_BlockCloner::cloneBlocks(TR::Block * from, TR::Block * lastBlock)
       {
       comp->setCurrentBlock(from);
       TR::Block * to =
-         new (from->trHeapMemory()) TR::Block(*from, TR::TreeTop::create(comp, NULL), TR::TreeTop::create(comp, NULL));
+         new (comp->trHeapMemory()) TR::Block(*from, TR::TreeTop::create(comp, NULL), TR::TreeTop::create(comp, NULL));
       to->getEntry()->join(to->getExit());
 
       if (bMap.getLast())

--- a/compiler/il/OMRBlock.cpp
+++ b/compiler/il/OMRBlock.cpp
@@ -1250,11 +1250,13 @@ OMR::Block::splitEdge(TR::Block *from, TR::Block *to, TR::Compilation *c, TR::Tr
    //traceMsg("Splitting edge (%d,%d)\n", from->getNumber(), to->getNumber());
    TR_ASSERT(!to->isOSRCatchBlock(), "Splitting edge to OSRCatchBlock (block_%d -> block_%d) is not supported\n", from->getNumber(), to->getNumber());
    TR::Node *exitNode = from->getExit()->getNode();
+   TR::CFG *cfg = c->getFlowGraph();
+   TR_Structure *rootStructure = cfg->getStructure();
    TR_Structure *fromContainingLoop = NULL;
-   if (from->getStructureOf())
+   if (rootStructure && from->getStructureOf())
       fromContainingLoop = from->getStructureOf()->getContainingLoop();
    TR_Structure *toContainingLoop = NULL;
-   if (to->getStructureOf())
+   if (rootStructure && to->getStructureOf())
       toContainingLoop = to->getStructureOf()->getContainingLoop();
    if (fromContainingLoop != toContainingLoop)
       {
@@ -1269,7 +1271,6 @@ OMR::Block::splitEdge(TR::Block *from, TR::Block *to, TR::Compilation *c, TR::Tr
          }
       }
 
-   TR::CFG * cfg = c->getFlowGraph();
    TR::Compilation *comp = cfg->comp();
    TR::TreeTop *entryTree = to->getEntry();
    TR::Block * newBlock;

--- a/compiler/il/OMRBlock.hpp
+++ b/compiler/il/OMRBlock.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -433,6 +433,18 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
    void setIsSpecialized(bool b = true)               { _flags.set(_isSpecialized, b); }
    bool isSpecialized()                               { return _flags.testAny(_isSpecialized); }
 
+   bool isLoopInvariantBlock()                        { return _flags.testAny(_isLoopInvariantBlock); }
+   void setAsLoopInvariantBlock(bool b)               { _flags.set(_isLoopInvariantBlock, b); }
+
+   bool isCreatedByVersioning()                       { return _flags.testAny(_isCreatedByVersioning); }
+   void setCreatedByVersioning(bool b)                { _flags.set(_isCreatedByVersioning, b); }
+
+   bool isEntryOfShortRunningLoop()                   { return _flags.testAny(_isEntryOfShortRunningLoop); }
+   void setIsEntryOfShortRunningLoop()                { _flags.set(_isEntryOfShortRunningLoop, true); }
+
+   bool wasHeaderOfCanonicalizedLoop()                { return _flags.testAny(_wasHeaderOfCanonicalizedLoop); }
+   void setWasHeaderOfCanonicalizedLoop(bool b)       { _flags.set(_wasHeaderOfCanonicalizedLoop, b); }
+
    enum partialFlags // Stored in lowest 8 bits of _moreflags
       {
       _unsanitizeable         = 0x00000001,
@@ -509,7 +521,11 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
       _createdAtCodeGen                     = 0x00080000,
       _hasCalls                             = 0x00200000,
       _hasCallToSuperCold                   = 0x00400000,
-      _isSpecialized                        = 0x00800000   // Block has been specialized by loop specializer
+      _isSpecialized                        = 0x00800000,  // Block has been specialized by loop specializer
+      _isLoopInvariantBlock                 = 0x01000000,
+      _isCreatedByVersioning                = 0x02000000,
+      _isEntryOfShortRunningLoop            = 0x04000000,
+      _wasHeaderOfCanonicalizedLoop         = 0x08000000,
       };
 
    TR::TreeTop *                         _pEntry;

--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -331,6 +331,8 @@ TR_Structure *
 OMR::CFG::invalidateStructure()
    {
    setStructure(NULL);
+   _structureRegion.~Region();
+   new (&_structureRegion) TR::Region(comp()->trMemory()->heapMemoryRegion());
    return getStructure();
    }
 

--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -121,24 +121,6 @@ OMR::CFG::addNode(TR::CFGNode *n, TR_RegionStructure *parent, bool isEntryInPare
 
    return n;
    }
-
-
-uint32_t
-OMR::CFG::addStructureSubGraphNodes(TR_StructureSubGraphNode * node)
-   {
-   uint32_t index = _structureGraphNodes.AddEntry(node);
-   node->setUniqueSubGraphIndex(index);
-   return index;
-   }
-
-
-void
-OMR::CFG::removeStructureSubGraphNodes(TR_StructureSubGraphNode * node)
-   {
-   uint32_t index = node->getUniqueSubGraphIndex();
-   _structureGraphNodes.RemoveEntry(index);
-   }
-
 
 void
 OMR::CFG::addEdge(TR::CFGEdge *e)

--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -83,7 +83,7 @@ OMR::CFG::addNode(TR::CFGNode *n, TR_RegionStructure *parent, bool isEntryInPare
          TR_BlockStructure *blockStructure = block->getStructureOf();
          TR_StructureSubGraphNode *blockNode = NULL;
          if (!blockStructure)
-            blockStructure = new (trHeapMemory()) TR_BlockStructure(comp(), block->getNumber(), block);
+            blockStructure = new (structureRegion()) TR_BlockStructure(comp(), block->getNumber(), block);
          else
             {
             TR_StructureSubGraphNode *node;
@@ -102,7 +102,7 @@ OMR::CFG::addNode(TR::CFGNode *n, TR_RegionStructure *parent, bool isEntryInPare
 
          if (!blockNode)
             {
-            blockNode = new (trHeapMemory()) TR_StructureSubGraphNode(blockStructure);
+            blockNode = new (structureRegion()) TR_StructureSubGraphNode(blockStructure);
             if (!isEntryInParent)
                {
                parent->addSubNode(blockNode);
@@ -330,7 +330,8 @@ OMR::CFG::copyExceptionSuccessors(
 TR_Structure *
 OMR::CFG::invalidateStructure()
    {
-   return setStructure(0);
+   setStructure(NULL);
+   return getStructure();
    }
 
 TR_Structure *
@@ -352,7 +353,7 @@ bool OMR::alwaysTrue(TR::CFGEdge * e)
    }
 
 
-TR_OrderedExceptionHandlerIterator::TR_OrderedExceptionHandlerIterator(TR::Block * tryBlock)
+TR_OrderedExceptionHandlerIterator::TR_OrderedExceptionHandlerIterator(TR::Block * tryBlock, TR::Region &workingRegion)
    {
    if (tryBlock->getExceptionSuccessors().empty())
       _dim = 0;
@@ -369,7 +370,7 @@ TR_OrderedExceptionHandlerIterator::TR_OrderedExceptionHandlerIterator(TR::Block
          }
 
       _dim = handlerDim * inlineDim;
-      _handlers = (TR::Block **)tryBlock->trMemory()->allocateStackMemory(_dim*sizeof(TR::Block *));
+      _handlers = (TR::Block **)workingRegion.allocate(_dim*sizeof(TR::Block *));
       memset(_handlers, 0, _dim*sizeof(TR::Block *));
 
       for (auto e = tryBlock->getExceptionSuccessors().begin(); e != tryBlock->getExceptionSuccessors().end(); ++e)
@@ -407,16 +408,30 @@ TR_OrderedExceptionHandlerIterator::getCurrent()
    }
 
 
-TR::CFGEdge::CFGEdge(TR::CFGNode *pF, TR::CFGNode *pT, TR_AllocationKind allocKind)
+TR::CFGEdge::CFGEdge(TR::CFGNode *pF, TR::CFGNode *pT)
    : _pFrom(pF), _pTo(pT), _visitCount(0), _frequency(0), _id(-1)
    {}
 
 TR::CFGEdge * TR::CFGEdge::createEdge (TR::CFGNode *pF, TR::CFGNode *pT, TR_Memory* trMemory, TR_AllocationKind allocKind)
    {
-   TR::CFGEdge * newEdge =  new (trMemory, allocKind) TR::CFGEdge(pF, pT, allocKind);
+   TR::CFGEdge * newEdge =  new (trMemory, allocKind) TR::CFGEdge(pF, pT);
 
-   pF->addSuccessor(newEdge, allocKind);
-   pT->addPredecessor(newEdge, allocKind);
+   pF->addSuccessor(newEdge);
+   pT->addPredecessor(newEdge);
+   if (pT->getFrequency() >= 0)
+      newEdge->setFrequency(pT->getFrequency());
+   if ((pF->getFrequency() >= 0) && (pF->getFrequency() < newEdge->getFrequency()))
+      newEdge->setFrequency(pF->getFrequency());
+
+   return newEdge;
+   }
+
+TR::CFGEdge * TR::CFGEdge::createEdge (TR::CFGNode *pF, TR::CFGNode *pT, TR::Region &region)
+   {
+   TR::CFGEdge * newEdge =  new (region) TR::CFGEdge(pF, pT);
+
+   pF->addSuccessor(newEdge);
+   pT->addPredecessor(newEdge);
    if (pT->getFrequency() >= 0)
       newEdge->setFrequency(pT->getFrequency());
    if ((pF->getFrequency() >= 0) && (pF->getFrequency() < newEdge->getFrequency()))
@@ -427,15 +442,23 @@ TR::CFGEdge * TR::CFGEdge::createEdge (TR::CFGNode *pF, TR::CFGNode *pT, TR_Memo
 
 TR::CFGEdge * TR::CFGEdge::createExceptionEdge (TR::CFGNode *pF, TR::CFGNode *pT, TR_Memory* trMemory, TR_AllocationKind allocKind)
    {
-   TR::CFGEdge * newEdge =  new (trMemory, allocKind) TR::CFGEdge(pF, pT, allocKind);
+   TR::CFGEdge * newEdge =  new (trMemory, allocKind) TR::CFGEdge(pF, pT);
 
-   pF->addExceptionSuccessor(newEdge, allocKind);
-   pT->addExceptionPredecessor(newEdge, allocKind);
+   pF->addExceptionSuccessor(newEdge);
+   pT->addExceptionPredecessor(newEdge);
 
    return newEdge;
    }
 
+TR::CFGEdge * TR::CFGEdge::createExceptionEdge (TR::CFGNode *pF, TR::CFGNode *pT, TR::Region &region)
+   {
+   TR::CFGEdge * newEdge =  new (region) TR::CFGEdge(pF, pT);
 
+   pF->addExceptionSuccessor(newEdge);
+   pT->addExceptionPredecessor(newEdge);
+
+   return newEdge;
+   }
 
 void TR::CFGEdge::setFrom(TR::CFGNode *pF)
    {
@@ -517,7 +540,7 @@ TR::CFGNode::CFGNode(TR_Memory * m)
      _frequency(-1),
      _forwardTraversalIndex(-1),
      _backwardTraversalIndex(-1),
-     _m(m),
+     _region(m->heapMemoryRegion()),
      _successors(m->heapMemoryRegion()),
      _predecessors(m->heapMemoryRegion()),
      _exceptionSuccessors(m->heapMemoryRegion()),
@@ -530,11 +553,37 @@ TR::CFGNode::CFGNode(int32_t n, TR_Memory * m)
      _frequency(-1),
      _forwardTraversalIndex(-1),
      _backwardTraversalIndex(-1),
-     _m(m),
+     _region(m->heapMemoryRegion()),
      _successors(m->heapMemoryRegion()),
      _predecessors(m->heapMemoryRegion()),
      _exceptionSuccessors(m->heapMemoryRegion()),
      _exceptionPredecessors(m->heapMemoryRegion())
+   {
+   }
+TR::CFGNode::CFGNode(TR::Region &region)
+   : _nodeNumber(-1),
+     _visitCount(0),
+     _frequency(-1),
+     _forwardTraversalIndex(-1),
+     _backwardTraversalIndex(-1),
+     _region(region),
+     _successors(region),
+     _predecessors(region),
+     _exceptionSuccessors(region),
+     _exceptionPredecessors(region)
+   {
+   }
+TR::CFGNode::CFGNode(int32_t n, TR::Region &region)
+   : _nodeNumber(n),
+     _visitCount(0),
+     _frequency(-1),
+     _forwardTraversalIndex(-1),
+     _backwardTraversalIndex(-1),
+     _region(region),
+     _successors(region),
+     _predecessors(region),
+     _exceptionSuccessors(region),
+     _exceptionPredecessors(region)
    {
    }
 
@@ -1707,7 +1756,7 @@ OMR::CFG::clone()
    //
    setStructure(0);
 
-   TR_BlockCloner *cloner = new (trHeapMemory()) TR_BlockCloner(self(), false, true);
+   TR_BlockCloner *cloner = new (structureRegion()) TR_BlockCloner(self(), false, true);
    TR::Block *clonedBlock = cloner->cloneBlocks(comp()->getStartTree()->getNode()->getBlock(), lastTreeTop->getNode()->getBlock());
    lastTreeTop->join(clonedBlock->getEntry());
 

--- a/compiler/infra/OMRCfg.hpp
+++ b/compiler/infra/OMRCfg.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -106,7 +106,6 @@ class CFG
       _doesHaveUnreachableBlocks(false),
       _removingUnreachableBlocks(false),
       _ignoreUnreachableBlocks(false),
-      _structureGraphNodes(c->allocator()),
       _removeEdgeNestingDepth(0),
       _forwardTraversalOrder(NULL),
       _backwardTraversalOrder(NULL),
@@ -156,7 +155,6 @@ class CFG
 
    uint32_t addStructureSubGraphNodes (TR_StructureSubGraphNode *node);
    void removeStructureSubGraphNodes(TR_StructureSubGraphNode *node);
-   TR_StructureSubGraphNode *getStructureSubGraphNode (uint32_t index) {return _structureGraphNodes[index];}
 
    void addEdge(TR::CFGEdge *e);
    TR::CFGEdge *addEdge(TR::CFGNode *f, TR::CFGNode *t, TR_AllocationKind = heapAlloc);
@@ -312,7 +310,6 @@ protected:
    TR_Structure *_rootStructure;
 
    TR_LinkHead1<TR::CFGNode> _nodes;
-   CS2::TableOf <TR_StructureSubGraphNode *,TR::Allocator> _structureGraphNodes;
    int32_t _numEdges;
    int32_t _nextNodeNumber;
 

--- a/compiler/infra/OMRCfg.hpp
+++ b/compiler/infra/OMRCfg.hpp
@@ -100,6 +100,7 @@ class CFG
       _rootStructure(NULL),
       _pStart(NULL),
       _pEnd(NULL),
+      _structureRegion(c->trMemory()->heapMemoryRegion()),
       _nextNodeNumber(0),
       _numEdges(0),
       _mightHaveUnreachableBlocks(false),
@@ -130,6 +131,7 @@ class CFG
    TR_Memory *trMemory() { return comp()->trMemory(); }
    TR_HeapMemory trHeapMemory() { return trMemory(); }
    TR_StackMemory trStackMemory() { return trMemory(); }
+   TR::Region &structureRegion() { return _structureRegion; }
 
    void setStartAndEnd(TR::CFGNode * s, TR::CFGNode * e) { addNode(s); addNode(e); setStart(s); setEnd(e); }
 
@@ -307,6 +309,7 @@ protected:
 
    TR::CFGNode *_pStart;
    TR::CFGNode *_pEnd;
+   TR::Region _structureRegion;
    TR_Structure *_rootStructure;
 
    TR_LinkHead1<TR::CFGNode> _nodes;
@@ -437,7 +440,7 @@ class TR_OrderedExceptionHandlerIterator
 public:
    TR_ALLOC(TR_Memory::OrderedExceptionHandlerIterator)
 
-   TR_OrderedExceptionHandlerIterator(TR::Block * tryBlock);
+   TR_OrderedExceptionHandlerIterator(TR::Block * tryBlock, TR::Region &workingRegion);
 
    TR::Block * getFirst();
 

--- a/compiler/infra/TRCfgEdge.hpp
+++ b/compiler/infra/TRCfgEdge.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -46,6 +46,8 @@ class CFGEdge : public TR_Link<CFGEdge>
 
    static CFGEdge * createEdge (CFGNode *pF, CFGNode *pT, TR_Memory* trMemory, TR_AllocationKind allocKind = heapAlloc);
    static CFGEdge * createExceptionEdge (CFGNode *pF, CFGNode *pT, TR_Memory* trMemory, TR_AllocationKind allocKind = heapAlloc);
+   static CFGEdge * createEdge (CFGNode *pF, CFGNode *pT, TR::Region &region);
+   static CFGEdge * createExceptionEdge (CFGNode *pF, CFGNode *pT, TR::Region &reigon);
 
    CFGNode *getFrom() {return _pFrom;}
    CFGNode *getTo()   {return _pTo;}
@@ -89,7 +91,7 @@ class CFGEdge : public TR_Link<CFGEdge>
    private:
 
    //keeping this c-tor private since there is no real need to make it public right now
-   CFGEdge(CFGNode *pF, CFGNode *pT, TR_AllocationKind allocKind = heapAlloc);
+   CFGEdge(CFGNode *pF, CFGNode *pT);
 
    enum  // flags
       {

--- a/compiler/infra/TRCfgNode.hpp
+++ b/compiler/infra/TRCfgNode.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -51,10 +51,11 @@ class CFGNode : public ::TR_Link1<CFGNode>
    CFGNode(TR_Memory * m);
    CFGNode(int32_t n, TR_Memory * m);
 
-   TR_Memory *        trMemory()  { return _m; }
-   TR_HeapMemory   trHeapMemory() { return trMemory(); }
-   TR_StackMemory trStackMemory() { return trMemory(); }
+   protected:
+   CFGNode(TR::Region &region);
+   CFGNode(int32_t n, TR::Region &region);
 
+   public:
    TR::CFGEdgeList& getSuccessors()            {return _successors;}
    TR::CFGEdgeList& getPredecessors()          {return _predecessors;}
    TR::CFGEdgeList& getExceptionSuccessors()   {return _exceptionSuccessors;}
@@ -141,13 +142,15 @@ class CFGNode : public ::TR_Link1<CFGNode>
    virtual TR_StructureSubGraphNode *asStructureSubGraphNode() {return NULL;}
 
    private:
-   TR_Memory * _m;
    template <typename FUNC>
    CFGEdge * getEdgeMatchingNodeInAList (CFGNode * n, TR::CFGEdgeList& list, FUNC blockGetter);
    static CFGNode * fromBlockGetter (CFGEdge * e) {return e->getFrom();};
    static CFGNode * toBlockGetter (CFGEdge * e)   {return e->getTo();};
 
+   protected:
+   TR::Region      &_region;
 
+   private:
    TR::CFGEdgeList _successors;
    TR::CFGEdgeList _predecessors;
    TR::CFGEdgeList _exceptionSuccessors;

--- a/compiler/optimizer/GeneralLoopUnroller.cpp
+++ b/compiler/optimizer/GeneralLoopUnroller.cpp
@@ -243,7 +243,7 @@ void TR_LoopUnroller::unrollLoopOnce(TR_RegionStructure *loop, TR_StructureSubGr
       //Clone all the substructures
       TR_Structure *subStruct = subNode->getStructure();
       TR_Structure *clonedSubStruct = cloneStructure(subStruct);
-      TR_StructureSubGraphNode *clonedSubNode = new (trHeapMemory()) TR_StructureSubGraphNode(clonedSubStruct);
+      TR_StructureSubGraphNode *clonedSubNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(clonedSubStruct);
 
       //Memorize the mapping between subNode and clonedSubNode
       SET_CLONE_NODE(subNode, clonedSubNode);
@@ -474,8 +474,8 @@ void TR_LoopUnroller::modifyBranchTree(TR_RegionStructure *loop,
       comp()->setStartTree(newBlock->getEntry());
 
       _cfg->addNode(newBlock);
-      TR_BlockStructure *newBlockStr = new (trHeapMemory()) TR_BlockStructure(comp(), newBlock->getNumber(), newBlock);
-      TR_StructureSubGraphNode *newNode  = new (trHeapMemory()) TR_StructureSubGraphNode(newBlockStr);
+      TR_BlockStructure *newBlockStr = new (_cfg->structureRegion()) TR_BlockStructure(comp(), newBlock->getNumber(), newBlock);
+      TR_StructureSubGraphNode *newNode  = new (_cfg->structureRegion()) TR_StructureSubGraphNode(newBlockStr);
 
       parent->addSubNode(newNode);
 
@@ -639,8 +639,8 @@ void TR_LoopUnroller::modifyBranchTree(TR_RegionStructure *loop,
 
          _cfg->addNode(newBlock);
 
-         TR_BlockStructure *newBlockStructure = new (trHeapMemory()) TR_BlockStructure(comp(), newBlock->getNumber(), newBlock);
-         TR_StructureSubGraphNode *newSubNode = new (trHeapMemory()) TR_StructureSubGraphNode(newBlockStructure);
+         TR_BlockStructure *newBlockStructure = new (_cfg->structureRegion()) TR_BlockStructure(comp(), newBlock->getNumber(), newBlock);
+         TR_StructureSubGraphNode *newSubNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(newBlockStructure);
          parent->addSubNode(newSubNode);
 
          TR::CFGEdge *edgeToRemove = pBlock->getSuccessors().front();
@@ -790,8 +790,8 @@ void TR_LoopUnroller::modifyBranchTree(TR_RegionStructure *loop,
          pBlock->getExit()->join(newBlock->getEntry());
 
          _cfg->addNode(newBlock);
-         TR_BlockStructure *newBlockStructure = new (trHeapMemory()) TR_BlockStructure(comp(), newBlock->getNumber(), newBlock);
-         TR_StructureSubGraphNode *newSubNode = new (trHeapMemory()) TR_StructureSubGraphNode(newBlockStructure);
+         TR_BlockStructure *newBlockStructure = new (_cfg->structureRegion()) TR_BlockStructure(comp(), newBlock->getNumber(), newBlock);
+         TR_StructureSubGraphNode *newSubNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(newBlockStructure);
          parent->addSubNode(newSubNode);
 
          TR::CFGEdge *edgeToRemove = NULL;
@@ -823,8 +823,8 @@ void TR_LoopUnroller::modifyBranchTree(TR_RegionStructure *loop,
          TR::Block *newBlock = pBlock->split(lastTree, _cfg);
          pBlock->append(iterGuard);
 
-         TR_BlockStructure *newBlockStructure = new (trHeapMemory()) TR_BlockStructure(comp(), newBlock->getNumber(), newBlock);
-         TR_StructureSubGraphNode *newSubNode = new (trHeapMemory()) TR_StructureSubGraphNode(newBlockStructure);
+         TR_BlockStructure *newBlockStructure = new (_cfg->structureRegion()) TR_BlockStructure(comp(), newBlock->getNumber(), newBlock);
+         TR_StructureSubGraphNode *newSubNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(newBlockStructure);
          parent->addSubNode(newSubNode);
 
          _cfg->addEdge(TR::CFGEdge::createEdge(pBlock,  spillBlock, trMemory()));
@@ -1188,8 +1188,8 @@ void TR_LoopUnroller::modifyOriginalLoop(TR_RegionStructure *loop, TR_StructureS
 
             newIfBlock->append(newIfTree);
             _cfg->addNode(newIfBlock);
-            newIfBlockStructure = new (trHeapMemory()) TR_BlockStructure(comp(), newIfBlock->getNumber(), newIfBlock);
-            newIfSubNode = new (trHeapMemory()) TR_StructureSubGraphNode(newIfBlockStructure);
+            newIfBlockStructure = new (_cfg->structureRegion()) TR_BlockStructure(comp(), newIfBlock->getNumber(), newIfBlock);
+            newIfSubNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(newIfBlockStructure);
             parent->addSubNode(newIfSubNode);
 
             TR::Node *gotoNode  = TR::Node::create(newIfTree->getNode(), TR::Goto);
@@ -1199,8 +1199,8 @@ void TR_LoopUnroller::modifyOriginalLoop(TR_RegionStructure *loop, TR_StructureS
             _cfg->addNode(gotoBlock);
             _cfg->addEdge(TR::CFGEdge::createEdge(gotoBlock, spillLoop->getEntryBlock(), trMemory()));
 
-            TR_StructureSubGraphNode *gotoSubNode = new (trHeapMemory()) TR_StructureSubGraphNode
-               (new (trHeapMemory()) TR_BlockStructure(comp(), gotoBlock->getNumber(), gotoBlock));
+            TR_StructureSubGraphNode *gotoSubNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode
+               (new (_cfg->structureRegion()) TR_BlockStructure(comp(), gotoBlock->getNumber(), gotoBlock));
             parent->addSubNode(gotoSubNode);
 
             if (spillLoop->contains(branchDestination->getStructureOf(), parent))
@@ -1413,16 +1413,16 @@ void TR_LoopUnroller::modifyOriginalLoop(TR_RegionStructure *loop, TR_StructureS
             newIfBlock->append(newIfTree);
 
             _cfg->addNode(newIfBlock);
-            newIfBlockStructure = new (trHeapMemory()) TR_BlockStructure(comp(), newIfBlock->getNumber(), newIfBlock);
-            newIfSubNode = new (trHeapMemory()) TR_StructureSubGraphNode(newIfBlockStructure);
+            newIfBlockStructure = new (_cfg->structureRegion()) TR_BlockStructure(comp(), newIfBlock->getNumber(), newIfBlock);
+            newIfSubNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(newIfBlockStructure);
             parent->addSubNode(newIfSubNode);
 
             gotoNode  = TR::Node::create(newIfTree->getNode(), TR::Goto);
             gotoBlock = TR::Block::createEmptyBlock(gotoNode, comp(), newIfBlock->getFrequency(), newIfBlock);
             gotoBlock->append(TR::TreeTop::create(comp(), gotoNode));
             _cfg->addNode(gotoBlock);
-            TR_StructureSubGraphNode *gotoSubNode = new (trHeapMemory()) TR_StructureSubGraphNode
-               (new (trHeapMemory()) TR_BlockStructure(comp(), gotoBlock->getNumber(), gotoBlock));
+            TR_StructureSubGraphNode *gotoSubNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode
+               (new (_cfg->structureRegion()) TR_BlockStructure(comp(), gotoBlock->getNumber(), gotoBlock));
             parent->addSubNode(gotoSubNode);
 
             if (spillLoop->contains(branchDestination->getStructureOf(), parent))
@@ -2168,7 +2168,7 @@ void TR_LoopUnroller::generateSpillLoop(TR_RegionStructure *loop,
    cloneBlocksInRegion(loop, true); // isSpillLoop = true
 
    TR_RegionStructure *spillLoop = cloneStructure(loop)->asRegion();
-   TR_StructureSubGraphNode *spillNode = new (trHeapMemory()) TR_StructureSubGraphNode(spillLoop);
+   TR_StructureSubGraphNode *spillNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(spillLoop);
    fixExitEdges(loop, spillLoop, branchNode);
 
    spillLoop->getEntryBlock()->getStructureOf()->setIsEntryOfShortRunningLoop();
@@ -2211,7 +2211,7 @@ void TR_LoopUnroller::generateSpillLoop(TR_RegionStructure *loop,
    //clone the loop
    cloneBlocksInRegion(loop);
    TR_RegionStructure *spillLoop = cloneStructure(loop)->asRegion();
-   TR_StructureSubGraphNode *spillNode = new (trHeapMemory()) TR_StructureSubGraphNode(spillLoop);
+   TR_StructureSubGraphNode *spillNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(spillLoop);
    fixExitEdges(loop, spillLoop, branchNode);
 
    TR_StructureSubGraphNode *clonedBranchNode = GET_CLONE_NODE(branchNode);
@@ -2230,9 +2230,9 @@ void TR_LoopUnroller::generateSpillLoop(TR_RegionStructure *loop,
    _cfg->addNode(newBranchBlock);
 
    //create the structure
-   TR_BlockStructure *newBranchStructure = new (trHeapMemory()) TR_BlockStructure(comp(), newBranchBlock->getNumber(),
+   TR_BlockStructure *newBranchStructure = new (_cfg->structureRegion()) TR_BlockStructure(comp(), newBranchBlock->getNumber(),
                                                                  newBranchBlock);
-   TR_StructureSubGraphNode *newBranchNode = new (trHeapMemory()) TR_StructureSubGraphNode(newBranchStructure);
+   TR_StructureSubGraphNode *newBranchNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(newBranchStructure);
    spillLoop->addSubNode(newBranchNode);
 
    //make newBranchNode the entryNode
@@ -2519,9 +2519,9 @@ void TR_LoopUnroller::addEdgeForSpillLoop(TR_RegionStructure *region,
                }
 
             //create the structures
-            TR_BlockStructure *gotoStruct = new (trHeapMemory()) TR_BlockStructure(comp(), gotoBlock->getNumber(),
+            TR_BlockStructure *gotoStruct = new (_cfg->structureRegion()) TR_BlockStructure(comp(), gotoBlock->getNumber(),
                                                                   gotoBlock);
-            TR_StructureSubGraphNode *gotoSubNode = new (trHeapMemory()) TR_StructureSubGraphNode(gotoStruct);
+            TR_StructureSubGraphNode *gotoSubNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(gotoStruct);
             region->addSubNode(gotoSubNode);
 
             //create the cfg edges
@@ -2654,9 +2654,9 @@ void TR_LoopUnroller::addExitEdgeAndFixEverything(TR_RegionStructure *region,
                      gotoBlock->getExit()->setNextTreeTop(NULL);
 
                   //create the structures
-                  TR_BlockStructure *gotoStruct = new (trHeapMemory()) TR_BlockStructure(comp(), gotoBlock->getNumber(),
+                  TR_BlockStructure *gotoStruct = new (_cfg->structureRegion()) TR_BlockStructure(comp(), gotoBlock->getNumber(),
                                                                         gotoBlock);
-                  TR_StructureSubGraphNode *gotoSubNode = new (trHeapMemory()) TR_StructureSubGraphNode(gotoStruct);
+                  TR_StructureSubGraphNode *gotoSubNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(gotoStruct);
                   region->addSubNode(gotoSubNode);
 
                   //create the cfg edges
@@ -2936,7 +2936,7 @@ TR_Structure *TR_LoopUnroller::cloneBlockStructure(TR_BlockStructure *blockStruc
    TR::Block *block = blockStructure->getBlock();
    TR::Block *clonedBlock = GET_CLONE_BLOCK(block);
    TR_BlockStructure *clonedBlockStructure =
-      new (trHeapMemory()) TR_BlockStructure(comp(), clonedBlock->getNumber(), clonedBlock);
+      new (_cfg->structureRegion()) TR_BlockStructure(comp(), clonedBlock->getNumber(), clonedBlock);
    clonedBlockStructure->setAsLoopInvariantBlock(blockStructure->isLoopInvariantBlock());
    clonedBlockStructure->setNestingDepth(blockStructure->getNestingDepth());
    clonedBlockStructure->setMaxNestingDepth(blockStructure->getMaxNestingDepth());
@@ -2945,7 +2945,7 @@ TR_Structure *TR_LoopUnroller::cloneBlockStructure(TR_BlockStructure *blockStruc
 
 TR_Structure *TR_LoopUnroller::cloneRegionStructure(TR_RegionStructure *region)
    {
-   TR_RegionStructure *clonedRegion = new (trHeapMemory()) TR_RegionStructure(comp(), 0xDeadF00d); //for now
+   TR_RegionStructure *clonedRegion = new (_cfg->structureRegion()) TR_RegionStructure(comp(), 0xDeadF00d); //for now
    clonedRegion->setAsCanonicalizedLoop(region->isCanonicalizedLoop());
    clonedRegion->setContainsInternalCycles(region->containsInternalCycles());
 
@@ -2957,7 +2957,7 @@ TR_Structure *TR_LoopUnroller::cloneRegionStructure(TR_RegionStructure *region)
       {
       subStruct = subNode->getStructure();
       TR_Structure *clonedSubStruct = cloneStructure(subStruct);
-      TR_StructureSubGraphNode *clonedSubNode = new (trHeapMemory()) TR_StructureSubGraphNode(clonedSubStruct);
+      TR_StructureSubGraphNode *clonedSubNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(clonedSubStruct);
       SET_CLONE_NODE(subNode, clonedSubNode);
       clonedRegion->addSubNode(clonedSubNode);
       if (subNode == region->getEntry())

--- a/compiler/optimizer/LoopCanonicalizer.cpp
+++ b/compiler/optimizer/LoopCanonicalizer.cpp
@@ -1405,14 +1405,14 @@ void TR_LoopCanonicalizer::canonicalizeNaturalLoop(TR_RegionStructure *whileLoop
    // new region replaces the original natural loop in its parent.
    //
    TR_Structure *parentStructure = whileLoop->getParent();
-   TR_RegionStructure *properRegion = new (trHeapMemory()) TR_RegionStructure(comp(), loopHeader->getNumber());
+   TR_RegionStructure *properRegion = new (_cfg->structureRegion()) TR_RegionStructure(comp(), loopHeader->getNumber());
    properRegion->setAsCanonicalizedLoop(true);
    parentStructure->replacePart(whileLoop, properRegion);
    whileLoop->setParent(properRegion);
 
    whileLoop->setEntry(bodyNode);
    whileLoop->setNumber(loopBody->getNumber());
-   TR_BlockStructure *clonedHdrBlockStructure = new (trHeapMemory()) TR_BlockStructure(comp(), clonedHeader->getNumber(), clonedHeader);
+   TR_BlockStructure *clonedHdrBlockStructure = new (_cfg->structureRegion()) TR_BlockStructure(comp(), clonedHeader->getNumber(), clonedHeader);
    if (needToSetFlag)
      {
      //clonedHdrBlockStructure->setIsEntryOfShortRunningLoop();
@@ -1431,21 +1431,21 @@ void TR_LoopCanonicalizer::canonicalizeNaturalLoop(TR_RegionStructure *whileLoop
    clonedHdrBlockStructure->setWasHeaderOfCanonicalizedLoop(true);
    whileLoop->replacePart(entryGraphNode->getStructure(), clonedHdrBlockStructure);
 
-   TR_StructureSubGraphNode *hdrNode = new (trHeapMemory()) TR_StructureSubGraphNode(loopHeader->getStructureOf());
+   TR_StructureSubGraphNode *hdrNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(loopHeader->getStructureOf());
    properRegion->addSubNode(hdrNode);
    properRegion->setEntry(hdrNode);
 
-   TR_StructureSubGraphNode *node = new (trHeapMemory()) TR_StructureSubGraphNode(new (trHeapMemory()) TR_BlockStructure(comp(), splitter2->getNumber(), splitter2));
+   TR_StructureSubGraphNode *node = new (_cfg->structureRegion()) TR_StructureSubGraphNode(new (_cfg->structureRegion()) TR_BlockStructure(comp(), splitter2->getNumber(), splitter2));
    node->getStructure()->asBlock()->setAsLoopInvariantBlock(true);
    _invariantBlocks.add(splitter2);
    properRegion->addSubNode(node);
    TR::CFGEdge::createEdge(hdrNode, node, trMemory());
 
-   TR_StructureSubGraphNode *loopNode = new (trHeapMemory()) TR_StructureSubGraphNode(whileLoop);
+   TR_StructureSubGraphNode *loopNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(whileLoop);
    properRegion->addSubNode(loopNode);
    TR::CFGEdge::createEdge(node, loopNode, trMemory());
 
-   node = new (trHeapMemory()) TR_StructureSubGraphNode(new (trHeapMemory()) TR_BlockStructure(comp(), splitter1->getNumber(), splitter1));
+   node = new (_cfg->structureRegion()) TR_StructureSubGraphNode(new (_cfg->structureRegion()) TR_BlockStructure(comp(), splitter1->getNumber(), splitter1));
    properRegion->addSubNode(node);
    TR::CFGEdge::createEdge(hdrNode, node, trMemory());
 
@@ -1477,8 +1477,8 @@ void TR_LoopCanonicalizer::canonicalizeNaturalLoop(TR_RegionStructure *whileLoop
    if (reversedBranch)
       {
       bool naturalLoopStillExitsToJoinNode = false;
-      TR_BlockStructure *extraGotoStruct = new (trHeapMemory()) TR_BlockStructure(comp(), extraGoto->getNumber(), extraGoto);
-      node = new (trHeapMemory()) TR_StructureSubGraphNode(extraGotoStruct);
+      TR_BlockStructure *extraGotoStruct = new (_cfg->structureRegion()) TR_BlockStructure(comp(), extraGoto->getNumber(), extraGoto);
+      node = new (_cfg->structureRegion()) TR_StructureSubGraphNode(extraGotoStruct);
       properRegion->addSubNode(node);
       TR::CFGEdge::createEdge(loopNode, node, trMemory());
 
@@ -1496,7 +1496,7 @@ void TR_LoopCanonicalizer::canonicalizeNaturalLoop(TR_RegionStructure *whileLoop
             {
             if (fromNode->getStructure() == clonedHdrBlockStructure)
                {
-               edge->setTo(TR_StructureSubGraphNode::create(node->getNumber(), whileLoop));     //new (trHeapMemory()) TR_StructureSubGraphNode(node->getNumber()));
+               edge->setTo(TR_StructureSubGraphNode::create(node->getNumber(), whileLoop));     //new (_cfg->structureRegion()) TR_StructureSubGraphNode(node->getNumber()));
                }
             else
                naturalLoopStillExitsToJoinNode = true;
@@ -1702,7 +1702,7 @@ void TR_LoopCanonicalizer::canonicalizeDoWhileLoop(TR_RegionStructure *doWhileLo
       newExit->join(blockHeadTreeTop);
       }
 
-   TR_BlockStructure *invariantBlockStructure = new (trHeapMemory()) TR_BlockStructure(comp(), loopInvariantBlock->getNumber(), loopInvariantBlock);
+   TR_BlockStructure *invariantBlockStructure = new (_cfg->structureRegion()) TR_BlockStructure(comp(), loopInvariantBlock->getNumber(), loopInvariantBlock);
    invariantBlockStructure->setAsLoopInvariantBlock(true);
 
    TR::Block *dummyEntryBlock = NULL;
@@ -1729,7 +1729,7 @@ void TR_LoopCanonicalizer::canonicalizeDoWhileLoop(TR_RegionStructure *doWhileLo
          dummyExit->join(newEntry);
          }
 
-      dummyEntryBlockStructure = new (trHeapMemory()) TR_BlockStructure(comp(), dummyEntryBlock->getNumber(), dummyEntryBlock);
+      dummyEntryBlockStructure = new (_cfg->structureRegion()) TR_BlockStructure(comp(), dummyEntryBlock->getNumber(), dummyEntryBlock);
       targetBlock = dummyEntryBlock;
       }
    else
@@ -1765,7 +1765,7 @@ void TR_LoopCanonicalizer::canonicalizeDoWhileLoop(TR_RegionStructure *doWhileLo
 
    _cfg->setStructure(_rootStructure);
 
-   TR_StructureSubGraphNode *invariantNode = new (trHeapMemory()) TR_StructureSubGraphNode(invariantBlockStructure);
+   TR_StructureSubGraphNode *invariantNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(invariantBlockStructure);
    parentStructure->addSubNode(invariantNode);
 
    TR::CFGEdge::createEdge(invariantNode,  doWhileNode, trMemory());
@@ -1774,7 +1774,7 @@ void TR_LoopCanonicalizer::canonicalizeDoWhileLoop(TR_RegionStructure *doWhileLo
    TR_Structure *targetStructure = NULL;
    if (isEntry)
       {
-      TR_StructureSubGraphNode *dummyEntryNode = new (trHeapMemory()) TR_StructureSubGraphNode(dummyEntryBlockStructure);
+      TR_StructureSubGraphNode *dummyEntryNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(dummyEntryBlockStructure);
       parentStructure->addSubNode(dummyEntryNode);
 
       TR::CFGEdge::createEdge(dummyEntryNode,  invariantNode, trMemory());

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -3869,7 +3869,7 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
                      }
                   }
 
-               TR_BlockStructure *newGotoBlockStructure = new (trHeapMemory()) TR_BlockStructure(comp(), newGotoBlock->getNumber(), newGotoBlock);
+               TR_BlockStructure *newGotoBlockStructure = new (_cfg->structureRegion()) TR_BlockStructure(comp(), newGotoBlock->getNumber(), newGotoBlock);
                newGotoBlockStructure->setCreatedByVersioning(true);
                if (!_neitherLoopCold)
                   {
@@ -4475,7 +4475,7 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
          endTree = gotoBlockExitTree;
          //_cfg->addEdge(TR::CFGEdge::createEdge(comparisonBlock,  newGotoBlock, trMemory()));
          //_cfg->addEdge(TR::CFGEdge::createEdge(newGotoBlock,  clonedLoopInvariantBlock, trMemory()));
-         TR_BlockStructure *newGotoBlockStructure = new (trHeapMemory()) TR_BlockStructure(comp(), newGotoBlock->getNumber(), newGotoBlock);
+         TR_BlockStructure *newGotoBlockStructure = new (_cfg->structureRegion()) TR_BlockStructure(comp(), newGotoBlock->getNumber(), newGotoBlock);
          newGotoBlockStructure->setCreatedByVersioning(true);
          if (!_neitherLoopCold)
             {
@@ -4672,20 +4672,20 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
    whileLoop->setVersionedLoop(clonedWhileLoop);
 
    TR_BlockStructure *invariantBlockStructure = invariantBlock->getStructureOf();
-   TR_BlockStructure *clonedInvariantBlockStructure = new (trHeapMemory()) TR_BlockStructure(comp(), clonedLoopInvariantBlock->getNumber(), clonedLoopInvariantBlock);
+   TR_BlockStructure *clonedInvariantBlockStructure = new (_cfg->structureRegion()) TR_BlockStructure(comp(), clonedLoopInvariantBlock->getNumber(), clonedLoopInvariantBlock);
    clonedInvariantBlockStructure->setCreatedByVersioning(true);
 
    if (!_neitherLoopCold)
    clonedInnerWhileLoops->deleteAll();
    clonedInvariantBlockStructure->setAsLoopInvariantBlock(true);
    TR_RegionStructure *parentStructure = whileLoop->getParent()->asRegion();
-   TR_RegionStructure *properRegion = new (trHeapMemory()) TR_RegionStructure(comp(), chooserBlock->getNumber());
+   TR_RegionStructure *properRegion = new (_cfg->structureRegion()) TR_RegionStructure(comp(), chooserBlock->getNumber());
    parentStructure->replacePart(invariantBlockStructure, properRegion);
 
-   TR_StructureSubGraphNode *clonedWhileNode = new (trHeapMemory()) TR_StructureSubGraphNode(clonedWhileLoop);
-   TR_StructureSubGraphNode *whileNode = new (trHeapMemory()) TR_StructureSubGraphNode(whileLoop);
-   TR_StructureSubGraphNode *invariantNode = new (trHeapMemory()) TR_StructureSubGraphNode(invariantBlockStructure);
-   TR_StructureSubGraphNode *clonedInvariantNode = new (trHeapMemory()) TR_StructureSubGraphNode(clonedInvariantBlockStructure);
+   TR_StructureSubGraphNode *clonedWhileNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(clonedWhileLoop);
+   TR_StructureSubGraphNode *whileNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(whileLoop);
+   TR_StructureSubGraphNode *invariantNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(invariantBlockStructure);
+   TR_StructureSubGraphNode *clonedInvariantNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(clonedInvariantBlockStructure);
 
    properRegion->addSubNode(whileNode);
    properRegion->addSubNode(clonedWhileNode);
@@ -4705,9 +4705,9 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
       {
       TR::Block *actualComparisonBlock = currComparisonBlock->getData();
 
-      TR_BlockStructure *comparisonBlockStructure = new (trHeapMemory()) TR_BlockStructure(comp(), actualComparisonBlock->getNumber(), actualComparisonBlock);
+      TR_BlockStructure *comparisonBlockStructure = new (_cfg->structureRegion()) TR_BlockStructure(comp(), actualComparisonBlock->getNumber(), actualComparisonBlock);
       comparisonBlockStructure->setCreatedByVersioning(true);
-      TR_StructureSubGraphNode *comparisonNode = new (trHeapMemory()) TR_StructureSubGraphNode(comparisonBlockStructure);
+      TR_StructureSubGraphNode *comparisonNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(comparisonBlockStructure);
       properRegion->addSubNode(comparisonNode);
 
       if (prevComparisonNode)
@@ -4721,7 +4721,7 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
 
       if (currComparisonBlock)
          {
-         TR_StructureSubGraphNode *criticalEdgeNode = new (trHeapMemory()) TR_StructureSubGraphNode(currCriticalEdgeBlock->getData()->getStructureOf());
+         TR_StructureSubGraphNode *criticalEdgeNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(currCriticalEdgeBlock->getData()->getStructureOf());
          properRegion->addSubNode(criticalEdgeNode);
          TR::CFGEdge::createEdge(prevComparisonNode,  criticalEdgeNode, trMemory());
          TR::CFGEdge::createEdge(criticalEdgeNode,  clonedInvariantNode, trMemory());
@@ -4813,7 +4813,7 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
    TR_BlockStructure *newGotoBlockStructure;
    for (newGotoBlockStructure = newGotoBlockStructuresIt.getCurrent(); newGotoBlockStructure; newGotoBlockStructure = newGotoBlockStructuresIt.getNext())
       {
-      TR_StructureSubGraphNode *newGotoBlockNode = new (trHeapMemory()) TR_StructureSubGraphNode(newGotoBlockStructure);
+      TR_StructureSubGraphNode *newGotoBlockNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(newGotoBlockStructure);
       properRegion->addSubNode(newGotoBlockNode);
       TR::CFGEdge::createEdge(clonedWhileNode,  newGotoBlockNode, trMemory());
       }

--- a/compiler/optimizer/OMRLocalCSE.cpp
+++ b/compiler/optimizer/OMRLocalCSE.cpp
@@ -73,7 +73,6 @@ OMR::LocalCSE::LocalCSE(TR::OptimizationManager *manager)
    : TR::Optimization(manager),
      _storeMap(NULL),
      _seenCallSymbolReferences(comp()->allocator()),
-     _seenKilledSymbolReferences(comp()->allocator()),
      _seenSymRefs(comp()->allocator()),
      _possiblyRelevantNodes(comp()->allocator()),
      _relevantNodes(comp()->allocator()),

--- a/compiler/optimizer/OMRLocalCSE.cpp
+++ b/compiler/optimizer/OMRLocalCSE.cpp
@@ -240,8 +240,6 @@ void OMR::LocalCSE::prePerformOnBlocks()
 
    _simulatedNodesAsArray = (TR::Node**)trMemory()->allocateStackMemory(comp()->getNodeCount()*sizeof(TR::Node*));
    memset(_simulatedNodesAsArray, 0, comp()->getNodeCount()*sizeof(TR::Node*));
-
-   memset (_previousNodeConversionsTable, 0, TR_PNC_BUCKETS * sizeof (OMR::PreviousNodeConversion *));
    }
 
 
@@ -1866,51 +1864,4 @@ rcount_t OMR::LocalCSE::recursivelyIncReferenceCount(TR::Node *node)
          recursivelyIncReferenceCount(node->getChild(childCount));
       }
    return count;
-   }
-
-
-void OMR::LocalCSE::setPreviousConversion(TR::Node *storeNode, TR::Node *convertedNode, TR::SymbolReference *symRef)
-   {
-   uint32_t hash = TR_PNC_HASH(storeNode) & (TR_PNC_BUCKETS - 1);
-
-   OMR::PreviousNodeConversion *cursor = _previousNodeConversionsTable[hash];
-   OMR::PreviousNodeConversion *prev = 0;
-
-   for (; cursor; prev = cursor, cursor = cursor->next)
-      {
-      if (cursor->getConvertedStoreNode() == storeNode)
-         {
-         cursor->addConvertedNode(convertedNode, symRef);
-         }
-      }
-
-   if (!cursor)
-      {
-      cursor = new (trHeapMemory()) OMR::PreviousNodeConversion(trMemory(), storeNode);
-      cursor->addConvertedNode(convertedNode, symRef);
-      cursor->next = 0;
-      if (prev)
-        prev->next = cursor;
-      else
-        _previousNodeConversionsTable[hash] = cursor;
-      }
-   }
-
-TR::Node *OMR::LocalCSE::getPreviousConversion(TR::Node *storeNode, TR::SymbolReference *symRef)
-   {
-   uint32_t hash = TR_PNC_HASH(storeNode) & (TR_PNC_BUCKETS - 1);
-
-   OMR::PreviousNodeConversion *cursor = _previousNodeConversionsTable[hash];
-   TR::Node *ret = NULL;
-
-   for (; cursor; cursor = cursor->next)
-      {
-      if (cursor->getConvertedStoreNode() == storeNode)
-         {
-         ret = cursor->findConvertedNodeForSymRef(symRef);
-         break;
-         }
-      }
-
-   return ret;
    }

--- a/compiler/optimizer/OMRLocalCSE.cpp
+++ b/compiler/optimizer/OMRLocalCSE.cpp
@@ -223,8 +223,8 @@ void OMR::LocalCSE::prePerformOnBlocks()
    TR::Region &stackRegion = comp()->trMemory()->currentStackRegion();
    _storeMap = new (stackRegion) StoreMap((StoreMapComparator()), StoreMapAllocator(stackRegion));
 
-   int32_t symRefCount = comp()->getSymRefCount();
-   int32_t nodeCount = comp()->getNodeCount();
+   int32_t symRefCount = 0;//comp()->getSymRefCount();
+   int32_t nodeCount = 0;//comp()->getNodeCount();
    _seenCallSymbolReferences.init(symRefCount, stackRegion, growable);
    _availableLoadExprs.init(symRefCount, stackRegion, growable);
    _availablePinningArrayExprs.init(symRefCount, stackRegion, growable);

--- a/compiler/optimizer/OMRLocalCSE.hpp
+++ b/compiler/optimizer/OMRLocalCSE.hpp
@@ -154,7 +154,7 @@ class LocalCSE : public TR::Optimization
    TR_BitVector _possiblyRelevantNodes;
    TR_BitVector _relevantNodes;
    SharedSparseBitVector _parentAddedToHT;
-   SharedSparseBitVector _killedNodes;
+   TR_BitVector _killedNodes;
    SharedSparseBitVector _availableLoadExprs;
    SharedSparseBitVector _availableCallExprs;
    SharedSparseBitVector _availablePinningArrayExprs;

--- a/compiler/optimizer/OMRLocalCSE.hpp
+++ b/compiler/optimizer/OMRLocalCSE.hpp
@@ -104,24 +104,24 @@ class LocalCSE : public TR::Optimization
    void addToHashTable(TR::Node *node, int32_t hashValue);
    void removeFromHashTable(HashTable *hashTable, int32_t hashValue);
    TR::Node *replaceCopySymbolReferenceByOriginalIn(TR::SymbolReference *,/* TR::SymbolReference *,*/ TR::Node *, TR::Node *, TR::Node *, TR::Node *, int32_t);
-   void examineNode(TR::Node *, SharedSparseBitVector &, TR::Node *, int32_t, int32_t *, bool *, int32_t);
+   void examineNode(TR::Node *, TR_BitVector &, TR::Node *, int32_t, int32_t *, bool *, int32_t);
    void commonNode(TR::Node *, int32_t, TR::Node *, TR::Node *);
    void transformBlock(TR::TreeTop *, TR::TreeTop *);
    void getNumberOfNodes(TR::Node *);
    bool allowNodeTypes(TR::Node *storeNode, TR::Node *node);
    void setIsInMemoryCopyPropFlag(TR::Node *rhsOfStoreDefNode);
-   void makeNodeAvailableForCommoning(TR::Node *, TR::Node *, SharedSparseBitVector &, bool *);
-   bool canBeAvailable(TR::Node *, TR::Node *, SharedSparseBitVector &, bool);
-   bool isAvailableNullCheck(TR::Node *, SharedSparseBitVector &);
+   void makeNodeAvailableForCommoning(TR::Node *, TR::Node *, TR_BitVector &, bool *);
+   bool canBeAvailable(TR::Node *, TR::Node *, TR_BitVector &, bool);
+   bool isAvailableNullCheck(TR::Node *, TR_BitVector &);
    TR::Node *getAvailableExpression(TR::Node *parent, TR::Node *node);
-   bool killExpressionsIfVolatileLoad(TR::Node *node, SharedSparseBitVector &seenAvailableLoadedSymbolReferences, TR_NodeKillAliasSetInterface &UseDefAliases);
-   void killAvailableExpressionsAtGCSafePoints(TR::Node *, TR::Node *, SharedSparseBitVector &);
+   bool killExpressionsIfVolatileLoad(TR::Node *node, TR_BitVector &seenAvailableLoadedSymbolReferences, TR_NodeKillAliasSetInterface &UseDefAliases);
+   void killAvailableExpressionsAtGCSafePoints(TR::Node *, TR::Node *, TR_BitVector &);
    void killAllAvailableExpressions();
-   void killAllDataStructures(SharedSparseBitVector &);
+   void killAllDataStructures(TR_BitVector &);
    void killAvailableExpressions(int32_t);
-   void killAvailableExpressionsUsingBitVector(HashTable *hashTable, SharedSparseBitVector &vec);
+   void killAvailableExpressionsUsingBitVector(HashTable *hashTable, TR_BitVector &vec);
    void killAvailableExpressionsUsingAliases(TR_NodeKillAliasSetInterface &);
-   void killAvailableExpressionsUsingAliases(SharedSparseBitVector &);
+   void killAvailableExpressionsUsingAliases(TR_BitVector &);
    void killAllInternalPointersBasedOnThisPinningArray(TR::SymbolReference *symRef);
 
    bool areSyntacticallyEquivalent(TR::Node *, TR::Node *, bool *);
@@ -149,15 +149,15 @@ class LocalCSE : public TR::Optimization
    TR::Node **_replacedNodesByAsArray;
    int32_t *_symReferencesTable;
 
-   SharedSparseBitVector _seenCallSymbolReferences;
+   TR_BitVector _seenCallSymbolReferences;
    TR_BitVector _seenSymRefs;
    TR_BitVector _possiblyRelevantNodes;
    TR_BitVector _relevantNodes;
    TR_BitVector _parentAddedToHT;
    TR_BitVector _killedNodes;
-   SharedSparseBitVector _availableLoadExprs;
-   SharedSparseBitVector _availableCallExprs;
-   SharedSparseBitVector _availablePinningArrayExprs;
+   TR_BitVector _availableLoadExprs;
+   TR_BitVector _availableCallExprs;
+   TR_BitVector _availablePinningArrayExprs;
    TR_BitVector _killedPinningArrayExprs;
 
    HashTable *_hashTable;

--- a/compiler/optimizer/OMRLocalCSE.hpp
+++ b/compiler/optimizer/OMRLocalCSE.hpp
@@ -153,12 +153,12 @@ class LocalCSE : public TR::Optimization
    TR_BitVector _seenSymRefs;
    TR_BitVector _possiblyRelevantNodes;
    TR_BitVector _relevantNodes;
-   SharedSparseBitVector _parentAddedToHT;
+   TR_BitVector _parentAddedToHT;
    TR_BitVector _killedNodes;
    SharedSparseBitVector _availableLoadExprs;
    SharedSparseBitVector _availableCallExprs;
    SharedSparseBitVector _availablePinningArrayExprs;
-   SharedSparseBitVector _killedPinningArrayExprs;
+   TR_BitVector _killedPinningArrayExprs;
 
    HashTable *_hashTable;
    HashTable *_hashTableWithSyms;

--- a/compiler/optimizer/OMRLocalCSE.hpp
+++ b/compiler/optimizer/OMRLocalCSE.hpp
@@ -177,7 +177,7 @@ class LocalCSE : public TR::Optimization
    bool _inSubTreeOfNullCheckReference;
    bool _isTreeTopNullCheck;
    TR::Block *_curBlock;
-   TR_ScratchList<TR::Node> _arrayRefNodes;
+   TR_ScratchList<TR::Node> *_arrayRefNodes;
 
    bool _loadaddrAsLoad;
 

--- a/compiler/optimizer/OMRLocalCSE.hpp
+++ b/compiler/optimizer/OMRLocalCSE.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -206,8 +206,10 @@ class LocalCSE : public TR::Optimization
    TR::Node *getNode(TR::Node *node);
 
    TR::TreeTop *_treeBeingExamined;
-   CS2::TableOf<TR::Node *, TR::Allocator> _storeNodes;
-   CS2::ArrayOf<uint32_t , TR::Allocator> _storeNodesIndex;
+   typedef TR::typed_allocator<std::pair<uint32_t, TR::Node*>, TR::Region&> StoreMapAllocator;
+   typedef std::less<uint32_t> StoreMapComparator;
+   typedef std::map<uint32_t, TR::Node*, StoreMapComparator, StoreMapAllocator> StoreMap;
+   StoreMap *_storeMap;
 
    TR::Node **_nullCheckNodesAsArray;
    TR::Node **_simulatedNodesAsArray;

--- a/compiler/optimizer/OMRLocalCSE.hpp
+++ b/compiler/optimizer/OMRLocalCSE.hpp
@@ -151,8 +151,8 @@ class LocalCSE : public TR::Optimization
 
    SharedSparseBitVector _seenCallSymbolReferences;
    SharedSparseBitVector _seenSymRefs;
-   SharedSparseBitVector _possiblyRelevantNodes;
-   SharedSparseBitVector _relevantNodes;
+   TR_BitVector _possiblyRelevantNodes;
+   TR_BitVector _relevantNodes;
    SharedSparseBitVector _parentAddedToHT;
    SharedSparseBitVector _killedNodes;
    SharedSparseBitVector _availableLoadExprs;

--- a/compiler/optimizer/OMRLocalCSE.hpp
+++ b/compiler/optimizer/OMRLocalCSE.hpp
@@ -150,7 +150,7 @@ class LocalCSE : public TR::Optimization
    int32_t *_symReferencesTable;
 
    SharedSparseBitVector _seenCallSymbolReferences;
-   SharedSparseBitVector _seenSymRefs;
+   TR_BitVector _seenSymRefs;
    TR_BitVector _possiblyRelevantNodes;
    TR_BitVector _relevantNodes;
    SharedSparseBitVector _parentAddedToHT;

--- a/compiler/optimizer/OMRLocalCSE.hpp
+++ b/compiler/optimizer/OMRLocalCSE.hpp
@@ -150,7 +150,6 @@ class LocalCSE : public TR::Optimization
    int32_t *_symReferencesTable;
 
    SharedSparseBitVector _seenCallSymbolReferences;
-   SharedSparseBitVector _seenKilledSymbolReferences;
    SharedSparseBitVector _seenSymRefs;
    SharedSparseBitVector _possiblyRelevantNodes;
    SharedSparseBitVector _relevantNodes;

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -3470,8 +3470,8 @@ static bool isLegalToMerge(TR::Node * node, TR::Block * block, TR::Block * nextB
    if (cfg &&
        /* cfg->getStructure() && */
           !s->comp()->cg()->getGRACompleted() &&
-       ((block->getStructureOf() && block->getStructureOf()->isLoopInvariantBlock()) ||
-        (nextBlock->getStructureOf() && nextBlock->getStructureOf()->isLoopInvariantBlock())))
+       ((block->isLoopInvariantBlock()) ||
+        (nextBlock->isLoopInvariantBlock())))
       return false;
 
    if (block->getLastRealTreeTop()->getNode()->getOpCode().isJumpWithMultipleTargets() ||

--- a/compiler/optimizer/OSRDefAnalysis.cpp
+++ b/compiler/optimizer/OSRDefAnalysis.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -636,7 +636,7 @@ int32_t TR_OSRDefAnalysis::perform()
 
    //set the structure to NULL so that the inliner (which is applied very soon after) doesn't need
    //update it.
-   optimizer()->getMethodSymbol()->getFlowGraph()->setStructure(NULL);
+   optimizer()->getMethodSymbol()->getFlowGraph()->invalidateStructure();
 
    return 0;
    }
@@ -776,7 +776,7 @@ int32_t TR_OSRLiveRangeAnalysis::perform()
 
    //set the structure to NULL so that the inliner (which is applied very soon after) doesn't need
    //update it.
-   optimizer()->getMethodSymbol()->getFlowGraph()->setStructure(NULL);
+   optimizer()->getMethodSymbol()->getFlowGraph()->invalidateStructure();
 
    TR::SymbolReferenceTable *symRefTab   = comp()->getSymRefTab();
 

--- a/compiler/optimizer/StructuralAnalysis.cpp
+++ b/compiler/optimizer/StructuralAnalysis.cpp
@@ -25,9 +25,6 @@
 #include "compile/Compilation.hpp"                    // for Compilation
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
-#include "cs2/arrayof.h"                              // for StaticArrayOf
-#include "cs2/bitvectr.h"
-#include "cs2/sparsrbit.h"
 #include "env/TRMemory.hpp"
 #include "il/Block.hpp"                               // for Block, toBlock
 #include "il/symbol/ResolvedMethodSymbol.hpp"
@@ -58,7 +55,7 @@ void TR_RegionAnalysis::simpleIterator (TR_Stack<int32_t>& workStack,
       // The exit block must only be made part of the region headed by the entry
       // block. It provides an exit for all other regions.
       //
-      if (doThisCheck && next._succ.IsZero() &&
+      if (doThisCheck && next._succ.isEmpty() &&
           next._originalBlock == _cfg->getEnd())
          {
          if (hdrBlock->getNumber() != 0)
@@ -71,9 +68,9 @@ void TR_RegionAnalysis::simpleIterator (TR_Stack<int32_t>& workStack,
       //We should be able to push the same node at most twice
       //so if we come across the same node the second time (nodesInPath[next]) we could say that we are done with this
       //particular node and move on
-      if (regionNodes.ValueAt(cursor))
+      if (regionNodes.get(cursor))
          {
-         if (!cyclesFound && nodesInPath.ValueAt(cursor) &&
+         if (!cyclesFound && nodesInPath.get(cursor) &&
              _dominators.dominates(hdrBlock, next._originalBlock))
             {
             cyclesFound = true;
@@ -107,7 +104,7 @@ void TR_RegionAnalysis::StructInfo::initialize(TR::Compilation * comp, int32_t i
  * analysis. The structure information blocks are ordered in depth-first
  * order of basic blocks, so we can do a postorder scan of the structures.
  */
-void TR_RegionAnalysis::createLeafStructures(TR::CFG *cfg)
+void TR_RegionAnalysis::createLeafStructures(TR::CFG *cfg, TR::Region &region)
    {
    TR::CFGNode              *cfgNode;
    TR::Block                *b;
@@ -115,15 +112,16 @@ void TR_RegionAnalysis::createLeafStructures(TR::CFG *cfg)
 
    _totalNumberOfNodes = 0;
 
+   _infoTable = (StructInfo**) _workingRegion.allocate((cfg->getNumberOfNodes()+1)*sizeof(StructInfo*));
+
    // We need two passes to initialize the array of StructInfo objects
    // because the order of nodes is not necessarily sequential.
    // The first constructs the objects in order and the second initializes them
    // (in a different order)
-   // Note that TableOf entries are 1-based, not 0-based
    for (cfgNode = cfg->getFirstNode(); cfgNode; cfgNode = cfgNode->getNext())
       {
       	// Construct the right number of table entries
-      _infoTable.AddEntry(_allocator);
+      _infoTable[_totalNumberOfNodes+1] = new (region) StructInfo(region);
       _totalNumberOfNodes++;
       }
 
@@ -143,25 +141,25 @@ void TR_RegionAnalysis::createLeafStructures(TR::CFG *cfg)
          {
          next = toBlock((*p)->getFrom());
          index = _dominators._dfNumbers[next->getNumber()];
-         si._pred[index] = true;
+         si._pred.set(index);
          }
       for (auto p = b->getSuccessors().begin(); p != b->getSuccessors().end(); ++p)
          {
          next = toBlock((*p)->getTo());
          index = _dominators._dfNumbers[next->getNumber()];
-         si._succ[index] = true;
+         si._succ.set(index);
          }
       for (auto p = b->getExceptionPredecessors().begin(); p != b->getExceptionPredecessors().end(); ++p)
          {
          next = toBlock((*p)->getFrom());
          index = _dominators._dfNumbers[next->getNumber()];
-         si._exceptionPred[index] = true;
+         si._exceptionPred.set(index);
          }
       for (auto p = b->getExceptionSuccessors().begin(); p != b->getExceptionSuccessors().end(); ++p)
          {
          next = toBlock((*p)->getTo());
          index = _dominators._dfNumbers[next->getNumber()];
-         si._exceptionSucc[index] = true;
+         si._exceptionSucc.set(index);
          }
       }
    }
@@ -188,7 +186,7 @@ TR_Structure *TR_RegionAnalysis::getRegions(TR::Compilation *comp, TR::ResolvedM
    TR::CFG *cfg = methSym->getFlowGraph();
    TR_ASSERT(cfg, "cfg is NULL\n");
 
-   TR_RegionAnalysis ra(comp, dominators, cfg, comp->allocator());
+   TR_RegionAnalysis ra(comp, dominators, cfg, stackMemoryRegion);
    ra._trace = comp->getOption(TR_TraceSA);
 
    ra._useNew = !comp->getOption(TR_DisableIterativeSA);
@@ -198,15 +196,17 @@ TR_Structure *TR_RegionAnalysis::getRegions(TR::Compilation *comp, TR::ResolvedM
       comp->getDebug()->print(comp->getOutFile(), cfg);
       }
 
-   ra.createLeafStructures(cfg);
+   ra.createLeafStructures(cfg, stackMemoryRegion);
 
    // Loop through the node set until there is only one node left - this is the
    // root of the control tree.
    //
-   TR_Structure *result = ra.findRegions();
+   TR_Structure *result = ra.findRegions(stackMemoryRegion);
 
    return result;
    }
+
+
 
 
 /**
@@ -230,7 +230,7 @@ TR_Structure *TR_RegionAnalysis::getRegions(TR::Compilation *comp)
 
    TR::CFG *cfg = comp->getFlowGraph();
 
-   TR_RegionAnalysis ra(comp, dominators, cfg, comp->allocator());
+   TR_RegionAnalysis ra(comp, dominators, cfg, stackMemoryRegion);
    ra._trace = comp->getOption(TR_TraceSA);
 
    ra._useNew = !comp->getOption(TR_DisableIterativeSA);
@@ -240,12 +240,12 @@ TR_Structure *TR_RegionAnalysis::getRegions(TR::Compilation *comp)
       comp->getDebug()->print(comp->getOutFile(), cfg);
       }
 
-   ra.createLeafStructures(cfg);
+   ra.createLeafStructures(cfg, stackMemoryRegion);
 
    // Loop through the node set until there is only one node left - this is the
    // root of the control tree.
    //
-   TR_Structure *result = ra.findRegions();
+   TR_Structure *result = ra.findRegions(stackMemoryRegion);
 
    return result;
    }
@@ -270,13 +270,13 @@ TR_Structure *TR_RegionAnalysis::getRegions(TR::Compilation *comp)
  * enough to consider.
  * The root region is returned.
  */
-TR_Structure *TR_RegionAnalysis::findRegions()
+TR_Structure *TR_RegionAnalysis::findRegions(TR::Region &memRegion)
    {
    // Create work areas
-   TR::BitVector regionNodes(comp()->allocator());
-   TR::BitVector nodesInPath(comp()->allocator());
+   TR_BitVector regionNodes(memRegion);
+   TR_BitVector nodesInPath(memRegion);
    // Create the array to hold created cfg nodes
-   SubGraphNodes cfgNodes(_totalNumberOfNodes, comp()->allocator());
+   SubGraphNodes cfgNodes(_totalNumberOfNodes, memRegion);
 
    // Loop through the active nodes in depth-first postorder looking for natural
    // loops.
@@ -298,7 +298,7 @@ TR_Structure *TR_RegionAnalysis::findRegions()
       //
       region = findNaturalLoop(node, regionNodes, nodesInPath);
       if (region != NULL)
-      	 buildRegionSubGraph(region, node, regionNodes, cfgNodes);
+      	 buildRegionSubGraph(region, node, regionNodes, cfgNodes, memRegion);
       }
 
    // Loop through the active nodes in depth-first postorder looking for other
@@ -320,7 +320,7 @@ TR_Structure *TR_RegionAnalysis::findRegions()
       region = findRegion(node, regionNodes, nodesInPath);
 
       if (region != NULL)
-         buildRegionSubGraph(region, node, regionNodes,cfgNodes);
+         buildRegionSubGraph(region, node, regionNodes,cfgNodes, memRegion);
       }
 
    TR_ASSERT(getInfo(0)._structure, "Region Analysis, root region not found");
@@ -337,9 +337,9 @@ TR_RegionStructure *TR_RegionAnalysis::findNaturalLoop(StructInfo &node,
                                                        WorkBitVector &regionNodes,
                                                        WorkBitVector &nodesInPath)
    {
-   regionNodes.Clear();
-   regionNodes[node._nodeIndex] = true;
-   nodesInPath.Clear();
+   regionNodes.empty();
+   regionNodes.set(node._nodeIndex);
+   nodesInPath.empty();
    bool cyclesFound = false;
 
    int32_t numBackEdges = 0;
@@ -369,7 +369,7 @@ TR_RegionStructure *TR_RegionAnalysis::findNaturalLoop(StructInfo &node,
    if (numBackEdges == 0)
       return NULL;
 
-   TR_RegionStructure *region = new (_cfg->structureRegion()) TR_RegionStructure(_compilation, node._structure->getNumber() /* node._nodeIndex */);
+   TR_RegionStructure *region = new (_structureRegion) TR_RegionStructure(_compilation, node._structure->getNumber() /* node._nodeIndex */);
    if (cyclesFound)
       {
       if (trace())
@@ -388,9 +388,9 @@ TR_RegionStructure *TR_RegionAnalysis::findNaturalLoop(StructInfo &node,
 void TR_RegionAnalysis::addNaturalLoopNodesIterativeVersion(StructInfo &node, WorkBitVector &regionNodes, WorkBitVector &nodesInPath, bool &cyclesFound, TR::Block *hdrBlock)
    {
    //special case for addNaturalLoops
-   if (regionNodes.ValueAt(node._nodeIndex))
+   if (regionNodes.get(node._nodeIndex))
       {
-      if (nodesInPath.ValueAt(node._nodeIndex))
+      if (nodesInPath.get(node._nodeIndex))
          {
          cyclesFound = true;
          if (trace())
@@ -410,21 +410,21 @@ void TR_RegionAnalysis::addNaturalLoopNodesIterativeVersion(StructInfo &node, Wo
       {
       int32_t index = workStack.pop();
 
-      if (nodesInPath.ValueAt(index))
+      if (nodesInPath.get(index))
          {
          // If node is in path, in region and cycles have been found then processing
          // the node again will not have any sideeffects, so we can skip it completely
-         if (regionNodes[index] && cyclesFound)
+         if (regionNodes.get(index) && cyclesFound)
             continue;
-         nodesInPath[index] = false;
+         nodesInPath.reset(index);
          continue;
          }
       else
          {
          workStack.push(index); //push again but now it will be marked in nodesInPath,
          //so the next time we come across this index we won't process it again
-         regionNodes[index] = true;
-         nodesInPath[index] = true;
+         regionNodes.set(index);
+         nodesInPath.set(index);
          }
 
       if (trace())
@@ -453,9 +453,9 @@ void TR_RegionAnalysis::addNaturalLoopNodes(StructInfo &node, WorkBitVector &reg
 
    // If the node was already found in the region we can stop tracking this path.
    //
-   if (regionNodes.ValueAt(index))
+   if (regionNodes.get(index))
       {
-      if (nodesInPath.ValueAt(index))
+      if (nodesInPath.get(index))
          {
          cyclesFound = true;
          if (trace())
@@ -468,8 +468,8 @@ void TR_RegionAnalysis::addNaturalLoopNodes(StructInfo &node, WorkBitVector &reg
 
    // Add this node to the region and to this path and look at its predecessors.
    //
-   regionNodes[index] = true;
-   nodesInPath[index] = true;
+   regionNodes.set(index);
+   nodesInPath.set(index);
 
    StructureBitVector::Cursor cursor(node._pred);
    for (cursor.SetToFirstOne(); cursor.Valid(); cursor.SetToNextOne())
@@ -485,7 +485,7 @@ void TR_RegionAnalysis::addNaturalLoopNodes(StructInfo &node, WorkBitVector &reg
       if (_dominators.dominates(hdrBlock, next._originalBlock))
          addNaturalLoopNodes(next, regionNodes, nodesInPath, cyclesFound, hdrBlock);
       }
-   nodesInPath[index] = false;
+   nodesInPath.reset(index);
    }
 
 
@@ -505,8 +505,8 @@ TR_RegionStructure *TR_RegionAnalysis::findRegion(StructInfo &node,
    {
 
    bool cyclesFound = false;
-   regionNodes.Clear();
-   nodesInPath.Clear();
+   regionNodes.empty();
+   nodesInPath.empty();
 
    if (_useNew)
       {
@@ -518,11 +518,11 @@ TR_RegionStructure *TR_RegionAnalysis::findRegion(StructInfo &node,
       }
    if (!cyclesFound && (node._nodeIndex > 0))
       {
-      if (regionNodes.PopulationCount() < 100)
+      if (regionNodes.elementCount() < 100)
          return NULL;
       }
 
-   TR_RegionStructure *region = new (_cfg->structureRegion()) TR_RegionStructure(_compilation, node._structure->getNumber() /* node._nodeIndex */);
+   TR_RegionStructure *region = new (_structureRegion) TR_RegionStructure(_compilation, node._structure->getNumber() /* node._nodeIndex */);
    if (cyclesFound)
       {
       if (trace())
@@ -546,17 +546,17 @@ void TR_RegionAnalysis::addRegionNodesIterativeVersion(StructInfo &node, WorkBit
    while (!workStack.isEmpty())
       {
       int32_t index = workStack.pop();
-      if (nodesInPath.ValueAt(index))
+      if (nodesInPath.get(index))
          {
-         nodesInPath[index] = false;
+         nodesInPath.reset(index);
          continue;
          }
       else
          {
          workStack.push(index); //push again but now it will be marked in nodesInPath,
          //so the next time we come across this index we won't process it again
-         regionNodes[index] = true;
-         nodesInPath[index] = true;
+         regionNodes.set(index);
+         nodesInPath.set(index);
          }
 
       if (trace())
@@ -585,9 +585,9 @@ void TR_RegionAnalysis::addRegionNodes(StructInfo &node, WorkBitVector &regionNo
 
    // If the node was already found in the region we can stop tracking this path.
    //
-   if (regionNodes.ValueAt(index))
+   if (regionNodes.get(index))
       {
-      if (nodesInPath.ValueAt(index))
+      if (nodesInPath.get(index))
          {
          cyclesFound = true;
          if (trace())
@@ -600,8 +600,8 @@ void TR_RegionAnalysis::addRegionNodes(StructInfo &node, WorkBitVector &regionNo
 
    // Add this node to the region and to this path and look at its successors.
    //
-   regionNodes[index] = true;
-   nodesInPath[index] = true;
+   regionNodes.set(index);
+   nodesInPath.set(index);
 
    StructureBitVector::Cursor cursor(node._succ);
    for (cursor.SetToFirstOne(); cursor.Valid(); cursor.SetToNextOne())
@@ -611,7 +611,7 @@ void TR_RegionAnalysis::addRegionNodes(StructInfo &node, WorkBitVector &regionNo
       // The exit block must only be made part of the region headed by the entry
       // block. It provides an exit for all other regions.
       //
-      if ((next._succ.IsZero()) &&
+      if ((next._succ.isEmpty()) &&
           next._originalBlock == _cfg->getEnd())
          {
          if (hdrBlock->getNumber() != 0)
@@ -628,7 +628,7 @@ void TR_RegionAnalysis::addRegionNodes(StructInfo &node, WorkBitVector &regionNo
       if (_dominators.dominates(hdrBlock, next._originalBlock))
          addRegionNodes(next, regionNodes, nodesInPath, cyclesFound, hdrBlock);
       }
-   nodesInPath[index] = false;
+   nodesInPath.reset(index);
    }
 
 /**
@@ -638,7 +638,8 @@ void TR_RegionAnalysis::addRegionNodes(StructInfo &node, WorkBitVector &regionNo
 void TR_RegionAnalysis::buildRegionSubGraph(TR_RegionStructure *region,
                                             StructInfo &entryNode,
                                             WorkBitVector &regionNodes,
-                                            SubGraphNodes &cfgNodes)
+                                            SubGraphNodes &cfgNodes,
+                                            TR::Region &memRegion)
    {
    StructInfo               *toNode;
    int32_t                   fromIndex, toIndex;
@@ -657,7 +658,7 @@ void TR_RegionAnalysis::buildRegionSubGraph(TR_RegionStructure *region,
 
    // Bits cannot be turned off while iterating over a CS2 sparse bit vector,
    // so they are accumulated in a separate vector and turned off after iteration
-   StructureBitVector bitsToBeRemoved(_compilation->allocator());
+   StructureBitVector bitsToBeRemoved(memRegion);
 
    WorkBitVector::Cursor rCursor(regionNodes);
    for (rCursor.SetToFirstOne(); rCursor.Valid(); rCursor.SetToNextOne())
@@ -666,7 +667,7 @@ void TR_RegionAnalysis::buildRegionSubGraph(TR_RegionStructure *region,
       StructInfo &fromNode = getInfo(fromIndex);
 
       if (cfgNodes[fromIndex] == NULL)
-         cfgNodes[fromIndex] = new (_cfg->structureRegion()) TR_StructureSubGraphNode(fromNode._structure);
+         cfgNodes[fromIndex] = new (_structureRegion) TR_StructureSubGraphNode(fromNode._structure);
       from = cfgNodes[fromIndex];
       region->addSubNode(from);
 
@@ -677,17 +678,17 @@ void TR_RegionAnalysis::buildRegionSubGraph(TR_RegionStructure *region,
          StructInfo &toNode = getInfo(toIndex);
          if (cfgNodes[toIndex] == NULL)
             {
-            if (regionNodes.ValueAt(toIndex))
-               cfgNodes[toIndex] = new (_cfg->structureRegion()) TR_StructureSubGraphNode(toNode._structure);
+            if (regionNodes.get(toIndex))
+               cfgNodes[toIndex] = new (_structureRegion) TR_StructureSubGraphNode(toNode._structure);
             else
-               cfgNodes[toIndex] = new (_cfg->structureRegion()) TR_StructureSubGraphNode(toNode._structure->getNumber(), _cfg->structureRegion());
+               cfgNodes[toIndex] = new (_structureRegion) TR_StructureSubGraphNode(toNode._structure->getNumber(), _structureRegion);
             }
          to = cfgNodes[toIndex];
-         edge = TR::CFGEdge::createEdge(from,  to, _cfg->structureRegion());
-         if (regionNodes.ValueAt(toIndex))
+         edge = TR::CFGEdge::createEdge(from,  to, _structureRegion);
+         if (regionNodes.get(toIndex))
             {
-            toNode._pred[fromIndex] = false;
-            bitsToBeRemoved[toIndex] = true;
+            toNode._pred.reset(fromIndex);
+            bitsToBeRemoved.set(toIndex);
             }
          else
             {
@@ -696,15 +697,15 @@ void TR_RegionAnalysis::buildRegionSubGraph(TR_RegionStructure *region,
                   {
                   // Change the successor edge to come from the new region
                   //
-               toNode._pred[fromIndex] = false;
-               toNode._pred[entryNode._nodeIndex] = true;
-               entryNode._succ[toIndex] = true;
+               toNode._pred.reset(fromIndex);
+               toNode._pred.set(entryNode._nodeIndex);
+               entryNode._succ.set(toIndex);
                }
             }
          }
       fromNode._succ -= bitsToBeRemoved;
 
-      bitsToBeRemoved.Clear();
+      bitsToBeRemoved.empty();
       StructureBitVector::Cursor eCursor(fromNode._exceptionSucc);
       for (eCursor.SetToFirstOne(); eCursor.Valid(); eCursor.SetToNextOne())
          {
@@ -712,26 +713,26 @@ void TR_RegionAnalysis::buildRegionSubGraph(TR_RegionStructure *region,
          StructInfo &toNode = getInfo(toIndex);
          if (cfgNodes[toIndex] == NULL)
             {
-            if (regionNodes.ValueAt(toIndex))
-               cfgNodes[toIndex] = new (_cfg->structureRegion()) TR_StructureSubGraphNode(toNode._structure);
+            if (regionNodes.get(toIndex))
+               cfgNodes[toIndex] = new (_structureRegion) TR_StructureSubGraphNode(toNode._structure);
             else
-               cfgNodes[toIndex] = new (_cfg->structureRegion()) TR_StructureSubGraphNode(toNode._structure->getNumber(), _cfg->structureRegion());
+               cfgNodes[toIndex] = new (_structureRegion) TR_StructureSubGraphNode(toNode._structure->getNumber(), _structureRegion);
             }
          to = cfgNodes[toIndex];
-         edge = TR::CFGEdge::createExceptionEdge(from, to, _cfg->structureRegion());
-         if (regionNodes.ValueAt(toIndex))
+         edge = TR::CFGEdge::createExceptionEdge(from, to, _structureRegion);
+         if (regionNodes.get(toIndex))
             {
-            toNode._exceptionPred[fromIndex] = false;
-            bitsToBeRemoved[toIndex] = true;
+            toNode._exceptionPred.reset(fromIndex);
+            bitsToBeRemoved.set(toIndex);
             }
          else
             {
             region->addExitEdge(edge);
             if (&fromNode != &entryNode)
                   {
-               toNode._exceptionPred[fromIndex] = false;
-               toNode._exceptionPred[entryNode._nodeIndex] = true;
-               entryNode._exceptionSucc[toIndex] = true;
+               toNode._exceptionPred.reset(fromIndex);
+               toNode._exceptionPred.set(entryNode._nodeIndex);
+               entryNode._exceptionSucc.set(toIndex);
                }
             }
          }

--- a/compiler/optimizer/Structure.cpp
+++ b/compiler/optimizer/Structure.cpp
@@ -61,14 +61,6 @@ TR_Structure::Kind TR_RegionStructure::getKind()            {return Region;}
 TR_BlockStructure::TR_BlockStructure(TR::Compilation * comp, int32_t index, TR::Block *b) :
    TR_Structure(comp, index), _block(b)
    {
-   TR_BlockStructure *old = b->getStructureOf();
-   if (old)
-      {
-      setAsLoopInvariantBlock(old->isLoopInvariantBlock());
-      if (old->isEntryOfShortRunningLoop())
-         setIsEntryOfShortRunningLoop();
-      setCreatedByVersioning(old->isCreatedByVersioning());
-      }
    b->setStructureOf(this);
    }
 
@@ -797,11 +789,8 @@ TR_Structure *TR_BlockStructure::cloneStructure(TR::Block **correspondingBlocks,
    {
    TR::Block *correspondingBlock = correspondingBlocks[getNumber()];
    TR_BlockStructure *clonedBlockStructure = new (cfg()->structureRegion()) TR_BlockStructure(comp(), correspondingBlock->getNumber(), correspondingBlock);
-   clonedBlockStructure->setAsLoopInvariantBlock(isLoopInvariantBlock());
    clonedBlockStructure->setNestingDepth(getNestingDepth());
    clonedBlockStructure->setMaxNestingDepth(getMaxNestingDepth());
-   if (isEntryOfShortRunningLoop())
-      clonedBlockStructure->setIsEntryOfShortRunningLoop();
    clonedBlockStructure->setDuplicatedBlock(this);
    return clonedBlockStructure;
    }

--- a/compiler/optimizer/Structure.hpp
+++ b/compiler/optimizer/Structure.hpp
@@ -70,6 +70,7 @@ class TR_Structure
       }
 
    TR::Compilation * comp() { return _comp; }
+   TR::CFG *cfg() { return _comp->getFlowGraph(); }
 
    TR_Memory *               trMemory()                    { return _trMemory; }
    TR_StackMemory            trStackMemory()               { return _trMemory; }
@@ -276,10 +277,10 @@ class TR_StructureSubGraphNode : public TR::CFGNode
    // Create a node for a concrete structure
    //
    TR_StructureSubGraphNode(TR_Structure *s)
-      : TR::CFGNode(s->getNumber(), s->trMemory()), _structure(s)  {s->setSubGraphNode(this);}
+      : TR::CFGNode(s->getNumber(), s->cfg()->structureRegion()), _structure(s)  {s->setSubGraphNode(this);}
 
-   TR_StructureSubGraphNode(int32_t n, TR_Memory * m)
-      : TR::CFGNode(n, m), _structure(0) {}
+   TR_StructureSubGraphNode(int32_t n, TR::Region &region)
+      : TR::CFGNode(n, region), _structure(0) {}
 
    static TR_StructureSubGraphNode *create(int32_t num, TR_RegionStructure *region);
 
@@ -425,8 +426,8 @@ class TR_RegionStructure : public TR_Structure
 
    TR_RegionStructure(TR::Compilation * c, int32_t index)
       : TR_Structure(c, index), _invariantSymbols(NULL), _blocksAtSameNestingLevel(NULL), _piv(NULL),
-        _basicIVs(c->trMemory()), _exitEdges(c->trMemory()), _subNodes(c->trMemory()->heapMemoryRegion()),
-        _invariantExpressions(NULL)
+        _basicIVs(c->getFlowGraph()->structureRegion()), _exitEdges(c->getFlowGraph()->structureRegion()),
+         _subNodes(c->getFlowGraph()->structureRegion()), _invariantExpressions(NULL)
       {
       }
 

--- a/compiler/optimizer/Structure.hpp
+++ b/compiler/optimizer/Structure.hpp
@@ -337,17 +337,17 @@ class TR_BlockStructure : public TR_Structure
 
    virtual List<TR::Block> *getBlocks(List<TR::Block> *);
 
-   bool isLoopInvariantBlock() {return _blockFlags.testAny(_isLoopInvariantBlock);}
-   void setAsLoopInvariantBlock(bool b) {_blockFlags.set(_isLoopInvariantBlock, b);}
+   bool isLoopInvariantBlock()          { return _block->isLoopInvariantBlock(); }
+   void setAsLoopInvariantBlock(bool b) { _block->setAsLoopInvariantBlock(b);    }
 
-   bool isCreatedByVersioning() {return _blockFlags.testAny(_isCreatedByVersioning);}
-   void setCreatedByVersioning(bool b) {_blockFlags.set(_isCreatedByVersioning, b);}
+   bool isCreatedByVersioning()         { return _block->isCreatedByVersioning(); }
+   void setCreatedByVersioning(bool b)  { _block->setCreatedByVersioning(b);     }
 
-   bool isEntryOfShortRunningLoop() { return _blockFlags.testAny(_isEntryOfShortRunningLoop); }
-   void setIsEntryOfShortRunningLoop() {_blockFlags.set(_isEntryOfShortRunningLoop, true);}
+   bool isEntryOfShortRunningLoop()     { return _block->isEntryOfShortRunningLoop(); }
+   void setIsEntryOfShortRunningLoop()  { _block->setIsEntryOfShortRunningLoop();     }
 
-   bool wasHeaderOfCanonicalizedLoop() { return _blockFlags.testAny(_wasHeaderOfCanonicalizedLoop); }
-   void setWasHeaderOfCanonicalizedLoop(bool b) {_blockFlags.set(_wasHeaderOfCanonicalizedLoop, b);}
+   bool wasHeaderOfCanonicalizedLoop()          { return _block->wasHeaderOfCanonicalizedLoop();  }
+   void setWasHeaderOfCanonicalizedLoop(bool b) { _block->setWasHeaderOfCanonicalizedLoop(b);    }
 
    virtual TR::Block *getEntryBlock() { return getBlock(); }
 
@@ -362,17 +362,8 @@ class TR_BlockStructure : public TR_Structure
    public:
    virtual List<TR::Block> *getBlocks(List<TR::Block> *, vcount_t);
 
-   enum  // flags
-      {
-      _isLoopInvariantBlock         = 0x01,
-      _isCreatedByVersioning        = 0x02,
-      _isEntryOfShortRunningLoop    = 0x04,
-      _wasHeaderOfCanonicalizedLoop = 0x08
-      };
-
    private:
    TR::Block          *_block;
-   flags8_t   _blockFlags;
    };
 
 // **********************************************************************

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -3361,7 +3361,7 @@ TR::Node *constrainThrow(OMR::ValuePropagation *vp, TR::Node *node)
       printf("\n\n throw type %.*s\n", len, sig);
       }
 
-   TR_OrderedExceptionHandlerIterator oehi(vp->_curBlock);
+   TR_OrderedExceptionHandlerIterator oehi(vp->_curBlock, vp->comp()->trMemory()->currentStackRegion());
    for (TR::Block *catchBlock = oehi.getFirst(); catchBlock; catchBlock = oehi.getNext())
       {
       if (catchBlock->isOSRCatchBlock())

--- a/compiler/optimizer/VirtualGuardCoalescer.cpp
+++ b/compiler/optimizer/VirtualGuardCoalescer.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -523,8 +523,8 @@ void TR_VirtualGuardTailSplitter::transformLinear(TR::Block *first, TR::Block *l
       if (_cfg->getStructure())
          {
          next->getStructureOf()->getParent()->asRegion()->
-            addSubNode(new (trHeapMemory()) TR_StructureSubGraphNode
-                       (new (trHeapMemory()) TR_BlockStructure(comp(), clone->getNumber(), clone)));
+            addSubNode(new (_cfg->structureRegion()) TR_StructureSubGraphNode
+                       (new (_cfg->structureRegion()) TR_BlockStructure(comp(), clone->getNumber(), clone)));
          }
 
       if (trace())

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -2267,11 +2267,11 @@ TR_Debug::printBlockInfo(TR::FILE *pOutFile, TR::Node *node)
          else if (block->isCold())
             trfprintf(pOutFile, " (cold)");
 
+         if (block->isLoopInvariantBlock())
+            trfprintf(pOutFile, " (loop pre-header)");
          TR_BlockStructure *blockStructure = block->getStructureOf();
-         if (blockStructure)
+         if (_comp->getFlowGraph()->getStructure() && blockStructure)
             {
-            if (blockStructure->isLoopInvariantBlock())
-               trfprintf(pOutFile, " (loop pre-header)");
             if (!inDebugExtension())
                {
                TR_Structure *parent = blockStructure->getParent();

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -1663,12 +1663,13 @@ TR_Debug::printNodeInfo(TR::Node * node, TR_PrettyPrinterString& output, bool pr
       else if (block->isCold())
          output.append(" (cold)");
 
+      if (block->isLoopInvariantBlock())
+         output.append(" (loop pre-header)");
       TR_BlockStructure *blockStructure = block->getStructureOf();
       if (blockStructure)
          {
-         if (blockStructure->isLoopInvariantBlock())
-            output.append(" (loop pre-header)");
-         if (!inDebugExtension())
+         if (!inDebugExtension()
+             && _comp->getFlowGraph()->getStructure())
             {
             TR_Structure *parent = blockStructure->getParent();
             while (parent)

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -361,7 +361,7 @@ TR_Debug::print(TR::FILE *outFile, TR_RegionAnalysis * regionAnalysis, uint32_t 
 
    for (int32_t index = 0; index < regionAnalysis->_totalNumberOfNodes; index++)
       {
-      TR_RegionAnalysis::StructInfo &node = regionAnalysis->_infoTable[index+1];
+      TR_RegionAnalysis::StructInfo &node = regionAnalysis->getInfo(index);
       if (node._structure == NULL)
          continue;
 


### PR DESCRIPTION
This commit changes the data storage of LocalCSE from using CS heap allocated structures to using region allocated structures so that we can release the memory consumed during the execution of LocalCSE. Without this improved memory management the optimization can leak hundereds of MB of memory during some large compilations.

This change is based on [Mem 9] and so commits from 'Convert LocalCSE CS2 TableOf into std::map' onward should be considered. This should be merged after Mem8 and Mem9