### PR TITLE
CMake: Fix error in gctest CMakeLists

### DIFF
--- a/fvtest/gctest/CMakeLists.txt
+++ b/fvtest/gctest/CMakeLists.txt
@@ -53,5 +53,5 @@ endif()
 
 
 add_test(NAME gctest
-	COMMAND omrgctest "--gtest_filter="gcFunctionalTest*""
+	COMMAND omrgctest "--gtest_filter=gcFunctionalTest*"
 	WORKING_DIRECTORY "${omr_SOURCE_DIR}")


### PR DESCRIPTION
Quotation marks are unnecissary in the gtest_filter arg, and cause
the filter to be parsed incorrectly by gtest. This resulted in
gc tests not being run.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>