### PR TITLE
Add CompactScheme delegate to Example/glue

### DIFF
--- a/example/glue/CollectorLanguageInterfaceImpl.cpp
+++ b/example/glue/CollectorLanguageInterfaceImpl.cpp
@@ -254,29 +254,3 @@ MM_CollectorLanguageInterfaceImpl::scavenger_fixupDestroyedSlot(MM_EnvironmentBa
 #endif /* OMR_INTERP_COMPRESSED_OBJECT_HEADER */
 #endif /* OMR_GC_MODRON_SCAVENGER */
 
-#if defined(OMR_GC_MODRON_COMPACTION)
-void
-MM_CollectorLanguageInterfaceImpl::compactScheme_verifyHeap(MM_EnvironmentBase *env, MM_MarkMap *markMap)
-{
-	Assert_MM_unimplemented();
-}
-
-void
-MM_CollectorLanguageInterfaceImpl::compactScheme_fixupRoots(MM_EnvironmentBase *env, MM_CompactScheme *compactScheme)
-{
-	Assert_MM_unimplemented();
-}
-
-void
-MM_CollectorLanguageInterfaceImpl::compactScheme_workerCleanupAfterGC(MM_EnvironmentBase *env)
-{
-	Assert_MM_unimplemented();
-}
-
-void
-MM_CollectorLanguageInterfaceImpl::compactScheme_languageMasterSetupForGC(MM_EnvironmentBase *env)
-{
-	Assert_MM_unimplemented();
-}
-#endif /* OMR_GC_MODRON_COMPACTION */
-

--- a/example/glue/CollectorLanguageInterfaceImpl.hpp
+++ b/example/glue/CollectorLanguageInterfaceImpl.hpp
@@ -85,12 +85,6 @@ public:
 #endif /* OMR_INTERP_COMPRESSED_OBJECT_HEADER */
 #endif /* OMR_GC_MODRON_SCAVENGER */
 
-#if defined(OMR_GC_MODRON_COMPACTION)
-	virtual void compactScheme_languageMasterSetupForGC(MM_EnvironmentBase *env);
-	virtual void compactScheme_fixupRoots(MM_EnvironmentBase *env, MM_CompactScheme *compactScheme);
-	virtual void compactScheme_workerCleanupAfterGC(MM_EnvironmentBase *env);
-	virtual void compactScheme_verifyHeap(MM_EnvironmentBase *env, MM_MarkMap *markMap);
-#endif /* OMR_GC_MODRON_COMPACTION */
 };
 
 #endif /* COLLECTORLANGUAGEINTERFACEIMPL_HPP_ */

--- a/example/glue/CompactDelegate.hpp
+++ b/example/glue/CompactDelegate.hpp
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ *******************************************************************************/
+
+#ifndef COMPACTDELEGATE_HPP_
+#define COMPACTDELEGATE_HPP_
+
+#include "omrcfg.h" 
+#include "omrgcconsts.h"
+
+class MM_CompactScheme;
+class MM_EnvironmentBase; 
+class MM_MarkMap;
+
+#if defined(OMR_GC_MODRON_COMPACTION)
+
+/**
+ * Delegate class provides implementations for methods required for Collector Language Interface
+ */
+class MM_CompactDelegate
+{
+	/*
+	 * Data members
+	 */
+private:
+	OMR_VM *_omrVM;
+	MM_CompactScheme *_compactScheme;
+	MM_MarkMap *_markMap;
+
+protected:
+
+public:
+
+	/*
+	 * Function members
+	 */
+private:
+
+protected:
+
+public:
+	/**
+	 * Initialize the delegate.
+	 *
+	 * @param omrVM
+	 * @return true if delegate initialized successfully
+	 */
+	void
+	tearDown(MM_EnvironmentBase *env) { }
+
+	bool
+	initialize(MM_EnvironmentBase *env, OMR_VM *omrVM, MM_MarkMap *markMap, MM_CompactScheme *compactScheme)
+	{
+		_omrVM  = omrVM;
+		_compactScheme = compactScheme;
+		_markMap = markMap;
+		return true;
+	}
+
+	void
+	verifyHeap(MM_EnvironmentBase *env, MM_MarkMap *markMap) { }
+
+	void
+	fixupRoots(MM_EnvironmentBase *env, MM_CompactScheme *compactScheme) { }
+
+	void
+	workerCleanupAfterGC(MM_EnvironmentBase *env) { }
+
+	void
+	masterSetupForGC(MM_EnvironmentBase *env) { }
+
+	MM_CompactDelegate()
+		: _compactScheme(NULL)
+		, _markMap(NULL)
+		, _omrVM(NULL)
+	{}
+};
+
+#endif /* OMR_GC_MODRON_COMPACTION */
+#endif /* COMPACTDELEGATE_HPP_ */

--- a/gc/base/CollectorLanguageInterface.hpp
+++ b/gc/base/CollectorLanguageInterface.hpp
@@ -58,13 +58,6 @@ public:
 
 	virtual void kill(MM_EnvironmentBase *env) = 0;
 
-#if defined(OMR_GC_MODRON_COMPACTION)
-	virtual void compactScheme_languageMasterSetupForGC(MM_EnvironmentBase *env) = 0;
-	virtual void compactScheme_fixupRoots(MM_EnvironmentBase *env, MM_CompactScheme *compactScheme) = 0;
-	virtual void compactScheme_workerCleanupAfterGC(MM_EnvironmentBase *env) = 0;
-	virtual void compactScheme_verifyHeap(MM_EnvironmentBase *env, MM_MarkMap *markMap) = 0;
-#endif /* OMR_GC_MODRON_COMPACTION */
-
 #if defined(OMR_GC_MODRON_SCAVENGER)
 	/**
 	 * This method will be called on the master GC thread after each scavenger cycle, successful or

--- a/gc/base/standard/CompactScheme.hpp
+++ b/gc/base/standard/CompactScheme.hpp
@@ -26,6 +26,8 @@
 #include "omrcfg.h"
 #include "omr.h"
 
+#if defined(OMR_GC_MODRON_COMPACTION)
+
 #include "BaseVirtual.hpp"
 #include "Debug.hpp"
 #include "EnvironmentStandard.hpp"
@@ -35,6 +37,7 @@
 #include "MarkingScheme.hpp"
 #include "MarkMap.hpp"
 #include "SlotObject.hpp"
+#include "CompactDelegate.hpp"
 
 class MM_AllocateDescription;
 class MM_EnvironmentStandard;
@@ -135,6 +138,8 @@ protected:
     SubAreaEntry *_subAreaTable;  /**< Reference to the subAreaTable which is shared data from the SweepHeapSectioning */
     omrobjectptr_t _compactFrom;
     omrobjectptr_t _compactTo;
+    MM_CompactDelegate _delegate;
+
 public:
 
     /*
@@ -330,9 +335,11 @@ public:
         , _markMap(markingScheme->getMarkMap())
         , _subAreaTableSize(0)
     	, _subAreaTable(NULL)
+    	, _delegate()
     {
     	_typeId = __FUNCTION__;
     }
 };
 
+#endif /* OMR_GC_MODRON_COMPACTION */
 #endif /* COMPACTSCHEMEBASE_HPP_ */

--- a/glue/CollectorLanguageInterfaceImpl.cpp
+++ b/glue/CollectorLanguageInterfaceImpl.cpp
@@ -207,29 +207,3 @@ MM_CollectorLanguageInterfaceImpl::scavenger_fixupDestroyedSlot(MM_EnvironmentBa
 #endif /* OMR_INTERP_COMPRESSED_OBJECT_HEADER */
 #endif /* OMR_GC_MODRON_SCAVENGER */
 
-#if defined(OMR_GC_MODRON_COMPACTION)
-void
-MM_CollectorLanguageInterfaceImpl::compactScheme_verifyHeap(MM_EnvironmentBase *env, MM_MarkMap *markMap)
-{
-	Assert_MM_unimplemented();
-}
-
-void
-MM_CollectorLanguageInterfaceImpl::compactScheme_fixupRoots(MM_EnvironmentBase *env, MM_CompactScheme *compactScheme)
-{
-	Assert_MM_unimplemented();
-}
-
-void
-MM_CollectorLanguageInterfaceImpl::compactScheme_workerCleanupAfterGC(MM_EnvironmentBase *env)
-{
-	Assert_MM_unimplemented();
-}
-
-void
-MM_CollectorLanguageInterfaceImpl::compactScheme_languageMasterSetupForGC(MM_EnvironmentBase *env)
-{
-	Assert_MM_unimplemented();
-}
-#endif /* OMR_GC_MODRON_COMPACTION */
-

--- a/glue/CollectorLanguageInterfaceImpl.hpp
+++ b/glue/CollectorLanguageInterfaceImpl.hpp
@@ -65,10 +65,7 @@ public:
 	virtual void kill(MM_EnvironmentBase *env);
 
 #if defined(OMR_GC_MODRON_COMPACTION)
-	virtual void compactScheme_languageMasterSetupForGC(MM_EnvironmentBase *env);
-	virtual void compactScheme_fixupRoots(MM_EnvironmentBase *env, MM_CompactScheme *compactScheme);
-	virtual void compactScheme_workerCleanupAfterGC(MM_EnvironmentBase *env);
-	virtual void compactScheme_verifyHeap(MM_EnvironmentBase *env, MM_MarkMap *markMap);
+	virtual CompactPreventedReason parallelGlobalGC_checkIfCompactionShouldBePrevented(MM_EnvironmentBase *env) {return COMPACT_PREVENTED_NONE;}
 #endif /* OMR_GC_MODRON_COMPACTION */
 
 #if defined(OMR_GC_MODRON_SCAVENGER)


### PR DESCRIPTION
Refactor MM_CollectorLanguageInterface (CLI) methods into a new
MM_CompactingDelegate (CD) class.

Signed-off-by: Jonathan Oommen <jon.oommen@gmail.com>

Reviewer: @ktbriggs 