### PR TITLE
Disable traps when z10 architecture is disabled

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -553,60 +553,6 @@ OMR::Z::CodeGenerator::CodeGenerator()
    // Initialize Linkage for Code Generator
    self()->initializeLinkage();
 
-   // Do random Disable<Platform> when -Xjit randomGen
-   if (comp->getOption(TR_Randomize))
-      {
-      switch(randomizer.randomInt(TR::Compiler->target.cpu.id() - TR_s370gp7))
-         {
-         case 1:
-            {
-            _processorInfo.disableArch(TR_S390ProcessorInfo::TR_z9);
-            traceMsg(comp,"disablez9");
-            break;
-            }
-
-         case 2:
-            {
-            _processorInfo.disableArch(TR_S390ProcessorInfo::TR_z10);
-            traceMsg(comp, "disablez10");
-            break;
-            }
-
-         case 3:
-            {
-            _processorInfo.disableArch(TR_S390ProcessorInfo::TR_z196);
-            traceMsg(comp, "disablez196");
-            break;
-            }
-
-         case 4:
-            {
-            _processorInfo.disableArch(TR_S390ProcessorInfo::TR_zEC12);
-            traceMsg(comp, "disablezEC12");
-            break;
-            }
-
-         case 5:
-            {
-            _processorInfo.disableArch(TR_S390ProcessorInfo::TR_z13);
-            traceMsg(comp, "disablez13");
-            break;
-            }
-         case 6:
-            {
-            _processorInfo.disableArch(TR_S390ProcessorInfo::TR_z14);
-            traceMsg(comp, "disablez14");
-            break;
-            }
-         case 7:
-            {
-            _processorInfo.disableArch(TR_S390ProcessorInfo::TR_zNext);
-            traceMsg(comp, "RandomGen: Setting disabling zNext processor architecture.");
-            break;
-            }
-         }
-      }
-
    // Check for -Xjit disable options and target this specific compilation for the proper target
    if (comp->getOption(TR_DisableZ10))
       {
@@ -753,6 +699,11 @@ OMR::Z::CodeGenerator::CodeGenerator()
    else
       {
       comp->setOption(TR_DisableCompareAndBranchInstruction);
+
+      // No trap instructions available for z10 and below.
+      // Set disable traps so that the optimizations and codegen can avoid generating
+      // trap-specific nodes or instructions.
+      comp->setOption(TR_DisableTraps);
       }
 
    if (_processorInfo.supportsArch(TR_S390ProcessorInfo::TR_z196))

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -1149,12 +1149,7 @@ public:
       }
 
 
-   /**
-    * _processorInfo contains the targetted hardware level for the compilation.
-    * This may be different than the real hardware the JVM is currently running
-    * on, due to user specified options.
-    */
-   TR_S390ProcessorInfo            _processorInfo;
+
    TR::S390ImmInstruction          *_returnTypeInfoInstruction;
    RegisterAssignmentDirection     assignmentDirection;
    int32_t                        _extentOfLitPool;  // excludes snippets
@@ -1166,6 +1161,12 @@ protected:
    TR::list<TR::S390ConstantDataSnippet*>  _constantList;
    TR::list<TR::S390ConstantDataSnippet*>  _snippetDataList;
 
+   /**
+    * _processorInfo contains the targeted hardware level for the compilation.
+    * This may be different than the real hardware the JIT compiler is currently running
+    * on, due to user specified options.
+    */
+   TR_S390ProcessorInfo            _processorInfo;
 
 private:
    TR::list<TR::S390WritableDataSnippet*>  _writableList;


### PR DESCRIPTION
If one chooses to disable z10 architecture level, traps should be disabled
so that the optimizations and codegen can avoid generating trap-related IL
nodes and instructions.

Move project specific random z architecture level disabling code out of
OMR and into the relevant project.