### PR TITLE
OMR updates to address z/TPF build errors

### DIFF
--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -4360,14 +4360,6 @@ static int32_t longNumberOfLeadingZeros (int64_t n) {return leadingZeroes (n);}
 static int32_t longNumberOfTrailingZeros (int64_t n) { return trailingZeroes(n); }
 static int32_t longBitCount (int64_t n) {return populationCount(n);}
 
-template <typename T>
-void swap (T& a, T& b)
-   {
-   T tmp = b;
-   b = a;
-   a = tmp;
-   }
-
 
 template <typename FUNC, typename FUNC2, typename T>
 void addValidRangeBlockOrGlobalConstraint (OMR::ValuePropagation *vp,
@@ -4382,7 +4374,7 @@ void addValidRangeBlockOrGlobalConstraint (OMR::ValuePropagation *vp,
 
    if (pLow > pHigh)
       {
-      swap (pLow, pHigh);
+      std::swap (pLow, pHigh);
       }
 
    if (vp->trace())


### PR DESCRIPTION
VPHandlers.cpp - rename swap() to VPHswap() as z/TPF already has an
opensource swap() function in our libstdc++ library.
TypedAllocator.hpp - compiler couldn't find a matching matching function
for call to "construct()".
Signed-off-by: pete lemieszewski <lemie@us.ibm.com>