### PR TITLE
Test output cleanup

### DIFF
--- a/fvtest/algotest/algoTest.cpp
+++ b/fvtest/algotest/algoTest.cpp
@@ -23,47 +23,168 @@
 #include "algorithm_test_internal.h"
 #include "omrTest.h"
 #include "testEnvironment.hpp"
+#include "pool_api.h"
 
 extern PortEnvironment *omrTestEnv;
 
+typedef struct AVLParams {
+	const char *testName;
+	const char *success;
+	const char *data;
+} AVLParams;
+
+static const AVLParams avlParams[] = {
+	{"Empty tree", "@", "0"},
+	{"Single element", "{=10@@}", "10, 0"},
+	{"Left heavy", "{L10{=5@@}@}", "10, 5, 0"},
+	{"Right heavy", "{R10@{=15@@}}", "10, 15, 0"},
+	{"Double insert", "{=10@@}", "10, 10, 0"},
+	{"Remove root: root is leaf node", "@", "10, -10, 0"},
+	{"Remove root: adding node after", "{=5@@}", "10, -10, 5, 0"},
+	{"Remove root: root is left branch", "{=5@@}", "10, 5, -10, 0"},
+	{"Remove root: root is right branch", "{=15@@}", "10, 15, -10, 0"},
+	{"Balanced tree: right then left", "{=10{=5@@}{=15@@}}", "10, 15, 5, 0"},
+	{"Balanced tree: left then right", "{=10{=5@@}{=15@@}}", "10, 5, 15, 0"},
+	{"Single rotate: left; including root; no children; via insertion", "{=10{=5@@}{=15@@}}", "5, 10, 15, 0"},
+	{"Single rotate: right; including root; no children; via insertion", "{=10{=5@@}{=15@@}}", "15, 10, 5, 0"},
+	{"Double rotate: left; including root; no children; via insertion", "{=10{=5@@}{=15@@}}", "5, 15, 10, 0"},
+	{"Double rotate: right; including root; no children; via insertion", "{=10{=5@@}{=15@@}}", "15, 5, 10, 0"},
+	{"Remove node: leaf node; right; no children", "{=10@@}", "10, 15, -15, 0"},
+	{"Remove node: leaf node; left; no children", "{=10@@}", "10, 5, -5, 0"},
+	{"Simple tree; height 3; right heavy", "{R5{=1@@}{=10{=7@@}{=15@@}}}", "5, 10, 1, 7, 15, 0"},
+	{"Simple tree; height 3; left heavy", "{L20{=10{=7@@}{=15@@}}{=25@@}}", "20, 25, 10, 7, 15, 0"},
+	{"Single rotate: left; including root; balanced; via deletion", "{L10{R5@{=7@@}}{=15@@}}", "5, 10, 1, 7, 15, -1, 0"},
+	{"Single rotate: right; including root; balanced; via deletion", "{R10{=7@@}{L20{=15@@}@}}", "20, 25, 10, 15, 7, -25, 0"},
+	{"double rotation; height 3; left heavy", "{L20{=7{=1@@}{=10@@}}{=25@@}}", "20, 25, 10, 1, 7, 0"},
+	{"Single rotate: right; not root; no graft", "{=30{=5{=1@@}{=10@@}}{L40{=35@@}@}}", "30, 10, 40, 5, 20, 35, 1, -20, 0"},
+	{"Delete non-existant node", "{R10@{=15@@}}", "10, 15, -20, 0"},
+	{"Delete node twice", "{=10@@}", "10, 15, -15, -15, 0"},
+	{"Delete node; no root" , "@", "-15, 0"},
+	{"single rotation test1", "{L20{=5{=1@@}{=10@@}}{=40@@}}", "20, 10, 40, 5, 1, 0"},
+	{"single rotation test2", "{=20{=5{=1@@}{=10@@}}{R40@{=50@@}}}", "20, 10, 40, 5, 50, 1, 0"},
+	{"single rotation test3", "{L20{R5{=1@@}{L10{=7@@}@}}{R40@{=50@@}}}", "20, 10, 40, 5, 15, 50, 1, 7, -15, 0"},
+	{"single rotation test4", "{=20{R5{=1@@}{L10{=7@@}@}}{R40{=30@@}{R50@{=60@@}}}}", "20, 10, 40, 5, 15, 30, 50, 1, 7, 60, -15, 0"},
+	{"single rotation test5", "{L20{=5{L4{=1@@}@}{=10{=7@@}{=15@@}}}{R40@{=50@@}}}", "20, 10, 40, 5, 15, 50, 4, 7, 1, 0"},
+	{"single rotation test6", "{=20{=5{L4{=1@@}@}{=10{=7@@}{=15@@}}}{R40{=30@@}{R50@{=60@@}}}}", "20, 10, 40, 5, 15, 30, 50, 4, 7, 60, 1, 0"},
+	{"single rotation test7", "{R80{=60@@}{=95{=90@@}{=99@@}}}", "80, 60, 90, 95, 99, 0"},
+	{"single rotation test8", "{=80{L60{=50@@}@}{=95{=90@@}{=99@@}}}", "80, 60, 90, 50, 95, 99, 0"},
+	{"single rotation test9", "{R80{L60{=50@@}@}{L95{R90@{=93@@}}{=99@@}}}", "80, 60, 90, 50, 85, 95, 93, 99, -85, 0"},
+	{"single rotation test10", "{=80{L60{L50{=40@@}@}{=70@@}}{L95{R90@{=93@@}}{=99@@}}}", "80, 60, 90, 50, 70, 85, 95, 40, 93, 99, -85, 0"},
+	{"single rotation test11", "{R80{L60{=50@@}@}{=95{=90{=85@@}{=93@@}}{R96@{=99@@}}}}", "80, 60, 90, 50, 85, 95, 93, 96, 99, 0"},
+	{"single rotation test12", "{=80{L60{L50{=40@@}@}{=70@@}}{=95{=90{=85@@}{=93@@}}{R96@{=99@@}}}}", "80, 60, 90, 50, 70, 85, 95, 40, 93, 96, 99, 0"},
+	{"remove with immediate leaf predecessor", "{R20{=10@@}{R30@{=50@@}}}", "20, 10, 40, 30, 50, -40, 0"},
+	{"remove with immediate left branch predecessor", "{=20{L10{=5@@}@}{=30{=25@@}{=50@@}}}", "20, 10, 40, 5, 30, 50, 25, -40, 0"},
+	{"remove with leaf predecessor", "{R20{L10{=5@@}@}{L35{L30{=25@@}@}{=50@@}}}", "20, 10, 40, 5, 30, 50, 25, 35, -40, 0"},
+	{"remove with leaf left branch predecessor", "{=20{L10{L5{=1@@}@}{=15@@}}{=35{=30{=25@@}{=32@@}}{R50@{=55@@}}}}", "20, 10, 40, 5, 15, 30, 50, 1, 25, 35, 55, 32, -40, 0"},
+	{"double rotation test1", "{L20{=7{=5@@}{=10@@}}{=40@@}}", "20, 10, 40, 5, 7, 0"},
+	{"double rotation test2", "{=20{=7{=5@@}{=10@@}}{R40@{=50@@}}}", "20, 10, 40, 5, 50, 7, 0"},
+	{"double rotation test3", "{L20{=12{=10@@}{=15@@}}{=40@@}}", "20, 10, 40, 15, 12, 0"},
+	{"double rotation test4", "{=20{=12{=10@@}{=15@@}}{R40@{=50@@}}}", "20, 10, 40, 15, 50, 12, 0"},
+	{"double rotation test5", "{L20{=7{L5{=4@@}@}{=10{=8@@}{=15@@}}}{R40@{=50@@}}}", "20, 10, 40, 5, 15, 50, 4, 7, 8, 0"},
+	{"double rotation test6", "{=20{=7{=5{=4@@}{=6@@}}{=10{=8@@}{=15@@}}}{R40{=30@@}{R50@{=60@@}}}}", "20, 10, 40, 5, 15, 30, 50, 4, 7, 17, 60, 6, 8, -17, 0"},
+	{"double rotation test7", "{L20{=13{L10{=5@@}@}{=15{=14@@}{=17@@}}}{R40@{=50@@}}}", "20, 10, 40, 5, 15, 50, 13, 17, 14, 0"},
+	{"double rotation test8", "{=20{=13{=10{=5@@}{=12@@}}{=15{=14@@}{=17@@}}}{R40{=30@@}{R50@{=60@@}}}}", "20, 10, 40, 5, 15, 30, 50, 4, 7, 13, 17, 60, 12, 14, -7, -4, 0"},
+	{"double rotation test9", "{R80{=60@@}{=93{=90@@}{=95@@}}}", "80, 60, 90, 95, 93, 0"},
+	{"double rotation test10", "{=80{L60{=50@@}@}{=93{=90@@}{=95@@}}}", "80, 60, 90, 50, 95, 93, 0"},
+	{"double rotation test11", "{R80{=60@@}{=87{=85@@}{=90@@}}}", "80, 60, 90, 85, 87, 0"},
+	{"double rotation test12", "{=80{L60{=50@@}@}{=87{=85@@}{=90@@}}}", "80, 60, 90, 85, 50, 87, 0"},
+	{"double rotation test13", "{R80{L60{=50@@}@}{=93{=90{=85@@}{=92@@}}{R95@{=96@@}}}}", "80, 60, 90, 50, 85, 95, 93, 96, 92, 0"},
+	{"double rotation test14", "{=80{L60{L50{=40@@}@}{=70@@}}{=93{=90{=85@@}{=92@@}}{=95{=94@@}{=96@@}}}}", "80, 60, 90, 50, 70, 85, 95, 40, 83, 93, 96, 92, 94, -83, 0"},
+	{"double rotation test15", "{R80{L60{=50@@}@}{=87{=85{=83@@}{=86@@}}{R90@{=95@@}}}}", "80, 60, 90, 50, 85, 95, 83, 87, 86, 0"},
+	{"double rotation test16", "{=80{L60{L50{=40@@}@}{=70@@}}{=87{=85{=83@@}{=86@@}}{=90{=88@@}{=95@@}}}}", "80, 60, 90, 50, 70, 85, 95, 40, 83, 87, 93, 86, 88, -93, 0"},
+};
+
+static const PoolInputData poolParams[] = {
+	{"very small pool",										1,		1,		sizeof(uintptr_t),		0,		0},
+	{"page size pool - with 4-byte elements",				4,		0,		sizeof(uintptr_t),		0,		0},
+	{"small pool",											4,		10,		sizeof(uintptr_t),		0,		0},
+	{"small pool - default alignment size",					4,		10,		0,						0,		0},
+	{"small pool - 8 alignment size",						4,		10,		8,						0,		0},
+	{"small pool - large alignment size",					4,		10,		64,						0,		0},
+	{"page size pool - with 8-byte elements", 				8,		0,		sizeof(uintptr_t),		0,		0},
+	{"medium pool",											8,		100,	sizeof(uintptr_t),		0,		0},
+	{"medium pool - default alignment size",				8,		100,	0,						0,		0},
+	{"medium pool - 8 alignment size",						8,		100,	8,						0,		0},
+	{"medium pool - large alignment size",					8,		100,	64,						0,		0},
+	{"page size pool - with 16-byte elements",				16,		0,		sizeof(uintptr_t),		0,		0},
+	{"larger pool",											16,		256,	sizeof(uintptr_t),		0,		0},
+	{"larger pool - default alignment size",				16,		256,	0,						0,		0},
+	{"larger pool - 8 alignment size",						16,		256,	8,						0,		0},
+	{"larger pool - large alignment size",					16,		256,	64,						0,		0},
+	{"large struct, small number",							9999,	5,		sizeof(uintptr_t),		0,		0},
+	{"small struct, large number",							4,		9999,	sizeof(uintptr_t),		0,		0},
+	{"zero minElements - should default to 1",				64,		0,		sizeof(uintptr_t),		0,		0},
+	{"zero alignment - should default to MIN_GRANULARITY",	64,		10,		0,						0,		0},
+	{"POOL_NO_ZERO flag",									32,		10,		sizeof(uintptr_t),		0,		POOL_NO_ZERO},
+	{"POOL_ALWAYS_KEEP_SORTED flag",						32,		10,		sizeof(uintptr_t),		0,		POOL_ALWAYS_KEEP_SORTED},
+	{"POOL_ROUND_TO_PAGE_SIZE flag",						32,		10,		sizeof(uintptr_t),		0,		POOL_ROUND_TO_PAGE_SIZE},
+	{"POOL_NEVER_FREE_PUDDLES flag",						32,		10,		sizeof(uintptr_t),		0,		POOL_NEVER_FREE_PUDDLES},
+};
+
+static const uintptr_t data1[] = {1, 2, 3, 4, 5, 6, 7, 17, 18, 19, 20, 21, 22, 23, 24, 25};
+static const uintptr_t data2[] = {1, 3, 5, 7, 18, 20, 22, 23, 24, 35, 36, 37};
+static const uintptr_t data3[] = {25, 24, 23, 22, 21, 20, 19, 18, 17, 7, 6, 5, 4, 3, 2, 1};
+static const uintptr_t data4[] = {37, 36, 35, 24, 23, 22, 20, 18, 7, 5, 3, 1};
+static const uintptr_t data5[] = {17, 14, 8, 73, 23, 38, 91, 84, 31, 25, 11, 41, 26, 87, 35, 6};
+static const uintptr_t data6[] = {17, 14, 8, 73, 23, 38, 91, 84, 31, 25, 11, 41, 26, 87, 35, 6, 13, 61, 10, 20, 92};
+static const uintptr_t data7[] = {
+	1, 87, 49, 12, 176, 178, 102, 166, 121, 193, 6, 84, 249, 230, 44, 163,
+	14, 197, 213, 181, 161, 85, 218, 80, 64, 239, 24, 226, 236, 142, 38, 200,
+	110, 177, 104, 103, 141, 253, 255, 50, 77, 101, 81, 18, 45, 96, 31, 222,
+	25, 107, 190, 70, 86, 237, 240, 34, 72, 242, 20, 214, 244, 227, 149, 235,
+	97, 234, 57, 22, 60, 250, 82, 175, 208, 5, 127, 199, 111, 62, 135, 248,
+	132, 56, 148, 75, 128, 133, 158, 100, 130, 126, 91, 13, 153, 246, 216, 219,
+	119, 68, 223, 78, 83, 88, 201, 99, 122, 11, 92, 32, 136, 114, 52, 10,
+	138, 30, 48, 183, 156, 35, 61, 26, 143, 74, 251, 94, 129, 162, 63, 152,
+	170, 7, 115, 167, 241, 206, 3, 150, 55, 59, 151, 220, 90, 53, 23, 131,
+};
+
+uint32_t listToTreeThresholdValues[] = {0, 1, 5, 10, 100};
+
+static const HashtableInputData hastableParams[] = {
+	{"Test1", data1, sizeof(data1) / sizeof(uintptr_t), FALSE},
+	{"Test2", data2, sizeof(data2) / sizeof(uintptr_t), FALSE},
+	{"Test3", data3, sizeof(data3) / sizeof(uintptr_t), FALSE},
+	{"Test4", data4, sizeof(data4) / sizeof(uintptr_t), FALSE},
+	{"Test5", data5, sizeof(data5) / sizeof(uintptr_t), FALSE},
+	{"Test6", data6, sizeof(data6) / sizeof(uintptr_t), FALSE},
+	{"Test6", data7, sizeof(data7) / sizeof(uintptr_t), FALSE},
+};
+
 static void showResult(OMRPortLibrary *portlib, uintptr_t passCount, uintptr_t failCount, int32_t numSuitesNotRun);
 
-TEST(OmrAlgoTest, avltest)
+class AVLTest: public ::testing::TestWithParam<AVLParams>
 {
-	char *avlTestFile = NULL;
-	uintptr_t passCount = 0;
-	uintptr_t failCount = 0;
-	int32_t numSuitesNotRun = 0;
+};
 
-	OMRPORT_ACCESS_FROM_OMRPORT(omrTestEnv->getPortLibrary());
+TEST_P(AVLTest, test)
+{
+	AVLParams params = GetParam();
+	const char *testName = params.testName;
+	const char *success = params.success;
+	const char *data = params.data;
 
-	for (int i = 0; i < omrTestEnv->_argc; i++) {
-		if (!strncmp("-avltest:", omrTestEnv->_argv[i], 9)) {
-			avlTestFile = &omrTestEnv->_argv[i][9];
-		}
-	}
-
-	if (avlTestFile) {
-		if (verifyAVLTree(privateOmrPortLibrary, avlTestFile, &passCount, &failCount)) {
-			numSuitesNotRun++;
-		}
-	} else {
-		omrtty_printf("No AVL test file specified (use: -avltest:filename)\n");
-		numSuitesNotRun++;
-	}
-	showResult(privateOmrPortLibrary, passCount, failCount, numSuitesNotRun);
+	ASSERT_EQ(0, buildAndVerifyAVLTree(omrTestEnv->getPortLibrary(), success, data)) << "Test verification failed for " << testName;
 }
 
-TEST(OmrAlgoTest, pooltest)
-{
-	uintptr_t passCount = 0;
-	uintptr_t failCount = 0;
-	int32_t numSuitesNotRun = 0;
+INSTANTIATE_TEST_CASE_P(OmrAlgoTest, AVLTest, ::testing::ValuesIn(avlParams));
 
-	if (verifyPools(omrTestEnv->getPortLibrary(), &passCount, &failCount)) {
-		numSuitesNotRun++;
-	}
-	showResult(omrTestEnv->getPortLibrary(), passCount, failCount, numSuitesNotRun);
+class PoolTest: public ::testing::TestWithParam<PoolInputData>
+{
+};
+
+TEST_P(PoolTest, test)
+{
+	PoolInputData params = GetParam();
+
+	ASSERT_EQ(0, createAndVerifyPool(omrTestEnv->getPortLibrary(), &params)) << "Test verification failed for " << params.poolName;
+}
+
+INSTANTIATE_TEST_CASE_P(OmrAlgoTest, PoolTest, ::testing::ValuesIn(poolParams));
+
+TEST(OmrAlgoTest, PoolTestPuddleSharing)
+{
+	ASSERT_EQ(0, testPoolPuddleListSharing(omrTestEnv->getPortLibrary()));
 }
 
 TEST(OmrAlgoTest, hookabletest)
@@ -78,17 +199,60 @@ TEST(OmrAlgoTest, hookabletest)
 	showResult(omrTestEnv->getPortLibrary(), passCount, failCount, numSuitesNotRun);
 }
 
-TEST(OmrAlgoTest, hashtabletest)
+class HashtableTest: public ::testing::TestWithParam<HashtableInputData>
 {
-	uintptr_t passCount = 0;
-	uintptr_t failCount = 0;
-	int32_t numSuitesNotRun = 0;
+};
 
-	if (verifyHashtable(omrTestEnv->getPortLibrary(), &passCount, &failCount)) {
-		numSuitesNotRun++;
-	}
-	showResult(omrTestEnv->getPortLibrary(), passCount, failCount, numSuitesNotRun);
+TEST_P(HashtableTest, Force)
+{
+	HashtableInputData params = GetParam();
+	params.forceCollisions = TRUE;
+	params.collisionResistant = FALSE;
+
+	ASSERT_EQ(0, buildAndVerifyHashtable(omrTestEnv->getPortLibrary(), &params)) << "Test verification failed for " << params.hashtableName;
 }
+
+TEST_P(HashtableTest, NoForce)
+{
+	HashtableInputData params = GetParam();
+	params.forceCollisions = FALSE;
+	params.collisionResistant = FALSE;
+
+	ASSERT_EQ(0, buildAndVerifyHashtable(omrTestEnv->getPortLibrary(), &params)) << "Test verification failed for " << params.hashtableName;
+}
+
+INSTANTIATE_TEST_CASE_P(OmrAlgoTest, HashtableTest, ::testing::ValuesIn(hastableParams));
+
+class CollisionResilientHashtableTest: public ::testing::TestWithParam< ::testing::tuple<HashtableInputData, uint32_t> >
+{
+};
+
+TEST_P(CollisionResilientHashtableTest, Force)
+{
+	HashtableInputData params = ::testing::get<0>(GetParam());
+	params.forceCollisions = TRUE;
+	params.collisionResistant = TRUE;
+	params.listToTreeThreshold = ::testing::get<1>(GetParam());
+
+	ASSERT_EQ(0, buildAndVerifyHashtable(omrTestEnv->getPortLibrary(), &params)) << "Test verification failed for " << params.hashtableName;
+}
+
+TEST_P(CollisionResilientHashtableTest, NoForce)
+{
+	HashtableInputData params = ::testing::get<0>(GetParam());
+	params.forceCollisions = FALSE;
+	params.collisionResistant = TRUE;
+	params.listToTreeThreshold = ::testing::get<1>(GetParam());
+
+	ASSERT_EQ(0, buildAndVerifyHashtable(omrTestEnv->getPortLibrary(), &params)) << "Test verification failed for " << params.hashtableName;
+}
+
+INSTANTIATE_TEST_CASE_P(OmrAlgoTest, CollisionResilientHashtableTest,
+	::testing::Combine(
+		::testing::ValuesIn(hastableParams),
+		::testing::ValuesIn(listToTreeThresholdValues)
+	)
+);
 
 static void
 showResult(OMRPortLibrary *portlib, uintptr_t passCount, uintptr_t failCount, int32_t numSuitesNotRun)

--- a/fvtest/algotest/algorithm_test_internal.h
+++ b/fvtest/algotest/algorithm_test_internal.h
@@ -23,9 +23,6 @@
 #define algorithm_test_internal_h
 
 /**
-* @file algorithm_test_internal.h
-* @brief Internal prototypes used within the ALGORITHM_TEST module.
-*
 * This file contains implementation-private function prototypes and
 * type definitions for the ALGORITHM_TEST module.
 *
@@ -37,30 +34,53 @@
 extern "C" {
 #endif
 
+typedef struct PoolInputData {
+	const char *poolName;
+	uint32_t structSize;
+	uint32_t numberElements;
+	uint32_t elementAlignment;
+	uint32_t padding;
+	uintptr_t poolFlags;
+} PoolInputData;
+
+typedef struct HashtableInputData {
+	const char* hashtableName;
+	const uintptr_t* data;
+	uintptr_t dataLength;
+	uint32_t listToTreeThreshold;
+	BOOLEAN forceCollisions;
+	BOOLEAN collisionResistant;
+} HashtableInputData;
+
 /* ---------------- avltest.c ---------------- */
 
 /**
 * @brief
 * @param *portLib
-* @param *testListFile
-* @param *passCount
-* @param *failCount
+* @param *testData
 * @return int32_t
 */
 int32_t
-verifyAVLTree(OMRPortLibrary *portLib, char *testListFile, uintptr_t *passCount, uintptr_t *failCount);
+buildAndVerifyAVLTree(OMRPortLibrary *portLib, const char *success, const char *testData);
 
 /* ---------------- pooltest.c ---------------- */
 
 /**
 * @brief
 * @param *portLib
-* @param *passCount
-* @param *failCount
+* @param *input
 * @return int32_t
 */
 int32_t
-verifyPools(OMRPortLibrary *portLib, uintptr_t *passCount, uintptr_t *failCount);
+createAndVerifyPool(OMRPortLibrary *portLib, PoolInputData *input);
+
+/**
+* @brief
+* @param *portLib
+* @return int32_t
+*/
+int32_t
+testPoolPuddleListSharing(OMRPortLibrary *portLib);
 
 /* ---------------- hooktest.c ---------------- */
 
@@ -85,6 +105,10 @@ verifyHookable(OMRPortLibrary *portLib, uintptr_t *passCount, uintptr_t *failCou
 */
 int32_t
 verifyHashtable(OMRPortLibrary *portLib, uintptr_t *passCount, uintptr_t *failCount);
+
+
+int32_t
+buildAndVerifyHashtable(OMRPortLibrary *portLib, HashtableInputData *inputData);
 
 #ifdef __cplusplus
 }

--- a/fvtest/algotest/avltest.c
+++ b/fvtest/algotest/avltest.c
@@ -32,8 +32,6 @@
 #define isspace(x) ( ((x)==' ')||((x)=='\t')||((x)=='\r')||((x)=='\n') )
 #endif
 
-#define AVL_TEST_MAX_LINELEN 4096
-
 typedef struct J9AVLTestNode {
 	J9WSRP leftChild;
 	J9WSRP rightChild;
@@ -43,199 +41,136 @@ typedef struct J9AVLTestNode {
 static BOOLEAN avlTestInsert(OMRPortLibrary *portlib, J9AVLTree *tree, uintptr_t val);
 static intptr_t testInsertionComparator(J9AVLTree *tree, J9AVLTestNode *insertNode, J9AVLTestNode *walkNode);
 static uintptr_t get_node_string(OMRPortLibrary *portlib, J9AVLTree *tree, J9AVLTestNode *walk, char *buffer, uintptr_t bufSize);
-static void avlReset(J9AVLTree *tree);
+static void avlSetup(J9AVLTree *tree);
 static uintptr_t get_datum_string(OMRPortLibrary *portlib, J9AVLTestNode *walk, char *buffer, uintptr_t bufSize);
 static void avl_get_string(OMRPortLibrary *portlib, J9AVLTree *tree, char *buffer, uintptr_t bufSize);
 static intptr_t testSearchComparator(J9AVLTree *tree, intptr_t search, J9AVLTestNode *walkNode);
 static void freeAVLTree(OMRPortLibrary *portlib, J9AVLTreeNode *currentNode);
 
-
-int32_t verifyAVLTree(OMRPortLibrary *portLib, char *testListFile, uintptr_t *passCount, uintptr_t *failCount)
+int32_t
+buildAndVerifyAVLTree(OMRPortLibrary *portLib, const char *success, const char *testData)
 {
 	J9AVLTree tree;
-	char buf[AVL_TEST_MAX_LINELEN];
 	char buffer[1024];
-	intptr_t handle;
-	int32_t line;
-	char *result;
-	char *title, *titleEnd;
-	char *success, *successEnd;
-	char *actionStr, *actionStrEnd;
+	const char *actionStr, *actionStrEnd;
 	int32_t action;
 	int remove;
 	int value;
+	int32_t result = -1;
 
 	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
 
-	handle = omrfile_open(testListFile, EsOpenRead, 0);
+	avlSetup(&tree);
 
-	if (handle == -1) {
-		omrtty_printf("AVL TEST FAILED: Couldn't open '%s'\n", testListFile);
-		return -1;
-	}
+	actionStr = testData;
 
-	line = 0;
-	while (NULL != (result = omrfile_read_text(handle, buf, AVL_TEST_MAX_LINELEN))) {
-		line++;
-
-		while (isspace(*result)) {
-			result++;
-		}
-		/* ignore comments */
-		if ((*result == '#') || (*result == 0)) {
-			continue;
+	for (;;) {
+		/* advance past the whitespace, so we can accurately determine failure */
+		while (isspace(*actionStr)) {
+			actionStr++;
 		}
 
-		avlReset(&tree);
-
-		title = result;
-		titleEnd = strchr(result, ',');
-		if (titleEnd == NULL) {
-			goto malformed_input;
+		/* walk past the number */
+		actionStrEnd = actionStr;
+		if (*actionStrEnd == '-') {
+			remove = 1;
+			actionStrEnd++;
+		} else {
+			remove = 0;
 		}
 
-		success = titleEnd + 1;
-		while (isspace(*success)) {
-			success++;
-		}
-		successEnd = strchr(success, ',');
-		if (successEnd == NULL) {
-			goto malformed_input;
-		}
+		action = 0;
 
-		actionStr = successEnd + 1;
-		/* walking backwards is safe -- we will stop on the first , */
-		while (isspace(successEnd[-1])) {
-			successEnd--;
-		}
-
-		omrtty_printf("AVLTest: %.*s: ", titleEnd - title, title);
-
+		/* a big wad of ugly ebcidic safe code */
 		for (;;) {
-			/* advance past the whitespace, so we can accurately determine failure */
-			while (isspace(*actionStr)) {
-				actionStr++;
-			}
-
-			/* walk past the number */
-			actionStrEnd = actionStr;
-			if (*actionStrEnd == '-') {
-				remove = 1;
-				actionStrEnd++;
-			} else {
-				remove = 0;
-			}
-
-			action = 0;
-
-			/* a big wad of ugly ebcidic safe code */
-			for (;;) {
-				switch (*actionStrEnd) {
-				case '0':
-					value = 0;
-					break;
-				case '1':
-					value = 1;
-					break;
-				case '2':
-					value = 2;
-					break;
-				case '3':
-					value = 3;
-					break;
-				case '4':
-					value = 4;
-					break;
-				case '5':
-					value = 5;
-					break;
-				case '6':
-					value = 6;
-					break;
-				case '7':
-					value = 7;
-					break;
-				case '8':
-					value = 8;
-					break;
-				case '9':
-					value = 9;
-					break;
-				default:
-					value = -1;
-					break;
-				}
-				if (value < 0) {
-					break;
-				}
-				action = action * 10 + value;
-				actionStrEnd++;
-			}
-
-			if (action == 0) {
-				/* -0 -garbage or garbage */
-				if ((remove == 1) || (actionStrEnd == actionStr)) {
-					goto malformed_input;
-				}
-				while (isspace(*actionStrEnd)) {
-					actionStrEnd++;
-				}
-				if (*actionStrEnd != 0) {
-					goto malformed_input;
-				}
-
-				avl_get_string(portLib, &tree, buffer, 1024);
-
-				if ((!strncmp(buffer, success, successEnd - success)) && (buffer[successEnd - success] == 0)) {
-					omrtty_printf(" PASSED\n");
-					(*passCount)++;
-				} else {
-					omrtty_printf(" FAILED\n");
-					omrtty_printf("\tExpected Result: %.*s\n", successEnd - success, success);
-					omrtty_printf("\tResult: %s\n\n", buffer);
-					(*failCount)++;
-				}
+			switch (*actionStrEnd) {
+			case '0':
+				value = 0;
+				break;
+			case '1':
+				value = 1;
+				break;
+			case '2':
+				value = 2;
+				break;
+			case '3':
+				value = 3;
+				break;
+			case '4':
+				value = 4;
+				break;
+			case '5':
+				value = 5;
+				break;
+			case '6':
+				value = 6;
+				break;
+			case '7':
+				value = 7;
+				break;
+			case '8':
+				value = 8;
+				break;
+			case '9':
+				value = 9;
+				break;
+			default:
+				value = -1;
 				break;
 			}
+			if (value < 0) {
+				break;
+			}
+			action = action * 10 + value;
+			actionStrEnd++;
+		}
 
-			actionStr = actionStrEnd;
-			while (isspace(*actionStr)) {
-				actionStr++;
+		if (action == 0) {
+			/* -0 -garbage or garbage */
+			if ((remove == 1) || (actionStrEnd == actionStr)) {
+				goto fail;
 			}
-			if (*actionStr != ',') {
-				goto malformed_input;
+			while (isspace(*actionStrEnd)) {
+				actionStrEnd++;
 			}
+			if (*actionStrEnd != 0) {
+				goto fail;
+			}
+
+			avl_get_string(portLib, &tree, buffer, 1024);
+
+			if (0 != strcmp(buffer, success)) {
+				goto fail;
+			}
+			break;
+		}
+
+		actionStr = actionStrEnd;
+		while (isspace(*actionStr)) {
 			actionStr++;
+		}
+		if (*actionStr != ',') {
+			goto fail;
+		}
+		actionStr++;
 
-			if (remove == 1) {
-				J9AVLTreeNode *n = avl_search(&tree, action);
-
-				if (n) {
-					avl_delete(&tree, n);
-					omrmem_free_memory(n);
-				}
-			} else {
-				if (avlTestInsert(portLib, &tree, action) == FALSE) {
-					goto fail;
-				}
+		if (remove == 1) {
+			J9AVLTreeNode *n = avl_search(&tree, action);
+			if (n) {
+				avl_delete(&tree, n);
+				omrmem_free_memory(n);
+			}
+		} else {
+			if (avlTestInsert(portLib, &tree, action) == FALSE) {
+				goto fail;
 			}
 		}
-		freeAVLTree(portLib, tree.rootNode);
 	}
 
-	avlReset(&tree);
-	omrfile_close(handle);
-	return 0;
+	result = 0;
 fail:
 	freeAVLTree(portLib, tree.rootNode);
-	omrfile_close(handle);
-	return -1;
-malformed_input:
-	avlReset(&tree);
-	omrtty_printf("AVL TEST FAILED: Invalid format on line %i:\n", line);
-	omrtty_printf("%s\n", result);
-	omrfile_close(handle);
-	return -1;
+	return result;
 }
 
 
@@ -250,8 +185,7 @@ get_datum_string(OMRPortLibrary *portlib, J9AVLTestNode *walk, char *buffer, uin
 	return out;
 }
 
-
-static void avlReset(J9AVLTree *tree)
+static void avlSetup(J9AVLTree *tree)
 {
 	memset(tree, 0, sizeof(J9AVLTree));
 	tree->insertionComparator = (intptr_t ( *)(struct J9AVLTree *, J9AVLTreeNode *, J9AVLTreeNode *))testInsertionComparator;

--- a/fvtest/algotest/hashtabletest.c
+++ b/fvtest/algotest/hashtabletest.c
@@ -21,6 +21,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include "algorithm_test_internal.h"
 #include "avl_api.h"
 #include "hashtable_api.h"
 #include "omrport.h"
@@ -37,11 +38,6 @@
 static uintptr_t hashFn(void *key, void *userData);
 static uintptr_t hashEqualFn(void *leftKey, void *rightKey, void *userData);
 static uintptr_t dataOffset(uintptr_t startOffset, uintptr_t dataLength, uintptr_t i);
-static BOOLEAN checkIntegrity(OMRPortLibrary *portLib, char *id, J9HashTable *table, uintptr_t *data, uintptr_t dataLength, uintptr_t removeOffset, uintptr_t i);
-static BOOLEAN runTests(OMRPortLibrary *portLib, char *id, J9HashTable *table, uintptr_t *data, uintptr_t dataLength, uintptr_t reverseRemove);
-static void testHashtable(OMRPortLibrary *portLib, char *id, uintptr_t *data, uintptr_t dataLength, uintptr_t *passCount, uintptr_t *failCount, BOOLEAN forceCollisions);
-static void testCollisionResilientHashTable(OMRPortLibrary *portLib, char *id, uintptr_t *data, uintptr_t dataLength, uintptr_t *passCount, uintptr_t *failCount, BOOLEAN forceCollisions, uint32_t listToTreeThreshold);
-static void printRandomData(OMRPortLibrary *portLib, uintptr_t *randData, uintptr_t randSize);
 
 extern const uint8_t RandomValues[256];
 
@@ -64,8 +60,6 @@ hashFn(void *key, void *userData)
 		return *(uintptr_t *)key;
 	}
 }
-
-
 
 static intptr_t
 hashComparatorFn(struct J9AVLTree *tree, struct J9AVLTreeNode *leftNode, struct J9AVLTreeNode *rightNode)
@@ -90,9 +84,8 @@ static uintptr_t dataOffset(uintptr_t startOffset, uintptr_t dataLength, uintptr
 }
 
 static BOOLEAN
-checkIntegrity(OMRPortLibrary *portLib, char *id, J9HashTable *table, uintptr_t *data, uintptr_t dataLength, uintptr_t removeOffset, uintptr_t i)
+checkHashtableIntegrity(OMRPortLibrary *portLib, J9HashTable *table, const uintptr_t *data, uintptr_t dataLength, uintptr_t removeOffset, uintptr_t i)
 {
-	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
 	uintptr_t count, j;
 	uintptr_t dup[256];
 	J9HashTableState walkState;
@@ -100,7 +93,6 @@ checkIntegrity(OMRPortLibrary *portLib, char *id, J9HashTable *table, uintptr_t 
 
 	count = hashTableGetCount(table);
 	if (count != dataLength - (i + 1)) {
-		omrtty_printf("Hashtable %s count failure: count %d expected %d\n", id, count, dataLength - (i + 1));
 		return FALSE;
 	}
 
@@ -114,11 +106,9 @@ checkIntegrity(OMRPortLibrary *portLib, char *id, J9HashTable *table, uintptr_t 
 		BOOLEAN found = FALSE;
 		count++;
 		if (*next >= sizeof(dup) / sizeof(uintptr_t)) {
-			omrtty_printf("Hashtable %s dup detection, values must be < %d\n", id, sizeof(dup) / sizeof(uintptr_t));
 			return FALSE;
 		}
 		if (dup[*next]) {
-			omrtty_printf("Hashtable %s walk duplicate failure\n", id);
 			return FALSE;
 		}
 		dup[*next] = 1;
@@ -129,25 +119,18 @@ checkIntegrity(OMRPortLibrary *portLib, char *id, J9HashTable *table, uintptr_t 
 			}
 		}
 		if (!found) {
-			omrtty_printf("Hashtable %s walk element failure\n", id);
 			return FALSE;
 		}
 
 		entry = *next;
 		node = hashTableFind(table, &entry);
 		if (node == NULL || *node != entry) {
-			if (node == NULL) {
-				omrtty_printf("Hashtable %s walk find failure: search %d\n", id, entry);
-			} else {
-				omrtty_printf("Hashtable %s walk find failure: search %d found %d\n", id, entry, *node);
-			}
 			return FALSE;
 		}
 
 		next = hashTableNextDo(&walkState);
 	}
 	if (count != dataLength - (i + 1)) {
-		omrtty_printf("Hashtable %s walk count failure\n", id);
 		return FALSE;
 	}
 
@@ -156,11 +139,6 @@ checkIntegrity(OMRPortLibrary *portLib, char *id, J9HashTable *table, uintptr_t 
 		uintptr_t entry = data[dataOffset(removeOffset, dataLength, j)];
 		node = hashTableFind(table, &entry);
 		if (node == NULL || *node != entry) {
-			if (node == NULL) {
-				omrtty_printf("Hashtable %s find failure: search %d\n", id, entry);
-			} else {
-				omrtty_printf("Hashtable %s find failure: search %d found %d\n", id, entry, *node);
-			}
 			return FALSE;
 		}
 	}
@@ -168,274 +146,116 @@ checkIntegrity(OMRPortLibrary *portLib, char *id, J9HashTable *table, uintptr_t 
 	return TRUE;
 }
 
-static BOOLEAN
-runTests(OMRPortLibrary *portLib, char *id, J9HashTable *table, uintptr_t *data, uintptr_t dataLength, uintptr_t removeOffset)
+static int32_t
+runHashtableTests(OMRPortLibrary *portLib, J9HashTable *table, const uintptr_t *data, uintptr_t dataLength, uintptr_t removeOffset)
 {
-	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
-	uintptr_t i, entry;
-	char *operation = "";
-	char buf[64];
+	uintptr_t i = 0;
+	uintptr_t entry = 0;
 
 	/* add all the data elements */
 	for (i = 0; i < dataLength; i++) {
 		entry = data[i];
 		if (hashTableAdd(table, &entry) == NULL) {
-			/* Failure to allocate a new node */
-			omrtty_printf("Hashtable %s add failure\n", id);
-			return FALSE;
+			return -1;
 		}
 	}
 
 	/* ensure the count is correct */
 	if (hashTableGetCount(table) != dataLength) {
-		omrtty_printf("Hashtable %s count failure\n", id);
-		return FALSE;
+		return -2;
 	}
 
 	/* find all the elements */
 	for (i = 0; i < dataLength; i++) {
-		uintptr_t *node;
+		uintptr_t *node = NULL;
 		entry = data[i];
 		node = hashTableFind(table, &entry);
 		if (node == NULL || *node != entry) {
-			if (node == NULL) {
-				omrtty_printf("Hashtable %s find failure: search %d\n", id, entry);
-			} else {
-				omrtty_printf("Hashtable %s find failure: search %d found %d\n", id, entry, *node);
-			}
-			return FALSE;
+			return -3;
 		}
 	}
 
-	if (checkIntegrity(portLib, id, table, data, dataLength, 0, -1) == FALSE) {
-		return FALSE;
+	if (checkHashtableIntegrity(portLib, table, data, dataLength, 0, -1) == FALSE) {
+		return -4;
 	}
 
 	/* remove all elements verifying the integrity */
-	if (removeOffset == REVERSE) {
-		omrstr_printf(buf, sizeof(buf), "%s reverse remove", id);
-		operation = buf;
-	} else if (removeOffset > 0) {
-		omrstr_printf(buf, sizeof(buf), "%s offset %d remove", id, removeOffset);
-		operation = buf;
-	}
 	for (i = 0; i < dataLength; i++) {
 		entry = data[dataOffset(removeOffset, dataLength, i)];
 		if (hashTableRemove(table, &entry) != 0) {
-			omrtty_printf("Hashtable %s failure\n", operation);
-			return FALSE;
+			return -5;
 		}
-		if (checkIntegrity(portLib, operation, table, data, dataLength, removeOffset, i) == FALSE) {
-			return FALSE;
+		if (checkHashtableIntegrity(portLib, table, data, dataLength, removeOffset, i) == FALSE) {
+			return -6;
 		}
 	}
 
-	return TRUE;
+	return 0;
 }
 
-static void
-testHashtable(OMRPortLibrary *portLib, char *id, uintptr_t *data, uintptr_t dataLength, uintptr_t *passCount, uintptr_t *failCount, BOOLEAN forceCollisions)
+static J9HashTable *
+allocateHashtable(OMRPortLibrary *portLib, HashtableInputData *inputData)
 {
-	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
-	J9HashTable *table;
-	uintptr_t i;
+	J9HashTable *hashtable = NULL;
+	const char *tableName = inputData->hashtableName;
+	uint32_t tableSize = 17;
+	uint32_t entrySize = sizeof(uintptr_t);
+	uint32_t flags = 0;
+	void *userData = (void *)(uintptr_t)inputData->forceCollisions;
 
-	if ((table = hashTableNew(portLib, "testTable", 17, sizeof(uintptr_t), sizeof(char *), J9HASH_TABLE_ALLOW_SIZE_OPTIMIZATION, OMRMEM_CATEGORY_VM, hashFn, hashEqualFn, NULL, (void *)(uintptr_t)forceCollisions)) == NULL) {
-		omrtty_printf("Hashtable %s creation failure\n", id);
-		goto fail;
+	if (TRUE == inputData->collisionResistant) {
+		hashtable = collisionResilientHashTableNew(portLib,
+				tableName,
+				tableSize,
+				entrySize,
+				flags,
+				OMRMEM_CATEGORY_VM,
+				inputData->listToTreeThreshold,
+				hashFn,
+				hashComparatorFn,
+				NULL,
+				userData);
+	} else {
+		hashtable = hashTableNew(portLib,
+				tableName,
+				tableSize,
+				entrySize,
+				sizeof(char *),
+				flags | J9HASH_TABLE_ALLOW_SIZE_OPTIMIZATION,
+				OMRMEM_CATEGORY_VM,
+				hashFn,
+				hashEqualFn,
+				NULL,
+				userData);
 	}
 
-	if (runTests(portLib, id, table, data, dataLength, REVERSE) == FALSE) {
-		goto fail;
-	}
-	for (i = 0; i < dataLength; i++) {
-		if (runTests(portLib, id, table, data, dataLength, i) == FALSE) {
-			goto fail;
-		}
-	}
-
-	hashTableFree(table);
-	(*passCount)++;
-	return;
-
-fail:
-	(*failCount)++;
-	hashTableFree(table);
-}
-
-static void
-testCollisionResilientHashTable(OMRPortLibrary *portLib, char *id, uintptr_t *data, uintptr_t dataLength, uintptr_t *passCount, uintptr_t *failCount, BOOLEAN forceCollisions, uint32_t listToTreeThreshold)
-{
-	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
-	J9HashTable *table = NULL;
-
-	uintptr_t i = 0;
-	if ((table = collisionResilientHashTableNew(portLib, "collisionResilient testTable", 17, sizeof(uintptr_t), 0, OMRMEM_CATEGORY_VM, listToTreeThreshold, hashFn, hashComparatorFn, NULL, (void *)(uintptr_t)forceCollisions)) == NULL) {
-		omrtty_printf("Hashtable %s creation failure\n", id);
-		goto fail;
-	}
-
-	if (runTests(portLib, id, table, data, dataLength, REVERSE) == FALSE) {
-		goto fail;
-	}
-	for (i = 0; i < dataLength; i++) {
-		if (runTests(portLib, id, table, data, dataLength, i) == FALSE) {
-			goto fail;
-		}
-	}
-
-	hashTableFree(table);
-	(*passCount)++;
-	return;
-
-fail:
-	(*failCount)++;
-	hashTableFree(table);
-}
-
-static void
-printRandomData(OMRPortLibrary *portLib, uintptr_t *randData, uintptr_t randSize)
-{
-	uintptr_t i = 0;
-	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
-
-	omrtty_printf("random data:\n");
-	for (i = 0; i < randSize; i++) {
-		omrtty_printf("%03d ", randData[i]);
-		if ((i + 1) % 16 == 0) {
-			omrtty_printf("\n");
-		}
-	}
-	omrtty_printf("\n");
+	return hashtable;
 }
 
 int32_t
-verifyHashtable(OMRPortLibrary *portLib, uintptr_t *passCount, uintptr_t *failCount)
+buildAndVerifyHashtable(OMRPortLibrary *portLib, HashtableInputData *inputData)
 {
-	int32_t rc = 0;
-	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
-	uintptr_t start, end;
-	U_64 testSetStart = 0;
-	U_64 testSetEnd = 0;
-	U_64 testDelta = 0;
-	uintptr_t randSize, i, orgFail;
-	uintptr_t data1[] = {1, 2, 3, 4, 5, 6, 7, 17, 18, 19, 20, 21, 22, 23, 24, 25};
-	uintptr_t data2[] = {1, 3, 5, 7, 18, 20, 22, 23, 24, 35, 36, 37};
-	uintptr_t data3[] = {25, 24, 23, 22, 21, 20, 19, 18, 17, 7, 6, 5, 4, 3, 2, 1};
-	uintptr_t data4[] = {37, 36, 35, 24, 23, 22, 20, 18, 7, 5, 3, 1};
-	uintptr_t data5[] = {17, 14, 8, 73, 23, 38, 91, 84, 31, 25, 11, 41, 26, 87, 35, 6};
-	uintptr_t data6[] = {17, 14, 8, 73, 23, 38, 91, 84, 31, 25, 11, 41, 26, 87, 35, 6, 13, 61, 10, 20, 92};
-	uintptr_t randData[256];
-	uint32_t listToTreeThresholdIndex = 0;
-	uint32_t listToTreeThresholdValues[] = {0, 1, 5, 10, 100};
+	J9HashTable *table = NULL;
+	uintptr_t i = 0;
+	int32_t result = 0;
 
-	omrtty_printf("Testing hashtable functions...\n");
-
-	start = portLib->time_usec_clock(portLib);
-
-	testSetStart = omrtime_hires_clock();
-	testHashtable(portLib, "Standard NoForce test1", data1, sizeof(data1) / sizeof(uintptr_t), passCount, failCount, FALSE);
-	testHashtable(portLib, "Standard NoForce test2", data2, sizeof(data2) / sizeof(uintptr_t), passCount, failCount, FALSE);
-	testHashtable(portLib, "Standard NoForce test3", data3, sizeof(data3) / sizeof(uintptr_t), passCount, failCount, FALSE);
-	testHashtable(portLib, "Standard NoForce test4", data4, sizeof(data4) / sizeof(uintptr_t), passCount, failCount, FALSE);
-	testHashtable(portLib, "Standard NoForce test5", data5, sizeof(data5) / sizeof(uintptr_t), passCount, failCount, FALSE);
-	testHashtable(portLib, "Standard NoForce test6", data6, sizeof(data6) / sizeof(uintptr_t), passCount, failCount, FALSE);
-	testSetEnd = omrtime_hires_clock();
-	testDelta = omrtime_hires_delta(testSetStart, testSetEnd, OMRPORT_TIME_DELTA_IN_MICROSECONDS);
-	omrtty_printf("Standard NoForce data tests: Elapsed Time=%llu.%03.3llums \n", testDelta / 1000, testDelta % 1000);
-
-	testSetStart = omrtime_hires_clock();
-	testHashtable(portLib, "Standard Force test1", data1, sizeof(data1) / sizeof(uintptr_t), passCount, failCount, TRUE);
-	testHashtable(portLib, "Standard Force test2", data2, sizeof(data2) / sizeof(uintptr_t), passCount, failCount, TRUE);
-	testHashtable(portLib, "Standard Force test3", data3, sizeof(data3) / sizeof(uintptr_t), passCount, failCount, TRUE);
-	testHashtable(portLib, "Standard Force test4", data4, sizeof(data4) / sizeof(uintptr_t), passCount, failCount, TRUE);
-	testHashtable(portLib, "Standard Force test5", data5, sizeof(data5) / sizeof(uintptr_t), passCount, failCount, TRUE);
-	testHashtable(portLib, "Standard Force test6", data6, sizeof(data6) / sizeof(uintptr_t), passCount, failCount, TRUE);
-	testSetEnd = omrtime_hires_clock();
-	testDelta = omrtime_hires_delta(testSetStart, testSetEnd, OMRPORT_TIME_DELTA_IN_MICROSECONDS);
-	omrtty_printf("Standard Force data tests: Elapsed Time=%llu.%03.3llums \n", testDelta / 1000, testDelta % 1000);
-
-
-	for (listToTreeThresholdIndex = 0; listToTreeThresholdIndex < sizeof(listToTreeThresholdValues) / sizeof(uint32_t); listToTreeThresholdIndex++) {
-		uint32_t listToTreeThreshold = listToTreeThresholdValues[listToTreeThresholdIndex];
-		testSetStart = omrtime_hires_clock();
-		testCollisionResilientHashTable(portLib, "CollisionResilient NoForce test1", data1, sizeof(data1) / sizeof(uintptr_t), passCount, failCount, FALSE, listToTreeThreshold);
-		testCollisionResilientHashTable(portLib, "CollisionResilient NoForce test2", data2, sizeof(data2) / sizeof(uintptr_t), passCount, failCount, FALSE, listToTreeThreshold);
-		testCollisionResilientHashTable(portLib, "CollisionResilient NoForce test3", data3, sizeof(data3) / sizeof(uintptr_t), passCount, failCount, FALSE, listToTreeThreshold);
-		testCollisionResilientHashTable(portLib, "CollisionResilient NoForce test4", data4, sizeof(data4) / sizeof(uintptr_t), passCount, failCount, FALSE, listToTreeThreshold);
-		testCollisionResilientHashTable(portLib, "CollisionResilient NoForce test5", data5, sizeof(data5) / sizeof(uintptr_t), passCount, failCount, FALSE, listToTreeThreshold);
-		testCollisionResilientHashTable(portLib, "CollisionResilient NoForce test6", data6, sizeof(data6) / sizeof(uintptr_t), passCount, failCount, FALSE, listToTreeThreshold);
-		testSetEnd = omrtime_hires_clock();
-		testDelta = omrtime_hires_delta(testSetStart, testSetEnd, OMRPORT_TIME_DELTA_IN_MICROSECONDS);
-		omrtty_printf("CollisionResilient NoForce data tests: listToThreshold=%zu, Elapsed Time=%llu.%03.3llums \n", (uintptr_t)listToTreeThreshold, testDelta / 1000, testDelta % 1000);
+	table = allocateHashtable(portLib, inputData);
+	if (NULL == table) {
+		result = -1;
+		goto fail;
 	}
 
-	for (listToTreeThresholdIndex = 0; listToTreeThresholdIndex < sizeof(listToTreeThresholdValues) / sizeof(uint32_t); listToTreeThresholdIndex++) {
-		uint32_t listToTreeThreshold = listToTreeThresholdValues[listToTreeThresholdIndex];
-		testSetStart = omrtime_hires_clock();
-		testCollisionResilientHashTable(portLib, "CollisionResilient Force test1", data1, sizeof(data1) / sizeof(uintptr_t), passCount, failCount, TRUE, listToTreeThreshold);
-		testCollisionResilientHashTable(portLib, "CollisionResilient Force test2", data2, sizeof(data2) / sizeof(uintptr_t), passCount, failCount, TRUE, listToTreeThreshold);
-		testCollisionResilientHashTable(portLib, "CollisionResilient Force test3", data3, sizeof(data3) / sizeof(uintptr_t), passCount, failCount, TRUE, listToTreeThreshold);
-		testCollisionResilientHashTable(portLib, "CollisionResilient Force test4", data4, sizeof(data4) / sizeof(uintptr_t), passCount, failCount, TRUE, listToTreeThreshold);
-		testCollisionResilientHashTable(portLib, "CollisionResilient Force test5", data5, sizeof(data5) / sizeof(uintptr_t), passCount, failCount, TRUE, listToTreeThreshold);
-		testCollisionResilientHashTable(portLib, "CollisionResilient Force test6", data6, sizeof(data6) / sizeof(uintptr_t), passCount, failCount, TRUE, listToTreeThreshold);
-		testSetEnd = omrtime_hires_clock();
-		testDelta = omrtime_hires_delta(testSetStart, testSetEnd, OMRPORT_TIME_DELTA_IN_MICROSECONDS);
-		omrtty_printf("CollisionResilient Force data tests: listToThreshold=%zu, Elapsed Time=%llu.%03.3llums \n", (uintptr_t)listToTreeThreshold, testDelta / 1000, testDelta % 1000);
+	if (0 != runHashtableTests(portLib, table, inputData->data, inputData->dataLength, REVERSE)) {
+		result = -2;
+		goto fail;
 	}
-
-	for (i = 0; i < sizeof(RandomValues); i++) {
-		uintptr_t j;
-		uintptr_t offset = i;
-		char name[256];
-
-		if (RandomValues[i] == 0) {
-			continue;
-		}
-		randSize = RandomValues[offset++] % 38;
-		for (j = 0; j < randSize; j++) {
-			if (offset == 256) {
-				offset = 0;
-			}
-			randData[j] = RandomValues[offset++];
-			if (randData[j] == 0) {
-				if (offset == 256) {
-					offset = 0;
-				}
-				randData[j] = RandomValues[offset++];
-			}
-		}
-		orgFail = *failCount;
-		omrstr_printf(name, sizeof(name), "HashTable randomData%d", i);
-		testHashtable(portLib, name, randData, randSize, passCount, failCount, FALSE);
-		if (orgFail != *failCount) {
-			printRandomData(portLib, randData, randSize);
-		}
-
-		for (listToTreeThresholdIndex = 0; listToTreeThresholdIndex < sizeof(listToTreeThresholdValues) / sizeof(uint32_t); listToTreeThresholdIndex++) {
-			uint32_t listToTreeThreshold = listToTreeThresholdValues[listToTreeThresholdIndex];
-			orgFail = *failCount;
-			omrstr_printf(name, sizeof(name), "CollisionResilientHashTable NoForce randomData%d", i);
-			testCollisionResilientHashTable(portLib, name, randData, randSize, passCount, failCount, FALSE, listToTreeThreshold);
-			if (orgFail != *failCount) {
-				printRandomData(portLib, randData, randSize);
-			}
-		}
-
-		for (listToTreeThresholdIndex = 0; listToTreeThresholdIndex < sizeof(listToTreeThresholdValues) / sizeof(uint32_t); listToTreeThresholdIndex++) {
-			uint32_t listToTreeThreshold = listToTreeThresholdValues[listToTreeThresholdIndex];
-			orgFail = *failCount;
-			omrstr_printf(name, sizeof(name), "CollisionResilientHashTable Force randomData%d", i);
-			testCollisionResilientHashTable(portLib, name, randData, randSize, passCount, failCount, TRUE, listToTreeThreshold);
-			if (orgFail != *failCount) {
-				printRandomData(portLib, randData, randSize);
-			}
+	for (i = 0; i < inputData->dataLength; i++) {
+		if (0 != runHashtableTests(portLib, table, inputData->data, inputData->dataLength, i)) {
+			result = -3;
+			goto fail;
 		}
 	}
-
-	end = portLib->time_usec_clock(portLib);
-	omrtty_printf("Finished testing hashtable functions.\n");
-	omrtty_printf("Hashtable functions execution time was %d (usec).\n", (end - start));
-
-	return rc;
+fail:
+	hashTableFree(table);
+	return result;
 }

--- a/fvtest/algotest/main.cpp
+++ b/fvtest/algotest/main.cpp
@@ -34,6 +34,8 @@ testMain(int argc, char **argv, char **envp)
 {
 	::testing::InitGoogleTest(&argc, argv);
 
+	OMREventListener::setDefaultTestListener();
+
 	ATTACH_J9THREAD();
 	omrTestEnv = (PortEnvironment *)testing::AddGlobalTestEnvironment(new PortEnvironment(argc, argv));
 	int result = RUN_ALL_TESTS();

--- a/fvtest/algotest/pooltest.c
+++ b/fvtest/algotest/pooltest.c
@@ -21,70 +21,11 @@
 
 #include <string.h>
 #include "omrport.h"
+#include "omrutil.h"
 #include "pool_api.h"
+#include "algorithm_test_internal.h"
 
 #define ROUND_TO(granularity, number) ( (((number) % (granularity)) ? ((number) + (granularity) - ((number) % (granularity))) : (number)))
-
-typedef struct J9NewPoolInputData {
-	uint32_t structSize;
-	uint32_t numberElements;
-	uint32_t elementAlignment;
-	uint32_t padding;
-	uintptr_t poolFlags;
-} J9NewPoolInputData;
-
-typedef struct J9NewPoolResultData {
-	J9Pool *poolResult;
-	uint32_t poolAllocSize;
-	uint32_t puddleAllocSize;
-	uint32_t elementsAdded;
-	uint32_t padding;
-	void *lastFreeAddress;
-} J9NewPoolResultData;
-
-typedef struct J9PoolUserData {
-	J9NewPoolInputData *inputData;
-	J9NewPoolResultData *resultData;
-	OMRPortLibrary *portLib;
-	uintptr_t *passCount;
-	uintptr_t *failCount;
-} J9PoolUserData;
-
-/* Table of parameters for pool_new, which will be used to test the various pool API functions. */
-static J9NewPoolInputData INPUTDATA[] = {
-	{1,		1,		sizeof(uintptr_t),		0,		0},					/* very small pool */
-	{4,		0,		sizeof(uintptr_t),		0,		0},					/* page size pool - with 4-byte elements */
-	{4,		10,		sizeof(uintptr_t),		0,		0},					/* small pool */
-	{4,		10,		0,					0,		0},					/* small pool - default alignment size */
-	{4,		10,		8,					0,		0},					/* small pool - 8 alignment size */
-	{4,		10,		64,					0,		0},					/* small pool - large alignment size */
-	{8,		0,		sizeof(uintptr_t),		0,		0},					/* page size pool - with 8-byte elements */
-	{8,		100,	sizeof(uintptr_t),		0,		0},					/* medium pool */
-	{8,		100,	0,					0,		0},					/* medium pool - default alignment size */
-	{8,		100,	8,					0,		0},					/* medium pool - 8 alignment size */
-	{8,		100,	64,					0,		0},					/* medium pool - large alignment size */
-	{16,	0,		sizeof(uintptr_t),		0,		0},					/* page size pool - with 16-byte elements */
-	{16,	256,	sizeof(uintptr_t),		0,		0},					/* larger pool */
-	{16,	256,	0,					0,		0},					/* larger pool - default alignment size */
-	{16,	256,	8,					0,		0},					/* larger pool - 8 alignment size */
-	{16,	256,	64,					0,		0},					/* larger pool - large alignment size */
-	{9999,	5,		sizeof(uintptr_t),		0,		0},					/* large struct, small number */
-	{4,		9999,	sizeof(uintptr_t),		0,		0},					/* small struct, large number */
-	{64,	0,		sizeof(uintptr_t),		0,		0},					/* zero minElements - should default to 1 */
-	{64,	10,		0,					0,		0},					/* zero alignment - should default to MIN_GRANULARITY */
-	{32,	10,		sizeof(uintptr_t),		0,		POOL_NO_ZERO},					/* POOL_NO_ZERO flag */
-	{32,	10,		sizeof(uintptr_t),		0,		POOL_ALWAYS_KEEP_SORTED},		/* POOL_ALWAYS_KEEP_SORTED flag */
-	{32,	10,		sizeof(uintptr_t),		0,		POOL_ROUND_TO_PAGE_SIZE},		/* POOL_ROUND_TO_PAGE_SIZE flag */
-	{32,	10,		sizeof(uintptr_t),		0,		POOL_NEVER_FREE_PUDDLES}		/* POOL_NEVER_FREE_PUDDLES flag */
-};
-
-#define NUM_POOLS sizeof(INPUTDATA)/sizeof(INPUTDATA[0])
-
-/* Results data for the pool tests. */
-static J9NewPoolResultData RESULTDATA[NUM_POOLS] = {{0}};
-
-/* User data to be passed into the pool's alloc and free functions. */
-static J9PoolUserData POOLUSERDATA[NUM_POOLS] = {{0}};
 
 /* Puddle list that will be shared by multiple pools in testPuddleListSharing(). */
 static J9PoolPuddleList *sharedPuddleList = NULL;
@@ -96,84 +37,50 @@ static int32_t sharedPuddleListReferenceCount = 0;
 #define BYTE_MARKER 2
 #define LAST_BYTE_MARKER 4
 
-static intptr_t createNewPools(OMRPortLibrary *portLib, uintptr_t *passCount, uintptr_t *failCount);
-static void testNewElement(OMRPortLibrary *portLib, uintptr_t *passCount, uintptr_t *failCount);
-static void testWalkFunctions(OMRPortLibrary *portLib, uintptr_t *passCount, uintptr_t *failCount);
-static void testRemoveElement(OMRPortLibrary *portLib, uintptr_t *passCount, uintptr_t *failCount);
-static void testKill(OMRPortLibrary *portLib, uintptr_t *passCount, uintptr_t *failCount);
-static void testClear(OMRPortLibrary *portLib, uintptr_t *passCount, uintptr_t *failCount);
-static void testPuddleListSharing(OMRPortLibrary *portLib, uintptr_t *passCount, uintptr_t *failCount);
+static J9Pool* createNewPool(OMRPortLibrary *portLib, PoolInputData *input);
+static int32_t testPoolNewElement(OMRPortLibrary *portLib, PoolInputData *inputData, J9Pool *currentPool);
+static int32_t testPoolWalkFunctions(OMRPortLibrary *portLib, PoolInputData *inputData, J9Pool *currentPool, uint32_t elementsAllocated);
+static int32_t testPoolClear(OMRPortLibrary *portLib, J9Pool *currentPool);
+static int32_t testPoolRemoveElement(OMRPortLibrary *portLib, J9Pool *currentPool);
 
-static void *customAlloc(J9PoolUserData *userData, uint32_t size, const char *callSite, uint32_t memoryCategory, uint32_t type, uint32_t *doInit);
-static void customFree(J9PoolUserData *userData, void *address, uint32_t type);
 static void *sharedPuddleListAlloc(OMRPortLibrary *portLib, uint32_t size, const char *callSite, uint32_t memoryCategory, uint32_t type, uint32_t *doInit);
 static void sharedPuddleListFree(OMRPortLibrary *portLib, void *address, uint32_t type);
 
 int32_t
-verifyPools(OMRPortLibrary *portLib, uintptr_t *passCount, uintptr_t *failCount)
+createAndVerifyPool(OMRPortLibrary *portLib, PoolInputData *input)
 {
-	int32_t rc = 0;
-	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
-	uintptr_t start, end;
-
-	omrtty_printf("Testing pool functions using %d test pools...\n", NUM_POOLS);
-
-	start = omrtime_usec_clock();
-	if (createNewPools(portLib, passCount, failCount)) {
-		testNewElement(portLib, passCount, failCount);
-		testWalkFunctions(portLib, passCount, failCount);
-		/* Clear the pools, and test new, walk, and remove again. */
-		testClear(portLib, passCount, failCount);
-		testNewElement(portLib, passCount, failCount);
-		testWalkFunctions(portLib, passCount, failCount);
-		testRemoveElement(portLib, passCount, failCount);
-		testKill(portLib, passCount, failCount);
+	J9Pool *pool = createNewPool(portLib, input);
+	if (NULL == pool) {
+		return -1;
 	}
-	/* Test kill on full pools. */
-	if (createNewPools(portLib, passCount, failCount)) {
-		testNewElement(portLib, passCount, failCount);
-		testKill(portLib, passCount, failCount);
+	int32_t elementCount = testPoolNewElement(portLib, input, pool);
+	if (elementCount < 0) {
+		return elementCount;
 	}
-	testPuddleListSharing(portLib, passCount, failCount);
-	end = omrtime_usec_clock();
-
-	omrtty_printf("Finished testing pool functions.\n");
-	omrtty_printf("Pool functions execution time was %d (usec).\n", (end - start));
-
-	return rc;
-}
-
-/* Allocates memory */
-static void *
-customAlloc(J9PoolUserData *userData, uint32_t size, const char *callSite, uint32_t memoryCategory, uint32_t type, uint32_t *doInit)
-{
-	J9NewPoolResultData *resultData = userData->resultData;
-	OMRPORT_ACCESS_FROM_OMRPORT(userData->portLib);
-
-	if (type == POOL_ALLOC_TYPE_POOL && resultData->poolAllocSize == 0) {
-		resultData->poolAllocSize = size;
-	} else if (resultData->poolAllocSize == 0) {
-		omrtty_printf("Error: Alloc called with type!=POOL_ALLOC_TYPE_POOL but poolAllocSize==0\n");
-	} else if (type == POOL_ALLOC_TYPE_PUDDLE && resultData->puddleAllocSize == 0) {
-		resultData->puddleAllocSize = size;
+	int32_t rc = testPoolWalkFunctions(portLib, input, pool, elementCount);
+	if (0 != rc) {
+		return rc;
 	}
-
-	return omrmem_allocate_memory(size, OMRMEM_CATEGORY_VM);
-}
-
-/* Frees memory */
-static void
-customFree(J9PoolUserData *userData, void *address, uint32_t type)
-{
-	J9NewPoolResultData *resultData = userData->resultData;
-	OMRPORT_ACCESS_FROM_OMRPORT(userData->portLib);
-
-	if (type == POOL_ALLOC_TYPE_PUDDLE && userData->inputData->poolFlags & POOL_NEVER_FREE_PUDDLES) {
-		omrtty_printf("Error: Pool should not have attempted to free puddle\n");
-		(*userData->failCount)++;
+	/* Clear the pools, and test new, walk, and remove again. */
+	rc = testPoolClear(portLib, pool);
+	if (0 != rc) {
+		return rc;
 	}
-	resultData->lastFreeAddress = address;
-	omrmem_free_memory(address);
+	elementCount = testPoolNewElement(portLib, input, pool);
+	if (elementCount < 0) {
+		return elementCount;
+	}
+	rc = testPoolWalkFunctions(portLib, input, pool, elementCount);
+	if (0 != rc) {
+		return rc;
+	}
+	rc = testPoolRemoveElement(portLib, pool);
+	if (0 != rc) {
+		return rc;
+	}
+	pool_kill(pool);
+
+	return 0;
 }
 
 static void *
@@ -213,312 +120,213 @@ sharedPuddleListFree(OMRPortLibrary *portLib, void *address, uint32_t type)
 	}
 }
 
-/* Create a bunch of new pools */
-static intptr_t
-createNewPools(OMRPortLibrary *portLib, uintptr_t *passCount, uintptr_t *failCount)
+static J9Pool *
+createNewPool(OMRPortLibrary *portLib, PoolInputData *input)
 {
-	intptr_t poolCntr;
-	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
+	uint32_t expectedNumElems = (input->numberElements == 0) ? 1 : input->numberElements;
+	uint32_t expectedAlignment = (input->elementAlignment == 0) ? MIN_GRANULARITY : input->elementAlignment;
 
-	for (poolCntr = 0; poolCntr < NUM_POOLS; poolCntr++) {
-		J9PoolUserData *userData = &POOLUSERDATA[poolCntr];
-		J9NewPoolInputData *inputData = &INPUTDATA[poolCntr];
-		J9NewPoolResultData *resultData = &RESULTDATA[poolCntr];
-		uint32_t expectedNumElems = (inputData->numberElements == 0) ? 1 : inputData->numberElements;
-		uint32_t expectedAlignment = (inputData->elementAlignment == 0) ? MIN_GRANULARITY : inputData->elementAlignment;
+	J9Pool *pool = pool_new(
+					input->structSize,
+					input->numberElements,
+					input->elementAlignment,
+					input->poolFlags,
+					OMR_GET_CALLSITE(),
+					OMRMEM_CATEGORY_VM,
+					POOL_FOR_PORT(portLib));
 
-		userData->inputData = inputData;
-		userData->passCount = passCount;
-		userData->failCount = failCount;
-		userData->portLib = portLib;
-		userData->resultData = resultData;
-
-		resultData->poolResult = pool_new(
-									 inputData->structSize,
-									 inputData->numberElements,
-									 inputData->elementAlignment,
-									 inputData->poolFlags,
-									 OMR_GET_CALLSITE(),
-									 OMRMEM_CATEGORY_VM,
-									 (omrmemAlloc_fptr_t)customAlloc,
-									 (omrmemFree_fptr_t)customFree,
-									 userData);
-
-		/* Check that creation succeeded */
-		if (resultData->poolResult == NULL) {
-			omrtty_printf("Error: pool_new returned NULL for pool test %d\n", poolCntr);
-			(*failCount)++;
-			return 0;
-		}
-
-		/* Check that sizes are all adequate */
-		if (resultData->puddleAllocSize <
-			((expectedNumElems * ROUND_TO(expectedAlignment, inputData->structSize)) +
-			 ROUND_TO(expectedAlignment, sizeof(J9PoolPuddle)))
-		) {
-			omrtty_printf("Error: Puddle size too small for pool test %d\n", poolCntr);
-			(*failCount)++;
-		} else if ((inputData->poolFlags & POOL_ROUND_TO_PAGE_SIZE) &&
-				   (resultData->puddleAllocSize < OS_PAGE_SIZE)) {
-			omrtty_printf("Error: Allocation size did not respect POOL_ROUND_TO_PAGE_SIZE flag for pool test %d\n", poolCntr);
-			(*failCount)++;
-		} else {
-			(*passCount)++;
-		}
+	/* Check that creation succeeded */
+	if (NULL == pool) {
+		return NULL;
 	}
-	return 1;
+
+	if (pool->puddleAllocSize < ((expectedNumElems * ROUND_TO(expectedAlignment, input->structSize)) + ROUND_TO(expectedAlignment, sizeof(J9PoolPuddle)))) {
+		pool_kill(pool);
+		return NULL;
+	}
+	else if ((input->poolFlags & POOL_ROUND_TO_PAGE_SIZE) && (pool->puddleAllocSize < OS_PAGE_SIZE)) {
+		pool_kill(pool);
+		return NULL;
+	}
+	return pool;
 }
 
-/* Call pool_newElement on a bunch of pools and try to use the data returned */
-static void
-testNewElement(OMRPortLibrary *portLib, uintptr_t *passCount, uintptr_t *failCount)
+static int32_t
+testPoolNewElement(OMRPortLibrary *portLib, PoolInputData *inputData, J9Pool *currentPool)
 {
-	uint32_t poolCntr, j;
-	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
+	void *element = NULL;
+	uint8_t *walkBytes;
+	uint32_t elementsInPuddle = 0;
+	uint32_t expectedNumElems = (inputData->numberElements == 0) ? 1 : inputData->numberElements;
+	uint32_t expectedAlignment = (inputData->elementAlignment == 0) ? MIN_GRANULARITY : inputData->elementAlignment;
 
-	for (poolCntr = 0; poolCntr < NUM_POOLS; poolCntr++) {
-		J9NewPoolInputData *inputData = &INPUTDATA[poolCntr];
-		J9NewPoolResultData *resultData = &RESULTDATA[poolCntr];
-		J9Pool *currentPool = resultData->poolResult;
-		uint32_t puddleAllocSize = resultData->puddleAllocSize;
-		void *element;
-		uint8_t *walkBytes;
-		uint32_t elementsInPuddle = 0;
-		uintptr_t prevPuddleSize = 0;
-		uint32_t expectedNumElems = (inputData->numberElements == 0) ? 1 : inputData->numberElements;
-		uint32_t expectedAlignment = (inputData->elementAlignment == 0) ? MIN_GRANULARITY : inputData->elementAlignment;
 
-		/* Call pool_newElement until a new puddle is allocated... and then allocate a couple of new elements into the new puddle */
-		resultData->puddleAllocSize = 0;
-		while (prevPuddleSize == 0) {
+	J9PoolPuddleList* puddleList = J9POOL_PUDDLELIST(currentPool);
+	J9PoolPuddle* initialPuddle = J9POOLPUDDLELIST_NEXTAVAILABLEPUDDLE(puddleList);
+	J9PoolPuddle* currentPuddle = initialPuddle;
 
-			/* Get a single element and check that it's the right size and that each byte can be written to */
-			prevPuddleSize = resultData->puddleAllocSize;		/* puddleAllocSize will be updated when the next puddle is allocated */
-			element = pool_newElement(currentPool);
-			resultData->elementsAdded++;
-			if (!element) {
-				omrtty_printf("Error: pool_newElement return NULL for pool test %d\n", poolCntr);
-				(*failCount)++;
-				return;
+	/* Call pool_newElement until a new puddle is allocated... and then allocate a couple of new elements into the new puddle */
+	while (initialPuddle == currentPuddle) {
+		uint32_t j = 0;
+		/* Get a single element and check that it's the right size and that each byte can be written to */
+		element = pool_newElement(currentPool);
+		if (NULL == element) {
+			return -1;
+		}
+
+		/* Verify element alignment. Aligned elements are expected for use in AVL trees, for example. */
+		if (((uintptr_t) element % expectedAlignment) != 0) {
+			return -2;
+		}
+
+		if (inputData->poolFlags & POOL_NO_ZERO) {
+			memset(element, 0, inputData->structSize);		/* Expect a crash if the element is too small */
+		}
+
+		/* Walk each byte of the returned element */
+		walkBytes = (uint8_t *)element;
+		for (j = 0; j < inputData->structSize; j++) {
+			if (walkBytes[j] != 0) {
+				return -3;
 			}
-
-			/* Verify element alignment. Aligned elements are expected for use in AVL trees, for example. */
-			if (((uintptr_t) element % expectedAlignment) != 0) {
-				omrtty_printf("Error: pool_newElement returned 0x%p, which is not aligned to %d "
-							  "for pool test %d\n", element, expectedAlignment, poolCntr);
-				(*failCount)++;
-			}
-
-			if (inputData->poolFlags & POOL_NO_ZERO) {
-				memset(element, 0, inputData->structSize);		/* Expect a crash if the element is too small */
-			}
-
-			/* Walk each byte of the returned element */
-			walkBytes = (uint8_t *)element;
-			for (j = 0; j < inputData->structSize; j++) {
-				if (walkBytes[j] != 0) {
-					omrtty_printf("Error: pool_newElement non-zero byte at offset %d in pool test %d\n", j, poolCntr);
-					(*failCount)++;
-				}
-				/* Test that we can write to each byte */
-				if (j == 0) {
-					walkBytes[j] = FIRST_BYTE_MARKER;
-				} else {
-					walkBytes[j] = BYTE_MARKER;
-				}
-			}
-			if (inputData->structSize > 1) {
-				walkBytes[inputData->structSize - 1] = LAST_BYTE_MARKER;
-			}
-			if (resultData->puddleAllocSize == 0) {
-				elementsInPuddle++;		/* Only increment while we're still in the first puddle */
+			/* Test that we can write to each byte */
+			if (j == 0) {
+				walkBytes[j] = FIRST_BYTE_MARKER;
+			} else {
+				walkBytes[j] = BYTE_MARKER;
 			}
 		}
-		if (resultData->puddleAllocSize != puddleAllocSize) {
-			omrtty_printf("Error: New puddle allocated is not the same size as the previous puddle in pool test %d\n", poolCntr);
-			(*failCount)++;
-		} else if (elementsInPuddle < expectedNumElems) {
-			omrtty_printf("Error: Pool initialized with minElements=%d but only %d elements were allocated in puddle, in pool test %d\n", expectedNumElems, elementsInPuddle, poolCntr);
-			(*failCount)++;
-		} else {
-			(*passCount)++;
+
+		if (inputData->structSize > 1) {
+			walkBytes[inputData->structSize - 1] = LAST_BYTE_MARKER;
 		}
+
+		/* currentPuddle will become NULL when the puddle being used becomes FULL if there has been no deletions */
+		elementsInPuddle++;
+
+		currentPuddle = J9POOLPUDDLELIST_NEXTAVAILABLEPUDDLE(puddleList);
 	}
+	if (elementsInPuddle < expectedNumElems) {
+		return -4;
+	}
+	return elementsInPuddle;
 }
 
-/* Walk the pools and ensure that they've been walked completely */
-static void
-testWalkFunctions(OMRPortLibrary *portLib, uintptr_t *passCount, uintptr_t *failCount)
+static int32_t
+testPoolWalkFunctions(OMRPortLibrary *portLib, PoolInputData *inputData, J9Pool *currentPool, uint32_t elementsAllocated)
 {
-	intptr_t poolCntr;
-	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
+	pool_state state;
+	uint8_t *element = NULL;
+	uint32_t walkCount = 0;
 
-	for (poolCntr = 0; poolCntr < NUM_POOLS; poolCntr++) {
-		J9NewPoolInputData *inputData = &INPUTDATA[poolCntr];
-		J9NewPoolResultData *resultData = &RESULTDATA[poolCntr];
-		J9Pool *currentPool = resultData->poolResult;
-		pool_state state;
-		uint8_t *element;
-		uintptr_t numFailed = 0;
-		uint32_t walkCount = 0;
+	element = (uint8_t *)pool_startDo(currentPool, &state);
+	do {
+		if (element[0] != FIRST_BYTE_MARKER) {
+			return -1;
+		}
+		if ((inputData->structSize > 1) && (element[inputData->structSize - 1] != LAST_BYTE_MARKER)) {
+			return -2;
+		}
+		if (!pool_includesElement(currentPool, element)) {
+			return -3;
+		}
+		walkCount++;
+		element = pool_nextDo(&state);
+	} while (element != NULL);
 
-		element = (uint8_t *)pool_startDo(currentPool, &state);
+	if (walkCount != elementsAllocated) {
+		return -4;
+	}
+	if (pool_numElements(currentPool) != elementsAllocated) {
+		return -5;
+	}
+	return 0;
+}
+
+static int32_t
+testPoolClear(OMRPortLibrary *portLib, J9Pool *currentPool)
+{
+	uintptr_t expectedCapacityAfterClear = pool_capacity(currentPool);
+
+	pool_clear(currentPool);
+
+	if (0 != pool_numElements(currentPool)) {
+		return -1;
+	} else if (expectedCapacityAfterClear != pool_capacity(currentPool)) {
+		return -2;
+	}
+	return 0;
+}
+
+static int32_t
+testPoolRemoveElement(OMRPortLibrary *portLib, J9Pool *currentPool)
+{
+	uintptr_t expectedNumElements = pool_numElements(currentPool);
+	pool_state state;
+	uintptr_t startCount, endCount;
+	uintptr_t expectedCapacityAfterRemovals = currentPool->elementsPerPuddle;
+
+	if (currentPool->flags & POOL_NEVER_FREE_PUDDLES) {
+		expectedCapacityAfterRemovals = pool_capacity(currentPool);
+	}
+
+	do {
+		uint8_t *element = (uint8_t *)pool_startDo(currentPool, &state);
+
+		startCount = pool_numElements(currentPool);
 		do {
-			if (element[0] != FIRST_BYTE_MARKER) {
-				omrtty_printf("Error: First byte of element is corrupted in pool test %d\n", poolCntr);
-				numFailed++;
-			}
-			if ((inputData->structSize > 1) && (element[inputData->structSize - 1] != LAST_BYTE_MARKER)) {
-				omrtty_printf("Error: Last byte of element is corrupted in pool test %d\n", poolCntr);
-				numFailed++;
-			}
+			expectedNumElements--;
 			if (!pool_includesElement(currentPool, element)) {
-				omrtty_printf("Error: pool_includesElement returned false for walked element in pool test %d\n", poolCntr);
-				numFailed++;
+				return -1;
 			}
-			walkCount++;
+			pool_removeElement(currentPool, element);
+			if (pool_numElements(currentPool) != expectedNumElements) {
+				return -2;
+			}
+			if (pool_includesElement(currentPool, element)) {
+				return -3;
+			}
+			/* Remove every other element each time - this deliberately creates fragmentation */
 			element = pool_nextDo(&state);
-		} while (element != NULL);
-
-		if (walkCount != resultData->elementsAdded) {
-			omrtty_printf("Error: Walk did not cover all the pool elements in pool test %d\n", poolCntr);
-			numFailed++;
-		}
-		if (pool_numElements(currentPool) != resultData->elementsAdded) {
-			omrtty_printf("Error: pool_numElements returned the wrong value in pool test %d\n", poolCntr);
-			numFailed++;
-		}
-		if (numFailed != 0) {
-			(*failCount)++;
-		} else {
-			(*passCount)++;
-		}
-	}
-}
-
-/* Walk the pools removing elements */
-static void
-testRemoveElement(OMRPortLibrary *portLib, uintptr_t *passCount, uintptr_t *failCount)
-{
-	intptr_t poolCntr;
-	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
-
-	for (poolCntr = 0; poolCntr < NUM_POOLS; poolCntr++) {
-		J9NewPoolResultData *resultData = &RESULTDATA[poolCntr];
-		J9Pool *currentPool = resultData->poolResult;
-		uintptr_t expectedNumElements = pool_numElements(currentPool);
-		pool_state state;
-		uintptr_t numFailed = 0;
-		uintptr_t startCount, endCount;
-
-		do {
-			uint8_t *element = (uint8_t *)pool_startDo(currentPool, &state);
-
-			startCount = pool_numElements(currentPool);
-			do {
-				expectedNumElements--;
-				if (!pool_includesElement(currentPool, element)) {
-					omrtty_printf("Error: pool_includesElement returned false before removing for walked element in pool test %d\n", poolCntr);
-					numFailed++;
-				}
-				pool_removeElement(currentPool, element);
-				if (pool_numElements(currentPool) != expectedNumElements) {
-					omrtty_printf("Error: pool_numElements returned the wrong value while removing in pool test %d\n", poolCntr);
-					numFailed++;
-				}
-				if (pool_includesElement(currentPool, element)) {
-					omrtty_printf("Error: pool_includesElement returned true while removing for walked element in pool test %d\n", poolCntr);
-					numFailed++;
-				}
-				/* Remove every other element each time - this deliberately creates fragmentation */
+			if (NULL != element) {
 				element = pool_nextDo(&state);
-				if (element) {
-					element = pool_nextDo(&state);
-				}
-			} while (element);
-			endCount = pool_numElements(currentPool);
-		} while ((endCount > 0) && (startCount != endCount));
+			}
+		} while (NULL != element);
+		endCount = pool_numElements(currentPool);
+	} while ((endCount > 0) && (startCount != endCount));
 
-		if (expectedNumElements != 0) {
-			omrtty_printf("Error: unexpected error - expectedNumElements is not zero for pool test %d\n", poolCntr);
-			numFailed++;
-		}
-
-		if (numFailed != 0) {
-			(*failCount)++;
-		} else {
-			(*passCount)++;
-		}
+	if (expectedNumElements != 0) {
+		return -5;
+	} else if (expectedCapacityAfterRemovals != pool_capacity(currentPool)) {
+		return -6;
 	}
+
+	return 0;
 }
 
-/* Kill the pools */
-static void
-testKill(OMRPortLibrary *portLib, uintptr_t *passCount, uintptr_t *failCount)
+int32_t
+testPoolPuddleListSharing(OMRPortLibrary *portLib)
 {
-	intptr_t poolCntr;
-	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
-
-	for (poolCntr = 0; poolCntr < NUM_POOLS; poolCntr++) {
-		J9NewPoolInputData *inputData = &INPUTDATA[poolCntr];
-		J9NewPoolResultData *resultData = &RESULTDATA[poolCntr];
-		J9Pool *currentPool = resultData->poolResult;
-
-		resultData->lastFreeAddress = 0;
-		inputData->poolFlags &= ~POOL_NEVER_FREE_PUDDLES;		/* Remove this flag so that the custom free functions don't complain */
-		pool_kill(currentPool);
-
-		if (resultData->lastFreeAddress != currentPool) {
-			omrtty_printf("Error: pool_kill did not free expected data %d\n", poolCntr);
-			(*failCount)++;
-		} else {
-			(*passCount)++;
-		}
-	}
-}
-
-/* Clear the pools */
-static void
-testClear(OMRPortLibrary *portLib, uintptr_t *passCount, uintptr_t *failCount)
-{
-	intptr_t poolCntr;
-	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
-
-	for (poolCntr = 0; poolCntr < NUM_POOLS; poolCntr++) {
-		J9NewPoolResultData *resultData = &RESULTDATA[poolCntr];
-		J9Pool *currentPool = resultData->poolResult;
-
-		resultData->lastFreeAddress = 0;
-		pool_clear(currentPool);
-
-		if (pool_numElements(currentPool) != 0) {
-			omrtty_printf("Error: pool_clear did not remove all the elements %d\n", poolCntr);
-			(*failCount)++;
-		} else {
-			(*passCount)++;
-			resultData->elementsAdded = 0;
-		}
-	}
-}
-
-static void
-testPuddleListSharing(OMRPortLibrary *portLib, uintptr_t *passCount, uintptr_t *failCount)
-{
-	uint32_t index;
-	uintptr_t numElements;
-	void *element;
+	uint32_t index = 0;
+	uintptr_t numElements = 0;
+	void *element = NULL;
 	J9Pool *pool[NUM_POOLS_TO_SHARE_PUDDLE_LIST];
 	pool_state state[NUM_POOLS_TO_SHARE_PUDDLE_LIST];
+	int32_t result = 0;
 
-	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
+	memset(pool, 0, sizeof(pool));
 
 	for (index = 0; index < NUM_POOLS_TO_SHARE_PUDDLE_LIST; index++) {
-
 		pool[index] = pool_new(sizeof(U_64), 0, 0, 0,
 							   OMR_GET_CALLSITE(), OMRMEM_CATEGORY_VM,
 							   (omrmemAlloc_fptr_t) sharedPuddleListAlloc,
 							   (omrmemFree_fptr_t) sharedPuddleListFree,
 							   portLib);
+
+		if (NULL == pool[index]) {
+			result = -1;
+			goto error;
+		}
 
 		/* Create an element every time we create a pool. */
 		pool_newElement(pool[index]);
@@ -529,11 +337,8 @@ testPuddleListSharing(OMRPortLibrary *portLib, uintptr_t *passCount, uintptr_t *
 		 */
 		numElements = pool_numElements(pool[index]);
 		if (numElements != (1 + index)) {
-			omrtty_printf("Error: pool_numElements (=%d) did not match expected value (=%d)"
-						  "in shared puddle list test\n", numElements, 1 + index);
-			(*failCount)++;
-		} else {
-			(*passCount)++;
+			result = -2;
+			goto error;
 		}
 	}
 
@@ -541,11 +346,8 @@ testPuddleListSharing(OMRPortLibrary *portLib, uintptr_t *passCount, uintptr_t *
 	numElements = pool_numElements(pool[0]);
 	for (index = 1; index < NUM_POOLS_TO_SHARE_PUDDLE_LIST; index++) {
 		if (numElements != pool_numElements(pool[index])) {
-			omrtty_printf("Error: pool_numElements did not match expected value "
-						  "in shared puddle list test");
-			(*failCount)++;
-		} else {
-			(*passCount)++;
+			result = -3;
+			goto error;
 		}
 	}
 
@@ -554,10 +356,8 @@ testPuddleListSharing(OMRPortLibrary *portLib, uintptr_t *passCount, uintptr_t *
 	/* Check the first element. */
 	for (index = 1; index < NUM_POOLS_TO_SHARE_PUDDLE_LIST; index++) {
 		if (element != pool_startDo(pool[index], &state[index])) {
-			omrtty_printf("Error: Elements returned in different order when iterating over pools with shared puddle lists");
-			(*failCount)++;
-		} else {
-			(*passCount)++;
+			result = -4;
+			goto error;
 		}
 	}
 	/* And all other elements. */
@@ -565,10 +365,8 @@ testPuddleListSharing(OMRPortLibrary *portLib, uintptr_t *passCount, uintptr_t *
 		element = pool_nextDo(&state[0]);
 		for (index = 1; index < NUM_POOLS_TO_SHARE_PUDDLE_LIST; index++) {
 			if (element != pool_nextDo(&state[index])) {
-				omrtty_printf("Error: Elements returned in different order when iterating over pools with shared puddle lists");
-				(*failCount)++;
-			} else {
-				(*passCount)++;
+				result = -5;
+				goto error;
 			}
 		}
 	}
@@ -576,19 +374,27 @@ testPuddleListSharing(OMRPortLibrary *portLib, uintptr_t *passCount, uintptr_t *
 	/* Now, kill the pools. */
 	for (index = 0; index < NUM_POOLS_TO_SHARE_PUDDLE_LIST; index++) {
 		if (numElements != pool_numElements(pool[index])) {
-			omrtty_printf("Error: pool_numElements did not match expected value "
-						  "in shared puddle list test");
-			(*failCount)++;
-		} else {
-			(*passCount)++;
+			result = -6;
+			goto error;
 		}
 		pool_kill(pool[index]);
+		pool[index] = NULL;
 	}
 
 	if (sharedPuddleList != NULL) {
-		omrtty_printf("Error: sharedPuddleList was not NULL after all pools were killed");
-		(*failCount)++;
-	} else {
-		(*passCount)++;
+		result = -7;
+		goto error;
 	}
+
+	return result;
+
+error:
+	for (index = 0; index < NUM_POOLS_TO_SHARE_PUDDLE_LIST; index++) {
+		if (NULL != pool[index]) {
+			pool_kill(pool[index]);
+			pool[index] = NULL;
+		}
+	}
+
+	return result;
 }

--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -39,7 +39,7 @@ add_executable(comptest
 
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../tril/tril ${CMAKE_CURRENT_BINARY_DIR}/tril)
 target_link_libraries(comptest
-   omrGtest
+   omrGtestGlue
    tril
 )
 

--- a/fvtest/compilertriltest/main.cpp
+++ b/fvtest/compilertriltest/main.cpp
@@ -19,9 +19,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-#include "gtest/gtest.h"
+#include "omrTest.h"
 
-int main(int argc, char** argv) {
+extern "C" {
+int testMain(int argc, char **argv, char **envp);
+}
+
+int testMain(int argc, char **argv, char **envp) {
    ::testing::InitGoogleTest(&argc, argv);
+   OMREventListener::setDefaultTestListener();
    return RUN_ALL_TESTS();
 }

--- a/fvtest/gctest/main.cpp
+++ b/fvtest/gctest/main.cpp
@@ -33,6 +33,8 @@ testMain(int argc, char **argv, char **envp)
 {
 	::testing::InitGoogleTest(&argc, argv);
 
+	OMREventListener::setDefaultTestListener();
+
 	gcTestEnv = (GCTestEnvironment *)testing::AddGlobalTestEnvironment(new GCTestEnvironment(argc, argv));
 	gcTestEnv->GCTestSetUp();
 	int result = RUN_ALL_TESTS();

--- a/fvtest/omrGtestGlue/omrTest.h
+++ b/fvtest/omrGtestGlue/omrTest.h
@@ -49,6 +49,90 @@ static int iconv_init_static_variable = iconv_initialization();
 #include "gtest/gtest.h"
 #endif
 
+using namespace testing;
+
+class OMREventListener: public TestEventListener {
+
+protected:
+	TestEventListener* _eventListener;
+
+public:
+	bool _showTestCases;
+	bool _showTests;
+	bool _showSuccess;
+	bool _showFailures;
+
+	OMREventListener(TestEventListener* theEventListener) :
+			_eventListener(theEventListener),
+			_showTestCases(true),
+			_showTests(true),
+			_showSuccess(true),
+			_showFailures(true)
+	{
+	}
+
+	virtual ~OMREventListener() {
+		delete _eventListener;
+	}
+	virtual void OnTestProgramStart(const UnitTest& unit_test) {
+		_eventListener->OnTestProgramStart(unit_test);
+	}
+	virtual void OnTestIterationStart(const UnitTest& unit_test, int iteration) {
+		_eventListener->OnTestIterationStart(unit_test, iteration);
+	}
+	virtual void OnEnvironmentsSetUpStart(const UnitTest& unit_test) {}
+	virtual void OnEnvironmentsSetUpEnd(const UnitTest& unit_test) {}
+
+	virtual void OnTestCaseStart(const TestCase& test_case) {
+		if (_showTestCases) {
+			_eventListener->OnTestCaseStart(test_case);
+		}
+	}
+	virtual void OnTestStart(const TestInfo& test_info) {
+		if (_showTests) {
+			_eventListener->OnTestStart(test_info);
+		}
+	}
+	virtual void OnTestPartResult(const TestPartResult& result) {
+		_eventListener->OnTestPartResult(result);
+	}
+	virtual void OnTestEnd(const TestInfo& test_info) {
+		if (test_info.result()->Failed()) {
+			if (_showFailures) {
+				_eventListener->OnTestEnd(test_info);
+			}
+		} else {
+			if (_showSuccess) {
+				_eventListener->OnTestEnd(test_info);
+			}
+		}
+	}
+	virtual void OnTestCaseEnd(const TestCase& test_case) {
+		if (_showTestCases) {
+			_eventListener->OnTestCaseEnd(test_case);
+		}
+	}
+	virtual void OnEnvironmentsTearDownStart(const UnitTest& unit_test) {}
+	virtual void OnEnvironmentsTearDownEnd(const UnitTest& unit_test) {}
+	virtual void OnTestIterationEnd(const UnitTest& unit_test, int iteration) {
+		_eventListener->OnTestIterationEnd(unit_test, iteration);
+	}
+	virtual void OnTestProgramEnd(const UnitTest& unit_test) {
+		_eventListener->OnTestProgramEnd(unit_test);
+	}
+
+	static void setDefaultTestListener(bool showTestCases = true, bool showTests = false, bool showSuccess = false, bool showFailures = true) {
+		TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
+		TestEventListener* default_printer = listeners.Release(listeners.default_result_printer());
+		OMREventListener *listener = new OMREventListener(default_printer);
+		listener->_showTestCases = showTestCases;
+		listener->_showTests = showTests;
+		listener->_showSuccess = showSuccess;
+		listener->_showFailures = showFailures;
+		listeners.Append(listener);
+	}
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/fvtest/porttest/main.cpp
+++ b/fvtest/porttest/main.cpp
@@ -52,6 +52,8 @@ testMain(int argc, char **argv, char **envp)
 		::testing::InitGoogleTest(&argc, argv);
 	}
 
+	OMREventListener::setDefaultTestListener();
+
 	ATTACH_J9THREAD();
 
 	portTestEnv = new PortTestEnvironment(argc, argv);

--- a/fvtest/rastest/main.cpp
+++ b/fvtest/rastest/main.cpp
@@ -32,7 +32,7 @@ int
 testMain(int argc, char **argv, char **envp)
 {
 	::testing::InitGoogleTest(&argc, argv);
-
+	OMREventListener::setDefaultTestListener();
 	ATTACH_J9THREAD();
 	rasTestEnv = (PortEnvironment *)testing::AddGlobalTestEnvironment(new PortEnvironment(argc, argv));
 	int result = RUN_ALL_TESTS();

--- a/fvtest/sigtest/main.cpp
+++ b/fvtest/sigtest/main.cpp
@@ -35,7 +35,7 @@ int
 testMain(int argc, char **argv, char **envp)
 {
 	::testing::InitGoogleTest(&argc, argv);
-
+	OMREventListener::setDefaultTestListener();
 	ATTACH_J9THREAD();
 	omrTestEnv = (PortEnvironment *)testing::AddGlobalTestEnvironment(new PortEnvironment(argc, argv));
 	int result = RUN_ALL_TESTS();

--- a/fvtest/threadextendedtest/threadExtendedTestMain.cpp
+++ b/fvtest/threadextendedtest/threadExtendedTestMain.cpp
@@ -28,7 +28,7 @@ extern "C" int
 testMain(int argc, char **argv, char **envp)
 {
 	::testing::InitGoogleTest(&argc, argv);
-
+	OMREventListener::setDefaultTestListener();
 	int result = 0;
 	OMRPortLibrary portLibrary;
 	thrExtendedTestSetUp(&portLibrary);

--- a/fvtest/threadtest/main.cpp
+++ b/fvtest/threadtest/main.cpp
@@ -29,6 +29,7 @@ extern "C" int
 testMain(int argc, char **argv, char **envp)
 {
 	::testing::InitGoogleTest(&argc, argv);
+	OMREventListener::setDefaultTestListener();
 	ATTACH_J9THREAD();
 	omrTestEnv = (ThreadTestEnvironment *)testing::AddGlobalTestEnvironment(new ThreadTestEnvironment(argc, argv));
 	int rc = RUN_ALL_TESTS();

--- a/fvtest/tril/test/CMakeLists.txt
+++ b/fvtest/tril/test/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(triltest
 
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../tril/ ${CMAKE_CURRENT_BINARY_DIR}/tril)
 target_link_libraries(triltest
+   omrGtestGlue
    tril
 )
 

--- a/fvtest/tril/test/main.cpp
+++ b/fvtest/tril/test/main.cpp
@@ -19,9 +19,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-#include "gtest/gtest.h"
+#include "omrTest.h"
 
-int main(int argc, char** argv) {
+extern "C" {
+int testMain(int argc, char **argv, char **envp);
+}
+
+int testMain(int argc, char **argv, char **envp) {
    ::testing::InitGoogleTest(&argc, argv);
+   OMREventListener::setDefaultTestListener();
    return RUN_ALL_TESTS();
 }

--- a/fvtest/utiltest/main.cpp
+++ b/fvtest/utiltest/main.cpp
@@ -30,7 +30,7 @@ int
 main(int argc, char **argv, char **envp)
 {
 	::testing::InitGoogleTest(&argc, argv);
-
+	OMREventListener::setDefaultTestListener();
 	return RUN_ALL_TESTS();
 }
 

--- a/fvtest/vmtest/main.cpp
+++ b/fvtest/vmtest/main.cpp
@@ -33,7 +33,7 @@ int
 testMain(int argc, char **argv, char **envp)
 {
 	::testing::InitGoogleTest(&argc, argv);
-
+	OMREventListener::setDefaultTestListener();
 	ATTACH_J9THREAD();
 	vmTestEnv = (PortEnvironment *)testing::AddGlobalTestEnvironment(new PortEnvironment(argc, argv));
 	int result = RUN_ALL_TESTS();


### PR DESCRIPTION
Cleanup hashtable, avl and pool testing to remove extra output

Add a new listener which prints less data
- Create a new TestEventListener which does not output as much data by
default as the default TestEventListener.  Make this new
TestEventListener the listener used by OMR testing.