### PR TITLE
Fix compilation issue on Windows

### DIFF
--- a/omr.rc.in
+++ b/omr.rc.in
@@ -1,24 +1,23 @@
-###############################################################################
-# Copyright (c) 2015, 2017 IBM Corp. and others
-# 
-# This program and the accompanying materials are made available under
-# the terms of the Eclipse Public License 2.0 which accompanies this
-# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-# or the Apache License, Version 2.0 which accompanies this distribution and
-# is available at https://www.apache.org/licenses/LICENSE-2.0.
-#      
-# This Source Code may also be made available under the following
-# Secondary Licenses when the conditions for such availability set
-# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-# General Public License, version 2 with the GNU Classpath
-# Exception [1] and GNU General Public License, version 2 with the
-# OpenJDK Assembly Exception [2].
-#    
-# [1] https://www.gnu.org/software/classpath/license.html
-# [2] http://openjdk.java.net/legal/assembly-exception.html
-#
-# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
-###############################################################################
+/*******************************************************************************
+ * Copyright (c) 2015, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
 
 #include <windows.h>
 #include <winver.h>


### PR DESCRIPTION
Comments in RC files are regular C comments. Switch the copyright header
to the proper format to resolve compilation issues.

This was missed on the AppVeyor builds since consuming the rc files have
not been implemented in CMake yet.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>