### PR TITLE
CMake: Set the module path relative to the current dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ include(cmake/versions.cmake) # Required for OMR_VERSION
 project(omr VERSION ${OMR_VERSION} LANGUAGES CXX C)
 set(OMR_ROOT ${CMAKE_CURRENT_LIST_DIR} CACHE INTERNAL "Root of OMR")
 
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules" ${CMAKE_MODULE_PATH})
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules" ${CMAKE_MODULE_PATH})
 
 include(OmrAssert)
 include(OmrFindFiles)


### PR DESCRIPTION
Using CMAKE_SOURCE_DIR will result in a bogus module path when there is
a parent cmake project vendoring OMR. IE CMAKE_SOURCE_DIR will not point
at the root of OMR.

Signed-off-by: Robert Young <rwy0717@gmail.com>