### PR TITLE
CS background threads

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -417,8 +417,9 @@ public:
 	bool scavengerRsoScanUnsafe;
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	bool concurrentScavenger; /**< CS enabled/disabled flag */
-	bool concurrentScavengerRequested; /**< set to true if CS is requested (by cmdline option), but there are more checks to do before deciding whether the request is to be obeyed */
+	bool concurrentScavengerForced; /**< set to true if CS is requested (by cmdline option), but there are more checks to do before deciding whether the request is to be obeyed */
 	uintptr_t concurrentScavengerBackgroundThreads; /**< number of background GC threads during concurrent phase of Scavenge */
+	bool concurrentScavengerBackgroundThreadsForced; /**< true if concurrentScavengerBackgroundThreads set via command line option */
 	uintptr_t concurrentScavengerSlack; /**< amount of bytes added on top of avearge allocated bytes during concurrent cycle, in calcualtion for survivor size */
 #endif	/* OMR_GC_CONCURRENT_SCAVENGER */
 	uintptr_t scavengerFailedTenureThreshold;
@@ -1335,8 +1336,9 @@ public:
 		, scavengerEnabled(false)
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 		, concurrentScavenger(false)
-		, concurrentScavengerRequested(false)
-		, concurrentScavengerBackgroundThreads(0)
+		, concurrentScavengerForced(false)
+		, concurrentScavengerBackgroundThreads(1)
+		, concurrentScavengerBackgroundThreadsForced(false)
 		, concurrentScavengerSlack(0)
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 		, scavengerFailedTenureThreshold(0)

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -4892,14 +4892,6 @@ MM_Scavenger::completeConcurrentCycle(MM_EnvironmentBase *env)
 	}
 }
 
-void
-MM_Scavenger::preMasterGCThreadInitialize(MM_EnvironmentBase *env)
-{
-	if (0 == _extensions->concurrentScavengerBackgroundThreads) {
-		_extensions->concurrentScavengerBackgroundThreads = OMR_MAX(1, _extensions->dispatcher->threadCount() / 2);
-	}
-}
-
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
 #endif /* OMR_GC_MODRON_SCAVENGER */

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -536,7 +536,6 @@ protected:
 	 * Perform partial initialization if Garbage Collection is called earlier then GC Master Thread is activated
 	 * @param env Master GC thread.
 	 */
-	virtual void preMasterGCThreadInitialize(MM_EnvironmentBase *env);
 	virtual MM_ConcurrentPhaseStatsBase *getConcurrentPhaseStats() { return &_concurrentPhaseStats; }
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 	


### PR DESCRIPTION
Two small changes:
1) set initial count of Concurrent Scavenger background threads to 1.
Remove special path initialization of background thread count, that was
used in rare scenarios when GC was triggered before MasterGCThread was
in place - in those cases we will just default to count 1 (same as
before).
2) Added a 'forced' flag that give us ability to explicitely set
background thread count (for example through command line option). This
way, the full blown count initialization at a later point (when Parallel
Dispatcher is in place) can distinguish between count 1 being default
(which could be overriden) and count 1 being explicitely set (which must
not be overridden).

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>