### PR TITLE
Cleanup logics related to SSE availability check 

### DIFF
--- a/compiler/env/FEBase.cpp
+++ b/compiler/env/FEBase.cpp
@@ -136,9 +136,6 @@ portLib_get390zLinuxMachineType()
 //  .o8"'88b   `8.   .88P `Y88   88P
 // o88'   888o  `boood8'   `88bod8'
 
-#if defined(TR_HOST_X86)
-extern "C" bool jitTestOSForSSESupport(void);
-#endif
 
 
 //                    o8o
@@ -273,10 +270,6 @@ void TR_LinkageInfo::setHasFailedRecompilation()
 // S390 specific fucntion - FIXME: make this only be a problem when HOST is s390.  Also, use a better
 // name for this
 void setDllSlip(char*CodeStart,char*CodeEnd,char*dllName,  TR::Compilation *comp) { notImplemented("setDllSlip"); }
-
-// X86 specific functions
-extern "C" bool jitTestOSForSSESupport(void) { return false; } // TODO there are some signal handling peculiarities on x86-32 linux
-
 
 // runtime assumptions
 #ifdef J9_PROJECT_SPECIFIC

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -101,8 +101,6 @@
 namespace OMR { class RegisterUsage; }
 namespace TR { class RegisterDependencyConditions; }
 
-extern "C" bool jitTestOSForSSESupport(void);
-
 // Hack markers
 #define CANT_REMATERIALIZE_ADDRESSES (TR::Compiler->target.is64Bit()) // AMD64 produces a memref with an unassigned addressRegister
 
@@ -227,7 +225,7 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
    //
 
 #if defined(TR_TARGET_X86) && !defined(J9HAMMER)
-   if (_targetProcessorInfo.supportsSSE2() && TR::Compiler->target.cpu.getX86OSSupportsSSE2(comp))
+   if (_targetProcessorInfo.supportsSSE2() && TR::Compiler->target.cpu.testOSForSSESupport(comp))
       supportsSSE2 = true;
 #endif // defined(TR_TARGET_X86) && !defined(J9HAMMER)
 
@@ -281,7 +279,7 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
    // 32-bit platforms must check the processor and OS.
    // 64-bit platforms unconditionally support prefetching.
    //
-   if (_targetProcessorInfo.supportsSSE() && jitTestOSForSSESupport())
+   if (_targetProcessorInfo.supportsSSE() && TR::Compiler->target.cpu.testOSForSSESupport(comp))
 #endif // defined(TR_TARGET_X86) && !defined(J9HAMMER)
       {
       self()->setTargetSupportsSoftwarePrefetches();

--- a/compiler/x/env/OMRCPU.cpp
+++ b/compiler/x/env/OMRCPU.cpp
@@ -116,39 +116,3 @@ OMR::X86::CPU::testOSForSSESupport(TR::Compilation *comp)
    {
    return false;
    }
-
-bool
-OMR::X86::CPU::getX86OSSupportsSSE(TR::Compilation *comp)
-   {
-   // If the FXSR (bit 24) and SSE (bit 25) bits in the feature flags are not set, SSE is unavailable
-   // on this processor.
-   //
-   uint32_t flags = self()->getX86ProcessorFeatureFlags(comp);
-
-   if ((flags & 0x03000000) != 0x03000000)
-      return false;
-
-   return self()->testOSForSSESupport(comp);
-   }
-
-bool
-OMR::X86::CPU::getX86OSSupportsSSE2(TR::Compilation *comp)
-   {
-   // If the FXSR (bit 24) and SSE2 (bit 26) bits in the feature flags are not set, SSE is unavailable
-   // on this processor.
-   //
-   uint32_t flags = self()->getX86ProcessorFeatureFlags(comp);
-   if ((flags & 0x05000000) != 0x05000000)
-      return false;
-
-   return self()->testOSForSSESupport(comp);
-   }
-
-bool
-OMR::X86::CPU::getX86SupportsTM(TR::Compilation *comp)
-   {
-   uint32_t flags8 = self()->getX86ProcessorFeatureFlags8(comp);
-   if ((flags8 & TR_RTM) != 0x00000000)
-         return true;
-   else return false;
-   }

--- a/compiler/x/env/OMRCPU.hpp
+++ b/compiler/x/env/OMRCPU.hpp
@@ -62,9 +62,6 @@ public:
    uint32_t getX86ProcessorFeatureFlags8(TR::Compilation *comp);
 
    bool testOSForSSESupport(TR::Compilation *comp);
-   bool getX86OSSupportsSSE(TR::Compilation *comp);
-   bool getX86OSSupportsSSE2(TR::Compilation *comp);
-   bool getX86SupportsTM(TR::Compilation *comp);
 
    };
 


### PR DESCRIPTION
1. X86 CodeGen now properly checks testOSForSSESupport() from target.cpu.
2. Unused redundant helpers related to SSE check are deleted.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>