### PR TITLE
Enable trivial inliner in OMR

### DIFF
--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -774,6 +774,8 @@ OMR::Optimizer::Optimizer(TR::Compilation *comp, TR::ResolvedMethodSymbol *metho
       new (comp->allocator()) TR::OptimizationManager(self(), TR_CopyPropagation::create, OMR::globalCopyPropagation);
    _opts[OMR::globalDeadStoreElimination] =
       new (comp->allocator()) TR::OptimizationManager(self(), TR_DeadStoreElimination::create, OMR::globalDeadStoreElimination);
+   _opts[OMR::inlining] =
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_TrivialInliner::create, OMR::inlining);
    _opts[OMR::innerPreexistence] =
       new (comp->allocator()) TR::OptimizationManager(self(), TR_InnerPreexistence::create, OMR::innerPreexistence);
    _opts[OMR::invariantArgumentPreexistence] =

--- a/jitbuilder/optimizer/JBOptimizer.cpp
+++ b/jitbuilder/optimizer/JBOptimizer.cpp
@@ -105,6 +105,7 @@ static const OptimizationStrategy JBcoldStrategyOpts[] =
 static const OptimizationStrategy JBwarmStrategyOpts[] =
    {
    { OMR::deadTreesElimination                                                     },
+   { OMR::inlining                                                                 },
    { OMR::treeSimplification                                                       },
    { OMR::localCSE                                                                 },
    { OMR::basicBlockOrdering                                                       }, // straighten goto's


### PR DESCRIPTION
1. Created a (trivial) inliner entry in the optimization table.
2. Added inlining in the JitBuilder's warm strategy.

Signed-off-by: Xiaoli Liang <xsliang@ca.ibm.com>