### PR TITLE
Stop generating butest node on X and P

### DIFF
--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -266,6 +266,10 @@ inline void setCCOr(T value, TR::Node *node, TR::Simplifier *s)
 
 static void convertToTestUnderMask(TR::Node *node, TR::Block *block, TR::Simplifier *s)
    {
+   // butest evaluator is only implemented on Z
+   if (!TR::Compiler->target.cpu.isZ())
+      return;
+
    if (debug("disableConvertToTestUnderMask"))
       return;
    auto cm = s->comp();


### PR DESCRIPTION
Opcode butest is not supported on X and P, thus optimizer should not
generate butest node on these two platforms.

issue: #1789

Signed-off-by: liqunl <liqunl@ca.ibm.com>