### PR TITLE
Cleanup tril builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,10 +117,6 @@ add_subdirectory(omr)
 add_subdirectory(third_party)
 add_subdirectory(omrsigcompat)
 
-if(OMR_FVTEST)
-	add_subdirectory(fvtest)
-endif()
-
 if(OMR_GC)
 	add_subdirectory(gc)
 endif(OMR_GC)
@@ -132,4 +128,11 @@ endif(OMR_DDR)
 if(OMR_JITBUILDER)
 	add_subdirectory(jitbuilder)
 endif(OMR_JITBUILDER)
+
+# This should come last to ensure dependencies 
+# are defined
+if(OMR_FVTEST)
+	add_subdirectory(fvtest)
+endif()
+
 

--- a/cmake/compiler_support.cmake
+++ b/cmake/compiler_support.cmake
@@ -47,8 +47,8 @@ set(MASM2GAS_PATH ${OMR_ROOT}/tools/compiler/scripts/masm2gas.pl)
 # This supplements the compile definitions, options and 
 # include directories.
 # 
-# Call as make_compiler_component(<target> COMPILER <compiler name>)
-function(make_compiler_target TARGET_NAME) 
+# Call as make_compiler_target(<target> <scope> COMPILER <compiler name>)
+function(make_compiler_target TARGET_NAME SCOPE)
 	cmake_parse_arguments(TARGET 
 		"" # Optional Arguments
 		"COMPILER" # One value arguments
@@ -60,12 +60,12 @@ function(make_compiler_target TARGET_NAME)
 	set(COMPILER_ROOT     ${${TARGET_COMPILER}_ROOT})
 	set(COMPILER_INCLUDES ${${TARGET_COMPILER}_INCLUDES})
 
-	target_include_directories(${TARGET_NAME} BEFORE PRIVATE 
+	target_include_directories(${TARGET_NAME} BEFORE ${SCOPE}
 		${COMPILER_INCLUDES}
 	)
 
 	# TODO: Extract into platform specific section.
-	target_compile_definitions(${TARGET_NAME} PRIVATE
+	target_compile_definitions(${TARGET_NAME} ${SCOPE}
 		BITVECTOR_BIT_NUMBERING_MSB
 		UT_DIRECT_TRACE_REGISTRATION
 		${TR_COMPILE_DEFINITIONS}
@@ -373,5 +373,5 @@ function(create_omr_compiler_library)
 
 
 	# Set include paths and defines.  
-	make_compiler_target(${COMPILER_NAME} COMPILER ${COMPILER_NAME})
+	make_compiler_target(${COMPILER_NAME} PRIVATE COMPILER ${COMPILER_NAME})
 endfunction(create_omr_compiler_library)

--- a/fvtest/CMakeLists.txt
+++ b/fvtest/CMakeLists.txt
@@ -45,6 +45,6 @@ if(OMR_TEST_COMPILER)
 endif()
 
 if(OMR_JITBUILDER)
+    add_subdirectory(tril) 
 	add_subdirectory(compilertriltest)
-	add_subdirectory(tril/test)
 endif()

--- a/fvtest/compilertest/CMakeLists.txt
+++ b/fvtest/compilertest/CMakeLists.txt
@@ -86,7 +86,7 @@ add_executable(compilertest
 
 
 # Inherit the include path from the compiler component
-make_compiler_target(compilertest COMPILER testcompiler)
+make_compiler_target(compilertest PRIVATE COMPILER testcompiler)
 
 # target_include_directories(compilertest PRIVATE 
 # 	${PROJECT_SOURCE_DIR}/third_party/gtest-1.7.0/

--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -37,7 +37,6 @@ add_executable(comptest
    ShiftAndRotateTest.cpp
 )
 
-add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../tril/tril ${CMAKE_CURRENT_BINARY_DIR}/tril)
 target_link_libraries(comptest
    omrGtest
    tril

--- a/fvtest/tril/README.md
+++ b/fvtest/tril/README.md
@@ -45,54 +45,35 @@ on your machine
 
 2. Clone the Eclipse OMR repo:
 
-```sh
-git clone https://github.com/eclipse/omr.git
-```
+    ```sh
+    git clone https://github.com/eclipse/omr.git
+    ```
 
-3. Build JitBuilder
+3. Build tril using `cmake`. To ensure OMR gets built in a compatible
+   configuration, we currently reccomend you use the CMake cache that drives
+   our TravisCI builds.
 
-```sh
-cd omr
-./configure SPEC=x86-64 --enable-OMR_JITBUILDER # set SPEC for your platfrom
-cd jitbuilder
-make -j4
-cd ..
-```
+    ```sh
+    mkdir build
+    cd build
+    cmake -C../cmake/caches/Travis.cmake ..
+    ```
 
-4. Build the Tril library
+    At this point you can use whatever generated build system to build
+    tril: 
 
-```sh
-cd fvtest/tril
-mkdir build
-cd build
-cmake -GNinja ..
-cmake --build .
-```
+    ```
+    make tril
+    ```
 
 5. You should now have a static archive called `libtril.a`
 
-### Building the Mandelbrot example
-
-Now that the Tril library was built, you should be able to build any of the
-provided examples.
-
-1. `cd` into the Tril top level directory (`cd ../..` if continuing from
-   previous section)
-
-2. Go to the Mandelbrot example directory and build
-
-```sh
-cd examples/mandelbrot
-mkdir build
-cd build
-cmake -GNinja ..
-cmake --build .
-```
-
-3. Run the example, optionally enabling Testarossa tracing
-
-```sh
-TR_Options=traceIlGen,traceFull,log=trace.log ./mandelbrot ../mandelbrot.tril
-```
+6. You can build the tests by building `triltest`, or the compiler tests built
+   using tril by by building `comptest`. There's also the `mandelbrot` and `incordec` 
+   examples.
 
 4. Enjoy the view!
+
+   ```
+   ./fvtest/tril/examples/mandelbrot/mandelbrot ../fvtest/tril/examples/mandelbrot/mandelbrot.tril
+   ```

--- a/fvtest/tril/examples/CMakeLists.txt
+++ b/fvtest/tril/examples/CMakeLists.txt
@@ -19,9 +19,5 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 ###############################################################################
 
-cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
-
-project(tril_examples)
-
 add_subdirectory(incordec)
 add_subdirectory(mandelbrot)

--- a/fvtest/tril/examples/incordec/CMakeLists.txt
+++ b/fvtest/tril/examples/incordec/CMakeLists.txt
@@ -31,7 +31,6 @@ add_executable(incordec
    main.cpp
 )
 
-add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../../tril/ ${CMAKE_CURRENT_BINARY_DIR}/tril)
 target_link_libraries(incordec
    tril
 )

--- a/fvtest/tril/examples/mandelbrot/CMakeLists.txt
+++ b/fvtest/tril/examples/mandelbrot/CMakeLists.txt
@@ -31,7 +31,6 @@ add_executable(mandelbrot
    main.cpp
 )
 
-add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../../tril/ ${CMAKE_CURRENT_BINARY_DIR}/tril)
 target_link_libraries(mandelbrot
    tril
 )

--- a/fvtest/tril/test/CMakeLists.txt
+++ b/fvtest/tril/test/CMakeLists.txt
@@ -19,17 +19,9 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 ###############################################################################
 
-cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
-
-if(NOT TARGET triltest)
-
-project(triltest LANGUAGES CXX)
-
-# not very robust but since we can't build JitBuilder by itself using cmake yet,
-# this will have to do
-if(NOT "${CMAKE_PROJECT_NAME}" STREQUAL "omr")
-   find_package(GTest REQUIRED)
-endif()
+# cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+# 
+# project(triltest LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
@@ -45,22 +37,12 @@ add_executable(triltest
    CompileTest.cpp
 )
 
-add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../tril/ ${CMAKE_CURRENT_BINARY_DIR}/tril)
 target_link_libraries(triltest
    tril
+   omrGtest
 )
-
-# not very robust but since we can't build JitBuilder by itself using cmake yet,
-# this will have to do
-if(NOT "${CMAKE_PROJECT_NAME}" STREQUAL "omr")
-    target_link_libraries(triltest ${GTEST_BOTH_LIBRARIES})
-else()
-    target_link_libraries(triltest omrGtest)
-endif()
 
 add_test(
     NAME triltest
-    COMMAND triltest --gtest_color=yes
+    COMMAND triltest
 )
-
-endif()

--- a/fvtest/tril/tril/CMakeLists.txt
+++ b/fvtest/tril/tril/CMakeLists.txt
@@ -19,17 +19,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 ###############################################################################
 
-cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
-
-if(NOT TARGET tril)
-
-project(tril LANGUAGES C CXX)
-
 find_package(BISON)
 find_package(FLEX)
-
-set(OMR_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../omr)
-set(JITBUILDER_PATH ${OMR_PATH}/jitbuilder)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
@@ -37,57 +28,31 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 BISON_TARGET(tril_parser tril.y ${CMAKE_CURRENT_BINARY_DIR}/tril.parser.c)
 FLEX_TARGET(tril_scanner tril.l ${CMAKE_CURRENT_BINARY_DIR}/tril.scanner.c
-    COMPILE_FLAGS "--yylineno --header-file=${CMAKE_CURRENT_BINARY_DIR}/tril.scanner.h")
+	COMPILE_FLAGS "--yylineno --header-file=${CMAKE_CURRENT_BINARY_DIR}/tril.scanner.h")
 #            DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/tril.scanner.h)
 ADD_FLEX_BISON_DEPENDENCY(tril_scanner tril_parser)
 
 add_library(tril STATIC
-    ${BISON_tril_parser_OUTPUTS}
-    ${FLEX_tril_scanner_OUTPUTS}
-    ast.cpp
-    ilgen.cpp
-    jitbuilder_compiler.cpp
+	${BISON_tril_parser_OUTPUTS}
+	${FLEX_tril_scanner_OUTPUTS}
+	ast.cpp
+	ilgen.cpp
+	jitbuilder_compiler.cpp
 )
 
-target_compile_definitions(tril PUBLIC
-    BITVECTOR_BIT_NUMBERING_MSB
-    UT_DIRECT_TRACE_REGISTRATION
-    JITTEST
-    JITBUILDER_SPECIFIC
-    PROD_WITH_ASSUMES
-    TR_HOST_X86
-    TR_HOST_64BIT
-    BITVECTOR_64BIT
-    LINUX
-    TR_TARGET_X86
-    TR_TARGET_64BIT
-    SUPPORTS_THREAD_LOCAL
-    _LONG_LONG
-)
+# This is mildly peculiar. Because tril relies
+# on jitbuilder as a 'backend' of sorts, we use
+# its includes. Tril exports this as interface
+make_compiler_target(tril PUBLIC COMPILER jitbuilder) 
 
 target_include_directories(tril PUBLIC
-    ${CMAKE_CURRENT_BINARY_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${JITBUILDER_PATH}/release/include
-    ${JITBUILDER_PATH}/x
-    ${JITBUILDER_PATH}
-    ${OMR_PATH}/compiler/x/amd64
-    ${OMR_PATH}/compiler/x
-    ${OMR_PATH}/compiler
-    ${OMR_PATH}
-    ${OMR_PATH}/include_core
+	${CMAKE_CURRENT_BINARY_DIR}
+	${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-# not very robust but since we can't build JitBuilder by itself using cmake yet,
-# this will have to do
-if(NOT "${CMAKE_PROJECT_NAME}" STREQUAL "omr")
-    set(OMR_JITBUILDER ON CACHE BOOL "")
-    set(OMR_WARNINGS_AS_ERRORS OFF CACHE BOOL "")
-    add_subdirectory(${OMR_PATH} ${CMAKE_CURRENT_BINARY_DIR}/omr)
-endif()
-target_link_libraries(tril INTERFACE
-    jitbuilder
-    dl
+target_link_libraries(tril PUBLIC 
+	jitbuilder
+	dl
 )
 
 add_executable(tril_dumper compiler.cpp) 
@@ -95,8 +60,8 @@ target_link_libraries(tril_dumper tril)
 
 add_executable(tril_compiler compiler.cpp) 
 target_link_libraries(tril_compiler tril)
+
 #export(TARGETS tril jitbuilder FILE tril-config.cmake)
 #install(FILES ast.h ilgen.hpp DESTINATION include)
 #install(TARGETS tril EXPORT tril-targets ARCHIVE DESTINATION lib)
 #install(EXPORT tril-targets FILE tril-config.cmake DESTINATION lib/cmake/tril)
-endif()

--- a/jitbuilder/CMakeLists.txt
+++ b/jitbuilder/CMakeLists.txt
@@ -64,9 +64,13 @@ create_omr_compiler_library(NAME       jitbuilder
 
 # Add interface path so that include paths propagate. 
 # NOTE: `release` directory  isn't being automatically setup, so this 
-#       Won't yet work on a clone!
-target_include_directories(jitbuilder 
-    INTERFACE release/include ../compiler/ ../
+#       is adding the actual compiler dir, as opposed to the 'composed'
+#       install directory.
+target_include_directories(jitbuilder
+	INTERFACE
+		release/include
+		../compiler/
+		../
 )
 
 


### PR DESCRIPTION
This moves much of the include path requirements into the CMake
scoped variables system.

One of the side effects is the modification of make_compiler_target to
allow specifying a different scope.

Signed-off-by: Matthew Gaudet <magaudet@ca.ibm.com>