### PR TITLE
CMake: make omr_find_file issue error on unfound file

### DIFF
--- a/cmake/modules/OmrFindFiles.cmake
+++ b/cmake/modules/OmrFindFiles.cmake
@@ -58,7 +58,7 @@ function(omr_find_files output_variable)
 				break()
 			endif()
 		endforeach()
-		omr_assert(WARNING TEST file_found MESSAGE "Could not find file: ${file}")
+		omr_assert(FATAL_ERROR TEST file_found MESSAGE "Could not find file: ${file}")
 	endforeach()
 
 	set(${output_variable} "${result}" PARENT_SCOPE)


### PR DESCRIPTION
Modify omr_find_files to issue a error rather than a warning if it cant
find a file.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>