### PR TITLE
Simplify byte, short, int, and long comparisons

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -370,6 +370,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableInliningDuringVPAtWarm",       "O\tdisable inlining during VP for warm bodies",    SET_OPTION_BIT(TR_DisableInliningDuringVPAtWarm), "F"},
    {DisableInliningOfNativesString,       "O\tdisable inlining of natives",                    SET_OPTION_BIT(TR_DisableInliningOfNatives), "F"},
    {"disableInnerPreexistence",           "O\tdisable inner preexistence",                     TR::Options::disableOptimization, innerPreexistence, 0, "P"},
+   {"disableIntegerCompareSimplification",      "O\tdisable byte/short/int/long compare simplification  ",      SET_OPTION_BIT(TR_DisableIntegerCompareSimplification), "F"},
    {"disableInterfaceCallCaching",                          "O\tdisable interfaceCall caching   ",      SET_OPTION_BIT(TR_disableInterfaceCallCaching), "F"},
    {"disableInterfaceInlining",           "O\tdisable merge new",                              SET_OPTION_BIT(TR_DisableInterfaceInlining), "F"},
    {"disableInternalPointers",            "O\tdisable internal pointer creation",              SET_OPTION_BIT(TR_DisableInternalPointers), "F"},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -386,7 +386,7 @@ enum TR_CompilationOptions
    TR_VerboseInlineProfiling              = 0x00004000 + 9,
    // Available                           = 0x00008000 + 9,
    // Available                           = 0x00010000 + 9,
-   // Available                           = 0x00020000 + 9,
+   TR_DisableIntegerCompareSimplification = 0x00020000 + 9,
    TR_DisableAutoSIMD                      = 0x00040000 + 9,
    TR_DisableOOL                          = 0x00080000 + 9,
    TR_DisableWriteBarriersRangeCheck      = 0x00100000 + 9,

--- a/compiler/optimizer/OMRSimplifierHandlers.hpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.hpp
@@ -271,4 +271,5 @@ TR::Node * lowerTreeSimplifier(TR::Node * node, TR::Block * block, TR::Simplifie
 TR::Node * arrayLengthSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 
 
+TR::Node * removeArithmeticsUnderIntegralCompare(TR::Node* node,TR::Simplifier * s);
 #endif


### PR DESCRIPTION
Remove integer arithmetics in integer comparisons to reduce the number of add/sub
instructions emitted.

e.g. an addition can be avoided if x-1>0 is transformed into x>1.

Signed-off-by: Nigel Yu <yunigel@ca.ibm.com>