### PR TITLE
Add missed _inlines header to PartialRedundancy.hpp

### DIFF
--- a/compiler/optimizer/PartialRedundancy.hpp
+++ b/compiler/optimizer/PartialRedundancy.hpp
@@ -29,6 +29,7 @@
 #include "infra/BitVector.hpp"                      // for TR_BitVector
 #include "infra/List.hpp"                           // for List (ptr only), etc
 #include "optimizer/Optimization.hpp"               // for Optimization
+#include "optimizer/Optimization_inlines.hpp"       // for trace etc.  
 #include "optimizer/OptimizationManager.hpp"
 #include "optimizer/DataFlowAnalysis.hpp"
 


### PR DESCRIPTION
Fixes a warning from GCC

    In file included from ../compiler/optimizer/Optimization.hpp:25:
    ../compiler/optimizer/OMROptimization.hpp:123:31: warning: inline function 'OMR::Optimization::trace' is not defined [-Wundefined-inline]
       inline bool                trace();
                                  ^
    ../compiler/optimizer/PartialRedundancy.hpp:207:46: note: used here
       bool trace() { return _partialRedundancy->trace(); }
                                                 ^

