### PR TITLE
Ignore OSR exit edges for induction variables

### DIFF
--- a/compiler/optimizer/InductionVariable.cpp
+++ b/compiler/optimizer/InductionVariable.cpp
@@ -5459,7 +5459,12 @@ static inline int64_t ceiling(int64_t numer, int64_t denom)
    }
 
 TR_InductionVariableAnalysis::TR_InductionVariableAnalysis(TR::OptimizationManager *manager)
-   : TR::Optimization(manager), _ivs(0), _blockInfo(0), _dominators(NULL)
+   : TR::Optimization(manager),
+     _ivs(0),
+     _blockInfo(0),
+     _dominators(NULL),
+     _seenInnerRegionExit(0, trMemory(), stackAlloc, growable),
+     _isOSRInduceBlock(0, trMemory(), stackAlloc, growable)
    {}
 
 int32_t TR_InductionVariableAnalysis::perform()
@@ -6382,6 +6387,46 @@ TR_InductionVariableAnalysis::analyzeExitEdges(TR_RegionStructure *loop,
 
       if (subNode->getStructure()->asRegion())
          {
+         // OSR blocks can be ignored here as they will not be impacted by a loop controlling
+         // condition.
+         //
+         // Exit edges do not have structure for their destination, rather they only specify
+         // the block number. As all OSRInduceBlocks have an edge to the exit, even though
+         // they end in a throw, it is possible to search for a block with a matching number.
+         // This is potentially expensive, so it is memoized with two bit vectors, _seenInnerRegionExit
+         // and _isOSRInduceBlock.
+         //
+         bool osrInduceExitEdge = false;
+         int32_t toNum = edge->getTo()->getNumber();
+         if (!_seenInnerRegionExit.get(toNum))
+            {
+            TR::Block *dest = NULL;
+            TR::CFGNode *end = comp()->getFlowGraph()->getEnd();
+            for (auto predEdge = end->getPredecessors().begin(); predEdge != end->getPredecessors().end(); ++predEdge)
+               {
+               if ((*predEdge)->getFrom()->getNumber() == toNum)
+                  {
+                  dest = (*predEdge)->getFrom()->asBlock();
+                  break;
+                  }
+               }
+
+            _seenInnerRegionExit.set(toNum);
+            if (dest && dest->isOSRInduceBlock())
+               {
+               _isOSRInduceBlock.set(toNum);
+               osrInduceExitEdge = true;
+               }
+            }
+         else
+            osrInduceExitEdge = _isOSRInduceBlock.get(toNum);
+
+         if (osrInduceExitEdge)
+            {
+            if (trace()) traceMsg(comp(), "\tbranch from inner region is to OSR block, ignoring\n");
+            continue;
+            }
+
          if (trace()) traceMsg(comp(), "\tReject - exit edge from inner region\n");
          return false;
          }

--- a/compiler/optimizer/InductionVariable.hpp
+++ b/compiler/optimizer/InductionVariable.hpp
@@ -548,6 +548,10 @@ class TR_InductionVariableAnalysis : public TR::Optimization
    DeltaInfo ***_blockInfo;
    TR_Array<TR_BasicInductionVariable*> *_ivs;
    TR_Dominators *_dominators;
+
+   // BitVectors to memoize a check in analyzeExitEdges
+   TR_BitVector _seenInnerRegionExit;
+   TR_BitVector _isOSRInduceBlock;
    };
 
 /*


### PR DESCRIPTION
Exit edges to OSR blocks can be ignored under
induction variable analysis as they do not
depend on the induction variable and will
not modify it. They are mostly ignored already
unless the exit edge is from an inner region.