### PR TITLE
Downgrade Tril's minimum compiler version

### DIFF
--- a/fvtest/compilertriltest/JitTest.hpp
+++ b/fvtest/compilertriltest/JitTest.hpp
@@ -25,10 +25,10 @@
 #include <gtest/gtest.h>
 #include "Jit.hpp"
 
-#define ASSERT_NULL(pointer) ASSERT_EQ(nullptr, (pointer))
-#define ASSERT_NOTNULL(pointer) ASSERT_TRUE(nullptr != (pointer))
-#define EXPECT_NULL(pointer) EXPECT_EQ(nullptr, (pointer))
-#define EXPECT_NOTNULL(pointer) EXPECT_TRUE(nullptr != (pointer))
+#define ASSERT_NULL(pointer) ASSERT_EQ(NULL, (pointer))
+#define ASSERT_NOTNULL(pointer) ASSERT_TRUE(NULL != (pointer))
+#define EXPECT_NULL(pointer) EXPECT_EQ(NULL, (pointer))
+#define EXPECT_NOTNULL(pointer) EXPECT_TRUE(NULL != (pointer))
 
 #define TRIL(code) #code
 

--- a/fvtest/compilertriltest/JitTestUtilitiesTest.cpp
+++ b/fvtest/compilertriltest/JitTestUtilitiesTest.cpp
@@ -24,7 +24,7 @@
 
 TEST(PtrTest, AssertNullWithNullValue)
    {
-   ASSERT_NULL(nullptr) << "This should always pass.";
+   ASSERT_NULL(NULL) << "This should always pass.";
    }
 
 TEST(PtrTest, AssertNotNullWithNonNullValue)
@@ -39,12 +39,12 @@ TEST(PtrTest, AssertNullWithNonNullValue)
 
 TEST(PtrTest, AssertNotNullWithNullValue)
    {
-   EXPECT_FATAL_FAILURE(ASSERT_NOTNULL(nullptr), "");
+   EXPECT_FATAL_FAILURE(ASSERT_NOTNULL(NULL), "");
    }
 
 TEST(PtrTest, ExpectNullWithNullValue)
    {
-   EXPECT_NULL(nullptr) << "This should always pass.";
+   EXPECT_NULL(NULL) << "This should always pass.";
    }
 
 TEST(PtrTest, ExpectNotNullWithNonNullValue)
@@ -59,7 +59,7 @@ TEST(PtrTest, ExpectNullWithNonNullValue)
 
 TEST(PtrTest, ExpectNotNullWithNullValue)
    {
-   EXPECT_NONFATAL_FAILURE(EXPECT_NOTNULL(nullptr), "");
+   EXPECT_NONFATAL_FAILURE(EXPECT_NOTNULL(NULL), "");
    }
 
 TEST(TRTestCombineVectorTest, CombineEmptyVectorsOfSameType)

--- a/fvtest/tril/examples/mandelbrot/main.cpp
+++ b/fvtest/tril/examples/mandelbrot/main.cpp
@@ -25,7 +25,7 @@
 #include <assert.h>
 #include <stdio.h>
 
-using MandelbrotFunction = void(int32_t, int32_t, int32_t*);
+typedef void (MandelbrotFunction) (int32_t, int32_t, int32_t*);
 
 int main(int argc, char const * const * const argv) {
     assert(argc == 2);
@@ -33,7 +33,7 @@ int main(int argc, char const * const * const argv) {
 
     // parse the input Tril file
     FILE* inputFile = fopen(argv[1], "r");
-    assert(inputFile != nullptr);
+    assert(inputFile != NULL);
     ASTNode* trees = parseFile(inputFile);
     fclose(inputFile);
 
@@ -45,8 +45,8 @@ int main(int argc, char const * const * const argv) {
     assert(mandelbrotCompiler.compile() == 0);
     auto mandelbrot = mandelbrotCompiler.getEntryPoint<MandelbrotFunction*>();
 
-    constexpr auto size = 80;                   // number of rows/columns in the output table
-    constexpr auto iterations = 1000;           // number of iterations to be performed
+    const auto size = 80;                   // number of rows/columns in the output table
+    const auto iterations = 1000;           // number of iterations to be performed
     int32_t table[size][size] = {{0}};          // the output table
 
     mandelbrot(iterations, size, &table[0][0]);

--- a/fvtest/tril/test/ASTTest.cpp
+++ b/fvtest/tril/test/ASTTest.cpp
@@ -332,7 +332,7 @@ TEST(ASTNodeArgumentTest, CreateListFrom3SingleArguments) {
 TEST(ASTNodeArgumentTest, CompareArgumentsWithSelf) {
     auto v = createIntegerValue(10);
     auto name = "arg0";
-    auto arg = createNodeArg(name, v, nullptr);
+    auto arg = createNodeArg(name, v, NULL);
 
     ASSERT_TRUE(*arg == *arg);
     ASSERT_FALSE(*arg != *arg);
@@ -343,8 +343,8 @@ TEST(ASTNodeArgumentTest, CompareEqualArguments) {
     auto v1 = createIntegerValue(10);
     auto name0 = "arg0";
     auto name1 = "arg0";
-    auto arg0 = createNodeArg(name0, v0, nullptr);
-    auto arg1 = createNodeArg(name1, v1, nullptr);
+    auto arg0 = createNodeArg(name0, v0, NULL);
+    auto arg1 = createNodeArg(name1, v1, NULL);
 
     ASSERT_TRUE(*arg0 == *arg1);
     ASSERT_FALSE(*arg0 != *arg1);
@@ -355,8 +355,8 @@ TEST(ASTNodeArgumentTest, CompareArgumentsWithDifferentNames) {
     auto v1 = createIntegerValue(10);
     auto name0 = "arg0";
     auto name1 = "arg1";
-    auto arg0 = createNodeArg(name0, v0, nullptr);
-    auto arg1 = createNodeArg(name1, v1, nullptr);
+    auto arg0 = createNodeArg(name0, v0, NULL);
+    auto arg1 = createNodeArg(name1, v1, NULL);
 
     ASSERT_TRUE(*arg0 != *arg1);
     ASSERT_FALSE(*arg0 == *arg1);
@@ -367,8 +367,8 @@ TEST(ASTNodeArgumentTest, CompareArgumentsWithDifferentValues) {
     auto v1 = createIntegerValue(14);
     auto name0 = "arg0";
     auto name1 = "arg0";
-    auto arg0 = createNodeArg(name0, v0, nullptr);
-    auto arg1 = createNodeArg(name1, v1, nullptr);
+    auto arg0 = createNodeArg(name0, v0, NULL);
+    auto arg1 = createNodeArg(name1, v1, NULL);
 
     ASSERT_TRUE(*arg0 != *arg1);
     ASSERT_FALSE(*arg0 == *arg1);
@@ -379,8 +379,8 @@ TEST(ASTNodeArgumentTest, CompareArgumentsWithDifferentTypes) {
     auto v1 = createFloatingPointValue(10.0);
     auto name0 = "arg0";
     auto name1 = "arg0";
-    auto arg0 = createNodeArg(name0, v0, nullptr);
-    auto arg1 = createNodeArg(name1, v1, nullptr);
+    auto arg0 = createNodeArg(name0, v0, NULL);
+    auto arg1 = createNodeArg(name1, v1, NULL);
 
     ASSERT_TRUE(*arg0 != *arg1);
     ASSERT_FALSE(*arg0 == *arg1);
@@ -540,17 +540,17 @@ TEST(ASTNodeTest, Concatenate3SingleNodes)  {
 }
 
 ASTNodeArg* getMixedArgumentList() {
-   auto argList = createNodeArg("arg0", createIntegerValue(3), nullptr);
-   appendSiblingArg(argList, createNodeArg("", createStrValue("value1"), nullptr));
-   appendSiblingArg(argList, createNodeArg("arg1", createFloatingPointValue(5.4), nullptr));
-   appendSiblingArg(argList, createNodeArg("", createStrValue("value3"), nullptr));
+   auto argList = createNodeArg("arg0", createIntegerValue(3), NULL);
+   appendSiblingArg(argList, createNodeArg("", createStrValue("value1"), NULL));
+   appendSiblingArg(argList, createNodeArg("arg1", createFloatingPointValue(5.4), NULL));
+   appendSiblingArg(argList, createNodeArg("", createStrValue("value3"), NULL));
 
    return argList;
 }
 
 TEST(ASTNodeTest, GetArgsTest) {
    auto argList = getMixedArgumentList();
-   auto node = createNode("testNode", argList, nullptr, nullptr);
+   auto node = createNode("testNode", argList, NULL, NULL);
 
    auto arg = node->getArgs();
    ASSERT_EQ(*argList, *arg);
@@ -567,7 +567,7 @@ TEST(ASTNodeTest, GetArgsTest) {
 
 TEST(ASTNodeTest, GetFirstArgumentTest) {
    auto argList = getMixedArgumentList();
-   auto node = createNode("testNode", argList, nullptr, nullptr);
+   auto node = createNode("testNode", argList, NULL, NULL);
 
    auto arg = node->getArgument(0);
    ASSERT_EQ(*argList, *arg);
@@ -575,7 +575,7 @@ TEST(ASTNodeTest, GetFirstArgumentTest) {
 
 TEST(ASTNodeTest, GetThirdArgumentTest) {
    auto argList = getMixedArgumentList();
-   auto node = createNode("testNode", argList, nullptr, nullptr);
+   auto node = createNode("testNode", argList, NULL, NULL);
 
    auto arg = node->getArgument(2);
    argList = argList->next->next;
@@ -584,7 +584,7 @@ TEST(ASTNodeTest, GetThirdArgumentTest) {
 
 TEST(ASTNodeTest, GetFirstPositionalArgumentTest) {
    auto argList = getMixedArgumentList();
-   auto node = createNode("testNode", argList, nullptr, nullptr);
+   auto node = createNode("testNode", argList, NULL, NULL);
 
    auto arg = node->getPositionalArg(0);
    argList = argList->next;
@@ -593,7 +593,7 @@ TEST(ASTNodeTest, GetFirstPositionalArgumentTest) {
 
 TEST(ASTNodeTest, GetSecondPositionalArgumentTest) {
    auto argList = getMixedArgumentList();
-   auto node = createNode("testNode", argList, nullptr, nullptr);
+   auto node = createNode("testNode", argList, NULL, NULL);
 
    auto arg = node->getPositionalArg(1);
    argList = argList->next->next->next;
@@ -602,7 +602,7 @@ TEST(ASTNodeTest, GetSecondPositionalArgumentTest) {
 
 TEST(ASTNodeTest, GetFirstNamedArgumentTest) {
    auto argList = getMixedArgumentList();
-   auto node = createNode("testNode", argList, nullptr, nullptr);
+   auto node = createNode("testNode", argList, NULL, NULL);
 
    auto arg = node->getArgByName("arg0");
    ASSERT_EQ(*argList, *arg);
@@ -610,7 +610,7 @@ TEST(ASTNodeTest, GetFirstNamedArgumentTest) {
 
 TEST(ASTNodeTest, GetSecondNamedArgumentTest) {
    auto argList = getMixedArgumentList();
-   auto node = createNode("testNode", argList, nullptr, nullptr);
+   auto node = createNode("testNode", argList, NULL, NULL);
 
    auto arg = node->getArgByName("arg1");
    argList = argList->next->next;

--- a/fvtest/tril/test/CompileTest.cpp
+++ b/fvtest/tril/test/CompileTest.cpp
@@ -24,8 +24,8 @@
 #include "ras/IlVerifier.hpp"
 #include "ras/IlVerifierHelpers.hpp"
 
-#define ASSERT_NULL(pointer) ASSERT_EQ(nullptr, (pointer))
-#define ASSERT_NOTNULL(pointer) ASSERT_TRUE(nullptr != (pointer))
+#define ASSERT_NULL(pointer) ASSERT_EQ(NULL, (pointer))
+#define ASSERT_NOTNULL(pointer) ASSERT_TRUE(NULL != (pointer))
 
 class CompileTest : public Tril::Test::JitTest {};
 
@@ -50,7 +50,7 @@ TEST_F(CompileTest, NoCodeGen) {
     ASSERT_NOTNULL(trees);
 
     Tril::JitBuilderCompiler compiler{trees};
-    TR::NoCodegenVerifier verifier{nullptr}; 
+    TR::NoCodegenVerifier verifier{NULL}; 
 
     EXPECT_NE(0, compiler.compileWithVerifier(&verifier)) << "Compilation succeeded";
 

--- a/fvtest/tril/test/IlGenTest.cpp
+++ b/fvtest/tril/test/IlGenTest.cpp
@@ -36,8 +36,8 @@
 #include "Jit.hpp"
 #include "ilgen/IlGeneratorMethodDetails_inlines.hpp"
 
-#define ASSERT_NULL(pointer) ASSERT_EQ(nullptr, (pointer))
-#define ASSERT_NOTNULL(pointer) ASSERT_TRUE(nullptr != (pointer))
+#define ASSERT_NULL(pointer) ASSERT_EQ(NULL, (pointer))
+#define ASSERT_NOTNULL(pointer) ASSERT_TRUE(NULL != (pointer))
 
 class IlGenTest : public Tril::Test::JitTest {};
 

--- a/fvtest/tril/test/MethodInfoTest.cpp
+++ b/fvtest/tril/test/MethodInfoTest.cpp
@@ -22,8 +22,8 @@
 #include "JitTest.hpp"
 #include "method_info.hpp"
 
-#define ASSERT_NULL(pointer) ASSERT_EQ(nullptr, (pointer))
-#define ASSERT_NOTNULL(pointer) ASSERT_TRUE(nullptr != (pointer))
+#define ASSERT_NULL(pointer) ASSERT_EQ(NULL, (pointer))
+#define ASSERT_NOTNULL(pointer) ASSERT_TRUE(NULL != (pointer))
 
 TEST(MethodInfoTest, EmptyMethod) {
     auto methodAST = parseString("(method return=\"NoType\")");

--- a/fvtest/tril/test/ParserTest.cpp
+++ b/fvtest/tril/test/ParserTest.cpp
@@ -23,8 +23,8 @@
 
 #include "ast.hpp"
 
-#define ASSERT_NULL(pointer) ASSERT_EQ(nullptr, (pointer))
-#define ASSERT_NOTNULL(pointer) ASSERT_TRUE(nullptr != (pointer))
+#define ASSERT_NULL(pointer) ASSERT_EQ(NULL, (pointer))
+#define ASSERT_NOTNULL(pointer) ASSERT_TRUE(NULL != (pointer))
 
 
 typedef std::pair<const char *, const char *> TestParamWithExpectedResultString;

--- a/fvtest/tril/tril/ast.cpp
+++ b/fvtest/tril/tril/ast.cpp
@@ -156,13 +156,13 @@ bool operator == (const ASTNodeArg& lhs, const ASTNodeArg& rhs) {
     auto lhsValue = lhs.getValue();
     auto rhsValue = rhs.getValue();
 
-    while (lhsValue != nullptr && rhsValue != nullptr) {
+    while (lhsValue != NULL && rhsValue != NULL) {
         if (*lhsValue != *rhsValue) return false;
         lhsValue = lhsValue->next;
         rhsValue = rhsValue->next;
     }
 
-    if (lhsValue != nullptr || rhsValue != nullptr) return false;
+    if (lhsValue != NULL || rhsValue != NULL) return false;
 
     return true;
 }

--- a/fvtest/tril/tril/ast.hpp
+++ b/fvtest/tril/tril/ast.hpp
@@ -23,6 +23,7 @@
 #define AST_HPP
 
 #include "ast.h"
+#include "enable_if.hpp"
 
 #include <type_traits>
 #include <assert.h>
@@ -59,9 +60,9 @@ struct ASTValue {
     enum ASTType {Integer, FloatingPoint, String} ;
 
     // aliases for the underlying C++ types used to store the different AST types
-    using Integer_t = uint64_t;
-    using FloatingPoint_t = double;
-    using String_t = const char *;
+    typedef uint64_t Integer_t;
+    typedef double FloatingPoint_t;
+    typedef const char* String_t;
 
     /**
      * STL compatible type traits for working with AST data types
@@ -76,17 +77,11 @@ struct ASTValue {
      * is_FloatintPoint_Compatible<double>::value; // true
      * is_String_Compatible<const char*>::value;   // true
      */
-    template <typename T>
-    using is_Integer_Compatible = std::is_integral<T>;
-    template <typename T>
-    using is_FloatingPoint_Compatible = std::is_floating_point<T>;
-    template <typename T>
-    using is_String_Compatible = std::is_same<String_t, T>;
 
     // constructors
-    explicit ASTValue(Integer_t v) : _type{Integer}, next{nullptr} { _value.integer = v; }
-    explicit ASTValue(FloatingPoint_t v) : _type{FloatingPoint}, next{nullptr} { _value.floatingPoint = v; }
-    explicit ASTValue(String_t v) : _type{String}, next{nullptr} { _value.str = v; }
+    explicit ASTValue(Integer_t v) : _type{Integer}, next{NULL} { _value.integer = v; }
+    explicit ASTValue(FloatingPoint_t v) : _type{FloatingPoint}, next{NULL} { _value.floatingPoint = v; }
+    explicit ASTValue(String_t v) : _type{String}, next{NULL} { _value.str = v; }
 
     /**
      * @brief Return the contained value as the specified type
@@ -108,18 +103,19 @@ struct ASTValue {
      * b.get<double>(); // returns 4.5 as a double
      * b.get<int>();    // causes an assertion failure
      */
+
     template <typename T>
-    typename std::enable_if<is_Integer_Compatible<T>::value, T>::type get() const {
+    typename Tril::enable_if<std::is_integral<T>::value , T>::type get() const {
         assert(Integer == _type);
         return static_cast<T>(_value.integer);
     }
     template <typename T>
-    typename std::enable_if<is_FloatingPoint_Compatible<T>::value, T>::type get() const {
+    typename Tril::enable_if<std::is_floating_point<T>::value, T>::type get() const {
         assert(FloatingPoint == _type);
         return static_cast<T>(_value.floatingPoint);
     }
     template <typename T>
-    typename std::enable_if<is_String_Compatible<T>::value, T>::type get() const {
+    typename Tril::enable_if<std::is_same<String_t, T>::value, T>::type get() const {
         assert(String == _type);
         return static_cast<T>(_value.str);
     }
@@ -155,16 +151,17 @@ struct ASTValue {
      * b.isCompatibleWith<double>(); // returns true
      * b.isCompatibleWith<int>();    // returns false
      */
+
     template <typename T>
-    typename std::enable_if<is_Integer_Compatible<T>::value, bool>::type isCompatibleWith() const {
+    typename Tril::enable_if<std::is_integral<T>::value , bool>::type isCompatibleWith() const {
         return Integer == _type;
     }
     template <typename T>
-    typename std::enable_if<is_FloatingPoint_Compatible<T>::value, bool>::type isCompatibleWith() const {
+    typename Tril::enable_if<std::is_floating_point<T>::value, bool>::type isCompatibleWith() const {
         return FloatingPoint == _type;
     }
     template <typename T>
-    typename std::enable_if<is_String_Compatible<T>::value, bool>::type isCompatibleWith() const {
+    typename Tril::enable_if<std::is_same<String_t, T>::value, bool>::type isCompatibleWith() const {
         return String == _type;
     }
 
@@ -220,7 +217,7 @@ struct ASTNodeArg {
     public:
     ASTNodeArg* next;
 
-    ASTNodeArg(const char* name, ASTValue* value, ASTNodeArg* next = nullptr)
+    ASTNodeArg(const char* name, ASTValue* value, ASTNodeArg* next = NULL)
         : _name{name}, _value{value}, next{next} {}
 
     const char* getName() const { return _name; }
@@ -265,7 +262,7 @@ struct ASTNode {
     const ASTNodeArg* getArgument(int index) const {
         auto arg = _args;
 
-        while (arg != nullptr && index > 0) {
+        while (arg != NULL && index > 0) {
             arg = arg->next;
             --index;
         }
@@ -297,9 +294,9 @@ struct ASTNode {
     const ASTNodeArg* getPositionalArg(int index) const {
         auto arg = _args;
 
-        while (arg != nullptr) {
+        while (arg != NULL) {
             const auto name = arg->getName();
-            if (name == nullptr || name[0] == '\0') {
+            if (name == NULL || name[0] == '\0') {
                 if (index > 0) { --index; }
                 else { break; }
             }
@@ -315,7 +312,7 @@ struct ASTNode {
         auto arg = _args;
         auto i = 0;
 
-        while (arg != nullptr) {
+        while (arg != NULL) {
             ++i;
             arg = arg->next;
         }

--- a/fvtest/tril/tril/enable_if.hpp
+++ b/fvtest/tril/tril/enable_if.hpp
@@ -19,37 +19,20 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-#ifndef JITBUILDER_COMPILER_HPP
-#define JITBUILDER_COMPILER_HPP
-
-#include "method_compiler.hpp"
-
-namespace TR { class IlVerifier; } 
+#ifndef ENABLE_IF_HPP
+#define ENABLE_IF_HPP
 
 namespace Tril {
+    // Create an implementation of std::enable_if which was only
+    //  added since C++11.
+    template <bool, typename T = void>
 
-/**
- * @brief Concrete realization of MethodCompiler that uses JitBuilder for compilation
- */
-class JitBuilderCompiler : public Tril::MethodCompiler {
-    public:
-        explicit JitBuilderCompiler(const ASTNode* methodNode)
-            : MethodCompiler{methodNode} {}
+    struct enable_if {};
 
-        /**
-         * @brief Compiles the Tril method using JitBuilder
-         * @return 0 on compilation success, an error code otherwise
-         */
-        int32_t compile() /* override */ ;
-
-        /**
-         * @brief Start compilation with a verifier. 
-         * @param verifier The verifier to run. 
-         * @return 0 on complilation success, an error code or exception otherwise. 
-         */
-        int32_t compileWithVerifier(TR::IlVerifier* verifier);
-};
-
+    template <typename T>
+    struct enable_if<true, T> {
+        typedef T type;
+    };
 } // namespace Tril
 
-#endif // JITBUILDER_COMPILER_HPP
+#endif // ENABLE_IF_HPP

--- a/fvtest/tril/tril/ilgen.cpp
+++ b/fvtest/tril/tril/ilgen.cpp
@@ -45,7 +45,9 @@ class OpCodeTable : public TR::ILOpCode {
       static TR::ILOpCodes getOpCodeFromName(const std::string& name) {
          auto opcode = _opcodeNameMap.find(name);
          if (opcode == _opcodeNameMap.cend()) {
-            for (const auto& p : _opCodeProperties) {
+            for (int i = TR::FirstOMROp; i< TR::NumIlOps; i++) {
+               const auto p_opCode = static_cast<TR::ILOpCodes>(i);
+               const auto& p = TR::ILOpCode::_opCodeProperties[p_opCode];
                if (name == p.name) {
                   _opcodeNameMap[name] = p.opcode;
                   return p.opcode;
@@ -79,7 +81,7 @@ std::unordered_map<std::string, TR::ILOpCodes> OpCodeTable::_opcodeNameMap;
  * reason, special opcodes are detected using opcode properties.
  */
 TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
-     TR::Node* node = nullptr;
+     TR::Node* node = NULL;
 
      auto childCount = tree->getChildCount();
 
@@ -93,7 +95,7 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
          }
          else {
              TraceIL("Failed to find node for commoning (@id \"%s\")\n", id)
-             return nullptr;
+             return NULL;
          }
      }
      else if (strcmp("@common", tree->getName()) == 0) {
@@ -108,7 +110,7 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
          }
          else {
              TraceIL("Failed to find node for commoning (@id \"%s\")\n", id)
-             return nullptr;
+             return NULL;
          }
      }
 
@@ -135,7 +137,7 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
                  node->setDouble(value->get<double>());
                  break;
               default:
-                 return nullptr;
+                 return NULL;
            }
            TraceIL("floating point value %f\n", value->getFloatingPoint());
         }
@@ -144,13 +146,13 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
         TraceIL("  is direct load of ", "");
 
         // the name of the first argument tells us what kind of symref we're loading
-        if (tree->getArgByName("parm") != nullptr) {
+        if (tree->getArgByName("parm") != NULL) {
              auto arg = tree->getArgByName("parm")->getValue()->get<int32_t>();
              TraceIL("parameter %d\n", arg);
              auto symref = symRefTab()->findOrCreateAutoSymbol(_methodSymbol, arg, opcode.getType() );
              node = TR::Node::createLoad(symref);
          }
-         else if (tree->getArgByName("temp") != nullptr) {
+         else if (tree->getArgByName("temp") != NULL) {
              const auto symName = tree->getArgByName("temp")->getValue()->getString();
              TraceIL("temporary %s\n", symName);
              auto symref = _symRefMap[symName];
@@ -158,14 +160,14 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
          }
          else {
              // symref kind not recognized
-             return nullptr;
+             return NULL;
          }
      }
      else if (opcode.isStoreDirect()) {
         TraceIL("  is direct store of ", "");
 
         // the name of the first argument tells us what kind of symref we're storing to
-        if (tree->getArgByName("temp") != nullptr) {
+        if (tree->getArgByName("temp") != NULL) {
             const auto symName = tree->getArgByName("temp")->getValue()->getString();
             TraceIL("temporary %s\n", symName);
 
@@ -180,7 +182,7 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
         }
         else {
             // symref kind not recognized
-            return nullptr;
+            return NULL;
         }
      }
      else if (opcode.isLoadIndirect() || opcode.isStoreIndirect()) {
@@ -227,7 +229,7 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
      TraceIL("  node index n%dn\n", node->getGlobalIndex());
 
      auto nodeIdArg = tree->getArgByName("id");
-     if (nodeIdArg != nullptr) {
+     if (nodeIdArg != NULL) {
          auto id = nodeIdArg->getValue()->getString();
          _nodeMap[id] = node;
          TraceIL("  node ID %s\n", id);
@@ -307,7 +309,7 @@ bool Tril::TRLangBuilder::injectIL() {
 
     // assign block names
     while (block) {
-       if (block->getArgByName("name") != nullptr) {
+       if (block->getArgByName("name") != NULL) {
            auto name = block->getArgByName("name")->getValue()->getString();
            _blockMap[name] = blockIndex;
            TraceIL("Name of block %d set to \"%s\"\n", blockIndex, name);
@@ -350,7 +352,7 @@ bool Tril::TRLangBuilder::injectIL() {
 
        // create fall-through edge
        auto fallthroughArg = block->getArgByName("fallthrough");
-       if (fallthroughArg != nullptr) {
+       if (fallthroughArg != NULL) {
            auto target = std::string(fallthroughArg->getValue()->getString());
            if (target == "@exit") {
                cfg()->addEdge(_currentBlock, cfg()->getEnd());

--- a/fvtest/tril/tril/ilgen.hpp
+++ b/fvtest/tril/tril/ilgen.hpp
@@ -50,7 +50,7 @@ class TRLangBuilder : public TR::IlInjector {
         TRLangBuilder(const ASTNode* trees, TR::TypeDictionary* d)
               : TR::IlInjector(d), _trees(trees) {}
 
-        bool injectIL() override;
+        bool injectIL(); /* override */
 
         /**
          * @brief Given an AST structure, returns a TR::Node represented by the AST

--- a/fvtest/tril/tril/jitbuilder_compiler.cpp
+++ b/fvtest/tril/tril/jitbuilder_compiler.cpp
@@ -50,9 +50,10 @@ int32_t Tril::JitBuilderCompiler::compileWithVerifier(TR::IlVerifier* verifier) 
     // into a list of `TR::IlType`
     auto argTypes = methodInfo.getArgTypes();
     auto argIlTypes = std::vector<TR::IlType*>{argTypes.size()};
-    std::transform(argTypes.cbegin(), argTypes.cend(), argIlTypes.begin(),
-                   [&types](TR::DataTypes d){ return types.PrimitiveType(d); } );
-
+    auto it_argIlTypes = argIlTypes.begin(); 
+    for (auto it = argTypes.cbegin(); it != argTypes.cend(); it++) {
+          *it_argIlTypes++ = types.PrimitiveType(*it);
+    }
     // construct a `TR::ResolvedMethod` instance from the IL generator and use
     // to compile the method
     TR::ResolvedMethod resolvedMethod("file", "line", "name",
@@ -64,13 +65,13 @@ int32_t Tril::JitBuilderCompiler::compileWithVerifier(TR::IlVerifier* verifier) 
     TR::IlGeneratorMethodDetails methodDetails(&resolvedMethod);
 
     // If a verifier is provided, set one up. 
-    if (nullptr != verifier) 
+    if (NULL != verifier) 
        {
        methodDetails.setIlVerifier(verifier);
        }
 
     int32_t rc = 0;
-    auto entry_point = compileMethodFromDetails(nullptr, methodDetails, warm, rc);
+    auto entry_point = compileMethodFromDetails(NULL, methodDetails, warm, rc);
 
     // if compilation was successful, set the entry point for the compiled body
     if (rc == 0) setEntryPoint(entry_point);

--- a/fvtest/tril/tril/method_compiler.hpp
+++ b/fvtest/tril/tril/method_compiler.hpp
@@ -44,7 +44,7 @@ class MethodCompiler {
          */
         explicit MethodCompiler(const ASTNode* methodNode)
             : _method{methodNode},
-              _entry_point{nullptr}
+              _entry_point{NULL}
         {}
 
         virtual ~MethodCompiler() = default;

--- a/fvtest/tril/tril/method_info.hpp
+++ b/fvtest/tril/tril/method_info.hpp
@@ -46,16 +46,16 @@ class MethodInfo {
             _returnType = getTRDataTypes(returnTypeArg->getValue()->getString());
 
             auto argTypesArg = _methodNode->getArgByName("args");
-            if (argTypesArg != nullptr) {
+            if (argTypesArg != NULL) {
                 auto typeValue = argTypesArg->getValue();
-                while (typeValue != nullptr) {
+                while (typeValue != NULL) {
                     _argTypes.push_back(getTRDataTypes(typeValue->getString()));
                     typeValue = typeValue->next;
                 }
             }
 
             auto nameArg = _methodNode->getArgByName("name");
-            if (nameArg != nullptr) {
+            if (nameArg != NULL) {
                 _name = nameArg->getValue()->get<ASTValue::String_t>();
             }
         }


### PR DESCRIPTION
There was some desire to use Tril in contexts where the compiler may not have full C++11 support.
This adds that support to tril and it's accompanying examples, while still retaining some of the C++11 only code (by guarding them with appropriate macros).