### PR TITLE
Make evaluators agree with codegen on CPU checks

### DIFF
--- a/compiler/p/codegen/FPTreeEvaluator.cpp
+++ b/compiler/p/codegen/FPTreeEvaluator.cpp
@@ -191,7 +191,7 @@ TR::Register *OMR::Power::TreeEvaluator::lbits2dEvaluator(TR::Node *node, TR::Co
       else
          {
          TR::Register *longReg = cg->evaluate(child);
-         if (TR::Compiler->target.cpu.id() == TR_PPCp8)
+         if (TR::Compiler->target.cpu.id() >= TR_PPCp8)
             {
             TR::Register * tmp1 = cg->allocateRegister(TR_FPR);
             generateMvFprGprInstructions(cg, node, gpr2fprHost32, false, target, longReg->getHighOrder(), longReg->getLowOrder(), tmp1);
@@ -260,7 +260,7 @@ TR::Register *OMR::Power::TreeEvaluator::dbits2lEvaluator(TR::Node *node, TR::Co
          {
          highReg = cg->allocateRegister();
          lowReg = cg->allocateRegister();
-         if (TR::Compiler->target.cpu.id() == TR_PPCp8)
+         if (TR::Compiler->target.cpu.id() >= TR_PPCp8)
             {
             TR::Register * tmp1 = cg->allocateRegister(TR_FPR);
             generateMvFprGprInstructions(cg, node, fpr2gprHost32, false, highReg, lowReg, doubleReg, tmp1);
@@ -1373,7 +1373,7 @@ TR::Register *OMR::Power::TreeEvaluator::int2dbl(TR::Node * node, TR::Register *
             else
                generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::srawi, node, tempReg, srcReg, 31);
 
-            if (TR::Compiler->target.cpu.id() == TR_PPCp8)
+            if (TR::Compiler->target.cpu.id() >= TR_PPCp8)
                {
                TR::Register * tmp1 = cg->allocateRegister(TR_FPR);
                generateMvFprGprInstructions(cg, node, gpr2fprHost32, false, trgReg, tempReg, srcReg, tmp1);
@@ -1527,7 +1527,7 @@ TR::Register *OMR::Power::TreeEvaluator::long2dbl(TR::Node *node, TR::CodeGenera
          generateMvFprGprInstructions(cg, node, gpr2fprHost64, false, trgReg, srcReg);
       else
          {
-         if (TR::Compiler->target.cpu.id() == TR_PPCp8)
+         if (TR::Compiler->target.cpu.id() >= TR_PPCp8)
             {
             TR::Register * tmp1 = cg->allocateRegister(TR_FPR);
             generateMvFprGprInstructions(cg, node, gpr2fprHost32, false, trgReg, srcReg->getHighOrder(), srcReg->getLowOrder(), tmp1);
@@ -1588,7 +1588,7 @@ TR::Register *OMR::Power::TreeEvaluator::long2float(TR::Node *node, TR::CodeGene
          generateMvFprGprInstructions(cg, node, gpr2fprHost64, false, trgReg, srcReg);
       else
          {
-         if (TR::Compiler->target.cpu.id() == TR_PPCp8)
+         if (TR::Compiler->target.cpu.id() >= TR_PPCp8)
             {
             TR::Register * tmp1 = cg->allocateRegister(TR_FPR);
             generateMvFprGprInstructions(cg, node, gpr2fprHost32, false, trgReg, srcReg->getHighOrder(), srcReg->getLowOrder(), tmp1);

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -688,7 +688,7 @@ TR::Register *OMR::Power::TreeEvaluator::lloadEvaluator(TR::Node *node, TR::Code
                }
             else
                {
-               if (TR::Compiler->target.cpu.id() == TR_PPCp8)
+               if (TR::Compiler->target.cpu.id() >= TR_PPCp8)
                   {
                   TR::Register * tmp1 = cg->allocateRegister(TR_FPR);
                   generateMvFprGprInstructions(cg, node, fpr2gprHost32, false, highReg, lowReg, doubleReg, tmp1);
@@ -1247,7 +1247,7 @@ TR::Register *OMR::Power::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::Cod
                   tempMRStore2->forceIndexedForm(node, cg);
                   TR::Register *highReg = cg->allocateRegister();
                   TR::Register *lowReg = cg->allocateRegister();
-                  if (TR::Compiler->target.cpu.id() == TR_PPCp8)
+                  if (TR::Compiler->target.cpu.id() >= TR_PPCp8)
                      {
                      TR::Register * tmp1 = cg->allocateRegister(TR_FPR);
                      generateMvFprGprInstructions(cg, node, fpr2gprHost32, false, highReg, lowReg, doubleReg, tmp1);
@@ -1269,7 +1269,7 @@ TR::Register *OMR::Power::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::Cod
                }
             else
                {
-               if (TR::Compiler->target.cpu.id() == TR_PPCp8)
+               if (TR::Compiler->target.cpu.id() >= TR_PPCp8)
                   {
                   TR::Register * tmp1 = cg->allocateRegister(TR_FPR);
                   generateMvFprGprInstructions(cg, node, gpr2fprHost32, false, doubleReg, valueReg->getHighOrder(), valueReg->getLowOrder(), tmp1);


### PR DESCRIPTION
Evaluators that call generateMvFprGprInstructions()
on Power with the gpr2fprHost32 or fpr2gprHost32
options need to check if the current CPU is '>= p8'
rather than just '== p8' so they can pass the required
temp register to generateMvFprGprInstructions().

Fixes #1415.

Signed-off-by: Younes Manton <ymanton@ca.ibm.com>