### PR TITLE
Support folding immutable array shadows

### DIFF
--- a/compiler/compile/OMRAliasBuilder.cpp
+++ b/compiler/compile/OMRAliasBuilder.cpp
@@ -51,6 +51,7 @@ OMR::AliasBuilder::AliasBuilder(TR::SymbolReferenceTable *symRefTab, size_t size
      _gcSafePointSymRefNumbers(sizeHint, c->trMemory(), heapAlloc, growable),
      _cpConstantSymRefs(sizeHint, c->trMemory(), heapAlloc, growable),
      _cpSymRefs(sizeHint, c->trMemory(), heapAlloc, growable),
+     _immutableArrayElementSymRefs(1, c->trMemory(), heapAlloc, growable),
      _refinedNonIntPrimitiveArrayShadows(1, c->trMemory(), heapAlloc, growable),
      _refinedAddressArrayShadows(1, c->trMemory(), heapAlloc, growable),
      _refinedIntArrayShadows(1, c->trMemory(), heapAlloc, growable),

--- a/compiler/compile/OMRAliasBuilder.hpp
+++ b/compiler/compile/OMRAliasBuilder.hpp
@@ -82,6 +82,7 @@ public:
    TR_BitVector & nonIntPrimitiveStaticSymRefs() { return _nonIntPrimitiveStaticSymRefs; }
    TR_BitVector & methodSymRefs() { return _methodSymRefs; }
    TR_BitVector & arrayElementSymRefs() { return _arrayElementSymRefs; }
+   TR_BitVector & immutableArrayElementSymRefs() { return _immutableArrayElementSymRefs; }
 
    TR::SymbolReference *getSymRefForAliasing(TR::Node *node, TR::Node *addrChild);
 
@@ -161,6 +162,7 @@ protected:
    TR_BitVector _nonIntPrimitiveStaticSymRefs;
    TR_BitVector _methodSymRefs;
    TR_BitVector _arrayElementSymRefs;
+   TR_BitVector _immutableArrayElementSymRefs;
 
    TR_BitVector _arrayletElementSymRefs;
    TR_BitVector _unsafeSymRefNumbers;

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -98,9 +98,6 @@ class SymbolReferenceTable
 
       firstArrayShadowSymbol,
 
-      lastWCodeNonhelperSymbol = firstArrayShadowSymbol + TR::NumTypes,
-      lastWCodeNonhelperSymbolX,
-
       firstArrayletShadowSymbol = firstArrayShadowSymbol + TR::NumTypes,
 
       firstCommonNonhelperNonArrayShadowSymbol = firstArrayletShadowSymbol + TR::NumTypes,
@@ -248,7 +245,7 @@ class SymbolReferenceTable
    int32_t getNonhelperIndex(CommonNonhelperSymbol s);
    int32_t getNumHelperSymbols()                      { return _numHelperSymbols; }
    int32_t getArrayShadowIndex(TR::DataType t)        { return _numHelperSymbols + firstArrayShadowSymbol + t; }
-   int32_t getArrayletShadowIndex(TR::DataType t) { return _numHelperSymbols + firstArrayShadowSymbol + TR::NumTypes + t; }
+   int32_t getArrayletShadowIndex(TR::DataType t) { return _numHelperSymbols + firstArrayletShadowSymbol + t; }
 
    template <class BitVector>
    void getAllSymRefs(BitVector &allSymRefs)
@@ -366,6 +363,7 @@ class SymbolReferenceTable
    TR::SymbolReference * findThisRangeExtensionSymRef(TR::ResolvedMethodSymbol *owningMethodSymbol = 0);
 
    TR::SymbolReference * findOrCreateSymRefWithKnownObject(TR::SymbolReference *original, uintptrj_t *referenceLocation);
+   TR::SymbolReference * findOrCreateSymRefWithKnownObject(TR::SymbolReference *original, uintptrj_t *referenceLocation, bool isArrayWithConstantElements);
    TR::SymbolReference * findOrCreateSymRefWithKnownObject(TR::SymbolReference *original, TR::KnownObjectTable::Index objectIndex);
    TR::SymbolReference * findOrCreateThisRangeExtensionSymRef(TR::ResolvedMethodSymbol *owningMethodSymbol = 0);
    TR::SymbolReference * findOrCreateContiguousArraySizeSymbolRef();
@@ -374,6 +372,8 @@ class SymbolReferenceTable
    TR::SymbolReference * findOrCreateNewObjectNoZeroInitSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);
    TR::SymbolReference * findOrCreateArrayStoreExceptionSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);
    TR::SymbolReference * findOrCreateArrayShadowSymbolRef(TR::DataType, TR::Node * baseAddress = 0);
+   TR::SymbolReference * findOrCreateImmutableArrayShadowSymbolRef(TR::DataType);
+   TR::SymbolReference * createImmutableArrayShadowSymbolRef(TR::DataType, TR::Symbol *sym);
    TR::SymbolReference * findOrCreateArrayletShadowSymbolRef(TR::DataType type);
    TR::SymbolReference * findOrCreateAsyncCheckSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol = 0);
    TR::SymbolReference * findOrCreateExcpSymbolRef();
@@ -425,6 +425,7 @@ class SymbolReferenceTable
    TR::SymbolReference * createRefinedArrayShadowSymbolRef(TR::DataType);
    TR::SymbolReference * createRefinedArrayShadowSymbolRef(TR::DataType, TR::Symbol *); // TODO: to be changed to a special sym ref
    bool                 isRefinedArrayShadow(TR::SymbolReference *symRef);
+   bool                 isImmutableArrayShadow(TR::SymbolReference *symRef);
 
 
    // A RegisterSymbol is a pseudo memory location that represents some machine

--- a/compiler/env/OMRClassEnv.cpp
+++ b/compiler/env/OMRClassEnv.cpp
@@ -26,6 +26,7 @@
 #include "env/jittypes.h"             // for uintptrj_t, intptrj_t
 #include "infra/Assert.hpp"           // for TR_ASSERT
 
+#define notImplemented(A) TR_ASSERT(0, "OMR::ClassEnv::%s is undefined", (A) )
 
 char *
 OMR::ClassEnv::classNameChars(TR::Compilation *comp, TR::SymbolReference *symRef, int32_t & len)
@@ -33,4 +34,11 @@ OMR::ClassEnv::classNameChars(TR::Compilation *comp, TR::SymbolReference *symRef
    char *name = "<no class name>";
    len = strlen(name);
    return name;
+   }
+
+uintptrj_t
+OMR::ClassEnv::getArrayElementWidthInBytes(TR::Compilation *comp, TR_OpaqueClassBlock* arrayClass)
+   {
+   notImplemented("getArrayElementWidthInBytes");
+   return 0;
    }

--- a/compiler/env/OMRClassEnv.hpp
+++ b/compiler/env/OMRClassEnv.hpp
@@ -90,6 +90,8 @@ public:
    bool jitStaticsAreSame(TR::Compilation *comp, TR_ResolvedMethod * method1, int32_t cpIndex1, TR_ResolvedMethod * method2, int32_t cpIndex2) { return false; }
    bool jitFieldsAreSame(TR::Compilation *comp, TR_ResolvedMethod * method1, int32_t cpIndex1, TR_ResolvedMethod * method2, int32_t cpIndex2, int32_t isStatic) { return false; }
 
+   uintptrj_t getArrayElementWidthInBytes(TR::Compilation *comp, TR_OpaqueClassBlock* arrayClass);
+
    uintptrj_t persistentClassPointerFromClassPointer(TR::Compilation *comp, TR_OpaqueClassBlock *clazz) { return 0; }
    TR_OpaqueClassBlock *objectClass(TR::Compilation *comp, uintptrj_t objectPointer) { return NULL; }
    TR_OpaqueClassBlock *classFromJavaLangClass(TR::Compilation *comp, uintptrj_t objectPointer) { return NULL; }

--- a/compiler/env/OMRKnownObjectTable.hpp
+++ b/compiler/env/OMRKnownObjectTable.hpp
@@ -36,6 +36,7 @@ namespace OMR { typedef OMR::KnownObjectTable KnownObjectTableConnector; }
 #include "env/FilePointerDecl.hpp"  // for FILE
 #include "env/jittypes.h"           // for uintptrj_t
 #include "infra/Annotations.hpp"    // for OMR_EXTENSIBLE
+#include "infra/BitVector.hpp"                 // for TR_BitVector
 
 class TR_FrontEnd;
 namespace TR { class Compilation; }
@@ -58,6 +59,7 @@ protected:
 
    KnownObjectTable(TR::Compilation *comp);
    TR::Compilation *_comp;
+   TR_BitVector* _arrayWithConstantElements;
 
 public:
 
@@ -74,6 +76,7 @@ public:
 
    virtual Index getEndIndex();                      // Highest index assigned so far + 1
    virtual Index getIndex(uintptrj_t objectPointer); // Must hold vm access for this
+   Index getIndex(uintptrj_t objectPointer, bool isArrayWithConstantElements); // Must hold vm access for this
    virtual uintptrj_t *getPointerLocation(Index index);
    virtual bool isNull(Index index);
 
@@ -81,11 +84,18 @@ public:
 
    // Handy wrappers
 
+   // API for checking if an known object is an array with immutable elements
+   bool isArrayWithConstantElements(Index index);
+
    Index getIndexAt(uintptrj_t *objectReferenceLocation);
+   Index getIndexAt(uintptrj_t *objectReferenceLocation, bool isArrayWithConstantElements);
    Index getExistingIndexAt(uintptrj_t *objectReferenceLocation);
 
    uintptrj_t getPointer(Index index);
    uintptrj_t *getfPointerLocationAt(uintptrj_t *objectReferenceLocation);
+
+protected:
+   void addArrayWithConstantElements(Index index);
 
    };
 }

--- a/compiler/env/OMRObjectModel.cpp
+++ b/compiler/env/OMRObjectModel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -76,6 +76,48 @@ int64_t
 OMR::ObjectModel::maxArraySizeInElements(int32_t knownMinElementSize, TR::Compilation *comp)
    {
    return LONG_MAX;
+   }
+
+bool
+OMR::ObjectModel::isDiscontiguousArray(TR::Compilation* comp, uintptrj_t objectPointer)
+   {
+   notImplemented("isDiscontiguousArray");
+   return false;
+   }
+
+intptrj_t
+OMR::ObjectModel::getArrayLengthInElements(TR::Compilation* comp, uintptrj_t objectPointer)
+   {
+   notImplemented("getArrayLengthInElements");
+   return 0;
+   }
+
+uintptrj_t
+OMR::ObjectModel::getArrayLengthInBytes(TR::Compilation* comp, uintptrj_t objectPointer)
+   {
+   notImplemented("getArrayLengthInBytes");
+   return 0;
+   }
+
+uintptrj_t
+OMR::ObjectModel::getArrayElementWidthInBytes(TR::DataType type)
+   {
+   notImplemented("getArrayElementWidthInBytes");
+   return 0;
+   }
+
+uintptrj_t
+OMR::ObjectModel::getArrayElementWidthInBytes(TR::Compilation* comp, uintptrj_t objectPointer)
+   {
+   notImplemented("getArrayElementWidthInBytes");
+   return 0;
+   }
+
+uintptrj_t
+OMR::ObjectModel::decompressReference(TR::Compilation* comp, uintptrj_t compressedReference)
+   {
+   notImplemented("decompressReference");
+   return 0;
    }
 
 int32_t

--- a/compiler/env/OMRObjectModel.hpp
+++ b/compiler/env/OMRObjectModel.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,6 +33,7 @@ namespace OMR { typedef OMR::ObjectModel ObjectModelConnector; }
 
 #include <stdint.h>        // for int32_t, int64_t, uint32_t
 #include "env/jittypes.h"  // for uintptrj_t, intptrj_t
+#include "il/DataTypes.hpp"
 
 class TR_OpaqueClassBlock;
 namespace OMR { class ObjectModel; }
@@ -72,6 +73,12 @@ class ObjectModel
 
    bool isDiscontiguousArray(int32_t sizeInBytes) { return false; }
    bool isDiscontiguousArray(int32_t sizeInElements, int32_t elementSize) { return false; }
+   bool isDiscontiguousArray(TR::Compilation* comp, uintptrj_t objectPointer);
+   intptrj_t getArrayLengthInElements(TR::Compilation* comp, uintptrj_t objectPointer);
+   uintptrj_t getArrayLengthInBytes(TR::Compilation* comp, uintptrj_t objectPointer);
+   uintptrj_t getArrayElementWidthInBytes(TR::DataType type);
+   uintptrj_t getArrayElementWidthInBytes(TR::Compilation* comp, uintptrj_t objectPointer);
+   uintptrj_t decompressReference(TR::Compilation* comp, uintptrj_t compressedReference);
 
 
    int32_t compressedReferenceShiftOffset();

--- a/compiler/il/Aliases.cpp
+++ b/compiler/il/Aliases.cpp
@@ -647,6 +647,22 @@ OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool includeGCSafePo
             aliases->set(symRefTab->getArrayShadowIndex(_symbol->getDataType().scalarToVector()));
             }
 
+         if (_symbol->isArrayShadowSymbol() &&
+             !symRefTab->aliasBuilder.immutableArrayElementSymRefs().isEmpty())
+            {
+            if (!aliases)
+               aliases = new (aliasRegion) TR_BitVector(bvInitialSize, aliasRegion, growability);
+
+            TR::DataType type = _symbol->getDataType();
+            TR_BitVectorIterator bvi(symRefTab->aliasBuilder.arrayElementSymRefs());
+            int32_t symRefNum;
+            while (bvi.hasMoreElements())
+               {
+               symRefNum = bvi.getNextElement();
+               if (symRefTab->getSymRef(symRefNum)->getSymbol()->getDataType() == type)
+                  aliases->set(symRefNum);
+               }
+            }
 
          if (_symbol->isArrayShadowSymbol() &&
              supportArrayRefinement &&

--- a/compiler/optimizer/VPConstraint.cpp
+++ b/compiler/optimizer/VPConstraint.cpp
@@ -616,6 +616,13 @@ TR_YesNoMaybe TR::VPKnownObject::isJavaLangClassObject()
    return _isJavaLangClass ? TR_yes : TR_no;
    }
 
+bool TR::VPKnownObject::isArrayWithConstantElements(TR::Compilation * comp)
+   {
+   TR::KnownObjectTable *knot = comp->getKnownObjectTable();
+   TR_ASSERT(knot, "TR::KnownObjectTable should not be null");
+   return knot->isArrayWithConstantElements(_index);
+   }
+
 TR_YesNoMaybe TR::VPClassType::isArray()
    {
    if (_sig[0] == '[')

--- a/compiler/optimizer/VPConstraint.hpp
+++ b/compiler/optimizer/VPConstraint.hpp
@@ -958,6 +958,7 @@ class VPKnownObject : public TR::VPFixedClass
    virtual TR::VPConstraint *intersect1(TR::VPConstraint *other, OMR::ValuePropagation *vp);
 
    virtual TR_YesNoMaybe isJavaLangClassObject();
+   virtual bool isArrayWithConstantElements(TR::Compilation * comp);
 
    virtual bool mustBeEqual(TR::VPConstraint *other, OMR::ValuePropagation *vp);
    virtual bool mustBeNotEqual(TR::VPConstraint *other, OMR::ValuePropagation *vp);

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -2179,8 +2179,11 @@ TR_Debug::getShadowName(TR::SymbolReference * symRef)
 
    if (symRef->getSymbol())
       {
-      if(symRef->getSymbol()->isArrayShadowSymbol())
+      if (comp()->getSymRefTab()->isRefinedArrayShadow(symRef))
          return "<refined-array-shadow>";
+
+      if (comp()->getSymRefTab()->isImmutableArrayShadow(symRef))
+         return "<immutable-array-shadow>";
 
       if(symRef->getSymbol()->isArrayletShadowSymbol())
          return "<arraylet-shadow>";


### PR DESCRIPTION
If we know an array is not going to be changed nor is its content, we
can fold the load of its element. This is done by adding a bit in
KnownObjectTable to indicate whether a known object is an array with
immutable content. When VP sees an array shadow load from such array,
it will improve the array shadow to an ImmutableArrayShadow, a new
symbol added for this optimzation, and ask transformIndirectLoadChain
to fold it. ImmutableArrayShadow is also served as an indicator to
transformIndirectLoadChain that it is safe to fold an array shadow with
such symbol.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>