### PR TITLE
Use Test Compiler as a Tril Backend

### DIFF
--- a/fvtest/compilertest/CMakeLists.txt
+++ b/fvtest/compilertest/CMakeLists.txt
@@ -70,6 +70,10 @@ create_omr_compiler_library(
 		PROD_WITH_ASSUMES
 		INCLUDES ${OMR_ROOT}/fvtest
 )
+
+# Export paths for dependent objects
+make_compiler_target(testcompiler INTERFACE COMPILER testcompiler)
+
 add_executable(compilertest
 	tests/main.cpp
 	tests/BarIlInjector.cpp

--- a/fvtest/compilertest/Jit.hpp
+++ b/fvtest/compilertest/Jit.hpp
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+#include <stdint.h>
+
+namespace TR { class MethodBuilder; }
+class TR_Memory;
+
+extern "C" bool initializeJit();
+extern "C" uint32_t compileMethodBuilder(TR::MethodBuilder *m, uint8_t **entry);
+extern "C" void shutdownJit();

--- a/fvtest/compilertriltest/ArithmeticTest.cpp
+++ b/fvtest/compilertriltest/ArithmeticTest.cpp
@@ -20,7 +20,7 @@
  *******************************************************************************/
 
 #include "OpCodeTest.hpp"
-#include "jitbuilder_compiler.hpp"
+#include "default_compiler.hpp"
 
 class Int32Arithmetic : public TRTest::BinaryOpTest<int32_t> {};
 
@@ -33,7 +33,7 @@ TEST_P(Int32Arithmetic, UsingConst) {
 
     ASSERT_NOTNULL(trees);
 
-    Tril::JitBuilderCompiler compiler{trees};
+    Tril::DefaultCompiler compiler{trees};
 
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
@@ -52,7 +52,7 @@ TEST_P(Int32Arithmetic, UsingLoadParam) {
 
     ASSERT_NOTNULL(trees);
 
-    Tril::JitBuilderCompiler compiler{trees};
+    Tril::DefaultCompiler compiler{trees};
 
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 

--- a/fvtest/compilertriltest/ILValidatorTest.cpp
+++ b/fvtest/compilertriltest/ILValidatorTest.cpp
@@ -20,7 +20,7 @@
  *******************************************************************************/
 
 #include "JitTest.hpp"
-#include "jitbuilder_compiler.hpp"
+#include "default_compiler.hpp"
 
 #include <string>
 
@@ -32,7 +32,7 @@ TEST_P(IllformedTrees, FailCompilation) {
 
     ASSERT_NOTNULL(trees);
 
-    Tril::JitBuilderCompiler compiler{trees};
+    Tril::DefaultCompiler compiler{trees};
 
     ASSERT_DEATH(compiler.compile(), "VALIDATION ERROR")
             << "Compilation did not fail due to ill-formed input trees";
@@ -64,7 +64,7 @@ TEST_P(WellformedTrees, CompileOnly) {
 
     ASSERT_NOTNULL(trees);
 
-    Tril::JitBuilderCompiler compiler{trees};
+    Tril::DefaultCompiler compiler{trees};
 
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly";
 }
@@ -101,7 +101,7 @@ TEST_P(CommoningTest, CommoningUnderSameTree)
    auto ast = parseString(tril);
    ASSERT_NOTNULL(ast) << "Parsing failed unexpectedly";
 
-   Tril::JitBuilderCompiler compiler{ast};
+   Tril::DefaultCompiler compiler{ast};
    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly";
 
    auto entry_point = compiler.getEntryPoint<int32_t (*)(int32_t, int32_t)>();
@@ -130,7 +130,7 @@ TEST_P(CommoningTest, CommoningWithinBlock)
    auto ast = parseString(tril);
    ASSERT_NOTNULL(ast) << "Parsing failed unexpectedly";
 
-   Tril::JitBuilderCompiler compiler{ast};
+   Tril::DefaultCompiler compiler{ast};
    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly";
 
    auto entry_point = compiler.getEntryPoint<int32_t (*)(int32_t, int32_t)>();
@@ -165,7 +165,7 @@ TEST_F(CommoningDeathTest, CommoningAcrossBlock)
    auto ast = parseString(tril);
    ASSERT_NOTNULL(ast) << "Parsing failed unexpectedly";
 
-   Tril::JitBuilderCompiler compiler{ast};
+   Tril::DefaultCompiler compiler{ast};
    ASSERT_DEATH(compiler.compile(), "VALIDATION ERROR")
       << "Compilation did not fail due to ill-formed input trees";
    }

--- a/fvtest/compilertriltest/IfxcmpgeReductionTest.cpp
+++ b/fvtest/compilertriltest/IfxcmpgeReductionTest.cpp
@@ -22,7 +22,7 @@
 #include <gtest/gtest.h>
 #include "Jit.hpp"
 #include "JitTest.hpp"
-#include "jitbuilder_compiler.hpp"
+#include "default_compiler.hpp"
 
 template <typename ValType>
 using IfxcmpgeReductionParamType = std::tuple<ValType, ValType, int32_t (*)(ValType, ValType)>;
@@ -120,7 +120,7 @@ TEST_P(Int8ReductionTest, Reduction)
 
    ASSERT_NOTNULL(trees);
 
-   Tril::JitBuilderCompiler compiler{trees};
+   Tril::DefaultCompiler compiler{trees};
 
    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
@@ -164,7 +164,7 @@ TEST_P(UInt8ReductionTest, Reduction)
 
    ASSERT_NOTNULL(trees);
 
-   Tril::JitBuilderCompiler compiler{trees};
+   Tril::DefaultCompiler compiler{trees};
 
    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
@@ -208,7 +208,7 @@ TEST_P(Int16ReductionTest, Reduction)
 
    ASSERT_NOTNULL(trees);
 
-   Tril::JitBuilderCompiler compiler{trees};
+   Tril::DefaultCompiler compiler{trees};
 
    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
@@ -252,7 +252,7 @@ TEST_P(UInt16ReductionTest, Reduction)
 
    ASSERT_NOTNULL(trees);
 
-   Tril::JitBuilderCompiler compiler{trees};
+   Tril::DefaultCompiler compiler{trees};
 
    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
@@ -295,7 +295,7 @@ TEST_P(Int32ReductionTest, Reduction)
 
    ASSERT_NOTNULL(trees);
 
-   Tril::JitBuilderCompiler compiler{trees};
+   Tril::DefaultCompiler compiler{trees};
 
    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
@@ -338,7 +338,7 @@ TEST_P(UInt32ReductionTest, Reduction)
 
    ASSERT_NOTNULL(trees);
 
-   Tril::JitBuilderCompiler compiler{trees};
+   Tril::DefaultCompiler compiler{trees};
 
    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
@@ -381,7 +381,7 @@ TEST_P(Int64ReductionTest, Reduction)
 
    ASSERT_NOTNULL(trees);
 
-   Tril::JitBuilderCompiler compiler{trees};
+   Tril::DefaultCompiler compiler{trees};
 
    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
@@ -424,7 +424,7 @@ TEST_P(UInt64ReductionTest, Reduction)
 
    ASSERT_NOTNULL(trees);
 
-   Tril::JitBuilderCompiler compiler{trees};
+   Tril::DefaultCompiler compiler{trees};
 
    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 

--- a/fvtest/compilertriltest/ShiftAndRotateTest.cpp
+++ b/fvtest/compilertriltest/ShiftAndRotateTest.cpp
@@ -20,7 +20,7 @@
  *******************************************************************************/
 
 #include "OpCodeTest.hpp"
-#include "jitbuilder_compiler.hpp"
+#include "default_compiler.hpp"
 
 template <typename T> static
 std::vector<std::tuple<T, int32_t>> test_input_values()
@@ -98,7 +98,7 @@ TEST_P(Int32ShiftAndRotate, UsingConst) {
 
     ASSERT_NOTNULL(trees);
 
-    Tril::JitBuilderCompiler compiler{trees};
+    Tril::DefaultCompiler compiler{trees};
 
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
@@ -115,7 +115,7 @@ TEST_P(Int32ShiftAndRotate, UsingLoadParam) {
 
     ASSERT_NOTNULL(trees);
 
-    Tril::JitBuilderCompiler compiler{trees};
+    Tril::DefaultCompiler compiler{trees};
 
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
@@ -140,7 +140,7 @@ TEST_P(Int64ShiftAndRotate, UsingConst) {
 
     ASSERT_NOTNULL(trees);
 
-    Tril::JitBuilderCompiler compiler{trees};
+    Tril::DefaultCompiler compiler{trees};
 
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
@@ -157,7 +157,7 @@ TEST_P(Int64ShiftAndRotate, UsingLoadParam) {
 
     ASSERT_NOTNULL(trees);
 
-    Tril::JitBuilderCompiler compiler{trees};
+    Tril::DefaultCompiler compiler{trees};
 
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
@@ -182,7 +182,7 @@ TEST_P(Int8ShiftAndRotate, UsingConst) {
 
     ASSERT_NOTNULL(trees);
 
-    Tril::JitBuilderCompiler compiler{trees};
+    Tril::DefaultCompiler compiler{trees};
 
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
@@ -199,7 +199,7 @@ TEST_P(Int8ShiftAndRotate, UsingLoadParam) {
 
     ASSERT_NOTNULL(trees);
 
-    Tril::JitBuilderCompiler compiler{trees};
+    Tril::DefaultCompiler compiler{trees};
 
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
@@ -223,7 +223,7 @@ TEST_P(Int16ShiftAndRotate, UsingConst) {
 
     ASSERT_NOTNULL(trees);
 
-    Tril::JitBuilderCompiler compiler{trees};
+    Tril::DefaultCompiler compiler{trees};
 
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
@@ -241,7 +241,7 @@ TEST_P(Int16ShiftAndRotate, UsingLoadParam) {
 
     ASSERT_NOTNULL(trees);
 
-    Tril::JitBuilderCompiler compiler{trees};
+    Tril::DefaultCompiler compiler{trees};
 
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
@@ -266,7 +266,7 @@ TEST_P(UInt32ShiftAndRotate, UsingConst) {
 
     ASSERT_NOTNULL(trees);
 
-    Tril::JitBuilderCompiler compiler{trees};
+    Tril::DefaultCompiler compiler{trees};
 
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
@@ -283,7 +283,7 @@ TEST_P(UInt32ShiftAndRotate, UsingLoadParam) {
 
     ASSERT_NOTNULL(trees);
 
-    Tril::JitBuilderCompiler compiler{trees};
+    Tril::DefaultCompiler compiler{trees};
 
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
@@ -306,7 +306,7 @@ TEST_P(UInt64ShiftAndRotate, UsingConst) {
 
     ASSERT_NOTNULL(trees);
 
-    Tril::JitBuilderCompiler compiler{trees};
+    Tril::DefaultCompiler compiler{trees};
 
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
@@ -323,7 +323,7 @@ TEST_P(UInt64ShiftAndRotate, UsingLoadParam) {
 
     ASSERT_NOTNULL(trees);
 
-    Tril::JitBuilderCompiler compiler{trees};
+    Tril::DefaultCompiler compiler{trees};
 
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
@@ -346,7 +346,7 @@ TEST_P(UInt8ShiftAndRotate, UsingConst) {
 
     ASSERT_NOTNULL(trees);
 
-    Tril::JitBuilderCompiler compiler{trees};
+    Tril::DefaultCompiler compiler{trees};
 
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
@@ -363,7 +363,7 @@ TEST_P(UInt8ShiftAndRotate, UsingLoadParam) {
 
     ASSERT_NOTNULL(trees);
 
-    Tril::JitBuilderCompiler compiler{trees};
+    Tril::DefaultCompiler compiler{trees};
 
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
@@ -386,7 +386,7 @@ TEST_P(UInt16ShiftAndRotate, UsingConst) {
 
     ASSERT_NOTNULL(trees);
 
-    Tril::JitBuilderCompiler compiler{trees};
+    Tril::DefaultCompiler compiler{trees};
 
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
@@ -403,7 +403,7 @@ TEST_P(UInt16ShiftAndRotate, UsingLoadParam) {
 
     ASSERT_NOTNULL(trees);
 
-    Tril::JitBuilderCompiler compiler{trees};
+    Tril::DefaultCompiler compiler{trees};
 
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 

--- a/fvtest/compilertriltest/SimplifierFoldAndTest.cpp
+++ b/fvtest/compilertriltest/SimplifierFoldAndTest.cpp
@@ -20,7 +20,7 @@
  *******************************************************************************/
 
 #include "JitTest.hpp"
-#include "jitbuilder_compiler.hpp"
+#include "default_compiler.hpp"
 #include "il/Node.hpp"
 #include "infra/ILWalk.hpp"
 #include "ras/IlVerifier.hpp"
@@ -104,7 +104,7 @@ TEST_F(SimplifierFoldAndTest, FoldHappens) {
 
     ASSERT_NOTNULL(trees);
 
-    Tril::JitBuilderCompiler compiler{trees};
+    Tril::DefaultCompiler compiler{trees};
     SimplifierFoldAndIlVerifier verifier;  
 
     ASSERT_EQ(0, compiler.compileWithVerifier(&verifier)) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;

--- a/fvtest/compilertriltest/VectorTest.cpp
+++ b/fvtest/compilertriltest/VectorTest.cpp
@@ -20,7 +20,7 @@
  *******************************************************************************/
 
 #include "JitTest.hpp"
-#include "jitbuilder_compiler.hpp"
+#include "default_compiler.hpp"
 
 class VectorTest : public TRTest::JitTest {};
 
@@ -40,7 +40,7 @@ TEST_F(VectorTest, VDoubleAdd) {
 
     ASSERT_NOTNULL(trees);
 
-    Tril::JitBuilderCompiler compiler{trees};
+    Tril::DefaultCompiler compiler{trees};
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
 

--- a/fvtest/tril/examples/incordec/main.cpp
+++ b/fvtest/tril/examples/incordec/main.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-#include "jitbuilder_compiler.hpp"
+#include "default_compiler.hpp"
 #include "Jit.hpp"
 
 #include <assert.h>
@@ -41,7 +41,7 @@ int main(int argc, char const * const * const argv) {
     printTrees(stdout, trees, 0);
 
     // assume that the file contians a single method and compile it
-    Tril::JitBuilderCompiler incordecCompiler{trees};
+    Tril::DefaultCompiler incordecCompiler{trees};
     assert(incordecCompiler.compile() == 0);
     auto incordec = incordecCompiler.getEntryPoint<IncOrDecFunction*>();
 

--- a/fvtest/tril/examples/mandelbrot/main.cpp
+++ b/fvtest/tril/examples/mandelbrot/main.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-#include "jitbuilder_compiler.hpp"
+#include "default_compiler.hpp"
 #include "Jit.hpp"
 
 #include <assert.h>
@@ -41,7 +41,7 @@ int main(int argc, char const * const * const argv) {
     printTrees(stdout, trees, 0);
 
     // assume that the file contians a single method and compile it
-    Tril::JitBuilderCompiler mandelbrotCompiler{trees};
+    Tril::DefaultCompiler mandelbrotCompiler{trees};
     assert(mandelbrotCompiler.compile() == 0);
     auto mandelbrot = mandelbrotCompiler.getEntryPoint<MandelbrotFunction*>();
 

--- a/fvtest/tril/test/CompileTest.cpp
+++ b/fvtest/tril/test/CompileTest.cpp
@@ -20,7 +20,7 @@
  *******************************************************************************/
 
 #include "JitTest.hpp"
-#include "jitbuilder_compiler.hpp"
+#include "default_compiler.hpp"
 #include "ras/IlVerifier.hpp"
 #include "ras/IlVerifierHelpers.hpp"
 
@@ -34,7 +34,7 @@ TEST_F(CompileTest, Return3) {
 
     ASSERT_NOTNULL(trees);
 
-    Tril::JitBuilderCompiler compiler{trees};
+    Tril::DefaultCompiler compiler{trees};
 
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed";
 
@@ -49,7 +49,7 @@ TEST_F(CompileTest, NoCodeGen) {
 
     ASSERT_NOTNULL(trees);
 
-    Tril::JitBuilderCompiler compiler{trees};
+    Tril::DefaultCompiler compiler{trees};
     TR::NoCodegenVerifier verifier{NULL}; 
 
     EXPECT_NE(0, compiler.compileWithVerifier(&verifier)) << "Compilation succeeded";

--- a/fvtest/tril/test/JitTest.hpp
+++ b/fvtest/tril/test/JitTest.hpp
@@ -29,13 +29,13 @@ namespace Tril {
 namespace Test {
 
 /**
- * @brief The JitBuilderTest class is a basic test fixture for JitBuilder test cases.
+ * @brief The JitTest class is a basic test fixture for Jit test cases.
  *
- * Most JitBuilder test case fixtures should publically inherit from this class.
+ * Most Jit test case fixtures should publically inherit from this class.
  *
  * Example use:
  *
- *    class MyTestCase : public JitBuilderTest {};
+ *    class MyTestCase : public JitTest {};
  */
 class JitTest : public ::testing::Test
    {

--- a/fvtest/tril/tril/CMakeLists.txt
+++ b/fvtest/tril/tril/CMakeLists.txt
@@ -32,26 +32,32 @@ FLEX_TARGET(tril_scanner tril.l ${CMAKE_CURRENT_BINARY_DIR}/tril.scanner.c
 #            DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/tril.scanner.h)
 ADD_FLEX_BISON_DEPENDENCY(tril_scanner tril_parser)
 
+if(TRIL_TEST_COMPILER)
+    set(TRIL_BACKEND_LIB      testcompiler)
+else()
+    set(TRIL_BACKEND_LIB      jitbuilder)
+endif()
+
 add_library(tril STATIC
 	${BISON_tril_parser_OUTPUTS}
 	${FLEX_tril_scanner_OUTPUTS}
 	ast.cpp
 	ilgen.cpp
-	jitbuilder_compiler.cpp
+	simple_compiler.cpp
 )
 
 # This is mildly peculiar. Because tril relies
 # on jitbuilder as a 'backend' of sorts, we use
 # its includes. Tril exports this as interface
-make_compiler_target(tril PUBLIC COMPILER jitbuilder)
+make_compiler_target(tril PUBLIC COMPILER ${TRIL_BACKEND_LIB}) 
 
 target_include_directories(tril PUBLIC
 	${CMAKE_CURRENT_BINARY_DIR}
 	${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-target_link_libraries(tril PUBLIC
-	jitbuilder
+target_link_libraries(tril PUBLIC 
+	${TRIL_BACKEND_LIB}
 	dl
 )
 

--- a/fvtest/tril/tril/default_compiler.hpp
+++ b/fvtest/tril/tril/default_compiler.hpp
@@ -19,50 +19,15 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-#include "default_compiler.hpp"
-#include "Jit.hpp"
-#include <cstdio>
-#include <string>
+#ifndef DEFAULT_COMPILER_HPP
+#define DEFAULT_COMPILER_HPP
 
+/* If you want to support more backends that are 
+ * incompatible with the SimpleCompiler interface,
+ * use #ifdefs to select them in this file. 
+ */
 
-int main(int argc, char** argv)
-   { 
+#include "simple_compiler.hpp"
+namespace Tril { typedef Tril::SimpleCompiler DefaultCompiler; } 
 
-   FILE* out = stdout; 
-   FILE* in = stdin;
-
-   std::string program_name = argv[0];
-
-   bool isDumper = program_name.find("tril_dumper") != std::string::npos;  
-
-   if (2 == argc)
-      {
-      in = fopen(argv[1], "r"); 
-      }
-
-   auto trees = parseFile(in);
-
-   if (trees)
-      {
-      printTrees(out, trees, 1); 
-      if (!isDumper) 
-         {
-         initializeJit();
-         Tril::DefaultCompiler compiler{trees}; 
-         if (compiler.compile() != 0) { 
-            fprintf(out, "Error compiling trees!"); 
-         }
-         shutdownJit();
-         }
-      }
-   else
-      { 
-      fprintf(out, "Parse error\n");
-      }
-
-
-   if (2 == argc)
-      {
-      fclose(in);
-      }
-   }
+#endif

--- a/fvtest/tril/tril/simple_compiler.cpp
+++ b/fvtest/tril/tril/simple_compiler.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-#include "jitbuilder_compiler.hpp"
+#include "simple_compiler.hpp"
 
 #include "env/jittypes.h"
 #include "il/DataTypes.hpp"
@@ -31,16 +31,16 @@
 #include "env/jittypes.h"
 #include "il/DataTypes.hpp"
 #include "ilgen.hpp"
-#include "Jit.hpp"
 #include "ilgen/IlGeneratorMethodDetails_inlines.hpp"
+#include "Jit.hpp" 
 
 #include <algorithm>
 
-int32_t Tril::JitBuilderCompiler::compile() {
+int32_t Tril::SimpleCompiler::compile() {
    return compileWithVerifier(NULL);
 }
 
-int32_t Tril::JitBuilderCompiler::compileWithVerifier(TR::IlVerifier* verifier) {
+int32_t Tril::SimpleCompiler::compileWithVerifier(TR::IlVerifier* verifier) {
     // construct an IL generator for the method
     auto methodInfo = getMethodInfo();
     TR::TypeDictionary types;

--- a/fvtest/tril/tril/simple_compiler.hpp
+++ b/fvtest/tril/tril/simple_compiler.hpp
@@ -29,15 +29,15 @@ namespace TR { class IlVerifier; }
 namespace Tril {
 
 /**
- * @brief Concrete realization of MethodCompiler that uses JitBuilder for compilation
+ * @brief Concrete realization of MethodCompiler 
  */
-class JitBuilderCompiler : public Tril::MethodCompiler {
+class SimpleCompiler : public Tril::MethodCompiler {
     public:
-        explicit JitBuilderCompiler(const ASTNode* methodNode)
+        explicit SimpleCompiler(const ASTNode* methodNode)
             : MethodCompiler{methodNode} {}
 
         /**
-         * @brief Compiles the Tril method using JitBuilder
+         * @brief Compiles the Tril method
          * @return 0 on compilation success, an error code otherwise
          */
         int32_t compile() /* override */ ;


### PR DESCRIPTION
An implementation for #1688 

Notes I'd like to call out: 

* ~This adds a header to the root of the compiler directory, called `Jit.hpp`, that mirrors the one in `jitbuilder/release/include`. This is a **controversial decision** as we've no had headers at that level before. The header exports a simple interface that I think most compilers might be able to meet, _but_ OpenJ9 may be a challenge.~
* Changes from `JitBuilderCompiler`, to `DefaultCompiler`, but interestingly, since both the test compiler and JitBuilder can meet the `Jit.hpp` interface, this allows us to create a concrete backend that's shared called `SimpleCompiler.` To use Tril with another backend one could connect up that backend by modifying Default.hpp. 