### PR TITLE
Fix compiler warning in sigtest on Linux 390

### DIFF
--- a/fvtest/sigtest/sigTest.cpp
+++ b/fvtest/sigtest/sigTest.cpp
@@ -23,6 +23,8 @@
 #endif /* defined(J9ZOS390) */
 
 #if !defined(WIN32)
+#include <stdint.h>
+#include <inttypes.h>
 #include <pthread.h>
 #include <dlfcn.h>
 #endif /* !defined(WIN32) */
@@ -55,6 +57,10 @@ enum TestAction {
 	test_omrsig_primary_sigaction
 #endif /* !defined(WIN32) */
 };
+
+#if !defined(PRId64)
+#define PRId64 "I64d"
+#endif
 
 static jmp_buf env;
 static volatile int handlerCalls;
@@ -310,21 +316,19 @@ test(TestAction testFunc)
 #endif /* defined(WIN32) */
 				signum,
 				testFunc)) {
+
+			int64_t flags = 0;
+#if !defined(WIN32)
+			flags = act.sa_flags;
+#endif
 			rc = OMR_ERROR_INTERNAL;
-#if (defined(S390) && defined(OMR_ENV_DATA64))
-			printf("Test %d:%d failed at %s:%d. Conditions: %sexisting primary, %sexisting secondary, flags = %ld, signum is %d, handler is 0x%p, %salt signal stack.\n",
-#else /* (defined(S390) && defined(OMR_ENV_DATA64)) */
-			printf("Test %d:%d failed at %s:%d. Conditions: %sexisting primary, %sexisting secondary, flags = %d, signum is %d, handler is 0x%p, %salt signal stack.\n",
-#endif /* (defined(S390) && defined(OMR_ENV_DATA64)) */
+
+			printf("Test %d:%d failed at %s:%d. Conditions: %sexisting primary, %sexisting secondary, flags = %" PRId64 ", signum is %d, handler is 0x%p, %salt signal stack.\n",
 				   testFunc, i,
 				   __FILE__, __LINE__,
 				   existingPrimary ? "" : "no ",
 				   existingSecondary ? "" : "no ",
-#if defined(WIN32)
-				   0,
-#else /* defined(WIN32) */
-				   act.sa_flags,
-#endif /* defined(WIN32) */
+				   flags,
 				   signum,
 				   handlerOptions[handlerIndex],
 				   onStack ? "" : "no ");


### PR DESCRIPTION
When compiling Linux 390 the size of sa_flags changes based which version of the C library you are using.  This causes some ugly code so instead I just always store the value into an int64_t and print that. This way there is not weird checks to decide the printf specifier.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>