### PR TITLE
[CMake] Refactor JIT platform detection

### DIFF
--- a/cmake/compiler_support.cmake
+++ b/cmake/compiler_support.cmake
@@ -31,22 +31,65 @@ if (NOT PERL_FOUND )
    message(FATAL_ERROR "Perl not found")
 endif()
 
+
 set(MASM2GAS_PATH ${OMR_ROOT}/tools/compiler/scripts/masm2gas.pl CACHE INTERNAL "MASM2GAS PATH")
 
 include(${OMR_ROOT}/cmake/AddPrefix.cmake) 
 
-# Platform setup code!
-# TODO: THis needs to be abstracted for cross platform builds
+# Fetch the OMR view of the system.
+include(OmrDetectSystemInformation)
 
-set(TR_TARGET_ARCH    x     CACHE INTERNAL "The architecture directory used for the compiler code (x, p, arm, or z)")
-set(TR_TARGET_SUBARCH amd64 CACHE INTERNAL "The subarchitecture directory used for the compiler code. May be empty (i386 or amd64)")
-set(TR_TARGET_BITS    64    CACHE INTERNAL  "Bitness of the target architecture")
+macro(tr_detect_system_information)
 
-set(TR_HOST_ARCH    x     CACHE INTERNAL "The architecture directory used for the compiler code (x, p, or z)")
-set(TR_HOST_SUBARCH amd64 CACHE INTERNAL "The subarchitecture directory used for the compiler code. May be empty (i386 or amd64)")
-set(TR_HOST_BITS    64    CACHE INTERNAL  "Bitness of the target architecture")
+	macro(jit_not_ready)
+		message(FATAL "JIT isn't ready to build with CMake on this platform")
+	endmacro()
 
-set(CMAKE_ASM-ATT_FLAGS "--64 --defsym TR_HOST_X86=1 --defsym TR_HOST_64BIT=1 --defsym BITVECTOR_64BIT=1 --defsym LINUX=1 --defsym TR_TARGET_X86=1 --defsym TR_TARGET_64BIT=1" CACHE INTERNAL "ASM FLags")
+
+	omr_detect_system_information()
+
+
+	set(TR_COMPILE_DEFINITIONS "")
+
+
+	# Platform setup code! 
+	# TODOs:
+	#  - Support more platforms, and, separate host and target arch. 
+	#  - Once we support all the platforms OMR supports with CMake, this can be
+	#    largely integrated into OmrDetectSystemInformation.cmake. 
+	if(OMR_ARCH_X86)
+		set(TR_HOST_ARCH    x     CACHE INTERNAL "The architecture directory used for the compiler code (x, p, or z)")
+		list(APPEND TR_COMPILE_DEFINITIONS TR_HOST_X86 TR_TARGET_X86)
+		if(OMR_ENV_DATA64)
+			set(TR_HOST_SUBARCH amd64 CACHE INTERNAL "The subarchitecture directory used for the compiler code. May be empty (i386 or amd64)")
+			set(TR_HOST_BITS    64    CACHE INTERNAL  "Bitness of the target architecture")
+			set(CMAKE_ASM-ATT_FLAGS "--64 --defsym TR_HOST_X86=1 --defsym TR_HOST_64BIT=1 --defsym BITVECTOR_64BIT=1 --defsym LINUX=1 --defsym TR_TARGET_X86=1 --defsym TR_TARGET_64BIT=1" CACHE INTERNAL "ASM FLags")
+			list(APPEND TR_COMPILE_DEFINITIONS TR_HOST_64BIT TR_TARGET_64BIT)
+		else()
+			jit_not_ready()
+		endif()
+	else()
+		jit_not_ready()
+	endif()
+
+	if(OMR_HOST_OS MATCHES "osx|linux")
+		list(APPEND TR_COMPILE_DEFINITIONS SUPPORTS_THREAD_LOCAL)
+		string(TOUPPER ${OMR_HOST_OS} upcase_os)
+		list(APPEND TR_COMPILE_DEFINITIONS ${upcase_os} SUPPORTS_THREAD_LOCAL)
+	else()
+		jit_not_ready()
+	endif()
+
+
+	# Currently not doing cross, so assume HOST == TARGET
+	set(TR_TARGET_ARCH    ${TR_HOST_ARCH}    CACHE INTERNAL "The architecture directory used for the compiler code (x, p, arm, or z)")
+	set(TR_TARGET_SUBARCH ${TR_HOST_SUBARCH} CACHE INTERNAL "The subarchitecture directory used for the compiler code. May be empty (i386 or amd64)")
+	set(TR_TARGET_BITS    ${TR_HOST_BITS}    CACHE INTERNAL  "Bitness of the target architecture")
+
+	message(STATUS "Set TR_COMPILE_DEFINITIONS to ${TR_COMPILE_DEFINITIONS}")
+endmacro(tr_detect_system_information)
+
+tr_detect_system_information()
 
 # Mark a target as consuming the compiler components. 
 # 
@@ -80,12 +123,7 @@ function(make_compiler_target TARGET_NAME)
    target_compile_definitions(${TARGET_NAME} PRIVATE
       BITVECTOR_BIT_NUMBERING_MSB
       UT_DIRECT_TRACE_REGISTRATION
-      TR_HOST_64BIT
-      LINUX
-      TR_HOST_X86
-      TR_TARGET_X86
-      TR_TARGET_64BIT
-      SUPPORTS_THREAD_LOCAL
+      ${TR_COMPILE_DEFINITIONS}
       ${COMPILER_DEFINES} 
       )
 endfunction(make_compiler_target)


### PR DESCRIPTION
This patch turns the JIT platform detection into a function, and starts
to separate some pieces into variables. A side effect of this patch is
that it adds support for building compiler components with OS/X.

Signed-off-by: Matthew Gaudet <magaudet@ca.ibm.com>