### PR TITLE
CMake: Compile omrthreadjlm.c

### DIFF
--- a/thread/CMakeLists.txt
+++ b/thread/CMakeLists.txt
@@ -42,10 +42,9 @@ list(APPEND OBJECTS
 	rwmutex.c
 )
 
-#TODO need to port this makefile snippet
-#ifeq (1,$(OMR_THR_JLM))
-  #OBJECTS += omrthreadjlm
-#endif
+if(OMR_THR_JLM)
+	list(APPEND OBJECTS omrthreadjlm.c)
+endif(OMR_THR_JLM)
 
 if(NOT OMR_HOST_OS STREQUAL "win")
 	list(APPEND OBJECTS unixpriority.c)


### PR DESCRIPTION
IF OMR_THR_JLM is enabled, compile omrthreadjlm.c as part of
thread library

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>