### PR TITLE
VGC improvements for CS

### DIFF
--- a/gc/base/Collector.hpp
+++ b/gc/base/Collector.hpp
@@ -30,7 +30,7 @@
 class MM_AllocateDescription;
 class MM_AllocationContext;
 class MM_CollectorLanguageInterface;
-class MM_ConcurrentGMPStats;
+class MM_ConcurrentPhaseStatsBase;
 class MM_MemoryPool;
 class MM_ObjectAllocationInterface;
 class MM_MemorySubSpace;
@@ -275,11 +275,15 @@ public:
 	virtual void preMasterGCThreadInitialize(MM_EnvironmentBase *env) {}
 	virtual	void masterThreadGarbageCollect(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, bool initMarkMap = false, bool rebuildMarkBits = false) {}
 	virtual bool isConcurrentWorkAvailable(MM_EnvironmentBase *env) { return false; }
-	virtual	void preConcurrentInitializeStatsAndReport(MM_EnvironmentBase *env, MM_ConcurrentGMPStats *stats) {}
+	virtual	void preConcurrentInitializeStatsAndReport(MM_EnvironmentBase *env, MM_ConcurrentPhaseStatsBase *stats) {}
 	virtual uintptr_t masterThreadConcurrentCollect(MM_EnvironmentBase *env) { return 0; }
-	virtual	void postConcurrentUpdateStatsAndReport(MM_EnvironmentBase *env, MM_ConcurrentGMPStats *stats, UDATA bytesConcurrentlyScanned) {}
+	virtual	void postConcurrentUpdateStatsAndReport(MM_EnvironmentBase *env, MM_ConcurrentPhaseStatsBase *stats, UDATA bytesConcurrentlyScanned) {}
 	virtual void forceConcurrentFinish() {}
 	virtual void completeExternalConcurrentCycle(MM_EnvironmentBase *env) {}
+	/**
+	 * @return pointer to collector/phase specific concurrent stats structure
+	 */
+	virtual MM_ConcurrentPhaseStatsBase *getConcurrentPhaseStats() { return NULL; }
 	
 	MM_Collector(MM_CollectorLanguageInterface *cli)
 		: MM_BaseVirtual()

--- a/gc/base/omrmmprivate.hdf
+++ b/gc/base/omrmmprivate.hdf
@@ -156,6 +156,7 @@
 		<data type="uint64_t" name="timestamp" description="time of event" />
 		<data type="uintptr_t" name="eventid" description="unique identifier for event" />
 		<data type="void*" name="subSpace" description="the subspace which was collected" />
+		<data type="bool" name="cycleEnd" description="true, if last GC increment in a cycle" />
 	</event>
 	
 	<event>
@@ -974,29 +975,29 @@
 	</event>
 		
 	<event>
-		<name>J9HOOK_MM_PRIVATE_CONCURRENT_GMP_START</name>
+		<name>J9HOOK_MM_PRIVATE_CONCURRENT_PHASE_START</name>
 		<description>
-			Triggered when concurrent GMP work begins.
+			Triggered when concurrent phase work begins.
 			NOTE:  Only expected to be used by verbose GC output.
 		</description>
-		<struct>MM_ConcurrentGMPStartEvent</struct>
+		<struct>MM_ConcurrentPhaseStartEvent</struct>
 		<data type="struct OMR_VMThread*" name="currentThread" description="current thread" />
 		<data type="uint64_t" name="timestamp" description="time of event" />
 		<data type="uintptr_t" name="eventid" description="unique identifier for event" />
-		<data type="void *" name="concurrentGMPStats" description="internal statistics for concurrent GMP" /> 
+		<data type="void *" name="concurrentStats" description="internal statistics for concurrent phase" /> 
 	</event>
 	
-	<event>
-		<name>J9HOOK_MM_PRIVATE_CONCURRENT_GMP_END</name>
+		<event>
+		<name>J9HOOK_MM_PRIVATE_CONCURRENT_PHASE_END</name>
 		<description>
-			Triggered when concurrent GMP work ends.
+			Triggered when concurrent phase work ends.
 			NOTE:  Only expected to be used by verbose GC output.
 		</description>
-		<struct>MM_ConcurrentGMPEndEvent</struct>
+		<struct>MM_ConcurrentPhaseEndEvent</struct>
 		<data type="struct OMR_VMThread*" name="currentThread" description="current thread" />
 		<data type="uint64_t" name="timestamp" description="time of event" />
 		<data type="uintptr_t" name="eventid" description="unique identifier for event" />
-		<data type="void *" name="concurrentGMPStats" description="internal statistics for concurrent GMP" /> 
+		<data type="void *" name="concurrentStats" description="internal statistics for concurrent phase" />
 	</event>
 	
 	<event>

--- a/gc/stats/ConcurrentPhaseStatsBase.hpp
+++ b/gc/stats/ConcurrentPhaseStatsBase.hpp
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 1991, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+
+/**
+ * @file
+ * @ingroup GC_Stats
+ */
+
+#if !defined(CONCURRENTPHASESTATSBASE_HPP_)
+#define CONCURRENTPHASESTATSBASE_HPP_
+
+#include "omrcfg.h"
+#include "omrcomp.h"
+
+#include "Base.hpp"
+
+/**
+  * @ingroup GC_Stats
+ */
+class MM_ConcurrentPhaseStatsBase : public MM_Base
+{
+	/* Data Members */
+private:
+protected:
+public:
+	uintptr_t _cycleID;	/**< The "_id" of the corresponding cycle */
+	uintptr_t _scanTargetInBytes;	/**< The number of bytes a given concurrent task was expected to scan before terminating */
+	uintptr_t _bytesScanned;	/**< The number of bytes a given concurrent task did scan before it terminated (can be lower than _scanTargetInBytes if the termination was asynchronously requested) */
+	bool _terminationWasRequested;	/**< True if a given concurrent task's termination was asynchronously requested (although it might have terminated due to meeting its target, anyway - there is a timing window which allows both of these reasons to be true) */
+
+	/* Member Functions */
+private:
+protected:
+public:
+	MM_ConcurrentPhaseStatsBase()
+		: MM_Base()
+		, _cycleID(0)
+		, _scanTargetInBytes(0)
+		, _bytesScanned(0)
+		, _terminationWasRequested(false)
+	{}
+}; 
+
+#endif /* CONCURRENTPHASESTATSBASE_HPP_ */

--- a/gc/verbose/VerboseHandlerOutput.hpp
+++ b/gc/verbose/VerboseHandlerOutput.hpp
@@ -445,6 +445,16 @@ public:
 	 * @param eventData hook specific event data.
 	 */
 	void handleGCEnd(J9HookInterface** hook, uintptr_t eventNum, void* eventData);
+	
+	void handleConcurrentStart(J9HookInterface** hook, UDATA eventNum, void* eventData);
+	void handleConcurrentEnd(J9HookInterface** hook, UDATA eventNum, void* eventData);
+	
+	virtual	void handleConcurrentStartInternal(J9HookInterface** hook, UDATA eventNum, void* eventData) {}
+	virtual void handleConcurrentEndInternal(J9HookInterface** hook, UDATA eventNum, void* eventData) {}
+	virtual const char *getConcurrentTypeString() { return NULL; }
+	
+	virtual void handleConcurrentGCOpStart(J9HookInterface** hook, uintptr_t eventNum, void* eventData) {}
+	virtual void handleConcurrentGCOpEnd(J9HookInterface** hook, uintptr_t eventNum, void* eventData) {}
 
 	void handleHeapResize(J9HookInterface** hook, uintptr_t eventNum, void* eventData);
 

--- a/gc/verbose/handler_standard/VerboseHandlerOutputStandard.hpp
+++ b/gc/verbose/handler_standard/VerboseHandlerOutputStandard.hpp
@@ -133,6 +133,10 @@ public:
 	 * @param eventData hook specific event data.
 	 */
 	void handleScavengePercolate(J9HookInterface** hook, uintptr_t eventNum, void* eventData);
+	
+	virtual const char *getConcurrentTypeString() { return "scavenge"; }
+	
+	virtual void handleConcurrentGCOpEnd(J9HookInterface** hook, uintptr_t eventNum, void* eventData);
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 
 #if defined(OMR_GC_MODRON_CONCURRENT_MARK)


### PR DESCRIPTION
Verbose GC improvements for Concurrent Scavenger. Now reporting gc-op
for each of 3 phases of CS (2xSTW and one concurrent). Also introducing
a wrapper stanza (concurrent-end) for concurrent scavenge gc-op:

    <concurrent-end id="12169" type="scavenge" contextid="12159" timestamp="2017-08-18T14:28:44.329">
    <gc-op id="12170" type="scavenge" timems="19.722" contextid="12159" timestamp="2017-08-18T14:28:44.329">
    <memory-copied type="nursery" objects="9888" bytes="450472" bytesdiscarded="7816" />
    <memory-copied type="tenure" objects="64" bytes="2256" bytesdiscarded="4112" />
    </gc-op>
    </concurrent-end>


In future, this wrapper may report some concurrent specific data of
scavenge (that gc-op does not report), like read barrier counts.


Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>