### PR TITLE
Make compiler configuration more portable

### DIFF
--- a/tools/compiler/scripts/guess-platform.sh
+++ b/tools/compiler/scripts/guess-platform.sh
@@ -33,7 +33,7 @@ error() {
 
 # chooseplatform 32bit_platform 64bit_platform
 chooseplatform() {
-    if [[ $thirty_two_bit -eq 1 ]] ; then
+    if [ $thirty_two_bit -eq 1 ] ; then
         platform=$1
     else
         platform=$2


### PR DESCRIPTION
use [ instead of [[

fixes #1449

Signed-off-by: Keith W. Campbell <keithc@ca.ibm.com>