### PR TITLE
JitBuilder cleanup

### DIFF
--- a/fvtest/omrtest.mk
+++ b/fvtest/omrtest.mk
@@ -44,8 +44,18 @@ omr_algotest:
 omr_gctest:
 	./omrgctest --gtest_filter="gcFunctionalTest*"
 
+# jitbuilder can run different sets of tests on linux_x86 and osx than on other platforms
+# until we common this up, run "testall" on linux_x86 and osx but run "test" everywhere else
 omr_jitbuilderexamples:
+ifeq (,$(findstring linux_x86,$(SPEC)))
+	make -C jitbuilder/release testall
+else
+ifeq (,$(findstring osx,$(SPEC)))
+	make -C jitbuilder/release testall
+else
 	make -C jitbuilder/release test
+endif
+endif
 
 omr_jitbuildertest:
 	./omrjitbuildertest

--- a/jitbuilder/optimizer/JBOptimizer.cpp
+++ b/jitbuilder/optimizer/JBOptimizer.cpp
@@ -117,11 +117,12 @@ static const OptimizationStrategy JBwarmStrategyOpts[] =
    { OMR::treeSimplification                                                       },
    { OMR::trivialDeadTreeRemoval,                    OMR::IfEnabled                },
 
-   { OMR::inductionVariableAnalysis,                 OMR::IfLoops                  },
-   { OMR::loopCanonicalization,                      OMR::IfLoops                  },
+   { OMR::basicBlockOrdering,                        OMR::IfLoops                  }, // clean up block order for loop canonicalization, if it will run
+   { OMR::loopCanonicalization,                      OMR::IfLoops                  }, // canonicalization must run before inductionVariableAnalysis else indvar data gets messed up
+   { OMR::inductionVariableAnalysis,                 OMR::IfLoops                  }, // needed for loop unroller
    { OMR::generalLoopUnroller,                       OMR::IfLoops                  },
-   { OMR::basicBlockExtension,                       OMR::MarkLastRun              }, // extend blocks; move trees around if reqd
-   { OMR::treeSimplification                                                       }, // revisit; not really required ?
+   { OMR::basicBlockExtension,                       OMR::MarkLastRun              }, // clean up order and extend blocks now
+   { OMR::treeSimplification                                                       },
    { OMR::localCSE                                                                 },
    { OMR::treeSimplification,                        OMR::IfEnabled                },
    { OMR::trivialDeadTreeRemoval,                    OMR::IfEnabled                },

--- a/jitbuilder/release/src/OperandArrayTests.cpp
+++ b/jitbuilder/release/src/OperandArrayTests.cpp
@@ -502,7 +502,7 @@ OperandArrayTestMethod::testArray(TR::BytecodeBuilder *builder, bool useEqual)
 bool
 OperandArrayTestMethod::buildIL()
    {
-   TR::IlType *pElementType = _types->PointerTo(Word);
+   TR::IlType *pElementType = _types->PointerTo(_types->PointerTo(Word));
 
    Call("createArray", 0);
 
@@ -530,7 +530,7 @@ OperandArrayTestUsingFalseMethod::OperandArrayTestUsingFalseMethod(TR::TypeDicti
 bool
 OperandArrayTestUsingFalseMethod::buildIL()
    {
-   TR::IlType *pElementType = _types->PointerTo(Word);
+   TR::IlType *pElementType = _types->PointerTo(_types->PointerTo(Word));
 
    Call("createArray", 0);
 


### PR DESCRIPTION
Three small corrections:

1. Reverse order of induction variable analysis and loop canonicalization in JitBuilder opt strategy, plus add a block ordering pass beforehand to clean up the blocks.
2. Workaround fix for an assertion in the OperandArrayTests code sample. The correct fix will be a broader change so I want to get this test working and into our pull request testing first.
3. For JitBuilder testing, run "make testall" on linux_x86 and osx platforms, but "test" elsewhere.