### PR TITLE
Store feGetEnv results in statics

### DIFF
--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -1174,7 +1174,7 @@ OMR::ResolvedMethodSymbol::genOSRHelperCall(int32_t currentInlinedSiteIndex, TR:
    TR::TreeTop *osrTT = TR::TreeTop::create(self()->comp(), osrNode);
    OSRCodeBlock->append(osrTT);
 
-   bool disableOSRwithTM = feGetEnv("TR_disableOSRwithTM") ? true: false;
+   static bool disableOSRwithTM = feGetEnv("TR_disableOSRwithTM") ? true: false;
    if (self()->comp()->cg()->getSupportsTM() && !self()->comp()->getOption(TR_DisableTLE) && !disableOSRwithTM)
       {
       TR::Node *tabortNode = TR::Node::create(osrNode, TR::tabort, 0, 0);

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -4608,7 +4608,8 @@ static bool isBitwiseLongComplement(TR::Node * n)
 template <typename T>
 static bool checkAndReplaceRotation(TR::Node *node,TR::Block *block, TR::Simplifier *s)
    {
-   if (feGetEnv("TR_DisableROLSimplification"))
+   static char* disableROLSimplification = feGetEnv("TR_DisableROLSimplification");
+   if (disableROLSimplification)
       return false;
 
    TR::Node *firstChild = node->getFirstChild();

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -991,7 +991,8 @@ void TR::X86RegRegInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigne
 
       bool regRegCopy = isRegRegMove();
       TR_X86OpCodes opCode = getOpCodeValue();
-      if (feGetEnv("TR_UseOutOfDatedRegRevMoveList"))
+      static char* useOutOfDateRegRegMoveList = feGetEnv("TR_UseOutOfDateRegRegMoveList");
+      if (useOutOfDateRegRegMoveList)
          {
          if (opCode == MOVAPSRegReg ||
              opCode == MOV8RegReg   ||


### PR DESCRIPTION
feGetEnv is a common debug tool to disable or enable
behaviour based on environment variables. To avoid
significant compile time overhead, the result of the
call should be stored in a static.