### PR TITLE
Remove the code related to TR::bztestnset

### DIFF
--- a/compiler/il/ILOpCodeProperties.hpp
+++ b/compiler/il/ILOpCodeProperties.hpp
@@ -10309,22 +10309,6 @@
    },
 
    {
-   /* .opcode               = */ TR::bztestnset,
-   /* .name                 = */ "bztestnset",
-   /* .properties1          = */ ILProp1::Call | ILProp1::HasSymbolRef,
-   /* .properties2          = */ 0,
-   /* .properties3          = */ ILProp3::LikeUse | ILProp3::LikeDef,
-   /* .properties4          = */ 0,
-   /* .dataType             = */ TR::Int8,
-   /* .typeProperties       = */ ILTypeProp::Size_1 | ILTypeProp::Integer,
-   /* .childProperties      = */ TWO_CHILD(TR::Address, ILChildProp::UnspecifiedChildType),
-   /* .swapChildrenOpCode   = */ TR::BadILOp,
-   /* .reverseBranchOpCode  = */ TR::BadILOp,
-   /* .booleanCompareOpCode = */ TR::BadILOp,
-   /* .ifCompareOpCode      = */ TR::BadILOp,
-   },
-
-   {
    /* .opcode               = */ TR::ibatomicor,
    /* .name                 = */ "ibatomicor",
    /* .properties1          = */ ILProp1::LoadVar | ILProp1::Store | ILProp1::Indirect | ILProp1::TreeTop | ILProp1::HasSymbolRef,

--- a/compiler/il/OMRILOpCodesEnum.hpp
+++ b/compiler/il/OMRILOpCodesEnum.hpp
@@ -710,7 +710,6 @@
 
    icmpset,    // icmpset(pointer,c,r): compare *pointer with c, if it matches, replace with r.  Returns 0 on match, 1 otherwise
    lcmpset,    // the operation is done atomically - return type is int for both [il]cmpset
-   bztestnset, // bztestnset(pointer,c): atomically sets *pointer to c and returns the original value of *p (represents Test And Set on Z)
 
    // the atomic ops.. atomically update the symref.  first child is address, second child is the RHS
    // interestingly, these ops act like loads and stores at the same time

--- a/compiler/optimizer/OMRSimplifierTableEnum.hpp
+++ b/compiler/optimizer/OMRSimplifierTableEnum.hpp
@@ -692,7 +692,6 @@
    lsubSimplifier,          // TR::lusubb
    dftSimplifier,           // TR::icmpset
    dftSimplifier,           // TR::lcmpset
-   dftSimplifier,           // TR::btestnset
    dftSimplifier,           // TR::ibatomicor
    dftSimplifier,           // TR::isatomicor
    dftSimplifier,           // TR::iiatomicor

--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -835,7 +835,6 @@ const ValuePropagationPtr constraintHandlers[] =
 
    constrainChildren,        // TR::icmpset
    constrainChildren,        // TR::lcmpset
-   constrainChildren,        // TR::bztestnset
    constrainChildren,        // TR::ibatomicor
    constrainChildren,        // TR::isatomicor
    constrainChildren,        // TR::iiatomicor

--- a/compiler/p/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/TreeEvaluatorTable.hpp
@@ -661,7 +661,6 @@
    TR::TreeEvaluator::lsubEvaluator,                    // TR::lusubb
    TR::TreeEvaluator::cmpsetEvaluator,                  // TR::icmpset
    TR::TreeEvaluator::cmpsetEvaluator,                  // TR::lcmpset
-   TR::TreeEvaluator::badILOpEvaluator,                    // TR::bztestnset
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::ibatomicor
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::isatomicor
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::iiatomicor

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -2968,7 +2968,6 @@ int32_t childTypes[] =
    TR::Int64 | (TR::Int8<<24),    // TR::lusubb
    TR::Int32 | (TR::Address<<8),    // TR::icmpset
    TR::Int64 | (TR::Address<<8),    // TR::lcmpset
-   TR::Int8  | (TR::Address<<8),    // TR::bztestnset
    TR::Int8  | (TR::Address<<8),     // TR::ibatomicor
    TR::Int16 | (TR::Address<<8),     // TR::isatomicor
    TR::Int32 | (TR::Address<<8),     // TR::iiatomicor

--- a/compiler/x/amd64/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/x/amd64/codegen/TreeEvaluatorTable.hpp
@@ -661,7 +661,6 @@
    TR::TreeEvaluator::integerSubEvaluator,              // TR::lusubb
    TR::TreeEvaluator::icmpsetEvaluator,                 // TR::icmpset
    TR::TreeEvaluator::icmpsetEvaluator,                 // TR::lcmpset
-   TR::TreeEvaluator::bztestnsetEvaluator,              // TR::bztestnset
    TR::TreeEvaluator::atomicorEvaluator,                // TR::ibatomicor
    TR::TreeEvaluator::atomicorEvaluator,                // TR::isatomicor
    TR::TreeEvaluator::atomicorEvaluator,                // TR::iiatomicor

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -5453,32 +5453,6 @@ OMR::X86::TreeEvaluator::icmpsetEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    return resultReg;
    }
 
-TR::Register *
-OMR::X86::TreeEvaluator::bztestnsetEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   TR::Node *pointer      = node->getChild(0);
-   TR::Node *replaceValue = node->getChild(1);
-
-   TR::Register *pointerReg = cg->evaluate(pointer);
-   TR::MemoryReference *memRef = generateX86MemoryReference(pointerReg, 0, cg);
-   TR::Register *replaceReg = cg->evaluate(replaceValue);
-
-   if (replaceValue->getReferenceCount() > 1)
-      {
-      TR::Register* replaceRegPrev = replaceReg;
-      replaceReg = cg->allocateRegister();
-      generateRegRegInstruction(MOV1RegReg, node, replaceReg, replaceRegPrev, cg);
-      }
-
-   generateMemRegInstruction(XCHG1RegMem, node, memRef, replaceReg, cg);
-
-   node->setRegister(replaceReg);
-   cg->decReferenceCount(replaceValue);
-   cg->decReferenceCount(pointer);
-
-   return replaceReg;
-   }
-
 
 TR::Register *OMR::X86::TreeEvaluator::PrefetchEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {

--- a/compiler/x/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.hpp
@@ -293,7 +293,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *SIMDsplatsEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
    static TR::Register *icmpsetEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *bztestnsetEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
    // VM dependent routines
    static TR::Register *VMifInstanceOfEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/x/i386/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/x/i386/codegen/TreeEvaluatorTable.hpp
@@ -662,7 +662,6 @@
    TR::TreeEvaluator::integerPairSubEvaluator,         // TR::lusubb
    TR::TreeEvaluator::icmpsetEvaluator,                 // TR::icmpset (zPDT)
    TR::TreeEvaluator::lcmpsetEvaluator,                // TR::lcmpset (zPDT)
-   TR::TreeEvaluator::bztestnsetEvaluator,              // TR::bztestnset (zPDT)
    TR::TreeEvaluator::atomicorEvaluator,                // TR::ibatomicor (zPDT)
    TR::TreeEvaluator::atomicorEvaluator,                // TR::isatomicor (zPDT)
    TR::TreeEvaluator::atomicorEvaluator,                // TR::iiatomicor (zPDT)


### PR DESCRIPTION
The TR::bztestnset opcode and evaluater is no longer used, so remove all
the related code.

Signed-off-by: Yixiao Zhu <zhuyixiao@gmail.com>