### PR TITLE
Make no-op hashtable printf into a function

### DIFF
--- a/util/hashtable/hashtable.c
+++ b/util/hashtable/hashtable.c
@@ -46,7 +46,7 @@
 #define hashTable_printf omrtty_printf
 #define HASHTABLE_DEBUG_PORT(_portLibrary) OMRPORT_ACCESS_FROM_OMRPORT(_portLibrary)
 #else
-#define hashTable_printf
+#define hashTable_printf(...)
 #define HASHTABLE_DEBUG_PORT(_portLibrary)
 #endif
 


### PR DESCRIPTION
Silence unused value warnings created by building the hashtable without
debug enabled.

Signed-off-by: Matthew Gaudet <magaudet@ca.ibm.com>