### PR TITLE
WIP: Prototype for representing the symbol reference table in Tril

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -878,6 +878,9 @@ static int32_t strHash(const char *str)
    return result;
    }
 
+#include "infra/TrilDumper.hpp"
+#include <stdio.h>
+
 int32_t OMR::Compilation::compile()
    {
 
@@ -977,6 +980,17 @@ int32_t OMR::Compilation::compile()
      _ilGenSuccess = _methodSymbol->genIL(self()->fe(), self(), self()->getSymRefTab(), _ilGenRequest);
      if (printCodegenTime) genILTime.stopTiming(self());
    }
+
+   if (_ilGenSuccess)
+      {
+      auto comp = self();
+      auto sym = comp->getJittedMethodSymbol();
+      TR::TrilDumper dumper{stderr};
+      TR::ILTraverser traverser(comp);
+      traverser.registerObserver(&dumper);
+      traverser.traverse(sym);
+      fprintf(stderr, "\n");
+      }
 
    // Force a crash during compilation if the crashDuringCompile option is set
    TR_ASSERT_FATAL(!self()->getOption(TR_CrashDuringCompilation), "crashDuringCompile option is set");

--- a/compiler/il/OMRSymbolReference.hpp
+++ b/compiler/il/OMRSymbolReference.hpp
@@ -304,26 +304,12 @@ protected:
    TR_BitVector *getUseonlyAliasesBV(TR::SymbolReferenceTable *symRefTab);
    TR_BitVector *getUseDefAliasesBV( bool isDirectCall = false, bool gcSafe = false);
 
-   enum // flags
-      {
-      Unresolved                        = 0x00000001,
-      CanGCandReturn                    = 0x00000002,
-      CanGCandExcept                    = 0x00000004,
-      ReallySharesSymbol                = 0x00000008,
-      StackAllocatedArrayAccess         = 0x00000010,
-      SideEffectInfo                    = 0x00000020,
-      LiteralPoolAddress                = 0x00000040,
-      FromLiteralPool                   = 0x00000080,
-      OverriddenBitAddress              = 0x00000100,
-      InitMethod                        = 0x00000200, ///< J9
-      TempVariableSizeSymRef            = 0x00000400,
-      Adjunct                           = 0x00000800, ///< auto symbol represents the adjunct part of the dual symbol
-      Dual                              = 0x00001000, ///< auto symbol represents a dual symbol consisting of two parts
-      TemporaryNegativeOffset           = 0x00002000,
-      HoldsMonitoredObjectForSyncMethod = 0x00004000,
-      AccessedAtRuntimeBase             = 0x10000000,
-      AccessedAtRuntimeMask             = 0x30000000
-      };
+   /**
+    * Enum values for _flags field.
+    */
+#define ENUM_NAME FlagsEnum
+#define ENUM_FILE "il/SymbolReferenceFlagsEnum.hpp"
+#include "infra/EnumTableFactor.hpp"
 
    TR::Symbol *                _symbol;                ///< Pointer to the symbol being referenced
 

--- a/compiler/il/OMRSymbolReference.hpp
+++ b/compiler/il/OMRSymbolReference.hpp
@@ -304,12 +304,18 @@ protected:
    TR_BitVector *getUseonlyAliasesBV(TR::SymbolReferenceTable *symRefTab);
    TR_BitVector *getUseDefAliasesBV( bool isDirectCall = false, bool gcSafe = false);
 
+public:
    /**
     * Enum values for _flags field.
     */
 #define ENUM_NAME FlagsEnum
 #define ENUM_FILE "il/SymbolReferenceFlagsEnum.hpp"
 #include "infra/EnumTableFactor.hpp"
+
+   uint32_t getFlags()                      { return _flags.getValue(); }
+   void setFlagValue(uint32_t v, bool b)    { _flags.setValue(v, b); }
+
+protected:
 
    TR::Symbol *                _symbol;                ///< Pointer to the symbol being referenced
 

--- a/compiler/il/SymbolReferenceFlagsEnum.hpp
+++ b/compiler/il/SymbolReferenceFlagsEnum.hpp
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+/**************************************************************
+ * NOTE: THIS FILE INTENTIONALLY DOES NOT HAVE INCLUDE GUARDS *
+ **************************************************************/
+
+ENUM_V(Unresolved                        , 0x00000001),
+ENUM_V(CanGCandReturn                    , 0x00000002),
+ENUM_V(CanGCandExcept                    , 0x00000004),
+ENUM_V(ReallySharesSymbol                , 0x00000008),
+ENUM_V(StackAllocatedArrayAccess         , 0x00000010),
+ENUM_V(SideEffectInfo                    , 0x00000020),
+ENUM_V(LiteralPoolAddress                , 0x00000040),
+ENUM_V(FromLiteralPool                   , 0x00000080),
+ENUM_V(OverriddenBitAddress              , 0x00000100),
+ENUM_V(InitMethod                        , 0x00000200), ///< J9
+ENUM_V(TempVariableSizeSymRef            , 0x00000400),
+ENUM_V(Adjunct                           , 0x00000800), ///< auto symbol represents the adjunct part of the dual symbol
+ENUM_V(Dual                              , 0x00001000), ///< auto symbol represents a dual symbol consisting of two parts
+ENUM_V(TemporaryNegativeOffset           , 0x00002000),
+ENUM_V(HoldsMonitoredObjectForSyncMethod , 0x00004000),
+ENUM_V(AccessedAtRuntimeBase             , 0x10000000),
+ENUM_V(AccessedAtRuntimeMask             , 0x30000000)

--- a/compiler/il/symbol/OMRSymbol.hpp
+++ b/compiler/il/symbol/OMRSymbol.hpp
@@ -50,6 +50,8 @@ namespace OMR { typedef OMR::Symbol SymbolConnector; }
 #include "infra/Assert.hpp"         // for TR_ASSERT
 #include "infra/Flags.hpp"          // for flags32_t
 
+#include <map>
+
 class TR_FrontEnd;
 class TR_ResolvedMethod;
 namespace TR { class AutomaticSymbol; }
@@ -197,6 +199,7 @@ public:
    uint32_t getFlags()                      { return _flags.getValue(); }
    uint32_t getFlags2()                     { return _flags2.getValue(); }
    void setFlagValue(uint32_t v, bool b)    { _flags.setValue(v, b); }
+   void setFlag2Value(uint32_t v, bool b)   { _flags2.setValue(v, b); }
 
    uint16_t getLocalIndex()                 { return _localIndex; }
    uint16_t setLocalIndex(uint16_t li)      { return (_localIndex = li); }
@@ -441,130 +444,16 @@ public:
    /**
     * Enum values for _flags field.
     */
-   enum
-      {
-      /**
-       * The low bits of the flag field are used to store the data type, and
-       * this is the mask used to access that data
-       */
-      DataTypeMask              = 0x000000FF,
-      // RegisterMappedSymbols must be before data symbols TODO: Why?
-      IsAutomatic               = 0x00000000,
-      IsParameter               = 0x00000100,
-      IsMethodMetaData          = 0x00000200,
-      LastRegisterMapped        = 0x00000200,
+#define ENUM_NAME FlagsEnum
+#define ENUM_FILE "il/symbol/SymbolFlagsEnum.hpp"
+#include "infra/EnumTableFactor.hpp"
 
-      IsStatic                  = 0x00000300,
-      IsMethod                  = 0x00000400,
-      IsResolvedMethod          = 0x00000500,
-      IsShadow                  = 0x00000600,
-      IsLabel                   = 0x00000700,
-
-      /**
-       * Mask used to access register kind
-       */
-      KindMask                  = 0x00000700,
-
-
-      IsInGlobalRegister        = 0x00000800,
-      Const                     = 0x00001000,
-      Volatile                  = 0x00002000,
-      InitializedReference      = 0x00004000,
-      ClassObject               = 0x00008000, ///< class object pointer
-      NotCollected              = 0x00010000,
-      Final                     = 0x00020000,
-      InternalPointer           = 0x00040000,
-      Private                   = 0x00080000,
-      AddressOfClassObject      = 0x00100000, ///< address of a class object pointer
-      SlotSharedByRefAndNonRef  = 0x00400000, ///< used in fsd to indicate that an reference symbol shares a slot with a nonreference symbol
-
-      HoldsMonitoredObject      = 0x08000000,
-      IsNamed                   = 0x00800000, ///< non-methods: symbol is actually an instance of a named subclass
-
-      // only use by Symbols for which isAuto is true
-      //
-      SpillTemp                 = 0x80000000,
-      IsLocalObject             = 0x40000000,
-      BehaveLikeNonTemp         = 0x20000000, ///< used for temporaries that are
-                                              ///< to behave as regular locals to
-                                              ///< preserve floating point semantics
-      PinningArrayPointer       = 0x10000000,
-      RegisterAuto              = 0x00020000, ///< Symbol to be translated to register at instruction selection
-      AutoAddressTaken          = 0x04000000, ///< a loadaddr of this auto exists
-      SpillTempLoaded           = 0x04000000, ///< share bit with loadaddr because spill temps will never have their address taken. Used to remove store to spill if never loaded
-      AutoMarkerSymbol          = 0x02000000, ///< dummy symbol marking some auto boundary
-      VariableSizeSymbol        = 0x01000000, ///< non-java only?: specially managed automatic symbols that contain both an activeSize and a size
-      ThisTempForObjectCtor     = 0x01000000, ///< java only; this temp for j/l/Object constructor
-
-      // only use by Symbols for which isParm is true
-      //
-      ParmHasToBeOnStack        = 0x80000000, ///< parameter is both loadAddr-ed and assigned a global register,
-                                              ///< or parameter has been stored (store opcode)
-      ReferencedParameter       = 0x40000000,
-      ReinstatedReceiver        = 0x20000000, ///< Receiver reinstated for DLT
-
-      // only use by Symbols for which isStatic is true
-      ConstString               = 0x80000000,
-      AddressIsCPIndexOfStatic  = 0x40000000,
-      RecognizedStatic          = 0x20000000,
-      // Available              = 0x10000000,
-      SetUpDLPFlags             = 0xF0000000, ///< Used by TR::StaticSymbol::SetupDLPFlags(), == ConstString | AddressIsCPIndexOfStatic | RecognizedStatic
-      CompiledMethod            = 0x08000000,
-      StartPC                   = 0x04000000,
-      CountForRecompile         = 0x02000000,
-      RecompilationCounter      = 0x01000000,
-      GCRPatchPoint             = 0x00400000,
-
-      //Only Used by Symbols for which isResolvedMethod is true;
-      IsJittedMethod            = 0x80000000,
-
-      // only use by Symbols for which isShadow is true
-      //
-      ArrayShadow               = 0x80000000,
-      RecognizedShadow          = 0x40000000, // recognized field
-      ArrayletShadow            = 0x20000000,
-      PythonLocalVariable       = 0x10000000, // Python local variable shadow  TODO: If we ever move this somewhere else, can we move UnsafeShadow from flags2 to here?
-      GlobalFragmentShadow      = 0x08000000,
-      MemoryTypeShadow          = 0x04000000,
-      Ordered                   = 0x02000000,
-      PythonConstant            = 0x01000000, // Python constant shadow
-      PythonName                = 0x00800000, // Python name shadow
-
-      // only use by Symbols for which isLabel is true
-      //
-      StartOfColdInstructionStream = 0x80000000, // label at the start of an out-of-line instruction stream
-      StartInternalControlFlow     = 0x40000000,
-      EndInternalControlFlow       = 0x20000000,
-      // Available                 = 0x10000000,
-      IsVMThreadLive               = 0x08000000, // reg assigner has determined that vmthread must be in the proper register at this label
-      // Available                 = 0x04000000,
-      InternalControlFlowMerge     = 0x02000000, // mainline merge label for OOL instructions
-      EndOfColdInstructionStream   = 0x01000000,
-      NonLinear                    = 0x01000000, // TAROK and temporary.  This bit is used in conjunction with StartOfColdInstructionStream
-                                                 //    to distinguish "classic" OOL instructions and the new form for Tarok.
-
-      IsGlobalLabel                = 0x30000000,
-      LabelKindMask                = 0x30000000,
-      OOLMask                      = 0x81000000, // Tarok and temporary
-
-      LastEnum
-      };
-
-   enum // For _flags2
-      {
-      RelativeLabel             = 0x00000001, // Label Symbols only *+N
-      ConstMethodType           = 0x00000002, // JSR292
-      ConstMethodHandle         = 0x00000004, // JSR292
-      CallSiteTableEntry        = 0x00000008, // JSR292
-      HasAddrTaken              = 0x00000010, // used to denote that we have a loadaddr of this symbol
-      MethodTypeTableEntry      = 0x00000020, // JSR292
-      NotDataAddress            = 0x00000040, // isStatic only: AOT
-      RealRegister              = 0x00000080, // RegisterSymbol is machine real register
-      UnsafeShadow              = 0x00000100,
-      NamedShadow               = 0x00000200,
-      ImmutableField            = 0x00000400,
-      PendingPush               = 0x00000800,
-      };
+   /**
+    * Enum values for _flags2 field
+    */
+#define ENUM_NAME Flags2Enum
+#define ENUM_FILE "il/symbol/SymbolFlags2Enum.hpp"
+#include "infra/EnumTableFactor.hpp"
 
 protected:
 

--- a/compiler/il/symbol/SymbolFlags2Enum.hpp
+++ b/compiler/il/symbol/SymbolFlags2Enum.hpp
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+/**************************************************************
+ * NOTE: THIS FILE INTENTIONALLY DOES NOT HAVE INCLUDE GUARDS *
+ **************************************************************/
+
+ENUM_V(RelativeLabel             , 0x00000001), // Label Symbols only *+N
+ENUM_V(ConstMethodType           , 0x00000002), // JSR292
+ENUM_V(ConstMethodHandle         , 0x00000004), // JSR292
+ENUM_V(CallSiteTableEntry        , 0x00000008), // JSR292
+ENUM_V(HasAddrTaken              , 0x00000010), // used to denote that we have a loadaddr of this symbol
+ENUM_V(MethodTypeTableEntry      , 0x00000020), // JSR292
+ENUM_V(NotDataAddress            , 0x00000040), // isStatic only: AOT
+ENUM_V(RealRegister              , 0x00000080), // RegisterSymbol is machine real register
+ENUM_V(UnsafeShadow              , 0x00000100),
+ENUM_V(NamedShadow               , 0x00000200),
+ENUM_V(ImmutableField            , 0x00000400),
+ENUM_V(PendingPush               , 0x00000800),

--- a/compiler/il/symbol/SymbolFlagsEnum.hpp
+++ b/compiler/il/symbol/SymbolFlagsEnum.hpp
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+/**************************************************************
+ * NOTE: THIS FILE INTENTIONALLY DOES NOT HAVE INCLUDE GUARDS *
+ **************************************************************/
+
+      /**
+       * The low bits of the flag field are used to store the data type, and
+       * this is the mask used to access that data
+       */
+ENUM_V(DataTypeMask              , 0x000000FF),
+      // RegisterMappedSymbols must be before data symbols TODO: Why?
+ENUM_V(IsAutomatic               , 0x00000000),
+ENUM_V(IsParameter               , 0x00000100),
+ENUM_V(IsMethodMetaData          , 0x00000200),
+ENUM_V(LastRegisterMapped        , 0x00000200),
+
+ENUM_V(IsStatic                  , 0x00000300),
+ENUM_V(IsMethod                  , 0x00000400),
+ENUM_V(IsResolvedMethod          , 0x00000500),
+ENUM_V(IsShadow                  , 0x00000600),
+ENUM_V(IsLabel                   , 0x00000700),
+
+      /**
+       * Mask used to access register kind
+       */
+ENUM_V(KindMask                  , 0x00000700),
+
+
+ENUM_V(IsInGlobalRegister        , 0x00000800),
+ENUM_V(Const                     , 0x00001000),
+ENUM_V(Volatile                  , 0x00002000),
+ENUM_V(InitializedReference      , 0x00004000),
+ENUM_V(ClassObject               , 0x00008000), ///< class object pointer
+ENUM_V(NotCollected              , 0x00010000),
+ENUM_V(Final                     , 0x00020000),
+ENUM_V(InternalPointer           , 0x00040000),
+ENUM_V(Private                   , 0x00080000),
+ENUM_V(AddressOfClassObject      , 0x00100000), ///< address of a class object pointer
+ENUM_V(SlotSharedByRefAndNonRef  , 0x00400000), ///< used in fsd to indicate that an reference symbol shares a slot with a nonreference symbol
+
+ENUM_V(HoldsMonitoredObject      , 0x08000000),
+ENUM_V(IsNamed                   , 0x00800000), ///< non-methods: symbol is actually an instance of a named subclass
+
+      // only use by Symbols for which isAuto is true
+      //
+ENUM_V(SpillTemp                 , 0x80000000),
+ENUM_V(IsLocalObject             , 0x40000000),
+ENUM_V(BehaveLikeNonTemp         , 0x20000000), ///< used for temporaries that are
+                                              ///< to behave as regular locals to
+                                              ///< preserve floating point semantics
+ENUM_V(PinningArrayPointer       , 0x10000000),
+ENUM_V(RegisterAuto              , 0x00020000), ///< Symbol to be translated to register at instruction selection
+ENUM_V(AutoAddressTaken          , 0x04000000), ///< a loadaddr of this auto exists
+ENUM_V(SpillTempLoaded           , 0x04000000), ///< share bit with loadaddr because spill temps will never have their address taken. Used to remove store to spill if never loaded
+ENUM_V(AutoMarkerSymbol          , 0x02000000), ///< dummy symbol marking some auto boundary
+ENUM_V(VariableSizeSymbol        , 0x01000000), ///< non-java only?: specially managed automatic symbols that contain both an activeSize and a size
+ENUM_V(ThisTempForObjectCtor     , 0x01000000), ///< java only; this temp for j/l/Object constructor
+
+      // only use by Symbols for which isParm is true
+      //
+ENUM_V(ParmHasToBeOnStack        , 0x80000000), ///< parameter is both loadAddr-ed and assigned a global register,
+                                              ///< or parameter has been stored (store opcode)
+ENUM_V(ReferencedParameter       , 0x40000000),
+ENUM_V(ReinstatedReceiver        , 0x20000000), ///< Receiver reinstated for DLT
+
+      // only use by Symbols for which isStatic is true
+ENUM_V(ConstString               , 0x80000000),
+ENUM_V(AddressIsCPIndexOfStatic  , 0x40000000),
+ENUM_V(RecognizedStatic          , 0x20000000),
+//ENUM_V(Available               , 0x10000000),
+ENUM_V(SetUpDLPFlags             , 0xF0000000), ///< Used by TR::StaticSymbol::SetupDLPFlags(), == ConstString | AddressIsCPIndexOfStatic | RecognizedStatic
+ENUM_V(CompiledMethod            , 0x08000000),
+ENUM_V(StartPC                   , 0x04000000),
+ENUM_V(CountForRecompile         , 0x02000000),
+ENUM_V(RecompilationCounter      , 0x01000000),
+ENUM_V(GCRPatchPoint             , 0x00400000),
+
+      //Only Used by Symbols for which isResolvedMethod is true;
+ENUM_V(IsJittedMethod            , 0x80000000),
+
+      // only use by Symbols for which isShadow is true
+      //
+ENUM_V(ArrayShadow               , 0x80000000),
+ENUM_V(RecognizedShadow          , 0x40000000), // recognized field
+ENUM_V(ArrayletShadow            , 0x20000000),
+ENUM_V(PythonLocalVariable       , 0x10000000), // Python local variable shadow  TODO: If we ever move this somewhere else, can we move UnsafeShadow from flags2 to here?
+ENUM_V(GlobalFragmentShadow      , 0x08000000),
+ENUM_V(MemoryTypeShadow          , 0x04000000),
+ENUM_V(Ordered                   , 0x02000000),
+ENUM_V(PythonConstant            , 0x01000000), // Python constant shadow
+ENUM_V(PythonName                , 0x00800000), // Python name shadow
+
+      // only use by Symbols for which isLabel is true
+      //
+ENUM_V(StartOfColdInstructionStream , 0x80000000), // label at the start of an out-of-line instruction stream
+ENUM_V(StartInternalControlFlow     , 0x40000000),
+ENUM_V(EndInternalControlFlow       , 0x20000000),
+//ENUM_V(Available                  , 0x10000000),
+ENUM_V(IsVMThreadLive               , 0x08000000), // reg assigner has determined that vmthread must be in the proper register at this label
+//ENUM_V(Available                  , 0x04000000),
+ENUM_V(InternalControlFlowMerge     , 0x02000000), // mainline merge label for OOL instructions
+ENUM_V(EndOfColdInstructionStream   , 0x01000000),
+ENUM_V(NonLinear                    , 0x01000000), // TAROK and temporary.  This bit is used in conjunction with StartOfColdInstructionStream
+                                                 //    to distinguish "classic" OOL instructions and the new form for Tarok.
+
+ENUM_V(IsGlobalLabel                , 0x30000000),
+ENUM_V(LabelKindMask                , 0x30000000),
+ENUM_V(OOLMask                      , 0x81000000), // Tarok and temporary
+
+ENUM(LastEnum)

--- a/compiler/infra/CMakeLists.txt
+++ b/compiler/infra/CMakeLists.txt
@@ -24,6 +24,7 @@ compiler_library(infra
 	${CMAKE_CURRENT_SOURCE_DIR}/HashTab.cpp 
 	${CMAKE_CURRENT_SOURCE_DIR}/IGBase.cpp 
 	${CMAKE_CURRENT_SOURCE_DIR}/IGNode.cpp 
+	${CMAKE_CURRENT_SOURCE_DIR}/ILTraverser.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/ILWalk.cpp 
 	${CMAKE_CURRENT_SOURCE_DIR}/InterferenceGraph.cpp 
 	${CMAKE_CURRENT_SOURCE_DIR}/OMRMonitor.cpp 
@@ -33,5 +34,6 @@ compiler_library(infra
 	${CMAKE_CURRENT_SOURCE_DIR}/STLUtils.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/Timer.cpp 
 	${CMAKE_CURRENT_SOURCE_DIR}/TreeServices.cpp 
+	${CMAKE_CURRENT_SOURCE_DIR}/TrilDumper.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/OMRCfg.cpp 
 )

--- a/compiler/infra/EnumTableFactor.hpp
+++ b/compiler/infra/EnumTableFactor.hpp
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+/**************************************************************
+ * NOTE: THIS FILE INTENTIONALLY DOES NOT HAVE INCLUDE GUARDS *
+ **************************************************************/
+
+
+#ifndef ENUM_NAME
+#error "ENUM_NAME must be defined as the name of the enum to be created."
+#endif
+
+#ifndef ENUM_FILE
+#error "ENUM_FILE must be defined as the path (a quoted string) to the file containing the enum definition."
+#endif
+
+// enum definition
+
+#define ENUM_V(name, value) name = value
+#define ENUM(name) name
+
+enum ENUM_NAME {
+#include ENUM_FILE
+};
+
+#undef ENUM
+#undef ENUM_V
+
+// map definition
+
+#ifndef TABLE_GETTER_NAME
+#define GET_TABLE_GETTER_NAME_2(base) get ## base ## Table
+#define GET_TABLE_GETTER_NAME(base) GET_TABLE_GETTER_NAME_2(base)
+#define TABLE_GETTER_NAME GET_TABLE_GETTER_NAME(ENUM_NAME)
+#endif
+
+#ifndef TABLE_TYPENAME
+#define GET_TABLE_TYPENAME_2(base) base ## _t
+#define GET_TABLE_TYPENAME(base) GET_TABLE_TYPENAME_2(base)
+#define TABLE_TYPENAME GET_TABLE_TYPENAME(TABLE_GETTER_NAME)
+#endif
+
+#define ENUM_V(name, value) { #name, ENUM_NAME::name }
+#define ENUM(name) { #name, ENUM_NAME::name }
+
+typedef std::map<std::string, uint32_t> TABLE_TYPENAME;
+
+static const TABLE_TYPENAME& TABLE_GETTER_NAME()
+   {
+   static const auto enumTable = TABLE_TYPENAME
+      {
+#include ENUM_FILE
+      };
+   return enumTable;
+   }
+
+#undef ENUM
+#undef ENUM_V
+
+// map clean up
+
+#ifdef GET_TABLE_GETTER_NAME_2
+#undef GET_TABLE_GETTER_NAME_2
+#endif
+#ifdef GET_TABLE_GETTER_NAME
+#undef GET_TABLE_GETTER_NAME
+#endif
+#ifdef GET_TABLE_TYPENAME_2
+#undef GET_TABLE_TYPENAME_2
+#endif
+#ifdef GET_TABLE_TYPENAME
+#undef GET_TABLE_TYPENAME
+#endif
+
+#undef TABLE_TYPENAME
+#undef TABLE_GETTER_NAME
+
+// other clean up
+
+#undef ENUM_FILE
+#undef ENUM_NAME

--- a/compiler/infra/ILTraverser.cpp
+++ b/compiler/infra/ILTraverser.cpp
@@ -26,7 +26,7 @@
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
 
-TR::ILTraverser::ILTraverser(TR::Compilation * comp) : _observers(comp->allocator()), _visitedNodes(comp), _comp(comp)
+TR::ILTraverser::ILTraverser(TR::Compilation * comp) : _observers(ObserverAllocator(comp->trMemory()->currentStackRegion())), _visitedNodes(comp), _comp(comp)
    {
    }
 

--- a/compiler/infra/ILTraverser.hpp
+++ b/compiler/infra/ILTraverser.hpp
@@ -156,7 +156,8 @@ class ILTraverser
    TR::Compilation* comp() { return _comp; }
 
    private:
-   std::vector<Observer*, TR::typed_allocator<Observer*, TR::Allocator>> _observers;
+   typedef TR::typed_allocator<Observer*, TR::Region&> ObserverAllocator;
+   std::vector<Observer*, ObserverAllocator> _observers;
    TR::NodeChecklist _visitedNodes;
    TR::Compilation* _comp;
    };

--- a/compiler/infra/ILTraverser.hpp
+++ b/compiler/infra/ILTraverser.hpp
@@ -103,8 +103,8 @@ class ILTraverser
     */
    void removeObserver(Observer* o)
       {
-      auto i = std::find(_observers.cbegin(), _observers.cend(), o);
-      if (i != _observers.cend())
+      auto i = std::find(_observers.begin(), _observers.end(), o);
+      if (i != _observers.end())
          {
          _observers.erase(i);
          }

--- a/compiler/infra/TrilDumper.cpp
+++ b/compiler/infra/TrilDumper.cpp
@@ -59,6 +59,42 @@ void TR::TrilDumper::visitingMethod(TR::ResolvedMethodSymbol* method)
          }
       fprintf(_outputFile, "] ");
       }
+
+   // dump symref table
+   fprintf(_outputFile, "(symreftab ");
+   auto symreftab = method->comp()->getSymRefTab();
+   for (auto i = (int)symreftab->getLastCommonNonhelperSymbol() + symreftab->getNumHelperSymbols(); i < symreftab->getNumSymRefs(); ++i)
+      {
+      auto symref = symreftab->getSymRef(i);
+      if (symref == NULL)
+         {
+         fprintf(_outputFile, "(NULLSYMREF %d)", i);
+         continue;
+         }
+
+      auto symbol = symref->getSymbol();
+
+      std::string kind = "symbol";
+      if (symbol->isAuto()) kind = "auto";
+      else if (symbol->isLabel()) kind = "label";
+      else if (symbol->isMethod()) kind = "method";
+      else if (symbol->isParm()) kind = "parm";
+      else if (symbol->isRegisterMappedSymbol()) kind = "parm";
+      else if (symbol->isResolvedMethod()) kind = "resolvedMethod";
+      else if (symbol->isStatic()) kind = "static";
+
+      fprintf(_outputFile, "(symref offset=%d flags=%#x (%s name=\"%s\" type=%s size=%d flags=%#x flags2=%#x)) ",
+              symref->getOffset(),
+              symref->getFlags(),
+              kind.c_str(),
+              symbol->getName(),
+              TR::DataType::getName(symbol->getDataType()),
+              symbol->getSize(),
+              symbol->getFlags(),
+              symbol->getFlags2()
+              );
+      }
+   fprintf(_outputFile, ") ");
    }
 
 void TR::TrilDumper::returnedToMethod(TR::ResolvedMethodSymbol* method)

--- a/compiler/infra/TrilDumper.cpp
+++ b/compiler/infra/TrilDumper.cpp
@@ -83,7 +83,7 @@ void TR::TrilDumper::visitingMethod(TR::ResolvedMethodSymbol* method)
       else if (symbol->isResolvedMethod()) kind = "resolvedMethod";
       else if (symbol->isStatic()) kind = "static";
 
-      fprintf(_outputFile, "(symref offset=%d flags=%#x (%s name=\"%s\" type=%s size=%d flags=%#x flags2=%#x)) ",
+      fprintf(_outputFile, "(symref offset=%d rawflags=%#x (%s name=\"%s\" type=%s size=%d rawflags=%#x rawflags2=%#x)) ",
               symref->getOffset(),
               symref->getFlags(),
               kind.c_str(),

--- a/fvtest/compilertest/build/files/common.mk
+++ b/fvtest/compilertest/build/files/common.mk
@@ -40,6 +40,8 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/infra/Random.cpp \
     $(JIT_OMR_DIRTY_DIR)/infra/Timer.cpp \
     $(JIT_OMR_DIRTY_DIR)/infra/TreeServices.cpp \
+    $(JIT_OMR_DIRTY_DIR)/infra/ILTraverser.cpp \
+    $(JIT_OMR_DIRTY_DIR)/infra/TrilDumper.cpp \
     $(JIT_OMR_DIRTY_DIR)/infra/OMRCfg.cpp \
     $(JIT_OMR_DIRTY_DIR)/infra/SimpleRegex.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/IlGenRequest.cpp \

--- a/fvtest/tril/test/CMakeLists.txt
+++ b/fvtest/tril/test/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(triltest
    MethodInfoTest.cpp
    IlGenTest.cpp
    CompileTest.cpp
+   SymRefTabTest.cpp
 )
 
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../tril/ ${CMAKE_CURRENT_BINARY_DIR}/tril)

--- a/fvtest/tril/test/SymRefTabTest.cpp
+++ b/fvtest/tril/test/SymRefTabTest.cpp
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#include "JitTest.hpp"
+#include "jitbuilder_compiler.hpp"
+
+#define ASSERT_NULL(pointer) ASSERT_EQ(nullptr, (pointer))
+#define ASSERT_NOTNULL(pointer) ASSERT_TRUE(nullptr != (pointer))
+
+class SymRefTabTest : public Tril::Test::JitTest {};
+
+TEST_F(SymRefTabTest, Return3) {
+    auto trees = parseString("(method return=Int32"
+                                 "(symreftab"
+                                    "(symref offset=0 (auto name=foo type=Address size=8 setflags=[IsAutomatic]) )"
+                                 ")"
+                                 "(block (ireturn (iconst 3))))");
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::JitBuilderCompiler compiler{trees};
+
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed";
+
+    auto entry = compiler.getEntryPoint<int32_t (*)(void)>();
+    ASSERT_NOTNULL(entry) << "Entry point of compiled body cannot be null";
+    ASSERT_EQ(3, entry()) << "Compiled body did not return expected value";
+}

--- a/fvtest/tril/tril/ilgen.hpp
+++ b/fvtest/tril/tril/ilgen.hpp
@@ -63,6 +63,9 @@ class TRLangBuilder : public TR::IlInjector {
          */
         bool cfgFor(const ASTNode* const tree);
 
+        TR::Symbol* generateSymbol(const ASTNode* symbolNode);
+        TR::SymbolReference* generateSymRef(const ASTNode* symrefNode);
+
     private:
         TR::TypeDictionary _types;
         const ASTNode* _trees;    // pointer to the AST node list representing Trees

--- a/fvtest/tril/tril/method_info.hpp
+++ b/fvtest/tril/tril/method_info.hpp
@@ -20,6 +20,7 @@
 #define METHOD_INFO_HPP
 
 #include "il/DataTypes.hpp"
+#include "type_info.hpp"
 #include "ilgen.hpp"
 
 #include <vector>
@@ -40,13 +41,13 @@ class MethodInfo {
          */
         explicit MethodInfo(const ASTNode* methodNode) : _methodNode{methodNode} {
             auto returnTypeArg = _methodNode->getArgByName("return");
-            _returnType = getTRDataTypes(returnTypeArg->getValue()->getString());
+            _returnType = Tril::TypeInfo::getTRDataTypes(returnTypeArg->getValue()->getString());
 
             auto argTypesArg = _methodNode->getArgByName("args");
             if (argTypesArg != nullptr) {
                 auto typeValue = argTypesArg->getValue();
                 while (typeValue != nullptr) {
-                    _argTypes.push_back(getTRDataTypes(typeValue->getString()));
+                    _argTypes.push_back(Tril::TypeInfo::getTRDataTypes(typeValue->getString()));
                     typeValue = typeValue->next;
                 }
             }
@@ -86,25 +87,6 @@ class MethodInfo {
          * @brief Returns the number of arguments the Tril method takes
          */
         std::size_t getArgCount() const { return _argTypes.size(); }
-
-        /**
-         * @brief Gets the TR::DataTypes value from the data type's name
-         * @param name is the name of the data type as a string
-         * @return the TR::DataTypes value corresponding to the specified name
-         */
-        static TR::DataTypes getTRDataTypes(const std::string& name) {
-            if (name == "Int8") return TR::Int8;
-            else if (name == "Int16") return TR::Int16;
-            else if (name == "Int32") return TR::Int32;
-            else if (name == "Int64") return TR::Int64;
-            else if (name == "Address") return TR::Address;
-            else if (name == "Float") return TR::Float;
-            else if (name == "Double") return TR::Double;
-            else if (name == "NoType") return TR::NoType;
-            else {
-                throw std::runtime_error{std::string{"Unknown type name: "}.append(name)};
-            }
-        }
 
     private:
         const ASTNode* _methodNode;

--- a/fvtest/tril/tril/type_info.hpp
+++ b/fvtest/tril/tril/type_info.hpp
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+#ifndef TYPE_INFO_HPP
+#define TYPE_INFO_HPP
+
+#include "il/DataTypes.hpp"
+
+#include <string>
+#include <stdexcept>
+
+namespace Tril {
+
+/**
+ * @brief Class for dealing with data types in Tril
+ */
+struct TypeInfo {
+    /**
+     * @brief Gets the TR::DataTypes value from the data type's name
+     * @param name is the name of the data type as a string
+     * @return the TR::DataTypes value corresponding to the specified name
+     */
+    static TR::DataTypes getTRDataTypes(const std::string& name) {
+        if (name == "Int8") return TR::Int8;
+        else if (name == "Int16") return TR::Int16;
+        else if (name == "Int32") return TR::Int32;
+        else if (name == "Int64") return TR::Int64;
+        else if (name == "Address") return TR::Address;
+        else if (name == "Float") return TR::Float;
+        else if (name == "Double") return TR::Double;
+        else if (name == "NoType") return TR::NoType;
+        else {
+            throw std::runtime_error{std::string{"Unknown type name: "}.append(name)};
+        }
+    }
+};
+
+} // namespace Tril
+
+#endif // TYPE_INFO_HPP

--- a/jitbuilder/build/files/common.mk
+++ b/jitbuilder/build/files/common.mk
@@ -32,6 +32,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/infra/STLUtils.cpp \
     $(JIT_OMR_DIRTY_DIR)/infra/IGBase.cpp \
     $(JIT_OMR_DIRTY_DIR)/infra/IGNode.cpp \
+    $(JIT_OMR_DIRTY_DIR)/infra/ILTraverser.cpp \
     $(JIT_OMR_DIRTY_DIR)/infra/ILWalk.cpp \
     $(JIT_OMR_DIRTY_DIR)/infra/InterferenceGraph.cpp \
     $(JIT_OMR_DIRTY_DIR)/infra/OMRMonitor.cpp \
@@ -41,6 +42,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/infra/TreeServices.cpp \
     $(JIT_OMR_DIRTY_DIR)/infra/OMRCfg.cpp \
     $(JIT_OMR_DIRTY_DIR)/infra/SimpleRegex.cpp \
+    $(JIT_OMR_DIRTY_DIR)/infra/TrilDumper.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/IlGenRequest.cpp \
     $(JIT_OMR_DIRTY_DIR)/il/symbol/OMRSymbol.cpp \
     $(JIT_OMR_DIRTY_DIR)/il/OMRBlock.cpp \


### PR DESCRIPTION
This prototype allows the OMR compiler's Symbol Reference Table (symreftab) to be represented in Tril. The prototype is not complete and should not be merged in its current state, so I'm marking as WIP. I am looking for feedback on the prototype (particularly from @0xdaryl, @mstoodle, and @mgaudet) regarding what (additional) information should be serialized and the technique used to serialize flags.

## Abstract

This PR does five important things:

1. Patches `OMR::Compilation::compile()` to dump the generated IL as Tril to stdout immediately after IL is generated (this needs to be undone before the PR can be merged)
2. Applies some fixes to the `TrilDumper` and `ILTraverser` classes
3. Adds the "Enum Table Factory" mechanism for mapping stringified enum names to the corresponding enum values
4. Adds a mechanism for dumping the symreftab as Tril
5. Adds a mechanism for (re-)generating the symreftab from Tril code

The last two points are the focus of this PR. The following sections describe some details of how the symreftab is represented in Tril.

## Symreftab Serialization

Currently, this prototype only supports a basic representation of symbol references (symrefs), symbols, and flags associated with each of them. (If you have suggestions for other specific things that should also be represented, please comment!)

The symreftab is a child-node of a Tril method (sibling of the method blocks):

```
(method ...
  (symreftab ...)
  (block ...)
   ...
)
```

Symrefs in the table are specified as children of `symreftab`:

```
(symreftab
  (symref ...)
  (symref ...)
   ...
)
```

Each `symref` expects one child representing the symbol it contains:

```
(symref ... (symbol ... ) )
```

The symbol kind is specified as the node-name:

```
(parm ...)   ; a parameter
(auto ...)   ; an automatic
(static ...) ; a static
(symbol ...) ; a generic symbol (e.g. a shadow)
```

A complete `symreftab` would look something like:

```
(method name="foo" returns=Int32
  (symreftab
    (symref ... (auto ...) )
    (symref ... (static ...) )
    (symref ... (symbol ...) )
     ...
  )
  (block ...)
  (block ...)
   ...
)
```

## Serializing Flags

Both symbols and symrefs can have flags associated with them. In the code, these are stored as bit-fields with enum values used as masks for the different flags. Because the enum names do not have a one-to-one mapping with values (i.e. multiple names map to the same value), serializing them directly is rather challenging. The mechanism proposed in this prototype tries to make manually specifying flags in Tril code easy and dumping flags from IL efficient.

To achieve these goal, flag states can be represented in three parts:

1. `rawflags`: the "initial" raw value of the bit-field used to store the flags (an integer value)
2. `setflags`: a list of additional flags to be set (modifier for `rawflags`)
3. `clearflags`: a list of additional flags to be cleared (modifier for `rawflags`)

If multiple bit-fields are used to store flags, the `*flags` argument names have an additional number at the end that corresponds to the bit-field number:

- `rawflags`, `setflags`, and `clearflags` apply to the first bit-field
- `rawflags2`, `setflags2`, and `clearflags2` apply to the second bit-field
- `rawflags3`, `setflags3`, and `clearflags3` apply to the third bit-field
- etc.

When the symreftab is dumped, flags are dumped as raw bit-fields. An example symreftab dump:

```
(symreftab
  (symref offset=0 rawflags=0x20000000 (parm name="(null)" type=Address size=8 rawflags=0x40000107 rawflags2=0))
  (symref offset=0 rawflags=0x20000000 (symbol name="foo" type=Int32 size=4 rawflags=0x603 rawflags2=0x200))
  (symref offset=0 rawflags=0x20000000 (symbol name="bar" type=Int32 size=4 rawflags=0x603 rawflags2=0x200))
  (symref offset=0 rawflags=0x20000000 (auto name="(null)" type=Int32 size=4 rawflags=0x3 rawflags2=0))
  (symref offset=0 rawflags=0x20000000 (symbol name="quux" type=Int32 size=4 rawflags=0x603 rawflags2=0x200))
)
```

When the symreftab is (re-)generated from Tril code, the raw bit-field (defaults to 0 if not specified) is first copied as-is into memory; the integer value is simply written to the bit-field used to store the flags. Then, if specified, additional flags that must be set/cleared are iterated over and the bit-field is modified accordingly.


This mechanism makes it easy to dump flags as no processing is done to identify the meaning of the raw bit-field. It is also easy for a user to manually set/clear flags by name if so desired.