### PR TITLE
CMake: Refactor linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,15 +85,22 @@ configure_file(./omrcfg.CMakeTemplate.h omrcfg.h)
 configure_file(./omrversionstrings.CMakeTemplate.h omrversionstrings.h)
 
 add_library(omrglue STATIC)
-# Link as private since we dont want the interface sources to propagate
 target_link_libraries(omrglue
-	PUBLIC
-	omrgc
 	PRIVATE
+	# Link as private since we dont want the interface sources to propagate
 	${OMR_GLUE_TARGET}
 )
 #but we need to propagate the include paths
-target_include_directories(omrglue INTERFACE $<TARGET_PROPERTY:${OMR_GLUE_TARGET},INTERFACE_INCLUDE_DIRECTORIES>)
+target_include_directories(omrglue
+	INTERFACE
+	$<TARGET_PROPERTY:${OMR_GLUE_TARGET},INTERFACE_INCLUDE_DIRECTORIES>
+	PRIVATE
+	$<TARGET_PROPERTY:omrgc,INTERFACE_INCLUDE_DIRECTORIES>
+)
+add_dependencies(omrglue
+	omrgc_hookgen
+	omrgc_tracegen
+)
 
 add_subdirectory(tools)
 # Yeah, its dumb doing this here. Read note in tools/CMakeLists.txt

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -35,6 +35,11 @@ set(OMR_THREAD ON CACHE BOOL "Enable thread library")
 # TODO: Support building only tools for cross-compilation build
 
 
+set(OMR_GC_LIB "omrgc" CACHE STRING "Name of the GC library to use")
+set(OMR_HOOK_LIB "j9hookstatic" CACHE STRING "Name of the hook library to link against")
+set(OMR_PORT_LIB "omrport" CACHE STRING "Name of the port library to link against")
+set(OMR_THREAD_LIB "j9thrstatic" CACHE STRING "Name of the thread library to link against")
+set(OMR_TRACE_LIB "omrtrace" CACHE STRING "Name of the trace library to link against")
 
 ###
 ### Boolean Feature Flags

--- a/fvtest/gctest/CMakeLists.txt
+++ b/fvtest/gctest/CMakeLists.txt
@@ -29,7 +29,13 @@ target_link_libraries(omrgctest
 	omrGtestGlue
 	pugixml
 	omrtestutil
-	omrgc
+	omrcore
+	omrglue
+	${OMR_HOOK_LIB}
+	${OMR_TRACE_LIB}
+	${OMR_GC_LIB}
+	${OMR_THREAD_LIB}
+	${OMR_PORT_LIB}
 )
 
 # TODO check linker flags from makefile are ported properly.

--- a/fvtest/sigtest/CMakeLists.txt
+++ b/fvtest/sigtest/CMakeLists.txt
@@ -43,7 +43,13 @@ target_link_libraries(omrsigtest
 	omrtestutil
 	j9hashtable
 	omrsig
+	${OMR_THREAD_LIB}
+	${OMR_PORT_LIB}
 )
+
+if(OMR_HOST_OS MATCHES "linux|osx")
+	target_link_libraries(omrsigtest dl)
+endif()
 
 #TODO Unported makefile section:
 #MODULE_INCLUDES += ../util

--- a/fvtest/threadextendedtest/CMakeLists.txt
+++ b/fvtest/threadextendedtest/CMakeLists.txt
@@ -28,8 +28,10 @@ add_executable(omrthreadextendedtest
 target_link_libraries(omrthreadextendedtest
 	omrtestutil
 	omrGtestGlue
-	j9thrstatic
-	omrport
+	omrutil
+	${OMR_PORT_LIB}
+	omrutil
+	${OMR_THREAD_LIB}
 )
 
 if(OMR_HOST_OS STREQUAL "zos")

--- a/fvtest/threadtest/CMakeLists.txt
+++ b/fvtest/threadtest/CMakeLists.txt
@@ -72,6 +72,7 @@ target_link_libraries(omrthreadtest
 	omrGtestGlue
 	j9thrstatic
 	j9hashtable
+	${OMR_PORT_LIB}
 )
 if(OMR_HOST_OS STREQUAL "win")
     target_link_libraries(omrthreadtest

--- a/gc/CMakeLists.txt
+++ b/gc/CMakeLists.txt
@@ -47,7 +47,7 @@ add_library(omrgc_tracegen OBJECT
 	${CMAKE_CURRENT_BINARY_DIR}/ut_j9vgc.c
 )
 
-add_library(omrgc
+add_library(omrgc STATIC
 	base/AddressOrderedListPopulator.cpp
 	base/AllocationContext.cpp
 	base/AllocationInterfaceGeneric.cpp
@@ -289,7 +289,11 @@ target_include_directories(omrgc
 
 target_link_libraries(omrgc
 	PUBLIC
-		omrcore
-		omrglue
-		j9hookstatic
+	omrglue
+	omrcore
+	omrglue
+	omrcore
+	${OMR_THREAD_LIB}
+	${OMR_HOOK_LIB}
+	${OMR_TRACE_LIB}
 )

--- a/omr/CMakeLists.txt
+++ b/omr/CMakeLists.txt
@@ -45,11 +45,11 @@ add_dependencies(omrcore omrgc_tracegen)
 target_include_directories(omrcore
 	PUBLIC
 		.
+	PRIVATE
+		$<TARGET_PROPERTY:omrgc,INTERFACE_INCLUDE_DIRECTORIES>
 )
 
 target_link_libraries(omrcore
 	PUBLIC
-		omrgc # mminitcore.h
-		omrport
-		omrtrace
+		${OMR_PORT_LIB}
 )

--- a/omrsigcompat/CMakeLists.txt
+++ b/omrsigcompat/CMakeLists.txt
@@ -82,8 +82,18 @@ endif()
 #endif
 #endif
 
-target_link_libraries(omrsig omrutil omr_shared)
+target_link_libraries(omrsig
+	PRIVATE
+	omrutil
+	omr_shared
+)
 
+if(OMR_HOST_OS MATCHES "linux|osx")
+	target_link_libraries(omrsig PRIVATE dl)
+endif()
+if(OMR_HOST_OS STREQUAL "zos")
+	target_link_libraries(omrsig PRIVATE j9a2e)
+endif()
 #TODO ensure we are linking in the same way as source makefile:
 #MODULE_STATIC_LIBS += omrutil
 #ifneq (,$(findstring linux,$(OMR_HOST_OS)))

--- a/omrtrace/CMakeLists.txt
+++ b/omrtrace/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(omrtrace STATIC
 
 target_link_libraries(omrtrace
 	PUBLIC
+	${OMR_THREAD_LIB}
 	omrutil
 )
 #TODO: check if following makefile fragment still required:

--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -340,7 +340,10 @@ add_library(omrport STATIC
 
 target_link_libraries(omrport
 	j9thrstatic
+	j9avl
 	j9hashtable
+	j9pool
+	omrglue
 )
 
 target_include_directories(omrport_obj PRIVATE

--- a/thread/CMakeLists.txt
+++ b/thread/CMakeLists.txt
@@ -304,6 +304,7 @@ target_include_directories(j9thrstatic
 target_link_libraries(j9thrstatic
 	omrutil
 	j9pool
+	omrglue
 )
 
 if(OMR_HOST_OS MATCHES "linux|osx")

--- a/util/hookable/CMakeLists.txt
+++ b/util/hookable/CMakeLists.txt
@@ -39,6 +39,8 @@ target_include_directories(j9hookstatic
 )
 target_link_libraries(j9hookstatic PUBLIC
 	j9thrstatic
+	j9pool
+	omrport
 )
 add_tracegen(j9hook.tdf)
 


### PR DESCRIPTION
Refactor linking in order to better represent dependencies.
In addition provide new cache variables to allow consumer to
override the use of trace, hook, port, thread, and gc libs

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>