### PR TITLE
Reduce OSRLiveRangeAnalysis overhead

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -847,6 +847,25 @@ OMR::Compilation::requiresAnalysisOSRPoint(TR::Node *node)
       }
    }
 
+/**
+ * To reduce OSR overhead, OSRLiveRangeAnalysis supports solving liveness analysis
+ * during IlGen, as an approximation of this information is commonly known at this
+ * stage.
+ *
+ * If this function returns true, OSRLiveRangeAnalysis expects pending push liveness
+ * information to be stashed in OSRData using addPendingPushLivenessInfo prior to
+ * its execution in IlGenOpts. Returning true without the correct information stashed
+ * will result in reduced performance and failed OSR transitions.
+ *
+ * If this function returns false, OSRLiveRangeAnalysis will perform liveness analysis
+ * on pending push symbols.
+ */
+bool
+OMR::Compilation::pendingPushLivenessDuringIlgen()
+   {
+   return false;
+   }
+
 bool
 OMR::Compilation::isProfilingCompilation()
    {

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -845,6 +845,8 @@ public:
    int32_t getOSRInductionOffset(TR::Node *node);
    bool requiresAnalysisOSRPoint(TR::Node *node);
 
+   bool pendingPushLivenessDuringIlgen();
+
    // for OSR
    TR_OSRCompilationData* getOSRCompilationData() {return _osrCompilationData;}
    void setSeenClassPreventingInducedOSR();

--- a/compiler/compile/OSRData.hpp
+++ b/compiler/compile/OSRData.hpp
@@ -293,6 +293,9 @@ class TR_OSRMethodData
    void addLiveRangeInfo(int32_t byteCodeIndex, TR_BitVector *liveRangeInfo);
    TR_BitVector *getLiveRangeInfo(int32_t byteCodeIndex);
 
+   void addPendingPushLivenessInfo(int32_t byteCodeIndex, TR_BitVector *livenessInfo);
+   TR_BitVector *getPendingPushLivenessInfo(int32_t byteCodeIndex);
+
    void ensureArgInfoAt(int32_t byteCodeIndex, int32_t argNum);
    void addArgInfo(int32_t byteCodeIndex, int32_t argIndex, int32_t argSymRef);
    TR_Array<int32_t>* getArgInfo(int32_t byteCodeIndex);
@@ -323,6 +326,7 @@ class TR_OSRMethodData
    TR_BCInfoHashTable           bcInfoHashTab;
 
    TR_BCLiveRangeInfoHashTable  bcLiveRangeInfoHashTab;
+   TR_BCLiveRangeInfoHashTable  bcPendingPushLivenessInfoHashTab;
 
    TR_ArgInfoHashTable argInfoHashTab;
 

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -461,6 +461,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
 #ifdef J9_PROJECT_SPECIFIC
    {"disableOSRGuardRemoval",             "O\tdisable OSR guard removal",                      TR::Options::disableOptimization, osrGuardRemoval, 0, "P"},
 #endif
+   {"disableOSRLiveRangeAnalysis",        "O\tdisable live range analysis for on-stack replacement", SET_OPTION_BIT(TR_DisableOSRLiveRangeAnalysis), "F"},
    {"disableOSRLocalRemat",               "O\tdisable use of remat when inserting guards for on-stack replacement", SET_OPTION_BIT(TR_DisableOSRLocalRemat), "F"},
    {"disableOSRSharedSlots",              "O\tdisable support for shared slots in on-stack replacement", SET_OPTION_BIT(TR_DisableOSRSharedSlots), "F"},
    {"disableOutlinedNew",                 "O\tdo object allocation logic inline instead of using a fast jit helper",  SET_OPTION_BIT(TR_DisableOutlinedNew), "F"},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -564,7 +564,7 @@ enum TR_CompilationOptions
    TR_DisableOSRLocalRemat                            = 0x00040000 + 15,
    TR_DoNotUsePersistentIprofiler                     = 0x00080000 + 15,
    TR_DoNotUseFastStackwalk                           = 0x00100000 + 15,
-   // Available                                       = 0x00200000 + 15,
+   TR_DisableOSRLiveRangeAnalysis                     = 0x00200000 + 15,
    // Available                                       = 0x00400000 + 15,
    // Available                                       = 0x00800000 + 15,
    //                                                 = 0x01000000 + 15,   AVAILABLE

--- a/compiler/optimizer/OSRDefAnalysis.cpp
+++ b/compiler/optimizer/OSRDefAnalysis.cpp
@@ -689,9 +689,7 @@ int32_t TR_OSRLiveRangeAnalysis::perform()
    {
    if (comp()->getOption(TR_EnableOSR))
       {
-      static const char *disableOSRLiveRangeAnalysis = feGetEnv("TR_DisableOSRLiveRangeAnalysis");
-      //if (comp()->getOption(TR_DisableOSRLiveRangeAnalysis)) // add to Options later
-      if (disableOSRLiveRangeAnalysis)
+      if (comp()->getOption(TR_DisableOSRLiveRangeAnalysis))
          {
          if (comp()->getOption(TR_TraceOSR))
             traceMsg(comp(), "OSR is enabled but OSR live range analysis is not.\n");

--- a/compiler/optimizer/OSRDefAnalysis.hpp
+++ b/compiler/optimizer/OSRDefAnalysis.hpp
@@ -85,19 +85,28 @@ class TR_OSRLiveRangeAnalysis : public TR::Optimization
 
    private:
 
-   bool canAffordAnalysis();
+   bool shouldPerformAnalysis();
+   int32_t fullAnalysis(bool sharedParm, bool containsPendingPush);
+   int32_t partialAnalysis();
+
    void buildOSRLiveRangeInfo(TR::Node *node, TR_BitVector *liveVars, TR_OSRPoint *osrPoint,
-      int32_t *liveLocalIndexToSymRefNumberMap, int32_t maxSymRefNumber, int32_t numBits,
-      TR_OSRMethodData *osrMethodData);
+      int32_t *liveLocalIndexToSymRefNumberMap, int32_t numBits, TR_OSRMethodData *osrMethodData);
    void buildOSRSlotSharingInfo(TR::Node *node, TR_BitVector *liveVars, TR_OSRPoint *osrPoint,
       int32_t *liveLocalIndexToSymRefNumberMap, TR_BitVector *slotSharingVars);
+
+   void pendingPushLiveRangeInfo(TR::Node *node, TR_BitVector *liveSymRefs,
+      TR_BitVector *allPendingPushSymRefs, TR_OSRPoint *osrPoint, TR_OSRMethodData *osrMethodData);
+   void pendingPushSlotSharingInfo(TR::Node *node, TR_BitVector *liveSymRefs,
+      TR_BitVector *slotSharingSymRefs, TR_OSRPoint *osrPoint);
+
    void maintainLiveness(TR::Node *node, TR::Node *parent, int32_t childNum, vcount_t  visitCount,
        TR_Liveness *liveLocals, TR_BitVector *liveVars, TR::Block *block);
    TR::TreeTop *collectPendingPush(TR_ByteCodeInfo bci, TR::TreeTop *pps, TR_BitVector *liveVars);
 
-   TR_BitVector *_deadVars;
    TR_BitVector *_liveVars;
-   TR_BitVector *_pendingPushVars;
+   TR_BitVector *_pendingPushSymRefs;
+   TR_BitVector *_sharedSymRefs;
+   TR_BitVector *_workBitVector;
    };
 
 class TR_OSRExceptionEdgeRemoval : public TR::Optimization

--- a/compiler/optimizer/OSRDefAnalysis.hpp
+++ b/compiler/optimizer/OSRDefAnalysis.hpp
@@ -70,20 +70,6 @@ class TR_OSRDefAnalysis : public TR::Optimization
    bool requiresAnalysis();
    };
 
-
-struct ParentInfo
-   {
-   int32_t             _childNum;
-   TR::Node            *_parent;
-   ParentInfo      *_next;
-   };
-
-struct NodeParentInfo
-   {
-   TR::Node *_node;
-   ParentInfo *_parentInfo;
-   };
-
 class TR_OSRLiveRangeAnalysis : public TR::Optimization
    {
    public:
@@ -112,7 +98,6 @@ class TR_OSRLiveRangeAnalysis : public TR::Optimization
    TR_BitVector *_deadVars;
    TR_BitVector *_liveVars;
    TR_BitVector *_pendingPushVars;
-   NodeParentInfo **_pendingSlotValueParents;
    };
 
 class TR_OSRExceptionEdgeRemoval : public TR::Optimization


### PR DESCRIPTION
This is a set of changes to reduce OSRLiveRangeAnalysis overhead, mostly focused on skipping the analysis where possible. It consists of:

- When calculating liveness at a treetop level, skip blocks that contain no OSR points
- Remove allocations, left over from disabled sections of the analysis
- Add a missing option to disable the analysis
- Skip the analysis for bodies that don't contain OSR points at all
- Skip the analysis for bodies that don't have symbols that require it
- Add the option to solve pending push liveness in IlGen