### PR TITLE
Add portlib api to return max heap size

### DIFF
--- a/gc/base/GCExtensionsBase.cpp
+++ b/gc/base/GCExtensionsBase.cpp
@@ -58,9 +58,6 @@ bool
 MM_GCExtensionsBase::initialize(MM_EnvironmentBase* env)
 {
 	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
-	uint64_t physicalMemory = 0;
-	uint64_t memoryLimit = 0;
-	uint64_t usableMemory = 0;
 	uint64_t memoryToRequest = 0;
 	uintptr_t *pageSizes = NULL;
 	uintptr_t *pageFlags = NULL;
@@ -99,38 +96,8 @@ MM_GCExtensionsBase::initialize(MM_EnvironmentBase* env)
 	excessiveGCStats.endGCTimeStamp = omrtime_hires_clock();
 	excessiveGCStats.lastEndGlobalGCTimeStamp = excessiveGCStats.endGCTimeStamp;
 
-	/* Set Xmx (heap default).  For most platforms the heap default is a fraction of
-	 * the available physical memory, bounded by the build specs.
-	 *
-	 * 	Windows: half the REAL memory; with a min of 16MiB and a max of 2GiB.
-	 *
-	 * Linux, AIX, and z/OS:  half of OMR_MIN(physical memory, RLIMIT_AS) with a min of
-	 * 16 MiB and a max of 512 MiB.
-	 * -note that RLIMIT_AS is as extracted from getrlimit and represents the resouce
-	 * limitation on address space.
-	 */
-
-	/* Initial physicalMemory as per system call. */
-	physicalMemory = omrsysinfo_get_physical_memory();
-	if (OMRPORT_LIMIT_LIMITED == omrsysinfo_get_limit(OMRPORT_RESOURCE_ADDRESS_SPACE, &memoryLimit)) {
-		/* there is a limit on the memory we can use so take the minimum of this usable amount and the physical memory */
-		usableMemory = OMR_MIN(memoryLimit, physicalMemory);
-	} else {
-		/* if there is no memory limit being imposed on us, we will use physical memory as our max */
-		usableMemory = physicalMemory;
-	}
-	/* we are going to try to request a slice of half the usable memory */
-	memoryToRequest = (usableMemory / 2);
-
-	/* TODO: Only cap HRT to 64M heap.  Should this be removed? */
-#define J9_PHYSICAL_MEMORY_MAX (uint64_t)(512 * 1024 * 1024)
-#define J9_PHYSICAL_MEMORY_DEFAULT (16 * 1024 * 1024)
-
-	if (0 == memoryToRequest) {
-		memoryToRequest = J9_PHYSICAL_MEMORY_DEFAULT;
-	}
-	memoryToRequest = OMR_MIN(memoryToRequest, J9_PHYSICAL_MEMORY_MAX);
-
+	memoryToRequest = omrsysinfo_get_physical_memory_for_heap();
+ 
 	/* Initialize Xmx, Xmdx */
 	memoryMax = MM_Math::roundToFloor(heapAlignment, (uintptr_t)memoryToRequest);
 	maxSizeDefaultMemorySpace = MM_Math::roundToFloor(heapAlignment, (uintptr_t)memoryToRequest);

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -1001,6 +1001,10 @@ typedef struct OMROSKernelInfo {
 	uint32_t minorRevision;
 } OMROSKernelInfo;
 
+#define OMR_HEAP_MEMORY_DEFAULT ((uint64_t)(16 * 1024 * 1024))
+#define OMR_HEAP_MEMORY_MAX ((uint64_t)(512 * 1024 * 1024))
+#define OMR_HEAP_MEMORY_FRACTION ((double)0.5) /* use half of the usable memory */
+
 struct OMRPortLibrary;
 typedef struct J9Heap J9Heap;
 
@@ -1446,6 +1450,12 @@ typedef struct OMRPortLibrary {
 	int32_t ( *sysinfo_cgroup_enable_limits)(struct OMRPortLibrary *portLibrary);
 	/** see @ref omrsysinfo.c::omrsysinfo_cgroup_get_memlimit "omrsysinfo_cgroup_get_memlimit"*/
 	int32_t (*sysinfo_cgroup_get_memlimit)(struct OMRPortLibrary *portLibrary, uint64_t *limit);
+	/** see @ref omrsysinfo.c::omrsysinfo_cgroup_use_memlimit_for_heap "omrsysinfo_cgroup_use_memlimit_for_heap"*/
+	void (*sysinfo_cgroup_use_memlimit_for_heap)(struct OMRPortLibrary *portLibrary);
+	/** see @ref omrsysinfo.c::omrsysinfo_get_usable_memory "omrsysinfo_get_usable_memory"*/
+	uint64_t (*sysinfo_get_usable_memory)(struct OMRPortLibrary *portLibrary);
+	/** see @ref omrsysinfo.c::omrsysinfo_get_physical_memory_for_heap "omrsysinfo_get_physical_memory_for_heap"*/
+	uint64_t (*sysinfo_get_physical_memory_for_heap)(struct OMRPortLibrary *portLibrary);
 	/** see @ref omrport.c::omrport_init_library "omrport_init_library"*/
 	int32_t (*port_init_library)(struct OMRPortLibrary *portLibrary, uintptr_t size) ;
 	/** see @ref omrport.c::omrport_startup_library "omrport_startup_library"*/
@@ -1890,6 +1900,9 @@ extern J9_CFUNC int32_t omrport_getVersion(struct OMRPortLibrary *portLibrary);
 #define omrsysinfo_cgroup_is_limits_enabled() privateOmrPortLibrary->sysinfo_cgroup_is_limits_enabled(privateOmrPortLibrary) 
 #define omrsysinfo_cgroup_enable_limits() privateOmrPortLibrary->sysinfo_cgroup_enable_limits(privateOmrPortLibrary)
 #define omrsysinfo_cgroup_get_memlimit(param1) privateOmrPortLibrary->sysinfo_cgroup_get_memlimit(privateOmrPortLibrary, param1)
+#define omrsysinfo_cgroup_use_memlimit_for_heap() privateOmrPortLibrary->sysinfo_cgroup_use_memlimit_for_heap(privateOmrPortLibrary)
+#define omrsysinfo_get_usable_memory() privateOmrPortLibrary->sysinfo_get_usable_memory(privateOmrPortLibrary)
+#define omrsysinfo_get_physical_memory_for_heap() privateOmrPortLibrary->sysinfo_get_physical_memory_for_heap(privateOmrPortLibrary) 
 #define omrintrospect_startup() privateOmrPortLibrary->introspect_startup(privateOmrPortLibrary)
 #define omrintrospect_shutdown() privateOmrPortLibrary->introspect_shutdown(privateOmrPortLibrary)
 #define omrintrospect_set_suspend_signal_offset(param1) privateOmrPortLibrary->introspect_set_suspend_signal_offset(privateOmrPortLibrary, param1)

--- a/port/common/omrport.c
+++ b/port/common/omrport.c
@@ -254,7 +254,10 @@ static OMRPortLibrary MasterPortLibraryTable = {
 	omrsysinfo_cgroup_is_limits_supported, /* sysinfo_cgroup_is_limits_supported */
 	omrsysinfo_cgroup_is_limits_enabled, /* sysinfo_cgroup_is_limits_enabled */
 	omrsysinfo_cgroup_enable_limits, /* sysinfo_cgroup_enable_limits */
-	omrsysinfo_cgroup_get_memlimit, /* sysinfo_cgroup_get_memlimit */	
+	omrsysinfo_cgroup_get_memlimit, /* sysinfo_cgroup_get_memlimit */
+	omrsysinfo_cgroup_use_memlimit_for_heap, /* sysinfo_cgroup_use_memlimit_for_heap */
+	omrsysinfo_get_usable_memory, /* sysinfo_get_usable_memory */
+	omrsysinfo_get_physical_memory_for_heap, /* sysinfo_get_physical_memory_for_heap */
 	omrport_init_library, /* port_init_library */
 	omrport_startup_library, /* port_startup_library */
 	omrport_create_library, /* port_create_library */

--- a/port/common/omrsysinfo.c
+++ b/port/common/omrsysinfo.c
@@ -863,3 +863,51 @@ omrsysinfo_cgroup_get_memlimit(struct OMRPortLibrary *portLibrary, uint64_t *lim
 {
 	return OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM;
 }
+
+/**
+ * Enable port library to use cgroup limits on memory
+ * for determining heap size
+ *
+ * @param[in] portLibrary pointer to OMRPortLibrary
+ *
+ * @return void
+ */
+void
+omrsysinfo_cgroup_use_memlimit_for_heap(struct OMRPortLibrary *portLibrary)
+{
+}
+
+/**
+ * Windows: returns physical memory
+ * Unix like systems: OMR_MIN(physical memory, RLIMIT_AS)
+ * where RLIMIT_AS is resourlce limitation on address space.
+ *
+ * @param[in] portLibrary pointer to OMRPortLibrary
+ *
+ * @return usable memory in the system
+ */
+uint64_t
+omrsysinfo_get_usable_memory(struct OMRPortLibrary *portLibrary)
+{
+	return 0;
+}
+
+/**
+ * Returns physical memory to be used for heap.
+ * For most platforms the heap default is a fraction of the available physical memory.
+ *
+ * Windows: half the physical memory with default of 16 MB and a max of 512 MB
+ *
+ * Linux, AIX, and z/OS:  half of OMR_MIN(physical memory, RLIMIT_AS) with a default of
+ * 16 MB and a max of 512 MB.
+ * RLIMIT_AS is the resource limitation on address space.
+ *
+ * @param[in] portLibrary pointer to OMRPortLibrary
+ *
+ * @return physical memory to be used for heap
+ */
+uint64_t
+omrsysinfo_get_physical_memory_for_heap(struct OMRPortLibrary *portLibrary)
+{
+	return 0;
+}

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -519,6 +519,12 @@ extern J9_CFUNC int32_t
 omrsysinfo_cgroup_enable_limits(struct OMRPortLibrary *portLibrary);
 extern J9_CFUNC int32_t 
 omrsysinfo_cgroup_get_memlimit(struct OMRPortLibrary *portLibrary, uint64_t *limit);
+extern J9_CFUNC void
+omrsysinfo_cgroup_use_memlimit_for_heap(struct OMRPortLibrary *portLibrary);
+extern J9_CFUNC uint64_t
+omrsysinfo_get_usable_memory(struct OMRPortLibrary *portLibrary);
+extern J9_CFUNC uint64_t
+omrsysinfo_get_physical_memory_for_heap(struct OMRPortLibrary *portLibrary);
 
 /* J9SourceJ9Signal*/
 extern J9_CFUNC int32_t

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -1602,6 +1602,7 @@ omrsysinfo_startup(struct OMRPortLibrary *portLibrary)
 	(void) find_executable_name(portLibrary, &PPG_si_executableName);
 
 #if defined(LINUX)
+	PPG_useCgroupMemLimitForHeap = FALSE;
 	PPG_cgroupEntryList = NULL;
 #endif /* defined(LINUX) */
 	return 0;
@@ -3525,3 +3526,53 @@ _end:
 #endif /* defined(LINUX) */
 	return rc;
 }
+
+void
+omrsysinfo_cgroup_use_memlimit_for_heap(struct OMRPortLibrary *portLibrary)
+{
+#if defined(LINUX)
+	PPG_useCgroupMemLimitForHeap = TRUE;
+#endif /* defined(LINUX) */
+}
+
+uint64_t
+omrsysinfo_get_usable_memory(struct OMRPortLibrary *portLibrary)
+{
+	uint64_t usableMemory = 0;
+	uint64_t memoryLimit = 0;
+
+#if defined(LINUX)
+	if (PPG_useCgroupMemLimitForHeap) {
+		int32_t rc = portLibrary->sysinfo_cgroup_get_memlimit(portLibrary, &usableMemory);
+		if (0 != rc) {
+			usableMemory = portLibrary->sysinfo_get_physical_memory(portLibrary);
+		}
+	}
+#else /* defined(LINUX) */
+	usableMemory = portLibrary->sysinfo_get_physical_memory(portLibrary);
+#endif /* defined(LINUX) */
+
+	if (OMRPORT_LIMIT_LIMITED == portLibrary->sysinfo_get_limit(portLibrary, OMRPORT_RESOURCE_ADDRESS_SPACE, &memoryLimit)) {
+		/* there is a limit on the memory we can use so take the minimum of this usable amount and the physical memory */
+		usableMemory = OMR_MIN(memoryLimit, usableMemory);
+	}
+
+	return usableMemory;    
+}
+
+uint64_t
+omrsysinfo_get_physical_memory_for_heap(struct OMRPortLibrary *portLibrary)
+{
+	uint64_t heapMemory = portLibrary->sysinfo_get_usable_memory(portLibrary);
+
+	if (0 == heapMemory) {
+		heapMemory = OMR_HEAP_MEMORY_DEFAULT;
+	} else {
+		Assert_PRT_true(OMR_HEAP_MEMORY_FRACTION < 1);
+		heapMemory = (heapMemory / 100) * (uint64_t)(OMR_HEAP_MEMORY_FRACTION * 100);
+		heapMemory = OMR_MIN(heapMemory, OMR_HEAP_MEMORY_MAX);
+	}
+
+	return heapMemory;
+}
+

--- a/port/unix_include/omrportpg.h
+++ b/port/unix_include/omrportpg.h
@@ -79,6 +79,7 @@ typedef struct OMRPortPlatformGlobals {
 	int32_t introspect_threadSuspendSignal;
 #endif /* defined(OMR_CONFIGURABLE_SUSPEND_SIGNAL) */
 #if defined(LINUX)
+	BOOLEAN useCgroupMemLimitForHeap; /**< indicates if cgroup memory limit be used for the heap */
 	BOOLEAN cgroupLimitsEnabled; /**< indicates if port library supports cgroup limits */
 	OMRCgroupEntry *cgroupEntryList; /**< head of the circular linked list, each element contains information about cgroup of the process for a subsystem */
 #endif /* defined(LINUX) */
@@ -120,6 +121,7 @@ typedef struct OMRPortPlatformGlobals {
 #endif
 
 #if defined(LINUX)
+#define PPG_useCgroupMemLimitForHeap (portLibrary->portGlobals->platformGlobals.useCgroupMemLimitForHeap)
 #define PPG_cgroupLimitsEnabled (portLibrary->portGlobals->platformGlobals.cgroupLimitsEnabled)
 #define PPG_cgroupEntryList (portLibrary->portGlobals->platformGlobals.cgroupEntryList)
 #endif /* defined(LINUX) */

--- a/port/win32/omrsysinfo.c
+++ b/port/win32/omrsysinfo.c
@@ -1636,3 +1636,30 @@ omrsysinfo_cgroup_get_memlimit(struct OMRPortLibrary *portLibrary, uint64_t *lim
 {
 	return OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM;
 }
+
+void
+omrsysinfo_cgroup_use_memlimit_for_heap(struct OMRPortLibrary *portLibrary)
+{
+}
+
+uint64_t
+omrsysinfo_get_usable_memory(struct OMRPortLibrary *portLibrary)
+{
+	return portLibrary->sysinfo_get_physical_memory(portLibrary);
+}
+
+uint64_t
+omrsysinfo_get_physical_memory_for_heap(struct OMRPortLibrary *portLibrary)
+{
+	uint64_t heapMemory = portLibrary->sysinfo_get_usable_memory(portLibrary);
+
+	if (0 == heapMemory) {
+		heapMemory = OMR_HEAP_MEMORY_DEFAULT;
+	} else {
+		Assert_PRT_true(OMR_HEAP_MEMORY_FRACTION < 1);
+		heapMemory = (heapMemory / 100) * (uint64_t)(OMR_HEAP_MEMORY_FRACTION * 100);
+		heapMemory = OMR_MIN(heapMemory, OMR_HEAP_MEMORY_MAX);
+	}
+
+	return heapMemory;
+}


### PR DESCRIPTION
A new port library API omrsysinfo_get_physical_memory_for_heap()
is added that returns the default max heap size taking into account
following factors:
1. physical memory in the system
2. cgroup limit on memory (conditional)
3. address space limit on memory

Another API omrsysinfo_cgroup_use_memlimit_for_heap() is added
that sets a flag which will cause omrsysinfo_get_physical_memory_for_heap()
to use cgroup limit on memory for determining the max heap size.

Signed-off-by: Ashutosh Mehra <asmehra1@in.ibm.com>