### PR TITLE
New option disableLoopTransfer

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -412,6 +412,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableLoopReplicator",              "O\tdisable loop replicator",                        TR::Options::disableOptimization, loopReplicator, 0, "P"},
    {"disableLoopReplicatorColdSideEntryCheck","I\tdisable cold side-entry check for replicating loops containing hot inner loops", SET_OPTION_BIT(TR_DisableLoopReplicatorColdSideEntryCheck), "P"},
    {"disableLoopStrider",                 "O\tdisable loop strider",                           TR::Options::disableOptimization, loopStrider, 0, "P"},
+   {"disableLoopTransfer",                "O\tdisable the loop transfer part of loop versioner", SET_OPTION_BIT(TR_DisableLoopTransfer), "F"},
    {"disableLoopVersioner",               "O\tdisable loop versioner",                         TR::Options::disableOptimization, loopVersioner, 0, "P"},
    {"disableMarkingOfHotFields",          "O\tdisable marking of Hot Fields",                  SET_OPTION_BIT(TR_DisableMarkingOfHotFields), "F"},
    {"disableMarshallingIntrinsics",       "O\tDisable packed decimal to binary marshalling and un-marshalling optimization. They will not be inlined.", SET_OPTION_BIT(TR_DisableMarshallingIntrinsics), "F"},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -286,7 +286,7 @@ enum TR_CompilationOptions
    TR_CompileBit                          = 0x00000080 + 6,
    TR_WaitBit                             = 0x00000100 + 6,
    TR_DisableZ14                          = 0x00000200 + 6,
-   // Available                           = 0x00000400 + 6,
+   TR_DisableLoopTransfer                 = 0x00000400 + 6, // disables the loop transfer part of loop versioner
    TR_EnableRangeSplittingGRA             = 0x00000800 + 6,
    TR_ForceUsePreexistence                = 0x00001000 + 6,
    TR_TLHPrefetch                         = 0x00002000 + 6,

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -703,8 +703,8 @@ int32_t TR_LoopVersioner::performWithoutDominators()
    ////if (!_virtualGuardPairs.isEmpty())
    if (!_virtualGuardInfo.isEmpty())
       {
-      static char *pEnv = feGetEnv("TR_disableLoopTransfer");
-      if (!pEnv)
+      bool disableLT = TR::Options::getCmdLineOptions()->getOption(TR_DisableLoopTransfer);
+      if (!disableLT) 
          performLoopTransfer();
       }
 
@@ -3249,7 +3249,9 @@ bool TR_LoopVersioner::detectChecksToBeEliminated(TR_RegionStructure *whileLoop,
          vcount_t visitCount = comp()->incVisitCount(); //@TODO: unsafe API/use pattern
          updateDefinitionsAndCollectProfiledExprs(NULL, currentNode, visitCount, specializedInvariantNodes, invariantNodes, invariantTranslationNodesList, NULL, collectProfiledExprs, nextBlock, warmBranchCount);
 
-         if (currentNode->isTheVirtualGuardForAGuardedInlinedCall() &&
+         bool disableLT = TR::Options::getCmdLineOptions()->getOption(TR_DisableLoopTransfer);
+         if (!disableLT &&
+             currentNode->isTheVirtualGuardForAGuardedInlinedCall() &&
              blocksInWhileLoop.find(currentNode->getBranchDestination()->getNode()->getBlock()))
             {
             _loopTransferDone = true;
@@ -3718,10 +3720,12 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
          }
 
       TR::Node *lastTree = nextBlock->getLastRealTreeTop()->getNode();
-      if (lastTree->getOpCode().isIf() &&
-         blocksInWhileLoop.find(lastTree->getBranchDestination()->getNode()->getBlock()) &&
-         lastTree->isTheVirtualGuardForAGuardedInlinedCall() &&
-         isBranchSuitableToDoLoopTransfer(&blocksInWhileLoop, lastTree, comp()))
+      bool disableLT = TR::Options::getCmdLineOptions()->getOption(TR_DisableLoopTransfer);
+      if (!disableLT &&
+          lastTree->getOpCode().isIf() &&
+          blocksInWhileLoop.find(lastTree->getBranchDestination()->getNode()->getBlock()) &&
+          lastTree->isTheVirtualGuardForAGuardedInlinedCall() &&
+          isBranchSuitableToDoLoopTransfer(&blocksInWhileLoop, lastTree, comp()))
          {
          // create the virtual guard info for this loop
          //


### PR DESCRIPTION
The new option disableLoopTransfer replaces the
use of environment variable TR_disableLoopTransfer. The option
is applied at both the original location and two further points
to more completely suppress the artifacts related to loop
transfer.

Signed-off-by: JamesKingdon <jkingdon@ca.ibm.com>