### PR TITLE
cmake: Support tools cross compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,9 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules" ${CMAKE_MODULE
 
 include(OmrAssert)
 include(OmrFindFiles)
+include(OmrHookgen)
 include(OmrPlatform)
+include(OmrTracegen)
 
 ###
 ### Set up the global platform configuration
@@ -95,10 +97,12 @@ endif()
 configure_file(./omrcfg.CMakeTemplate.h omrcfg.h)
 configure_file(./omrversionstrings.CMakeTemplate.h omrversionstrings.h)
 
-add_subdirectory(tools)
-# Yeah, its dumb doing this here. Read note in tools/CMakeLists.txt
-if(CMAKE_CROSSCOMPILING)
-	include(${OMR_TOOLS_IMPORTFILE})
+if(OMR_TOOLS_IMPORTFILE)
+	include("${OMR_TOOLS_IMPORTFILE}")
+elseif(OMR_TOOLS)
+	add_subdirectory(tools)
+else()
+	message(FATAL_ERROR "OMR: Build tools are required. See OMR_TOOLS and OMR_TOOLS_IMPORTFILE")
 endif()
 
 add_subdirectory(thread)

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -31,9 +31,19 @@ set(OMR_OMRSIG ON CACHE BOOL "Enable the OMR signal compatibility library")
 set(OMR_PORT ON CACHE BOOL "Enable portability library")
 set(OMR_TEST_COMPILER OFF CACHE BOOL "Enable building the test compiler")
 set(OMR_THREAD ON CACHE BOOL "Enable thread library")
-# set(OMR_TOOLS On CACHE BOOL "Enable the build tools")
-# TODO: Support building only tools for cross-compilation build
+set(OMR_TOOLS ON CACHE BOOL "Enable the native build tools")
 
+###
+### Tooling
+###
+
+set(OMR_TOOLS_IMPORTFILE "IMPORTFILE-NOTFOUND" CACHE FILEPATH
+	"Point it to the ImportTools.cmake file of a native build"
+)
+
+###
+### Library names
+###
 
 set(OMR_GC_LIB "omrgc" CACHE STRING "Name of the GC library to use")
 set(OMR_HOOK_LIB "j9hookstatic" CACHE STRING "Name of the hook library to link against")

--- a/cmake/modules/OmrHookgen.cmake
+++ b/cmake/modules/OmrHookgen.cmake
@@ -1,6 +1,6 @@
 ###############################################################################
 #
-# (c) Copyright IBM Corp. 2017, 2017
+# (c) Copyright IBM Corp. 2017
 #
 #  This program and the accompanying materials are made available
 #  under the terms of the Eclipse Public License v1.0 and
@@ -16,19 +16,23 @@
 #    Multiple authors (IBM Corp.) - initial implementation and documentation
 ###############################################################################
 
-include(OmrAssert)
+if(OMR_HOOKGEN_)
+	return()
+endif()
+set(OMR_HOOKGEN_ 1)
 
-omr_assert(TEST OMR_TOOLS)
-omr_assert(TEST NOT OMR_TOOLS_IMPORTFILE)
+#TODO: currently output in source tree, should be in build tree
+#TODO: Dependecy checking is broken, since it checks for output in build tree rather than src
+function(omr_add_hookgen input)
+	get_filename_component(input_dir "${input}" DIRECTORY)
+	add_custom_command(
+		OUTPUT ${ARGN}
+		COMMAND hookgen ${CMAKE_CURRENT_SOURCE_DIR}/${input}
+		DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${input}"
+		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${input_dir}
+	)
+endfunction(omr_add_hookgen)
 
-if(CMAKE_CROSSCOMPILING)
-	message(STATUS "OMR: Using cross compiled tools.")
-	message(STATUS "OMR: You may need to import tools from a native project.")
-	message(STATUS "OMR: See OMR_TOOLS_IMPORTFILE.")
-endif(CMAKE_CROSSCOMPILING)
-
-add_subdirectory(hookgen)
-add_subdirectory(tracemerge)
-add_subdirectory(tracegen)
-
-export(TARGETS hookgen tracemerge tracegen FILE "ImportTools.cmake")
+macro(add_hookgen)
+	omr_add_hookgen(${ARGN})
+endmacro(add_hookgen)

--- a/cmake/modules/OmrHookgen.cmake
+++ b/cmake/modules/OmrHookgen.cmake
@@ -21,8 +21,10 @@ if(OMR_HOOKGEN_)
 endif()
 set(OMR_HOOKGEN_ 1)
 
-#TODO: currently output in source tree, should be in build tree
-#TODO: Dependecy checking is broken, since it checks for output in build tree rather than src
+# Process an input hookgen file to generate output source files.
+# Usage: omr_add_hookgen(<input> <output>...)
+# TODO: currently output in source tree, should be in build tree
+# TODO: Dependecy checking is broken, since it checks for output in build tree rather than src
 function(omr_add_hookgen input)
 	get_filename_component(input_dir "${input}" DIRECTORY)
 	add_custom_command(

--- a/cmake/modules/OmrTracegen.cmake
+++ b/cmake/modules/OmrTracegen.cmake
@@ -21,6 +21,13 @@ if(OMR_TRACEGEN_)
 endif()
 set(OMR_TRACEGEN 1)
 
+# Process an <input> tracegen file to produce trace headers, sources, and pdat files.
+# Usage: omr_add_tracegen(<input> [<output>])
+# By default, <output> is derived from the base name of <input>.
+# tracegen will produce:
+#   ut_<output>.h
+#   ut_<output>.c
+#   ut_<output>.pdat
 #TODO: pehaps should detect output by searching for "executable=" line
 #takes extra optional argument name to override output filename
 function(omr_add_tracegen input)

--- a/cmake/modules/OmrTracegen.cmake
+++ b/cmake/modules/OmrTracegen.cmake
@@ -1,0 +1,46 @@
+###############################################################################
+#
+# (c) Copyright IBM Corp. 2017, 2017
+#
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License v1.0 and
+#  Apache License v2.0 which accompanies this distribution.
+#
+#      The Eclipse Public License is available at
+#      http://www.eclipse.org/legal/epl-v10.html
+#
+#      The Apache License v2.0 is available at
+#      http://www.opensource.org/licenses/apache2.0.php
+#
+# Contributors:
+#    Multiple authors (IBM Corp.) - initial implementation and documentation
+###############################################################################
+
+if(OMR_TRACEGEN_)
+	return()
+endif()
+set(OMR_TRACEGEN 1)
+
+#TODO: pehaps should detect output by searching for "executable=" line
+#takes extra optional argument name to override output filename
+function(omr_add_tracegen input)
+	get_filename_component(input_dir "${input}" DIRECTORY)
+
+	if(ARGV1)
+		set(base_name "${ARGV1}")
+	else()
+		get_filename_component(base_name "${input}" NAME_WE)
+	endif()
+	file(TO_CMAKE_PATH "${CMAKE_CURRENT_BINARY_DIR}/ut_${base_name}" generated_filename)
+
+	add_custom_command(
+		OUTPUT "${generated_filename}.c" "${generated_filename}.h" "${generated_filename}.pdat"
+		COMMAND tracegen -w2cd -treatWarningAsError -generatecfiles -threshold 1 -file ${CMAKE_CURRENT_SOURCE_DIR}/${input}
+		DEPENDS ${input}
+		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+	)
+endfunction(omr_add_tracegen)
+
+macro(add_tracegen)
+	omr_add_tracegen(${ARGN})
+endmacro(add_tracegen)


### PR DESCRIPTION
This patch lets us compile and use the tools when cross compiling for
x86 on an x86-64 machine.

I've simplified the tools directory, moving the add_tracegen and
add_hookgen macros to seperate modules. This lets them be used outside
of OMR more easily. Now, we can completely skip the tools directory when
importing.

Do not skip the tools directory when cross compiling. Instead, emit a
message that the tools will be cross compiled.

The OMR_TOOLS flag is now respected. If you have the hookgen or tracegen
tools installed on your system, you should be able to disable building
the bundled tools completely. Imported tools will always be used,
regardless of the OMR_TOOLS state.

Signed-off-by: Robert Young <rwy0717@gmail.com>