### PR TITLE
Create code metadata support

### DIFF
--- a/compiler/runtime/CodeMetaData.hpp
+++ b/compiler/runtime/CodeMetaData.hpp
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+#ifndef TR_METHOD_METADATA_INCL
+#define TR_METHOD_METADATA_INCL
+
+#include "runtime/OMRCodeMetaData.hpp"
+#include "infra/Annotations.hpp"
+
+namespace TR
+{
+
+class OMR_EXTENSIBLE CodeMetaData : public OMR::CodeMetaDataConnector
+   {
+public:
+
+   CodeMetaData(TR::Compilation *comp) : OMR::CodeMetaDataConnector(comp) {}
+
+   };
+
+}
+
+#endif
+
+

--- a/compiler/runtime/OMRCodeMetaData.cpp
+++ b/compiler/runtime/OMRCodeMetaData.cpp
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+#include "runtime/OMRCodeMetaData.hpp"
+
+#include "compile/Compilation.hpp"              // for Compilation, comp
+#include "compile/ResolvedMethod.hpp"           // for TR_ResolvedMethod
+
+
+TR::CodeMetaData *
+OMR::CodeMetaData::self()
+   {
+   return static_cast<TR::CodeMetaData *>(this);
+   }
+
+OMR::CodeMetaData::CodeMetaData(TR::Compilation *comp)
+   {
+   _codeAllocStart = comp->cg()->getBinaryBufferStart();
+   _codeAllocSize = comp->cg()->getEstimatedMethodLength();
+
+   _interpreterEntryPC = comp->cg()->getCodeStart();
+   
+   _compiledEntryPC = _interpreterEntryPC;
+   _compiledEndPC = comp->cg()->getWarmCodeEnd();
+
+   _hotness = comp->cg()->getMethodHotness();
+   }
+

--- a/compiler/runtime/OMRCodeMetaData.hpp
+++ b/compiler/runtime/OMRCodeMetaData.hpp
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+#ifndef OMR_CODE_METADATA_INCL
+#define OMR_CODE_METADATA_INCL
+
+/*
+ * The following #define(s) and typedef(s) must appear before any #includes in this file
+ */
+#ifndef OMR_CODE_METADATA_CONNECTOR
+#define OMR_CODE_METADATA_CONNECTOR
+namespace OMR { struct CodeMetaData; }
+namespace OMR { typedef OMR::CodeMetaData CodeMetaDataConnector; }
+#endif
+
+#include "env/jittypes.h"         // for uintptrj_t
+#include "infra/Annotations.hpp"  // for OMR_EXTENSIBLE
+
+namespace TR { class CodeMetaData; }
+namespace TR { class Compilation; }
+
+/**
+ * CodeMetaData contains metadata information about a single method.
+ */
+
+namespace OMR
+{
+
+class OMR_EXTENSIBLE CodeMetaData
+   {
+   public:
+
+   TR::CodeMetaData *self();
+
+   /**
+    * @brief Constructor method to create metadata for a method.
+    */
+   CodeMetaData(TR::Compilation *comp);
+
+   /**
+    * @brief Returns the address of allocated code memory within a code
+    * cache for a method.
+    */
+   uintptrj_t codeAllocStart() { return _codeAllocStart; }
+
+   /**
+    * @brief Returns the total size of code memory allocated for a method 
+    * within a code cache.
+    */
+   uint32_t codeAllocSize() { return _codeAllocSize; }
+
+   /**
+    * @brief Returns the starting address of compiled code for a
+    * method when invoked from an interpreter.
+    *
+    * Interpreter entry PC may preceed compiled entry PC and may point 
+    * to code necessary for proper execution of this method if invoked 
+    * from an interpreter. For example, it may need to marshall method 
+    * arguments from an interpreter linkage to a compiled method linkage.
+    *
+    * By default, the interpreter entry PC and compiled entry PC point 
+    * to the same address.
+    */
+   uintptrj_t interpreterEntryPC() { return _interpreterEntryPC; }
+
+   /**
+    * @brief Returns the starting address of compiled code for a
+    * method when invoked from compiled code.
+    * 
+    * By default, the interpreter entry PC and compiled entry PC point 
+    * to the same address.
+    */
+   uintptrj_t compiledEntryPC() { return _compiledEntryPC; }
+
+   /**
+    * @brief Returns the end address of compiled code for a method.
+    */
+   uintptrj_t compiledEndPC() { return _compiledEndPC; }
+
+   /**
+    * @brief Returns the compilation hotness level of a compiled method.
+    */
+   TR_Hotness codeHotness() { return _hotness; }
+
+   protected:
+
+   uintptrj_t _codeAllocStart;
+   uint32_t _codeAllocSize;
+
+   uintptrj_t _interpreterEntryPC;
+   uintptrj_t _compiledEntryPC;
+   uintptrj_t _compiledEndPC;
+
+   TR_Hotness _hotness;
+   };
+
+}
+
+#endif


### PR DESCRIPTION
Create CodeMetaData class in OMR to keep track of runtime metadata 
related to a method, such as the code cache starting address and size, 
the interpreter entry PC, the compiled entry PC, the compiled end PC, 
and the compilation hotness level.

Signed-off-by: Xiaoli Liang <xsliang@ca.ibm.com>