### PR TITLE
Enable AVX support on X86

### DIFF
--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -1432,6 +1432,9 @@ TR::X86RegInstruction::enlarge(int32_t requestedEnlargementSize, int32_t maxEnla
    if (disableRexExpansion || TR::comp()->getOption(TR_DisableZealousCodegenOpts))
       return OMR::X86::EnlargementResult(0, 0);
 
+   if (getOpCode().info().supportsAVX() && getOpCode().info().allowsAVX())
+      return OMR::X86::EnlargementResult(0, 0); // REX expansion isn't allowed for AVX instructions
+
    if ((maxEnlargementSize < requestedEnlargementSize && !allowPartialEnlargement) || requestedEnlargementSize < 1)
       return OMR::X86::EnlargementResult(0, 0);
 

--- a/compiler/x/codegen/X86Ops.hpp
+++ b/compiler/x/codegen/X86Ops.hpp
@@ -384,8 +384,7 @@ class TR_X86OpCode
       template <class TBuffer> inline typename TBuffer::cursor_t encode(typename TBuffer::cursor_t cursor, uint8_t rexbits) const;
       // finalize instruction prefix information, currently only in-use for AVX instructions for VEX.vvvv field
       inline void finalize(uint8_t* cursor) const;
-      private:
-      inline static bool allowsAVX();
+      inline bool allowsAVX() const;
       };
    template <typename TCursor>
    class BufferBase

--- a/compiler/x/codegen/X86Ops_inlines.hpp
+++ b/compiler/x/codegen/X86Ops_inlines.hpp
@@ -22,24 +22,23 @@
 #ifndef X86OPS_INLINES_INCL
 #define X86OPS_INLINES_INCL
 
-inline bool TR_X86OpCode::OpCode_t::allowsAVX()
+inline bool TR_X86OpCode::OpCode_t::allowsAVX() const
    {
-   static bool enable = feGetEnv("TR_EnableAVX") && TR::CodeGenerator::getX86ProcessorInfo().supportsAVX();
+   static bool enable = TR::CodeGenerator::getX86ProcessorInfo().supportsAVX() && !feGetEnv("TR_DisableAVX");
    return enable;
    }
 
 template <typename TBuffer> inline typename TBuffer::cursor_t TR_X86OpCode::OpCode_t::encode(typename TBuffer::cursor_t cursor, uint8_t rexbits) const
    {
+   TBuffer buffer(cursor);
    if (isX87())
       {
-      TBuffer buffer(cursor);
       buffer.append(opcode);
       // Heuristics for X87 second byte opcode
       // It could be eliminated if GCC/MSVC fully support initializer list
       buffer.append((uint8_t)((modrm_opcode << 5) | (modrm_form << 3) | immediate_size));
       return buffer;
       }
-   TBuffer buffer(cursor);
    // Prefixes
    TR::Instruction::REX rex(rexbits);
    rex.W = rex_w;


### PR DESCRIPTION
X86 CodeGen now generates AVX instructions unless the machine does
not support AVX or environment variable TR_DisableAVX is set.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>