### PR TITLE
Remove default constructor for MethodBuilder

### DIFF
--- a/compiler/ilgen/MethodBuilder.cpp
+++ b/compiler/ilgen/MethodBuilder.cpp
@@ -148,8 +148,6 @@ MethodBuilder::MethodBuilder(TR::TypeDictionary *types, OMR::VirtualMachineState
    })
    }
 
-MethodBuilder::MethodBuilder(const MethodBuilder &src) = default;
-
 MethodBuilder::~MethodBuilder()
    {
    // Cleanup allocations in _memoryRegion *before* its destroyed below (see note in constructor)


### PR DESCRIPTION
Systems with older compilers have trouble with the
"= default" notation from C++11, particularly in
combination with the array fields in MethodBuilder.
Nothing currently requires this constructor, so just
remove it.

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>