### PR TITLE
PPC fixes

### DIFF
--- a/compiler/p/codegen/PPCSystemLinkage.cpp
+++ b/compiler/p/codegen/PPCSystemLinkage.cpp
@@ -1717,7 +1717,6 @@ void TR::PPCSystemLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSy
                }
             numFloatArgs++;
             numIntArgs++;
-            if (paramCursor->getDataType() == TR::Double) numIntArgs++;
             break;
          case TR::Aggregate:
             {


### PR DESCRIPTION
First, resolve a POWER System Linkage "accounting" bug in the parameter slot assignments when double parameters are used.

Second, enable repeated `initializeJit()`, `shutdownJit()` cycles on POWER, which are used in the JitBuilderTests.