### PR TITLE
Distribute Testarossa Platform Support. 

### DIFF
--- a/cmake/compiler_support.cmake
+++ b/cmake/compiler_support.cmake
@@ -32,114 +32,12 @@ if (NOT PERL_FOUND )
 	message(FATAL_ERROR "Perl not found")
 endif()
 
+# Currently not doing cross, so assume HOST == TARGET
+set(TR_TARGET_ARCH    ${TR_HOST_ARCH})
+set(TR_TARGET_SUBARCH ${TR_HOST_SUBARCH})
+set(TR_TARGET_BITS    ${TR_HOST_BITS})
 
-macro(tr_detect_system_information)
-	macro(jit_not_ready)
-		message(FATAL_ERROR "JIT isn't ready to build with CMake on this platform: ")
-	endmacro()
-
-	set(TR_COMPILE_DEFINITIONS "")
-	set(TR_COMPILE_OPTIONS     "")
-
-
-	# Platform setup code! 
-	# 
-	# Longer term this will have to be integrated into the evolving platform story, 
-	# hence the attempt to try to isolate the pieces by architecture, OS, and toolconfig.
-	if(OMR_ARCH_X86)
-		set(TR_HOST_ARCH    x)
-		list(APPEND TR_COMPILE_DEFINITIONS TR_HOST_X86 TR_TARGET_X86)
-		if(OMR_ENV_DATA64)
-			set(TR_HOST_SUBARCH amd64)
-			set(TR_HOST_BITS    64)
-			set(CMAKE_ASM-ATT_FLAGS "--64 --defsym TR_HOST_X86=1 --defsym TR_HOST_64BIT=1 --defsym BITVECTOR_64BIT=1 --defsym LINUX=1 --defsym TR_TARGET_X86=1 --defsym TR_TARGET_64BIT=1")
-
-			list(APPEND TR_COMPILE_DEFINITIONS TR_HOST_64BIT TR_TARGET_64BIT)
-		else()
-			jit_not_ready()
-		endif()
-	elseif(OMR_ARCH_POWER)
-		set(TR_HOST_ARCH p)
-		list(APPEND TR_COMPILE_DEFINITIONS TR_HOST_POWER TR_TARGET_POWER)
-		if(OMR_ENV_DATA64)
-			set(TR_HOST_BITS    64)
-			list(APPEND TR_COMPILE_DEFINITIONS TR_HOST_64BIT TR_TARGET_64BIT)
-		else()
-			jit_not_ready()
-		endif()
-	else()
-		jit_not_ready()
-	endif()
-
-	# OS Setup Code. 
-	if(OMR_HOST_OS MATCHES "linux")
-		list(APPEND TR_COMPILE_DEFINITIONS
-			SUPPORTS_THREAD_LOCAL
-			LINUX
-		)
-		
-        elseif(OMR_HOST_OS MATCHES "osx")
-		list(APPEND TR_COMPILE_DEFINITIONS
-			SUPPORTS_THREAD_LOCAL
-			OSX
-		)
-		
-	elseif(OMR_HOST_OS MATCHES "aix")
-		list(APPEND TR_COMPILE_DEFINITIONS
-			SUPPORTS_THREAD_LOCAL
-			_XOPEN_SOURCE_EXTENDED=1 
-			_ALL_SOURCE
-			AIX
-		)
-	else()
-		jit_not_ready()
-	endif()
-
-	message("OMR_TOOLCONFIG is ${OMR_TOOLCONFIG}")
-	# TOOLCHAIN setup code. 
-	if(OMR_TOOLCONFIG MATCHES "gnu|clang")
-		list(APPEND TR_COMPILE_OPTIONS 
-			-std=c++0x
-			-Wno-write-strings #This warning swamps almost all other output
-			) 
-
-		set(PASM_CMD ${CMAKE_C_COMPILER}) 
-		set(PASM_FLAGS -x assembler-with-cpp -E -P) 
-
-		set(SPP_CMD ${CMAKE_C_COMPILER}) 
-		set(SPP_FLAGS -x assembler-with-cpp -E -P) 
-	elseif(OMR_TOOLCONFIG MATCHES "msvc")
-		# MSVC Specifics
-		jit_not_ready()
-	elseif(OMR_TOOLCONFIG MATCHES "xlc") 
-		list(APPEND TR_COMPILE_OPTIONS
-			-qarch=pwr7
-			-qtls 
-			-qnotempinc 
-			-qenum=small 
-			-qmbcs 
-			-qlanglvl=extended0x 
-			-qfuncsect 
-			-qsuppress=1540-1087:1540-1088:1540-1090:1540-029:1500-029
-			-qdebug=nscrep
-			)
-
-		set(SPP_CMD ${CMAKE_C_COMPILER}) 
-		set(SPP_FLAGS -E -P) 
-	endif()
-
-
-	# Currently not doing cross, so assume HOST == TARGET
-	set(TR_TARGET_ARCH    ${TR_HOST_ARCH})
-	set(TR_TARGET_SUBARCH ${TR_HOST_SUBARCH})
-	set(TR_TARGET_BITS    ${TR_HOST_BITS})
-
-	set(MASM2GAS_PATH ${OMR_ROOT}/tools/compiler/scripts/masm2gas.pl)
-
-	message(STATUS "Set TR_COMPILE_DEFINITIONS to ${TR_COMPILE_DEFINITIONS}")
-endmacro(tr_detect_system_information)
-
-tr_detect_system_information()
+set(MASM2GAS_PATH ${OMR_ROOT}/tools/compiler/scripts/masm2gas.pl)
 
 # Mark a target as consuming the compiler components. 
 # 

--- a/cmake/compiler_support.cmake
+++ b/cmake/compiler_support.cmake
@@ -69,10 +69,6 @@ function(make_compiler_target TARGET_NAME)
 		${COMPILER_DEFINES} 
 	)
 
-target_compile_options(${TARGET_NAME} PRIVATE 
-		${TR_COMPILE_OPTIONS}
-	)
-
 	message("Made ${TARGET_NAME} into a compiler target,for ${TARGET_COMPILER}.")
 	message("Defines are ${COMPILER_DEFINES} and ${TR_COMPILE_DEFINITIONS}, arch is ${TR_TARGET_ARCH} and ${TR_TARGET_SUBARCH}, compile options are ${TR_COMPILE_OPTIONS} ") 
 endfunction(make_compiler_target)
@@ -239,6 +235,15 @@ function(omr_inject_object_modification_targets result compiler_name)
 	set(${result} ${arg} PARENT_SCOPE)
 endfunction(omr_inject_object_modification_targets)
 
+# Setup the current scope for compiling the Testarossa compiler technology. Used in 
+# conjunction with make_compiler_target -- Only can infect add_directory scope.
+macro(set_tr_compile_options)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TR_COMPILE_OPTIONS} ${TR_CXX_COMPILE_OPTIONS}" PARENT_SCOPE)
+	set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} ${TR_COMPILE_OPTIONS}   ${TR_C_COMPILE_OPTIONS}" PARENT_SCOPE)
+	# message("[set_tr_compile_options] Set CMAKE_CXX_FLAGS to ${CMAKE_CXX_FLAGS}")
+	# message("[set_tr_compile_options] Set CMAKE_C_FLAGS to ${CMAKE_C_FLAGS}")
+endmacro(set_tr_compile_options)
+
 # Create an OMR Compiler component
 # 
 # call like this: 
@@ -267,6 +272,8 @@ function(create_omr_compiler_library)
 		message("Creating static library for ${COMPILER_NAME}")
 		set(LIB_TYPE STATIC)
 	endif()
+
+	set_tr_compile_options()
 
 
 	get_filename_component(abs_root ${CMAKE_CURRENT_LIST_DIR} ABSOLUTE)

--- a/cmake/modules/platform/arch/ppc.cmake
+++ b/cmake/modules/platform/arch/ppc.cmake
@@ -25,3 +25,16 @@ endif()
 list(APPEND OMR_PLATFORM_DEFINITIONS
 	-DPPC
 )
+
+# Testarossa build variables. Longer term the distinction between TR and the rest 
+# of the OMR code should be heavily reduced. In the mean time, we keep
+# the distinction
+set(TR_HOST_ARCH p)
+list(APPEND TR_COMPILE_DEFINITIONS TR_HOST_POWER TR_TARGET_POWER)
+
+if(OMR_ENV_DATA64)
+	set(TR_HOST_BITS    64)
+	list(APPEND TR_COMPILE_DEFINITIONS TR_HOST_64BIT TR_TARGET_64BIT)
+else()
+	message(FATAL_ERROR "JIT isn't ready to build with CMake on this platform: ")
+endif()

--- a/cmake/modules/platform/arch/s390.cmake
+++ b/cmake/modules/platform/arch/s390.cmake
@@ -19,3 +19,15 @@
 list(APPEND OMR_PLATFORM_DEFINITIONS
 	-DJ9VM_TIERED_CODE_CACHE
 )
+
+# Testarossa build variables. Longer term the distinction between TR and the rest 
+# of the OMR code should be heavily reduced. In the mean time, we keep
+# the distinction
+set(TR_HOST_ARCH    z)
+set(TR_HOST_BITS    64)
+list(APPEND TR_COMPILE_DEFINITIONS TR_HOST_S390 TR_TARGET_S390)
+
+if(OMR_ENV_DATA64)
+	list(APPEND TR_COMPILE_DEFINITIONS TR_HOST_64BIT TR_TARGET_64BIT)
+endif()
+set(CMAKE_ASM-ATT_FLAGS "-noexecstack -march=z9-109")

--- a/cmake/modules/platform/arch/x86.cmake
+++ b/cmake/modules/platform/arch/x86.cmake
@@ -25,3 +25,21 @@ else()
 		-DJ9X86
 	)
 endif()
+
+# Testarossa build variables. Longer term the distinction between TR and the rest 
+# of the OMR code should be heavily reduced. In the mean time, we keep
+# the distinction
+list(APPEND TR_COMPILE_DEFINITIONS -DTR_HOST_X86 -DTR_TARGET_X86)
+
+set(TR_HOST_ARCH    x)
+
+if(OMR_ENV_DATA64)
+	list(APPEND TR_COMPILE_DEFINITIONS -DTR_HOST_64BIT -DTR_TARGET_64BIT)
+
+
+	set(TR_HOST_SUBARCH amd64)
+	set(TR_HOST_BITS    64)
+	set(CMAKE_ASM-ATT_FLAGS "--64 --defsym TR_HOST_X86=1 --defsym TR_HOST_64BIT=1 --defsym BITVECTOR_64BIT=1 --defsym LINUX=1 --defsym TR_TARGET_X86=1 --defsym TR_TARGET_64BIT=1")
+else()
+		message(FATAL_ERROR "JIT isn't ready to build with CMake on this platform: ")
+endif()

--- a/cmake/modules/platform/os/aix.cmake
+++ b/cmake/modules/platform/os/aix.cmake
@@ -26,3 +26,8 @@ set(OMR_PLATFORM_DEFINITIONS
 	-D_LARGE_FILES
 	-D_ALL_SOURCE
 )
+
+# Testarossa build variables. Longer term the distinction between TR and the rest 
+# of the OMR code should be heavily reduced. In the mean time, we keep
+# the distinction
+list(APPEND TR_COMPILE_DEFINITIONS -DSUPPORTS_THREAD_LOCAL -D_XOPEN_SOURCE_EXTENDED=1 -D_ALL_SOURCE -DAIX)

--- a/cmake/modules/platform/os/linux.cmake
+++ b/cmake/modules/platform/os/linux.cmake
@@ -60,3 +60,9 @@ if(NOT DEFINED OMR_NEED_LIBRT)
 	endif()
 	mark_as_advanced(OMR_NEED_LIBRT)
 endif()
+
+
+# Testarossa build variables. Longer term the distinction between TR and the rest 
+# of the OMR code should be heavily reduced. In the mean time, we keep
+# the distinction
+list(APPEND TR_COMPILE_DEFINITIONS -DSUPPORTS_THREAD_LOCAL -DLINUX)

--- a/cmake/modules/platform/os/osx.cmake
+++ b/cmake/modules/platform/os/osx.cmake
@@ -24,3 +24,9 @@ list(APPEND OMR_PLATFORM_DEFINITIONS
 list(APPEND OMR_PLATFORM_COMPILE_OPTIONS
 	-pthread
 )
+
+
+# Testarossa build variables. Longer term the distinction between TR and the rest 
+# of the OMR code should be heavily reduced. In the mean time, we keep
+# the distinction
+list(APPEND TR_COMPILE_DEFINITIONS -DSUPPORTS_THREAD_LOCAL -DOSX)

--- a/cmake/modules/platform/toolcfg/gnu.cmake
+++ b/cmake/modules/platform/toolcfg/gnu.cmake
@@ -28,3 +28,18 @@ else()
 		-msse2
 	)
 endif()
+
+# Testarossa build variables. Longer term the distinction between TR and the rest 
+# of the OMR code should be heavily reduced. In the mean time, we keep
+# the distinction
+
+list(APPEND TR_COMPILE_OPTIONS 
+	-std=c++0x
+	-Wno-write-strings #This warning swamps almost all other output
+) 
+
+set(PASM_CMD ${CMAKE_C_COMPILER}) 
+set(PASM_FLAGS -x assembler-with-cpp -E -P) 
+
+set(SPP_CMD ${CMAKE_C_COMPILER}) 
+set(SPP_FLAGS -x assembler-with-cpp -E -P) 

--- a/cmake/modules/platform/toolcfg/gnu.cmake
+++ b/cmake/modules/platform/toolcfg/gnu.cmake
@@ -33,10 +33,23 @@ endif()
 # of the OMR code should be heavily reduced. In the mean time, we keep
 # the distinction
 
+
+# TR_COMPILE_OPTIONS are variables appended to CMAKE_{C,CXX}_FLAGS, and so 
+# apply to both C and C++ compilations. 
 list(APPEND TR_COMPILE_OPTIONS 
-	-std=c++0x
 	-Wno-write-strings #This warning swamps almost all other output
 ) 
+
+# TR_CXX_COMPILE_OPTIONS are appended to CMAKE_CXX_FLAGS, and so apply only to
+# C++ file compilation
+list(APPEND TR_CXX_COMPILE_OPTIONS 
+	-std=c++0x
+)
+
+# TR_C_COMPILE_OPTIONS are appended to CMAKE_C_FLAGS, and so apply only to
+# C file compilation
+list(APPEND TR_C_COMPILE_OPTIONS 
+)
 
 set(PASM_CMD ${CMAKE_C_COMPILER}) 
 set(PASM_FLAGS -x assembler-with-cpp -E -P) 

--- a/cmake/modules/platform/toolcfg/xlc.cmake
+++ b/cmake/modules/platform/toolcfg/xlc.cmake
@@ -62,17 +62,30 @@ endif()
 # Testarossa build variables. Longer term the distinction between TR and the rest 
 # of the OMR code should be heavily reduced. In the mean time, we keep
 # the distinction
+
+# TR_COMPILE_OPTIONS are variables appended to CMAKE_{C,CXX}_FLAGS, and so 
+# apply to both C and C++ compilations. 
 list(APPEND TR_COMPILE_OPTIONS
 	-qarch=pwr7
 	-qtls 
 	-qnotempinc 
 	-qenum=small 
 	-qmbcs 
-	-qlanglvl=extended0x 
 	-qfuncsect 
 	-qsuppress=1540-1087:1540-1088:1540-1090:1540-029:1500-029
 	-qdebug=nscrep
-	)
+)
+
+# TR_CXX_COMPILE_OPTIONS are appended to CMAKE_CXX_FLAGS, and so apply only to
+# C++ file compilation
+list(APPEND TR_CXX_COMPILE_OPTIONS
+	-qlanglvl=extended0x 
+)
+
+# TR_C_COMPILE_OPTIONS are appended to CMAKE_C_FLAGS, and so apply only to
+# C file compilation
+list(APPEND TR_C_COMPILE_OPTIONS 
+)
 
 set(SPP_CMD ${CMAKE_C_COMPILER}) 
 set(SPP_FLAGS -E -P) 

--- a/cmake/modules/platform/toolcfg/xlc.cmake
+++ b/cmake/modules/platform/toolcfg/xlc.cmake
@@ -58,3 +58,21 @@ elseif(OMR_HOST_OS STREQUAL "linux")
 		-qxflag=selinux
 	)
 endif()
+
+# Testarossa build variables. Longer term the distinction between TR and the rest 
+# of the OMR code should be heavily reduced. In the mean time, we keep
+# the distinction
+list(APPEND TR_COMPILE_OPTIONS
+	-qarch=pwr7
+	-qtls 
+	-qnotempinc 
+	-qenum=small 
+	-qmbcs 
+	-qlanglvl=extended0x 
+	-qfuncsect 
+	-qsuppress=1540-1087:1540-1088:1540-1090:1540-029:1500-029
+	-qdebug=nscrep
+	)
+
+set(SPP_CMD ${CMAKE_C_COMPILER}) 
+set(SPP_FLAGS -E -P) 


### PR DESCRIPTION
Remove `tr_detect_system_information` and integrate the compiler build variables into the broader OMR platform system. 