### PR TITLE
GC: Update the GC Forge Allocator API

### DIFF
--- a/gc/base/GCExtensionsBase.cpp
+++ b/gc/base/GCExtensionsBase.cpp
@@ -179,7 +179,7 @@ MM_GCExtensionsBase::initialize(MM_EnvironmentBase* env)
 	}
 
 
-	if (!_forge.initialize(env)) {
+	if (!_forge.initialize(env->getPortLibrary())) {
 		goto failed;
 	}
 
@@ -275,7 +275,7 @@ MM_GCExtensionsBase::tearDown(MM_EnvironmentBase* env)
 		_lightweightNonReentrantLockPoolMutex = (omrthread_monitor_t) NULL;
 	}
 
-	_forge.tearDown(env);
+	_forge.tearDown();
 
 	J9HookInterface** tmpHookInterface = getPrivateHookInterface();
 	if ((NULL != tmpHookInterface) && (NULL != *tmpHookInterface)) {


### PR DESCRIPTION
* Do not take an environment in initialize/shutdown. The forge is
  typically initialized before any environments are attached.
* Wrap the forge in the OMR namespace. Provide a backwards compatible
  typedef. Do not put MemoryStatistic or AllocationCategory inside the
  OMR namespace just yet, they are used in C code.
* Provide a set of new/delete operators for wrapping forge allocations.
  Now you can pass the forge as a parameter of the new operator. This
  should simplify the newInstance idiom used throughout the GC.

Signed-off-by: Robert Young <rwy0717@gmail.com>
/cc @youngar @charliegracie @ktbriggs