### PR TITLE
CMake: Do not use OMR_GLUE as a subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,15 +33,6 @@ set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules" ${CMAKE_MODULE_PATH})
 include(OmrAssert)
 include(OmrFindFiles)
 
-###
-### Getting the glue directory
-###
-
-if (NOT DEFINED OMR_GLUE)
-    set(OMR_GLUE "./example/glue" CACHE PATH "The glue directory")
-    message(STATUS "Glue not set, defaulting to example glue")
-endif()
-
 # TODO: OMR_EXAMPLE flag
 # TODO: OMR_RTTI flag
 
@@ -91,6 +82,11 @@ if(CMAKE_CROSSCOMPILING)
 	include(${OMR_TOOLS_IMPORTFILE})
 endif()
 
+if(OMR_EXAMPLE)
+	message(STATUS "Building example (Enabled by OMR_EXAMPLE).")
+	add_subdirectory(example)
+endif(OMR_EXAMPLE)
+
 add_subdirectory(thread)
 add_subdirectory(port)
 add_subdirectory(util)
@@ -103,8 +99,7 @@ add_subdirectory(omrsigcompat)
 add_subdirectory(fvtest)
 
 if(OMR_GC)
-  add_subdirectory(gc)
-  add_subdirectory("${OMR_GLUE}")
+	add_subdirectory(gc)
 endif(OMR_GC)
 
 if(OMR_JITBUILDER)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -16,6 +16,10 @@
 #    Multiple authors (IBM Corp.) - initial implementation and documentation
 ###############################################################################
 
+include(OmrAssert)
+
+omr_assert(TEST OMR_EXAMPLE)
+
 add_executable(example
   main.cpp
 )


### PR DESCRIPTION
We can't realistically use the OMR_GLUE as a subdirectory. This will
break when the glue is outside OMR. Instead, we have to rely on a parent
project defining all the right glue targets and variables, before
building omr.

Instead of testing for the existence of the OMR_GLUE variable,
The OMR_EXAMPLE flag can be used to conditionally add the example
directory, which will define the glue library.

OMR_EXAMPLE is already enabled in the CI.

There is an issue of interdependence here that we have yet to sort out.

Signed-off-by: Robert Young <rwy0717@gmail.com>