### PR TITLE
Fix incorrect parsing of Int values

### DIFF
--- a/fvtest/tril/tril/tril.l
+++ b/fvtest/tril/tril/tril.l
@@ -38,12 +38,12 @@
                        };
 
 [-]?[0-9]+      {
-                yylval.integer = atol(yytext);
+                yylval.integer = strtoul(yytext, NULL, 10);
                 return INTEGER;
             };
 
 [-]?0x[0-9a-fA-F]+      {
-                yylval.integer = strtol(yytext, NULL, 16);
+                yylval.integer = strtoul(yytext, NULL, 16);
                 return INTEGER;
             }
 


### PR DESCRIPTION
There was an error in tril when trying to parse a large hex value (such as  0xFFFFFFFF00000000). This corrects that, and makes the parser test more robust. 