### PR TITLE
Added Makefile rule for building JitBuilder library

### DIFF
--- a/jitbuilder/release/Makefile
+++ b/jitbuilder/release/Makefile
@@ -21,6 +21,9 @@
 CXX?=g++
 CXXFLAGS=-g -std=c++0x -O2 -c -fno-rtti -fPIC -I./include/compiler -I./include
 
+OMR_ROOT_DIR=../..
+JIT_BUILDER_DIR=$(OMR_ROOT_DIR)/jitbuilder
+
 .SUFFIXES: .cpp .o
 
 # NOTE: replay purposefully left out of these lists
@@ -303,6 +306,8 @@ thunks : libjitbuilder.a Thunk.o
 Thunk.o: src/Thunk.cpp
 	$(CXX) -o $@ $(CXXFLAGS) $<
 
+libjitbuilder.a :
+	make -C $(JIT_BUILDER_DIR)
 
 clean:
 	@rm -f $(ALL_TESTS) replay *.o


### PR DESCRIPTION
- <s>Added `operandarraytests` (which is the binary of a JitBuilder example) to the corresponding gitignore list.</s>

- Added a rule in the JitBuilder release Makefile for building the JitBuilder library, if its not present. This usability enhancement will eliminate an extra step (and any ambiguity) when trying to build the JitBuilder examples in the absence of a JitBuilder binary.