### PR TITLE
Cmake: Link the system thread library portably

### DIFF
--- a/fvtest/omrGtestGlue/CMakeLists.txt
+++ b/fvtest/omrGtestGlue/CMakeLists.txt
@@ -16,9 +16,12 @@
 #    Multiple authors (IBM Corp.) - initial implementation and documentation
 ###############################################################################
 
-
 add_library(omrGtest STATIC
-	omrGtest.cpp)
+	omrGtest.cpp
+)
+
+target_link_libraries(omrGtest omrcore omrport j9thrstatic)
+
 target_include_directories(omrGtest
 	PRIVATE
 		${PROJECT_SOURCE_DIR}/third_party/gtest-1.7.0/
@@ -26,6 +29,7 @@ target_include_directories(omrGtest
 	PUBLIC
 		${PROJECT_SOURCE_DIR}/third_party/gtest-1.7.0/include
 )
+
 add_library(omrGtestGlue INTERFACE)
 
 target_include_directories(omrGtestGlue
@@ -38,11 +42,3 @@ target_sources(omrGtestGlue INTERFACE
 )
 
 target_link_libraries(omrGtestGlue INTERFACE omrGtest)
-
-#TODO  system thread library should be linked in a more generic way.
-if(NOT OMR_HOST_OS STREQUAL "win")
-	if(NOT OMR_HOST_OS STREQUAL "zos")
-		target_link_libraries(omrGtest pthread)
-	endif()
-endif()
-#target_link_libraries(omrGtest INTERFACE omrGtestGlue)


### PR DESCRIPTION
j9thrstatic is our portable library for threading. If gtest needs
threading, this is how it should be getting it.

Also link omr_core for basic OMR flags.

Signed-off-by: Robert Young <rwy0717@gmail.com>