### PR TITLE
Correct allocator types

### DIFF
--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -438,7 +438,7 @@ OMR::CodeGenPhase::performSetupForInstructionSelectionPhase(TR::CodeGenerator * 
 
       auto mapAllocator = getTypedAllocator<std::pair<TR::TreeTop*, TR::TreeTop*> >(comp->allocator());
 
-      std::map<TR::TreeTop*, TR::TreeTop*, std::less<TR::TreeTop*>, TR::typed_allocator<std::pair<TR::TreeTop*, TR::TreeTop*>, TR::Allocator> >
+      std::map<TR::TreeTop*, TR::TreeTop*, std::less<TR::TreeTop*>, TR::typed_allocator<std::pair<TR::TreeTop* const, TR::TreeTop*>, TR::Allocator> >
          currentTreeTopToappendTreeTop(std::less<TR::TreeTop*> (), mapAllocator);
 
       TR_BitVector *unAnchorableAloadiNodes = comp->getBitVectorPool().get();

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -243,7 +243,7 @@ enum MonitorInBlock
 class TR_SetMonitorStateOnBlockEntry
    {
 public:
-   typedef TR::typed_allocator<std::pair<int32_t , TR_Stack<TR::SymbolReference *>*>, TR::Region&> LiveMonitorStacksAllocator;
+   typedef TR::typed_allocator<std::pair<int32_t const, TR_Stack<TR::SymbolReference *>*>, TR::Region&> LiveMonitorStacksAllocator;
    typedef std::less<int32_t> LiveMonitorStacksComparator;
    typedef std::map<int32_t, TR_Stack<TR::SymbolReference *>*, LiveMonitorStacksComparator, LiveMonitorStacksAllocator> LiveMonitorStacks;
    TR_SetMonitorStateOnBlockEntry(TR::Compilation * c, LiveMonitorStacks *liveMonitorStacks)

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -503,7 +503,7 @@ class SymbolReferenceTable
    SymrefsByOwningMethodAndString      _methodsBySignature;
 
    // Aliasmap is keyed by a symbol reference's reference number
-   typedef TR::typed_allocator<std::pair<int32_t, TR_BitVector *>, TR::Allocator> AliasMapAllocator;
+   typedef TR::typed_allocator<std::pair<int32_t const, TR_BitVector * >, TR::Allocator> AliasMapAllocator;
    typedef std::map<int32_t, TR_BitVector *, std::less<int32_t>, AliasMapAllocator> AliasMap;
    AliasMap                            *_sharedAliasMap;
 

--- a/compiler/ilgen/MethodBuilder.hpp
+++ b/compiler/ilgen/MethodBuilder.hpp
@@ -190,21 +190,21 @@ class MethodBuilder : public TR::IlBuilder
 
    typedef bool (*StrComparator)(const char *, const char*);
 
-   typedef TR::typed_allocator<std::pair<const char *, TR::SymbolReference *>, TR::Region &> SymbolMapAllocator;
+   typedef TR::typed_allocator<std::pair<const char * const, TR::SymbolReference *>, TR::Region &> SymbolMapAllocator;
    typedef std::map<const char *, TR::SymbolReference *, StrComparator, SymbolMapAllocator> SymbolMap;
 
    // This map should only be accessed inside a compilation via lookupSymbol
    SymbolMap                   _symbols;
 
-   typedef TR::typed_allocator<std::pair<const char *, int32_t>, TR::Region &> ParameterMapAllocator;
+   typedef TR::typed_allocator<std::pair<const char * const, int32_t>, TR::Region &> ParameterMapAllocator;
    typedef std::map<const char *, int32_t, StrComparator, ParameterMapAllocator> ParameterMap;
    ParameterMap                _parameterSlot;
 
-   typedef TR::typed_allocator<std::pair<const char *, TR::IlType *>, TR::Region &> SymbolTypeMapAllocator;
+   typedef TR::typed_allocator<std::pair<const char * const, TR::IlType *>, TR::Region &> SymbolTypeMapAllocator;
    typedef std::map<const char *, TR::IlType *, StrComparator, SymbolTypeMapAllocator> SymbolTypeMap;
    SymbolTypeMap               _symbolTypes;
 
-   typedef TR::typed_allocator<std::pair<int32_t, const char *>, TR::Region &> SlotToSymNameMapAllocator;
+   typedef TR::typed_allocator<std::pair<int32_t const, const char *>, TR::Region &> SlotToSymNameMapAllocator;
    typedef std::map<int32_t, const char *, std::less<int32_t>, SlotToSymNameMapAllocator> SlotToSymNameMap;
    SlotToSymNameMap            _symbolNameFromSlot;
    
@@ -214,11 +214,11 @@ class MethodBuilder : public TR::IlBuilder
    // This set acts as an identifier for symbols which correspond to arrays
    ArrayIdentifierSet          _symbolIsArray;
 
-   typedef TR::typed_allocator<std::pair<const char *, void *>, TR::Region &> MemoryLocationMapAllocator;
+   typedef TR::typed_allocator<std::pair<const char * const, void *>, TR::Region &> MemoryLocationMapAllocator;
    typedef std::map<const char *, void *, StrComparator, MemoryLocationMapAllocator> MemoryLocationMap;
    MemoryLocationMap           _memoryLocations;
 
-   typedef TR::typed_allocator<std::pair<const char *, TR::ResolvedMethod *>, TR::Region &> FunctionMapAllocator;
+   typedef TR::typed_allocator<std::pair<const char * const, TR::ResolvedMethod *>, TR::Region &> FunctionMapAllocator;
    typedef std::map<const char *, TR::ResolvedMethod *, StrComparator, FunctionMapAllocator> FunctionMap;
    FunctionMap                 _functions;
 

--- a/compiler/ilgen/TypeDictionary.hpp
+++ b/compiler/ilgen/TypeDictionary.hpp
@@ -426,11 +426,11 @@ protected:
 
    typedef bool (*StrComparator)(const char *, const char *);
 
-   typedef TR::typed_allocator<std::pair<const char *, OMR::StructType *>, TR::Region &> StructMapAllocator;
+   typedef TR::typed_allocator<std::pair<const char * const, OMR::StructType *>, TR::Region &> StructMapAllocator;
    typedef std::map<const char *, OMR::StructType *, StrComparator, StructMapAllocator> StructMap;
    StructMap          _structsByName;
 
-   typedef TR::typed_allocator<std::pair<const char *, OMR::UnionType *>, TR::Region &> UnionMapAllocator;
+   typedef TR::typed_allocator<std::pair<const char * const, OMR::UnionType *>, TR::Region &> UnionMapAllocator;
    typedef std::map<const char *, OMR::UnionType *, StrComparator, UnionMapAllocator> UnionMap;
    UnionMap           _unionsByName;
 

--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -1388,7 +1388,7 @@ void OMR::CFG::findLoopingBlocks(TR_BitVector &loopingBlocks)
    int32_t numberOfBlocks = getNextNodeNumber();
    TR::deque<int32_t, TR::Region&> seenIndex(numberOfBlocks, workingSpace);
    TR::deque<TR::Block *, TR::Region&> stack(numberOfBlocks, workingSpace);
-   typedef TR::typed_allocator<std::pair<int32_t, LoopInfo*>, TR::Region&> LoopMapAllocator;
+   typedef TR::typed_allocator<std::pair<int32_t const, LoopInfo*>, TR::Region&> LoopMapAllocator;
    typedef std::less<int32_t> LoopMapComparator;
    typedef std::map<int32_t, LoopInfo*, LoopMapComparator, LoopMapAllocator> LoopMap;
    LoopMap loops((LoopMapComparator()), LoopMapAllocator(workingSpace));

--- a/compiler/optimizer/CopyPropagation.cpp
+++ b/compiler/optimizer/CopyPropagation.cpp
@@ -466,7 +466,7 @@ int32_t TR_CopyPropagation::perform()
    int32_t lastDefIndex      = useDefInfo->getLastDefIndex();
    int32_t numDefNodes       = lastDefIndex - firstRealDefIndex + 1;
 
-   typedef TR::typed_allocator<std::pair<int32_t, int32_t>, TR::Region&> UDMapAllocator;
+   typedef TR::typed_allocator<std::pair<int32_t const, int32_t>, TR::Region&> UDMapAllocator;
    typedef std::less<int32_t> UDMapComparator;
    typedef std::map<int32_t, int32_t, UDMapComparator, UDMapAllocator> UsesToBeFixedMap;
    typedef std::map<int32_t, int32_t, UDMapComparator, UDMapAllocator> EquivalentDefMap;
@@ -474,7 +474,7 @@ int32_t TR_CopyPropagation::perform()
    UsesToBeFixedMap usesToBeFixed((UDMapComparator()), UDMapAllocator(trMemory()->currentStackRegion()));
    EquivalentDefMap equivalentDefs((UDMapComparator()), UDMapAllocator(trMemory()->currentStackRegion()));
 
-   typedef TR::typed_allocator<std::pair<TR::Node*, TR::deque<TR::Node*, TR::Region&>*>, TR::Region&> StoreNodeMapAllocator;
+   typedef TR::typed_allocator<std::pair<TR::Node* const, TR::deque<TR::Node*, TR::Region&>*>, TR::Region&> StoreNodeMapAllocator;
    typedef std::less<TR::Node*> StoreNodeMapComparator;
    typedef std::map<TR::Node*, TR::deque<TR::Node*, TR::Region&>*, StoreNodeMapComparator, StoreNodeMapAllocator> StoreNodeMap;
 

--- a/compiler/optimizer/CopyPropagation.hpp
+++ b/compiler/optimizer/CopyPropagation.hpp
@@ -107,12 +107,12 @@ class TR_CopyPropagation : public TR::Optimization
    TR::TreeTop *_storeTree;
    TR::TreeTop *_useTree;
 
-   typedef TR::typed_allocator<std::pair<TR::Node*, TR::TreeTop*>, TR::Region&> StoreTreeMapAllocator;
+   typedef TR::typed_allocator<std::pair<TR::Node* const, TR::TreeTop*>, TR::Region&> StoreTreeMapAllocator;
    typedef std::less<TR::Node*> StoreTreeMapComparator;
    typedef std::map<TR::Node *, TR::TreeTop *, StoreTreeMapComparator, StoreTreeMapAllocator> StoreTreeMap;
    StoreTreeMap _storeTreeTops;
 
-   typedef TR::typed_allocator<std::pair<TR::Node*, TR::TreeTop*>, TR::Region&> UseTreeMapAllocator;
+   typedef TR::typed_allocator<std::pair<TR::Node* const, TR::TreeTop*>, TR::Region&> UseTreeMapAllocator;
    typedef std::less<TR::Node*> UseTreeMapComparator;
    typedef std::map<TR::Node*, TR::TreeTop*, UseTreeMapComparator, UseTreeMapAllocator> UseTreeMap;
    UseTreeMap _useTreeTops;

--- a/compiler/optimizer/DeadTreesElimination.cpp
+++ b/compiler/optimizer/DeadTreesElimination.cpp
@@ -212,7 +212,7 @@ static int32_t getLongestPathOfDAG(TR::Node *entry, TR::Compilation *cm)
    {
    TR::StackMemoryRegion stackMemoryRegion(*cm->trMemory());
    TR::deque<TR::Node *, TR::Region&> queue(stackMemoryRegion);
-   typedef TR::typed_allocator<std::pair<TR::Node *, int32_t>, TR::Region&> LongestPathAllocator;
+   typedef TR::typed_allocator<std::pair<TR::Node * const, int32_t>, TR::Region&> LongestPathAllocator;
    typedef std::less<TR::Node *> LongestPathComparator;
    typedef std::map<TR::Node *, int32_t, LongestPathComparator, LongestPathAllocator> LongestPathMap;
    LongestPathMap longestPathLens((LongestPathComparator()), stackMemoryRegion);

--- a/compiler/optimizer/GlobalRegisterAllocator.hpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.hpp
@@ -100,7 +100,7 @@ class TR_LiveRangeSplitter : public TR::Optimization
    virtual int32_t perform();
    virtual const char * optDetailString() const throw();
 
-   typedef TR::typed_allocator<std::pair<uint32_t, TR_RegisterCandidate*>, TR::Region&> SymRefCandidateMapAllocator;
+   typedef TR::typed_allocator<std::pair<uint32_t const, TR_RegisterCandidate*>, TR::Region&> SymRefCandidateMapAllocator;
    typedef std::less<uint32_t> SymRefCandidateMapComparator;
    typedef std::map<uint32_t, TR_RegisterCandidate*, SymRefCandidateMapComparator, SymRefCandidateMapAllocator> SymRefCandidateMap;
 
@@ -177,7 +177,7 @@ public:
    TR::Node *           resolveTypeMismatch(TR::DataType inputOldType, TR::Node *oldNode, TR::Node *newNode);
 
 private:
-   typedef TR::typed_allocator<std::pair<uint32_t, TR_RegisterCandidate*>, TR::Region&> SymRefCandidateMapAllocator;
+   typedef TR::typed_allocator<std::pair<uint32_t const, TR_RegisterCandidate*>, TR::Region&> SymRefCandidateMapAllocator;
    typedef std::less<uint32_t> SymRefCandidateMapComparator;
    typedef std::map<uint32_t, TR_RegisterCandidate*, SymRefCandidateMapComparator, SymRefCandidateMapAllocator> SymRefCandidateMap;
 

--- a/compiler/optimizer/InductionVariable.hpp
+++ b/compiler/optimizer/InductionVariable.hpp
@@ -189,7 +189,7 @@ class TR_LoopStrider : public TR_LoopTransformer
 
    // Maps are keyed by a node's global index, because a node's address could
    // be reused after its reference count decreases to zero.
-   typedef TR::typed_allocator<std::pair<ncount_t, SignExtEntry>, TR::Allocator> SignExtMemoAllocator;
+   typedef TR::typed_allocator<std::pair<ncount_t const, SignExtEntry>, TR::Allocator> SignExtMemoAllocator;
    typedef std::map<ncount_t, SignExtEntry, std::less<ncount_t>, SignExtMemoAllocator> SignExtMemo;
 
    void morphExpressionsLinearInInductionVariable(TR_Structure *, vcount_t);
@@ -305,14 +305,14 @@ class TR_LoopStrider : public TR_LoopTransformer
    int64_t **_linearEquations;
    TR::Node **_loadUsedInNewLoopIncrement;
 
-   typedef TR::typed_allocator<std::pair<uint32_t, TR::SymbolReference*>, TR::Region&> SymRefMapAllocator;
+   typedef TR::typed_allocator<std::pair<uint32_t const, TR::SymbolReference*>, TR::Region&> SymRefMapAllocator;
    typedef std::less<uint32_t> SymRefMapComparator;
    typedef std::map<uint32_t, TR::SymbolReference*, SymRefMapComparator, SymRefMapAllocator> SymRefMap;
    SymRefMap *_reassociatedAutos;
 
    List<TR::Node> _reassociatedNodes;
 
-   typedef TR::typed_allocator<std::pair<uint32_t, List<TR_StoreTreeInfo> *>, TR::Region&> StoreTreeMapAllocator;
+   typedef TR::typed_allocator<std::pair<uint32_t const, List<TR_StoreTreeInfo> *>, TR::Region&> StoreTreeMapAllocator;
    typedef std::less<uint32_t> StoreTreeMapComparator;
    typedef std::map<uint32_t, List<TR_StoreTreeInfo>*, StoreTreeMapComparator, StoreTreeMapAllocator> StoreTreeMap;
    StoreTreeMap  _storeTreesSingleton;
@@ -321,7 +321,7 @@ class TR_LoopStrider : public TR_LoopTransformer
 
    int32_t _numSymRefs;
 
-   typedef TR::typed_allocator<std::pair<uint32_t, SymRefPair*>, TR::Region&> SymRefPairMapAllocator;
+   typedef TR::typed_allocator<std::pair<uint32_t const, SymRefPair*>, TR::Region&> SymRefPairMapAllocator;
    typedef std::less<uint32_t> SymRefPairMapComparator;
    typedef std::map<uint32_t, SymRefPair*, SymRefPairMapComparator, SymRefPairMapAllocator> SymRefPairMap;
    SymRefPairMap *_hoistedAutos;

--- a/compiler/optimizer/OMRLocalCSE.hpp
+++ b/compiler/optimizer/OMRLocalCSE.hpp
@@ -141,7 +141,7 @@ class LocalCSE : public TR::Optimization
    TR::Node *getNode(TR::Node *node);
 
    TR::TreeTop *_treeBeingExamined;
-   typedef TR::typed_allocator<std::pair<uint32_t, TR::Node*>, TR::Region&> StoreMapAllocator;
+   typedef TR::typed_allocator<std::pair<uint32_t const, TR::Node*>, TR::Region&> StoreMapAllocator;
    typedef std::less<uint32_t> StoreMapComparator;
    typedef std::map<uint32_t, TR::Node*, StoreMapComparator, StoreMapAllocator> StoreMap;
    StoreMap *_storeMap;

--- a/compiler/optimizer/RegisterCandidate.hpp
+++ b/compiler/optimizer/RegisterCandidate.hpp
@@ -76,7 +76,7 @@ private:
 
    TR::Region &_region;
    TR_BitVector _empty;
-   typedef TR::typed_allocator<std::pair<uint32_t, TR_BitVector*>, TR::Region&> RefMapAllocator;
+   typedef TR::typed_allocator<std::pair<uint32_t const, TR_BitVector*>, TR::Region&> RefMapAllocator;
    typedef std::less<uint32_t> RefMapComparator;
    typedef std::map<uint32_t, TR_BitVector*, RefMapComparator, RefMapAllocator> RefMap;
    RefMap _refAutosPerBlock;
@@ -100,7 +100,7 @@ public:
    TR_RegisterCandidate(TR::SymbolReference *, TR::Region &r);
 
    class BlockInfo {
-     typedef TR::typed_allocator<std::pair<uint32_t, uint32_t>, TR::Region &> InfoMapAllocator;
+     typedef TR::typed_allocator<std::pair<uint32_t const, uint32_t>, TR::Region &> InfoMapAllocator;
      typedef std::less<uint32_t> InfoMapComparator;
      typedef std::map<uint32_t, uint32_t, InfoMapComparator, InfoMapAllocator> InfoMap;
      InfoMap _blockMap;
@@ -377,7 +377,7 @@ private:
    static int32_t                    _candidateTypeWeights[TR_NumRegisterCandidateTypes];
    TR::GlobalSet            *_referencedAutoSymRefsInBlock;
 
-   typedef TR::typed_allocator<std::pair<uint32_t, TR_RegisterCandidate*>, TR::Region&> SymRefCandidateMapAllocator;
+   typedef TR::typed_allocator<std::pair<uint32_t const, TR_RegisterCandidate*>, TR::Region&> SymRefCandidateMapAllocator;
    typedef std::less<uint32_t> SymRefCandidateMapComparator;
    typedef std::map<uint32_t, TR_RegisterCandidate*, SymRefCandidateMapComparator, SymRefCandidateMapAllocator> SymRefCandidateMap;
 
@@ -405,11 +405,11 @@ public:
      uint32_t first, last;
    };
 
-   typedef TR::typed_allocator<std::pair<int32_t, struct coordinates>, TR::Region &> CoordinatesAllocator;
+   typedef TR::typed_allocator<std::pair<int32_t const, struct coordinates>, TR::Region &> CoordinatesAllocator;
    typedef std::less<int32_t> CoordinatesComparator;
    typedef std::map<int32_t, struct coordinates, CoordinatesComparator, CoordinatesAllocator> Coordinates;
 
-   typedef TR::typed_allocator<std::pair<uint32_t, Coordinates *>, TR::Region &> ReferenceTableAllocator;
+   typedef TR::typed_allocator<std::pair<uint32_t const, Coordinates *>, TR::Region &> ReferenceTableAllocator;
    typedef std::less<uint32_t> ReferenceTableComparator;
    typedef std::map<uint32_t, Coordinates *, ReferenceTableComparator, ReferenceTableAllocator> ReferenceTable;
 private:


### PR DESCRIPTION
The allocator types were missing consts, however, only recently did
compilers start checking this (see #1707 for details).

Signed-off-by: Matthew Gaudet <magaudet@ca.ibm.com>