### PR TITLE
Remove assertions in _patchVirtualGuard

### DIFF
--- a/compiler/z/runtime/VirtualGuardRuntime.cpp
+++ b/compiler/z/runtime/VirtualGuardRuntime.cpp
@@ -26,8 +26,7 @@
 
 
 /** \brief
-  *    Patch an existing BRC / BRCL virtual guard at \p locationAddr to branch to \p destinationAddr or encode a BRC /
-  *    BRCL at \p locationAddr to branch to \p destinationAddr if a NOP BRC / BRCL does not exist.
+  *    Encode a BRC / BRCL at \p locationAddr to branch to \p destinationAddr.
   *
   * \param locationAddr
   *    The location to patch.
@@ -41,9 +40,7 @@
   * \note
   *    It is up to the caller to ensure that if a NOP BRC / BRCL does not exist at \p locationAddr then a non-atomic
   *    4 or 6 byte (depending on distance between \p locationAddr and \p destinationAddr) store to the instruction
-  *    stream at \p locationAddr is safe. If an existing BRC / BRCL already exists at \p locationAddr then this
-  *    function only stores a single byte to modify the BRC / BRCL mask value to an always taken branch mask, and hence
-  *    the store will be atomic.
+  *    stream at \p locationAddr is safe.
   */
 extern "C" void _patchVirtualGuard(uint8_t* locationAddr, uint8_t* destinationAddr, int32_t smpFlag)
    {
@@ -56,37 +53,31 @@ extern "C" void _patchVirtualGuard(uint8_t* locationAddr, uint8_t* destinationAd
 
    int64_t displacement = static_cast<int64_t>(destinationAddr - locationAddr) / 2;
 
-   if ((locationAddr[0] == 0xA7 || locationAddr[0] == 0xC0) && locationAddr[1] == 0x04)
+   // If there is a NOP BRC / BRCL at locationAddr the application could be asynchronously executing this branch as
+   // we are patching it. Because the caller / codegen ensured this branch will never execute if it is to be patched
+   // asynchronously, modifying the displacement first should always be valid. Thus we modify the displacement first,
+   // and then activate the branch mask to avoid any potential race conditions.
+   if (displacement >= MIN_IMMEDIATE_VAL && displacement <= MAX_IMMEDIATE_VAL)
       {
-      if (locationAddr[0] == 0xA7)
-         {
-         TR_ASSERT_FATAL(*reinterpret_cast<int16_t*>(locationAddr + 2) == displacement, "Branch RI displacement at %p (%x) does not match the displacement calculated from argument %p (%x)\n", locationAddr, *reinterpret_cast<int16_t*>(locationAddr + 2), destinationAddr, displacement);
-         }
-      else
-         {
-         TR_ASSERT_FATAL(*reinterpret_cast<int32_t*>(locationAddr + 2) == displacement, "Branch RI displacement at %p (%x) does not match the displacement calculated from argument %p (%x)\n", locationAddr, *reinterpret_cast<int32_t*>(locationAddr + 2), destinationAddr, displacement);
-         }
+      // Note the 0 mask value
+      locationAddr[1] = 0x04;
 
-      // Modify the mask value to an always taken branch
-      locationAddr[1] = 0xF4;
+      locationAddr[0] = 0xA7;
+      locationAddr[2] = (displacement & 0xFF00) >> 8;
+      locationAddr[3] = (displacement & 0x00FF);
       }
    else
       {
-      if (displacement >= MIN_IMMEDIATE_VAL && displacement <= MAX_IMMEDIATE_VAL)
-         {
-         locationAddr[0] = 0xA7;
-         locationAddr[1] = 0xF4;
-         locationAddr[2] = (displacement & 0xFF00) >> 8;
-         locationAddr[3] = (displacement & 0x00FF);
-         }
-      else
-         {
-         locationAddr[0] = 0xC0;
-         locationAddr[1] = 0xF4;
-         locationAddr[2] = (displacement & 0xFF000000) >> 24;
-         locationAddr[3] = (displacement & 0x00FF0000) >> 16;
-         locationAddr[4] = (displacement & 0x0000FF00) >> 8;
-         locationAddr[5] = (displacement & 0x000000FF);
-         }
+      // Note the 0 mask value
+      locationAddr[1] = 0x04;
+
+      locationAddr[0] = 0xC0;
+      locationAddr[2] = (displacement & 0xFF000000) >> 24;
+      locationAddr[3] = (displacement & 0x00FF0000) >> 16;
+      locationAddr[4] = (displacement & 0x0000FF00) >> 8;
+      locationAddr[5] = (displacement & 0x000000FF);
       }
+
+   // Modify the mask value to an always taken branch (after modifying displacement - order matters; see above)
+   locationAddr[1] = 0xF4;
    }


### PR DESCRIPTION
It does not appear for there to be a safe way to tell whether we are
patching synchronously or asynchronously without false positives. The
asserts placed in this function are firing off on upstream projects
because runtime virtual guards that are placed as NOP guards could have
arbitrary code after them, even other NOP branches. 

As such for a synchronous virtual guard we will be clobbering the block
it is guarding and we cannot be certain what is at the location we will
be patching. It could in fact be another NOP branch which may confuse us
when trying to distinguish whether we are patching a NOP BRC / BRCL.

All assertions have been removed from this function. Furthermore the
patching order has been re-ordered to be as safe as possible with the
information we have at hand. It will be up to the caller / codegen to
ensure the non-atomic patching is safe.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>