### PR TITLE
Fix lowering methodExitHook simplifier

### DIFF
--- a/compiler/optimizer/OMRSimplifier.hpp
+++ b/compiler/optimizer/OMRSimplifier.hpp
@@ -283,6 +283,7 @@ class Simplifier : public TR::Optimization
 
    TR::TreeTop      *_performLowerTreeSimplifier;
    TR::Node         *_performLowerTreeNode;
+   TR::list<std::pair<TR::TreeTop*, TR::Node*> > _performLowerTreeNodePairs;
    };
 
 }

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -16885,10 +16885,9 @@ TR::Node *NewSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
 // Used by MethodEnter/ExitHook
 TR::Node *lowerTreeSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    {
-   if(node->getOpCodeValue() == TR::MethodExitHook)
+   if(node->getOpCodeValue() == TR::MethodExitHook || node->getOpCodeValue() == TR::MethodEnterHook)
       {
-      s->_performLowerTreeSimplifier = s->_curTree;
-      s->_performLowerTreeNode = node;
+      s->_performLowerTreeNodePairs.push_back(std::make_pair(s->_curTree, node));
       return node;
       }
    else


### PR DESCRIPTION
Fix lowering methodExitHook simplifier

With inlining in debugging mode, there might be multiple method
enter/exit hooks in one extended basic block and the old way of
lowering them is wrong. This PR collect enter/exit treetops and nodes
into a list and process them after finishing all other nodes in
the same extended basic blocks to avoid spliting a block while in
the process of analyzing the block.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>
