### PR TITLE
CMake: Add basic support for installing targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,23 @@ endif()
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 ###
+### Set up install path stuff
+###
+# Note the paths are a bit odd compared to standard gnu install paths
+# This is because we arent expecting to actually be installing globally
+# since we don't have a good story for installing OMR system-wide
+set(CMAKE_INSTALL_BINDIR ".")
+set(CMAKE_INSTALL_LIBDIR ".")
+set(OMR_INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}" CACHE PATH "Root path where to install OMR")
+set(CMAKE_INSTALL_PREFIX "${OMR_INSTALL_PREFIX}")
+include(GNUInstallDirs)
+set(CMAKE_INSTALL_RPATH "\$ORIGIN")
+add_custom_target(omr_install_tooling
+	COMMAND ${CMAKE_COMMAND} --build tools --target preinstall
+	COMMAND ${CMAKE_COMMAND} -DCMAKE_INSTALL_COMPONENT=tooling -P "${CMAKE_BINARY_DIR}/cmake_install.cmake"
+)
+
+###
 ### Getting the glue target
 ###
 set(OMR_GC_GLUE_TARGET "omr_example_gc_glue" CACHE STRING "The gc glue target, must be interface library")

--- a/omrsigcompat/CMakeLists.txt
+++ b/omrsigcompat/CMakeLists.txt
@@ -108,4 +108,8 @@ endif()
 #ifneq (,$(findstring osx,$(OMR_HOST_OS)))
     #MODULE_SHARED_LIBS += pthread
 #endif
+install(TARGETS omrsig
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
 

--- a/tools/hookgen/CMakeLists.txt
+++ b/tools/hookgen/CMakeLists.txt
@@ -30,3 +30,8 @@ target_link_libraries(hookgen pugixml)
 if(OMR_HOST_OS STREQUAL "zos")
 	target_link_libraries(hookgen j9a2e)
 endif()
+
+install(TARGETS hookgen
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+	COMPONENT tooling
+)

--- a/tools/tracegen/CMakeLists.txt
+++ b/tools/tracegen/CMakeLists.txt
@@ -52,3 +52,8 @@ target_include_directories(trace
 if(OMR_HOST_OS STREQUAL "zos")
 	target_link_libraries(trace j9a2e)
 endif()
+
+install(TARGETS tracegen
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+	COMPONENT tooling
+)

--- a/tools/tracemerge/CMakeLists.txt
+++ b/tools/tracemerge/CMakeLists.txt
@@ -34,3 +34,8 @@ target_link_libraries(tracemerge
 	PRIVATE
 		trace # static
 )
+
+install(TARGETS tracemerge
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+	COMPONENT tooling
+)


### PR DESCRIPTION
At the moment only installs tooling and omrsig (only the minimum required
for building openJ9).

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>