### PR TITLE
Correct LoopVersioners use of isPotentialOSRPoint

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -632,7 +632,7 @@ bool OMR::Compilation::isShortRunningMethod(int32_t callerIndex)
    return false;
    }
 
-bool OMR::Compilation::isPotentialOSRPoint(TR::Node *node, TR::Node **osrPointNode)
+bool OMR::Compilation::isPotentialOSRPoint(TR::Node *node, TR::Node **osrPointNode, bool ignoreInfra)
    {
    static char *disableAsyncCheckOSR = feGetEnv("TR_disableAsyncCheckOSR");
    static char *disableGuardedCallOSR = feGetEnv("TR_disableGuardedCallOSR");
@@ -644,7 +644,7 @@ bool OMR::Compilation::isPotentialOSRPoint(TR::Node *node, TR::Node **osrPointNo
       if (node->getOpCodeValue() == TR::treetop || node->getOpCode().isCheck())
          node = node->getFirstChild(); 
 
-      if (_osrInfrastructureRemoved)
+      if (_osrInfrastructureRemoved && !ignoreInfra)
          potentialOSRPoint = false;
       else if (node->getOpCodeValue() == TR::asynccheck)
          {

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -827,8 +827,12 @@ public:
     *
     * osrPointNode can be used to identify the node that is believed to be the
     * potential OSR point. Multiple OSR points are not expected within a tree.
+    *
+    * The ignoreInfra flag will result in the call checking the node even if
+    * OSR infrastructure has been removed. By default, if infrastructure has been
+    * removed, this call will always return false.
     */
-   bool isPotentialOSRPoint(TR::Node *node, TR::Node **osrPointNode=NULL);
+   bool isPotentialOSRPoint(TR::Node *node, TR::Node **osrPointNode=NULL, bool ignoreInfra=false);
    bool isPotentialOSRPointWithSupport(TR::TreeTop *tt);
 
    TR::OSRMode getOSRMode();

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -4399,7 +4399,7 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
          {
          for (TR::TreeTop *tt = block->getEntry(); tt != block->getExit(); tt = tt->getNextTreeTop())
             {
-            if (comp()->isPotentialOSRPoint(tt->getNode()))
+            if (comp()->isPotentialOSRPoint(tt->getNode(), NULL, true))
                {
                safeToRemoveOSRGuards = false;
                break;


### PR DESCRIPTION
isPotentialOSRPoint will check if OSR infrastructure
has been removed, preventing yield points from appearing
as though they require special consideration after OSR
transitions can no longer be added. However, loop versioner
was using the call to identify any yield point, irregardless
of the infrastructure state.