### PR TITLE
Yet another batch of Tril improvements

### DIFF
--- a/compiler/infra/TrilDumper.cpp
+++ b/compiler/infra/TrilDumper.cpp
@@ -165,7 +165,7 @@ void TR::TrilDumper::visitingCommonedChildNode(TR::Node* node)
    {
    // for commoned nodes, we can "close" the node right away since the children
    // are not re-visited
-   fprintf(_outputFile, "(@common id=\"n%dn\") ", node->getGlobalIndex());
+   fprintf(_outputFile, "(@id \"n%dn\") ", node->getGlobalIndex());
    }
 
 void TR::TrilDumper::visitedAllChildrenOfNode(TR::Node* node)

--- a/fvtest/compilertriltest/ILValidatorTest.cpp
+++ b/fvtest/compilertriltest/ILValidatorTest.cpp
@@ -85,10 +85,10 @@ TEST_P(CommoningTest, CommoningUnderSameTree)
                                (icmpeq
                                   (imul
                                      (iadd (iload parm=0 id="loadParm0") (iload parm=1 id="loadParm1"))
-                                     (isub (@common id="loadParm0") (@common id="loadParm1")))
+                                     (isub (@id "loadParm0") (@id "loadParm1")))
                                   (isub
-                                     (imul (@common id="loadParm0") (@common id="loadParm0"))
-                                     (imul (@common id="loadParm1") (@common id="loadParm1")))
+                                     (imul (@id "loadParm0") (@id "loadParm0"))
+                                     (imul (@id "loadParm1") (@id "loadParm1")))
                                   )))));
 
    auto ast = parseString(tril);
@@ -113,11 +113,11 @@ TEST_P(CommoningTest, CommoningWithinBlock)
                            (ireturn
                                (icmpeq
                                   (imul
-                                     (iadd (@common id="loadParm0") (@common id="loadParm1"))
-                                     (isub (@common id="loadParm0") (@common id="loadParm1")))
+                                     (iadd (@id "loadParm0") (@id "loadParm1"))
+                                     (isub (@id "loadParm0") (@id "loadParm1")))
                                   (isub
-                                     (imul (@common id="loadParm0") (@common id="loadParm0"))
-                                     (imul (@common id="loadParm1") (@common id="loadParm1")))
+                                     (imul (@id "loadParm0") (@id "loadParm0"))
+                                     (imul (@id "loadParm1") (@id "loadParm1")))
                                   )))));
 
    auto ast = parseString(tril);

--- a/fvtest/tril/examples/mandelbrot/mandelbrot.tril
+++ b/fvtest/tril/examples/mandelbrot/mandelbrot.tril
@@ -62,12 +62,12 @@
                (ddiv
                   (dconst 2.0000)
                   (i2d
-                     (@common id="setup_iload_parm1") ) ) )
+                     (@id "setup_iload_parm1") ) ) )
             (dconst 1.0000) ) )
       (dstore temp="x"                          ; double x = 0.0;
          (dconst 0.0000 id="setup_dconst_0") )
       (dstore temp="y"                          ; double y = 0.0;
-         (@common id="setup_dconst_0") )
+         (@id "setup_dconst_0") )
       (istore temp="iter"                       ; int iter = 0;
          (iconst 0) ) )
    (block name="loop"                           ; loop:
@@ -76,10 +76,10 @@
             (dadd
                (dmul
                   (dload temp="x" id="loop_dload_x")
-                  (@common id="loop_dload_x") )
+                  (@id "loop_dload_x") )
                (dmul
                   (dload temp="y" id="loop_dload_y")
-                  (@common id="loop_dload_y") ) )
+                  (@id "loop_dload_y") ) )
             (dconst 4.0000) ) )
       (istore temp="comp2"                      ; int comp2 = iter < parm0;
          (icmplt
@@ -97,10 +97,10 @@
             (dsub
                (dmul
                   (dload temp="x" id="loop_body_dload_x")
-                  (@common id="loop_body_dload_x") )
+                  (@id "loop_body_dload_x") )
                (dmul
                   (dload temp="y" id="loop_body_dload_y")
-                  (@common id="loop_body_dload_y") ) ) ) )
+                  (@id "loop_body_dload_y") ) ) ) )
       (dstore temp="y"                          ; y = y0 + 2.0 * x * y;
          (dadd
             (dload temp="y0")

--- a/fvtest/tril/test/ASTTest.cpp
+++ b/fvtest/tril/test/ASTTest.cpp
@@ -326,6 +326,63 @@ TEST(ASTNodeArgumentTest, CreateListFrom3SingleArguments) {
    ASSERT_EQ(NULL, arg_2->next);
 }
 
+TEST(ASTNodeArgumentTest, CompareArgumentsWithSelf) {
+    auto v = createIntegerValue(10);
+    auto name = "arg0";
+    auto arg = createNodeArg(name, v, nullptr);
+
+    ASSERT_TRUE(*arg == *arg);
+    ASSERT_FALSE(*arg != *arg);
+}
+
+TEST(ASTNodeArgumentTest, CompareEqualArguments) {
+    auto v0 = createIntegerValue(10);
+    auto v1 = createIntegerValue(10);
+    auto name0 = "arg0";
+    auto name1 = "arg0";
+    auto arg0 = createNodeArg(name0, v0, nullptr);
+    auto arg1 = createNodeArg(name1, v1, nullptr);
+
+    ASSERT_TRUE(*arg0 == *arg1);
+    ASSERT_FALSE(*arg0 != *arg1);
+}
+
+TEST(ASTNodeArgumentTest, CompareArgumentsWithDifferentNames) {
+    auto v0 = createIntegerValue(10);
+    auto v1 = createIntegerValue(10);
+    auto name0 = "arg0";
+    auto name1 = "arg1";
+    auto arg0 = createNodeArg(name0, v0, nullptr);
+    auto arg1 = createNodeArg(name1, v1, nullptr);
+
+    ASSERT_TRUE(*arg0 != *arg1);
+    ASSERT_FALSE(*arg0 == *arg1);
+}
+
+TEST(ASTNodeArgumentTest, CompareArgumentsWithDifferentValues) {
+    auto v0 = createIntegerValue(10);
+    auto v1 = createIntegerValue(14);
+    auto name0 = "arg0";
+    auto name1 = "arg0";
+    auto arg0 = createNodeArg(name0, v0, nullptr);
+    auto arg1 = createNodeArg(name1, v1, nullptr);
+
+    ASSERT_TRUE(*arg0 != *arg1);
+    ASSERT_FALSE(*arg0 == *arg1);
+}
+
+TEST(ASTNodeArgumentTest, CompareArgumentsWithDifferentTypes) {
+    auto v0 = createIntegerValue(10);
+    auto v1 = createFloatingPointValue(10.0);
+    auto name0 = "arg0";
+    auto name1 = "arg0";
+    auto arg0 = createNodeArg(name0, v0, nullptr);
+    auto arg1 = createNodeArg(name1, v1, nullptr);
+
+    ASSERT_TRUE(*arg0 != *arg1);
+    ASSERT_FALSE(*arg0 == *arg1);
+}
+
 TEST(ASTNodeTest, CreateNullNode) {
    auto node = createNode(NULL, NULL, NULL, NULL);
 

--- a/fvtest/tril/test/ASTTest.cpp
+++ b/fvtest/tril/test/ASTTest.cpp
@@ -18,7 +18,7 @@
 
 #include <cstring>
 #include <gtest/gtest.h>
-#include "ast.h"
+#include "ast.hpp"
 
 bool operator == (ASTValue lhs, ASTValue rhs) {
    if (lhs.type == rhs.type) {

--- a/fvtest/tril/test/ASTTest.cpp
+++ b/fvtest/tril/test/ASTTest.cpp
@@ -75,6 +75,111 @@ TEST(ASTValueTest, CreateValueList) {
     ASSERT_EQ(NULL, v->next);
 }
 
+/*
+ * Since the comparison tests verify the behavior of overloaded comparison
+ * operators, they explicitly call the operators inside an ASSERT_{TRUE|FALSE}
+ * instead of using comparison ASSERTs (ASSERT_EQ, ASSERT_NE, etc.).
+ */
+
+TEST(ASTValueTest, CompareIntegerValueWithSelf) {
+    const auto intBaseValue = 10UL;
+    auto value = createIntegerValue(intBaseValue);
+
+    ASSERT_TRUE(*value == *value);
+    ASSERT_FALSE(*value != *value);
+}
+
+TEST(ASTValueTest, CompareEqualIntegerValues) {
+    const auto intBaseValue = 10UL;
+    auto value1 = createIntegerValue(intBaseValue);
+    auto value2 = createIntegerValue(intBaseValue);
+
+    ASSERT_TRUE(*value1 == *value2);
+    ASSERT_FALSE(*value1 != *value2);
+}
+
+TEST(ASTValueTest, CompareFloatingPointValueWithSelf) {
+    const double doubleBaseValue = 4.56;
+    auto value = createFloatingPointValue(doubleBaseValue);
+
+    ASSERT_TRUE(*value == *value);
+    ASSERT_FALSE(*value != *value);
+}
+
+TEST(ASTValueTest, CompareEqualFloatingPointValues) {
+    const double doubleBaseValue = 4.56;
+    auto value1 = createFloatingPointValue(doubleBaseValue);
+    auto value2 = createFloatingPointValue(doubleBaseValue);
+
+    ASSERT_TRUE(*value1 == *value2);
+    ASSERT_FALSE(*value1 != *value2);
+}
+
+TEST(ASTValueTest, CompareStringValueWithSelf) {
+    auto baseStrValue = "Some string\n";
+    auto value = createStrValue(baseStrValue);
+
+    ASSERT_TRUE(*value == *value);
+    ASSERT_FALSE(*value != *value);
+}
+
+TEST(ASTValueTest, CompareEqualStringValues) {
+    auto baseStrValue = "Some string\n";
+    auto value1 = createStrValue(baseStrValue);
+    auto value2 = createStrValue(baseStrValue);
+
+    ASSERT_TRUE(*value1 == *value2);
+    ASSERT_FALSE(*value1 != *value2);
+}
+
+TEST(ASTValueTest, CompareDifferentIntegerValues) {
+    auto value1 = createIntegerValue(3);
+    auto value2 = createIntegerValue(15);
+
+    ASSERT_TRUE(*value1 != *value2);
+    ASSERT_FALSE(*value1 == *value2);
+}
+
+TEST(ASTValueTest, CompareDifferentFloatingPointValues) {
+    auto value1 = createFloatingPointValue(3.6);
+    auto value2 = createFloatingPointValue(3.4);
+
+    ASSERT_TRUE(*value1 != *value2);
+    ASSERT_FALSE(*value1 == *value2);
+}
+
+TEST(ASTValueTest, CompareDifferentStringValues) {
+    auto value1 = createStrValue("string 1");
+    auto value2 = createStrValue("string 2");
+
+    ASSERT_TRUE(*value1 != *value2);
+    ASSERT_FALSE(*value1 == *value2);
+}
+
+TEST(ASTValueTest, CompareIntegerAndFloatingPointValues) {
+    auto value1 = createIntegerValue(3);
+    auto value2 = createFloatingPointValue(3.0);
+
+    ASSERT_TRUE(*value1 != *value2);
+    ASSERT_FALSE(*value1 == *value2);
+}
+
+TEST(ASTValueTest, CompareFloatingPointAndStringValues) {
+    auto value1 = createFloatingPointValue(3.6);
+    auto value2 = createStrValue("3.6");
+
+    ASSERT_TRUE(*value1 != *value2);
+    ASSERT_FALSE(*value1 == *value2);
+}
+
+TEST(ASTValueTest, CompareStringAndIntegerValues) {
+    auto value1 = createStrValue("123");
+    auto value2 = createIntegerValue(123);
+
+    ASSERT_TRUE(*value1 != *value2);
+    ASSERT_FALSE(*value1 == *value2);
+}
+
 TEST(ASTNodeArgumentTest, CreateNodeArgumentWithJustInt64Value) {
    auto baseValue = 3UL;
    auto value = createIntegerValue(baseValue);

--- a/fvtest/tril/test/ASTTest.cpp
+++ b/fvtest/tril/test/ASTTest.cpp
@@ -25,8 +25,8 @@ TEST(ASTValueTest, CreateInt64ASTValue) {
 
    auto value = createInt64Value(baseValue);
 
-   ASSERT_EQ(Int64, value->type);
-   ASSERT_EQ(baseValue, value->value.int64);
+   ASSERT_EQ(Int64, value->getType());
+   ASSERT_EQ(baseValue, value->get<ASTValue::Integer_t>());
 }
 
 TEST(ASTValueTest, CreateFloat64ASTValue) {
@@ -34,8 +34,8 @@ TEST(ASTValueTest, CreateFloat64ASTValue) {
 
    auto value = createDoubleValue(baseValue);
 
-   ASSERT_EQ(Double, value->type);
-   ASSERT_EQ(baseValue, value->value.f64);
+   ASSERT_EQ(Double, value->getType());
+   ASSERT_EQ(baseValue, value->get<ASTValue::Double_t>());
 }
 
 TEST(ASTValueTest, CreateStringASTValue) {
@@ -43,8 +43,8 @@ TEST(ASTValueTest, CreateStringASTValue) {
 
    auto value = createStrValue(baseValue);
 
-   ASSERT_EQ(String, value->type);
-   ASSERT_STREQ(baseValue, value->value.str);
+   ASSERT_EQ(String, value->getType());
+   ASSERT_STREQ(baseValue, value->get<ASTValue::String_t>());
 }
 
 TEST(ASTValueTest, CreateValueList) {
@@ -60,18 +60,18 @@ TEST(ASTValueTest, CreateValueList) {
     appendSiblingValue(intValue, stringValue);
 
     auto v = intValue;
-    ASSERT_EQ(Int64, v->type);
-    ASSERT_EQ(intBaseValue, v->value.int64);
+    ASSERT_EQ(Int64, v->getType());
+    ASSERT_EQ(intBaseValue, v->get<ASTValue::Integer_t>());
     ASSERT_EQ(doubleValue, v->next);
 
     v = v->next;
-    ASSERT_EQ(Double, v->type);
-    ASSERT_EQ(doubleBaseValue, v->value.f64);
+    ASSERT_EQ(Double, v->getType());
+    ASSERT_EQ(doubleBaseValue, v->get<ASTValue::Double_t>());
     ASSERT_EQ(stringValue, v->next);
 
     v = v->next;
-    ASSERT_EQ(String, v->type);
-    ASSERT_STREQ(stringBaseValue, v->value.str);
+    ASSERT_EQ(String, v->getType());
+    ASSERT_STREQ(stringBaseValue, v->get<ASTValue::String_t>());
     ASSERT_EQ(NULL, v->next);
 }
 

--- a/fvtest/tril/test/ASTTest.cpp
+++ b/fvtest/tril/test/ASTTest.cpp
@@ -61,17 +61,17 @@ TEST(ASTValueTest, CreateValueList) {
 
     auto v = intValue;
     ASSERT_EQ(ASTValue::Integer, v->getType());
-    ASSERT_EQ(intBaseValue, v->get<ASTValue::Integer_t>());
+    ASSERT_EQ(intBaseValue, v->getInteger());
     ASSERT_EQ(doubleValue, v->next);
 
     v = v->next;
     ASSERT_EQ(ASTValue::FloatingPoint, v->getType());
-    ASSERT_EQ(doubleBaseValue, v->get<ASTValue::FloatingPoint_t>());
+    ASSERT_EQ(doubleBaseValue, v->getFloatingPoint());
     ASSERT_EQ(stringValue, v->next);
 
     v = v->next;
     ASSERT_EQ(ASTValue::String, v->getType());
-    ASSERT_STREQ(stringBaseValue, v->get<ASTValue::String_t>());
+    ASSERT_STREQ(stringBaseValue, v->getString());
     ASSERT_EQ(NULL, v->next);
 }
 

--- a/fvtest/tril/test/ASTTest.cpp
+++ b/fvtest/tril/test/ASTTest.cpp
@@ -80,8 +80,8 @@ TEST(ASTNodeArgumentTest, CreateNodeArgumentWithJustInt64Value) {
    auto value = createInt64Value(baseValue);
    auto arg = createNodeArg(NULL, value, NULL);
 
-   ASSERT_STREQ(NULL, arg->name);
-   ASSERT_EQ(value, arg->value);
+   ASSERT_STREQ(NULL, arg->getName());
+   ASSERT_EQ(value, arg->getValue());
    ASSERT_EQ(NULL, arg->next);
 }
 
@@ -90,8 +90,8 @@ TEST(ASTNodeArgumentTest, CreateNodeArgumentWithJustFloat64Value) {
    auto value = createDoubleValue(baseValue);
    auto arg = createNodeArg(NULL, value, NULL);
 
-   ASSERT_STREQ(NULL, arg->name);
-   ASSERT_EQ(value, arg->value);
+   ASSERT_STREQ(NULL, arg->getName());
+   ASSERT_EQ(value, arg->getValue());
    ASSERT_EQ(NULL, arg->next);
 }
 
@@ -100,8 +100,8 @@ TEST(ASTNodeArgumentTest, CreateNodeArgumentWithJustStringValue) {
    auto value = createStrValue(baseValue);
    auto arg = createNodeArg(NULL, value, NULL);
 
-   ASSERT_STREQ(NULL, arg->name);
-   ASSERT_EQ(value, arg->value);
+   ASSERT_STREQ(NULL, arg->getName());
+   ASSERT_EQ(value, arg->getValue());
    ASSERT_EQ(NULL, arg->next);
 }
 
@@ -111,8 +111,8 @@ TEST(ASTNodeArgumentTest, CreateNodeArgumentWithNameAndInt64Value) {
    auto value = createInt64Value(baseValue);
    auto arg = createNodeArg(argName, value, NULL);
 
-   ASSERT_STREQ(argName, arg->name);
-   ASSERT_EQ(value, arg->value);
+   ASSERT_STREQ(argName, arg->getName());
+   ASSERT_EQ(value, arg->getValue());
    ASSERT_EQ(NULL, arg->next);
 }
 
@@ -127,12 +127,12 @@ TEST(ASTNodeArgumentTest, CreateListFrom2SingleNodeArguments) {
    auto value_0 = createDoubleValue(baseValue_0);
    auto arg_0 = createNodeArg(argName_0, value_0, arg_1);
 
-   ASSERT_STREQ(argName_0, arg_0->name);
-   ASSERT_EQ(value_0, arg_0->value);
+   ASSERT_STREQ(argName_0, arg_0->getName());
+   ASSERT_EQ(value_0, arg_0->getValue());
    ASSERT_EQ(arg_1, arg_0->next);
 
-   ASSERT_STREQ(argName_1, arg_1->name);
-   ASSERT_EQ(value_1, arg_1->value);
+   ASSERT_STREQ(argName_1, arg_1->getName());
+   ASSERT_EQ(value_1, arg_1->getValue());
    ASSERT_EQ(NULL, arg_1->next);
 }
 
@@ -149,12 +149,12 @@ TEST(ASTNodeArgumentTest, Concatenate2SingleNodeArguments) {
 
    appendSiblingArg(arg_0, arg_1);
 
-   ASSERT_STREQ(argName_0, arg_0->name);
-   ASSERT_EQ(value_0, arg_0->value);
+   ASSERT_STREQ(argName_0, arg_0->getName());
+   ASSERT_EQ(value_0, arg_0->getValue());
    ASSERT_EQ(arg_1, arg_0->next);
 
-   ASSERT_STREQ(argName_1, arg_1->name);
-   ASSERT_EQ(value_1, arg_1->value);
+   ASSERT_STREQ(argName_1, arg_1->getName());
+   ASSERT_EQ(value_1, arg_1->getValue());
    ASSERT_EQ(NULL, arg_1->next);
 }
 
@@ -176,16 +176,16 @@ TEST(ASTNodeArgumentTest, CreateListFromListOf2AndSingleArgument) {
 
    appendSiblingArg(arg_0, arg_2);
 
-   ASSERT_STREQ(argName_0, arg_0->name);
-   ASSERT_EQ(value_0, arg_0->value);
+   ASSERT_STREQ(argName_0, arg_0->getName());
+   ASSERT_EQ(value_0, arg_0->getValue());
    ASSERT_EQ(arg_1, arg_0->next);
 
-   ASSERT_STREQ(argName_1, arg_1->name);
-   ASSERT_EQ(value_1, arg_1->value);
+   ASSERT_STREQ(argName_1, arg_1->getName());
+   ASSERT_EQ(value_1, arg_1->getValue());
    ASSERT_EQ(arg_2, arg_1->next);
 
-   ASSERT_STREQ(argName_2, arg_2->name);
-   ASSERT_EQ(value_2, arg_2->value);
+   ASSERT_STREQ(argName_2, arg_2->getName());
+   ASSERT_EQ(value_2, arg_2->getValue());
    ASSERT_EQ(NULL, arg_2->next);
 }
 
@@ -208,16 +208,16 @@ TEST(ASTNodeArgumentTest, CreateListFrom3SingleArguments) {
    appendSiblingArg(arg_0, arg_1);
    appendSiblingArg(arg_0, arg_2);
 
-   ASSERT_STREQ(argName_0, arg_0->name);
-   ASSERT_EQ(value_0, arg_0->value);
+   ASSERT_STREQ(argName_0, arg_0->getName());
+   ASSERT_EQ(value_0, arg_0->getValue());
    ASSERT_EQ(arg_1, arg_0->next);
 
-   ASSERT_STREQ(argName_1, arg_1->name);
-   ASSERT_EQ(value_1, arg_1->value);
+   ASSERT_STREQ(argName_1, arg_1->getName());
+   ASSERT_EQ(value_1, arg_1->getValue());
    ASSERT_EQ(arg_2, arg_1->next);
 
-   ASSERT_STREQ(argName_2, arg_2->name);
-   ASSERT_EQ(value_2, arg_2->value);
+   ASSERT_STREQ(argName_2, arg_2->getName());
+   ASSERT_EQ(value_2, arg_2->getValue());
    ASSERT_EQ(NULL, arg_2->next);
 }
 

--- a/fvtest/tril/test/ASTTest.cpp
+++ b/fvtest/tril/test/ASTTest.cpp
@@ -20,17 +20,6 @@
 #include <gtest/gtest.h>
 #include "ast.hpp"
 
-bool operator == (ASTValue lhs, ASTValue rhs) {
-   if (lhs.type == rhs.type) {
-      switch (lhs.type) {
-         case Int64: return lhs.value.int64 == rhs.value.int64;
-         case Double: return lhs.value.f64 == rhs.value.f64;
-         case String: return std::strcmp(lhs.value.str, rhs.value.str) == 0;
-      }
-   }
-   return false;
-}
-
 TEST(ASTValueTest, CreateInt64ASTValue) {
    auto baseValue = 3UL;
 

--- a/fvtest/tril/test/ASTTest.cpp
+++ b/fvtest/tril/test/ASTTest.cpp
@@ -23,19 +23,19 @@
 TEST(ASTValueTest, CreateInt64ASTValue) {
    auto baseValue = 3UL;
 
-   auto value = createInt64Value(baseValue);
+   auto value = createIntegerValue(baseValue);
 
-   ASSERT_EQ(Int64, value->getType());
+   ASSERT_EQ(ASTValue::Integer, value->getType());
    ASSERT_EQ(baseValue, value->get<ASTValue::Integer_t>());
 }
 
 TEST(ASTValueTest, CreateFloat64ASTValue) {
    auto baseValue = 3.0;
 
-   auto value = createDoubleValue(baseValue);
+   auto value = createFloatingPointValue(baseValue);
 
-   ASSERT_EQ(Double, value->getType());
-   ASSERT_EQ(baseValue, value->get<ASTValue::Double_t>());
+   ASSERT_EQ(ASTValue::FloatingPoint, value->getType());
+   ASSERT_EQ(baseValue, value->get<ASTValue::FloatingPoint_t>());
 }
 
 TEST(ASTValueTest, CreateStringASTValue) {
@@ -43,7 +43,7 @@ TEST(ASTValueTest, CreateStringASTValue) {
 
    auto value = createStrValue(baseValue);
 
-   ASSERT_EQ(String, value->getType());
+   ASSERT_EQ(ASTValue::String, value->getType());
    ASSERT_STREQ(baseValue, value->get<ASTValue::String_t>());
 }
 
@@ -52,32 +52,32 @@ TEST(ASTValueTest, CreateValueList) {
     auto doubleBaseValue = 2.71828;
     auto stringBaseValue = "a string";
 
-    auto intValue = createInt64Value(intBaseValue);
-    auto doubleValue = createDoubleValue(doubleBaseValue);
+    auto intValue = createIntegerValue(intBaseValue);
+    auto doubleValue = createFloatingPointValue(doubleBaseValue);
     auto stringValue = createStrValue(stringBaseValue);
 
     appendSiblingValue(intValue, doubleValue);
     appendSiblingValue(intValue, stringValue);
 
     auto v = intValue;
-    ASSERT_EQ(Int64, v->getType());
+    ASSERT_EQ(ASTValue::Integer, v->getType());
     ASSERT_EQ(intBaseValue, v->get<ASTValue::Integer_t>());
     ASSERT_EQ(doubleValue, v->next);
 
     v = v->next;
-    ASSERT_EQ(Double, v->getType());
-    ASSERT_EQ(doubleBaseValue, v->get<ASTValue::Double_t>());
+    ASSERT_EQ(ASTValue::FloatingPoint, v->getType());
+    ASSERT_EQ(doubleBaseValue, v->get<ASTValue::FloatingPoint_t>());
     ASSERT_EQ(stringValue, v->next);
 
     v = v->next;
-    ASSERT_EQ(String, v->getType());
+    ASSERT_EQ(ASTValue::String, v->getType());
     ASSERT_STREQ(stringBaseValue, v->get<ASTValue::String_t>());
     ASSERT_EQ(NULL, v->next);
 }
 
 TEST(ASTNodeArgumentTest, CreateNodeArgumentWithJustInt64Value) {
    auto baseValue = 3UL;
-   auto value = createInt64Value(baseValue);
+   auto value = createIntegerValue(baseValue);
    auto arg = createNodeArg(NULL, value, NULL);
 
    ASSERT_STREQ(NULL, arg->getName());
@@ -87,7 +87,7 @@ TEST(ASTNodeArgumentTest, CreateNodeArgumentWithJustInt64Value) {
 
 TEST(ASTNodeArgumentTest, CreateNodeArgumentWithJustFloat64Value) {
    auto baseValue = 3.0;
-   auto value = createDoubleValue(baseValue);
+   auto value = createFloatingPointValue(baseValue);
    auto arg = createNodeArg(NULL, value, NULL);
 
    ASSERT_STREQ(NULL, arg->getName());
@@ -108,7 +108,7 @@ TEST(ASTNodeArgumentTest, CreateNodeArgumentWithJustStringValue) {
 TEST(ASTNodeArgumentTest, CreateNodeArgumentWithNameAndInt64Value) {
    auto baseValue = 3UL;
    auto argName = "the argument name";
-   auto value = createInt64Value(baseValue);
+   auto value = createIntegerValue(baseValue);
    auto arg = createNodeArg(argName, value, NULL);
 
    ASSERT_STREQ(argName, arg->getName());
@@ -124,7 +124,7 @@ TEST(ASTNodeArgumentTest, CreateListFrom2SingleNodeArguments) {
 
    auto baseValue_0 = 3.0;
    auto argName_0 = "the argument name";
-   auto value_0 = createDoubleValue(baseValue_0);
+   auto value_0 = createFloatingPointValue(baseValue_0);
    auto arg_0 = createNodeArg(argName_0, value_0, arg_1);
 
    ASSERT_STREQ(argName_0, arg_0->getName());
@@ -144,7 +144,7 @@ TEST(ASTNodeArgumentTest, Concatenate2SingleNodeArguments) {
 
    auto baseValue_0 = 3.0;
    auto argName_0 = "the argument name";
-   auto value_0 = createDoubleValue(baseValue_0);
+   auto value_0 = createFloatingPointValue(baseValue_0);
    auto arg_0 = createNodeArg(argName_0, value_0, NULL);
 
    appendSiblingArg(arg_0, arg_1);
@@ -161,7 +161,7 @@ TEST(ASTNodeArgumentTest, Concatenate2SingleNodeArguments) {
 TEST(ASTNodeArgumentTest, CreateListFromListOf2AndSingleArgument) {
    auto baseValue_2 = 3.0;
    auto argName_2 = "the argument name";
-   auto value_2 = createDoubleValue(baseValue_2);
+   auto value_2 = createFloatingPointValue(baseValue_2);
    auto arg_2 = createNodeArg(argName_2, value_2, NULL);
 
    auto baseValue_1 = "a simple string";
@@ -171,7 +171,7 @@ TEST(ASTNodeArgumentTest, CreateListFromListOf2AndSingleArgument) {
 
    auto baseValue_0 = 3.0;
    auto argName_0 = "yet another name";
-   auto value_0 = createDoubleValue(baseValue_0);
+   auto value_0 = createFloatingPointValue(baseValue_0);
    auto arg_0 = createNodeArg(argName_0, value_0, arg_1);
 
    appendSiblingArg(arg_0, arg_2);
@@ -192,7 +192,7 @@ TEST(ASTNodeArgumentTest, CreateListFromListOf2AndSingleArgument) {
 TEST(ASTNodeArgumentTest, CreateListFrom3SingleArguments) {
    auto baseValue_2 = 3.0;
    auto argName_2 = "the argument name";
-   auto value_2 = createDoubleValue(baseValue_2);
+   auto value_2 = createFloatingPointValue(baseValue_2);
    auto arg_2 = createNodeArg(argName_2, value_2, NULL);
 
    auto baseValue_1 = "a simple string";
@@ -202,7 +202,7 @@ TEST(ASTNodeArgumentTest, CreateListFrom3SingleArguments) {
 
    auto baseValue_0 = 3.0;
    auto argName_0 = "yet another name";
-   auto value_0 = createDoubleValue(baseValue_0);
+   auto value_0 = createFloatingPointValue(baseValue_0);
    auto arg_0 = createNodeArg(argName_0, value_0, NULL);
 
    appendSiblingArg(arg_0, arg_1);
@@ -241,7 +241,7 @@ TEST(ASTNodeTest, CreateNodeWithJustName) {
 }
 
 TEST(ASTNodeTest, CreateNodeWithJust1Argument) {
-   auto nodeArgValue = createDoubleValue(3.0);
+   auto nodeArgValue = createFloatingPointValue(3.0);
    auto nodeArg = createNodeArg("someArgument", nodeArgValue, NULL);
    auto node = createNode(NULL, nodeArg, NULL, NULL);
 
@@ -252,9 +252,9 @@ TEST(ASTNodeTest, CreateNodeWithJust1Argument) {
 }
 
 ASTNodeArg* getNodeArgList() {
-   auto nodeArgValue_2 = createDoubleValue(3.0);
+   auto nodeArgValue_2 = createFloatingPointValue(3.0);
    auto nodeArg_2 = createNodeArg("someArgument", nodeArgValue_2, NULL);
-   auto nodeArgValue_1 = createInt64Value(3);
+   auto nodeArgValue_1 = createIntegerValue(3);
    auto nodeArg_1 = createNodeArg("someArgument", nodeArgValue_1, nodeArg_2);
    auto nodeArgValue_0 = createStrValue("some string");
    auto nodeArg_0 = createNodeArg("someArgument", nodeArgValue_0, nodeArg_1);

--- a/fvtest/tril/test/ASTTest.cpp
+++ b/fvtest/tril/test/ASTTest.cpp
@@ -536,3 +536,80 @@ TEST(ASTNodeTest, Concatenate3SingleNodes)  {
    ASSERT_EQ(NULL, node_2->next);
 }
 
+ASTNodeArg* getMixedArgumentList() {
+   auto argList = createNodeArg("arg0", createIntegerValue(3), nullptr);
+   appendSiblingArg(argList, createNodeArg("", createStrValue("value1"), nullptr));
+   appendSiblingArg(argList, createNodeArg("arg1", createFloatingPointValue(5.4), nullptr));
+   appendSiblingArg(argList, createNodeArg("", createStrValue("value3"), nullptr));
+
+   return argList;
+}
+
+TEST(ASTNodeTest, GetArgsTest) {
+   auto argList = getMixedArgumentList();
+   auto node = createNode("testNode", argList, nullptr, nullptr);
+
+   auto arg = node->getArgs();
+   ASSERT_EQ(*argList, *arg);
+   arg = arg->next;
+   argList = argList->next;
+   ASSERT_EQ(*argList, *arg);
+   arg = arg->next;
+   argList = argList->next;
+   ASSERT_EQ(*argList, *arg);
+   arg = arg->next;
+   argList = argList->next;
+   ASSERT_EQ(*argList, *arg);
+}
+
+TEST(ASTNodeTest, GetFirstArgumentTest) {
+   auto argList = getMixedArgumentList();
+   auto node = createNode("testNode", argList, nullptr, nullptr);
+
+   auto arg = node->getArgument(0);
+   ASSERT_EQ(*argList, *arg);
+}
+
+TEST(ASTNodeTest, GetThirdArgumentTest) {
+   auto argList = getMixedArgumentList();
+   auto node = createNode("testNode", argList, nullptr, nullptr);
+
+   auto arg = node->getArgument(2);
+   argList = argList->next->next;
+   ASSERT_EQ(*argList, *arg);
+}
+
+TEST(ASTNodeTest, GetFirstPositionalArgumentTest) {
+   auto argList = getMixedArgumentList();
+   auto node = createNode("testNode", argList, nullptr, nullptr);
+
+   auto arg = node->getPositionalArg(0);
+   argList = argList->next;
+   ASSERT_EQ(*argList, *arg);
+}
+
+TEST(ASTNodeTest, GetSecondPositionalArgumentTest) {
+   auto argList = getMixedArgumentList();
+   auto node = createNode("testNode", argList, nullptr, nullptr);
+
+   auto arg = node->getPositionalArg(1);
+   argList = argList->next->next->next;
+   ASSERT_EQ(*argList, *arg);
+}
+
+TEST(ASTNodeTest, GetFirstNamedArgumentTest) {
+   auto argList = getMixedArgumentList();
+   auto node = createNode("testNode", argList, nullptr, nullptr);
+
+   auto arg = node->getArgByName("arg0");
+   ASSERT_EQ(*argList, *arg);
+}
+
+TEST(ASTNodeTest, GetSecondNamedArgumentTest) {
+   auto argList = getMixedArgumentList();
+   auto node = createNode("testNode", argList, nullptr, nullptr);
+
+   auto arg = node->getArgByName("arg1");
+   argList = argList->next->next;
+   ASSERT_EQ(*argList, *arg);
+}

--- a/fvtest/tril/test/ASTTest.cpp
+++ b/fvtest/tril/test/ASTTest.cpp
@@ -224,9 +224,9 @@ TEST(ASTNodeArgumentTest, CreateListFrom3SingleArguments) {
 TEST(ASTNodeTest, CreateNullNode) {
    auto node = createNode(NULL, NULL, NULL, NULL);
 
-   ASSERT_STREQ(NULL, node->name);
-   ASSERT_EQ(NULL, node->args);
-   ASSERT_EQ(NULL, node->children);
+   ASSERT_STREQ(NULL, node->getName());
+   ASSERT_EQ(NULL, node->getArgs());
+   ASSERT_EQ(NULL, node->getChildren());
    ASSERT_EQ(NULL, node->next);
 }
 
@@ -234,9 +234,9 @@ TEST(ASTNodeTest, CreateNodeWithJustName) {
    auto nodeName = "theName";
    auto node = createNode(nodeName, NULL, NULL, NULL);
 
-   ASSERT_STREQ(nodeName, node->name);
-   ASSERT_EQ(NULL, node->args);
-   ASSERT_EQ(NULL, node->children);
+   ASSERT_STREQ(nodeName, node->getName());
+   ASSERT_EQ(NULL, node->getArgs());
+   ASSERT_EQ(NULL, node->getChildren());
    ASSERT_EQ(NULL, node->next);
 }
 
@@ -245,9 +245,9 @@ TEST(ASTNodeTest, CreateNodeWithJust1Argument) {
    auto nodeArg = createNodeArg("someArgument", nodeArgValue, NULL);
    auto node = createNode(NULL, nodeArg, NULL, NULL);
 
-   ASSERT_STREQ(NULL, node->name);
-   ASSERT_EQ(nodeArg, node->args);
-   ASSERT_EQ(NULL, node->children);
+   ASSERT_STREQ(NULL, node->getName());
+   ASSERT_EQ(nodeArg, node->getArgs());
+   ASSERT_EQ(NULL, node->getChildren());
    ASSERT_EQ(NULL, node->next);
 }
 
@@ -266,12 +266,12 @@ TEST(ASTNodeTest, CreateNodeWithJustArgumentList) {
    auto argList = getNodeArgList();
    auto node = createNode(NULL, argList, NULL, NULL);
 
-   ASSERT_STREQ(NULL, node->name);
-   ASSERT_EQ(argList, node->args);
-   ASSERT_EQ(argList->next, node->args->next);
-   ASSERT_EQ(argList->next->next, node->args->next->next);
-   ASSERT_EQ(argList->next->next->next, node->args->next->next->next);
-   ASSERT_EQ(NULL, node->children);
+   ASSERT_STREQ(NULL, node->getName());
+   ASSERT_EQ(argList, node->getArgs());
+   ASSERT_EQ(argList->next, node->getArgs()->next);
+   ASSERT_EQ(argList->next->next, node->getArgs()->next->next);
+   ASSERT_EQ(argList->next->next->next, node->getArgs()->next->next->next);
+   ASSERT_EQ(NULL, node->getChildren());
    ASSERT_EQ(NULL, node->next);
 }
 
@@ -285,14 +285,14 @@ TEST(ASTNodeTest, CreateListFrom2SingleNodes) {
 
    appendSiblingNode(node_0, node_1);
 
-   ASSERT_STREQ(nodeName_0, node_0->name);
-   ASSERT_EQ(argList_0, node_0->args);
-   ASSERT_EQ(NULL, node_0->children);
+   ASSERT_STREQ(nodeName_0, node_0->getName());
+   ASSERT_EQ(argList_0, node_0->getArgs());
+   ASSERT_EQ(NULL, node_0->getChildren());
    ASSERT_EQ(node_1, node_0->next);
 
-   ASSERT_STREQ(nodeName_1, node_1->name);
-   ASSERT_EQ(argList_1, node_1->args);
-   ASSERT_EQ(NULL, node_1->children);
+   ASSERT_STREQ(nodeName_1, node_1->getName());
+   ASSERT_EQ(argList_1, node_1->getArgs());
+   ASSERT_EQ(NULL, node_1->getChildren());
    ASSERT_EQ(NULL, node_1->next);
 }
 
@@ -304,14 +304,14 @@ TEST(ASTNodeTest, Concatenate2SingleNodes)  {
    ASTNodeArg* argList_0 = getNodeArgList();
    auto node_0 = createNode(nodeName_0, argList_0, NULL, node_1);
 
-   ASSERT_STREQ(nodeName_0, node_0->name);
-   ASSERT_EQ(argList_0, node_0->args);
-   ASSERT_EQ(NULL, node_0->children);
+   ASSERT_STREQ(nodeName_0, node_0->getName());
+   ASSERT_EQ(argList_0, node_0->getArgs());
+   ASSERT_EQ(NULL, node_0->getChildren());
    ASSERT_EQ(node_1, node_0->next);
 
-   ASSERT_STREQ(nodeName_1, node_1->name);
-   ASSERT_EQ(argList_1, node_1->args);
-   ASSERT_EQ(NULL, node_1->children);
+   ASSERT_STREQ(nodeName_1, node_1->getName());
+   ASSERT_EQ(argList_1, node_1->getArgs());
+   ASSERT_EQ(NULL, node_1->getChildren());
    ASSERT_EQ(NULL, node_1->next);
 }
 
@@ -329,19 +329,19 @@ TEST(ASTNodeTest, CreateListFromListOf2AndSingleNode) {
    appendSiblingNode(node_0, node_1);
    appendSiblingNode(node_0, node_2);
 
-   ASSERT_STREQ(nodeName_0, node_0->name);
-   ASSERT_EQ(argList_0, node_0->args);
-   ASSERT_EQ(NULL, node_0->children);
+   ASSERT_STREQ(nodeName_0, node_0->getName());
+   ASSERT_EQ(argList_0, node_0->getArgs());
+   ASSERT_EQ(NULL, node_0->getChildren());
    ASSERT_EQ(node_1, node_0->next);
 
-   ASSERT_STREQ(nodeName_1, node_1->name);
-   ASSERT_EQ(argList_1, node_1->args);
-   ASSERT_EQ(NULL, node_1->children);
+   ASSERT_STREQ(nodeName_1, node_1->getName());
+   ASSERT_EQ(argList_1, node_1->getArgs());
+   ASSERT_EQ(NULL, node_1->getChildren());
    ASSERT_EQ(node_2, node_1->next);
 
-   ASSERT_STREQ(nodeName_2, node_2->name);
-   ASSERT_EQ(argList_2, node_2->args);
-   ASSERT_EQ(NULL, node_2->children);
+   ASSERT_STREQ(nodeName_2, node_2->getName());
+   ASSERT_EQ(argList_2, node_2->getArgs());
+   ASSERT_EQ(NULL, node_2->getChildren());
    ASSERT_EQ(NULL, node_2->next);
 }
 
@@ -358,19 +358,19 @@ TEST(ASTNodeTest, Concatenate3SingleNodes)  {
 
    appendSiblingNode(node_0, node_2);
 
-   ASSERT_STREQ(nodeName_0, node_0->name);
-   ASSERT_EQ(argList_0, node_0->args);
-   ASSERT_EQ(NULL, node_0->children);
+   ASSERT_STREQ(nodeName_0, node_0->getName());
+   ASSERT_EQ(argList_0, node_0->getArgs());
+   ASSERT_EQ(NULL, node_0->getChildren());
    ASSERT_EQ(node_1, node_0->next);
 
-   ASSERT_STREQ(nodeName_1, node_1->name);
-   ASSERT_EQ(argList_1, node_1->args);
-   ASSERT_EQ(NULL, node_1->children);
+   ASSERT_STREQ(nodeName_1, node_1->getName());
+   ASSERT_EQ(argList_1, node_1->getArgs());
+   ASSERT_EQ(NULL, node_1->getChildren());
    ASSERT_EQ(node_2, node_1->next);
 
-   ASSERT_STREQ(nodeName_2, node_2->name);
-   ASSERT_EQ(argList_2, node_2->args);
-   ASSERT_EQ(NULL, node_2->children);
+   ASSERT_STREQ(nodeName_2, node_2->getName());
+   ASSERT_EQ(argList_2, node_2->getArgs());
+   ASSERT_EQ(NULL, node_2->getChildren());
    ASSERT_EQ(NULL, node_2->next);
 }
 

--- a/fvtest/tril/test/ParserTest.cpp
+++ b/fvtest/tril/test/ParserTest.cpp
@@ -108,8 +108,8 @@ TEST(ParserTest, SingleNodeWithIntArg) {
 
     auto arg = trees->args;
     ASSERT_STREQ("", arg->name);
-    ASSERT_EQ(Int64, arg->value->type);
-    ASSERT_EQ(3, arg->value->value.int64);
+    ASSERT_EQ(Int64, arg->value->getType());
+    ASSERT_EQ(3, arg->value->get<ASTValue::Integer_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -124,8 +124,8 @@ TEST(ParserTest, SingleNodeWithFloatArg) {
 
     auto arg = trees->args;
     ASSERT_STREQ("", arg->name);
-    ASSERT_EQ(Double, arg->value->type);
-    ASSERT_EQ(3.00, arg->value->value.f64);
+    ASSERT_EQ(Double, arg->value->getType());
+    ASSERT_EQ(3.00, arg->value->get<ASTValue::Double_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -140,8 +140,8 @@ TEST(ParserTest, SingleNodeWithStringArg) {
 
     auto arg = trees->args;
     ASSERT_STREQ("", arg->name);
-    ASSERT_EQ(String, arg->value->type);
-    ASSERT_STREQ("foo", arg->value->value.str);
+    ASSERT_EQ(String, arg->value->getType());
+    ASSERT_STREQ("foo", arg->value->get<ASTValue::String_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -156,8 +156,8 @@ TEST(ParserTest, SingleNodeWithIdentiferArg) {
 
     auto arg = trees->args;
     ASSERT_STREQ("", arg->name);
-    ASSERT_EQ(String, arg->value->type);
-    ASSERT_STREQ("id", arg->value->value.str);
+    ASSERT_EQ(String, arg->value->getType());
+    ASSERT_STREQ("id", arg->value->get<ASTValue::String_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -172,8 +172,8 @@ TEST(ParserTest, SingleNodeWithCommandArg) {
 
     auto arg = trees->args;
     ASSERT_STREQ("", arg->name);
-    ASSERT_EQ(String, arg->value->type);
-    ASSERT_STREQ("@cmd", arg->value->value.str);
+    ASSERT_EQ(String, arg->value->getType());
+    ASSERT_STREQ("@cmd", arg->value->get<ASTValue::String_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -188,8 +188,8 @@ TEST(ParserTest, SingleNodeWithNamedArg) {
 
     auto arg = trees->args;
     ASSERT_STREQ("arg", arg->name);
-    ASSERT_EQ(Double, arg->value->type);
-    ASSERT_EQ(3.14, arg->value->value.f64);
+    ASSERT_EQ(Double, arg->value->getType());
+    ASSERT_EQ(3.14, arg->value->get<ASTValue::Double_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -204,8 +204,8 @@ TEST(ParserTest, SingleNodeWithNamedIdentifierArg) {
 
     auto arg = trees->args;
     ASSERT_STREQ("arg", arg->name);
-    ASSERT_EQ(String, arg->value->type);
-    ASSERT_STREQ("ID", arg->value->value.str);
+    ASSERT_EQ(String, arg->value->getType());
+    ASSERT_STREQ("ID", arg->value->get<ASTValue::String_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -220,8 +220,8 @@ TEST(ParserTest, SingleNodeWithNamedCommandArg) {
 
     auto arg = trees->args;
     ASSERT_STREQ("arg", arg->name);
-    ASSERT_EQ(String, arg->value->type);
-    ASSERT_STREQ("@cmd", arg->value->value.str);
+    ASSERT_EQ(String, arg->value->getType());
+    ASSERT_STREQ("@cmd", arg->value->get<ASTValue::String_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -236,14 +236,14 @@ TEST(ParserTest, SingleNodeWithNamedArgAndAnonymousArg) {
 
     auto arg = trees->args;
     ASSERT_STREQ("arg", arg->name);
-    ASSERT_EQ(String, arg->value->type);
-    ASSERT_STREQ("foo", arg->value->value.str);
+    ASSERT_EQ(String, arg->value->getType());
+    ASSERT_STREQ("foo", arg->value->get<ASTValue::String_t>());
     ASSERT_NOTNULL(arg->next);
 
     arg = arg->next;
     ASSERT_STREQ("", arg->name);
-    ASSERT_EQ(Double, arg->value->type);
-    ASSERT_EQ(6.33, arg->value->value.f64);
+    ASSERT_EQ(Double, arg->value->getType());
+    ASSERT_EQ(6.33, arg->value->get<ASTValue::Double_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -261,18 +261,18 @@ TEST(ParserTest, SingleNodeWithNamedListArg) {
     ASSERT_NOTNULL(arg->value);
 
     auto value = arg->value;
-    ASSERT_EQ(Int64, value->type);
-    ASSERT_EQ(5, value->value.int64);
+    ASSERT_EQ(Int64, value->getType());
+    ASSERT_EQ(5, value->get<ASTValue::Integer_t>());
     ASSERT_NOTNULL(value->next);
 
     value = value->next;
-    ASSERT_EQ(Double, value->type);
-    ASSERT_EQ(3.14159, value->value.f64);
+    ASSERT_EQ(Double, value->getType());
+    ASSERT_EQ(3.14159, value->get<ASTValue::Double_t>());
     ASSERT_NOTNULL(value->next);
 
     value = value->next;
-    ASSERT_EQ(String, value->type);
-    ASSERT_STREQ("foo", value->value.str);
+    ASSERT_EQ(String, value->getType());
+    ASSERT_STREQ("foo", value->get<ASTValue::String_t>());
     ASSERT_NULL(value->next);
 }
 
@@ -287,14 +287,14 @@ TEST(ParserTest, SingleNodeWithAnonymousArgAndNamedArg) {
 
     auto arg = trees->args;
     ASSERT_STREQ("", arg->name);
-    ASSERT_EQ(Double, arg->value->type);
-    ASSERT_EQ(5.11, arg->value->value.f64);
+    ASSERT_EQ(Double, arg->value->getType());
+    ASSERT_EQ(5.11, arg->value->get<ASTValue::Double_t>());
     ASSERT_NOTNULL(arg->next);
 
     arg = arg->next;
     ASSERT_STREQ("arg2", arg->name);
-    ASSERT_EQ(Int64, arg->value->type);
-    ASSERT_EQ(2, arg->value->value.int64);
+    ASSERT_EQ(Int64, arg->value->getType());
+    ASSERT_EQ(2, arg->value->get<ASTValue::Integer_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -309,8 +309,8 @@ TEST(ParserTest, SingleNodeWithNamedArgAndChild) {
 
     auto arg = trees->args;
     ASSERT_STREQ("arg", arg->name);
-    ASSERT_EQ(Int64, arg->value->type);
-    ASSERT_EQ(3, arg->value->value.int64);
+    ASSERT_EQ(Int64, arg->value->getType());
+    ASSERT_EQ(3, arg->value->get<ASTValue::Integer_t>());
     ASSERT_NULL(arg->next);
 
     trees = trees->children;
@@ -331,8 +331,8 @@ TEST(ParserTest, SingleNodeWithAnonymousArgAndChildWithNamedArg) {
 
     auto arg = trees->args;
     ASSERT_STREQ("", arg->name);
-    ASSERT_EQ(String, arg->value->type);
-    ASSERT_STREQ("bar", arg->value->value.str);
+    ASSERT_EQ(String, arg->value->getType());
+    ASSERT_STREQ("bar", arg->value->get<ASTValue::String_t>());
     ASSERT_NULL(arg->next);
 
     trees = trees->children;
@@ -343,8 +343,8 @@ TEST(ParserTest, SingleNodeWithAnonymousArgAndChildWithNamedArg) {
 
     arg = trees->args;
     ASSERT_STREQ("arg", arg->name);
-    ASSERT_EQ(Double, arg->value->type);
-    ASSERT_EQ(4.0, arg->value->value.f64);
+    ASSERT_EQ(Double, arg->value->getType());
+    ASSERT_EQ(4.0, arg->value->get<ASTValue::Double_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -359,14 +359,14 @@ TEST(ParserTest, SingleNodeWithTwoAnonymousArgs) {
 
     auto arg = trees->args;
     ASSERT_STREQ("", arg->name);
-    ASSERT_EQ(Double, arg->value->type);
-    ASSERT_EQ(2.71828, arg->value->value.f64);
+    ASSERT_EQ(Double, arg->value->getType());
+    ASSERT_EQ(2.71828, arg->value->get<ASTValue::Double_t>());
     ASSERT_NOTNULL(arg->next);
 
     arg = arg->next;
     ASSERT_STREQ("", arg->name);
-    ASSERT_EQ(Double, arg->value->type);
-    ASSERT_EQ(3.14159, arg->value->value.f64);
+    ASSERT_EQ(Double, arg->value->getType());
+    ASSERT_EQ(3.14159, arg->value->get<ASTValue::Double_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -381,13 +381,13 @@ TEST(ParserTest, SingleNodeWithTwoNamedArgs) {
 
     auto arg = trees->args;
     ASSERT_STREQ("pi", arg->name);
-    ASSERT_EQ(Double, arg->value->type);
-    ASSERT_EQ(3.14159, arg->value->value.f64);
+    ASSERT_EQ(Double, arg->value->getType());
+    ASSERT_EQ(3.14159, arg->value->get<ASTValue::Double_t>());
     ASSERT_NOTNULL(arg->next);
 
     arg = arg->next;
     ASSERT_STREQ("e", arg->name);
-    ASSERT_EQ(Double, arg->value->type);
-    ASSERT_EQ(2.71828, arg->value->value.f64);
+    ASSERT_EQ(Double, arg->value->getType());
+    ASSERT_EQ(2.71828, arg->value->get<ASTValue::Double_t>());
     ASSERT_NULL(arg->next);
 }

--- a/fvtest/tril/test/ParserTest.cpp
+++ b/fvtest/tril/test/ParserTest.cpp
@@ -109,7 +109,7 @@ TEST(ParserTest, SingleNodeWithIntArg) {
     auto arg = trees->getArgs();
     ASSERT_STREQ("", arg->getName());
     ASSERT_EQ(ASTValue::Integer, arg->getValue()->getType());
-    ASSERT_EQ(3, arg->getValue()->get<ASTValue::Integer_t>());
+    ASSERT_EQ(3, arg->getValue()->getInteger());
     ASSERT_NULL(arg->next);
 }
 
@@ -125,7 +125,7 @@ TEST(ParserTest, SingleNodeWithFloatArg) {
     auto arg = trees->getArgs();
     ASSERT_STREQ("", arg->getName());
     ASSERT_EQ(ASTValue::FloatingPoint, arg->getValue()->getType());
-    ASSERT_EQ(3.00, arg->getValue()->get<ASTValue::FloatingPoint_t>());
+    ASSERT_EQ(3.00, arg->getValue()->getFloatingPoint());
     ASSERT_NULL(arg->next);
 }
 
@@ -141,7 +141,7 @@ TEST(ParserTest, SingleNodeWithStringArg) {
     auto arg = trees->getArgs();
     ASSERT_STREQ("", arg->getName());
     ASSERT_EQ(ASTValue::String, arg->getValue()->getType());
-    ASSERT_STREQ("foo", arg->getValue()->get<ASTValue::String_t>());
+    ASSERT_STREQ("foo", arg->getValue()->getString());
     ASSERT_NULL(arg->next);
 }
 
@@ -157,7 +157,7 @@ TEST(ParserTest, SingleNodeWithIdentiferArg) {
     auto arg = trees->getArgs();
     ASSERT_STREQ("", arg->getName());
     ASSERT_EQ(ASTValue::String, arg->getValue()->getType());
-    ASSERT_STREQ("id", arg->getValue()->get<ASTValue::String_t>());
+    ASSERT_STREQ("id", arg->getValue()->getString());
     ASSERT_NULL(arg->next);
 }
 
@@ -173,7 +173,7 @@ TEST(ParserTest, SingleNodeWithCommandArg) {
     auto arg = trees->getArgs();
     ASSERT_STREQ("", arg->getName());
     ASSERT_EQ(ASTValue::String, arg->getValue()->getType());
-    ASSERT_STREQ("@cmd", arg->getValue()->get<ASTValue::String_t>());
+    ASSERT_STREQ("@cmd", arg->getValue()->getString());
     ASSERT_NULL(arg->next);
 }
 
@@ -189,7 +189,7 @@ TEST(ParserTest, SingleNodeWithNamedArg) {
     auto arg = trees->getArgs();
     ASSERT_STREQ("arg", arg->getName());
     ASSERT_EQ(ASTValue::FloatingPoint, arg->getValue()->getType());
-    ASSERT_EQ(3.14, arg->getValue()->get<ASTValue::FloatingPoint_t>());
+    ASSERT_EQ(3.14, arg->getValue()->getFloatingPoint());
     ASSERT_NULL(arg->next);
 }
 
@@ -205,7 +205,7 @@ TEST(ParserTest, SingleNodeWithNamedIdentifierArg) {
     auto arg = trees->getArgs();
     ASSERT_STREQ("arg", arg->getName());
     ASSERT_EQ(ASTValue::String, arg->getValue()->getType());
-    ASSERT_STREQ("ID", arg->getValue()->get<ASTValue::String_t>());
+    ASSERT_STREQ("ID", arg->getValue()->getString());
     ASSERT_NULL(arg->next);
 }
 
@@ -221,7 +221,7 @@ TEST(ParserTest, SingleNodeWithNamedCommandArg) {
     auto arg = trees->getArgs();
     ASSERT_STREQ("arg", arg->getName());
     ASSERT_EQ(ASTValue::String, arg->getValue()->getType());
-    ASSERT_STREQ("@cmd", arg->getValue()->get<ASTValue::String_t>());
+    ASSERT_STREQ("@cmd", arg->getValue()->getString());
     ASSERT_NULL(arg->next);
 }
 
@@ -237,13 +237,13 @@ TEST(ParserTest, SingleNodeWithNamedArgAndAnonymousArg) {
     auto arg = trees->getArgs();
     ASSERT_STREQ("arg", arg->getName());
     ASSERT_EQ(ASTValue::String, arg->getValue()->getType());
-    ASSERT_STREQ("foo", arg->getValue()->get<ASTValue::String_t>());
+    ASSERT_STREQ("foo", arg->getValue()->getString());
     ASSERT_NOTNULL(arg->next);
 
     arg = arg->next;
     ASSERT_STREQ("", arg->getName());
     ASSERT_EQ(ASTValue::FloatingPoint, arg->getValue()->getType());
-    ASSERT_EQ(6.33, arg->getValue()->get<ASTValue::FloatingPoint_t>());
+    ASSERT_EQ(6.33, arg->getValue()->getFloatingPoint());
     ASSERT_NULL(arg->next);
 }
 
@@ -262,17 +262,17 @@ TEST(ParserTest, SingleNodeWithNamedListArg) {
 
     auto value = arg->getValue();
     ASSERT_EQ(ASTValue::Integer, value->getType());
-    ASSERT_EQ(5, value->get<ASTValue::Integer_t>());
+    ASSERT_EQ(5, value->getInteger());
     ASSERT_NOTNULL(value->next);
 
     value = value->next;
     ASSERT_EQ(ASTValue::FloatingPoint, value->getType());
-    ASSERT_EQ(3.14159, value->get<ASTValue::FloatingPoint_t>());
+    ASSERT_EQ(3.14159, value->getFloatingPoint());
     ASSERT_NOTNULL(value->next);
 
     value = value->next;
     ASSERT_EQ(ASTValue::String, value->getType());
-    ASSERT_STREQ("foo", value->get<ASTValue::String_t>());
+    ASSERT_STREQ("foo", value->getString());
     ASSERT_NULL(value->next);
 }
 
@@ -288,13 +288,13 @@ TEST(ParserTest, SingleNodeWithAnonymousArgAndNamedArg) {
     auto arg = trees->getArgs();
     ASSERT_STREQ("", arg->getName());
     ASSERT_EQ(ASTValue::FloatingPoint, arg->getValue()->getType());
-    ASSERT_EQ(5.11, arg->getValue()->get<ASTValue::FloatingPoint_t>());
+    ASSERT_EQ(5.11, arg->getValue()->getFloatingPoint());
     ASSERT_NOTNULL(arg->next);
 
     arg = arg->next;
     ASSERT_STREQ("arg2", arg->getName());
     ASSERT_EQ(ASTValue::Integer, arg->getValue()->getType());
-    ASSERT_EQ(2, arg->getValue()->get<ASTValue::Integer_t>());
+    ASSERT_EQ(2, arg->getValue()->getInteger());
     ASSERT_NULL(arg->next);
 }
 
@@ -310,7 +310,7 @@ TEST(ParserTest, SingleNodeWithNamedArgAndChild) {
     auto arg = trees->getArgs();
     ASSERT_STREQ("arg", arg->getName());
     ASSERT_EQ(ASTValue::Integer, arg->getValue()->getType());
-    ASSERT_EQ(3, arg->getValue()->get<ASTValue::Integer_t>());
+    ASSERT_EQ(3, arg->getValue()->getInteger());
     ASSERT_NULL(arg->next);
 
     trees = trees->getChildren();
@@ -332,7 +332,7 @@ TEST(ParserTest, SingleNodeWithAnonymousArgAndChildWithNamedArg) {
     auto arg = trees->getArgs();
     ASSERT_STREQ("", arg->getName());
     ASSERT_EQ(ASTValue::String, arg->getValue()->getType());
-    ASSERT_STREQ("bar", arg->getValue()->get<ASTValue::String_t>());
+    ASSERT_STREQ("bar", arg->getValue()->getString());
     ASSERT_NULL(arg->next);
 
     trees = trees->getChildren();
@@ -344,7 +344,7 @@ TEST(ParserTest, SingleNodeWithAnonymousArgAndChildWithNamedArg) {
     arg = trees->getArgs();
     ASSERT_STREQ("arg", arg->getName());
     ASSERT_EQ(ASTValue::FloatingPoint, arg->getValue()->getType());
-    ASSERT_EQ(4.0, arg->getValue()->get<ASTValue::FloatingPoint_t>());
+    ASSERT_EQ(4.0, arg->getValue()->getFloatingPoint());
     ASSERT_NULL(arg->next);
 }
 
@@ -360,13 +360,13 @@ TEST(ParserTest, SingleNodeWithTwoAnonymousArgs) {
     auto arg = trees->getArgs();
     ASSERT_STREQ("", arg->getName());
     ASSERT_EQ(ASTValue::FloatingPoint, arg->getValue()->getType());
-    ASSERT_EQ(2.71828, arg->getValue()->get<ASTValue::FloatingPoint_t>());
+    ASSERT_EQ(2.71828, arg->getValue()->getFloatingPoint());
     ASSERT_NOTNULL(arg->next);
 
     arg = arg->next;
     ASSERT_STREQ("", arg->getName());
     ASSERT_EQ(ASTValue::FloatingPoint, arg->getValue()->getType());
-    ASSERT_EQ(3.14159, arg->getValue()->get<ASTValue::FloatingPoint_t>());
+    ASSERT_EQ(3.14159, arg->getValue()->getFloatingPoint());
     ASSERT_NULL(arg->next);
 }
 
@@ -382,12 +382,12 @@ TEST(ParserTest, SingleNodeWithTwoNamedArgs) {
     auto arg = trees->getArgs();
     ASSERT_STREQ("pi", arg->getName());
     ASSERT_EQ(ASTValue::FloatingPoint, arg->getValue()->getType());
-    ASSERT_EQ(3.14159, arg->getValue()->get<ASTValue::FloatingPoint_t>());
+    ASSERT_EQ(3.14159, arg->getValue()->getFloatingPoint());
     ASSERT_NOTNULL(arg->next);
 
     arg = arg->next;
     ASSERT_STREQ("e", arg->getName());
     ASSERT_EQ(ASTValue::FloatingPoint, arg->getValue()->getType());
-    ASSERT_EQ(2.71828, arg->getValue()->get<ASTValue::FloatingPoint_t>());
+    ASSERT_EQ(2.71828, arg->getValue()->getFloatingPoint());
     ASSERT_NULL(arg->next);
 }

--- a/fvtest/tril/test/ParserTest.cpp
+++ b/fvtest/tril/test/ParserTest.cpp
@@ -107,9 +107,9 @@ TEST(ParserTest, SingleNodeWithIntArg) {
     ASSERT_NULL(trees->next);
 
     auto arg = trees->args;
-    ASSERT_STREQ("", arg->name);
-    ASSERT_EQ(Int64, arg->value->getType());
-    ASSERT_EQ(3, arg->value->get<ASTValue::Integer_t>());
+    ASSERT_STREQ("", arg->getName());
+    ASSERT_EQ(Int64, arg->getValue()->getType());
+    ASSERT_EQ(3, arg->getValue()->get<ASTValue::Integer_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -123,9 +123,9 @@ TEST(ParserTest, SingleNodeWithFloatArg) {
     ASSERT_NULL(trees->next);
 
     auto arg = trees->args;
-    ASSERT_STREQ("", arg->name);
-    ASSERT_EQ(Double, arg->value->getType());
-    ASSERT_EQ(3.00, arg->value->get<ASTValue::Double_t>());
+    ASSERT_STREQ("", arg->getName());
+    ASSERT_EQ(Double, arg->getValue()->getType());
+    ASSERT_EQ(3.00, arg->getValue()->get<ASTValue::Double_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -139,9 +139,9 @@ TEST(ParserTest, SingleNodeWithStringArg) {
     ASSERT_NULL(trees->next);
 
     auto arg = trees->args;
-    ASSERT_STREQ("", arg->name);
-    ASSERT_EQ(String, arg->value->getType());
-    ASSERT_STREQ("foo", arg->value->get<ASTValue::String_t>());
+    ASSERT_STREQ("", arg->getName());
+    ASSERT_EQ(String, arg->getValue()->getType());
+    ASSERT_STREQ("foo", arg->getValue()->get<ASTValue::String_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -155,9 +155,9 @@ TEST(ParserTest, SingleNodeWithIdentiferArg) {
     ASSERT_NULL(trees->next);
 
     auto arg = trees->args;
-    ASSERT_STREQ("", arg->name);
-    ASSERT_EQ(String, arg->value->getType());
-    ASSERT_STREQ("id", arg->value->get<ASTValue::String_t>());
+    ASSERT_STREQ("", arg->getName());
+    ASSERT_EQ(String, arg->getValue()->getType());
+    ASSERT_STREQ("id", arg->getValue()->get<ASTValue::String_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -171,9 +171,9 @@ TEST(ParserTest, SingleNodeWithCommandArg) {
     ASSERT_NULL(trees->next);
 
     auto arg = trees->args;
-    ASSERT_STREQ("", arg->name);
-    ASSERT_EQ(String, arg->value->getType());
-    ASSERT_STREQ("@cmd", arg->value->get<ASTValue::String_t>());
+    ASSERT_STREQ("", arg->getName());
+    ASSERT_EQ(String, arg->getValue()->getType());
+    ASSERT_STREQ("@cmd", arg->getValue()->get<ASTValue::String_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -187,9 +187,9 @@ TEST(ParserTest, SingleNodeWithNamedArg) {
     ASSERT_NULL(trees->next);
 
     auto arg = trees->args;
-    ASSERT_STREQ("arg", arg->name);
-    ASSERT_EQ(Double, arg->value->getType());
-    ASSERT_EQ(3.14, arg->value->get<ASTValue::Double_t>());
+    ASSERT_STREQ("arg", arg->getName());
+    ASSERT_EQ(Double, arg->getValue()->getType());
+    ASSERT_EQ(3.14, arg->getValue()->get<ASTValue::Double_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -203,9 +203,9 @@ TEST(ParserTest, SingleNodeWithNamedIdentifierArg) {
     ASSERT_NULL(trees->next);
 
     auto arg = trees->args;
-    ASSERT_STREQ("arg", arg->name);
-    ASSERT_EQ(String, arg->value->getType());
-    ASSERT_STREQ("ID", arg->value->get<ASTValue::String_t>());
+    ASSERT_STREQ("arg", arg->getName());
+    ASSERT_EQ(String, arg->getValue()->getType());
+    ASSERT_STREQ("ID", arg->getValue()->get<ASTValue::String_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -219,9 +219,9 @@ TEST(ParserTest, SingleNodeWithNamedCommandArg) {
     ASSERT_NULL(trees->next);
 
     auto arg = trees->args;
-    ASSERT_STREQ("arg", arg->name);
-    ASSERT_EQ(String, arg->value->getType());
-    ASSERT_STREQ("@cmd", arg->value->get<ASTValue::String_t>());
+    ASSERT_STREQ("arg", arg->getName());
+    ASSERT_EQ(String, arg->getValue()->getType());
+    ASSERT_STREQ("@cmd", arg->getValue()->get<ASTValue::String_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -235,15 +235,15 @@ TEST(ParserTest, SingleNodeWithNamedArgAndAnonymousArg) {
     ASSERT_NULL(trees->next);
 
     auto arg = trees->args;
-    ASSERT_STREQ("arg", arg->name);
-    ASSERT_EQ(String, arg->value->getType());
-    ASSERT_STREQ("foo", arg->value->get<ASTValue::String_t>());
+    ASSERT_STREQ("arg", arg->getName());
+    ASSERT_EQ(String, arg->getValue()->getType());
+    ASSERT_STREQ("foo", arg->getValue()->get<ASTValue::String_t>());
     ASSERT_NOTNULL(arg->next);
 
     arg = arg->next;
-    ASSERT_STREQ("", arg->name);
-    ASSERT_EQ(Double, arg->value->getType());
-    ASSERT_EQ(6.33, arg->value->get<ASTValue::Double_t>());
+    ASSERT_STREQ("", arg->getName());
+    ASSERT_EQ(Double, arg->getValue()->getType());
+    ASSERT_EQ(6.33, arg->getValue()->get<ASTValue::Double_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -257,10 +257,10 @@ TEST(ParserTest, SingleNodeWithNamedListArg) {
     ASSERT_NULL(trees->next);
 
     auto arg = trees->args;
-    ASSERT_STREQ("arg", arg->name);
-    ASSERT_NOTNULL(arg->value);
+    ASSERT_STREQ("arg", arg->getName());
+    ASSERT_NOTNULL(arg->getValue());
 
-    auto value = arg->value;
+    auto value = arg->getValue();
     ASSERT_EQ(Int64, value->getType());
     ASSERT_EQ(5, value->get<ASTValue::Integer_t>());
     ASSERT_NOTNULL(value->next);
@@ -286,15 +286,15 @@ TEST(ParserTest, SingleNodeWithAnonymousArgAndNamedArg) {
     ASSERT_NULL(trees->next);
 
     auto arg = trees->args;
-    ASSERT_STREQ("", arg->name);
-    ASSERT_EQ(Double, arg->value->getType());
-    ASSERT_EQ(5.11, arg->value->get<ASTValue::Double_t>());
+    ASSERT_STREQ("", arg->getName());
+    ASSERT_EQ(Double, arg->getValue()->getType());
+    ASSERT_EQ(5.11, arg->getValue()->get<ASTValue::Double_t>());
     ASSERT_NOTNULL(arg->next);
 
     arg = arg->next;
-    ASSERT_STREQ("arg2", arg->name);
-    ASSERT_EQ(Int64, arg->value->getType());
-    ASSERT_EQ(2, arg->value->get<ASTValue::Integer_t>());
+    ASSERT_STREQ("arg2", arg->getName());
+    ASSERT_EQ(Int64, arg->getValue()->getType());
+    ASSERT_EQ(2, arg->getValue()->get<ASTValue::Integer_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -308,9 +308,9 @@ TEST(ParserTest, SingleNodeWithNamedArgAndChild) {
     ASSERT_NULL(trees->next);
 
     auto arg = trees->args;
-    ASSERT_STREQ("arg", arg->name);
-    ASSERT_EQ(Int64, arg->value->getType());
-    ASSERT_EQ(3, arg->value->get<ASTValue::Integer_t>());
+    ASSERT_STREQ("arg", arg->getName());
+    ASSERT_EQ(Int64, arg->getValue()->getType());
+    ASSERT_EQ(3, arg->getValue()->get<ASTValue::Integer_t>());
     ASSERT_NULL(arg->next);
 
     trees = trees->children;
@@ -330,9 +330,9 @@ TEST(ParserTest, SingleNodeWithAnonymousArgAndChildWithNamedArg) {
     ASSERT_NULL(trees->next);
 
     auto arg = trees->args;
-    ASSERT_STREQ("", arg->name);
-    ASSERT_EQ(String, arg->value->getType());
-    ASSERT_STREQ("bar", arg->value->get<ASTValue::String_t>());
+    ASSERT_STREQ("", arg->getName());
+    ASSERT_EQ(String, arg->getValue()->getType());
+    ASSERT_STREQ("bar", arg->getValue()->get<ASTValue::String_t>());
     ASSERT_NULL(arg->next);
 
     trees = trees->children;
@@ -342,9 +342,9 @@ TEST(ParserTest, SingleNodeWithAnonymousArgAndChildWithNamedArg) {
     ASSERT_NULL(trees->next);
 
     arg = trees->args;
-    ASSERT_STREQ("arg", arg->name);
-    ASSERT_EQ(Double, arg->value->getType());
-    ASSERT_EQ(4.0, arg->value->get<ASTValue::Double_t>());
+    ASSERT_STREQ("arg", arg->getName());
+    ASSERT_EQ(Double, arg->getValue()->getType());
+    ASSERT_EQ(4.0, arg->getValue()->get<ASTValue::Double_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -358,15 +358,15 @@ TEST(ParserTest, SingleNodeWithTwoAnonymousArgs) {
     ASSERT_NULL(trees->next);
 
     auto arg = trees->args;
-    ASSERT_STREQ("", arg->name);
-    ASSERT_EQ(Double, arg->value->getType());
-    ASSERT_EQ(2.71828, arg->value->get<ASTValue::Double_t>());
+    ASSERT_STREQ("", arg->getName());
+    ASSERT_EQ(Double, arg->getValue()->getType());
+    ASSERT_EQ(2.71828, arg->getValue()->get<ASTValue::Double_t>());
     ASSERT_NOTNULL(arg->next);
 
     arg = arg->next;
-    ASSERT_STREQ("", arg->name);
-    ASSERT_EQ(Double, arg->value->getType());
-    ASSERT_EQ(3.14159, arg->value->get<ASTValue::Double_t>());
+    ASSERT_STREQ("", arg->getName());
+    ASSERT_EQ(Double, arg->getValue()->getType());
+    ASSERT_EQ(3.14159, arg->getValue()->get<ASTValue::Double_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -380,14 +380,14 @@ TEST(ParserTest, SingleNodeWithTwoNamedArgs) {
     ASSERT_NULL(trees->next);
 
     auto arg = trees->args;
-    ASSERT_STREQ("pi", arg->name);
-    ASSERT_EQ(Double, arg->value->getType());
-    ASSERT_EQ(3.14159, arg->value->get<ASTValue::Double_t>());
+    ASSERT_STREQ("pi", arg->getName());
+    ASSERT_EQ(Double, arg->getValue()->getType());
+    ASSERT_EQ(3.14159, arg->getValue()->get<ASTValue::Double_t>());
     ASSERT_NOTNULL(arg->next);
 
     arg = arg->next;
-    ASSERT_STREQ("e", arg->name);
-    ASSERT_EQ(Double, arg->value->getType());
-    ASSERT_EQ(2.71828, arg->value->get<ASTValue::Double_t>());
+    ASSERT_STREQ("e", arg->getName());
+    ASSERT_EQ(Double, arg->getValue()->getType());
+    ASSERT_EQ(2.71828, arg->getValue()->get<ASTValue::Double_t>());
     ASSERT_NULL(arg->next);
 }

--- a/fvtest/tril/test/ParserTest.cpp
+++ b/fvtest/tril/test/ParserTest.cpp
@@ -108,7 +108,7 @@ TEST(ParserTest, SingleNodeWithIntArg) {
 
     auto arg = trees->getArgs();
     ASSERT_STREQ("", arg->getName());
-    ASSERT_EQ(Int64, arg->getValue()->getType());
+    ASSERT_EQ(ASTValue::Integer, arg->getValue()->getType());
     ASSERT_EQ(3, arg->getValue()->get<ASTValue::Integer_t>());
     ASSERT_NULL(arg->next);
 }
@@ -124,8 +124,8 @@ TEST(ParserTest, SingleNodeWithFloatArg) {
 
     auto arg = trees->getArgs();
     ASSERT_STREQ("", arg->getName());
-    ASSERT_EQ(Double, arg->getValue()->getType());
-    ASSERT_EQ(3.00, arg->getValue()->get<ASTValue::Double_t>());
+    ASSERT_EQ(ASTValue::FloatingPoint, arg->getValue()->getType());
+    ASSERT_EQ(3.00, arg->getValue()->get<ASTValue::FloatingPoint_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -140,7 +140,7 @@ TEST(ParserTest, SingleNodeWithStringArg) {
 
     auto arg = trees->getArgs();
     ASSERT_STREQ("", arg->getName());
-    ASSERT_EQ(String, arg->getValue()->getType());
+    ASSERT_EQ(ASTValue::String, arg->getValue()->getType());
     ASSERT_STREQ("foo", arg->getValue()->get<ASTValue::String_t>());
     ASSERT_NULL(arg->next);
 }
@@ -156,7 +156,7 @@ TEST(ParserTest, SingleNodeWithIdentiferArg) {
 
     auto arg = trees->getArgs();
     ASSERT_STREQ("", arg->getName());
-    ASSERT_EQ(String, arg->getValue()->getType());
+    ASSERT_EQ(ASTValue::String, arg->getValue()->getType());
     ASSERT_STREQ("id", arg->getValue()->get<ASTValue::String_t>());
     ASSERT_NULL(arg->next);
 }
@@ -172,7 +172,7 @@ TEST(ParserTest, SingleNodeWithCommandArg) {
 
     auto arg = trees->getArgs();
     ASSERT_STREQ("", arg->getName());
-    ASSERT_EQ(String, arg->getValue()->getType());
+    ASSERT_EQ(ASTValue::String, arg->getValue()->getType());
     ASSERT_STREQ("@cmd", arg->getValue()->get<ASTValue::String_t>());
     ASSERT_NULL(arg->next);
 }
@@ -188,8 +188,8 @@ TEST(ParserTest, SingleNodeWithNamedArg) {
 
     auto arg = trees->getArgs();
     ASSERT_STREQ("arg", arg->getName());
-    ASSERT_EQ(Double, arg->getValue()->getType());
-    ASSERT_EQ(3.14, arg->getValue()->get<ASTValue::Double_t>());
+    ASSERT_EQ(ASTValue::FloatingPoint, arg->getValue()->getType());
+    ASSERT_EQ(3.14, arg->getValue()->get<ASTValue::FloatingPoint_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -204,7 +204,7 @@ TEST(ParserTest, SingleNodeWithNamedIdentifierArg) {
 
     auto arg = trees->getArgs();
     ASSERT_STREQ("arg", arg->getName());
-    ASSERT_EQ(String, arg->getValue()->getType());
+    ASSERT_EQ(ASTValue::String, arg->getValue()->getType());
     ASSERT_STREQ("ID", arg->getValue()->get<ASTValue::String_t>());
     ASSERT_NULL(arg->next);
 }
@@ -220,7 +220,7 @@ TEST(ParserTest, SingleNodeWithNamedCommandArg) {
 
     auto arg = trees->getArgs();
     ASSERT_STREQ("arg", arg->getName());
-    ASSERT_EQ(String, arg->getValue()->getType());
+    ASSERT_EQ(ASTValue::String, arg->getValue()->getType());
     ASSERT_STREQ("@cmd", arg->getValue()->get<ASTValue::String_t>());
     ASSERT_NULL(arg->next);
 }
@@ -236,14 +236,14 @@ TEST(ParserTest, SingleNodeWithNamedArgAndAnonymousArg) {
 
     auto arg = trees->getArgs();
     ASSERT_STREQ("arg", arg->getName());
-    ASSERT_EQ(String, arg->getValue()->getType());
+    ASSERT_EQ(ASTValue::String, arg->getValue()->getType());
     ASSERT_STREQ("foo", arg->getValue()->get<ASTValue::String_t>());
     ASSERT_NOTNULL(arg->next);
 
     arg = arg->next;
     ASSERT_STREQ("", arg->getName());
-    ASSERT_EQ(Double, arg->getValue()->getType());
-    ASSERT_EQ(6.33, arg->getValue()->get<ASTValue::Double_t>());
+    ASSERT_EQ(ASTValue::FloatingPoint, arg->getValue()->getType());
+    ASSERT_EQ(6.33, arg->getValue()->get<ASTValue::FloatingPoint_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -261,17 +261,17 @@ TEST(ParserTest, SingleNodeWithNamedListArg) {
     ASSERT_NOTNULL(arg->getValue());
 
     auto value = arg->getValue();
-    ASSERT_EQ(Int64, value->getType());
+    ASSERT_EQ(ASTValue::Integer, value->getType());
     ASSERT_EQ(5, value->get<ASTValue::Integer_t>());
     ASSERT_NOTNULL(value->next);
 
     value = value->next;
-    ASSERT_EQ(Double, value->getType());
-    ASSERT_EQ(3.14159, value->get<ASTValue::Double_t>());
+    ASSERT_EQ(ASTValue::FloatingPoint, value->getType());
+    ASSERT_EQ(3.14159, value->get<ASTValue::FloatingPoint_t>());
     ASSERT_NOTNULL(value->next);
 
     value = value->next;
-    ASSERT_EQ(String, value->getType());
+    ASSERT_EQ(ASTValue::String, value->getType());
     ASSERT_STREQ("foo", value->get<ASTValue::String_t>());
     ASSERT_NULL(value->next);
 }
@@ -287,13 +287,13 @@ TEST(ParserTest, SingleNodeWithAnonymousArgAndNamedArg) {
 
     auto arg = trees->getArgs();
     ASSERT_STREQ("", arg->getName());
-    ASSERT_EQ(Double, arg->getValue()->getType());
-    ASSERT_EQ(5.11, arg->getValue()->get<ASTValue::Double_t>());
+    ASSERT_EQ(ASTValue::FloatingPoint, arg->getValue()->getType());
+    ASSERT_EQ(5.11, arg->getValue()->get<ASTValue::FloatingPoint_t>());
     ASSERT_NOTNULL(arg->next);
 
     arg = arg->next;
     ASSERT_STREQ("arg2", arg->getName());
-    ASSERT_EQ(Int64, arg->getValue()->getType());
+    ASSERT_EQ(ASTValue::Integer, arg->getValue()->getType());
     ASSERT_EQ(2, arg->getValue()->get<ASTValue::Integer_t>());
     ASSERT_NULL(arg->next);
 }
@@ -309,7 +309,7 @@ TEST(ParserTest, SingleNodeWithNamedArgAndChild) {
 
     auto arg = trees->getArgs();
     ASSERT_STREQ("arg", arg->getName());
-    ASSERT_EQ(Int64, arg->getValue()->getType());
+    ASSERT_EQ(ASTValue::Integer, arg->getValue()->getType());
     ASSERT_EQ(3, arg->getValue()->get<ASTValue::Integer_t>());
     ASSERT_NULL(arg->next);
 
@@ -331,7 +331,7 @@ TEST(ParserTest, SingleNodeWithAnonymousArgAndChildWithNamedArg) {
 
     auto arg = trees->getArgs();
     ASSERT_STREQ("", arg->getName());
-    ASSERT_EQ(String, arg->getValue()->getType());
+    ASSERT_EQ(ASTValue::String, arg->getValue()->getType());
     ASSERT_STREQ("bar", arg->getValue()->get<ASTValue::String_t>());
     ASSERT_NULL(arg->next);
 
@@ -343,8 +343,8 @@ TEST(ParserTest, SingleNodeWithAnonymousArgAndChildWithNamedArg) {
 
     arg = trees->getArgs();
     ASSERT_STREQ("arg", arg->getName());
-    ASSERT_EQ(Double, arg->getValue()->getType());
-    ASSERT_EQ(4.0, arg->getValue()->get<ASTValue::Double_t>());
+    ASSERT_EQ(ASTValue::FloatingPoint, arg->getValue()->getType());
+    ASSERT_EQ(4.0, arg->getValue()->get<ASTValue::FloatingPoint_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -359,14 +359,14 @@ TEST(ParserTest, SingleNodeWithTwoAnonymousArgs) {
 
     auto arg = trees->getArgs();
     ASSERT_STREQ("", arg->getName());
-    ASSERT_EQ(Double, arg->getValue()->getType());
-    ASSERT_EQ(2.71828, arg->getValue()->get<ASTValue::Double_t>());
+    ASSERT_EQ(ASTValue::FloatingPoint, arg->getValue()->getType());
+    ASSERT_EQ(2.71828, arg->getValue()->get<ASTValue::FloatingPoint_t>());
     ASSERT_NOTNULL(arg->next);
 
     arg = arg->next;
     ASSERT_STREQ("", arg->getName());
-    ASSERT_EQ(Double, arg->getValue()->getType());
-    ASSERT_EQ(3.14159, arg->getValue()->get<ASTValue::Double_t>());
+    ASSERT_EQ(ASTValue::FloatingPoint, arg->getValue()->getType());
+    ASSERT_EQ(3.14159, arg->getValue()->get<ASTValue::FloatingPoint_t>());
     ASSERT_NULL(arg->next);
 }
 
@@ -381,13 +381,13 @@ TEST(ParserTest, SingleNodeWithTwoNamedArgs) {
 
     auto arg = trees->getArgs();
     ASSERT_STREQ("pi", arg->getName());
-    ASSERT_EQ(Double, arg->getValue()->getType());
-    ASSERT_EQ(3.14159, arg->getValue()->get<ASTValue::Double_t>());
+    ASSERT_EQ(ASTValue::FloatingPoint, arg->getValue()->getType());
+    ASSERT_EQ(3.14159, arg->getValue()->get<ASTValue::FloatingPoint_t>());
     ASSERT_NOTNULL(arg->next);
 
     arg = arg->next;
     ASSERT_STREQ("e", arg->getName());
-    ASSERT_EQ(Double, arg->getValue()->getType());
-    ASSERT_EQ(2.71828, arg->getValue()->get<ASTValue::Double_t>());
+    ASSERT_EQ(ASTValue::FloatingPoint, arg->getValue()->getType());
+    ASSERT_EQ(2.71828, arg->getValue()->get<ASTValue::FloatingPoint_t>());
     ASSERT_NULL(arg->next);
 }

--- a/fvtest/tril/test/ParserTest.cpp
+++ b/fvtest/tril/test/ParserTest.cpp
@@ -27,9 +27,9 @@ TEST(ParserTest, SingleNodeWithJustName) {
     auto trees = parseString("(nodeName)");
 
     ASSERT_NOTNULL(trees);
-    ASSERT_STREQ("nodeName", trees->name);
-    ASSERT_NULL(trees->args);
-    ASSERT_NULL(trees->children);
+    ASSERT_STREQ("nodeName", trees->getName());
+    ASSERT_NULL(trees->getArgs());
+    ASSERT_NULL(trees->getChildren());
     ASSERT_NULL(trees->next);
 }
 
@@ -37,9 +37,9 @@ TEST(ParserTest, SingleCommandNodeWithJustName) {
     auto trees = parseString("(@commandName)");
 
     ASSERT_NOTNULL(trees);
-    ASSERT_STREQ("@commandName", trees->name);
-    ASSERT_NULL(trees->args);
-    ASSERT_NULL(trees->children);
+    ASSERT_STREQ("@commandName", trees->getName());
+    ASSERT_NULL(trees->getArgs());
+    ASSERT_NULL(trees->getChildren());
     ASSERT_NULL(trees->next);
 }
 
@@ -47,31 +47,31 @@ TEST(ParserTest, TwoNodesWithJustName) {
     auto trees = parseString("(nodeName)(otherNode)");
 
     ASSERT_NOTNULL(trees);
-    ASSERT_STREQ("nodeName", trees->name);
-    ASSERT_NULL(trees->args);
-    ASSERT_NULL(trees->children);
+    ASSERT_STREQ("nodeName", trees->getName());
+    ASSERT_NULL(trees->getArgs());
+    ASSERT_NULL(trees->getChildren());
     ASSERT_NOTNULL(trees->next);
 
     trees = trees->next;
-    ASSERT_STREQ("otherNode", trees->name);
-    ASSERT_NULL(trees->args);
-    ASSERT_NULL(trees->children);
+    ASSERT_STREQ("otherNode", trees->getName());
+    ASSERT_NULL(trees->getArgs());
+    ASSERT_NULL(trees->getChildren());
     ASSERT_NULL(trees->next);
 }
 
 TEST(ParserTest, SingleNodeWithChild) {
-    auto trees = parseString("(nodeName (childNode))");
+    const auto* trees = parseString("(nodeName (childNode))");
 
     ASSERT_NOTNULL(trees);
-    ASSERT_STREQ("nodeName", trees->name);
-    ASSERT_NULL(trees->args);
-    ASSERT_NOTNULL(trees->children);
+    ASSERT_STREQ("nodeName", trees->getName());
+    ASSERT_NULL(trees->getArgs());
+    ASSERT_NOTNULL(trees->getChildren());
     ASSERT_NULL(trees->next);
 
-    trees = trees->children;
-    ASSERT_STREQ("childNode", trees->name);
-    ASSERT_NULL(trees->args);
-    ASSERT_NULL(trees->children);
+    trees = trees->getChildren();
+    ASSERT_STREQ("childNode", trees->getName());
+    ASSERT_NULL(trees->getArgs());
+    ASSERT_NULL(trees->getChildren());
     ASSERT_NULL(trees->next);
 }
 
@@ -79,21 +79,21 @@ TEST(ParserTest, NodeWithChildAndSibling) {
     auto trees = parseString("(nodeName (childNode)) (siblingNode)");
 
     ASSERT_NOTNULL(trees);
-    ASSERT_STREQ("nodeName", trees->name);
-    ASSERT_NULL(trees->args);
-    ASSERT_NOTNULL(trees->children);
+    ASSERT_STREQ("nodeName", trees->getName());
+    ASSERT_NULL(trees->getArgs());
+    ASSERT_NOTNULL(trees->getChildren());
     ASSERT_NOTNULL(trees->next);
 
-    auto child = trees->children;
-    ASSERT_STREQ("childNode", child->name);
-    ASSERT_NULL(child->args);
-    ASSERT_NULL(child->children);
+    auto child = trees->getChildren();
+    ASSERT_STREQ("childNode", child->getName());
+    ASSERT_NULL(child->getArgs());
+    ASSERT_NULL(child->getChildren());
     ASSERT_NULL(child->next);
 
     auto sibling = trees->next;
-    ASSERT_STREQ("siblingNode", sibling->name);
-    ASSERT_NULL(sibling->args);
-    ASSERT_NULL(sibling->children);
+    ASSERT_STREQ("siblingNode", sibling->getName());
+    ASSERT_NULL(sibling->getArgs());
+    ASSERT_NULL(sibling->getChildren());
     ASSERT_NULL(sibling->next);
 }
 
@@ -101,12 +101,12 @@ TEST(ParserTest, SingleNodeWithIntArg) {
     auto trees = parseString("(nodeName 3)");
 
     ASSERT_NOTNULL(trees);
-    ASSERT_STREQ("nodeName", trees->name);
-    ASSERT_NOTNULL(trees->args);
-    ASSERT_NULL(trees->children);
+    ASSERT_STREQ("nodeName", trees->getName());
+    ASSERT_NOTNULL(trees->getArgs());
+    ASSERT_NULL(trees->getChildren());
     ASSERT_NULL(trees->next);
 
-    auto arg = trees->args;
+    auto arg = trees->getArgs();
     ASSERT_STREQ("", arg->getName());
     ASSERT_EQ(Int64, arg->getValue()->getType());
     ASSERT_EQ(3, arg->getValue()->get<ASTValue::Integer_t>());
@@ -117,12 +117,12 @@ TEST(ParserTest, SingleNodeWithFloatArg) {
     auto trees = parseString("(nodeName 3.00)");
 
     ASSERT_NOTNULL(trees);
-    ASSERT_STREQ("nodeName", trees->name);
-    ASSERT_NOTNULL(trees->args);
-    ASSERT_NULL(trees->children);
+    ASSERT_STREQ("nodeName", trees->getName());
+    ASSERT_NOTNULL(trees->getArgs());
+    ASSERT_NULL(trees->getChildren());
     ASSERT_NULL(trees->next);
 
-    auto arg = trees->args;
+    auto arg = trees->getArgs();
     ASSERT_STREQ("", arg->getName());
     ASSERT_EQ(Double, arg->getValue()->getType());
     ASSERT_EQ(3.00, arg->getValue()->get<ASTValue::Double_t>());
@@ -133,12 +133,12 @@ TEST(ParserTest, SingleNodeWithStringArg) {
     auto trees = parseString("(nodeName \"foo\")");
 
     ASSERT_NOTNULL(trees);
-    ASSERT_STREQ("nodeName", trees->name);
-    ASSERT_NOTNULL(trees->args);
-    ASSERT_NULL(trees->children);
+    ASSERT_STREQ("nodeName", trees->getName());
+    ASSERT_NOTNULL(trees->getArgs());
+    ASSERT_NULL(trees->getChildren());
     ASSERT_NULL(trees->next);
 
-    auto arg = trees->args;
+    auto arg = trees->getArgs();
     ASSERT_STREQ("", arg->getName());
     ASSERT_EQ(String, arg->getValue()->getType());
     ASSERT_STREQ("foo", arg->getValue()->get<ASTValue::String_t>());
@@ -149,12 +149,12 @@ TEST(ParserTest, SingleNodeWithIdentiferArg) {
     auto trees = parseString("(nodeName id)");
 
     ASSERT_NOTNULL(trees);
-    ASSERT_STREQ("nodeName", trees->name);
-    ASSERT_NOTNULL(trees->args);
-    ASSERT_NULL(trees->children);
+    ASSERT_STREQ("nodeName", trees->getName());
+    ASSERT_NOTNULL(trees->getArgs());
+    ASSERT_NULL(trees->getChildren());
     ASSERT_NULL(trees->next);
 
-    auto arg = trees->args;
+    auto arg = trees->getArgs();
     ASSERT_STREQ("", arg->getName());
     ASSERT_EQ(String, arg->getValue()->getType());
     ASSERT_STREQ("id", arg->getValue()->get<ASTValue::String_t>());
@@ -165,12 +165,12 @@ TEST(ParserTest, SingleNodeWithCommandArg) {
     auto trees = parseString("(nodeName @cmd)");
 
     ASSERT_NOTNULL(trees);
-    ASSERT_STREQ("nodeName", trees->name);
-    ASSERT_NOTNULL(trees->args);
-    ASSERT_NULL(trees->children);
+    ASSERT_STREQ("nodeName", trees->getName());
+    ASSERT_NOTNULL(trees->getArgs());
+    ASSERT_NULL(trees->getChildren());
     ASSERT_NULL(trees->next);
 
-    auto arg = trees->args;
+    auto arg = trees->getArgs();
     ASSERT_STREQ("", arg->getName());
     ASSERT_EQ(String, arg->getValue()->getType());
     ASSERT_STREQ("@cmd", arg->getValue()->get<ASTValue::String_t>());
@@ -181,12 +181,12 @@ TEST(ParserTest, SingleNodeWithNamedArg) {
     auto trees = parseString("(nodeName arg=3.14)");
 
     ASSERT_NOTNULL(trees);
-    ASSERT_STREQ("nodeName", trees->name);
-    ASSERT_NOTNULL(trees->args);
-    ASSERT_NULL(trees->children);
+    ASSERT_STREQ("nodeName", trees->getName());
+    ASSERT_NOTNULL(trees->getArgs());
+    ASSERT_NULL(trees->getChildren());
     ASSERT_NULL(trees->next);
 
-    auto arg = trees->args;
+    auto arg = trees->getArgs();
     ASSERT_STREQ("arg", arg->getName());
     ASSERT_EQ(Double, arg->getValue()->getType());
     ASSERT_EQ(3.14, arg->getValue()->get<ASTValue::Double_t>());
@@ -197,12 +197,12 @@ TEST(ParserTest, SingleNodeWithNamedIdentifierArg) {
     auto trees = parseString("(nodeName arg=ID)");
 
     ASSERT_NOTNULL(trees);
-    ASSERT_STREQ("nodeName", trees->name);
-    ASSERT_NOTNULL(trees->args);
-    ASSERT_NULL(trees->children);
+    ASSERT_STREQ("nodeName", trees->getName());
+    ASSERT_NOTNULL(trees->getArgs());
+    ASSERT_NULL(trees->getChildren());
     ASSERT_NULL(trees->next);
 
-    auto arg = trees->args;
+    auto arg = trees->getArgs();
     ASSERT_STREQ("arg", arg->getName());
     ASSERT_EQ(String, arg->getValue()->getType());
     ASSERT_STREQ("ID", arg->getValue()->get<ASTValue::String_t>());
@@ -213,12 +213,12 @@ TEST(ParserTest, SingleNodeWithNamedCommandArg) {
     auto trees = parseString("(nodeName arg=@cmd)");
 
     ASSERT_NOTNULL(trees);
-    ASSERT_STREQ("nodeName", trees->name);
-    ASSERT_NOTNULL(trees->args);
-    ASSERT_NULL(trees->children);
+    ASSERT_STREQ("nodeName", trees->getName());
+    ASSERT_NOTNULL(trees->getArgs());
+    ASSERT_NULL(trees->getChildren());
     ASSERT_NULL(trees->next);
 
-    auto arg = trees->args;
+    auto arg = trees->getArgs();
     ASSERT_STREQ("arg", arg->getName());
     ASSERT_EQ(String, arg->getValue()->getType());
     ASSERT_STREQ("@cmd", arg->getValue()->get<ASTValue::String_t>());
@@ -229,12 +229,12 @@ TEST(ParserTest, SingleNodeWithNamedArgAndAnonymousArg) {
     auto trees = parseString("(nodeName arg=\"foo\" 6.33)");
 
     ASSERT_NOTNULL(trees);
-    ASSERT_STREQ("nodeName", trees->name);
-    ASSERT_NOTNULL(trees->args);
-    ASSERT_NULL(trees->children);
+    ASSERT_STREQ("nodeName", trees->getName());
+    ASSERT_NOTNULL(trees->getArgs());
+    ASSERT_NULL(trees->getChildren());
     ASSERT_NULL(trees->next);
 
-    auto arg = trees->args;
+    auto arg = trees->getArgs();
     ASSERT_STREQ("arg", arg->getName());
     ASSERT_EQ(String, arg->getValue()->getType());
     ASSERT_STREQ("foo", arg->getValue()->get<ASTValue::String_t>());
@@ -251,12 +251,12 @@ TEST(ParserTest, SingleNodeWithNamedListArg) {
     auto trees = parseString("(nodeName arg=[5, 3.14159, \"foo\"])");
 
     ASSERT_NOTNULL(trees);
-    ASSERT_STREQ("nodeName", trees->name);
-    ASSERT_NOTNULL(trees->args);
-    ASSERT_NULL(trees->children);
+    ASSERT_STREQ("nodeName", trees->getName());
+    ASSERT_NOTNULL(trees->getArgs());
+    ASSERT_NULL(trees->getChildren());
     ASSERT_NULL(trees->next);
 
-    auto arg = trees->args;
+    auto arg = trees->getArgs();
     ASSERT_STREQ("arg", arg->getName());
     ASSERT_NOTNULL(arg->getValue());
 
@@ -280,12 +280,12 @@ TEST(ParserTest, SingleNodeWithAnonymousArgAndNamedArg) {
     auto trees = parseString("(nodeName 5.11 arg2=2)");
 
     ASSERT_NOTNULL(trees);
-    ASSERT_STREQ("nodeName", trees->name);
-    ASSERT_NOTNULL(trees->args);
-    ASSERT_NULL(trees->children);
+    ASSERT_STREQ("nodeName", trees->getName());
+    ASSERT_NOTNULL(trees->getArgs());
+    ASSERT_NULL(trees->getChildren());
     ASSERT_NULL(trees->next);
 
-    auto arg = trees->args;
+    auto arg = trees->getArgs();
     ASSERT_STREQ("", arg->getName());
     ASSERT_EQ(Double, arg->getValue()->getType());
     ASSERT_EQ(5.11, arg->getValue()->get<ASTValue::Double_t>());
@@ -299,49 +299,49 @@ TEST(ParserTest, SingleNodeWithAnonymousArgAndNamedArg) {
 }
 
 TEST(ParserTest, SingleNodeWithNamedArgAndChild) {
-    auto trees = parseString("(nodeName arg=3 (childNode))");
+    const auto* trees = parseString("(nodeName arg=3 (childNode))");
 
     ASSERT_NOTNULL(trees);
-    ASSERT_STREQ("nodeName", trees->name);
-    ASSERT_NOTNULL(trees->args);
-    ASSERT_NOTNULL(trees->children);
+    ASSERT_STREQ("nodeName", trees->getName());
+    ASSERT_NOTNULL(trees->getArgs());
+    ASSERT_NOTNULL(trees->getChildren());
     ASSERT_NULL(trees->next);
 
-    auto arg = trees->args;
+    auto arg = trees->getArgs();
     ASSERT_STREQ("arg", arg->getName());
     ASSERT_EQ(Int64, arg->getValue()->getType());
     ASSERT_EQ(3, arg->getValue()->get<ASTValue::Integer_t>());
     ASSERT_NULL(arg->next);
 
-    trees = trees->children;
-    ASSERT_STREQ("childNode", trees->name);
-    ASSERT_NULL(trees->args);
-    ASSERT_NULL(trees->children);
+    trees = trees->getChildren();
+    ASSERT_STREQ("childNode", trees->getName());
+    ASSERT_NULL(trees->getArgs());
+    ASSERT_NULL(trees->getChildren());
     ASSERT_NULL(trees->next);
 }
 
 TEST(ParserTest, SingleNodeWithAnonymousArgAndChildWithNamedArg) {
-    auto trees = parseString("(nodeName \"bar\" (childNode arg=4.0))");
+    const auto* trees = parseString("(nodeName \"bar\" (childNode arg=4.0))");
 
     ASSERT_NOTNULL(trees);
-    ASSERT_STREQ("nodeName", trees->name);
-    ASSERT_NOTNULL(trees->args);
-    ASSERT_NOTNULL(trees->children);
+    ASSERT_STREQ("nodeName", trees->getName());
+    ASSERT_NOTNULL(trees->getArgs());
+    ASSERT_NOTNULL(trees->getChildren());
     ASSERT_NULL(trees->next);
 
-    auto arg = trees->args;
+    auto arg = trees->getArgs();
     ASSERT_STREQ("", arg->getName());
     ASSERT_EQ(String, arg->getValue()->getType());
     ASSERT_STREQ("bar", arg->getValue()->get<ASTValue::String_t>());
     ASSERT_NULL(arg->next);
 
-    trees = trees->children;
-    ASSERT_STREQ("childNode", trees->name);
-    ASSERT_NOTNULL(trees->args);
-    ASSERT_NULL(trees->children);
+    trees = trees->getChildren();
+    ASSERT_STREQ("childNode", trees->getName());
+    ASSERT_NOTNULL(trees->getArgs());
+    ASSERT_NULL(trees->getChildren());
     ASSERT_NULL(trees->next);
 
-    arg = trees->args;
+    arg = trees->getArgs();
     ASSERT_STREQ("arg", arg->getName());
     ASSERT_EQ(Double, arg->getValue()->getType());
     ASSERT_EQ(4.0, arg->getValue()->get<ASTValue::Double_t>());
@@ -352,12 +352,12 @@ TEST(ParserTest, SingleNodeWithTwoAnonymousArgs) {
     auto trees = parseString("(nodeName 2.71828 3.14159)");
 
     ASSERT_NOTNULL(trees);
-    ASSERT_STREQ("nodeName", trees->name);
-    ASSERT_NOTNULL(trees->args);
-    ASSERT_NULL(trees->children);
+    ASSERT_STREQ("nodeName", trees->getName());
+    ASSERT_NOTNULL(trees->getArgs());
+    ASSERT_NULL(trees->getChildren());
     ASSERT_NULL(trees->next);
 
-    auto arg = trees->args;
+    auto arg = trees->getArgs();
     ASSERT_STREQ("", arg->getName());
     ASSERT_EQ(Double, arg->getValue()->getType());
     ASSERT_EQ(2.71828, arg->getValue()->get<ASTValue::Double_t>());
@@ -374,12 +374,12 @@ TEST(ParserTest, SingleNodeWithTwoNamedArgs) {
     auto trees = parseString("(nodeName pi=3.14159 e=2.71828)");
 
     ASSERT_NOTNULL(trees);
-    ASSERT_STREQ("nodeName", trees->name);
-    ASSERT_NOTNULL(trees->args);
-    ASSERT_NULL(trees->children);
+    ASSERT_STREQ("nodeName", trees->getName());
+    ASSERT_NOTNULL(trees->getArgs());
+    ASSERT_NULL(trees->getChildren());
     ASSERT_NULL(trees->next);
 
-    auto arg = trees->args;
+    auto arg = trees->getArgs();
     ASSERT_STREQ("pi", arg->getName());
     ASSERT_EQ(Double, arg->getValue()->getType());
     ASSERT_EQ(3.14159, arg->getValue()->get<ASTValue::Double_t>());

--- a/fvtest/tril/test/ParserTest.cpp
+++ b/fvtest/tril/test/ParserTest.cpp
@@ -18,7 +18,7 @@
 
 #include "gtest/gtest.h"
 
-#include "ast.h"
+#include "ast.hpp"
 
 #define ASSERT_NULL(pointer) ASSERT_EQ(nullptr, (pointer))
 #define ASSERT_NOTNULL(pointer) ASSERT_TRUE(nullptr != (pointer))

--- a/fvtest/tril/test/ParserTest.cpp
+++ b/fvtest/tril/test/ParserTest.cpp
@@ -113,6 +113,39 @@ TEST(ParserTest, SingleNodeWithIntArg) {
     ASSERT_NULL(arg->next);
 }
 
+TEST(ParserTest, SingleNodeWithHexArg) {
+    auto trees = parseString("(nodeName 0xabc123)");
+
+    ASSERT_NOTNULL(trees);
+    ASSERT_STREQ("nodeName", trees->getName());
+    ASSERT_NOTNULL(trees->getArgs());
+    ASSERT_NULL(trees->getChildren());
+    ASSERT_NULL(trees->next);
+
+    auto arg = trees->getArgs();
+    ASSERT_STREQ("", arg->getName());
+    ASSERT_EQ(ASTValue::Integer, arg->getValue()->getType());
+    ASSERT_EQ(0xabc123, arg->getValue()->getInteger());
+    ASSERT_NULL(arg->next);
+}
+
+TEST(ParserTest, SingleNodeWithNegativeHexArg) {
+    auto trees = parseString("(nodeName -0x249DEF)");
+
+    ASSERT_NOTNULL(trees);
+    ASSERT_STREQ("nodeName", trees->getName());
+    ASSERT_NOTNULL(trees->getArgs());
+    ASSERT_NULL(trees->getChildren());
+    ASSERT_NULL(trees->next);
+
+    auto arg = trees->getArgs();
+    ASSERT_STREQ("", arg->getName());
+    ASSERT_EQ(ASTValue::Integer, arg->getValue()->getType());
+    ASSERT_EQ(-0x249DEF, arg->getValue()->getInteger());
+    ASSERT_NULL(arg->next);
+}
+
+
 TEST(ParserTest, SingleNodeWithFloatArg) {
     auto trees = parseString("(nodeName 3.00)");
 

--- a/fvtest/tril/tril/CMakeLists.txt
+++ b/fvtest/tril/tril/CMakeLists.txt
@@ -41,7 +41,7 @@ ADD_FLEX_BISON_DEPENDENCY(tril_scanner tril_parser)
 add_library(tril STATIC
     ${BISON_tril_parser_OUTPUTS}
     ${FLEX_tril_scanner_OUTPUTS}
-    ast.c
+    ast.cpp
     ilgen.cpp
     jitbuilder_compiler.cpp
 )

--- a/fvtest/tril/tril/ast.cpp
+++ b/fvtest/tril/tril/ast.cpp
@@ -18,7 +18,7 @@
 
 #include "ast.hpp"
 #include <stdlib.h>
-#include <string.h>
+#include <string>
 
 ASTNode* createNode(const char * name, ASTNodeArg* args, ASTNode* children,  ASTNode* next) {
     return new ASTNode{name, args, children, next};
@@ -154,4 +154,23 @@ void printTrees(FILE* file, const ASTNode* trees, int indent) {
         printTrees(file, t->getChildren(), indent + 1);
         t = t->next;
     }
+}
+
+bool operator == (const ASTNodeArg& lhs, const ASTNodeArg& rhs) {
+    std::string lhsName = lhs.getName();
+    std::string rhsName = rhs.getName();
+    if (lhsName != rhsName) return false;
+
+    auto lhsValue = lhs.getValue();
+    auto rhsValue = rhs.getValue();
+
+    while (lhsValue != nullptr && rhsValue != nullptr) {
+        if (*lhsValue != *rhsValue) return false;
+        lhsValue = lhsValue->next;
+        rhsValue = rhsValue->next;
+    }
+
+    if (lhsValue != nullptr || rhsValue != nullptr) return false;
+
+    return true;
 }

--- a/fvtest/tril/tril/ast.cpp
+++ b/fvtest/tril/tril/ast.cpp
@@ -108,9 +108,9 @@ const ASTNode* findNodeByNameInTree(const ASTNode* tree, const char* name) {
 
 void printASTValueUnion(FILE* file, const ASTValue* value) {
     switch (value->getType()) {
-        case ASTValue::Integer: fprintf(file, "%lu", value->get<ASTValue::Integer_t>()); break;
-        case ASTValue::FloatingPoint: fprintf(file, "%f", value->get<ASTValue::FloatingPoint_t>()); break;
-        case ASTValue::String: fprintf(file, "\"%s\"", value->get<ASTValue::String_t>()); break;
+        case ASTValue::Integer: fprintf(file, "%lu", value->getInteger()); break;
+        case ASTValue::FloatingPoint: fprintf(file, "%f", value->getFloatingPoint()); break;
+        case ASTValue::String: fprintf(file, "\"%s\"", value->getString()); break;
         default: fprintf(file, "{bad arg type %d}", value->getType());
     };
 }

--- a/fvtest/tril/tril/ast.cpp
+++ b/fvtest/tril/tril/ast.cpp
@@ -28,11 +28,11 @@ ASTNodeArg* createNodeArg(const char * name, ASTValue* value,  ASTNodeArg* next)
     return new ASTNodeArg{name, value, next};
 }
 
-ASTValue* createInt64Value(uint64_t val) {
+ASTValue* createIntegerValue(uint64_t val) {
     return new ASTValue{val};
 }
 
-ASTValue* createDoubleValue(double val) {
+ASTValue* createFloatingPointValue(double val) {
     return new ASTValue{val};
 }
 
@@ -108,9 +108,9 @@ const ASTNode* findNodeByNameInTree(const ASTNode* tree, const char* name) {
 
 void printASTValueUnion(FILE* file, const ASTValue* value) {
     switch (value->getType()) {
-        case Int64: fprintf(file, "%lu", value->get<ASTValue::Integer_t>()); break;
-        case Double: fprintf(file, "%f", value->get<ASTValue::Double_t>()); break;
-        case String: fprintf(file, "\"%s\"", value->get<ASTValue::String_t>()); break;
+        case ASTValue::Integer: fprintf(file, "%lu", value->get<ASTValue::Integer_t>()); break;
+        case ASTValue::FloatingPoint: fprintf(file, "%f", value->get<ASTValue::FloatingPoint_t>()); break;
+        case ASTValue::String: fprintf(file, "\"%s\"", value->get<ASTValue::String_t>()); break;
         default: fprintf(file, "{bad arg type %d}", value->getType());
     };
 }

--- a/fvtest/tril/tril/ast.cpp
+++ b/fvtest/tril/tril/ast.cpp
@@ -32,11 +32,7 @@ ASTNode* createNode(const char * name, ASTNodeArg* args, ASTNode* children,  AST
 }
 
 ASTNodeArg* createNodeArg(const char * name, ASTValue* value,  ASTNodeArg* next) {
-    ASTNodeArg* a = (ASTNodeArg*)malloc(sizeof(ASTNodeArg));
-    a->name = name;
-    a->value = value;
-    a->next = next;
-    return a;
+    return new ASTNodeArg{name, value, next};
 }
 
 ASTValue* createInt64Value(uint64_t val) {
@@ -81,7 +77,7 @@ uint16_t countNodes(const ASTNode* n) {
 const ASTNodeArg* getArgByName(const ASTNode* node, const char* name) {
     const ASTNodeArg* arg = node->args;
     while (arg) {
-        if (arg->name != NULL && strcmp(name, arg->name) == 0) { // arg need not have a name
+        if (arg->getName() != NULL && strcmp(name, arg->getName()) == 0) { // arg need not have a name
             return arg;
         }
         arg = arg->next;
@@ -117,7 +113,7 @@ const ASTNode* findNodeByNameInTree(const ASTNode* tree, const char* name) {
     return NULL;
 }
 
-void printASTValueUnion(FILE* file, ASTValue* value) {
+void printASTValueUnion(FILE* file, const ASTValue* value) {
     switch (value->getType()) {
         case Int64: fprintf(file, "%lu", value->get<ASTValue::Integer_t>()); break;
         case Double: fprintf(file, "%f", value->get<ASTValue::Double_t>()); break;
@@ -126,8 +122,8 @@ void printASTValueUnion(FILE* file, ASTValue* value) {
     };
 }
 
-void printASTValue(FILE* file, ASTValue* value) {
-    ASTValue* v = value;
+void printASTValue(FILE* file, const ASTValue* value) {
+    const ASTValue* v = value;
     int isList = v->next != NULL;
     if (isList) {
         printf("[");
@@ -147,10 +143,10 @@ void printASTArgs(FILE* file, ASTNodeArg* args) {
     ASTNodeArg* a = args;
     while (a) {
         printf(" ");
-        if (a->name != NULL && strcmp("", a->name) != 0) {
-            fprintf(file, "%s=", a->name);
+        if (a->getName() != NULL && strcmp("", a->getName()) != 0) {
+            fprintf(file, "%s=", a->getName());
         }
-        printASTValue(file, a->value);
+        printASTValue(file, a->getValue());
         a = a->next;
     }
 }

--- a/fvtest/tril/tril/ast.cpp
+++ b/fvtest/tril/tril/ast.cpp
@@ -40,27 +40,15 @@ ASTNodeArg* createNodeArg(const char * name, ASTValue* value,  ASTNodeArg* next)
 }
 
 ASTValue* createInt64Value(uint64_t val) {
-    ASTValue* v = (ASTValue*)malloc(sizeof(ASTValue));
-    v->type = Int64;
-    v->value.int64 = val;
-    v->next = NULL;
-    return v;
+    return new ASTValue{val};
 }
 
 ASTValue* createDoubleValue(double val) {
-    ASTValue* v = (ASTValue*)malloc(sizeof(ASTValue));
-    v->type = Double;
-    v->value.f64 = val;
-    v->next = NULL;
-    return v;
+    return new ASTValue{val};
 }
 
 ASTValue* createStrValue(const char* val) {
-   ASTValue* v = (ASTValue*)malloc(sizeof(ASTValue));
-   v->type = String;
-   v->value.str = val;
-   v->next = NULL;
-   return v;
+    return new ASTValue{val};
 }
 
 void appendSiblingNode(ASTNode* list, ASTNode* newNode) {
@@ -130,11 +118,11 @@ const ASTNode* findNodeByNameInTree(const ASTNode* tree, const char* name) {
 }
 
 void printASTValueUnion(FILE* file, ASTValue* value) {
-    switch (value->type) {
-        case Int64: fprintf(file, "%lu", value->value.int64); break;
-        case Double: fprintf(file, "%f", value->value.f64); break;
-        case String: fprintf(file, "\"%s\"", value->value.str); break;
-        default: fprintf(file, "{bad arg type %d}", value->type);
+    switch (value->getType()) {
+        case Int64: fprintf(file, "%lu", value->get<ASTValue::Integer_t>()); break;
+        case Double: fprintf(file, "%f", value->get<ASTValue::Double_t>()); break;
+        case String: fprintf(file, "\"%s\"", value->get<ASTValue::String_t>()); break;
+        default: fprintf(file, "{bad arg type %d}", value->getType());
     };
 }
 

--- a/fvtest/tril/tril/ast.cpp
+++ b/fvtest/tril/tril/ast.cpp
@@ -67,17 +67,6 @@ uint16_t countNodes(const ASTNode* n) {
     return count;
 }
 
-const ASTNodeArg* getArgByName(const ASTNode* node, const char* name) {
-    const ASTNodeArg* arg = node->getArgs();
-    while (arg) {
-        if (arg->getName() != NULL && strcmp(name, arg->getName()) == 0) { // arg need not have a name
-            return arg;
-        }
-        arg = arg->next;
-    }
-    return NULL;
-}
-
 const ASTNode* findNodeByNameInList(const ASTNode* list, const char* name) {
     const ASTNode* node = list;
     while (node) {

--- a/fvtest/tril/tril/ast.cpp
+++ b/fvtest/tril/tril/ast.cpp
@@ -21,14 +21,7 @@
 #include <string.h>
 
 ASTNode* createNode(const char * name, ASTNodeArg* args, ASTNode* children,  ASTNode* next) {
-    ASTNode* n = (ASTNode*)malloc(sizeof(ASTNode));
-    //printf("  node at %p\n", n);
-    n->name = name;
-    n->args = args;
-    n->next = next;
-    //printf("  children at %p\n", children);
-    n->children = children;
-    return n;
+    return new ASTNode{name, args, children, next};
 }
 
 ASTNodeArg* createNodeArg(const char * name, ASTValue* value,  ASTNodeArg* next) {
@@ -75,7 +68,7 @@ uint16_t countNodes(const ASTNode* n) {
 }
 
 const ASTNodeArg* getArgByName(const ASTNode* node, const char* name) {
-    const ASTNodeArg* arg = node->args;
+    const ASTNodeArg* arg = node->getArgs();
     while (arg) {
         if (arg->getName() != NULL && strcmp(name, arg->getName()) == 0) { // arg need not have a name
             return arg;
@@ -88,7 +81,7 @@ const ASTNodeArg* getArgByName(const ASTNode* node, const char* name) {
 const ASTNode* findNodeByNameInList(const ASTNode* list, const char* name) {
     const ASTNode* node = list;
     while (node) {
-        if (strcmp(name, node->name) == 0) {
+        if (strcmp(name, node->getName()) == 0) {
             return node;
         }
         node = node->next;
@@ -99,7 +92,7 @@ const ASTNode* findNodeByNameInList(const ASTNode* list, const char* name) {
 const ASTNode* findNodeByNameInTree(const ASTNode* tree, const char* name) {
     const ASTNode* node = tree;
     while (node) {
-        if (strcmp(name, node->name) == 0) {
+        if (strcmp(name, node->getName()) == 0) {
             return node;
         }
 
@@ -139,8 +132,8 @@ void printASTValue(FILE* file, const ASTValue* value) {
     }
 }
 
-void printASTArgs(FILE* file, ASTNodeArg* args) {
-    ASTNodeArg* a = args;
+void printASTArgs(FILE* file, const ASTNodeArg* args) {
+    const ASTNodeArg* a = args;
     while (a) {
         printf(" ");
         if (a->getName() != NULL && strcmp("", a->getName()) != 0) {
@@ -151,14 +144,14 @@ void printASTArgs(FILE* file, ASTNodeArg* args) {
     }
 }
 
-void printTrees(FILE* file, ASTNode* trees, int indent) {
-    ASTNode* t = trees;
+void printTrees(FILE* file, const ASTNode* trees, int indent) {
+    const ASTNode* t = trees;
     while(t) {
-        int indentVal = indent*2 + (int)strlen(t->name); // indent with two spaces
-        fprintf(file, "(%p) %*s", t, indentVal, t->name);
-        printASTArgs(file, t->args);
+        int indentVal = indent*2 + (int)strlen(t->getName()); // indent with two spaces
+        fprintf(file, "(%p) %*s", t, indentVal, t->getName());
+        printASTArgs(file, t->getArgs());
         fprintf(file, "\n");
-        printTrees(file, t->children, indent + 1);
+        printTrees(file, t->getChildren(), indent + 1);
         t = t->next;
     }
 }

--- a/fvtest/tril/tril/ast.cpp
+++ b/fvtest/tril/tril/ast.cpp
@@ -16,7 +16,7 @@
  *    Multiple authors (IBM Corp.) - initial implementation and documentation
  ******************************************************************************/
 
-#include "ast.h"
+#include "ast.hpp"
 #include <stdlib.h>
 #include <string.h>
 

--- a/fvtest/tril/tril/ast.h
+++ b/fvtest/tril/tril/ast.h
@@ -80,14 +80,6 @@ void appendSiblingValue(ASTValue* list, ASTValue* newValue);
 uint16_t countNodes(const ASTNode* n);
 
 /**
- * @brief Searches a (linked-) list for an instance of ASTNodeArg with a given name
- * @param node is the start of the linked-list to be searched
- * @param name is the name of the ASTNodeArg instance being searched for
- * @return the instance of ASTNodeArg if found, NULL otherwise
- */
-const ASTNodeArg* getArgByName(const ASTNode* node, const char* name);
-
-/**
  * @brief Searches a (linked-) list for an instance of ASTNode with a given name
  * @param list is the start of the linked-list to be searched
  * @param name is the name of the ASTNode instance being searched for

--- a/fvtest/tril/tril/ast.h
+++ b/fvtest/tril/tril/ast.h
@@ -50,8 +50,8 @@ const ASTNodeArg* getArgByName(const ASTNode* node, const char* name);
 const ASTNode* findNodeByNameInList(const ASTNode* list, const char* name);
 const ASTNode* findNodeByNameInTree(const ASTNode* tree, const char* name);
 
-void printASTValueUnion(FILE* file, ASTValue* value);
-void printASTValue(FILE* file, ASTValue* value);
+void printASTValueUnion(FILE* file, const ASTValue* value);
+void printASTValue(FILE* file, const ASTValue* value);
 void printASTArgs(FILE* file, ASTNodeArg* args);
 void printTrees(FILE* file, ASTNode* trees, int indent);
 

--- a/fvtest/tril/tril/ast.h
+++ b/fvtest/tril/tril/ast.h
@@ -28,34 +28,9 @@ extern "C" {
 
 typedef enum {Int64, Double, String} ASTValueType;
 
-struct ASTValue;
 typedef struct ASTValue ASTValue;
-struct ASTValue {
-    ASTValueType type;
-    union {
-        uint64_t int64;
-        double f64;
-        const char* str;
-    } value;
-    ASTValue* next;
-};
-
-struct ASTNodeArg;
 typedef struct ASTNodeArg ASTNodeArg;
-struct ASTNodeArg {
-    const char* name;
-    ASTValue* value;
-    ASTNodeArg* next;
-};
-
-struct ASTNode;
 typedef struct ASTNode ASTNode;
-struct ASTNode {
-    const char* name;
-    ASTNodeArg* args;
-    ASTNode* children;
-    ASTNode* next;
-};
 
 ASTNode* createNode(const char* name, ASTNodeArg* args, ASTNode* children,  ASTNode* next);
 

--- a/fvtest/tril/tril/ast.h
+++ b/fvtest/tril/tril/ast.h
@@ -52,8 +52,8 @@ const ASTNode* findNodeByNameInTree(const ASTNode* tree, const char* name);
 
 void printASTValueUnion(FILE* file, const ASTValue* value);
 void printASTValue(FILE* file, const ASTValue* value);
-void printASTArgs(FILE* file, ASTNodeArg* args);
-void printTrees(FILE* file, ASTNode* trees, int indent);
+void printASTArgs(FILE* file, const ASTNodeArg* args);
+void printTrees(FILE* file, const ASTNode* trees, int indent);
 
 ASTNode* parseFile(FILE* in);
 ASTNode* parseString(const char* in);

--- a/fvtest/tril/tril/ast.h
+++ b/fvtest/tril/tril/ast.h
@@ -19,16 +19,30 @@
 #ifndef AST_H
 #define AST_H
 
+#include <stdio.h>
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include <stdio.h>
-#include <stdint.h>
+/*
+ * This file containes declarations that act as a C wrapper around the Tril AST
+ * interface. This wrapper is mainly used by the Flex/Bison parser.
+ */
 
+/*
+ * Forward declarations for the AST structs (classes)
+ *
+ * These allow C code to interact with pointers to the AST structures.
+ */
 typedef struct ASTValue ASTValue;
 typedef struct ASTNodeArg ASTNodeArg;
 typedef struct ASTNode ASTNode;
+
+/*
+ * The following functions are wrappers for the AST struct constructors.
+ */
 
 ASTNode* createNode(const char* name, ASTNodeArg* args, ASTNode* children,  ASTNode* next);
 
@@ -38,22 +52,78 @@ ASTValue* createIntegerValue(uint64_t val);
 ASTValue* createFloatingPointValue(double val);
 ASTValue* createStrValue(const char* val);
 
+/**
+ * @brief Adds an instance of ASTNode to the end of a (linked-) list
+ * @param list is the linked-list that will be added to
+ * @param newNode is the object that will be added to the list
+ */
 void appendSiblingNode(ASTNode* list, ASTNode* newNode);
+
+/**
+ * @brief Adds an instance of ASTNodeArg to the end of a (linked-) list
+ * @param list is the linked-list that will be added to
+ * @param newArg is the object that will be added to the list
+ */
 void appendSiblingArg(ASTNodeArg* list, ASTNodeArg* newArg);
+
+/**
+ * @brief Adds an instance of ASTValue to the end of a (linked-) list
+ * @param list is the linked-list that will be added to
+ * @param newValue is the object that will be added to the list
+ */
 void appendSiblingValue(ASTValue* list, ASTValue* newValue);
 
+/**
+ * @brief Returns the number of ASTNode instances in a (linked-) list
+ * @param n is the start of the linked-list
+ */
 uint16_t countNodes(const ASTNode* n);
 
+/**
+ * @brief Searches a (linked-) list for an instance of ASTNodeArg with a given name
+ * @param node is the start of the linked-list to be searched
+ * @param name is the name of the ASTNodeArg instance being searched for
+ * @return the instance of ASTNodeArg if found, NULL otherwise
+ */
 const ASTNodeArg* getArgByName(const ASTNode* node, const char* name);
+
+/**
+ * @brief Searches a (linked-) list for an instance of ASTNode with a given name
+ * @param list is the start of the linked-list to be searched
+ * @param name is the name of the ASTNode instance being searched for
+ * @return the instance of ASTNode if found, NULL otherwise
+ */
 const ASTNode* findNodeByNameInList(const ASTNode* list, const char* name);
+
+/**
+ * @brief Searches an AST sub-tree for an instance of ASTNode with a given name
+ * @param tree is the root of the tree to be searched
+ * @param name is the name of the ASTNode instance being searched for
+ * @return the instance for ASTNode if found, NULL otherwise
+ */
 const ASTNode* findNodeByNameInTree(const ASTNode* tree, const char* name);
+
+/*
+ * Convenience functions for printing an AST sub-tree to a file handle.
+ */
 
 void printASTValueUnion(FILE* file, const ASTValue* value);
 void printASTValue(FILE* file, const ASTValue* value);
 void printASTArgs(FILE* file, const ASTNodeArg* args);
 void printTrees(FILE* file, const ASTNode* trees, int indent);
 
+/**
+ * @brief Parse an input file containing Tril code
+ * @param in is a handle pointing to the input file
+ * @return a Tril AST representing the parsed code, or NULL if parsing failed
+ */
 ASTNode* parseFile(FILE* in);
+
+/**
+ * @brief Parse Tril code from an input string
+ * @param in is the string to be parsed
+ * @return a Tril AST representing the parsed code, or NULL if parsing failed
+ */
 ASTNode* parseString(const char* in);
 
 #ifdef __cplusplus

--- a/fvtest/tril/tril/ast.h
+++ b/fvtest/tril/tril/ast.h
@@ -26,8 +26,6 @@ extern "C" {
 #include <stdio.h>
 #include <stdint.h>
 
-typedef enum {Int64, Double, String} ASTValueType;
-
 typedef struct ASTValue ASTValue;
 typedef struct ASTNodeArg ASTNodeArg;
 typedef struct ASTNode ASTNode;
@@ -36,8 +34,8 @@ ASTNode* createNode(const char* name, ASTNodeArg* args, ASTNode* children,  ASTN
 
 ASTNodeArg* createNodeArg(const char* name, ASTValue * value,  ASTNodeArg* next);
 
-ASTValue* createInt64Value(uint64_t val);
-ASTValue* createDoubleValue(double val);
+ASTValue* createIntegerValue(uint64_t val);
+ASTValue* createFloatingPointValue(double val);
 ASTValue* createStrValue(const char* val);
 
 void appendSiblingNode(ASTNode* list, ASTNode* newNode);

--- a/fvtest/tril/tril/ast.hpp
+++ b/fvtest/tril/tril/ast.hpp
@@ -106,10 +106,21 @@ struct ASTNodeArg {
 };
 
 struct ASTNode {
-    const char* name;
-    ASTNodeArg* args;
-    ASTNode* children;
+    private:
+    const char* _name;
+    ASTNodeArg* _args;
+    ASTNode* _children;
+
+    public:
     ASTNode* next;
+
+    ASTNode(const char* name, ASTNodeArg* args, ASTNode* children, ASTNode* next)
+        : _name{name}, _args{args}, _children{children}, next{next} {}
+
+    const char* getName() const { return _name; }
+    const ASTNodeArg* getArgs() const { return _args; }
+    const ASTNode* getChildren() const { return _children; }
+    int getChildCount() const { return countNodes(_children); }
 };
 
 #endif // AST_HPP

--- a/fvtest/tril/tril/ast.hpp
+++ b/fvtest/tril/tril/ast.hpp
@@ -21,6 +21,8 @@
 
 #include "ast.h"
 
+#include <cstring>
+
 struct ASTValue {
     ASTValueType type;
     union {
@@ -43,5 +45,16 @@ struct ASTNode {
     ASTNode* children;
     ASTNode* next;
 };
+
+inline bool operator == (ASTValue lhs, ASTValue rhs) {
+   if (lhs.type == rhs.type) {
+      switch (lhs.type) {
+         case Int64: return lhs.value.int64 == rhs.value.int64;
+         case Double: return lhs.value.f64 == rhs.value.f64;
+         case String: return std::strcmp(lhs.value.str, rhs.value.str) == 0;
+      }
+   }
+   return false;
+}
 
 #endif // AST_HPP

--- a/fvtest/tril/tril/ast.hpp
+++ b/fvtest/tril/tril/ast.hpp
@@ -248,7 +248,78 @@ struct ASTNode {
         : _name{name}, _args{args}, _children{children}, next{next} {}
 
     const char* getName() const { return _name; }
+
+    /**
+     * @brief Returns pointer to linked list of arguments
+     */
     const ASTNodeArg* getArgs() const { return _args; }
+
+    /**
+     * @brief Finds and returns an argument by its index
+     * @param index is the index of the argument
+     * @return the argument at the given index if found, NULL otherwise
+     */
+    const ASTNodeArg* getArgument(int index) const {
+        auto arg = _args;
+
+        while (arg != nullptr && index > 0) {
+            arg = arg->next;
+            --index;
+        }
+
+        return arg;
+    }
+
+    /**
+     * @brief Finds and returns an argument by name
+     * @param name is the name for the argument
+     * @return the argument with the given name if found, NULL otherwise
+     */
+    const ASTNodeArg* getArgByName(const char* name) const {
+        auto arg = _args;
+        while (arg) {
+            if (arg->getName() != NULL && strcmp(name, arg->getName()) == 0) { // arg need not have a name
+                return arg;
+            }
+            arg = arg->next;
+        }
+        return NULL;
+    }
+
+    /**
+     * @brief Finds and returns a positional (nameless) argument by its position (index)
+     * @param index is the index of the positional argument
+     * @return the positional argument at the given index if found, NULL otherwise
+     */
+    const ASTNodeArg* getPositionalArg(int index) const {
+        auto arg = _args;
+
+        while (arg != nullptr) {
+            const auto name = arg->getName();
+            if (name == nullptr || name[0] == '\0') {
+                if (index > 0) { --index; }
+                else { break; }
+            }
+            arg = arg->next;
+        }
+        return arg;
+    }
+
+    /**
+     * @brief Returns the number of arguments the node has
+     */
+    int argumentCount() const {
+        auto arg = _args;
+        auto i = 0;
+
+        while (arg != nullptr) {
+            ++i;
+            arg = arg->next;
+        }
+
+        return i;
+    }
+
     const ASTNode* getChildren() const { return _children; }
     int getChildCount() const { return countNodes(_children); }
 };

--- a/fvtest/tril/tril/ast.hpp
+++ b/fvtest/tril/tril/ast.hpp
@@ -187,7 +187,9 @@ struct ASTValue {
     ASTValue* next;
 };
 
-// overloaded operators for ASTValue
+/*
+ * Overloaded operators for ASTValue
+ */
 
 inline bool operator == (const ASTValue& lhs, const ASTValue& rhs) {
    if (lhs.getType() == rhs.getType()) {
@@ -198,6 +200,10 @@ inline bool operator == (const ASTValue& lhs, const ASTValue& rhs) {
       }
    }
    return false;
+}
+
+inline bool operator != (const ASTValue& lhs, const ASTValue& rhs) {
+    return ! (lhs == rhs);
 }
 
 /**

--- a/fvtest/tril/tril/ast.hpp
+++ b/fvtest/tril/tril/ast.hpp
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#ifndef AST_HPP
+#define AST_HPP
+
+#include "ast.h"
+
+struct ASTValue {
+    ASTValueType type;
+    union {
+        uint64_t int64;
+        double f64;
+        const char* str;
+    } value;
+    ASTValue* next;
+};
+
+struct ASTNodeArg {
+    const char* name;
+    ASTValue* value;
+    ASTNodeArg* next;
+};
+
+struct ASTNode {
+    const char* name;
+    ASTNodeArg* args;
+    ASTNode* children;
+    ASTNode* next;
+};
+
+#endif // AST_HPP

--- a/fvtest/tril/tril/ast.hpp
+++ b/fvtest/tril/tril/ast.hpp
@@ -26,8 +26,11 @@
 #include <cstring>
 
 struct ASTValue {
+    public:
+    enum ASTType {Integer, FloatingPoint, String} ;
+
     private:
-    ASTValueType _type;
+    ASTType _type;
     union {
         uint64_t integer;
         double floatingPoint;
@@ -38,22 +41,22 @@ struct ASTValue {
     ASTValue* next;
 
     using Integer_t = uint64_t;
-    using Double_t = double;
+    using FloatingPoint_t = double;
     using String_t = const char *;
 
-    explicit ASTValue(Integer_t v) : _type{Int64}, next{nullptr} { _value.integer = v; }
-    explicit ASTValue(Double_t v) : _type{Double}, next{nullptr} { _value.floatingPoint = v; }
+    explicit ASTValue(Integer_t v) : _type{Integer}, next{nullptr} { _value.integer = v; }
+    explicit ASTValue(FloatingPoint_t v) : _type{FloatingPoint}, next{nullptr} { _value.floatingPoint = v; }
     explicit ASTValue(String_t v) : _type{String}, next{nullptr} { _value.str = v; }
 
     template <typename T>
     typename std::enable_if<std::is_integral<T>::value, T>::type get() const {
-        assert(Int64 == _type);
+        assert(Integer == _type);
         return static_cast<T>(_value.integer);
     }
 
     template <typename T>
     typename std::enable_if<std::is_floating_point<T>::value, T>::type get() const {
-        assert(Double == _type);
+        assert(FloatingPoint == _type);
         return static_cast<T>(_value.floatingPoint);
     }
 
@@ -65,26 +68,26 @@ struct ASTValue {
 
     template <typename T>
     typename std::enable_if<std::is_integral<T>::value, bool>::type isCompatibleWith() const {
-        return Int64 == _type;
+        return Integer == _type;
     }
     template <typename T>
     typename std::enable_if<std::is_floating_point<T>::value, bool>::type isCompatibleWith() const {
-        return Double == _type;
+        return FloatingPoint == _type;
     }
     template <typename T>
     typename std::enable_if<std::is_same<String_t, T>::value, bool>::type isCompatibleWith() const {
         return String == _type;
     }
 
-    ASTValueType getType() const { return _type; }
+    ASTType getType() const { return _type; }
 };
 
 inline bool operator == (const ASTValue& lhs, const ASTValue& rhs) {
    if (lhs.getType() == rhs.getType()) {
       switch (lhs.getType()) {
-         case Int64: return lhs.get<ASTValue::Integer_t>() == rhs.get<ASTValue::Integer_t>();
-         case Double: return lhs.get<ASTValue::Double_t>() == rhs.get<ASTValue::Double_t>();
-         case String: return std::strcmp(lhs.get<ASTValue::String_t>(), rhs.get<ASTValue::String_t>()) == 0;
+         case ASTValue::Integer: return lhs.get<ASTValue::Integer_t>() == rhs.get<ASTValue::Integer_t>();
+         case ASTValue::FloatingPoint: return lhs.get<ASTValue::FloatingPoint_t>() == rhs.get<ASTValue::FloatingPoint_t>();
+         case ASTValue::String: return std::strcmp(lhs.get<ASTValue::String_t>(), rhs.get<ASTValue::String_t>()) == 0;
       }
    }
    return false;

--- a/fvtest/tril/tril/ast.hpp
+++ b/fvtest/tril/tril/ast.hpp
@@ -91,9 +91,18 @@ inline bool operator == (const ASTValue& lhs, const ASTValue& rhs) {
 }
 
 struct ASTNodeArg {
-    const char* name;
-    ASTValue* value;
+    private:
+    const char* _name;
+    const ASTValue* _value;
+
+    public:
     ASTNodeArg* next;
+
+    ASTNodeArg(const char* name, ASTValue* value, ASTNodeArg* next = nullptr)
+        : _name{name}, _value{value}, next{next} {}
+
+    const char* getName() const { return _name; }
+    const ASTValue* getValue() const { return _value; }
 };
 
 struct ASTNode {

--- a/fvtest/tril/tril/ast.hpp
+++ b/fvtest/tril/tril/ast.hpp
@@ -224,6 +224,14 @@ struct ASTNodeArg {
     const ASTValue* getValue() const { return _value; }
 };
 
+// overloaded operators for ASTNodeArg
+
+bool operator == (const ASTNodeArg& lhs, const ASTNodeArg& rhs);
+
+inline bool operator != (const ASTNodeArg& lhs, const ASTNodeArg& rhs) {
+    return ! (lhs == rhs);
+}
+
 /**
  * @brief A struct representing nodes in the Tril AST
  */

--- a/fvtest/tril/tril/ast.hpp
+++ b/fvtest/tril/tril/ast.hpp
@@ -102,6 +102,21 @@ struct ASTValue {
     }
 
     /**
+     * @brief Return the contained value as its underlying integer type, if that is its type
+     */
+    Integer_t getInteger() const { assert(Integer == _type); return _value.integer; }
+
+    /**
+     * @brief Return the contained value as its underlying floating point type, if that is its type
+     */
+    FloatingPoint_t getFloatingPoint() const { assert(FloatingPoint == _type); return _value.floatingPoint; }
+
+    /**
+     * @brief Return the contained value as its underlying string type, if that is its type
+     */
+    String_t getString() const { assert(String == _type); return _value.str; }
+
+    /**
      * @brief Checks whether the type of the contained value and the specified type are compatible
      * @tparam T is the type to be checked for compatibility
      *
@@ -157,9 +172,9 @@ struct ASTValue {
 inline bool operator == (const ASTValue& lhs, const ASTValue& rhs) {
    if (lhs.getType() == rhs.getType()) {
       switch (lhs.getType()) {
-         case ASTValue::Integer: return lhs.get<ASTValue::Integer_t>() == rhs.get<ASTValue::Integer_t>();
-         case ASTValue::FloatingPoint: return lhs.get<ASTValue::FloatingPoint_t>() == rhs.get<ASTValue::FloatingPoint_t>();
-         case ASTValue::String: return std::strcmp(lhs.get<ASTValue::String_t>(), rhs.get<ASTValue::String_t>()) == 0;
+         case ASTValue::Integer: return lhs.getInteger() == rhs.getInteger();
+         case ASTValue::FloatingPoint: return lhs.getFloatingPoint() == rhs.getFloatingPoint();
+         case ASTValue::String: return std::strcmp(lhs.getString(), rhs.getString()) == 0;
       }
    }
    return false;

--- a/fvtest/tril/tril/ast.hpp
+++ b/fvtest/tril/tril/ast.hpp
@@ -60,6 +60,26 @@ struct ASTValue {
     using FloatingPoint_t = double;
     using String_t = const char *;
 
+    /**
+     * STL compatible type traits for working with AST data types
+     *
+     * The `is_*_Compatible` type traits have their `::value` field set to true
+     * if the specified type is compatible with the named type, false otherwise.
+     *
+     * Examples:
+     *
+     * is_Integer_Compatible<int>::value;          // true
+     * is_Integer_Compatible<double>::value;       // false
+     * is_FloatintPoint_Compatible<double>::value; // true
+     * is_String_Compatible<const char*>::value;   // true
+     */
+    template <typename T>
+    using is_Integer_Compatible = std::is_integral<T>;
+    template <typename T>
+    using is_FloatingPoint_Compatible = std::is_floating_point<T>;
+    template <typename T>
+    using is_String_Compatible = std::is_same<String_t, T>;
+
     // constructors
     explicit ASTValue(Integer_t v) : _type{Integer}, next{nullptr} { _value.integer = v; }
     explicit ASTValue(FloatingPoint_t v) : _type{FloatingPoint}, next{nullptr} { _value.floatingPoint = v; }
@@ -86,19 +106,19 @@ struct ASTValue {
      * b.get<int>();    // causes an assertion failure
      */
     template <typename T>
-    typename std::enable_if<std::is_integral<T>::value, T>::type get() const {
+    typename std::enable_if<is_Integer_Compatible<T>::value, T>::type get() const {
         assert(Integer == _type);
         return static_cast<T>(_value.integer);
     }
     template <typename T>
-    typename std::enable_if<std::is_floating_point<T>::value, T>::type get() const {
+    typename std::enable_if<is_FloatingPoint_Compatible<T>::value, T>::type get() const {
         assert(FloatingPoint == _type);
         return static_cast<T>(_value.floatingPoint);
     }
     template <typename T>
-    typename std::enable_if<std::is_same<String_t, T>::value, T>::type get() const {
+    typename std::enable_if<is_String_Compatible<T>::value, T>::type get() const {
         assert(String == _type);
-        return _value.str;
+        return static_cast<T>(_value.str);
     }
 
     /**
@@ -133,15 +153,15 @@ struct ASTValue {
      * b.isCompatibleWith<int>();    // returns false
      */
     template <typename T>
-    typename std::enable_if<std::is_integral<T>::value, bool>::type isCompatibleWith() const {
+    typename std::enable_if<is_Integer_Compatible<T>::value, bool>::type isCompatibleWith() const {
         return Integer == _type;
     }
     template <typename T>
-    typename std::enable_if<std::is_floating_point<T>::value, bool>::type isCompatibleWith() const {
+    typename std::enable_if<is_FloatingPoint_Compatible<T>::value, bool>::type isCompatibleWith() const {
         return FloatingPoint == _type;
     }
     template <typename T>
-    typename std::enable_if<std::is_same<String_t, T>::value, bool>::type isCompatibleWith() const {
+    typename std::enable_if<is_String_Compatible<T>::value, bool>::type isCompatibleWith() const {
         return String == _type;
     }
 

--- a/fvtest/tril/tril/ilgen.cpp
+++ b/fvtest/tril/tril/ilgen.cpp
@@ -78,9 +78,9 @@ std::unordered_map<std::string, TR::ILOpCodes> OpCodeTable::_opcodeNameMap;
 TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
      TR::Node* node = nullptr;
 
-     auto childCount = countNodes(tree->children);
+     auto childCount = tree->getChildCount();
 
-     if (strcmp("@common", tree->name) == 0) {
+     if (strcmp("@common", tree->getName()) == 0) {
          auto idArg = getArgByName(tree, "id");
          auto id = idArg->getValue()->get<ASTValue::String_t>();
          auto iter = _nodeMap.find(id);
@@ -95,7 +95,7 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
          }
      }
 
-     auto opcode = OpCodeTable{tree->name};
+     auto opcode = OpCodeTable{tree->getName()};
 
      TraceIL("Creating %s from ASTNode %p\n", opcode.getName(), tree);
      if (opcode.isLoadConst()) {
@@ -104,36 +104,36 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
 
         // assume the constant to be loaded is the first argument of the AST node
         if (opcode.isIntegerOrAddress()) {
-           auto v = tree->args->getValue()->get<int64_t>();
+           auto v = tree->getArgs()->getValue()->get<int64_t>();
            node->set64bitIntegralValue(v);
            TraceIL("integral value %d\n", v);
         }
         else {
            switch (opcode.getType()) {
               case TR::Float:
-                 node->setFloat(tree->args->getValue()->get<float>());
+                 node->setFloat(tree->getArgs()->getValue()->get<float>());
                  break;
               case TR::Double:
-                 node->setDouble(tree->args->getValue()->get<double>());
+                 node->setDouble(tree->getArgs()->getValue()->get<double>());
                  break;
               default:
                  return nullptr;
            }
-           TraceIL("floating point value %f\n", tree->args->getValue()->get<ASTValue::Double_t>());
+           TraceIL("floating point value %f\n", tree->getArgs()->getValue()->get<ASTValue::Double_t>());
         }
      }
      else if (opcode.isLoadDirect()) {
         TraceIL("  is direct load of ", "");
 
         // the name of the first argument tells us what kind of symref we're loading
-        if (strcmp("parm", tree->args->getName()) == 0) {
-             auto arg = tree->args->getValue()->get<int32_t>();
+        if (strcmp("parm", tree->getArgs()->getName()) == 0) {
+             auto arg = tree->getArgs()->getValue()->get<int32_t>();
              TraceIL("parameter %d\n", arg);
              auto symref = symRefTab()->findOrCreateAutoSymbol(_methodSymbol, arg, opcode.getType() );
              node = TR::Node::createLoad(symref);
          }
-         else if (strcmp("temp", tree->args->getName()) == 0) {
-             const auto symName = tree->args->getValue()->get<ASTValue::String_t>();
+         else if (strcmp("temp", tree->getArgs()->getName()) == 0) {
+             const auto symName = tree->getArgs()->getValue()->get<ASTValue::String_t>();
              TraceIL("temporary %s\n", symName);
              auto symref = _symRefMap[symName];
              node = TR::Node::createLoad(symref);
@@ -147,8 +147,8 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
         TraceIL("  is direct store of ", "");
 
         // the name of the first argument tells us what kind of symref we're storing to
-        if (strcmp("temp", tree->args->getName()) == 0) {
-            const auto symName = tree->args->getValue()->get<ASTValue::String_t>();
+        if (strcmp("temp", tree->getArgs()->getName()) == 0) {
+            const auto symName = tree->getArgs()->getValue()->get<ASTValue::String_t>();
             TraceIL("temporary %s\n", symName);
 
             // check if a symref has already been created for the temp
@@ -167,9 +167,9 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
      }
      else if (opcode.isLoadIndirect() || opcode.isStoreIndirect()) {
          // the first AST node argument holds the offset
-         auto offset = tree->args->getValue()->get<int32_t>();
+         auto offset = tree->getArgs()->getValue()->get<int32_t>();
          TraceIL("  is indirect store/load with offset %d\n", offset);
-         const auto name = tree->name;
+         const auto name = tree->getName();
          auto type = opcode.getType();
          auto compilation = TR::comp();
          TR::Symbol *sym = TR::Symbol::createNamedShadow(compilation->trHeapMemory(), type, TR::DataType::getSize(opcode.getType()), (char*)name);
@@ -178,7 +178,7 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
          node = TR::Node::createWithSymRef(opcode.getOpCodeValue(), childCount, symref);
      }
      else if (opcode.isIf()) {
-         const auto targetName = tree->args->getValue()->get<ASTValue::String_t>();
+         const auto targetName = tree->getArgs()->getValue()->get<ASTValue::String_t>();
          auto targetId = _blockMap[targetName];
          auto targetEntry = _blocks[targetId]->getEntry();
          TraceIL("  is if with target block %d (%s, entry = %p", targetId, targetName, targetEntry);
@@ -195,7 +195,7 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
          node = TR::Node::createif(opcode.getOpCodeValue(), c1, c2, targetEntry);
      }
      else if (opcode.isBranch()) {
-         const auto targetName = tree->args->getValue()->get<ASTValue::String_t>();
+         const auto targetName = tree->getArgs()->getValue()->get<ASTValue::String_t>();
          auto targetId = _blockMap[targetName];
          auto targetEntry = _blocks[targetId]->getEntry();
          TraceIL("  is branch to target block %d (%s, entry = %p", targetId, targetName, targetEntry);
@@ -217,7 +217,7 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
      }
 
      // create a set child nodes
-     const ASTNode* t = tree->children;
+     const ASTNode* t = tree->getChildren();
      int i = 0;
      while (t) {
          auto child = toTRNode(t);
@@ -243,25 +243,25 @@ bool Tril::TRLangBuilder::cfgFor(const ASTNode* const tree) {
    auto isFallthroughNeeded = true;
 
    // visit the children first
-   const ASTNode* t = tree->children;
+   const ASTNode* t = tree->getChildren();
    while (t) {
        isFallthroughNeeded = isFallthroughNeeded && cfgFor(t);
        t = t->next;
    }
 
-   auto opcode = OpCodeTable{tree->name};
+   auto opcode = OpCodeTable{tree->getName()};
 
    if (opcode.isReturn()) {
        cfg()->addEdge(_currentBlock, cfg()->getEnd());
        isFallthroughNeeded = false;
-       TraceIL("Added CFG edge from block %d to @exit -> %s\n", _currentBlockNumber, tree->name);
+       TraceIL("Added CFG edge from block %d to @exit -> %s\n", _currentBlockNumber, tree->getName());
    }
    else if (opcode.isBranch()) {
-      const auto targetName = tree->args->getValue()->get<ASTValue::String_t>();
+      const auto targetName = tree->getArgs()->getValue()->get<ASTValue::String_t>();
       auto targetId = _blockMap[targetName];
       cfg()->addEdge(_currentBlock, _blocks[targetId]);
       isFallthroughNeeded = isFallthroughNeeded && opcode.isIf();
-      TraceIL("Added CFG edge from block %d to block %d (\"%s\") -> %s\n", _currentBlockNumber, targetId, targetName, tree->name);
+      TraceIL("Added CFG edge from block %d to block %d (\"%s\") -> %s\n", _currentBlockNumber, targetId, targetName, tree->getName());
    }
 
    if (!isFallthroughNeeded) {
@@ -290,7 +290,7 @@ bool Tril::TRLangBuilder::injectIL() {
 
     // iterate over each argument for each basic block
     while (block) {
-       const ASTNodeArg* a = block->args;
+       const ASTNodeArg* a = block->getArgs();
        while (a) {
            if (strcmp("name", a->getName()) == 0) {
                auto name = a->getValue()->get<ASTValue::String_t>();
@@ -309,7 +309,7 @@ bool Tril::TRLangBuilder::injectIL() {
 
     // iterate over each treetop in each basic block
     while (block) {
-       const ASTNode* t = block->children;
+       const ASTNode* t = block->getChildren();
        while (t) {
            auto node = toTRNode(t);
            const auto tt = genTreeTop(node);
@@ -329,7 +329,7 @@ bool Tril::TRLangBuilder::injectIL() {
        auto isFallthroughNeeded = true;
 
        // create CFG edges from the nodes withing the current basic block
-       const ASTNode* t = block->children;
+       const ASTNode* t = block->getChildren();
        while (t) {
            isFallthroughNeeded = isFallthroughNeeded && cfgFor(t);
            t = t->next;

--- a/fvtest/tril/tril/ilgen.cpp
+++ b/fvtest/tril/tril/ilgen.cpp
@@ -80,17 +80,31 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
 
      auto childCount = tree->getChildCount();
 
-     if (strcmp("@common", tree->getName()) == 0) {
-         auto idArg = tree->getArgByName("id");
-         auto id = idArg->getValue()->getString();
+     if (strcmp("@id", tree->getName()) == 0) {
+         auto id = tree->getPositionalArg(0)->getValue()->getString();
          auto iter = _nodeMap.find(id);
          if (iter != _nodeMap.end()) {
              auto n = iter->second;
-             TraceIL("Commoning node n%dn (%p) from ASTNode %p (ID \"%s\")\n", n->getGlobalIndex(), n, tree, id);
+             TraceIL("Commoning node n%dn (%p) from ASTNode %p (@id \"%s\")\n", n->getGlobalIndex(), n, tree, id);
              return n;
          }
          else {
-             TraceIL("Failed to find node for commoning (id=\"%s\")\n", id)
+             TraceIL("Failed to find node for commoning (@id \"%s\")\n", id)
+             return nullptr;
+         }
+     }
+     else if (strcmp("@common", tree->getName()) == 0) {
+         auto id = tree->getArgByName("id")->getValue()->getString();
+         TraceIL("WARNING: Using @common is deprecated. Please use (@id \"%s\") instead.\n", id);
+         fprintf(stderr, "WARNING: Using @common is deprecated. Please use (@id \"%s\") instead.\n", id);
+         auto iter = _nodeMap.find(id);
+         if (iter != _nodeMap.end()) {
+             auto n = iter->second;
+             TraceIL("Commoning node n%dn (%p) from ASTNode %p (@id \"%s\")\n", n->getGlobalIndex(), n, tree, id);
+             return n;
+         }
+         else {
+             TraceIL("Failed to find node for commoning (@id \"%s\")\n", id)
              return nullptr;
          }
      }

--- a/fvtest/tril/tril/ilgen.cpp
+++ b/fvtest/tril/tril/ilgen.cpp
@@ -119,7 +119,7 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
               default:
                  return nullptr;
            }
-           TraceIL("floating point value %f\n", tree->getArgs()->getValue()->get<ASTValue::Double_t>());
+           TraceIL("floating point value %f\n", tree->getArgs()->getValue()->get<ASTValue::FloatingPoint_t>());
         }
      }
      else if (opcode.isLoadDirect()) {

--- a/fvtest/tril/tril/ilgen.cpp
+++ b/fvtest/tril/tril/ilgen.cpp
@@ -82,7 +82,7 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
 
      if (strcmp("@common", tree->getName()) == 0) {
          auto idArg = getArgByName(tree, "id");
-         auto id = idArg->getValue()->get<ASTValue::String_t>();
+         auto id = idArg->getValue()->getString();
          auto iter = _nodeMap.find(id);
          if (iter != _nodeMap.end()) {
              auto n = iter->second;
@@ -119,7 +119,7 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
               default:
                  return nullptr;
            }
-           TraceIL("floating point value %f\n", tree->getArgs()->getValue()->get<ASTValue::FloatingPoint_t>());
+           TraceIL("floating point value %f\n", tree->getArgs()->getValue()->getFloatingPoint());
         }
      }
      else if (opcode.isLoadDirect()) {
@@ -133,7 +133,7 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
              node = TR::Node::createLoad(symref);
          }
          else if (strcmp("temp", tree->getArgs()->getName()) == 0) {
-             const auto symName = tree->getArgs()->getValue()->get<ASTValue::String_t>();
+             const auto symName = tree->getArgs()->getValue()->getString();
              TraceIL("temporary %s\n", symName);
              auto symref = _symRefMap[symName];
              node = TR::Node::createLoad(symref);
@@ -148,7 +148,7 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
 
         // the name of the first argument tells us what kind of symref we're storing to
         if (strcmp("temp", tree->getArgs()->getName()) == 0) {
-            const auto symName = tree->getArgs()->getValue()->get<ASTValue::String_t>();
+            const auto symName = tree->getArgs()->getValue()->getString();
             TraceIL("temporary %s\n", symName);
 
             // check if a symref has already been created for the temp
@@ -178,7 +178,7 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
          node = TR::Node::createWithSymRef(opcode.getOpCodeValue(), childCount, symref);
      }
      else if (opcode.isIf()) {
-         const auto targetName = tree->getArgs()->getValue()->get<ASTValue::String_t>();
+         const auto targetName = tree->getArgs()->getValue()->getString();
          auto targetId = _blockMap[targetName];
          auto targetEntry = _blocks[targetId]->getEntry();
          TraceIL("  is if with target block %d (%s, entry = %p", targetId, targetName, targetEntry);
@@ -195,7 +195,7 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
          node = TR::Node::createif(opcode.getOpCodeValue(), c1, c2, targetEntry);
      }
      else if (opcode.isBranch()) {
-         const auto targetName = tree->getArgs()->getValue()->get<ASTValue::String_t>();
+         const auto targetName = tree->getArgs()->getValue()->getString();
          auto targetId = _blockMap[targetName];
          auto targetEntry = _blocks[targetId]->getEntry();
          TraceIL("  is branch to target block %d (%s, entry = %p", targetId, targetName, targetEntry);
@@ -211,7 +211,7 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
 
      auto nodeIdArg = getArgByName(tree, "id");
      if (nodeIdArg != nullptr) {
-         auto id = nodeIdArg->getValue()->get<ASTValue::String_t>();
+         auto id = nodeIdArg->getValue()->getString();
          _nodeMap[id] = node;
          TraceIL("  node ID %s\n", id);
      }
@@ -257,7 +257,7 @@ bool Tril::TRLangBuilder::cfgFor(const ASTNode* const tree) {
        TraceIL("Added CFG edge from block %d to @exit -> %s\n", _currentBlockNumber, tree->getName());
    }
    else if (opcode.isBranch()) {
-      const auto targetName = tree->getArgs()->getValue()->get<ASTValue::String_t>();
+      const auto targetName = tree->getArgs()->getValue()->getString();
       auto targetId = _blockMap[targetName];
       cfg()->addEdge(_currentBlock, _blocks[targetId]);
       isFallthroughNeeded = isFallthroughNeeded && opcode.isIf();
@@ -293,7 +293,7 @@ bool Tril::TRLangBuilder::injectIL() {
        const ASTNodeArg* a = block->getArgs();
        while (a) {
            if (strcmp("name", a->getName()) == 0) {
-               auto name = a->getValue()->get<ASTValue::String_t>();
+               auto name = a->getValue()->getString();
                _blockMap[name] = blockIndex;
                TraceIL("Name of block %d set to \"%s\"\n", blockIndex, name);
            }
@@ -338,7 +338,7 @@ bool Tril::TRLangBuilder::injectIL() {
        // create fall-through edge
        auto fallthroughArg = getArgByName(block, "fallthrough");
        if (fallthroughArg != nullptr) {
-           auto target = std::string(fallthroughArg->getValue()->get<ASTValue::String_t>());
+           auto target = std::string(fallthroughArg->getValue()->getString());
            if (target == "@exit") {
                cfg()->addEdge(_currentBlock, cfg()->getEnd());
                TraceIL("Added fallthrough edge from block %d to \"%s\"\n", _currentBlockNumber, target.c_str());

--- a/fvtest/tril/tril/ilgen.hpp
+++ b/fvtest/tril/tril/ilgen.hpp
@@ -22,7 +22,7 @@
 #include "ilgen/TypeDictionary.hpp"
 #include "ilgen/IlInjector.hpp"
 
-#include "ast.h"
+#include "ast.hpp"
 
 #include <map>
 #include <string>

--- a/fvtest/tril/tril/method_info.hpp
+++ b/fvtest/tril/tril/method_info.hpp
@@ -40,20 +40,20 @@ class MethodInfo {
          */
         explicit MethodInfo(const ASTNode* methodNode) : _methodNode{methodNode} {
             auto returnTypeArg = getArgByName(_methodNode, "return");
-            _returnType = getTRDataTypes(returnTypeArg->value->value.str);
+            _returnType = getTRDataTypes(returnTypeArg->value->get<ASTValue::String_t>());
 
             auto argTypesArg = getArgByName(_methodNode, "args");
             if (argTypesArg != nullptr) {
                 auto typeValue = argTypesArg->value;
                 while (typeValue != nullptr) {
-                    _argTypes.push_back(getTRDataTypes(typeValue->value.str));
+                    _argTypes.push_back(getTRDataTypes(typeValue->get<ASTValue::String_t>()));
                     typeValue = typeValue->next;
                 }
             }
 
             auto nameArg = getArgByName(_methodNode, "name");
             if (nameArg != nullptr) {
-                _name = nameArg->value->value.str;
+                _name = nameArg->value->get<ASTValue::String_t>();
             }
         }
 

--- a/fvtest/tril/tril/method_info.hpp
+++ b/fvtest/tril/tril/method_info.hpp
@@ -39,10 +39,10 @@ class MethodInfo {
          * @param methodNode is the Tril AST node
          */
         explicit MethodInfo(const ASTNode* methodNode) : _methodNode{methodNode} {
-            auto returnTypeArg = getArgByName(_methodNode, "return");
+            auto returnTypeArg = _methodNode->getArgByName("return");
             _returnType = getTRDataTypes(returnTypeArg->getValue()->getString());
 
-            auto argTypesArg = getArgByName(_methodNode, "args");
+            auto argTypesArg = _methodNode->getArgByName("args");
             if (argTypesArg != nullptr) {
                 auto typeValue = argTypesArg->getValue();
                 while (typeValue != nullptr) {
@@ -51,7 +51,7 @@ class MethodInfo {
                 }
             }
 
-            auto nameArg = getArgByName(_methodNode, "name");
+            auto nameArg = _methodNode->getArgByName("name");
             if (nameArg != nullptr) {
                 _name = nameArg->getValue()->get<ASTValue::String_t>();
             }

--- a/fvtest/tril/tril/method_info.hpp
+++ b/fvtest/tril/tril/method_info.hpp
@@ -70,7 +70,7 @@ class MethodInfo {
         /**
          * @brief Returns the AST representation of the method's body
          */
-        const ASTNode* getBodyAST() const { return _methodNode->children; }
+        const ASTNode* getBodyAST() const { return _methodNode->getChildren(); }
 
         /**
          * @brief Returns the return type of the method

--- a/fvtest/tril/tril/method_info.hpp
+++ b/fvtest/tril/tril/method_info.hpp
@@ -40,13 +40,13 @@ class MethodInfo {
          */
         explicit MethodInfo(const ASTNode* methodNode) : _methodNode{methodNode} {
             auto returnTypeArg = getArgByName(_methodNode, "return");
-            _returnType = getTRDataTypes(returnTypeArg->getValue()->get<ASTValue::String_t>());
+            _returnType = getTRDataTypes(returnTypeArg->getValue()->getString());
 
             auto argTypesArg = getArgByName(_methodNode, "args");
             if (argTypesArg != nullptr) {
                 auto typeValue = argTypesArg->getValue();
                 while (typeValue != nullptr) {
-                    _argTypes.push_back(getTRDataTypes(typeValue->get<ASTValue::String_t>()));
+                    _argTypes.push_back(getTRDataTypes(typeValue->getString()));
                     typeValue = typeValue->next;
                 }
             }

--- a/fvtest/tril/tril/method_info.hpp
+++ b/fvtest/tril/tril/method_info.hpp
@@ -40,11 +40,11 @@ class MethodInfo {
          */
         explicit MethodInfo(const ASTNode* methodNode) : _methodNode{methodNode} {
             auto returnTypeArg = getArgByName(_methodNode, "return");
-            _returnType = getTRDataTypes(returnTypeArg->value->get<ASTValue::String_t>());
+            _returnType = getTRDataTypes(returnTypeArg->getValue()->get<ASTValue::String_t>());
 
             auto argTypesArg = getArgByName(_methodNode, "args");
             if (argTypesArg != nullptr) {
-                auto typeValue = argTypesArg->value;
+                auto typeValue = argTypesArg->getValue();
                 while (typeValue != nullptr) {
                     _argTypes.push_back(getTRDataTypes(typeValue->get<ASTValue::String_t>()));
                     typeValue = typeValue->next;
@@ -53,7 +53,7 @@ class MethodInfo {
 
             auto nameArg = getArgByName(_methodNode, "name");
             if (nameArg != nullptr) {
-                _name = nameArg->value->get<ASTValue::String_t>();
+                _name = nameArg->getValue()->get<ASTValue::String_t>();
             }
         }
 

--- a/fvtest/tril/tril/tril.l
+++ b/fvtest/tril/tril/tril.l
@@ -18,7 +18,13 @@
 [-]?[0-9]+      {
                 yylval.integer = atol(yytext);
                 return INTEGER;
+            };
+
+[-]?0x[0-9a-fA-F]+      {
+                yylval.integer = strtol(yytext, NULL, 16);
+                return INTEGER;
             }
+
 
 [-]?[0-9]+[.][0-9]+      {
                 yylval.f64 = strtod(yytext, NULL);

--- a/fvtest/tril/tril/tril.y
+++ b/fvtest/tril/tril/tril.y
@@ -109,11 +109,11 @@ value:
     INTEGER
         {
             //printf("Generating value %d\n", $1);
-            $$ = createInt64Value($1);
+            $$ = createIntegerValue($1);
         }
     | DOUBLE
         {
-            $$ = createDoubleValue($1);
+            $$ = createFloatingPointValue($1);
         }
     | STRING
         {


### PR DESCRIPTION
This batch of changes makes several improvements to Tril, including:

* A better API for the AST
* Support for hex literals
* Deprecate `@common` syntax in favor of `@id` (issue #1508)
* More documentation 
* More tests

Fixes #1508 