### PR TITLE
Fix casting issues in generateRILInstruction() API

### DIFF
--- a/compiler/z/codegen/BinaryEvaluator.cpp
+++ b/compiler/z/codegen/BinaryEvaluator.cpp
@@ -810,7 +810,7 @@ lDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
       else if ((shiftAmnt = TR::TreeEvaluator::checkPositiveOrNegativePowerOfTwo(denominator)) > 0 &&
             performTransformation(comp, "O^O Denominator is powerOfTwo (%d) for ldir/lrem.\n",denominator))
          {
-         int64_t absValueOfDenomintor = denominator>0 ? denominator : -denominator;
+         int64_t absValueOfDenominator = denominator>0 ? denominator : -denominator;
          TR::LabelSymbol * done = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
 
          //setup dependencies for shift instructions for division or remainder
@@ -829,7 +829,7 @@ lDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
                cursor->setStartInternalControlFlow();
 
                //adjustment to dividend if dividend is negative
-               dividendPair = laddConst(node, cg, dividendPair,absValueOfDenomintor-1, dep);
+               dividendPair = laddConst(node, cg, dividendPair,absValueOfDenominator-1, dep);
 
                generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, skipSet, dep);
                skipSet->setEndInternalControlFlow();
@@ -863,13 +863,13 @@ lDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
                generateRRInstruction(cg, TR::InstOpCode::LR, node, tempRegisterPair1->getLowOrder(), dividendPair->getLowOrder());
                generateRRInstruction(cg, TR::InstOpCode::LR, node, tempRegisterPair1->getHighOrder(), dividendPair->getHighOrder());
                generateRSInstruction(cg, TR::InstOpCode::SRDA, node, tempRegisterPair2, 63);
-               generateRILInstruction(cg, TR::InstOpCode::NILF, node, tempRegisterPair2->getLowOrder(), (int32_t) (absValueOfDenomintor-1) );
-               generateRILInstruction(cg, TR::InstOpCode::NILF, node, tempRegisterPair2->getHighOrder(), (int32_t) ((absValueOfDenomintor-1)>>32) );
+               generateRILInstruction(cg, TR::InstOpCode::NILF, node, tempRegisterPair2->getLowOrder(), static_cast<int32_t>(absValueOfDenominator-1) );
+               generateRILInstruction(cg, TR::InstOpCode::NILF, node, tempRegisterPair2->getHighOrder(), static_cast<int32_t>((absValueOfDenominator-1)>>32) );
                generateRRInstruction(cg, TR::InstOpCode::ALR, node, dividendPair->getLowOrder(), tempRegisterPair2->getLowOrder());
                generateRRInstruction(cg, TR::InstOpCode::ALCR, node, dividendPair->getHighOrder(), tempRegisterPair2->getHighOrder());
-               generateRILInstruction(cg, TR::InstOpCode::NILF, node, dividendPair->getLowOrder(), (int32_t) ((int64_t) CONSTANT64(0xFFFFFFFFFFFFFFFF) - absValueOfDenomintor +1) );
-               if (absValueOfDenomintor != (int32_t) absValueOfDenomintor)
-                  generateRILInstruction(cg, TR::InstOpCode::NILF, node, dividendPair->getHighOrder(), (int32_t) (((int64_t) CONSTANT64(0xFFFFFFFFFFFFFFFF) - absValueOfDenomintor +1)>>32) );
+               generateRILInstruction(cg, TR::InstOpCode::NILF, node, dividendPair->getLowOrder(), static_cast<int32_t>( CONSTANT64(0xFFFFFFFFFFFFFFFF) - absValueOfDenominator +1) );
+               if (absValueOfDenominator != static_cast<int32_t>(absValueOfDenominator))
+                  generateRILInstruction(cg, TR::InstOpCode::NILF, node, dividendPair->getHighOrder(), static_cast<int32_t>(( CONSTANT64(0xFFFFFFFFFFFFFFFF) - absValueOfDenominator +1)>>32) );
                generateRRInstruction(cg, TR::InstOpCode::SLR, node, tempRegisterPair1->getLowOrder(), dividendPair->getLowOrder());
                generateRRInstruction(cg, TR::InstOpCode::SLBR, node, tempRegisterPair1->getHighOrder(), dividendPair->getHighOrder());
                generateRRInstruction(cg, TR::InstOpCode::LR, node, dividendPair->getLowOrder(), tempRegisterPair1->getLowOrder());
@@ -1204,7 +1204,7 @@ lDivRemGenericEvaluator64(TR::Node * node, TR::CodeGenerator * cg, bool isDivisi
          {
          TR::Register * firstRegister = NULL;
 
-         int64_t absValueOfDenomintor = denominator>0 ? denominator : -denominator;
+         int64_t absValueOfDenominator = denominator>0 ? denominator : -denominator;
 
          if (isDivision)
             {
@@ -1219,7 +1219,7 @@ lDivRemGenericEvaluator64(TR::Node * node, TR::CodeGenerator * cg, bool isDivisi
                //adjustment to dividend if dividend is negative
                TR::RegisterDependencyConditions *deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 2, cg);
                deps->addPostCondition(firstRegister, TR::RealRegister::AssignAny);
-               generateS390ImmOp(cg, TR::InstOpCode::AG, node, firstRegister, firstRegister, absValueOfDenomintor-1, deps);
+               generateS390ImmOp(cg, TR::InstOpCode::AG, node, firstRegister, firstRegister, absValueOfDenominator-1, deps);
                skipSet->setEndInternalControlFlow();
                generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, skipSet, deps);
                }
@@ -1246,12 +1246,12 @@ lDivRemGenericEvaluator64(TR::Node * node, TR::CodeGenerator * cg, bool isDivisi
                TR::Register * tempRegister2 = cg->allocate64bitRegister();
                generateRSInstruction(cg, TR::InstOpCode::SRAG, node, tempRegister2, firstRegister, 63);
                generateRRInstruction(cg, TR::InstOpCode::LGR, node, tempRegister1, firstRegister);
-               generateRILInstruction(cg, TR::InstOpCode::NIHF, node, tempRegister2, (int32_t)((absValueOfDenomintor-1)>>32) );
-               generateRILInstruction(cg, TR::InstOpCode::NILF, node, tempRegister2, (int32_t)(absValueOfDenomintor-1));
+               generateRILInstruction(cg, TR::InstOpCode::NIHF, node, tempRegister2, static_cast<int32_t>((absValueOfDenominator-1)>>32) );
+               generateRILInstruction(cg, TR::InstOpCode::NILF, node, tempRegister2, static_cast<int32_t>(absValueOfDenominator-1));
                generateRRInstruction(cg, TR::InstOpCode::AGR, node, firstRegister, tempRegister2);
-               if (denominator != (int32_t) absValueOfDenomintor)
-                  generateRILInstruction(cg, TR::InstOpCode::NIHF, node, firstRegister, (int32_t) (((int64_t) CONSTANT64(0xFFFFFFFFFFFFFFFF) - absValueOfDenomintor +1)>>32));
-               generateRILInstruction(cg, TR::InstOpCode::NILF, node, firstRegister, (int32_t) ((int64_t) CONSTANT64(0xFFFFFFFFFFFFFFFF) - absValueOfDenomintor +1));
+               if (denominator != static_cast<int32_t>(absValueOfDenominator))
+                  generateRILInstruction(cg, TR::InstOpCode::NIHF, node, firstRegister, static_cast<int32_t>(( CONSTANT64(0xFFFFFFFFFFFFFFFF) - absValueOfDenominator +1)>>32));
+               generateRILInstruction(cg, TR::InstOpCode::NILF, node, firstRegister, static_cast<int32_t>( CONSTANT64(0xFFFFFFFFFFFFFFFF) - absValueOfDenominator +1));
                generateRRInstruction(cg, TR::InstOpCode::SGR, node, tempRegister1, firstRegister);
                generateRRInstruction(cg, TR::InstOpCode::LGR, node, firstRegister, tempRegister1);
                cg->stopUsingRegister(tempRegister1);
@@ -1359,7 +1359,7 @@ lDivRemGenericEvaluator64(TR::Node * node, TR::CodeGenerator * cg, bool isDivisi
 
          if (value <= TR::getMaxSigned<TR::Int32>())
             {
-            generateRILInstruction(cg, TR::InstOpCode::CLGFI, node, absDividendReg, value);
+            generateRILInstruction(cg, TR::InstOpCode::CLGFI, node, absDividendReg, static_cast<int32_t>(value));
             }
          else
             {

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -3831,7 +3831,7 @@ OMR::Z::TreeEvaluator::ternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       if (comp->getOption(TR_TraceCG))
          traceMsg(comp, "emitting a compare with 0 instruction\n");
 
-      TR::Instruction *compareInst = generateRILInstruction(cg,condition->getOpCode().isLongCompare() ? TR::InstOpCode::CGFI : TR::InstOpCode::CFI,condition,condition->getRegister(),(uintptrj_t)0);
+      TR::Instruction *compareInst = generateRILInstruction(cg,condition->getOpCode().isLongCompare() ? TR::InstOpCode::CGFI : TR::InstOpCode::CFI,condition,condition->getRegister(), 0);
 
       // Load on condition is supported on z196 and up
       if (cg->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_z196))

--- a/compiler/z/codegen/FPTreeEvaluator.cpp
+++ b/compiler/z/codegen/FPTreeEvaluator.cpp
@@ -448,7 +448,7 @@ convertToFixed(TR::Node * node, TR::CodeGenerator * cg)
          generateRRFInstruction(cg, convertOp, node, targetRegister, srcRegCpy, (int8_t) 0x5, true);
 
          //4) Handle the sign bit by XOR
-         generateRILInstruction(cg, TR::InstOpCode::XILF, node, targetRegister, (uintptrj_t)0x80000000);
+         generateRILInstruction(cg, TR::InstOpCode::XILF, node, targetRegister, 0x80000000);
 
          //5) Convert the targetRegister value to appropriate integer type, if needed
          generateValueConversionToIntType(cg, node, targetRegister);

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -5352,7 +5352,7 @@ TR_S390Peephole::reloadLiteralPoolRegisterForCatchBlock()
       if ((_cg->getLinkage())->setupLiteralPoolRegister(firstSnippet) > 0)
          {
          // the imm. operand will be patched when the actual address of the literal pool is known at binary encoding phase
-         TR::S390RILInstruction * inst = (TR::S390RILInstruction *) generateRILInstruction(_cg, TR::InstOpCode::LARL, _cursor->getNode(), _cg->getLitPoolRealRegister(), 0xBABE, _cursor);
+         TR::S390RILInstruction * inst = (TR::S390RILInstruction *) generateRILInstruction(_cg, TR::InstOpCode::LARL, _cursor->getNode(), _cg->getLitPoolRealRegister(), reinterpret_cast<void*>(0xBABE), _cursor);
          inst->setIsLiteralPoolAddress();
          }
       }
@@ -10184,7 +10184,7 @@ OMR::Z::CodeGenerator::clearHighOrderBits( TR::Node * node, TR::Register * targe
 
       case 24:
          // Can use AND immediate to clear high 24 bits
-         generateRILInstruction(self(), TR::InstOpCode::NILF, node, targetRegister, (int32_t)0x000000FF);
+         generateRILInstruction(self(), TR::InstOpCode::NILF, node, targetRegister, 0x000000FF);
          break;
 
       case 48:

--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -4380,7 +4380,7 @@ OMR::Z::Machine::spillRegister(TR::Instruction * currentInstruction, TR::Registe
                   {
                   cursor = generateExtendedHighWordInstruction(currentNode, _cg, TR::InstOpCode::LLHFR, best, freeHighWordReg, 0, currentInstruction);
                   self()->cg()->traceRAInstruction(cursor);
-                  cursor = generateRILInstruction(_cg, TR::InstOpCode::IIHF, currentNode, best, (uintptrj_t)0, cursor);
+                  cursor = generateRILInstruction(_cg, TR::InstOpCode::IIHF, currentNode, best, 0, cursor);
                   self()->cg()->traceRAInstruction(cursor);
                   }
                else
@@ -5191,7 +5191,7 @@ OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction                       
                   TR_ASSERT(currentAssignedRegister->isLowWordRegister(), " OOL HPR spill: 64-bit reg assigned to HPR and is not spilled to HPR");
                   cursor = generateExtendedHighWordInstruction(currentNode, _cg, TR::InstOpCode::LLHFR, currentAssignedRegister, targetRegister, 0, currentInstruction);
                   _cg->traceRAInstruction(cursor);
-                  cursor = generateRILInstruction(_cg, TR::InstOpCode::IIHF, currentNode, currentAssignedRegister, (uintptrj_t)0, cursor);
+                  cursor = generateRILInstruction(_cg, TR::InstOpCode::IIHF, currentNode, currentAssignedRegister, 0, cursor);
                   _cg->traceRAInstruction(cursor);
 
                   // fix up states
@@ -5589,7 +5589,7 @@ OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction                       
                   TR_ASSERT(currentAssignedRegister->isLowWordRegister(), " OOL HPR spill: 64-bit reg assigned to HPR and is not spilled to HPR");
                   cursor = generateExtendedHighWordInstruction(currentNode, _cg, TR::InstOpCode::LLHFR, currentAssignedRegister, targetRegister, 0, currentInstruction);
                   _cg->traceRAInstruction(cursor);
-                  cursor = generateRILInstruction(_cg, TR::InstOpCode::IIHF, currentNode, currentAssignedRegister, (uintptrj_t)0, cursor);
+                  cursor = generateRILInstruction(_cg, TR::InstOpCode::IIHF, currentNode, currentAssignedRegister, 0, cursor);
                   _cg->traceRAInstruction(cursor);
 
                   // fix up states

--- a/compiler/z/codegen/OpMemToMem.cpp
+++ b/compiler/z/codegen/OpMemToMem.cpp
@@ -1084,7 +1084,7 @@ MemInitVarLenMacroOp::generateRemainder()
       if(TR::Compiler->target.is64Bit())
          {
          generateRILInstruction(_cg, TR::InstOpCode::NILF, _rootNode, _regLen, 0xFF);
-         generateRILInstruction(_cg, TR::InstOpCode::NIHF, _rootNode, _regLen, (uintptrj_t)0);
+         generateRILInstruction(_cg, TR::InstOpCode::NIHF, _rootNode, _regLen, 0);
          }
       else
          {

--- a/compiler/z/codegen/S390GenerateInstructions.cpp
+++ b/compiler/z/codegen/S390GenerateInstructions.cpp
@@ -994,13 +994,13 @@ generateRIInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
     }
 
 TR::Instruction *
-generateRILInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * treg, TR::SymbolReference * sr, uintptrj_t imm, TR::Instruction * preced)
+generateRILInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * treg, TR::SymbolReference * sr, void * addr, TR::Instruction * preced)
    {
    if (preced)
       {
-      return new (INSN_HEAP) TR::S390RILInstruction(op, n, treg, imm, sr, preced, cg);
+      return new (INSN_HEAP) TR::S390RILInstruction(op, n, treg, addr, sr, preced, cg);
       }
-   return new (INSN_HEAP) TR::S390RILInstruction(op, n, treg, imm, sr, cg);
+   return new (INSN_HEAP) TR::S390RILInstruction(op, n, treg, addr, sr, cg);
    }
 
 TR::Instruction *
@@ -1012,24 +1012,43 @@ generateRILInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
    }
 
 TR::Instruction *
-generateRILInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * treg, uintptrj_t imm, TR::Instruction * preced)
+generateRILInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * treg, uint32_t imm, TR::Instruction * preced)
    {
-   if (cg->supportsHighWordFacility() && cg->comp()->getOption(TR_DisableHighWordRA) && treg->assignToHPR())
-      {
-      switch(op)
-         {
-         case TR::InstOpCode::AFI:
-            return generateRILInstruction(cg, TR::InstOpCode::AIH, n, treg, imm, preced);
-            break;
-         default:
-            break;
-         }
-      }
    if (preced)
       {
       return new (INSN_HEAP) TR::S390RILInstruction(op, n, treg, imm, preced, cg);
       }
    return new (INSN_HEAP) TR::S390RILInstruction(op, n, treg, imm, cg);
+   }
+
+TR::Instruction *
+generateRILInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * treg, int32_t imm, TR::Instruction * preced)
+   {
+   if (preced)
+      {
+      return new (INSN_HEAP) TR::S390RILInstruction(op, n, treg, imm, preced, cg);
+      }
+   return new (INSN_HEAP) TR::S390RILInstruction(op, n, treg, imm, cg);
+   }
+
+TR::Instruction *
+generateRILInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * treg, void * addr, TR::Instruction * preced)
+   {
+   if (preced)
+      {
+      return new (INSN_HEAP) TR::S390RILInstruction(op, n, treg, addr, preced, cg);
+      }
+   return new (INSN_HEAP) TR::S390RILInstruction(op, n, treg, addr, cg);
+   }
+
+TR::Instruction *
+generateRILInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t mask, void * addr, TR::Instruction * preced)
+   {
+   if (preced)
+      {
+      return new (INSN_HEAP) TR::S390RILInstruction(op, n, mask, addr, preced, cg);
+      }
+   return new (INSN_HEAP) TR::S390RILInstruction(op, n, mask, addr, cg);
    }
 
 TR::Instruction *
@@ -2337,7 +2356,7 @@ generateDirectCall(TR::CodeGenerator * cg, TR::Node * callNode, bool myself, TR:
          if (comp->getOption(TR_EnableRMODE64))
 #endif
             {
-            tempInst = (new (INSN_HEAP) TR::S390RILInstruction(TR::InstOpCode::BRASL, callNode, RegRA, imm, callSymRef, cg));
+            tempInst = (new (INSN_HEAP) TR::S390RILInstruction(TR::InstOpCode::BRASL, callNode, RegRA, reinterpret_cast<void*>(imm), callSymRef, cg));
             }
 #endif
 #if !defined(TR_TARGET_64BIT) || (defined(TR_TARGET_64BIT) && defined(J9ZOS390))
@@ -2346,7 +2365,7 @@ generateDirectCall(TR::CodeGenerator * cg, TR::Node * callNode, bool myself, TR:
 #endif
 
             {
-            tempInst = new (INSN_HEAP) TR::S390RILInstruction(TR::InstOpCode::BRASL, callNode, RegRA, imm, cg);
+            tempInst = new (INSN_HEAP) TR::S390RILInstruction(TR::InstOpCode::BRASL, callNode, RegRA, reinterpret_cast<void*>(imm), cg);
 
 
             if (isHelper)
@@ -2439,7 +2458,7 @@ generateLoadLiteralPoolAddress(TR::CodeGenerator * cg, TR::Node * node, TR::Regi
    TR::Instruction *cursor;
 
    //support f/w only so far
-   TR::S390RILInstruction *LARLinst = (TR::S390RILInstruction *) generateRILInstruction(cg, TR::InstOpCode::LARL, node, treg, 0xBABE, 0);
+   TR::S390RILInstruction *LARLinst = (TR::S390RILInstruction *) generateRILInstruction(cg, TR::InstOpCode::LARL, node, treg, reinterpret_cast<void*>(0xBABE), 0);
    LARLinst->setIsLiteralPoolAddress();
    cursor = LARLinst;
 

--- a/compiler/z/codegen/S390GenerateInstructions.hpp
+++ b/compiler/z/codegen/S390GenerateInstructions.hpp
@@ -434,41 +434,168 @@ TR::Instruction * generateRIInstruction(
                    TR::InstOpCode::Mnemonic          op,
                    TR::Node                *n,
                    TR::Register            *treg,
-                   char                   *data,
+                   char                    *data,
                    TR::Instruction         *preced = 0);
 
+/** \brief
+ *     Generates a new S390RILInstruction object.
+ *
+ *     RIL type instructions have 2 different kinds of immediates. One is a "pure" immediate, meaning
+ *     the immediate is used as is, usually as an integer for an instruction like AFI. The other is a
+ *     relative immediate used to calculate an address in instructions like BRASL and LARL.
+ *
+ *     This function is to be used for instructions with relative immediates. A fatal assert will trigger
+ *     if this function is used with a mnemonic which has a pure immediate.
+ *
+ *  \param cg
+ *     The code generator used to generate the instructions.
+ *
+ *  \param op
+ *     The opcode mnemonic of the instruction to be generated.
+ *
+ *  \param n
+ *     The node for which an instruction is being generated.
+ *
+ *  \param treg
+ *     The target register for the instruction.
+ *
+ *  \param sr
+ *     The symbol reference to be used.
+ *
+ *  \param addr
+ *     The address to be used in the generated instruction. An absolute address needs to be used.
+ *     Binary Encoding will automatically change the absolute address to the relative offset format
+ *     needed by the instruction.
+ *
+ *  \param preced
+ *     The preceeding instruction.
+ *
+ *  \return
+ *     The generated S390RILInstruction.
+ */
 TR::Instruction * generateRILInstruction(
-                   TR::CodeGenerator       *cg,
-                   TR::InstOpCode::Mnemonic          op,
-                   TR::Node                *n,
-                   TR::Register            *treg,
-                   TR::SymbolReference     *sr,
-                   uintptrj_t              imm,
-                   TR::Instruction         *preced = 0);
+                   TR::CodeGenerator        *cg,
+                   TR::InstOpCode::Mnemonic  op,
+                   TR::Node                 *n,
+                   TR::Register             *treg,
+                   TR::SymbolReference      *sr,
+                   void                     *addr,
+                   TR::Instruction          *preced = 0);
 
 TR::Instruction * generateRILInstruction(
-                   TR::CodeGenerator       *cg,
-                   TR::InstOpCode::Mnemonic         op,
-                   TR::Node                *n,
-                   TR::Register            *treg,
+                   TR::CodeGenerator        *cg,
+                   TR::InstOpCode::Mnemonic  op,
+                   TR::Node                 *n,
+                   TR::Register             *treg,
                    TR::LabelSymbol          *label,
-                   TR::Instruction         *preced = 0);
+                   TR::Instruction          *preced = 0);
+
+/** \brief
+ *     Generates a new S390RILInstruction object.
+ *
+ *     RIL type instructions have 2 different kinds of immediates. One is a "pure" immediate, meaning
+ *     the immediate is used as is, usually as an integer for an instruction like AFI. The other is a
+ *     relative immediate used to calculate an address in instructions like BRASL and LARL.
+ *
+ *     This function is to be used for instructions with pure immediates. A fatal assert will trigger
+ *     if this function is used with a mnemonic which has a relative immediate.
+ *
+ *  \param cg
+ *     The code generator used to generate the instructions.
+ *
+ *  \param op
+ *     The opcode mnemonic of the instruction to be generated.
+ *
+ *  \param n
+ *     The node for which an instruction is being generated.
+ *
+ *  \param treg
+ *     The target register for the instruction.
+ *
+ *  \param imm
+ *     The pure immediate to be used.
+ *
+ *  \param preced
+ *     The preceeding instruction.
+ *
+ *  \return
+ *     The generated S390RILInstruction.
+ */
+TR::Instruction * generateRILInstruction(
+                   TR::CodeGenerator        *cg,
+                   TR::InstOpCode::Mnemonic  op,
+                   TR::Node                 *n,
+                   TR::Register             *treg,
+                   uint32_t                  imm,
+                   TR::Instruction          *preced = 0);
 
 TR::Instruction * generateRILInstruction(
-                   TR::CodeGenerator       *cg,
-                   TR::InstOpCode::Mnemonic          op,
-                   TR::Node                *n,
-                   TR::Register            *treg,
-                   uintptrj_t              imm,
-                   TR::Instruction         *preced = 0);
+                   TR::CodeGenerator        *cg,
+                   TR::InstOpCode::Mnemonic  op,
+                   TR::Node                 *n,
+                   TR::Register             *treg,
+                   int32_t                   imm,
+                   TR::Instruction          *preced = 0);
+
+/** \brief
+ *     Generates a new S390RILInstruction object.
+ *
+ *     RIL type instructions have 2 different kinds of immediates. One is a "pure" immediate, meaning
+ *     the immediate is used as is, usually as an integer for an instruction like AFI. The other is a
+ *     relative immediate used to calculate an address in instructions like BRASL and LARL.
+ *
+ *     This function is to be used for instructions with relative immediates. A fatal assert will trigger
+ *     if this function is used with a mnemonic which has a pure immediate.
+ *
+ *  \param cg
+ *     The code generator used to generate the instructions.
+ *
+ *  \param op
+ *     The opcode mnemonic of the instruction to be generated.
+ *
+ *  \param n
+ *     The node for which an instruction is being generated.
+ *
+ *  \param treg
+ *     The target register for the instruction.
+ *
+ *  \param sr
+ *     The symbol reference to be used.
+ *
+ *  \param addr
+ *     The address to be used in the generated instruction. An absolute address needs to be used.
+ *     Binary Encoding will automatically change the absolute address to the relative offset format
+ *     needed by the instruction.
+ *
+ *  \param preced
+ *     The preceeding instruction.
+ *
+ *  \return
+ *     The generated S390RILInstruction.
+ */
+TR::Instruction * generateRILInstruction(
+                   TR::CodeGenerator        *cg,
+                   TR::InstOpCode::Mnemonic  op,
+                   TR::Node                 *n,
+                   TR::Register             *treg,
+                   void                     *addr,
+                   TR::Instruction          *preced = 0);
 
 TR::Instruction * generateRILInstruction(
-                   TR::CodeGenerator       *cg,
-                   TR::InstOpCode::Mnemonic         op,
-                   TR::Node                *n,
-                   TR::Register            *treg,
-                   TR::Snippet             *ts,
-                   TR::Instruction         *preced);
+                   TR::CodeGenerator        *cg,
+                   TR::InstOpCode::Mnemonic  op,
+                   TR::Node                 *n,
+                   uint32_t                  mask,
+                   void                     *addr,
+                   TR::Instruction          *preced = 0);
+
+TR::Instruction * generateRILInstruction(
+                   TR::CodeGenerator        *cg,
+                   TR::InstOpCode::Mnemonic  op,
+                   TR::Node                 *n,
+                   TR::Register             *treg,
+                   TR::Snippet              *ts,
+                   TR::Instruction          *preced = 0);
 
 TR::Instruction * generateSIInstruction(
                    TR::CodeGenerator *cg,


### PR DESCRIPTION
Splitting the generateRILInstruction() API to handle the different
types of immediates that RIL instructions can take separately.
One kind is a pure immediate which is used for say an ADD
instruction. The other is when the immediate is used as a relative
offset for address calculation like LARL or BRASL instructions.
This allows calls to the API to have more sensible casting.
They are modified for this change and unsafe casting is switched
to static casting and some code has its style improved.

Signed-off-by: Simon Hirst <shirst@ca.ibm.com>