### PR TITLE
Improve CMake JitBuilder support for Linux P

### DIFF
--- a/jitbuilder/CMakeLists.txt
+++ b/jitbuilder/CMakeLists.txt
@@ -53,6 +53,7 @@ elseif(OMR_ARCH_POWER)
 		p/runtime/CodeSync.cpp
 		p/runtime/AsmUtil.spp
 		p/runtime/CodeDispatch.spp
+		${OMR_ROOT}/compiler/p/env/OMRDebugEnv.cpp
 	)
 endif()
 
@@ -61,7 +62,7 @@ endif()
 create_omr_compiler_library(
 	NAME    jitbuilder
 	OBJECTS ${JITBUILDER_OBJECTS}
-	DEFINES PROD_WITH_ASSUMES
+	DEFINES PROD_WITH_ASSUMES JITTEST
 )
 
 # Add interface path so that include paths propagate.


### PR DESCRIPTION
JitBuilder requires 2 defines which were not being set and the
compilation was missing a file for Linux P.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>