### PR TITLE
Aborted CS and RS overflow

### DIFF
--- a/gc/base/ParallelHeapWalker.hpp
+++ b/gc/base/ParallelHeapWalker.hpp
@@ -52,14 +52,14 @@ public:
 	/**
 	 * Walk through all live objects of the heap in parallel and apply the provided function.
 	 */
-	void allObjectsDoParallel(MM_EnvironmentBase *env, MM_HeapWalkerObjectFunc function, void *userData, UDATA walkFlags);
+	void allObjectsDoParallel(MM_EnvironmentBase *env, MM_HeapWalkerObjectFunc function, void *userData, uintptr_t walkFlags);
 
 	/**
 	 * Walk through all live objects of the heap and apply the provided function.
 	 * If parallel is set to true, task is dispatched to GC threads and walks the heap segments in parallel,
 	 * otherwise walk all objects in the heap in a single threaded linear fashion.
 	 */
-	virtual void allObjectsDo(MM_EnvironmentBase *env, MM_HeapWalkerObjectFunc function, void *userData, UDATA walkFlags, bool parallel, bool prepareHeapForWalk);
+	virtual void allObjectsDo(MM_EnvironmentBase *env, MM_HeapWalkerObjectFunc function, void *userData, uintptr_t walkFlags, bool parallel, bool prepareHeapForWalk);
 
 	MM_MarkMap *getMarkMap() {
 		return _markMap;


### PR DESCRIPTION
Handle a special case of aborted Concurrent Scavenger when Remembered
Set is in overflow. This is not much different from handling it when RS
is not overflowed - we just clear RS. All heap fixup (restoring
references to forwarded objects and self-forwarded objects) occurs in
the following global GC and fixup hook.

Also, fixign a bug in Parallel Heap Walker that was ignoring walk flags.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>