### PR TITLE
Add exception throwing case for ZEROCHK

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -3560,6 +3560,9 @@ OMR::Node::exceptionsRaised()
 
    switch (node->getOpCodeValue())
       {
+      case TR::ZEROCHK:
+         possibleExceptions |= TR::Block:: CanCatchEverything;
+      break;
       case TR::DIVCHK:
          possibleExceptions |= TR::Block:: CanCatchDivCheck;
          break;


### PR DESCRIPTION
Modify OMR::Node::exceptionsRaised to indicate the fact that Node
with zerochk opcode can throw exception

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>