### PR TITLE
Removing Allocatable class and inheritance

### DIFF
--- a/compiler/env/TRMemory.hpp
+++ b/compiler/env/TRMemory.hpp
@@ -958,21 +958,6 @@ namespace TR
    typedef CS2::ASparseBitVector<TR::GlobalAllocator> GlobalSparseBitVector;
    typedef CS2::ABitVector<TR::GlobalAllocator>       GlobalBitVector;
 
-   template <typename T, typename Allocator>
-   class Allocatable
-      {
-      public:
-      static void *operator new(size_t size, Allocator a)
-         { return a.allocate(size); }
-      static void  operator delete(void *ptr, size_t size)
-         { ((T*)ptr)->allocator().deallocate(ptr, size); } /* t->allocator() better return the same allocator as used for new */
-
-      /* Virtual destructor is necessary for the above delete operator to work
-       * See "Modern C++ Design" section 4.7
-       */
-      virtual ~Allocatable() {}
-      };
-
    class AllocatedMemoryMeter
       {
       private:

--- a/compiler/optimizer/DataFlowAnalysis.hpp
+++ b/compiler/optimizer/DataFlowAnalysis.hpp
@@ -100,9 +100,20 @@ template<class Container>class TR_BackwardUnionDFSetAnalysis<Container *>;
 // the analyses to perform TR::Node and TR::TreeTop related computations.
 //
 //
-class TR_DataFlowAnalysis : public TR::Allocatable<TR_DataFlowAnalysis, TR::Allocator>
+class TR_DataFlowAnalysis
    {
    public:
+
+   static void *operator new(size_t size, TR::Allocator a)
+      { return a.allocate(size); }
+   static void  operator delete(void *ptr, size_t size)
+      { ((TR_DataFlowAnalysis*)ptr)->allocator().deallocate(ptr, size); } /* t->allocator() better return the same allocator as used for new */
+
+   /* Virtual destructor is necessary for the above delete operator to work
+    * See "Modern C++ Design" section 4.7
+    */
+   virtual ~TR_DataFlowAnalysis() {}
+
 
    TR_DataFlowAnalysis(TR::Compilation *comp, TR::CFG *cfg, TR::Optimizer *optimizer, bool trace)
       : _comp(comp),

--- a/compiler/optimizer/OMROptimization.hpp
+++ b/compiler/optimizer/OMROptimization.hpp
@@ -50,10 +50,19 @@ namespace TR { class Optimization; }
 namespace OMR
 {
 
-class OMR_EXTENSIBLE Optimization: public TR_HasRandomGenerator,
-                                   public TR::Allocatable<TR::Optimization, TR::Allocator>
+class OMR_EXTENSIBLE Optimization: public TR_HasRandomGenerator
    {
-public:
+   public:
+
+   static void *operator new(size_t size, TR::Allocator a)
+      { return a.allocate(size); }
+   static void  operator delete(void *ptr, size_t size)
+      { ((Optimization*)ptr)->allocator().deallocate(ptr, size); } /* t->allocator() better return the same allocator as used for new */
+
+   /* Virtual destructor is necessary for the above delete operator to work
+    * See "Modern C++ Design" section 4.7
+    */
+   virtual ~Optimization() {}
 
    inline TR::Optimization * self();
 

--- a/compiler/optimizer/OMROptimizationManager.hpp
+++ b/compiler/optimizer/OMROptimizationManager.hpp
@@ -55,9 +55,19 @@ typedef TR::Optimization *(*OptimizationFactory)(TR::OptimizationManager *m);
 namespace OMR
 {
 
-class OMR_EXTENSIBLE OptimizationManager : public TR::Allocatable<OptimizationManager, TR::Allocator>
+class OMR_EXTENSIBLE OptimizationManager
    {
    public:
+
+   static void *operator new(size_t size, TR::Allocator a)
+      { return a.allocate(size); }
+   static void  operator delete(void *ptr, size_t size)
+      { ((OptimizationManager*)ptr)->allocator().deallocate(ptr, size); } /* t->allocator() must return the same allocator as used for new */
+
+   /* Virtual destructor is necessary for the above delete operator to work
+    * See "Modern C++ Design" section 4.7
+    */
+   virtual ~OptimizationManager() {}
 
    TR::OptimizationManager *self();
 

--- a/compiler/optimizer/OptimizationData.hpp
+++ b/compiler/optimizer/OptimizationData.hpp
@@ -25,11 +25,21 @@
 namespace TR
 {
 
-class OptimizationData : public TR::Allocatable<OptimizationData, TR::Allocator>
+class OptimizationData
 	{
 	public:
 
-	OptimizationData(TR::Compilation *comp) : _comp(comp) {}
+	static void *operator new(size_t size, TR::Allocator a)
+           { return a.allocate(size); }
+        static void  operator delete(void *ptr, size_t size)
+           { ((OptimizationData*)ptr)->allocator().deallocate(ptr, size); } /* t->allocator() must return the same allocator as used for new */
+
+        /* Virtual destructor is necessary for the above delete operator to work
+         * See "Modern C++ Design" section 4.7
+         */
+        virtual ~OptimizationData() {}
+
+        OptimizationData(TR::Compilation *comp) : _comp(comp) {}
 
 	TR::Compilation *comp() { return _comp; }
 	TR::Allocator allocator() { return comp()->allocator(); }

--- a/compiler/optimizer/OptimizationPolicy.hpp
+++ b/compiler/optimizer/OptimizationPolicy.hpp
@@ -25,20 +25,29 @@
 namespace TR
 {
 
-class OptimizationPolicy: public TR::Allocatable<OptimizationPolicy, TR::Allocator>
-	{
-	public:
+class OptimizationPolicy
+   {
+   public:
+   static void *operator new(size_t size, TR::Allocator a)
+      { return a.allocate(size); }
+   static void  operator delete(void *ptr, size_t size)
+      { ((OptimizationPolicy*)ptr)->allocator().deallocate(ptr, size); } /* t->allocator() must return the same allocator as used for new */
 
-	OptimizationPolicy(TR::Compilation *comp) : _comp(comp) {}
+   /* Virtual destructor is necessary for the above delete operator to work
+    * See "Modern C++ Design" section 4.7
+    */
+   virtual ~OptimizationPolicy() {}
+   
+   OptimizationPolicy(TR::Compilation *comp) : _comp(comp) {}
 
-	TR::Compilation *comp()   { return _comp; }
-        TR_FrontEnd *fe()         { return _comp->fe(); }
-	TR::Allocator allocator() { return comp()->allocator(); }
-        TR_Memory * trMemory()    { return comp()->trMemory(); }
+   TR::Compilation *comp()   { return _comp; }
+   TR_FrontEnd *fe()         { return _comp->fe(); }
+   TR::Allocator allocator() { return comp()->allocator(); }
+   TR_Memory * trMemory()    { return comp()->trMemory(); }
 
-	private:
-	TR::Compilation *_comp;
-	};
+   private:
+   TR::Compilation *_comp;
+   };
 
 }
 

--- a/compiler/optimizer/OptimizationUtil.hpp
+++ b/compiler/optimizer/OptimizationUtil.hpp
@@ -25,20 +25,29 @@
 namespace TR
 {
 
-class OptimizationUtil: public TR::Allocatable<OptimizationUtil, TR::Allocator>
-	{
-	public:
+class OptimizationUtil
+   {
+   public:
+   static void *operator new(size_t size, TR::Allocator a)
+      { return a.allocate(size); }
+   static void  operator delete(void *ptr, size_t size)
+      { ((OptimizationUtil*)ptr)->allocator().deallocate(ptr, size); } /* t->allocator() must return the same allocator as used for new */
 
-	OptimizationUtil(TR::Compilation *comp) : _comp(comp) {}
+   /* Virtual destructor is necessary for the above delete operator to work
+    * See "Modern C++ Design" section 4.7
+    */
+   virtual ~OptimizationUtil() {}
 
-	TR::Compilation *comp() { return _comp; }
-   TR_FrontEnd *fe() {return _comp->fe(); }
-	TR::Allocator allocator() { return comp()->allocator(); }
-   TR_Memory * trMemory()                    { return comp()->trMemory(); }
+   OptimizationUtil(TR::Compilation *comp) : _comp(comp) {}
 
-	private:
-	TR::Compilation *_comp;
-	};
+   TR::Compilation *comp() { return _comp; }
+   TR_FrontEnd *fe() { return _comp->fe(); }
+   TR::Allocator allocator() { return comp()->allocator(); }
+   TR_Memory * trMemory() { return comp()->trMemory(); }
+
+   private:
+   TR::Compilation *_comp;
+   };
 
 }
 #endif

--- a/compiler/optimizer/SinkStores.hpp
+++ b/compiler/optimizer/SinkStores.hpp
@@ -46,9 +46,20 @@ namespace TR { class TreeTop; }
 // Store Sinking
 // There are two implementations: TR_TrivialSinkStores and TR_GeneralSinkStores
 
-class TR_LiveOnNotAllPaths : public TR::Allocatable<TR_LiveOnNotAllPaths, TR::Allocator>
+class TR_LiveOnNotAllPaths
    {
    public:
+   
+   static void *operator new(size_t size, TR::Allocator a)
+      { return a.allocate(size); }
+   static void  operator delete(void *ptr, size_t size)
+      { ((TR_LiveOnNotAllPaths*)ptr)->allocator().deallocate(ptr, size); } /* t->allocator() must return the same allocator as used for new */
+
+   /* Virtual destructor is necessary for the above delete operator to work
+    * See "Modern C++ Design" section 4.7
+    */
+   virtual ~TR_LiveOnNotAllPaths() {}
+  
    TR_LiveOnNotAllPaths(TR::Compilation *comp, TR_Liveness *liveOnSomePaths, TR_LiveOnAllPaths *liveOnAllPaths);
 
    TR::Compilation *   comp()          { return _comp; }

--- a/compiler/optimizer/UseDefInfo.hpp
+++ b/compiler/optimizer/UseDefInfo.hpp
@@ -56,10 +56,20 @@ namespace TR { class TreeTop; }
  * This means that there are a total of Z index values.
  * The bit vectors that hold use information are of size (Z-X).
  */
-class TR_UseDefInfo : public TR::Allocatable<TR_UseDefInfo, TR::Allocator>
+class TR_UseDefInfo
    {
    TR::Region _region;
    public:
+
+   static void *operator new(size_t size, TR::Allocator a)
+      { return a.allocate(size); }
+   static void  operator delete(void *ptr, size_t size)
+      { ((TR_UseDefInfo*)ptr)->allocator().deallocate(ptr, size); } /* t->allocator() better return the same allocator as used for new */
+
+   /* Virtual destructor is necessary for the above delete operator to work
+    * See "Modern C++ Design" section 4.7
+    */
+   virtual ~TR_UseDefInfo() {}
 
    // Construct use def info for the current method's trees. This also assigns
    // use/def index values to the relevant nodes.

--- a/compiler/optimizer/ValueNumberInfo.hpp
+++ b/compiler/optimizer/ValueNumberInfo.hpp
@@ -31,10 +31,22 @@ class TR_UseDefInfo;
 namespace TR { class Optimizer; }
 namespace TR { class ParameterSymbol; }
 
-class TR_ValueNumberInfo : public TR::Allocatable<TR_ValueNumberInfo, TR::Allocator>
+class TR_ValueNumberInfo
    {
 
    public:
+  
+   static void *operator new(size_t size, TR::Allocator a)
+      { return a.allocate(size); }
+   static void  operator delete(void *ptr, size_t size)
+      { ((TR_ValueNumberInfo*)ptr)->allocator().deallocate(ptr, size); } /* t->allocator() must return the same allocator as used for new */
+
+   /* Virtual destructor is necessary for the above delete operator to work
+    * See "Modern C++ Design" section 4.7
+    */
+   virtual ~TR_ValueNumberInfo() {}     
+ 
+
    TR_ValueNumberInfo(TR::Compilation *);
    TR_ValueNumberInfo(TR::Compilation *, TR::Optimizer *, bool requiresGlobals = false, bool prefersGlobals = true, bool noUseDefInfo = false);
 

--- a/compiler/z/codegen/OMRInstruction.hpp
+++ b/compiler/z/codegen/OMRInstruction.hpp
@@ -345,10 +345,20 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
       { return (_targetMemSize!=0) ? ((TR::MemoryReference**)_operands)+_targetRegSize+_sourceRegSize+_sourceMemSize : NULL;  }
 
    template <typename T>
-   class RegisterArray : public TR::Allocatable<RegisterArray<T>, TR::Allocator>
+   class RegisterArray
       {
       public:
          TR::Allocator allocator() { return TR::comp()->allocator(); }
+
+         static void *operator new(size_t size, TR::Allocator a)
+            { return a.allocate(size); }
+         static void  operator delete(void *ptr, size_t size)
+            { ((RegisterArray*)ptr)->allocator().deallocate(ptr, size); } /* t->allocator() must return the same allocator as used for new */
+
+         /* Virtual destructor is necessary for the above delete operator to work
+          * See "Modern C++ Design" section 4.7
+          */
+         virtual ~RegisterArray() {}
 
       private:
          // template <class AElementType, class Allocator = CS2::allocator, size_t segmentBits = 8>
@@ -384,9 +394,20 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
             }
       };
 
-   class RegisterBitVector : public TR::Allocatable<RegisterBitVector, TR::Allocator>
+   class RegisterBitVector
       {
       public:
+
+         static void *operator new(size_t size, TR::Allocator a)
+            { return a.allocate(size); }
+         static void  operator delete(void *ptr, size_t size)
+            { ((RegisterBitVector*)ptr)->allocator().deallocate(ptr, size); } /* t->allocator() must return the same allocator as used for new */
+
+         /* Virtual destructor is necessary for the above delete operator to work
+          * See "Modern C++ Design" section 4.7
+          */
+         virtual ~RegisterBitVector() {}
+
          TR::Allocator allocator() { return TR::comp()->allocator(); }
 
       private:


### PR DESCRIPTION
Removed inheritance from classes using Allocatable due to
infrequent and inconsistent usage of the class. Functionality
required from Allocatable has been copied directly into the
classes that require it.

Signed-off-by: Arianne Butler <arianne.butler@ibm.com>