### PR TITLE
Do not define _XOPEN_SOURCE globally

### DIFF
--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -921,6 +921,9 @@ typedef struct J9MmapHandle {
 #define _XOPEN_SOURCE
 #endif /* defined(OSX) */
 #include <ucontext.h>
+#if defined(OSX)
+#undef _XOPEN_SOURCE
+#endif /* OSX */
 #endif /* !WIN32 */
 
 #if defined(J9ZOS390)


### PR DESCRIPTION
Important bits of OSX's pthread library are disabled when this symbol is
defined. This seems to be new behaviour as of xcode 9. This fixes many
compilation errors in the C++ standard library.

This fixes one of the compilation issues in #1707.

Signed-off-by: Robert Young <rwy0717@gmail.com>