### PR TITLE
Remove unused TR_HOST_Power macro

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1701,11 +1701,7 @@ int32_t       OMR::Options::_TransactionalMemoryRetryCount = 2048;
 int32_t       OMR::Options::_TransactionalMemoryRetryCount = 1;
 #endif
 
-#ifdef TR_HOST_Power
-int32_t       OMR::Options::_minimalNumberOfTreeTopsInsideTMMonitor = 2;
-#else
 int32_t       OMR::Options::_minimalNumberOfTreeTopsInsideTMMonitor = 6;
-#endif
 
 TR::SimpleRegex *OMR::Options::_debugCounterInsertByteCode = NULL;
 TR::SimpleRegex *OMR::Options::_debugCounterInsertJittedBody = NULL;


### PR DESCRIPTION
`TR_HOST_Power` is arguably a typo for the correct host macro `TR_HOST_POWER`.
As nothing in Eclipse OMR nor any known downstream projects sets this incorrect
macro, replace it with the correct macro.

However, because the "wrong" path has been taken for such a long time I question
the value of providing a separate value just for Power and folded the setting of
this option into a single store for all architectures.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>