### PR TITLE
Add Tril tests to Travis builds

### DIFF
--- a/cmake/compiler_support.cmake
+++ b/cmake/compiler_support.cmake
@@ -95,6 +95,7 @@ function(make_compiler_target TARGET_NAME)
       TR_HOST_X86
       TR_TARGET_X86
       TR_TARGET_64BIT
+      SUPPORTS_THREAD_LOCAL
       ${COMPILER_DEFINES} 
       )
 endfunction(make_compiler_target)

--- a/fvtest/CMakeLists.txt
+++ b/fvtest/CMakeLists.txt
@@ -34,3 +34,8 @@ add_subdirectory(vmtest)
 if(OMR_TEST_COMPILER)
 	add_subdirectory(compilertest)
 endif()
+
+if(OMR_JITBUILDER)
+	add_subdirectory(compilertriltest)
+	add_subdirectory(tril/test)
+endif()

--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -24,9 +24,6 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CXX_EXTENSIONS OFF)
 
-enable_testing()
-find_package(GTest REQUIRED)
-
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fno-rtti -fno-threadsafe-statics -Wno-deprecated -Wno-enum-compare -Wno-invalid-offsetof -Wno-write-strings -O3 -pthread -fomit-frame-pointer -fasynchronous-unwind-tables -Wreturn-type -fno-dollars-in-identifiers -m64 -fno-strict-aliasing")
 
 add_executable(comptest
@@ -39,7 +36,7 @@ add_executable(comptest
 
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../tril/tril ${CMAKE_CURRENT_BINARY_DIR}/tril)
 target_link_libraries(comptest
-   ${GTEST_BOTH_LIBRARIES}
+   omrGtest
    tril
 )
 

--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -28,7 +28,7 @@ enable_testing()
 find_package(GTest REQUIRED)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../tril/tril ${CMAKE_CURRENT_BINARY_DIR}/tril)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fdiagnostics-color=always -fno-rtti -fno-threadsafe-statics -Wno-deprecated -Wno-enum-compare -Wno-invalid-offsetof -Wno-write-strings -O3 -pthread -fomit-frame-pointer -fasynchronous-unwind-tables -Wreturn-type -fno-dollars-in-identifiers -m64 -fno-strict-aliasing")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fno-rtti -fno-threadsafe-statics -Wno-deprecated -Wno-enum-compare -Wno-invalid-offsetof -Wno-write-strings -O3 -pthread -fomit-frame-pointer -fasynchronous-unwind-tables -Wreturn-type -fno-dollars-in-identifiers -m64 -fno-strict-aliasing")
 
 add_executable(comptest
    main.cpp

--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -26,7 +26,6 @@ set(CXX_EXTENSIONS OFF)
 
 enable_testing()
 find_package(GTest REQUIRED)
-add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../tril/tril ${CMAKE_CURRENT_BINARY_DIR}/tril)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fno-rtti -fno-threadsafe-statics -Wno-deprecated -Wno-enum-compare -Wno-invalid-offsetof -Wno-write-strings -O3 -pthread -fomit-frame-pointer -fasynchronous-unwind-tables -Wreturn-type -fno-dollars-in-identifiers -m64 -fno-strict-aliasing")
 
@@ -38,6 +37,7 @@ add_executable(comptest
    ShiftAndRotateTest.cpp
 )
 
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../tril/tril ${CMAKE_CURRENT_BINARY_DIR}/tril)
 target_link_libraries(comptest
    ${GTEST_BOTH_LIBRARIES}
    tril

--- a/fvtest/tril/CMakeLists.txt
+++ b/fvtest/tril/CMakeLists.txt
@@ -1,0 +1,5 @@
+project(tril_project)
+
+add_subdirectory(tril)
+add_subdirectory(test)
+add_subdirectory(examples)

--- a/fvtest/tril/examples/CMakeLists.txt
+++ b/fvtest/tril/examples/CMakeLists.txt
@@ -20,9 +20,5 @@ cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
 
 project(tril_examples)
 
-if(NOT DEFINED tril_DIR)
-    set(tril_DIR ${CMAKE_CURRENT_LIST_DIR}/../tril/build)
-endif()
-
 add_subdirectory(incordec)
 add_subdirectory(mandelbrot)

--- a/fvtest/tril/examples/incordec/CMakeLists.txt
+++ b/fvtest/tril/examples/incordec/CMakeLists.txt
@@ -34,7 +34,7 @@ if(NOT tril_FOUND)
     message(FATAL "404: Tril not found.")
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fno-inline -fdiagnostics-color=always -fno-rtti -fno-threadsafe-statics -Wno-deprecated -Wno-enum-compare -Wno-invalid-offsetof -Wno-write-strings -O3 -pthread -fomit-frame-pointer -fasynchronous-unwind-tables -Wreturn-type -fno-dollars-in-identifiers -m64 -fno-strict-aliasing")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fno-inline -fno-rtti -fno-threadsafe-statics -Wno-deprecated -Wno-enum-compare -Wno-invalid-offsetof -Wno-write-strings -O3 -pthread -fomit-frame-pointer -fasynchronous-unwind-tables -Wreturn-type -fno-dollars-in-identifiers -m64 -fno-strict-aliasing")
 
 add_executable(incordec
    main.cpp

--- a/fvtest/tril/examples/incordec/CMakeLists.txt
+++ b/fvtest/tril/examples/incordec/CMakeLists.txt
@@ -22,25 +22,13 @@ project(tril_incordec LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
-set(CXX_EXTENSIONS OFF)
-
-if(NOT DEFINED tril_DIR)
-    set(tril_DIR ${CMAKE_CURRENT_LIST_DIR}/../../tril/build)
-endif()
-
-find_package(tril REQUIRED)
-
-if(NOT tril_FOUND)
-    message(FATAL "404: Tril not found.")
-endif()
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fno-inline -fno-rtti -fno-threadsafe-statics -Wno-deprecated -Wno-enum-compare -Wno-invalid-offsetof -Wno-write-strings -O3 -pthread -fomit-frame-pointer -fasynchronous-unwind-tables -Wreturn-type -fno-dollars-in-identifiers -m64 -fno-strict-aliasing")
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_executable(incordec
    main.cpp
 )
 
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../../tril/ ${CMAKE_CURRENT_BINARY_DIR}/tril)
 target_link_libraries(incordec
-   ${tril_LIBRAREIS}
    tril
 )

--- a/fvtest/tril/examples/mandelbrot/CMakeLists.txt
+++ b/fvtest/tril/examples/mandelbrot/CMakeLists.txt
@@ -34,7 +34,7 @@ if(NOT tril_FOUND)
     message(FATAL "404: Tril not found.")
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fdiagnostics-color=always -fno-rtti -fno-threadsafe-statics -Wno-deprecated -Wno-enum-compare -Wno-invalid-offsetof -Wno-write-strings -O3 -pthread -fomit-frame-pointer -fasynchronous-unwind-tables -Wreturn-type -fno-dollars-in-identifiers -m64 -fno-strict-aliasing")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fno-rtti -fno-threadsafe-statics -Wno-deprecated -Wno-enum-compare -Wno-invalid-offsetof -Wno-write-strings -O3 -pthread -fomit-frame-pointer -fasynchronous-unwind-tables -Wreturn-type -fno-dollars-in-identifiers -m64 -fno-strict-aliasing")
 
 add_executable(mandelbrot
    main.cpp

--- a/fvtest/tril/examples/mandelbrot/CMakeLists.txt
+++ b/fvtest/tril/examples/mandelbrot/CMakeLists.txt
@@ -22,25 +22,13 @@ project(tril_mandelbrot LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
-set(CXX_EXTENSIONS OFF)
-
-if(NOT DEFINED tril_DIR)
-    set(tril_DIR ${CMAKE_CURRENT_LIST_DIR}/../../tril/build)
-endif()
-
-find_package(tril REQUIRED)
-
-if(NOT tril_FOUND)
-    message(FATAL "404: Tril not found.")
-endif()
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fno-rtti -fno-threadsafe-statics -Wno-deprecated -Wno-enum-compare -Wno-invalid-offsetof -Wno-write-strings -O3 -pthread -fomit-frame-pointer -fasynchronous-unwind-tables -Wreturn-type -fno-dollars-in-identifiers -m64 -fno-strict-aliasing")
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_executable(mandelbrot
    main.cpp
 )
 
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../../tril/ ${CMAKE_CURRENT_BINARY_DIR}/tril)
 target_link_libraries(mandelbrot
-   ${tril_LIBRAREIS}
    tril
 )

--- a/fvtest/tril/test/CMakeLists.txt
+++ b/fvtest/tril/test/CMakeLists.txt
@@ -24,10 +24,10 @@ project(triltest LANGUAGES CXX)
 enable_testing()
 find_package(GTest REQUIRED)
 
-add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../tril/ ${CMAKE_CURRENT_BINARY_DIR}/tril)
-
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 
 add_executable(triltest
    ASTTest.cpp
@@ -37,7 +37,8 @@ add_executable(triltest
    CompileTest.cpp
 )
 
-target_link_libraries(triltest 
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../tril/ ${CMAKE_CURRENT_BINARY_DIR}/tril)
+target_link_libraries(triltest
    ${GTEST_BOTH_LIBRARIES}
    tril
 )

--- a/fvtest/tril/test/CMakeLists.txt
+++ b/fvtest/tril/test/CMakeLists.txt
@@ -18,11 +18,15 @@
 
 cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
 
+if(NOT TARGET triltest)
+
 project(triltest LANGUAGES CXX)
 
-# Setup testing
-enable_testing()
-find_package(GTest REQUIRED)
+# not very robust but since we can't build JitBuilder by itself using cmake yet,
+# this will have to do
+if(NOT "${CMAKE_PROJECT_NAME}" STREQUAL "omr")
+   find_package(GTest REQUIRED)
+endif()
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
@@ -30,6 +34,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 
 add_executable(triltest
+   main.cpp
    ASTTest.cpp
    ParserTest.cpp
    MethodInfoTest.cpp
@@ -39,12 +44,21 @@ add_executable(triltest
 
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../tril/ ${CMAKE_CURRENT_BINARY_DIR}/tril)
 target_link_libraries(triltest
-   ${GTEST_BOTH_LIBRARIES}
    tril
 )
+
+# not very robust but since we can't build JitBuilder by itself using cmake yet,
+# this will have to do
+if(NOT "${CMAKE_PROJECT_NAME}" STREQUAL "omr")
+    target_link_libraries(triltest ${GTEST_BOTH_LIBRARIES})
+else()
+    target_link_libraries(triltest omrGtest)
+endif()
 
 add_test(
     NAME triltest
     COMMAND triltest --gtest_color=yes
 )
+
+endif()
 

--- a/fvtest/tril/test/main.cpp
+++ b/fvtest/tril/test/main.cpp
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#include "gtest/gtest.h"
+
+int main(int argc, char** argv) {
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}

--- a/fvtest/tril/tril/CMakeLists.txt
+++ b/fvtest/tril/tril/CMakeLists.txt
@@ -18,6 +18,8 @@
 
 cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
 
+if(NOT TARGET tril)
+
 project(tril LANGUAGES C CXX)
 
 find_package(BISON)
@@ -28,18 +30,12 @@ set(JITBUILDER_PATH ${OMR_PATH}/jitbuilder)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
-set(CXX_EXTENSIONS OFF)
-
-set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
-set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
-
-add_definitions(-g -Wno-deprecated -Wno-enum-compare -Wno-write-strings -O3 -pthread -fomit-frame-pointer -fasynchronous-unwind-tables -Wreturn-type -fno-dollars-in-identifiers -m64 -fno-strict-aliasing)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fno-threadsafe-statics -Wno-invalid-offsetof")
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 BISON_TARGET(tril_parser tril.y ${CMAKE_CURRENT_BINARY_DIR}/tril.parser.c)
 FLEX_TARGET(tril_scanner tril.l ${CMAKE_CURRENT_BINARY_DIR}/tril.scanner.c
-            COMPILE_FLAGS "--yylineno"
-            DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/tril.scanner.h)
+    COMPILE_FLAGS "--yylineno --header-file=${CMAKE_CURRENT_BINARY_DIR}/tril.scanner.h")
+#            DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/tril.scanner.h)
 ADD_FLEX_BISON_DEPENDENCY(tril_scanner tril_parser)
 
 add_library(tril STATIC
@@ -64,7 +60,6 @@ target_compile_definitions(tril PUBLIC
     TR_TARGET_64BIT
     SUPPORTS_THREAD_LOCAL
     _LONG_LONG
-    J9HAMMER
 )
 
 target_include_directories(tril PUBLIC
@@ -79,12 +74,21 @@ target_include_directories(tril PUBLIC
     ${OMR_PATH}
     ${OMR_PATH}/include_core
 )
+
+# not very robust but since we can't build JitBuilder by itself using cmake yet,
+# this will have to do
+if(NOT "${CMAKE_PROJECT_NAME}" STREQUAL "omr")
+    set(OMR_JITBUILDER ON CACHE BOOL "")
+    set(OMR_WARNINGS_AS_ERRORS OFF CACHE BOOL "")
+    add_subdirectory(${OMR_PATH} ${CMAKE_CURRENT_BINARY_DIR}/omr)
+endif()
 target_link_libraries(tril INTERFACE
-    ${JITBUILDER_PATH}/release/libjitbuilder.a
+    jitbuilder
     dl
 )
 
-export(TARGETS tril FILE tril-config.cmake)
+#export(TARGETS tril jitbuilder FILE tril-config.cmake)
 #install(FILES ast.h ilgen.hpp DESTINATION include)
 #install(TARGETS tril EXPORT tril-targets ARCHIVE DESTINATION lib)
 #install(EXPORT tril-targets FILE tril-config.cmake DESTINATION lib/cmake/tril)
+endif()

--- a/fvtest/tril/tril/CMakeLists.txt
+++ b/fvtest/tril/tril/CMakeLists.txt
@@ -33,7 +33,7 @@ set(CXX_EXTENSIONS OFF)
 set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
-add_definitions(-g -fdiagnostics-color=always -Wno-deprecated -Wno-enum-compare -Wno-write-strings -O3 -pthread -fomit-frame-pointer -fasynchronous-unwind-tables -Wreturn-type -fno-dollars-in-identifiers -m64 -fno-strict-aliasing)
+add_definitions(-g -Wno-deprecated -Wno-enum-compare -Wno-write-strings -O3 -pthread -fomit-frame-pointer -fasynchronous-unwind-tables -Wreturn-type -fno-dollars-in-identifiers -m64 -fno-strict-aliasing)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fno-threadsafe-statics -Wno-invalid-offsetof")
 
 BISON_TARGET(tril_parser tril.y ${CMAKE_CURRENT_BINARY_DIR}/tril.parser.c)

--- a/fvtest/tril/tril/jitbuilder_compiler.cpp
+++ b/fvtest/tril/tril/jitbuilder_compiler.cpp
@@ -26,7 +26,6 @@
 #include "compile/Method.hpp"
 #include "control/CompileMethod.hpp"
 #include "env/jittypes.h"
-#include "gtest/gtest.h"
 #include "il/DataTypes.hpp"
 #include "ilgen.hpp"
 #include "Jit.hpp"

--- a/jitbuilder/CMakeLists.txt
+++ b/jitbuilder/CMakeLists.txt
@@ -52,7 +52,8 @@ endif()
 
 # Create jitbuilder library. 
 create_omr_compiler_library(NAME       jitbuilder
-                            OBJECTS    ${JITBUILDER_OBJECTS})
+                            OBJECTS    ${JITBUILDER_OBJECTS}
+                            DEFINES    PROD_WITH_ASSUMES)
 
 # Add interface path so that include paths propagate. 
 # NOTE: `release` directory  isn't being automatically setup, so this 


### PR DESCRIPTION
This change set does some clean up to Tril and its cmake files to allow better integrate with the other OMR cmake files. It also adds the Tril tests and Tril-based compiler tests to the Travis builds.