### PR TITLE
Support more MSVC runtime versions

### DIFF
--- a/cmake/modules/OmrMsvcRuntime.cmake
+++ b/cmake/modules/OmrMsvcRuntime.cmake
@@ -1,0 +1,85 @@
+##############################################################################
+#
+# (c) Copyright IBM Corp. 2017, 2017
+#
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License v1.0 and
+#  Apache License v2.0 which accompanies this distribution.
+#
+#      The Eclipse Public License is available at
+#      http://www.eclipse.org/legal/epl-v10.html
+#
+#      The Apache License v2.0 is available at
+#      http://www.opensource.org/licenses/apache2.0.php
+#
+# Contributors:
+#    Multiple authors (IBM Corp.) - initial implementation and documentation
+###############################################################################
+
+# Find the MSVC Runtime libraries.
+# Will set:
+#   OMR_MSVC_CRT: The name of the MSVC runtime DLL, or NOTFOUND.
+#
+# This module will determine the MSVC runtime names from the version of MSVC being used.
+
+if(OMR_MSVC_RUNTIME_)
+	return()
+endif()
+set(OMR_MSVC_RUNTIME_ 1)
+
+include(OmrAssert)
+
+# OMR_MSVC_CRT
+
+if(DEFINED ENV{MSVC_CRT})
+	set(msvc_crt "$ENV{MSVC_CRT}")
+elseif(MSVC_VERSION EQUAL 1200) # VS 6
+	string(CONCAT msvc_crt
+		$<$<CONFIG:Debug>:MSVCR60D>
+		$<$<CONFIG:Release>:MSVCR60>
+	)
+elseif(MSVC_VERSION EQUAL 1300) # VS 7
+	string(CONCAT msvc_crt
+		$<$<CONFIG:Debug>:MSVCR70D>
+		$<$<CONFIG:Release>:MSVCR70>
+	)
+elseif(MSVC_VERSION EQUAL 1310) # VS 7.1
+	string(CONCAT msvc_crt
+		$<$<CONFIG:Debug>:MSVCR71D>
+		$<$<CONFIG:Release>:MSVCR71>
+	)
+elseif(MSVC_VERSION EQUAL 1400) # VS 8
+	string(CONCAT msvc_crt
+		$<$<CONFIG:Debug>:MSVCR80D>
+		$<$<CONFIG:Release>:MSVCR80>
+	)
+elseif(MSVC_VERSION EQUAL 1500) # VS 9
+	string(CONCAT msvc_crt
+		$<$<CONFIG:Debug>:MSVCR90D>
+		$<$<CONFIG:Release>:MSVCR90>
+	)
+elseif(MSVC_VERSION EQUAL 1600) # VS 10
+	string(CONCAT msvc_crt
+		$<$<CONFIG:Debug>:MSVCR100D>
+		$<$<CONFIG:Release>:MSVCR100>
+	)
+elseif(MSVC_VERSION EQUAL 1700) # VS 11
+	string(CONCAT msvc_crt
+		$<$<CONFIG:Debug>:MSVCR110D>
+		$<$<CONFIG:Release>:MSVCR110>
+	)
+elseif(MSVC_VERSION EQUAL 1800) # VS 12
+	string(CONCAT msvc_crt
+		$<$<CONFIG:Debug>:MSVCR120D>
+		$<$<CONFIG:Release>:MSVCR120>
+	)
+elseif(MSVC_VERSION GREATER 1800) # VS 14+
+	string(CONCAT msvc_crt
+		$<$<CONFIG:Debug>:UCRTBASED>
+		$<$<CONFIG:Release>:UCRTBASE>
+	)
+else()
+	set(msvc_crt NOTFOUND)
+endif()
+
+set(OMR_MSVC_CRT "${msvc_crt}" CACHE STRING "The MSVC runtime library")

--- a/omrsigcompat/CMakeLists.txt
+++ b/omrsigcompat/CMakeLists.txt
@@ -16,6 +16,8 @@
 #    Multiple authors (IBM Corp.) - initial implementation and documentation
 ###############################################################################
 
+include(OmrMsvcRuntime)
+
 add_library(omrsig SHARED
 	omrsig.cpp
 )
@@ -29,20 +31,16 @@ set(exportedSyms
 
 #for now only export symbols on windows
 if(OMR_HOST_OS STREQUAL "win")
+
 	file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/omrsig.exportlist" "EXPORTS\n" )
 	foreach(exportSymbol ${exportedSyms})
 		file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/omrsig.exportlist" "${exportSymbol}\n" )
 	endforeach()
+
 	set_target_properties(omrsig
 		PROPERTIES LINK_FLAGS "-def:${CMAKE_CURRENT_BINARY_DIR}/omrsig.exportlist")
-	set(CRT_DLL "MSVC100.dll")
-	#TODO: below assumes we are using debug builds
-	if(MSVC12)
-		set(CRT_DLL "MSVC120d.dll")
-	elseif(MSVC14)
-		set(CRT_DLL "ucrtbased.dll")
-	endif()
-	target_compile_definitions(omrsig PRIVATE -DMSVC_RUNTIME_DLL="${CRT_DLL}")
+
+	target_compile_definitions(omrsig PRIVATE -DMSVC_RUNTIME_DLL="${OMR_MSVC_CRT}")
 endif()
 
 #Symbols exported from source makefile:


### PR DESCRIPTION
Move msvc runtime processing out into a new module.
Use the new module to set the CPP define in OMR sig.

This PR contains the omrsig/msvc patches originally in PR #1563. I'm moving this patch to a seperate PR because there are still issues with the compile options patches (which rely on this PR).

/cc @charliegracie @dnakamura 
Signed-off-by: Robert Young <rwy0717@gmail.com>