### PR TITLE
Add missing JitBuilder examples to CMake 

### DIFF
--- a/jitbuilder/CMakeLists.txt
+++ b/jitbuilder/CMakeLists.txt
@@ -28,6 +28,8 @@ set(JITBUILDER_OBJECTS
     optimizer/JBOptimizer.cpp
     optimizer/Optimizer.hpp
     runtime/JBCodeCacheManager.cpp
+    ${OMR_ROOT}/compiler/ilgen/VirtualMachineOperandArray.cpp
+    ${OMR_ROOT}/compiler/ilgen/VirtualMachineOperandStack.cpp
     )
 
 if(OMR_ARCH_X86)

--- a/jitbuilder/release/CMakeLists.txt
+++ b/jitbuilder/release/CMakeLists.txt
@@ -26,11 +26,43 @@ macro(create_jitbuilder_test target)
     add_test(NAME ${target}_example_as_test COMMAND ${target}) 
 endmacro(create_jitbuilder_test) 
 
+# Basic Tests: These should run properly on all platforms. 
+create_jitbuilder_test(conditionals    src/Conditionals.cpp) 
+create_jitbuilder_test(isSupportedType src/IsSupportedType.cpp)
+create_jitbuilder_test(iterfib         src/IterativeFib.cpp)
+create_jitbuilder_test(nestedloop      src/NestedLoop.cpp)
+create_jitbuilder_test(pow2            src/Pow2.cpp)
+create_jitbuilder_test(simple          src/Simple.cpp) 
+create_jitbuilder_test(toiltype        src/ToIlType.cpp)
+create_jitbuilder_test(worklist        src/Worklist.cpp)
 
-create_jitbuilder_test(simple       src/Simple.cpp) 
-create_jitbuilder_test(conditionals src/Conditionals.cpp) 
-create_jitbuilder_test(dotproduct   src/DotProduct.cpp) 
+# Additional Tests: These may not run properly on all platforms
+# Opt in by setting OMR_JITBUILDER_ADDITIONAL
+if(OMR_JITBUILDER_ADDITIONAL) 
+    create_jitbuilder_test(call              src/Call.cpp) 
+    create_jitbuilder_test(conststring       src/ConstString.cpp) 
+    create_jitbuilder_test(dotproduct        src/DotProduct.cpp) 
+    create_jitbuilder_test(fieldaddress      src/FieldAddress.cpp) 
+    create_jitbuilder_test(linkedlist        src/LinkedList.cpp) 
+    create_jitbuilder_test(localarray        src/LocalArray.cpp) 
+    create_jitbuilder_test(operandarraytests src/OperandArrayTests.cpp) 
+    create_jitbuilder_test(operandstacktests src/OperandStackTests.cpp) 
+    create_jitbuilder_test(pointer           src/Pointer.cpp) 
+    create_jitbuilder_test(recfib            src/RecursiveFib.cpp) 
+    create_jitbuilder_test(structArray       src/StructArray.cpp) 
+    create_jitbuilder_test(switch            src/Switch.cpp) 
+    create_jitbuilder_test(union             src/Union.cpp) 
+endif()
 
+# Experimental Tests: These are still on the experimental side 
+# Opt in by setting OMR_JITBUILDER_EXPERIMENTAL
+if(OMR_JITBUILDER_EXPERIMENTAL) 
+    create_jitbuilder_test(atomicoperations             src/AtomicOperations.cpp) 
+    create_jitbuilder_test(transactionaloperations      src/TransactionalOperations.cpp) 
+endif()
+
+
+# Additional Tests: These may not run properly on all platforms
 # Mandelbrot takes arguments for its test 
 # so will require we enhance create_jitbuilder_target. 
 #create_jitbuilder_target(mandelbrot   src/Mandelbrot.cpp) 


### PR DESCRIPTION
Also add the missed virtual machine modelling files to the CMake source lists. 