### PR TITLE
Don't set CMAKE_INCLUDE_CURRENT_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,9 +58,6 @@ include(cmake/config.cmake)
 
 enable_testing()
 
-#include current source dir and current bin dir automatically
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
 include_directories(
   ${PROJECT_BINARY_DIR}
   ./include/

--- a/omr/CMakeLists.txt
+++ b/omr/CMakeLists.txt
@@ -16,6 +16,8 @@
 #    Multiple authors (IBM Corp.) - initial implementation and documentation
 ###############################################################################
 
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
 add_tracegen(omrti.tdf)
 add_tracegen(omrvm.tdf)
 

--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -21,6 +21,8 @@ include(OmrFindFiles)
 set(OBJECTS "")
 set(VPATH "")
 
+include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+
 add_tracegen(common/omrport.tdf)
 
 # Logic below will set the target_includes, and supplement the 

--- a/scripts/build-on-travis.sh
+++ b/scripts/build-on-travis.sh
@@ -19,7 +19,7 @@
 
 set -evx
 
-export JOBS=4
+export JOBS=2
 
 if test "x$CMAKE_GENERATOR" = "x"; then
   export CMAKE_GENERATOR="Ninja"

--- a/thread/CMakeLists.txt
+++ b/thread/CMakeLists.txt
@@ -18,6 +18,8 @@
 
 include(OmrFindFiles)
 
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
 add_tracegen(j9thr.tdf)
 
 

--- a/util/avl/CMakeLists.txt
+++ b/util/avl/CMakeLists.txt
@@ -16,6 +16,8 @@
 #    Multiple authors (IBM Corp.) - initial implementation and documentation
 ###############################################################################
 
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
 add_tracegen(avl.tdf)
 
 add_library(j9avl STATIC

--- a/util/hashtable/CMakeLists.txt
+++ b/util/hashtable/CMakeLists.txt
@@ -17,6 +17,8 @@
 ###############################################################################
 
 
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
 #TODO need to port following makefile snippet
 #ifeq ($(OMR_TOOLCHAIN),gcc)
 #    MODULE_CFLAGS += -Wno-unused-value

--- a/util/hookable/CMakeLists.txt
+++ b/util/hookable/CMakeLists.txt
@@ -16,6 +16,8 @@
 #    Multiple authors (IBM Corp.) - initial implementation and documentation
 ###############################################################################
 
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
 #TODO there is a bunch of stuff with vpaths, presumably for some extensibility reasons
 # need to figure out if its actually needed and implement properly if required
 add_library(j9hookstatic STATIC

--- a/util/omrutil/CMakeLists.txt
+++ b/util/omrutil/CMakeLists.txt
@@ -16,6 +16,8 @@
 #    Multiple authors (IBM Corp.) - initial implementation and documentation
 ###############################################################################
 
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
 #TODO port following vpath code:
 #ifeq (s390,$(OMR_HOST_ARCH))
   #ifeq (zos,$(OMR_HOST_OS))

--- a/util/pool/CMakeLists.txt
+++ b/util/pool/CMakeLists.txt
@@ -16,6 +16,8 @@
 #    Multiple authors (IBM Corp.) - initial implementation and documentation
 ###############################################################################
 
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
 add_tracegen(pool.tdf)
 
 add_library(j9pool STATIC


### PR DESCRIPTION
* Propagate include directories to the CMakeLists.txt that need them
* Throttle Travis builds. I'm seeing timeouts  that I can't reproduce locally. 