### PR TITLE
Reduce OSR logging and disable by default

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -558,19 +558,11 @@ bool OMR::Compilation::canAffordOSRControlFlow()
    {
    if (self()->getOption(TR_DisableOSR) || !self()->getOption(TR_EnableOSR))
       {
-      if (self()->getOption(TR_TraceOSR))
-         {
-         traceMsg(self(), "canAffordOSRControlFlow returning false due to OSR options: disableOSR %d, enableOSR %d\n", self()->getOption(TR_DisableOSR), self()->getOption(TR_EnableOSR));
-         }
       return false;
       }
 
    if (self()->osrInfrastructureRemoved())
       {
-      if (self()->getOption(TR_TraceOSR))
-         {
-         traceMsg(self(), "canAffordOSRControlFlow returning false due to removal of OSR infrastructure\n");
-         }
       return false;
       }
 

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -112,7 +112,6 @@ enum TR_CompilationOptions
 
    TR_TraceBC                    = 0x00010000,
    TR_TraceInfo                  = 0x00020000,
-   TR_TraceOSR                   = TR_TraceInfo, // We want this on by default with traceFull
    TR_TraceTrees                 = 0x00040000,
    TR_TraceCG                    = 0x00080000,
    TR_TraceAliases               = 0x00100000,
@@ -534,7 +533,7 @@ enum TR_CompilationOptions
    TR_DebugInliner                                    = 0x00040000 + 14,
    TR_TracePartialInlining                            = 0x00080000 + 14,
    // Available                                       = 0x00100000 + 14,
-   // Available                                       = 0x00200000 + 14,
+   TR_TraceOSR                                        = 0x00200000 + 14,
    TR_EnableOSR                                       = 0x00400000 + 14,
    TR_DisableAOTCheckCastInlining                     = 0x00800000 + 14,
    TR_DisableAOTInstanceOfInlining                    = 0x01000000 + 14,

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -782,7 +782,9 @@ OMR::ResolvedMethodSymbol::genInduceOSRCall(TR::TreeTop* insertionPoint,
 
    self()->insertRematableStoresFromCallSites(self()->comp(), inlinedSiteIndex, induceOSRCallTree);
    self()->insertStoresForDeadStackSlotsBeforeInducingOSR(self()->comp(), inlinedSiteIndex, insertionPoint->getNode()->getByteCodeInfo(), induceOSRCallTree);
-   traceMsg(self()->comp(), "last real tree n%dn\n", enclosingBlock->getLastRealTreeTop()->getNode()->getGlobalIndex());
+
+   if (self()->comp()->getOption(TR_TraceOSR))
+      traceMsg(self()->comp(), "last real tree n%dn\n", enclosingBlock->getLastRealTreeTop()->getNode()->getGlobalIndex());
    return induceOSRCallTree;
    }
 

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -4419,7 +4419,8 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
 
             // Duplicate the OSR guard tree
             TR::Node *guard = osrGuard->duplicateTree();
-            traceMsg(comp(), "OSRGuard n%dn has been created to guard against method invalidation\n", guard->getGlobalIndex());
+            if (trace())
+               traceMsg(comp(), "OSRGuard n%dn has been created to guard against method invalidation\n", guard->getGlobalIndex());
             guard->setBranchDestination(clonedLoopInvariantBlock->getEntry());
             comparisonTrees.add(guard);
             }


### PR DESCRIPTION
Ensure OSR related tracing is properly guarded
by the TraceOSR option and disable it by default.

Signed-off-by: Nicholas Coughlin <cnic@ca.ibm.com>