### PR TITLE
Revert back heap top calculation

### DIFF
--- a/gc/base/VirtualMemory.cpp
+++ b/gc/base/VirtualMemory.cpp
@@ -114,9 +114,9 @@ MM_VirtualMemory::initialize(MM_EnvironmentBase* env, uintptr_t size, void* pref
 
 		/* If heap touches top of address range */
 		if (lastByte == HIGH_ADDRESS) {
-			_heapTop = (void*)MM_Math::roundToFloor(_heapAlignment, ((uintptr_t)_heapBase) + (allocateSize - _tailPadding - _heapAlignment));
+			_heapTop = (void*)MM_Math::roundToFloor(_heapAlignment, ((uintptr_t)_baseAddress) + (allocateSize - _tailPadding - _heapAlignment));
 		} else {
-			_heapTop = (void*)MM_Math::roundToFloor(_heapAlignment, ((uintptr_t)_heapBase) + (allocateSize - _tailPadding));
+			_heapTop = (void*)MM_Math::roundToFloor(_heapAlignment, ((uintptr_t)_baseAddress) + (allocateSize - _tailPadding));
 		}
 
 		if ((_heapBase >= _heapTop) /* CMVC 45178: Need to catch the case where we aligned heapTop and heapBase to the same address and consider it an error. */


### PR DESCRIPTION
Use unaligned address for heap start and tolerate the fact that heap
might be shorter by region in case of unfortunate alignment. Shorter by
region heap is allowed by logic.

Signed-off-by: dmitripivkine <Dmitri_Pivkine@ca.ibm.com>