### PR TITLE
Fixing heap top address calculation

### DIFF
--- a/gc/base/MemoryManager.cpp
+++ b/gc/base/MemoryManager.cpp
@@ -336,9 +336,9 @@ MM_MemoryManager::createVirtualMemoryForHeap(MM_EnvironmentBase* env, MM_MemoryH
 				handle->setMemoryBase((void *)heapBase);
 
 				/* top of adjusted Nursery should fit reserved memory */
-				Assert_GC_true_with_message4(env, ((heapBase + size) <= ((uintptr_t)handle->getMemoryTop() - tailPadding)),
-						"End of projected heap (base 0x%zx + size 0x%zx) is larger then (Top allocated %p - tailPadding 0x%zx)",
-						heapBase, size, handle->getMemoryTop(), tailPadding);
+				Assert_GC_true_with_message3(env, ((heapBase + size) <= (uintptr_t)handle->getMemoryTop()),
+						"End of projected heap (base 0x%zx + size 0x%zx) is larger then Top allocated %p\n",
+						heapBase, size, handle->getMemoryTop());
 			}
 
 			/* adjust heap top to lowest possible address */

--- a/gc/base/ModronAssertions.cpp
+++ b/gc/base/ModronAssertions.cpp
@@ -39,17 +39,19 @@ extern "C" {
  */
 
 void
-omrGcDebugAssertionOutput(OMR_VMThread *omrVMThread, const char *format, ...)
+omrGcDebugAssertionOutput(OMRPortLibrary *portLibrary, OMR_VMThread *omrVMThread, const char *format, ...)
 {
 	char buffer[ASSERTION_MESSAGE_BUFFER_SIZE];
-	OMRPortLibrary *portLibrary = omrVMThread->_vm->_runtime->_portLibrary;
 
 	va_list args;
 	va_start(args, format);
 	portLibrary->str_vprintf(portLibrary, buffer, ASSERTION_MESSAGE_BUFFER_SIZE, format, args);
 	va_end(args);
 
-	Trc_MM_AssertionWithMessage_outputMessage(omrVMThread->_language_vmthread, buffer);
+	if (NULL != omrVMThread) {
+		/* omrVMThread might be NULL if Environment is partially initialized at startup time */
+		Trc_MM_AssertionWithMessage_outputMessage(omrVMThread->_language_vmthread, buffer);
+	}
 	portLibrary->tty_printf(portLibrary, "%s", buffer);
 }
 

--- a/gc/base/ModronAssertions.h
+++ b/gc/base/ModronAssertions.h
@@ -41,7 +41,7 @@ extern "C" {
 /* Currently, there are startup errors pointed out by these assertions so only enable them on combination spec until they are fixed for everyone */
 #if defined(OMR_GC_DEBUG_ASSERTS)
 
-extern void omrGcDebugAssertionOutput(OMR_VMThread *omrVMThread, const char *format, ...);
+extern void omrGcDebugAssertionOutput(OMRPortLibrary *portLibrary, OMR_VMThread *omrVMThread, const char *format, ...);
 
 #define Assert_MM_true(arg) \
 	do {\
@@ -81,7 +81,7 @@ extern void omrGcDebugAssertionOutput(OMR_VMThread *omrVMThread, const char *for
 #define Assert_GC_true_with_message(__env__,__condition,__message,__parameter) \
 do {\
 	if(!(__condition)) {\
-		omrGcDebugAssertionOutput(__env__->getOmrVMThread(), __message, __parameter);\
+		omrGcDebugAssertionOutput(__env__->getPortLibrary(), __env__->getOmrVMThread(), __message, __parameter);\
 		Assert_MM_unreachable();\
 	}\
 } while (false)
@@ -90,7 +90,7 @@ do {\
 #define Assert_GC_true_with_message2(__env__,__condition,__message,__parameter1,__parameter2) \
 do {\
 	if(!(__condition)) {\
-		omrGcDebugAssertionOutput(__env__->getOmrVMThread(), __message, __parameter1, __parameter2);\
+		omrGcDebugAssertionOutput(__env__->getPortLibrary(), __env__->getOmrVMThread(), __message, __parameter1, __parameter2);\
 		Assert_MM_unreachable();\
 	}\
 } while (false)
@@ -99,7 +99,7 @@ do {\
 #define Assert_GC_true_with_message3(__env__,__condition,__message,__parameter1,__parameter2,__parameter3) \
 do {\
 	if(!(__condition)) {\
-		omrGcDebugAssertionOutput(__env__->getOmrVMThread(), __message, __parameter1, __parameter2, __parameter3);\
+		omrGcDebugAssertionOutput(__env__->getPortLibrary(), __env__->getOmrVMThread(), __message, __parameter1, __parameter2, __parameter3);\
 		Assert_MM_unreachable();\
 	}\
 } while (false)
@@ -108,7 +108,7 @@ do {\
 #define Assert_GC_true_with_message4(__env__,__condition,__message,__parameter1,__parameter2,__parameter3,__parameter4) \
 do {\
 	if(!(__condition)) {\
-		omrGcDebugAssertionOutput(__env__->getOmrVMThread(), __message, __parameter1, __parameter2, __parameter3, __parameter4);\
+		omrGcDebugAssertionOutput(__env__->getPortLibrary(), __env__->getOmrVMThread(), __message, __parameter1, __parameter2, __parameter3, __parameter4);\
 		Assert_MM_unreachable();\
 	}\
 } while (false)

--- a/gc/base/VirtualMemory.cpp
+++ b/gc/base/VirtualMemory.cpp
@@ -114,9 +114,9 @@ MM_VirtualMemory::initialize(MM_EnvironmentBase* env, uintptr_t size, void* pref
 
 		/* If heap touches top of address range */
 		if (lastByte == HIGH_ADDRESS) {
-			_heapTop = (void*)MM_Math::roundToFloor(_heapAlignment, ((uintptr_t)_baseAddress) + (allocateSize - _tailPadding - _heapAlignment));
+			_heapTop = (void*)MM_Math::roundToFloor(_heapAlignment, ((uintptr_t)_heapBase) + (allocateSize - _tailPadding - _heapAlignment));
 		} else {
-			_heapTop = (void*)MM_Math::roundToFloor(_heapAlignment, ((uintptr_t)_baseAddress) + (allocateSize - _tailPadding));
+			_heapTop = (void*)MM_Math::roundToFloor(_heapAlignment, ((uintptr_t)_heapBase) + (allocateSize - _tailPadding));
 		}
 
 		if ((_heapBase >= _heapTop) /* CMVC 45178: Need to catch the case where we aligned heapTop and heapBase to the same address and consider it an error. */


### PR DESCRIPTION
- The top heap address calculation should use aligned start address.
Otherwise a region aligned heap size might be shorter by region.

- Concurrent Scavenger code in Memory Manager should not step back by
tail padding as far as top address does not include it. tailpadding info
has been removed from Modron Assertion message

- Modron Assertions has been improved to work in startup time in case if
OMR VM Thread is not initialized. Tracepoint output should be skip in
this case.  

Signed-off-by: dmitripivkine <Dmitri_Pivkine@ca.ibm.com>