### PR TITLE
Change privatized wrtbar into an aStore

### DIFF
--- a/compiler/optimizer/FieldPrivatizer.cpp
+++ b/compiler/optimizer/FieldPrivatizer.cpp
@@ -709,7 +709,7 @@ void TR_FieldPrivatizer::privatizeFields(TR::Node *node, bool postDominatesEntry
             node->setSymbolReference(autoForField);
             TR::Node *newFirstChild = 0;
             int32_t newFirstChildNum = -1;
-            if ( opCode.isIndirect() )
+            if (opCode.isIndirect())
                {
                if (opCode.isStore())
                   {
@@ -719,13 +719,16 @@ void TR_FieldPrivatizer::privatizeFields(TR::Node *node, bool postDominatesEntry
                   newFirstChildNum = 1;
                   }
                else
-                  TR::Node::recreate(node, comp()->il.opCodeForDirectLoad(nodeDataType));
-
-               int32_t j;
-               for (j=0;j<node->getNumChildren();j++)
                   {
-                  if (j != newFirstChildNum)
-                     node->getChild(j)->recursivelyDecReferenceCount();
+                  TR::Node::recreate(node, comp()->il.opCodeForDirectLoad(nodeDataType));
+                  }
+
+               for (int32_t i = 0; i < node->getNumChildren(); i++)
+                  {
+                  if (i != newFirstChildNum)
+                     {
+                     node->getChild(i)->recursivelyDecReferenceCount();
+                     }
                   }
 
                if (newFirstChild)
@@ -734,22 +737,31 @@ void TR_FieldPrivatizer::privatizeFields(TR::Node *node, bool postDominatesEntry
                   node->setNumChildren(1);
                   }
                else
+                  {
                   node->setNumChildren(0);
+                  }
                }
             else
                {
-               if ( opCode.isStore() )
+               if (opCode.isStore())
                   {
                   _needToStoreBack->set(autoForField->getReferenceNumber());
+                  if (node->getOpCodeValue() == TR::wrtbar)
+                     {
+                     node->getChild(1)->recursivelyDecReferenceCount();
+                     node->setNumChildren(1);
+                     TR::Node::recreate(node, comp()->il.opCodeForDirectStore(nodeDataType));
+                     }
                   }
                }
             }
          }
       }
 
-   int32_t i;
-   for (i=0;i<node->getNumChildren();i++)
+   for (int32_t i = 0; i < node->getNumChildren(); i++)
+      {
       privatizeFields(node->getChild(i), postDominatesEntry, visitCount);
+      }
    }
 
 


### PR DESCRIPTION
Field privatizer can turn wrtbars that store to a static into a wrtbar
that stores to an auto. However, stores to autos do not need a wrtbar.
This change causes field privatizer to instead convert the wrtbar to an
aStore.

The second child of the original wrtbar is not needed by the new aStore so
it get anchored. This change set also fixes the issue with privatizing
indirect loads and stores where the children that were not being used were
not being anchored. Those children will now be anchored as well.
Particular care was taken to ensure that the nodes are anchored in the
same order they would have normally have been evaluatated in.

Issue: #1426
Signed-off-by: jimmyk <jimmyk@ca.ibm.com>