### PR TITLE
Extract concurrent GC delegate from CLI

### DIFF
--- a/example/glue/CMakeLists.txt
+++ b/example/glue/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(omr_example_gc_glue INTERFACE)
 target_sources(omr_example_gc_glue INTERFACE
 	${CMAKE_CURRENT_SOURCE_DIR}/CollectorLanguageInterfaceImpl.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/CompactSchemeFixupObject.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/ConcurrentMarkingDelegate.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/EnvironmentDelegate.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/FrequentObjectsStats.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/GlobalCollectorDelegate.cpp

--- a/example/glue/CollectorLanguageInterfaceImpl.hpp
+++ b/example/glue/CollectorLanguageInterfaceImpl.hpp
@@ -46,7 +46,6 @@ private:
 protected:
 	OMR_VM *_omrVM;
 	MM_GCExtensionsBase *_extensions;
-	MM_MarkingScheme *_markingScheme;
 public:
 
 private:
@@ -65,33 +64,6 @@ protected:
 public:
 	static MM_CollectorLanguageInterfaceImpl *newInstance(MM_EnvironmentBase *env);
 	virtual void kill(MM_EnvironmentBase *env);
-
-#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
-	virtual MM_ConcurrentSafepointCallback* concurrentGC_createSafepointCallback(MM_EnvironmentBase *env);
-	virtual omrsig_handler_fn concurrentGC_getProtectedSignalHandler(void **signalHandlerArg) {*signalHandlerArg = NULL; return NULL;}
-	virtual void concurrentGC_concurrentInitializationComplete(MM_EnvironmentStandard *env) {}
-	virtual bool concurrentGC_forceConcurrentKickoff(MM_EnvironmentBase *env, uintptr_t gcCode, uintptr_t *languageKickoffReason)
-	{
-		if (NULL != languageKickoffReason) {
-			*languageKickoffReason = NO_LANGUAGE_KICKOFF_REASON;
-		}
-		return false;
-	}
-	virtual uintptr_t concurrentGC_getNextTracingMode(uintptr_t executionMode);
-	virtual uintptr_t concurrentGC_collectRoots(MM_EnvironmentStandard *env, uintptr_t concurrentStatus, bool *collectedRoots, bool *paidTax);
-	virtual void concurrentGC_signalThreadsToTraceStacks(MM_EnvironmentStandard *env) {}
-	virtual void concurrentGC_signalThreadsToDirtyCards(MM_EnvironmentStandard *env) {}
-	virtual void concurrentGC_signalThreadsToStopDirtyingCards(MM_EnvironmentStandard *env) {}
-	virtual void concurrentGC_kickoffCardCleaning(MM_EnvironmentStandard *env) {}
-	virtual void concurrentGC_flushRegionReferenceLists(MM_EnvironmentBase *env) {}
-	virtual void concurrentGC_flushThreadReferenceBuffer(MM_EnvironmentBase *env) {}
-	virtual bool concurrentGC_isThreadReferenceBufferEmpty(MM_EnvironmentBase *env) {return true;}
-	virtual bool concurrentGC_startConcurrentScanning(MM_EnvironmentStandard *env, uintptr_t *bytesTraced, bool *collectedRoots) {*bytesTraced = 0; *collectedRoots = false; return false;}
-	virtual void concurrentGC_concurrentScanningStarted(MM_EnvironmentStandard *env, bool isConcurrentScanningComplete) {}
-	virtual bool concurrentGC_isConcurrentScanningComplete(MM_EnvironmentBase *env) {return true;}
-	virtual uintptr_t concurrentGC_reportConcurrentScanningMode(MM_EnvironmentBase *env) {return 0;}
-	virtual void concurrentGC_scanThread(MM_EnvironmentBase *env) {}
-#endif /* OMR_GC_MODRON_CONCURRENT_MARK */
 
 #if defined(OMR_GC_MODRON_SCAVENGER)
 	virtual void scavenger_masterSetupForGC(MM_EnvironmentBase *env);

--- a/example/glue/ConcurrentMarkingDelegate.cpp
+++ b/example/glue/ConcurrentMarkingDelegate.cpp
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+
+#include "ConcurrentMarkingDelegate.hpp"
+#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
+#include "ConcurrentGC.hpp"
+#include "MarkingScheme.hpp"
+
+bool
+MM_ConcurrentMarkingDelegate::initialize(MM_EnvironmentBase *env, MM_ConcurrentGC *collector)
+{
+	MM_GCExtensionsBase *extensions = env->getExtensions();
+	_objectModel = &(extensions->objectModel);
+	_markingScheme = collector->getMarkingScheme();
+	_collector = collector;
+	return true;
+}
+
+uintptr_t
+MM_ConcurrentMarkingDelegate::collectRoots(MM_EnvironmentBase *env, uintptr_t concurrentStatus, bool *collectedRoots, bool *paidTax)
+{
+	uintptr_t bytesScanned = 0;
+	*collectedRoots = true;
+	*paidTax = true;
+
+	switch (concurrentStatus) {
+	case CONCURRENT_ROOT_TRACING1:
+		_markingScheme->markLiveObjectsRoots(env);
+		break;
+	default:
+		Assert_MM_unreachable();
+	}
+
+	return bytesScanned;
+}
+#endif /* defined(OMR_GC_MODRON_CONCURRENT_MARK) */
+
+
+
+

--- a/example/glue/ConcurrentMarkingDelegate.hpp
+++ b/example/glue/ConcurrentMarkingDelegate.hpp
@@ -1,0 +1,302 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+
+#if !defined(CONCURRENTMARKINGDELEGATE_HPP_)
+#define CONCURRENTMARKINGDELEGATE_HPP_
+
+#include "omrcfg.h"
+#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
+#include "objectdescription.h"
+#include "omrgcconsts.h"
+#include "omrport.h"
+
+#include "ConcurrentSafepointCallback.hpp"
+#include "EnvironmentBase.hpp"
+#include "GCExtensionsBase.hpp"
+
+class MM_ConcurrentGC;
+class MM_MarkingScheme;
+
+/**
+ * Provides language-specific support for marking.
+ */
+class MM_ConcurrentMarkingDelegate
+{
+	/*
+	 * Data members
+	 */
+private:
+
+protected:
+	GC_ObjectModel *_objectModel;
+	MM_ConcurrentGC *_collector;
+	MM_MarkingScheme *_markingScheme;
+
+public:
+	/* This enum extends ConcurrentStatus with values in the exclusive range (CONCURRENT_ROOT_TRACING,
+	 * CONCURRENT_TRACE_ONLY). ConcurrentStatus extensions allow the client language to define discrete
+	 * units of work that can be executed in parallel by mutator threads when they are called upon to
+	 * do some tracing work to pay an allocation tax. To extract this tax, ConcurrentGC will call
+	 * MM_ConcurrentMarkingDelegate::collectRoots(..., concurrentStatus, ...) with the current tracing
+	 * mode determined by the value returned by MM_ConcurrentMarkingDelegate::getNextTracingMode(). The
+	 * thread that receives the collectRoots() call can check the concurrentStatus value to select and
+	 * execute the appropriate unit of work.
+	 *
+	 * @see ConcurrentStatus (omrgcconsts.h)
+	 * @see MM_ConcurrentMarkingDelegate::getNextTracingMode(uintptr_t)
+	 * @see MM_ConcurrentMarkingDelegate::collectRoots(MM_EnvironmentBase *, uintptr_t, bool *, bool *)
+	 */
+	enum {
+		CONCURRENT_ROOT_TRACING1 = CONCURRENT_ROOT_TRACING + 1
+	};
+
+	/*
+	 * Function members
+	 */
+private:
+
+protected:
+
+public:
+	/**
+	 * Initialize the delegate.
+	 *
+	 * @param env environment for calling thread
+	 * @param collector pointer to MM_ConcurrentGC (concurrent collector)
+	 * @return true if delegate initialized successfully
+	 */
+	bool initialize(MM_EnvironmentBase *env, MM_ConcurrentGC *collector);
+
+	/**
+	 * In the case of Weak Consistency platforms we require this method to bring mutator threads to a safe point. A safe
+	 * point is a point at which a GC may occur.
+	 *
+	 * @param[in] env The environment for the calling thread.
+	 * @return An instance of a MM_ConcurrentSafepointCallback instance that can signal all mutator threads and cause them
+	 * to synchronize at a safe point
+	 * @see MM_ConcurrentSafepointCallback
+	 */
+	MMINLINE MM_ConcurrentSafepointCallback*
+	createSafepointCallback(MM_EnvironmentBase *env)
+	{
+		return MM_ConcurrentSafepointCallback::newInstance(env);
+	}
+
+	/**
+	 * Concurrent marking component maintains a background helper thread to assist with concurrent marking
+	 * tasks. The delegate may provide a specialized signal handler (and associated argument) to process
+	 * signals raised from this thread.
+	 *
+	 * @param[out] signalHandlerArg receives (nullable) pointer to argument to be passed to signal handler when invoked
+	 * @return a pointer to the signal handler function (or NULL if no signal handler)
+	 */
+	MMINLINE omrsig_handler_fn
+	getProtectedSignalHandler(void **signalHandlerArg)
+	{
+		*signalHandlerArg = NULL;
+		return NULL;
+	}
+
+	/**
+	 * Test whether a GC can be started. Under some circumstances it may be desirable to circumvent continued
+	 * concurrent marking and allow a GC to kick off immediately. In that case this method should return true
+	 * and set the kick off reason.
+	 *
+	 * If this method returns false, the GC cycle may be started immediately. Otherwise, concurrent marking
+	 * will kick off and the GC cycle will be deferred until concurrent marking completes.
+	 *
+	 * @param env the calling thread environment
+	 * @param gcCode the GC code identifying the cause of the GC request
+	 * @param[out] languageKickoffReason set this to the value to be reported as kickoff reson in verbose GC log
+	 * @see J9MMCONSTANT_* (j9nonbuilderr.h) for gcCode values
+	 * @return true if Kickoff can be forced
+	 */
+	MMINLINE bool
+	canForceConcurrentKickoff(MM_EnvironmentBase *env, uintptr_t gcCode, uintptr_t *languageKickoffReason)
+	{
+		if (NULL != languageKickoffReason) {
+			*languageKickoffReason = NO_LANGUAGE_KICKOFF_REASON;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine the next unit of tracing work that must be performed during root collection. Each distinct
+	 * value returned represents a discrete unit of language-dependent root collection work. The executionMode
+	 * parameter represents the current tracing mode, the returned valued with be the next tracing mode. The
+	 * first call during a concurrent collection cycle will receive CONCURRENT_ROOT_TRACING as current tracing
+	 * mode. When all language defined values have been returned, this method must return CONCURRENT_TRACE_ONLY
+	 * to indicate that all root objects have been traced.
+	 *
+	 * @param executionMode the current (most recently completed) tracing mode
+	 * @return the next language-defined tracing mode, or CONCURRENT_TRACE_ONLY if all language-defined roots have been traced
+	 * @see MM_ConcurrentMarkingDelegate::collectRoots(MM_EnvironmentBase *, uintptr_t, bool *, bool *)
+	 */
+	MMINLINE uintptr_t
+	getNextTracingMode(uintptr_t executionMode)
+	{
+		uintptr_t nextExecutionMode = CONCURRENT_TRACE_ONLY;
+		switch (executionMode) {
+		case CONCURRENT_ROOT_TRACING:
+			nextExecutionMode = CONCURRENT_ROOT_TRACING1;
+			break;
+		case CONCURRENT_ROOT_TRACING1:
+			nextExecutionMode = CONCURRENT_TRACE_ONLY;
+			break;
+		default:
+			Assert_MM_unreachable();
+		}
+
+		return nextExecutionMode;
+	}
+
+	/**
+	 * Trace language-defined roots. The concurrentStatus parameter receives the current tracing mode, which
+	 * will be one of the language-defined tracing modes returned by getNextTracingMode().
+	 *
+	 * @param env the calling thread environment
+	 * @param concurrentStatus the current tracing mode (language-defined ConcurrentStatus enum)
+	 * @param[out] collectedRoots set this to true if all roots were collected
+	 * @param[out] taxPaid set this to true if any roots were collected
+	 * @see MM_ConcurrentMarkingDelegate::getNextTracingMode(uintptr_t)
+	 */
+	uintptr_t collectRoots(MM_EnvironmentBase *env, uintptr_t concurrentStatus, bool *collectedRoots, bool *paidTax);
+
+	/**
+	 * Informative. This method will be called when concurrent initialization is complete and root tracing
+	 * is about to begin.
+	 */
+	MMINLINE void concurrentInitializationComplete(MM_EnvironmentBase *env) { }
+
+	/**
+	 * This method will be called to inform all mutator threads that they should trace their own
+	 * thread structures and stacks to mark all thread-referenced and stack-referenced heap objects.
+	 * Stack tracing can be performed only at safe points and this method may be required to request
+	 * an asynchronous callback or otherwise defer this until the receiving thread can safely make
+	 * the call.
+	 *
+	 * @see MM_ConcurrentMarkingDelegate::scanThreadRoots(MM_EnvironmentBase *
+	 */
+	MMINLINE void signalThreadsToTraceStacks(MM_EnvironmentBase *env) { }
+
+	/**
+	 * Once concurrent tracing has started, mutator threads must dirty cards at the appropriate
+	 * write barrier(s) whenever a reference-value field is updated, until a GC cycle is started.
+	 */
+	MMINLINE bool signalThreadsToDirtyCards(MM_EnvironmentBase *env)
+	{
+		return true;
+	}
+
+	/**
+	 * This can be used to optimize the concurrent write barrier(s) by conditioning threads to stop
+	 * dirtying cards once a GC has started.
+	 */
+	MMINLINE void signalThreadsToStopDirtyingCards(MM_EnvironmentBase *env) { }
+
+	/**
+	 * Informational. Will be called when concurrent tracing has completed and card cleaning has started.
+	 */
+	MMINLINE void cardCleaningStarted(MM_EnvironmentBase *env) { }
+
+	/**
+	 * This method is called during card cleaning for each object associated with an uncleaned,
+	 * dirty card in the card table. No client actions are necessary but this method may be overridden
+	 * if desired to hook into card cleaning.
+	 *
+	 * @param[in] env The environment for the calling thread.
+	 * @param[in] objectPtr Reference to an object associated with an uncleaned, dirty card.
+	 */
+	MMINLINE void processItem(MM_EnvironmentBase *env, omrobjectptr_t objectPtr) { }
+
+	/**
+	 * Scan a thread structure and stack frames for roots. Implementation must call
+	 * MM_MarkingScheme::markObject(..) for each heap object reference found on the
+	 * thread's stack or in thread structure.
+	 *
+	 * @param env the thread environment for the thread to be scanned
+	 * @return true if the thread was scanned successfully
+	 */
+	MMINLINE bool
+	scanThreadRoots(MM_EnvironmentBase *env)
+	{
+		return true;
+	}
+
+	/**
+	 * Flush any roots held in thread local buffers.
+	 *
+	 * @param env the thread environment for the thread to be flushed
+	 * @return true if any data were flushed, false otherwise
+	 */
+	MMINLINE bool
+	flushThreadRoots(MM_EnvironmentBase *env)
+	{
+		return false;
+	}
+
+	/**
+	 * Informational. Will be called if the concurrent collection cycle is aborted.
+	 */
+	MMINLINE void abortCollection(MM_EnvironmentBase *env) { }
+
+	/**
+	 * Deprecated. Use this default implementation unless otherwise required.
+	 */
+	MMINLINE bool
+	startConcurrentScanning(MM_EnvironmentBase *env, uintptr_t *bytesTraced, bool *collectedRoots)
+	{
+		*bytesTraced = 0;
+		*collectedRoots = false;
+		return false;
+	}
+
+	/**
+	 * Deprecated. Use this default implementation unless otherwise required.
+	 */
+	MMINLINE void concurrentScanningStarted(MM_EnvironmentBase *env, uintptr_t bytesTraced) { }
+
+	/**
+	 * Deprecated. Use this default implementation unless otherwise required.
+	 */
+	MMINLINE bool
+	isConcurrentScanningComplete(MM_EnvironmentBase *env)
+	{
+		return true;
+	}
+
+	/**
+	 * Deprecated. Use this default implementation unless otherwise required.
+	 */
+	MMINLINE uintptr_t
+	reportConcurrentScanningMode(MM_EnvironmentBase *env)
+	{
+		return 0;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	MMINLINE MM_ConcurrentMarkingDelegate()
+		: _objectModel(NULL)
+		, _markingScheme(NULL)
+	{ }
+};
+
+#endif /* defined(OMR_GC_MODRON_CONCURRENT_MARK) */
+#endif /* CONCURRENTMARKINGDELEGATE_HPP_ */

--- a/gc/base/Collector.hpp
+++ b/gc/base/Collector.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * (c) Copyright 1991, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -52,7 +52,6 @@ private:
 	uintptr_t _exclusiveAccessCount; /**< The number of times exclusive access requests have been made to use the receiver */
 
 protected:
-	MM_CollectorLanguageInterface *_cli; /**< Language specific interface used to extend the Modron GC framework */
 
 	uintptr_t _bytesRequested;
 
@@ -289,10 +288,9 @@ public:
 	 */
 	virtual MM_ConcurrentPhaseStatsBase *getConcurrentPhaseStats() { return NULL; }
 	
-	MM_Collector(MM_CollectorLanguageInterface *cli)
+	MM_Collector()
 		: MM_BaseVirtual()
 		, _exclusiveAccessCount(0)
-		, _cli(cli)
 		, _bytesRequested(0)
 		, _globalCollector(false)
 		, _gcCompleted(false)

--- a/gc/base/CollectorLanguageInterface.hpp
+++ b/gc/base/CollectorLanguageInterface.hpp
@@ -27,27 +27,16 @@
 #include "objectdescription.h"
 
 #include "BaseVirtual.hpp"
-#include "ConcurrentGCStats.hpp"
 #include "EnvironmentBase.hpp"
 #include "GCExtensionsBase.hpp"
 #include "SlotObject.hpp"
 
 class GC_ObjectScanner;
-class MM_Collector;
 class MM_CompactScheme;
-#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
-class MM_ConcurrentSafepointCallback;
-#endif /* OMR_GC_MODRON_CONCURRENT_MARK */
 class MM_EnvironmentStandard;
 class MM_ForwardedHeader;
-class MM_GlobalCollector;
 class MM_MarkMap;
-class MM_HeapRegionDescriptor;
-class MM_HeapWalker;
-class MM_MemorySubSpace;
 class MM_MemorySubSpaceSemiSpace;
-class MM_ParallelSweepScheme;
-class MM_WorkPackets;
 
 /**
  * Class representing a collector language interface. This defines the API between the OMR
@@ -58,9 +47,6 @@ class MM_CollectorLanguageInterface : public MM_BaseVirtual {
 private:
 
 protected:
-#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
-	MM_ConcurrentGCStats _concurrentStats;
-#endif /* OMR_GC_MODRON_CONCURRENT_MARK */
 
 public:
 
@@ -262,237 +248,6 @@ public:
 	virtual void scavenger_fixupIndirectObjectSlots(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr) = 0;
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 #endif /* OMR_GC_MODRON_SCAVENGER */
-
-#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
-	/**
-	 * Return a pointer to the concurrent GC stats.
-	 */
-	MM_ConcurrentGCStats *concurrentGC_getConcurrentStats() { return &_concurrentStats; };
-
-	/**
-	 * This method is called during card cleaning for each object associated with an uncleaned, dirty card in the card
-	 * table. No client actions are necessary but this method may be overridden if desired to hook into card cleaning.
-	 *
-	 * @param[in] env The environment for the calling thread.
-	 * @param[in] objectPtr Reference to an object associated with an uncleaned, dirty card.
-	 */
-	virtual void concurrentGC_processItem(MM_EnvironmentBase *env, omrobjectptr_t objectPtr) {}
-
-	/**
-	 * In the case of Weak Consistency platforms we require this method to bring mutator threads to a safe point. A safe
-	 * point is a point at which a GC may occur.
-	 *
-	 * @param[in] env The environment for the calling thread.
-	 * @return An instance of a MM_ConcurrentSafepointCallback instance that can signal all mutator threads and cause them
-	 * to synchronize at a safe point
-	 * @see MM_ConcurrentSafepointCallback
-	 */
-	virtual MM_ConcurrentSafepointCallback* concurrentGC_createSafepointCallback(MM_EnvironmentBase *env) = 0;
-
-	/**
-	 * This method must return a pointer to a signal handling function that will be used by the concurrent helper thread,
-	 * along with an optional (NULLable) pointer to an opaque data structure that will be supplied to the signal handling
-	 * function whenever it is called.
-	 *
-	 * @param[out] signalHandlerArg A pointer that will receive a pointer to an opaque data structure that will be supplied
-	 * to the signal handling function whenever it is called
-	 * @return A pointer to the signal handling function
-	 */
-	virtual omrsig_handler_fn concurrentGC_getProtectedSignalHandler(void **signalHandlerArg) = 0;
-
-	/**
-	 * This method will be called when concurrent initialization is complete. There are no specific requirements for the
-	 * implementation of this method but it may serve to process client-language concerns when concurrent initialization
-	 * completes.
-	 *
-	 * @param[in] env The environment for the calling thread.
-	 */
-	virtual void concurrentGC_concurrentInitializationComplete(MM_EnvironmentStandard *env) = 0;
-
-	/**
-	 * This method may be used to force concurrent kickoff in certain contexts (eg, when determining whether a GC should
-	 * be started). A concurrent GC cycle will be started if this method returns true.
-	 *
-	 * @param[in] env The environment for the calling thread.
-	 * @param[in] gcCode the GC code to use for the concurrent GC cycle
-	 * @param[out] languagekickoffReason a numeric value indicating the client language reason for forcing kickoff
-	 * @return true if a concurrent GC kickoff is required
-	 */
-	virtual bool concurrentGC_forceConcurrentKickoff(MM_EnvironmentBase *env, uintptr_t gcCode, uintptr_t *languagekickoffReason) = 0;
-
-	/* Client language can define an enumeration of constant values to denote language-specific
-	 * marking tasks that can be parallelized.
-	 *
-	 * This enum extends ConcurrentStatus with values >CONCURRENT_ROOT_TRACING and <CONCURRENT_TRACE_ONLY.
-	 * Values from this range and from ConcurrentStatus are treated as uintptr_t values everywhere except
-	 * when used as case labels in switch() statements where manifest constants are required.
-	 *
-	 * ConcurrentStatus extensions allow the client language to define discrete units of work
-	 * that can be executed in parallel by concurrent threads. ConcurrentGC will call
-	 * MM_CollectorLanguageInterface::concurrentGC_collectRoots(..., concurrentStatus, ...)
-	 * only once with each client-defined status value. The thread that receives the call
-	 * can check the concurrentStatus value to select and execute the appropriate unit of work.
-	 *
-	 * ConcurrentGC will query the CLI to determine the next concurrent status value by calling
-	 * MM_CollectorLanguageInterface::concurrentGC_getNextTracingMode(currentStatus), with an
-	 * initial value of CONCURRENT_ROOT_TRACING. The returned value will be passed to
-	 * MM_CollectorLanguageInterface::concurrentGC_collectRoots(..., value, ...). When the
-	 * client language has processed all status extension values, it must terminate root
-	 * tracing by returning CONCURRENT_TRACE_ONLY from  concurrentGC_getNextTracingMode().
-	 *
-	 * @param[in] executionMode The current execution mode
-	 * @return the next execution mode (CONCURRENT_ROOT_TRACING < nextExecutionMode <= CONCURRENT_TRACE_ONLY)
-	 */
-	virtual uintptr_t concurrentGC_getNextTracingMode(uintptr_t executionMode) = 0;
-
-	/**
-	 * After concurrent GC is kicked off, mutator threads are required to contribute by paying an allocation tax
-	 * whenever they attempt to allocate new objects. Concurrent root tracing can be partitioned into discrete,
-	 * disjoint work units that can be executed concurrently. The client language is responsible for identifying
-	 * and enumerating these work units corresponding to the ConcurrentStatus extensions as described for
-	 * concurrentGC_getNextTracingMode().
-	 *
-	 * As each mutator thread pays its allocation tax and the execution mode shifts into the range reserved
-	 * for client extensions CONCURRENT_ROOT_TRACING < executionMode < CONCURRENT_TRACE_ONLY), this method
-	 * is called to allow the mutator thread to pay some or all of its allocation tax. The enumerator for the mode
-	 * to execute is supplied as a input parameter.
-	 *
-	 * @param[in] env The environment for the calling thread.
-	 * @param[in] concurrentStatus The current execution mode
-	 * @param[out] collectedRoots Set this to true if the work unit was completed
-	 * @param[out] Set this to true if all mutator tax paid
-	 */
-	virtual uintptr_t concurrentGC_collectRoots(MM_EnvironmentStandard *env, uintptr_t concurrentStatus, bool *collectedRoots, bool *paidTax) = 0;
-
-	/**
-	 * Tracing a mutator thread stack can only be accomplished safely when the thread is at as safe point. This
-	 * method is called when concurrent GC is ready to trace mutator stacks. The implementation must signal each
-	 * mutator thread to force it to trace its stack at the next safe point. Each mutator thread receiving this
-	 * signal (at a safe point) must call memorySubSpaceAsynchCallbackHandler(OMR_VMThread *) to trace its stack.
-	 *
-	 * @param[in] env The environment for the calling thread.
-	 */
-	virtual void concurrentGC_signalThreadsToTraceStacks(MM_EnvironmentStandard *env) = 0;
-
-	/**
-	 * When a concurrent GC cycle is in progress mutators are required to mark cards dirty in the card table
-	 * whenever they change the object reference graph. Once concurrent GC initialization is complete this
-	 * method will be called. The implementation must ensure that each mutator thread is conditioned to
-	 * dirty cards no later then its next safe point and continue to dirty cards until told to stop (see
-	 * concurrentGC_signalThreadsToStopDirtyingCards()).
-	 *
-	 * @param[in] env The environment for the calling thread.
-	 */
-	virtual void concurrentGC_signalThreadsToDirtyCards(MM_EnvironmentStandard *env) = 0;
-
-	/**
-	 * This method is called after a concurrent GC cycle has completed. the implementation may inform each
-	 * mutator thread to stop dirtying cards. Note that it is acceptable (but less performant) for all
-	 * mutator threads to always dirty cards).
-	 *
-	 * @param[in] env The environment for the calling thread.
-	 */
-	virtual void concurrentGC_signalThreadsToStopDirtyingCards(MM_EnvironmentStandard *env) = 0;
-
-	/**
-	 * This method is called after root tracing has completed (executionMode == CONCURRENT_TRACE_ONLY) if
-	 * the current estimate of available free space is below the card cleaning threshold. No specific
-	 * actions are required but the client language may perform some client-specific work here.
-	 *
-	 * @param[in] env The environment for the calling thread.
-	 */
-	virtual void concurrentGC_kickoffCardCleaning(MM_EnvironmentStandard *env) = 0;
-
-	/**
-	 * This method is called when a concurrent GC cycle is aborted. No specific actions are required but
-	 * the client language may perform some client-specific work here.
-	 *
-	 * @param[in] env The environment for the calling thread.
-	 *
-	 */
-	/* TODO: This method name is too Java-specific. Rename to concurrentGC_abortCollection() */
-	virtual void concurrentGC_flushRegionReferenceLists(MM_EnvironmentBase *env) = 0;
-
-	/**
-	 * This method is called when a concurrent unit of work is completed by a mutator thread while
-	 * paying its allocation tax, for example, after every call to concurrentGC_collectRoots() that
-	 * returns with taxPaid==true. No specific actions are required but the client language may perform
-	 * some client-specific work here.
-	 *
-	 * @param[in] env The environment for the calling thread.
-	 *
-	 */
-	/* TODO: This method name is too Java-specific. Rename to concurrentGC_flushConcurrentRoots() */
-	virtual void concurrentGC_flushThreadReferenceBuffer(MM_EnvironmentBase *env) = 0;
-
-	/**
-	 * This method is called to ensure that a mutator thread is not holding any object references that
-	 * have not previously been flushed in concurrentGC_flushThreadReferenceBuffer(). This invariant
-	 * must hold when a mutator threads begins/ends paying allocation tax, and at the beginning of a
-	 * GC cycle.
-	 *
-	 * @param[in] env The environment for the calling thread.
-	 *
-	 */
-	/* TODO: This method name is too Java-specific. Rename to concurrentGC_hasFlushedConcurrentRoots() */
-	virtual bool concurrentGC_isThreadReferenceBufferEmpty(MM_EnvironmentBase *env) = 0;
-
-	/**
-	 * This method may be used to kick off a client-specific marking task after root collection is complete
-	 * ie, after concurrentGC_getNextTracingMode() returns CONCURRENT_TRACE_ONLY. This task will run concurrently
-	 * with other mutator and GC threads that are engaged in concurrent marking.
-	 *
-	 * Implementation should frequently check for pending exclusive access request and exit in that case.
-	 *
-	 * @param[in] env The environment for the calling thread.
-	 * @param[out] bytesTraced The number of bytes traced
-	 * @param[out] collectedRoots Return true unless exited prematurely to defer to exclusive access request
-	 */
-	virtual bool concurrentGC_startConcurrentScanning(MM_EnvironmentStandard *env, uintptr_t *bytesTraced, bool *collectedRoots) = 0;
-
-	/**
-	 * If concurrentGC_startConcurrentScanning() returns true, this method will be called to inform the client of
-	 * the status of concurrent scanning.
-	 *
-	 * @param[in] env The environment for the calling thread.
-	 * @param[out] isConcurrentScanningComplete true if concurrentGC_startConcurrentScanning() reports >0 bytes traced.
-	 */
-	virtual void concurrentGC_concurrentScanningStarted(MM_EnvironmentStandard *env, bool isConcurrentScanningComplete) = 0;
-
-	/**
-	 * This method will be called to determine whether concurrent scanning has completed.
-	 *
-	 * @param[in] env The environment for the calling thread.
-	 * @return true if concurrent scanning was not started or is complete
-	 */
-	virtual bool concurrentGC_isConcurrentScanningComplete(MM_EnvironmentBase *env) = 0;
-
-	/**
-	 * This method must return an integer-valued code to be reported in the verbose GC log at the end of a concurrent GC cycle.
-	 *
-	 * @param[in] env The environment for the calling thread.
-	 * @return integer-valued code to be reported in the verbose GC log
-	 */
-	virtual uintptr_t concurrentGC_reportConcurrentScanningMode(MM_EnvironmentBase *env) = 0;
-
-
-	/**
-	 * This method is called to scan the stack of a mutator thread. Implementation must call MM_MarkingScheme::markObject()
-	 * for each object reference found on the thread's stack.
-	 *
-	 * @param[in] env The environment for the calling thread.
-	 */
-	virtual void concurrentGC_scanThread(MM_EnvironmentBase *env) = 0;
-#endif /* OMR_GC_MODRON_CONCURRENT_MARK */
-
-
-	/**
-	 * This method is called to check if vm is in Startup stage, return true if vm is in Startup stage(Default: false).
-	 *
-	 * @param[in] env The environment for the calling thread.
-	 * @return true if vm is in Startup stage.
-	 */
-	virtual bool isVMInStartupPhase(MM_EnvironmentBase *env) { return false; }
 
 	MM_CollectorLanguageInterface()
 		: MM_BaseVirtual()

--- a/gc/base/ConcurrentSafepointCallback.hpp
+++ b/gc/base/ConcurrentSafepointCallback.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 IBM Corp. and others
+ * Copyright (c) 2015, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,14 +25,12 @@
 
 #include "omrcfg.h"
 
-
 #include "omrcomp.h"
 #include "BaseVirtual.hpp"
 
 #if defined (OMR_GC_MODRON_CONCURRENT_MARK)
 
 class MM_EnvironmentBase;
-class MM_EnvironmentStandard;
 
 typedef void (*SafepointCallbackHandler)(struct OMR_VMThread * currentThread, void * userData);
 
@@ -54,9 +52,9 @@ public:
 	virtual void registerCallback(MM_EnvironmentBase *env,  SafepointCallbackHandler handler, void *userData);
 #endif /* defined(AIXPPC) || defined(LINUXPPC) */
 
-	virtual void requestCallback(MM_EnvironmentStandard *env);
+	virtual void requestCallback(MM_EnvironmentBase *env);
 
-	virtual void cancelCallback(MM_EnvironmentStandard *env);
+	virtual void cancelCallback(MM_EnvironmentBase *env);
 
 	/* Providing this no-op class as a concrete implementation reduces the glue burden on client languages. */
 	static MM_ConcurrentSafepointCallback *newInstance(MM_EnvironmentBase *env);

--- a/gc/base/GlobalCollector.hpp
+++ b/gc/base/GlobalCollector.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -95,8 +95,8 @@ public:
  	*/
 	virtual void deleteSweepPoolState(MM_EnvironmentBase* env, void* sweepPoolState) = 0;
 
-	MM_GlobalCollector(MM_EnvironmentBase* env, MM_CollectorLanguageInterface *cli)
-		: MM_Collector(cli)
+	MM_GlobalCollector()
+		: MM_Collector()
 		, _delegate()
 	{
 		_typeId = __FUNCTION__;

--- a/gc/base/MarkingScheme.cpp
+++ b/gc/base/MarkingScheme.cpp
@@ -26,6 +26,10 @@
 
 #include <string.h>
 
+#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
+#include "ConcurrentGC.hpp"
+#include "ConcurrentGCStats.hpp"
+#endif /* defined(OMR_GC_MODRON_CONCURRENT_MARK) */
 #include "EnvironmentBase.hpp"
 #include "GCExtensionsBase.hpp"
 #include "Heap.hpp"
@@ -392,5 +396,18 @@ MM_MarkingScheme::createWorkPackets(MM_EnvironmentBase *env) {
 
 	return workPackets;
 }
+
+
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+bool
+MM_MarkingScheme::isConcurrentMarkInProgress() {
+#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
+	uintptr_t mode = ((MM_ConcurrentGC *)_extensions->getGlobalCollector())->getConcurrentGCStats()->getExecutionMode();
+	return (CONCURRENT_ROOT_TRACING <= mode) && (mode < CONCURRENT_EXHAUSTED);
+#else
+	return false;
+#endif /* OMR_GC_MODRON_CONCURRENT_MARK */
+}
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
 

--- a/gc/base/MarkingScheme.hpp
+++ b/gc/base/MarkingScheme.hpp
@@ -29,9 +29,6 @@
 
 #include "BaseVirtual.hpp"
 
-#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
-#include "CollectorLanguageInterface.hpp"
-#endif /* defined(OMR_GC_MODRON_CONCURRENT_MARK) */
 #include "EnvironmentBase.hpp"
 #include "GCExtensionsBase.hpp"
 #include "MarkingDelegate.hpp"
@@ -67,17 +64,8 @@ public:
 	 */
 private:
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
-	bool isConcurrentMarkInProgress() {
-#if defined(OMR_GC_MODRON_CONCURRENT_MARK) 
-		uintptr_t mode = _extensions->collectorLanguageInterface->concurrentGC_getConcurrentStats()->getExecutionMode();
-		return (CONCURRENT_ROOT_TRACING <= mode) && (mode < CONCURRENT_EXHAUSTED);
-#else	
-		return false;
-#endif /* OMR_GC_MODRON_CONCURRENT_MARK */
-	}
+	bool isConcurrentMarkInProgress();
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
-	
-
 
 	MMINLINE void
 	assertSaneObjectPtr(MM_EnvironmentBase *env, omrobjectptr_t objectPtr)

--- a/gc/base/segregated/ConfigurationSegregated.cpp
+++ b/gc/base/segregated/ConfigurationSegregated.cpp
@@ -217,7 +217,7 @@ MM_ConfigurationSegregated::createHeapRegionManager(MM_EnvironmentBase *env)
 MM_GlobalCollector*
 MM_ConfigurationSegregated::createGlobalCollector(MM_EnvironmentBase* env)
 {
-	return MM_SegregatedGC::newInstance(env, env->getExtensions()->collectorLanguageInterface);
+	return MM_SegregatedGC::newInstance(env);
 }
 
 MM_Dispatcher *

--- a/gc/base/segregated/SegregatedGC.cpp
+++ b/gc/base/segregated/SegregatedGC.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -52,13 +52,13 @@
  * Initialization
  */
 MM_SegregatedGC *
-MM_SegregatedGC::newInstance(MM_EnvironmentBase *env, MM_CollectorLanguageInterface *cli)
+MM_SegregatedGC::newInstance(MM_EnvironmentBase *env)
 {
 	MM_SegregatedGC *globalGC;
 
 	globalGC = (MM_SegregatedGC *)env->getForge()->allocate(sizeof(MM_SegregatedGC), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL != globalGC) {
-		new(globalGC) MM_SegregatedGC(env, cli);
+		new(globalGC) MM_SegregatedGC(env);
 		if (!globalGC->initialize(env)) { 
 			globalGC->kill(env);
 			globalGC = NULL;

--- a/gc/base/segregated/SegregatedGC.hpp
+++ b/gc/base/segregated/SegregatedGC.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -74,7 +74,7 @@ protected:
 	void reportSweepEnd(MM_EnvironmentBase *env);
 
 public:
-	static MM_SegregatedGC *newInstance(MM_EnvironmentBase *env, MM_CollectorLanguageInterface *cli);
+	static MM_SegregatedGC *newInstance(MM_EnvironmentBase *env);
 	virtual void kill(MM_EnvironmentBase *env);
 	bool initialize(MM_EnvironmentBase *env);
 	void tearDown(MM_EnvironmentBase *env);
@@ -113,8 +113,8 @@ public:
 		return _sweepScheme;
 	}
 
-	MM_SegregatedGC(MM_EnvironmentBase *env, MM_CollectorLanguageInterface *cli)
-		: MM_GlobalCollector(env, cli)
+	MM_SegregatedGC(MM_EnvironmentBase *env)
+		: MM_GlobalCollector()
 		, _extensions(MM_GCExtensionsBase::getExtensions(env->getOmrVM()))
 		, _portLibrary(env->getPortLibrary())
 		, _markingScheme(NULL)

--- a/gc/base/standard/ConcurrentCardTable.hpp
+++ b/gc/base/standard/ConcurrentCardTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -123,7 +123,7 @@ typedef enum {
 } BitMapAction;	
 
 
-class MM_EnvironmentStandard;
+class MM_EnvironmentBase;
 class MM_ConcurrentGC;
 class MM_Dispatcher;
 class MM_MarkingScheme;
@@ -182,20 +182,20 @@ public:
 private:
 	virtual void tearDown(MM_EnvironmentBase *env);
 	
-	bool allocateCardTableEntriesForHeapRange(MM_EnvironmentStandard *env, MM_MemorySubSpace *subspace, uintptr_t size, void *lowAddress, void *highAddress, bool clearNewCards);
-	bool freeCardTableEntriesForHeapRange(MM_EnvironmentStandard *env, uintptr_t size, void *lowAddress, void *highAddress, void *lowValidAddress, void *highValidAddress);
-	bool allocateTLHMarkMapEntriesForHeapRange(MM_EnvironmentStandard *env, MM_MemorySubSpace *subspace, uintptr_t size, void *lowAddress, void *highAddress);
-	bool freeTLHMarkMapEntriesForHeapRange(MM_EnvironmentStandard *env, uintptr_t size, void *lowAddress, void *highAddress, void *lowValidAddress, void *highValidAddress);
+	bool allocateCardTableEntriesForHeapRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace, uintptr_t size, void *lowAddress, void *highAddress, bool clearNewCards);
+	bool freeCardTableEntriesForHeapRange(MM_EnvironmentBase *env, uintptr_t size, void *lowAddress, void *highAddress, void *lowValidAddress, void *highValidAddress);
+	bool allocateTLHMarkMapEntriesForHeapRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace, uintptr_t size, void *lowAddress, void *highAddress);
+	bool freeTLHMarkMapEntriesForHeapRange(MM_EnvironmentBase *env, uintptr_t size, void *lowAddress, void *highAddress, void *lowValidAddress, void *highValidAddress);
 	
-	void setTLHMarkBits(MM_EnvironmentStandard *env, uintptr_t slotIndex, uintptr_t slotBits);
-	void clearTLHMarkBits(MM_EnvironmentStandard *env, uintptr_t slotIndex, uintptr_t slotBits);
-	static uintptr_t calculateTLHMarkMapSize(MM_EnvironmentStandard *env, uintptr_t cardTableSize);
+	void setTLHMarkBits(MM_EnvironmentBase *env, uintptr_t slotIndex, uintptr_t slotBits);
+	void clearTLHMarkBits(MM_EnvironmentBase *env, uintptr_t slotIndex, uintptr_t slotBits);
+	static uintptr_t calculateTLHMarkMapSize(MM_EnvironmentBase *env, uintptr_t cardTableSize);
 	
-	void determineCleaningRanges(MM_EnvironmentStandard *env);
-	void resetCleaningRanges(MM_EnvironmentStandard *env);
-	bool isCardInActiveTLH(MM_EnvironmentStandard *env, Card *card);
+	void determineCleaningRanges(MM_EnvironmentBase *env);
+	void resetCleaningRanges(MM_EnvironmentBase *env);
+	bool isCardInActiveTLH(MM_EnvironmentBase *env, Card *card);
 	
-	void reportCardCleanPass2Start(MM_EnvironmentStandard *env);
+	void reportCardCleanPass2Start(MM_EnvironmentBase *env);
 		
 	MMINLINE uintptr_t getTLHMarkBitMask(uintptr_t index)
 	{
@@ -224,19 +224,19 @@ private:
 #endif		
 	}
 	
-	void processTLHMarkBits(MM_EnvironmentStandard *env, MM_MemorySubSpace *subspace, void *tlhBase, void *tlhTop, BitMapAction action);
+	void processTLHMarkBits(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace, void *tlhBase, void *tlhTop, BitMapAction action);
 	
 protected:
 	bool initialize(MM_EnvironmentBase *env, MM_Heap *heap);
 	
-	bool cleanSingleCard(MM_EnvironmentStandard *env, Card *card, uintptr_t bytesToClean, uintptr_t *totalBytesCleaned);
-	Card* getNextDirtyCard(MM_EnvironmentStandard *env, Card cardMask, bool concurrentCardClean);
+	bool cleanSingleCard(MM_EnvironmentBase *env, Card *card, uintptr_t bytesToClean, uintptr_t *totalBytesCleaned);
+	Card* getNextDirtyCard(MM_EnvironmentBase *env, Card cardMask, bool concurrentCardClean);
 	
-	bool cardHasMarkedObjects(MM_EnvironmentStandard *env, Card *card);
+	bool cardHasMarkedObjects(MM_EnvironmentBase *env, Card *card);
 	
-	virtual void prepareCardsForCleaning(MM_EnvironmentStandard *env); 
-	virtual bool getExclusiveCardTableAccess(MM_EnvironmentStandard *env, CardCleanPhase currentPhase, bool threadAtSafePoint);
-	virtual void releaseExclusiveCardTableAccess(MM_EnvironmentStandard *env);
+	virtual void prepareCardsForCleaning(MM_EnvironmentBase *env);
+	virtual bool getExclusiveCardTableAccess(MM_EnvironmentBase *env, CardCleanPhase currentPhase, bool threadAtSafePoint);
+	virtual void releaseExclusiveCardTableAccess(MM_EnvironmentBase *env);
 	
 	MMINLINE virtual void concurrentCleanCard(Card *card) { *card = CARD_CLEAN; };
 	MMINLINE virtual void finalCleanCard(Card *card) { *card = CARD_CLEAN; };
@@ -306,7 +306,7 @@ public:
 	 * @param[in] cleanNewCards True if the new cards included in this range should be cleared (true if the subspace is collectable)
 	 * @return true if expansion is successful
 	 */
-	bool heapAddRange(MM_EnvironmentStandard *env, MM_MemorySubSpace *subspace, uintptr_t size, void *lowAddress, void *highAddress, bool cleaNewCards);
+	bool heapAddRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace, uintptr_t size, void *lowAddress, void *highAddress, bool cleaNewCards);
 	/**
 	 * Called when a range of memory has been removed from the heap.
 	 * @param[in] env The thread which initiated the contraction request (typically the master GC thread)
@@ -319,13 +319,13 @@ public:
 	 * @param[in] cleanNewCards True if the new cards included in this range should be cleared (true if the subspace is collectable)
 	 * @return true if contraction is successful
 	 */
-	bool heapRemoveRange(MM_EnvironmentStandard *env, MM_MemorySubSpace *subspace, uintptr_t size, void *lowAddress, void *highAddress, void *lowValidAddress, void *highValidAddress);
+	bool heapRemoveRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace, uintptr_t size, void *lowAddress, void *highAddress, void *lowValidAddress, void *highValidAddress);
 	/**
 	 * Called when the heap geometry has been reconfigured but no memory was added or removed from the heap (happens during tilt).
 	 * @param[in] env The thread which caused the heap geometry change (typically the master GC thread)
 	 * @note This implementation does nothing.
 	 */
-	void heapReconfigured(MM_EnvironmentStandard *env);
+	void heapReconfigured(MM_EnvironmentBase *env);
 	
 	/**
 	 * @return A pointer to the mutable card table stats structure
@@ -341,7 +341,7 @@ public:
 	 * @return The size, in bytes, of all the cards which map to the supplied heap range
 	 * @note Only called by MM_ConcurrentCardTable and MM_ConcurrentGC
 	 */
-	uintptr_t cardBytesForHeapRange(MM_EnvironmentStandard *env, void *heapBase, void *heapTop);
+	uintptr_t cardBytesForHeapRange(MM_EnvironmentBase *env, void *heapBase, void *heapTop);
 	/**
 	 * Dirties the card backing the given range of the heap.  Will dirty the heapBase and heapTop cards, inclusively.
 	 * @param[in] env The thread which caused the remembered set to resize
@@ -349,21 +349,21 @@ public:
 	 * @param[in] heapTop The byte after the highest address of the heap excluded from the remembered set
 	 * @note Called when the remembered set resizes to exclude a range of the heap
 	 */
-	void dirtyCardsInRange(MM_EnvironmentStandard *env, void *heapBase, void *heapTop);
+	void dirtyCardsInRange(MM_EnvironmentBase *env, void *heapBase, void *heapTop);
 	/**
 	 * Called to clear the cards backing the heap regions which are in active but not concurrently collectable subspaces.
 	 * The purpose of this call is to clear the cards backing active nursery heap ranges, under the gencon policy.
 	 * @param[in] env The thread which reported the concurrent work stack overflow
 	 * @note Called only from MM_ConcurrentGC during concurrent work stack overflow
 	 */
-	void clearNonConcurrentCards(MM_EnvironmentStandard *env);
+	void clearNonConcurrentCards(MM_EnvironmentBase *env);
 	
 	/**
 	 * Prepare for next concurrent marking cycle (atomically sets internal state of the card table).
 	 * @param[in] env The initializing concurrent card cleaning
 	 * @note Called only from MM_ConcurrentGC
 	 */
-	void initializeCardCleaning(MM_EnvironmentStandard *env);
+	void initializeCardCleaning(MM_EnvironmentBase *env);
 	
 	/**
 	 * Start or continue the card cleaning process.
@@ -379,13 +379,13 @@ public:
 	 * @param threadAtSafePoint Whether the calling thread is at a safe point or not
 	 * @return FALSE if a GC occurs during during card table preperation.
 	 */
-	bool cleanCards(MM_EnvironmentStandard *env, bool isMutator, uintptr_t sizeToDo, uintptr_t *sizeDone, bool threadAtSafePoint);
+	bool cleanCards(MM_EnvironmentBase *env, bool isMutator, uintptr_t sizeToDo, uintptr_t *sizeDone, bool threadAtSafePoint);
 	/**
 	 * Initialize for final card cleaning.
 	 *
 	 * Called by STW to do any necessary initialization prior to final card cleaning.
 	 */
-	virtual void initializeFinalCardCleaning(MM_EnvironmentStandard *env);
+	virtual void initializeFinalCardCleaning(MM_EnvironmentBase *env);
 	/**
 	 * Do final card cleaning.
 	 *
@@ -400,7 +400,7 @@ public:
 	 * 			processed. Also returns number of bytes traced whilst cleaning cards.
 	 *
 	 */
-	bool finalCleanCards(MM_EnvironmentStandard *env, uintptr_t *bytesTraced);
+	bool finalCleanCards(MM_EnvironmentBase *env, uintptr_t *bytesTraced);
 	/**
 	 * Determine whether the referenced object is within a dirty card. Used if
 	 * object reference may not be in tenure or nursery.
@@ -408,7 +408,7 @@ public:
 	 * @param object - reference to object to be checked
 	 * @return TRUE if reference is to an object within a dirty card; FALSE otherwise
 	 */
-	bool isObjectInDirtyCard(MM_EnvironmentStandard *env, omrobjectptr_t object);
+	bool isObjectInDirtyCard(MM_EnvironmentBase *env, omrobjectptr_t object);
 	/**
 	 * Is object in a dirty card
 	 *
@@ -419,7 +419,7 @@ public:
 	 * @param object - reference to object to be checked
 	 * @return TRUE if reference is to an object within a dirty card; FALSE otherwise
 	 */
-	bool isObjectInDirtyCardNoCheck(MM_EnvironmentStandard *env, omrobjectptr_t object);
+	bool isObjectInDirtyCardNoCheck(MM_EnvironmentBase *env, omrobjectptr_t object);
 	
 	/**
 	 * Is object in an uncleaned dirty card
@@ -431,7 +431,7 @@ public:
 	 *
 	 * @return TRUE if card has NOT already been cleaned; FALSE otherwise
 	 */
-	virtual bool isObjectInUncleanedDirtyCard(MM_EnvironmentStandard *env, omrobjectptr_t object);
+	virtual bool isObjectInUncleanedDirtyCard(MM_EnvironmentBase *env, omrobjectptr_t object);
 	
 	/**
 	 * @return TRUE if we are at least in PHASE1_CLEANING.
@@ -452,7 +452,7 @@ public:
 	 * @return TRUE if reference is to an object within an active TLH; FALSE otherwise
 	 * @note Only called from MM_ConcurrentGC and internally
 	 */
-	bool isObjectInActiveTLH(MM_EnvironmentStandard *env, omrobjectptr_t object);
+	bool isObjectInActiveTLH(MM_EnvironmentBase *env, omrobjectptr_t object);
 	
 	/**
 	 * Is TLH mark bits empty?
@@ -469,8 +469,8 @@ public:
 	static void tlhRefreshed(J9HookInterface** hook, uintptr_t eventNum, void* eventData, void* userData);
 		
 #if defined(DEBUG)
-	bool isTLHMarkBitsEmpty(MM_EnvironmentStandard *env);
-	bool isCardTableEmpty(MM_EnvironmentStandard *env);
+	bool isTLHMarkBitsEmpty(MM_EnvironmentBase *env);
+	bool isCardTableEmpty(MM_EnvironmentBase *env);
 #endif /* DEBUG */
 	
 	/**

--- a/gc/base/standard/ConcurrentCardTableForWC.cpp
+++ b/gc/base/standard/ConcurrentCardTableForWC.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,7 +21,7 @@
  *******************************************************************************/
 
 #include "omrcfg.h"
-/* TODO 90354 rm: #include "j9.h" */
+
 #if defined(AIXPPC) || defined(LINUXPPC)
 
 #if defined(OMR_GC_MODRON_CONCURRENT_MARK)
@@ -33,6 +33,7 @@
 #include "AtomicOperations.hpp" 
 #include "CollectorLanguageInterface.hpp"
 #include "ConcurrentCardTableForWC.hpp"
+#include "ConcurrentGC.hpp"
 #include "ConcurrentPrepareCardTableTask.hpp"
 #include "Debug.hpp"
 #include "Dispatcher.hpp"
@@ -78,7 +79,7 @@ MM_ConcurrentCardTableForWC::initialize(MM_EnvironmentBase *env, MM_Heap *heap)
 		goto error_no_memory;
 	}	
 	
-	_callback = env->getExtensions()->collectorLanguageInterface->concurrentGC_createSafepointCallback(env);
+	_callback = _collector->_concurrentDelegate.createSafepointCallback(env);
 
 	if (NULL == _callback) {
 		goto error_no_memory;

--- a/gc/base/standard/ConcurrentGC.cpp
+++ b/gc/base/standard/ConcurrentGC.cpp
@@ -56,7 +56,7 @@
 #include "CycleState.hpp"
 #include "Debug.hpp"
 #include "Dispatcher.hpp"
-#include "EnvironmentStandard.hpp"
+#include "EnvironmentBase.hpp"
 #include "GCExtensionsBase.hpp"
 #include "Heap.hpp"
 #include "HeapMapIterator.hpp"
@@ -99,7 +99,7 @@ extern "C" {
 void
 J9ConcurrentWriteBarrierStore (OMR_VMThread *vmThread, omrobjectptr_t destinationObject, omrobjectptr_t storedObject)
 {
-	MM_EnvironmentStandard *env = MM_EnvironmentStandard::getEnvironment(vmThread);
+	MM_EnvironmentBase *env = MM_EnvironmentBase::getEnvironment(vmThread);
 	MM_GCExtensionsBase *extensions = env->getExtensions();
 
 	extensions->cardTable->dirtyCard(env, (omrobjectptr_t)destinationObject);
@@ -115,7 +115,7 @@ J9ConcurrentWriteBarrierStore (OMR_VMThread *vmThread, omrobjectptr_t destinatio
 void
 J9ConcurrentWriteBarrierBatchStore (OMR_VMThread *vmThread, omrobjectptr_t destinationObject)
 {
-	MM_EnvironmentStandard *env = MM_EnvironmentStandard::getEnvironment(vmThread);
+	MM_EnvironmentBase *env = MM_EnvironmentBase::getEnvironment(vmThread);
 	MM_GCExtensionsBase *extensions = env->getExtensions();
 
 	extensions->cardTable->dirtyCard(env, (omrobjectptr_t)destinationObject);
@@ -130,11 +130,12 @@ int J9THREAD_PROC
 con_helper_thread_proc(void *info)
 {
 	ConHelperThreadInfo *conHelperThreadInfo = (ConHelperThreadInfo *)info;
+	MM_ConcurrentGC *collector = conHelperThreadInfo->collector;
 	OMRPORT_ACCESS_FROM_OMRVM(conHelperThreadInfo->omrVM);
 
 	uintptr_t rc;
 	void *signalHandlerArg = NULL;
-	omrsig_handler_fn signalHandler = conHelperThreadInfo->collector->_cli->concurrentGC_getProtectedSignalHandler(&signalHandlerArg);
+	omrsig_handler_fn signalHandler = collector->_concurrentDelegate.getProtectedSignalHandler(&signalHandlerArg);
 	omrsig_protect(con_helper_thread_proc2, info, signalHandler, signalHandlerArg,
 		OMRPORT_SIG_FLAG_SIGALLSYNC | OMRPORT_SIG_FLAG_MAY_CONTINUE_EXECUTION,
 		&rc);
@@ -177,14 +178,14 @@ con_helper_thread_proc2(OMRPortLibrary* portLib, void *info)
 } /* extern "C" */
 
 void
-MM_ConcurrentGC::reportConcurrentKickoff(MM_EnvironmentStandard *env)
+MM_ConcurrentGC::reportConcurrentKickoff(MM_EnvironmentBase *env)
 {
 	OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
 
 	Trc_MM_ConcurrentKickoff(env->getLanguageVMThread(),
-		_stats->getTraceSizeTarget(),
-		_stats->getKickoffThreshold(),
-		_stats->getRemainingFree()
+		_stats.getTraceSizeTarget(),
+		_stats.getKickoffThreshold(),
+		_stats.getRemainingFree()
 	);
 
 	MM_CommonGCData commonData;
@@ -195,16 +196,16 @@ MM_ConcurrentGC::reportConcurrentKickoff(MM_EnvironmentStandard *env)
 		omrtime_hires_clock(),
 		J9HOOK_MM_PRIVATE_CONCURRENT_KICKOFF,
 		_extensions->getHeap()->initializeCommonGCData(env, &commonData),
-		_stats->getTraceSizeTarget(),
-		_stats->getKickoffThreshold(),
-		_stats->getRemainingFree(),
-		_stats->getKickoffReason(),
+		_stats.getTraceSizeTarget(),
+		_stats.getKickoffThreshold(),
+		_stats.getRemainingFree(),
+		_stats.getKickoffReason(),
 		_languageKickoffReason
 	);
 }
 
 void
-MM_ConcurrentGC::reportConcurrentAborted(MM_EnvironmentStandard *env, CollectionAbortReason reason)
+MM_ConcurrentGC::reportConcurrentAborted(MM_EnvironmentBase *env, CollectionAbortReason reason)
 {
 	OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
 
@@ -220,26 +221,26 @@ MM_ConcurrentGC::reportConcurrentAborted(MM_EnvironmentStandard *env, Collection
 }
 
 void
-MM_ConcurrentGC::reportConcurrentHalted(MM_EnvironmentStandard *env)
+MM_ConcurrentGC::reportConcurrentHalted(MM_EnvironmentBase *env)
 {
 	MM_ConcurrentCardTable *cardTable = (MM_ConcurrentCardTable *)_cardTable;
 	OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
 
 	Trc_MM_ConcurrentHalted(env->getLanguageVMThread(),
-		(uintptr_t) _stats->getExecutionModeAtGC(),
-		_stats->getTraceSizeTarget(),
-		_stats->getTotalTraced(),
-		_stats->getMutatorsTraced(),
-		_stats->getConHelperTraced(),
+		(uintptr_t) _stats.getExecutionModeAtGC(),
+		_stats.getTraceSizeTarget(),
+		_stats.getTotalTraced(),
+		_stats.getMutatorsTraced(),
+		_stats.getConHelperTraced(),
 		cardTable->getCardTableStats()->getConcurrentCleanedCards(),
-		_stats->getCardCleaningThreshold(),
-		(_stats->getConcurrentWorkStackOverflowOcurred() ? "true" : "false"),
-		_stats->getConcurrentWorkStackOverflowCount()
+		_stats.getCardCleaningThreshold(),
+		(_stats.getConcurrentWorkStackOverflowOcurred() ? "true" : "false"),
+		_stats.getConcurrentWorkStackOverflowCount()
 	);
 
 	Trc_MM_ConcurrentHaltedState(env->getLanguageVMThread(),
 		cardTable->isCardCleaningComplete() ? "complete" : "incomplete",
-		_cli->concurrentGC_isConcurrentScanningComplete(env) ? "complete" : "incomplete",
+		_concurrentDelegate.isConcurrentScanningComplete(env) ? "complete" : "incomplete",
 		_markingScheme->getWorkPackets()->tracingExhausted() ? "complete" : "incomplete"
 	);
 
@@ -248,40 +249,40 @@ MM_ConcurrentGC::reportConcurrentHalted(MM_EnvironmentStandard *env)
 		env->getOmrVMThread(),
 		omrtime_hires_clock(),
 		J9HOOK_MM_PRIVATE_CONCURRENT_HALTED,
-		(uintptr_t)_stats->getExecutionModeAtGC(),
-		_stats->getTraceSizeTarget(),
-		_stats->getTotalTraced(),
-		_stats->getMutatorsTraced(),
-		_stats->getConHelperTraced(),
+		(uintptr_t)_stats.getExecutionModeAtGC(),
+		_stats.getTraceSizeTarget(),
+		_stats.getTotalTraced(),
+		_stats.getMutatorsTraced(),
+		_stats.getConHelperTraced(),
 		cardTable->getCardTableStats()->getConcurrentCleanedCards(),
-		_stats->getCardCleaningThreshold(),
-		_stats->getConcurrentWorkStackOverflowOcurred(),
-		_stats->getConcurrentWorkStackOverflowCount(),
+		_stats.getCardCleaningThreshold(),
+		_stats.getConcurrentWorkStackOverflowOcurred(),
+		_stats.getConcurrentWorkStackOverflowCount(),
 		(uintptr_t)cardTable->isCardCleaningComplete(),
-		_cli->concurrentGC_reportConcurrentScanningMode(env),
+		_concurrentDelegate.reportConcurrentScanningMode(env),
 		(uintptr_t)_markingScheme->getWorkPackets()->tracingExhausted()
 	);
 }
 
 void
-MM_ConcurrentGC::reportConcurrentFinalCardCleaningStart(MM_EnvironmentStandard *env)
+MM_ConcurrentGC::reportConcurrentFinalCardCleaningStart(MM_EnvironmentBase *env)
 {
 	OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
 
 	Trc_MM_ConcurrentCollectionCardCleaningStart(env->getLanguageVMThread(),
-		_stats->getConcurrentWorkStackOverflowCount()
+		_stats.getConcurrentWorkStackOverflowCount()
 	);
 	TRIGGER_J9HOOK_MM_PRIVATE_CONCURRENT_COLLECTION_CARD_CLEANING_START(
 		_extensions->privateHookInterface,
 		env->getOmrVMThread(),
 		omrtime_hires_clock(),
 		J9HOOK_MM_PRIVATE_CONCURRENT_COLLECTION_CARD_CLEANING_START,
-		_stats->getConcurrentWorkStackOverflowCount()
+		_stats.getConcurrentWorkStackOverflowCount()
 	);
 }
 
 void
-MM_ConcurrentGC::reportConcurrentFinalCardCleaningEnd(MM_EnvironmentStandard *env, uint64_t duration)
+MM_ConcurrentGC::reportConcurrentFinalCardCleaningEnd(MM_EnvironmentBase *env, uint64_t duration)
 {
 	MM_ConcurrentCardTable *cardTable = (MM_ConcurrentCardTable *)_cardTable;
 	OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
@@ -296,21 +297,21 @@ MM_ConcurrentGC::reportConcurrentFinalCardCleaningEnd(MM_EnvironmentStandard *en
 		cardTable->getCardTableStats()->getFinalCleanedCardsPhase1(),
 		cardTable->getCardTableStats()->getFinalCleanedCardsPhase2(),
 		cardTable->getCardTableStats()->getFinalCleanedCards(),
-		_stats->getFinalTraceCount() + _stats->getFinalCardCleanCount(),
+		_stats.getFinalTraceCount() + _stats.getFinalCardCleanCount(),
 		cardTable->getCardTableStats()->getConcurrentCleanedCardsPhase1(),
 		cardTable->getCardTableStats()->getConcurrentCleanedCardsPhase2(),
 		cardTable->getCardTableStats()->getConcurrentCleanedCardsPhase3(),
 		cardTable->getCardTableStats()->getConcurrentCleanedCards(),
-		_stats->getCardCleaningThreshold(),
+		_stats.getCardCleaningThreshold(),
 		cardTable->getCardTableStats()->getCardCleaningPhase1Kickoff(),
 		cardTable->getCardTableStats()->getCardCleaningPhase2Kickoff(),
 		cardTable->getCardTableStats()->getCardCleaningPhase3Kickoff(),
-		_stats->getConcurrentWorkStackOverflowCount()
+		_stats.getConcurrentWorkStackOverflowCount()
 	);
 }
 
 void
-MM_ConcurrentGC::reportConcurrentCollectionStart(MM_EnvironmentStandard *env)
+MM_ConcurrentGC::reportConcurrentCollectionStart(MM_EnvironmentBase *env)
 {
 	MM_ConcurrentCardTable *cardTable = (MM_ConcurrentCardTable *)_cardTable;
 	OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
@@ -322,14 +323,14 @@ MM_ConcurrentGC::reportConcurrentCollectionStart(MM_EnvironmentStandard *env)
 		_extensions->heap->getActiveMemorySize(MEMORY_TYPE_OLD),
 		(_extensions-> largeObjectArea ? _extensions->heap->getApproximateActiveFreeLOAMemorySize(MEMORY_TYPE_OLD) : 0 ),
 		(_extensions-> largeObjectArea ? _extensions->heap->getActiveLOAMemorySize(MEMORY_TYPE_OLD) : 0 ),
-		_stats->getTraceSizeTarget(),
-		_stats->getTotalTraced(),
-		_stats->getMutatorsTraced(),
-		_stats->getConHelperTraced(),
+		_stats.getTraceSizeTarget(),
+		_stats.getTotalTraced(),
+		_stats.getMutatorsTraced(),
+		_stats.getConHelperTraced(),
 		cardTable->getCardTableStats()->getConcurrentCleanedCards(),
-		_stats->getCardCleaningThreshold(),
-		(_stats->getConcurrentWorkStackOverflowOcurred() ? "true" : "false"),
-		_stats->getConcurrentWorkStackOverflowCount()
+		_stats.getCardCleaningThreshold(),
+		(_stats.getConcurrentWorkStackOverflowOcurred() ? "true" : "false"),
+		_stats.getConcurrentWorkStackOverflowCount()
 	);
 
 	uint64_t exclusiveAccessTimeMicros = omrtime_hires_delta(0, env->getExclusiveAccessTime(), OMRPORT_TIME_DELTA_IN_MICROSECONDS);
@@ -353,23 +354,23 @@ MM_ConcurrentGC::reportConcurrentCollectionStart(MM_EnvironmentStandard *env)
 			omrtime_hires_clock(),
 			J9HOOK_MM_PRIVATE_CONCURRENT_COLLECTION_START,
 			&commonData,
-			_stats->getTraceSizeTarget(),
-			_stats->getTotalTraced(),
-			_stats->getMutatorsTraced(),
-			_stats->getConHelperTraced(),
+			_stats.getTraceSizeTarget(),
+			_stats.getTotalTraced(),
+			_stats.getMutatorsTraced(),
+			_stats.getConHelperTraced(),
 			cardTable->getCardTableStats()->getConcurrentCleanedCards(),
-			_stats->getCardCleaningThreshold(),
-			_stats->getConcurrentWorkStackOverflowOcurred(),
-			_stats->getConcurrentWorkStackOverflowCount(),
-			_stats->getThreadsToScanCount(),
-			_stats->getThreadsScannedCount(),
-			_stats->getCardCleaningReason()
+			_stats.getCardCleaningThreshold(),
+			_stats.getConcurrentWorkStackOverflowOcurred(),
+			_stats.getConcurrentWorkStackOverflowCount(),
+			_stats.getThreadsToScanCount(),
+			_stats.getThreadsScannedCount(),
+			_stats.getCardCleaningReason()
 		);
 	}
 }
 
 void
-MM_ConcurrentGC::reportConcurrentCollectionEnd(MM_EnvironmentStandard *env, uint64_t duration)
+MM_ConcurrentGC::reportConcurrentCollectionEnd(MM_EnvironmentBase *env, uint64_t duration)
 {
 	OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
 
@@ -399,26 +400,26 @@ MM_ConcurrentGC::reportConcurrentCollectionEnd(MM_EnvironmentStandard *env, uint
 }
 
 void
-MM_ConcurrentGC::reportConcurrentBackgroundThreadActivated(MM_EnvironmentStandard *env)
+MM_ConcurrentGC::reportConcurrentBackgroundThreadActivated(MM_EnvironmentBase *env)
 {
 	Trc_MM_ConcurrentBackgroundThreadActivated(env->getLanguageVMThread());
 	TRIGGER_J9HOOK_MM_PRIVATE_CONCURRENT_BACKGROUND_THREAD_ACTIVATED(_extensions->privateHookInterface, env->getOmrVMThread());
 }
 
 void
-MM_ConcurrentGC::reportConcurrentBackgroundThreadFinished(MM_EnvironmentStandard *env, uintptr_t traceTotal)
+MM_ConcurrentGC::reportConcurrentBackgroundThreadFinished(MM_EnvironmentBase *env, uintptr_t traceTotal)
 {
 	Trc_MM_ConcurrentBackgroundThreadFinished(env->getLanguageVMThread());
 	TRIGGER_J9HOOK_MM_PRIVATE_CONCURRENT_BACKGROUND_THREAD_FINISHED(_extensions->privateHookInterface, env->getOmrVMThread(), traceTotal);
 }
 
 void
-MM_ConcurrentGC::reportConcurrentCompleteTracingStart(MM_EnvironmentStandard *env)
+MM_ConcurrentGC::reportConcurrentCompleteTracingStart(MM_EnvironmentBase *env)
 {
 	OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
 
 	Trc_MM_ConcurrentCompleteTracingStart(env->getLanguageVMThread(),
-		_stats->getConcurrentWorkStackOverflowCount()
+		_stats.getConcurrentWorkStackOverflowCount()
 	);
 
 	TRIGGER_J9HOOK_MM_PRIVATE_CONCURRENT_COMPLETE_TRACING_START(
@@ -426,18 +427,18 @@ MM_ConcurrentGC::reportConcurrentCompleteTracingStart(MM_EnvironmentStandard *en
 		env->getOmrVMThread(),
 		omrtime_hires_clock(),
 		J9HOOK_MM_PRIVATE_CONCURRENT_COMPLETE_TRACING_START,
-		_stats->getConcurrentWorkStackOverflowCount()
+		_stats.getConcurrentWorkStackOverflowCount()
 	);
 }
 
 void
-MM_ConcurrentGC::reportConcurrentCompleteTracingEnd(MM_EnvironmentStandard *env, uint64_t duration)
+MM_ConcurrentGC::reportConcurrentCompleteTracingEnd(MM_EnvironmentBase *env, uint64_t duration)
 {
 	OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
 
 	Trc_MM_ConcurrentCompleteTracingEnd(env->getLanguageVMThread(),
-		_stats->getCompleteTracingCount(),
-		_stats->getConcurrentWorkStackOverflowCount()
+		_stats.getCompleteTracingCount(),
+		_stats.getConcurrentWorkStackOverflowCount()
 	);
 
 	TRIGGER_J9HOOK_MM_PRIVATE_CONCURRENT_COMPLETE_TRACING_END(
@@ -446,37 +447,37 @@ MM_ConcurrentGC::reportConcurrentCompleteTracingEnd(MM_EnvironmentStandard *env,
 		omrtime_hires_clock(),
 		J9HOOK_MM_PRIVATE_CONCURRENT_COMPLETE_TRACING_END,
 		duration,
-		_stats->getCompleteTracingCount(),
-		_stats->getConcurrentWorkStackOverflowCount()
+		_stats.getCompleteTracingCount(),
+		_stats.getConcurrentWorkStackOverflowCount()
 	);
 }
 
 void
-MM_ConcurrentGC::reportConcurrentRememberedSetScanStart(MM_EnvironmentStandard *env)
+MM_ConcurrentGC::reportConcurrentRememberedSetScanStart(MM_EnvironmentBase *env)
 {
 	OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
 
 	Trc_MM_ConcurrentRememberedSetScanStart(env->getLanguageVMThread(),
-		_stats->getConcurrentWorkStackOverflowCount()
+		_stats.getConcurrentWorkStackOverflowCount()
 	);
 	TRIGGER_J9HOOK_MM_PRIVATE_CONCURRENT_REMEMBERED_SET_SCAN_START(
 		_extensions->privateHookInterface,
 		env->getOmrVMThread(),
 		omrtime_hires_clock(),
 		J9HOOK_MM_PRIVATE_CONCURRENT_REMEMBERED_SET_SCAN_START,
-		_stats->getConcurrentWorkStackOverflowCount()
+		_stats.getConcurrentWorkStackOverflowCount()
 	);
 }
 
 void
-MM_ConcurrentGC::reportConcurrentRememberedSetScanEnd(MM_EnvironmentStandard *env, uint64_t duration)
+MM_ConcurrentGC::reportConcurrentRememberedSetScanEnd(MM_EnvironmentBase *env, uint64_t duration)
 {
 	OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
 
 	Trc_MM_ConcurrentRememberedSetScanEnd(env->getLanguageVMThread(),
-		_stats->getRSObjectsFound(),
-		_stats->getRSScanTraceCount(),
-		_stats->getConcurrentWorkStackOverflowCount()
+		_stats.getRSObjectsFound(),
+		_stats.getRSScanTraceCount(),
+		_stats.getConcurrentWorkStackOverflowCount()
 	);
 	TRIGGER_J9HOOK_MM_PRIVATE_CONCURRENT_REMEMBERED_SET_SCAN_END(
 		_extensions->privateHookInterface,
@@ -484,9 +485,9 @@ MM_ConcurrentGC::reportConcurrentRememberedSetScanEnd(MM_EnvironmentStandard *en
 		omrtime_hires_clock(),
 		J9HOOK_MM_PRIVATE_CONCURRENT_REMEMBERED_SET_SCAN_END,
 		duration,
-		_stats->getRSObjectsFound(),
-		_stats->getRSScanTraceCount(),
-		_stats->getConcurrentWorkStackOverflowCount()
+		_stats.getRSObjectsFound(),
+		_stats.getRSScanTraceCount(),
+		_stats.getConcurrentWorkStackOverflowCount()
 	);
 }
 
@@ -499,7 +500,7 @@ void
 MM_ConcurrentGC::hookOldToOldReferenceCreated(J9HookInterface** hook, uintptr_t eventNum, void* eventData, void* userData)
 {
 	MM_OldToOldReferenceCreatedEvent* event = (MM_OldToOldReferenceCreatedEvent*)eventData;
-	MM_EnvironmentStandard *env = MM_EnvironmentStandard::getEnvironment(event->currentThread);
+	MM_EnvironmentBase *env = MM_EnvironmentBase::getEnvironment(event->currentThread);
 
 	((MM_ConcurrentGC *)userData)->oldToOldReferenceCreated(env, static_cast<omrobjectptr_t>(event->objectPtr));
 }
@@ -513,7 +514,7 @@ void
 MM_ConcurrentGC::hookCardCleanPass2Start(J9HookInterface** hook, uintptr_t eventNum, void* eventData, void* userData)
 {
 	MM_CardCleanPass2StartEvent* event = (MM_CardCleanPass2StartEvent *)eventData;
-	MM_EnvironmentStandard *env = MM_EnvironmentStandard::getEnvironment(event->currentThread);
+	MM_EnvironmentBase *env = MM_EnvironmentBase::getEnvironment(event->currentThread);
 
 	((MM_ConcurrentGC *)userData)->recordCardCleanPass2Start(env);
 
@@ -530,7 +531,7 @@ void
 MM_ConcurrentGC::signalThreadsToDirtyCardsAsyncEventHandler(OMR_VMThread *omrVMThread, void *userData)
 {
 	MM_ConcurrentGC *collector  = (MM_ConcurrentGC *)userData;
-	MM_EnvironmentStandard *env = MM_EnvironmentStandard::getEnvironment(omrVMThread);
+	MM_EnvironmentBase *env = MM_EnvironmentBase::getEnvironment(omrVMThread);
 
 	collector->signalThreadsToDirtyCards(env);
 }
@@ -541,11 +542,11 @@ MM_ConcurrentGC::signalThreadsToDirtyCardsAsyncEventHandler(OMR_VMThread *omrVMT
  * @return Reference to new MM_COncurrentGC object or NULL
  */
 MM_ConcurrentGC *
-MM_ConcurrentGC::newInstance(MM_EnvironmentBase *env, MM_CollectorLanguageInterface *cli)
+MM_ConcurrentGC::newInstance(MM_EnvironmentBase *env)
 {
 	MM_ConcurrentGC *concurrentGC = (MM_ConcurrentGC *)env->getForge()->allocate(sizeof(MM_ConcurrentGC), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL != concurrentGC) {
-		new(concurrentGC) MM_ConcurrentGC(env, cli);
+		new(concurrentGC) MM_ConcurrentGC(env);
 		if (!concurrentGC->initialize(env)) {
 			concurrentGC->kill(env);
 			concurrentGC = NULL;
@@ -562,9 +563,8 @@ MM_ConcurrentGC::newInstance(MM_EnvironmentBase *env, MM_CollectorLanguageInterf
 void
 MM_ConcurrentGC::kill(MM_EnvironmentBase *env)
 {
-	MM_EnvironmentStandard *envStandard = MM_EnvironmentStandard::getEnvironment(env);
-	tearDown(envStandard);
-	envStandard->getForge()->free(this);
+	tearDown(env);
+	env->getForge()->free(this);
 }
 
 /**
@@ -585,12 +585,16 @@ MM_ConcurrentGC::initialize(MM_EnvironmentBase *env)
 		goto error_no_memory;
 	}
 
+	if (!_concurrentDelegate.initialize(env, this)) {
+		goto error_no_memory;
+	}
+
 	if(!createCardTable(env)) {
 		goto error_no_memory;
 	}
 
 	if (_extensions->optimizeConcurrentWB) {
-		_callback = env->getExtensions()->collectorLanguageInterface->concurrentGC_createSafepointCallback(env);
+		_callback = _concurrentDelegate.createSafepointCallback(env);
 		if (NULL == _callback) {
 			goto error_no_memory;
 		}
@@ -825,7 +829,7 @@ MM_ConcurrentGC::interpolateInRange(float val1, float val8, float val10, uintptr
  * collectable. All associated cards in card table will be set to clean (0x00).
  */
 void
-MM_ConcurrentGC::determineInitWork(MM_EnvironmentStandard *env)
+MM_ConcurrentGC::determineInitWork(MM_EnvironmentBase *env)
 {
 	bool initDone= false;
 	uintptr_t initWork;
@@ -917,7 +921,7 @@ MM_ConcurrentGC::determineInitWork(MM_EnvironmentStandard *env)
 		}
 	}
 
-	_stats->setInitWorkRequired(initWork);
+	_stats.setInitWorkRequired(initWork);
 	_rebuildInitWork = false;
 
 	Trc_MM_ConcurrentGC_determineInitWork_Exit(env->getLanguageVMThread());
@@ -929,7 +933,7 @@ MM_ConcurrentGC::determineInitWork(MM_EnvironmentStandard *env)
  * i.e reset "current" to "base" for all ranges.
  */
 void
-MM_ConcurrentGC::resetInitRangesForConcurrentKO(MM_EnvironmentStandard *env)
+MM_ConcurrentGC::resetInitRangesForConcurrentKO()
 {
 	for (uint32_t i=0; i < _numInitRanges; i++) {
 		_initRanges[i].current= _initRanges[i].base;
@@ -947,7 +951,7 @@ MM_ConcurrentGC::resetInitRangesForConcurrentKO(MM_EnvironmentStandard *env)
  * the concurrent mark cycle but we must do so during a full collection.
  */
 void
-MM_ConcurrentGC::resetInitRangesForSTW(MM_EnvironmentStandard *env)
+MM_ConcurrentGC::resetInitRangesForSTW()
 {
 	for (uint32_t i=0; i < _numInitRanges; i++) {
 		if (MARK_BITS  == _initRanges[i].type && (!((_initRanges[i].subspace)->isConcurrentCollectable())) ) {
@@ -976,7 +980,7 @@ MM_ConcurrentGC::resetInitRangesForSTW(MM_EnvironmentStandard *env)
  * @return TRUE if work left to be done, FALSE otherwise.
  */
 bool
-MM_ConcurrentGC::getInitRange(MM_EnvironmentStandard *env, void **from, void **to, InitType *type, bool *concurrentCollectable )
+MM_ConcurrentGC::getInitRange(MM_EnvironmentBase *env, void **from, void **to, InitType *type, bool *concurrentCollectable )
 {
     uint32_t i;
     void *localTo,*localFrom;
@@ -1039,7 +1043,7 @@ MM_ConcurrentGC::getInitRange(MM_EnvironmentStandard *env, void **from, void **t
  * @return TRUIE if we are past the peak; FALSE otherwise
  */
 bool
-MM_ConcurrentGC::tracingRateDropped(MM_EnvironmentStandard *env)
+MM_ConcurrentGC::tracingRateDropped(MM_EnvironmentBase *env)
 {
 	// Always return false for now until we understand how to fix this code to ensure
 	// we do not prematurely report that the rate has dropped and so start card cleaning
@@ -1094,7 +1098,7 @@ MM_ConcurrentGC::getConHelperRequest(MM_EnvironmentBase *env)
 void
 MM_ConcurrentGC::conHelperEntryPoint(OMR_VMThread *omrThread, uintptr_t slaveID)
 {
-	MM_EnvironmentStandard *env = MM_EnvironmentStandard::getEnvironment(omrThread);
+	MM_EnvironmentBase *env = MM_EnvironmentBase::getEnvironment(omrThread);
 	ConHelperRequest request = CONCURRENT_HELPER_WAIT;
 	uintptr_t sizeTraced = 0;
 	uintptr_t totalScanned = 0;
@@ -1122,7 +1126,7 @@ MM_ConcurrentGC::conHelperEntryPoint(OMR_VMThread *omrThread, uintptr_t slaveID)
 			env->releaseVMAccess();
 			continue;
 		}
-		Assert_GC_true_with_message(env, CONCURRENT_OFF != _stats->getExecutionMode(), "MM_ConcurrentStats::_executionMode = %zu\n", _stats->getExecutionMode());
+		Assert_GC_true_with_message(env, CONCURRENT_OFF != _stats.getExecutionMode(), "MM_ConcurrentStats::_executionMode = %zu\n", _stats.getExecutionMode());
 
 		sizeTraced = 0;
 		totalScanned = 0;
@@ -1138,7 +1142,7 @@ MM_ConcurrentGC::conHelperEntryPoint(OMR_VMThread *omrThread, uintptr_t slaveID)
 				&& spinLimiter.spin()) {
 			sizeTraced = localMark(env, sizeToTrace);
 			if (sizeTraced > 0 ) {
-				_stats->incConHelperTraceSizeCount(sizeTraced);
+				_stats.incConHelperTraceSizeCount(sizeTraced);
 				totalScanned += sizeTraced;
 				spinLimiter.reset();
 			}
@@ -1149,13 +1153,13 @@ MM_ConcurrentGC::conHelperEntryPoint(OMR_VMThread *omrThread, uintptr_t slaveID)
 
 		/* clean cards */
 		while ((CONCURRENT_HELPER_MARK == request)
-				&& (CONCURRENT_CLEAN_TRACE == _stats->getExecutionMode())
+				&& (CONCURRENT_CLEAN_TRACE == _stats.getExecutionMode())
 				&& _cardTable->isCardCleaningStarted()
 				&& !_cardTable->isCardCleaningComplete()
 				&& spinLimiter.spin()) {
 			if (cleanCards(env, false, _conHelperCleanSize, &sizeTraced, false)) {
 				if (sizeTraced > 0 ) {
-					_stats->incConHelperCardCleanCount(sizeTraced);
+					_stats.incConHelperCardCleanCount(sizeTraced);
 					totalScanned += sizeTraced;
 					spinLimiter.reset();
 				}
@@ -1310,7 +1314,7 @@ MM_ConcurrentGC::shutdownConHelperThreads(MM_GCExtensionsBase *extensions)
  *
  */
 void
-MM_ConcurrentGC::resumeConHelperThreads(MM_EnvironmentStandard *env)
+MM_ConcurrentGC::resumeConHelperThreads(MM_EnvironmentBase *env)
 {
 	if (_conHelpersStarted > 0) {
 		omrthread_monitor_enter(_conHelpersActivationMonitor);
@@ -1330,7 +1334,7 @@ MM_ConcurrentGC::resumeConHelperThreads(MM_EnvironmentStandard *env)
  * card cleaning) will need to be performed during the next concurrent mark cycle.
  */
 void
-MM_ConcurrentGC::tuneToHeap(MM_EnvironmentStandard *env)
+MM_ConcurrentGC::tuneToHeap(MM_EnvironmentBase *env)
 {
 	MM_Heap *heap = (MM_Heap *)_extensions->heap;
 	uintptr_t heapSize = heap->getActiveMemorySize(MEMORY_TYPE_OLD);
@@ -1360,7 +1364,7 @@ MM_ConcurrentGC::tuneToHeap(MM_EnvironmentStandard *env)
 	 *
 	 * Note: Heap can change in size outside a global GC and after a system GC.
 	 */
-	if(0 == _stats->getKickoffThreshold() || _retuneAfterHeapResize ) {
+	if(0 == _stats.getKickoffThreshold() || _retuneAfterHeapResize ) {
 		totalBytesToTrace = (uintptr_t)(heapSize * _tenureLiveObjectFactor * _tenureNonLeafObjectFactor);
 		_bytesToTracePass1 = (uintptr_t)((float)totalBytesToTrace * _bytesTracedInPass1Factor);
 		_bytesToTracePass2 = MM_Math::saturatingSubtract(totalBytesToTrace, _bytesToTracePass1);
@@ -1371,10 +1375,10 @@ MM_ConcurrentGC::tuneToHeap(MM_EnvironmentStandard *env)
 		/* Re-tune based on actual amount traced if we completed tracing on last cycle */
 		if ((NULL == env->_cycleState) || env->_cycleState->_gcCode.isExplicitGC() || !_globalCollectionInProgress) {
 			/* Nothing to do - we can't update statistics on a system GC or when no cycle is running */
-		} else if (CONCURRENT_EXHAUSTED <= _stats->getExecutionModeAtGC()) {
+		} else if (CONCURRENT_EXHAUSTED <= _stats.getExecutionModeAtGC()) {
 
-			uintptr_t totalTraced = _stats->getTraceSizeCount() + _stats->getConHelperTraceSizeCount();
-			uintptr_t totalCleaned = _stats->getCardCleanCount() + _stats->getConHelperCardCleanCount();
+			uintptr_t totalTraced = _stats.getTraceSizeCount() + _stats.getConHelperTraceSizeCount();
+			uintptr_t totalCleaned = _stats.getCardCleanCount() + _stats.getConHelperCardCleanCount();
 
 			if (_secondCardCleanPass) {
 				assume0(_totalCleanedAtPass2KO != HIGH_VALUES);
@@ -1394,19 +1398,19 @@ MM_ConcurrentGC::tuneToHeap(MM_EnvironmentStandard *env)
 				_bytesToCleanPass2 = 0;
 
 			}
-		} else if (_stats->getExecutionModeAtGC() == CONCURRENT_CLEAN_TRACE) {
+		} else if (_stats.getExecutionModeAtGC() == CONCURRENT_CLEAN_TRACE) {
 			/* Assume amount to be traced on next cycle will what we traced this time PLUS
 			 * the tracing we did to complete processing of any work packets that remained at
 			 * the start of the collection PLUS tracing done during final card cleaning.
 			 * This is an over estimate but will get us back on track.
 			 */
-			 totalBytesToTrace = _stats->getTraceSizeCount() +
-			 					 _stats->getConHelperTraceSizeCount() +
-			 					 _stats->getCompleteTracingCount() +
-			 					 _stats->getFinalTraceCount();
-			 totalBytesToClean = _stats->getCardCleanCount() +
-			 					 _stats->getConHelperCardCleanCount() +
-			 					 _stats->getFinalCardCleanCount();
+			 totalBytesToTrace = _stats.getTraceSizeCount() +
+			 					 _stats.getConHelperTraceSizeCount() +
+			 					 _stats.getCompleteTracingCount() +
+			 					 _stats.getFinalTraceCount();
+			 totalBytesToClean = _stats.getCardCleanCount() +
+			 					 _stats.getConHelperCardCleanCount() +
+			 					 _stats.getFinalCardCleanCount();
 
 			if (_secondCardCleanPass) {
 				float pass1Ratio = _cardCleaningFactorPass2 > 0 ? (_cardCleaningFactorPass1 / (_cardCleaningFactorPass1 + _cardCleaningFactorPass2)) : 1;
@@ -1439,7 +1443,7 @@ MM_ConcurrentGC::tuneToHeap(MM_EnvironmentStandard *env)
 		determineInitWork(env);
 	} else {
 		/* ..else just reset for next cycle */
-		resetInitRangesForConcurrentKO(env);
+		resetInitRangesForConcurrentKO();
 	}
 
 	/* Reset trace rate for next concurrent cycle */
@@ -1451,13 +1455,13 @@ MM_ConcurrentGC::tuneToHeap(MM_EnvironmentStandard *env)
 	 */
 	_traceTargetPass1 = _bytesToTracePass1 + _bytesToCleanPass1;
 	_traceTargetPass2 = _bytesToTracePass2 + _bytesToCleanPass2;
-	_stats->setTraceSizeTarget(_traceTargetPass1 + _traceTargetPass2);
+	_stats.setTraceSizeTarget(_traceTargetPass1 + _traceTargetPass2);
 
 	/* Calculate the KO point for concurrent. As we trace at different rates during the
 	 * initialization and marking phases we need to allow for that when calculating
 	 * the KO point.
 	 */
-	kickoffThreshold = (_stats->getInitWorkRequired() / _allocToInitRate) +
+	kickoffThreshold = (_stats.getInitWorkRequired() / _allocToInitRate) +
 					   (_traceTargetPass1 / _allocToTraceRateNormal) +
 					   (_traceTargetPass2 / (_allocToTraceRateNormal * _allocToTraceRateCardCleanPass2Boost));
 
@@ -1485,8 +1489,8 @@ MM_ConcurrentGC::tuneToHeap(MM_EnvironmentStandard *env)
 	float cardCleaningProportion = (float)cardCleaningThreshold / (float)kickoffThreshold;
 
 	kickoffThresholdPlusBuffer = (uintptr_t)((float)kickoffThreshold + boost + ((float)_extensions->concurrentSlack * kickoffProportion));
-	_stats->setKickoffThreshold(kickoffThresholdPlusBuffer);
-	_stats->setCardCleaningThreshold((uintptr_t)((float)cardCleaningThreshold + boost + ((float)_extensions->concurrentSlack * cardCleaningProportion)));
+	_stats.setKickoffThreshold(kickoffThresholdPlusBuffer);
+	_stats.setCardCleaningThreshold((uintptr_t)((float)cardCleaningThreshold + boost + ((float)_extensions->concurrentSlack * cardCleaningProportion)));
 	_kickoffThresholdBuffer = MM_Math::saturatingSubtract(kickoffThresholdPlusBuffer, kickoffThreshold);
 
 	if (_extensions->debugConcurrentMark) {
@@ -1496,17 +1500,17 @@ MM_ConcurrentGC::tuneToHeap(MM_EnvironmentStandard *env)
 		omrtty_printf("               Trace target Pass 2=\"%zu\" (Trace=\"%zu\" Clean=\"%zu\")\n",
 							_traceTargetPass2, _bytesToTracePass2, _bytesToCleanPass2);
 		omrtty_printf("               KO threshold=\"%zu\" KO threshold buffer=\"%zu\"\n",
-							 _stats->getKickoffThreshold(), _kickoffThresholdBuffer);
+							 _stats.getKickoffThreshold(), _kickoffThresholdBuffer);
 		omrtty_printf("               Card Cleaning Threshold=\"%zu\" \n",
-							_stats->getCardCleaningThreshold());
+							_stats.getCardCleaningThreshold());
 		omrtty_printf("               Init Work Required=\"%zu\" \n",
-							_stats->getInitWorkRequired());							
+							_stats.getInitWorkRequired());
 	}
 
 	_initSetupDone = false;
 
 	/* Reset all ConcurrentStats for next cycle */
-	_stats->reset();
+	_stats.reset();
 
 	_totalTracedAtPass2KO = HIGH_VALUES;
 	_totalCleanedAtPass2KO = HIGH_VALUES;
@@ -1519,7 +1523,7 @@ MM_ConcurrentGC::tuneToHeap(MM_EnvironmentStandard *env)
     _lastFreeSize = LAST_FREE_SIZE_NEEDS_INITIALIZING;
 	_lastTotalTraced = 0;
 
-	Trc_MM_ConcurrentGC_tuneToHeap_Exit2(env->getLanguageVMThread(), _stats->getTraceSizeTarget(), _stats->getInitWorkRequired(), _stats->getKickoffThreshold());
+	Trc_MM_ConcurrentGC_tuneToHeap_Exit2(env->getLanguageVMThread(), _stats.getTraceSizeTarget(), _stats.getInitWorkRequired(), _stats.getKickoffThreshold());
 }
 
 /**
@@ -1529,7 +1533,7 @@ MM_ConcurrentGC::tuneToHeap(MM_EnvironmentStandard *env)
  * ate is adjusted accordingly on subsequent allocations.
  */
 void
-MM_ConcurrentGC::adjustTraceTarget(MM_EnvironmentStandard *env)
+MM_ConcurrentGC::adjustTraceTarget()
 {
 	uintptr_t newTraceTarget, totalBytesToTrace;
 	MM_Heap *heap = (MM_Heap *)_extensions->heap;
@@ -1544,7 +1548,7 @@ MM_ConcurrentGC::adjustTraceTarget(MM_EnvironmentStandard *env)
 
 	/* Calculate new trace target */
 	newTraceTarget = _bytesToTracePass1 + _bytesToTracePass2 + _bytesToCleanPass1 + _bytesToCleanPass2;
-	_stats->setTraceSizeTarget(newTraceTarget);
+	_stats.setTraceSizeTarget(newTraceTarget);
 }
 
 /**
@@ -1563,7 +1567,7 @@ MM_ConcurrentGC::updateTuningStatistics(MM_EnvironmentBase *env)
 {
 	/* Dont update statistics if its a system GC or we aborted a concurrent collection cycle
 	 */
-    if (env->_cycleState->_gcCode.isExplicitGC() || (CONCURRENT_TRACE_ONLY > _stats->getExecutionModeAtGC())) {
+    if (env->_cycleState->_gcCode.isExplicitGC() || (CONCURRENT_TRACE_ONLY > _stats.getExecutionModeAtGC())) {
         return;
     } else {
 		/* Get current heap size and free bytes */
@@ -1590,20 +1594,20 @@ MM_ConcurrentGC::updateTuningStatistics(MM_EnvironmentBase *env)
 		 * how much we actually traced and the amount of live bytes
 		 * found by collector
 		*/
-		bytesTraced = _stats->getTraceSizeCount() + _stats->getConHelperTraceSizeCount();
+		bytesTraced = _stats.getTraceSizeCount() + _stats.getConHelperTraceSizeCount();
 
 		/* If we did not complete mark add in those we missed. This will be an over estimate
 		 * but will get us back on track
 		 */
-		if (CONCURRENT_EXHAUSTED > _stats->getExecutionModeAtGC()) {
-			bytesTraced += _stats->getFinalTraceCount();
+		if (CONCURRENT_EXHAUSTED > _stats.getExecutionModeAtGC()) {
+			bytesTraced += _stats.getFinalTraceCount();
 		}
 
 		newNonLeafObjectFactor = (float)bytesTraced / (float)totalLiveObjects;
 		_tenureNonLeafObjectFactor = MM_Math::weightedAverage(_tenureNonLeafObjectFactor, newNonLeafObjectFactor, NON_LEAF_HISTORY_WEIGHT);
 
 		/* Recalculate _cardCleaningFactor depending on status */
-		uintptr_t executionModeAtGC = _stats->getExecutionModeAtGC();
+		uintptr_t executionModeAtGC = _stats.getExecutionModeAtGC();
 		switch (executionModeAtGC) {
 		/* Don't change values if concurrent not started */
 		case CONCURRENT_OFF:
@@ -1623,8 +1627,8 @@ MM_ConcurrentGC::updateTuningStatistics(MM_EnvironmentBase *env)
 		case CONCURRENT_EXHAUSTED:
 		case CONCURRENT_FINAL_COLLECTION:
 
-			totalTraced = _stats->getTraceSizeCount() + _stats->getConHelperTraceSizeCount();
-			totalCleaned = _stats->getCardCleanCount() + _stats->getConHelperCardCleanCount();
+			totalTraced = _stats.getTraceSizeCount() + _stats.getConHelperTraceSizeCount();
+			totalCleaned = _stats.getCardCleanCount() + _stats.getConHelperCardCleanCount();
 
 			if (_secondCardCleanPass) {
 				assume0(_totalTracedAtPass2KO != HIGH_VALUES && _totalCleanedAtPass2KO != HIGH_VALUES);
@@ -1704,7 +1708,7 @@ MM_ConcurrentGC::updateTuningStatistics(MM_EnvironmentBase *env)
  * @return the allocation tax
  */
 uintptr_t
-MM_ConcurrentGC::calculateInitSize(MM_EnvironmentStandard *env, uintptr_t allocationSize)
+MM_ConcurrentGC::calculateInitSize(MM_EnvironmentBase *env, uintptr_t allocationSize)
 {
 	/* During initialization we boost the target trace rate in order to complete init ASAP */
 	return allocationSize * _allocToInitRate;
@@ -1718,7 +1722,7 @@ MM_ConcurrentGC::calculateInitSize(MM_EnvironmentStandard *env, uintptr_t alloca
  * @return the allocation tax
  */
 uintptr_t
-MM_ConcurrentGC::calculateTraceSize(MM_EnvironmentStandard *env, MM_AllocateDescription *allocDescription)
+MM_ConcurrentGC::calculateTraceSize(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription)
 {
 	float thisTraceRate;
 	uintptr_t sizeToTrace, remainingFree, workCompleteSoFar, traceTarget;
@@ -1755,8 +1759,8 @@ MM_ConcurrentGC::calculateTraceSize(MM_EnvironmentStandard *env, MM_AllocateDesc
 	/* Calculate the size to trace for this alloc based on the
 	 * trace target and how much work has been already completed.
 	 */
-	workCompleteSoFar = (_stats->getTraceSizeCount() + _stats->getCardCleanCount() +
-						 _stats->getConHelperTraceSizeCount() + _stats->getConHelperCardCleanCount());
+	workCompleteSoFar = (_stats.getTraceSizeCount() + _stats.getCardCleanCount() +
+						 _stats.getConHelperTraceSizeCount() + _stats.getConHelperCardCleanCount());
 
 	/* Calculate how much work we need to get through */
 	traceTarget = _pass2Started ? _traceTargetPass1 + _traceTargetPass2 : _traceTargetPass1;
@@ -1823,7 +1827,7 @@ MM_ConcurrentGC::calculateTraceSize(MM_EnvironmentStandard *env, MM_AllocateDesc
  * @return TRUE if its time for periodical tuning; FALSE otherwise
  */
 bool
-MM_ConcurrentGC::periodicalTuningNeeded(MM_EnvironmentStandard *env, uintptr_t freeSize)
+MM_ConcurrentGC::periodicalTuningNeeded(MM_EnvironmentBase *env, uintptr_t freeSize)
 {
 	/* Is it time to update statistics. If _lastFreeSize <= freeSize another thread
 	 * has already updated statistics for this interval
@@ -1847,7 +1851,7 @@ MM_ConcurrentGC::periodicalTuningNeeded(MM_EnvironmentStandard *env, uintptr_t f
  * @return  Number of bytes available for allocation before old area is exhausted
  */
 MMINLINE uintptr_t
-MM_ConcurrentGC::potentialFreeSpace(MM_EnvironmentStandard *env, MM_AllocateDescription *allocDescription)
+MM_ConcurrentGC::potentialFreeSpace(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription)
 {
 		uintptr_t nurseryPromotion, nurseryInitialFree, currentOldFree, currentNurseryFree;
 		MM_MemorySpace *memorySpace = env->getExtensions()->heap->getDefaultMemorySpace();
@@ -1893,7 +1897,7 @@ MM_ConcurrentGC::potentialFreeSpace(MM_EnvironmentStandard *env, MM_AllocateDesc
 		uintptr_t scavengesRemaining;
 		if (scavengerStats->_nextScavengeWillPercolate) {
 			scavengesRemaining = 0;
-			_stats->setKickoffReason(NEXT_SCAVENGE_WILL_PERCOLATE);
+			_stats.setKickoffReason(NEXT_SCAVENGE_WILL_PERCOLATE);
 			_languageKickoffReason = NO_LANGUAGE_KICKOFF_REASON;
 		} else {
 			scavengesRemaining =  (uintptr_t)(currentOldFree/nurseryPromotion);
@@ -1940,7 +1944,7 @@ MM_ConcurrentGC::potentialFreeSpace(MM_EnvironmentStandard *env, MM_AllocateDesc
  * @param  freeSize the current amount of free space in the old area
  */
 void
-MM_ConcurrentGC::periodicalTuning(MM_EnvironmentStandard *env, uintptr_t freeSize)
+MM_ConcurrentGC::periodicalTuning(MM_EnvironmentBase *env, uintptr_t freeSize)
 {
 	float newConHelperRate;
 
@@ -1965,12 +1969,12 @@ MM_ConcurrentGC::periodicalTuning(MM_EnvironmentStandard *env, uintptr_t freeSiz
         /* This thread first to update for this interval so calculate
          * total traced so far
          */
-		uintptr_t totalTraced = _stats->getTraceSizeCount() + _stats->getCardCleanCount();
+		uintptr_t totalTraced = _stats.getTraceSizeCount() + _stats.getCardCleanCount();
 		uintptr_t freeSpaceUsed = _lastFreeSize - freeSize;
 
 		/* Update concurrent helper trace rate if we have any */
 		if (_conHelpersStarted > 0) {
-			uintptr_t conTraced = _stats->getConHelperTraceSizeCount() +  _stats->getConHelperCardCleanCount();
+			uintptr_t conTraced = _stats.getConHelperTraceSizeCount() +  _stats.getConHelperCardCleanCount();
 			newConHelperRate =  (float)(conTraced - _lastConHelperTraceSizeCount) / (float) (freeSpaceUsed);
 			_lastConHelperTraceSizeCount = conTraced;
 			_alloc2ConHelperTraceRate = MM_Math::weightedAverage(_alloc2ConHelperTraceRate,
@@ -2001,12 +2005,12 @@ MM_ConcurrentGC::periodicalTuning(MM_EnvironmentStandard *env, uintptr_t freeSiz
  *
  */
 void
-MM_ConcurrentGC::kickoffCardCleaning(MM_EnvironmentStandard *env, ConcurrentCardCleaningReason reason)
+MM_ConcurrentGC::kickoffCardCleaning(MM_EnvironmentBase *env, ConcurrentCardCleaningReason reason)
 {
 	/* Switch to CONCURRENT_CLEAN_TRACE...if we fail someone beat us to it */
-	if (_stats->switchExecutionMode(CONCURRENT_TRACE_ONLY, CONCURRENT_CLEAN_TRACE)) {
-		_stats->setCardCleaningReason(reason);
-		_cli->concurrentGC_kickoffCardCleaning(env);
+	if (_stats.switchExecutionMode(CONCURRENT_TRACE_ONLY, CONCURRENT_CLEAN_TRACE)) {
+		_stats.setCardCleaningReason(reason);
+		_concurrentDelegate.cardCleaningStarted(env);
 	}
 }
 
@@ -2035,11 +2039,10 @@ MM_ConcurrentGC::replenishPoolForAllocate(MM_EnvironmentBase *env, MM_MemoryPool
 void
 MM_ConcurrentGC::payAllocationTax(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace,	MM_MemorySubSpace *baseSubSpace, MM_AllocateDescription *allocDescription)
 {
-	MM_EnvironmentStandard *envStandard = MM_EnvironmentStandard::getEnvironment(env);
-
 	/* Allocation size must be greater than zero */
 	assume0(allocDescription->getAllocationTaxSize() >  0);
-	Assert_MM_true(_cli->concurrentGC_isThreadReferenceBufferEmpty(env));
+	/* Thread roots must have been flushed by this point */
+	Assert_MM_true(!_concurrentDelegate.flushThreadRoots(env));
 
 #if defined(OMR_GC_LARGE_OBJECT_AREA)
 	/* Do we need to tax this allocation ? */
@@ -2051,12 +2054,12 @@ MM_ConcurrentGC::payAllocationTax(MM_EnvironmentBase *env, MM_MemorySubSpace *su
 #endif /* OMR_GC_LARGE_OBJECT_AREA */
 
 	/* Check if its time to KO */
-	if (CONCURRENT_OFF == _stats->getExecutionMode()) {
-		if (!timeToKickoffConcurrent(envStandard, allocDescription)) {
+	if (CONCURRENT_OFF == _stats.getExecutionMode()) {
+		if (!timeToKickoffConcurrent(env, allocDescription)) {
 #if defined(OMR_GC_CONCURRENT_SWEEP)
 			/* Try to do some concurrent sweeping */
 			if(_extensions->concurrentSweep) {
-				concurrentSweep(MM_EnvironmentStandard::getEnvironment(envStandard), baseSubSpace, allocDescription);
+				concurrentSweep(env, baseSubSpace, allocDescription);
 			}
 #endif /* OMR_GC_CONCURRENT_SWEEP */
 			return;
@@ -2064,8 +2067,9 @@ MM_ConcurrentGC::payAllocationTax(MM_EnvironmentBase *env, MM_MemorySubSpace *su
 	}
 
 	/* Concurrent marking is active */
-	concurrentMark(envStandard, subspace, allocDescription);
-	Assert_MM_true(_cli->concurrentGC_isThreadReferenceBufferEmpty(env));
+	concurrentMark(env, subspace, allocDescription);
+	/* Thread roots must have been flushed by this point */
+	Assert_MM_true(!_concurrentDelegate.flushThreadRoots(env));
 }
 
 /**
@@ -2077,7 +2081,7 @@ MM_ConcurrentGC::payAllocationTax(MM_EnvironmentBase *env, MM_MemorySubSpace *su
  * @note This is a potential GC point.
  */
 void
-MM_ConcurrentGC::concurrentMark(MM_EnvironmentStandard *env, MM_MemorySubSpace *subspace, MM_AllocateDescription *allocDescription)
+MM_ConcurrentGC::concurrentMark(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace, MM_AllocateDescription *allocDescription)
 {
 	uintptr_t oldVMstate = env->pushVMstate(J9VMSTATE_GC_CONCURRENT_MARK_TRACE);
 
@@ -2089,7 +2093,7 @@ MM_ConcurrentGC::concurrentMark(MM_EnvironmentStandard *env, MM_MemorySubSpace *
 	assume0(allocationSize > 0);
 	/* .. we must not mark anything if WB not yet active */
 #if 0	/* TODO 90354: Find a way to reestablish this assertion */
-	Assert_MM_true((_stats->getExecutionMode() < CONCURRENT_ROOT_TRACING1) || (((J9VMThread *)env->getLanguageVMThread())->privateFlags & J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE));
+	Assert_MM_true((_stats.getExecutionMode() < CONCURRENT_ROOT_TRACING1) || (((J9VMThread *)env->getLanguageVMThread())->privateFlags & J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE));
 #endif
 
 	/* Boost priority of thread whilst we are paying our tax; dont want low priority
@@ -2104,6 +2108,7 @@ MM_ConcurrentGC::concurrentMark(MM_EnvironmentStandard *env, MM_MemorySubSpace *
 	uintptr_t sizeToTrace = 0;
 	bool taxPaid = false;
 
+	env->_workStack.prepareForWork(env, _markingScheme->getWorkPackets());
 	while (!taxPaid) {
 
 		/* If another thread is waiting for exclusive VM access, possibly
@@ -2115,7 +2120,7 @@ MM_ConcurrentGC::concurrentMark(MM_EnvironmentStandard *env, MM_MemorySubSpace *
 		}
 
 		uintptr_t nextExecutionMode = CONCURRENT_TRACE_ONLY;
-		uintptr_t executionMode = _stats->getExecutionMode();
+		uintptr_t executionMode = _stats.getExecutionMode();
 		switch (executionMode) {
 		case CONCURRENT_OFF:
 			taxPaid = true;
@@ -2155,7 +2160,7 @@ MM_ConcurrentGC::concurrentMark(MM_EnvironmentStandard *env, MM_MemorySubSpace *
 				}
 			} else {
 				/* TODO: Once optimizeConcurrentWB enabled by default this code will be deleted */
-				_stats->switchExecutionMode(CONCURRENT_INIT_COMPLETE, CONCURRENT_ROOT_TRACING);
+				_stats.switchExecutionMode(CONCURRENT_INIT_COMPLETE, CONCURRENT_ROOT_TRACING);
 			}
 			break;
 
@@ -2178,11 +2183,11 @@ MM_ConcurrentGC::concurrentMark(MM_EnvironmentStandard *env, MM_MemorySubSpace *
 			break;
 
 		case CONCURRENT_ROOT_TRACING:
-			nextExecutionMode = _cli->concurrentGC_getNextTracingMode(CONCURRENT_ROOT_TRACING);
-			Assert_GC_true_with_message(env, (CONCURRENT_ROOT_TRACING < nextExecutionMode) || (CONCURRENT_TRACE_ONLY == nextExecutionMode), "_cli->concurrentGC_getNextTracingMode(CONCURRENT_ROOT_TRACING) = %zu\n", nextExecutionMode);
-			if(_stats->switchExecutionMode(CONCURRENT_ROOT_TRACING, nextExecutionMode)) {
+			nextExecutionMode = _concurrentDelegate.getNextTracingMode(CONCURRENT_ROOT_TRACING);
+			Assert_GC_true_with_message(env, (CONCURRENT_ROOT_TRACING < nextExecutionMode) || (CONCURRENT_TRACE_ONLY == nextExecutionMode), "MM_ConcurrentMarkingDelegate::getNextTracingMode(CONCURRENT_ROOT_TRACING) = %zu\n", nextExecutionMode);
+			if(_stats.switchExecutionMode(CONCURRENT_ROOT_TRACING, nextExecutionMode)) {
 				/* Signal threads for async callback to scan stack*/
-				_cli->concurrentGC_signalThreadsToTraceStacks(env);
+				_concurrentDelegate.signalThreadsToTraceStacks(env);
 				taxPaid = true;
 			}
 			break;
@@ -2190,12 +2195,12 @@ MM_ConcurrentGC::concurrentMark(MM_EnvironmentStandard *env, MM_MemorySubSpace *
 		default:
 			/* Client language defines 1 or more execution modes with values > CONCURRENT_ROOT_TRACING */
 			Assert_GC_true_with_message(env, (CONCURRENT_ROOT_TRACING < executionMode) && (CONCURRENT_TRACE_ONLY > executionMode), "MM_ConcurrentStats::_executionMode = %zu\n", executionMode);
-			nextExecutionMode = _cli->concurrentGC_getNextTracingMode(executionMode);
-			if (_stats->switchExecutionMode(executionMode, nextExecutionMode)) {
-				Assert_GC_true_with_message2(env, (CONCURRENT_ROOT_TRACING < nextExecutionMode) && (CONCURRENT_TRACE_ONLY >= nextExecutionMode), "MM_ConcurrentStats::_executionMode = %zu; _cli->concurrentGC_getNextTracingMode(MM_ConcurrentStats::_executionMode) = %zu\n", executionMode, nextExecutionMode);
+			nextExecutionMode = _concurrentDelegate.getNextTracingMode(executionMode);
+			if (_stats.switchExecutionMode(executionMode, nextExecutionMode)) {
+				Assert_GC_true_with_message2(env, (CONCURRENT_ROOT_TRACING < nextExecutionMode) && (CONCURRENT_TRACE_ONLY >= nextExecutionMode), "MM_ConcurrentStats::_executionMode = %zu; MM_ConcurrentMarkingDelegate::getNextTracingMode(MM_ConcurrentStats::_executionMode) = %zu\n", executionMode, nextExecutionMode);
 				/* Collect some roots */
 				bool collectedRoots = false;
-				_cli->concurrentGC_collectRoots(env, executionMode, &collectedRoots, &taxPaid);
+				_concurrentDelegate.collectRoots(env, executionMode, &collectedRoots, &taxPaid);
 				if (collectedRoots) {
 					/* Resume concurrent helper threads to help mark any roots we have found. Another
 					 * CONCURRENT_ROOT_TRACING thread may have beat us to it but if thread
@@ -2207,31 +2212,34 @@ MM_ConcurrentGC::concurrentMark(MM_EnvironmentStandard *env, MM_MemorySubSpace *
 					flushLocalBuffers(env);
 				}
 				if (CONCURRENT_TRACE_ONLY == nextExecutionMode) {
-					_stats->setModeComplete(CONCURRENT_ROOT_TRACING);
+					_stats.setModeComplete(CONCURRENT_ROOT_TRACING);
 				}
 			}
 			break;
 		}
 	} /* !taxPaid */
 
+	flushLocalBuffers(env);
+
 	if (_extensions->debugConcurrentMark) {
-		_stats->analyzeAllocationTax(sizeToTrace, sizeTraced);
+		_stats.analyzeAllocationTax(sizeToTrace, sizeTraced);
 	}
 
 	/* Reset priority of thread if we boosted it on entry */
 	if(priority < J9THREAD_PRIORITY_NORMAL) {
 		env->setPriority(priority);
 	}
+
 	env->popVMstate(oldVMstate);
 }
 
 void
-MM_ConcurrentGC::signalThreadsToDirtyCards(MM_EnvironmentStandard *env)
+MM_ConcurrentGC::signalThreadsToDirtyCards(MM_EnvironmentBase *env)
 {
 	uintptr_t gcCount = _extensions->globalGCStats.gcCount;
 
 	/* Things may have moved on since async callback requested */
-	while (CONCURRENT_INIT_COMPLETE == _stats->getExecutionMode()) {
+	while (CONCURRENT_INIT_COMPLETE == _stats.getExecutionMode()) {
 		/* We may or may not have exclusive access but another thread may have beat us to it and
 		 * prepared the threads or even collected.
 		 */
@@ -2243,8 +2251,8 @@ MM_ConcurrentGC::signalThreadsToDirtyCards(MM_EnvironmentStandard *env)
 			reportGCCycleStart(env);
 			env->_cycleState = previousCycleState;
 
-			_cli->concurrentGC_signalThreadsToDirtyCards(env);
-			_stats->switchExecutionMode(CONCURRENT_INIT_COMPLETE, CONCURRENT_ROOT_TRACING);
+			_concurrentDelegate.signalThreadsToDirtyCards(env);
+			_stats.switchExecutionMode(CONCURRENT_INIT_COMPLETE, CONCURRENT_ROOT_TRACING);
 			/* Cancel any outstanding call backs on other threads as this thread has done the necessary work */
 			_callback->cancelCallback(env);
 
@@ -2265,8 +2273,8 @@ MM_ConcurrentGC::signalThreadsToDirtyCards(MM_EnvironmentStandard *env)
 bool
 MM_ConcurrentGC::forceKickoff(MM_EnvironmentBase *env, MM_MemorySubSpace *subSpace, MM_AllocateDescription *allocDescription, uint32_t gcCode)
 {
-	if (_extensions->concurrentKickoffEnabled && _cli->concurrentGC_forceConcurrentKickoff(env, gcCode, &_languageKickoffReason)) {
-		_stats->setKickoffReason(LANGUAGE_DEFINED_REASON);
+	if (_extensions->concurrentKickoffEnabled && _concurrentDelegate.canForceConcurrentKickoff(env, gcCode, &_languageKickoffReason)) {
+		_stats.setKickoffReason(LANGUAGE_DEFINED_REASON);
 		_forcedKickoff = true;
 		return true;
 	} else {
@@ -2282,7 +2290,7 @@ MM_ConcurrentGC::forceKickoff(MM_EnvironmentBase *env, MM_MemorySubSpace *subSpa
  * @return TRUE if concurrent KO threshold reached; FALSE  otherwise
  */
 bool
-MM_ConcurrentGC::timeToKickoffConcurrent(MM_EnvironmentStandard *env, MM_AllocateDescription *allocDescription)
+MM_ConcurrentGC::timeToKickoffConcurrent(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription)
 {
 	uintptr_t remainingFree;
 
@@ -2315,16 +2323,16 @@ MM_ConcurrentGC::timeToKickoffConcurrent(MM_EnvironmentStandard *env, MM_Allocat
 		return false;
 	}
 
-	if ((remainingFree < _stats->getKickoffThreshold()) || _forcedKickoff) {
+	if ((remainingFree < _stats.getKickoffThreshold()) || _forcedKickoff) {
 #if defined(OMR_GC_CONCURRENT_SWEEP)
 		/* Finish off any sweep work that was still in progress */
 		completeConcurrentSweepForKickoff(env);
 #endif /* OMR_GC_CONCURRENT_SWEEP */
 
-		if(_stats->switchExecutionMode(CONCURRENT_OFF, CONCURRENT_INIT_RUNNING)) {
-			_stats->setRemainingFree(remainingFree);
+		if(_stats.switchExecutionMode(CONCURRENT_OFF, CONCURRENT_INIT_RUNNING)) {
+			_stats.setRemainingFree(remainingFree);
 			/* Set kickoff reason if it is not set yet */
-			_stats->setKickoffReason(KICKOFF_THRESHOLD_REACHED);
+			_stats.setKickoffReason(KICKOFF_THRESHOLD_REACHED);
 			_languageKickoffReason = NO_LANGUAGE_KICKOFF_REASON;
 			reportConcurrentKickoff(env);
 		}
@@ -2339,7 +2347,7 @@ MM_ConcurrentGC::timeToKickoffConcurrent(MM_EnvironmentStandard *env, MM_Allocat
  * Run a concurrent sweep as part of the current allocation tax.
  */
 void
-MM_ConcurrentGC::concurrentSweep(MM_EnvironmentStandard *env, MM_MemorySubSpace *subspace, MM_AllocateDescription *allocDescription)
+MM_ConcurrentGC::concurrentSweep(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace, MM_AllocateDescription *allocDescription)
 {
 	uintptr_t oldVMstate = env->pushVMstate(J9VMSTATE_GC_CONCURRENT_SWEEP);
 	((MM_ConcurrentSweepScheme *)_sweepScheme)->payAllocationTax(env, subspace, allocDescription);
@@ -2353,7 +2361,7 @@ MM_ConcurrentGC::concurrentSweep(MM_EnvironmentStandard *env, MM_MemorySubSpace 
  * @note Expects to have parallel helper threads available.
  */
 void
-MM_ConcurrentGC::completeConcurrentSweep(MM_EnvironmentStandard *env)
+MM_ConcurrentGC::completeConcurrentSweep(MM_EnvironmentBase *env)
 {
 	/* If concurrent sweep is not enabled, do nothing */
 	if(!_extensions->concurrentSweep) {
@@ -2374,7 +2382,7 @@ MM_ConcurrentGC::completeConcurrentSweep(MM_EnvironmentStandard *env)
  * Finish all concurrent sweep activities.
  */
 void
-MM_ConcurrentGC::completeConcurrentSweepForKickoff(MM_EnvironmentStandard *env)
+MM_ConcurrentGC::completeConcurrentSweepForKickoff(MM_EnvironmentBase *env)
 {
 	/* If concurrent sweep is not enabled, do nothing */
 	if(!_extensions->concurrentSweep) {
@@ -2397,7 +2405,7 @@ MM_ConcurrentGC::completeConcurrentSweepForKickoff(MM_EnvironmentStandard *env)
  * @return the amount of initialization work actually done
  */
 uintptr_t
-MM_ConcurrentGC::doConcurrentInitialization(MM_EnvironmentStandard *env, uintptr_t initToDo)
+MM_ConcurrentGC::doConcurrentInitialization(MM_EnvironmentBase *env, uintptr_t initToDo)
 {
 	uintptr_t initDone = 0;
 	void *from, *to;
@@ -2407,7 +2415,7 @@ MM_ConcurrentGC::doConcurrentInitialization(MM_EnvironmentStandard *env, uintptr
 	omrthread_monitor_enter(_initWorkMonitor);
 
 	/* If the execution state has changed then return */
-	if(_stats->getExecutionMode() != CONCURRENT_INIT_RUNNING) {
+	if(_stats.getExecutionMode() != CONCURRENT_INIT_RUNNING) {
 		omrthread_monitor_exit(_initWorkMonitor);
 		return initDone;
 	}
@@ -2488,8 +2496,8 @@ MM_ConcurrentGC::doConcurrentInitialization(MM_EnvironmentStandard *env, uintptr
 	} else {
 		/* We are last initializer so tidy up */
 		if (allInitRangesProcessed()) {
-			_cli->concurrentGC_concurrentInitializationComplete(env);
-			_stats->switchExecutionMode(CONCURRENT_INIT_RUNNING, CONCURRENT_INIT_COMPLETE);
+			_concurrentDelegate.concurrentInitializationComplete(env);
+			_stats.switchExecutionMode(CONCURRENT_INIT_RUNNING, CONCURRENT_INIT_COMPLETE);
 		}
 
 		if (allInitRangesProcessed() || env->isExclusiveAccessRequestWaiting()) {
@@ -2518,7 +2526,7 @@ MM_ConcurrentGC::doConcurrentInitialization(MM_EnvironmentStandard *env, uintptr
  * @return the amount of tracing work actually done
  */
 uintptr_t
-MM_ConcurrentGC::doConcurrentTrace(MM_EnvironmentStandard *env,
+MM_ConcurrentGC::doConcurrentTrace(MM_EnvironmentBase *env,
 								MM_AllocateDescription *allocDescription,
 								uintptr_t sizeToTrace,
 								MM_MemorySubSpace *subspace,
@@ -2553,19 +2561,19 @@ MM_ConcurrentGC::doConcurrentTrace(MM_EnvironmentStandard *env,
 	}
 
 	/* Switch state if card cleaning stage 1 threshold reached */
-	if( (CONCURRENT_TRACE_ONLY == _stats->getExecutionMode()) && (remainingFree < _stats->getCardCleaningThreshold())) {
+	if( (CONCURRENT_TRACE_ONLY == _stats.getExecutionMode()) && (remainingFree < _stats.getCardCleaningThreshold())) {
 		kickoffCardCleaning(env, CARD_CLEANING_THRESHOLD_REACHED);
 	}
 
 	uintptr_t bytesTraced = 0;
 	bool completedConcurrentScanning = false;
-	if (_cli->concurrentGC_startConcurrentScanning(env, &bytesTraced, &completedConcurrentScanning)) {
+	if (_concurrentDelegate.startConcurrentScanning(env, &bytesTraced, &completedConcurrentScanning)) {
 		if (completedConcurrentScanning) {
 			resumeConHelperThreads(env);
 		}
 		flushLocalBuffers(env);
 		Trc_MM_concurrentClassMarkEnd(env->getLanguageVMThread(), sizeTraced);
-		_cli->concurrentGC_concurrentScanningStarted(env, 0 == bytesTraced);
+		_concurrentDelegate.concurrentScanningStarted(env, bytesTraced);
 		sizeTraced += bytesTraced;
 	}
 
@@ -2573,12 +2581,22 @@ MM_ConcurrentGC::doConcurrentTrace(MM_EnvironmentStandard *env,
 	 * a TLH allocation as we are not at a safe point.
 	 */
 	if(!env->isThreadScanned() && threadAtSafePoint) {
-		_cli->concurrentGC_scanThread(env);
-		if (env->isThreadScanned()) {
-			/* Resume concurrent helper threads to help mark any roots we have found.
-			 * If thread already active this notify will be ignored
-			 */
-			resumeConHelperThreads(env);
+		/* If call back is late, i.e after the collect,  then ignore it */
+		/* CMVC 119942 : add a top range of CONCURRENT_EXHAUSTED so that we don't scan threads
+		 * at the last second and report them as being scanned when we haven't actually had a
+		 * chance to follow any of the references
+		 */
+		uintptr_t mode = _stats.getExecutionMode();
+		if ((CONCURRENT_ROOT_TRACING <= mode) && (CONCURRENT_EXHAUSTED > mode)) {
+			if (_concurrentDelegate.scanThreadRoots(env)) {
+				flushLocalBuffers(env);
+				env->setThreadScanned(true);
+				_stats.incThreadsScannedCount();
+				/* Resume concurrent helper threads to help mark any roots we have found.
+				 * If thread already active this notify will be ignored
+				 */
+				resumeConHelperThreads(env);
+			}
 		}
 	}
 
@@ -2588,7 +2606,7 @@ MM_ConcurrentGC::doConcurrentTrace(MM_EnvironmentStandard *env,
 	while (!env->isExclusiveAccessRequestWaiting() &&
 			(sizeTraced < sizeToTrace) &&
 			(sizeTraced != sizeTracedPreviously) &&
-			(CONCURRENT_CLEAN_TRACE >= _stats->getExecutionMode())
+			(CONCURRENT_CLEAN_TRACE >= _stats.getExecutionMode())
 	) {
 
 		/* CMVC 131721 - record the amount traced up until now. If any iteration of this loop fails
@@ -2602,7 +2620,7 @@ MM_ConcurrentGC::doConcurrentTrace(MM_EnvironmentStandard *env,
 		uintptr_t bytesTraced = localMark(env,(sizeToTrace - sizeTraced));
 		if (bytesTraced > 0 ) {
 			/* Update global count of amount  traced */
-			_stats->incTraceSizeCount(bytesTraced);
+			_stats.incTraceSizeCount(bytesTraced);
 			/* ..and local count */
 			sizeTraced += bytesTraced;
 		}
@@ -2610,12 +2628,12 @@ MM_ConcurrentGC::doConcurrentTrace(MM_EnvironmentStandard *env,
 		/* If GC is not waiting and we did not have enough to trace */
 		if (!env->isExclusiveAccessRequestWaiting() && sizeTraced < sizeToTrace) {
 			/* Check to see if we need to start card cleaning early */
-			if (CONCURRENT_TRACE_ONLY == _stats->getExecutionMode()) {
+			if (CONCURRENT_TRACE_ONLY == _stats.getExecutionMode()) {
 				/* We have run out of tracing work. If all tracing is complete or
 				 * we have passed the peak of tracing activity then we may as well
 				 * start card cleaning now.
 				 */
-				if ((_markingScheme->getWorkPackets()->tracingExhausted() || tracingRateDropped(env)) && _stats->isRootTracingComplete()) {
+				if ((_markingScheme->getWorkPackets()->tracingExhausted() || tracingRateDropped(env)) && _stats.isRootTracingComplete()) {
 					kickoffCardCleaning(env, TRACING_COMPLETED);
 				} else {
 					/* Nothing to do and not time to start card cleaning yet */
@@ -2623,7 +2641,7 @@ MM_ConcurrentGC::doConcurrentTrace(MM_EnvironmentStandard *env,
 				}
 			}
 
-			if (CONCURRENT_CLEAN_TRACE == _stats->getExecutionMode()) {
+			if (CONCURRENT_CLEAN_TRACE == _stats.getExecutionMode()) {
 				if(!((MM_ConcurrentCardTable *)_cardTable)->isCardCleaningComplete()) {
 					/* Clean some cards. Returns when enough cards traced, no more cards
 					 * to trace, _gcWaiting true or a GC occurred preparing cards.
@@ -2633,7 +2651,7 @@ MM_ConcurrentGC::doConcurrentTrace(MM_EnvironmentStandard *env,
 					if(cleanCards(env, true, (sizeToTrace - sizeTraced), &bytesCleaned, threadAtSafePoint)) {
 						if (bytesCleaned > 0 ) {
 							/* Update global count */
-							_stats->incCardCleanCount(bytesCleaned);
+							_stats.incCardCleanCount(bytesCleaned);
 							/* ..and local count */
 							sizeTraced += bytesCleaned;
 						}
@@ -2691,9 +2709,9 @@ MM_ConcurrentGC::doConcurrentTrace(MM_EnvironmentStandard *env,
 		/* If no more work left (and concurrent scanning is complete or disabled) then switch to exhausted now */
 		if (((MM_ConcurrentCardTable *)_cardTable)->isCardCleaningComplete() &&
 			_markingScheme->getWorkPackets()->tracingExhausted() &&
-			_cli->concurrentGC_isConcurrentScanningComplete(env)) {
+			_concurrentDelegate.isConcurrentScanningComplete(env)) {
 
-			if(_stats->switchExecutionMode(CONCURRENT_CLEAN_TRACE, CONCURRENT_EXHAUSTED)) {
+			if(_stats.switchExecutionMode(CONCURRENT_CLEAN_TRACE, CONCURRENT_EXHAUSTED)) {
 				/* Tell all MSS to use slow path allocate and so get to a safe
 				* point before paying allocation tax.
 				*/
@@ -2725,10 +2743,10 @@ MM_ConcurrentGC::doConcurrentTrace(MM_EnvironmentStandard *env,
  * @return TRUE if final collection actually requested; FALSE otherwise
  */
 bool
-MM_ConcurrentGC::concurrentFinalCollection(MM_EnvironmentStandard *env, MM_MemorySubSpace *subSpace)
+MM_ConcurrentGC::concurrentFinalCollection(MM_EnvironmentBase *env, MM_MemorySubSpace *subSpace)
 {
 	/* Switch to FINAL_COLLECTION; if we fail another thread beat us to it so just return */
-	if	(_stats->switchExecutionMode(CONCURRENT_EXHAUSTED, CONCURRENT_FINAL_COLLECTION)) {
+	if	(_stats.switchExecutionMode(CONCURRENT_EXHAUSTED, CONCURRENT_FINAL_COLLECTION)) {
 
 		if(env->acquireExclusiveVMAccessForGC(this, true, true)) {
 			OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
@@ -2760,14 +2778,14 @@ MM_ConcurrentGC::concurrentFinalCollection(MM_EnvironmentStandard *env, MM_Memor
  * @return The actual amount of work done
  */
 uintptr_t
-MM_ConcurrentGC::localMark(MM_EnvironmentStandard *env, uintptr_t sizeToTrace)
+MM_ConcurrentGC::localMark(MM_EnvironmentBase *env, uintptr_t sizeToTrace)
 {
 	omrobjectptr_t objectPtr;
 	uintptr_t gcCount = _extensions->globalGCStats.gcCount;
 
 	env->_workStack.reset(env, _markingScheme->getWorkPackets());
 	Assert_MM_true(env->_cycleState == NULL);
-	Assert_MM_true(CONCURRENT_OFF < _stats->getExecutionMode());
+	Assert_MM_true(CONCURRENT_OFF < _stats.getExecutionMode());
 	Assert_MM_true(_concurrentCycleState._referenceObjectOptions == MM_CycleState::references_default);
 	env->_cycleState = &_concurrentCycleState;
 
@@ -2787,10 +2805,9 @@ MM_ConcurrentGC::localMark(MM_EnvironmentStandard *env, uintptr_t sizeToTrace)
 			 */
 			sizeTraced += _extensions->objectModel.getSizeInBytesWithHeader(objectPtr);
 
-			 _extensions->collectorLanguageInterface->concurrentGC_processItem(env, objectPtr);
+			_concurrentDelegate.processItem(env, objectPtr);
 
-			 /*
-			 * If its a partially processed array this will leave the low_tagged
+			/* If its a partially processed array this will leave the low_tagged
 			 * scanPtr on the stack. Rather than check for it now we will just ignore the
 			 * reference when we pop it or before we exit localMark()
 			 */
@@ -2842,7 +2859,7 @@ MM_ConcurrentGC::localMark(MM_EnvironmentStandard *env, uintptr_t sizeToTrace)
  * if a GC is requested whilst we are tracing.
  */
 MMINLINE bool
-MM_ConcurrentGC::cleanCards(MM_EnvironmentStandard *env, bool isMutator, uintptr_t sizeToDo, uintptr_t *sizeDone, bool threadAtSafePoint)
+MM_ConcurrentGC::cleanCards(MM_EnvironmentBase *env, bool isMutator, uintptr_t sizeToDo, uintptr_t *sizeDone, bool threadAtSafePoint)
 {
 	/* Clean required number of cards and... */
 	env->_workStack.reset(env, _markingScheme->getWorkPackets());
@@ -2868,8 +2885,8 @@ MM_ConcurrentGC::cleanCards(MM_EnvironmentStandard *env, bool isMutator, uintptr
 void
 MM_ConcurrentGC::concurrentWorkStackOverflow()
 {
-	_stats->setConcurrentWorkStackOverflowOcurred(true);
-	_stats->incConcurrentWorkStackOverflowCount();
+	_stats.setConcurrentWorkStackOverflowOcurred(true);
+	_stats.incConcurrentWorkStackOverflowCount();
 }
 
 /**
@@ -2877,9 +2894,9 @@ MM_ConcurrentGC::concurrentWorkStackOverflow()
  *
  */
 void
-MM_ConcurrentGC::clearConcurrentWorkStackOverflow(MM_EnvironmentStandard *env)
+MM_ConcurrentGC::clearConcurrentWorkStackOverflow()
 {
-	_stats->setConcurrentWorkStackOverflowOcurred(false);
+	_stats.setConcurrentWorkStackOverflowOcurred(false);
 
 #if defined(OMR_GC_MODRON_SCAVENGER)
 	MM_WorkPacketsConcurrent *packets = (MM_WorkPacketsConcurrent *)_markingScheme->getWorkPackets();
@@ -2898,13 +2915,12 @@ MM_ConcurrentGC::clearConcurrentWorkStackOverflow(MM_EnvironmentStandard *env)
 void
 MM_ConcurrentGC::internalPreCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *subSpace, MM_AllocateDescription *allocDescription, uint32_t gcCode)
 {
-	MM_EnvironmentStandard *envStandard = MM_EnvironmentStandard::getEnvironment(env);
 	OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
 
-	Trc_MM_ConcurrentGC_internalPreCollect_Entry(envStandard->getLanguageVMThread(), subSpace);
+	Trc_MM_ConcurrentGC_internalPreCollect_Entry(env->getLanguageVMThread(), subSpace);
 
-	/* Should be flushed at concurrent stage */
-	Assert_MM_true(_cli->concurrentGC_isThreadReferenceBufferEmpty(env));
+	/* Thread roots must have been flushed by this point */
+	Assert_MM_true(!_concurrentDelegate.flushThreadRoots(env));
 
 #if defined(OMR_GC_CONCURRENT_SWEEP)
 	/**
@@ -2912,7 +2928,7 @@ MM_ConcurrentGC::internalPreCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *
 	 * heap is walkable (the sweep could have connected part of an entry that spans many chunks,
 	 * thus creating an unwalkable portion of the heap).
 	 */
-	completeConcurrentSweep(envStandard);
+	completeConcurrentSweep(env);
 #endif /* OMR_GC_CONCURRENT_SWEEP */
 
 	/* Ensure caller acquired exclusive VM access before calling */
@@ -2929,8 +2945,8 @@ MM_ConcurrentGC::internalPreCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *
 	_initializeMarkMap = true;
 
 	/* Remember the executionMode at the point when the GC was triggered */
-	uintptr_t executionModeAtGC = _stats->getExecutionMode();
-	_stats->setExecutionModeAtGC(executionModeAtGC);
+	uintptr_t executionModeAtGC = _stats.getExecutionMode();
+	_stats.setExecutionModeAtGC(executionModeAtGC);
 	
 	Assert_MM_true(NULL == env->_cycleState);
 
@@ -2948,11 +2964,11 @@ MM_ConcurrentGC::internalPreCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *
 	}
 
 	if (executionModeAtGC > CONCURRENT_OFF && _extensions->debugConcurrentMark) {
-		_stats->printAllocationTaxReport(env->getOmrVM());
+		_stats.printAllocationTaxReport(env->getOmrVM());
 	}
 
 #if defined(OMR_GC_LARGE_OBJECT_AREA)
-	updateMeteringHistoryBeforeGC(envStandard);
+	updateMeteringHistoryBeforeGC(env);
 #endif /* OMR_GC_LARGE_OBJECT_AREA */
 
 	/* Empty all the Packets if we are aborting concurrent mark.
@@ -2961,17 +2977,17 @@ MM_ConcurrentGC::internalPreCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *
 	 */
 	if (_extensions->isRememberedSetInOverflowState() || ((CONCURRENT_OFF < executionModeAtGC) && (CONCURRENT_TRACE_ONLY > executionModeAtGC))) {
 		CollectionAbortReason reason = (_extensions->isRememberedSetInOverflowState() ? ABORT_COLLECTION_REMEMBERSET_OVERFLOW : ABORT_COLLECTION_INSUFFICENT_PROGRESS);
-		abortCollection(envStandard, reason);
+		abortCollection(env, reason);
 		/* concurrent cycle was aborted so we need to kick off a new cycle and set up the cycle state */
-		MM_ParallelGlobalGC::internalPreCollect(envStandard, subSpace, allocDescription, gcCode);
+		MM_ParallelGlobalGC::internalPreCollect(env, subSpace, allocDescription, gcCode);
 	} else if (CONCURRENT_TRACE_ONLY <= executionModeAtGC) {
 		/* We are going to complete the concurrent cycle to generate the GCStart/GCIncrement events */
-		reportGCStart(envStandard);
-		reportGCIncrementStart(envStandard);
-		reportGlobalGCIncrementStart(envStandard);
+		reportGCStart(env);
+		reportGCIncrementStart(env);
+		reportGlobalGCIncrementStart(env);
 
 		/* Switch the executionMode to OFF to complete the STW collection */
-		_stats->switchExecutionMode(executionModeAtGC, CONCURRENT_OFF);
+		_stats.switchExecutionMode(executionModeAtGC, CONCURRENT_OFF);
 
 		/* Mark map is usable. We got far enough into the concurrent to be
 		 * sure we at least initialized the mark map so no need to do so again.
@@ -2979,26 +2995,26 @@ MM_ConcurrentGC::internalPreCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *
 		_initializeMarkMap = false;
 
 		if (CONCURRENT_FINAL_COLLECTION > executionModeAtGC) {
-			reportConcurrentHalted(envStandard);
+			reportConcurrentHalted(env);
 
 			if (!_markingScheme->getWorkPackets()->tracingExhausted()) {
 
-				reportConcurrentCompleteTracingStart(envStandard);
+				reportConcurrentCompleteTracingStart(env);
 				uint64_t startTime = omrtime_hires_clock();
 				/* Get assistance from all slave threads to complete processing of any remaining work packets.
 				 * In the event of work stack overflow we will just dirty cards which will get processed during
 				 * final card cleaning.
 				 */
-				MM_ConcurrentCompleteTracingTask completeTracingTask(envStandard, _dispatcher, this, envStandard->_cycleState);
-				_dispatcher->run(envStandard, &completeTracingTask);
+				MM_ConcurrentCompleteTracingTask completeTracingTask(env, _dispatcher, this, env->_cycleState);
+				_dispatcher->run(env, &completeTracingTask);
 
-				reportConcurrentCompleteTracingEnd(envStandard, omrtime_hires_clock() - startTime);
+				reportConcurrentCompleteTracingEnd(env, omrtime_hires_clock() - startTime);
 			}
 		}
 
 #if defined(OMR_GC_MODRON_SCAVENGER)
 		if(_extensions->scavengerEnabled) {
-			reportConcurrentRememberedSetScanStart(envStandard);
+			reportConcurrentRememberedSetScanStart(env);
 			uint64_t startTime = omrtime_hires_clock();
 
 			/* Do we need to clear mark bits for any NEW heaps ?
@@ -3007,27 +3023,25 @@ MM_ConcurrentGC::internalPreCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *
 			 * NEW bits which need clearing
 			 */
 			if (_rebuildInitWork) {
-				determineInitWork(envStandard);
-				resetInitRangesForSTW(envStandard);
-			} else {
-				resetInitRangesForSTW(envStandard);
+				determineInitWork(env);
 			}
+			resetInitRangesForSTW();
 
 			/* Get assistance from all slave threads to reset all mark bits for any NEW areas of heap */
-			MM_ConcurrentClearNewMarkBitsTask clearNewMarkBitsTask(envStandard, _dispatcher, this);
-			_dispatcher->run(envStandard, &clearNewMarkBitsTask);
+			MM_ConcurrentClearNewMarkBitsTask clearNewMarkBitsTask(env, _dispatcher, this);
+			_dispatcher->run(env, &clearNewMarkBitsTask);
 
 			/* If remembered set if not empty then re-scan any objects in the remembered set */
 			if (!(_extensions->rememberedSet.isEmpty())) {
-				MM_ConcurrentScanRememberedSetTask scanRememberedSetTask(envStandard, _dispatcher, this, envStandard->_cycleState);
-				_dispatcher->run(envStandard, &scanRememberedSetTask);
+				MM_ConcurrentScanRememberedSetTask scanRememberedSetTask(env, _dispatcher, this, env->_cycleState);
+				_dispatcher->run(env, &scanRememberedSetTask);
 			}
 
-			reportConcurrentRememberedSetScanEnd(envStandard, omrtime_hires_clock() - startTime);
+			reportConcurrentRememberedSetScanEnd(env, omrtime_hires_clock() - startTime);
 		}
 #endif /* OMR_GC_MODRON_SCAVENGER */
 
-		reportConcurrentFinalCardCleaningStart(envStandard);
+		reportConcurrentFinalCardCleaningStart(env);
 		uint64_t startTime = omrtime_hires_clock();
 
 		bool overflow = false; /* assume the worst case*/
@@ -3035,32 +3049,32 @@ MM_ConcurrentGC::internalPreCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *
 
         do {
 			/* remember count when we start */
-			overflowCount = _stats->getConcurrentWorkStackOverflowCount();
+			overflowCount = _stats.getConcurrentWorkStackOverflowCount();
 
 			/* Get assistance from all slave threads to do final card cleaning */
-			MM_ConcurrentFinalCleanCardsTask cleanCardsTask(envStandard, _dispatcher, this, envStandard->_cycleState);
-			((MM_ConcurrentCardTable *)_cardTable)->initializeFinalCardCleaning(envStandard);
+			MM_ConcurrentFinalCleanCardsTask cleanCardsTask(env, _dispatcher, this, env->_cycleState);
+			((MM_ConcurrentCardTable *)_cardTable)->initializeFinalCardCleaning(env);
 
-			_dispatcher->run(envStandard, &cleanCardsTask);
+			_dispatcher->run(env, &cleanCardsTask);
 
 			/* Have we had a work stack overflow whilst processing card table ? */
-			overflow = (overflowCount != _stats->getConcurrentWorkStackOverflowCount());
+			overflow = (overflowCount != _stats.getConcurrentWorkStackOverflowCount());
 		} while (overflow);
 
         /* reset overflow flag */
     	_markingScheme->getWorkPackets()->clearOverflowFlag();
 
-    	reportConcurrentFinalCardCleaningEnd(envStandard, omrtime_hires_clock() - startTime);
+    	reportConcurrentFinalCardCleaningEnd(env, omrtime_hires_clock() - startTime);
 
-		assume(_cardTable->isCardTableEmpty(envStandard),"internalPreCollect: card cleaning has failed to clean all cards");
+		assume(_cardTable->isCardTableEmpty(env),"internalPreCollect: card cleaning has failed to clean all cards");
 
 		/* Move any remaining deferred work packets to regular lists */
-		_markingScheme->getWorkPackets()->reuseDeferredPackets(envStandard);
+		_markingScheme->getWorkPackets()->reuseDeferredPackets(env);
 	}
 
 	switchConHelperRequest(CONCURRENT_HELPER_MARK, CONCURRENT_HELPER_WAIT);
 
-	Trc_MM_ConcurrentGC_internalPreCollect_Exit(envStandard->getLanguageVMThread(), subSpace);
+	Trc_MM_ConcurrentGC_internalPreCollect_Exit(env->getLanguageVMThread(), subSpace);
 }
 
 /* (non-doxygen)
@@ -3069,11 +3083,9 @@ MM_ConcurrentGC::internalPreCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *
 bool
 MM_ConcurrentGC::internalGarbageCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *subSpace, MM_AllocateDescription *allocDescription)
 {
-	MM_EnvironmentStandard *envStandard = MM_EnvironmentStandard::getEnvironment(env);
-	
 	_extensions->globalGCStats.gcCount += 1;
 
-	masterThreadGarbageCollect(envStandard, static_cast<MM_AllocateDescription*>(allocDescription), _initializeMarkMap, false);
+	masterThreadGarbageCollect(env, static_cast<MM_AllocateDescription*>(allocDescription), _initializeMarkMap, false);
 
 	/* Restore normal allocation rules.
 	 * It's not good to do it in concurrentFinalCollection(), as an AF may occur before we get chance to do final collection, so we may miss to restore it.
@@ -3106,52 +3118,50 @@ MM_ConcurrentGC::postMark(MM_EnvironmentBase *envModron)
 void
 MM_ConcurrentGC::internalPostCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *subSpace)
 {
-	MM_EnvironmentStandard *envStandard = MM_EnvironmentStandard::getEnvironment(env);
-
-	Trc_MM_ConcurrentGC_internalPostCollect_Entry(envStandard->getLanguageVMThread(), subSpace);
+	Trc_MM_ConcurrentGC_internalPostCollect_Entry(env->getLanguageVMThread(), subSpace);
 
 #if defined(OMR_GC_LARGE_OBJECT_AREA)
-	updateMeteringHistoryAfterGC(envStandard);
+	updateMeteringHistoryAfterGC(env);
 #endif /* OMR_GC_LARGE_OBJECT_AREA */
 
 	if (_extensions->debugConcurrentMark) {
-		_stats->clearAllocationTaxCounts();
+		_stats.clearAllocationTaxCounts();
 	}
 
 	 /* Reset concurrent work stack overflow flags for next cycle */
-	clearConcurrentWorkStackOverflow(envStandard);
+	clearConcurrentWorkStackOverflow();
 
 	/* If we flushed all the TLH's correctly in GC the TLH mark bits should be
 	 * all OFF
 	 */
-	assume(_cardTable->isTLHMarkBitsEmpty(envStandard),"TLH mark map not empty");
+	assume(_cardTable->isTLHMarkBitsEmpty(env),"TLH mark map not empty");
 
 	/* Re tune for next concurrent cycle if we have had a heap resize or we got far enough
 	 * last time. We only re-tune on a system GC in the event of a heap resize.
 	 */
-	if (_retuneAfterHeapResize || _stats->getExecutionModeAtGC() > CONCURRENT_OFF) {
-		tuneToHeap(envStandard);
+	if (_retuneAfterHeapResize || _stats.getExecutionModeAtGC() > CONCURRENT_OFF) {
+		tuneToHeap(env);
 	}
 
 	/* Collection is complete so reset flags */
 	_globalCollectionInProgress = false;
 	_forcedKickoff  = false;
-	_stats->clearKickoffReason();
+	_stats.clearKickoffReason();
 
 	if (_extensions->optimizeConcurrentWB) {
 		/* Reset vmThread flag so mutators don't dirty cards until next concurrent KO */
-		if (_stats->getExecutionModeAtGC() > CONCURRENT_INIT_RUNNING) {
-			_cli->concurrentGC_signalThreadsToStopDirtyingCards(envStandard);
+		if (_stats.getExecutionModeAtGC() > CONCURRENT_INIT_RUNNING) {
+			_concurrentDelegate.signalThreadsToStopDirtyingCards(env);
 		}
 
 		/* Cancel any outstanding call backs */
-		_callback->cancelCallback(envStandard);
+		_callback->cancelCallback(env);
 	}
 
 	/* Call the super class to do any required work */
-	MM_ParallelGlobalGC::internalPostCollect(envStandard, subSpace);
+	MM_ParallelGlobalGC::internalPostCollect(env, subSpace);
 
-	Trc_MM_ConcurrentGC_internalPostCollect_Exit(envStandard->getLanguageVMThread(), subSpace);
+	Trc_MM_ConcurrentGC_internalPostCollect_Exit(env->getLanguageVMThread(), subSpace);
 }
 
 /**
@@ -3165,29 +3175,28 @@ MM_ConcurrentGC::internalPostCollect(MM_EnvironmentBase *env, MM_MemorySubSpace 
 void
 MM_ConcurrentGC::abortCollection(MM_EnvironmentBase *env, CollectionAbortReason reason)
 {
-	MM_EnvironmentStandard *envStandard = MM_EnvironmentStandard::getEnvironment(env);
 	/* Allow the superclass to do its work */
-	MM_ParallelGlobalGC::abortCollection(envStandard, reason);
+	MM_ParallelGlobalGC::abortCollection(env, reason);
 
 	/* If concurrent is OFF nothing to do so get out now */
-	if ( CONCURRENT_OFF == _stats->getExecutionMode()) {
+	if ( CONCURRENT_OFF == _stats.getExecutionMode()) {
 		Assert_MM_true(_markingScheme->getWorkPackets()->isAllPacketsEmpty());
 		return;
 	}
 
-	MM_CycleState *oldCycleState = envStandard->_cycleState;
-	envStandard->_cycleState = &_concurrentCycleState;
-	reportConcurrentAborted(envStandard, reason);
-	reportGCCycleEnd(envStandard);
-	envStandard->_cycleState = oldCycleState;
+	MM_CycleState *oldCycleState = env->_cycleState;
+	env->_cycleState = &_concurrentCycleState;
+	reportConcurrentAborted(env, reason);
+	reportGCCycleEnd(env);
+	env->_cycleState = oldCycleState;
 
 	/* Since all of the current mark data is being flushed make sure to flush the reference
 	 * lists so they can be properly rebuilt by the next mark phase.
 	 */
-	_cli->concurrentGC_flushRegionReferenceLists(env);
+	_concurrentDelegate.abortCollection(env);
 
 	/* Clear contents of all work packets */
-	_markingScheme->getWorkPackets()->resetAllPackets(envStandard);
+	_markingScheme->getWorkPackets()->resetAllPackets(env);
 
 	/* Unconditionally change execution mode back to OFF. On a subsequent allocation
 	 * we will then restart a concurrent mark cycle. We probably won't finish before
@@ -3198,13 +3207,13 @@ MM_ConcurrentGC::abortCollection(MM_EnvironmentBase *env, CollectionAbortReason 
 	 */
 	switchConHelperRequest(CONCURRENT_HELPER_MARK, CONCURRENT_HELPER_WAIT);
 
-	_stats->switchExecutionMode(_stats->getExecutionMode(), CONCURRENT_OFF );
+	_stats.switchExecutionMode(_stats.getExecutionMode(), CONCURRENT_OFF );
 
 	/* make sure to reset the init ranges before the next kickOff */
-	resetInitRangesForConcurrentKO(envStandard);
+	resetInitRangesForConcurrentKO();
 
 	/* ...but just in case check it does */
-	Assert_GC_true_with_message(env, CONCURRENT_OFF == _stats->getExecutionMode(), "MM_ConcurrentStats::_executionMode = %zu\n", _stats->getExecutionMode());
+	Assert_GC_true_with_message(env, CONCURRENT_OFF == _stats.getExecutionMode(), "MM_ConcurrentStats::_executionMode = %zu\n", _stats.getExecutionMode());
 }
 
 /**
@@ -3235,10 +3244,9 @@ MM_ConcurrentGC::prepareHeapForWalk(MM_EnvironmentBase *envModron)
 bool
 MM_ConcurrentGC::heapAddRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace, uintptr_t size, void *lowAddress, void *highAddress)
 {
-	MM_EnvironmentStandard *envStandard = MM_EnvironmentStandard::getEnvironment(env);
 	bool clearCards = false;
 
-	Trc_MM_ConcurrentGC_heapAddRange_Entry(envStandard->getLanguageVMThread(), subspace, size, lowAddress, highAddress);
+	Trc_MM_ConcurrentGC_heapAddRange_Entry(env->getLanguageVMThread(), subspace, size, lowAddress, highAddress);
 
 	_rebuildInitWork = true;
 	if (subspace->isConcurrentCollectable()) {
@@ -3246,32 +3254,32 @@ MM_ConcurrentGC::heapAddRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subspa
 	}
 
 	/* Expand any superclass structures including mark bits*/
-	bool result = MM_ParallelGlobalGC::heapAddRange(envStandard, subspace, size, lowAddress, highAddress);
+	bool result = MM_ParallelGlobalGC::heapAddRange(env, subspace, size, lowAddress, highAddress);
 
 	if (result) {
 		/* If we are within a concurrent cycle we need to initialize the mark bits
 		 * for new region of heap now
 		 */
-		if (CONCURRENT_OFF < _stats->getExecutionMode()) {
+		if (CONCURRENT_OFF < _stats.getExecutionMode()) {
 			/* If subspace is concurrently collectible then clear bits otherwise
 			 * set the bits on to stop tracing INTO this area during concurrent
 			 * mark cycle.
 			 */
 			if (subspace->isConcurrentCollectable()) {
-				_markingScheme->setMarkBitsInRange(envStandard, lowAddress, highAddress, true);
+				_markingScheme->setMarkBitsInRange(env, lowAddress, highAddress, true);
 				clearCards = true;
 			} else {
-				_markingScheme->setMarkBitsInRange(envStandard, lowAddress, highAddress, false);
+				_markingScheme->setMarkBitsInRange(env, lowAddress, highAddress, false);
 			}
 		}
 
 		/* ...and then expand the card table */
-		result = ((MM_ConcurrentCardTable *)_cardTable)->heapAddRange(envStandard, subspace, size, lowAddress, highAddress, clearCards);
+		result = ((MM_ConcurrentCardTable *)_cardTable)->heapAddRange(env, subspace, size, lowAddress, highAddress, clearCards);
 		if (!result) {
 			/* Expansion of Concurrent Card Table has failed
 			 * ParallelGlobalGC expansion must be reversed
 			 */
-			MM_ParallelGlobalGC::heapRemoveRange(envStandard, subspace, size, lowAddress, highAddress, NULL, NULL);
+			MM_ParallelGlobalGC::heapRemoveRange(env, subspace, size, lowAddress, highAddress, NULL, NULL);
 		}
 	}
 
@@ -3288,17 +3296,17 @@ MM_ConcurrentGC::heapAddRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subspa
 		 *  we will try to memset ranges that are now contracted (decommitted memory)
 		 *  when we resume the init work.
 		 */
-		if (_stats->getExecutionMode() < CONCURRENT_INIT_COMPLETE) {
-			tuneToHeap(envStandard);
+		if (_stats.getExecutionMode() < CONCURRENT_INIT_COMPLETE) {
+			tuneToHeap(env);
 		} else {
 			/* Heap expand is during a concurrent cycle..we need to adjust the trace target so
 		 	* that the trace rate is adjusted correctly on subsequent allocates.
 		 	*/
-			adjustTraceTarget(envStandard);
+			adjustTraceTarget();
 		}
 	}
 
-	Trc_MM_ConcurrentGC_heapAddRange_Exit(envStandard->getLanguageVMThread());
+	Trc_MM_ConcurrentGC_heapAddRange_Exit(env->getLanguageVMThread());
 
 	return result;
 }
@@ -3318,9 +3326,7 @@ MM_ConcurrentGC::heapAddRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subspa
 bool
 MM_ConcurrentGC::heapRemoveRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace, uintptr_t size, void *lowAddress, void *highAddress, void *lowValidAddress, void *highValidAddress)
 {
-	MM_EnvironmentStandard *envStandard = MM_EnvironmentStandard::getEnvironment(env);
-
-	Trc_MM_ConcurrentGC_heapRemoveRange_Entry(envStandard->getLanguageVMThread(), subspace, size, lowAddress, highAddress, lowValidAddress, highValidAddress);
+	Trc_MM_ConcurrentGC_heapRemoveRange_Entry(env->getLanguageVMThread(), subspace, size, lowAddress, highAddress, lowValidAddress, highValidAddress);
 
 	_rebuildInitWork = true;
 	if (subspace->isConcurrentCollectable()) {
@@ -3328,10 +3334,10 @@ MM_ConcurrentGC::heapRemoveRange(MM_EnvironmentBase *env, MM_MemorySubSpace *sub
 	}
 
 	/* Contract any superclass structures */
-	bool result = MM_ParallelGlobalGC::heapRemoveRange(envStandard, subspace, size, lowAddress, highAddress, lowValidAddress, highValidAddress);
+	bool result = MM_ParallelGlobalGC::heapRemoveRange(env, subspace, size, lowAddress, highAddress, lowValidAddress, highValidAddress);
 
 	/* ...and then contract the card table */
-	result = result && ((MM_ConcurrentCardTable *)_cardTable)->heapRemoveRange(envStandard, subspace, size, lowAddress, highAddress, lowValidAddress, highValidAddress);
+	result = result && ((MM_ConcurrentCardTable *)_cardTable)->heapRemoveRange(env, subspace, size, lowAddress, highAddress, lowValidAddress, highValidAddress);
 	_heapAlloc = (void *)_extensions->heap->getHeapTop();
 
 	/* If called outside a global collection for a heap contract..
@@ -3345,17 +3351,17 @@ MM_ConcurrentGC::heapRemoveRange(MM_EnvironmentBase *env, MM_MemorySubSpace *sub
 		 *  we will try to memset ranges that are now contracted (decommitted memory)
 		 *  when we resume the init work.
 		 */
-		if (_stats->getExecutionMode() < CONCURRENT_INIT_COMPLETE) {
-			tuneToHeap(envStandard);
+		if (_stats.getExecutionMode() < CONCURRENT_INIT_COMPLETE) {
+			tuneToHeap(env);
 		} else {
 			/* Heap contract is during a concurrent cycle..we need to adjust the trace target so
 			 * that the trace rate is adjusted correctly on  subsequent allocates.
 			 */
-			adjustTraceTarget(envStandard);
+			adjustTraceTarget();
 		}
 	}
 
-	Trc_MM_ConcurrentGC_heapRemoveRange_Exit(envStandard->getLanguageVMThread());
+	Trc_MM_ConcurrentGC_heapRemoveRange_Exit(env->getLanguageVMThread());
 
 	return result;
 }
@@ -3366,13 +3372,11 @@ MM_ConcurrentGC::heapRemoveRange(MM_EnvironmentBase *env, MM_MemorySubSpace *sub
 void
 MM_ConcurrentGC::heapReconfigured(MM_EnvironmentBase *env)
 {
-	MM_EnvironmentStandard *envStandard = MM_EnvironmentStandard::getEnvironment(env);
-
 	/* Expand any superclass structures */
-	MM_ParallelGlobalGC::heapReconfigured(envStandard);
+	MM_ParallelGlobalGC::heapReconfigured(env);
 
 	/* ...and then expand the card table */
-	((MM_ConcurrentCardTable *)_cardTable)->heapReconfigured(envStandard);
+	((MM_ConcurrentCardTable *)_cardTable)->heapReconfigured(env);
 
 	/* The heap has been reconfigured; most likely a change in scavenger tilt ratio
 	 * so flag we need to recalculate the intialization work
@@ -3388,7 +3392,7 @@ MM_ConcurrentGC::heapReconfigured(MM_EnvironmentBase *env)
  * threads during internalPreCollect().
  */
 void
-MM_ConcurrentGC::clearNewMarkBits(MM_EnvironmentStandard *env)
+MM_ConcurrentGC::clearNewMarkBits(MM_EnvironmentBase *env)
 {
 	void *from, *to;
 	InitType type;
@@ -3413,7 +3417,7 @@ MM_ConcurrentGC::clearNewMarkBits(MM_EnvironmentStandard *env)
  *
  */
 void
-MM_ConcurrentGC::completeTracing(MM_EnvironmentStandard *env)
+MM_ConcurrentGC::completeTracing(MM_EnvironmentBase *env)
 {
 	omrobjectptr_t objectPtr;
 	uintptr_t bytesTraced = 0;
@@ -3425,7 +3429,7 @@ MM_ConcurrentGC::completeTracing(MM_EnvironmentStandard *env)
 	env->_workStack.clearPushCount();
 
 	/* ..and amount traced */
-	_stats->incCompleteTracingCount(bytesTraced);
+	_stats.incCompleteTracingCount(bytesTraced);
 
 	flushLocalBuffers(env);
 }
@@ -3437,7 +3441,7 @@ MM_ConcurrentGC::completeTracing(MM_EnvironmentStandard *env)
  * any cards not cleaned during the concurrent phase.
  */
 void
-MM_ConcurrentGC::finalCleanCards(MM_EnvironmentStandard *env)
+MM_ConcurrentGC::finalCleanCards(MM_EnvironmentBase *env)
 {
  	omrobjectptr_t objectPtr;
  	bool moreCards = true;
@@ -3497,7 +3501,7 @@ MM_ConcurrentGC::finalCleanCards(MM_EnvironmentStandard *env)
 					if (!dirty) {
 						totalTraced += _markingScheme->scanObject(env, objectPtr, SCAN_REASON_PACKET);
 					} else {
-						_extensions->collectorLanguageInterface->concurrentGC_processItem(env, objectPtr);
+						_concurrentDelegate.processItem(env, objectPtr);
 					}
 				}
 			}
@@ -3513,8 +3517,8 @@ MM_ConcurrentGC::finalCleanCards(MM_EnvironmentStandard *env)
 	}
 
 	flushLocalBuffers(env);
-	_stats->incFinalTraceCount(totalTraced);
-	_stats->incFinalCardCleanCount(totalCleaned);
+	_stats.incFinalTraceCount(totalTraced);
+	_stats.incFinalCardCleanCount(totalCleaned);
 }
 
 #if defined(OMR_GC_MODRON_SCAVENGER)
@@ -3527,7 +3531,7 @@ MM_ConcurrentGC::finalCleanCards(MM_EnvironmentStandard *env)
  * during internalPreCollect().
  */
 void
-MM_ConcurrentGC::scanRememberedSet(MM_EnvironmentStandard *env)
+MM_ConcurrentGC::scanRememberedSet(MM_EnvironmentBase *env)
 {
 	OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
 	MM_SublistPuddle *puddle;
@@ -3593,10 +3597,10 @@ MM_ConcurrentGC::scanRememberedSet(MM_EnvironmentStandard *env)
 	flushLocalBuffers(env);
 
 	/* Add RS objects found to global count */
-	_stats->incRSObjectsFound(RSObjects);
+	_stats.incRSObjectsFound(RSObjects);
 
 	/* ..and amount traced */
-	_stats->incRSScanTraceCount(bytesTraced);
+	_stats.incRSScanTraceCount(bytesTraced);
 }
 
 /**
@@ -3607,12 +3611,12 @@ MM_ConcurrentGC::scanRememberedSet(MM_EnvironmentStandard *env)
  * @param objectPtr  Parent old object that has a reference to a child old object
  */
 void
-MM_ConcurrentGC::oldToOldReferenceCreated(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr)
+MM_ConcurrentGC::oldToOldReferenceCreated(MM_EnvironmentBase *env, omrobjectptr_t objectPtr)
 {
 	/* todo: Consider doing mark and push-to-scan on child object.
 	 * Child object will be tenured only once during a Scavenge cycle,
 	 * so there are no risks of creating duplicates in scan queue. */
-	if (CONCURRENT_OFF != _stats->getExecutionMode()) {
+	if (CONCURRENT_OFF != _stats.getExecutionMode()) {
 		Assert_MM_true(_extensions->isOld(objectPtr));
 		if (_markingScheme->isMarkedOutline(objectPtr) ) {
 			_cardTable->dirtyCard(env,objectPtr);
@@ -3622,13 +3626,13 @@ MM_ConcurrentGC::oldToOldReferenceCreated(MM_EnvironmentStandard *env, omrobject
 #endif /* OMR_GC_MODRON_SCAVENGER */
 
 void
-MM_ConcurrentGC::recordCardCleanPass2Start(MM_EnvironmentStandard *env)
+MM_ConcurrentGC::recordCardCleanPass2Start(MM_EnvironmentBase *env)
 {
 	_pass2Started = true;
 
 	/* Record how mush work we did before pass 2 KO */
-	_totalTracedAtPass2KO = _stats->getTraceSizeCount() + _stats->getConHelperTraceSizeCount();
-	_totalCleanedAtPass2KO = _stats->getCardCleanCount() + _stats->getConHelperCardCleanCount();
+	_totalTracedAtPass2KO = _stats.getTraceSizeCount() + _stats.getConHelperTraceSizeCount();
+	_totalCleanedAtPass2KO = _stats.getCardCleanCount() + _stats.getConHelperCardCleanCount();
 
 	/* ..and boost tracing rate from here to end of cycle so we complete pass 2 ASAP */
 	_allocToTraceRate *= _allocToTraceRateCardCleanPass2Boost;
@@ -3663,13 +3667,16 @@ MM_ConcurrentGC::collectorShutdown(MM_GCExtensionsBase *extensions)
 }
 
 void
-MM_ConcurrentGC::flushLocalBuffers(MM_EnvironmentStandard *env)
+MM_ConcurrentGC::flushLocalBuffers(MM_EnvironmentBase *env)
 {
 	/* flush local reference object buffer */
-	_cli->concurrentGC_flushThreadReferenceBuffer(env);
+	_concurrentDelegate.flushThreadRoots(env);
 
 	/* Return any work packets to appropriate lists */
 	env->_workStack.flush(env);
+
+	/* set up local workstack for more marking */
+	env->_workStack.reset(env, _markingScheme->getWorkPackets());
 }
 
 #if defined(OMR_GC_LARGE_OBJECT_AREA)
@@ -3679,7 +3686,7 @@ MM_ConcurrentGC::flushLocalBuffers(MM_EnvironmentStandard *env)
  * @see MM_ParallelGlobalGC::collectorShutdown()
  */
 void
-MM_ConcurrentGC::updateMeteringHistoryBeforeGC(MM_EnvironmentStandard *env)
+MM_ConcurrentGC::updateMeteringHistoryBeforeGC(MM_EnvironmentBase *env)
 {
 	/* If LOA disabled or a system GC then nothing to do */
 	if (!_extensions->largeObjectArea || env->_cycleState->_gcCode.isExplicitGC()) {
@@ -3710,7 +3717,7 @@ MM_ConcurrentGC::updateMeteringHistoryBeforeGC(MM_EnvironmentStandard *env)
  * @see MM_ParallelGlobalGC::collectorShutdown()
  */
 void
-MM_ConcurrentGC::updateMeteringHistoryAfterGC(MM_EnvironmentStandard *env)
+MM_ConcurrentGC::updateMeteringHistoryAfterGC(MM_EnvironmentBase *env)
 {
 	/* If LOA disabled or a system GC then nothing to do */
 	if (!_extensions->largeObjectArea || env->_cycleState->_gcCode.isExplicitGC()) {

--- a/gc/base/standard/ConcurrentSafepointCallback.cpp
+++ b/gc/base/standard/ConcurrentSafepointCallback.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2015 IBM Corp. and others
+ * Copyright (c) 2015, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -56,7 +56,7 @@ MM_ConcurrentSafepointCallback::registerCallback(MM_EnvironmentBase *env, Safepo
 }
 
 void
-MM_ConcurrentSafepointCallback::requestCallback(MM_EnvironmentStandard *env)
+MM_ConcurrentSafepointCallback::requestCallback(MM_EnvironmentBase *env)
 {
 	/* In uncomplicated cases that always call the concurrent write barrier
 	 * (MM_CollectorLanguageInterface::writeBarrierStore/Update()) this can
@@ -69,7 +69,7 @@ MM_ConcurrentSafepointCallback::requestCallback(MM_EnvironmentStandard *env)
 
 
 void
-MM_ConcurrentSafepointCallback::cancelCallback(MM_EnvironmentStandard *env)
+MM_ConcurrentSafepointCallback::cancelCallback(MM_EnvironmentBase *env)
 {
 	/* To facilitate simple Card Table logic treat cancelCallback as a no-op */
 }

--- a/gc/base/standard/ConcurrentSweepScheme.cpp
+++ b/gc/base/standard/ConcurrentSweepScheme.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1089,7 +1089,7 @@ MM_ConcurrentSweepScheme::calculateTax(MM_EnvironmentBase *envModron, UDATA allo
 
 #if defined(OMR_GC_MODRON_CONCURRENT_MARK)
 	if(_extensions->concurrentMark) {
-		UDATA kickoffThreshold = ((MM_ConcurrentGC *)_collector)->_stats->getKickoffThreshold();
+		UDATA kickoffThreshold = ((MM_ConcurrentGC *)_collector)->getConcurrentGCStats()->getKickoffThreshold();
 		
 		/* Another thread may have pushed us over the kickoffThreshold leaving us with a 
 		 * negative difference between remainingFree and kickoffThreshold 

--- a/gc/base/standard/ConfigurationGenerational.cpp
+++ b/gc/base/standard/ConfigurationGenerational.cpp
@@ -152,7 +152,7 @@ MM_ConfigurationGenerational::createDefaultMemorySpace(MM_EnvironmentBase *envBa
 	/* then we build "new-space" - note that if we fail during this we must remember to kill() the oldspace we created */
 
 	/* join them with a semispace */
-	if(NULL == (scavenger = MM_Scavenger::newInstance(env, ext->collectorLanguageInterface, ext->heapRegionManager))) {
+	if(NULL == (scavenger = MM_Scavenger::newInstance(env, ext->heapRegionManager))) {
 		memorySubSpaceOld->kill(env);
 		return NULL;
 	}

--- a/gc/base/standard/ConfigurationStandard.cpp
+++ b/gc/base/standard/ConfigurationStandard.cpp
@@ -96,15 +96,15 @@ MM_ConfigurationStandard::createGlobalCollector(MM_EnvironmentBase* env)
 	MM_GCExtensionsBase *extensions = env->getExtensions();
 #if defined(OMR_GC_MODRON_CONCURRENT_MARK)
 	if (extensions->concurrentMark) {
-		return MM_ConcurrentGC::newInstance(env, extensions->collectorLanguageInterface);
+		return MM_ConcurrentGC::newInstance(env);
 	}
 #endif /* OMR_GC_MODRON_CONCURRENT_MARK */
 #if defined(OMR_GC_CONCURRENT_SWEEP)
 	if (extensions->concurrentSweep) {
-		return MM_ConcurrentSweepGC::newInstance((MM_EnvironmentStandard *)env, extensions->collectorLanguageInterface);
+		return MM_ConcurrentSweepGC::newInstance(env);
 	}
 #endif /* OMR_GC_CONCURRENT_SWEEP */
-	return MM_ParallelGlobalGC::newInstance(env, extensions->collectorLanguageInterface);
+	return MM_ParallelGlobalGC::newInstance(env);
 }
 
 /**

--- a/gc/base/standard/EnvironmentStandard.hpp
+++ b/gc/base/standard/EnvironmentStandard.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -62,9 +62,6 @@ public:
 	void *_survivorTLHRemainderBase; /**< base and top pointers of the last unused survivor TLH copy cache, that might be reused  on next copy refresh */
 	void *_survivorTLHRemainderTop;
 
-	/* TODO: Temporary hiding place for thread specific GC structures */
-	bool _threadCleaningCards;
-
 protected:
 
 private:
@@ -91,7 +88,6 @@ public:
 		,_loaAllocation(false)
 		,_survivorTLHRemainderBase(NULL)
 		,_survivorTLHRemainderTop(NULL)
-		,_threadCleaningCards(false)
 	{
 		_typeId = __FUNCTION__;
 	}

--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -187,13 +187,13 @@ hookGlobalGcSweepEndAbortedCSFixHeap(J9HookInterface** hook, UDATA eventNum, voi
  * Initialization
  */
 MM_ParallelGlobalGC *
-MM_ParallelGlobalGC::newInstance(MM_EnvironmentBase *env, MM_CollectorLanguageInterface *cli)
+MM_ParallelGlobalGC::newInstance(MM_EnvironmentBase *env)
 {
 	MM_ParallelGlobalGC *globalGC;
 		
 	globalGC = (MM_ParallelGlobalGC *)env->getForge()->allocate(sizeof(MM_ParallelGlobalGC), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (globalGC) {
-		new(globalGC) MM_ParallelGlobalGC(env, cli);
+		new(globalGC) MM_ParallelGlobalGC(env);
 		if (!globalGC->initialize(env)) { 
 			globalGC->kill(env);
 			globalGC = NULL;

--- a/gc/base/standard/ParallelGlobalGC.hpp
+++ b/gc/base/standard/ParallelGlobalGC.hpp
@@ -253,7 +253,7 @@ protected:
 	}
 
 public:
-	static MM_ParallelGlobalGC *newInstance(MM_EnvironmentBase *env, MM_CollectorLanguageInterface *cli);
+	static MM_ParallelGlobalGC *newInstance(MM_EnvironmentBase *env);
 	virtual void kill(MM_EnvironmentBase *env);
 
 	virtual uintptr_t getVMStateID();
@@ -307,8 +307,8 @@ public:
 
 	virtual void completeExternalConcurrentCycle(MM_EnvironmentBase *env);
 
-	MM_ParallelGlobalGC(MM_EnvironmentBase *env, MM_CollectorLanguageInterface *cli)
-		: MM_GlobalCollector(env, cli)
+	MM_ParallelGlobalGC(MM_EnvironmentBase *env)
+		: MM_GlobalCollector()
 		, _extensions(MM_GCExtensionsBase::getExtensions(env->getOmrVM()))
 		, _portLibrary(env->getPortLibrary())
 #if defined(OMR_GC_MODRON_COMPACTION)

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -175,13 +175,13 @@ MM_Scavenger::deleteSweepPoolState(MM_EnvironmentBase *env, void *sweepPoolState
  * @return a new instance of the receiver or NULL on failure.
  */
 MM_Scavenger *
-MM_Scavenger::newInstance(MM_EnvironmentStandard *env, MM_CollectorLanguageInterface *cli, MM_HeapRegionManager *regionManager)
+MM_Scavenger::newInstance(MM_EnvironmentStandard *env, MM_HeapRegionManager *regionManager)
 {
 	MM_Scavenger *scavenger;
 
 	scavenger = (MM_Scavenger *)env->getForge()->allocate(sizeof(MM_Scavenger), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (scavenger) {
-		new(scavenger) MM_Scavenger(env, cli, regionManager);
+		new(scavenger) MM_Scavenger(env, regionManager);
 		if (!scavenger->initialize(env)) {
 			scavenger->kill(env);
 			scavenger = NULL;

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -67,6 +67,7 @@ class MM_Scavenger : public MM_Collector
 	 * Data members
 	 */
 private:
+	MM_CollectorLanguageInterface *_cli;
 	const uintptr_t _objectAlignmentInBytes;	/**< Run-time objects alignment in bytes */
 	bool _isRememberedSetInOverflowAtTheBeginning; /**< Cached RS Overflow flag at the beginning of the scavenge */
 
@@ -545,7 +546,7 @@ protected:
 	
 public:
 
-	static MM_Scavenger *newInstance(MM_EnvironmentStandard *env, MM_CollectorLanguageInterface *cli, MM_HeapRegionManager *regionManager);
+	static MM_Scavenger *newInstance(MM_EnvironmentStandard *env, MM_HeapRegionManager *regionManager);
 	virtual void kill(MM_EnvironmentBase *env);
 	
 	virtual bool collectorStartup(MM_GCExtensionsBase* extensions);
@@ -731,8 +732,9 @@ public:
 
 	virtual void heapReconfigured(MM_EnvironmentBase *env);
 
-	MM_Scavenger(MM_EnvironmentBase *env, MM_CollectorLanguageInterface *cli, MM_HeapRegionManager *regionManager) :
-		MM_Collector(cli)
+	MM_Scavenger(MM_EnvironmentBase *env, MM_HeapRegionManager *regionManager) :
+		MM_Collector()
+		, _cli(env->getExtensions()->collectorLanguageInterface)
 		, _objectAlignmentInBytes(env->getObjectAlignmentInBytes())
 		, _isRememberedSetInOverflowAtTheBeginning(false)
 		, _extensions(env->getExtensions())

--- a/glue/CollectorLanguageInterfaceImpl.cpp
+++ b/glue/CollectorLanguageInterfaceImpl.cpp
@@ -41,20 +41,6 @@
 #include "Scavenger.hpp"
 #include "SlotObject.hpp"
 
-/* This enum extends ConcurrentStatus with values > CONCURRENT_ROOT_TRACING. Values from this
- * and from ConcurrentStatus are treated as uintptr_t values everywhere except when used as
- * case labels in switch() statements where manifest constants are required.
- * 
- * ConcurrentStatus extensions allow the client language to define discrete units of work
- * that can be executed in parallel by concurrent threads. ConcurrentGC will call 
- * MM_CollectorLanguageInterfaceImpl::concurrentGC_collectRoots(..., concurrentStatus, ...)
- * only once with each client-defined status value. The thread that receives the call
- * can check the concurrentStatus value to select and execute the appropriate unit of work.
- */
-enum {
-	CONCURRENT_ROOT_TRACING1 = ((uintptr_t)((uintptr_t)CONCURRENT_ROOT_TRACING + 1))
-};
-
 /**
  * Initialization
  */
@@ -247,46 +233,3 @@ MM_CollectorLanguageInterfaceImpl::compactScheme_languageMasterSetupForGC(MM_Env
 }
 #endif /* OMR_GC_MODRON_COMPACTION */
 
-#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
-MM_ConcurrentSafepointCallback*
-MM_CollectorLanguageInterfaceImpl::concurrentGC_createSafepointCallback(MM_EnvironmentBase *env)
-{
-	MM_EnvironmentStandard *envStd = MM_EnvironmentStandard::getEnvironment(env);
-	return MM_ConcurrentSafepointCallback::newInstance(envStd);
-}
-
-uintptr_t
-MM_CollectorLanguageInterfaceImpl::concurrentGC_getNextTracingMode(uintptr_t executionMode)
-{
-	uintptr_t nextExecutionMode = CONCURRENT_TRACE_ONLY;
-	switch (executionMode) {
-	case CONCURRENT_ROOT_TRACING:
-		nextExecutionMode = CONCURRENT_ROOT_TRACING1;
-		break;
-	case CONCURRENT_ROOT_TRACING1:
-		nextExecutionMode = CONCURRENT_TRACE_ONLY;
-		break;
-	default:
-		Assert_MM_unreachable();
-	}
-
-	return nextExecutionMode;
-}
-
-uintptr_t
-MM_CollectorLanguageInterfaceImpl::concurrentGC_collectRoots(MM_EnvironmentStandard *env, uintptr_t concurrentStatus, bool *collectedRoots, bool *paidTax)
-{
-	uintptr_t bytesScanned = 0;
-	*collectedRoots = true;
-	*paidTax = true;
-
-	switch (concurrentStatus) {
-	case CONCURRENT_ROOT_TRACING1:
-		break;
-	default:
-		Assert_MM_unreachable();
-	}
-
-	return bytesScanned;
-}
-#endif /* OMR_GC_MODRON_CONCURRENT_MARK */

--- a/glue/CollectorLanguageInterfaceImpl.hpp
+++ b/glue/CollectorLanguageInterfaceImpl.hpp
@@ -64,33 +64,6 @@ public:
 	static MM_CollectorLanguageInterfaceImpl *newInstance(MM_EnvironmentBase *env);
 	virtual void kill(MM_EnvironmentBase *env);
 
-#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
-	virtual MM_ConcurrentSafepointCallback* concurrentGC_createSafepointCallback(MM_EnvironmentBase *env);
-	virtual omrsig_handler_fn concurrentGC_getProtectedSignalHandler(void **signalHandlerArg) {*signalHandlerArg = NULL; return NULL;}
-	virtual void concurrentGC_concurrentInitializationComplete(MM_EnvironmentStandard *env) {}
-	virtual bool concurrentGC_forceConcurrentKickoff(MM_EnvironmentBase *env, uintptr_t gcCode, uintptr_t *languageKickoffReason)
-	{
-		if (NULL != languageKickoffReason) {
-			*languageKickoffReason = NO_LANGUAGE_KICKOFF_REASON;
-		}
-		return false;
-	}
-	virtual uintptr_t concurrentGC_getNextTracingMode(uintptr_t executionMode);
-	virtual uintptr_t concurrentGC_collectRoots(MM_EnvironmentStandard *env, uintptr_t concurrentStatus, bool *collectedRoots, bool *paidTax);
-	virtual void concurrentGC_signalThreadsToTraceStacks(MM_EnvironmentStandard *env) {}
-	virtual void concurrentGC_signalThreadsToDirtyCards(MM_EnvironmentStandard *env) {}
-	virtual void concurrentGC_signalThreadsToStopDirtyingCards(MM_EnvironmentStandard *env) {}
-	virtual void concurrentGC_kickoffCardCleaning(MM_EnvironmentStandard *env) {}
-	virtual void concurrentGC_flushRegionReferenceLists(MM_EnvironmentBase *env) {}
-	virtual void concurrentGC_flushThreadReferenceBuffer(MM_EnvironmentBase *env) {}
-	virtual bool concurrentGC_isThreadReferenceBufferEmpty(MM_EnvironmentBase *env) {return true;}
-	virtual bool concurrentGC_startConcurrentScanning(MM_EnvironmentStandard *env, uintptr_t *bytesTraced, bool *collectedRoots) {*bytesTraced = 0; *collectedRoots = false; return false;}
-	virtual void concurrentGC_concurrentScanningStarted(MM_EnvironmentStandard *env, bool isConcurrentScanningComplete) {}
-	virtual bool concurrentGC_isConcurrentScanningComplete(MM_EnvironmentBase *env) {return true;}
-	virtual uintptr_t concurrentGC_reportConcurrentScanningMode(MM_EnvironmentBase *env) {return 0;}
-	virtual void concurrentGC_scanThread(MM_EnvironmentBase *env) {}
-#endif /* OMR_GC_MODRON_CONCURRENT_MARK */
-
 #if defined(OMR_GC_MODRON_COMPACTION)
 	virtual void compactScheme_languageMasterSetupForGC(MM_EnvironmentBase *env);
 	virtual void compactScheme_fixupRoots(MM_EnvironmentBase *env, MM_CompactScheme *compactScheme);


### PR DESCRIPTION
Extract concurrent collector marking delegate
(MM_ConcurrentMarkingDelegate)
from deprecated collector language interface 
(MM_CollectorLanguageInterface*).

Structures and methods extracted:
(MM_CollectorLanguageInterface -> MM_ConcurrentGC)
```
_concurrentStats -> _stats
```
(MM_CollectorLanguageInterface -> MM_ConcurrentMarkingDelegate)
```
concurrentGC_processItem()
 -> processItem()
concurrentGC_createSafepointCallback()
 -> createSafepointCallback()
concurrentGC_getProtectedSignalHandler()
 -> getProtectedSignalHandler()
concurrentGC_concurrentInitializationComplete()
 -> concurrentInitializationComplete()
concurrentGC_forceConcurrentKickoff()
 -> *canForceConcurrentKickoff()*
concurrentGC_getNextTracingMode()
 -> getNextTracingMode()
concurrentGC_collectRoots()
 -> collectRoots()
concurrentGC_signalThreadsToTraceStacks()
 -> signalThreadsToTraceStacks()
concurrentGC_signalThreadsToDirtyCards()
 -> signalThreadsToDirtyCards()
concurrentGC_signalThreadsToStopDirtyingCards()
 -> signalThreadsToStopDirtyingCards()
concurrentGC_kickoffCardCleaning()
 -> *cardCleaningStarted()*
concurrentGC_flushRegionReferenceLists()
 -> *abortCollection()*
concurrentGC_flushThreadReferenceBuffer()
 -> *flushThreadRoots()*
concurrentGC_isThreadReferenceBufferEmpty()
 -> *removed* (usage replaced with !flushThreadRoots())
concurrentGC_startConcurrentScanning()
 -> startConcurrentScanning()
concurrentGC_concurrentScanningStarted()
 -> concurrentScanningStarted()
concurrentGC_isConcurrentScanningComplete()
 -> isConcurrentScanningComplete()
concurrentGC_reportConcurrentScanningMode()
 -> reportConcurrentScanningMode()
concurrentGC_scanThread()
 -> *scanThreadRoots()*
```

Other changes: normalize MM_EnvironmentBase use in concurrent collector
(MM_ConcurrentGC) to eliminate spurious casting to
MM_EnvironmentStandard (MM_EnvironmentStandard extensions to 
MM_EnvironmentBase are not used by concurrent collector in mark/sweep 
or generational configurations); eliminate MM_CollectorLanguageInterface
parameter from constructors in MM_Collector and subclasses.

OMR Issue #1577
Signed-off-by: Kim Briggs <briggs@ca.ibm.com>