### PR TITLE
Merge HCR guards in all HCR modes

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -1845,7 +1845,6 @@ TR_InlinerBase::addGuardForVirtual(
       // when using OSR to implement HCR we keep the HCR guards distinct since they
       // will undergo special processing later in the compilation
       if (virtualGuard &&
-          comp()->getHCRMode() != TR::osr &&
           comp()->cg()->supportsMergingGuards())
          {
          TR::Node *guardNode = virtualGuard->getNode();


### PR DESCRIPTION
HCR guards were not merged with other guards
in the OSR implementation of HCR to simplify the
analysis. This change enables the merging, to reduce
compile time overhead, as the analysis should now
support it.