### PR TITLE
Fix compilation issue with older MSVC compilers

### DIFF
--- a/compiler/codegen/StaticRelocation.hpp
+++ b/compiler/codegen/StaticRelocation.hpp
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include <inttypes.h>
+#include <stdint.h>
 
 class TR_ResolvedMethod;
 


### PR DESCRIPTION
The use of inttypes.h in StaticRelocation.hpp is not compatible with
many older versions of the Microsoft Visual C/C++ compiler. This commit
changes this to stdint.h which should be more portable without affecting
the implementation.