### PR TITLE
Fix Windows compile issue

### DIFF
--- a/fvtest/algotest/pooltest.c
+++ b/fvtest/algotest/pooltest.c
@@ -50,14 +50,17 @@ int32_t
 createAndVerifyPool(OMRPortLibrary *portLib, PoolInputData *input)
 {
 	J9Pool *pool = createNewPool(portLib, input);
+	int32_t elementCount = 0;
+	int32_t rc = 0;
+
 	if (NULL == pool) {
 		return -1;
 	}
-	int32_t elementCount = testPoolNewElement(portLib, input, pool);
+	elementCount = testPoolNewElement(portLib, input, pool);
 	if (elementCount < 0) {
 		return elementCount;
 	}
-	int32_t rc = testPoolWalkFunctions(portLib, input, pool, elementCount);
+	rc = testPoolWalkFunctions(portLib, input, pool, elementCount);
 	if (0 != rc) {
 		return rc;
 	}


### PR DESCRIPTION
Older versions of msvc run with c89 support by default. The AppVeyor
builds run with c99 by default so this was not caught in the CI testing

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>