### PR TITLE
Port: Mark signalMap static

### DIFF
--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -187,7 +187,7 @@ static omrthread_tls_key_t tlsKey;
 /* key to get the current synchronous signal */
 static omrthread_tls_key_t tlsKeyCurrentSignal;
 
-struct {
+static struct {
 	uint32_t portLibSignalNo;
 	int unixSignalNo;
 } signalMap[] = {


### PR DESCRIPTION
Executables are able to override global symbols defined in a shared lib.
Thus if a program ever defines a symbol signalMap, and consumes the
port library as a shared library, it will cause incorrect behaviour

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>