### PR TITLE
Document and enforce assertion in _patchVirtualGuard

### DIFF
--- a/compiler/z/runtime/VirtualGuardRuntime.cpp
+++ b/compiler/z/runtime/VirtualGuardRuntime.cpp
@@ -19,46 +19,76 @@
 #include <stdio.h>
 #include <stdint.h>
 #include "codegen/FrontEnd.hpp"
+#include "codegen/OMRMachine.hpp"
 #include "compile/Compilation.hpp"
 #include "env/jittypes.h"
 #include "infra/Assert.hpp"
 
-// Patch instruction at location.  It should be either a BRC or BRCL, and the offset field should
-// already be set--just need to toggle bits 12 to 16 from 0x0 to 0xf to turn the BRC[L] from
-// a nop to an unconditional branch.
-// Since we're modifying 4 bits in the 2nd byte, it will not stradle a double word boundary and
-// so the instruction should move from nop->branch atomically.
-extern "C" void _patchVirtualGuard(uint8_t *locationAddr, uint8_t *destinationAddr, int32_t smpFlag){
 
-   int64_t offset;
-   static bool doTrace = (debug("traceVGNOP") != 0);
+/** \brief
+  *    Patch an existing BRC / BRCL virtual guard at \p locationAddr to branch to \p destinationAddr or encode a BRC /
+  *    BRCL at \p locationAddr to branch to \p destinationAddr if a NOP BRC / BRCL does not exist.
+  *
+  * \param locationAddr
+  *    The location to patch.
+  *
+  * \param destinationAddr
+  *    The destination of the branch target.
+  *
+  * \param smpFlag
+  *    N/A.
+  *
+  * \note
+  *    It is up to the caller to ensure that if a NOP BRC / BRCL does not exist at \p locationAddr then a non-atomic
+  *    4 or 6 byte (depending on distance between \p locationAddr and \p destinationAddr) store to the instruction
+  *    stream at \p locationAddr is safe. If an existing BRC / BRCL already exists at \p locationAddr then this
+  *    function only stores a single byte to modify the BRC / BRCL mask value to an always taken branch mask, and hence
+  *    the store will be atomic.
+  */
+extern "C" void _patchVirtualGuard(uint8_t* locationAddr, uint8_t* destinationAddr, int32_t smpFlag)
+   {
+   static bool debugTrace = debug("traceVGNOP") != NULL;
 
-   if(doTrace)
-      printf("####> patching VGNOP at %p (%x) destAddr: %p (%x), flag:%d\n",
-              locationAddr,*(int32_t*)locationAddr,
-              destinationAddr,*(int32_t*)destinationAddr,smpFlag);
-
-   intptrj_t distance = destinationAddr - locationAddr;
-   offset = destinationAddr - locationAddr;
-   offset = offset / 2;
-
-   if (distance >= -32768 && distance <= 32767)
+   if (debugTrace)
       {
-      locationAddr[0] = 0xa7;
-      locationAddr[1] = 0xf4;
-      locationAddr[2] = (offset >> 8)  & 0x00ff;
-      locationAddr[3] = offset         & 0x00ff;
+      printf("####> Patching VGNOP at locationAddr %p (%x), destinationAddr %p (%x), smpFlag: %d\n", locationAddr, *reinterpret_cast<intptrj_t*>(locationAddr), destinationAddr, *reinterpret_cast<intptrj_t*>(destinationAddr), smpFlag);
+      }
+
+   int64_t displacement = static_cast<int64_t>(destinationAddr - locationAddr) / 2;
+
+   if (locationAddr[0] == 0xA7 || locationAddr[0] == 0xC0)
+      {
+      TR_ASSERT_FATAL((locationAddr[1] & 0x04) == 0x04, "Expected to find BRC (0xA704) or BRCL (0xC004) instruction at %p but instead found %x\n", locationAddr, *reinterpret_cast<int16_t*>(locationAddr + 2));
+
+      if (locationAddr[0] == 0xA7)
+         {
+         TR_ASSERT_FATAL(*reinterpret_cast<int16_t*>(locationAddr + 2) == displacement, "Branch RI displacement at %p (%x) does not match the displacement calculated from argument %p (%x)\n", locationAddr, *reinterpret_cast<int16_t*>(locationAddr + 2), destinationAddr, displacement);
+         }
+      else
+         {
+         TR_ASSERT_FATAL(*reinterpret_cast<int32_t*>(locationAddr + 2) == displacement, "Branch RI displacement at %p (%x) does not match the displacement calculated from argument %p (%x)\n", locationAddr, *reinterpret_cast<int32_t*>(locationAddr + 2), destinationAddr, displacement);
+         }
+
+      // Modify the mask value to an always taken branch
+      locationAddr[1] = 0xF4;
       }
    else
       {
-      locationAddr[0] = 0xc0;
-      locationAddr[1] = 0xf4;
-      locationAddr[2] = (offset >> 24) & 0x000000ff;
-      locationAddr[3] = (offset >> 16) & 0x000000ff;
-      locationAddr[4] = (offset >> 8)  & 0x000000ff;
-      locationAddr[5] = offset         & 0x000000ff;
+      if (displacement >= MIN_IMMEDIATE_VAL && displacement <= MAX_IMMEDIATE_VAL)
+         {
+         locationAddr[0] = 0xA7;
+         locationAddr[1] = 0xF4;
+         locationAddr[2] = (displacement & 0xFF00) >> 8;
+         locationAddr[3] = (displacement & 0x00FF);
+         }
+      else
+         {
+         locationAddr[0] = 0xC0;
+         locationAddr[1] = 0xF4;
+         locationAddr[2] = (displacement & 0xFF000000) >> 24;
+         locationAddr[3] = (displacement & 0x00FF0000) >> 16;
+         locationAddr[4] = (displacement & 0x0000FF00) >> 8;
+         locationAddr[5] = (displacement & 0x000000FF);
+         }
       }
-
-   TR_ASSERT(destinationAddr == (distance + locationAddr),
-          "%p != %p(2*%ld+%p)\n",destinationAddr,distance+locationAddr,offset,locationAddr);
-}
+   }


### PR DESCRIPTION
_patchVirtualGuard is a sensitive function which carries out runtime
patching. It is essential this function is properly documented and that
its semantics are enforced to prevent potential runtime patching bugs in
the future.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>