### PR TITLE
Fix compile failure related to PRId64

### DIFF
--- a/fvtest/sigtest/sigTest.cpp
+++ b/fvtest/sigtest/sigTest.cpp
@@ -25,6 +25,7 @@
 #endif /* defined(J9ZOS390) */
 
 #if !defined(WIN32)
+#define __STDC_FORMAT_MACROS
 #include <stdint.h>
 #include <inttypes.h>
 #include <pthread.h>
@@ -61,7 +62,11 @@ enum TestAction {
 };
 
 #if !defined(PRId64)
+#if defined(WIN32) || defined(J9ZOS390)
 #define PRId64 "I64d"
+#else
+#error no value for PRId64
+#endif
 #endif
 
 static jmp_buf env;


### PR DESCRIPTION
This resolves issues with compiling on RHEL 6 and ensures that the format macros are available.

The single format macro used in this file is known not to exist on older version of visual studio so it is defined in this file.  I updated the check to only define the macro for Windows and zOS and cause an error on other platforms so that we can find platforms that do not provide these specifiers.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>