### PR TITLE
UseDef and AliasSet Compile Time Improvements

### DIFF
--- a/compiler/optimizer/DataFlowAnalysis.hpp
+++ b/compiler/optimizer/DataFlowAnalysis.hpp
@@ -495,7 +495,7 @@ class TR_ReachingDefinitions : public TR_UnionBitVectorAnalysis
 
    private:
 
-   void initializeGenAndKillSetInfoForNode(TR::Node *node, TR_UseDefInfo::BitVector &defsKilled, bool seenException, int32_t blockNum, TR::Node *parent);
+   void initializeGenAndKillSetInfoForNode(TR::Node *node, TR_BitVector &defsKilled, bool seenException, int32_t blockNum, TR::Node *parent);
 
    TR_UseDefInfo *_useDefInfo;
    TR_UseDefInfo::AuxiliaryData &_aux;

--- a/compiler/optimizer/ReachingDefinitions.cpp
+++ b/compiler/optimizer/ReachingDefinitions.cpp
@@ -119,8 +119,7 @@ void TR_ReachingDefinitions::initializeGenAndKillSetInfo()
    TR::Block *block;
    int32_t   blockNum = 0;
    bool      seenException = false;
-   TR_UseDefInfo::BitVector defsKilled(comp()->allocator());
-   defsKilled.GrowTo(getNumberOfBits());
+   TR_BitVector defsKilled(getNumberOfBits(), trMemory()->currentStackRegion());
 
    comp()->incVisitCount();
    for (TR::TreeTop *treeTop = comp()->getStartTree(); treeTop; treeTop = treeTop->getNextTreeTop())
@@ -173,7 +172,7 @@ void TR_ReachingDefinitions::initializeGenAndKillSetInfo()
    }
 
 
-void TR_ReachingDefinitions::initializeGenAndKillSetInfoForNode(TR::Node *node, TR_UseDefInfo::BitVector &defsKilled, bool seenException, int32_t blockNum, TR::Node *parent)
+void TR_ReachingDefinitions::initializeGenAndKillSetInfoForNode(TR::Node *node, TR_BitVector &defsKilled, bool seenException, int32_t blockNum, TR::Node *parent)
    {
    // Update gen and kill info for nodes in this subtree
    //
@@ -206,7 +205,7 @@ void TR_ReachingDefinitions::initializeGenAndKillSetInfoForNode(TR::Node *node, 
 
    bool foundDefsToKill = false;
    int32_t numDefNodes = 0;
-   defsKilled.Clear();
+   defsKilled.empty();
 
    TR::ILOpCode &opCode = node->getOpCode();
    TR::SymbolReference *symRef;

--- a/compiler/optimizer/UseDefInfo.cpp
+++ b/compiler/optimizer/UseDefInfo.cpp
@@ -635,6 +635,19 @@ void TR_UseDefInfo::findTrivialSymbolsToExclude(TR::Node *node, TR::TreeTop *tre
 
 bool TR_UseDefInfo::isTrivialUseDefNode(TR::Node *node, AuxiliaryData &aux)
    {
+   if (aux._doneTrivialNode.get(node->getGlobalIndex()))
+      return aux._isTrivialNode.get(node->getGlobalIndex());
+
+   bool result = isTrivialUseDefNodeImpl(node, aux);
+   aux._doneTrivialNode.set(node->getGlobalIndex());
+   if (result)
+      aux._isTrivialNode.set(node->getGlobalIndex());
+
+   return result;
+   }
+
+bool TR_UseDefInfo::isTrivialUseDefNodeImpl(TR::Node *node, AuxiliaryData &aux)
+   {
    if (node->getOpCode().isStore() &&
        node->getSymbol()->isAutoOrParm() &&
        node->storedValueIsIrrelevant())
@@ -653,6 +666,9 @@ bool TR_UseDefInfo::isTrivialUseDefNode(TR::Node *node, AuxiliaryData &aux)
          return false;
          }
       }
+
+   if (isTrivialUseDefSymRef(symRef, aux))
+      return true;
 
    if (_hasLoadsAsDefs && symRef->getSymbol()->isAutoOrParm())
       {
@@ -678,7 +694,7 @@ bool TR_UseDefInfo::isTrivialUseDefNode(TR::Node *node, AuxiliaryData &aux)
          return true;
       }
 
-   return isTrivialUseDefSymRef(symRef, aux);
+   return false;
    }
 
 

--- a/compiler/optimizer/UseDefInfo.cpp
+++ b/compiler/optimizer/UseDefInfo.cpp
@@ -583,7 +583,6 @@ void TR_UseDefInfo::findTrivialSymbolsToExclude(TR::Node *node, TR::TreeTop *tre
          if (aux._neverWrittenSymbols.get(symRefNum))
             {
             aux._neverWrittenSymbols.reset(symRefNum);
-            aux._nodesByGlobalIndex[node->getGlobalIndex()] = node;
 
             if (trace())
                traceMsg(comp(), "Resetting write bit %d at node %p\n", symRefNum, node);
@@ -600,23 +599,7 @@ void TR_UseDefInfo::findTrivialSymbolsToExclude(TR::Node *node, TR::TreeTop *tre
             }
          else if (!aux._onceWrittenSymbolsIndices[symRefNum].IsNull())
             {
-            // following code fails assert when aux._onceWrittenSymbolsIndices[symRefNum].IsZero() - needs to be fixed
-            // int32_t prevStoreIndex = aux._onceWrittenSymbolsIndices[symRefNum].FirstOne();
-            // TR::Node *prevStoreNode = aux._nodesByGlobalIndex[prevStoreIndex];
-            if (_hasLoadsAsDefs && 0 /* &&
-             (prevStoreNode->getByteCodeIndex() == node->getByteCodeIndex()) &&
-             (prevStoreNode->getInlinedSiteIndex() == node->getInlinedSiteIndex()) */)
-               {
-               aux._onceWrittenSymbolsIndices[symRefNum][node->getGlobalIndex()] = true;
-               aux._nodesByGlobalIndex[node->getGlobalIndex()] = node;
-
-               if (trace())
-                  traceMsg(comp(), "SETTING node %p symRefNum %d\n", node, symRefNum);
-               }
-            else
-               {
-               aux._onceWrittenSymbolsIndices[symRefNum].ClearToNull();
-               }
+            aux._onceWrittenSymbolsIndices[symRefNum].ClearToNull();
             }
          }
       }
@@ -627,8 +610,6 @@ void TR_UseDefInfo::findTrivialSymbolsToExclude(TR::Node *node, TR::TreeTop *tre
       int32_t symRefNum = symRef->getReferenceNumber();
       if (symRef->getSymbol()->isAutoOrParm())
          {
-         //aux._nodesByGlobalIndex[node->getGlobalIndex()] = node;
-
          if (aux._neverReadSymbols.get(symRefNum))
             {
             aux._neverReadSymbols.reset(symRefNum);

--- a/compiler/optimizer/UseDefInfo.cpp
+++ b/compiler/optimizer/UseDefInfo.cpp
@@ -2423,7 +2423,9 @@ void TR_UseDefInfo::buildUseDefs(TR::Node *node, void *vanalysisInfo, TR_BitVect
 
       if (!aux._defsForSymbol[symIndex]->isEmpty())
          {
-         TR_BitVector defs(comp()->trMemory()->currentStackRegion());
+         // Use the temporary work BitVector
+         TR_BitVector *defs = &(aux._workBitVector);
+         defs->empty();
 
          // assume aux._defsForSymbol[symIndex] is never NULL if _possibleDefs is non-NULL
          if (trace())
@@ -2433,7 +2435,7 @@ void TR_UseDefInfo::buildUseDefs(TR::Node *node, void *vanalysisInfo, TR_BitVect
             traceMsg(comp(), "\n");
             }
 
-         defs = *(aux._defsForSymbol[symIndex]);
+         *defs = *(aux._defsForSymbol[symIndex]);
 
          if (memSymIndex != -1 && !aux._defsForSymbol[memSymIndex]->isEmpty())
             {
@@ -2443,14 +2445,14 @@ void TR_UseDefInfo::buildUseDefs(TR::Node *node, void *vanalysisInfo, TR_BitVect
                aux._defsForSymbol[memSymIndex]->print(comp());
                traceMsg(comp(), "\n");
                }
-            defs |= *(aux._defsForSymbol[memSymIndex]);
+            *defs |= *(aux._defsForSymbol[memSymIndex]);
             }
 
          if (analysisInfo)
-            defs &= *analysisInfo;
+            *defs &= *analysisInfo;
 
          bool ignoreDefsOnEntry = false;
-         if (memSymIndex != -1 && !defs.get(memSymIndex))
+         if (memSymIndex != -1 && !defs->get(memSymIndex))
             ignoreDefsOnEntry = true;
 
 #if 0
@@ -2464,7 +2466,7 @@ void TR_UseDefInfo::buildUseDefs(TR::Node *node, void *vanalysisInfo, TR_BitVect
 
          TR_Method *method = comp()->getMethodSymbol()->getMethod();
 
-         TR_BitVectorIterator cursor(defs);
+         TR_BitVectorIterator cursor(*defs);
          while (cursor.hasMoreElements())
             {
             i = cursor.getNextElement();

--- a/compiler/optimizer/UseDefInfo.hpp
+++ b/compiler/optimizer/UseDefInfo.hpp
@@ -106,12 +106,18 @@ class TR_UseDefInfo
              _numAliases(numSymRefs, _region),
              _loadsBySymRefNum(numSymRefs, _region),
              _defsForOSR(0, static_cast<TR_BitVector*>(NULL), _region),
-             _workBitVector(_region)
+             _workBitVector(_region),
+             _doneTrivialNode(_region),
+             _isTrivialNode(_region)
             {}
       TR::Region _region;
 
       // BitVector for temporary work. Used in buildUseDefs.
       TR_BitVector _workBitVector;
+
+      // Cache results from isTrivialNode
+      TR_BitVector _doneTrivialNode;
+      TR_BitVector _isTrivialNode;
 
       TR::vector<TR_BitVector *, TR::Region&> _onceReadSymbols;
       TR::vector<TR_BitVector *, TR::Region&> _onceWrittenSymbols;
@@ -208,6 +214,7 @@ class TR_UseDefInfo
 
    void    findTrivialSymbolsToExclude(TR::Node *node, TR::TreeTop *treeTop, AuxiliaryData &aux);
    bool    isTrivialUseDefNode(TR::Node *node, AuxiliaryData &aux);
+   bool    isTrivialUseDefNodeImpl(TR::Node *node, AuxiliaryData &aux);
    bool    isTrivialUseDefSymRef(TR::SymbolReference *symRef, AuxiliaryData &aux);
 
    // For Languages where an auto can alias a volatile, extra care needs to be taken when setting up use-def

--- a/compiler/optimizer/UseDefInfo.hpp
+++ b/compiler/optimizer/UseDefInfo.hpp
@@ -94,7 +94,7 @@ class TR_UseDefInfo
              _region(region),
              _onceReadSymbols(numSymRefs, static_cast<TR_BitVector*>(NULL), _region),
              _onceWrittenSymbols(numSymRefs, static_cast<TR_BitVector*>(NULL), _region),
-             _defsForSymbol(0, BitVector(allocator), _region),
+             _defsForSymbol(0, static_cast<TR_BitVector*>(NULL), _region),
              _neverReadSymbols(numSymRefs, _region),
              _neverReferencedSymbols(numSymRefs, _region),
              _neverWrittenSymbols(numSymRefs, _region),
@@ -106,14 +106,14 @@ class TR_UseDefInfo
              _numAliases(numSymRefs, _region),
              _nodesByGlobalIndex(nodeCount, _region),
              _loadsBySymRefNum(numSymRefs, _region),
-             _defsForOSR(0, TR_UseDefInfo::BitVector(allocator), _region)
+             _defsForOSR(0, static_cast<TR_BitVector*>(NULL), _region)
             {}
       TR::Region _region;
 
       TR::vector<TR_BitVector *, TR::Region&> _onceReadSymbols;
       TR::vector<TR_BitVector *, TR::Region&> _onceWrittenSymbols;
       // defsForSymbol are known definitions of the symbol
-      TR::vector<BitVector, TR::Region&> _defsForSymbol;
+      TR::vector<TR_BitVector *, TR::Region&> _defsForSymbol;
       TR_BitVector _neverReadSymbols;
       TR_BitVector _neverReferencedSymbols;
       TR_BitVector _neverWrittenSymbols;
@@ -133,7 +133,7 @@ class TR_UseDefInfo
 
       protected:
       // used only in TR_OSRDefInfo - should extend AuxiliaryData really:
-      TR::vector<BitVector, TR::Region&> _defsForOSR;
+      TR::vector<TR_BitVector *, TR::Region&> _defsForOSR;
 
       friend class TR_UseDefInfo;
       friend class TR_ReachingDefinitions;
@@ -264,15 +264,15 @@ class TR_UseDefInfo
    bool    isExpandedUseDefIndex(uint32_t index)
                { return index >= _numExpandedDefOnlyNodes && index < getNumExpandedDefNodes(); }
 
-   bool getDefsForSymbol(BitVector &defs, int32_t symIndex, AuxiliaryData &aux)
+   bool getDefsForSymbol(TR_BitVector &defs, int32_t symIndex, AuxiliaryData &aux)
       {
-      defs.Or(aux._defsForSymbol[symIndex]);
-      return !defs.IsZero();
+      defs |= *(aux._defsForSymbol[symIndex]);
+      return !defs.isEmpty();
       }
 
    bool getDefsForSymbolIsZero(int32_t symIndex, AuxiliaryData &aux)
       {
-      return aux._defsForSymbol[symIndex].IsZero();
+      return aux._defsForSymbol[symIndex]->isEmpty();
       }
 
    bool hasLoadsAsDefs() { return _hasLoadsAsDefs; }
@@ -314,7 +314,7 @@ class TR_UseDefInfo
    bool childIndexIndicatesImplicitStore(TR::Node * node, int32_t childIndex);
    void insertData(TR::Block *, TR::Node *node, TR::Node *parent, TR::TreeTop *treeTop, AuxiliaryData &aux, TR::SparseBitVector &, bool considerImplicitStores = false);
    void buildUseDefs(void *vblockInfo, AuxiliaryData &aux);
-   void buildUseDefs(TR::Node *node, void *vanalysisInfo, TR::BitVector &nodesToBeDereferenced, TR::Node *parent, AuxiliaryData &aux);
+   void buildUseDefs(TR::Node *node, void *vanalysisInfo, TR_BitVector &nodesToBeDereferenced, TR::Node *parent, AuxiliaryData &aux);
    int32_t setSingleDefiningLoad(int32_t useIndex, BitVector &nodesLookedAt, BitVector &loadDefs);
 
    protected:

--- a/compiler/optimizer/UseDefInfo.hpp
+++ b/compiler/optimizer/UseDefInfo.hpp
@@ -185,7 +185,7 @@ class TR_UseDefInfo
    bool getUseDef_noExpansion(BitVector &useDef, int32_t useIndex);
    private:
    const BitVector &getUseDef_ref(int32_t useIndex, BitVector *defs = NULL);
-   const BitVector &getUseDef_ref_body(int32_t useIndex, TR_UseDefInfo::BitVector &visitedDefs, TR_UseDefInfo::BitVector *defs = NULL);
+   const BitVector &getUseDef_ref_body(int32_t useIndex, TR_BitVector *visitedDefs, TR_UseDefInfo::BitVector *defs = NULL);
    public:
 
    void          setUseDef(int32_t useIndex, int32_t defIndex);
@@ -340,6 +340,9 @@ class TR_UseDefInfo
    TR::vector<BitVector, TR::Region&> _defUseInfo;
    TR::vector<BitVector, TR::Region&> _loadDefUseInfo;
    TR::vector<int32_t, TR::Region&> _sideTableToSymRefNumMap;
+
+   // Checklist used in getUseDef_ref
+   TR_BitVector        *_defsChecklist;
 
    int32_t             _numDefOnlyNodes;
    int32_t             _numDefUseNodes;

--- a/compiler/optimizer/UseDefInfo.hpp
+++ b/compiler/optimizer/UseDefInfo.hpp
@@ -104,7 +104,6 @@ class TR_UseDefInfo
              _expandedAtoms(0, std::make_pair<TR::Node *, TR::TreeTop *>(NULL, NULL), _region),
              _sideTableToUseDefMap(_region),
              _numAliases(numSymRefs, _region),
-             _nodesByGlobalIndex(nodeCount, _region),
              _loadsBySymRefNum(numSymRefs, _region),
              _defsForOSR(0, static_cast<TR_BitVector*>(NULL), _region),
              _workBitVector(_region)
@@ -132,7 +131,6 @@ class TR_UseDefInfo
       TR::deque<uint32_t, TR::Region&> _sideTableToUseDefMap;
       private:
       TR::deque<uint32_t, TR::Region&> _numAliases;
-      TR::deque<TR::Node *, TR::Region&> _nodesByGlobalIndex;
       TR::deque<TR::Node *, TR::Region&> _loadsBySymRefNum;
 
       protected:

--- a/compiler/optimizer/UseDefInfo.hpp
+++ b/compiler/optimizer/UseDefInfo.hpp
@@ -106,9 +106,13 @@ class TR_UseDefInfo
              _numAliases(numSymRefs, _region),
              _nodesByGlobalIndex(nodeCount, _region),
              _loadsBySymRefNum(numSymRefs, _region),
-             _defsForOSR(0, static_cast<TR_BitVector*>(NULL), _region)
+             _defsForOSR(0, static_cast<TR_BitVector*>(NULL), _region),
+             _workBitVector(_region)
             {}
       TR::Region _region;
+
+      // BitVector for temporary work. Used in buildUseDefs.
+      TR_BitVector _workBitVector;
 
       TR::vector<TR_BitVector *, TR::Region&> _onceReadSymbols;
       TR::vector<TR_BitVector *, TR::Region&> _onceWrittenSymbols;


### PR DESCRIPTION
This contains a series of changes to reduce the compile time overhead of UseDef and the AliasSetInterface.

- Replace use of TR_BitContainer with TR_BitVector, as only the Node interface used the extra functionality
- Add TR_BitVector calls to the AliasSetInterface, matching existing CS2 BitVector functionality
- Replace CS2 BitVectors with TR_BitVector in ReachingDefinitions, OSRDefInfo and UseDefInfo's `_defsForSymbol`
- Add a reusable checklist to UseDefInfo
- Remove `nodesByGlobalIndex` for UseDefInfo, as it is no longer needed
- Replace the use of a HashTable to express several calls to the AliasSetInterface with the individual calls
- Rearrange and cache `isTrivialUseDefNode`, as its results are constant throughout the analysis