### PR TITLE
Simplify checkDependencyGroup to reduce compile time

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -10934,7 +10934,7 @@ void handleLoadWithRegRanges(TR::Instruction *inst, TR::CodeGenerator *cg)
    lowRegNum = lowRegNum == (isVector ? numVRFs - 1 : 15) ? 0 : lowRegNum + 1;
    // wrap around for loop terminal index to 0 at 15 or 31 for Vector Registers
 
-   uint32_t availForShuffle = cg->machine()->genBitVectOfAssignableGPRs() & ~(getRegMaskFromRange(inst));
+   uint32_t availForShuffle = cg->machine()->genBitMapOfAssignableGPRs() & ~(getRegMaskFromRange(inst));
 
    for (uint32_t i  = lowRegNum  ;
                  i != highRegNum ;

--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -791,10 +791,10 @@ OMR::Z::Machine::findBestSwapRegister(TR::Register* reg1, TR::Register* reg2)
    }
 
 /**
- * @return a bit vector identifying assignable regs as 1's.
+ * @return a bit map identifying assignable regs as 1's.
  */
 uint32_t
-OMR::Z::Machine::genBitVectOfAssignableGPRs()
+OMR::Z::Machine::genBitMapOfAssignableGPRs()
    {
    int32_t first = TR::RealRegister::FirstGPR;
    int32_t last = TR::RealRegister::LastAssignableGPR;

--- a/compiler/z/codegen/OMRMachine.hpp
+++ b/compiler/z/codegen/OMRMachine.hpp
@@ -280,7 +280,7 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
                                        bool            doBookKeeping,
                                        uint64_t        availRegMask = 0x0000ffff);
 
-   uint32_t genBitVectOfAssignableGPRs();
+   uint32_t genBitMapOfAssignableGPRs();
    uint8_t genBitVectOfLiveGPRPairs();
 
    TR::RealRegister* findBestSwapRegister(TR::Register* reg1, TR::Register* reg2);

--- a/compiler/z/codegen/OMRRegisterDependency.hpp
+++ b/compiler/z/codegen/OMRRegisterDependency.hpp
@@ -149,13 +149,24 @@ class TR_S390RegisterDependencyGroup
       return -1;
       }
 
-   uint32_t genBitVectOfAssignableGPRs(TR::Instruction   *currentInstruction,
-                                       uint32_t          numberOfRegisters,
-                                       TR::CodeGenerator *cg);
+   uint32_t genBitMapOfAssignableGPRs(TR::CodeGenerator *cg, uint32_t numberOfRegisters);
 
-   uint32_t checkDependencyGroup(TR::Instruction  *currentInstruction,
-                                 uint32_t numberOfRegisters,
-                                 TR::CodeGenerator *cg);
+   void setRealRegisterForDependency(int32_t index, TR::RealRegister::RegNum regNum)
+      {
+      _dependencies[index].setRealRegister(regNum);
+      }
+
+   void checkRegisterPairSufficiencyAndHPRAssignment(TR::CodeGenerator *cg,
+                                     TR::Instruction  *currentInstruction,
+                                     const uint32_t availableGPRMap,
+                                     uint32_t numOfDependencies);
+
+   void checkRegisterDependencyDuplicates(TR::CodeGenerator* cg,
+                                          const uint32_t numOfDependencies);
+
+   uint32_t checkDependencyGroup(TR::CodeGenerator *cg,
+                                 TR::Instruction  *currentInstruction,
+                                 uint32_t numOfDependencies);
 
    void assignRegisters(TR::Instruction  *currentInstruction,
                         TR_RegisterKinds kindToBeAssigned,


### PR DESCRIPTION
The previous implementation of codegen checkDependencyGroup() performs
unnecessary checks. This change simplifies the original one but still
keeps the O(n^2) algorithm.

Signed-off-by: Nigel Yu <yunigel@ca.ibm.com>