### PR TITLE
Flush GC caches in Concurrent Scavenger

### DIFF
--- a/gc/base/EnvironmentBase.hpp
+++ b/gc/base/EnvironmentBase.hpp
@@ -574,6 +574,8 @@ public:
 	MMINLINE MM_WorkStack *getWorkStack() { return &_workStack; }
 
 	MMINLINE void flushNonAllocationCaches() { _delegate.flushNonAllocationCaches(); }
+	virtual void flushGCCaches(MM_EnvironmentBase *env) {}
+	
 
 	/**
 	 * Get a pointer to common GC metadata attached to this environment. The GC environment structure

--- a/gc/base/OMRVMThreadInterface.cpp
+++ b/gc/base/OMRVMThreadInterface.cpp
@@ -33,6 +33,9 @@ void
 GC_OMRVMThreadInterface::flushCachesForWalk(MM_EnvironmentBase *env)
 {
 	env->_objectAllocationInterface->flushCache(env);
+	/* If we are in a middle of a concurrent GC, we want to flush GC caches, typically for mutator threads doing GC work.
+	 * (GC threads are  smart enough to do it themselves, before they let the walk occur) */
+	env->flushGCCaches(env);
 }
 
 void

--- a/gc/base/standard/EnvironmentStandard.hpp
+++ b/gc/base/standard/EnvironmentStandard.hpp
@@ -72,6 +72,8 @@ private:
 /* Functionality Section */
 public:
 	static MM_EnvironmentStandard *newInstance(MM_GCExtensionsBase *extensions, OMR_VMThread *vmThread);
+	
+	virtual void flushGCCaches(MM_EnvironmentBase *env);
 
 	MMINLINE static MM_EnvironmentStandard *getEnvironment(OMR_VMThread *omrVMThread) { return static_cast<MM_EnvironmentStandard*>(omrVMThread->_gcOmrVMThreadExtensions); }
 	MMINLINE static MM_EnvironmentStandard *getEnvironment(MM_EnvironmentBase *env) { return static_cast<MM_EnvironmentStandard*>(env); }

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -558,17 +558,24 @@ public:
 	virtual uintptr_t masterThreadConcurrentCollect(MM_EnvironmentBase *env);
 	virtual void postConcurrentUpdateStatsAndReport(MM_EnvironmentBase *env, MM_ConcurrentPhaseStatsBase *stats, UDATA bytesConcurrentlyScanned);
 
-	/* master thread */
+	/* master thread specific methods */
 	bool scavengeIncremental(MM_EnvironmentBase *env);
-	
 	bool scavengeInit(MM_EnvironmentBase *env);
 	bool scavengeRoots(MM_EnvironmentBase *env);
 	bool scavengeScan(MM_EnvironmentBase *env);
 	bool scavengeComplete(MM_EnvironmentBase *env);
 	
-	/* mutator thread */
-	void mutatorFinalReleaseCopyCaches(MM_EnvironmentBase *env, MM_EnvironmentBase *threadEnvironment);
+	/* mutator thread specific methods */
 	void mutatorSetupForGC(MM_EnvironmentBase *env);
+	
+	/* methods used by either mutator or GC threads */
+	/**
+	 * All open copy caches (even if not full) are pushed onto scan queue. Unused memory is abondoned.
+	 * @param env Invoking thread. Could be master thread on behalf on mutator threads (threadEnvironment) for which copy caches are to be released, or could be mutator or GC thread itself.
+	 * @param threadEnvironment Thread for which copy caches are to be released. Could be either GC or mutator thread.
+	 */
+	void threadFinalReleaseCopyCaches(MM_EnvironmentBase *env, MM_EnvironmentBase *threadEnvironment);
+	
 	/**
 	 * trigger STW phase (either start or end) of a Concurrent Scavenger Cycle 
 	 */ 


### PR DESCRIPTION
Push any open GC copy caches to scan queue, and abandon unused parts:

1) for mutator threads (that created copy caches while copying in read
barrier), when requested heap walk in a middle of a CS cycle. 

2) at the end of first STW phase of CS
This will help with scan work created by GC threads that were involved
in this phase, but not involved in following concurrent phase (which
generally uses less GC threads). That work will be then completed during
concurrent phase, instead of waiting for those GC threads to be
re-activated at the final STW phase. 
This will also help with heap walkability (in a middle of a GC cycle).

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>