### PR TITLE
Add support for nopable breakpoint guard

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1195,6 +1195,9 @@ class OMR_EXTENSIBLE CodeGenerator
    // Used to find the guard instruction where a given guard will actually patch
    // currently can only return a value other than vgdnop for HCR guards
    TR::Instruction* getVirtualGuardForPatching(TR::Instruction *vgdnop);
+   bool isStopTheWorldGuard(TR::Node *node);
+   bool mergeableGuard(TR::Instruction *guard);
+   bool mergeableGuards(TR::Instruction *earlierGuard, TR::Instruction *laterGuard);
 
    void jitAddPicToPatchOnClassUnload(void *classPointer, void *addressToBePatched) {}
    void jitAdd32BitPicToPatchOnClassUnload(void *classPointer, void *addressToBePatched) {}

--- a/compiler/compile/VirtualGuard.cpp
+++ b/compiler/compile/VirtualGuard.cpp
@@ -227,12 +227,12 @@ TR_VirtualGuard::createBreakpointGuardNode
 #ifdef J9_PROJECT_SPECIFIC
 /*
  * Shape of a breakpoint guard:
- * iflcmpeq/ificmpeq
+ * iflcmpne/ificmpne
  *    land/iand
  *       lloadi/iloadi <ConstantPool shadow>
  *          aconst J9Method
  *       isBreakpointedBit 
- *    isBreakpointedBit 
+ *    iconst 0 
  */
    bool is64Bit = TR::Compiler->target.is64Bit();
    TR::SymbolReferenceTable * symRefTab = comp->getSymRefTab();
@@ -244,20 +244,22 @@ TR_VirtualGuard::createBreakpointGuardNode
    aconstNode->setByteCodeIndex(0);
    TR::Node * flagBit = NULL;
    TR::Node *guard = NULL;
+   TR::Node * zero = NULL;
    if (TR::Compiler->target.is64Bit())
       {
       flagBit = TR::Node::create(callNode, TR::lconst, 0, 0);
       flagBit->setLongInt(comp->fej9()->offsetOfMethodIsBreakpointedBit());
-
+      zero = TR::Node::create(callNode, TR::lconst, 0, 0);
       }
    else
       {
       flagBit = TR::Node::create(callNode, TR::iconst, 0, comp->fej9()->offsetOfMethodIsBreakpointedBit());
+      zero = TR::Node::create(callNode, TR::iconst, 0, 0);
       }
 
-   guard =  TR::Node::createif(is64Bit? TR::iflcmpeq: TR::ificmpeq,
+   guard =  TR::Node::createif(is64Bit? TR::iflcmpne: TR::ificmpne,
             TR::Node::create(is64Bit? TR::land: TR::iand, 2, constantPool, flagBit),
-            flagBit,
+            zero,
             destination);
    return guard;
 #else
@@ -278,6 +280,8 @@ TR_VirtualGuard::createBreakpointGuard
    TR_VirtualGuard *vg = new (comp->trHeapMemory()) TR_VirtualGuard(TR_FSDTest, TR_BreakpointGuard, comp, callNode, guard, calleeIndex, comp->getCurrentInlinedSiteIndex());
    setGuardKind(guard, TR_BreakpointGuard, comp);
 
+   if (!comp->getOption(TR_DisableNopBreakpointGuard))
+      vg->dontGenerateChildrenCode();
    traceMsg(comp ,"create breakpoint guard: callNode %p guardNode %p isBreakpointGuard %d\n", callNode, guard, guard->isBreakpointGuard());
    return guard;
    }

--- a/compiler/compile/VirtualGuard.hpp
+++ b/compiler/compile/VirtualGuard.hpp
@@ -212,6 +212,7 @@ class TR_VirtualGuard
          {
          case TR_DummyTest:
          case TR_NonoverriddenTest:
+         case TR_FSDTest:
             return false;
          default:
             return true;

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -446,6 +446,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableNextGenHCR",                  "O\tdisable HCR implemented with on-stack replacement",  SET_OPTION_BIT(TR_DisableNextGenHCR), "F"},
 
    {"disableNonvirtualInlining",          "O\tdisable inlining of non virtual methods",        SET_OPTION_BIT(TR_DisableNonvirtualInlining), "F"},
+   {"disableNopBreakpointGuard",          "O\tdisable nop of breakpoint guards",        SET_OPTION_BIT(TR_DisableNopBreakpointGuard), "F"},
    {"disableNoServerDuringStartup",       "M\tDo not use NoServer during startup",  SET_OPTION_BIT(TR_DisableNoServerDuringStartup), "F"},
    {"disableNoVMAccess",                  "O\tdisable compilation without holding VM access",  SET_OPTION_BIT(TR_DisableNoVMAccess), "F"},
    {"disableOnDemandLiteralPoolRegister", "O\tdisable on demand literal pool register",        SET_OPTION_BIT(TR_DisableOnDemandLiteralPoolRegister), "F"},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -294,7 +294,7 @@ enum TR_CompilationOptions
    TR_TLHPrefetch                         = 0x00002000 + 6,
    TR_ReservingLocks                      = 0x00004000 + 6, // Can be merged with TR_DisableLockResevation when lock reservation is enabled on all platforms
    TR_DisableLockResevation               = 0x00008000 + 6,
-   // Available                           = 0x00010000 + 6,
+   TR_DisableNopBreakpointGuard           = 0x00010000 + 6,
    TR_DisableAggressiveRecompilations     = 0x00020000 + 6,
    TR_DisableVariablePrecisionDAA         = 0x00040000 + 6,
    // Available                           =0x00080000 + 6,

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -7510,10 +7510,10 @@ OMR::Node::resetIsTheVirtualGuardForAGuardedInlinedCall()
 bool
 OMR::Node::isNopableInlineGuard()
    {
-   return self()->isTheVirtualGuardForAGuardedInlinedCall() && !self()->isProfiledGuard() && !self()->isBreakpointGuard();
+   TR::Compilation * c = TR::comp();
+   return self()->isTheVirtualGuardForAGuardedInlinedCall() && !self()->isProfiledGuard() && 
+      !(self()->isBreakpointGuard() && c->getOption(TR_DisableNopBreakpointGuard));
    }
-
-
 
 bool
 OMR::Node::isMutableCallSiteTargetGuard()

--- a/compiler/runtime/OMRRuntimeAssumptions.cpp
+++ b/compiler/runtime/OMRRuntimeAssumptions.cpp
@@ -35,6 +35,15 @@ extern "C" void _patchVirtualGuard(uint8_t *locationAddr, uint8_t *destinationAd
 extern "C" void ASM_CALL _patchVirtualGuard(uint8_t*, uint8_t*, uint32_t);
 #endif
 
+TR::PatchNOPedGuardSiteOnMethodBreakPoint* TR::PatchNOPedGuardSiteOnMethodBreakPoint::make(
+      TR_FrontEnd *fe, TR_PersistentMemory * pm, TR_OpaqueMethodBlock *method, uint8_t *location, uint8_t *destination,
+      OMR::RuntimeAssumption **sentinel)
+   {
+   TR::PatchNOPedGuardSiteOnMethodBreakPoint *result = new (pm) TR::PatchNOPedGuardSiteOnMethodBreakPoint(pm, method, location, destination);
+   result->addToRAT(pm, RuntimeAssumptionOnMethodBreakPoint, fe, sentinel);
+   return result;
+   }
+ 
 
 void TR::PatchNOPedGuardSite::compensate(bool isSMP, uint8_t *location, uint8_t *destination)
    {

--- a/compiler/runtime/OMRRuntimeAssumptions.hpp
+++ b/compiler/runtime/OMRRuntimeAssumptions.hpp
@@ -185,6 +185,21 @@ class PatchNOPedGuardSite : public OMR::LocationRedirectRuntimeAssumption
    uint8_t *_destination;
    }; // TR::PatchNOPedGuardSite
 
+class PatchNOPedGuardSiteOnMethodBreakPoint : public PatchNOPedGuardSite
+   {
+   protected:
+   PatchNOPedGuardSiteOnMethodBreakPoint(TR_PersistentMemory *pm, TR_OpaqueMethodBlock *j9method,
+                       uint8_t *location, uint8_t *destination)
+      : PatchNOPedGuardSite(pm, (uintptrj_t)j9method, RuntimeAssumptionOnMethodBreakPoint, location, destination) {}
+
+   public: 
+   static PatchNOPedGuardSiteOnMethodBreakPoint *make(
+      TR_FrontEnd *fe, TR_PersistentMemory * pm, TR_OpaqueMethodBlock *j9method, uint8_t *location, uint8_t *destination,
+      OMR::RuntimeAssumption **sentinel);
+ 
+   virtual TR_RuntimeAssumptionKind getAssumptionKind() { return RuntimeAssumptionOnMethodBreakPoint; }
+   };
+
 }  // namespace TR
 
 #endif

--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -2531,12 +2531,13 @@ static bool virtualGuardHelper(TR::Node *node, TR::CodeGenerator *cg)
    TR::LabelSymbol *label = node->getBranchDestination()->getNode()->getLabel();
 
    cg->setVMThreadRequired(true);
+
    TR::Instruction *vgnopInstr = generateVirtualGuardNOPInstruction(node, site, deps, label, cg);
    TR::Instruction *patchPoint = cg->getVirtualGuardForPatching(vgnopInstr);
 
-   // HCR guards are patched when the threads are stopped.
-   // No issues with multithreaded patching, therefore alignment is not required
-   if (TR::Compiler->target.isSMP() && !node->isHCRGuard() && !node->isOSRGuard())
+   // Guards patched when the threads are stopped have no issues with multithreaded patching. 
+   // therefore alignment is not required
+   if (TR::Compiler->target.isSMP() && !cg->isStopTheWorldGuard(node))
       {
       // the compiler is now capable of generating a train of vgnops all looking to patch the
       // same point with different constraints. alignment is required before the delegated patch
@@ -2576,8 +2577,6 @@ static bool virtualGuardHelper(TR::Node *node, TR::CodeGenerator *cg)
    return false;
 #endif
    }
-
-
 
 void
 OMR::X86::CodeGenerator::addMetaDataForBranchTableAddress(


### PR DESCRIPTION
To lower the overhead for the breakpoint guard instruction sequence,
the guard is nopped when compiling a method and patched
only when a breakpoint is set for that method. This changeset contains
the code for adding a new runtime assumption for breakpoint guard

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>