### PR TITLE
Move initialization of JitOptTest _strategy

### DIFF
--- a/fvtest/compilertriltest/JitTest.hpp
+++ b/fvtest/compilertriltest/JitTest.hpp
@@ -81,14 +81,16 @@ class JitOptTest : public JitTest
    JitOptTest() :
       JitTest(), _optimizations(), _strategy(NULL)
       {
-      // This is an allocated pointer because the strategy needs to 
-      // live as long as this fixture
-      _strategy = new OptimizationStrategy[_optimizations.size() + 1];
       } 
 
    virtual void SetUp()
       {
       JitTest::SetUp();
+
+      // This is an allocated pointer because the strategy needs to 
+      // live as long as this fixture
+      _strategy = new OptimizationStrategy[_optimizations.size() + 1];
+
       makeOptimizationStrategyArray(_strategy);
       TR::Optimizer::setMockStrategy(_strategy);
       }


### PR DESCRIPTION
This avoids a mis-sized buffer. Without this change, the buffer is
allocated before the correct size has been determined, and is not
resized before usage.

Issue found with -fsanitize=address, running the Tril tests.

Signed-off-by: Matthew Gaudet <magaudet@ca.ibm.com>