### PR TITLE
Add support for nopable breakpoint guard

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -294,7 +294,8 @@ class OMR_EXTENSIBLE CodeGenerator
    uint32_t _prePrologueSize;
 
    TR::Instruction *_implicitExceptionPoint;
-
+   bool mergeableGuard(TR::Instruction *guard);
+   bool mergeableGuards(TR::Instruction *earlierGuard, TR::Instruction *laterGuard);
 
    protected:
 
@@ -1195,6 +1196,8 @@ class OMR_EXTENSIBLE CodeGenerator
    // Used to find the guard instruction where a given guard will actually patch
    // currently can only return a value other than vgdnop for HCR guards
    TR::Instruction* getVirtualGuardForPatching(TR::Instruction *vgdnop);
+
+   bool isStopTheWorldGuard(TR::Node *node);
 
    void jitAddPicToPatchOnClassUnload(void *classPointer, void *addressToBePatched) {}
    void jitAdd32BitPicToPatchOnClassUnload(void *classPointer, void *addressToBePatched) {}

--- a/compiler/compile/VirtualGuard.hpp
+++ b/compiler/compile/VirtualGuard.hpp
@@ -212,6 +212,7 @@ class TR_VirtualGuard
          {
          case TR_DummyTest:
          case TR_NonoverriddenTest:
+         case TR_FSDTest:
             return false;
          default:
             return true;

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -446,6 +446,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableNextGenHCR",                  "O\tdisable HCR implemented with on-stack replacement",  SET_OPTION_BIT(TR_DisableNextGenHCR), "F"},
 
    {"disableNonvirtualInlining",          "O\tdisable inlining of non virtual methods",        SET_OPTION_BIT(TR_DisableNonvirtualInlining), "F"},
+   {"disableNopBreakpointGuard",          "O\tdisable nop of breakpoint guards",        SET_OPTION_BIT(TR_DisableNopBreakpointGuard), "F"},
    {"disableNoServerDuringStartup",       "M\tDo not use NoServer during startup",  SET_OPTION_BIT(TR_DisableNoServerDuringStartup), "F"},
    {"disableNoVMAccess",                  "O\tdisable compilation without holding VM access",  SET_OPTION_BIT(TR_DisableNoVMAccess), "F"},
    {"disableOnDemandLiteralPoolRegister", "O\tdisable on demand literal pool register",        SET_OPTION_BIT(TR_DisableOnDemandLiteralPoolRegister), "F"},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -294,7 +294,7 @@ enum TR_CompilationOptions
    TR_TLHPrefetch                         = 0x00002000 + 6,
    TR_ReservingLocks                      = 0x00004000 + 6, // Can be merged with TR_DisableLockResevation when lock reservation is enabled on all platforms
    TR_DisableLockResevation               = 0x00008000 + 6,
-   // Available                           = 0x00010000 + 6,
+   TR_DisableNopBreakpointGuard           = 0x00010000 + 6,
    TR_DisableAggressiveRecompilations     = 0x00020000 + 6,
    TR_DisableVariablePrecisionDAA         = 0x00040000 + 6,
    // Available                           =0x00080000 + 6,

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -7510,10 +7510,10 @@ OMR::Node::resetIsTheVirtualGuardForAGuardedInlinedCall()
 bool
 OMR::Node::isNopableInlineGuard()
    {
-   return self()->isTheVirtualGuardForAGuardedInlinedCall() && !self()->isProfiledGuard() && !self()->isBreakpointGuard();
+   TR::Compilation * c = TR::comp();
+   return self()->isTheVirtualGuardForAGuardedInlinedCall() && !self()->isProfiledGuard() && 
+      !(self()->isBreakpointGuard() && c->getOption(TR_DisableNopBreakpointGuard));
    }
-
-
 
 bool
 OMR::Node::isMutableCallSiteTargetGuard()

--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -2531,12 +2531,13 @@ static bool virtualGuardHelper(TR::Node *node, TR::CodeGenerator *cg)
    TR::LabelSymbol *label = node->getBranchDestination()->getNode()->getLabel();
 
    cg->setVMThreadRequired(true);
+
    TR::Instruction *vgnopInstr = generateVirtualGuardNOPInstruction(node, site, deps, label, cg);
    TR::Instruction *patchPoint = cg->getVirtualGuardForPatching(vgnopInstr);
 
-   // HCR guards are patched when the threads are stopped.
-   // No issues with multithreaded patching, therefore alignment is not required
-   if (TR::Compiler->target.isSMP() && !node->isHCRGuard() && !node->isOSRGuard())
+   // Guards patched when the threads are stopped have no issues with multithreaded patching. 
+   // therefore alignment is not required
+   if (TR::Compiler->target.isSMP() && !cg->isStopTheWorldGuard(node))
       {
       // the compiler is now capable of generating a train of vgnops all looking to patch the
       // same point with different constraints. alignment is required before the delegated patch
@@ -2576,8 +2577,6 @@ static bool virtualGuardHelper(TR::Node *node, TR::CodeGenerator *cg)
    return false;
 #endif
    }
-
-
 
 void
 OMR::X86::CodeGenerator::addMetaDataForBranchTableAddress(

--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -5804,17 +5804,17 @@ TR::S390VirtualGuardNOPInstruction::generateBinaryEncoding()
    // in) if the patching occurs during GC pause times.  The patching of up to 6-bytes is potentially
    // not atomic.
 
-   bool performEmptyPatch = getNode()->isHCRGuard() || getNode()->isProfiledGuard() || getNode()->isOSRGuard();
+   bool performEmptyPatch = cg()->isStopTheWorldGuard(getNode()) || getNode()->isProfiledGuard();
 
-   // HCR guards that are merged with profiled guards never need to generate NOPs for patching because
-   // the profiled guard will generate the NOP branch to the same location the HCR guard needs to branch
-   // to, so we can always use the NOP branch form the profiled guard as our HCR patch point.
+   // Stop the world guards that are merged with profiled guards never need to generate NOPs for patching because
+   // the profiled guard will generate the NOP branch to the same location the stop the world guard needs to branch
+   // to, so we can always use the NOP branch form the profiled guard as our stop the world patch point.
 
    int32_t sumEstimatedBinaryLength = getNode()->isProfiledGuard() ? 6 : 0;
 
    if (performEmptyPatch)
       {
-      // so at this point we know we are an HCR guard and that there may be other HCR guards
+      // so at this point we know we are an stop the world guard and that there may be other stop the world guards
       // after us that will use us as their patch point. We now calculate how much space we
       // are sure to have to overwrite to inform us about what to do next
       TR::Node *firstBBEnd = NULL;


### PR DESCRIPTION
To lower the overhead for the breakpoint guard instruction sequence,
the guard is nopped when compiling a method and patched
only when a breakpoint is set for that method. This changeset cleans
up related queries and adds the option to disable nopping breakpoint
guard

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>
