### PR TITLE
WIP: Convert OMR_PLATFORM_COMPILE_OPTIONS to flag append

### DIFF
--- a/cmake/modules/OmrPlatform.cmake
+++ b/cmake/modules/OmrPlatform.cmake
@@ -58,7 +58,13 @@ macro(omr_platform_global_setup)
 
 	set(OMR_PLATFORM_GLOBALLY_INITIALIZED 1)
 
-	add_compile_options(${OMR_PLATFORM_COMPILE_OPTIONS})
+	omr_append_flags(CMAKE_C_FLAGS
+		${OMR_PLATFORM_COMPILE_OPTIONS}
+	)
+
+	omr_append_flags(CMAKE_CXX_FLAGS
+		${OMR_PLATFORM_COMPILE_OPTIONS}
+	)
 
 	omr_append_flags(CMAKE_C_FLAGS
 		${OMR_PLATFORM_C_COMPILE_OPTIONS}


### PR DESCRIPTION
Currently in our AIX toolconfig we have `OMR_PLATFORM_COMPILE_OPTIONS` set
to (among other flags) `-qlanglvl=extended`.

In the compiler technology, the `TR_CXX_COMPILE_OPTIONS` flag is used to
upgrade C++ compilations to the `-qlanglvl=extended0x`, as the compiler
technology takes advantage of some of the C++11 features provided by
that compiler option.

The problem is that using `add_compile_options`, the arguments are
appended to the compilation string very late. This produces a
compilation string like

    ... -qlanglvl=extended0x ... -qlanglvl=extended

In most traditional command line processors, XLC included, the last
option superceeds earlier options, so this breaks AIX compilation of 
the compiler component. 

This commmit stops using `add_compile_options`, replacing it with
appending to both the `CMAKE_C_FLAGS` and `CMAKE_CXX_FLAGS`. This is at
least mildly distasteful, however, I'm not sure how else to be able to
override definitions from the 'global' platform options in a
subcomponent, if the global options are set with `add_compile_options`.

(A side note: One initial option that you might want to consider is
having the compiler technology add its own options with
add_compile_options. The issue here is that there is no way to add a
compile option using that command for only one language, which is
a requirement here, without using generator expressions. Now, it may be
acceptable to do so for XLC, however, language specific generator
expressions are documented to not work for MSVC, and so we have
historically avoided them)