### PR TITLE
Resolve more compiler warnings

### DIFF
--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -2389,7 +2389,7 @@ static TR_RegisterCandidate *findCandidate(TR::SymbolReference *symRef, TR_LinkH
 static void rememberMostRecentValue(TR::SymbolReference *symRef, TR::Node *valueNode, OMR::CodeGenerator::TR_RegisterPressureState *state, TR::CodeGenerator *cg)
    {
    if (  state->_alreadyAssignedOnExit.isSet(symRef->getReferenceNumber())
-      || state->_candidate && state->getCandidateSymRef() == symRef)
+      || (state->_candidate && (state->getCandidateSymRef() == symRef)))
       {
       TR_RegisterCandidate *candidate = findCandidate(symRef, state->_candidatesAlreadyAssigned, state->_candidate);
       TR_ASSERT(candidate, "rememberMostRecentValue: there should be a matching candidate for #%d %s", symRef->getReferenceNumber(), cg->getDebug()->getName(symRef));

--- a/compiler/il/Aliases.cpp
+++ b/compiler/il/Aliases.cpp
@@ -243,7 +243,7 @@ OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool includeGCSafePo
             {
             if ((self()->isUnresolved() && !_symbol->isConstObjectRef()) || _symbol->isVolatile() || self()->isLiteralPoolAddress() ||
                 self()->isFromLiteralPool() || _symbol->isUnsafeShadowSymbol() ||
-                _symbol->isArrayShadowSymbol() && comp->getMethodSymbol()->hasVeryRefinedAliasSets())
+                (_symbol->isArrayShadowSymbol() && comp->getMethodSymbol()->hasVeryRefinedAliasSets()))
                {
                // getUseDefAliases might not return NULL
                }

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -160,7 +160,7 @@ OMR::ResolvedMethodSymbol::ResolvedMethodSymbol(TR_ResolvedMethod * method, TR::
    // Set the interpreted flag for an interpreted method unless we're calling
    // the method that's being jitted
    //
-   if (_methodIndex > JITTED_METHOD_INDEX && !_resolvedMethod->isSameMethod(comp->getJittedMethodSymbol()->getResolvedMethod()) || comp->isDLT())
+   if ((_methodIndex > JITTED_METHOD_INDEX && !_resolvedMethod->isSameMethod(comp->getJittedMethodSymbol()->getResolvedMethod())) || comp->isDLT())
       {
       if (_resolvedMethod->isInterpreted())
          {

--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -1822,7 +1822,7 @@ IlBuilder::genCall(TR::SymbolReference *methodSymRef, int32_t numArgs, TR::IlVal
    for (int32_t a=0;a < numArgs;a++)
       {
       TR::IlValue *arg = argValues[a];
-      if (arg->getDataType() == TR::Int8 || arg->getDataType() == TR::Int16 || Word == Int64 && arg->getDataType() == TR::Int32)
+      if (arg->getDataType() == TR::Int8 || arg->getDataType() == TR::Int16 || (Word == Int64 && arg->getDataType() == TR::Int32))
          arg = ConvertTo(Word, arg);
       callNode->setAndIncChild(childIndex++, loadValue(arg));
       }

--- a/compiler/optimizer/ExpressionsSimplification.hpp
+++ b/compiler/optimizer/ExpressionsSimplification.hpp
@@ -113,7 +113,7 @@ class TR_ExpressionsSimplification : public TR::Optimization
          if (_increment == 0)
             return 0;
 
-         if (_increment > 0 && _lowerBound > _upperBound || _increment < 0 && _lowerBound < _upperBound)
+         if ((_increment > 0 && _lowerBound > _upperBound) || (_increment < 0 && _lowerBound < _upperBound))
             return 0;
 
          if (isEquals())

--- a/compiler/optimizer/IsolatedStoreElimination.cpp
+++ b/compiler/optimizer/IsolatedStoreElimination.cpp
@@ -1672,7 +1672,7 @@ TR_IsolatedStoreElimination::markNodesAndLocateSideEffectIn(TR::Node *node, vcou
        node->getOpCode().isReturn() ||
        node->getOpCode().isLoadReg() ||
        node->getOpCode().isStoreReg() ||
-       node->getOpCode().hasSymbolReference() && node->getSymbolReference()->getSymbol()->isVolatile() ||
+       (node->getOpCode().hasSymbolReference() && node->getSymbolReference()->getSymbol()->isVolatile()) ||
        ((node->getOpCode().isStore() ||
          (node->getOpCode().hasSymbolReference() &&
           node->getSymbolReference()->getSymbol()->isVolatile())) &&

--- a/compiler/optimizer/LoopCanonicalizer.cpp
+++ b/compiler/optimizer/LoopCanonicalizer.cpp
@@ -3473,8 +3473,8 @@ void TR_LoopTransformer::updateInfo(TR::Node *node, vcount_t visitCount, updateI
 
    TR::BitVector defAliases(comp()->allocator());
 
-   if (node->getOpCode().isStore()
-         && !node->isTheVirtualCallNodeForAGuardedInlinedCall()
+   if ((node->getOpCode().isStore()
+         && !node->isTheVirtualCallNodeForAGuardedInlinedCall())
          || !_doingVersioning)
       {
       if (refNo == 0 || !uinfo.seenMultipleStores[refNo])

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -5003,8 +5003,8 @@ void TR_LoopVersioner::buildNullCheckComparisonsTree(List<TR::Node> *nullChecked
               nextNode->getData()->getFirstChild()->getOpCode().hasSymbolReference() &&
               nextNode->getData()->getFirstChild()->getSymbolReference()->getSymbol()->isAuto();
 
-         if (nextNode->getData()->getOpCode().hasSymbolReference() &&
-             nextNode->getData()->getSymbolReference()->getSymbol()->isAuto() ||
+         if ((nextNode->getData()->getOpCode().hasSymbolReference() &&
+             nextNode->getData()->getSymbolReference()->getSymbol()->isAuto()) ||
              nullCheckReferenceisField)
             {
             TR::Node *invariantNullCheckReference = isDependentOnInvariant(nextNode->getData());
@@ -5893,8 +5893,8 @@ void TR_LoopVersioner::buildConditionalTree(List<TR::TreeTop> *nullCheckTrees, L
                   }
 
                if(isInductionVar &&
-                 (conditionalNode->isVersionableIfWithMaxExpr() && isAddition ||
-                  conditionalNode->isVersionableIfWithMinExpr() && !isAddition ))
+                 ((conditionalNode->isVersionableIfWithMaxExpr() && isAddition) ||
+                  (conditionalNode->isVersionableIfWithMinExpr() && !isAddition) ))
                   {
                   replaceIndexWithExpr=true;
                   //replace ind var with max value;

--- a/compiler/optimizer/OMRLocalCSE.cpp
+++ b/compiler/optimizer/OMRLocalCSE.cpp
@@ -1622,8 +1622,8 @@ int32_t OMR::LocalCSE::hash(TR::Node *parent, TR::Node *node)
        (!parent || !(parent->isTheVirtualGuardForAGuardedInlinedCall() && parent->isProfiledGuard())))
       return 0;
 
-   if (node->getOpCode().hasSymbolReference() &&
-       node->getOpCode().isLoadVar() || node->getOpCode().isCall())
+   if ((node->getOpCode().hasSymbolReference() &&
+       node->getOpCode().isLoadVar()) || node->getOpCode().isCall())
       return node->getSymbolReference()->getReferenceNumber();
 
    // Hash on the opcode of the children

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -5646,7 +5646,7 @@ TR::Node *directStoreSimplifier(TR::Node * node, TR::Block * block, TR::Simplifi
       bool secondLoadsSymRef = (secondGrandchild->getOpCode().isLoadVar() && symRef == secondGrandchild->getSymbolReference()); // && secondGrandchild->getReferenceCount() > 1);
       bool secondIsLoadConst = (secondGrandchild->getOpCode().isLoadConst());
 
-      if (firstLoadsSymRef && secondIsLoadConst || firstIsLoadConst && secondLoadsSymRef)
+      if ((firstLoadsSymRef && secondIsLoadConst) || (firstIsLoadConst && secondLoadsSymRef))
          {
          // found a candidate update form tree: now walk trees forward until either something stores to <sym> or end of block
          // remember tree where last use of node was on this walk: insert our update tree following that last use tree

--- a/compiler/optimizer/OrderBlocks.cpp
+++ b/compiler/optimizer/OrderBlocks.cpp
@@ -695,7 +695,7 @@ TR::CFGNode *TR_OrderBlocks::chooseBestFallThroughSuccessor(TR::CFG *cfg, TR::CF
             TR_Structure *outerLoop = candBlock->getStructureOf()->getContainingLoop() ;
 
             //outer loop does not exist or contains the inner loop
-            if (!outerLoop || innerLoop!=outerLoop && outerLoop->contains(innerLoop))
+            if (!outerLoop || ((innerLoop!=outerLoop) && outerLoop->contains(innerLoop)))
                {
                TR::CFGEdgeList& successors = block->asBlock()->getSuccessors();
                if (successors.size() !=2 )

--- a/compiler/optimizer/PrefetchInsertion.cpp
+++ b/compiler/optimizer/PrefetchInsertion.cpp
@@ -424,8 +424,8 @@ void TR_PrefetchInsertion::examineNode(TR::TreeTop *treeTop, TR::Block *block, T
          TR_PrimaryInductionVariable *closestPIV = NULL;  // argument loop is the most outer loop
          TR_BasicInductionVariable *biv = NULL;  // argument loop is the most outer loop
          if (firstChild->getOpCode().isLoadDirect() &&
-             ((closestPIV=getClosestPIV(block)) && (firstChild->getOpCode().hasSymbolReference() && firstChild->getSymbolReference() == closestPIV->getSymRef()) ||
-             closestPIV == NULL && isBIV(firstChild->getSymbolReference(), block, biv)))
+             (((closestPIV=getClosestPIV(block)) && (firstChild->getOpCode().hasSymbolReference() && firstChild->getSymbolReference() == closestPIV->getSymRef())) ||
+             (closestPIV == NULL && isBIV(firstChild->getSymbolReference(), block, biv))))
             {
             if (closestPIV)
                biv = closestPIV;
@@ -433,8 +433,8 @@ void TR_PrefetchInsertion::examineNode(TR::TreeTop *treeTop, TR::Block *block, T
             int64_t stepInBytes = mulConstBytes * (mulConst * (int64_t)biv->getDeltaOnBackEdge() + addConst);
             TR_Structure *loop1= treeTop->getEnclosingBlock()->getStructureOf()->getContainingLoop();
             bool isTreetopInLoop = (loop1 && (loop1->asRegion() == loop)) ? true : false;
-            if (isTreetopInLoop && (stepInBytes > 0 &&  stepInBytes <= TR::Compiler->vm.heapTailPaddingSizeInBytes() ||
-                stepInBytes < 0 && -stepInBytes <= TR::Compiler->om.contiguousArrayHeaderSizeInBytes()))
+            if (isTreetopInLoop && ((stepInBytes > 0 &&  stepInBytes <= TR::Compiler->vm.heapTailPaddingSizeInBytes()) ||
+                (stepInBytes < 0 && -stepInBytes <= TR::Compiler->om.contiguousArrayHeaderSizeInBytes())))
                {
                // Save array access info
                //

--- a/compiler/optimizer/RedundantAsyncCheckRemoval.cpp
+++ b/compiler/optimizer/RedundantAsyncCheckRemoval.cpp
@@ -2008,8 +2008,8 @@ void TR_LoopEstimator::mergeWithLoopIncrements(TR::Block *block, IncrementInfo *
 void TR_LoopEstimator::IncrementInfo::merge(IncrementInfo *other)
    {
    if (other->isUnknownValue() ||
-       _kind == Arithmetic && other->_kind == Geometric ||
-       _kind == Geometric && other->_kind == Arithmetic)
+       (_kind == Arithmetic && other->_kind == Geometric) ||
+       (_kind == Geometric && other->_kind == Arithmetic))
       _unknown = true;
    else if (!_unknown)
       {

--- a/compiler/optimizer/RegisterCandidate.cpp
+++ b/compiler/optimizer/RegisterCandidate.cpp
@@ -788,7 +788,7 @@ TR_RegisterCandidate::processLiveOnEntryBlocks(TR::Block * * blocks, int32_t *bl
                   // Fixed by Nakaike
                   // if (predBlock && !predBlock->isExtensionOfPreviousBlock())
                   if (parentPredBlock == predBlock ||
-                      parentPredBlock->getNextBlock() && ( parentPredBlock->getNextBlock() == block || !parentPredBlock->getNextBlock()->isExtensionOfPreviousBlock()))
+                      (parentPredBlock->getNextBlock() && ( parentPredBlock->getNextBlock() == block || !parentPredBlock->getNextBlock()->isExtensionOfPreviousBlock())))
                      break;
                   parentPredBlock = parentPredBlock->getNextBlock();
                   }
@@ -2174,7 +2174,7 @@ TR_RegisterCandidates::assign(TR::Block ** cfgBlocks, int32_t numberOfBlocks, in
          {
          if (node->getType().isInt64())
             {
-            if (node->getSymbolReference()->getSymbol()->isAutoOrParm() || 0 && node->getSymbolReference()->getSymbol()->isMethodMetaData())
+            if (node->getSymbolReference()->getSymbol()->isAutoOrParm() || (0 && node->getSymbolReference()->getSymbol()->isMethodMetaData()))
                {
                if ((!node->getFirstChild()->isHighWordZero() &&
                     !node->getFirstChild()->getOpCode().isLoadConst()) ||

--- a/compiler/optimizer/SinkStores.cpp
+++ b/compiler/optimizer/SinkStores.cpp
@@ -3167,15 +3167,15 @@ bool TR_TrivialSinkStores::storeCanMoveThroughBlock(TR_BitVector *blockKilledSet
    {
    return (blockKilledSet == NULL || !blockKilledSet->get(symIdx))
           &&
-          (blockUsedSet == NULL || !blockUsedSet->intersects(*_killedSymbolsToMove) && !blockUsedSet->get(symIdx));
+          (blockUsedSet == NULL || (!blockUsedSet->intersects(*_killedSymbolsToMove) && !blockUsedSet->get(symIdx)));
    }
 
 bool TR_SinkStores::storeCanMoveThroughBlock(TR_BitVector *blockKilledSet, TR_BitVector *blockUsedSet, int symIdx, TR_BitVector *allBlockUsedSymbols, TR_BitVector *allBlockKilledSymbols)
    {
    bool canMove =
-      (blockKilledSet == NULL || !blockKilledSet->intersects(*_usedSymbolsToMove) && !blockKilledSet->get(symIdx))
+      (blockKilledSet == NULL || (!blockKilledSet->intersects(*_usedSymbolsToMove) && !blockKilledSet->get(symIdx)))
       &&
-      (blockUsedSet == NULL || !blockUsedSet->intersects(*_killedSymbolsToMove) && !blockUsedSet->get(symIdx));
+      (blockUsedSet == NULL || (!blockUsedSet->intersects(*_killedSymbolsToMove) && !blockUsedSet->get(symIdx)));
 
    if (canMove)
       {

--- a/compiler/ras/ILValidator.cpp
+++ b/compiler/ras/ILValidator.cpp
@@ -264,9 +264,9 @@ bool TR::ILValidator::treesAreValid(TR::TreeTop *start, TR::TreeTop *stop)
                {
                const auto expChildType = opcode.expectedChildType(i);
                const auto actChildType = childOpcode.getDataType().getDataType();
-               const auto expChildTypeName = (expChildType == ILChildProp::UnspecifiedChildType) ? "UnspecifiedChildType" : TR::DataType::getName(expChildType);
+               const auto expChildTypeName = (expChildType >= TR::NumTypes) ? "UnspecifiedChildType" : TR::DataType::getName(expChildType);
                const auto actChildTypeName = TR::DataType::getName(actChildType);
-               validityRule(iter, ((expChildType == ILChildProp::UnspecifiedChildType) || (actChildType == expChildType)),
+               validityRule(iter, ((expChildType >= TR::NumTypes) || (actChildType == expChildType)),
                             "Child %d has unexpected type %s (expected %s)" , i, actChildTypeName, expChildTypeName);
                }
             else

--- a/compiler/x/codegen/BinaryCommutativeAnalyser.cpp
+++ b/compiler/x/codegen/BinaryCommutativeAnalyser.cpp
@@ -823,7 +823,7 @@ TR::Register *TR_X86BinaryCommutativeAnalyser::integerAddAnalyserImpl(TR::Node  
    // maybe a register that did not exist before has just been created,
    // and this new register contains a collected reference
    // arraylets: aiadd is technically internal pointer into spine object, but isn't marked as internal pointer
-   if (root->isInternalPointer() || comp->generateArraylets() && root->getOpCodeValue() == TR::aiadd)
+   if (root->isInternalPointer() || (comp->generateArraylets() && root->getOpCodeValue() == TR::aiadd))
       {
       // check whether a newly created register contains collected reference
       if ((getEvalChild1() && ((!firstRegister->containsInternalPointer()) || (firstRegister->getPinningArrayPointer() != root->getPinningArrayPointer()))) ||

--- a/compiler/x/codegen/BinaryEvaluator.cpp
+++ b/compiler/x/codegen/BinaryEvaluator.cpp
@@ -2319,7 +2319,7 @@ TR::Register *OMR::X86::TreeEvaluator::signedIntegerDivOrRemAnalyser(TR::Node *n
             {
             generateRegRegInstruction(SUBRegReg(nodeIs64Bit), node, tempRegister, edxRegister, cg);
             }
-         else if (!nodeIs64Bit || dvalue > 0 && dvalue <= CONSTANT64(0x80000000))
+         else if (!nodeIs64Bit || (dvalue > 0 && dvalue <= CONSTANT64(0x80000000)))
             {
             int32_t mask = dvalue-1;
             TR_ASSERT(mask >= 0,

--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -666,8 +666,8 @@ void OMR::X86::TreeEvaluator::compareIntegersForEquality(TR::Node *node, TR::Cod
    intptrj_t constValue;
    if (secondChild->getOpCode().isLoadConst() &&
        secondChild->getRegister() == NULL     &&
-       ((secondChild->getSize() <= 2) && (!secondChild->isUnsigned()) ||
-       TR::TreeEvaluator::constNodeValueIs32BitSigned(secondChild, &constValue, cg) && !cg->constantAddressesCanChangeSize(secondChild)))
+       (((secondChild->getSize() <= 2) && (!secondChild->isUnsigned())) ||
+       (TR::TreeEvaluator::constNodeValueIs32BitSigned(secondChild, &constValue, cg) && !cg->constantAddressesCanChangeSize(secondChild))))
       {
       if(secondChild->getSize() <= 2)
          constValue = (intptrj_t)secondChild->get64bitIntegralValue();

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -538,7 +538,7 @@ OMR::X86::MemoryReference::populateMemoryReference(
       evalSubTree = false;
 
    if (evalSubTree &&
-       subTree->getReferenceCount() > 1 || subTree->getRegister() != NULL || self()->inUpcastingMode() && !subTree->cannotOverflow())
+       subTree->getReferenceCount() > 1 || subTree->getRegister() != NULL || (self()->inUpcastingMode() && !subTree->cannotOverflow()))
       {
       if (_baseRegister != NULL)
          {

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -3951,7 +3951,7 @@ static void arraycopyForShortConstArrayWithoutDirection(TR::Node* node, TR::Regi
 
 TR::Register *OMR::X86::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   static bool useNewArraycopy = feGetEnv("TR_UseNewArraycopy");
+   static char *useNewArraycopy = feGetEnv("TR_UseNewArraycopy");
    if (useNewArraycopy == NULL)
       {
       return deprecated_arraycopyEvaluator(node, cg);


### PR DESCRIPTION
This PR resolves a lot of the warnings of the following types:
`-Wpointer-arith compile warnings`
`-Wtautological-constant-out-of-range-compare`
`-Wlogical-op-parentheses`
