### PR TITLE
CMake: small fixes

### DIFF
--- a/gc/CMakeLists.txt
+++ b/gc/CMakeLists.txt
@@ -20,9 +20,6 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 ###############################################################################
 
-project(libomrgc VERSION 0.0.1 LANGUAGES CXX)
-
-
 add_hookgen(include/omrmm.hdf
 	${CMAKE_CURRENT_SOURCE_DIR}/../include_core/mmomrhook.h
 	${CMAKE_CURRENT_SOURCE_DIR}/base/mmomrhook_internal.h

--- a/util/omrutil/CMakeLists.txt
+++ b/util/omrutil/CMakeLists.txt
@@ -44,7 +44,6 @@ add_library(omrutil_obj OBJECT
 )
 
 list(APPEND VPATH .)
-target_include_directories(omrport PRIVATE .)
 
 if(OMR_ARCH_S390)
 	if(OMR_HOST_OS STREQUAL zos)


### PR DESCRIPTION
A couple of small fixes.

- Remove `project(libomrgc ....)`
- Remove typo in `omrutil`