### PR TITLE
Add two prototype Tril utilities

### DIFF
--- a/fvtest/tril/tril/CMakeLists.txt
+++ b/fvtest/tril/tril/CMakeLists.txt
@@ -87,6 +87,11 @@ target_link_libraries(tril INTERFACE
     dl
 )
 
+add_executable(tril_dumper compiler.cpp) 
+target_link_libraries(tril_dumper tril)
+
+add_executable(tril_compiler compiler.cpp) 
+target_link_libraries(tril_compiler tril)
 #export(TARGETS tril jitbuilder FILE tril-config.cmake)
 #install(FILES ast.h ilgen.hpp DESTINATION include)
 #install(TARGETS tril EXPORT tril-targets ARCHIVE DESTINATION lib)

--- a/fvtest/tril/tril/compiler.cpp
+++ b/fvtest/tril/tril/compiler.cpp
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#include "jitbuilder_compiler.hpp"
+#include "Jit.hpp"
+#include <cstdio>
+#include <string>
+
+
+int main(int argc, char** argv)
+   { 
+
+   FILE* out = stdout; 
+   FILE* in = stdin;
+
+   std::string program_name = argv[0];
+
+   bool isDumper = program_name.find("tril_dumper") != std::string::npos;  
+
+   if (2 == argc)
+      {
+      in = fopen(argv[1], "r"); 
+      }
+
+   auto trees = parseFile(in);
+
+   if (trees)
+      {
+      printTrees(out, trees, 1); 
+      if (!isDumper) 
+         {
+         initializeJit();
+         Tril::JitBuilderCompiler compiler{trees}; 
+         if (compiler.compile() != 0) { 
+            fprintf(out, "Error compiling trees!"); 
+         }
+         shutdownJit();
+         }
+      }
+   else
+      { 
+      fprintf(out, "Parse error\n");
+      }
+
+
+   if (2 == argc)
+      {
+      fclose(in);
+      }
+   }


### PR DESCRIPTION
- tril_dumper takes a tril program on stdin or as a file argument,
  parses it and then dumps the AST to stdout.
- tril_compiler does the same, then compiles the code. It does nothing
  with the compiled code, but this can be useful for checking validation
  errors quickly.

Signed-off-by: Matthew Gaudet <magaudet@ca.ibm.com>