### PR TITLE
WIP: VGC improvements for CS

### DIFF
--- a/gc/base/Collector.hpp
+++ b/gc/base/Collector.hpp
@@ -30,7 +30,7 @@
 class MM_AllocateDescription;
 class MM_AllocationContext;
 class MM_CollectorLanguageInterface;
-class MM_ConcurrentGMPStats;
+class MM_ConcurrentPhaseStatsBase;
 class MM_MemoryPool;
 class MM_ObjectAllocationInterface;
 class MM_MemorySubSpace;
@@ -275,11 +275,15 @@ public:
 	virtual void preMasterGCThreadInitialize(MM_EnvironmentBase *env) {}
 	virtual	void masterThreadGarbageCollect(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, bool initMarkMap = false, bool rebuildMarkBits = false) {}
 	virtual bool isConcurrentWorkAvailable(MM_EnvironmentBase *env) { return false; }
-	virtual	void preConcurrentInitializeStatsAndReport(MM_EnvironmentBase *env, MM_ConcurrentGMPStats *stats) {}
+	virtual	void preConcurrentInitializeStatsAndReport(MM_EnvironmentBase *env, MM_ConcurrentPhaseStatsBase *stats) {}
 	virtual uintptr_t masterThreadConcurrentCollect(MM_EnvironmentBase *env) { return 0; }
-	virtual	void postConcurrentUpdateStatsAndReport(MM_EnvironmentBase *env, MM_ConcurrentGMPStats *stats, UDATA bytesConcurrentlyScanned) {}
+	virtual	void postConcurrentUpdateStatsAndReport(MM_EnvironmentBase *env, MM_ConcurrentPhaseStatsBase *stats, UDATA bytesConcurrentlyScanned) {}
 	virtual void forceConcurrentFinish() {}
 	virtual void completeExternalConcurrentCycle(MM_EnvironmentBase *env) {}
+	/**
+	 * @return pointer to collector/phase specific concurrent stats structure
+	 */
+	virtual MM_ConcurrentPhaseStatsBase *getConcurrentPhaseStats() { return NULL; }
 	
 	MM_Collector(MM_CollectorLanguageInterface *cli)
 		: MM_BaseVirtual()

--- a/gc/base/omrmmprivate.hdf
+++ b/gc/base/omrmmprivate.hdf
@@ -156,6 +156,7 @@
 		<data type="uint64_t" name="timestamp" description="time of event" />
 		<data type="uintptr_t" name="eventid" description="unique identifier for event" />
 		<data type="void*" name="subSpace" description="the subspace which was collected" />
+		<data type="bool" name="cycleEnd" description="true, if last GC increment in a cycle" />
 	</event>
 	
 	<event>
@@ -974,29 +975,29 @@
 	</event>
 		
 	<event>
-		<name>J9HOOK_MM_PRIVATE_CONCURRENT_GMP_START</name>
+		<name>J9HOOK_MM_PRIVATE_CONCURRENT_PHASE_START</name>
 		<description>
-			Triggered when concurrent GMP work begins.
+			Triggered when concurrent phase work begins.
 			NOTE:  Only expected to be used by verbose GC output.
 		</description>
-		<struct>MM_ConcurrentGMPStartEvent</struct>
+		<struct>MM_ConcurrentPhaseStartEvent</struct>
 		<data type="struct OMR_VMThread*" name="currentThread" description="current thread" />
 		<data type="uint64_t" name="timestamp" description="time of event" />
 		<data type="uintptr_t" name="eventid" description="unique identifier for event" />
-		<data type="void *" name="concurrentGMPStats" description="internal statistics for concurrent GMP" /> 
+		<data type="void *" name="concurrentStats" description="internal statistics for concurrent phase" /> 
 	</event>
 	
-	<event>
-		<name>J9HOOK_MM_PRIVATE_CONCURRENT_GMP_END</name>
+		<event>
+		<name>J9HOOK_MM_PRIVATE_CONCURRENT_PHASE_END</name>
 		<description>
-			Triggered when concurrent GMP work ends.
+			Triggered when concurrent phase work ends.
 			NOTE:  Only expected to be used by verbose GC output.
 		</description>
-		<struct>MM_ConcurrentGMPEndEvent</struct>
+		<struct>MM_ConcurrentPhaseEndEvent</struct>
 		<data type="struct OMR_VMThread*" name="currentThread" description="current thread" />
 		<data type="uint64_t" name="timestamp" description="time of event" />
 		<data type="uintptr_t" name="eventid" description="unique identifier for event" />
-		<data type="void *" name="concurrentGMPStats" description="internal statistics for concurrent GMP" /> 
+		<data type="void *" name="concurrentStats" description="internal statistics for concurrent phase" />
 	</event>
 	
 	<event>

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -469,7 +469,7 @@ MM_Scavenger::reportScavengeStart(MM_EnvironmentStandard *env)
 }
 
 void
-MM_Scavenger::reportScavengeEnd(MM_EnvironmentStandard *env)
+MM_Scavenger::reportScavengeEnd(MM_EnvironmentStandard *env, bool lastIncrement)
 {
 	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
 
@@ -485,7 +485,8 @@ MM_Scavenger::reportScavengeEnd(MM_EnvironmentStandard *env)
 		env->getOmrVMThread(),
 		omrtime_hires_clock(),
 		J9HOOK_MM_PRIVATE_SCAVENGE_END,
-		env->_cycleState->_activeSubSpace
+		env->_cycleState->_activeSubSpace,
+		lastIncrement
 	);
 }
 
@@ -647,7 +648,7 @@ MM_Scavenger::mergeHotFieldStats(MM_EnvironmentStandard *env)
  * Clear any global stats associated to the scavenger.
  */
 void
-MM_Scavenger::clearGCStats(MM_EnvironmentStandard *env)
+MM_Scavenger::clearGCStats(MM_EnvironmentBase *env)
 {
 	_extensions->scavengerStats.clear();
 }
@@ -656,7 +657,7 @@ MM_Scavenger::clearGCStats(MM_EnvironmentStandard *env)
  * Merge the current threads scavenge stats into the global scavenge stats.
  */
 void
-MM_Scavenger::mergeGCStats(MM_EnvironmentStandard *env)
+MM_Scavenger::mergeGCStats(MM_EnvironmentBase *env)
 {
 	OMRPORT_ACCESS_FROM_OMRVM(_omrVM);
 
@@ -3477,19 +3478,12 @@ MM_Scavenger::masterThreadGarbageCollect(MM_EnvironmentBase *envBase, MM_Allocat
 		}
 
 		reportGCCycleStart(env);
+		masterSetupForGC(env);
 	}
 	reportGCStart(env);
 	reportGCIncrementStart(env);
-#if defined(OMR_GC_CONCURRENT_SCAVENGER)
-	if (!isConcurrentInProgress())
-#endif
-	{
-		reportScavengeStart(env);
-
-		_extensions->scavengerStats._startTime = omrtime_hires_clock();
-
-		masterSetupForGC(env);
-	}
+	reportScavengeStart(env);
+	_extensions->scavengerStats._startTime = omrtime_hires_clock();
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	if (_extensions->concurrentScavenger) {
@@ -3500,17 +3494,17 @@ MM_Scavenger::masterThreadGarbageCollect(MM_EnvironmentBase *envBase, MM_Allocat
 		scavenge(env);
 	}
 
+	_extensions->scavengerStats._endTime = omrtime_hires_clock();
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
-	if (!isConcurrentInProgress())
+	if (isConcurrentInProgress()) {
+		reportScavengeEnd(env, false);
+	} else
 #endif
 	{
+		reportScavengeEnd(env, true);
+
 		/* defer to collector language interface */
 		_cli->scavenger_masterThreadGarbageCollect_scavengeComplete(env);
-
-		/* Record the completion time of the scavenge */
-		_extensions->scavengerStats._endTime = omrtime_hires_clock();
-
-		reportScavengeEnd(env);
 
 		/* Reset the resizable flag of the semi space.
 		 * NOTE: Must be done before we attempt to resize the new space.
@@ -3786,19 +3780,28 @@ MM_Scavenger::getCollectorExpandSize(MM_EnvironmentBase *env)
 void
 MM_Scavenger::internalPreCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *subSpace, MM_AllocateDescription *allocDescription, uint32_t gcCode)
 {
-	_cycleState = MM_CycleState();
 	env->_cycleState = &_cycleState;
-	env->_cycleState->_gcCode = MM_GCCode(gcCode);
-	env->_cycleState->_type = _cycleType;
-	env->_cycleState->_collectionStatistics = &_collectionStatistics;
 
-	/* If we are in an excessiveGC level beyond normal then an aggressive GC is
-	 * conducted to free up as much space as possible
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	/* Cycle state is initialized only once at the beginning of a cycle. We do not want, in mid-end cycle phases, to reset some members
+	 * that are initialized at the beginning (such as verboseContextID).
 	 */
-	if (!env->_cycleState->_gcCode.isExplicitGC()) {
-		if(excessive_gc_normal != _extensions->excessiveGCLevel) {
-			/* convert the current mode to excessive GC mode */
-			env->_cycleState->_gcCode = MM_GCCode(J9MMCONSTANT_IMPLICIT_GC_EXCESSIVE);
+	if (!isConcurrentInProgress())
+#endif
+	{
+		_cycleState = MM_CycleState();
+		_cycleState._gcCode = MM_GCCode(gcCode);
+		_cycleState._type = _cycleType;
+		_cycleState._collectionStatistics = &_collectionStatistics;
+
+		/* If we are in an excessiveGC level beyond normal then an aggressive GC is
+		 * conducted to free up as much space as possible
+		 */
+		if (!_cycleState._gcCode.isExplicitGC()) {
+			if(excessive_gc_normal != _extensions->excessiveGCLevel) {
+				/* convert the current mode to excessive GC mode */
+				_cycleState._gcCode = MM_GCCode(J9MMCONSTANT_IMPLICIT_GC_EXCESSIVE);
+			}
 		}
 	}
 
@@ -3814,7 +3817,7 @@ MM_Scavenger::internalPostCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *su
 {
 	calcGCStats((MM_EnvironmentStandard*)env);
 
-	return ;
+	Assert_MM_true(env->_cycleState == &_cycleState);
 }
 
 /**
@@ -4535,6 +4538,8 @@ MM_Scavenger::scavengeComplete(MM_EnvironmentBase *envBase)
 
 	Assert_MM_true(concurrent_state_complete == _concurrentState);
 
+	clearGCStats(env);
+
 	GC_OMRVMThreadListIterator threadIterator(_extensions->getOmrVM());
 	OMR_VMThread *walkThread = NULL;
 
@@ -4597,7 +4602,7 @@ MM_Scavenger::scavengeIncremental(MM_EnvironmentBase *env)
 		case concurrent_state_scan:
 		{
 			/* This is just for corner cases that must be run in STW mode.
-			 * Default main scan phase is done by scavengeConcurrent. */
+			 * Default main scan phase is done within masterThreadConcurrentCollect. */
 
 			timeout = scavengeScan(env);
 
@@ -4639,23 +4644,33 @@ MM_Scavenger::workThreadProcessRoots(MM_EnvironmentStandard *env)
 	rootScanner.scavengeRememberedSet(env);
 
 	rootScanner.scanRoots(env);
+
+	mergeGCStats(env);
 }
 
 void
 MM_Scavenger::workThreadScan(MM_EnvironmentStandard *env)
 {
+	/* Clear thread local stats */
+	memset((void *)&(env->_scavengerStats), 0, sizeof(MM_ScavengerStats));
+
 	completeScan(env);
 	// todo: are these two steps really necessary?
 	// we probably have to clear all things for master since it'll be doing final release/clear on behalf of mutator threads
 	// but is it really needed for slaves as well?
 	addCopyCachesToFreeList(env);
 	abandonTLHRemainders(env);
+
+	mergeGCStats(env);
 }
 
 void
 MM_Scavenger::workThreadComplete(MM_EnvironmentStandard *env)
 {
 	Assert_MM_true(_extensions->concurrentScavenger);
+
+	/* Clear thread local stats */
+	memset((void *)&(env->_scavengerStats), 0, sizeof(MM_ScavengerStats));
 
 	MM_ScavengerRootScanner rootScanner(env, this);
 
@@ -4703,45 +4718,61 @@ MM_Scavenger::workThreadComplete(MM_EnvironmentStandard *env)
 }
 
 uintptr_t
-MM_Scavenger::scavengeConcurrent(MM_EnvironmentBase *env, UDATA totalBytesToScavenge, volatile bool *forceExit)
+MM_Scavenger::masterThreadConcurrentCollect(MM_EnvironmentBase *env)
 {
 	Assert_MM_true(concurrent_state_scan == _concurrentState);
 
-	MM_ConcurrentScavengeTask scavengeTask(env, _dispatcher, this, MM_ConcurrentScavengeTask::SCAVENGE_SCAN, totalBytesToScavenge, forceExit, env->_cycleState);
+	clearGCStats(env);
+
+	MM_ConcurrentScavengeTask scavengeTask(env, _dispatcher, this, MM_ConcurrentScavengeTask::SCAVENGE_SCAN, UDATA_MAX, &_forceConcurrentTermination, env->_cycleState);
 	/* Concurrent background task will run with different (typically lower) number of threads. */
 	_dispatcher->run(env, &scavengeTask, _extensions->concurrentScavengerBackgroundThreads);
 
-	uintptr_t bytesScanned = scavengeTask.getBytesScanned();
 	/* we can't assert the work queue is empty. some mutator threads could have just flushed their copy caches, after the task terminated */
 	_concurrentState = concurrent_state_complete;
 	/* make allocate space non-allocatable to trigger the final GC phase */
 	_activeSubSpace->flip(env, MM_MemorySubSpaceSemiSpace::disable_allocation);
 
-	return bytesScanned;
+	/* return the number of bytes scanned since the caller needs to pass it into postConcurrentUpdateStatsAndReport for stats reporting */
+	return scavengeTask.getBytesScanned();
 }
 
-uintptr_t
-MM_Scavenger::masterThreadConcurrentCollect(MM_EnvironmentBase *env)
+void MM_Scavenger::preConcurrentInitializeStatsAndReport(MM_EnvironmentBase *env, MM_ConcurrentPhaseStatsBase *stats)
 {
-	/* note that we can't check isConcurrentWorkAvailable at this point since another thread could have set _forceConcurrentTermination since the
-	 * master thread calls this outside of the control monitor
-	 */
+	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
 	Assert_MM_true(NULL == env->_cycleState);
-	Assert_MM_true(concurrent_state_scan == _concurrentState);
-
 	env->_cycleState = &_cycleState;
 
-	/* We pass a pointer to _forceConcurrentTermination so that we can cause the concurrent to terminate early by setting the
-	 * flag to true if we want to interrupt it so that the master thread returns to the control mutex in order to receive a
-	 * new GC request.
-	 */
-	uintptr_t bytesConcurrentlyScanned = scavengeConcurrent(env, 100000, &_forceConcurrentTermination);
+	stats->_cycleID = _cycleState._verboseContextID;
+
+	TRIGGER_J9HOOK_MM_PRIVATE_CONCURRENT_PHASE_START(
+			_extensions->privateHookInterface,
+			env->getOmrVMThread(),
+			omrtime_hires_clock(),
+			J9HOOK_MM_PRIVATE_CONCURRENT_PHASE_START,
+			stats);
+
+	_extensions->scavengerStats._startTime = omrtime_hires_clock();
+}
+
+void MM_Scavenger::postConcurrentUpdateStatsAndReport(MM_EnvironmentBase *env, MM_ConcurrentPhaseStatsBase *stats, UDATA bytesConcurrentlyScanned)
+{
+	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
+
+	stats->_terminationWasRequested = _forceConcurrentTermination;
+
+	_extensions->scavengerStats._endTime = omrtime_hires_clock();
+
+	TRIGGER_J9HOOK_MM_PRIVATE_CONCURRENT_PHASE_END(
+		_extensions->privateHookInterface,
+		env->getOmrVMThread(),
+		omrtime_hires_clock(),
+		J9HOOK_MM_PRIVATE_CONCURRENT_PHASE_END,
+		stats);
 
 	env->_cycleState = NULL;
-
-	/* return the number of bytes scanned since the caller needs to pass it into postConcurrentUpdateStatsAndReport for stats reporting */
-	return bytesConcurrentlyScanned;
 }
+
 
 void
 MM_Scavenger::switchConcurrentForThread(MM_EnvironmentBase *env)

--- a/gc/stats/ConcurrentPhaseStatsBase.hpp
+++ b/gc/stats/ConcurrentPhaseStatsBase.hpp
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 1991, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+
+/**
+ * @file
+ * @ingroup GC_Stats
+ */
+
+#if !defined(CONCURRENTPHASESTATSBASE_HPP_)
+#define CONCURRENTPHASESTATSBASE_HPP_
+
+#include "omrcfg.h"
+#include "omrcomp.h"
+
+#include "Base.hpp"
+
+/**
+  * @ingroup GC_Stats
+ */
+class MM_ConcurrentPhaseStatsBase : public MM_Base
+{
+	/* Data Members */
+private:
+protected:
+public:
+	uintptr_t _cycleID;	/**< The "_id" of the corresponding cycle */
+	uintptr_t _scanTargetInBytes;	/**< The number of bytes a given concurrent task was expected to scan before terminating */
+	uintptr_t _bytesScanned;	/**< The number of bytes a given concurrent task did scan before it terminated (can be lower than _scanTargetInBytes if the termination was asynchronously requested) */
+	bool _terminationWasRequested;	/**< True if a given concurrent task's termination was asynchronously requested (although it might have terminated due to meeting its target, anyway - there is a timing window which allows both of these reasons to be true) */
+
+	/* Member Functions */
+private:
+protected:
+public:
+	MM_ConcurrentPhaseStatsBase()
+		: MM_Base()
+		, _cycleID(0)
+		, _scanTargetInBytes(0)
+		, _bytesScanned(0)
+		, _terminationWasRequested(false)
+	{}
+}; 
+
+#endif /* CONCURRENTPHASESTATSBASE_HPP_ */

--- a/gc/verbose/VerboseHandlerOutput.hpp
+++ b/gc/verbose/VerboseHandlerOutput.hpp
@@ -445,6 +445,16 @@ public:
 	 * @param eventData hook specific event data.
 	 */
 	void handleGCEnd(J9HookInterface** hook, uintptr_t eventNum, void* eventData);
+	
+	void handleConcurrentStart(J9HookInterface** hook, UDATA eventNum, void* eventData);
+	void handleConcurrentEnd(J9HookInterface** hook, UDATA eventNum, void* eventData);
+	
+	virtual	void handleConcurrentStartInternal(J9HookInterface** hook, UDATA eventNum, void* eventData) {}
+	virtual void handleConcurrentEndInternal(J9HookInterface** hook, UDATA eventNum, void* eventData) {}
+	virtual const char *getConcurrentTypeString() { return NULL; }
+	
+	virtual void handleConcurrentGCOpStart(J9HookInterface** hook, uintptr_t eventNum, void* eventData) {}
+	virtual void handleConcurrentGCOpEnd(J9HookInterface** hook, uintptr_t eventNum, void* eventData) {}
 
 	void handleHeapResize(J9HookInterface** hook, uintptr_t eventNum, void* eventData);
 

--- a/gc/verbose/handler_standard/VerboseHandlerOutputStandard.hpp
+++ b/gc/verbose/handler_standard/VerboseHandlerOutputStandard.hpp
@@ -133,6 +133,10 @@ public:
 	 * @param eventData hook specific event data.
 	 */
 	void handleScavengePercolate(J9HookInterface** hook, uintptr_t eventNum, void* eventData);
+	
+	virtual const char *getConcurrentTypeString() { return "scavenge"; }
+	
+	virtual void handleConcurrentGCOpEnd(J9HookInterface** hook, uintptr_t eventNum, void* eventData);
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 
 #if defined(OMR_GC_MODRON_CONCURRENT_MARK)


### PR DESCRIPTION
Verbose GC improvements for Concurrent Scavenger. Now reporting gc-op
for each of 3 phases of CS (2xSTW and one concurrent). Also introducing
a wrapper stanza (concurrent-end) for concurrent scavenge gc-op:

 <concurrent-end id="12169" type="scavenge" contextid="12159"
timestamp="2017-08-18T14:28:44.329">
 <gc-op id="12170" type="scavenge" timems="19.722" contextid="12159"
timestamp="2017-08-18T14:28:44.329">
 <memory-copied type="nursery" objects="9888" bytes="450472"
bytesdiscarded="7816" />
 <memory-copied type="tenure" objects="64" bytes="2256"
bytesdiscarded="4112" />
 </gc-op>
 </concurrent-end>


In future, this wrapper may report some concurrent specific data of
scavenge (that gc-op does not report), like read barrier counts.


Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>