### PR TITLE
Fix BNDCHK versioning tests under substitution

### DIFF
--- a/compiler/optimizer/LoopVersioner.hpp
+++ b/compiler/optimizer/LoopVersioner.hpp
@@ -195,7 +195,7 @@ class TR_LoopVersioner : public TR_LoopTransformer
    bool isStoreInSpecialForm(int32_t, TR_Structure *);
    bool isConditionalTreeCandidateForElimination(TR::TreeTop * curTree) { return (!curTree->getNode()->getFirstChild()->getOpCode().isLoadConst() ||
                                                                                   !curTree->getNode()->getSecondChild()->getOpCode().isLoadConst()); };
-   TR::Node *isDependentOnInductionVariable(TR::Node *, bool, bool &, TR::Node* &, TR::Node* &);
+   TR::Node *isDependentOnInductionVariable(TR::Node *, bool, bool &, TR::Node* &, TR::Node* &, bool &);
    TR::Node *isDependentOnInvariant(TR::Node *);
    bool boundCheckUsesUnchangedValue(TR::TreeTop *, TR::Node *, TR::SymbolReference *, TR_RegionStructure *);
    bool findStore(TR::TreeTop *start, TR::TreeTop *end, TR::Node *node, TR::SymbolReference *symRef, bool ignoreLoads = false, bool lastTimeThrough = false);


### PR DESCRIPTION
In order to identify appropriate expressions of induction variables (IVs) under `BNDCHK` nodes, loop versioner looks through loads of autos to their definitions (when there are unique definitions).  In this way a `BNDCHK` may be versioned even if no load of its IV feeds directly into the index.  For instance, the following `BNDCHK` can be versioned as long as `n` and `array` are invariant.

    BBStart <loop0>
    istore derived
      isub
        iload n
        iload i
    if... --> exit
    BBEnd </loop0>

    BBStart <loop1>
    BNDCHK
      arraylength
        aload array
      iload derived
    ...
    istore i
      isub
        iload i
        iconst -1
    ificmple --> loop0
      ==>isub
      iload n
    BBEnd </loop1>

This commit fixes some problems with the versioning tests generated in cases like this one:

1. Substitution into the third test sometimes used the IV instead of the substituted variable's definition.  In the above example, derived would be replaced by `i`, not `n - i`.  This only happened in cases where the entire index expression is a load.  If the index were instead `derived + 1`, then it would be correctly rewritten to `n - i + 1`.

2. All of the `BNDCHK` versioning tests are sensitive to whether the IV occurs in a negative position, but versioner did not account for subtractions within the definition of a substituted variable.