### PR TITLE
Fix maxprec() call to avoid fixed-point overflows on Z

### DIFF
--- a/port/linuxs390/omrrttime.s
+++ b/port/linuxs390/omrrttime.s
@@ -36,7 +36,7 @@ maxprec:
     brc 3,.LCarry
     ahi %r2,-1
 .LCarry:
-    s   %r2,.LC0-.LT0(%r1)
+    sl   %r2,.LC0-.LT0(%r1)
     srdl %r2,1
     br  %r14
 

--- a/port/linuxs39064/omrrttime.s
+++ b/port/linuxs39064/omrrttime.s
@@ -31,7 +31,7 @@ maxprec:
     
     stckf 64(%r15)
     lg  %r1,64(%r15)
-    sg %r1,.LC0-.LT0(%r3)
+    slg %r1,.LC0-.LT0(%r3)
     srlg %r1,%r1,1
     lgr %r2,%r1
     br  %r14

--- a/port/zos390/omrrttime.s
+++ b/port/zos390/omrrttime.s
@@ -49,7 +49,7 @@ LCarry0  sl   r2,LC0
          sl  r3,CVTLSO+4
          brc NOBORROW,LCarry1
          ahi r2,-1
-LCarry1  s   r2,CVTLSO
+LCarry1  sl  r2,CVTLSO
          drop r0,r1
          srdl r2,1
          EDCXEPLG

--- a/port/zos390/omrrttime.s
+++ b/port/zos390/omrrttime.s
@@ -40,7 +40,7 @@ maxprec  EDCXPRLG BASEREG=8
          sl  r3,LC0+4
          brc NOBORROW,LCarry0
          ahi r2,-1
-LCarry0  s   r2,LC0
+LCarry0  sl   r2,LC0
          using PSA,r0
          l   r1,FLCCVT
          using CVT,r1
@@ -59,7 +59,7 @@ LCarry1  s   r2,CVTLSO
 maxprec  CELQPRLG BASEREG=8
          stckf CLOCK64(r4)
          lg  r3,CLOCK64(r4)
-         sg  r3,LC0
+         slg  r3,LC0
          using PSA,r0
          llgt  r1,FLCCVT
          using CVT,r1

--- a/port/ztpf/omrrttime.s
+++ b/port/ztpf/omrrttime.s
@@ -30,7 +30,7 @@ maxprec:
     
     stck 64(%r15)
     lg  %r1,64(%r15)
-    sg %r1,.LC0-.LT0(%r3)
+    slg %r1,.LC0-.LT0(%r3)
     srlg %r1,%r1,9
     lgr %r2,%r1
     br  %r14


### PR DESCRIPTION
The maxprec() routine that obtains current time on Z-plaforms
triggers fixed-point overflows if the PSW Fixed Point Oveflow mask
happens to be turned on. The reason for the overflow is that a subtract
operation used for calculating the current time mistakenly uses signed
rather than unsigned subtraction. The time value of the TOD-clock
(returned via STCK/STCKF instruction) will always be unsigned, so a
subtract logical instruction should be used instead of subtract - this 
would avoid Fixed-point Overflows.

The fix applies to z/OS, z/Linux and z/TPF platforms.

Signed-off-by: Deepthi Sebastian <deesebas@in.ibm.com>