### PR TITLE
Correct the jit builder test platform coverage

### DIFF
--- a/fvtest/omrtest.mk
+++ b/fvtest/omrtest.mk
@@ -51,10 +51,10 @@ omr_gctest:
 # jitbuilder can run different sets of tests on linux_x86 and osx than on other platforms
 # until we common this up, run "testall" on linux_x86 and osx but run "test" everywhere else
 omr_jitbuilderexamples:
-ifeq (,$(findstring linux_x86,$(SPEC)))
+ifneq (,$(findstring linux_x86,$(SPEC)))
 	make -C jitbuilder/release testall
 else
-ifeq (,$(findstring osx,$(SPEC)))
+ifneq (,$(findstring osx,$(SPEC)))
 	make -C jitbuilder/release testall
 else
 	make -C jitbuilder/release test


### PR DESCRIPTION
OSX and Linux x86 are the only platforms which can run testall. The
conditional for the test makefile was checking the wrong values. This
change fixes the conditionals so the correct tests run on each platform.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>