### PR TITLE
Link to OpenJ9 in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ to promote fairness, openness, and inclusion.
 Who is using Eclipse OMR?
 =========================
 
-* The most comprehensive consumer of the Eclipse OMR technology is the IBM J9
-  Virtual Machine: a high performance, scalable, enterprise class Java Virtual
-  Machine implementation representing hundreds of person years of effort, built
-  using the core implementations provided by Eclipse OMR. IBM is working actively
-  to open source J9.
+* The most comprehensive consumer of the Eclipse OMR technology is the [Eclipse
+  OpenJ9 Virtual Machine](https://github.com/eclipse/openj9): a high
+  performance, scalable, enterprise class Java Virtual Machine implementation
+  representing hundreds of person years of effort, built on top of the core 
+  technologies provided by Eclipse OMR. 
 * The Ruby+OMR Technology Preview has used Eclipse OMR components to add a JIT
   compiler to the CRuby implementation, and to experiment with replacing the
   garbage collector in CRuby.


### PR DESCRIPTION
Now that OpenJ9 is out, we should link to it in the README. 