### PR TITLE
Upgrade brew before using it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ addons:
       - g++-multilib
       - ninja-build
 before_install:
-  - if [ $TRAVIS_OS_NAME = osx ]; then brew install ccache ; fi
+  - if [ $TRAVIS_OS_NAME = osx ]; then brew update && brew install ccache; fi
 env:
   matrix:
     - BUILD_WITH_CMAKE=yes CMAKE_GENERATOR=Ninja


### PR DESCRIPTION
Brew is not very smart. When we install ccache, brew will auto update
first, installing ruby 2.3. Unfortunately, the install will require the
new ruby, but will run with the old ruby brew used to upgrade. So now,
we need to update brew before running any other commands. This is a new
issue with brew.

This patch will fix all the brew-related osx travis failures we are
seeing across the board.

Signed-off-by: Robert Young <rwy0717@gmail.com>