### PR TITLE
Cache CFG end for repeated OSR induce calls

### DIFF
--- a/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
@@ -169,7 +169,7 @@ public:
 
    bool canInjectInduceOSR(TR::Node* node);
 
-   bool induceOSRAfter(TR::TreeTop *insertionPoint, TR_ByteCodeInfo induceBCI, TR::TreeTop* branch, bool extendRemainder, int32_t offset);
+   bool induceOSRAfter(TR::TreeTop *insertionPoint, TR_ByteCodeInfo induceBCI, TR::TreeTop* branch, bool extendRemainder, int32_t offset, TR::TreeTop ** lastTreeTop = NULL);
    TR::TreeTop *induceImmediateOSRWithoutChecksBefore(TR::TreeTop *insertionPoint);
 
    int32_t incTempIndex(TR_FrontEnd * fe);


### PR DESCRIPTION
When adding an OSR guard, it is necessary to append
OSR blocks to the end of the CFG. The final treetop
is necessary for this, found by walking the entire
IL. Therefore, it is cheaper to maintain a pointer
to the last treetop through repeated OSR guard
insertions.