### PR TITLE
Merge stats across CS phases

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -225,7 +225,8 @@ public:
 	MM_GlobalGCStats globalGCStats;
 #endif /* OMR_GC_MODRON_STANDARD || OMR_GC_REALTIME */
 #if defined(OMR_GC_MODRON_SCAVENGER)
-	MM_ScavengerStats scavengerStats;
+	MM_ScavengerStats incrementScavengerStats; /**< scavengerStats for the current phase/increment; typically just used for reporting purposes */
+	MM_ScavengerStats scavengerStats; /**< cumulative scavengerStats for all phases/increments (STW and concurrent) within a single cycle; typically used for various heursitics at the end of GC */
 	MM_ScavengerCopyScanRatio copyScanRatio; /* Most recent estimate of ratio of aggregate slots copied to slots scanned in completeScan() */
 #endif /* OMR_GC_MODRON_SCAVENGER */
 #if defined(OMR_GC_VLHGC)

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -362,11 +362,11 @@ public:
 	void reportScavengeStart(MM_EnvironmentStandard *env);
 	void reportScavengeEnd(MM_EnvironmentStandard *env, bool lastIncrement);
 
-	MMINLINE MM_ScavengerHotFieldStats *getHotFieldStats(MM_EnvironmentStandard *env) { return &(env->_hotFieldStats); }
+	MMINLINE MM_ScavengerHotFieldStats *getHotFieldStats(MM_EnvironmentBase *env) { return &(env->_hotFieldStats); }
 	void masterClearHotFieldStats();
 	void masterReportHotFieldStats();
-	void clearHotFieldStats(MM_EnvironmentStandard *env);
-	void mergeHotFieldStats(MM_EnvironmentStandard *env);
+	void clearHotFieldStats(MM_EnvironmentBase *env);
+	void mergeHotFieldStats(MM_EnvironmentBase *env);
 
 	/**
 	 * Add the specified object to the remembered set.
@@ -413,8 +413,33 @@ public:
 	 */
 	bool processRememberedThreadReference(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr);
 
-	void clearGCStats(MM_EnvironmentBase *env);
-	void mergeGCStats(MM_EnvironmentBase *env);
+	/**
+	 * Clear global (not thread local) stats for current phase/increment
+	 * @param firstIncrement true if first increment in a cycle
+	 */
+	void clearIncrementGCStats(MM_EnvironmentBase *env, bool firstIncrement);
+	/**
+	 * Clear global (not thread local) cumulative cycle stats 
+	 */
+	void clearCycleGCStats(MM_EnvironmentBase *env);
+	/**
+	 * Clear thread local stats for current phase/increment
+	 * @param firstIncrement true if first increment in a cycle
+	 */
+	void clearThreadGCStats(MM_EnvironmentBase *env, bool firstIncrement);
+	/**
+	 * Merge thread local stats for current phase/increment in to global current increment stats
+	 */	
+	void mergeThreadGCStats(MM_EnvironmentBase *env);
+	/**
+	 * Merge global current increment stats in to global cycle stats
+	 * @param firstIncrement true if last increment in a cycle
+	 */		
+	void mergeIncrementGCStats(MM_EnvironmentBase *env, bool lastIncrement);
+	/**
+	 * Common merge logic used for both thread and increment level merges.
+	 */
+	void mergeGCStatsBase(MM_EnvironmentBase *env, MM_ScavengerStats *finalGCStats, MM_ScavengerStats *scavStats);
 	bool canCalcGCStats(MM_EnvironmentStandard *env);
 	void calcGCStats(MM_EnvironmentStandard *env);
 

--- a/gc/stats/ScavengerStats.cpp
+++ b/gc/stats/ScavengerStats.cpp
@@ -105,10 +105,17 @@ MM_ScavengerStats::getFlipHistory(uintptr_t lookback)
 }
 
 void 
-MM_ScavengerStats::clear()
+MM_ScavengerStats::clear(bool firstIncrement)
 {
-	/* Increment the histogram offset and loop if necessary */
-	_flipHistoryNewIndex = (_flipHistoryNewIndex + 1) % SCAVENGER_FLIP_HISTORY_SIZE;
+	if (firstIncrement) {
+		/* clear() can be called several times per a cycle (in Concurrent Scavenger), but some stats/params must be reset/updated only once per a cycle */
+
+		/* Increment the histogram offset and loop if necessary */
+		/* TODO: this does not properly work for Master GC threads, which is implicit (a random mutator thread), for standard (non CS) Scavenger.
+		 * Flip history stats (or complete ScavengerStats) should be one place (in GcExtensions or Scavenger), not scattered among mutator threads.
+		 */
+		_flipHistoryNewIndex = (_flipHistoryNewIndex + 1) % SCAVENGER_FLIP_HISTORY_SIZE;
+	}
 
 	/* Clear the new histogram row */
 	memset(&_flipHistory[_flipHistoryNewIndex], 0, sizeof(_flipHistory[_flipHistoryNewIndex]));

--- a/gc/stats/ScavengerStats.hpp
+++ b/gc/stats/ScavengerStats.hpp
@@ -136,6 +136,7 @@ public:
 protected:
 
 private:
+public:
 	uintptr_t _flipHistoryNewIndex; /**< Index in to the first dimension of _flipHistory for the freshest history. */
 	FlipHistory _flipHistory[SCAVENGER_FLIP_HISTORY_SIZE]; /**< Array for storing object flip stats. */
 
@@ -214,7 +215,7 @@ public:
 		_copy_cachesize_sum += copyCacheSize;
 	}
 
-	void clear();
+	void clear(bool firstIncrement);
 	MM_ScavengerStats();
 
 	struct FlipHistory* getFlipHistory(uintptr_t lookback);

--- a/gc/verbose/handler_standard/VerboseHandlerOutputStandard.cpp
+++ b/gc/verbose/handler_standard/VerboseHandlerOutputStandard.cpp
@@ -399,7 +399,8 @@ MM_VerboseHandlerOutputStandard::handleScavengeEnd(J9HookInterface** hook, uintp
 	MM_GCExtensionsBase *extensions = MM_GCExtensionsBase::getExtensions(env->getOmrVM());
 	MM_VerboseManager* manager = getManager();
 	MM_VerboseWriterChain* writer = manager->getWriterChain();
-	MM_ScavengerStats *scavengerStats = &extensions->scavengerStats;
+	MM_ScavengerStats *scavengerStats = &extensions->incrementScavengerStats;
+	MM_ScavengerStats *cycleScavengerStats = &extensions->scavengerStats;
 	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
 	uint64_t duration = 0;
 	bool deltaTimeSuccess = getTimeDeltaInMicroSeconds(&duration, scavengerStats->_startTime, scavengerStats->_endTime);
@@ -408,7 +409,8 @@ MM_VerboseHandlerOutputStandard::handleScavengeEnd(J9HookInterface** hook, uintp
 	handleGCOPOuterStanzaStart(env, "scavenge", env->_cycleState->_verboseContextID, duration, deltaTimeSuccess);
 
 	if (event->cycleEnd) {
-		writer->formatAndOutput(env, 1, "<scavenger-info tenureage=\"%zu\" tenuremask=\"%4zx\" tiltratio=\"%zu\" />", scavengerStats->_tenureAge, scavengerStats->getFlipHistory(0)->_tenureMask, scavengerStats->_tiltRatio);
+		writer->formatAndOutput(env, 1, "<scavenger-info tenureage=\"%zu\" tenuremask=\"%4zx\" tiltratio=\"%zu\" />",
+				cycleScavengerStats->_tenureAge, cycleScavengerStats->getFlipHistory(0)->_tenureMask, cycleScavengerStats->_tiltRatio);
 	}
 
 	if (0 != scavengerStats->_flipCount) {


### PR DESCRIPTION
In Concurrent Scavenger gather per phase/increment Scavenger stats.
These are typically used for reported purposes. Than at the end of a
cycle merge those stats. Those are typically used for various heuristics
(like tilting) that are performed at the end of a cycle. Currently,
since we clear per increment stats and do not merge them, the heuristics
rely only on last increment, which is vary small data subset.

Standard Scavenger is not meant to be affected, although a lot of code
is shared with CS. There is still a notion of an increment, but there is
only one. We still merge that one with the cycle stats, so there are
identical.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>