### PR TITLE
Improve JitBuilder handling of shift operands

### DIFF
--- a/compiler/ilgen/IlBuilder.hpp
+++ b/compiler/ilgen/IlBuilder.hpp
@@ -457,6 +457,9 @@ protected:
    TR::Node *binaryOpNodeFromNodes(TR::ILOpCodes op, TR::Node *leftNode, TR::Node *rightNode);
    TR::IlValue *binaryOpFromOpMap(OpCodeMapper mapOp, TR::IlValue *left, TR::IlValue *right);
    TR::IlValue *binaryOpFromOpCode(TR::ILOpCodes op, TR::IlValue *left, TR::IlValue *right);
+   TR::Node *shiftOpNodeFromNodes(TR::ILOpCodes op, TR::Node *leftNode, TR::Node *rightNode);
+   TR::IlValue *shiftOpFromNodes(TR::ILOpCodes op, TR::Node *leftNode, TR::Node *rightNode);
+   TR::IlValue *shiftOpFromOpMap(OpCodeMapper mapOp, TR::IlValue *left, TR::IlValue *right);
    TR::IlValue *compareOp(TR_ComparisonTypes ct, bool needUnsigned, TR::IlValue *left, TR::IlValue *right);
    TR::IlValue *convertTo(TR::IlType *t, TR::IlValue *v, bool needUnsigned);
 


### PR DESCRIPTION
After the new IL validator showed up, it exposed some weaknesses in
how operands of shift operations were being handled by JitBuilder.
In particular, shift operands are validated using the same mechanism
as for other binary operations, and that mechanism is entirely
inappropriate for shifts. In fact, it only really works for 32-bit
shift operands

This commit separates out the handling of shift operations from the
generic binaryOp* handling and makes the operand testing a bit more
relevant: the left operand must be integer typed, if the left operand
is narrower than 32-bits then it will be automatically widened to
32-bits, the right operand will be automatically converted to a
32-bit integer. If no conversion exists for either operand,
ConvertTo should assert.

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>