### PR TITLE
GC: Don't use the GC in omrcore when OMR_GC is OFF

### DIFF
--- a/omr/CMakeLists.txt
+++ b/omr/CMakeLists.txt
@@ -45,23 +45,27 @@ add_library(omrcore STATIC
 	ut_omrvm.h
 )
 
-add_dependencies(omrcore
-	omrgc_tracegen
-	omrgc_hookgen
-)
-
-target_link_libraries(omrcore
-	PRIVATE
-		${OMR_CORE_GLUE_TARGET}
-		omrtrace
-		omrgc
-)
-
 target_include_directories(omrcore
 	PUBLIC
 		.
-	PRIVATE
-		$<TARGET_PROPERTY:omrgc,INTERFACE_INCLUDE_DIRECTORIES>
-		$<TARGET_PROPERTY:${OMR_GC_GLUE_TARGET},INTERFACE_INCLUDE_DIRECTORIES>
 )
 
+if(OMR_GC)
+	add_dependencies(omrcore
+		omrgc_tracegen
+		omrgc_hookgen
+	)
+
+	target_link_libraries(omrcore
+		PRIVATE
+			${OMR_CORE_GLUE_TARGET}
+			omrtrace
+			omrgc
+	)
+
+	target_include_directories(omrcore
+		PRIVATE
+			$<TARGET_PROPERTY:omrgc,INTERFACE_INCLUDE_DIRECTORIES>
+			$<TARGET_PROPERTY:${OMR_GC_GLUE_TARGET},INTERFACE_INCLUDE_DIRECTORIES>
+	)
+endif(OMR_GC)

--- a/omr/OMR_VM.cpp
+++ b/omr/OMR_VM.cpp
@@ -20,10 +20,15 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
+#include "omrcfg.h"
+
 #define linkNext _linkNext
 #define linkPrevious _linkPrevious
+
 #include "omrlinkedlist.h"
+#if defined(OMR_GC)
 #include "mminitcore.h"
+#endif /* OMR_GC */
 #include "omrtrace.h"
 #include "ut_omrvm.h"
 #include "omrutil.h"


### PR DESCRIPTION
This fixes some issues in base9, where we want to use only jitbuilder, but OMR can't compile with the GC disabled.

/cc @dnakamura @youngar

Signed-off-by: Robert Young <rwy0717@gmail.com>