### PR TITLE
Scavenger backout flag on weak memory CPUs

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -183,7 +183,7 @@ private:
 
 	bool _isRememberedSetInOverflow;
 
-	BackOutState _backOutState; /**< set if a thread is unable to copy an object due to lack of free space in both Survivor and Tenure */
+	volatile BackOutState _backOutState; /**< set if a thread is unable to copy an object due to lack of free space in both Survivor and Tenure */
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	bool debugConcurrentScavengerPageAlignment; /**< if true allows debug output prints for Concurrent Scavenger Page Alignment logic */
 	uintptr_t concurrentScavengerPageSectionSize; /**< selected section size for Concurrent Scavenger Page */

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -3027,9 +3027,9 @@ MM_Scavenger::setBackOutFlag(MM_EnvironmentBase *env, BackOutState backOutState)
 	/* Skip triggering of trace point and hook if we trying to set flag to true multiple times */
 	if (_extensions->getScavengerBackOutState() != backOutState) {
 		_backOutDoneIndex = _doneIndex;
-		_extensions->setScavengerBackOutState(backOutState);
-		/* Might be an overkill, but ensure that other CPUs see correct _backOutDoneIndex, by the time they see _backOutFlag is set */
+		/* Ensure that other CPUs see correct _backOutDoneIndex, by the time they see _backOutFlag is set */
 		MM_AtomicOperations::writeBarrier();
+		_extensions->setScavengerBackOutState(backOutState);
 		if (backOutStarted > backOutState) {
 			Trc_MM_ScavengerBackout(env->getLanguageVMThread(), backOutFlagCleared < backOutState ? "true" : "false");
 			TRIGGER_J9HOOK_MM_PRIVATE_SCAVENGER_BACK_OUT(_extensions->privateHookInterface, env->getOmrVM(), backOutFlagCleared < backOutState);

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -104,7 +104,7 @@ private:
 	uintptr_t _cacheLineAlignment; /**< The number of bytes per cache line which is used to determine which boundaries in memory represent the beginning of a cache line */
 	volatile bool _rescanThreadsForRememberedObjects; /**< Indicates that thread-referenced objects were tenured and threads must be rescanned */
 
-	uintptr_t _backOutDoneIndex; /**< snapshot of _doneIndex, when backOut was detected */
+	volatile uintptr_t _backOutDoneIndex; /**< snapshot of _doneIndex, when backOut was detected */
 
 	void *_heapBase;  /**< Cached base pointer of heap */
 	void *_heapTop;  /**< Cached top pointer of heap */


### PR DESCRIPTION
Fix the order of writes vs write fence when setting Scavenger backout
flag/index, on weak memory model CPUs.

Also declare the index as volatile. There is no proven problem atm, but
it indeed is being modified/consumed by/from multiple threads.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>