### PR TITLE
VM access during Concurrent Scavenger

### DIFF
--- a/example/glue/EnvironmentDelegate.cpp
+++ b/example/glue/EnvironmentDelegate.cpp
@@ -138,7 +138,7 @@ MM_EnvironmentDelegate::releaseExclusiveVMAccess()
  * @see assumeExclusiveVMAccess(uintptr_t)
  */
 uintptr_t
-MM_EnvironmentDelegate::relinquishExclusiveVMAccess()
+MM_EnvironmentDelegate::relinquishExclusiveVMAccess(bool *deferredVMAccessRelease)
 {
 	uintptr_t relinquishedExclusiveCount = _env->getOmrVMThread()->exclusiveCount;
 	_env->getOmrVMThread()->exclusiveCount = 0;

--- a/example/glue/EnvironmentDelegate.hpp
+++ b/example/glue/EnvironmentDelegate.hpp
@@ -210,7 +210,7 @@ public:
 	 * @return the exclusive count of the current thread before relinquishing
 	 * @see assumeExclusiveVMAccess(uintptr_t)
 	 */
-	uintptr_t relinquishExclusiveVMAccess();
+	uintptr_t relinquishExclusiveVMAccess(bool *deferredVMAccessRelease);
 
 	/**
 	 * Assume exclusive access from a collaborating thread (i.e. main-to-master or master-to-main).

--- a/gc/base/EnvironmentBase.cpp
+++ b/gc/base/EnvironmentBase.cpp
@@ -493,9 +493,9 @@ MM_EnvironmentBase::unwindExclusiveVMAccessForGC()
 }
 
 uintptr_t
-MM_EnvironmentBase::relinquishExclusiveVMAccess()
+MM_EnvironmentBase::relinquishExclusiveVMAccess(bool *deferredVMAccessRelease)
 {
-	return _delegate.relinquishExclusiveVMAccess();
+	return _delegate.relinquishExclusiveVMAccess(deferredVMAccessRelease);
 }
 
 void

--- a/gc/base/EnvironmentBase.hpp
+++ b/gc/base/EnvironmentBase.hpp
@@ -443,9 +443,10 @@ public:
 	
 	/**
 	 * Give up exclusive access in preparation for transferring it to a collaborating thread (i.e. main-to-master or master-to-main)
+	 * @deferredVMAccessRelease Set to true if caller wants to defer releasing VM access (for the calling thread) at a later point (to be done explicitly by the caller). The method may set it back to false, if unable to obey the request.
 	 * @return the exclusive count of the current thread before relinquishing 
 	 */
-	uintptr_t relinquishExclusiveVMAccess();
+	uintptr_t relinquishExclusiveVMAccess(bool *deferredVMAccessRelease = NULL);
 
 	/**
 	 * Assume exclusive access from a collaborating thread i.e. main-to-master or master-to-main)


### PR DESCRIPTION
During Concurrent phase of Concurrent Scavenger (CS) cycle, GC should
keep VM access (since it's indeed accessing heap and furthermore
mutating it), to prevent/delay other parties (for example RAS) from
obtaining exclusive VM access.

It's sufficient that only Master GC thread holds the access. 

In existing handshaking when Master GC thread release exclusive access
(and passes it to the mutator thread that triggered GC), normally,
Master GC thread would release VM access. This change will make it to
defer this action if it's known that the current STW phase is
immediately followed by concurrent phase. Only when the concurrent phase
is complete, master GC thread will release VM access.

Language specific code may disobey the request to defer release VM
access. If so, it will notify the caller, and the caller (Master GC
thread) will release it right away.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>