### PR TITLE
Delete unused isDebugable

### DIFF
--- a/compiler/compile/Method.cpp
+++ b/compiler/compile/Method.cpp
@@ -380,7 +380,6 @@ bool         TR_ResolvedMethod::isPrivate()                                { not
 bool         TR_ResolvedMethod::isProtected()                              { notImplemented("isProtected"); return false; }
 bool         TR_ResolvedMethod::isPublic()                                 { notImplemented("isPublic"); return false; }
 bool         TR_ResolvedMethod::isFinal()                                  { notImplemented("isFinal"); return false; }
-bool         TR_ResolvedMethod::isDebugable()                              { notImplemented("isFinal"); return false; }
 bool         TR_ResolvedMethod::isStrictFP()                               { notImplemented("isStrictFP"); return false; }
 bool         TR_ResolvedMethod::isInterpreted()                            { notImplemented("isInterpreted"); return false; }
 bool         TR_ResolvedMethod::hasBackwardBranches()                      { notImplemented("hasBackwardBranches"); return false; }

--- a/compiler/compile/ResolvedMethod.hpp
+++ b/compiler/compile/ResolvedMethod.hpp
@@ -78,8 +78,7 @@ public:
    virtual bool isProtected();
    virtual bool isPublic();
    virtual bool isFinal();
-   virtual bool isDebugable();
-
+   
    virtual bool isInterpreted();
    virtual bool hasBackwardBranches();
    virtual bool isObjectConstructor();


### PR DESCRIPTION
isDebugable is no longer used by any language implementation.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>