### PR TITLE
Refactor and clean up CodeCacheManager

### DIFF
--- a/compiler/env/FEBase.hpp
+++ b/compiler/env/FEBase.hpp
@@ -84,7 +84,7 @@ class FEBase : public FECommon
    FEBase()
       : FECommon(),
       _config(),
-      _codeCacheManager(this),
+      _codeCacheManager(TR::Compiler->rawAllocator),
       _start_time(TR::Compiler->vm.getUSecClock()),
       _persistentMemory(jitConfig(), TR::Compiler->persistentAllocator())
       {

--- a/compiler/runtime/CodeCacheManager.hpp
+++ b/compiler/runtime/CodeCacheManager.hpp
@@ -32,7 +32,7 @@ namespace TR
 class OMR_EXTENSIBLE CodeCacheManager : public OMR::CodeCacheManagerConnector
    {
    public:
-   CodeCacheManager(TR_FrontEnd *fe) : OMR::CodeCacheManagerConnector(fe) { }
+   CodeCacheManager(TR::RawAllocator rawAllocator) : OMR::CodeCacheManagerConnector(rawAllocator) { }
    };
 
 }

--- a/compiler/runtime/OMRCodeCacheManager.cpp
+++ b/compiler/runtime/OMRCodeCacheManager.cpp
@@ -48,6 +48,12 @@
 #include <unistd.h>                     // for getpid, pid_t
 #endif
 
+OMR::CodeCacheManager::CodeCacheManager(TR::RawAllocator rawAllocator) :
+   _rawAllocator(rawAllocator),
+   _initialized(false)
+   {
+   }
+
 TR::CodeCacheManager *
 OMR::CodeCacheManager::self()
    {
@@ -213,6 +219,17 @@ OMR::CodeCacheManager::destroy()
    _initialized = false;
    }
 
+void *
+OMR::CodeCacheManager::getMemory(size_t sizeInBytes)
+   {
+   return _rawAllocator.allocate(sizeInBytes, std::nothrow);
+   }
+
+void
+OMR::CodeCacheManager::freeMemory(void *memoryToFree)
+   {
+   _rawAllocator.deallocate(memoryToFree);
+   }
 
 TR::CodeCache *
 OMR::CodeCacheManager::allocateCodeCacheObject(TR::CodeCacheMemorySegment *codeCacheSegment,

--- a/compiler/runtime/OMRCodeCacheManager.hpp
+++ b/compiler/runtime/OMRCodeCacheManager.hpp
@@ -30,6 +30,7 @@
 #include "runtime/MethodExceptionData.hpp"     // for MethodExceptionData
 #include "runtime/Runtime.hpp"                 // for TR_CCPreLoadedCode, etc
 #include "runtime/CodeCacheTypes.hpp"
+#include "env/RawAllocator.hpp"
 
 class TR_FrontEnd;
 class TR_OpaqueMethodBlock;
@@ -120,10 +121,7 @@ protected:
 public:
    enum ErrorCode { };
 
-   CodeCacheManager(TR_FrontEnd *fe) : _fe(fe)
-      {
-      _initialized = false;
-      }
+   CodeCacheManager(TR::RawAllocator rawAllocator);
 
    class CacheListCriticalSection : public CriticalSection
       {
@@ -138,7 +136,6 @@ public:
       };
 
    TR::CodeCacheConfig & codeCacheConfig() { return _config; }
-   TR_FrontEnd *fe()                       { return _fe; }
 
    TR::CodeCache *initialize(bool useConsolidatedCache, uint32_t numberOfCodeCachesToCreateAtStartup);
    void lateInitialization();
@@ -246,8 +243,8 @@ protected:
    void printRemainingSpaceInCodeCaches();
    void printOccupancyStats();
 
+   TR::RawAllocator               _rawAllocator;
    TR::CodeCacheConfig            _config;
-   TR_FrontEnd                   *_fe;
    TR::CodeCache                 *_lastCache;                         /*!< last code cache round robined through */
    CodeCacheList                  _codeCacheList;                     /*!< list of allocated code caches */
    int32_t                        _curNumberOfCodeCaches;

--- a/fvtest/compilertest/runtime/CodeCacheManager.hpp
+++ b/fvtest/compilertest/runtime/CodeCacheManager.hpp
@@ -30,7 +30,7 @@ namespace TR
 class OMR_EXTENSIBLE CodeCacheManager : public TestCompiler::CodeCacheManagerConnector
    {
    public:
-   CodeCacheManager(TR_FrontEnd *fe) : TestCompiler::CodeCacheManagerConnector(fe) { }
+   CodeCacheManager(TR::RawAllocator rawAllocator) : TestCompiler::CodeCacheManagerConnector(rawAllocator) { }
    };
 
 } // namespace TR

--- a/fvtest/compilertest/runtime/TestCodeCacheManager.cpp
+++ b/fvtest/compilertest/runtime/TestCodeCacheManager.cpp
@@ -34,45 +34,16 @@
 
 
 TR::CodeCacheManager *TestCompiler::CodeCacheManager::_codeCacheManager = NULL;
-TestCompiler::JitConfig *TestCompiler::CodeCacheManager::_jitConfig = NULL;
-
+TestCompiler::CodeCacheManager::CodeCacheManager(TR::RawAllocator rawAllocator)
+   : OMR::CodeCacheManagerConnector(rawAllocator)
+   {
+   _codeCacheManager = self();
+   }
 
 TR::CodeCacheManager *
 TestCompiler::CodeCacheManager::self()
    {
    return static_cast<TR::CodeCacheManager *>(this);
-   }
-
-TestCompiler::FrontEnd *
-TestCompiler::CodeCacheManager::pyfe()
-   {
-   return reinterpret_cast<FrontEnd *>(self()->fe());
-   }
-
-TR::CodeCache *
-TestCompiler::CodeCacheManager::initialize(bool useConsolidatedCache, uint32_t numberOfCodeCachesToCreateAtStartup)
-   {
-   _jitConfig = self()->pyfe()->jitConfig();
-   //_allocator = TR::globalAllocator("CodeCache");
-   return self()->OMR::CodeCacheManager::initialize(useConsolidatedCache, numberOfCodeCachesToCreateAtStartup);
-   }
-
-void *
-TestCompiler::CodeCacheManager::getMemory(size_t sizeInBytes)
-   {
-   void * ptr = malloc(sizeInBytes);
-   //fprintf(stderr,"TestCompiler::CodeCacheManager::getMemory(%d) allocated %p\n", sizeInBytes, ptr);
-
-   return ptr;
-   //return _allocator.allocate(sizeInBytes);
-   }
-
-void
-TestCompiler::CodeCacheManager::freeMemory(void *memoryToFree)
-   {
-   //fprintf(stderr,"TestCompiler::CodeCacheManager::free(%p)\n", memoryToFree);
-   free(memoryToFree);
-   //return _allocator.deallocate(memoryToFree, 0);
    }
 
 TR::CodeCacheMemorySegment *

--- a/fvtest/compilertest/runtime/TestCodeCacheManager.hpp
+++ b/fvtest/compilertest/runtime/TestCodeCacheManager.hpp
@@ -47,21 +47,11 @@ class OMR_EXTENSIBLE CodeCacheManager : public OMR::CodeCacheManagerConnector
    TR::CodeCacheManager *self();
 
 public:
-   CodeCacheManager(TR_FrontEnd *fe) : OMR::CodeCacheManagerConnector(fe)
-      {
-      _codeCacheManager = reinterpret_cast<TR::CodeCacheManager *>(this);
-      }
+   CodeCacheManager(TR::RawAllocator rawAllocator);
 
    void *operator new(size_t s, TR::CodeCacheManager *m) { return m; }
 
    static TR::CodeCacheManager *instance()  { return _codeCacheManager; }
-   static JitConfig *jitConfig()            { return _jitConfig; }
-   FrontEnd *pyfe();
-
-   TR::CodeCache *initialize(bool useConsolidatedCache, uint32_t numberOfCodeCachesToCreateAtStartup);
-
-   void *getMemory(size_t sizeInBytes);
-   void  freeMemory(void *memoryToFree);
 
    TR::CodeCacheMemorySegment *allocateCodeCacheSegment(size_t segmentSize,
                                                         size_t &codeCacheSizeToAllocate,
@@ -69,8 +59,6 @@ public:
 
 private :
    static TR::CodeCacheManager *_codeCacheManager;
-   static JitConfig *_jitConfig;
-   //static TR::GlobalAllocator & _allocator;
    };
 
 } // namespace TestCompiler

--- a/jitbuilder/runtime/CodeCacheManager.hpp
+++ b/jitbuilder/runtime/CodeCacheManager.hpp
@@ -34,7 +34,7 @@ namespace TR
    class CodeCacheManager : public JitBuilder::CodeCacheManager
       {
       public:
-      CodeCacheManager(TR_FrontEnd *fe) : JitBuilder::CodeCacheManager(fe) { }
+      CodeCacheManager(TR::RawAllocator rawAllocator) : JitBuilder::CodeCacheManager(rawAllocator) { }
       };
 
 } // namespace TR

--- a/jitbuilder/runtime/JBCodeCacheManager.cpp
+++ b/jitbuilder/runtime/JBCodeCacheManager.cpp
@@ -35,40 +35,19 @@
 
 
 TR::CodeCacheManager *JitBuilder::CodeCacheManager::_codeCacheManager = NULL;
-JitBuilder::JitConfig *JitBuilder::CodeCacheManager::_jitConfig = NULL;
 
+JitBuilder::CodeCacheManager::CodeCacheManager(TR::RawAllocator rawAllocator)
+   : OMR::CodeCacheManagerConnector(rawAllocator)
+   {
+   TR_ASSERT_FATAL(!_codeCacheManager, "CodeCacheManager already instantiated. "
+                                       "Cannot create multiple instances");
+   _codeCacheManager = self();
+   }
 
 TR::CodeCacheManager *
 JitBuilder::CodeCacheManager::self()
    {
    return static_cast<TR::CodeCacheManager *>(this);
-   }
-
-
-TR::CodeCache *
-JitBuilder::CodeCacheManager::initialize(bool useConsolidatedCache, uint32_t numberOfCodeCachesToCreateAtStartup)
-   {
-   _jitConfig = pyfe()->jitConfig();
-   //_allocator = TR::globalAllocator("CodeCache");
-   return this->OMR::CodeCacheManager::initialize(useConsolidatedCache, numberOfCodeCachesToCreateAtStartup);
-   }
-
-void *
-JitBuilder::CodeCacheManager::getMemory(size_t sizeInBytes)
-   {
-   void * ptr = malloc(sizeInBytes);
-   //fprintf(stderr,"JitBuilder::CodeCacheManager::getMemory(%d) allocated %p\n", sizeInBytes, ptr);
-
-   return ptr;
-   //return _allocator.allocate(sizeInBytes);
-   }
-
-void
-JitBuilder::CodeCacheManager::freeMemory(void *memoryToFree)
-   {
-   //fprintf(stderr,"JitBuilder::CodeCacheManager::free(%p)\n", memoryToFree);
-   free(memoryToFree);
-   //return _allocator.deallocate(memoryToFree, 0);
    }
 
 TR::CodeCacheMemorySegment *

--- a/jitbuilder/runtime/JBCodeCacheManager.hpp
+++ b/jitbuilder/runtime/JBCodeCacheManager.hpp
@@ -52,13 +52,7 @@ class OMR_EXTENSIBLE CodeCacheManager : public OMR::CodeCacheManagerConnector
    TR::CodeCacheManager *self();
 
 public:
-   CodeCacheManager(TR_FrontEnd *fe) : OMR::CodeCacheManagerConnector(fe)
-      {
-      TR_ASSERT_FATAL(!_codeCacheManager, "CodeCacheManager already instantiated. "
-                                          "Cannot create multiple instances");
-
-      _codeCacheManager = reinterpret_cast<TR::CodeCacheManager *>(this);
-      }
+   CodeCacheManager(TR::RawAllocator rawAllocator);
 
    void *operator new(size_t s, TR::CodeCacheManager *m) { return m; }
 
@@ -68,22 +62,12 @@ public:
       return _codeCacheManager;
       }
 
-   static JitConfig *jitConfig()            { return _jitConfig; }
-   FrontEnd *pyfe()                         { return reinterpret_cast<FrontEnd *>(fe()); }
-
-   TR::CodeCache *initialize(bool useConsolidatedCache, uint32_t numberOfCodeCachesToCreateAtStartup);
-
-   void *getMemory(size_t sizeInBytes);
-   void  freeMemory(void *memoryToFree);
-
    TR::CodeCacheMemorySegment *allocateCodeCacheSegment(size_t segmentSize,
                                                         size_t &codeCacheSizeToAllocate,
                                                         void *preferredStartAddress);
 
 private :
    static TR::CodeCacheManager *_codeCacheManager;
-   static JitConfig *_jitConfig;
-   //static TR::GlobalAllocator & _allocator;
    };
 
 


### PR DESCRIPTION
- Modifies the CodeCacheManager constructor, adding a TR::RawAllocator
parameter and removing the TR_FrontEnd parameter.

- Uses the newly provided TR::RawAllocator when allocating and freeing
memory, moving the implementation to the OMR Layer.

- Removes the _fe field and the fe and pyfe methods

- Removes the static JitConfig field, as well as its getter method in
the test compiler and JitBuilder environments.

Resolves #1191 (JBCodeCacheManager should not define "pyfe()")

Signed-off-by: Luc des Trois Maisons <lmaisons@ca.ibm.com>