### PR TITLE
[Mem15] Reduce LoopStrider memory usage

### DIFF
--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -954,6 +954,9 @@ public:
 
    bool notYetRunMeansCold();
 
+   TR::Region &aliasRegion();
+   void invalidateAliasRegion();
+
 private:
    void resetVisitCounts(vcount_t, TR::ResolvedMethodSymbol *);
    int16_t restoreInlineDepthUntil(int32_t stopIndex, TR_ByteCodeInfo &currentInfo);
@@ -1027,6 +1030,7 @@ private:
    TR_ResolvedMethod                 *_method; // must be declared before _flowGraph
    TR_ArenaAllocator                 _arenaAllocator;
    const char *                      _allocatorName;
+   TR::Region                        _aliasRegion;
 
 
    TR_IlGenerator                    *_ilGenerator;

--- a/compiler/env/Region.hpp
+++ b/compiler/env/Region.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -126,7 +126,7 @@ public:
       }
 
    size_t bytesAllocated() { return _bytesAllocated; }
-
+   static size_t initialSize() { return INITIAL_SEGMENT_SIZE; }
 private:
    friend class TR::RegionProfiler;
 

--- a/compiler/optimizer/FieldPrivatizer.cpp
+++ b/compiler/optimizer/FieldPrivatizer.cpp
@@ -1142,7 +1142,7 @@ void TR_FieldPrivatizer::placeStoresBackInExit(TR::Block *block, bool placeAtEnd
             // Add global reg candidate in exit as well
             // so that store backs are done from the registers
             //
-            privatizedCandidate->getData()->addBlock(block, blockWeight, trMemory());
+            privatizedCandidate->getData()->addBlock(block, blockWeight);
          }
 
       currentNodeElem = currentNodeElem->getNextElement();

--- a/compiler/optimizer/GlobalRegisterAllocator.cpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.cpp
@@ -3384,7 +3384,7 @@ TR_GlobalRegisterAllocator::findIfThenRegisterCandidates()
                            if (mergeBlock1->getStructureOf())
                               optimizer()->getStaticFrequency(mergeBlock1, &weight);
 
-                           rc->addBlock(mergeBlock1, weight, trMemory());
+                           rc->addBlock(mergeBlock1, weight);
                            }
                         if (toBlock(block)->findFirstReference(symRef->getSymbol(), comp()->incVisitCount()))
                            {
@@ -3392,8 +3392,8 @@ TR_GlobalRegisterAllocator::findIfThenRegisterCandidates()
                            if (toBlock(block)->getStructureOf())
                               optimizer()->getStaticFrequency(toBlock(block), &weight);
 
-                           rc->addBlock(block1, weight, trMemory());
-                           rc->addBlock(block2, weight, trMemory());
+                           rc->addBlock(block1, weight);
+                           rc->addBlock(block2, weight);
                            }
                         }
                      }
@@ -3428,7 +3428,7 @@ TR_GlobalRegisterAllocator::findIfThenRegisterCandidates()
                         if (branchBlock->getStructureOf())
                            optimizer()->getStaticFrequency(branchBlock, &weight);
                         //printf("Adding symRef %d in block_%d\n", symRef->getReferenceNumber(), branchBlock->getNumber());
-                        rc->addBlock(branchBlock, weight, trMemory());
+                        rc->addBlock(branchBlock, weight);
                         }
                      }
                   }
@@ -3967,7 +3967,7 @@ TR_GlobalRegisterAllocator::findLoopsAndCorrespondingAutos(TR_StructureSubGraphN
                   int32_t nextCandidate = bvi.getNextElement();
                   //dumpOptDetails(comp(), "For loop %d exit block_%d candidate %d\n", structureNode->getNumber(), exitBlock->getNumber(), nextCandidate);
                   TR_RegisterCandidate *rc = registerCandidates[nextCandidate];
-                  rc->addBlock(exitBlock, 0, trMemory());
+                  rc->addBlock(exitBlock, 0);
                   rc->addLoopExitBlock(exitBlock);
                   }
                }
@@ -4513,7 +4513,7 @@ TR_GlobalRegisterAllocator::markAutosUsedIn(
                if (!rc->hasBlock(nextBlock))
                   {
                   if (nextBlock != cfg->getStart())
-                     rc->addBlock(nextBlock, 0, trMemory());
+                     rc->addBlock(nextBlock, 0);
                   }
                }
             }
@@ -4530,7 +4530,7 @@ TR_GlobalRegisterAllocator::markAutosUsedIn(
             if ((node->getOpCode().isStoreDirect() && isSplittingCopy(node)) ||
                 (node->getOpCode().isLoadVarDirect() && parent && parent->getOpCode().isStoreDirect() && isSplittingCopy(parent)))
                {
-               rc->addBlock(block, 0, trMemory());
+               rc->addBlock(block, 0);
                }
             else
                {
@@ -4545,13 +4545,13 @@ TR_GlobalRegisterAllocator::markAutosUsedIn(
                      (grandParent->getOpCode().isStoreIndirect() ||
                      grandParent->getOpCode().isLoadIndirect()))))
                   {
-                  rc->addBlock(block, executionFrequency*10, trMemory());
+                  rc->addBlock(block, executionFrequency*10);
                   if (trace())
                       dumpOptDetails(comp(), "Increased weight of candidate #%d in block_%d to reduce AGI\n", rc->getSymbolReference()->getReferenceNumber(), block->getNumber());
                   }
                else
                   {
-                  rc->addBlock(block, executionFrequency, trMemory());
+                  rc->addBlock(block, executionFrequency);
                   }
                }
             }
@@ -5584,12 +5584,12 @@ TR_LiveRangeSplitter::fixExitsAfterSplit(TR::SymbolReference *symRef, TR_SymRefC
                if (rc->hasBlock(nextBlock))
                   {
                   int32_t numLoadsAndStores = rc->removeBlock(nextBlock);
-                  correspondingRc->addBlock(nextBlock, numLoadsAndStores, trMemory());
+                  correspondingRc->addBlock(nextBlock, numLoadsAndStores);
                   }
                blocksInInnerLoop->set(nextBlock->getNumber());
                }
 
-            correspondingRc->addBlock(loopInvariantBlock, 1, trMemory());
+            correspondingRc->addBlock(loopInvariantBlock, 1);
 
             TR_Structure *parentOfLoop = loop->getStructure()->getContainingLoop();
             if (parentOfLoop)
@@ -5604,7 +5604,7 @@ TR_LiveRangeSplitter::fixExitsAfterSplit(TR::SymbolReference *symRef, TR_SymRefC
                      {
          if (trace())
                         traceMsg(comp(), "Adding original candidate #%d in block_%d in outer loop %d (%p)\n", rc->getSymbolReference()->getReferenceNumber(), nextBlock->getNumber(), parentOfLoop->getNumber(), parentOfLoop);
-                     rc->addBlock(nextBlock, 0, trMemory());
+                     rc->addBlock(nextBlock, 0);
                      }
                   }
                }

--- a/compiler/optimizer/GlobalRegisterAllocator.cpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.cpp
@@ -381,12 +381,10 @@ TR_GlobalRegisterAllocator::perform()
    int32_t numberOfBlocks = cfg->getNextNodeNumber();
 
    TR_RegisterCandidates * candidates = comp()->getGlobalRegisterCandidates();
-   candidates->_candidateForSymRefsSize = CANDIDATE_FOR_SYMREF_SIZE;
-   candidates->_candidateForSymRefs = (TR_RegisterCandidate **)trMemory()->allocateStackMemory(CANDIDATE_FOR_SYMREF_SIZE*sizeof(TR_RegisterCandidate *));
-   memset(candidates->_candidateForSymRefs, 0, CANDIDATE_FOR_SYMREF_SIZE*sizeof(TR_RegisterCandidates *));
+   candidates->_candidateForSymRefs = new (trStackMemory()) TR_RegisterCandidates::SymRefCandidateMap((TR_RegisterCandidates::SymRefCandidateMapComparator()), (TR_RegisterCandidates::SymRefCandidateMapAllocator(trMemory()->currentStackRegion())));
    TR_RegisterCandidate *rc = candidates->getFirst();
    for (; rc ; rc = rc->getNext())
-      candidates->_candidateForSymRefs[GET_INDEX_FOR_CANDIDATE_FOR_SYMREF(rc->getSymbolReference())] = rc;
+      (*candidates->_candidateForSymRefs)[GET_INDEX_FOR_CANDIDATE_FOR_SYMREF(rc->getSymbolReference())] = rc;
 
    candidates->_startOfExtendedBBForBB.init(trMemory(),
                                             (uint32_t)(comp()->getFlowGraph()->getNextNodeNumber() * sizeof(TR::Block *) * 1.5),

--- a/compiler/optimizer/GlobalRegisterAllocator.cpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.cpp
@@ -3460,7 +3460,6 @@ void TR_GlobalRegisterAllocator::offerAllAutosAndRegisterParmAsCandidates(TR::Bl
 
    TR_RegisterCandidates * candidates = comp()->getGlobalRegisterCandidates();
    TR::GlobalSet& referencedAutoSymRefsInBlock = candidates->getReferencedAutoSymRefs();
-   referencedAutoSymRefsInBlock.initialize(symRefCount,numberOfNodes);
 
    if (newOffer || new2Offer)
       {
@@ -3745,7 +3744,6 @@ void TR_GlobalRegisterAllocator::offerAllFPAutosAndParmsAsCandidates(TR::Block *
 
    TR_RegisterCandidates * candidates = comp()->getGlobalRegisterCandidates();
    TR::GlobalSet& referencedAutoSymRefsInBlock = candidates->getReferencedAutoSymRefs();
-   referencedAutoSymRefsInBlock.initialize(symRefCount,numberOfNodes);
 //   TR_BitVector **referencedAutoSymRefsInBlock; // = candidates->getReferencedAutoSymRefs();
 //   referencedAutoSymRefsInBlock = (TR_BitVector **)trMemory()->allocateStackMemory(numberOfNodes*sizeof(TR_BitVector *));
 //   memset(referencedAutoSymRefsInBlock, 0, numberOfNodes*sizeof(TR_BitVector *));

--- a/compiler/optimizer/GlobalRegisterAllocator.cpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.cpp
@@ -3515,9 +3515,10 @@ void TR_GlobalRegisterAllocator::offerAllAutosAndRegisterParmAsCandidates(TR::Bl
          int32_t symRefNumber = symRef->getReferenceNumber();
          if (rc)
             {
-            for (auto itr = rc->_blocks.begin(), end = rc->_blocks.end(); itr != end; ++itr)
+            TR_RegisterCandidate::BlockInfo::iterator itr = rc->_blocks.getIterator();
+            while (itr.hasMoreElements())
                {
-               int32_t block_num = itr->first;
+               int32_t block_num = itr.getNextElement();
                TR_ASSERT(block_num < numberOfNodes, "Overflow on candidate BB numbers");
                block = cfgBlocks[block_num];
                if (!block) continue;
@@ -3641,9 +3642,10 @@ void TR_GlobalRegisterAllocator::offerAllAutosAndRegisterParmAsCandidates(TR::Bl
                // If it is new then set the count to zero or one based on use in the block
                if (rc)
                   {
-                  for (auto itr = rc->_blocks.begin(), end = rc->_blocks.end(); itr != end; ++itr)
+                  TR_RegisterCandidate::BlockInfo::iterator itr = rc->_blocks.getIterator();
+                  while (itr.hasMoreElements())
                      {
-                     int32_t block_num = itr->first;
+                     int32_t block_num = itr.getNextElement();
                      TR_ASSERT(block_num < numberOfNodes, "Overflow on candidate BB numbers");
                      block = cfgBlocks[block_num];
                      if (!block) continue;
@@ -3787,10 +3789,11 @@ void TR_GlobalRegisterAllocator::offerAllFPAutosAndParmsAsCandidates(TR::Block *
                  (sym->isParm() && methodSymbol->getParameterList().find(sym->castToParmSymbol()) && sym->isReferencedParameter())))
                {
                TR_RegisterCandidate *rc = comp()->getGlobalRegisterCandidates()->findOrCreate(symRef);
-               
-               for (auto itr = rc->_blocks.begin(), end = rc->_blocks.end(); itr != end; ++itr)
+              
+               TR_RegisterCandidate::BlockInfo::iterator itr = rc->_blocks.getIterator(); 
+               while (itr.hasMoreElements())
                   {
-                  int32_t block_num = itr->first;
+                  int32_t block_num = itr.getNextElement();
                   TR_ASSERT(block_num < numberOfNodes, "Overflow on candidate BB numbers");
       block = cfgBlocks[block_num];
                   if (!block) continue;

--- a/compiler/optimizer/GlobalRegisterAllocator.hpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.hpp
@@ -96,12 +96,16 @@ class TR_LiveRangeSplitter : public TR::Optimization
 
    virtual int32_t perform();
 
+   typedef TR::typed_allocator<std::pair<uint32_t, TR_RegisterCandidate*>, TR::Region&> SymRefCandidateMapAllocator;
+   typedef std::less<uint32_t> SymRefCandidateMapComparator;
+   typedef std::map<uint32_t, TR_RegisterCandidate*, SymRefCandidateMapComparator, SymRefCandidateMapAllocator> SymRefCandidateMap;
+
    void splitLiveRanges();
    void splitLiveRanges(TR_StructureSubGraphNode *structureNode);
-   void replaceAutosUsedIn(TR::TreeTop *currentTree, TR::Node *node, TR::Node *parent, TR::Block * block, List<TR::Block> *blocksInLoop, List<TR::Block> *exitBlocks, vcount_t visitCount, int32_t executionFrequency, TR_RegisterCandidate **registerCandidates, TR_SymRefCandidatePair **correspondingSymRefs, TR_BitVector *replacedAutosInCurrentLoop, TR_BitVector *autosThatCannotBereplacedInCurrentLoop, TR_StructureSubGraphNode *loop, TR::Block *loopInvariantBlock);
+   void replaceAutosUsedIn(TR::TreeTop *currentTree, TR::Node *node, TR::Node *parent, TR::Block * block, List<TR::Block> *blocksInLoop, List<TR::Block> *exitBlocks, vcount_t visitCount, int32_t executionFrequency, SymRefCandidateMap &registerCandidates, TR_SymRefCandidatePair **correspondingSymRefs, TR_BitVector *replacedAutosInCurrentLoop, TR_BitVector *autosThatCannotBereplacedInCurrentLoop, TR_StructureSubGraphNode *loop, TR::Block *loopInvariantBlock);
    void placeStoresInLoopExits(TR::Node *node, TR_StructureSubGraphNode *loop, List<TR::Block> *blocksInLoop, TR::SymbolReference *orig, TR::SymbolReference *replacement);
    TR_SymRefCandidatePair *splitAndFixPreHeader(TR::SymbolReference *symRef, TR_SymRefCandidatePair **correspondingSymRefs, TR::Block *loopInvariantBlock, TR::Node *node);
-   void fixExitsAfterSplit(TR::SymbolReference *symRef, TR_SymRefCandidatePair *correspondingSymRefCandidate, TR_SymRefCandidatePair **correspondingSymRefs, TR::Block *loopInvariantBlock, List<TR::Block> *blocksInLoop, TR::Node *node, TR_RegisterCandidate **registerCandidates, TR_StructureSubGraphNode *loop, TR_BitVector *replacedAutosInCurrentLoop, TR::SymbolReference *origSymRef);
+   void fixExitsAfterSplit(TR::SymbolReference *symRef, TR_SymRefCandidatePair *correspondingSymRefCandidate, TR_SymRefCandidatePair **correspondingSymRefs, TR::Block *loopInvariantBlock, List<TR::Block> *blocksInLoop, TR::Node *node, SymRefCandidateMap &registerCandidates, TR_StructureSubGraphNode *loop, TR_BitVector *replacedAutosInCurrentLoop, TR::SymbolReference *origSymRef);
    void appendStoreToBlock(TR::SymbolReference *storeSymRef, TR::SymbolReference *loadSymRef, TR::Block *block, TR::Node *node);
    void prependStoreToBlock(TR::SymbolReference *storeSymRef, TR::SymbolReference *loadSymRef, TR::Block *block, TR::Node *node);
 
@@ -168,13 +172,16 @@ public:
    TR::Node *           resolveTypeMismatch(TR::DataType inputOldType, TR::Node *oldNode, TR::Node *newNode);
 
 private:
+   typedef TR::typed_allocator<std::pair<uint32_t, TR_RegisterCandidate*>, TR::Region&> SymRefCandidateMapAllocator;
+   typedef std::less<uint32_t> SymRefCandidateMapComparator;
+   typedef std::map<uint32_t, TR_RegisterCandidate*, SymRefCandidateMapComparator, SymRefCandidateMapAllocator> SymRefCandidateMap;
 
    void                findIfThenRegisterCandidates();
    void                findLoopAutoRegisterCandidates();
-   void                findLoopsAndCorrespondingAutos(TR_StructureSubGraphNode *, vcount_t, TR_RegisterCandidate **);
+   void                findLoopsAndCorrespondingAutos(TR_StructureSubGraphNode *, vcount_t, SymRefCandidateMap &);
    void                findLoopsAndAutosNoStructureInfo(vcount_t visitCount, TR_RegisterCandidate **registerCandidates);
    void                initializeControlFlowInfo();
-   void                markAutosUsedIn(TR::Node *, TR::Node *, TR::Node *, TR::Node **, TR::Block *, List<TR::Block> *, vcount_t, int32_t, TR_RegisterCandidate **, TR_BitVector *, TR_BitVector *, bool);
+   void                markAutosUsedIn(TR::Node *, TR::Node *, TR::Node *, TR::Node **, TR::Block *, List<TR::Block> *, vcount_t, int32_t, SymRefCandidateMap &, TR_BitVector *, TR_BitVector *, bool);
    void                signExtendAllDefNodes(TR::Node *, List<TR::Node> *);
    void                findSymsUsedInIndirectAccesses(TR::Node *, TR_BitVector *, TR_BitVector *, bool);
 
@@ -243,9 +250,6 @@ private:
 
    void populateSymRefNodes(TR::Node *node, vcount_t visitCount);
 
-   typedef TR::typed_allocator<std::pair<uint32_t, TR_RegisterCandidate*>, TR::Region&> SymRefCandidateMapAllocator;
-   typedef std::less<uint32_t> SymRefCandidateMapComparator;
-   typedef std::map<uint32_t, TR_RegisterCandidate*, SymRefCandidateMapComparator, SymRefCandidateMapAllocator> SymRefCandidateMap;
    /*
    void splitLiveRanges();
    void splitLiveRanges(TR_StructureSubGraphNode *structureNode, vcount_t visitCount, TR_RegisterCandidate **registerCandidates);

--- a/compiler/optimizer/GlobalRegisterAllocator.hpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.hpp
@@ -243,6 +243,9 @@ private:
 
    void populateSymRefNodes(TR::Node *node, vcount_t visitCount);
 
+   typedef TR::typed_allocator<std::pair<uint32_t, TR_RegisterCandidate*>, TR::Region&> SymRefCandidateMapAllocator;
+   typedef std::less<uint32_t> SymRefCandidateMapComparator;
+   typedef std::map<uint32_t, TR_RegisterCandidate*, SymRefCandidateMapComparator, SymRefCandidateMapAllocator> SymRefCandidateMap;
    /*
    void splitLiveRanges();
    void splitLiveRanges(TR_StructureSubGraphNode *structureNode, vcount_t visitCount, TR_RegisterCandidate **registerCandidates);
@@ -256,7 +259,7 @@ private:
    int32_t      _lastGlobalRegisterNumber;
    bool         _gotoCreated;
    TR::Block    *_appendBlock;
-   TR_RegisterCandidate **_registerCandidates;
+   SymRefCandidateMap *_registerCandidates;
    TR_ScratchList<TR::Block> _newBlocks;
    TR_BitVector *_temp, *_temp2;
    TR_BitVector *_candidatesNeedingSignExtension;

--- a/compiler/optimizer/InductionVariable.hpp
+++ b/compiler/optimizer/InductionVariable.hpp
@@ -300,14 +300,24 @@ class TR_LoopStrider : public TR_LoopTransformer
 
    int64_t **_linearEquations;
    TR::Node **_loadUsedInNewLoopIncrement;
-   TR::SymbolReference **_reassociatedAutos;
+
+   typedef TR::typed_allocator<std::pair<uint32_t, TR::SymbolReference*>, TR::Region&> SymRefMapAllocator;
+   typedef std::less<uint32_t> SymRefMapComparator;
+   typedef std::map<uint32_t, TR::SymbolReference*, SymRefMapComparator, SymRefMapAllocator> SymRefMap;
+   SymRefMap *_reassociatedAutos;
+
    List<TR::Node> _reassociatedNodes;
 
    List<TR_StoreTreeInfo> **_storeTreesList;
    //List<TR::Node> **_loadUsedInNewLoopIncrementList;
 
    int32_t _numSymRefs;
-   SymRefPair **_hoistedAutos;
+
+   typedef TR::typed_allocator<std::pair<uint32_t, SymRefPair*>, TR::Region&> SymRefPairMapAllocator;
+   typedef std::less<uint32_t> SymRefPairMapComparator;
+   typedef std::map<uint32_t, SymRefPair*, SymRefPairMapComparator, SymRefPairMapAllocator> SymRefPairMap;
+   SymRefPairMap *_hoistedAutos;
+
    SymRefPair *_parmAutoPairs;
    int32_t _count;
    int32_t _numberOfLinearExprs, _numInternalPointers;

--- a/compiler/optimizer/InductionVariable.hpp
+++ b/compiler/optimizer/InductionVariable.hpp
@@ -308,7 +308,11 @@ class TR_LoopStrider : public TR_LoopTransformer
 
    List<TR::Node> _reassociatedNodes;
 
-   List<TR_StoreTreeInfo> **_storeTreesList;
+   typedef TR::typed_allocator<std::pair<uint32_t, List<TR_StoreTreeInfo> *>, TR::Region&> StoreTreeMapAllocator;
+   typedef std::less<uint32_t> StoreTreeMapComparator;
+   typedef std::map<uint32_t, List<TR_StoreTreeInfo>*, StoreTreeMapComparator, StoreTreeMapAllocator> StoreTreeMap;
+   StoreTreeMap  _storeTreesSingleton;
+   StoreTreeMap *_storeTreesList;
    //List<TR::Node> **_loadUsedInNewLoopIncrementList;
 
    int32_t _numSymRefs;

--- a/compiler/optimizer/OMRLocalCSE.cpp
+++ b/compiler/optimizer/OMRLocalCSE.cpp
@@ -365,7 +365,7 @@ void OMR::LocalCSE::transformBlock(TR::TreeTop * entryTree, TR::TreeTop * exitTr
       bool nodeCanBeAvailable = true;
       examineNode(currentNode, seenAvailableLoadedSymbolReferences, NULL, -1, &nextNodeIndex, &nodeCanBeAvailable, 0);
       }
-
+   comp()->invalidateAliasRegion();
    }
 
 #ifdef J9_PROJECT_SPECIFIC

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -2050,6 +2050,10 @@ int32_t OMR::Optimizer::performOptimization(const OptimizationStrategy *optimiza
          }
 
       delete opt;
+      // we cannot easily invalidate during IL gen since we could be peeking and we cannot destroy our
+      // caller's alias sets
+      if (!isIlGenOpt())
+         comp()->invalidateAliasRegion();
       breakForTesting(-optNum);
       comp()->setAllocatorName(NULL);
 

--- a/compiler/optimizer/OMROptimizer.hpp
+++ b/compiler/optimizer/OMROptimizer.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * (c) Copyright IBM Corp. 2000, 2016
+ * (c) Copyright IBM Corp. 2000, 2017
  *
  *  This program and the accompanying materials are made available
  *  under the terms of the Eclipse Public License v1.0 and
@@ -296,7 +296,6 @@ class Optimizer
       } AnalysisPhases;
 
    protected:
-
    TR::OptimizationManager *      _opts[OMR::numGroups];
 
    private:

--- a/compiler/optimizer/RegisterCandidate.cpp
+++ b/compiler/optimizer/RegisterCandidate.cpp
@@ -83,12 +83,12 @@
 
 TR::GlobalSet::GlobalSet(TR::Compilation * comp, TR::Region &region)
    :_refAutosPerBlock((RefMapComparator()),(RefMapAllocator(region))),
-    _comp(comp),_maxEntries(0)
+    _comp(comp)
    {
    }
 
 
-void TR::GlobalSet::DenseSet::print(TR::Compilation * comp)
+void TR::GlobalSet::Set::print(TR::Compilation * comp)
    {
    TR_BitVectorIterator bits(_refs);
    for (int32_t bit = bits.getFirstElement(); bits.hasMoreElements(); bit = bits.getNextElement())
@@ -96,31 +96,15 @@ void TR::GlobalSet::DenseSet::print(TR::Compilation * comp)
      traceMsg(comp,"%d ",bit);
      }
    traceMsg(comp,"\n");
-   }
-
-void TR::GlobalSet::SparseSet::print(TR::Compilation * comp)
-   {
-   TR_BitVectorIterator bits(_refs);
-   for (int32_t bit = bits.getFirstElement(); bits.hasMoreElements(); bit = bits.getNextElement())
-     {
-     traceMsg(comp,"%d ",bit);
-     }
-   traceMsg(comp,"\n");
-
    }
 
 void TR::GlobalSet::collectReferencedAutoSymRefs(TR::Block * BB)
    {
-   TR_ASSERT(_maxEntries > 0, " Entries unknown\n");
    if (!(BB->getEntry() && BB->getExit()))
         return;
 
    Set * refAutos = NULL;
-   TR::Allocator alloc = _comp->allocator();
-   if (_maxEntries > MB50)
-     refAutos  = new (_comp->trStackMemory()) SparseSet(_comp->trMemory()->currentStackRegion());
-   else
-     refAutos  = new (_comp->trStackMemory()) DenseSet(_comp->trMemory()->currentStackRegion());
+   refAutos  = new (_comp->trStackMemory()) Set(_comp->trMemory()->currentStackRegion());
 
    _refAutosPerBlock[BB->getNumber()] = refAutos;
 

--- a/compiler/optimizer/RegisterCandidate.cpp
+++ b/compiler/optimizer/RegisterCandidate.cpp
@@ -194,7 +194,7 @@ void TR_RegisterCandidate::addAllBlocksInStructure(TR_Structure *structure, TR::
       TR_BlockStructure *blockStructure = structure->asBlock();
       TR::Block *block = blockStructure->getBlock();
 
-      addBlock(block, 0, comp->trMemory());
+      addBlock(block, 0);
 
       if (description)
          traceMsg(comp, "\nAdded %s #%d (symRef %p) as global reg candidate in block_%d\n", description, getSymbolReference()->getReferenceNumber(), getSymbolReference(), block->getNumber());
@@ -298,14 +298,9 @@ TR_RegisterCandidate::find(TR::Block * b)
    }
 
 void
-TR_RegisterCandidate::addBlock(TR::Block * block, int32_t numberOfLoadsAndStores, TR_Memory * m,
-                               bool ifNotFound)
+TR_RegisterCandidate::addBlock(TR::Block * block, int32_t numberOfLoadsAndStores)
    {
-     if (find(block)) {
-       if (!ifNotFound)
-         _blocks.incNumberOfLoadsAndStores(block->getNumber(), numberOfLoadsAndStores);
-     } else
-         _blocks.setNumberOfLoadsAndStores(block->getNumber(), numberOfLoadsAndStores);
+   _blocks.incNumberOfLoadsAndStores(block->getNumber(), numberOfLoadsAndStores);
    }
 
 int32_t
@@ -313,9 +308,9 @@ TR_RegisterCandidate::removeBlock(TR::Block * block)
    {
    if (find(block))
       {
-        int32_t numLoadsAndStores = _blocks.getNumberOfLoadsAndStores(block->getNumber());
-        _blocks.removeBlock(block->getNumber());
-        return numLoadsAndStores;
+      int32_t numLoadsAndStores = _blocks.getNumberOfLoadsAndStores(block->getNumber());
+      _blocks.removeBlock(block->getNumber());
+      return numLoadsAndStores;
       }
    return 0;
    }

--- a/compiler/optimizer/RegisterCandidate.cpp
+++ b/compiler/optimizer/RegisterCandidate.cpp
@@ -88,22 +88,12 @@ TR::GlobalSet::GlobalSet(TR::Compilation * comp, TR::Region &region)
    }
 
 
-void TR::GlobalSet::Set::print(TR::Compilation * comp)
-   {
-   TR_BitVectorIterator bits(_refs);
-   for (int32_t bit = bits.getFirstElement(); bits.hasMoreElements(); bit = bits.getNextElement())
-     {
-     traceMsg(comp,"%d ",bit);
-     }
-   traceMsg(comp,"\n");
-   }
-
 void TR::GlobalSet::collectReferencedAutoSymRefs(TR::Block * BB)
    {
    if (!(BB->getEntry() && BB->getExit()))
         return;
 
-   Set * refAutos = new (_comp->trStackMemory()) Set(_comp->trMemory()->currentStackRegion());
+   TR_BitVector * refAutos = new (_comp->trStackMemory()) TR_BitVector(_comp->trMemory()->currentStackRegion());
 
    _refAutosPerBlock[BB->getNumber()] = refAutos;
 
@@ -112,7 +102,7 @@ void TR::GlobalSet::collectReferencedAutoSymRefs(TR::Block * BB)
      collectReferencedAutoSymRefs(tt->getNode(), refAutos, visitCount);
    }
 
-void TR::GlobalSet::collectReferencedAutoSymRefs(TR::Node * node, Set * referencedAutoSymRefs, vcount_t visitCount)
+void TR::GlobalSet::collectReferencedAutoSymRefs(TR::Node * node, TR_BitVector * referencedAutoSymRefs, vcount_t visitCount)
    {
    if (node->getVisitCount() == visitCount)
       return;
@@ -1704,7 +1694,7 @@ TR_RegisterCandidate::extendLiveRangesForLiveOnExit(TR::Compilation *comp, TR::B
                {
                blocksVisited.set(currBlock->getNumber());
 
-               TR::GlobalSet::Set *autosInBlock = comp->getGlobalRegisterCandidates()->getReferencedAutoSymRefsInBlock(currBlock->getNumber());
+               TR_BitVector *autosInBlock = comp->getGlobalRegisterCandidates()->getReferencedAutoSymRefsInBlock(currBlock->getNumber());
                if (autosInBlock &&
                   autosInBlock->get(getSymbolReference()->getReferenceNumber()))
                   getAvailableOnExit()->set(currBlock->getNumber());
@@ -3147,7 +3137,7 @@ TR_RegisterCandidates::assign(TR::Block ** cfgBlocks, int32_t numberOfBlocks, in
                     TR::Block * block = blocks[blockNumber];
                     TR_BlockStructure *blockStructure = block->getStructureOf();
                     int32_t blockWeight = 1;
-                    TR::GlobalSet::Set *autosInBlock = getReferencedAutoSymRefsInBlock(block->getNumber());
+                    TR_BitVector *autosInBlock = getReferencedAutoSymRefsInBlock(block->getNumber());
 
                     if (blockStructure)
                        {

--- a/compiler/optimizer/RegisterCandidate.cpp
+++ b/compiler/optimizer/RegisterCandidate.cpp
@@ -566,9 +566,10 @@ TR_RegisterCandidate::setWeight(TR::Block * * blocks, int32_t *blockStructureWei
    _loadsAndStores = new (comp->trStackMemory()) TR_Array<uint32_t>(comp->trMemory(), numberOfBlocks, true, stackAlloc);
 
    TR::CodeGenerator * cg = comp->cg();
-   for (auto itr = _blocks.begin(), end = _blocks.end(); itr != end; ++itr)
+   BlockInfo::iterator itr = _blocks.getIterator();
+   while (itr.hasMoreElements())
       {
-      int32_t blockNumber = itr->first;
+      int32_t blockNumber = itr.getNextElement();
       TR_ASSERT(blockNumber < cfg->getNextNodeNumber(), "Overflow on candidate BB numbers");
       TR::Block * b = blocks[blockNumber];
       if (!b) continue;
@@ -577,7 +578,7 @@ TR_RegisterCandidate::setWeight(TR::Block * * blocks, int32_t *blockStructureWei
       bool hasLoadNearStart = !isExtensionOfPreviousBlock.isSet(blockNumber) && findLoadNearStartOfBlock(b, getSymbolReference());
       TR_ASSERT((blockNumber < cfg->getNextNodeNumber()) && (blocks[blockNumber] == b),"blockNumber is wrong");
       
-      int32_t blockWeight = itr->second;
+      int32_t blockWeight = _blocks.getNumberOfLoadsAndStores(blockNumber);
       bool firstBlock = firstBlocks.isSet(blockNumber);
       if ((firstBlock && isAllBlocks() && cg->getSupportsGlRegDepOnFirstBlock()) ||
            (!firstBlock && (symbolIsLive(b) || (hasLoopExitBlock(b) && (blockWeight==0)))))

--- a/compiler/optimizer/RegisterCandidate.hpp
+++ b/compiler/optimizer/RegisterCandidate.hpp
@@ -373,8 +373,12 @@ private:
 
    static int32_t                    _candidateTypeWeights[TR_NumRegisterCandidateTypes];
    TR::GlobalSet            *_referencedAutoSymRefsInBlock;
-   TR_RegisterCandidate **  _candidateForSymRefs;
-   uint32_t                 _candidateForSymRefsSize;
+
+   typedef TR::typed_allocator<std::pair<uint32_t, TR_RegisterCandidate*>, TR::Region&> SymRefCandidateMapAllocator;
+   typedef std::less<uint32_t> SymRefCandidateMapComparator;
+   typedef std::map<uint32_t, TR_RegisterCandidate*, SymRefCandidateMapComparator, SymRefCandidateMapAllocator> SymRefCandidateMap;
+
+   SymRefCandidateMap    *  _candidateForSymRefs;
    TR_Array<TR::Block *> _startOfExtendedBBForBB;
 
    // scratch arrays for calculating register conflicts

--- a/compiler/optimizer/RegisterCandidate.hpp
+++ b/compiler/optimizer/RegisterCandidate.hpp
@@ -50,8 +50,7 @@ class GlobalSet
 public:
    GlobalSet(TR::Compilation * comp, TR::Region &region);
 
-   class Set;
-   Set * operator[](uint32_t blockNum)
+   TR_BitVector * operator[](uint32_t blockNum)
       {
       if (blockNum == TR::CFG::StartBlock || blockNum == TR::CFG::EndBlock)
          return NULL;
@@ -63,25 +62,13 @@ public:
    bool isEmpty() { return _refAutosPerBlock.empty(); }
    void makeEmpty() { _refAutosPerBlock.clear(); }
 
-   class Set
-      {
-      public:
-      TR_ALLOC(TR_Memory::RegisterCandidates);
-      Set(TR::Region &region):_refs(region){}
-      bool get(uint32_t refId) { return _refs.get(refId); }
-      void set(uint32_t refId) { _refs.set(refId); }
-      void print(TR::Compilation * comp);
-      private:
-      TR_BitVector _refs;
-      };
-
 private:
 
-   void collectReferencedAutoSymRefs(TR::Node * node, Set * referencedAutos, vcount_t visitCount);
+   void collectReferencedAutoSymRefs(TR::Node * node, TR_BitVector * referencedAutos, vcount_t visitCount);
 
-   typedef TR::typed_allocator<std::pair<uint32_t, Set*>, TR::Region&> RefMapAllocator;
+   typedef TR::typed_allocator<std::pair<uint32_t, TR_BitVector*>, TR::Region&> RefMapAllocator;
    typedef std::less<uint32_t> RefMapComparator;
-   typedef std::map<uint32_t, Set *, RefMapComparator, RefMapAllocator> RefMap;
+   typedef std::map<uint32_t, TR_BitVector*, RefMapComparator, RefMapAllocator> RefMap;
    RefMap _refAutosPerBlock;
    TR::Compilation * _comp;
    };
@@ -312,7 +299,7 @@ public:
    TR_RegisterCandidate * find(TR::Symbol * sym);
 
    TR::GlobalSet&      getReferencedAutoSymRefs() { return _referencedAutoSymRefsInBlock; }
-   TR::GlobalSet::Set *getReferencedAutoSymRefsInBlock(int32_t i)
+   TR_BitVector *getReferencedAutoSymRefsInBlock(int32_t i)
       {
       if (_referencedAutoSymRefsInBlock.isEmpty())
          return 0;

--- a/compiler/optimizer/RegisterCandidate.hpp
+++ b/compiler/optimizer/RegisterCandidate.hpp
@@ -132,7 +132,7 @@ public:
 
    void addAllBlocks()         { setAllBlocks(true); }
 
-   void addBlock(TR::Block * b, int32_t numberOfLoadsAndStores, TR_Memory *, bool ifNotFound = false);
+   void addBlock(TR::Block * b, int32_t numberOfLoadsAndStores);
 
    void addLoopExitBlock(TR::Block *b);
    int32_t removeBlock(TR::Block * b);

--- a/compiler/optimizer/RegisterCandidate.hpp
+++ b/compiler/optimizer/RegisterCandidate.hpp
@@ -268,7 +268,6 @@ private:
    TR_BitVector            _liveOnExit;
    TR_BitVector            _originalLiveOnEntry;
    TR_BitVector           *_availableOnExit;
-   TR_Array<uint32_t> *    _loadsAndStores;
    List<TR::TreeTop>        _stores;
    List<TR_Structure>      _loopsWithHoles;
    TR::Node                *_mostRecentValue;

--- a/compiler/optimizer/RegisterCandidate.hpp
+++ b/compiler/optimizer/RegisterCandidate.hpp
@@ -179,7 +179,6 @@ public:
 
    TR_BitVector &          getBlocksLiveOnEntry()     { return _liveOnEntry; }
    TR_BitVector &          getBlocksLiveOnExit()      { return _liveOnExit; }
-   TR_BitVector &          getBlocksLiveWithinGenSetsOnly() { return _liveWithinGenSetsOnly; }
    TR::Symbol *            getSymbol();
 
    TR::DataType           getDataType();
@@ -222,10 +221,8 @@ public:
    void extendLiveRangesForLiveOnExit(TR::Compilation *, TR::Block **, TR_Array<TR::Block *>& startOfExtendedBBForBB);
 
    TR_BitVector *          getAvailableOnExit()     { return _availableOnExit; }
-   TR_BitVector *          getBlocksVisited()       { return _blocksVisited; }
 
    void          setAvailableOnExit(TR_BitVector *b)     { _availableOnExit = b; }
-   void          setBlocksVisited(TR_BitVector *b)       { _blocksVisited = b; }
 
    void recalculateWeight(TR::Block * *, int32_t *, TR::Compilation *,
                           TR_Array<int32_t>&,TR_Array<int32_t>&,TR_Array<int32_t>&,TR_BitVector *, TR_Array<TR::Block *>& startOfExtendedBB);
@@ -269,9 +266,7 @@ private:
    TR_BitVector            _liveOnEntry;
    TR_BitVector            _liveOnExit;
    TR_BitVector            _originalLiveOnEntry;
-   TR_BitVector            _liveWithinGenSetsOnly;
    TR_BitVector           *_availableOnExit;
-   TR_BitVector           *_blocksVisited;
    TR_Array<uint32_t> *    _loadsAndStores;
    List<TR::TreeTop>        _stores;
    List<TR_Structure>      _loopsWithHoles;

--- a/compiler/optimizer/RegisterCandidate.hpp
+++ b/compiler/optimizer/RegisterCandidate.hpp
@@ -51,60 +51,30 @@ public:
 
    class Set;
    Set * operator[](uint32_t blockNum)
-   {
-    if(blockNum == TR::CFG::StartBlock || blockNum == TR::CFG::EndBlock)
-        return NULL;
+      {
+      if (blockNum == TR::CFG::StartBlock || blockNum == TR::CFG::EndBlock)
+         return NULL;
     
-    return _refAutosPerBlock[blockNum];
-   }
+      return _refAutosPerBlock[blockNum];
+      }
 
    void collectReferencedAutoSymRefs(TR::Block * BB);
    bool isEmpty() { return _refAutosPerBlock.empty(); }
    void makeEmpty() { _refAutosPerBlock.clear(); }
-   void initialize(uint32_t numSymRefs, int32_t numBlocks) {_maxEntries = numSymRefs * numBlocks;}
 
-   //Set, SparseSet and DenseSet
    class Set
       {
-   public:
-      virtual bool get(uint32_t refNum)            = 0;
-      virtual void set(uint32_t symRefNum)         = 0;
-      virtual void print(TR::Compilation* comp)    = 0;
-   };
+      public:
+      TR_ALLOC(TR_Memory::RegisterCandidates);
+      Set(TR::Region &region):_refs(region){}
+      bool get(uint32_t refId) { return _refs.get(refId); }
+      void set(uint32_t refId) { _refs.set(refId); }
+      void print(TR::Compilation * comp);
+      private:
+      TR_BitVector _refs;
+      };
 
 private:
-
-   class SparseSet: public Set
-   {
-   public:
-   TR_ALLOC(TR_Memory::RegisterCandidates);
-   SparseSet(TR::Region &region):_refs(region){}
-   virtual bool get(uint32_t refId) {return _refs.get(refId); }
-   virtual void set(uint32_t refId) {_refs.set(refId);     }
-   virtual void print(TR::Compilation * comp);
-   private:
-   TR_BitVector _refs;
-   };
-
-   class DenseSet: public Set
-   {
-   public:
-   TR_ALLOC(TR_Memory::RegisterCandidates);
-   DenseSet(TR::Region &region):_refs(region){}
-   virtual bool get(uint32_t refId) {return _refs.get(refId); }
-   virtual void set(uint32_t refId) {_refs.set(refId); }
-   virtual void print(TR::Compilation * comp);
-   private:
-   TR_BitVector _refs;
-   };
-
-
-
-   enum
-   {
-     MB50     = 0x19000000,
-     MB100    = 0x32000000
-   };
 
    void collectReferencedAutoSymRefs(TR::Node * node, Set * referencedAutos, vcount_t visitCount);
 
@@ -113,7 +83,6 @@ private:
    typedef std::map<uint32_t, Set *, RefMapComparator, RefMapAllocator> RefMap;
    RefMap _refAutosPerBlock;
    TR::Compilation * _comp;
-   uint32_t _maxEntries;
    };
 
 }

--- a/compiler/optimizer/Structure.cpp
+++ b/compiler/optimizer/Structure.cpp
@@ -354,7 +354,7 @@ void TR_RegionStructure::addGlobalRegisterCandidateToExits(TR_RegisterCandidate 
       if (nextBlock->getStructureOf())
          {
          nextBlock->getStructureOf()->calculateFrequencyOfExecution(&blockWeight);
-         inductionCandidate->addBlock(nextBlock, blockWeight, trMemory());
+         inductionCandidate->addBlock(nextBlock, blockWeight);
          }
       }
    }


### PR DESCRIPTION
Currently the loop strider allocates large amounts memory during it recursive analysis routines and this memory leaks during the analysis. This memory leaks until the optimization has finished running which has caused some massive growth in memory consumption. Further, some data structures are pre-sized to the number of symbol references when the actual number of live entries is very small. To reduce this wasted space, several key data structures are transformed from arrays to maps keyed by symref index.

This commit is based on top of Mem 9, 10, 11, 12 and 13 and so should be merged after these other changes. The delta in this commit is 2 commits beyond those in Mem 13.