### PR TITLE
Shut-off OMR_RTTI Configuration

### DIFF
--- a/glue/configure_includes/configure_linux_ztpf_390.mk
+++ b/glue/configure_includes/configure_linux_ztpf_390.mk
@@ -29,7 +29,6 @@ endif
 
 ifeq (linux_ztpf_390-64_cmprssptrs_codecov, $(SPEC))
   	CONFIGURE_ARGS += \
-		--enable-OMR_RTTI\
 		--enable-OMRTHREAD_LIB_UNIX \
 		--enable-OMR_ARCH_S390 \
 		--enable-OMR_ENV_DATA64 \
@@ -42,11 +41,11 @@ ifeq (linux_ztpf_390-64_cmprssptrs_codecov, $(SPEC))
 		--enable-OMR_THR_YIELD_ALG \
 		--enable-OMR_GC_ARRAYLETS
 #    --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+#    --enable-OMR_RTTI
 endif
 
 ifeq (linux_ztpf_390-64_cmprssptrs, $(SPEC))
 	CONFIGURE_ARGS += \
-		--enable-OMR_RTTI\
 		--enable-OMRTHREAD_LIB_UNIX \
 		--enable-OMR_ARCH_S390 \
 		--enable-OMR_ENV_DATA64 \
@@ -59,11 +58,11 @@ ifeq (linux_ztpf_390-64_cmprssptrs, $(SPEC))
 		--enable-OMR_THR_YIELD_ALG \
 		--enable-OMR_GC_ARRAYLETS
 #    --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+#    --enable-OMR_RTTI
 endif
 
 ifeq (linux_ztpf_390-64_codecov, $(SPEC))
 	CONFIGURE_ARGS += \
-		--enable-OMR_RTTI\
 		--enable-OMRTHREAD_LIB_UNIX \
 		--enable-OMR_ARCH_S390 \
 		--enable-OMR_ENV_DATA64 \
@@ -73,11 +72,11 @@ ifeq (linux_ztpf_390-64_codecov, $(SPEC))
 		--enable-OMR_THR_YIELD_ALG \
 		--enable-OMR_GC_ARRAYLETS
 #    --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+#    --enable-OMR_RTTI
 endif
 
 ifeq (linux_ztpf_390-64, $(SPEC))
 	CONFIGURE_ARGS += \
-		--enable-OMR_RTTI\
 		--enable-OMRTHREAD_LIB_UNIX \
 		--enable-OMR_ARCH_S390 \
 		--enable-OMR_ENV_DATA64 \
@@ -87,11 +86,11 @@ ifeq (linux_ztpf_390-64, $(SPEC))
 		--enable-OMR_THR_YIELD_ALG \
 		--enable-OMR_GC_ARRAYLETS
 #    --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+#    --enable-OMR_RTTI
 endif
 
 ifeq (linux_ztpf_390, $(SPEC))
 	CONFIGURE_ARGS += \
-		--enable-OMR_RTTI\
 		--enable-OMRTHREAD_LIB_UNIX \
 		--enable-OMR_ARCH_S390 \
 		--enable-OMR_PORT_RUNTIME_INSTRUMENTATION \
@@ -100,6 +99,7 @@ ifeq (linux_ztpf_390, $(SPEC))
 		--enable-OMR_THR_YIELD_ALG \
 		--enable-OMR_GC_ARRAYLETS
 #    --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+#    --enable-OMR_RTTI
 endif
 
 CONFIGURE_ARGS += libprefix=lib exeext= solibext=.so arlibext=.a objext=.o


### PR DESCRIPTION
Shut-off OMR_RTTI Configuration.  Mistmatch in z/TPF compilation lead
to an unresolve looking for an RTTI object.

Signed-off-by: jjohnst-us <jjohnst@us.ibm.com>