### PR TITLE
Modified getMaskForBranchCondition(...)

### DIFF
--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -3734,12 +3734,12 @@ OMR::Z::TreeEvaluator::ternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg)
             
             auto mnemonic = is64BitRegister ? TR::InstOpCode::LOCGR: TR::InstOpCode::LOCR;
 
-            generateRRFInstruction(cg, mnemonic, node, trueReg->getHighOrder(), falseReg->getHighOrder(), getMaskForBranchCondition(TR::InstOpCode::COND_BER)>>4, true);
-            generateRRFInstruction(cg, mnemonic, node, trueReg->getLowOrder(), falseReg->getLowOrder(), getMaskForBranchCondition(TR::InstOpCode::COND_BER)>>4, true);
+            generateRRFInstruction(cg, mnemonic, node, trueReg->getHighOrder(), falseReg->getHighOrder(), getMaskForBranchCondition(TR::InstOpCode::COND_BER), true);
+            generateRRFInstruction(cg, mnemonic, node, trueReg->getLowOrder(), falseReg->getLowOrder(), getMaskForBranchCondition(TR::InstOpCode::COND_BER), true);
             }
          else
             {
-            generateRRFInstruction(cg, trueVal->getOpCode().is8Byte() ? TR::InstOpCode::LOCGR: TR::InstOpCode::LOCR, node, trueReg, falseReg, getMaskForBranchCondition(TR::TreeEvaluator::mapBranchConditionToLOCRCondition(bc))>>4, true);
+            generateRRFInstruction(cg, trueVal->getOpCode().is8Byte() ? TR::InstOpCode::LOCGR: TR::InstOpCode::LOCR, node, trueReg, falseReg, getMaskForBranchCondition(TR::TreeEvaluator::mapBranchConditionToLOCRCondition(bc)), true);
             }
          }
       else
@@ -3845,14 +3845,14 @@ OMR::Z::TreeEvaluator::ternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 
             auto mnemonic = trueReg->getKind() == TR_GPR64 || cg->use64BitRegsOn32Bit() ? TR::InstOpCode::LOCGR: TR::InstOpCode::LOCR;
 
-            generateRRFInstruction(cg, mnemonic, node, trueReg->getHighOrder(), falseReg->getHighOrder(), getMaskForBranchCondition(TR::InstOpCode::COND_BER) >> 4, true);
-            generateRRFInstruction(cg, mnemonic, node, trueReg->getLowOrder(), falseReg->getLowOrder(), getMaskForBranchCondition(TR::InstOpCode::COND_BER) >> 4, true);
+            generateRRFInstruction(cg, mnemonic, node, trueReg->getHighOrder(), falseReg->getHighOrder(), getMaskForBranchCondition(TR::InstOpCode::COND_BER), true);
+            generateRRFInstruction(cg, mnemonic, node, trueReg->getLowOrder(), falseReg->getLowOrder(), getMaskForBranchCondition(TR::InstOpCode::COND_BER), true);
             }
          else
             {
             auto mnemonic = trueVal->getOpCode().is8Byte() ? TR::InstOpCode::LOCGR: TR::InstOpCode::LOCR;
 
-            generateRRFInstruction(cg, mnemonic, node, trueReg, falseReg->getRegister(), getMaskForBranchCondition(TR::InstOpCode::COND_BER)>>4, true);
+            generateRRFInstruction(cg, mnemonic, node, trueReg, falseReg->getRegister(), getMaskForBranchCondition(TR::InstOpCode::COND_BER), true);
             }
          }
       else
@@ -4048,7 +4048,7 @@ TR::Instruction *generateAlwaysTrapSequence(TR::Node *node, TR::CodeGenerator *c
    TR::RegisterDependencyConditions *regDeps =
          new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 1, cg);
    regDeps->addPostCondition(zeroReg, TR::RealRegister::AssignAny);
-   cursor = new (cg->trHeapMemory()) TR::S390RRFInstruction(TR::InstOpCode::CLRT, node, zeroReg, zeroReg, getMaskForBranchCondition(TR::InstOpCode::COND_BER)>>4, true, cg);
+   cursor = new (cg->trHeapMemory()) TR::S390RRFInstruction(TR::InstOpCode::CLRT, node, zeroReg, zeroReg, getMaskForBranchCondition(TR::InstOpCode::COND_BER), true, cg);
    cursor->setDependencyConditions(regDeps);
 
    cg->stopUsingRegister(zeroReg);

--- a/compiler/z/codegen/InstOpCode.hpp
+++ b/compiler/z/codegen/InstOpCode.hpp
@@ -104,59 +104,59 @@ getMaskForBranchCondition (TR::InstOpCode::S390BranchCondition branchCond)
       case TR::InstOpCode::COND_MASK1       :
       case TR::InstOpCode::COND_BO          :
       case TR::InstOpCode::COND_BOR         :
-      case TR::InstOpCode::COND_BRO         : return 0x10 ;
+      case TR::InstOpCode::COND_BRO         : return 0x01 ;
       case TR::InstOpCode::COND_MASK2       :
       case TR::InstOpCode::COND_BH          :
       case TR::InstOpCode::COND_BHR         :
       case TR::InstOpCode::COND_BP          :
       case TR::InstOpCode::COND_BPR         :
       case TR::InstOpCode::COND_BRH         :
-      case TR::InstOpCode::COND_BRP         : return 0x20 ;
-      case TR::InstOpCode::COND_MASK3       : return 0x30 ;
+      case TR::InstOpCode::COND_BRP         : return 0x02 ;
+      case TR::InstOpCode::COND_MASK3       : return 0x03 ;
       case TR::InstOpCode::COND_MASK4       :
       case TR::InstOpCode::COND_BL          :
       case TR::InstOpCode::COND_BLR         :
       case TR::InstOpCode::COND_BM          :
       case TR::InstOpCode::COND_BMR         :
       case TR::InstOpCode::COND_BRL         : 
-      case TR::InstOpCode::COND_BRM         : return 0x40 ;
-      case TR::InstOpCode::COND_MASK5       : return 0x50 ;
+      case TR::InstOpCode::COND_BRM         : return 0x04 ;
+      case TR::InstOpCode::COND_MASK5       : return 0x05 ;
       case TR::InstOpCode::COND_MASK6       :
       case TR::InstOpCode::COND_BNE         :
       case TR::InstOpCode::COND_BNER        :
       case TR::InstOpCode::COND_BNZ         :
-      case TR::InstOpCode::COND_BNZR        : return 0x60 ;
+      case TR::InstOpCode::COND_BNZR        : return 0x06 ;
       case TR::InstOpCode::COND_MASK7       :
       case TR::InstOpCode::COND_BRNE        :
-      case TR::InstOpCode::COND_BRNZ        : return 0x70 ;
+      case TR::InstOpCode::COND_BRNZ        : return 0x07 ;
       case TR::InstOpCode::COND_MASK8       :
       case TR::InstOpCode::COND_BE          :
       case TR::InstOpCode::COND_BER         :
       case TR::InstOpCode::COND_BRE         :
       case TR::InstOpCode::COND_BRZ         :
       case TR::InstOpCode::COND_BZ          :
-      case TR::InstOpCode::COND_BZR         : return 0x80 ;
-      case TR::InstOpCode::COND_MASK9       : return 0x90 ;
+      case TR::InstOpCode::COND_BZR         : return 0x08 ;
+      case TR::InstOpCode::COND_MASK9       : return 0x09 ;
       case TR::InstOpCode::COND_MASK10      :
       case TR::InstOpCode::COND_BNL         :
       case TR::InstOpCode::COND_BNLR        :
       case TR::InstOpCode::COND_BNM         :
-      case TR::InstOpCode::COND_BNMR        : return 0xA0 ;
+      case TR::InstOpCode::COND_BNMR        : return 0x0A ;
       case TR::InstOpCode::COND_MASK11      :
       case TR::InstOpCode::COND_BRNL        : 
-      case TR::InstOpCode::COND_BRNM        : return 0xB0 ;
+      case TR::InstOpCode::COND_BRNM        : return 0x0B ;
       case TR::InstOpCode::COND_MASK12      :
       case TR::InstOpCode::COND_BNH         :
       case TR::InstOpCode::COND_BNHR        :
       case TR::InstOpCode::COND_BNP         :
-      case TR::InstOpCode::COND_BNPR        : return 0xC0 ;
+      case TR::InstOpCode::COND_BNPR        : return 0x0C ;
       case TR::InstOpCode::COND_MASK13      :
       case TR::InstOpCode::COND_BRNH        : 
-      case TR::InstOpCode::COND_BRNP        : return 0xD0 ;
+      case TR::InstOpCode::COND_BRNP        : return 0x0D ;
       case TR::InstOpCode::COND_MASK14      :
       case TR::InstOpCode::COND_BNO         :
       case TR::InstOpCode::COND_BNOR        :
-      case TR::InstOpCode::COND_BRNO        : return 0xE0 ;
+      case TR::InstOpCode::COND_BRNO        : return 0x0E ;
       case TR::InstOpCode::COND_MASK15      :
       case TR::InstOpCode::COND_B           :
       case TR::InstOpCode::COND_BC          :
@@ -164,7 +164,7 @@ getMaskForBranchCondition (TR::InstOpCode::S390BranchCondition branchCond)
       case TR::InstOpCode::COND_BR          :
       case TR::InstOpCode::COND_BRC         :
       case TR::InstOpCode::COND_BRU         : 
-      case TR::InstOpCode::COND_BRUL        : return 0xF0 ;
+      case TR::InstOpCode::COND_BRUL        : return 0x0F ;
       default:
          TR_ASSERT(0, "Unknown branch instruction specified");
          return 0;
@@ -214,7 +214,7 @@ getReverseBranchCondition(TR::InstOpCode::S390BranchCondition bc)
          return TR::InstOpCode::COND_BMR;
       default:
          {
-         uint8_t mask = (getMaskForBranchCondition(bc)>>4);
+         uint8_t mask = getMaskForBranchCondition(bc);
          uint8_t newMask = getReverseBranchMask(mask & 0xe) | (mask & 0x1);
          if (mask == newMask) return bc;
          else                 return getBranchConditionForMask(newMask);

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -4062,7 +4062,7 @@ TR_S390Peephole::ConditionalBranchReduction(TR::InstOpCode::Mnemonic branchOPRep
    currInst = _cursor;
    nextInst = _cursor->getNext();
 
-   TR::InstOpCode::S390BranchCondition cond = getBranchConditionForMask(0xF - ((getMaskForBranchCondition(branchInst->getBranchCondition()) >> 4) & 0xF));
+   TR::InstOpCode::S390BranchCondition cond = getBranchConditionForMask(0xF - (getMaskForBranchCondition(branchInst->getBranchCondition()) & 0xF));
 
    if (performTransformation(comp(), "O^O S390 PEEPHOLE: Conditionalizing fall-through block following %p.\n", currInst))
       {

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -753,7 +753,7 @@ public:
    void setCondCodeShouldBePreserved(bool b) { _cgFlags.set(S390CG_condCodeShouldBePreserved, b); }
 
    uint8_t getFCondMoveBranchOpCond() { return fCondMoveBranchOpCond; }
-   void setFCondMoveBranchOpCond(TR::InstOpCode::S390BranchCondition b) { fCondMoveBranchOpCond = (getMaskForBranchCondition(b) >> 4) & 0xF; }
+   void setFCondMoveBranchOpCond(TR::InstOpCode::S390BranchCondition b) { fCondMoveBranchOpCond = (getMaskForBranchCondition(b)) & 0xF; }
 
    uint8_t getRCondMoveBranchOpCond() { return 0xF - fCondMoveBranchOpCond; }
 

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -3670,8 +3670,8 @@ generateS390CompareBool(TR::Node * node, TR::CodeGenerator * cg, TR::InstOpCode:
       TR::InstOpCode::S390BranchCondition branchOpCond =
          generateS390CompareOps(node, cg, fBranchOpCond, rBranchOpCond);
       uint8_t branchMask = getMaskForBranchCondition(branchOpCond);
-      branchMask += 0x10;
-      branchOpCond = getBranchConditionForMask(branchMask>>4);
+      branchMask += 0x01;
+      branchOpCond = getBranchConditionForMask(branchMask);
       cursor = generateS390BranchInstruction(cg, branchOp, branchOpCond, node, doneCmp);
       }
    else
@@ -3975,7 +3975,7 @@ TR::InstOpCode::S390BranchCondition convertComparisonBranchConditionToTestUnderM
    TR::InstOpCode::S390BranchCondition newCond = brCond;
    if (getIntegralValue(constNode) == 0)
       { 
-      if (getBranchConditionForMask(getMaskForBranchCondition(brCond)>>4) == TR::InstOpCode::COND_MASK8)
+      if (getBranchConditionForMask(getMaskForBranchCondition(brCond)) == TR::InstOpCode::COND_MASK8)
          {
          newCond = TR::InstOpCode::COND_BZ;
          }
@@ -3984,7 +3984,7 @@ TR::InstOpCode::S390BranchCondition convertComparisonBranchConditionToTestUnderM
          newCond = TR::InstOpCode::COND_MASK7;
          }
       }
-   else if (getBranchConditionForMask(getMaskForBranchCondition(brCond)>>4) == TR::InstOpCode::COND_MASK8)
+   else if (getBranchConditionForMask(getMaskForBranchCondition(brCond)) == TR::InstOpCode::COND_MASK8)
       {
       newCond = TR::InstOpCode::COND_BO;
       }
@@ -4804,8 +4804,8 @@ generateS390CompareBranch(TR::Node * node, TR::CodeGenerator * cg, TR::InstOpCod
          if (comp->getOption(TR_TraceCG))
             traceMsg(comp, "in else statement\n");
          uint8_t branchMask = getMaskForBranchCondition(opBranchCond);
-         branchMask += 0x10;
-         opBranchCond = getBranchConditionForMask(branchMask>>4);
+         branchMask += 0x01;
+         opBranchCond = getBranchConditionForMask(branchMask);
 
          generateS390BranchInstruction(cg, branchOp, opBranchCond, node, node->getBranchDestination()->getNode()->getLabel(),deps);
          }
@@ -10278,7 +10278,7 @@ OMR::Z::TreeEvaluator::arraycmpHelper(TR::Node *node,
       ifxcmpBrCond = getStandardIfBranchConditionForArraycmp(ificmpNode, cg);
       }
 
-   bool isIfxcmpBrCondContainEqual = getMaskForBranchCondition(ifxcmpBrCond) & 0x80;
+   bool isIfxcmpBrCondContainEqual = getMaskForBranchCondition(ifxcmpBrCond) & 0x08;
    bool isStartInternalControlFlowSet = false;
    bool isCondLabelNeeded = true;
    bool isEndLabelNeeded = false;
@@ -15590,7 +15590,7 @@ void arraycmpWithPadHelper::generateConstCLCSpacePaddingLoop()
       {
       //if src1leng < src2len and remain == 1, CLI forces a reverse compare order which leads an additional BRC following CLI. i.e.,
       //CLI
-      //TR::InstOpCode::S390BranchCondition brCond = getBranchConditionForMask(getReverseBranchMask((getMaskForBranchCondition(finalBrCond) >> 4) & 0x0E));
+      //TR::InstOpCode::S390BranchCondition brCond = getBranchConditionForMask(getReverseBranchMask((getMaskForBranchCondition(finalBrCond)) & 0x0E));
       ////Do not use --> TR::InstOpCode::S390BranchCondition brCond = getReverseBranchCondition(finalBrCond);
       //BRC on brCond
       //Not worth doing that.
@@ -18021,7 +18021,7 @@ OMR::Z::TreeEvaluator::arraycmpSIMDHelper(TR::Node *node,
       needResultReg = false;// Result register is not applicable for the isFoldedIf case
       }
 
-   bool isIfxcmpBrCondContainEqual = getMaskForBranchCondition(ifxcmpBrCond) & 0x80;
+   bool isIfxcmpBrCondContainEqual = getMaskForBranchCondition(ifxcmpBrCond) & 0x08;
 
    TR::Register * firstAddrReg = cg->gprClobberEvaluate(firstAddrNode);
    TR::Register * secondAddrReg = cg->gprClobberEvaluate(secondAddrNode);

--- a/compiler/z/codegen/S390Instruction.hpp
+++ b/compiler/z/codegen/S390Instruction.hpp
@@ -312,7 +312,7 @@ class S390BranchInstruction : public TR::S390LabeledInstruction
    void assignRegistersAndDependencies(TR_RegisterKinds kindToBeAssigned);
    TR::InstOpCode::S390BranchCondition getBranchCondition()  {return _branchCondition;}
    TR::InstOpCode::S390BranchCondition setBranchCondition(TR::InstOpCode::S390BranchCondition branchCondition) {return _branchCondition = branchCondition;}
-   uint8_t getMask() {return getMaskForBranchCondition(getBranchCondition());}
+   uint8_t getMask() {return getMaskForBranchCondition(getBranchCondition()) << 4;}
    };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1464,7 +1464,7 @@ class S390RegInstruction : public TR::Instruction
 
    TR::InstOpCode::S390BranchCondition getBranchCondition()  {return _branchCondition;}
    TR::InstOpCode::S390BranchCondition setBranchCondition(TR::InstOpCode::S390BranchCondition branchCondition) {return _branchCondition = branchCondition;}
-   uint8_t getMask() {return getMaskForBranchCondition(getBranchCondition());}
+   uint8_t getMask() {return getMaskForBranchCondition(getBranchCondition()) << 4;}
    };
 
 
@@ -2963,7 +2963,7 @@ class S390RRSInstruction : public TR::S390RRInstruction
    /** Get branch condition information */
    virtual TR::InstOpCode::S390BranchCondition getBranchCondition()  {return _branchCondition;}
    virtual TR::InstOpCode::S390BranchCondition setBranchCondition(TR::InstOpCode::S390BranchCondition branchCondition) {return _branchCondition = branchCondition;}
-   uint8_t getMask() {return getMaskForBranchCondition(getBranchCondition());}
+   uint8_t getMask() {return getMaskForBranchCondition(getBranchCondition()) << 4;}
 
    /** Get branch destination information */
    virtual TR::MemoryReference * getBranchDestinationLabel() { return _branchDestination; }
@@ -3402,7 +3402,7 @@ class S390RIEInstruction : public TR::S390RegInstruction
    /** Get branch condition information */
    virtual TR::InstOpCode::S390BranchCondition getBranchCondition()  {return _branchCondition;}
    virtual TR::InstOpCode::S390BranchCondition setBranchCondition(TR::InstOpCode::S390BranchCondition branchCondition) {return _branchCondition = branchCondition;}
-   uint8_t getMask() {return getMaskForBranchCondition(getBranchCondition());}
+   uint8_t getMask() {return getMaskForBranchCondition(getBranchCondition()) << 4;}
 
    /** Get branch destination information */
    virtual TR::LabelSymbol * getBranchDestinationLabel() { return _branchDestination; }
@@ -3616,7 +3616,7 @@ class S390RISInstruction : public TR::S390RIInstruction
    /** Get branch condition information */
    virtual TR::InstOpCode::S390BranchCondition getBranchCondition()  {return _branchCondition;}
    virtual TR::InstOpCode::S390BranchCondition setBranchCondition(TR::InstOpCode::S390BranchCondition branchCondition) {return _branchCondition = branchCondition;}
-   uint8_t getMask() {return getMaskForBranchCondition(getBranchCondition());}
+   uint8_t getMask() {return getMaskForBranchCondition(getBranchCondition()) << 4;}
 
    /** Get branch destination information */
    virtual TR::MemoryReference * getBranchDestinationLabel() { return _branchDestination; }


### PR DESCRIPTION
Modified getMaskForBranchCondition to return expected hex values
instead of expected hex values bit shifted by 4. Modified function
calls that were compensating for this bit shift.

Signed-off-by: Arianne Butler <arianne.butler@ibm.com>