### PR TITLE
Test improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,6 @@ addons:
       - gcc-multilib
       - g++-multilib
       - ninja-build
-      - valgrind
-install:
-  - if [ $TRAVIS_OS_NAME = osx ]; then brew install valgrind; fi
 env:
   matrix:
     - BUILD_WITH_CMAKE=yes CMAKE_GENERATOR=Ninja

--- a/fvtest/porttest/omrfileTest.cpp
+++ b/fvtest/porttest/omrfileTest.cpp
@@ -2720,7 +2720,7 @@ omrfile_test22_child_1(OMRPortLibrary *portLibrary)
 		SleepFor(1);
 	}
 
-	SleepFor(5);
+	SleepFor(1);
 
 	unlockRc = FILE_UNLOCK_BYTES_FUNCTION(OMRPORTLIB, fd, offset, length);
 
@@ -3071,7 +3071,7 @@ omrfile_test24_child_1(OMRPortLibrary *portLibrary)
 		SleepFor(1);
 	}
 
-	SleepFor(5);
+	SleepFor(1);
 
 	unlockRc = FILE_UNLOCK_BYTES_FUNCTION(OMRPORTLIB, fd, offset, length);
 
@@ -3258,7 +3258,7 @@ omrfile_test25_child_1(OMRPortLibrary *portLibrary)
 		SleepFor(1);
 	}
 
-	SleepFor(5);
+	SleepFor(1);
 
 #if defined(_WIN32) || defined(OSX)
 	unlockRc = FILE_UNLOCK_BYTES_FUNCTION(OMRPORTLIB, fd, offset, length);

--- a/fvtest/porttest/omrtimeTest.cpp
+++ b/fvtest/porttest/omrtimeTest.cpp
@@ -503,7 +503,7 @@ TEST(DISABLED_PortTimeTest, time_test4)
 }
 
 
-#define J9TIME_TEST_DIRECTION_TIMEOUT_MILLIS 300000 /* 5 minutes */
+#define J9TIME_TEST_DIRECTION_TIMEOUT_MILLIS 60000 /* 1 minute */
 static uintptr_t omrtimeTestDirectionNumThreads = 0;
 
 typedef struct J9TimeTestDirectionStruct {
@@ -549,7 +549,7 @@ TEST(PortTimeTest, time_nano_time_direction)
 		if (0 == omrthread_monitor_init(&tds.monitor, 0)) {
 			uintptr_t i;
 			intptr_t waitRetVal = 0;
-			const uintptr_t threadToCPUFactor = 10;
+			const uintptr_t threadToCPUFactor = 2;
 			omrthread_t *threads = NULL;
 
 			omrtimeTestDirectionNumThreads = omrsysinfo_get_number_CPUs_by_type(OMRPORT_CPU_ONLINE) * threadToCPUFactor;

--- a/fvtest/threadextendedtest/timeBaseTest.cpp
+++ b/fvtest/threadextendedtest/timeBaseTest.cpp
@@ -23,11 +23,11 @@
 #include "thrdsup.h"
 #include "threadExtendedTestHelpers.hpp"
 
-#define NUM_ITERATIONS		12
-#define FIVE_SEC_IN_MSEC	5000 /**< 5 sec in ms */
+#define NUM_ITERATIONS		3
+#define TIME_IN_MILLIS		500
 
 /**
- * Generate CPU Load for 5 seconds
+ * Generate CPU Load for 1 seconds
  */
 static void
 cpuLoad(void)
@@ -37,14 +37,13 @@ cpuLoad(void)
 	int64_t end = 0;
 
 	start = omrtime_current_time_millis();
-	/* Generate CPU Load for 5 seconds */
 	do {
 		end = omrtime_current_time_millis();
-	} while ((end - start) < FIVE_SEC_IN_MSEC);
+	} while ((end - start) < TIME_IN_MILLIS);
 }
 
 /**
- * Test the monotonicity of the GET_HIRES_CLOCK()/getTimebase() functions.
+ * Test the monotonicity of omrtime_current_time_millis.
  *
  */
 TEST(ThreadExtendedTest, TestTimeBaseMonotonicity)

--- a/fvtest/threadtest/rwMutexTest.cpp
+++ b/fvtest/threadtest/rwMutexTest.cpp
@@ -23,7 +23,7 @@
 #include "testHelper.hpp"
 #include "thread_api.h"
 
-#define MILLI_TIMEOUT	10000
+#define MILLI_TIMEOUT	1000
 #define NANO_TIMEOUT	0
 
 #define STEP_MILLI_TIMEOUT		600000

--- a/fvtest/threadtest/sanityTest.cpp
+++ b/fvtest/threadtest/sanityTest.cpp
@@ -42,7 +42,7 @@ protected:
 		}
 	}
 };
-unsigned int SanityTest::runTime = 10; /* default test run time of 10 seconds */
+unsigned int SanityTest::runTime = 2; /* default test run time of 2 second */
 
 TEST_F(SanityTest, simpleSanity)
 {

--- a/fvtest/threadtest/sanityTestHelper.cpp
+++ b/fvtest/threadtest/sanityTestHelper.cpp
@@ -41,12 +41,12 @@ SimpleSanity(void)
 		CMonitor mon2(0, "monitor2");
 		omrTestEnv->log("Enter on 1 and hold, contended enter on 2\n");
 		omrTestEnv->changeIndent(1);
-		CEnterExit thread1(mon2, 10 * 1000);
+		CEnterExit thread1(mon2, 1000);
 		CEnterExit thread2(mon2, 0);
 
 		omrTestEnv->log("Starting thread 1\n");
 		thread1.Start();
-		omrthread_sleep(2 * 1000);
+		omrthread_sleep(2000);
 		omrTestEnv->log("starting thread 2\n");
 		thread2.Start();
 
@@ -182,9 +182,6 @@ void
 SanityTestNThreads(unsigned int numThreads, unsigned int runTime)
 {
 	omrTestEnv->changeIndent(1);
-	
-	omrTestEnv->log("1000ms\n");
-	TestNThreadsLooping(numThreads, 1000, runTime, false);
 
 	omrTestEnv->log("100ms\n");
 	TestNThreadsLooping(numThreads, 100, runTime, false);

--- a/scripts/build-on-travis.sh
+++ b/scripts/build-on-travis.sh
@@ -37,7 +37,7 @@ if test "x$BUILD_WITH_CMAKE" = "xyes"; then
   if test "x$RUN_BUILD" != "xno"; then
     time cmake --build . -- -j $JOBS
     if test "x$RUN_TESTS" != "xno"; then
-      time ctest -V --parallel $JOBS
+      time ctest -V
     fi
   fi
 else


### PR DESCRIPTION
A lot of the OMR tests take a very long time to complete. This change
reduces a number of these tests to a more managable time.  The
reductions were the result of fewer loops and smaller sleep/timout
times.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>