### PR TITLE
WIP: Split Language standard out in CMake

### DIFF
--- a/cmake/modules/OmrPlatform.cmake
+++ b/cmake/modules/OmrPlatform.cmake
@@ -62,10 +62,12 @@ macro(omr_platform_global_setup)
 
 	omr_append_flags(CMAKE_C_FLAGS
 		${OMR_PLATFORM_C_COMPILE_OPTIONS}
+		${OMR_C_LANGUAGE_STANDARD}
 	)
 
 	omr_append_flags(CMAKE_CXX_FLAGS
 		${OMR_PLATFORM_CXX_COMPILE_OPTIONS}
+		${OMR_CXX_LANUAGE_STANDARD} 
 	)
 
 	omr_append_flags(CMAKE_EXE_LINKER_FLAGS

--- a/cmake/modules/platform/toolcfg/gnu.cmake
+++ b/cmake/modules/platform/toolcfg/gnu.cmake
@@ -34,6 +34,9 @@ else()
 	)
 endif()
 
+set(OMR_C_LANGUAGE_STANDARD "") 
+set(OMR_CXX_LANGUAGE_STANDARD "") 
+
 # Testarossa build variables. Longer term the distinction between TR and the rest
 # of the OMR code should be heavily reduced. In the mean time, we keep
 # the distinction

--- a/cmake/modules/platform/toolcfg/msvc.cmake
+++ b/cmake/modules/platform/toolcfg/msvc.cmake
@@ -36,6 +36,9 @@ else()
 	set(TARGET_MACHINE "i386")
 endif()
 
+set(OMR_C_LANGUAGE_STANDARD "") 
+set(OMR_CXX_LANGUAGE_STANDARD "") 
+
 list(APPEND OMR_PLATFORM_LINKER_OPTIONS
 	-subsystem:console
 	-machine:${TARGET_MACHINE}

--- a/cmake/modules/platform/toolcfg/xlc.cmake
+++ b/cmake/modules/platform/toolcfg/xlc.cmake
@@ -38,12 +38,16 @@ else()
 	)
 endif()
 
+set(OMR_C_LANGUAGE_STANDARD "") 
+set(OMR_CXX_LANGUAGE_STANDARD "") 
 
 if(OMR_HOST_OS STREQUAL "aix")
 	list(APPEND OMR_PLATFORM_COMPILE_OPTIONS
-		-qlanglvl=extended
 		-qinfo=pro
 	)
+
+	set(OMR_C_LANGUAGE_STANDARD "-qlanglvl=extended")
+	set(OMR_CXX_LANGUAGE_STANDARD "-qlanglvl=extended")
 
 	set(CMAKE_CXX_STANDARD_LIBRARIES "${CMAKE_CXX_STANDARD_LIBRARIES} -lm -liconv -ldl -lperfstat")
 


### PR DESCRIPTION
Currently in our AIX toolconfig we have OMR_PLATFORM_COMPILE_OPTIONS set
to (among other flags) -qlanglvl=extended.

In the compiler technology, the TR_CXX_COMPILE_OPTIONS flag is used to
upgrade C++ compilations to the -qlanglvl=extended0x, as the compiler
technology takes advantage of some of the C++11 features provided by
that compiler option.

The problem is that using add_compile_options, the arguments are
appended to the compilation string very late. This produces a
compilation string like

    ... -qlanglvl=extended0x ... -qlanglvl=extended

In most traditional command line processors, XLC included, the last
option superceeds earlier options, so this breaks AIX compilation of
the compiler component.

This commit hoists the language standard out to two new platform
controllable variables: OMR_C_LANGUAGE_STANDARD and
OMR_CXX_LANGUAGE_STANDARD. These flags are put in the command line
via modification of the CMAKE_C_FLAGS and CMAKE_CXX_FLAGS respectively.

As a result, the compiler technology remains free to append a higher
standard later (or, if desired, we could later us omr_remove_flag,
to replace it entirely).

Signed-off-by: Matthew Gaudet <magaudet@ca.ibm.com>