### PR TITLE
WIP: CMake: Add toolchain targeting x86

### DIFF
--- a/cmake/toolchains/gnu-x86.cmake
+++ b/cmake/toolchains/gnu-x86.cmake
@@ -1,0 +1,8 @@
+# Cross compile to x86 from an x86-64 machine on a gnu-ish toolchain
+
+set(CMAKE_SYSTEM_PROCESSOR "x86")
+set(CMAKE_C_FLAGS "-m32 -msse2")
+set(CMAKE_CXX_FLAGS "-m32 -msse2")
+set(CMAKE_EXE_LINKER_FLAGS "-m32")
+set(CMAKE_SHARED_LINKER_FLAGS "-m32")
+set(CMAKE_STATIC_LINKER_FLAGS "-m32")


### PR DESCRIPTION
This toolchain can be used to generate binaries for x86, with any gnuish
platform.

Signed-off-by: Robert Young <rwy0717@gmail.com>