### PR TITLE
Prevent LoopVersioner from checking guards

### DIFF
--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -3438,6 +3438,11 @@ void TR_LoopVersioner::updateDefinitionsAndCollectProfiledExprs(TR::Node *parent
    if (node->getVisitCount() == visitCount)
       return;
 
+   // There will be no definitions or profiled expressions
+   // beneath a nopable guard
+   if (node->isNopableInlineGuard() || node->isOSRGuard())
+      return;
+
    if(node->getOpCode().isIndirect() && refineAliases())
       collectArrayAliasCandidates(node,visitCount);
 


### PR DESCRIPTION
LoopVersioner will search for profiled nodes,
to build versions of loops where the profiling
is disabled. If a node beneath a nopable guard
shares BCI with a profiled value, LoopVersioner may
mistake the guard's child as being profiled. This
change prevents the method from analysing the children
for a nopable guard.

Signed-off-by: Nicholas Coughlin <cnic@ca.ibm.com>