### PR TITLE
Move ELF test make dependencies

### DIFF
--- a/jitbuilder/release/Makefile
+++ b/jitbuilder/release/Makefile
@@ -56,8 +56,6 @@ ALL_TESTS = \
             transactionaloperations \
             union \
             worklist \
-            useIncrement \
-            useCall \
 
 
 # Compile all the tests by default
@@ -97,7 +95,7 @@ all_goal: common_goal
 # Tests that are still on the experimental side
 # If you add to this list and want them to be built under "make", please
 # also add to ALL_TESTS
-experimental_goal: common_goal
+experimental_goal: common_goal useIncrement useCall
 	./atomicoperations
 	./transactionaloperations
 	./useIncrement
@@ -335,4 +333,4 @@ test_calls.o : call
 
 
 clean:
-	@rm -f $(ALL_TESTS) replay *.o
+	@rm -f $(ALL_TESTS) useIncrement useCall replay *.o


### PR DESCRIPTION
Move the make dependencies for the ELF tests from ALL_TESTS to explicit
dependencies of experimental_goal.

This is required because entries in ALL_TESTS get built on all
platforms, even if they can't run on all platforms. However, the
distinction between 'building' and 'running' the ELF tests if fuzzy
enough that if a platform doesn't support running the test, it doesn't
support building it either.

Fixes #1748

Signed-off-by: Luc des Trois Maisons <lmaisons@ca.ibm.com>