### PR TITLE
Hoist IlVerifier

### DIFF
--- a/compiler/control/CompileMethod.cpp
+++ b/compiler/control/CompileMethod.cpp
@@ -336,9 +336,7 @@ compileMethodFromDetails(
          compiler.setDebug(createDebugObject(&compiler));
          }
 
-#ifdef TEST_PROJECT_SPECIFIC
       compiler.setIlVerifier(details.getIlVerifier());
-#endif
 
       if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCompileStart))
          {

--- a/compiler/ilgen/OMRIlGeneratorMethodDetails.hpp
+++ b/compiler/ilgen/OMRIlGeneratorMethodDetails.hpp
@@ -38,29 +38,16 @@ namespace OMR { typedef OMR::IlGeneratorMethodDetails IlGeneratorMethodDetailsCo
 class TR_FrontEnd;
 class TR_ResolvedMethod;
 namespace TR { class IlGeneratorMethodDetails; }
+namespace TR { class IlVerifier; }
 
 namespace OMR
 {
 
 /**
- * IlGeneratorMethodDetailsBase defines the IlGeneratorMethodDetails API that common code can count on.  A front
- *   end will typically extend this class (perhaps even with a hierarchy of classes) and then map its own concrete
- *   base class onto OMR::IlGeneratorMethodDetails.  In this way, common code can count on a particular API
- *   existing, but IlGeneratorMethodDetails will be passed around with all front-end specific data and API intact
- *   (so less up/down casting).
+ * Accessing ANY language-specific API/data in common code is prohibited.
  *
- * Accessing ANY front-end specific API/data in common code is prohibited.
- *
- * IlGeneratorMethodDetailsBase defines the IlGenRequest API that common code can count on, although it's more documentation
- *   then enforcement.  A front end will typically extend this class (perhaps even with a hierarchy of classes)
- *   and then map its own concrete base class onto OMR::IlGeneratorMethodDetailsBase.
- *
- * Accessing ANY front-end specific API/data in common code is prohibited since other front end builds would fail.
- *
- * Note all functions are non-virtual in this class, so declarations should never use the IlGeneratorMethodDetailsBase type
- *   directly: all variable declarations should use the OMR::IlGeneratorMethodDetails type instead.
+ * IlGeneratorMethodDetails defines the IlGenRequest API.
  */
-
 class OMR_EXTENSIBLE IlGeneratorMethodDetails
    {
 
@@ -76,13 +63,17 @@ public:
 
    inline static TR::IlGeneratorMethodDetails & create(TR::IlGeneratorMethodDetails & target, TR_ResolvedMethod *method);
 
+   TR::IlVerifier * getIlVerifier()                     { return _ilVerifier; }
+   void setIlVerifier(TR::IlVerifier * ilVerifier)      { _ilVerifier = ilVerifier; }
+
 protected:
-   IlGeneratorMethodDetails() { }
+   IlGeneratorMethodDetails() : _ilVerifier(NULL) { }
    virtual ~IlGeneratorMethodDetails() {}
 
    void *operator new(size_t size, TR::IlGeneratorMethodDetails *p){ return (void*) p; }
    void *operator new(size_t size, TR::IlGeneratorMethodDetails &p){ return (void*)&p; }
 
+   TR::IlVerifier     * _ilVerifier;
    };
 
 }

--- a/compiler/ras/IlVerifier.hpp
+++ b/compiler/ras/IlVerifier.hpp
@@ -32,7 +32,7 @@ class IlVerifier
    /**
     * Verify the IL of a method has certain properties.
     *
-    * @return 0 on success, or a non-zero error code. If 0 is returned,
+    * @return 0 on success, or a non-zero error code. If non-zero is returned,
     * compilation stops.
     */
    virtual int32_t verify(TR::ResolvedMethodSymbol *methodSymbol) = 0; 

--- a/compiler/ras/IlVerifierHelpers.hpp
+++ b/compiler/ras/IlVerifierHelpers.hpp
@@ -30,6 +30,7 @@
 #define IlVerifierHelpers_hpp
 
 #include <vector>
+#include "compile/CompilationException.hpp"
 #include "ras/IlVerifier.hpp"
 
 namespace TR { class ResolvedMethodSymbol; }

--- a/fvtest/compilertest/ilgen/TestIlGeneratorMethodDetails.cpp
+++ b/fvtest/compilertest/ilgen/TestIlGeneratorMethodDetails.cpp
@@ -33,8 +33,7 @@ namespace TestCompiler
 {
 
 IlGeneratorMethodDetails::IlGeneratorMethodDetails(TR_ResolvedMethod *method) :
-   _method(static_cast<TR::ResolvedMethod *>(method)),
-   _ilVerifier(NULL)
+   _method(static_cast<TR::ResolvedMethod *>(method))
    {
    }
 

--- a/fvtest/compilertest/ilgen/TestIlGeneratorMethodDetails.hpp
+++ b/fvtest/compilertest/ilgen/TestIlGeneratorMethodDetails.hpp
@@ -56,13 +56,13 @@ class OMR_EXTENSIBLE IlGeneratorMethodDetails : public OMR::IlGeneratorMethodDet
 public:
 
    IlGeneratorMethodDetails() :
-      _method(NULL),
-      _ilVerifier(NULL)
+      OMR::IlGeneratorMethodDetailsConnector(),
+      _method(NULL)
       { }
 
    IlGeneratorMethodDetails(TR::ResolvedMethod *method) :
-      _method(method),
-      _ilVerifier(NULL)
+      OMR::IlGeneratorMethodDetailsConnector(),
+      _method(method)
       { }
 
    IlGeneratorMethodDetails(TR_ResolvedMethod *method);
@@ -81,13 +81,9 @@ public:
                                           bool forceClassLookahead,
                                           TR_InlineBlocks *blocksToInline);
 
-   TR::IlVerifier * getIlVerifier() { return _ilVerifier; }
-   void setIlVerifier(TR::IlVerifier * ilVerifier) { _ilVerifier = ilVerifier; }
-
 protected:
 
    TR::ResolvedMethod * _method;
-   TR::IlVerifier     * _ilVerifier;
    };
 
 }

--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(comptest
    ILValidatorTest.cpp
    ArithmeticTest.cpp
    ShiftAndRotateTest.cpp
+   SimplifierFoldAndTest.cpp
 )
 
 target_link_libraries(comptest

--- a/fvtest/compilertriltest/SimplifierFoldAndTest.cpp
+++ b/fvtest/compilertriltest/SimplifierFoldAndTest.cpp
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+#include "JitTest.hpp"
+#include "jitbuilder_compiler.hpp"
+#include "il/Node.hpp"
+#include "infra/ILWalk.hpp"
+#include "ras/IlVerifier.hpp"
+#include "ras/IlVerifierHelpers.hpp"
+
+/**
+ * Verify the optimization was correctly applied.
+ * A test failure is triggered by using `EXPECT_*`, and
+ * compilation is stopped by returning a non-zero return code.
+ * `ADD_FAILURE` is equivalent to expecting something false.
+ *
+ * While anything can be done in `verify`, this test
+ * is implemented by traversing the IL, and checking if
+ * there are AND operations remaining. 
+ */
+class SimplifierFoldAndIlVerifier : public TR::IlVerifier
+   {
+   public:
+   int32_t verifyNode(TR::Node *node)
+      {
+      if (node->getOpCode().isAnd()) 
+         {
+         ADD_FAILURE() << "Found an AND operation: " << node->getOpCodeValue();
+         return 1;
+         }
+      return 0;
+      }
+
+   int32_t verify(TR::ResolvedMethodSymbol *sym) override
+      {
+      for(TR::PreorderNodeIterator iter(sym->getFirstTreeTop(), sym->comp()); iter.currentTree(); ++iter)
+         {
+         int32_t rtn = verifyNode(iter.currentNode());
+         if(rtn)
+            return rtn;
+         }
+
+      return 0;
+      }
+   };
+
+
+class DISABLED_SimplifierFoldAndTest : public TRTest::JitTest  {};
+
+/*
+ * method(int32_t parameter) 
+ *   int64_t i = ((int64_t) parameter) & 0xFFFFFFFF00000000ll;
+ *   return i;
+ *
+ * Note that the combo of the mask and width of the parameter means
+ * the expression should always fold to zero. 
+ */
+TEST_F(DISABLED_SimplifierFoldAndTest, FoldHappens) {
+
+    auto inputTrees ="(method return=Int64 args=[Int32]  "
+                     " (block                            "
+                     "  (lreturn                         "
+                     "  (land                            " 
+                     "      (lconst 0xFFFFFFFF00000000)  "
+                     "      (iu2l (iload parm=0))))))    "; 
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::JitBuilderCompiler compiler{trees};
+    SimplifierFoldAndIlVerifier verifier;  
+
+    ASSERT_EQ(0, compiler.compileWithVerifier(&verifier)) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int64_t (*)(int32_t)>();
+    // Invoke the compiled method, and assert the output is correct.
+    EXPECT_EQ(0ll, entry_point(0));
+    EXPECT_EQ(0ll, entry_point(1));
+    EXPECT_EQ(0ll, entry_point(-1));
+    EXPECT_EQ(0ll, entry_point(-9));
+    EXPECT_EQ(0ll, entry_point(2147483647));
+}

--- a/fvtest/tril/test/CompileTest.cpp
+++ b/fvtest/tril/test/CompileTest.cpp
@@ -21,6 +21,8 @@
 
 #include "JitTest.hpp"
 #include "jitbuilder_compiler.hpp"
+#include "ras/IlVerifier.hpp"
+#include "ras/IlVerifierHelpers.hpp"
 
 #define ASSERT_NULL(pointer) ASSERT_EQ(nullptr, (pointer))
 #define ASSERT_NOTNULL(pointer) ASSERT_TRUE(nullptr != (pointer))
@@ -39,4 +41,18 @@ TEST_F(CompileTest, Return3) {
     auto entry = compiler.getEntryPoint<int32_t (*)(void)>();
     ASSERT_NOTNULL(entry) << "Entry point of compiled body cannot be null";
     ASSERT_EQ(3, entry()) << "Compiled body did not return expected value";
+}
+
+
+TEST_F(CompileTest, NoCodeGen) {
+    auto trees = parseString("(method return=\"Int32\" (block (ireturn (iconst 3))))");
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::JitBuilderCompiler compiler{trees};
+    TR::NoCodegenVerifier verifier{nullptr}; 
+
+    EXPECT_NE(0, compiler.compileWithVerifier(&verifier)) << "Compilation succeeded";
+
+    EXPECT_TRUE(verifier.hasRun());
 }

--- a/fvtest/tril/tril/jitbuilder_compiler.cpp
+++ b/fvtest/tril/tril/jitbuilder_compiler.cpp
@@ -37,6 +37,10 @@
 #include <algorithm>
 
 int32_t Tril::JitBuilderCompiler::compile() {
+   return compileWithVerifier(NULL);
+}
+
+int32_t Tril::JitBuilderCompiler::compileWithVerifier(TR::IlVerifier* verifier) {
     // construct an IL generator for the method
     auto methodInfo = getMethodInfo();
     TR::TypeDictionary types;
@@ -58,6 +62,13 @@ int32_t Tril::JitBuilderCompiler::compile() {
                                       0,
                                       &ilgenerator);
     TR::IlGeneratorMethodDetails methodDetails(&resolvedMethod);
+
+    // If a verifier is provided, set one up. 
+    if (nullptr != verifier) 
+       {
+       methodDetails.setIlVerifier(verifier);
+       }
+
     int32_t rc = 0;
     auto entry_point = compileMethodFromDetails(nullptr, methodDetails, warm, rc);
 

--- a/fvtest/tril/tril/jitbuilder_compiler.hpp
+++ b/fvtest/tril/tril/jitbuilder_compiler.hpp
@@ -24,6 +24,8 @@
 
 #include "method_compiler.hpp"
 
+namespace TR { class IlVerifier; } 
+
 namespace Tril {
 
 /**
@@ -39,6 +41,13 @@ class JitBuilderCompiler : public Tril::MethodCompiler {
          * @return 0 on compilation success, an error code otherwise
          */
         int32_t compile() override;
+
+        /**
+         * @brief Start compilation with a verifier. 
+         * @param verifier The verifier to run. 
+         * @return 0 on complilation success, an error code or exception otherwise. 
+         */
+        int32_t compileWithVerifier(TR::IlVerifier* verifier);
 };
 
 } // namespace Tril

--- a/jitbuilder/ilgen/JBIlGeneratorMethodDetails.cpp
+++ b/jitbuilder/ilgen/JBIlGeneratorMethodDetails.cpp
@@ -34,6 +34,7 @@ namespace JitBuilder
 {
 
 IlGeneratorMethodDetails::IlGeneratorMethodDetails(TR_ResolvedMethod *method) :
+   OMR::IlGeneratorMethodDetailsConnector(),
    _method(static_cast<TR::ResolvedMethod *>(method))
    {
    }

--- a/jitbuilder/ilgen/JBIlGeneratorMethodDetails.hpp
+++ b/jitbuilder/ilgen/JBIlGeneratorMethodDetails.hpp
@@ -55,9 +55,15 @@ class OMR_EXTENSIBLE IlGeneratorMethodDetails : public OMR::IlGeneratorMethodDet
 
 public:
 
-   IlGeneratorMethodDetails() : _method(NULL) { }
+   IlGeneratorMethodDetails() :
+      OMR::IlGeneratorMethodDetailsConnector(),
+      _method(NULL)
+   { }
 
-   IlGeneratorMethodDetails(TR::ResolvedMethod *method) : _method(method) { }
+   IlGeneratorMethodDetails(TR::ResolvedMethod *method) :
+      OMR::IlGeneratorMethodDetailsConnector(),
+      _method(method)
+   { }
 
    IlGeneratorMethodDetails(TR_ResolvedMethod *method);
 


### PR DESCRIPTION
Enable other projects to use the IlVerifiers, and port one test case from compiler test to tril. 

This is WIP for review, and to allow a fix that requires the test to be disabled to land. 