### PR TITLE
Enable the tree verifier and replace a test case

### DIFF
--- a/fvtest/compilertest/control/TestJit.cpp
+++ b/fvtest/compilertest/control/TestJit.cpp
@@ -137,6 +137,12 @@ extern "C"
 bool
 initializeTestJit(TR_RuntimeHelper *helperIDs, void **helperAddresses, int32_t numHelpers, char *options)
    {
+    // Force enable tree verifier
+    std::string optionsWithVerifier = options;
+    if(optionsWithVerifier == "-Xjit")
+        optionsWithVerifier += ":paranoidOptCheck";
+    else
+        optionsWithVerifier += ",paranoidOptCheck";
 
    // Create a bootstrap raw allocator.
    //
@@ -161,7 +167,7 @@ initializeTestJit(TR_RuntimeHelper *helperIDs, void **helperAddresses, int32_t n
 
    initializeAllHelpers(jitConfig, helperIDs, helperAddresses, numHelpers);
 
-   if (commonJitInit(fe, options) < 0)
+   if (commonJitInit(fe, const_cast<char *>(optionsWithVerifier.c_str())) < 0)
       return false;
 
    initializeCodeCache(fe.codeCacheManager());

--- a/fvtest/compilertest/tests/BuilderTest.cpp
+++ b/fvtest/compilertest/tests/BuilderTest.cpp
@@ -101,10 +101,6 @@ BuilderTest::compileControlFlowTestMethods()
    rc = compileMethodBuilder(&maxIfThenMethodBuilder, &entry);
    _maxIfThenMethod = (IfFunctionType *) entry;
 
-   SubIfFalseThenMethod subIfFalseThenMethodBuilder(&types, this);
-   rc = compileMethodBuilder(&subIfFalseThenMethodBuilder, &entry);
-   _subIfFalseThenMethod = (IfLongFunctionType *) entry;
-
    DoWhileFibonnaciMethod doWhileFibonnaciMethodBuilder(&types, this);
    rc = compileMethodBuilder(&doWhileFibonnaciMethodBuilder, &entry);
    _doWhileFibMethod = (DoWhileFibFunctionType *) entry;
@@ -1568,32 +1564,6 @@ MaxIfThenMethod::buildIL()
 
    Return(
       Load("rightV"));
-
-   return true;
-   }
-
-SubIfFalseThenMethod::SubIfFalseThenMethod(TR::TypeDictionary *types, BuilderTest *test)
-   : TR::MethodBuilder(types, test)
-   {
-   DefineLine(LINETOSTR(__LINE__));
-   DefineFile(__FILE__);
-
-   DefineName("SubIfFalseThenMethod");
-   DefineParameter("valueA", Int64);
-   DefineParameter("valueB", Int64);
-   DefineReturnType(Int64);
-   }
-
-bool
-SubIfFalseThenMethod::buildIL()
-   {
-   TR::IlBuilder *elsePath = NULL;
-   IfThenElse(NULL, &elsePath, ConstInt64(0));
-
-   elsePath->Return(
-   elsePath->   Sub(
-   elsePath->      Load("valueA"),
-   elsePath->      Load("valueB")));
 
    return true;
    }

--- a/fvtest/compilertest/tests/BuilderTest.hpp
+++ b/fvtest/compilertest/tests/BuilderTest.hpp
@@ -232,13 +232,6 @@ class MaxIfThenMethod : public TR::MethodBuilder
    virtual bool buildIL();
    };
 
-class SubIfFalseThenMethod : public TR::MethodBuilder
-   {
-   public:
-   SubIfFalseThenMethod(TR::TypeDictionary *types, BuilderTest *test);
-   virtual bool buildIL();
-   };
-
 class IfThenElseLoopMethod : public TR::MethodBuilder
    {
    public:

--- a/fvtest/jitbuildertest/IfThenElseTest.cpp
+++ b/fvtest/jitbuildertest/IfThenElseTest.cpp
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#include "JBTestUtil.hpp"
+#include "compiler/ilgen/IlBuilder.hpp"
+
+
+// Both path exist, no merge return needed
+DEFINE_BUILDER(SubIfThenElseBothPathBuilder,
+               Int64,
+               PARAM("valueA", Int64),
+               PARAM("valueB", Int64) )
+   {
+   TR::IlBuilder *elsePath = NULL;
+   TR::IlBuilder *thenPath = NULL;
+
+   IfThenElse(&thenPath, &elsePath, ConstInt64(0));
+   thenPath->Return(
+                   thenPath->Sub(
+                   thenPath->Load("valueA"),
+                   thenPath->Load("valueB")));
+   elsePath->Return(
+                   elsePath->Sub(
+                   elsePath->Load("valueB"),
+                   elsePath->Load("valueA")));
+   return true;
+   }
+
+// one path exist and will be taken, still need hardcoded Return
+DEFINE_BUILDER(SubIfThenNullBuilder,
+               Int64,
+               PARAM("valueA", Int64),
+               PARAM("valueB", Int64) )
+   {
+   TR::IlBuilder *thenPath = NULL;
+
+   IfThenElse(&thenPath, NULL, ConstInt64(1));
+   thenPath->Return(
+                   thenPath->Sub(
+                   thenPath->Load("valueA"),
+                   thenPath->Load("valueB")));
+
+   Return(Sub(
+              Load("valueB"),
+              Load("valueA")));
+   return true;
+   }
+
+// The NULL path will be taken, need hardcoded Return
+DEFINE_BUILDER(SubIfNullElseBuilder,
+               Int64,
+               PARAM("valueA", Int64),
+               PARAM("valueB", Int64) )
+   {
+   TR::IlBuilder *elsePath = NULL;
+
+   IfThenElse(NULL, &elsePath, ConstInt64(1));
+   elsePath->Return(
+                   elsePath->Sub(
+                   elsePath->Load("valueB"),
+                   elsePath->Load("valueA")));
+
+   Return(Sub(
+              Load("valueA"),
+              Load("valueB")));
+   return true;
+   }
+
+typedef int64_t (*IfLongFunctionType)(int64_t, int64_t);
+class IfThenElseTest : public JitBuilderTest {};
+
+TEST_F(IfThenElseTest, TrueBothPath)
+   {
+   IfLongFunctionType typeIfFunction;
+   ASSERT_COMPILE(TR::TypeDictionary, SubIfThenElseBothPathBuilder, typeIfFunction);
+   ASSERT_EQ(typeIfFunction(10, 5), -5);
+   }
+
+TEST_F(IfThenElseTest, TrueElsePath)
+   {
+   IfLongFunctionType typeIfFunction;
+   ASSERT_COMPILE(TR::TypeDictionary, SubIfThenNullBuilder, typeIfFunction);
+   ASSERT_EQ(typeIfFunction(10, 5), 5);
+   }
+
+TEST_F(IfThenElseTest, FalseBothPath)
+   {
+   IfLongFunctionType typeIfFunction;
+   ASSERT_COMPILE(TR::TypeDictionary, SubIfNullElseBuilder, typeIfFunction);
+   ASSERT_EQ(typeIfFunction(10, 5), 5);
+   }

--- a/fvtest/jitbuildertest/Makefile
+++ b/fvtest/jitbuildertest/Makefile
@@ -30,7 +30,8 @@ OBJECTS := \
 	AnonymousTest \
 	ControlFlowTest \
 	SystemLinkageTest \
-	WorklistTest
+	WorklistTest \
+	IfThenElseTest
 
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
 


### PR DESCRIPTION
This PR includes:
- A change to enable "paranoidOpCheck" option every time when test compiler runs.
- A change to replace the SubIfThenElseMethod test, with three test cases. The original test has no return value, resulting in failing the CFG checker. So three new test cases are added to completely replace it. 
```
Fixes #1317