### PR TITLE
Fix _patchVirtualGuard to not assert on false positives

### DIFF
--- a/compiler/z/runtime/VirtualGuardRuntime.cpp
+++ b/compiler/z/runtime/VirtualGuardRuntime.cpp
@@ -56,10 +56,8 @@ extern "C" void _patchVirtualGuard(uint8_t* locationAddr, uint8_t* destinationAd
 
    int64_t displacement = static_cast<int64_t>(destinationAddr - locationAddr) / 2;
 
-   if (locationAddr[0] == 0xA7 || locationAddr[0] == 0xC0)
+   if ((locationAddr[0] == 0xA7 || locationAddr[0] == 0xC0) && locationAddr[1] == 0x04)
       {
-      TR_ASSERT_FATAL((locationAddr[1] & 0x04) == 0x04, "Expected to find BRC (0xA704) or BRCL (0xC004) instruction at %p but instead found %x\n", locationAddr, *reinterpret_cast<int16_t*>(locationAddr + 2));
-
       if (locationAddr[0] == 0xA7)
          {
          TR_ASSERT_FATAL(*reinterpret_cast<int16_t*>(locationAddr + 2) == displacement, "Branch RI displacement at %p (%x) does not match the displacement calculated from argument %p (%x)\n", locationAddr, *reinterpret_cast<int16_t*>(locationAddr + 2), destinationAddr, displacement);


### PR DESCRIPTION
When patching happens synchronously we are effectively patching in a
jump with a guarantee no processor will be executing the patch location.
Thus there is no race condition. This means we will be overwriting
existing instructions. If it so happens that the instruction at the
patch location has opcode 0xA7 or 0xC0 as the first byte we may
encounter a false positive and incorrectly assert. Such an example can
be seen if an LHI R8,0 (0xA7880000) instruction is after the VGNOP.

This fix strengthens the condition of when one byte patching happens,
i.e. if and only if we are certain a BRC or BRCL is present.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>