### PR TITLE
z/TPF update to NSIG for validSignalNum

### DIFF
--- a/omrsigcompat/omrsig_internal.hpp
+++ b/omrsigcompat/omrsig_internal.hpp
@@ -68,6 +68,11 @@ struct OMR_SigData {
 
 #if defined(J9ZOS390)
 #define NSIG 65
+#elif defined(OMRZTPF)
+#ifdef NSIG
+#undef NSIG
+#endif /* ifdef NSIG */
+#define NSIG MNSIG
 #endif /* defined(J9ZOS390) */
 
 

--- a/port/ztpf/omrsignal_context.h
+++ b/port/ztpf/omrsignal_context.h
@@ -30,7 +30,7 @@
 #include <unistd.h>
 #include <sys/ucontext.h>
 
-#define MAX_UNIX_SIGNAL_TYPES  32
+#define MAX_UNIX_SIGNAL_TYPES  MNSIG
 
 #define __USE_GNU 1
 #include <dlfcn.h>


### PR DESCRIPTION
Signal Number validation fails for z/TPF because NSIG has
a slightly different use in z/TPF.

Signed-off-by: jjohnst-us <jjohnst@us.ibm.com>