### PR TITLE
Partial GC initialization for Concurrent Scavenger

### DIFF
--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -4798,6 +4798,14 @@ MM_Scavenger::completeConcurrentCycle(MM_EnvironmentBase *env)
 	}
 }
 
+void
+MM_Scavenger::preMasterGCThreadInitialize(MM_EnvironmentBase *env)
+{
+	if (0 == _extensions->concurrentScavengerBackgroundThreads) {
+		_extensions->concurrentScavengerBackgroundThreads = OMR_MAX(1, _extensions->dispatcher->threadCount() / 2);
+	}
+}
+
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
 #endif /* OMR_GC_MODRON_SCAVENGER */

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -502,6 +502,14 @@ protected:
 	 * @param env Master GC thread.
 	 */
 	virtual void processLargeAllocateStatsAfterGC(MM_EnvironmentBase *env);
+
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	/**
+	 * Perform partial initialization if Garbage Collection is called earlier then GC Master Thread is activated
+	 * @param env Master GC thread.
+	 */
+	virtual void preMasterGCThreadInitialize(MM_EnvironmentBase *env);
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
 	
 public:
 


### PR DESCRIPTION
Concurrent Scavenger might be called earlier then GC Master Thread
initialization is complete. So pre-initialization required.
Add preMasterGCThreadInitialize() implementation to the Scavenger.

Signed-off-by: dmitripivkine <Dmitri_Pivkine@ca.ibm.com>