### PR TITLE
Remove omr_shared

### DIFF
--- a/cmake/modules/OmrPlatform.cmake
+++ b/cmake/modules/OmrPlatform.cmake
@@ -47,11 +47,6 @@ include(platform/toolcfg/${OMR_TOOLCONFIG})
 # Verify toolconfig!
 include(platform/toolcfg/verify)
 
-
-# interface library for exporting symbols from dynamic library
-# currently does nothing except on zos
-add_library(omr_shared INTERFACE)
-
 macro(omr_platform_global_setup)
 
 	omr_assert(WARNING TEST NOT OMR_PLATFORM_GLOBALLY_INITIALIZED

--- a/cmake/modules/platform/os/zos.cmake
+++ b/cmake/modules/platform/os/zos.cmake
@@ -54,6 +54,11 @@ list(APPEND OMR_PLATFORM_CXX_COMPILE_OPTIONS
 	"\"-qnosearch\""
 )
 
+list(APPEND OMR_PLATFORM_SHARED_COMPILE_OPTIONS
+	"\"-Wc,DLL\""
+	"\"-Wc,EXPORTALL\""
+)
+
 list(APPEND OMR_PLATFORM_SHARED_LINKER_OPTIONS
 	"\"-Wl,xplink\""
 	"\"-Wl,dll\""
@@ -79,8 +84,6 @@ macro(omr_os_global_setup)
 	enable_language(ASM-ZOS)
 
 	omr_append_flags(CMAKE_ASM-ZOS_FLAGS ${OMR_PLATFORM_COMPILE_OPTIONS})
-
-	target_compile_options(omr_shared INTERFACE "-Wc,DLL,EXPORTALL")
 
 	#TODO below is a chunk of the original makefile which still needs to be ported
 	# # This is the first option applied to the C++ linking command.

--- a/fvtest/porttest/CMakeLists.txt
+++ b/fvtest/porttest/CMakeLists.txt
@@ -89,11 +89,14 @@ if(OMR_HOST_OS STREQUAL "zos")
 	target_link_libraries(omrporttest j9a2e)
 endif()
 
-
 add_library(sltestlib SHARED
-	sltestlib/sltest.c)
-target_link_libraries(sltestlib PRIVATE omr_shared)
+	sltestlib/sltest.c
+)
 
+target_compile_options(sltestlib
+	PRIVATE
+		${OMR_PLATFORM_SHARED_COMPILE_OPTIONS}
+)
 
 add_test(NAME porttest COMMAND omrporttest)
 

--- a/omrsigcompat/CMakeLists.txt
+++ b/omrsigcompat/CMakeLists.txt
@@ -84,8 +84,12 @@ endif()
 
 target_link_libraries(omrsig
 	PRIVATE
-	omrutil
-	omr_shared
+		omrutil
+)
+
+target_compile_options(omrsig
+	PRIVATE
+		${OMR_PLATFORM_SHARED_COMPILE_OPTIONS}
 )
 
 if(OMR_HOST_OS MATCHES "linux|osx")

--- a/util/a2e/CMakeLists.txt
+++ b/util/a2e/CMakeLists.txt
@@ -22,7 +22,10 @@ add_library(j9a2e SHARED
 	atoe_utils.c
 )
 
-target_link_libraries(j9a2e PRIVATE omr_shared)
+target_compile_options(j9a2e
+	PRIVATE
+		${OMR_PLATFORM_SHARED_COMPILE_OPTIONS}
+)
 
 target_include_directories(j9a2e
 	PUBLIC


### PR DESCRIPTION
OmrPlatform is meant to be re-includable. However, when we define
omr_shared in this module, this is no longer the case.

omr_shared was used to pass compile options needed to create shared
libraries. Any shared library in OMR would link privately against this
lib.

Instead, we introduce a new platform variable
OMR_PLATFORM_SHARED_COMPILE_OPTIONS

This variable contains the same set of compile options normally
inherited through omr_shared. All usages of omr_shared have been replace
with target_add_compile_options and this new variable.

Besides making OmrPlatform reincludable, this also makes shared compile
options more conventional.

/cc @dnakamura @mgaudet @charliegracie
Signed-off-by: Robert Young <rwy0717@gmail.com>