### PR TITLE
Typo fix for function 'setVolatileSybolsIndexAndRecurse'

### DIFF
--- a/compiler/optimizer/UseDefInfo.cpp
+++ b/compiler/optimizer/UseDefInfo.cpp
@@ -410,7 +410,7 @@ bool TR_UseDefInfo::_runReachingDefinitions(TR_ReachingDefinitions& reachingDefi
    return succeeded;
    }
 
-void TR_UseDefInfo::setVolatileSybolsIndexAndRecurse(TR::BitVector &volatileSymbols, int32_t symRefNum)
+void TR_UseDefInfo::setVolatileSymbolsIndexAndRecurse(TR::BitVector &volatileSymbols, int32_t symRefNum)
    {
    TR::SymbolReference* symRef = comp()->getSymRefTab()->getSymRef(symRefNum);
 
@@ -446,7 +446,7 @@ void TR_UseDefInfo::setVolatileSybolsIndexAndRecurse(TR::BitVector &volatileSymb
 //      if (symRef->getSymbol()->isVolatile())
 //         {
 //         traceMsg(comp(), "Recursing on alias %d\n",aliasedSymRef->getReferenceNumber());
-         setVolatileSybolsIndexAndRecurse(volatileSymbols,aliasedSymRef->getReferenceNumber());
+         setVolatileSymbolsIndexAndRecurse(volatileSymbols,aliasedSymRef->getReferenceNumber());
 //         }
 //      else if (aliasedSymRef->getSymbol()->isVolatile())
 //         {
@@ -469,7 +469,7 @@ void TR_UseDefInfo::findAndPopulateVolatileSymbolsIndex(TR::BitVector &volatileS
       if (symRef->getSymbol()->isVolatile())
          {
  //        traceMsg(comp(), "it is volatile");
-         setVolatileSybolsIndexAndRecurse(volatileSymbols, symRefNumber);
+         setVolatileSymbolsIndexAndRecurse(volatileSymbols, symRefNumber);
          }
  //     traceMsg(comp(), "\n");
       }

--- a/compiler/optimizer/UseDefInfo.hpp
+++ b/compiler/optimizer/UseDefInfo.hpp
@@ -198,7 +198,7 @@ class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
    // For Languages where an auto can alias a volatile, extra care needs to be taken when setting up use-def
    // The conservative answer is to not index autos that have volatile aliases.
 
-   void setVolatileSybolsIndexAndRecurse(TR::BitVector &volatileSymbols, int32_t symRefNum);
+   void setVolatileSymbolsIndexAndRecurse(TR::BitVector &volatileSymbols, int32_t symRefNum);
    void findAndPopulateVolatileSymbolsIndex(TR::BitVector &volatileSymbols);
 
    bool shouldIndexVolatileSym(TR::SymbolReference *ref, AuxiliaryData &aux);


### PR DESCRIPTION
The function defined and referred in `compiler/optimizer/UseDefInfo.hpp` and `compiler/optimizer/UseDefInfo.cpp` obviously contain a typo:

```
setVolatileSybolsIndexAndRecurse()
```
It needs to be corrected to:
```
setVolatileSymbolsIndexAndRecurse()
```
