### PR TITLE
Change TOC size from 256KB to 64KB in -Xquickstart mode

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -5025,6 +5025,7 @@ void OMR::Options::setQuickStart()
    {
    _quickstartDetected = true;
    _initialOptLevel = cold;
+   _tocSizeInKB = 64;
    self()->setOption (TR_DisableInterpreterProfiling, true);
    self()->setOption (TR_ForceAOT, true);
    self()->setOption (TR_DisableAggressiveRecompilations, true);


### PR DESCRIPTION
We are changing the TOC size from 256KB back to the original 64KB in -Xquickstart mode in an effort to decrease footprint.

The default TOC size was changed from 64KB to 256KB in commit bdc1efa to help with performance in Liberty/Hadoop/Spark. However, since throughput is not very important in -Xquickstart mode, we can afford to revert back to 64KB in this mode. 

This change will decrease footprint.

Signed-off-by: Harry Yu <harryyu1994@gmail.com>