### PR TITLE
Make ILvalidator handle tstart correctly

### DIFF
--- a/compiler/il/ILOpCodeProperties.hpp
+++ b/compiler/il/ILOpCodeProperties.hpp
@@ -8658,7 +8658,7 @@
    /* .properties4          = */ 0,
    /* .dataType             = */ TR::NoType,
    /* .typeProperties       = */ 0,
-   /* .childProperties      = */ ILChildProp::NoChildren,
+   /* .childProperties      = */ THREE_SAME_CHILD(TR::NoType),
    /* .swapChildrenOpCode   = */ TR::BadILOp,
    /* .reverseBranchOpCode  = */ TR::BadILOp,
    /* .booleanCompareOpCode = */ TR::BadILOp,

--- a/compiler/il/ILOpCodeProperties.hpp
+++ b/compiler/il/ILOpCodeProperties.hpp
@@ -10416,7 +10416,7 @@
    /* .properties4          = */ 0,
    /* .dataType             = */ TR::NoType,
    /* .typeProperties       = */ 0,
-   /* .childProperties      = */ ONE_CHILD(ILChildProp::UnspecifiedChildType),
+   /* .childProperties      = */ ILChildProp::NoChildren,
    /* .swapChildrenOpCode   = */ TR::BadILOp,
    /* .reverseBranchOpCode  = */ TR::BadILOp,
    /* .booleanCompareOpCode = */ TR::BadILOp,

--- a/compiler/il/OMRILOpCodesEnum.hpp
+++ b/compiler/il/OMRILOpCodesEnum.hpp
@@ -725,7 +725,7 @@
    dexp,     // double exponent
 
 
-   branch,     // generic branch --> first child is a constant indicating the mask
+   branch,     // generic branch --> DEPRECATED use TR::case instead
    igoto,      // indirect goto, branches to the address specified by a child
 
    bexp,     // signed byte exponent  (raise signed byte to power)


### PR DESCRIPTION
These commits allow the ILValidator to correctly check `branch` opcodes.

Fixes #1553 