### PR TITLE
z/TPF Fixes during initial sniff testing.

### DIFF
--- a/compiler/env/DebugSegmentProvider.cpp
+++ b/compiler/env/DebugSegmentProvider.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-#if defined(LINUX) || defined(__APPLE__) || defined(_AIX)
+#if (defined(LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || defined(_AIX)
 #include <sys/mman.h>
 #if defined(__APPLE__) || !defined(MAP_ANONYMOUS)
 #define MAP_ANONYMOUS MAP_ANON
@@ -45,7 +45,7 @@ TR::DebugSegmentProvider::~DebugSegmentProvider() throw()
    {
    for ( auto it = _segments.begin(); it != _segments.end(); it = _segments.begin() )
       {
-#if defined(LINUX) || defined(__APPLE__) || defined(_AIX)
+#if (defined(LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || defined(_AIX)
       munmap(it->base(), it->size());
 #elif defined(_WIN32)
       VirtualFree(it->base(), 0, MEM_RELEASE);
@@ -60,7 +60,7 @@ TR::MemorySegment &
 TR::DebugSegmentProvider::request(size_t requiredSize)
    {
    size_t adjustedSize = ( ( requiredSize + (defaultSegmentSize() - 1) ) / defaultSegmentSize() ) * defaultSegmentSize();
-#if defined(LINUX) || defined(__APPLE__) || defined(_AIX)
+#if (defined(LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || defined(_AIX)
    void *newSegmentArea = mmap(NULL, adjustedSize, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
    if (newSegmentArea == MAP_FAILED) throw std::bad_alloc();
 #elif defined(_WIN32)
@@ -79,7 +79,7 @@ TR::DebugSegmentProvider::request(size_t requiredSize)
       }
    catch (...)
       {
-#if defined(LINUX) || defined(__APPLE__) || defined(_AIX)
+#if (defined(LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || defined(_AIX)
       munmap(newSegmentArea, adjustedSize);
 #elif defined(_WIN32)
       VirtualFree(newSegmentArea, 0, MEM_RELEASE);
@@ -93,7 +93,7 @@ TR::DebugSegmentProvider::request(size_t requiredSize)
 void
 TR::DebugSegmentProvider::release(TR::MemorySegment &segment) throw()
    {
-#if defined(LINUX) || defined(__APPLE__) || defined(_AIX)
+#if (defined(LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || defined(_AIX)
    void * remap = mmap(segment.base(), segment.size(), PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED, -1, 0);
    TR_ASSERT(remap == segment.base(), "Remapping of memory failed!");
 #elif defined(_WIN32)

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -235,7 +235,7 @@
 #define OMRPORT_TIME_DELTA_IN_NANOSECONDS ((uint64_t) 1000000000)
 /** @} */
 
-#if defined(S390) || defined(J9ZOS390)
+#if (defined(S390) || defined(J9ZOS390)) && !defined(OMRZTPF)
 /**
  * @name Constants to calculate time from high-resolution timer
  * @anchor hiresConstants
@@ -253,14 +253,21 @@
 #define OMRPORT_TIME_HIRES_MILLITIME_DIVISOR ((uint64_t) 2048000)
 #define OMRTIME_HIRES_CLOCK_FREQUENCY ((uint64_t) 2048000000) /* Frequency is microseconds / second */
 
-#else
+#elif defined(OMRZTPF)
+#define OMRPORT_TIME_HIRES_NANOTIME_NUMERATOR ((uint64_t) 125)
+#define OMRPORT_TIME_HIRES_NANOTIME_DENOMINATOR ((uint64_t) 256)
+#define OMRPORT_TIME_HIRES_MICROTIME_DIVISOR ((uint64_t) 8)
+#define OMRPORT_TIME_HIRES_MILLITIME_DIVISOR ((uint64_t) 8000)
+#define OMRTIME_HIRES_CLOCK_FREQUENCY ((uint64_t) 8000000) /* Frequency is microseconds / second */
+
+#else /* (defined(S390) || defined(J9ZOS390)) && !defined(OMRZTPF) */
 
 #define OMRPORT_TIME_HIRES_NANOTIME_NUMERATOR ((uint64_t) 0)
 #define OMRPORT_TIME_HIRES_NANOTIME_DENOMINATOR ((uint64_t) 0)
 #define OMRPORT_TIME_HIRES_MICROTIME_DIVISOR ((uint64_t) 0)
 #define OMRPORT_TIME_HIRES_MILLITIME_DIVISOR ((uint64_t) 0)
 
-#endif /* defined(S390) || defined(J9ZOS390) */
+#endif /* (defined(S390) || defined(J9ZOS390)) && !defined(OMRZTPF) */
 /** @} */
 
 #if defined(LINUX) && !defined(OMRZTPF)

--- a/port/ztpf/omrsignal_context.c
+++ b/port/ztpf/omrsignal_context.c
@@ -216,6 +216,7 @@ reenter:
 	rtnv->argv.sii = &(rtnv->siginfo);
 	rtnv->argv.uct = &(rtnv->ucontext);
 	rtnv->argv.sct = &(rtnv->sigcontext);
+	rtnv->sigcontext.sregs = &(rtnv->_sregs); /* point to actual _sigregs struct */
 	rtnv->argv.wkspcSize = PATH_MAX;
 	rtnv->argv.wkSpace = &(rtnv->workbuffer[0]);
 	rtnv->argv.OSFilename = &(rtnv->filename[0]);
@@ -326,13 +327,12 @@ ztpfDeriveSiginfo( siginfo_t *build ) {
 
 static void
 ztpfDeriveSigcontext( struct sigcontext *sigcPtr, ucontext_t *uctPtr ) {
-        memset( sigcPtr, 0, sizeof(*sigcPtr) );         /* Set it all to zeros, then fill it all in.     */
 
         sigcPtr->sregs->regs.psw.mask  = uctPtr->uc_mcontext.psw.mask;
         sigcPtr->sregs->regs.psw.addr  = uctPtr->uc_mcontext.psw.addr;
 
-        memcpy(&(sigcPtr->sregs->regs.gprs), &(uctPtr->uc_mcontext.gregs),sizeof(sigcPtr->sregs->regs.gprs));
-        memcpy(&(sigcPtr->sregs->regs.acrs), &(uctPtr->uc_mcontext.aregs),sizeof(sigcPtr->sregs->regs.acrs));
+        memcpy(&(sigcPtr->sregs->regs.gprs), &(uctPtr->uc_mcontext.gregs),sizeof(uctPtr->uc_mcontext.gregs));
+        memcpy(&(sigcPtr->sregs->regs.acrs), &(uctPtr->uc_mcontext.aregs),sizeof(uctPtr->uc_mcontext.aregs));
 
         memcpy(&(sigcPtr->sregs->fpregs), &(uctPtr->uc_mcontext.fpregs), sizeof(fpregset_t));
 
@@ -348,7 +348,6 @@ ztpfDeriveUcontext( ucontext_t *uscPtr ) {
    DBFITEM * pDbi = NULL;
    void * lowcore = NULL;
 
-   memset( uscPtr, 0, sizeof(*uscPtr) );	/* Zeroize everything		*/
    if( pJdb ) {					 /* If JDB contents are for this thread */
 	  if( pJdb->ijavcnt ) {		 /*  and the JDB is unlocked			*/
 		 pDbi = (DBFITEM *)(pJdb+1);		 /* Point at the JDB base	*/

--- a/port/ztpf/safe_storage.h
+++ b/port/ztpf/safe_storage.h
@@ -46,6 +46,7 @@ typedef struct _durable_storage {
 	siginfo_t	siginfo;
 	ucontext_t ucontext;
 	struct sigcontext sigcontext;
+	_sigregs _sregs; /* sigcontext struct contains pointer to _sigregs */
 	DIB	*pDIB;
 	struct iproc *pPROC;
 	args argv;

--- a/thread/unix/omrthreadattr.c
+++ b/thread/unix/omrthreadattr.c
@@ -462,6 +462,7 @@ setStacksize(pthread_attr_t *pattr, uintptr_t stacksize)
 {
 	/* stacksize may be adjusted to satisfy platform-specific quirks */
 
+#if !defined(OMRZTPF)
 #if defined(LINUX) || defined(OSX)
 	/* Linux allocates 2MB if you ask for a stack smaller than STACK_MIN */
 	{
@@ -476,10 +477,11 @@ setStacksize(pthread_attr_t *pattr, uintptr_t stacksize)
 	}
 #endif /* defined(LINUX) || defined(OSX) */
 
-
 	if (DEBUG_SYSCALL(pthread_attr_setstacksize(pattr, stacksize)) != 0) {
 		return J9THREAD_ERR_INVALID_VALUE;
 	}
+#endif /* !defined(OMRZTPF) */
+
 	return J9THREAD_SUCCESS;
 }
 


### PR DESCRIPTION
z/TPF fixes during initial sniff testing.  Fixes unresolved functions.
Fixes High Resolution Timer defines.  Modified setstacksize to match 
z/TPF architecture.

Signed-off-by: jjohnst-us <jjohnst@us.ibm.com>