### PR TITLE
CMake: Build with CMake on Travis OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,6 @@ env:
 matrix:
   exclude:
     - os: osx
-      env: BUILD_WITH_CMAKE=yes CMAKE_GENERATOR=Ninja
-    - os: osx
       env: BUILD_WITH_CMAKE=yes CMAKE_GENERATOR="Unix Makefiles"
   include:
     - os: linux
@@ -63,8 +61,6 @@ matrix:
       dist: precise
     - os: linux
       env: SPEC=linux_x86 PLATFORM=amd64-linux-gcc
-    - os: osx
-      env: SPEC=osx_x86-64
 before_script:
   - ulimit -c unlimited
 script:

--- a/scripts/build-on-travis.sh
+++ b/scripts/build-on-travis.sh
@@ -26,6 +26,11 @@ if test "x$CMAKE_GENERATOR" = "x"; then
 fi
 
 if test "x$BUILD_WITH_CMAKE" = "xyes"; then
+
+  if test "x$TRAVIS_OS_NAME" = "xosx" && test "x$CMAKE_GENERATOR" = "xNinja"; then
+    brew install ninja
+  fi
+
   mkdir build
   cd build
   time cmake -Wdev -G "$CMAKE_GENERATOR" -C../cmake/caches/Travis.cmake ..


### PR DESCRIPTION
Delete the old osx build, because they are slow and keeping both will
bog down our CI.

Signed-off-by: Robert Young <rwy0717@gmail.com>