### PR TITLE
Avoid inflating frequencies in block splitter

### DIFF
--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -6390,8 +6390,12 @@ int32_t TR_BlockSplitter::perform()
          int16_t coldFreq = mergeNode->getFrequency() - hotFreq;
          if (hotFreq < splitPred->getFrequency())
             {
-            TR::DebugCounter::incStaticDebugCounter(comp(), TR::DebugCounter::debugCounterName(comp(), "blockSplitter.inconsistentFreqs/%s/(%s)/block_%d", comp()->getHotnessName(comp()->getMethodHotness()), comp()->signature(), mergeNode->getNumber()));
-            hotFreq = splitPred->getFrequency();
+            static const bool force = feGetEnv("TR_forceBlockSplitterFrequencyAdjustment") != NULL;
+            if (force || splitPred->getSuccessors().size() == 1)
+               {
+               TR::DebugCounter::incStaticDebugCounter(comp(), TR::DebugCounter::debugCounterName(comp(), "blockSplitter.inconsistentFreqs/%s/(%s)/block_%d", comp()->getHotnessName(comp()->getMethodHotness()), comp()->signature(), mergeNode->getNumber()));
+               hotFreq = splitPred->getFrequency();
+               }
             }
          int16_t hotEdgeFreq = splitPred_to_mergeNode_edge->getFrequency();
          int16_t coldEdgeFreq = (predEdgeFrequency - splitPred_to_mergeNode_edge->getFrequency()) / predEdgeFrequency;


### PR DESCRIPTION
When block splitter copies a merge block, it distributes some of the frequency of the original block to the copy, based on the proportion of the predecessors' total frequency belonging to the hot predecessor. A subsequent check raises the resulting frequency if necessary to ensure that it's no less than that of the predecessor, with a static debug counter suggesting that otherwise the frequencies would be inconsistent. However, when the predecessor branches, it's expected for the new block to be less frequent.

In particular, if the predecessor is in a loop not containing the merge block, the duplicate's frequency would be raised to match frequencies within the loop, interfering with proper layout of the loop.

This commit restricts the frequency adjustment to cases in which the predecessor does not branch, i.e. cases in which it really would restore consistency.