### PR TITLE
Tril test improvements

### DIFF
--- a/compiler/ilgen/IlInjector.cpp
+++ b/compiler/ilgen/IlInjector.cpp
@@ -34,6 +34,7 @@
 #include "ilgen/IlGeneratorMethodDetails_inlines.hpp"
 #include "ilgen/TypeDictionary.hpp"
 #include "infra/Cfg.hpp"
+#include "ras/ILValidator.hpp"
 
 #define OPT_DETAILS "O^O ILGEN: "
 
@@ -130,6 +131,13 @@ OMR::IlInjector::genIL()
    _comp->setCurrentIlGenerator(this);
    bool success = injectIL();
    _comp->setCurrentIlGenerator(0);
+
+   if (success)
+      {
+      TR::ILValidator validator(_comp);
+      success = validator.treesAreValid(_methodSymbol->getFirstTreeTop());
+      }
+
    return success;
    }
 

--- a/compiler/ras/ILValidator.cpp
+++ b/compiler/ras/ILValidator.cpp
@@ -39,6 +39,7 @@
 
 TR::ILValidator::ILValidator(TR::Compilation *comp)
    :_comp(comp)
+   ,_isValidSoFar(true)
    ,_nodeStates(comp->trMemory())
    ,_liveNodes(_nodeStates, comp->trMemory())
    {

--- a/fvtest/compilertriltest/ArithmeticTest.cpp
+++ b/fvtest/compilertriltest/ArithmeticTest.cpp
@@ -35,7 +35,9 @@ TEST_P(Int32Arithmetic, UsingConst) {
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
     auto entry_point = compiler.getEntryPoint<int32_t (*)(void)>();
-    ASSERT_EQ(param.oracle(param.lhs, param.rhs), entry_point());
+    volatile auto exp = param.oracle(param.lhs, param.rhs);
+    volatile auto act = entry_point();
+    ASSERT_EQ(exp, act);
 }
 
 TEST_P(Int32Arithmetic, UsingLoadParam) {
@@ -62,10 +64,31 @@ INSTANTIATE_TEST_CASE_P(ArithmeticTest, Int32Arithmetic, ::testing::Combine(
         std::make_tuple("isub", [](int32_t l, int32_t r){return l-r;}),
         std::make_tuple("imul", [](int32_t l, int32_t r){return l*r;}) )));
 
+/**
+ * @brief Filter function for *div opcodes
+ * @tparam T is the data type of the div opcode
+ * @param a is the set of input values to be tested for filtering
+ *
+ * This function is a predicate for filtering invalid input values for the
+ * *div opcodes. This includes pairs where the divisor is 0, and pairs where
+ * dividend is the minimum (negative) value for the type and the divisor is -1.
+ * The latter is a problem because in two's complement, the quotient of the
+ * signed minimum and -1 is greater than the maximum value representable by
+ * the given type. On some platforms this computation results in SIGFPE.
+ */
+template <typename T>
+bool div_filter(std::tuple<T, T> a)
+   {
+   auto isDivisorZero = std::get<1>(a) == 0;
+   auto isDividendMin = std::get<0>(a) == std::numeric_limits<T>::min();
+   auto isDivisorNegativeOne = std::get<1>(a) == TRTest::negative_one_value<T>();
+
+   return isDivisorZero || (isDividendMin && isDivisorNegativeOne);
+   }
+
 INSTANTIATE_TEST_CASE_P(DivArithmeticTest, Int32Arithmetic, ::testing::Combine(
     ::testing::ValuesIn(
-        TRTest::filter(TRTest::const_value_pairs<int32_t, int32_t>(),
-                       [](std::tuple<int32_t, int32_t> a){ return std::get<1>(a) == 0;} )),
+        TRTest::filter(TRTest::const_value_pairs<int32_t, int32_t>(), div_filter<int32_t> )),
     ::testing::Values(
         std::make_tuple("idiv", [](int32_t l, int32_t r){return l/r;}),
         std::make_tuple("irem", [](int32_t l, int32_t r){return l%r;}) )));

--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -29,7 +29,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fno-rtti -fno-threadsafe-statics -Wn
 add_executable(comptest
    main.cpp
    JitTestUtilitiesTest.cpp
-   TreeVerifierTest.cpp
+   ILValidatorTest.cpp
    ArithmeticTest.cpp
    ShiftAndRotateTest.cpp
 )

--- a/fvtest/compilertriltest/ILValidatorTest.cpp
+++ b/fvtest/compilertriltest/ILValidatorTest.cpp
@@ -35,7 +35,7 @@ TEST_P(IllformedTrees, FailCompilation) {
             << "Compilation did not fail due to ill-formed input trees";
 }
 
-INSTANTIATE_TEST_CASE_P(TreeVerifierDeathTest, IllformedTrees, ::testing::Values(
+INSTANTIATE_TEST_CASE_P(ILValidatorDeathTest, IllformedTrees, ::testing::Values(
     "(method return=Int32 (block (ireturn (iadd (iconst 1) (sconst 3)))))",
     "(method return=Int32 (block (ireturn (sadd (iconst 1) (iconst 3)))))",
     "(method return=Address (block (areturn (aiadd (aconst 4) (lconst 1)))))",
@@ -64,7 +64,7 @@ TEST_P(WellformedTrees, CompileOnly) {
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly";
 }
 
-INSTANTIATE_TEST_CASE_P(TreeVerifierTest, WellformedTrees, ::testing::Values(
+INSTANTIATE_TEST_CASE_P(ILValidatorTest, WellformedTrees, ::testing::Values(
     "(method return=Int32 (block (ireturn (iconst 3))))",
     "(method return=Int32 (block (ireturn (sconst 3))))",
     "(method return=Int32 (block (ireturn (iadd (iconst 1) (iconst 3)))))",

--- a/fvtest/compilertriltest/JitTest.hpp
+++ b/fvtest/compilertriltest/JitTest.hpp
@@ -125,8 +125,10 @@ C filter(C range, Predicate pred) {
  * @brief A family of functions returning constants of the specified type
  */
 template <typename T> constexpr T zero_value() { return static_cast<T>(0); }
-template <typename T> constexpr T positive_value() { return static_cast<T>(3); }
-template <typename T> constexpr T negative_value() { return static_cast<T>(-2); }
+template <typename T> constexpr T one_value() { return static_cast<T>(1); }
+template <typename T> constexpr T negative_one_value() { return static_cast<T>(-1); }
+template <typename T> constexpr T positive_value() { return static_cast<T>(42); }
+template <typename T> constexpr T negative_value() { return static_cast<T>(-42); }
 
 /**
  * @brief Convenience function returning possible test inputs of the specified type
@@ -135,10 +137,15 @@ template <typename T>
 std::vector<T> const_values()
    {
    return std::vector<T>{ zero_value<T>(),
+                          one_value<T>(),
+                          negative_one_value<T>(),
                           positive_value<T>(),
                           negative_value<T>(),
                           std::numeric_limits<T>::min(),
-                          std::numeric_limits<T>::max() };
+                          std::numeric_limits<T>::max(),
+                          std::numeric_limits<T>::min() + 1,
+                          std::numeric_limits<T>::max() - 1
+                        };
    }
 
 /**

--- a/fvtest/compilertriltest/JitTest.hpp
+++ b/fvtest/compilertriltest/JitTest.hpp
@@ -27,6 +27,8 @@
 #define EXPECT_NULL(pointer) EXPECT_EQ(nullptr, (pointer))
 #define EXPECT_NOTNULL(pointer) EXPECT_TRUE(nullptr != (pointer))
 
+#define TRIL(code) #code
+
 extern "C" bool initializeJitWithOptions(char *options);
 
 namespace TRTest
@@ -118,6 +120,35 @@ C filter(C range, Predicate pred) {
     range.erase(end, range.end());
     return range;
 }
+
+/**
+ * @brief A family of functions returning constants of the specified type
+ */
+template <typename T> constexpr T zero_value() { return static_cast<T>(0); }
+template <typename T> constexpr T positive_value() { return static_cast<T>(3); }
+template <typename T> constexpr T negative_value() { return static_cast<T>(-2); }
+
+/**
+ * @brief Convenience function returning possible test inputs of the specified type
+ */
+template <typename T>
+std::vector<T> const_values()
+   {
+   return std::vector<T>{ zero_value<T>(),
+                          positive_value<T>(),
+                          negative_value<T>(),
+                          std::numeric_limits<T>::min(),
+                          std::numeric_limits<T>::max() };
+   }
+
+/**
+ * @brief Convenience function returning pairs of possible test inputs of the specified types
+ */
+template <typename L, typename R>
+std::vector<std::tuple<L,R>> const_value_pairs()
+   {
+   return TRTest::combine(const_values<L>(), const_values<R>());
+   }
 
 } // namespace CompTest
 

--- a/fvtest/compilertriltest/OpCodeTest.hpp
+++ b/fvtest/compilertriltest/OpCodeTest.hpp
@@ -32,35 +32,6 @@ namespace TRTest
 {
 
 /**
- * @brief A family of functions returning constants of the specified type
- */
-template <typename T> constexpr T zero_value() { return static_cast<T>(0); }
-template <typename T> constexpr T positive_value() { return static_cast<T>(3); }
-template <typename T> constexpr T negative_value() { return static_cast<T>(-2); }
-
-/**
- * @brief Convenience function returning possible test inputs of the specified type
- */
-template <typename T>
-std::vector<T> const_values()
-   {
-   return std::vector<T>{ zero_value<T>(),
-                          positive_value<T>(),
-                          negative_value<T>(),
-                          std::numeric_limits<T>::min(),
-                          std::numeric_limits<T>::max() };
-   }
-
-/**
- * @brief Convenience function returning pairs of possible test inputs of the specified types
- */
-template <typename L, typename R>
-std::vector<std::tuple<L,R>> const_value_pairs()
-   {
-   return TRTest::combine(const_values<L>(), const_values<R>());
-   }
-
-/**
  * @brief Type for holding argument to parameterized opcode tests
  * @tparam Ret the type returned by the opcode
  * @tparam Args the types of the arguments to the opcode

--- a/fvtest/tril/test/ASTTest.cpp
+++ b/fvtest/tril/test/ASTTest.cpp
@@ -242,8 +242,7 @@ TEST(ASTNodeTest, CreateNullNode) {
 }
 
 TEST(ASTNodeTest, CreateNodeWithJustName) {
-   char* nodeName = "theName";
-
+   auto nodeName = "theName";
    auto node = createNode(nodeName, NULL, NULL, NULL);
 
    ASSERT_STREQ(nodeName, node->name);
@@ -288,10 +287,10 @@ TEST(ASTNodeTest, CreateNodeWithJustArgumentList) {
 }
 
 TEST(ASTNodeTest, CreateListFrom2SingleNodes) {
-   char* nodeName_1 = "a node name";
+   auto nodeName_1 = "a node name";
    ASTNodeArg* argList_1 = NULL;
    auto node_1 = createNode(nodeName_1, argList_1, NULL, NULL);
-   char* nodeName_0 = "another node name";
+   auto nodeName_0 = "another node name";
    ASTNodeArg* argList_0 = getNodeArgList();
    auto node_0 = createNode(nodeName_0, argList_0, NULL, NULL);
 
@@ -309,10 +308,10 @@ TEST(ASTNodeTest, CreateListFrom2SingleNodes) {
 }
 
 TEST(ASTNodeTest, Concatenate2SingleNodes)  {
-   char* nodeName_1 = "a node name";
+   auto nodeName_1 = "a node name";
    ASTNodeArg* argList_1 = NULL;
    auto node_1 = createNode(nodeName_1, argList_1, NULL, NULL);
-   char* nodeName_0 = "another node name";
+   auto nodeName_0 = "another node name";
    ASTNodeArg* argList_0 = getNodeArgList();
    auto node_0 = createNode(nodeName_0, argList_0, NULL, node_1);
 
@@ -328,13 +327,13 @@ TEST(ASTNodeTest, Concatenate2SingleNodes)  {
 }
 
 TEST(ASTNodeTest, CreateListFromListOf2AndSingleNode) {
-   char* nodeName_2 = "some node name";
+   auto nodeName_2 = "some node name";
    ASTNodeArg* argList_2 = getNodeArgList();
    auto node_2 = createNode(nodeName_2, argList_2, NULL, NULL);
-   char* nodeName_1 = "a node name";
+   auto nodeName_1 = "a node name";
    ASTNodeArg* argList_1 = NULL;
    auto node_1 = createNode(nodeName_1, argList_1, NULL, NULL);
-   char* nodeName_0 = "another node name";
+   auto nodeName_0 = "another node name";
    ASTNodeArg* argList_0 = getNodeArgList();
    auto node_0 = createNode(nodeName_0, argList_0, NULL, NULL);
 
@@ -358,13 +357,13 @@ TEST(ASTNodeTest, CreateListFromListOf2AndSingleNode) {
 }
 
 TEST(ASTNodeTest, Concatenate3SingleNodes)  {
-   char* nodeName_2 = "some node name";
+   auto nodeName_2 = "some node name";
    ASTNodeArg* argList_2 = getNodeArgList();
    auto node_2 = createNode(nodeName_2, argList_2, NULL, NULL);
-   char* nodeName_1 = "a node name";
+   auto nodeName_1 = "a node name";
    ASTNodeArg* argList_1 = NULL;
    auto node_1 = createNode(nodeName_1, argList_1, NULL, NULL);
-   char* nodeName_0 = "another node name";
+   auto nodeName_0 = "another node name";
    ASTNodeArg* argList_0 = getNodeArgList();
    auto node_0 = createNode(nodeName_0, argList_0, NULL, node_1);
 

--- a/fvtest/tril/tril/ast.c
+++ b/fvtest/tril/tril/ast.c
@@ -20,7 +20,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-ASTNode* createNode(char * name, ASTNodeArg* args, ASTNode* children,  ASTNode* next) {
+ASTNode* createNode(const char * name, ASTNodeArg* args, ASTNode* children,  ASTNode* next) {
     ASTNode* n = (ASTNode*)malloc(sizeof(ASTNode));
     //printf("  node at %p\n", n);
     n->name = name;

--- a/fvtest/tril/tril/ast.h
+++ b/fvtest/tril/tril/ast.h
@@ -51,13 +51,13 @@ struct ASTNodeArg {
 struct ASTNode;
 typedef struct ASTNode ASTNode;
 struct ASTNode {
-    char* name;
+    const char* name;
     ASTNodeArg* args;
     ASTNode* children;
     ASTNode* next;
 };
 
-ASTNode* createNode(char* name, ASTNodeArg* args, ASTNode* children,  ASTNode* next);
+ASTNode* createNode(const char* name, ASTNodeArg* args, ASTNode* children,  ASTNode* next);
 
 ASTNodeArg* createNodeArg(const char* name, ASTValue * value,  ASTNodeArg* next);
 

--- a/fvtest/tril/tril/ilgen.cpp
+++ b/fvtest/tril/tril/ilgen.cpp
@@ -173,7 +173,7 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
          const auto name = tree->name;
          auto type = opcode.getType();
          auto compilation = TR::comp();
-         TR::Symbol *sym = TR::Symbol::createNamedShadow(compilation->trHeapMemory(), type, TR::DataType::getSize(opcode.getType()), name);
+         TR::Symbol *sym = TR::Symbol::createNamedShadow(compilation->trHeapMemory(), type, TR::DataType::getSize(opcode.getType()), (char*)name);
          TR::SymbolReference *symref = new (compilation->trHeapMemory()) TR::SymbolReference(compilation->getSymRefTab(), sym, compilation->getMethodSymbol()->getResolvedMethodIndex(), -1);
          symref->setOffset(offset);
          node = TR::Node::createWithSymRef(opcode.getOpCodeValue(), childCount, symref);


### PR DESCRIPTION
Various improvements to Tril-based tests:

- remove some compiler warnings
- rename some tests
- improve availability of some testing utilities
- add tests and test input values
- run ILValidator immediately IlGen in IlInjector