### PR TITLE
Explicitly list include directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,9 +58,6 @@ include(cmake/config.cmake)
 
 enable_testing()
 
-#include current source dir and current bin dir automatically
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
 include_directories(
   ${PROJECT_BINARY_DIR}
   ./include/

--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(omrport_obj OBJECT
 	ut_omrport.c
 )
 
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 if(OMR_HOST_OS STREQUAL "aix")
 	list(APPEND OBJECTS omrgetsp.c)


### PR DESCRIPTION
This is required by the compiler technology because of the include path magic used to implement static polymorphism

Fixes #1514